### PR TITLE
Remove useless object in class InCondition

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/InCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/InCondition.java
@@ -101,8 +101,6 @@ public class InCondition extends BooleanExpression {
   }
 
   protected static Object executeQuery(final SelectStatement rightStatement, final CommandContext context) {
-    final BasicCommandContext subcontext = new BasicCommandContext();
-    subcontext.setParentWithoutOverridingChild(context);
     final ResultSet result = rightStatement.execute(context.getDatabase(), context.getInputParameters());
     return result.stream().collect(Collectors.toSet());
   }


### PR DESCRIPTION
## What does this PR do?

Remove useless object in class `InCondition`, method `executeQuery`.

## Motivation

Found by `spotbugs`

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
