### PR TITLE
Propagate parsing errors to the Postgres layer.

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SQLEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SQLEngine.java
@@ -94,7 +94,11 @@ public class SQLEngine {
   }
 
   public static Statement parse(final String query, final DatabaseInternal database) {
-    return database.getStatementCache().get(query);
+    try {
+      return database.getStatementCache().get(query);
+    } catch (Error e) {
+      throw new CommandSQLParsingException(e);
+    }
   }
 
   public static List<Statement> parseScript(final String script, final DatabaseInternal database) {


### PR DESCRIPTION
## What does this PR do?
Propagate "Error" exceptions as "CommandSQLParsingException" to the Postgres layer. 

## Motivation
Malformed unicode escapes like ```SELECT 'abc \u030 def'``` did not result in an error message on the client side.

## Related issues
Discussed in #677 .

## Checklist
- [x] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
