### PR TITLE
Ensure distance functions have only first letter in upper case

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/vector/distance/DistanceFunctionFactory.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/distance/DistanceFunctionFactory.java
@@ -37,23 +37,21 @@ public class DistanceFunctionFactory {
 
   static {
     registerImplementation("FloatCosine", DistanceFunctions.FLOAT_COSINE_DISTANCE);
-    registerImplementation("FloatInnerProduct", DistanceFunctions.FLOAT_INNER_PRODUCT);
+    registerImplementation("FloatInnerproduct", DistanceFunctions.FLOAT_INNER_PRODUCT);
     registerImplementation("FloatEuclidean", DistanceFunctions.FLOAT_EUCLIDEAN_DISTANCE);
     registerImplementation("FloatCanberra", DistanceFunctions.FLOAT_CANBERRA_DISTANCE);
-    registerImplementation("FloatBrayCurtis", DistanceFunctions.FLOAT_BRAY_CURTIS_DISTANCE);
+    registerImplementation("FloatBraycurtis", DistanceFunctions.FLOAT_BRAY_CURTIS_DISTANCE);
     registerImplementation("FloatCorrelation", DistanceFunctions.FLOAT_CORRELATION_DISTANCE);
     registerImplementation("FloatManhattan", DistanceFunctions.FLOAT_MANHATTAN_DISTANCE);
     registerImplementation("FloatChebyshev", new ChebyshevDistance.FloatChebyshevDistance());
     registerImplementation("DoubleCosine", DistanceFunctions.DOUBLE_COSINE_DISTANCE);
-    registerImplementation("DoubleInnerProduct", DistanceFunctions.DOUBLE_INNER_PRODUCT);
+    registerImplementation("DoubleInnerproduct", DistanceFunctions.DOUBLE_INNER_PRODUCT);
     registerImplementation("DoubleEuclidean", DistanceFunctions.DOUBLE_EUCLIDEAN_DISTANCE);
     registerImplementation("DoubleCanberra", DistanceFunctions.DOUBLE_CANBERRA_DISTANCE);
-    registerImplementation("DoubleBrayCurtis", DistanceFunctions.DOUBLE_BRAY_CURTIS_DISTANCE);
+    registerImplementation("DoubleBraycurtis", DistanceFunctions.DOUBLE_BRAY_CURTIS_DISTANCE);
     registerImplementation("DoubleCorrelation", DistanceFunctions.DOUBLE_CORRELATION_DISTANCE);
     registerImplementation("DoubleManhattan", DistanceFunctions.DOUBLE_MANHATTAN_DISTANCE);
     registerImplementation("DoubleChebyshev", new ChebyshevDistance.DoubleChebyshevDistance());
-    registerImplementation("FloatSparseVectorInnerProduct", DistanceFunctions.FLOAT_SPARSE_VECTOR_INNER_PRODUCT);
-    registerImplementation("DoubleSparseVectorInnerProduct", DistanceFunctions.DOUBLE_SPARSE_VECTOR_INNER_PRODUCT);
   }
 
   public static DistanceFunction getImplementationByName(final String name) {


### PR DESCRIPTION
## What does this PR do?
This PR fixes the problem of missing distance functions. This is achieved by making the the registered names of distance functions in the factory lower case except the first letter.

## Additional Notes
I removed the `Sparse Vector Inner Product` function(s) since they seem to be based on internal unsupported type (SparseVector<NumberType>) which AFAIK is not used in ArcadeDB

## Checklist
- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
