### PR TITLE
chore: Rework starting scripts for Windows

### DIFF
--- a/package/src/main/scripts/stresstester.bat
+++ b/package/src/main/scripts/stresstester.bat
@@ -15,26 +15,35 @@
 @REM
 
 @echo off
-rem
-rem Copyright (c) Arcade Analytics LTD (https://www.arcadeanalytics.com)
-rem
-rem Guess ARCADEDB_HOME if not defined
-set CURRENT_DIR=%cd%
+echo ARCADEDB - PLAY WITH DATA - https://arcadedb.com
 
-if exist "%JAVA_HOME%\bin\java.exe" goto setJavaHome
-set JAVA="java"
-goto okJava
+@setlocal
 
-:setJavaHome
-set JAVA="%JAVA_HOME%\bin\java"
+set ERROR_CODE=0
 
-:okJava
+rem Validations
+if not "%JAVA_HOME%"=="" goto OkJHome
+
+rem Look for java executable
+for %%i in (java.exe) do set "JAVACMD=%%~$PATH:i"
+goto checkJCmd
+
+:OkJHome
+set "JAVACMD=%JAVA_HOME%\bin\java.exe"
+
+:checkJCmd
+if exist "%JAVACMD%" goto chkArcHome
+
+echo The JAVA_HOME environment variable is not defined correctly, >&2
+echo this environment variable is needed to run this program. >&2
+goto error
+
+:chkArcHome
 if not "%ARCADEDB_HOME%" == "" goto gotHome
-set ARCADEDB_HOME=%CURRENT_DIR%
-if exist "%ARCADEDB_HOME%\bin\stresstester.bat" goto okHome
-cd ..
-set ARCADEDB_HOME=%cd%
-cd %CURRENT_DIR%
+
+rem Guess ARCADEDB_HOME if not defined
+set "ARCADEDB_HOME=%~dp0"
+set "ARCADEDB_HOME=%ARCADEDB_HOME:~0,-5%"
 
 :gotHome
 if exist "%ARCADEDB_HOME%\bin\stresstester.bat" goto okHome
@@ -43,6 +52,9 @@ echo This environment variable is needed to run this program
 goto end
 
 :okHome
+rem Always change directory to HOME directory
+cd /d %ARCADEDB_HOME%
+
 rem Get remaining unshifted command line arguments and save them in the
 set CMD_LINE_ARGS=
 
@@ -54,6 +66,10 @@ goto setArgs
 
 :doneSetArgs
 
-call %JAVA% -client -cp "%ARCADEDB_HOME%\lib\*;%ARCADEDB_HOME%\plugins\*" com.arcadedb.console.stresstest.StressTester %CMD_LINE_ARGS%
+%JAVACMD% ^
+  -client ^
+  -cp "%ARCADEDB_HOME%\lib\*;%ARCADEDB_HOME%\plugins\*" ^
+  com.arcadedb.console.stresstest.StressTester ^
+  %CMD_LINE_ARGS% ^
 
 :end

--- a/package/src/main/scripts/stresstester.bat
+++ b/package/src/main/scripts/stresstester.bat
@@ -52,6 +52,9 @@ echo This environment variable is needed to run this program
 goto end
 
 :okHome
+echo ARCADEDB stresstester script path = %~dpnx0
+echo ARCADEDB home directory           = %ARCADEDB_HOME%
+
 rem Always change directory to HOME directory
 cd /d %ARCADEDB_HOME%
 
@@ -70,6 +73,6 @@ goto setArgs
   -client ^
   -cp "%ARCADEDB_HOME%\lib\*;%ARCADEDB_HOME%\plugins\*" ^
   com.arcadedb.console.stresstest.StressTester ^
-  %CMD_LINE_ARGS% ^
+  %CMD_LINE_ARGS%
 
 :end


### PR DESCRIPTION
## What does this PR do?

This PR improves following: 
- covers `server.bat`, `console.bat` and even `stresstester.bat`
- fixes syntactic issues in batch files for Windows when lookup up for java executable
- now it searches for java executable on PATH
- prints actual resolved ARCADEDB_HOME and script path to output at launch
- always changes directory to ARCADEDB_HOME so database files, logs and config directories are used correctly even if `console.bat` or `server.bat` are launched from a different current directory
- Inspiration was taken partially from Maven's `mvn.cmd` but only a little bit

## Motivation

Improve experience for Windows developers.
I'm able to create a manifest for [Scoop installer](scoop.sh) and make ArcadeDB installable using simple `scoop install arcadedb` once we have launch scripts in a good shape.

## Additional Notes

My appologies I actually touched license blocks. There was one duplicate in `console.bat` and conflicting copyright on `stresstester.bat`. I expect request for change with suggestion during review.

Also I was unable to test `stresstester.bat` as I'm missing some classes.

I changed arcadedb.com to https://arcadedb.com intentionally on console output reason being terminals actually can make this link clickable.

## Demo

### Launch server
![arcadedb-server](https://user-images.githubusercontent.com/544082/210458397-d93d9925-891a-4ca8-b20c-626d590ecd39.png)

### Launch console
![arcadedb-console](https://user-images.githubusercontent.com/544082/210458403-1ab1f4c6-8226-41b7-8952-7fbb7d9adb2f.png)

## Checklist
- [N/A] I have run the build using `mvn clean package` command
- [N/A] My unit tests cover both failure and success scenarios
