### PR TITLE
Add test for two empty strings in binary comparator

### DIFF
--- a/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
@@ -396,7 +396,7 @@ public class BinaryComparator {
     if (buffer1 == null || buffer2 == null)
       return false;
 
-    if (buffer1.equals("") && buffer2.equals(""))
+    if (buffer1.isEmpty() && buffer2.isEmpty())
       return true;
 
     return equalsBytes(buffer1.getBytes(DatabaseFactory.getDefaultCharset()),

--- a/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinaryComparator.java
@@ -396,6 +396,9 @@ public class BinaryComparator {
     if (buffer1 == null || buffer2 == null)
       return false;
 
+    if (buffer1.equals("") && buffer2.equals(""))
+      return true;
+
     return equalsBytes(buffer1.getBytes(DatabaseFactory.getDefaultCharset()),
         buffer2.getBytes(DatabaseFactory.getDefaultCharset()));
   }


### PR DESCRIPTION
## What does this PR do?
This change adds a check for two empty strings to be compared to the `equalsString` method of the `BinaryComparator` class. As far as I understand it, strings are compared as byte arrays which can cause the observed error when comparing the last byte. However for a length of zero, as an empty string has, this causes an error.

Now I cannot say why this error does not happen with the current repo head, but I think it should or still might, thus I added this check for both argument strings being empty and preventing this error.

## Related issues
https://github.com/ArcadeData/arcadedb/issues/1297

## Additional Notes
This specifically does not add the check to the `equalsBytes` as I do not know if a zero length array can actually be created.

## Checklist
- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
