### PR TITLE
Fix https://github.com/ArcadeData/arcadedb/issues/97

### DIFF
--- a/package/src/main/scripts/console.bat
+++ b/package/src/main/scripts/console.bat
@@ -14,6 +14,7 @@
 @REM limitations under the License.
 @REM
 
+@echo off
 @setlocal
 
 set ERROR_CODE=0
@@ -55,27 +56,20 @@ echo ARCADEDB home directory      = %ARCADEDB_HOME%
 rem Always change directory to HOME directory
 cd /d %ARCADEDB_HOME%
 
-rem Get remaining unshifted command line arguments and save them in the
-set CMD_LINE_ARGS=
+rem Get full command line arguments for the batch file
+set CMD_LINE_ARGS=%*
 
-:setArgs
-if ""%1""=="""" goto doneSetArgs
-set CMD_LINE_ARGS=%CMD_LINE_ARGS% %1
-shift
-goto setArgs
-
-:doneSetArgs
 set JAVA_OPTS_SCRIPT=-XX:+HeapDumpOnOutOfMemoryError -Djava.awt.headless=true -Dfile.encoding=UTF8 -Dpolyglot.engine.WarnInterpreterOnly=false
 
 "%JAVACMD%" ^
-  -client ^
-  %JAVA_OPTS% ^
-  %JAVA_OPTS_SCRIPT% ^
-  %ARCADEDB_OPTS_MEMORY% ^
-  %ARCADEDB_JMX% ^
-  %ARCADEDB_SETTINGS% ^
-  -cp "%ARCADEDB_HOME%\lib\*" ^
-  %CMD_LINE_ARGS% ^
-  com.arcadedb.console.Console
+ -client ^
+ %JAVA_OPTS% ^
+ %JAVA_OPTS_SCRIPT% ^
+ %ARCADEDB_OPTS_MEMORY% ^
+ %ARCADEDB_JMX% ^
+ %ARCADEDB_SETTINGS% ^
+ %CMD_LINE_ARGS% ^
+ -cp "%ARCADEDB_HOME%\lib\*" ^
+ com.arcadedb.console.Console
 
 :end

--- a/package/src/main/scripts/server.bat
+++ b/package/src/main/scripts/server.bat
@@ -70,11 +70,8 @@ cd /d %ARCADEDB_HOME%
 rem Get remaining unshifted command line arguments and save them in the
 set CMD_LINE_ARGS=
 
-:setArgs
-if ""%1""=="""" goto doneSetArgs
-set CMD_LINE_ARGS=%CMD_LINE_ARGS% %1
-shift
-goto setArgs
+:rem Get full command line arguments for the batch file
+set CMD_LINE_ARGS=%*
 
 :doneSetArgs
 
@@ -90,13 +87,14 @@ rem -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=1044
 rem AND ATTACH TO THE CURRENT HOST, PORT 1044
 
 "%JAVACMD%" ^
-  -server %JAVA_OPTS% ^
-  %ARCADEDB_OPTS_MEMORY% ^
-  %JAVA_OPTS_SCRIPT% ^
-  %ARCADEDB_JMX% ^
-  %ARCADEDB_SETTINGS% ^
-  -cp "%ARCADEDB_HOME%\lib\*" ^
-  %CMD_LINE_ARGS% com.arcadedb.server.ArcadeDBServer
+ -server %JAVA_OPTS% ^
+ %ARCADEDB_OPTS_MEMORY% ^
+ %JAVA_OPTS_SCRIPT% ^
+ %ARCADEDB_JMX% ^
+ %ARCADEDB_SETTINGS% ^
+ %CMD_LINE_ARGS% ^
+ -cp "%ARCADEDB_HOME%\lib\*" ^
+ com.arcadedb.server.ArcadeDBServer
 
 if ERRORLEVEL 1 goto error
 goto end


### PR DESCRIPTION
## What does this PR do?
Both console.bat and serer.bat don't take command line argument well due to two similar defects.

## Motivation
Share the fixes so that the windows users can use arcadedb out of the box in the arcadedb future releases.

## Related issues
The @echo off also partially addressed the noisy issue with https://github.com/ArcadeData/arcadedb/issues/1331

## Additional Notes
Test:

create a test database at a new location with console and import something
```
.\arcadedb-23.10.1\bin\console.bat -Darcadedb.server.databaseDirectory=Z:\arcadedb\databases
> create database arcadedb_test

Database 'arcadedb_test' created
{arcadedb_test}> import database https://github.com/ArcadeData/arcadedb-datasets/raw/main/orientdb/OpenBeer.gz
{arcadedb_test}> quit
```

start the server with the newly created databse
```
\arcadedb-23.10.1\bin\server.bat -Darcadedb.server.plugins=Postgres:com.arcadedb.postgres.PostgresProtocolPlugin -Darcadedb.postgres.port=3333 -Darcadedb.server.databaseDirectory=Z:\arcadedb\databases
...

2023-11-18 18:29:33.567 INFO  [PostgresNetworkListener] <ArcadeDB_0> Listening for incoming connections on 0.0.0.0:3333 (protocol v.-1)
2023-11-18 18:29:33.567 INFO  [ArcadeDBServer] <ArcadeDB_0> - Postgres plugin started
...
```

Test and found the database in the web console (-Darcadedb.server.databaseDirectory=... now works) and it is accessible using pg8000 with code example in https://github.com/ArcadeData/arcadedb/discussions/399

## Checklist
- [X ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
