### PR TITLE
added docker compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.9"
+services:
+    arcade:
+        image: arcadedata/arcadedb:latest
+        ports:
+            - 2480:2480  # host : container port
+            - 2424:2424  # host : container port            
+        environment:
+            JAVA_OPTS: >
+                -Darcadedb.server.rootPassword=playwithdata 
+                -Darcadedb.dumpConfigAtStartup=true
+                -Darcadedb.server.defaultDatabases=Imported[root]{import:https://github.com/ArcadeData/arcadedb-datasets/raw/main/orientdb/OpenBeer.gz}
+        restart: always
+volumes:
+    arcade_db_vol:
+
+networks:
+    default:


### PR DESCRIPTION
will enable users to replace the long docker command with docker compose up

## What does this PR do?
It will enable users to use $> docker compose up 
to start ArcadeDB

## Motivation
Love Arcade DB wanted to help contribute convenience for users to use it.

## Related issues
Just added alternative start method

## Additional Notes
Thats it.

## Checklist
- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
