### PR TITLE
Fixes #30 Postgres: NPE executig command when portal is null

### DIFF
--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -278,7 +278,6 @@ public class PostgresNetworkExecutor extends Thread {
       final PostgresPortal portal = getPortal(portalName, true);
       if (portal == null) {
         writeNoData();
-        writeCommandComplete(portal.query, portal.cachedResultset == null ? 0 : portal.cachedResultset.size());
         return;
       }
 


### PR DESCRIPTION
What does this PR do?
Deletes unnecessary statement that threw an NPE

Motivation
I'm against NPEs

Related issues
#30 


Checklist
[X] I have run the build using `mvn clean package` command
[] My unit tests cover both failure and success scenarios
