### PR TITLE
Test multi platform build with fabric8/docker-maven-plugin

### DIFF
--- a/package/pom.xml
+++ b/package/pom.xml
@@ -142,9 +142,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.eclipse.jkube</groupId>
-                        <artifactId>kubernetes-maven-plugin</artifactId>
-                        <version>${kubernetes-maven-plugin.version}</version>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>default</id>
@@ -162,22 +161,24 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <verbose>true</verbose>
                             <images>
                                 <image>
                                     <name>arcadedata/arcadedb</name>
                                     <build>
-                                        <dockerFile>${project.basedir}/src/main/docker/Dockerfile</dockerFile>
-                                        <contextDir>${project.build.directory}/arcadedb-${project.version}.dir</contextDir>
-                                        <args>
-                                            <docker.buildArg.ARCH>arm64v8/,amd64/,winamd64/,arm32v7/</docker.buildArg.ARCH>
-                                        </args>
+                                        <contextDir>${project.basedir}</contextDir>
+                                        <dockerFile>src/main/docker/Dockerfile</dockerFile> 
+                                        <buildx>
+                                            <platforms>
+                                                <platform>linux/amd64</platform>
+                                                <platform>linux/arm64</platform>
+                                            </platforms>
+                                        </buildx>
                                         <tags>
                                             <tag>latest</tag>
                                             <tag>${project.version}</tag>
                                         </tags>
                                     </build>
-                                </image>
+                               </image>
                             </images>
                         </configuration>
                     </plugin>

--- a/package/src/main/docker/Dockerfile
+++ b/package/src/main/docker/Dockerfile
@@ -34,7 +34,7 @@ WORKDIR /home/arcadedb
 
 USER arcadedb
 
-COPY --chown=arcadedb:arcadedb ./maven/arcadedb-* ./
+COPY --chown=arcadedb:arcadedb ./target/arcadedb-*.dir/* ./
 
 RUN chmod +x ./bin/*.sh
 


### PR DESCRIPTION
## What does this PR do?
These changes test multi platform package build (and deploy) of docker images with fabric8's docker-maven-plugin.

## Related issues
https://github.com/ArcadeData/arcadedb/issues/894

## Additional Notes
Please revert if it does not work

## Checklist
- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
