### PR TITLE
Console fixes and extensions

### DIFF
--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -127,7 +127,8 @@ public class Console {
   public static void main(String[] args) throws IOException {
     if (args.length > 0) {
       final Console console = new Console(false);
-      console.parse(args[0], false);
+      console.parse(args[0], true);
+      console.parse("exit",true);
     } else
       new Console(true);
   }

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -212,6 +212,8 @@ public class Console {
           executeRollback();
         else if (lineLowerCase.startsWith("set"))
           executeSet(line.substring("set".length()).trim());
+        else if (lineLowerCase.startsWith("--"))
+          return true;
         else {
           executeSQL(line);
         }

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -174,8 +174,11 @@ public class Console {
 
   private boolean execute(String line) throws IOException {
     try {
+
+      line = line.trim();
+
       if (line != null && !line.isEmpty()) {
-        line = line.trim();
+
         final String lineLowerCase = line.toLowerCase();
 
         if (lineLowerCase.startsWith("begin"))

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -637,18 +637,24 @@ public class Console {
   }
 
   private void executeHelp() {
-    outputLine("HELP");
-    outputLine("begin                               -> begins a new transaction");
-    outputLine("check database                      -> check database integrity");
-    outputLine("close                               -> closes the database");
-    outputLine("create database <path>|remote:<url> -> creates a new database");
-    outputLine("commit                              -> commits current transaction");
-    outputLine("connect <path>|remote:<url>         -> connects to a database stored on <path>");
-    outputLine("help|?                              -> ask for this help");
-    outputLine("info types                          -> print available types");
-    outputLine("info transaction                    -> print current transaction");
-    outputLine("rollback                            -> rollbacks current transaction");
-    outputLine("quit or exit                        -> exits from the console");
+    outputLine("HELP:");
+    outputLine("begin                                             -> begins a new transaction");
+    outputLine("check database                                    -> check database integrity");
+    outputLine("close |<path>|remote:<url> <user> <pw>            -> closes the database");
+    outputLine("commit                                            -> commits current transaction");
+    outputLine("connect <path>|remote:<url> <user> <pw>           -> connects to a database");
+    outputLine("create database <path>|remote:<url> <user> <pw>   -> creates a new database");
+    outputLine("create user <user> identified by <pw> [grant connect to <db>*] -> creates a user");
+    outputLine("drop database <path>|remote:<url> <user> <pw>     -> deletes a database");
+    outputLine("drop user <user>                                  -> deletes a user");
+    outputLine("help|?                                            -> ask for this help");
+    outputLine("info types                                        -> prints available types");
+    outputLine("info transaction                                  -> prints current transaction");
+    outputLine("load <path>                                       -> runs local script");
+    outputLine("rollback                                          -> rolls back current transaction");
+    outputLine("set language = sql|sqlscript|cypher|gremlin|mongo -> sets console query language");
+    outputLine("-- <comment>                                      -> comment (no operation)");
+    outputLine("quit|exit                                         -> exits from the console");
   }
 
   private void checkDatabaseIsOpen() {

--- a/package/src/main/scripts/console.sh
+++ b/package/src/main/scripts/console.sh
@@ -51,9 +51,18 @@ if [ -z "$JAVA_OPTS_SCRIPT" ] ; then
     JAVA_OPTS_SCRIPT="-XX:+HeapDumpOnOutOfMemoryError -Djava.awt.headless=true -Dfile.encoding=UTF8"
 fi
 
-exec "$JAVA" $JAVA_OPTS \
-    $ARCADEDB_OPTS_MEMORY \
-    $JAVA_OPTS_SCRIPT \
-    $ARCADEDB_SETTINGS \
-    -cp "$ARCADEDB_HOME/lib/*" \
-    $ARGS com.arcadedb.console.Console $*
+if [ $# -gt 0 ] ; then
+    exec "$JAVA" $JAVA_OPTS \
+        $ARCADEDB_OPTS_MEMORY \
+        $JAVA_OPTS_SCRIPT \
+        $ARCADEDB_SETTINGS \
+        -cp "$ARCADEDB_HOME/lib/*" \
+        $ARGS com.arcadedb.console.Console "$*"
+else
+    exec "$JAVA" $JAVA_OPTS \
+        $ARCADEDB_OPTS_MEMORY \
+        $JAVA_OPTS_SCRIPT \
+        $ARCADEDB_SETTINGS \
+        -cp "$ARCADEDB_HOME/lib/*" \
+        $ARGS com.arcadedb.console.Console
+fi


### PR DESCRIPTION
## What does this PR do?
* `console.sh`
The problem was: when calling the console with anargument which contains spaces, these were removed by the shell script, for example:
```
> bin/console.sh "load test.sql"
```
did not work, as the space between `load` and `test` was automatically removed. 986fcc09850b922d8923223097a272c02db6f5db fixes this.

* `Console.java`
Calling a script from the shell can result in hanging of the console. This is fixed by forcing an `exit` command at the end of a non-interactive session. fb500e24683ee3bd588bab372d55aa7eb338d8bf fixes this.

* `Console.java`
Entering multiple whitespaces in the console prompt results in an (SQL) error. To fix this the `trim` of the currently parsed line is moved out of the `if` block deciding if a command is empty, so a white-sapce only command is skipped.
f044e854d807f5196dff2c7331e3d3eaf2c9b470 fixes this.

* `Console.java`
I added a comment "command" which is introduced by `--`. This is useful for longer scripts. 5f2d4b93ddee2ca922275f3dc53ae3fd5bc1722a adds this.

* `Console.java`
I updated the help message to the current state. 3d41636ce809797865928b9066ff509b64006eed does that.

## Motivation
All these changes result from loading a script via console.

## Related issues
https://github.com/ArcadeData/arcadedb/discussions/611

## Additional Notes
Anything else we should know when reviewing?

## Checklist
- [X] I have run the build using `mvn clean package` command (up to and including the `console` step tests pass)
- [ ] My unit tests cover both failure and success scenarios
