### PR TITLE
fix: implicit narrowing conversion in compound assignment

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CountFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CountFromIndexStep.java
@@ -34,7 +34,7 @@ public class CountFromIndexStep extends AbstractExecutionStep {
   private final String          alias;
 
   private boolean executed = false;
-  private int     cost     = -1;
+  private long    cost     = -1;
 
   /**
    * @param targetIndex      the index name as it is parsed by the SQL parsed

--- a/postgresw/src/test/resources/python/requirements.txt
+++ b/postgresw/src/test/resources/python/requirements.txt
@@ -1,6 +1,6 @@
-asyncpg==0.29.0 
+asyncpg==0.29.0
 nest_asyncio==1.5.8
-pg8000==1.30.3 
+pg8000==1.30.3
 psycopg==3.1.12
 psycopg-binary==3.1.12
 psycopg2-binary==2.9.9


### PR DESCRIPTION
## What does this PR do?
This change adapts the attribute `cost` from `int` to `long`.

## Motivation
https://github.com/gramian/arcadedb/security/code-scanning/40

## Checklist
- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
