### PR TITLE
Deprecate execute in RemoteDatabase.

### DIFF
--- a/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
@@ -318,10 +318,14 @@ public class RemoteDatabase extends RWLockContext implements BasicDatabase {
     return (ResultSet) databaseCommand("query", language, command, params, false, (connection, response) -> createResultSet(response));
   }
 
+  /**
+   * @deprecated use {@link #command() command} instead
+   */
+  @Deprecated
   @Override
   public ResultSet execute(final String language, final String command, final Object... args) {
     final Map<String, Object> params = mapArgs(args);
-    return (ResultSet) databaseCommand("execute", language, command, params, false, (connection, response) -> createResultSet(response));
+    return (ResultSet) databaseCommand("command", language, command, params, false, (connection, response) -> createResultSet(response));
   }
 
   public CONNECTION_STRATEGY getConnectionStrategy() {


### PR DESCRIPTION
As "execute" is not supported by the http-API, currently the best thing to do is to send a "command" call. Either support "execute" on the server side, or specify, what exactly the RemoteDatabase should do with an "execute" in contrast to "command".

## What does this PR do?
Set deprecation annotation before "execute(...).
For the time being, as long as it is not clear, what the execute should do, just send a "command(...)"

## Motivation
Currently the http-request to /server/execute returns a 404 error. This must be avoided.


## Checklist
- [ x] I have run the build using `mvn clean package` command
- [ x] My unit tests cover both failure and success scenarios
