### PR TITLE
feat: add server setting for providing root password

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -285,6 +285,10 @@ public enum GlobalConfiguration {
       "Password for root user to use at first startup of the server. Set this to avoid asking the password to the user",
       String.class, null),
 
+  SERVER_ROOT_PASSWORD_PATH("arcadedb.server.rootPasswordPath", SCOPE.SERVER,
+      "Path to file with password for root user to use at first startup of the server. Set this to avoid asking the password to the user",
+      String.class, null),
+
   SERVER_MODE("arcadedb.server.mode", SCOPE.SERVER, "Server mode between 'development', 'test' and 'production'", String.class,
       "development", Set.of((Object[]) new String[] { "development", "test", "production" })),
 

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -39,6 +39,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
 import java.io.*;
+import java.nio.file.*;
 import java.nio.charset.*;
 import java.security.*;
 import java.security.spec.*;
@@ -331,6 +332,19 @@ public class ServerSecurity implements ServerPlugin, com.arcadedb.security.Secur
     String rootPassword = server != null ?
         server.getConfiguration().getValueAsString(GlobalConfiguration.SERVER_ROOT_PASSWORD) :
         GlobalConfiguration.SERVER_ROOT_PASSWORD.getValueAsString();
+
+    if (rootPassword == null) {
+      final String rootPasswordPath = server != null ?
+          server.getConfiguration().getValueAsString(GlobalConfiguration.SERVER_ROOT_PASSWORD_PATH) :
+          GlobalConfiguration.SERVER_ROOT_PASSWORD_PATH.getValueAsString();
+
+      if (rootPasswordPath != null) {
+        if (Files.isReadable(Paths.get(rootPasswordPath)))
+          rootPassword = Files.readString(Paths.get(rootPasswordPath));
+        else
+          throw new ServerSecurityException("Error reading password file at path '" + rootPasswordPath + "'");
+      }
+    }
 
     if (rootPassword == null) {
       if (server != null ?


### PR DESCRIPTION
## What does this PR do?

These changes add a server setting  `arcadedb.server.rootPasswordPath`, from which the contents are loaded (if possible) and used as root password.

## Motivation

If ArcadeDB is used inside container, the root password secret can now be assigned file-based preventing exposure via the environment or process command-line. 

## Related issues

https://github.com/ArcadeData/arcadedb/issues/597

## Additional Notes

The exception thrown in case the file is unreadable is kept in the style of other password shortcomings, like too short password.

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
