### PR TITLE
fix: Add missing option to env var in Dockerfiles

### DIFF
--- a/package/src/main/docker/Dockerfile
+++ b/package/src/main/docker/Dockerfile
@@ -21,7 +21,7 @@ LABEL maintainer="Arcade Data LTD (info@arcadedb.com)"
 
 ENV JAVA_OPTS=" "
 
-ENV JAVA_OPTS_SCRIPT="--add-opens java.base/java.io=ALL-UNNAMED -Dpolyglot.engine.WarnInterpreterOnly=false -Djna.nosys=true -XX:+HeapDumpOnOutOfMemoryError -Djava.awt.headless=true -Dfile.encoding=UTF8"
+ENV JAVA_OPTS_SCRIPT="--add-opens java.base/java.io=ALL-UNNAMED --add-exports java.management/sun.management=ALL-UNNAMED -Dpolyglot.engine.WarnInterpreterOnly=false -Djna.nosys=true -XX:+HeapDumpOnOutOfMemoryError -Djava.awt.headless=true -Dfile.encoding=UTF8"
 
 ENV ARCADEDB_OPTS_MEMORY="-Xms2G -Xmx2G"
 

--- a/package/src/main/docker/Dockerfile-multi
+++ b/package/src/main/docker/Dockerfile-multi
@@ -27,7 +27,7 @@ LABEL maintainer="Arcade Data LTD (info@arcadedb.com)"
 
 ENV JAVA_OPTS=" "
 
-ENV JAVA_OPTS_SCRIPT="--add-opens java.base/java.io=ALL-UNNAMED -Dpolyglot.engine.WarnInterpreterOnly=false -Djna.nosys=true -XX:+HeapDumpOnOutOfMemoryError -Djava.awt.headless=true -Dfile.encoding=UTF8"
+ENV JAVA_OPTS_SCRIPT="--add-opens java.base/java.io=ALL-UNNAMED --add-exports java.management/sun.management=ALL-UNNAMED -Dpolyglot.engine.WarnInterpreterOnly=false -Djna.nosys=true -XX:+HeapDumpOnOutOfMemoryError -Djava.awt.headless=true -Dfile.encoding=UTF8"
 
 ENV ARCADEDB_OPTS_MEMORY="-Xms2G -Xmx2G"
 


### PR DESCRIPTION
## What does this PR do?
After getting this error running ArcadeDB in a container:

```
Exception in thread "Thread-8" java.lang.IllegalAccessError: class com.arcadedb.server.monitor.ServerMonitor (in unnamed module @0x17c386de) cannot access class sun.management.ManagementFactoryHelper (in module java.management) because module java.management does not export sun.management to unnamed module @0x17c386de
	at com.arcadedb.server.monitor.ServerMonitor.checkJVMHotSpot(ServerMonitor.java:107)
	at com.arcadedb.server.monitor.ServerMonitor.monitor(ServerMonitor.java:61)
	at com.arcadedb.server.monitor.ServerMonitor.lambda$start$0(ServerMonitor.java:52)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

I figured out that the `JAVA_OPTS_SCRIPT` environment variable was missing an option, namely `--add-exports java.management/sun.management=ALL-UNNAMED` which seems to cause this error and is present in the [`server.sh`](https://github.com/ArcadeData/arcadedb/blob/main/package/src/main/scripts/server.sh#L76) script. Thus, I added this option to the `Dockerfile` and `Dockerfile-multi`.

## Checklist
- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
