### PR TITLE
Add `backupDirectory` setting

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -267,6 +267,9 @@ public enum GlobalConfiguration {
   SERVER_DATABASE_DIRECTORY("arcadedb.server.databaseDirectory", SCOPE.JVM, "Directory containing the database", String.class,
       "${arcadedb.server.rootPath}/databases"),
 
+  SERVER_BACKUP_DIRECTORY("arcadedb.server.backupDirectory", SCOPE.JVM, "Directory containing the backups", String.class,
+      "${arcadedb.server.rootPath}/backups"),
+
   SERVER_DATABASE_LOADATSTARTUP("arcadedb.server.databaseLoadAtStartup", SCOPE.SERVER, "Open all the available databases at server startup", Boolean.class,
       true),
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BackupDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BackupDatabaseStatement.java
@@ -21,6 +21,8 @@
 package com.arcadedb.query.sql.parser;
 
 import com.arcadedb.database.Database;
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -29,11 +31,13 @@ import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
 
 import java.lang.reflect.*;
+import java.io.*;
 import java.util.*;
 import java.util.logging.*;
 
 public class BackupDatabaseStatement extends SimpleExecStatement {
-  protected Url url;
+  private final ContextConfiguration configuration = new ContextConfiguration();
+  protected     Url                  url;
 
   public BackupDatabaseStatement(final int id) {
     super(id);
@@ -57,7 +61,10 @@ public class BackupDatabaseStatement extends SimpleExecStatement {
       final Object backup = clazz.getConstructor(Database.class, String.class).newInstance(context.getDatabase(), targetUrl);
 
       // ASSURE THE DIRECTORY CANNOT BE CHANGED
-      clazz.getMethod("setDirectory", String.class).invoke(backup, "backups/" + context.getDatabase().getName());
+      String backupDirectory = configuration.getValueAsString(GlobalConfiguration.SERVER_BACKUP_DIRECTORY);
+      if (!backupDirectory.endsWith(File.separator))
+        backupDirectory += File.separator;
+      clazz.getMethod("setDirectory", String.class).invoke(backup, backupDirectory + context.getDatabase().getName());
       clazz.getMethod("setVerboseLevel", Integer.TYPE).invoke(backup, 1);
       final String backupFile = (String) clazz.getMethod("backupDatabase").invoke(backup);
 


### PR DESCRIPTION
## What does this PR do?
This is an attempt to add the setting `backupDirectory` which sets directory of backups.

## Motivation
When using containered ArcadeDB, I want to store my database backups on a volume. One can overlay the default `backups` directory with a symlink to the volume, but this is just a hack.

## Related issues
https://github.com/ArcadeData/arcadedb/issues/597

## Additional Notes
I am checking if the setting's path has a file separator suffix in the statement, but I guess it would be better to do that right when assigning the setting in to the `GlobalConfiguration` (the same goes for `databaseDirectory`). However, I don't know how to do that elegantly. @lvca can you refactor if necessary?

## Checklist
- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
