### PR TITLE
Add `base64url` format to `encode` and `decode` functions

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/function/misc/SQLFunctionDecode.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/function/misc/SQLFunctionDecode.java
@@ -50,6 +50,9 @@ public class SQLFunctionDecode extends SQLFunctionAbstract {
 
     if (SQLFunctionEncode.FORMAT_BASE64.equalsIgnoreCase(format)) {
       return Base64.getDecoder().decode(candidate);
+    } else if (SQLFunctionEncode.FORMAT_BASE64URL.equalsIgnoreCase(format)) {
+      final int padding = (candidate.length() % 4 == 2 ? 2 : (candidate.length() % 4 == 3 ? 1 : 0));
+      return Base64.getDecoder().decode(candidate.replace('-','+').replace('_','/') + "=".repeat(padding));
     } else {
       throw new CommandSQLParsingException("Unknown format :" + format);
     }

--- a/engine/src/main/java/com/arcadedb/query/sql/function/misc/SQLFunctionEncode.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/function/misc/SQLFunctionEncode.java
@@ -35,8 +35,9 @@ import java.util.*;
  */
 public class SQLFunctionEncode extends SQLFunctionAbstract {
 
-  public static final String NAME          = "encode";
-  public static final String FORMAT_BASE64 = "base64";
+  public static final String NAME             = "encode";
+  public static final String FORMAT_BASE64    = "base64";
+  public static final String FORMAT_BASE64URL = "base64url";
 
   /**
    * Get the date at construction to have the same date for all the iteration.
@@ -54,6 +55,8 @@ public class SQLFunctionEncode extends SQLFunctionAbstract {
     byte[] data = null;
     if (candidate instanceof byte[]) {
       data = (byte[]) candidate;
+    } else if (candidate instanceof String) {
+      data = ((String) candidate).getBytes();
     } else if (candidate instanceof RID) {
       final Record rec = ((RID) candidate).getRecord();
       if (rec instanceof Binary) {
@@ -67,6 +70,8 @@ public class SQLFunctionEncode extends SQLFunctionAbstract {
 
     if (FORMAT_BASE64.equalsIgnoreCase(format)) {
       return Base64.getEncoder().encodeToString(data);
+    } else if (FORMAT_BASE64URL.equalsIgnoreCase(format)) {
+      return Base64.getEncoder().withoutPadding().encodeToString(data).replace('+','-').replace('/','_');
     } else {
       throw new CommandSQLParsingException("Unknown format :" + format);
     }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/misc/SQLMethodAsString.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/misc/SQLMethodAsString.java
@@ -35,7 +35,12 @@ public class SQLMethodAsString extends AbstractSQLMethod {
 
   @Override
   public Object execute(final Object iThis, final Identifiable iCurrentRecord, final CommandContext iContext, Object ioResult, final Object[] iParams) {
-    ioResult = ioResult != null ? ioResult.toString() : null;
-    return ioResult;
+    if (ioResult == null) {
+      return null;
+    } else if (ioResult instanceof byte[]) {
+      return new String((byte[]) ioResult);
+    } else {
+      return ioResult.toString();
+    }
   }
 }


### PR DESCRIPTION
## What does this PR do?
These changes add the `base64url` format to the `encode` and `decode` SQL functions.
Additionally, I modified the `asString()` method to convert `BINARY` types to their content as string.

## Motivation
I want to encode and decode RIDs (as strings) in URLs.

## Related issues
https://github.com/ArcadeData/arcadedb/discussions/1016

## Checklist
- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
