### PR TITLE
Fix console.bat not handling spaces in path

### DIFF
--- a/package/src/main/scripts/console.bat
+++ b/package/src/main/scripts/console.bat
@@ -79,7 +79,7 @@ goto setArgs
 :doneSetArgs
 set JAVA_OPTS_SCRIPT=-XX:+HeapDumpOnOutOfMemoryError -Djava.awt.headless=true -Dfile.encoding=UTF8 -Dpolyglot.engine.WarnInterpreterOnly=false
 
-%JAVACMD% ^
+"%JAVACMD%" ^
   -client ^
   %JAVA_OPTS% ^
   %JAVA_OPTS_SCRIPT% ^


### PR DESCRIPTION
This was just making it consistent with server.bat. It was breaking for me on launch since I have spaces in my java path.