### PR TITLE
ensure banner is flushed

### DIFF
--- a/package/src/main/scripts/server.sh
+++ b/package/src/main/scripts/server.sh
@@ -22,7 +22,7 @@ echo "███████║██████╔╝██║     ████
 echo "██╔══██║██╔══██╗██║     ██╔══██║██║  ██║██╔══╝  ██║  ██║██╔══██╗"
 echo "██║  ██║██║  ██║╚██████╗██║  ██║██████╔╝███████╗██████╔╝██████╔╝"
 echo "╚═╝  ╚═╝╚═╝  ╚═╝ ╚═════╝╚═╝  ╚═╝╚═════╝ ╚══════╝╚═════╝ ╚═════╝"
-echo "PLAY WITH DATA                                    arcadedb.com"
+echo "PLAY WITH DATA                                    arcadedb.com\n"
 
 # resolve links - $0 may be a softlink
 PRG="$0"


### PR DESCRIPTION
## What does this PR do?
This change adds a newline to the end of the last line of the banner in the server script.

## Motivation
Banner is not flushed when used from container in GitLab CI.

## Checklist
- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
