### PR TITLE
Accept local Url + tests

### DIFF
--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -55,6 +55,7 @@ import java.util.*;
 public class Console {
   private static final String               PROMPT               = "%n%s> ";
   private static final String               REMOTE_PREFIX        = "remote:";
+  private static final String               LOCAL_PREFIX         = "local:";
   private static final String               SQL_LANGUAGE         = "SQL";
   private final        boolean              system               = System.console() != null;
   private final        Terminal             terminal;
@@ -714,7 +715,11 @@ public class Console {
   }
 
   private String parseLocalUrl(final String url) {
-    return databaseDirectory + url.replaceFirst("file://", "");
+    if(url.startsWith(LOCAL_PREFIX + "//")) {
+      return url.replaceFirst(LOCAL_PREFIX + "//", "/");
+    } else {
+      return databaseDirectory + url.replaceFirst("file://", "");
+    }
   }
 
   private void connectToRemoteServer(final String url, final Boolean needsDatabase) {


### PR DESCRIPTION
## What does this PR do?
A local URL like : `local:<absolutePathToDB>/DB` can be used within the Console to connect to a local DB, to create and drop it.

## Motivation
It should be possible to use the Console not relying on the current work-directory. It might also be advantageous not to depend on a global setting like when using the `-Darcadedb.server.databaseDirectory` parameter at startup of the console.  

## Related issues
Introduction of the `-Darcadedb.server.databaseDirectory` parameter for the Console.

## Additional Notes
The commit also contains Unit Tests for the local connect, as well as a test whether the local URL can also be used with the `CREATE DB` and the `DROP DB` commands.
I used JDK 19 for compiling and testing, but the code is compatible with Java 8.

## Checklist
- [x] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios: No, this seems not necessary. There is also no negative test for the existing connect test.
