### PR TITLE
Add readonly default server group

### DIFF
--- a/package/src/main/config/server-groups.json
+++ b/package/src/main/config/server-groups.json
@@ -20,6 +20,18 @@
             }
           }
         },
+        "readonly": {
+          "access": [],
+          "resultSetLimit": -1,
+          "readTimeout": -1,
+          "types": {
+            "*": {
+              "access": [
+                "readRecord"
+              ]
+            }
+          }
+        },
         "*": {
           "access": [],
           "resultSetLimit": -1,


### PR DESCRIPTION
## What does this PR do?
A default server group is added to the config which just permits reading and is thus pretty safe.

## Motivation
Volume constraints of the config folder in the Docker image

## Related Issue
https://github.com/ArcadeData/arcadedb/issues/985

## Checklist
- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
