### PR TITLE
adds global configuration key to register gremlin traversal sources

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -214,6 +214,10 @@ public enum GlobalConfiguration {
       "Gremlin engine to use. By default the `auto` setting uses the legacy `groovy` engine in case parameters are set, otherwise, the new native `java` is preferred. If you have compatibility issues with gremlin statements that use lambdas or in general, switch to the `groovy` one",
       String.class, "auto", Set.of("auto", "groovy", "java")),
 
+  GREMLIN_TRAVERSAL_BINDINGS("arcadedb.gremlin.traversalbindings", SCOPE.DATABASE,
+      "Additional Gremlin traversal sources to bind into the `GremlinScriptEngine`, expected to be of the shape `Map<String, ArcadeTraversalBinder.TraversalSupplier>`.",
+      Map.class, Map.of()),
+
   /**
    * Not in use anymore after removing Gremlin Executor
    */

--- a/gremlin/pom.xml
+++ b/gremlin/pom.xml
@@ -100,6 +100,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.tinkerpop</groupId>
+            <artifactId>gremlin-annotations</artifactId>
+            <version>${gremlin.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <version>${junit.jupiter.version}</version>
@@ -120,6 +126,24 @@
             <!--                    </execution>-->
             <!--                </executions>-->
             <!--            </plugin>-->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+		<configuration>
+                  <annotationProcessorPaths>
+                    <annotationProcessorPath>
+		      <groupId>org.apache.tinkerpop</groupId>
+		      <artifactId>gremlin-annotations</artifactId>
+		      <version>${gremlin.version}</version>
+                    </annotationProcessorPath>
+                  </annotationProcessorPaths>
+                  <annotationProcessors>
+                    <annotationProcessor>org.apache.tinkerpop.gremlin.process.traversal.dsl.GremlinDslProcessor</annotationProcessor>
+                  </annotationProcessors>
+              </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
@@ -476,6 +476,5 @@ public class ArcadeGraph implements Graph, Closeable {
 
     serviceRegistry = new ArcadeServiceRegistry(this);
     serviceRegistry.registerService(new VectorNeighborsFactory(this));
-
   }
 }

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
@@ -460,15 +460,22 @@ public class ArcadeGraph implements Graph, Closeable {
     importPlugin.classImports(Math.class, CustomFunctions.class, CustomPredicate.class);
     importPlugin.methodImports(List.of("java.lang.Math#*", "org.opencypher.gremlin.traversal.CustomFunctions#*"));
 
+    final ArcadeTraversalBinder traversalBinder = new ArcadeTraversalBinder(this);
+
     // INITIALIZE JAVA ENGINE
     gremlinJavaEngine = new GremlinLangScriptEngine(importPlugin.create().getCustomizers().get());
     gremlinJavaEngine.getFactory().setCustomizerManager(new DefaultGremlinScriptEngineManager());
+    gremlinJavaEngine.put("g", traversal());
+    traversalBinder.bind(gremlinJavaEngine);
 
     // INITIALIZE GROOVY ENGINE
     gremlinGroovyEngine = new GremlinGroovyScriptEngine(importPlugin.create().getCustomizers().get());
     gremlinGroovyEngine.getFactory().setCustomizerManager(new DefaultGremlinScriptEngineManager());
+    gremlinGroovyEngine.put("g", traversal());
+    traversalBinder.bind(gremlinGroovyEngine);
 
     serviceRegistry = new ArcadeServiceRegistry(this);
     serviceRegistry.registerService(new VectorNeighborsFactory(this));
+
   }
 }

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGremlin.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGremlin.java
@@ -38,11 +38,12 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.DefaultGraphTrav
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.Mutating;
 
-import javax.script.ScriptException;
-import javax.script.SimpleBindings;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.logging.*;
+import javax.script.ScriptContext;
+import javax.script.ScriptException;
+import javax.script.SimpleBindings;
 
 /**
  * Gremlin Expression builder.
@@ -207,7 +208,8 @@ public class ArcadeGremlin extends ArcadeQuery {
       final GremlinLangScriptEngine gremlinEngineImpl = graph.getGremlinJavaEngine();
 
       final SimpleBindings bindings = new SimpleBindings();
-      bindings.put("g", graph.traversal());
+      bindings.putAll(gremlinEngineImpl.getBindings(ScriptContext.ENGINE_SCOPE));
+
       if (parameters != null)
         bindings.putAll(parameters);
       result = gremlinEngineImpl.eval(query, bindings);
@@ -217,7 +219,8 @@ public class ArcadeGremlin extends ArcadeQuery {
       final GremlinGroovyScriptEngine gremlinEngineImpl = graph.getGremlinGroovyEngine();
 
       final SimpleBindings bindings = new SimpleBindings();
-      bindings.put("g", graph.traversal());
+      bindings.putAll(gremlinEngineImpl.getBindings(ScriptContext.ENGINE_SCOPE));
+
       if (parameters != null)
         bindings.putAll(parameters);
       result = gremlinEngineImpl.eval(query, bindings);

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeTraversalBinder.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeTraversalBinder.java
@@ -7,20 +7,59 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 
 import java.util.Map;
 
-public class ArcadeTraversalBinder {
+/**
+ * Binds a tinkerpop `TraversalSource` to a named script binding. See the following tinkerpop
+ * documentation for more information:
+ *
+ * https://tinkerpop.apache.org/docs/current/reference/#gremlin-java-dsl
+ * https://tinkerpop.apache.org/docs/current/reference/#traversalstrategy
+ */
+public final class ArcadeTraversalBinder {
+
+  /**
+   * Thrown in `ArcadeTraversalBinder` constructor if the `GREMLIN_TRAVERSAL_BINDINGS` configuration
+   * contains invalid map entries.
+   *
+   * The `GlobalConfiguration.GREMLIN_TRAVERSAL_BINDINGS` is typed a a raw `Map` type in order to a
+   * avoid circular dependencies on the arcadedb gremlin packages. Instead of declaring types,
+   * validates the entries of the map at runtime as early as possible.
+   */
+  static final class IllegalTraversalBindingsEntry extends IllegalArgumentException {
+    private IllegalTraversalBindingsEntry(String message) {
+      super(message);
+    }
+  }
 
   private final Map<String, TraversalSupplier> traversalBindings;
   private final Graph graph;
 
+  /**
+   * A lambda builder interface which accepts a `Graph` object and returns a `TraversalSource`,
+   * meant for use in binding a named entry point in the `GremlinScriptEngine`.
+   */
   @FunctionalInterface
   public interface TraversalSupplier {
+
+    /**
+     * Convenience function for creating a travesal supplier for a particular traversal source
+     * class. More custom requirements to configure a `TraversalSource` with extensive additions
+     * should instead implement the lambda `TraversalSupplier` interface.
+     */
+    public static <T extends TraversalSource> TraversalSupplier of(Class<T> klass) {
+      return graph -> graph.traversal(klass);
+    }
+
     TraversalSource get(Graph g);
   }
 
+  /**
+   * @throws IllegalTraversalBindingsEntry
+   */
   ArcadeTraversalBinder(ArcadeGraph arcadeGraph) {
     graph = arcadeGraph;
     traversalBindings = arcadeGraph.getDatabase().getConfiguration()
         .getValue(GlobalConfiguration.GREMLIN_TRAVERSAL_BINDINGS);
+    validateTraversalBindings(traversalBindings);
   }
 
   void bind(GremlinScriptEngine engine) {
@@ -28,6 +67,19 @@ public class ArcadeTraversalBinder {
           var bindingName = e.getKey();
           var supplier = e.getValue();
           engine.put(bindingName, supplier.get(graph));
+        });
+  }
+
+  private static void validateTraversalBindings(Map<String, TraversalSupplier> bindings) {
+    bindings.entrySet().forEach(entry -> {
+          try {
+            String key = String.class.cast(entry.getKey());
+            TraversalSupplier supplier = TraversalSupplier.class.cast(entry.getValue());
+          } catch (ClassCastException e) {
+            throw new IllegalTraversalBindingsEntry(
+                "illegal Map<String, TraversalSupplier> entry in GREMLIN_TRAVERSAL_BINDINGS "
+                + "configuration: %s".formatted(e));
+          }
         });
   }
 }

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeTraversalBinder.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeTraversalBinder.java
@@ -16,6 +16,9 @@ import java.util.Map;
  */
 public final class ArcadeTraversalBinder {
 
+  private final Map<String, TraversalSupplier> traversalBindings;
+  private final Graph graph;
+
   /**
    * Thrown in `ArcadeTraversalBinder` constructor if the `GREMLIN_TRAVERSAL_BINDINGS` configuration
    * contains invalid map entries.
@@ -29,9 +32,6 @@ public final class ArcadeTraversalBinder {
       super(message);
     }
   }
-
-  private final Map<String, TraversalSupplier> traversalBindings;
-  private final Graph graph;
 
   /**
    * A lambda builder interface which accepts a `Graph` object and returns a `TraversalSource`,

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeTraversalBinder.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeTraversalBinder.java
@@ -41,7 +41,7 @@ public final class ArcadeTraversalBinder {
   public interface TraversalSupplier {
 
     /**
-     * Convenience function for creating a travesal supplier for a particular traversal source
+     * Convenience function for creating a traversal supplier for a particular traversal source
      * class. More custom requirements to configure a `TraversalSource` with extensive additions
      * should instead implement the lambda `TraversalSupplier` interface.
      */
@@ -73,12 +73,12 @@ public final class ArcadeTraversalBinder {
   private static void validateTraversalBindings(Map<String, TraversalSupplier> bindings) {
     bindings.entrySet().forEach(entry -> {
           try {
-            String key = String.class.cast(entry.getKey());
-            TraversalSupplier supplier = TraversalSupplier.class.cast(entry.getValue());
+            String unusedBindingName = String.class.cast(entry.getKey());
+            TraversalSupplier unusedSupplier = TraversalSupplier.class.cast(entry.getValue());
           } catch (ClassCastException e) {
             throw new IllegalTraversalBindingsEntry(
                 "illegal Map<String, TraversalSupplier> entry in GREMLIN_TRAVERSAL_BINDINGS "
-                + "configuration: %s".formatted(e));
+                + "configuration: %s".formatted(entry));
           }
         });
   }

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeTraversalBinder.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeTraversalBinder.java
@@ -1,0 +1,34 @@
+package com.arcadedb.gremlin;
+
+import com.arcadedb.GlobalConfiguration;
+import org.apache.tinkerpop.gremlin.jsr223.GremlinScriptEngine;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+
+import java.util.Map;
+import java.util.function.Function;
+
+public class ArcadeTraversalBinder {
+
+  @FunctionalInterface
+  public interface TraversalSupplier {
+    TraversalSource get(Graph g);
+  }
+
+  private final Map<String, TraversalSupplier> traversalBindings;
+  private final Graph graph;
+
+  ArcadeTraversalBinder(ArcadeGraph arcadeGraph) {
+    graph = arcadeGraph;
+    traversalBindings = arcadeGraph.getDatabase().getConfiguration()
+        .getValue(GlobalConfiguration.GREMLIN_TRAVERSAL_BINDINGS);
+  }
+
+  void bind(GremlinScriptEngine engine) {
+    traversalBindings.entrySet().forEach(e -> {
+          var bindingName = e.getKey();
+          var supplier = e.getValue();
+          engine.put(bindingName, supplier.get(graph));
+        });
+  }
+}

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeTraversalBinder.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeTraversalBinder.java
@@ -73,8 +73,8 @@ public final class ArcadeTraversalBinder {
   private static void validateTraversalBindings(Map<String, TraversalSupplier> bindings) {
     bindings.entrySet().forEach(entry -> {
           try {
-            String unusedBindingName = String.class.cast(entry.getKey());
-            TraversalSupplier unusedSupplier = TraversalSupplier.class.cast(entry.getValue());
+            String.class.cast(entry.getKey());
+            TraversalSupplier.class.cast(entry.getValue());
           } catch (ClassCastException e) {
             throw new IllegalTraversalBindingsEntry(
                 "illegal Map<String, TraversalSupplier> entry in GREMLIN_TRAVERSAL_BINDINGS "

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeTraversalBinder.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeTraversalBinder.java
@@ -6,17 +6,16 @@ import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 
 import java.util.Map;
-import java.util.function.Function;
 
 public class ArcadeTraversalBinder {
+
+  private final Map<String, TraversalSupplier> traversalBindings;
+  private final Graph graph;
 
   @FunctionalInterface
   public interface TraversalSupplier {
     TraversalSource get(Graph g);
   }
-
-  private final Map<String, TraversalSupplier> traversalBindings;
-  private final Graph graph;
 
   ArcadeTraversalBinder(ArcadeGraph arcadeGraph) {
     graph = arcadeGraph;

--- a/gremlin/src/test/java/com/arcadedb/gremlin/GremlinTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/GremlinTest.java
@@ -484,7 +484,7 @@ public class GremlinTest {
       final Vertex bob = graph.addVertex(T.label, "Person", "name", "Bob");
       alice.addEdge("FriendOf", bob);
 
-      ResultSet resultSet = graph.gremlin("friends.V().named('Alice').friend('Bob')").execute();
+      ResultSet resultSet = graph.gremlin("friends.V().person('Alice').friendOf('Bob')").execute();
       Result result = resultSet.nextIfAvailable();
       Assertions.assertEquals(result.getProperty("name"), "Bob");
 

--- a/gremlin/src/test/java/com/arcadedb/gremlin/GremlinTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/GremlinTest.java
@@ -503,7 +503,7 @@ public class GremlinTest {
     invalidBindingMaps.forEach(map -> {
           GlobalConfiguration.GREMLIN_TRAVERSAL_BINDINGS.setValue(map);
           Assertions.assertThrows(ArcadeTraversalBinder.IllegalTraversalBindingsEntry.class,
-              () -> ArcadeGraph.open("./target/testTraversalBindings"));
+              () -> ArcadeGraph.open("./target/testInvalidTraversalBindings"));
         });
   }
 

--- a/gremlin/src/test/java/com/arcadedb/gremlin/SocialTraversalDsl.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/SocialTraversalDsl.java
@@ -1,0 +1,22 @@
+package com.arcadedb.gremlin;
+
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.GremlinDsl;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+
+/**
+ * See tinkerpop documentation:
+ *
+ * https://tinkerpop.apache.org/docs/current/reference/#gremlin-java-dsl
+ */
+@GremlinDsl
+public interface SocialTraversalDsl<S, E> extends GraphTraversal.Admin<S, E> {
+
+  public default GraphTraversal<S, Vertex> named(String name) {
+    return V().hasLabel("Person").has("name", name);
+  }
+
+  public default GraphTraversal<S, Vertex> friend(String name) {
+    return out("FriendOf").hasLabel("Person").has("name", name);
+  }
+}

--- a/gremlin/src/test/java/com/arcadedb/gremlin/SocialTraversalDsl.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/SocialTraversalDsl.java
@@ -12,11 +12,11 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 @GremlinDsl
 public interface SocialTraversalDsl<S, E> extends GraphTraversal.Admin<S, E> {
 
-  public default GraphTraversal<S, Vertex> named(String name) {
+  public default GraphTraversal<S, Vertex> person(String name) {
     return V().hasLabel("Person").has("name", name);
   }
 
-  public default GraphTraversal<S, Vertex> friend(String name) {
+  public default GraphTraversal<S, Vertex> friendOf(String name) {
     return out("FriendOf").hasLabel("Person").has("name", name);
   }
 }


### PR DESCRIPTION
Allows customizing the gremlin script engines traversal sources. This allows clients of the database to register tinkerpop traversal DSLs or customize the traversal strategies.

## Motivation
Using tinkerpop DSLs and customizing traversal strategies.

## Related issues
A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

## Additional Notes
Anything else we should know when reviewing?

## Checklist
- [x] I have run the build using `mvn clean package` command (some tests seem flaky, but unrelated)
- [x ] My unit tests cover both failure and success scenarios
