### PR TITLE
#371 #413 : replace "/" with File.pathSeparator to be more OS agnostic

### DIFF
--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -150,13 +150,13 @@ public class Console {
 
     if (this.rootDirectory == null || this.rootDirectory.isEmpty())
       this.rootDirectory = ".";
-    else if (this.rootDirectory.endsWith(File.pathSeparator))
+    else if (this.rootDirectory.endsWith(File.separator))
       this.rootDirectory = this.rootDirectory.substring(0, this.rootDirectory.length() - 1);
 
-    if (!new File(this.rootDirectory + File.pathSeparator+ "config").exists() && new File(this.rootDirectory + File.pathSeparator + ".." +File.pathSeparator + "config").exists()) {
-      databaseDirectory = new File(this.rootDirectory).getAbsoluteFile().getParentFile().getPath() + File.pathSeparator+ "databases"+ File.pathSeparator;
+    if (!new File(this.rootDirectory + File.separator+ "config").exists() && new File(this.rootDirectory + File.separator + ".." +File.separator + "config").exists()) {
+      databaseDirectory = new File(this.rootDirectory).getAbsoluteFile().getParentFile().getPath() + File.separator+ "databases"+ File.separator;
     } else
-      databaseDirectory = this.rootDirectory + File.pathSeparator+ "databases"+ File.pathSeparator;
+      databaseDirectory = this.rootDirectory + File.separator+ "databases"+ File.separator;
 
     return this;
   }

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -150,13 +150,13 @@ public class Console {
 
     if (this.rootDirectory == null || this.rootDirectory.isEmpty())
       this.rootDirectory = ".";
-    else if (this.rootDirectory.endsWith("/"))
+    else if (this.rootDirectory.endsWith(File.pathSeparator))
       this.rootDirectory = this.rootDirectory.substring(0, this.rootDirectory.length() - 1);
 
-    if (!new File(this.rootDirectory + "/config").exists() && new File(this.rootDirectory + "/../config").exists()) {
-      databaseDirectory = new File(this.rootDirectory).getAbsoluteFile().getParentFile().getPath() + "/databases/";
+    if (!new File(this.rootDirectory + File.pathSeparator+ "config").exists() && new File(this.rootDirectory + File.pathSeparator + ".." +File.pathSeparator + "config").exists()) {
+      databaseDirectory = new File(this.rootDirectory).getAbsoluteFile().getParentFile().getPath() + File.pathSeparator+ "databases"+ File.pathSeparator;
     } else
-      databaseDirectory = this.rootDirectory + "/databases/";
+      databaseDirectory = this.rootDirectory + File.pathSeparator+ "databases"+ File.pathSeparator;
 
     return this;
   }

--- a/engine/src/main/java/com/arcadedb/database/DatabaseFactory.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseFactory.java
@@ -44,7 +44,7 @@ public class DatabaseFactory implements AutoCloseable {
     if (path == null || path.isEmpty())
       throw new IllegalArgumentException("Missing path");
 
-    if (path.endsWith("/") || path.endsWith("\\"))
+    if (path.endsWith(File.pathSeparator))
       databasePath = path.substring(0, path.length() - 1);
     else
       databasePath = path;
@@ -56,9 +56,9 @@ public class DatabaseFactory implements AutoCloseable {
   }
 
   public boolean exists() {
-    boolean exists = new File(databasePath + "/" + EmbeddedSchema.SCHEMA_FILE_NAME).exists();
+    boolean exists = new File(databasePath + File.pathSeparator + EmbeddedSchema.SCHEMA_FILE_NAME).exists();
     if (!exists)
-      exists = new File(databasePath + "/" + EmbeddedSchema.SCHEMA_PREV_FILE_NAME).exists();
+      exists = new File(databasePath + File.pathSeparator + EmbeddedSchema.SCHEMA_PREV_FILE_NAME).exists();
     return exists;
   }
 

--- a/engine/src/main/java/com/arcadedb/database/DatabaseFactory.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseFactory.java
@@ -44,7 +44,7 @@ public class DatabaseFactory implements AutoCloseable {
     if (path == null || path.isEmpty())
       throw new IllegalArgumentException("Missing path");
 
-    if (path.endsWith(File.pathSeparator))
+    if (path.endsWith(File.separator))
       databasePath = path.substring(0, path.length() - 1);
     else
       databasePath = path;
@@ -56,9 +56,9 @@ public class DatabaseFactory implements AutoCloseable {
   }
 
   public boolean exists() {
-    boolean exists = new File(databasePath + File.pathSeparator + EmbeddedSchema.SCHEMA_FILE_NAME).exists();
+    boolean exists = new File(databasePath + File.separator + EmbeddedSchema.SCHEMA_FILE_NAME).exists();
     if (!exists)
-      exists = new File(databasePath + File.pathSeparator + EmbeddedSchema.SCHEMA_PREV_FILE_NAME).exists();
+      exists = new File(databasePath + File.separator + EmbeddedSchema.SCHEMA_PREV_FILE_NAME).exists();
     return exists;
   }
 

--- a/engine/src/main/java/com/arcadedb/database/EmbeddedDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/EmbeddedDatabase.java
@@ -97,9 +97,12 @@ import java.util.stream.*;
 public class EmbeddedDatabase extends RWLockContext implements DatabaseInternal {
   public static final  int                                       EDGE_LIST_INITIAL_CHUNK_SIZE         = 64;
   public static final  int                                       MAX_RECOMMENDED_EDGE_LIST_CHUNK_SIZE = 8192;
-  private static final Set<String>                               SUPPORTED_FILE_EXT                   = Collections.unmodifiableSet(new HashSet<>(
-      Arrays.asList(Dictionary.DICT_EXT, Bucket.BUCKET_EXT, LSMTreeIndexMutable.NOTUNIQUE_INDEX_EXT, LSMTreeIndexMutable.UNIQUE_INDEX_EXT,
-          LSMTreeIndexCompacted.NOTUNIQUE_INDEX_EXT, LSMTreeIndexCompacted.UNIQUE_INDEX_EXT)));
+  private static final Set<String>                               SUPPORTED_FILE_EXT                   = Set.of(Dictionary.DICT_EXT,
+          Bucket.BUCKET_EXT,
+          LSMTreeIndexMutable.NOTUNIQUE_INDEX_EXT,
+          LSMTreeIndexMutable.UNIQUE_INDEX_EXT,
+          LSMTreeIndexCompacted.NOTUNIQUE_INDEX_EXT,
+          LSMTreeIndexCompacted.UNIQUE_INDEX_EXT);
   public final         AtomicLong                                indexCompactions                     = new AtomicLong();
   protected final      String                                    name;
   protected final      PaginatedFile.MODE                        mode;
@@ -146,12 +149,12 @@ public class EmbeddedDatabase extends RWLockContext implements DatabaseInternal 
       this.statementCache = new StatementCache(this, configuration.getValueAsInteger(GlobalConfiguration.SQL_STATEMENT_CACHE));
       this.executionPlanCache = new ExecutionPlanCache(this, configuration.getValueAsInteger(GlobalConfiguration.SQL_STATEMENT_CACHE));
 
-      if (path.endsWith("/") || path.endsWith("\\"))
+      if (path.endsWith(File.pathSeparator))
         databasePath = path.substring(0, path.length() - 1);
       else
         databasePath = path;
 
-      configurationFile = new File(databasePath + "/configuration.json");
+      configurationFile = new File(databasePath + File.pathSeparator + "configuration.json");
 
       final int lastSeparatorPos = path.lastIndexOf(File.separator);
       if (lastSeparatorPos > -1)

--- a/engine/src/main/java/com/arcadedb/database/EmbeddedDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/EmbeddedDatabase.java
@@ -149,12 +149,12 @@ public class EmbeddedDatabase extends RWLockContext implements DatabaseInternal 
       this.statementCache = new StatementCache(this, configuration.getValueAsInteger(GlobalConfiguration.SQL_STATEMENT_CACHE));
       this.executionPlanCache = new ExecutionPlanCache(this, configuration.getValueAsInteger(GlobalConfiguration.SQL_STATEMENT_CACHE));
 
-      if (path.endsWith(File.pathSeparator))
+      if (path.endsWith(File.separator))
         databasePath = path.substring(0, path.length() - 1);
       else
         databasePath = path;
 
-      configurationFile = new File(databasePath + File.pathSeparator + "configuration.json");
+      configurationFile = new File(databasePath + File.separator + "configuration.json");
 
       final int lastSeparatorPos = path.lastIndexOf(File.separator);
       if (lastSeparatorPos > -1)

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -189,7 +189,7 @@ public class TransactionManager {
       activeWALFilePool = new WALFile[walFiles.length];
       for (int i = 0; i < walFiles.length; ++i) {
         try {
-          activeWALFilePool[i] = new WALFile(database.getDatabasePath() + File.pathSeparator + walFiles[i].getName());
+          activeWALFilePool[i] = new WALFile(database.getDatabasePath() + File.separator + walFiles[i].getName());
         } catch (FileNotFoundException e) {
           LogManager.instance().log(this, Level.SEVERE, "Error on WAL file management for file '%s'", e, database.getDatabasePath() + walFiles[i].getName());
         }

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -189,7 +189,7 @@ public class TransactionManager {
       activeWALFilePool = new WALFile[walFiles.length];
       for (int i = 0; i < walFiles.length; ++i) {
         try {
-          activeWALFilePool[i] = new WALFile(database.getDatabasePath() + "/" + walFiles[i].getName());
+          activeWALFilePool[i] = new WALFile(database.getDatabasePath() + File.pathSeparator + walFiles[i].getName());
         } catch (FileNotFoundException e) {
           LogManager.instance().log(this, Level.SEVERE, "Error on WAL file management for file '%s'", e, database.getDatabasePath() + walFiles[i].getName());
         }

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
@@ -31,6 +31,7 @@ import com.arcadedb.serializer.BinaryComparator;
 import com.arcadedb.serializer.BinaryTypes;
 import com.arcadedb.utility.RWLockContext;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.*;
@@ -463,7 +464,7 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
         final String newName = mutable.getName().substring(0, last_) + "_" + System.nanoTime();
 
         final LSMTreeIndexMutable newMutableIndex = new LSMTreeIndexMutable(this, database, newName, mutable.isUnique(),
-            database.getDatabasePath() + "/" + newName, mutable.getKeyTypes(), pageSize, LSMTreeIndexMutable.CURRENT_VERSION, compactedIndex);
+            database.getDatabasePath() + File.pathSeparator + newName, mutable.getKeyTypes(), pageSize, LSMTreeIndexMutable.CURRENT_VERSION, compactedIndex);
         database.getSchema().getEmbedded().registerFile(newMutableIndex);
 
         final List<MutablePage> modifiedPages = new ArrayList<>(2 + mutable.getTotalPages() - startingFromPage);

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
@@ -464,7 +464,7 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
         final String newName = mutable.getName().substring(0, last_) + "_" + System.nanoTime();
 
         final LSMTreeIndexMutable newMutableIndex = new LSMTreeIndexMutable(this, database, newName, mutable.isUnique(),
-            database.getDatabasePath() + File.pathSeparator + newName, mutable.getKeyTypes(), pageSize, LSMTreeIndexMutable.CURRENT_VERSION, compactedIndex);
+            database.getDatabasePath() + File.separator + newName, mutable.getKeyTypes(), pageSize, LSMTreeIndexMutable.CURRENT_VERSION, compactedIndex);
         database.getSchema().getEmbedded().registerFile(newMutableIndex);
 
         final List<MutablePage> modifiedPages = new ArrayList<>(2 + mutable.getTotalPages() - startingFromPage);

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
@@ -37,6 +37,7 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.BinaryTypes;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
@@ -155,7 +156,7 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
     int last_ = name.lastIndexOf('_');
     final String newName = name.substring(0, last_) + "_" + System.nanoTime();
 
-    return new LSMTreeIndexCompacted(mainIndex, database, newName, unique, database.getDatabasePath() + "/" + newName, binaryKeyTypes, pageSize);
+    return new LSMTreeIndexCompacted(mainIndex, database, newName, unique, database.getDatabasePath() + File.pathSeparator + newName, binaryKeyTypes, pageSize);
   }
 
   public IndexCursor iterator(final boolean ascendingOrder, final Object[] fromKeys, final boolean inclusive) throws IOException {

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
@@ -156,7 +156,7 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
     int last_ = name.lastIndexOf('_');
     final String newName = name.substring(0, last_) + "_" + System.nanoTime();
 
-    return new LSMTreeIndexCompacted(mainIndex, database, newName, unique, database.getDatabasePath() + File.pathSeparator + newName, binaryKeyTypes, pageSize);
+    return new LSMTreeIndexCompacted(mainIndex, database, newName, unique, database.getDatabasePath() + File.separator + newName, binaryKeyTypes, pageSize);
   }
 
   public IndexCursor iterator(final boolean ascendingOrder, final Object[] fromKeys, final boolean inclusive) throws IOException {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ExportDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ExportDatabaseStatement.java
@@ -54,10 +54,10 @@ public class ExportDatabaseStatement extends SimpleExecStatement {
     result.setProperty("toUrl", targetUrl);
 
     String fileName = targetUrl.startsWith("file://") ? targetUrl.substring("file://".length()) : targetUrl;
-    if (fileName.contains("..") || fileName.contains(File.pathSeparator) )
+    if (fileName.contains("..") || fileName.contains(File.separator) )
       throw new IllegalArgumentException("Export file cannot contain path change because the directory is specified");
 
-    fileName = "exports" + File.pathSeparator + fileName;
+    fileName = "exports" + File.separator + fileName;
 
     try {
       final Class<?> clazz = Class.forName("com.arcadedb.integration.exporter.Exporter");

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ExportDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ExportDatabaseStatement.java
@@ -27,6 +27,7 @@ import com.arcadedb.query.sql.executor.InternalResultSet;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
 
+import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 import java.util.Objects;
@@ -53,10 +54,10 @@ public class ExportDatabaseStatement extends SimpleExecStatement {
     result.setProperty("toUrl", targetUrl);
 
     String fileName = targetUrl.startsWith("file://") ? targetUrl.substring("file://".length()) : targetUrl;
-    if (fileName.contains("..") || fileName.contains("/") || fileName.contains("\\"))
+    if (fileName.contains("..") || fileName.contains(File.pathSeparator) )
       throw new IllegalArgumentException("Export file cannot contain path change because the directory is specified");
 
-    fileName = "exports/" + fileName;
+    fileName = "exports" + File.pathSeparator + fileName;
 
     try {
       final Class<?> clazz = Class.forName("com.arcadedb.integration.exporter.Exporter");

--- a/engine/src/main/java/com/arcadedb/schema/EmbeddedSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/EmbeddedSchema.java
@@ -100,7 +100,7 @@ public class EmbeddedSchema implements Schema {
 
     indexFactory.register(INDEX_TYPE.LSM_TREE.name(), new LSMTreeIndex.IndexFactoryHandler());
     indexFactory.register(INDEX_TYPE.FULL_TEXT.name(), new LSMTreeFullTextIndex.IndexFactoryHandler());
-    configurationFile = new File(databasePath + "/" + SCHEMA_FILE_NAME);
+    configurationFile = new File(databasePath + File.pathSeparator + SCHEMA_FILE_NAME);
   }
 
   @Override
@@ -268,7 +268,7 @@ public class EmbeddedSchema implements Schema {
 
     return recordFileChanges(() -> {
       try {
-        final Bucket bucket = new Bucket(database, bucketName, databasePath + "/" + bucketName, PaginatedFile.MODE.READ_WRITE, pageSize,
+        final Bucket bucket = new Bucket(database, bucketName, databasePath + File.pathSeparator + bucketName, PaginatedFile.MODE.READ_WRITE, pageSize,
             Bucket.CURRENT_VERSION);
         registerFile(bucket);
         bucketMap.put(bucketName, bucket);
@@ -605,7 +605,7 @@ public class EmbeddedSchema implements Schema {
     if (indexMap.containsKey(indexName))
       throw new DatabaseMetadataException("Cannot create index '" + indexName + "' on type '" + typeName + "' because it already exists");
 
-    final IndexInternal index = indexFactory.createIndex(indexType.name(), database, indexName, unique, databasePath + "/" + indexName,
+    final IndexInternal index = indexFactory.createIndex(indexType.name(), database, indexName, unique, databasePath + File.pathSeparator + indexName,
         PaginatedFile.MODE.READ_WRITE, keyTypes, pageSize, nullStrategy, callback);
 
     try {
@@ -636,7 +636,7 @@ public class EmbeddedSchema implements Schema {
       database.transaction(() -> {
 
         final IndexInternal index = indexFactory.createIndex(indexType.name(), database, FileUtils.encode(indexName, ENCODING), unique,
-            databasePath + "/" + indexName, PaginatedFile.MODE.READ_WRITE, keyTypes, pageSize, nullStrategy, null);
+            databasePath + File.pathSeparator + indexName, PaginatedFile.MODE.READ_WRITE, keyTypes, pageSize, nullStrategy, null);
 
         result.set(index);
 
@@ -1073,9 +1073,9 @@ public class EmbeddedSchema implements Schema {
 
     boolean saveConfiguration = false;
     try {
-      File file = new File(databasePath + "/" + SCHEMA_FILE_NAME);
+      File file = new File(databasePath + File.pathSeparator + SCHEMA_FILE_NAME);
       if (!file.exists() || file.length() == 0) {
-        file = new File(databasePath + "/" + SCHEMA_PREV_FILE_NAME);
+        file = new File(databasePath + File.pathSeparator + SCHEMA_PREV_FILE_NAME);
         if (!file.exists())
           return;
 
@@ -1298,7 +1298,7 @@ public class EmbeddedSchema implements Schema {
       dirtyConfiguration = false;
 
     } catch (IOException e) {
-      LogManager.instance().log(this, Level.SEVERE, "Error on saving schema configuration to file: %s", e, databasePath + "/" + SCHEMA_FILE_NAME);
+      LogManager.instance().log(this, Level.SEVERE, "Error on saving schema configuration to file: %s", e, databasePath + File.pathSeparator + SCHEMA_FILE_NAME);
     }
   }
 
@@ -1393,7 +1393,7 @@ public class EmbeddedSchema implements Schema {
     final String latestSchema = newSchema.toString();
 
     if (configurationFile.exists()) {
-      final File copy = new File(databasePath + "/" + SCHEMA_PREV_FILE_NAME);
+      final File copy = new File(databasePath + File.pathSeparator + SCHEMA_PREV_FILE_NAME);
       if (copy.exists())
         if (!copy.delete())
           LogManager.instance().log(this, Level.WARNING, "Error on deleting previous schema file '%s'", null, copy);
@@ -1402,7 +1402,7 @@ public class EmbeddedSchema implements Schema {
         LogManager.instance().log(this, Level.WARNING, "Error on renaming previous schema file '%s'", null, copy);
     }
 
-    try (FileWriter file = new FileWriter(databasePath + "/" + SCHEMA_FILE_NAME)) {
+    try (FileWriter file = new FileWriter(databasePath + File.pathSeparator + SCHEMA_FILE_NAME)) {
       file.write(latestSchema);
     }
 

--- a/engine/src/main/java/com/arcadedb/schema/EmbeddedSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/EmbeddedSchema.java
@@ -100,7 +100,7 @@ public class EmbeddedSchema implements Schema {
 
     indexFactory.register(INDEX_TYPE.LSM_TREE.name(), new LSMTreeIndex.IndexFactoryHandler());
     indexFactory.register(INDEX_TYPE.FULL_TEXT.name(), new LSMTreeFullTextIndex.IndexFactoryHandler());
-    configurationFile = new File(databasePath + File.pathSeparator + SCHEMA_FILE_NAME);
+    configurationFile = new File(databasePath + File.separator + SCHEMA_FILE_NAME);
   }
 
   @Override
@@ -268,7 +268,7 @@ public class EmbeddedSchema implements Schema {
 
     return recordFileChanges(() -> {
       try {
-        final Bucket bucket = new Bucket(database, bucketName, databasePath + File.pathSeparator + bucketName, PaginatedFile.MODE.READ_WRITE, pageSize,
+        final Bucket bucket = new Bucket(database, bucketName, databasePath + File.separator + bucketName, PaginatedFile.MODE.READ_WRITE, pageSize,
             Bucket.CURRENT_VERSION);
         registerFile(bucket);
         bucketMap.put(bucketName, bucket);
@@ -605,7 +605,7 @@ public class EmbeddedSchema implements Schema {
     if (indexMap.containsKey(indexName))
       throw new DatabaseMetadataException("Cannot create index '" + indexName + "' on type '" + typeName + "' because it already exists");
 
-    final IndexInternal index = indexFactory.createIndex(indexType.name(), database, indexName, unique, databasePath + File.pathSeparator + indexName,
+    final IndexInternal index = indexFactory.createIndex(indexType.name(), database, indexName, unique, databasePath + File.separator + indexName,
         PaginatedFile.MODE.READ_WRITE, keyTypes, pageSize, nullStrategy, callback);
 
     try {
@@ -636,7 +636,7 @@ public class EmbeddedSchema implements Schema {
       database.transaction(() -> {
 
         final IndexInternal index = indexFactory.createIndex(indexType.name(), database, FileUtils.encode(indexName, ENCODING), unique,
-            databasePath + File.pathSeparator + indexName, PaginatedFile.MODE.READ_WRITE, keyTypes, pageSize, nullStrategy, null);
+            databasePath + File.separator + indexName, PaginatedFile.MODE.READ_WRITE, keyTypes, pageSize, nullStrategy, null);
 
         result.set(index);
 
@@ -1073,9 +1073,9 @@ public class EmbeddedSchema implements Schema {
 
     boolean saveConfiguration = false;
     try {
-      File file = new File(databasePath + File.pathSeparator + SCHEMA_FILE_NAME);
+      File file = new File(databasePath + File.separator + SCHEMA_FILE_NAME);
       if (!file.exists() || file.length() == 0) {
-        file = new File(databasePath + File.pathSeparator + SCHEMA_PREV_FILE_NAME);
+        file = new File(databasePath + File.separator + SCHEMA_PREV_FILE_NAME);
         if (!file.exists())
           return;
 
@@ -1298,7 +1298,7 @@ public class EmbeddedSchema implements Schema {
       dirtyConfiguration = false;
 
     } catch (IOException e) {
-      LogManager.instance().log(this, Level.SEVERE, "Error on saving schema configuration to file: %s", e, databasePath + File.pathSeparator + SCHEMA_FILE_NAME);
+      LogManager.instance().log(this, Level.SEVERE, "Error on saving schema configuration to file: %s", e, databasePath + File.separator + SCHEMA_FILE_NAME);
     }
   }
 
@@ -1393,7 +1393,7 @@ public class EmbeddedSchema implements Schema {
     final String latestSchema = newSchema.toString();
 
     if (configurationFile.exists()) {
-      final File copy = new File(databasePath + File.pathSeparator + SCHEMA_PREV_FILE_NAME);
+      final File copy = new File(databasePath + File.separator + SCHEMA_PREV_FILE_NAME);
       if (copy.exists())
         if (!copy.delete())
           LogManager.instance().log(this, Level.WARNING, "Error on deleting previous schema file '%s'", null, copy);
@@ -1402,7 +1402,7 @@ public class EmbeddedSchema implements Schema {
         LogManager.instance().log(this, Level.WARNING, "Error on renaming previous schema file '%s'", null, copy);
     }
 
-    try (FileWriter file = new FileWriter(databasePath + File.pathSeparator + SCHEMA_FILE_NAME)) {
+    try (FileWriter file = new FileWriter(databasePath + File.separator + SCHEMA_FILE_NAME)) {
       file.write(latestSchema);
     }
 

--- a/engine/src/main/java/com/arcadedb/utility/FileUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/FileUtils.java
@@ -155,7 +155,7 @@ public class FileUtils {
   }
 
   public static void checkValidName(final String iFileName) throws IOException {
-    if (iFileName.contains("..") || iFileName.contains(File.pathSeparator))
+    if (iFileName.contains("..") || iFileName.contains(File.separator))
       throw new IOException("Invalid file name '" + iFileName + "'");
   }
 
@@ -240,7 +240,7 @@ public class FileUtils {
       destination.mkdirs();
 
     for (File f : source.listFiles()) {
-      final File target = new File(destination.getAbsolutePath() + File.pathSeparator + f.getName());
+      final File target = new File(destination.getAbsolutePath() + File.separator + f.getName());
       if (f.isFile())
         copyFile(f, target);
       else

--- a/engine/src/main/java/com/arcadedb/utility/FileUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/FileUtils.java
@@ -155,7 +155,7 @@ public class FileUtils {
   }
 
   public static void checkValidName(final String iFileName) throws IOException {
-    if (iFileName.contains("..") || iFileName.contains("/") || iFileName.contains("\\"))
+    if (iFileName.contains("..") || iFileName.contains(File.pathSeparator))
       throw new IOException("Invalid file name '" + iFileName + "'");
   }
 
@@ -240,7 +240,7 @@ public class FileUtils {
       destination.mkdirs();
 
     for (File f : source.listFiles()) {
-      final File target = new File(destination.getAbsolutePath() + "/" + f.getName());
+      final File target = new File(destination.getAbsolutePath() + File.pathSeparator + f.getName());
       if (f.isFile())
         copyFile(f, target);
       else

--- a/integration/src/main/java/com/arcadedb/integration/backup/BackupSettings.java
+++ b/integration/src/main/java/com/arcadedb/integration/backup/BackupSettings.java
@@ -51,7 +51,7 @@ public class BackupSettings {
 
     if (directory != null && file != null) {
       final String f = file.startsWith("file://") ? file.substring("file://".length()) : file;
-      if (f.contains("..") || f.contains(File.pathSeparator))
+      if (f.contains("..") || f.contains(File.separator))
         throw new IllegalArgumentException("Backup file cannot contain path change because the directory is specified");
     }
 
@@ -71,7 +71,7 @@ public class BackupSettings {
         format = value.toLowerCase();
     } else if ("dir".equals(name)) {
       if (value != null)
-        directory = value.endsWith(File.pathSeparator) ? value : value + File.pathSeparator;
+        directory = value.endsWith(File.separator) ? value : value + File.separator;
     } else if ("f".equals(name)) {
       if (value != null)
         file = value;

--- a/integration/src/main/java/com/arcadedb/integration/backup/BackupSettings.java
+++ b/integration/src/main/java/com/arcadedb/integration/backup/BackupSettings.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.integration.backup;
 
+import java.io.File;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
@@ -50,7 +51,7 @@ public class BackupSettings {
 
     if (directory != null && file != null) {
       final String f = file.startsWith("file://") ? file.substring("file://".length()) : file;
-      if (f.contains("..") || f.contains("/"))
+      if (f.contains("..") || f.contains(File.pathSeparator))
         throw new IllegalArgumentException("Backup file cannot contain path change because the directory is specified");
     }
 
@@ -70,7 +71,7 @@ public class BackupSettings {
         format = value.toLowerCase();
     } else if ("dir".equals(name)) {
       if (value != null)
-        directory = value.endsWith("/") ? value : value + "/";
+        directory = value.endsWith(File.pathSeparator) ? value : value + File.pathSeparator;
     } else if ("f".equals(name)) {
       if (value != null)
         file = value;

--- a/integration/src/main/java/com/arcadedb/integration/backup/format/FullBackupFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/backup/format/FullBackupFormat.java
@@ -52,7 +52,7 @@ public class FullBackupFormat extends AbstractBackupFormat {
       fileName = settings.file;
 
     if (settings.directory != null)
-      fileName = settings.directory + "/" + fileName;
+      fileName = settings.directory + File.pathSeparator + fileName;
 
     final File backupFile = new File(fileName);
 

--- a/integration/src/main/java/com/arcadedb/integration/backup/format/FullBackupFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/backup/format/FullBackupFormat.java
@@ -52,7 +52,7 @@ public class FullBackupFormat extends AbstractBackupFormat {
       fileName = settings.file;
 
     if (settings.directory != null)
-      fileName = settings.directory + File.pathSeparator + fileName;
+      fileName = settings.directory + File.separator + fileName;
 
     final File backupFile = new File(fileName);
 

--- a/integration/src/main/java/com/arcadedb/integration/restore/RestoreSettings.java
+++ b/integration/src/main/java/com/arcadedb/integration/restore/RestoreSettings.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.integration.restore;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -69,7 +70,7 @@ public class RestoreSettings {
     if (databaseDirectory == null)
       throw new IllegalArgumentException("Missing database url. Use -d <database-directory>");
 
-    if (inputFileURL.contains("..") || inputFileURL.startsWith("/"))
+    if (inputFileURL.contains("..") || inputFileURL.startsWith(File.pathSeparator))
       throw new IllegalArgumentException("Invalid backup file: cannot contain '..' or start with '/'");
   }
 }

--- a/integration/src/main/java/com/arcadedb/integration/restore/RestoreSettings.java
+++ b/integration/src/main/java/com/arcadedb/integration/restore/RestoreSettings.java
@@ -70,7 +70,7 @@ public class RestoreSettings {
     if (databaseDirectory == null)
       throw new IllegalArgumentException("Missing database url. Use -d <database-directory>");
 
-    if (inputFileURL.contains("..") || inputFileURL.startsWith(File.pathSeparator))
+    if (inputFileURL.contains("..") || inputFileURL.startsWith(File.separator))
       throw new IllegalArgumentException("Invalid backup file: cannot contain '..' or start with '/'");
   }
 }

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -282,7 +282,7 @@ public class ArcadeDBServer {
       throw new IllegalArgumentException("Database '" + databaseName + "' already exists");
 
     final DatabaseFactory factory = new DatabaseFactory(
-        configuration.getValueAsString(GlobalConfiguration.SERVER_DATABASE_DIRECTORY) + "/" + databaseName).setAutoTransaction(true);
+        configuration.getValueAsString(GlobalConfiguration.SERVER_DATABASE_DIRECTORY) + File.pathSeparator + databaseName).setAutoTransaction(true);
 
     if (factory.exists())
       throw new IllegalArgumentException("Database '" + databaseName + "' already exists");
@@ -347,7 +347,7 @@ public class ArcadeDBServer {
       if (!allowLoad)
         throw new DatabaseIsClosedException("Database '" + databaseName + "' is not available");
 
-      final String path = configuration.getValueAsString(GlobalConfiguration.SERVER_DATABASE_DIRECTORY) + "/" + databaseName;
+      final String path = configuration.getValueAsString(GlobalConfiguration.SERVER_DATABASE_DIRECTORY) + File.pathSeparator + databaseName;
 
       final DatabaseFactory factory = new DatabaseFactory(path).setAutoTransaction(true);
 
@@ -422,7 +422,7 @@ public class ArcadeDBServer {
                 ((DatabaseInternal) database).getEmbedded().drop();
                 databases.remove(dbName);
               }
-              String dbPath = configuration.getValueAsString(GlobalConfiguration.SERVER_DATABASE_DIRECTORY) + "/" + dbName;
+              String dbPath = configuration.getValueAsString(GlobalConfiguration.SERVER_DATABASE_DIRECTORY) + File.pathSeparator + dbName;
 //              new Restore(commandParams, dbPath).restoreDatabase();
 
               try {
@@ -508,7 +508,7 @@ public class ArcadeDBServer {
   }
 
   private void loadConfiguration() {
-    final File file = new File(getRootPath() + "/" + CONFIG_SERVER_CONFIGURATION_FILENAME);
+    final File file = new File(getRootPath() + File.pathSeparator + CONFIG_SERVER_CONFIGURATION_FILENAME);
     if (file.exists()) {
       try {
         final String content = FileUtils.readFileAsString(file, "UTF8");

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -282,7 +282,7 @@ public class ArcadeDBServer {
       throw new IllegalArgumentException("Database '" + databaseName + "' already exists");
 
     final DatabaseFactory factory = new DatabaseFactory(
-        configuration.getValueAsString(GlobalConfiguration.SERVER_DATABASE_DIRECTORY) + File.pathSeparator + databaseName).setAutoTransaction(true);
+        configuration.getValueAsString(GlobalConfiguration.SERVER_DATABASE_DIRECTORY) + File.separator + databaseName).setAutoTransaction(true);
 
     if (factory.exists())
       throw new IllegalArgumentException("Database '" + databaseName + "' already exists");
@@ -347,7 +347,7 @@ public class ArcadeDBServer {
       if (!allowLoad)
         throw new DatabaseIsClosedException("Database '" + databaseName + "' is not available");
 
-      final String path = configuration.getValueAsString(GlobalConfiguration.SERVER_DATABASE_DIRECTORY) + File.pathSeparator + databaseName;
+      final String path = configuration.getValueAsString(GlobalConfiguration.SERVER_DATABASE_DIRECTORY) + File.separator + databaseName;
 
       final DatabaseFactory factory = new DatabaseFactory(path).setAutoTransaction(true);
 
@@ -422,7 +422,7 @@ public class ArcadeDBServer {
                 ((DatabaseInternal) database).getEmbedded().drop();
                 databases.remove(dbName);
               }
-              String dbPath = configuration.getValueAsString(GlobalConfiguration.SERVER_DATABASE_DIRECTORY) + File.pathSeparator + dbName;
+              String dbPath = configuration.getValueAsString(GlobalConfiguration.SERVER_DATABASE_DIRECTORY) + File.separator + dbName;
 //              new Restore(commandParams, dbPath).restoreDatabase();
 
               try {
@@ -508,7 +508,7 @@ public class ArcadeDBServer {
   }
 
   private void loadConfiguration() {
-    final File file = new File(getRootPath() + File.pathSeparator + CONFIG_SERVER_CONFIGURATION_FILENAME);
+    final File file = new File(getRootPath() + File.separator + CONFIG_SERVER_CONFIGURATION_FILENAME);
     if (file.exists()) {
       try {
         final String content = FileUtils.readFileAsString(file, "UTF8");

--- a/server/src/main/java/com/arcadedb/server/ha/Replica2LeaderNetworkExecutor.java
+++ b/server/src/main/java/com/arcadedb/server/ha/Replica2LeaderNetworkExecutor.java
@@ -37,6 +37,7 @@ import com.arcadedb.server.ha.message.*;
 import com.arcadedb.utility.FileUtils;
 import com.arcadedb.utility.Pair;
 
+import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
@@ -412,7 +413,7 @@ public class Replica2LeaderNetworkExecutor extends Thread {
       throws IOException {
 
     // WRITE THE SCHEMA
-    try (final FileWriter schemaFile = new FileWriter(database.getDatabasePath() + "/" + EmbeddedSchema.SCHEMA_FILE_NAME,
+    try (final FileWriter schemaFile = new FileWriter(database.getDatabasePath() + File.pathSeparator + EmbeddedSchema.SCHEMA_FILE_NAME,
         DatabaseFactory.getDefaultCharset())) {
       schemaFile.write(dbStructure.getSchemaJson());
     }

--- a/server/src/main/java/com/arcadedb/server/ha/Replica2LeaderNetworkExecutor.java
+++ b/server/src/main/java/com/arcadedb/server/ha/Replica2LeaderNetworkExecutor.java
@@ -413,7 +413,7 @@ public class Replica2LeaderNetworkExecutor extends Thread {
       throws IOException {
 
     // WRITE THE SCHEMA
-    try (final FileWriter schemaFile = new FileWriter(database.getDatabasePath() + File.pathSeparator + EmbeddedSchema.SCHEMA_FILE_NAME,
+    try (final FileWriter schemaFile = new FileWriter(database.getDatabasePath() + File.separator + EmbeddedSchema.SCHEMA_FILE_NAME,
         DatabaseFactory.getDefaultCharset())) {
       schemaFile.write(dbStructure.getSchemaJson());
     }

--- a/server/src/main/java/com/arcadedb/server/ha/message/DatabaseChangeStructureRequest.java
+++ b/server/src/main/java/com/arcadedb/server/ha/message/DatabaseChangeStructureRequest.java
@@ -134,7 +134,7 @@ public class DatabaseChangeStructureRequest extends HAAbstractCommand {
 
     // ADD FILES
     for (Map.Entry<Integer, String> entry : filesToAdd.entrySet())
-      db.getFileManager().getOrCreateFile(entry.getKey(), databasePath + File.pathSeparator + entry.getValue());
+      db.getFileManager().getOrCreateFile(entry.getKey(), databasePath + File.separator + entry.getValue());
 
     // REMOVE FILES
     for (Map.Entry<Integer, String> entry : filesToRemove.entrySet()) {

--- a/server/src/main/java/com/arcadedb/server/ha/message/DatabaseChangeStructureRequest.java
+++ b/server/src/main/java/com/arcadedb/server/ha/message/DatabaseChangeStructureRequest.java
@@ -27,6 +27,7 @@ import com.arcadedb.server.ha.HAServer;
 import com.arcadedb.server.ha.ReplicationException;
 import org.json.JSONObject;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -133,7 +134,7 @@ public class DatabaseChangeStructureRequest extends HAAbstractCommand {
 
     // ADD FILES
     for (Map.Entry<Integer, String> entry : filesToAdd.entrySet())
-      db.getFileManager().getOrCreateFile(entry.getKey(), databasePath + "/" + entry.getValue());
+      db.getFileManager().getOrCreateFile(entry.getKey(), databasePath + File.pathSeparator + entry.getValue());
 
     // REMOVE FILES
     for (Map.Entry<Integer, String> entry : filesToRemove.entrySet()) {

--- a/server/src/main/java/com/arcadedb/server/ha/message/DatabaseStructureRequest.java
+++ b/server/src/main/java/com/arcadedb/server/ha/message/DatabaseStructureRequest.java
@@ -47,7 +47,7 @@ public class DatabaseStructureRequest extends HAAbstractCommand {
   public HACommand execute(final HAServer server, final String remoteServerName, final long messageNumber) {
     final DatabaseInternal db = (DatabaseInternal) server.getServer().getDatabase(databaseName);
 
-    final File file = new File(db.getDatabasePath() + "/" + EmbeddedSchema.SCHEMA_FILE_NAME);
+    final File file = new File(db.getDatabasePath() + File.pathSeparator + EmbeddedSchema.SCHEMA_FILE_NAME);
     try {
       final String schemaJson;
       if (file.exists()) {

--- a/server/src/main/java/com/arcadedb/server/ha/message/DatabaseStructureRequest.java
+++ b/server/src/main/java/com/arcadedb/server/ha/message/DatabaseStructureRequest.java
@@ -47,7 +47,7 @@ public class DatabaseStructureRequest extends HAAbstractCommand {
   public HACommand execute(final HAServer server, final String remoteServerName, final long messageNumber) {
     final DatabaseInternal db = (DatabaseInternal) server.getServer().getDatabase(databaseName);
 
-    final File file = new File(db.getDatabasePath() + File.pathSeparator + EmbeddedSchema.SCHEMA_FILE_NAME);
+    final File file = new File(db.getDatabasePath() + File.separator + EmbeddedSchema.SCHEMA_FILE_NAME);
     try {
       final String schemaJson;
       if (file.exists()) {

--- a/server/src/main/java/com/arcadedb/server/ha/message/FileContentResponse.java
+++ b/server/src/main/java/com/arcadedb/server/ha/message/FileContentResponse.java
@@ -30,6 +30,7 @@ import com.arcadedb.server.ha.HAServer;
 import com.arcadedb.server.ha.ReplicationException;
 import com.arcadedb.utility.FileUtils;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.logging.Level;
 
@@ -76,7 +77,7 @@ public class FileContentResponse extends HAAbstractCommand {
     final PageManager pageManager = database.getPageManager();
 
     try {
-      final PaginatedFile file = database.getFileManager().getOrCreateFile(fileId, database.getDatabasePath() + "/" + fileName);
+      final PaginatedFile file = database.getFileManager().getOrCreateFile(fileId, database.getDatabasePath() + File.pathSeparator + fileName);
 
       if (totalPages == 0)
         return null;

--- a/server/src/main/java/com/arcadedb/server/ha/message/FileContentResponse.java
+++ b/server/src/main/java/com/arcadedb/server/ha/message/FileContentResponse.java
@@ -77,7 +77,7 @@ public class FileContentResponse extends HAAbstractCommand {
     final PageManager pageManager = database.getPageManager();
 
     try {
-      final PaginatedFile file = database.getFileManager().getOrCreateFile(fileId, database.getDatabasePath() + File.pathSeparator + fileName);
+      final PaginatedFile file = database.getFileManager().getOrCreateFile(fileId, database.getDatabasePath() + File.separator + fileName);
 
       if (totalPages == 0)
         return null;

--- a/server/src/main/java/com/arcadedb/server/security/SecurityGroupFileRepository.java
+++ b/server/src/main/java/com/arcadedb/server/security/SecurityGroupFileRepository.java
@@ -45,8 +45,8 @@ public class SecurityGroupFileRepository {
   private              Callable<Void, JSONObject> reloadCallback          = null;
 
   public SecurityGroupFileRepository(String securityConfPath) {
-    if (!securityConfPath.endsWith(File.pathSeparator))
-      securityConfPath += File.pathSeparator;
+    if (!securityConfPath.endsWith(File.separator))
+      securityConfPath += File.separator;
     this.securityConfPath = securityConfPath;
     file = new File(securityConfPath, FILE_NAME);
   }

--- a/server/src/main/java/com/arcadedb/server/security/SecurityGroupFileRepository.java
+++ b/server/src/main/java/com/arcadedb/server/security/SecurityGroupFileRepository.java
@@ -45,8 +45,8 @@ public class SecurityGroupFileRepository {
   private              Callable<Void, JSONObject> reloadCallback          = null;
 
   public SecurityGroupFileRepository(String securityConfPath) {
-    if (!securityConfPath.endsWith("/") && !securityConfPath.endsWith("\\"))
-      securityConfPath += "/";
+    if (!securityConfPath.endsWith(File.pathSeparator))
+      securityConfPath += File.pathSeparator;
     this.securityConfPath = securityConfPath;
     file = new File(securityConfPath, FILE_NAME);
   }

--- a/server/src/main/java/com/arcadedb/server/security/SecurityUserFileRepository.java
+++ b/server/src/main/java/com/arcadedb/server/security/SecurityUserFileRepository.java
@@ -35,8 +35,8 @@ public class SecurityUserFileRepository {
   private              long   fileLastModified = -1;
 
   public SecurityUserFileRepository(String securityConfPath) {
-    if (!securityConfPath.endsWith(File.pathSeparator) )
-      securityConfPath += File.pathSeparator;
+    if (!securityConfPath.endsWith(File.separator) )
+      securityConfPath += File.separator;
     this.securityConfPath = securityConfPath;
   }
 

--- a/server/src/main/java/com/arcadedb/server/security/SecurityUserFileRepository.java
+++ b/server/src/main/java/com/arcadedb/server/security/SecurityUserFileRepository.java
@@ -35,8 +35,8 @@ public class SecurityUserFileRepository {
   private              long   fileLastModified = -1;
 
   public SecurityUserFileRepository(String securityConfPath) {
-    if (!securityConfPath.endsWith("/") && !securityConfPath.endsWith("\\"))
-      securityConfPath += "/";
+    if (!securityConfPath.endsWith(File.pathSeparator) )
+      securityConfPath += File.pathSeparator;
     this.securityConfPath = securityConfPath;
   }
 

--- a/server/src/test/java/com/arcadedb/server/BaseGraphServerTest.java
+++ b/server/src/test/java/com/arcadedb/server/BaseGraphServerTest.java
@@ -359,7 +359,7 @@ public abstract class BaseGraphServerTest {
   }
 
   protected String getDatabasePath(final int serverId) {
-    return GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + serverId + "/" + getDatabaseName();
+    return GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + serverId + File.pathSeparator + getDatabaseName();
   }
 
   protected String readResponse(final HttpURLConnection connection) throws IOException {
@@ -432,8 +432,8 @@ public abstract class BaseGraphServerTest {
     TestServerHelper.checkActiveDatabases();
 
     for (int i = 0; i < getServerCount(); ++i)
-      FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + i + "/"));
-    FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_ROOT_PATH.getValueAsString() + "/replication"));
+      FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + i + File.pathSeparator));
+    FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_ROOT_PATH.getValueAsString() + File.pathSeparator+ "replication"));
   }
 
   protected void checkDatabasesAreIdentical() {

--- a/server/src/test/java/com/arcadedb/server/BaseGraphServerTest.java
+++ b/server/src/test/java/com/arcadedb/server/BaseGraphServerTest.java
@@ -359,7 +359,7 @@ public abstract class BaseGraphServerTest {
   }
 
   protected String getDatabasePath(final int serverId) {
-    return GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + serverId + File.pathSeparator + getDatabaseName();
+    return GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + serverId + File.separator + getDatabaseName();
   }
 
   protected String readResponse(final HttpURLConnection connection) throws IOException {
@@ -432,8 +432,8 @@ public abstract class BaseGraphServerTest {
     TestServerHelper.checkActiveDatabases();
 
     for (int i = 0; i < getServerCount(); ++i)
-      FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + i + File.pathSeparator));
-    FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_ROOT_PATH.getValueAsString() + File.pathSeparator+ "replication"));
+      FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + i + File.separator));
+    FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_ROOT_PATH.getValueAsString() + File.separator+ "replication"));
   }
 
   protected void checkDatabasesAreIdentical() {

--- a/server/src/test/java/com/arcadedb/server/ServerConfigurationIT.java
+++ b/server/src/test/java/com/arcadedb/server/ServerConfigurationIT.java
@@ -39,7 +39,7 @@ public class ServerConfigurationIT extends BaseGraphServerTest {
 
     Assertions.assertFalse(cfg.getValueAsBoolean(TX_WAL));
 
-    final File file = new File(getServer(0).getRootPath() + "/" + ArcadeDBServer.CONFIG_SERVER_CONFIGURATION_FILENAME);
+    final File file = new File(getServer(0).getRootPath() + File.pathSeparator + ArcadeDBServer.CONFIG_SERVER_CONFIGURATION_FILENAME);
     if (file.exists())
       file.delete();
 

--- a/server/src/test/java/com/arcadedb/server/ServerConfigurationIT.java
+++ b/server/src/test/java/com/arcadedb/server/ServerConfigurationIT.java
@@ -39,7 +39,7 @@ public class ServerConfigurationIT extends BaseGraphServerTest {
 
     Assertions.assertFalse(cfg.getValueAsBoolean(TX_WAL));
 
-    final File file = new File(getServer(0).getRootPath() + File.pathSeparator + ArcadeDBServer.CONFIG_SERVER_CONFIGURATION_FILENAME);
+    final File file = new File(getServer(0).getRootPath() + File.separator + ArcadeDBServer.CONFIG_SERVER_CONFIGURATION_FILENAME);
     if (file.exists())
       file.delete();
 

--- a/server/src/test/java/com/arcadedb/server/StaticBaseServerTest.java
+++ b/server/src/test/java/com/arcadedb/server/StaticBaseServerTest.java
@@ -288,7 +288,7 @@ public abstract class StaticBaseServerTest {
   }
 
   protected static String getDatabasePath(final int serverId) {
-    return GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + serverId + File.pathSeparator + getDatabaseName();
+    return GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + serverId + File.separator + getDatabaseName();
   }
 
   protected String readResponse(final HttpURLConnection connection) throws IOException {
@@ -366,8 +366,8 @@ public abstract class StaticBaseServerTest {
     TestServerHelper.checkActiveDatabases();
 
     for (int i = 0; i < getServerCount(); ++i)
-      FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + i + File.pathSeparator));
-    FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_ROOT_PATH.getValueAsString() + File.pathSeparator + "replication"));
+      FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + i + File.separator));
+    FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_ROOT_PATH.getValueAsString() + File.separator + "replication"));
   }
 
   protected static void checkDatabasesAreIdentical() {

--- a/server/src/test/java/com/arcadedb/server/StaticBaseServerTest.java
+++ b/server/src/test/java/com/arcadedb/server/StaticBaseServerTest.java
@@ -288,7 +288,7 @@ public abstract class StaticBaseServerTest {
   }
 
   protected static String getDatabasePath(final int serverId) {
-    return GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + serverId + "/" + getDatabaseName();
+    return GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + serverId + File.pathSeparator + getDatabaseName();
   }
 
   protected String readResponse(final HttpURLConnection connection) throws IOException {
@@ -366,8 +366,8 @@ public abstract class StaticBaseServerTest {
     TestServerHelper.checkActiveDatabases();
 
     for (int i = 0; i < getServerCount(); ++i)
-      FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + i + "/"));
-    FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_ROOT_PATH.getValueAsString() + "/replication"));
+      FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + i + File.pathSeparator));
+    FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_ROOT_PATH.getValueAsString() + File.pathSeparator + "replication"));
   }
 
   protected static void checkDatabasesAreIdentical() {

--- a/server/src/test/java/performance/BasePerformanceTest.java
+++ b/server/src/test/java/performance/BasePerformanceTest.java
@@ -149,7 +149,7 @@ public abstract class BasePerformanceTest {
   }
 
   protected String getDatabasePath(final int serverId) {
-    return GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + serverId + File.pathSeparator + getDatabaseName();
+    return GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + serverId + File.separator + getDatabaseName();
   }
 
   protected ArcadeDBServer getLeaderServer() {
@@ -184,8 +184,8 @@ public abstract class BasePerformanceTest {
     TestServerHelper.checkActiveDatabases();
 
     for (int i = 0; i < getServerCount(); ++i)
-      FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + i + File.pathSeparator));
-    FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_ROOT_PATH.getValueAsString() + File.pathSeparator + "replication"));
+      FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + i + File.separator));
+    FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_ROOT_PATH.getValueAsString() + File.separator + "replication"));
   }
 
   protected void checkDatabasesAreIdentical() {

--- a/server/src/test/java/performance/BasePerformanceTest.java
+++ b/server/src/test/java/performance/BasePerformanceTest.java
@@ -149,7 +149,7 @@ public abstract class BasePerformanceTest {
   }
 
   protected String getDatabasePath(final int serverId) {
-    return GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + serverId + "/" + getDatabaseName();
+    return GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + serverId + File.pathSeparator + getDatabaseName();
   }
 
   protected ArcadeDBServer getLeaderServer() {
@@ -184,8 +184,8 @@ public abstract class BasePerformanceTest {
     TestServerHelper.checkActiveDatabases();
 
     for (int i = 0; i < getServerCount(); ++i)
-      FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + i + "/"));
-    FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_ROOT_PATH.getValueAsString() + "/replication"));
+      FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + i + File.pathSeparator));
+    FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_ROOT_PATH.getValueAsString() + File.pathSeparator + "replication"));
   }
 
   protected void checkDatabasesAreIdentical() {


### PR DESCRIPTION
## What does this PR do?
replace "/" with File.pathSeparator to be more OS agnostic

## Motivation
Paths are built using string concatenation and **/** as the path separator

## Related issues
#371 #413 


## Checklist
- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
