### PR TITLE
Update github CI workflow

### DIFF
--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Test
         continue-on-error: ${{ matrix.continue-on-error }}
-        run: mvn verify  -Pintegration -Pcoverage -Pdocker --batch-mode  --errors --fail-at-end --show-version  -pl !e2e
+        run: mvn verify  -Pintegration -Pcoverage -Pdocker --batch-mode  --errors --fail-never --show-version  -pl !e2e
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## What does this PR do?
Make maven in github workflow integration tests fail never.

## Motivation
First failing test aborts remaining module's tests.

## Checklist
- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
