### PR TITLE
javadoc for ResultSet#countEntries

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ResultSet.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ResultSet.java
@@ -59,6 +59,10 @@ public interface ResultSet extends Spliterator<Result>, Iterator<Result>, AutoCl
     return false;
   }
 
+  /**
+   * Returns the count of the remaining uniterated results in the {@link ResultSet}. Note, that the
+   * default implementation will consume the iterator.
+   */
   default long countEntries() {
     long tot = 0;
 


### PR DESCRIPTION
Adds javadoc to ResultSet#countEntries to indicate that the underlying iterator will be consumed and unavailable for iteration.

## What does this PR do?
Adds javadoc

## Motivation
exploring the ArcadeDB APIs I was surprised to find that AsyncResultsetCallback#onNext receives no calls when calling resultSet#countEntries in the #onStart method.

## Checklist
- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
