### PR TITLE
Implicitly create buckets for CREATE TYPE

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateDocumentTypeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateDocumentTypeStatement.java
@@ -48,9 +48,12 @@ public class CreateDocumentTypeStatement extends CreateTypeAbstractStatement {
       else {
         // CHECK THE BUCKETS FIRST
         final List<Bucket> bucketInstances = new ArrayList<>();
-        for (final BucketIdentifier b : buckets)
-          bucketInstances.add(b.bucketName != null ? schema.getBucketByName(b.bucketName.getStringValue()) : schema.getBucketById(b.bucketId.value.intValue()));
+        for (final BucketIdentifier b : buckets) {
+          if (!schema.existsBucket(b.bucketName.getStringValue()))
+            schema.createBucket(b.bucketName.getStringValue());
 
+          bucketInstances.add(b.bucketName != null ? schema.getBucketByName(b.bucketName.getStringValue()) : schema.getBucketById(b.bucketId.value.intValue()));
+        }
         type = schema.createDocumentType(name.getStringValue(), bucketInstances);
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateEdgeTypeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateEdgeTypeStatement.java
@@ -48,9 +48,12 @@ public class CreateEdgeTypeStatement extends CreateTypeAbstractStatement {
       else {
         // CHECK THE BUCKETS FIRST
         final List<Bucket> bucketInstances = new ArrayList<>();
-        for (final BucketIdentifier b : buckets)
-          bucketInstances.add(b.bucketName != null ? schema.getBucketByName(b.bucketName.getStringValue()) : schema.getBucketById(b.bucketId.value.intValue()));
+        for (final BucketIdentifier b : buckets) {
+          if (!schema.existsBucket(b.bucketName.getStringValue()))
+            schema.createBucket(b.bucketName.getStringValue());
 
+          bucketInstances.add(b.bucketName != null ? schema.getBucketByName(b.bucketName.getStringValue()) : schema.getBucketById(b.bucketId.value.intValue()));
+        }
         type = schema.createEdgeType(name.getStringValue(), bucketInstances);
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateVertexTypeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateVertexTypeStatement.java
@@ -48,9 +48,12 @@ public class CreateVertexTypeStatement extends CreateTypeAbstractStatement {
       else {
         // CHECK THE BUCKETS FIRST
         final List<Bucket> bucketInstances = new ArrayList<>();
-        for (final BucketIdentifier b : buckets)
-          bucketInstances.add(b.bucketName != null ? schema.getBucketByName(b.bucketName.getStringValue()) : schema.getBucketById(b.bucketId.value.intValue()));
+        for (final BucketIdentifier b : buckets) {
+          if (!schema.existsBucket(b.bucketName.getStringValue()))
+            schema.createBucket(b.bucketName.getStringValue());
 
+          bucketInstances.add(b.bucketName != null ? schema.getBucketByName(b.bucketName.getStringValue()) : schema.getBucketById(b.bucketId.value.intValue()));
+        }
         type = schema.createVertexType(name.getStringValue(), bucketInstances);
       }
     }


### PR DESCRIPTION
## What does this PR do?
These changes add implicit bucket creation for the SQL `CREATE TYPE` statement.
To this end I updated `CREATE DOCUMENT TYPE`, `CREATE VERTEX TYPE`, and `CREATE EDGE TYPE` with a conditional bucket creation based on `ALTER TYPE`, see https://github.com/ArcadeData/arcadedb/blob/main/engine/src/main/java/com/arcadedb/query/sql/parser/AlterTypeStatement.java#L121

## Motivation
The docs state that not existing buckets are created when creating type.

## Related issues
https://github.com/ArcadeData/arcadedb/issues/892

## Additional Notes
Given that I added three times the same code, maybe this mechanism should go to `[CreateTypeAbstractStatement.java](https://github.com/ArcadeData/arcadedb/blob/main/engine/src/main/java/com/arcadedb/query/sql/parser/CreateTypeAbstractStatement.java)`


## Checklist
- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios - I have not written tests

During testing I get:
```
[ERROR] Failures: 
[ERROR]   LSMTreeIndexTest.testUniqueConcurrentWithIndexesCompaction:1125 expected: <2000> but was: <2001>
```
but I cannot say if this is related.