### PR TITLE
Added CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,17 @@
+cff-version: 1.2.0
+title: ArcadeDB
+message: If you use this software, please cite it using the metadata from this file.
+type: software
+authors:
+  - given-names: Luca
+    family-names: Garulli
+repository-code: 'https://github.com/ArcadeData/arcadedb'
+url: 'https://arcadedb.com'
+abstract: Play With Data!
+keywords:
+  - Multi-Model
+  - NoSQL
+  - SQL
+  - Database
+  - DBMS
+license: Apache-2.0


### PR DESCRIPTION
## What does this PR do?
A [`CITATION.cff`](https://citation-file-format.github.io/) metadata file is added to the project root.

## Motivation
Having this file is a best practice for scientific software. Even though ArcadeDB is not scientific software, this file makes using this software in research and science easier and it bundles project metadata in standardized form.
