### PR TITLE
fix: add pwd command to console help

### DIFF
--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -872,6 +872,7 @@ public class Console {
     outputLine(1, "info transaction                                  -> prints current transaction");
     outputLine(1, "list databases |remote:<url> <user> <pw>          -> prints list of databases");
     outputLine(1, "load <path>                                       -> runs local script");
+    outputLine(1, "pwd                                               -> returns current directory");
     outputLine(1, "rollback                                          -> rolls back current transaction");
     outputLine(1, "set language = sql|sqlscript|cypher|gremlin|mongo -> sets console query language");
     outputLine(1, "-- <comment>                                      -> comment (no operation)");


### PR DESCRIPTION
## What does this PR do?

A line is added to the online console help with the `pwd` command.

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
