### PR TITLE
Provide default values for the time fields of a date.

### DIFF
--- a/engine/src/main/java/com/arcadedb/utility/DateUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/DateUtils.java
@@ -342,7 +342,11 @@ public class DateUtils {
   }
 
   public static DateTimeFormatter getFormatter(final String format) {
-    return CACHED_FORMATTERS.computeIfAbsent(format, (f) -> DateTimeFormatter.ofPattern(f));
+    return CACHED_FORMATTERS.computeIfAbsent(format, (f) -> new DateTimeFormatterBuilder().appendPattern(f)
+                                                                .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+                                                                .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+                                                                .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
+                                                                .toFormatter());
   }
 
   public static Object getDate(final Object date, final Class impl) {


### PR DESCRIPTION
Adding defaults allows parsing a string without time information to a date + time object.

## What does this PR do?
Use the ```date()``` function with just a date, i.e. without time fields: ```SELECT date('2012-07-02')```.

## Motivation
Specifying a date without time fields raised an exception.

## Related issues
This patch fixes #1232 .

## Additional Notes
Still working on test cases, sorry.

## Checklist
- [x] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
