### PR TITLE
Add `bool_and` and `bool_or` functions

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/function/DefaultSQLFunctionFactory.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/function/DefaultSQLFunctionFactory.java
@@ -60,6 +60,8 @@ import com.arcadedb.query.sql.function.misc.SQLFunctionIf;
 import com.arcadedb.query.sql.function.misc.SQLFunctionIfNull;
 import com.arcadedb.query.sql.function.misc.SQLFunctionStrcmpci;
 import com.arcadedb.query.sql.function.misc.SQLFunctionUUID;
+import com.arcadedb.query.sql.function.misc.SQLFunctionBoolAnd;
+import com.arcadedb.query.sql.function.misc.SQLFunctionBoolOr;
 import com.arcadedb.query.sql.function.stat.SQLFunctionMedian;
 import com.arcadedb.query.sql.function.stat.SQLFunctionMode;
 import com.arcadedb.query.sql.function.stat.SQLFunctionPercentile;
@@ -113,6 +115,8 @@ public final class DefaultSQLFunctionFactory extends SQLFunctionFactoryTemplate 
     register(SQLFunctionConcat.NAME, SQLFunctionConcat.class);
     register(SQLFunctionAbsoluteValue.NAME, SQLFunctionAbsoluteValue.class);
     register(SQLFunctionStrcmpci.NAME, SQLFunctionStrcmpci.class);
+    register(SQLFunctionBoolAnd.NAME, SQLFunctionBoolAnd.class);
+    register(SQLFunctionBoolOr.NAME, SQLFunctionBoolOr.class);
     // GRAPH
     register(SQLFunctionOut.NAME, SQLFunctionOut.class);
     register(SQLFunctionIn.NAME, SQLFunctionIn.class);

--- a/engine/src/main/java/com/arcadedb/query/sql/function/misc/SQLFunctionBoolAnd.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/function/misc/SQLFunctionBoolAnd.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.function.misc;
+
+import com.arcadedb.query.sql.function.SQLFunctionConfigurableAbstract;
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.MultiValue;
+import com.arcadedb.schema.Type;
+
+/**
+ * TODO: summary
+ *
+ * @author Luca Garulli (l.garulli--(at)--gmail.com)
+ */
+public class SQLFunctionBoolAnd extends SQLFunctionConfigurableAbstract {
+  public static final String NAME = "bool_and";
+
+  private Boolean and;
+
+  public SQLFunctionBoolAnd() {
+    super(NAME);
+  }
+
+  public Object execute(final Object iThis, final Identifiable iCurrentRecord, final Object iCurrentResult, final Object[] iParams,
+      final CommandContext iContext) {
+    if (iParams.length == 1) {
+      if (iParams[0] instanceof Boolean)
+        and((Boolean) iParams[0]);
+      else if (MultiValue.isMultiValue(iParams[0]))
+        for (final Object n : MultiValue.getMultiValueIterable(iParams[0])) {
+          and((Boolean) n);
+          if (and) break;
+        }
+    } else {
+      and = null;
+      for (int i = 0; i < iParams.length; ++i) {
+        and((Boolean) iParams[i]);
+        if (and) break;
+      }
+    }
+    return and;
+  }
+
+  protected void and(final Boolean value) {
+    if (value != null) {
+      if (and == null)
+        // FIRST TIME
+        and = value;
+      else
+        and = and && value;
+    }
+  }
+
+  @Override
+  public boolean aggregateResults() {
+    return configuredParameters.length == 1;
+  }
+
+  public String getSyntax() {
+    return "bool_and(<field> [,<field>*])";
+  }
+
+  @Override
+  public Object getResult() {
+    return and == null ? true : and;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/sql/function/misc/SQLFunctionBoolAnd.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/function/misc/SQLFunctionBoolAnd.java
@@ -25,7 +25,7 @@ import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.schema.Type;
 
 /**
- * TODO: summary
+ * Computes the aggregate "and" over a field.
  *
  * @author Luca Garulli (l.garulli--(at)--gmail.com)
  */

--- a/engine/src/main/java/com/arcadedb/query/sql/function/misc/SQLFunctionBoolAnd.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/function/misc/SQLFunctionBoolAnd.java
@@ -22,7 +22,6 @@ import com.arcadedb.query.sql.function.SQLFunctionConfigurableAbstract;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.MultiValue;
-import com.arcadedb.schema.Type;
 
 /**
  * Computes the aggregate "and" over a field.

--- a/engine/src/main/java/com/arcadedb/query/sql/function/misc/SQLFunctionBoolOr.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/function/misc/SQLFunctionBoolOr.java
@@ -25,7 +25,7 @@ import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.schema.Type;
 
 /**
- * TODO:
+ * Computes the aggregate "or" over a field.
  *
  * @author Luca Garulli (l.garulli--(at)--gmail.com)
  */
@@ -62,7 +62,7 @@ public class SQLFunctionBoolOr extends SQLFunctionConfigurableAbstract {
     if (value != null) {
       if (or == null)
         // FIRST TIME
-        or = false;
+        or = value;
       else
         or = or || value;
     }

--- a/engine/src/main/java/com/arcadedb/query/sql/function/misc/SQLFunctionBoolOr.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/function/misc/SQLFunctionBoolOr.java
@@ -22,7 +22,6 @@ import com.arcadedb.query.sql.function.SQLFunctionConfigurableAbstract;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.MultiValue;
-import com.arcadedb.schema.Type;
 
 /**
  * Computes the aggregate "or" over a field.

--- a/engine/src/main/java/com/arcadedb/query/sql/function/misc/SQLFunctionBoolOr.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/function/misc/SQLFunctionBoolOr.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.function.misc;
+
+import com.arcadedb.query.sql.function.SQLFunctionConfigurableAbstract;
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.MultiValue;
+import com.arcadedb.schema.Type;
+
+/**
+ * TODO:
+ *
+ * @author Luca Garulli (l.garulli--(at)--gmail.com)
+ */
+public class SQLFunctionBoolOr extends SQLFunctionConfigurableAbstract {
+  public static final String NAME = "bool_or";
+
+  private Boolean or;
+
+  public SQLFunctionBoolOr() {
+    super(NAME);
+  }
+
+  public Object execute(final Object iThis, final Identifiable iCurrentRecord, final Object iCurrentResult, final Object[] iParams,
+      final CommandContext iContext) {
+    if (iParams.length == 1) {
+      if (iParams[0] instanceof Boolean)
+        or((Boolean) iParams[0]);
+      else if (MultiValue.isMultiValue(iParams[0]))
+        for (final Object n : MultiValue.getMultiValueIterable(iParams[0])) {
+          or((Boolean) n);
+          if (or) break;
+        }
+    } else {
+      or = null;
+      for (int i = 0; i < iParams.length; ++i) {
+        or((Boolean) iParams[i]);
+        if (or) break;
+      }
+    }
+    return or;
+  }
+
+  protected void or(final Boolean value) {
+    if (value != null) {
+      if (or == null)
+        // FIRST TIME
+        or = false;
+      else
+        or = or || value;
+    }
+  }
+
+  @Override
+  public boolean aggregateResults() {
+    return configuredParameters.length == 1;
+  }
+
+  public String getSyntax() {
+    return "bool_or(<field> [,<field>*])";
+  }
+
+  @Override
+  public Object getResult() {
+    return or == null ? false : or;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/functions/misc/SQLFunctionBoolAndTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/functions/misc/SQLFunctionBoolAndTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.functions.misc;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.query.sql.function.misc.SQLFunctionBoolAnd;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class SQLFunctionBoolAndTest extends TestHelper {
+
+  @Test
+  public void testBoolAnd_SingleNull() {
+    database.transaction(() -> {
+      database.command("sql", "create document type doc0;");
+      database.command("sql", "create property doc0.bool boolean;");
+      database.command("sql", "insert into doc0 set bool = null;");
+      ResultSet result = database.query("sql","select bool_and(bool) as bool_and from doc0;");
+      Assertions.assertTrue(result.hasNext());
+      Assertions.assertTrue((Boolean) result.next().getProperty("bool_and"));
+    });
+  }
+
+  @Test
+  public void testBoolAnd_SingleTrue() {
+    database.transaction(() -> {
+      database.command("sql", "create document type doc1;");
+      database.command("sql", "create property doc1.bool boolean;");
+      database.command("sql", "insert into doc1 set bool = true;");
+      ResultSet result = database.query("sql","select bool_and(bool) as bool_and from doc1;");
+      Assertions.assertTrue(result.hasNext());
+      Assertions.assertTrue((Boolean) result.next().getProperty("bool_and"));
+    });
+  }
+
+  @Test
+  public void testBoolAnd_SingleFalse() {
+    database.transaction(() -> {
+      database.command("sql", "create document type doc2;");
+      database.command("sql", "create property doc2.bool boolean;");
+      database.command("sql", "insert into doc2 set bool = false;");
+      ResultSet result = database.query("sql","select bool_and(bool) as bool_and from doc2;");
+      Assertions.assertTrue(result.hasNext());
+      Assertions.assertFalse((Boolean) result.next().getProperty("bool_and"));
+    });
+  }
+
+  @Test
+  public void testBoolAnd_MultiNull() {
+    database.transaction(() -> {
+      database.command("sql", "create document type doc3;");
+      database.command("sql", "create property doc3.bool boolean;");
+      database.command("sql", "insert into doc3 (bool) values (null), (null), (null);");
+      ResultSet result = database.query("sql","select bool_and(bool) as bool_and from doc3;");
+      Assertions.assertTrue(result.hasNext());
+      Assertions.assertTrue((Boolean) result.next().getProperty("bool_and"));
+    });
+  }
+
+  @Test
+  public void testBoolAnd_MultiTrue() {
+    database.transaction(() -> {
+      database.command("sql", "create document type doc4;");
+      database.command("sql", "create property doc4.bool boolean;");
+      database.command("sql", "insert into doc4 (bool) values (true), (true), (true);");
+      ResultSet result = database.query("sql","select bool_and(bool) as bool_and from doc4;");
+      Assertions.assertTrue(result.hasNext());
+      Assertions.assertTrue((Boolean) result.next().getProperty("bool_and"));
+    });
+  }
+
+  @Test
+  public void testBoolAnd_MultiFalse() {
+    database.transaction(() -> {
+      database.command("sql", "create document type doc5;");
+      database.command("sql", "create property doc5.bool boolean;");
+      database.command("sql", "insert into doc5 (bool) values (true), (true), (false);");
+      ResultSet result = database.query("sql","select bool_and(bool) as bool_and from doc5;");
+      Assertions.assertTrue(result.hasNext());
+      Assertions.assertFalse((Boolean) result.next().getProperty("bool_and"));
+    });
+  }
+
+  @Test
+  public void testBoolAnd_MultiTrueHasNull() {
+    database.transaction(() -> {
+      database.command("sql", "create document type doc6;");
+      database.command("sql", "create property doc6.bool boolean;");
+      database.command("sql", "insert into doc6 (bool) values (true), (null), (true);");
+      ResultSet result = database.query("sql","select bool_and(bool) as bool_and from doc6;");
+      Assertions.assertTrue(result.hasNext());
+      Assertions.assertTrue((Boolean) result.next().getProperty("bool_and"));
+    });
+  }
+
+  @Test
+  public void testBoolAnd_MultiFalseHasNull() {
+    database.transaction(() -> {
+      database.command("sql", "create document type doc7;");
+      database.command("sql", "create property doc7.bool boolean;");
+      database.command("sql", "insert into doc7 (bool) values (true), (null), (false);");
+      ResultSet result = database.query("sql","select bool_and(bool) as bool_and from doc7;");
+      Assertions.assertTrue(result.hasNext());
+      Assertions.assertFalse((Boolean) result.next().getProperty("bool_and"));
+    });
+  }
+
+  @Test
+  public void testBoolAnd_MultiNullIsNull() {
+    database.transaction(() -> {
+      database.command("sql", "create document type doc8;");
+      database.command("sql", "create property doc8.bool boolean;");
+      database.command("sql", "insert into doc8 (bool) values (null), (null), (null);");
+      ResultSet result = database.query("sql","select bool_and((bool is null)) as bool_and from doc8;");
+      Assertions.assertTrue(result.hasNext());
+      Assertions.assertTrue((Boolean) result.next().getProperty("bool_and"));
+    });
+  }
+
+  @Test
+  public void testBoolAnd_MultiHasNull() {
+    database.transaction(() -> {
+      database.command("sql", "create document type doc9;");
+      database.command("sql", "create property doc9.bool boolean;");
+      database.command("sql", "insert into doc9 (bool) values (true), (null), (false);");
+      ResultSet result = database.query("sql","select bool_and((bool is not null)) as bool_and from doc9;");
+      Assertions.assertTrue(result.hasNext());
+      Assertions.assertFalse((Boolean) result.next().getProperty("bool_and"));
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/functions/misc/SQLFunctionBoolOrTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/functions/misc/SQLFunctionBoolOrTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.functions.misc;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.query.sql.function.misc.SQLFunctionBoolOr;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class SQLFunctionBoolOrTest extends TestHelper {
+
+  @Test
+  public void testBoolOr_SingleNull() {
+    database.transaction(() -> {
+      database.command("sql", "create document type doc0;");
+      database.command("sql", "create property doc0.bool boolean;");
+      database.command("sql", "insert into doc0 set bool = null;");
+      ResultSet result = database.query("sql","select bool_or(bool) as bool_or from doc0;");
+      Assertions.assertTrue(result.hasNext());
+      Assertions.assertFalse((Boolean) result.next().getProperty("bool_or"));
+    });
+  }
+
+  @Test
+  public void testBoolOr_SingleTrue() {
+    database.transaction(() -> {
+      database.command("sql", "create document type doc1;");
+      database.command("sql", "create property doc1.bool boolean;");
+      database.command("sql", "insert into doc1 set bool = true;");
+      ResultSet result = database.query("sql","select bool_or(bool) as bool_or from doc1;");
+      Assertions.assertTrue(result.hasNext());
+      Assertions.assertTrue((Boolean) result.next().getProperty("bool_or"));
+    });
+  }
+
+  @Test
+  public void testBoolOr_SingleFalse() {
+    database.transaction(() -> {
+      database.command("sql", "create document type doc2;");
+      database.command("sql", "create property doc2.bool boolean;");
+      database.command("sql", "insert into doc2 set bool = false;");
+      ResultSet result = database.query("sql","select bool_or(bool) as bool_or from doc2;");
+      Assertions.assertTrue(result.hasNext());
+      Assertions.assertFalse((Boolean) result.next().getProperty("bool_or"));
+    });
+  }
+
+  @Test
+  public void testBoolOr_MultiNull() {
+    database.transaction(() -> {
+      database.command("sql", "create document type doc3;");
+      database.command("sql", "create property doc3.bool boolean;");
+      database.command("sql", "insert into doc3 (bool) values (null), (null), (null);");
+      ResultSet result = database.query("sql","select bool_or(bool) as bool_or from doc3;");
+      Assertions.assertTrue(result.hasNext());
+      Assertions.assertFalse((Boolean) result.next().getProperty("bool_or"));
+    });
+  }
+
+  @Test
+  public void testBoolOr_MultiTrue() {
+    database.transaction(() -> {
+      database.command("sql", "create document type doc4;");
+      database.command("sql", "create property doc4.bool boolean;");
+      database.command("sql", "insert into doc4 (bool) values (false), (false), (true);");
+      ResultSet result = database.query("sql","select bool_or(bool) as bool_or from doc4;");
+      Assertions.assertTrue(result.hasNext());
+      Assertions.assertTrue((Boolean) result.next().getProperty("bool_or"));
+    });
+  }
+
+  @Test
+  public void testBoolOr_MultiFalse() {
+    database.transaction(() -> {
+      database.command("sql", "create document type doc5;");
+      database.command("sql", "create property doc5.bool boolean;");
+      database.command("sql", "insert into doc5 (bool) values (false), (false), (false);");
+      ResultSet result = database.query("sql","select bool_or(bool) as bool_or from doc5;");
+      Assertions.assertTrue(result.hasNext());
+      Assertions.assertFalse((Boolean) result.next().getProperty("bool_or"));
+    });
+  }
+
+  @Test
+  public void testBoolOr_MultiTrueHasNull() {
+    database.transaction(() -> {
+      database.command("sql", "create document type doc6;");
+      database.command("sql", "create property doc6.bool boolean;");
+      database.command("sql", "insert into doc6 (bool) values (false), (null), (true);");
+      ResultSet result = database.query("sql","select bool_or(bool) as bool_or from doc6;");
+      Assertions.assertTrue(result.hasNext());
+      Assertions.assertTrue((Boolean) result.next().getProperty("bool_or"));
+    });
+  }
+
+  @Test
+  public void testBoolOr_MultiFalseHasNull() {
+    database.transaction(() -> {
+      database.command("sql", "create document type doc7;");
+      database.command("sql", "create property doc7.bool boolean;");
+      database.command("sql", "insert into doc7 (bool) values (false), (null), (false);");
+      ResultSet result = database.query("sql","select bool_or(bool) as bool_or from doc7;");
+      Assertions.assertTrue(result.hasNext());
+      Assertions.assertFalse((Boolean) result.next().getProperty("bool_or"));
+    });
+  }
+
+  @Test
+  public void testBoolOr_MultiNullIsNull() {
+    database.transaction(() -> {
+      database.command("sql", "create document type doc8;");
+      database.command("sql", "create property doc8.bool boolean;");
+      database.command("sql", "insert into doc8 (bool) values (null), (null), (null);");
+      ResultSet result = database.query("sql","select bool_or((bool is not null)) as bool_or from doc8;");
+      Assertions.assertTrue(result.hasNext());
+      Assertions.assertFalse((Boolean) result.next().getProperty("bool_or"));
+    });
+  }
+
+  @Test
+  public void testBoolOr_MultiHasNull() {
+    database.transaction(() -> {
+      database.command("sql", "create document type doc9;");
+      database.command("sql", "create property doc9.bool boolean;");
+      database.command("sql", "insert into doc9 (bool) values (true), (null), (false);");
+      ResultSet result = database.query("sql","select bool_or((bool is null)) as bool_or from doc9;");
+      Assertions.assertTrue(result.hasNext());
+      Assertions.assertTrue((Boolean) result.next().getProperty("bool_or"));
+    });
+  }
+}


### PR DESCRIPTION
## What does this PR do?
These changes add the SQL functions `bool_and` and `bool_or` as well as registering them. Also some tests for both new functions are added.

## Related issues
https://github.com/ArcadeData/arcadedb/issues/1011

## Additional Notes
The test sets run rather slow, maybe I am doing something inefficiently?

## Checklist
- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios (currently only success)
