### PR TITLE
Compare with value and not with reference

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/OrderByItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/OrderByItem.java
@@ -136,7 +136,7 @@ public class OrderByItem {
         result = 0;
       }
     }
-    if (type == DESC) {
+    if (DESC.equals(type)) {
       result = -1 * result;
     }
     return result;


### PR DESCRIPTION
What does this PR do?
I have found this line of code and I think maybe a wrong variable compare.
Both vars are String. In this situation, the correct comparison is a .equals() not a ==

Motivation
I think to have found a bug inside the code

Related issues
-

Additional Notes
-

Checklist
[x] I have run the build using `mvn clean package` command
[] My unit tests cover both failure and success scenarios
