### PR TITLE
Studio: Add syntax highlighting to sqlscript language

### DIFF
--- a/server/src/main/resources/static/query.html
+++ b/server/src/main/resources/static/query.html
@@ -344,6 +344,8 @@ function getEditorMode(){
   let mime = null;
   if( language == "sql" )
     mime = "text/x-sql";
+  else if( language == "sqlScript" )
+    mime = "text/x-sql";
   else if( language == "cypher" )
     mime = "application/x-cypher-query";
   else if( language == "gremlin" )


### PR DESCRIPTION
## What does this PR do?
The query box when language "SQL" is selected has syntax highlighting, till now when "SQL Script" is selected it hasn't. Thes change adds it.

## Related issues
https://github.com/ArcadeData/arcadedb/issues/1027

## Checklist
- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
