### PR TITLE
Added "Reset" button to Studio

### DIFF
--- a/server/src/main/resources/static/database.html
+++ b/server/src/main/resources/static/database.html
@@ -5,7 +5,7 @@
   </div>
 
   <div class="row">
-    <div class="col-9">
+    <div class="col-8">
       <div class="form-inline">
         <div class="form-group">
           <label>Connected as&nbsp;</label><label for="inputDatabase" id="user"></label>@
@@ -13,9 +13,10 @@
         </div>
       </div>
     </div>
-    <div class="col-3">
+    <div class="col-4">
       <button class="btn btn-pill" onclick="createDatabase()"><i class="fa fa-plus"></i> Create</button>
       <button class="btn btn-pill" onclick="dropDatabase()"><i class="fa fa-minus"></i> Drop</button>
+      <button class="btn btn-pill" onclick="resetDatabase()"><i class="fa fa-sync"></i> Reset</button>
       <button class="btn btn-pill" onclick="backupDatabase()"><i class="fa fa-archive"></i> Backup</button>
     </div>
   </div>

--- a/server/src/main/resources/static/js/studio-database.js
+++ b/server/src/main/resources/static/js/studio-database.js
@@ -153,6 +153,45 @@ function dropDatabase(){
   });
 }
 
+function resetDatabase(){
+  let database = escapeHtml( getCurrentDatabase() );
+  if( database == "" ){
+    globalNotify( "Error", "Database not selected", "danger");
+    return;
+  }
+
+  globalConfirm("Reset database", "Are you sure you want to reset the database '"+database+"' (All data will be deleted)?<br>WARNING: The operation cannot be undone.", "warning", function(){
+    jQuery.ajax({
+      type: "POST",
+      url: "/api/v1/server",
+      data: "{ 'command': 'drop database " + database + "' }",
+      beforeSend: function (xhr){
+        xhr.setRequestHeader('Authorization', globalCredentials);
+      }
+    })
+    .done(function(data){
+      jQuery.ajax({
+        type: "POST",
+        url: "/api/v1/server",
+        data: "{ 'command': 'create database " + database + "' }",
+        beforeSend: function (xhr){
+          xhr.setRequestHeader('Authorization', globalCredentials);
+        }
+      })
+      .done(function(data){
+        $("#inputDatabase").val(database);
+        updateDatabases();
+      })
+      .fail(function( jqXHR, textStatus, errorThrown ){
+        globalNotifyError( jqXHR.responseText );
+      });
+    })
+    .fail(function( jqXHR, textStatus, errorThrown ){
+      globalNotifyError( jqXHR.responseText );
+    });
+  });
+}
+
 function backupDatabase(){
   let database = getCurrentDatabase();
   if( database == "" ){


### PR DESCRIPTION
## What does this PR do?
This adds a "Reset" button to the "Database" tqb of the studio tool.

## Motivation
While testing, the need for quicky deleting all contents of a database arose.

## Additional Notes
The reset works by dropping an existing database an creating a new one with the same name.

## Checklist
- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
