### PR TITLE
Revert "build(deps): bump graalvm.version from 22.3.2 to 23.0.0"

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -38,7 +38,7 @@
         <gson.version>2.10.1</gson.version>
         <lz4-java.version>1.8.0</lz4-java.version>
         <lucene.version>8.11.2</lucene.version>
-        <graalvm.version>23.0.0</graalvm.version>
+        <graalvm.version>22.3.2</graalvm.version>
         <hnswlib.version>1.1.0</hnswlib.version>
     </properties>
 


### PR DESCRIPTION
Reverts ArcadeData/arcadedb#1151 because this version of GraalVM has been compiled with Java17 and doesn't work with ArcadeDB (still on Java11):

```
[ERROR]     class file has wrong version 61.0, should be 55.0
```