### PR TITLE
Attempt to fix REUSE API compliance of CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,10 +8,12 @@ authors:
 repository-code: 'https://github.com/ArcadeData/arcadedb'
 url: 'https://arcadedb.com'
 abstract: Play With Data!
+license: Apache-2.0
+copyright: Copyright (c) 2021 Arcade Data Ltd
 keywords:
   - Multi-Model
   - NoSQL
   - SQL
   - Database
   - DBMS
-license: Apache-2.0
+


### PR DESCRIPTION
## What does this PR do?
Moving license key, newline at end of file and copyright key to fix REUSE API compliance of CITATION.cff.

