### PR TITLE
Remove environment variable definition from Dockerfiles

### DIFF
--- a/package/src/main/docker/Dockerfile
+++ b/package/src/main/docker/Dockerfile
@@ -21,8 +21,6 @@ LABEL maintainer="Arcade Data LTD (info@arcadedb.com)"
 
 ENV JAVA_OPTS=" "
 
-ENV JAVA_OPTS_SCRIPT="--add-opens java.base/java.io=ALL-UNNAMED --add-exports java.management/sun.management=ALL-UNNAMED -Dpolyglot.engine.WarnInterpreterOnly=false -Djna.nosys=true -XX:+HeapDumpOnOutOfMemoryError -Djava.awt.headless=true -Dfile.encoding=UTF8"
-
 ENV ARCADEDB_OPTS_MEMORY="-Xms2G -Xmx2G"
 
 ENV ARCADEDB_JMX="-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.rmi.port=9998"

--- a/package/src/main/docker/Dockerfile-multi
+++ b/package/src/main/docker/Dockerfile-multi
@@ -27,8 +27,6 @@ LABEL maintainer="Arcade Data LTD (info@arcadedb.com)"
 
 ENV JAVA_OPTS=" "
 
-ENV JAVA_OPTS_SCRIPT="--add-opens java.base/java.io=ALL-UNNAMED --add-exports java.management/sun.management=ALL-UNNAMED -Dpolyglot.engine.WarnInterpreterOnly=false -Djna.nosys=true -XX:+HeapDumpOnOutOfMemoryError -Djava.awt.headless=true -Dfile.encoding=UTF8"
-
 ENV ARCADEDB_OPTS_MEMORY="-Xms2G -Xmx2G"
 
 ENV ARCADEDB_JMX="-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.rmi.port=9998"


### PR DESCRIPTION
## What does this PR do?
This change removes the environment variable `JAVA_OPTS_SCRIPT` from the Dockerfiles. This has the consequence that this variable will be set in the `server.sh` or `console.sh` scripts respectively. Thus classic and container usage behave the same.

## Motivation
Scary warning message when starting the console inside a container

## Related issues
https://github.com/ArcadeData/arcadedb/issues/1331

## Checklist
- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
