### PR TITLE
Make abstract HTTP handler set auth challenge

### DIFF
--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -89,8 +89,9 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
 
       final HeaderValues authorization = exchange.getRequestHeaders().get("Authorization");
       if (isRequireAuthentication() && (authorization == null || authorization.isEmpty())) {
-        exchange.setStatusCode(403);
-        sendErrorResponse(exchange, 403, "No authentication was provided", null, null);
+        exchange.setStatusCode(401);
+        exchange.getResponseHeaders().put(Headers.WWW_AUTHENTICATE,"Basic");
+        sendErrorResponse(exchange, 401, "", null, null);
         return;
       }
 

--- a/server/src/test/java/com/arcadedb/server/HTTPDocumentIT.java
+++ b/server/src/test/java/com/arcadedb/server/HTTPDocumentIT.java
@@ -121,7 +121,7 @@ public class HTTPDocumentIT extends BaseGraphServerTest {
         readResponse(connection);
         Assertions.fail("Authentication was bypassed!");
       } catch (final IOException e) {
-        Assertions.assertTrue(e.toString().contains("403"));
+        Assertions.assertTrue(e.toString().contains("401"));
       } finally {
         connection.disconnect();
       }

--- a/server/src/test/java/com/arcadedb/server/HTTPGraphIT.java
+++ b/server/src/test/java/com/arcadedb/server/HTTPGraphIT.java
@@ -26,7 +26,7 @@ public class HTTPGraphIT extends BaseGraphServerTest {
         readResponse(connection);
         Assertions.fail("Authentication was bypassed!");
       } catch (final IOException e) {
-        Assertions.assertTrue(e.toString().contains("403"));
+        Assertions.assertTrue(e.toString().contains("401"));
       } finally {
         connection.disconnect();
       }
@@ -45,7 +45,7 @@ public class HTTPGraphIT extends BaseGraphServerTest {
         readResponse(connection);
         Assertions.fail("Authentication was bypassed!");
       } catch (final IOException e) {
-        Assertions.assertTrue(e.toString().contains("403"));
+        Assertions.assertTrue(e.toString().contains("401"));
       } finally {
         connection.disconnect();
       }


### PR DESCRIPTION
## What does this PR do?
This change modifies the error response of the `AbstractServerHttpHandler` such that a request without `Authorization` header field returns a HTTP status `401` together with a header `WWW-Authenticate` (= `Basic`) challenge, instead of a HTTP status `403`.

## Motivation
The prior behavior means that for some clients like `wget` a non-standard option (`--no-auth-challenge`) is needed.

## Additional Notes
~~Currently the test set `ConsoleAsyncInsertTest` fails.~~

## Checklist
- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
