### PR TITLE
Do loop with Iterable instead of Collection

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -381,7 +381,7 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
     Object value = nextElementInKey.execute(new ResultInternal(), ctx);
     if (value instanceof Iterable && !(value instanceof Identifiable)) {
       List<PCollection> result = new ArrayList<>();
-      for (Object elemInKey : (java.util.Collection) value) {
+      for (Object elemInKey : (Iterable<?>) value) {
         PCollection newHead = new PCollection(-1);
         for (Expression exp : head.getExpressions()) {
           newHead.add(exp.copy());


### PR DESCRIPTION
What does this PR do?
Loop over previous checked type to prevent Classcast exception.

Motivation
Arguments passed as Iterables should work
