### PR TITLE
Replication: fixed difference in schema version between servers

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/DatabaseComparator.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseComparator.java
@@ -105,7 +105,6 @@ public class DatabaseComparator {
         db2.getPageManager().removePageFromCache(page2.getPageId());
       }
     }
-
   }
 
   public void compareTypes(final Database db1, final Database db2) {

--- a/server/src/main/java/com/arcadedb/server/ha/message/DatabaseChangeStructureRequest.java
+++ b/server/src/main/java/com/arcadedb/server/ha/message/DatabaseChangeStructureRequest.java
@@ -16,15 +16,13 @@
 package com.arcadedb.server.ha.message;
 
 import com.arcadedb.database.Binary;
-import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.engine.PaginatedFile;
 import com.arcadedb.log.LogManager;
-import com.arcadedb.schema.EmbeddedSchema;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.ha.HAServer;
 import com.arcadedb.server.ha.ReplicationException;
-import com.arcadedb.utility.FileUtils;
+import org.json.JSONObject;
 
 import java.io.*;
 import java.util.*;
@@ -130,18 +128,16 @@ public class DatabaseChangeStructureRequest extends HAAbstractCommand {
     final String databasePath = db.getDatabasePath();
 
     // ADD FILES
-    for (Map.Entry<Integer, String> entry : filesToAdd.entrySet()) {
+    for (Map.Entry<Integer, String> entry : filesToAdd.entrySet())
       db.getFileManager().getOrCreateFile(entry.getKey(), databasePath + "/" + entry.getValue());
-    }
 
     // REMOVE FILES
-    for (Map.Entry<Integer, String> entry : filesToRemove.entrySet()) {
+    for (Map.Entry<Integer, String> entry : filesToRemove.entrySet())
       db.getFileManager().dropFile(entry.getKey());
-    }
 
-    // REPLACE SCHEMA FILE
-    final File file = new File(db.getDatabasePath() + "/" + EmbeddedSchema.SCHEMA_FILE_NAME);
-    FileUtils.writeContentToStream(file, schemaJson.getBytes(DatabaseFactory.getDefaultCharset()));
+    if (!schemaJson.isEmpty())
+      // REPLACE SCHEMA FILE
+      db.getSchema().getEmbedded().update(new JSONObject(schemaJson));
   }
 
   @Override

--- a/server/src/test/java/com/arcadedb/server/ha/ReplicationChangeSchemaIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/ReplicationChangeSchemaIT.java
@@ -24,18 +24,22 @@ import com.arcadedb.schema.Property;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.schema.VertexType;
+import com.arcadedb.utility.Callable;
 import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
+import java.util.*;
 
 public class ReplicationChangeSchemaIT extends ReplicationServerIT {
+  private final Database            databases[] = new Database[getServerCount()];
+  private final Map<String, String> schemaFiles = new LinkedHashMap<>(getServerCount());
+
   @Test
   public void testReplication() throws Exception {
     super.testReplication();
 
-    final Database databases[] = new Database[getServerCount()];
     for (int i = 0; i < getServerCount(); i++) {
       databases[i] = getServer(i).getDatabase(getDatabaseName());
       databases[i].commit();
@@ -43,17 +47,11 @@ public class ReplicationChangeSchemaIT extends ReplicationServerIT {
 
     // CREATE NEW TYPE
     final VertexType type1 = databases[0].getSchema().createVertexType("RuntimeVertex0");
-    for (Database database : databases) {
-      Assertions.assertNotNull(database.getSchema().getType("RuntimeVertex0"));
-      isInSchemaFile(database, "RuntimeVertex0");
-    }
+    testOnAllServers((database) -> isInSchemaFile(database, "RuntimeVertex0"));
 
     // CREATE NEW PROPERTY
     type1.createProperty("nameNotFoundInDictionary", Type.STRING);
-    for (Database database : databases) {
-      Assertions.assertNotNull(database.getSchema().getType("RuntimeVertex0").getProperty("nameNotFoundInDictionary"));
-      isInSchemaFile(database, "nameNotFoundInDictionary");
-    }
+    testOnAllServers((database) -> isInSchemaFile(database, "nameNotFoundInDictionary"));
 
     // CREATE NEW BUCKET
     final Bucket newBucket = databases[0].getSchema().createBucket("newBucket");
@@ -61,10 +59,7 @@ public class ReplicationChangeSchemaIT extends ReplicationServerIT {
       Assertions.assertTrue(database.getSchema().existsBucket("newBucket"));
 
     type1.addBucket(newBucket);
-    for (Database database : databases) {
-      Assertions.assertTrue(database.getSchema().getType("RuntimeVertex0").hasBucket("newBucket"));
-      isInSchemaFile(database, "newBucket");
-    }
+    testOnAllServers((database) -> isInSchemaFile(database, "newBucket"));
 
     // CHANGE SCHEMA FROM A REPLICA (ERROR EXPECTED)
     try {
@@ -74,17 +69,11 @@ public class ReplicationChangeSchemaIT extends ReplicationServerIT {
       // EXPECTED
     }
 
-    for (Database database : databases) {
-      Assertions.assertFalse(database.getSchema().existsType("RuntimeVertex1"));
-      isNotInSchemaFile(database, "RuntimeVertex1");
-    }
+    testOnAllServers((database) -> isNotInSchemaFile(database, "RuntimeVertex1"));
 
     // DROP PROPERTY
     type1.dropProperty("nameNotFoundInDictionary");
-    for (Database database : databases) {
-      Assertions.assertFalse(database.getSchema().getType("RuntimeVertex0").existsProperty("nameNotFoundInDictionary"));
-      isNotInSchemaFile(database, "nameNotFoundInDictionary");
-    }
+    testOnAllServers((database) -> isNotInSchemaFile(database, "nameNotFoundInDictionary"));
 
     // DROP NEW BUCKET
     try {
@@ -98,36 +87,21 @@ public class ReplicationChangeSchemaIT extends ReplicationServerIT {
       Assertions.assertFalse(database.getSchema().getType("RuntimeVertex0").hasBucket("newBucket"));
 
     databases[0].getSchema().dropBucket("newBucket");
-    for (Database database : databases) {
-      Assertions.assertFalse(database.getSchema().existsBucket("newBucket"));
-      isNotInSchemaFile(database, "newBucket");
-    }
+    testOnAllServers((database) -> isNotInSchemaFile(database, "newBucket"));
 
     // DROP TYPE
     databases[0].getSchema().dropType("RuntimeVertex0");
-    for (Database database : databases) {
-      Assertions.assertFalse(database.getSchema().existsType("RuntimeVertex0"));
-      isNotInSchemaFile(database, "RuntimeVertex0");
-    }
+    testOnAllServers((database) -> isNotInSchemaFile(database, "RuntimeVertex0"));
 
     final VertexType indexedType = databases[0].getSchema().createVertexType("IndexedVertex0");
-    for (Database database : databases) {
-      Assertions.assertNotNull(database.getSchema().getType("IndexedVertex0"));
-      isInSchemaFile(database, "IndexedVertex0");
-    }
+    testOnAllServers((database) -> isInSchemaFile(database, "IndexedVertex0"));
 
     // CREATE NEW PROPERTY
     final Property indexedProperty = indexedType.createProperty("propertyIndexed", Type.INTEGER);
-    for (Database database : databases) {
-      Assertions.assertNotNull(database.getSchema().getType("IndexedVertex0").getProperty("propertyIndexed"));
-      isInSchemaFile(database, "propertyIndexed");
-    }
+    testOnAllServers((database) -> isInSchemaFile(database, "propertyIndexed"));
 
     final Index idx = indexedProperty.createIndex(Schema.INDEX_TYPE.LSM_TREE, true);
-    for (Database database : databases) {
-      Assertions.assertEquals(1, database.getSchema().getType("IndexedVertex0").getAllIndexes(true).size());
-      isInSchemaFile(database, "\"IndexedVertex0\":{\"indexes\":{\"IndexedVertex0_");
-    }
+    testOnAllServers((database) -> isInSchemaFile(database, "\"IndexedVertex0\":{\"indexes\":{\"IndexedVertex0_"));
 
     databases[0].transaction(() -> {
       for (int i = 0; i < 10; i++)
@@ -145,14 +119,7 @@ public class ReplicationChangeSchemaIT extends ReplicationServerIT {
     }
 
     databases[0].getSchema().dropIndex(idx.getName());
-    for (Database database : databases) {
-      try {
-        Assertions.assertEquals(0, database.getSchema().getType("IndexedVertex0").getAllIndexes(true).size());
-        isNotInSchemaFile(database, idx.getName());
-      } catch (Exception e) {
-        Assertions.fail(e);
-      }
-    }
+    testOnAllServers((database) -> isNotInSchemaFile(database, idx.getName()));
 
     // CREATE NEW TYPE IN TRANSACTION
     databases[0].transaction(() -> {
@@ -163,18 +130,55 @@ public class ReplicationChangeSchemaIT extends ReplicationServerIT {
       }
     });
 
+    testOnAllServers((database) -> isInSchemaFile(database, "RuntimeVertexTx0"));
+  }
+
+  private void testOnAllServers(final Callable<String, Database> callback) {
+    // CREATE NEW TYPE
+    schemaFiles.clear();
     for (Database database : databases) {
-      Assertions.assertNotNull(database.getSchema().getType("RuntimeVertexTx0"));
-      isInSchemaFile(database, "RuntimeVertexTx0");
+      try {
+        final String result = callback.call(database);
+        schemaFiles.put(database.getDatabasePath(), result);
+      } catch (Exception e) {
+        Assertions.fail(e);
+      }
+    }
+    checkSchemaFilesAreTheSameOnAllServers();
+  }
+
+  private String isInSchemaFile(final Database database, final String match) {
+    try {
+      final String content = FileUtils.readFileAsString(database.getSchema().getEmbedded().getConfigurationFile(), "UTF8");
+      Assertions.assertTrue(content.contains(match));
+      return content;
+    } catch (IOException e) {
+      Assertions.fail(e);
+      return null;
     }
   }
 
-  private void isInSchemaFile(final Database database, final String match) throws IOException {
-    Assertions.assertTrue(FileUtils.readFileAsString(database.getSchema().getEmbedded().getConfigurationFile(), "UTF8").contains(match));
+  private String isNotInSchemaFile(final Database database, final String match) {
+    try {
+      final String content = FileUtils.readFileAsString(database.getSchema().getEmbedded().getConfigurationFile(), "UTF8");
+      Assertions.assertFalse(content.contains(match));
+      return content;
+    } catch (IOException e) {
+      Assertions.fail(e);
+      return null;
+    }
   }
 
-  private void isNotInSchemaFile(final Database database, final String match) throws IOException {
-    Assertions.assertFalse(FileUtils.readFileAsString(database.getSchema().getEmbedded().getConfigurationFile(), "UTF8").contains(match));
+  private void checkSchemaFilesAreTheSameOnAllServers() {
+    Assertions.assertEquals(getServerCount(), schemaFiles.size());
+    String first = null;
+    for (Map.Entry<String, String> entry : schemaFiles.entrySet()) {
+      if (first == null)
+        first = entry.getValue();
+      else
+        Assertions.assertEquals(first, entry.getValue(),
+            "Server " + entry.getKey() + " has different schema saved:\nFIRST SERVER:\n" + first + "\n" + entry.getKey() + " SERVER:\n" + entry.getValue());
+    }
   }
 
   protected int getServerCount() {


### PR DESCRIPTION
Issue reported by @jimmarino about the difference in version between servers. Even if the schema is identical, the version is different between servers, where the leader has version=+1.