### PR TITLE
Fix potential XXE vulnerability 

### DIFF
--- a/console/src/main/java/com/arcadedb/importer/XMLImporter.java
+++ b/console/src/main/java/com/arcadedb/importer/XMLImporter.java
@@ -28,6 +28,7 @@ import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.utility.FileUtils;
 
+import javax.xml.XMLConstants;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
@@ -52,6 +53,8 @@ public class XMLImporter implements ContentImporter {
       }
 
       final XMLInputFactory xmlFactory = XMLInputFactory.newInstance();
+      xmlFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+      xmlFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
       final XMLStreamReader xmlReader = xmlFactory.createXMLStreamReader(parser.getInputStream());
 
       int nestLevel = 0;
@@ -169,6 +172,9 @@ public class XMLImporter implements ContentImporter {
       parser.reset();
 
       final XMLInputFactory xmlFactory = XMLInputFactory.newInstance();
+      xmlFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+      xmlFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+
       final XMLStreamReader xmlReader = xmlFactory.createXMLStreamReader(parser.getInputStream());
 
       int nestLevel = 0;


### PR DESCRIPTION
What does this PR do?
protect Java XML Parsers from XXE attacks by adding by adding [JAXP Properties for External Access Restrictions](https://docs.oracle.com/en/java/javase/13/security/java-api-xml-processing-jaxp-security-guide.html#GUID-94ABC0EE-9DC8-44F0-84AD-47ADD5340477)

Motivation
prevent  XXE attacks

Additional Notes
Inspired by[ SonarQube rule](https://rules.sonarsource.com/java/RSPEC-2755)

Checklist
[X] I have run the build using `mvn clean package` command
[] My unit tests cover both failure and success scenarios
