### PR TITLE
Make LIKE case sensitive

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/QueryHelper.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/QueryHelper.java
@@ -29,9 +29,6 @@ public class QueryHelper {
       // EMPTY/NULL PARAMETERS
       return false;
 
-    value = value.toLowerCase(Locale.ENGLISH);
-    currentValue = currentValue.toLowerCase(Locale.ENGLISH);
-
     value = convertForRegExp(value);
 
     return currentValue.matches(value);


### PR DESCRIPTION
## What does this PR do?
This change removes the `lowerCase` conversions from the `QueryHelper`'s `like` method which is used for the `LIKE` operator

## Motivation
Odd (case-insensitive) behavior of `LIKE`.

## Additional Notes
This is just naively deleting lower case conversion.

## Checklist
- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
