### PR TITLE
Update docker image building for multiple platforms

### DIFF
--- a/package/pom.xml
+++ b/package/pom.xml
@@ -168,11 +168,9 @@
                                     <name>arcadedata/arcadedb</name>
                                     <build>
                                         <dockerFile>${project.basedir}/src/main/docker/Dockerfile</dockerFile>
-                                        <contextDir>${project.build.directory}/arcadedb-${project.version}.dir
-                                        </contextDir>
+                                        <contextDir>${project.build.directory}/arcadedb-${project.version}.dir</contextDir>
                                         <args>
-                                            <docker.buildArg.platform>linux/arm64,linux/amd64,linux/arm/v7</docker.buildArg.platform>
-
+                                            <docker.buildArg.ARCH>arm64v8/,amd64/,winamd64/,arm32v7/</docker.buildArg.ARCH>
                                         </args>
                                         <tags>
                                             <tag>latest</tag>

--- a/package/src/main/docker/Dockerfile
+++ b/package/src/main/docker/Dockerfile
@@ -14,7 +14,9 @@
 # limitations under the License.
 #
 
-FROM eclipse-temurin:11
+ARG ARCH=
+
+FROM ${ARCH}eclipse-temurin:11
 
 LABEL maintainer="Arcade Data LTD (info@arcadedb.com)"
 


### PR DESCRIPTION
## What does this PR do?
This is an attempt enable building platform dependent Docker images.

## Motivation
Poor performance on Apple M2 of current docker image.

## Related issues
https://github.com/ArcadeData/arcadedb/issues/894

## Additional Notes
Please test this if it does not produce problems with other platforms, I just tested `arm64v8`.

## Checklist
- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
