### PR TITLE
fix: should call stopImporting() even if database is null

### DIFF
--- a/integration/src/main/java/com/arcadedb/integration/importer/Importer.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/Importer.java
@@ -62,8 +62,8 @@ public class Importer extends AbstractImporter {
     } catch (final Exception e) {
       throw new ImportException("Error on parsing source '" + source + "'", e);
     } finally {
+      stopImporting();
       if (database != null) {
-        stopImporting();
         closeDatabase();
       }
       closeInputFile();


### PR DESCRIPTION
## What does this PR do?
Fixes repeated import status messages from being logged to stdout every 5 seconds, when the database is disposed (i.e. `database == null`).

## Motivation
The status message repeats itself multiple times after the import logic completes, clogging up stdout. Debugging/monitoring is more difficult, and a runaway task runs a risk of system resources being consumed.

## Related issues
N/A

## Additional Notes
N/A

## Checklist
- [Y] I have run the build using `mvn clean package` command
- [N/A] My unit tests cover both failure and success scenarios
