### PR TITLE
Add list command to console

### DIFF
--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -84,7 +84,7 @@ public class Console {
 
     terminal = TerminalBuilder.builder().system(system).streams(System.in, System.out).jansi(true).build();
     Completer completer = new StringsCompleter("align database", "begin", "rollback", "commit", "check database", "close", "connect", "create database",
-        "create user", "drop database", "drop user", "export", "import", "help", "info types", "load", "exit", "quit", "set", "match", "select", "insert into",
+        "create user", "drop database", "drop user", "export", "import", "help", "info types", "list databases", "load", "exit", "quit", "set", "match", "select", "insert into",
         "update", "delete", "pwd");
 
     lineReader = LineReaderBuilder.builder().terminal(terminal).parser(parser).variable("history-file", ".history").history(new DefaultHistory())
@@ -187,7 +187,7 @@ public class Console {
           executeClose();
         else if (lineLowerCase.startsWith("commit"))
           executeCommit();
-        else if (lineLowerCase.startsWith("list"))
+        else if (lineLowerCase.startsWith("list databases"))
           executeList(line);
         else if (lineLowerCase.startsWith("connect"))
           executeConnect(line);
@@ -315,17 +315,18 @@ public class Console {
   }
 
   private void executeList(final String line) {
-    final String url = line.substring("list".length()).trim();
+    final String url = line.substring("list databases".length()).trim();
 
     final String[] urlParts = url.split(" ");
 
     outputLine("Databases:");
     if (urlParts[0].startsWith(REMOTE_PREFIX)) {
+      final RemoteDatabase holdRemoteDatabase = remoteDatabase;
       connectToRemoteServer(url, false);
       for (Object f : remoteDatabase.databases()) {
         outputLine(f.toString());
       }
-      remoteDatabase = null;
+      remoteDatabase = holdRemoteDatabase;
 
     } else {
       File file = new File(databaseDirectory);
@@ -674,7 +675,7 @@ public class Console {
     outputLine("help|?                                            -> ask for this help");
     outputLine("info types                                        -> prints available types");
     outputLine("info transaction                                  -> prints current transaction");
-    outputLine("list |remote:<url> <user> <pw>                    -> lists databases");
+    outputLine("list databases |remote:<url> <user> <pw>          -> lists databases");
     outputLine("load <path>                                       -> runs local script");
     outputLine("rollback                                          -> rolls back current transaction");
     outputLine("set language = sql|sqlscript|cypher|gremlin|mongo -> sets console query language");

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -187,6 +187,8 @@ public class Console {
           executeClose();
         else if (lineLowerCase.startsWith("commit"))
           executeCommit();
+        else if (lineLowerCase.startsWith("list"))
+          executeList(line);
         else if (lineLowerCase.startsWith("connect"))
           executeConnect(line);
         else if (lineLowerCase.startsWith("create database"))
@@ -312,6 +314,28 @@ public class Console {
     }
   }
 
+  private void executeList(final String line) {
+    final String url = line.substring("list".length()).trim();
+
+    final String[] urlParts = url.split(" ");
+
+    outputLine("Databases:");
+    if (urlParts[0].startsWith(REMOTE_PREFIX)) {
+      connectToRemoteServer(url, false);
+      for (Object f : remoteDatabase.databases()) {
+        outputLine(f.toString());
+      }
+      remoteDatabase = null;
+
+    } else {
+      File file = new File(databaseDirectory);
+      for (String f : file.list()) {
+        outputLine(f);
+      }
+    }
+    flushOutput();
+  }
+
   private void executeConnect(final String line) {
     final String url = line.substring("connect".length()).trim();
 
@@ -321,7 +345,7 @@ public class Console {
       outputLine("Database already connected, to connect to a different database close the current one first");
     else if (!urlParts[0].isEmpty()) {
       if (urlParts[0].startsWith(REMOTE_PREFIX)) {
-        connectToRemoteServer(url);
+        connectToRemoteServer(url, true);
 
         outputLine("Connected");
         flushOutput();
@@ -346,7 +370,7 @@ public class Console {
       outputLine("Database already connected, to connect to a different database close the current one first");
     else if (!url.isEmpty()) {
       if (url.startsWith(REMOTE_PREFIX)) {
-        connectToRemoteServer(url);
+        connectToRemoteServer(url, true);
         remoteDatabase.create();
 
         outputLine("Database created");
@@ -411,7 +435,7 @@ public class Console {
       outputLine("A database is open, close the database first");
     else if (!url.isEmpty()) {
       if (url.startsWith(REMOTE_PREFIX)) {
-        connectToRemoteServer(url);
+        connectToRemoteServer(url, true);
         remoteDatabase.drop();
 
         outputLine("Database dropped");
@@ -650,6 +674,7 @@ public class Console {
     outputLine("help|?                                            -> ask for this help");
     outputLine("info types                                        -> prints available types");
     outputLine("info transaction                                  -> prints current transaction");
+    outputLine("list |remote:<url> <user> <pw>                    -> lists databases");
     outputLine("load <path>                                       -> runs local script");
     outputLine("rollback                                          -> rolls back current transaction");
     outputLine("set language = sql|sqlscript|cypher|gremlin|mongo -> sets console query language");
@@ -662,15 +687,15 @@ public class Console {
       throw new ArcadeDBException("No active database. Open a database first");
   }
 
-  private void connectToRemoteServer(final String url) {
+  private void connectToRemoteServer(final String url, final Boolean needsDatabase) {
     final String conn = url.startsWith(REMOTE_PREFIX + "//") ? url.substring((REMOTE_PREFIX + "//").length()) : url.substring(REMOTE_PREFIX.length());
 
-    final String[] serverUserPassword = conn.split(" ");
+    final String[] serverUserPassword = conn.trim().split(" ");
     if (serverUserPassword.length != 3)
       throw new ConsoleException("URL username and password are missing");
 
     final String[] serverParts = serverUserPassword[0].split("/");
-    if (serverParts.length != 2)
+    if ((needsDatabase && serverParts.length != 2) || (!needsDatabase && serverParts.length != 1))
       throw new ConsoleException("Remote URL '" + url + "' not valid");
 
     String remoteServer;
@@ -685,7 +710,15 @@ public class Console {
       remotePort = Integer.parseInt(serverParts[0].substring(portPos + 1));
     }
 
-    remoteDatabase = new RemoteDatabase(remoteServer, remotePort, serverParts[1], serverUserPassword[1], serverUserPassword[2]);
+    String serverDatabaseName;
+
+    if (needsDatabase) {
+      serverDatabaseName = serverParts[1];
+    } else {
+      serverDatabaseName = "";
+    }
+
+    remoteDatabase = new RemoteDatabase(remoteServer, remotePort, serverDatabaseName, serverUserPassword[1], serverUserPassword[2]);
   }
 
   private void flushOutput() {

--- a/console/src/test/java/com/arcadedb/console/ConsoleTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleTest.java
@@ -55,6 +55,11 @@ public class ConsoleTest {
   }
 
   @Test
+  public void testList() throws IOException {
+    Assertions.assertTrue(console.parse("list;", false));
+  }
+
+  @Test
   public void testConnect() throws IOException {
     Assertions.assertTrue(console.parse("connect " + DB_NAME + ";info types", false));
   }

--- a/console/src/test/java/com/arcadedb/console/ConsoleTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleTest.java
@@ -56,7 +56,7 @@ public class ConsoleTest {
 
   @Test
   public void testList() throws IOException {
-    Assertions.assertTrue(console.parse("list;", false));
+    Assertions.assertTrue(console.parse("list databases;", false));
   }
 
   @Test

--- a/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
@@ -108,6 +108,13 @@ public class RemoteDatabase extends RWLockContext {
     databaseCommand("create", "SQL", null, null, true, null);
   }
 
+  public List databases() {
+    return (List) serverCommand("GET","databases", "SQL", null, null, true, true, (connection, response) -> {
+
+      return response.getJSONArray("result").toList();
+    });
+  }
+
   public boolean exists() {
     return (boolean) databaseCommand("exists", "SQL", null, null, true, (connection, response) -> {
 


### PR DESCRIPTION
## What does this PR do?
The console supports a `list` command for local and remote databases.

## Motivation
A list command is available in the HTTP API but not in the console.

## Related issues
https://github.com/ArcadeData/arcadedb/discussions/716

## Additional Notes
This PR consists out of five parts:
1. I added a `executeList` method to `Console` class
2. I added a "list" case to the `execute` method
3. I extended the `connectToRemoteServer` method not only handle database commands but also server commands
   This became necessary as this method tested for a database name, which in the "list" case is not given. Hence, I added a boolean parameter to the method which indicates whether a the calling method needs a database name or not. (I added a `true` argument to all other calls to this method)
4. I added a line for the list function in the `executeHelp` function
5. I added a `databases` method to the `RemoteDatabase` class

Additionally, I added a `trim` to the `serverUserPassword` binding (in `connectToRemoteServer`), so not only `remote:localhost` but also `remote: localhost` is recognized.

Feel free to improve this solution.

## Checklist
- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios (currently only a simple test is included)
