### PR TITLE
Studio: add event to text field in create-database inputbox to allow confirm via enter key.

### DIFF
--- a/server/src/main/resources/static/js/studio-database.js
+++ b/server/src/main/resources/static/js/studio-database.js
@@ -93,7 +93,7 @@ function updateDatabases( callback ){
 
 
 function createDatabase(){
-  let html = "<label for='inputCreateDatabaseName'>Enter the database name:&nbsp;&nbsp;</label><input id='inputCreateDatabaseName'>";
+  let html = "<label for='inputCreateDatabaseName'>Enter the database name:&nbsp;&nbsp;</label><input onkeydown='if (event.which === 13) Swal.clickConfirm()' id='inputCreateDatabaseName'>";
 
   Swal.fire({
     title: 'Create a new database',


### PR DESCRIPTION
## What does this PR do?
This change adds a keydown event to the text box in the create-new-database inputbox, so that a confirm is not only triggered by pressing the confirm button but also when pressing the enter key.

## Motivation
Less tabbing or mouse movement.

## Checklist
- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
