### PR TITLE
feat: probeOnly setting for importer and import database

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ImportDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ImportDatabaseStatement.java
@@ -45,6 +45,7 @@ public class ImportDatabaseStatement extends SimpleExecStatement {
   public ResultSet executeSimple(final CommandContext context) {
     final ResultInternal result = new ResultInternal();
     result.setProperty("operation", "import database");
+
     if (this.url != null)
       result.setProperty("fromUrl", this.url.getUrlString());
 
@@ -66,7 +67,10 @@ public class ImportDatabaseStatement extends SimpleExecStatement {
     } catch (final ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InstantiationException e) {
       throw new CommandExecutionException("Error on importing database, importer libs not found in classpath", e);
     } catch (final InvocationTargetException e) {
-      throw new CommandExecutionException("Error on importing database", e.getTargetException());
+      if (e.getCause().getClass().getSimpleName().equals("IllegalArgumentException"))
+        result.setProperty("result", "FAIL");
+      else
+        throw new CommandExecutionException("Error on importing database", e.getTargetException());
     }
 
     result.setProperty("result", "OK");

--- a/integration/src/main/java/com/arcadedb/integration/importer/Importer.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/Importer.java
@@ -56,11 +56,17 @@ public class Importer extends AbstractImporter {
       loadFromSource(settings.vertices, AnalyzedEntity.ENTITY_TYPE.VERTEX, analyzedSchema);
       loadFromSource(settings.edges, AnalyzedEntity.ENTITY_TYPE.EDGE, analyzedSchema);
 
+      if (settings.probeOnly)
+        return null;
+
       if (database.isTransactionActive())
         database.commit();
 
     } catch (final Exception e) {
-      throw new ImportException("Error on parsing source '" + source + "'", e);
+        if (settings.probeOnly)
+          throw new IllegalArgumentException(e);
+        else
+          throw new ImportException("Error on parsing source '" + source + "'", e);
     } finally {
       stopImporting();
       if (database != null) {
@@ -78,6 +84,12 @@ public class Importer extends AbstractImporter {
       return;
 
     final SourceDiscovery sourceDiscovery = new SourceDiscovery(url);
+
+    if (settings.probeOnly) {
+      sourceDiscovery.getSource();
+      return;
+    }
+
     final SourceSchema sourceSchema = sourceDiscovery.getSchema(settings, entityType, analyzedSchema, logger);
     if (sourceSchema == null) {
       //LogManager.instance().log(this, Level.WARNING, "XML importing aborted because unable to determine the schema");

--- a/integration/src/main/java/com/arcadedb/integration/importer/ImporterSettings.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/ImporterSettings.java
@@ -27,6 +27,7 @@ public class ImporterSettings {
   public String  url          = null;
   public boolean wal          = false;
   public int     verboseLevel = 2;
+  public boolean probeOnly    = false;
 
   public String documents;
   public String documentsFileType;
@@ -120,6 +121,8 @@ public class ImporterSettings {
       parsingLimitEntries = Long.parseLong(value);
     else if ("mapping".equals(name))
       mapping = value;
+    else if ("probeOnly".equals(name))
+      probeOnly = Boolean.parseBoolean(value);
 
       // DOCUMENT SETTINGS
 


### PR DESCRIPTION
## What does this PR do?

These changes add a `probeOnly` setting to the `Importer` and the `IMPORT DATABASE` command

A (failed) import result is forwarded from the `Importer` via an `IllegalArgumentException` instead of the otherwise `ImportException`, so the `IMPORT DATABASE` command can distinguish and communicate failure instead of fire a server exception.

@lvca 

* Is this mechanism OK?
* Is the naming `probeOnly` OK?

## Motivation

Dry-run testing sources and imports.

## Related issues

https://github.com/ArcadeData/arcadedb/issues/1396

## Additional Notes

This small change makes the `IMPORT DATABASE` command a lot more powerful, because now this command can also be used to access a `GET` or bodyless `POST` HTTP endpoint, still being a non-idempotent command and without altering a database.

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
