### PR TITLE
Remove runtime option from compiler args in main pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,8 +151,6 @@
                     <compilerArgs>
                         <arg>--add-exports</arg>
                         <arg>java.management/sun.management=ALL-UNNAMED</arg>
-                        <arg>--add-opens</arg>
-                        <arg>java.base/java.util.concurrent.atomic=ALL-UNNAMED</arg>
                     </compilerArgs>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## What does this PR do?
This change removes a runtime option from compiler options which causes a warning during build.

## Motivation
The warning.

## Additional Notes
See https://openjdk.org/jeps/261

## Checklist
- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
