### PR TITLE
fix: use normalized file paths to identify database folders (#1345)

### DIFF
--- a/engine/src/test/java/com/arcadedb/database/DatabaseFactoryTest.java
+++ b/engine/src/test/java/com/arcadedb/database/DatabaseFactoryTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.database;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.exception.DatabaseOperationException;
 import com.arcadedb.security.SecurityManager;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -71,5 +72,31 @@ class DatabaseFactoryTest extends TestHelper {
 
     db.drop();
     f.close();
+  }
+
+  @Test
+  void testDatabaseRegistrationWithDifferentPathTypes() {
+    final DatabaseFactory f = new DatabaseFactory("path/to/database");
+    final Database db = f.create();
+
+    Assertions.assertEquals(db, DatabaseFactory.getActiveDatabaseInstance("path/to/database"));
+    Assertions.assertEquals(db, DatabaseFactory.getActiveDatabaseInstance("path\\to\\database"));
+    Assertions.assertEquals(db, DatabaseFactory.getActiveDatabaseInstance("./path/../path/to/database"));
+
+    db.drop();
+    f.close();
+  }
+  
+  @Test
+  void testDuplicatedDatabaseCreationWithDifferentPathTypes() {
+    final DatabaseFactory f1 = new DatabaseFactory("path/to/database");
+    final Database db = f1.create();
+    
+    final DatabaseFactory f2 = new DatabaseFactory(".\\path\\to\\database");
+    Assertions.assertThrows(DatabaseOperationException.class, () -> f2.create());
+
+    db.drop();
+    f1.close();
+    f2.close();
   }
 }


### PR DESCRIPTION
## What does this PR do?
Local database folders can now be identified properly when using different paths which reference the same folder (e.g. an absolute path can reference the same file/folder as a different relative path).

## Related issues
See #1345 

## Additional Notes
1. I wasn't able to successfully execute all tests in the project, but it's probably not related to my changes, since I get the same errors when performing the tests on the `main` branch.
2. It might be a good idea to do some additional refactoring by changing `LocalDatabase.databasePath` and `DatabaseFactory.databasePath` to type `Path` instead of `String`, but I'm not 100% sure if we can always expect strings which can be parsed into a `Path` object (URIs could cause issues, I guess).

## Checklist
- [X] I have run the build using `mvn clean package` command (see additional note above)
- [X] My unit tests cover both failure and success scenarios