### PR TITLE
Add english locale to case conversions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: check-json
       - id: check-xml
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.3
+    rev: v3.0.0-alpha.4
     hooks:
       - id: prettier
         types: [ java ]

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -228,7 +228,7 @@ public class Console {
       if (lineTrimmed.isEmpty() || lineTrimmed.startsWith("--"))
         return true;
 
-      final String lineLowerCase = lineTrimmed.toLowerCase();
+      final String lineLowerCase = lineTrimmed.toLowerCase(Locale.ENGLISH);
 
       if (lineLowerCase.equals("quit") || lineLowerCase.equals("exit")) {
         executeClose();
@@ -411,7 +411,7 @@ public class Console {
 
       ComponentFile.MODE mode = ComponentFile.MODE.READ_WRITE;
       if (urlParts.length > 1)
-        mode = ComponentFile.MODE.valueOf(urlParts[1].toUpperCase());
+        mode = ComponentFile.MODE.valueOf(urlParts[1].toUpperCase(Locale.ENGLISH));
 
       databaseFactory = new DatabaseFactory(localUrl);
       databaseProxy = databaseFactory.setAutoTransaction(true).open(mode);
@@ -451,7 +451,7 @@ public class Console {
   private void executeCreateUser(final String params) {
     checkRemoteDatabaseIsConnected();
 
-    final String paramsUpperCase = params.toUpperCase();
+    final String paramsUpperCase = params.toUpperCase(Locale.ENGLISH);
 
     final int identifiedByPos = paramsUpperCase.indexOf("IDENTIFIED BY");
     if (identifiedByPos < 0)
@@ -808,7 +808,7 @@ public class Console {
 
       final Result result = typeResult.next();
 
-      outputLine(0, result.getProperty("type").toString().toUpperCase() + " TYPE '" + typeName + "'\n");
+      outputLine(0, result.getProperty("type").toString().toUpperCase(Locale.ENGLISH) + " TYPE '" + typeName + "'\n");
       outputLine(0, "Super types.......: " + result.getProperty("parentTypes"));
       outputLine(0, "Buckets...........: " + result.getProperty("buckets"));
       outputLine(0, "Bucket selection..: " + result.getProperty("bucketSelectionStrategy"));

--- a/engine/src/main/java/com/arcadedb/ContextConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/ContextConfiguration.java
@@ -133,7 +133,7 @@ public class ContextConfiguration implements Serializable {
     if (enumType.isAssignableFrom(value.getClass())) {
       return enumType.cast(value);
     } else if (value instanceof String) {
-      final String presentation = value.toString().toUpperCase();
+      final String presentation = value.toString().toUpperCase(Locale.ENGLISH);
       return Enum.valueOf(enumType, presentation);
     } else {
       throw new ClassCastException("Value " + value + " can not be cast to enumeration " + enumType.getSimpleName());

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -360,7 +360,7 @@ public enum GlobalConfiguration {
 
   HA_CLUSTER_NAME("arcadedb.ha.clusterName", SCOPE.SERVER,
       "Cluster name. By default is 'arcadedb'. Useful in case of multiple clusters in the same network", String.class,
-      Constants.PRODUCT.toLowerCase()),
+      Constants.PRODUCT.toLowerCase(Locale.ENGLISH)),
 
   HA_SERVER_LIST("arcadedb.ha.serverList", SCOPE.SERVER,
       "Servers in the cluster as a list of <hostname/ip-address:port> items separated by comma. Example: localhost:2424,192.168.0.1:2424",
@@ -695,7 +695,7 @@ public enum GlobalConfiguration {
         }
 
       if (allowed != null && value != null)
-        if (!allowed.contains(value.toString().toLowerCase()))
+        if (!allowed.contains(value.toString().toLowerCase(Locale.ENGLISH)))
           throw new IllegalArgumentException(
               "Global setting '" + key + "=" + value + "' is not valid. Allowed values are " + allowed);
 

--- a/engine/src/main/java/com/arcadedb/index/vector/distance/DistanceFunctionFactory.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/distance/DistanceFunctionFactory.java
@@ -55,7 +55,7 @@ public class DistanceFunctionFactory {
   }
 
   public static DistanceFunction getImplementationByName(final String name) {
-    return implementationsByName.get(name.toLowerCase());
+    return implementationsByName.get(name.toLowerCase(Locale.ENGLISH));
   }
 
   public static DistanceFunction getImplementationByClassName(final String name) {
@@ -63,7 +63,7 @@ public class DistanceFunctionFactory {
   }
 
   public static void registerImplementation(final String name, final DistanceFunction impl) {
-    implementationsByName.put(name.toLowerCase(), impl);
+    implementationsByName.put(name.toLowerCase(Locale.ENGLISH), impl);
     implementationsByClassName.put(impl.getClass().getSimpleName(), impl);
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/QueryEngineManager.java
+++ b/engine/src/main/java/com/arcadedb/query/QueryEngineManager.java
@@ -56,11 +56,11 @@ public class QueryEngineManager {
   }
 
   public void register(final QueryEngine.QueryEngineFactory impl) {
-    implementations.put(impl.getLanguage().toLowerCase(), impl);
+    implementations.put(impl.getLanguage().toLowerCase(Locale.ENGLISH), impl);
   }
 
   public QueryEngine getInstance(final String language, final DatabaseInternal database) {
-    final QueryEngine.QueryEngineFactory impl = implementations.get(language.toLowerCase());
+    final QueryEngine.QueryEngineFactory impl = implementations.get(language.toLowerCase(Locale.ENGLISH));
     if (impl == null)
       throw new IllegalArgumentException("Query engine '" + language + "' was not found. Check your configuration");
     return impl.getInstance(database);

--- a/engine/src/main/java/com/arcadedb/query/select/SelectOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectOperator.java
@@ -105,7 +105,7 @@ public enum SelectOperator {
   ilike("ilike", false, 1) {
     @Override
     Object eval(final Document record, final Object left, final Object right) {
-      return QueryHelper.like(((String) SelectExecutor.evaluateValue(record, left)).toLowerCase(),
+      return QueryHelper.like(((String) SelectExecutor.evaluateValue(record, left)).toLowerCase(Locale.ENGLISH),
           ((String) SelectExecutor.evaluateValue(record, right)).toLowerCase());
     }
   },

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CastToStepAbstract.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CastToStepAbstract.java
@@ -22,6 +22,8 @@ import com.arcadedb.database.Document;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.TimeoutException;
 
+import java.util.*;
+
 /**
  * Created by luigidellaquila on 20/02/17.
  */
@@ -82,7 +84,7 @@ public abstract class CastToStepAbstract extends AbstractExecutionStep {
 
   @Override
   public String prettyPrint(final int depth, final int indent) {
-    String result = ExecutionStepInternal.getIndent(depth, indent) + "+ CAST TO " + clsName.toUpperCase();
+    String result = ExecutionStepInternal.getIndent(depth, indent) + "+ CAST TO " + clsName.toUpperCase(Locale.ENGLISH);
     if (profilingEnabled) {
       result += " (" + getCostFormatted() + ")";
     }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromSchemaDatabaseStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromSchemaDatabaseStep.java
@@ -110,7 +110,7 @@ public class FetchFromSchemaDatabaseStep extends AbstractExecutionStep {
   }
 
   private Object convertValue(final String key, Object value) {
-    if (key.toLowerCase().contains("password"))
+    if (key.toLowerCase(Locale.ENGLISH).contains("password"))
       // MASK SENSITIVE DATA
       value = "*****";
 

--- a/engine/src/main/java/com/arcadedb/query/sql/method/DefaultSQLMethodFactory.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/DefaultSQLMethodFactory.java
@@ -162,7 +162,7 @@ public class DefaultSQLMethodFactory implements SQLMethodFactory {
 
   @Override
   public SQLMethod createMethod(final String name) throws CommandExecutionException {
-    final Object m = methods.get(name.toLowerCase());
+    final Object m = methods.get(name.toLowerCase(Locale.ENGLISH));
     final SQLMethod method;
 
     if (m instanceof Class<?>)

--- a/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodCapitalize.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodCapitalize.java
@@ -42,7 +42,7 @@ public class SQLMethodCapitalize extends AbstractSQLMethod {
     return ioResult != null ? Pattern.compile("\\b(.)(.*?)\\b")
                                      .matcher(ioResult.toString())
                                      .replaceAll(match -> match.group(1).toUpperCase(Locale.ENGLISH) +
-                                                          match.group(2).toLowerCase())
+                                                          match.group(2).toLowerCase(Locale.ENGLISH))
                             : null;
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodToLowerCase.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodToLowerCase.java
@@ -22,6 +22,8 @@ import com.arcadedb.database.Identifiable;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.method.AbstractSQLMethod;
 
+import java.util.*;
+
 /**
  * @author Johann Sorel (Geomatys)
  * @author Luca Garulli (l.garulli--(at)--gmail.com)
@@ -36,6 +38,6 @@ public class SQLMethodToLowerCase extends AbstractSQLMethod {
 
   @Override
   public Object execute(final Object iThis, final Identifiable iCurrentRecord, final CommandContext iContext, final Object ioResult, final Object[] iParams) {
-    return ioResult != null ? ioResult.toString().toLowerCase() : null;
+    return ioResult != null ? ioResult.toString().toLowerCase(Locale.ENGLISH) : null;
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/AlterPropertyStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/AlterPropertyStatement.java
@@ -71,7 +71,7 @@ public class AlterPropertyStatement extends DDLStatement {
       result.setProperty("oldValue", oldValue);
       result.setProperty("newValue", finalValue);
     } else if (settingName != null) {
-      final String setting = settingName.getStringValue().toLowerCase();
+      final String setting = settingName.getStringValue().toLowerCase(Locale.ENGLISH);
       final Object finalValue = settingValue.execute((Identifiable) null, context);
 
       final Object oldValue;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/AlterTypeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/AlterTypeStatement.java
@@ -109,7 +109,7 @@ public class AlterTypeStatement extends DDLStatement {
     final ResultInternal result = new ResultInternal();
 
     if (property != null) {
-      switch (property.toLowerCase()) {
+      switch (property.toLowerCase(Locale.ENGLISH)) {
       case "bucket":
         for (int i = 0; i < identifierListValue.size(); i++) {
           final Identifier identifierValue = identifierListValue.get(i);

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BeginStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BeginStatement.java
@@ -38,7 +38,7 @@ public class BeginStatement extends SimpleExecStatement {
   @Override
   public ResultSet executeSimple(final CommandContext context) {
     if (isolation != null)
-      context.getDatabase().begin(Database.TRANSACTION_ISOLATION_LEVEL.valueOf(isolation.getStringValue().toUpperCase()));
+      context.getDatabase().begin(Database.TRANSACTION_ISOLATION_LEVEL.valueOf(isolation.getStringValue().toUpperCase(Locale.ENGLISH)));
     else
       // USE THE STANDARD ISOLATION LEVEL
       context.getDatabase().begin();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ILikeOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ILikeOperator.java
@@ -24,6 +24,8 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.executor.QueryHelper;
 
+import java.util.*;
+
 public class ILikeOperator extends SimpleNode implements BinaryCompareOperator {
   public ILikeOperator(final int id) {
     super(id);
@@ -37,7 +39,7 @@ public class ILikeOperator extends SimpleNode implements BinaryCompareOperator {
     if (iLeft == null || iRight == null) {
       return false;
     }
-    return QueryHelper.like(iLeft.toString().toLowerCase(), iRight.toString().toLowerCase());
+    return QueryHelper.like(iLeft.toString().toLowerCase(Locale.ENGLISH), iRight.toString().toLowerCase(Locale.ENGLISH));
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MethodCall.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MethodCall.java
@@ -133,7 +133,7 @@ public class MethodCall extends SimpleNode {
   }
 
   public Object executeReverse(final Object targetObjects, final CommandContext context) {
-    final String straightName = methodName.getStringValue().toLowerCase();
+    final String straightName = methodName.getStringValue().toLowerCase(Locale.ENGLISH);
     final String inverseMethodName = bidirectionalMethods.get(straightName);
 
     if (inverseMethodName != null)

--- a/engine/src/main/java/com/arcadedb/schema/Property.java
+++ b/engine/src/main/java/com/arcadedb/schema/Property.java
@@ -140,7 +140,7 @@ public class Property {
     if (changed) {
       if (type == Type.LIST || type == Type.MAP) {
         if (Type.getTypeByName(ofType) != null) {
-          ofType = ofType.toUpperCase();
+          ofType = ofType.toUpperCase(Locale.ENGLISH);
         } else {
           if (!owner.schema.existsType(ofType))
             throw new SchemaException("Type '" + ofType + "' not defined");

--- a/engine/src/main/java/com/arcadedb/schema/Type.java
+++ b/engine/src/main/java/com/arcadedb/schema/Type.java
@@ -116,7 +116,7 @@ public enum Type {
   static {
     for (final Type type : values()) {
       TYPES_BY_ID[type.id] = type;
-      TYPES_BY_NAME.put(type.name.toLowerCase(), type);
+      TYPES_BY_NAME.put(type.name.toLowerCase(Locale.ENGLISH), type);
     }
 
     // This is made by hand because not all types should be add.
@@ -175,7 +175,7 @@ public enum Type {
 
   Type(final String iName, final int iId, final byte binaryType, final Class<?> iJavaDefaultType,
       final Class<?>[] iAllowAssignmentBy) {
-    this.name = iName.toUpperCase();
+    this.name = iName.toUpperCase(Locale.ENGLISH);
     this.id = iId;
     this.binaryType = binaryType;
     this.javaDefaultType = iJavaDefaultType;
@@ -280,7 +280,7 @@ public enum Type {
   }
 
   public static Type getTypeByName(final String name) {
-    return TYPES_BY_NAME.get(name.toLowerCase());
+    return TYPES_BY_NAME.get(name.toLowerCase(Locale.ENGLISH));
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/utility/AnsiCode.java
+++ b/engine/src/main/java/com/arcadedb/utility/AnsiCode.java
@@ -65,7 +65,7 @@ public enum AnsiCode {
       SUPPORTS_COLORS = true;
     else if ("auto".equalsIgnoreCase(ansiSupport)) {
       // AUTOMATIC CHECK
-      SUPPORTS_COLORS = System.console() != null && !System.getProperty("os.name").toLowerCase().contains("win");
+      SUPPORTS_COLORS = System.console() != null && !System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win");
     } else
       // DO NOT SUPPORT ANSI
       SUPPORTS_COLORS = false;

--- a/graphql/src/main/java/com/arcadedb/graphql/schema/GraphQLSchema.java
+++ b/graphql/src/main/java/com/arcadedb/graphql/schema/GraphQLSchema.java
@@ -185,7 +185,7 @@ public class GraphQLSchema {
 
   private GraphQLResultSet parseNativeQueryDirective(final String language, final Directive directive, final Selection selection, final ObjectTypeDefinition returnType) {
     if (directive.getArguments() == null)
-      throw new CommandParsingException(language.toUpperCase() + " directive has no `statement` argument");
+      throw new CommandParsingException(language.toUpperCase(Locale.ENGLISH) + " directive has no `statement` argument");
 
     String statement = null;
     Map<String, Object> arguments = null;

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeFilterByIndexStep.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeFilterByIndexStep.java
@@ -105,7 +105,7 @@ public class ArcadeFilterByIndexStep<S, E extends Element> extends AbstractStep<
   }
 
   public String toString() {
-    return StringFactory.stepString(this, this.returnClass.getSimpleName().toLowerCase(), indexCursors);
+    return StringFactory.stepString(this, this.returnClass.getSimpleName().toLowerCase(Locale.ENGLISH), indexCursors);
   }
 
   @Override

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeFilterByTypeStep.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeFilterByTypeStep.java
@@ -124,7 +124,7 @@ public class ArcadeFilterByTypeStep<S, E extends Element> extends AbstractStep<S
   }
 
   public String toString() {
-    return StringFactory.stepString(this, this.returnClass.getSimpleName().toLowerCase(), typeName);
+    return StringFactory.stepString(this, this.returnClass.getSimpleName().toLowerCase(Locale.ENGLISH), typeName);
   }
 
   @Override

--- a/integration/src/main/java/com/arcadedb/integration/backup/Backup.java
+++ b/integration/src/main/java/com/arcadedb/integration/backup/Backup.java
@@ -108,7 +108,7 @@ public class Backup {
   }
 
   protected AbstractBackupFormat createFormatImplementation() {
-    switch (settings.format.toLowerCase()) {
+    switch (settings.format.toLowerCase(Locale.ENGLISH)) {
     case "full":
       return new FullBackupFormat(database, settings, logger);
 

--- a/integration/src/main/java/com/arcadedb/integration/backup/BackupSettings.java
+++ b/integration/src/main/java/com/arcadedb/integration/backup/BackupSettings.java
@@ -63,7 +63,7 @@ public class BackupSettings {
   public int parseParameter(final String name, final String value) {
     if ("format".equals(name)) {
       if (value != null)
-        format = value.toLowerCase();
+        format = value.toLowerCase(Locale.ENGLISH);
     } else if ("dir".equals(name)) {
       if (value != null)
         directory = value.endsWith(File.separator) ? value : value + File.separator;

--- a/integration/src/main/java/com/arcadedb/integration/exporter/Exporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/exporter/Exporter.java
@@ -184,7 +184,7 @@ public class Exporter {
   }
 
   protected AbstractExporterFormat createFormatImplementation() {
-    switch (settings.format.toLowerCase()) {
+    switch (settings.format.toLowerCase(Locale.ENGLISH)) {
     case JsonlExporterFormat.NAME:
       return new JsonlExporterFormat(database, settings, context, logger);
 

--- a/integration/src/main/java/com/arcadedb/integration/exporter/ExporterSettings.java
+++ b/integration/src/main/java/com/arcadedb/integration/exporter/ExporterSettings.java
@@ -66,7 +66,7 @@ public class ExporterSettings {
     name = FileUtils.getStringContent(name);
 
     if ("format".equals(name))
-      format = value.toLowerCase();
+      format = value.toLowerCase(Locale.ENGLISH);
     else if ("f".equals(name) || "file".equals(name))
       file = value;
     else if ("d".equals(name))

--- a/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
@@ -623,7 +623,7 @@ public class Neo4jImporter {
         else if (state.equals("batchSize"))
           batchSize = Integer.parseInt(arg);
         else if (state.equals("decimalType"))
-          typeForDecimals = Type.valueOf(arg.toUpperCase());
+          typeForDecimals = Type.valueOf(arg.toUpperCase(Locale.ENGLISH));
       }
     }
   }

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/CSVImporterFormat.java
@@ -186,7 +186,7 @@ public class CSVImporterFormat extends AbstractImporterFormat {
 
     try {
       context.graphImporter = new GraphImporter((DatabaseInternal) database, (int) expectedVertices, (int) settings.expectedEdges,
-          Type.valueOf(settings.typeIdType.toUpperCase()));
+          Type.valueOf(settings.typeIdType.toUpperCase(Locale.ENGLISH)));
     } catch (ClassNotFoundException e) {
       throw new ImportException("Error on creating internal component", e);
     }
@@ -315,7 +315,7 @@ public class CSVImporterFormat extends AbstractImporterFormat {
 
     try {
       if (context.graphImporter == null)
-        context.graphImporter = new GraphImporter(database, (int) expectedVertices, (int) expectedEdges, Type.valueOf(settings.typeIdType.toUpperCase()));
+        context.graphImporter = new GraphImporter(database, (int) expectedVertices, (int) expectedEdges, Type.valueOf(settings.typeIdType.toUpperCase(Locale.ENGLISH)));
     } catch (ClassNotFoundException e) {
       throw new ImportException("Error on creating internal component", e);
     }

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JSONImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JSONImporterFormat.java
@@ -321,7 +321,7 @@ public class JSONImporterFormat implements FormatImporter {
 
         Type propType = Type.getTypeByValue(idValue);
         if (mapping.has("@idType"))
-          propType = Type.getTypeByName(mapping.getString("@idType").toUpperCase());
+          propType = Type.getTypeByName(mapping.getString("@idType").toUpperCase(Locale.ENGLISH));
 
         prop = type.createProperty(id, propType);
       }

--- a/integration/src/main/java/com/arcadedb/integration/importer/vector/TextEmbeddingsImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/vector/TextEmbeddingsImporter.java
@@ -80,13 +80,13 @@ public class TextEmbeddingsImporter {
 
     if (settings.options.containsKey("distanceFunction")) {
       this.distanceFunctionName = settings.options.get("distanceFunction");
-      this.distanceFunctionName = Character.toUpperCase(this.distanceFunctionName.charAt(0)) + this.distanceFunctionName.substring(1).toLowerCase();
+      this.distanceFunctionName = Character.toUpperCase(this.distanceFunctionName.charAt(0)) + this.distanceFunctionName.substring(1).toLowerCase(Locale.ENGLISH);
     }
 
     if (settings.options.containsKey("vectorType")) {
       this.vectorTypeName = settings.options.get("vectorType");
       // USE CAMEL CASE FOR THE VECTOR TYPE
-      this.vectorTypeName = Character.toUpperCase(this.vectorTypeName.charAt(0)) + this.vectorTypeName.substring(1).toLowerCase();
+      this.vectorTypeName = Character.toUpperCase(this.vectorTypeName.charAt(0)) + this.vectorTypeName.substring(1).toLowerCase(Locale.ENGLISH);
     }
 
     if (settings.options.containsKey("vectorProperty"))

--- a/integration/src/main/java/com/arcadedb/integration/restore/Restore.java
+++ b/integration/src/main/java/com/arcadedb/integration/restore/Restore.java
@@ -65,7 +65,7 @@ public class Restore {
   }
 
   protected AbstractRestoreFormat createFormatImplementation() {
-    switch (settings.format.toLowerCase()) {
+    switch (settings.format.toLowerCase(Locale.ENGLISH)) {
     case "full":
       return new FullRestoreFormat(database, settings, logger);
 

--- a/integration/src/main/java/com/arcadedb/integration/restore/RestoreSettings.java
+++ b/integration/src/main/java/com/arcadedb/integration/restore/RestoreSettings.java
@@ -40,7 +40,7 @@ public class RestoreSettings {
   public int parseParameter(final String name, final String value) {
     if ("format".equals(name)) {
       if (value != null)
-        format = value.toLowerCase();
+        format = value.toLowerCase(Locale.ENGLISH);
     } else if ("f".equals(name)) {
       if (value != null)
         inputFileURL = value;

--- a/network/src/main/java/com/arcadedb/remote/RemoteVertex.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteVertex.java
@@ -37,7 +37,7 @@ public class RemoteVertex {
   }
 
   public long countEdges(final Vertex.DIRECTION direction, final String edgeType) {
-    String query = "select " + direction.toString().toLowerCase() + "(";
+    String query = "select " + direction.toString().toLowerCase(Locale.ENGLISH) + "(";
     if (edgeType != null)
       query += "'" + edgeType + "'";
 
@@ -92,13 +92,13 @@ public class RemoteVertex {
 
   public boolean isConnectedTo(final Identifiable toVertex, final Vertex.DIRECTION direction) {
     final String query =
-        "select from ( select " + direction.toString().toLowerCase() + "() as vertices from " + vertex.getIdentity() + " ) where vertices contains " + toVertex;
+        "select from ( select " + direction.toString().toLowerCase(Locale.ENGLISH) + "() as vertices from " + vertex.getIdentity() + " ) where vertices contains " + toVertex;
     final ResultSet resultSet = remoteDatabase.query("sql", query);
     return resultSet.hasNext();
   }
 
   public boolean isConnectedTo(final Identifiable toVertex, final Vertex.DIRECTION direction, final String edgeType) {
-    final String query = "select from ( select " + direction.toString().toLowerCase() + "('" + edgeType + "') as vertices from " + vertex.getIdentity()
+    final String query = "select from ( select " + direction.toString().toLowerCase(Locale.ENGLISH) + "('" + edgeType + "') as vertices from " + vertex.getIdentity()
         + " ) where vertices contains " + toVertex;
     final ResultSet resultSet = remoteDatabase.query("sql", query);
     return resultSet.hasNext();
@@ -144,7 +144,7 @@ public class RemoteVertex {
   }
 
   private ResultSet fetch(final String suffix, final Vertex.DIRECTION direction, final String[] types) {
-    String query = "select expand( " + direction.toString().toLowerCase() + suffix + "(";
+    String query = "select expand( " + direction.toString().toLowerCase(Locale.ENGLISH) + suffix + "(";
     for (int i = 0; i < types.length; ++i) {
       if (i > 0)
         query += ",";

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -624,7 +624,7 @@ public class PostgresNetworkExecutor extends Thread {
         return;
       }
 
-      final String upperCaseText = portal.query.toUpperCase();
+      final String upperCaseText = portal.query.toUpperCase(Locale.ENGLISH);
 
       if (portal.query.isEmpty() ||//
           (ignoreQueriesAppNames.contains(connectionProperties.get("application_name")) &&//
@@ -1079,7 +1079,7 @@ public class PostgresNetworkExecutor extends Thread {
   }
 
   private void writeCommandComplete(final String queryText, final int resultSetCount) {
-    final String upperCaseText = queryText.toUpperCase();
+    final String upperCaseText = queryText.toUpperCase(Locale.ENGLISH);
     String tag = "";
     if (upperCaseText.startsWith("CREATE VERTEX") || upperCaseText.startsWith("INSERT INTO"))
       tag = "INSERT 0 " + resultSetCount;

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -108,7 +108,7 @@ public class RedisNetworkExecutor extends Thread {
       if (!(cmd instanceof String))
         LogManager.instance().log(this, Level.SEVERE, "Redis wrapper: Invalid command[0] %s (type=%s)", command, cmd.getClass());
 
-      final String cmdString = ((String) cmd).toUpperCase();
+      final String cmdString = ((String) cmd).toUpperCase(Locale.ENGLISH);
 
       try {
         switch (cmdString) {

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -523,7 +523,7 @@ public class ArcadeDBServer {
               LogManager.instance().log(this, Level.WARNING, "Error in startup command configuration format: '%s'", commands);
               break;
             }
-            final String commandType = command.substring(0, commandSeparator).toLowerCase();
+            final String commandType = command.substring(0, commandSeparator).toLowerCase(Locale.ENGLISH);
             final String commandParams = command.substring(commandSeparator + 1);
 
             switch (commandType) {

--- a/server/src/main/java/com/arcadedb/server/ha/HAServer.java
+++ b/server/src/main/java/com/arcadedb/server/ha/HAServer.java
@@ -139,7 +139,7 @@ public class HAServer implements ServerPlugin {
     this.bucketName = configuration.getValueAsString(GlobalConfiguration.HA_CLUSTER_NAME);
     this.startedOn = System.currentTimeMillis();
     this.replicationPath = server.getRootPath() + "/replication";
-    this.serverRole = SERVER_ROLE.valueOf(configuration.getValueAsString(GlobalConfiguration.HA_SERVER_ROLE).toUpperCase());
+    this.serverRole = SERVER_ROLE.valueOf(configuration.getValueAsString(GlobalConfiguration.HA_SERVER_ROLE).toUpperCase(Locale.ENGLISH));
   }
 
   @Override

--- a/server/src/main/java/com/arcadedb/server/ha/ReplicatedDatabase.java
+++ b/server/src/main/java/com/arcadedb/server/ha/ReplicatedDatabase.java
@@ -90,7 +90,7 @@ public class ReplicatedDatabase implements DatabaseInternal {
 
     this.server = server;
     this.proxied = proxied;
-    this.quorum = HAServer.QUORUM.valueOf(proxied.getConfiguration().getValueAsString(GlobalConfiguration.HA_QUORUM).toUpperCase());
+    this.quorum = HAServer.QUORUM.valueOf(proxied.getConfiguration().getValueAsString(GlobalConfiguration.HA_QUORUM).toUpperCase(Locale.ENGLISH));
     this.timeout = proxied.getConfiguration().getValueAsLong(GlobalConfiguration.HA_QUORUM_TIMEOUT);
     this.proxied.setWrappedDatabaseInstance(this);
   }

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetServerHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetServerHandler.java
@@ -219,7 +219,7 @@ public class GetServerHandler extends AbstractServerHttpHandler {
   }
 
   private Object convertValue(final String key, Object value) {
-    if (key.toLowerCase().contains("password"))
+    if (key.toLowerCase(Locale.ENGLISH).contains("password"))
       // MASK SENSITIVE DATA
       value = "*****";
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
@@ -71,7 +71,7 @@ public class PostCommandHandler extends AbstractQueryHandler {
 
     if (limit != -1) {
       if (language.equalsIgnoreCase("sql") || language.equalsIgnoreCase("sqlScript")) {
-        final String commandLC = command.toLowerCase().trim();
+        final String commandLC = command.toLowerCase(Locale.ENGLISH).trim();
         if ((commandLC.startsWith("select") || commandLC.startsWith("match")) && !commandLC.endsWith(";")) {
           if (!commandLC.contains(" limit ") && !commandLC.contains("\nlimit ")) {
             command += " limit " + limit;

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -80,7 +80,7 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
 
     final JSONObject response = createResult(user, null).put("result","ok");
 
-    final String command_lc = command.toLowerCase();
+    final String command_lc = command.toLowerCase(Locale.ENGLISH);
 
     if (command_lc.equals(LIST_DATABASES))
       return listDatabases(user);

--- a/server/src/main/java/com/arcadedb/server/http/ws/ChangeEvent.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/ChangeEvent.java
@@ -21,6 +21,8 @@ package com.arcadedb.server.http.ws;
 import com.arcadedb.database.Record;
 import com.arcadedb.serializer.json.JSONObject;
 
+import java.util.*;
+
 public class ChangeEvent {
   private final TYPE   type;
   private final Record record;
@@ -42,7 +44,7 @@ public class ChangeEvent {
 
   public String toJSON() {
     final var jsonObject = new JSONObject();
-    jsonObject.put("changeType", this.type.toString().toLowerCase());
+    jsonObject.put("changeType", this.type.toString().toLowerCase(Locale.ENGLISH));
     jsonObject.put("record", this.record.toJSON());
     jsonObject.put("database", this.record.getDatabase().getName());
     return jsonObject.toString();

--- a/server/src/main/java/com/arcadedb/server/http/ws/WebSocketReceiveListener.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/WebSocketReceiveListener.java
@@ -53,7 +53,7 @@ public class WebSocketReceiveListener extends AbstractReceiveListener {
       final var rawAction = message.optString("action", "");
       var action = ACTION.UNKNOWN;
       try {
-        action = ACTION.valueOf(rawAction.toUpperCase());
+        action = ACTION.valueOf(rawAction.toUpperCase(Locale.ENGLISH));
       } catch (final IllegalArgumentException ignored) {
       }
 
@@ -62,7 +62,7 @@ public class WebSocketReceiveListener extends AbstractReceiveListener {
         final var jsonChangeTypes = !message.isNull("changeTypes") ? message.getJSONArray("changeTypes") : null;
         final var changeTypes = jsonChangeTypes == null ?
             null :
-            jsonChangeTypes.toList().stream().map(t -> ChangeEvent.TYPE.valueOf(t.toString().toUpperCase())).collect(Collectors.toSet());
+            jsonChangeTypes.toList().stream().map(t -> ChangeEvent.TYPE.valueOf(t.toString().toUpperCase(Locale.ENGLISH))).collect(Collectors.toSet());
         this.webSocketEventBus.subscribe(message.getString("database"), message.optString("type", null), changeTypes, channel);
         this.sendAck(channel, action);
         break;
@@ -96,7 +96,7 @@ public class WebSocketReceiveListener extends AbstractReceiveListener {
 
   private void sendAck(final WebSocketChannel channel, final ACTION action) {
     final var json = new JSONObject("{\"result\": \"ok\"}");
-    json.put("action", action.toString().toLowerCase());
+    json.put("action", action.toString().toLowerCase(Locale.ENGLISH));
     WebSockets.sendText(json.toString(), channel, null);
   }
 


### PR DESCRIPTION
## What does this PR do?
These changes add `LOCALE.English` to all calls of `toLowerCase` and `toUpperCase`. For all strings related to commands,keywords or configuration, english localization is obvious, but it seems even for user/data strings `LOCALE.English` seems to be fine (see [here](https://stackoverflow.com/a/11063161)).

## Motivation
This is an internationalization best practice in `spotbugs`.

## Additional Notes
The change in `.pre-commit-config.yaml` was necessary to be able to commit.

## Checklist
- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
