### PR TITLE
Add SQL Method "Capitalize"

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/method/DefaultSQLMethodFactory.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/DefaultSQLMethodFactory.java
@@ -66,6 +66,7 @@ import com.arcadedb.query.sql.method.misc.SQLMethodType;
 
 // String
 import com.arcadedb.query.sql.method.string.SQLMethodAppend;
+import com.arcadedb.query.sql.method.string.SQLMethodCapitalize;
 import com.arcadedb.query.sql.method.string.SQLMethodCharAt;
 import com.arcadedb.query.sql.method.string.SQLMethodFormat;
 import com.arcadedb.query.sql.method.string.SQLMethodIndexOf;
@@ -137,6 +138,7 @@ public class DefaultSQLMethodFactory implements SQLMethodFactory {
 
     // String
     register(SQLMethodAppend.NAME, new SQLMethodAppend());
+    register(SQLMethodCapitalize.NAME, new SQLMethodCapitalize());
     register(SQLMethodCharAt.NAME, new SQLMethodCharAt());
     register(SQLMethodFormat.NAME, new SQLMethodFormat());
     register(SQLMethodIndexOf.NAME, new SQLMethodIndexOf());

--- a/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodCapitalize.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodCapitalize.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.method.string;
+
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.method.AbstractSQLMethod;
+
+import java.util.*;
+import java.util.regex.Pattern;
+
+/**
+ * @author Christian Himpe (gramian)
+ * @author Luca Garulli (l.garulli--(at)--gmail.com)
+ */
+public class SQLMethodCapitalize extends AbstractSQLMethod {
+
+  public static final String NAME = "capitalize";
+
+  public SQLMethodCapitalize() {
+    super(NAME);
+  }
+
+  @Override
+  public Object execute(final Object iThis, final Identifiable iCurrentRecord, final CommandContext iContext, final Object ioResult, final Object[] iParams) {
+    return ioResult != null ? Pattern.compile("\\b(.)(.*?)\\b")
+                                     .matcher(ioResult.toString())
+                                     .replaceAll(match -> match.group(1).toUpperCase(Locale.ENGLISH) +
+                                                          match.group(2).toLowerCase())
+                            : null;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodToLowerCase.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodToLowerCase.java
@@ -35,8 +35,7 @@ public class SQLMethodToLowerCase extends AbstractSQLMethod {
   }
 
   @Override
-  public Object execute(final Object iThis, final Identifiable iCurrentRecord, final CommandContext iContext, Object ioResult, final Object[] iParams) {
-    ioResult = ioResult != null ? ioResult.toString().toLowerCase() : null;
-    return ioResult;
+  public Object execute(final Object iThis, final Identifiable iCurrentRecord, final CommandContext iContext, final Object ioResult, final Object[] iParams) {
+    return ioResult != null ? ioResult.toString().toLowerCase() : null;
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodToUpperCase.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodToUpperCase.java
@@ -37,8 +37,7 @@ public class SQLMethodToUpperCase extends AbstractSQLMethod {
   }
 
   @Override
-  public Object execute(final Object iThis, final Identifiable iCurrentRecord, final CommandContext iContext, Object ioResult, final Object[] iParams) {
-    ioResult = ioResult != null ? ioResult.toString().toUpperCase(Locale.ENGLISH) : null;
-    return ioResult;
+  public Object execute(final Object iThis, final Identifiable iCurrentRecord, final CommandContext iContext, final Object ioResult, final Object[] iParams) {
+    return ioResult != null ? ioResult.toString().toUpperCase(Locale.ENGLISH) : null;
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodTrim.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodTrim.java
@@ -35,8 +35,7 @@ public class SQLMethodTrim extends AbstractSQLMethod {
   }
 
   @Override
-  public Object execute(final Object iThis, final Identifiable iCurrentRecord, final CommandContext iContext, Object ioResult, final Object[] iParams) {
-    ioResult = ioResult != null ? ioResult.toString().trim() : null;
-    return ioResult;
+  public Object execute(final Object iThis, final Identifiable iCurrentRecord, final CommandContext iContext, final Object ioResult, final Object[] iParams) {
+    return ioResult != null ? ioResult.toString().trim() : null;
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/method/string/SQLMethodCapitalizeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/string/SQLMethodCapitalizeTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.method.string;
+
+import com.arcadedb.query.sql.executor.SQLMethod;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SQLMethodCapitalizeTest {
+
+    private SQLMethod method;
+
+    @BeforeEach
+    void setUp() {
+        method = new SQLMethodCapitalize();
+    }
+
+    @Test
+    void testNullReturnedAsNull() {
+        final Object result = method.execute(null, null, null, null, null);
+        assertThat(result).isNull();
+    }
+
+
+    @Test
+    void testCapitalizeEmpty() {
+        final Object result = method.execute(null, null, null, "", null);
+        assertThat(result).isEqualTo("");
+
+    }
+
+    @Test
+    void testCapitalizeIdentity() {
+        final Object result = method.execute(null, null, null, "Capitalize This", null);
+        assertThat(result).isEqualTo("Capitalize This");
+
+    }
+
+    @Test
+    void testCapitalizeLower() {
+        final Object result = method.execute(null, null, null, "CAPITALIZE THIS", null);
+        assertThat(result).isEqualTo("Capitalize This");
+
+    }
+
+    @Test
+    void testCapitalizeUpper() {
+        final Object result = method.execute(null, null, null, "capitalize this", null);
+        assertThat(result).isEqualTo("Capitalize This");
+
+    }
+
+    @Test
+    void testCapitalizeSingle() {
+        final Object result = method.execute(null, null, null, "c t", null);
+        assertThat(result).isEqualTo("C T");
+
+    }
+
+    @Test
+    void testCapitalizeNumbers() {
+        final Object result = method.execute(null, null, null, "111 222", null);
+        assertThat(result).isEqualTo("111 222");
+
+    }
+}


### PR DESCRIPTION
## What does this PR do?
This PR add a SQL methods for strings `capitalize` which transforms an argument string such that each word's first character is upper-cased and the remaining characters lower-cased.

## Motivation
This function can be useful for situations where lowercase variants of words or phrases are stored in the database  to save a `toLowerCase` for every comparison against those; and allow to still display these ie in labels or select boxes in a front-end.

## Related issues
/

## Additional Notes
Additionally, I changes the string methods `toLowerCase`, `toUpperCase`, and `Trim` such that the class method's argument is `final`.

I will update the docs soon after the PR is accepted.

## Checklist
- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios (no failure scenario yet)
