### PR TITLE
Change JVM version string

### DIFF
--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -172,11 +172,9 @@ public class ArcadeDBServer {
     final String osVersion = System.getProperty("os.version");
     final String vmName = System.getProperty("java.vm.name");
     final String vmVendorVersion = System.getProperty("java.vendor.version");
-    if (vmName != null)
-      LogManager.instance().log(this, Level.INFO,
-          "Running on " + osName + " " + osVersion + " - " + vmName + " " + (vmVendorVersion != null ? vmVendorVersion : System.getProperty("java.version")));
-    else
-      LogManager.instance().log(this, Level.INFO, "Running on " + osName + " " + osVersion + " - Java " + System.getProperty(" java.version"));
+    final String vmVersion = System.getProperty("java.version");
+    LogManager.instance().log(this, Level.INFO,
+      "Running on " + osName + " " + osVersion + " - " + (vmName != null ? vmName : "Java") + " " + vmVersion + " " + (vmVendorVersion != null ? "(" + vmVendorVersion + ")" : ""));
   }
 
   private Set<String> getPluginNames() {


### PR DESCRIPTION
## What does this PR do?
This change simplifies the system property report in th log 

## Motivation
For Homebrew the `vendorVersion` is `"Homebrew"` and not `"11.X.Y"`, so the `java.version` should always be reported. Now the log line looks as follows:
```
Running on Mac OS X 12.6.4 - OpenJDK 64-Bit Server VM 11.0.18 (Homebrew)
```
while before:
```
Running on Mac OS X 12.6.4 - OpenJDK 64-Bit Server VM Homebrew
```
the java version was not reported.

## Additional Notes
This may just be case for Homebrew and not for other JDKs. However, now the vendor version is reported last in parenthesis.

## Checklist
- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
