### PR TITLE
Add server POST endpoint and remove document endpoints on api page

### DIFF
--- a/server/src/main/resources/static/api.html
+++ b/server/src/main/resources/static/api.html
@@ -45,6 +45,18 @@
 
       <div class="row">
         <div class="col-1">
+          GET
+        </div>
+        <div class="col-4">
+          <pre>/api/v1/server</pre>
+        </div>
+        <div class="col-7">
+          <a class="link" href="https://docs.arcadedb.com/#HTTP-ServerCommand">Send server command</a>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-1">
           POST
         </div>
         <div class="col-4">
@@ -196,30 +208,6 @@
         </div>
         <div class="col-7">
           <a class="link" href="https://docs.arcadedb.com/#HTTP-Rollback">Rollback a transaction</a>
-        </div>
-      </div>
-
-      <div class="row">
-        <div class="col-1">
-          POST
-        </div>
-        <div class="col-4">
-          <pre>/api/v1/document/{database}</pre>
-        </div>
-        <div class="col-7">
-          <a class="link" href="https://docs.arcadedb.com/#HTTP-CreateDocument">Create a document (Deprecated)</a>
-        </div>
-      </div>
-
-      <div class="row">
-        <div class="col-1">
-          GET
-        </div>
-        <div class="col-4">
-          <pre>/api/v1/document/{database}/{rid}</pre>
-        </div>
-        <div class="col-7">
-          <a class="link" href="https://docs.arcadedb.com/#HTTP-LoadDocument">Load a document (Deprecated)</a>
         </div>
       </div>
 


### PR DESCRIPTION
## What does this PR do?
On the API page of the studio the new server POST endpoint is added and the deprecated document endpoints are removed.

## Motivation
Be in sync with docu


## Checklist
- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
