### PR TITLE
Fix issue with group set only on second start

### DIFF
--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -553,6 +553,11 @@ public class ArcadeDBServer {
           security.createUser(new JSONObject().put("name", userName)//
               .put("password", security.encodePassword(userPassword))//
               .put("databases", new JSONObject().put(dbName, new JSONArray())));
+          
+          // UPDATE DB LIST + GROUP
+          ServerSecurityUser user = security.getUser(userName);
+          user.addDatabase(dbName, new String[] { userGroup });
+          security.saveUsers();
         }
       }
     }


### PR DESCRIPTION
## What does this PR do?
This change fixes a problem, that a group is only assigned on second start.

## Related issues
https://github.com/ArcadeData/arcadedb/issues/988

## Additional Notes
The whole block from lines 530--562 can maybe refactored to reduce duplications.

## Checklist
- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
