### PR TITLE
Add settings for mongo host and port

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -360,6 +360,12 @@ public enum GlobalConfiguration {
 
   REDIS_HOST("arcadedb.redis.host", SCOPE.SERVER, "TCP/IP host name used for incoming connections for Redis plugin. Default is '0.0.0.0'", String.class,
       "0.0.0.0"),
+
+  // MONGO
+  MONGO_PORT("arcadedb.mongo.port", SCOPE.SERVER, "TCP/IP port number used for incoming connections for Mongo plugin. Default is 27017", Integer.class, 27017),
+
+  MONGO_HOST("arcadedb.mongo.host", SCOPE.SERVER, "TCP/IP host name used for incoming connections for Mongo plugin. Default is '0.0.0.0'", String.class,
+      "0.0.0.0"),
   ;
 
   /**

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBProtocolPlugin.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBProtocolPlugin.java
@@ -19,6 +19,7 @@
 package com.arcadedb.mongo;
 
 import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.ServerPlugin;
 import de.bwaldvogel.mongo.MongoDatabase;
@@ -43,7 +44,7 @@ public class MongoDBProtocolPlugin implements ServerPlugin {
         return new MongoDBDatabaseWrapper(server.getDatabase(databaseName), this);
       }
     });
-    mongoDBServer.bind("localhost", 27017);
+    mongoDBServer.bind(GlobalConfiguration.MONGO_HOST.getValueAsString(), GlobalConfiguration.MONGO_PORT.getValueAsInteger());
   }
 
   @Override


### PR DESCRIPTION
## What does this PR do?
Entries for the `MONGO_HOST` and `MONGO_PORT` are added to the `GlobalConfiguration` and used by the Mongo plugin.

## Related issues
https://github.com/ArcadeData/arcadedb/issues/917

## Additional Notes
Originally the host for mongo was `"localhost"` which I changed to the `"0.0.0.0"` as for the other host settings. If this needs to be exactly "localhot" for Mongo please change.

## Checklist
- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios (not added tests)
