### PR TITLE
Speedup query execution by removing not necessary operations

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/EmbeddedDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/EmbeddedDatabase.java
@@ -93,7 +93,6 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 import java.util.concurrent.locks.*;
 import java.util.logging.*;
-import java.util.stream.*;
 
 public class EmbeddedDatabase extends RWLockContext implements DatabaseInternal {
   public static final  int                                       EDGE_LIST_INITIAL_CHUNK_SIZE         = 64;
@@ -1696,14 +1695,13 @@ public class EmbeddedDatabase extends RWLockContext implements DatabaseInternal 
   private ResultSet executeInternal(final List<Statement> statements, final CommandContext scriptContext) {
     ScriptExecutionPlan plan = new ScriptExecutionPlan(scriptContext);
 
-    plan.setStatement(statements.stream().map(Statement::toString).collect(Collectors.joining(";")));
+    plan.setStatements(statements);
 
     List<Statement> lastRetryBlock = new ArrayList<>();
     int nestedTxLevel = 0;
 
     for (Statement stm : statements) {
-      if (stm.getOriginalStatement() == null)
-        stm.setOriginalStatement(stm.toString());
+      stm.setOriginalStatement(stm);
 
       if (stm instanceof BeginStatement)
         nestedTxLevel++;

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/BasicCommandContext.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/BasicCommandContext.java
@@ -366,6 +366,9 @@ public class BasicCommandContext implements CommandContext {
     return this;
   }
 
+  /**
+   * TODO OPTIMIZE THIS
+   */
   public static int getLowerIndexOf(final String iText, final int iBeginOffset, final String... iToSearch) {
     int lowest = -1;
     for (String toSearch : iToSearch) {
@@ -401,14 +404,17 @@ public class BasicCommandContext implements CommandContext {
     return lowest;
   }
 
+  /**
+   * TODO: optimize this
+   */
   public static int getHigherIndexOf(final String iText, final int iBeginOffset, final String... iToSearch) {
-    int lowest = -1;
+    int highest = -1;
     for (String toSearch : iToSearch) {
       int index = iText.indexOf(toSearch, iBeginOffset);
-      if (index > -1 && (lowest == -1 || index > lowest))
-        lowest = index;
+      if (index > -1 && (highest == -1 || index > highest))
+        highest = index;
     }
-    return lowest;
+    return highest;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ConvertToUpdatableResultStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ConvertToUpdatableResultStep.java
@@ -124,7 +124,7 @@ public class ConvertToUpdatableResultStep extends AbstractExecutionStep {
         Result result = nextItem;
         nextItem = null;
         fetched++;
-        ctx.setVariable("$current", result);
+        ctx.setVariable("current", result);
         return result;
       }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/EmptyDataGeneratorStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/EmptyDataGeneratorStep.java
@@ -54,7 +54,7 @@ public class EmptyDataGeneratorStep extends AbstractExecutionStep {
           if (served < size) {
             served++;
             ResultInternal result = new ResultInternal();
-            ctx.setVariable("$current", result);
+            ctx.setVariable("current", result);
             return result;
           }
           throw new IllegalStateException();

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromClassExecutionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromClassExecutionStep.java
@@ -174,7 +174,7 @@ public class FetchFromClassExecutionStep extends AbstractExecutionStep {
           if (currentResultSet != null && currentResultSet.hasNext()) {
             totDispatched++;
             Result result = currentResultSet.next();
-            ctx.setVariable("$current", result);
+            ctx.setVariable("current", result);
             return result;
           } else {
             if (currentStep >= getSubSteps().size()) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromClusterExecutionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromClusterExecutionStep.java
@@ -124,7 +124,7 @@ public class FetchFromClusterExecutionStep extends AbstractExecutionStep {
             nFetched++;
             ResultInternal result = new ResultInternal();
             result.element = (Document) record;
-            ctx.setVariable("$current", result);
+            ctx.setVariable("current", result);
             return result;
           } finally {
             if (profilingEnabled) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -117,7 +117,7 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
           ResultInternal result = new ResultInternal();
           result.setProperty("key", key);
           result.setProperty("rid", value);
-          ctx.setVariable("$current", result);
+          ctx.setVariable("current", result);
           return result;
         } finally {
           if (profilingEnabled) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/InternalExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/InternalExecutionPlan.java
@@ -18,6 +18,10 @@
  */
 package com.arcadedb.query.sql.executor;
 
+import com.arcadedb.query.sql.parser.Statement;
+
+import java.util.*;
+
 /**
  * Created by luigidellaquila on 06/07/16.
  */
@@ -59,6 +63,6 @@ public interface InternalExecutionPlan extends ExecutionPlan {
     return null;
   }
 
-  default void setStatement(String stm) {
+  default void setStatements(List<Statement> stm) {
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchEdgeTraverser.java
@@ -175,7 +175,7 @@ public class MatchEdgeTraverser {
           }
 
           public void fetchNext() {
-            Object previousMatch = iCommandContext.getVariable("$currentMatch");
+            Object previousMatch = iCommandContext.getVariable("currentMatch");
             ResultInternal matched = (ResultInternal) iCommandContext.getVariable("matched");
             if (matched != null) {
               matched.setProperty(getStartingPointAlias(), sourceRecord.getProperty(getStartingPointAlias()));
@@ -183,14 +183,14 @@ public class MatchEdgeTraverser {
             while (iter.hasNext()) {
               ResultInternal next = iter.next();
               Document elem = next.toElement();
-              iCommandContext.setVariable("$currentMatch", elem);
+              iCommandContext.setVariable("currentMatch", elem);
               if (matchesFilters(iCommandContext, theFilter, elem) && matchesClass(iCommandContext, theClassName, elem) && matchesCluster(iCommandContext,
                   theClusterId, elem) && matchesRid(iCommandContext, theTargetRid, elem)) {
                 nextElement = next;
                 break;
               }
             }
-            iCommandContext.setVariable("$currentMatch", previousMatch);
+            iCommandContext.setVariable("currentMatch", previousMatch);
           }
         };
       };
@@ -198,9 +198,9 @@ public class MatchEdgeTraverser {
     } else { // in this case also zero level (starting point) is considered and traversal depth is
       // given by the while condition
       result = new ArrayList<>();
-      iCommandContext.setVariable("$depth", depth);
-      Object previousMatch = iCommandContext.getVariable("$currentMatch");
-      iCommandContext.setVariable("$currentMatch", startingPoint);
+      iCommandContext.setVariable("depth", depth);
+      Object previousMatch = iCommandContext.getVariable("currentMatch");
+      iCommandContext.setVariable("currentMatch", startingPoint);
 
       if (matchesFilters(iCommandContext, filter, startingPoint) && matchesClass(iCommandContext, className, startingPoint) && matchesCluster(iCommandContext,
           clusterId, startingPoint) && matchesRid(iCommandContext, targetRid, startingPoint)) {
@@ -241,7 +241,7 @@ public class MatchEdgeTraverser {
           }
         }
       }
-      iCommandContext.setVariable("$currentMatch", previousMatch);
+      iCommandContext.setVariable("currentMatch", previousMatch);
     }
     return result;
   }
@@ -334,13 +334,13 @@ public class MatchEdgeTraverser {
       }
     }
 
-    Object prevCurrent = iCommandContext.getVariable("$current");
-    iCommandContext.setVariable("$current", startingPoint);
+    Object prevCurrent = iCommandContext.getVariable("current");
+    iCommandContext.setVariable("current", startingPoint);
     Object qR;
     try {
       qR = this.item.getMethod().execute(startingPoint, possibleResults, iCommandContext);
     } finally {
-      iCommandContext.setVariable("$current", prevCurrent);
+      iCommandContext.setVariable("current", prevCurrent);
     }
 
     if (qR == null) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchFieldTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchFieldTraverser.java
@@ -49,14 +49,14 @@ public class MatchFieldTraverser extends MatchEdgeTraverser {
       }
     }
 
-    Object prevCurrent = iCommandContext.getVariable("$current");
-    iCommandContext.setVariable("$current", startingPoint);
+    Object prevCurrent = iCommandContext.getVariable("current");
+    iCommandContext.setVariable("current", startingPoint);
     Object qR;
     try {
       // TODO check possible results!
       qR = ((FieldMatchPathItem) this.item).getExp().execute(startingPoint, iCommandContext);
     } finally {
-      iCommandContext.setVariable("$current", prevCurrent);
+      iCommandContext.setVariable("current", prevCurrent);
     }
 
     if (qR == null) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchFirstStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchFirstStep.java
@@ -83,7 +83,7 @@ public class MatchFirstStep extends AbstractExecutionStep {
         } else {
           result.setProperty(getAlias(), subResultSet.next());
         }
-        ctx.setVariable("$matched", result);
+        ctx.setVariable("matched", result);
         currentCount++;
         return result;
       }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchMultiEdgeTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchMultiEdgeTraverser.java
@@ -58,7 +58,7 @@ public class MatchMultiEdgeTraverser extends MatchEdgeTraverser {
     List<Object> nextStep = new ArrayList<>();
     nextStep.add(startingPoint);
 
-    Object oldCurrent = iCommandContext.getVariable("$current");
+    Object oldCurrent = iCommandContext.getVariable("current");
     for (MatchPathItem sub : item.getItems()) {
       List<ResultInternal> rightSide = new ArrayList<>();
       for (Object o : nextStep) {
@@ -78,7 +78,7 @@ public class MatchMultiEdgeTraverser extends MatchEdgeTraverser {
           subtraverser.executeTraversal(iCommandContext, sub, (Identifiable) current, 0, null).forEach(x -> rightSide.add(x));
 
         } else {
-          iCommandContext.setVariable("$current", o);
+          iCommandContext.setVariable("current", o);
           Object nextSteps = method.execute(o, possibleResults, iCommandContext);
           if (nextSteps instanceof Collection) {
             ((Collection) nextSteps).stream().map(x -> toOResultInternal(x)).filter(Objects::nonNull)
@@ -109,7 +109,7 @@ public class MatchMultiEdgeTraverser extends MatchEdgeTraverser {
       result = rightSide;
     }
 
-    iCommandContext.setVariable("$current", oldCurrent);
+    iCommandContext.setVariable("current", oldCurrent);
     //    return (qR instanceof Iterable) ? (Iterable) qR : Collections.singleton((PIdentifiable) qR);
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MatchStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MatchStep.java
@@ -77,7 +77,7 @@ public class MatchStep extends AbstractExecutionStep {
         Result result = nextResult;
         fetchNext(ctx, nRecords);
         localCount++;
-        ctx.setVariable("$matched", result);
+        ctx.setVariable("matched", result);
         return result;
       }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ProjectionCalculationStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ProjectionCalculationStep.java
@@ -52,10 +52,10 @@ public class ProjectionCalculationStep extends AbstractExecutionStep {
       @Override
       public Result next() {
         Result item = parentRs.next();
-        Object oldCurrent = ctx.getVariable("$current");
-        ctx.setVariable("$current", item);
+        Object oldCurrent = ctx.getVariable("current");
+        ctx.setVariable("current", item);
         Result result = calculateProjections(ctx, item);
-        ctx.setVariable("$current", oldCurrent);
+        ctx.setVariable("current", oldCurrent);
         return result;
       }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ResultInternal.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ResultInternal.java
@@ -276,27 +276,6 @@ public class ResultInternal implements Result {
     metadata.put(key, value);
   }
 
-  public void clearMetadata() {
-    metadata = null;
-  }
-
-  public void removeMetadata(final String key) {
-    if (key == null || metadata == null)
-      return;
-
-    metadata.remove(key);
-  }
-
-  public void addMetadata(final Map<String, Object> values) {
-    if (values == null)
-      return;
-
-    if (this.metadata == null)
-      this.metadata = new HashMap<>();
-
-    this.metadata.putAll(values);
-  }
-
   @Override
   public Set<String> getMetadataKeys() {
     return metadata == null ? Collections.emptySet() : metadata.keySet();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BaseExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BaseExpression.java
@@ -71,11 +71,6 @@ public class BaseExpression extends MathExpression {
     }
   }
 
-  @Override
-  public String toString() {
-    return super.toString();
-  }
-
   public void toString(final Map<String, Object> params, final StringBuilder builder) {
     if (number != null) {
       number.toString(params, builder);
@@ -304,6 +299,7 @@ public class BaseExpression extends MathExpression {
     result.inputParam = inputParam == null ? null : inputParam.copy();
     result.string = string;
     result.modifier = modifier == null ? null : modifier.copy();
+    result.cachedStringForm = cachedStringForm;
     return result;
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/FirstLevelExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/FirstLevelExpression.java
@@ -38,11 +38,5 @@ public class FirstLevelExpression extends MathExpression {
   public boolean isBaseIdentifier() {
     return value instanceof Identifier;
   }
-
-  //never used, this class is never returned by the parser!
-  @Override
-  public MathExpression copy() {
-    return super.copy();
-  }
 }
 /* JavaCC - OriginalChecksum=30dc1016b686d4841bbd57d6e6c0bfbd (do not edit this line) */

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/FunctionCall.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/FunctionCall.java
@@ -104,7 +104,7 @@ public class FunctionCall extends SimpleNode {
       }
     }
     if (record == null) {
-      Object current = ctx == null ? null : ctx.getVariable("$current");
+      Object current = ctx == null ? null : ctx.getVariable("current");
       if (current != null) {
         if (current instanceof Identifiable) {
           record = current;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MatchPathItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MatchPathItem.java
@@ -87,17 +87,17 @@ public class MatchPathItem extends SimpleNode {
       }
 
       for (Identifiable origin : queryResult) {
-        Object previousMatch = iCommandContext.getVariable("$currentMatch");
-        iCommandContext.setVariable("$currentMatch", origin);
+        Object previousMatch = iCommandContext.getVariable("currentMatch");
+        iCommandContext.setVariable("currentMatch", origin);
         if ((oClass == null || matchesClass(origin, oClass)) && (filter == null || filter.matchesFilters(origin, iCommandContext))) {
           result.add(origin);
         }
-        iCommandContext.setVariable("$currentMatch", previousMatch);
+        iCommandContext.setVariable("currentMatch", previousMatch);
       }
     } else {// in this case also zero level (starting point) is considered and traversal depth is given by the while condition
-      iCommandContext.setVariable("$depth", depth);
-      Object previousMatch = iCommandContext.getVariable("$currentMatch");
-      iCommandContext.setVariable("$currentMatch", startingPoint);
+      iCommandContext.setVariable("depth", depth);
+      Object previousMatch = iCommandContext.getVariable("currentMatch");
+      iCommandContext.setVariable("currentMatch", startingPoint);
       if ((oClass == null || matchesClass(startingPoint, oClass)) && (filter == null || filter.matchesFilters(startingPoint, iCommandContext))) {
         result.add(startingPoint);
       }
@@ -118,7 +118,7 @@ public class MatchPathItem extends SimpleNode {
           }
         }
       }
-      iCommandContext.setVariable("$currentMatch", previousMatch);
+      iCommandContext.setVariable("currentMatch", previousMatch);
     }
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MethodCall.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MethodCall.java
@@ -89,7 +89,7 @@ public class MethodCall extends SimpleNode {
   private Object execute(final Object targetObjects, final CommandContext ctx, final String name, final List<Expression> iParams,
       final Iterable<Identifiable> iPossibleResults) {
     final List<Object> paramValues = new ArrayList<Object>();
-    Object val = ctx.getVariable("$current");
+    Object val = ctx.getVariable("current");
     if (val == null && targetObjects == null) {
       return null;
     }
@@ -109,13 +109,13 @@ public class MethodCall extends SimpleNode {
     if (isGraphFunction()) {
       SQLFunction function = ((SQLQueryEngine) ctx.getDatabase().getQueryEngine("sql")).getFunction(name);
       if (function instanceof SQLFunctionFiltered) {
-        Object current = ctx.getVariable("$current");
+        Object current = ctx.getVariable("current");
         if (current instanceof Result) {
           current = ((Result) current).getElement().orElse(null);
         }
         return ((SQLFunctionFiltered) function).execute(targetObjects, (Identifiable) current, null, paramValues.toArray(), iPossibleResults, ctx);
       } else {
-        final Object current = ctx.getVariable("$current");
+        final Object current = ctx.getVariable("current");
         if (current instanceof Identifiable) {
           return function.execute(targetObjects, (Identifiable) current, null, paramValues.toArray(), ctx);
         } else if (current instanceof Result) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ParenthesisExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ParenthesisExpression.java
@@ -35,21 +35,21 @@ public class ParenthesisExpression extends MathExpression {
   protected Expression expression;
   protected Statement  statement;
 
-  public ParenthesisExpression(int id) {
+  public ParenthesisExpression(final int id) {
     super(id);
   }
 
-  public ParenthesisExpression(SqlParser p, int id) {
+  public ParenthesisExpression(final SqlParser p, final int id) {
     super(p, id);
   }
 
-  public ParenthesisExpression(Expression exp) {
+  public ParenthesisExpression(final Expression exp) {
     super(-1);
     this.expression = exp;
   }
 
   @Override
-  public Object execute(Identifiable iCurrentRecord, CommandContext ctx) {
+  public Object execute(final Identifiable iCurrentRecord, final CommandContext ctx) {
     if (expression != null) {
       return expression.execute(iCurrentRecord, ctx);
     }
@@ -60,7 +60,7 @@ public class ParenthesisExpression extends MathExpression {
   }
 
   @Override
-  public Object execute(Result iCurrentRecord, CommandContext ctx) {
+  public Object execute(final Result iCurrentRecord, final CommandContext ctx) {
     if (expression != null) {
       return expression.execute(iCurrentRecord, ctx);
     }
@@ -143,31 +143,32 @@ public class ParenthesisExpression extends MathExpression {
 
   @Override
   public ParenthesisExpression copy() {
-    ParenthesisExpression result = new ParenthesisExpression(-1);
+    final ParenthesisExpression result = new ParenthesisExpression(-1);
     result.expression = expression == null ? null : expression.copy();
     result.statement = statement == null ? null : statement.copy();
+    result.cachedStringForm = cachedStringForm;
     return result;
   }
 
-  public void setStatement(Statement statement) {
+  public void setStatement(final Statement statement) {
     this.statement = statement;
   }
 
-  public void extractSubQueries(SubQueryCollector collector) {
+  public void extractSubQueries(final SubQueryCollector collector) {
     if (expression != null) {
       expression.extractSubQueries(collector);
     } else if (statement != null) {
-      Identifier alias = collector.addStatement(statement);
+      final Identifier alias = collector.addStatement(statement);
       statement = null;
       expression = new Expression(alias);
     }
   }
 
-  public void extractSubQueries(Identifier letAlias, SubQueryCollector collector) {
+  public void extractSubQueries(final Identifier letAlias, final SubQueryCollector collector) {
     if (expression != null) {
       expression.extractSubQueries(collector);
     } else if (statement != null) {
-      Identifier alias = collector.addStatement(letAlias, statement);
+      final Identifier alias = collector.addStatement(letAlias, statement);
       statement = null;
       expression = new Expression(alias);
     }
@@ -181,7 +182,7 @@ public class ParenthesisExpression extends MathExpression {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o)
       return true;
     if (o == null || getClass() != o.getClass())
@@ -189,7 +190,7 @@ public class ParenthesisExpression extends MathExpression {
     if (!super.equals(o))
       return false;
 
-    ParenthesisExpression that = (ParenthesisExpression) o;
+    final ParenthesisExpression that = (ParenthesisExpression) o;
 
     if (!Objects.equals(expression, that.expression))
       return false;
@@ -218,7 +219,7 @@ public class ParenthesisExpression extends MathExpression {
   }
 
   public Result serialize() {
-    ResultInternal result = (ResultInternal) super.serialize();
+    final ResultInternal result = (ResultInternal) super.serialize();
     if (expression != null) {
       result.setProperty("expression", expression.serialize());
     }
@@ -228,7 +229,7 @@ public class ParenthesisExpression extends MathExpression {
     return result;
   }
 
-  public void deserialize(Result fromResult) {
+  public void deserialize(final Result fromResult) {
     super.deserialize(fromResult);
     if (fromResult.getProperty("expression") != null) {
       expression = new Expression(-1);

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/SelectStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/SelectStatement.java
@@ -156,20 +156,17 @@ public class SelectStatement extends Statement {
 
   @Override
   public boolean executionPlanCanBeCached() {
-    if (originalStatement == null) {
+    if (originalStatementAsString == null && originalStatement == null)
       return false;
-    }
-    if (this.target != null && !this.target.isCacheable()) {
-      return false;
-    }
 
-    if (this.letClause != null && !this.letClause.isCacheable()) {
+    if (this.target != null && !this.target.isCacheable())
       return false;
-    }
 
-    if (projection != null && !this.projection.isCacheable()) {
+    if (this.letClause != null && !this.letClause.isCacheable())
       return false;
-    }
+
+    if (projection != null && !this.projection.isCacheable())
+      return false;
 
     return whereClause == null || whereClause.isCacheable();
   }
@@ -219,25 +216,23 @@ public class SelectStatement extends Statement {
 
   @Override
   public SelectStatement copy() {
-    SelectStatement result = null;
     try {
-      result = getClass().getConstructor(Integer.TYPE).newInstance(-1);
+      final SelectStatement result = getClass().getConstructor(Integer.TYPE).newInstance(-1);
+      result.originalStatement = originalStatement;
+      result.target = target == null ? null : target.copy();
+      result.projection = projection == null ? null : projection.copy();
+      result.whereClause = whereClause == null ? null : whereClause.copy();
+      result.groupBy = groupBy == null ? null : groupBy.copy();
+      result.orderBy = orderBy == null ? null : orderBy.copy();
+      result.unwind = unwind == null ? null : unwind.copy();
+      result.skip = skip == null ? null : skip.copy();
+      result.limit = limit == null ? null : limit.copy();
+      result.letClause = letClause == null ? null : letClause.copy();
+      result.timeout = timeout == null ? null : timeout.copy();
+      return result;
     } catch (Exception e) {
       throw new ArcadeDBException(e);
     }
-    result.originalStatement = originalStatement;
-    result.target = target == null ? null : target.copy();
-    result.projection = projection == null ? null : projection.copy();
-    result.whereClause = whereClause == null ? null : whereClause.copy();
-    result.groupBy = groupBy == null ? null : groupBy.copy();
-    result.orderBy = orderBy == null ? null : orderBy.copy();
-    result.unwind = unwind == null ? null : unwind.copy();
-    result.skip = skip == null ? null : skip.copy();
-    result.limit = limit == null ? null : limit.copy();
-    result.letClause = letClause == null ? null : letClause.copy();
-    result.timeout = timeout == null ? null : timeout.copy();
-
-    return result;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/SimpleNode.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/SimpleNode.java
@@ -30,16 +30,17 @@ public class SimpleNode implements Node {
   protected SqlParser parser;
   protected Token     firstToken;
   protected Token     lastToken;
+  protected String    cachedStringForm;
 
   public SimpleNode() {
     id = -1;
   }
 
-  public SimpleNode(int i) {
+  public SimpleNode(final int i) {
     id = i;
   }
 
-  public SimpleNode(SqlParser p, int i) {
+  public SimpleNode(final SqlParser p, final int i) {
     this(i);
     parser = p;
   }
@@ -50,7 +51,7 @@ public class SimpleNode implements Node {
   public void jjtClose() {
   }
 
-  public void jjtSetParent(Node n) {
+  public void jjtSetParent(final Node n) {
     parent = n;
   }
 
@@ -58,11 +59,11 @@ public class SimpleNode implements Node {
     return parent;
   }
 
-  public void jjtAddChild(Node n, int i) {
+  public void jjtAddChild(final Node n, final int i) {
     if (children == null) {
       children = new Node[i + 1];
     } else if (i >= children.length) {
-      Node[] c = new Node[i + 1];
+      final Node[] c = new Node[i + 1];
       System.arraycopy(children, 0, c, 0, children.length);
       children = c;
     }
@@ -77,7 +78,7 @@ public class SimpleNode implements Node {
     return (children == null) ? 0 : children.length;
   }
 
-  public void jjtSetValue(Object value) {
+  public void jjtSetValue(final Object value) {
     this.value = value;
   }
 
@@ -89,7 +90,7 @@ public class SimpleNode implements Node {
     return firstToken;
   }
 
-  public void jjtSetFirstToken(Token token) {
+  public void jjtSetFirstToken(final Token token) {
     this.firstToken = token;
   }
 
@@ -97,7 +98,7 @@ public class SimpleNode implements Node {
     return lastToken;
   }
 
-  public void jjtSetLastToken(Token token) {
+  public void jjtSetLastToken(final Token token) {
     this.lastToken = token;
   }
 
@@ -127,12 +128,15 @@ public class SimpleNode implements Node {
    */
 
   public String toString() {
-    StringBuilder result = new StringBuilder();
-    toString(null, result);
-    return result.toString();
+    if (cachedStringForm == null) {
+      final StringBuilder result = new StringBuilder();
+      toString(null, result);
+      cachedStringForm = result.toString();
+    }
+    return cachedStringForm;
   }
 
-  public String toString(String prefix) {
+  public String toString(final String prefix) {
     return prefix + this;
   }
 
@@ -140,7 +144,7 @@ public class SimpleNode implements Node {
    * Override this method if you want to customize how the node dumps out its children.
    */
 
-  public void dump(String prefix) {
+  public void dump(final String prefix) {
     System.out.println(toString(prefix));
     if (children != null) {
       for (int i = 0; i < children.length; ++i) {
@@ -152,8 +156,8 @@ public class SimpleNode implements Node {
     }
   }
 
-  public void toString(Map<String, Object> params, StringBuilder builder) {
-    throw new UnsupportedOperationException("not implemented in " + getClass().getSimpleName());
+  public void toString(final Map<String, Object> params, final StringBuilder builder) {
+    throw new UnsupportedOperationException("Not implemented in " + getClass().getSimpleName());
   }
 
   public Object getValue() {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Statement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Statement.java
@@ -34,9 +34,10 @@ import java.util.*;
 public class Statement extends SimpleNode {
 
   //only for internal use!!! (caching)
-  protected String  originalStatement;
-  protected Limit   limit   = null;
-  protected Timeout timeout = null;
+  protected Statement originalStatement;
+  protected String    originalStatementAsString;
+  protected Limit     limit   = null;
+  protected Timeout   timeout = null;
 
   public static final String CUSTOM_STRICT_SQL = "strictSql";
 
@@ -162,11 +163,16 @@ public class Statement extends SimpleNode {
   }
 
   public String getOriginalStatement() {
-    return originalStatement;
+    if (originalStatementAsString == null)
+      originalStatementAsString = originalStatement.toString();
+    return originalStatementAsString;
   }
 
-  public void setOriginalStatement(String originalStatement) {
-    this.originalStatement = originalStatement;
+  public void setOriginalStatement(final Statement originalStatement) {
+    if (!originalStatement.equals(this.originalStatement)) {
+      this.originalStatement = originalStatement;
+      this.originalStatementAsString = null;
+    }
   }
 
   public Limit getLimit() {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/StatementCache.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/StatementCache.java
@@ -107,10 +107,11 @@ public class StatementCache {
           osql = new SqlParser(db, is);
         }
       }
-      Statement result = osql.parse();
-      result.originalStatement = statement;
 
+      final Statement result = osql.parse();
+      result.originalStatementAsString = statement;
       return result;
+
     } catch (ParseException e) {
       throwParsingException(e, statement);
     } catch (TokenMgrError e2) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/WhileStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/WhileStep.java
@@ -70,7 +70,7 @@ public class WhileStep extends AbstractExecutionStep {
     final ScriptExecutionPlan plan = new ScriptExecutionPlan(subCtx1);
     for (Statement stm : statements) {
       if (stm.originalStatement == null) {
-        stm.originalStatement = stm.toString();
+        stm.originalStatement = stm;
       }
       InternalExecutionPlan subPlan = stm.createExecutionPlan(subCtx1, profilingEnabled);
       plan.chain(subPlan, profilingEnabled);


### PR DESCRIPTION
While digging into the query execution with the profiler, there were a lot of calls to the toString() of the element of the query AST. This PR optimizes the usage of toString() by caching the string representation.

Also, context variables are now always set without the dollar sign ($) as prefix saving one copy of the string per execution.

