### PR TITLE
feat: Enhance `RemoteServer` and `Console` create-user to assign group

### DIFF
--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -467,16 +467,25 @@ public class Console {
     checkHasSpaces("User name", userName);
 
     final String password;
-    final List<String> databases;
+    HashMap<String,String> databases = new HashMap<String,String>();
 
     if (databasesByPos > -1) {
       password = params.substring(identifiedByPos + "IDENTIFIED BY".length() + 1, databasesByPos).trim();
       final String databasesList = params.substring(databasesByPos + " GRANT CONNECT TO ".length()).trim();
       final String[] databasesArray = databasesList.split(",");
-      databases = List.of(databasesArray);
+      final List<String> databasesName = List.of(databasesArray);
+      for (final String db : databasesName) {
+        final int colonPos = db.indexOf(":");
+        if (colonPos > -1) {
+          final String dbname = db.substring(0,colonPos -1).trim();
+          final String dbgroup = db.substring(colonPos + 1).trim();
+          databases.put(dbname,dbgroup);
+        } else {
+          databases.put(db,"admin");
+        }
+      }
     } else {
       password = params.substring(identifiedByPos + "IDENTIFIED BY".length() + 1).trim();
-      databases = new ArrayList<>();
     }
 
     checkIsEmpty("User password", password);

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -872,6 +872,7 @@ public class Console {
     outputLine(1, "info transaction                                  -> prints current transaction");
     outputLine(1, "list databases |remote:<url> <user> <pw>          -> prints list of databases");
     outputLine(1, "load <path>                                       -> runs local script");
+    outputLine(1, "pwd                                               -> returns current directory");
     outputLine(1, "rollback                                          -> rolls back current transaction");
     outputLine(1, "set language = sql|sqlscript|cypher|gremlin|mongo -> sets console query language");
     outputLine(1, "-- <comment>                                      -> comment (no operation)");

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -467,7 +467,7 @@ public class Console {
     checkHasSpaces("User name", userName);
 
     final String password;
-    HashMap<String,String> databases = new HashMap<String,String>();
+    Map<String,String> databases = new HashMap<String,String>();
 
     if (databasesByPos > -1) {
       password = params.substring(identifiedByPos + "IDENTIFIED BY".length() + 1, databasesByPos).trim();

--- a/console/src/test/java/com/arcadedb/console/RemoteConsoleIT.java
+++ b/console/src/test/java/com/arcadedb/console/RemoteConsoleIT.java
@@ -198,6 +198,7 @@ public class RemoteConsoleIT extends BaseGraphServerTest {
     }
 
     Assertions.assertTrue(console.parse("create user elon identified by musk grant connect to db1"));
+    Assertions.assertTrue(console.parse("create user jeff identified by amazon grant connect to db1:readonly"));
     Assertions.assertTrue(console.parse("drop user elon"));
   }
 

--- a/network/src/main/java/com/arcadedb/remote/RemoteServer.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteServer.java
@@ -74,7 +74,7 @@ public class RemoteServer extends RemoteHttpComponent {
     return protocol + "://" + currentServer + ":" + currentPort;
   }
 
-  public void createUser(final String userName, final String password, final HashMap<String,String> databases) {
+  public void createUser(final String userName, final String password, final Map<String,String> databases) {
     try {
       final HttpURLConnection connection = createConnection("POST", getUrl("server"));
 
@@ -103,7 +103,7 @@ public class RemoteServer extends RemoteHttpComponent {
 
   public void createUser(final String userName, final String password, final List<String> databases) {
 
-    HashMap<String,String> databasesWithGroups = new HashMap<String, String>();
+    Map<String,String> databasesWithGroups = new HashMap<String, String>();
 
     for (final String dbName : databases)
       databasesWithGroups.put(dbName, "admin");

--- a/network/src/main/java/com/arcadedb/remote/RemoteServer.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteServer.java
@@ -74,7 +74,7 @@ public class RemoteServer extends RemoteHttpComponent {
     return protocol + "://" + currentServer + ":" + currentPort;
   }
 
-  public void createUser(final String userName, final String password, final List<String> databases) {
+  public void createUser(final String userName, final String password, final HashMap<String,String> databases) {
     try {
       final HttpURLConnection connection = createConnection("POST", getUrl("server"));
 
@@ -83,8 +83,8 @@ public class RemoteServer extends RemoteHttpComponent {
       jsonUser.put("password", password);
       if (databases != null && !databases.isEmpty()) {
         final JSONObject databasesJson = new JSONObject();
-        for (final String dbName : databases)
-          databasesJson.put(dbName, new String[] { "admin" });
+        for (Map.Entry<String, String> entry : databases.entrySet())
+          databasesJson.put(entry.getKey(), new String[] { entry.getValue() });
         jsonUser.put("databases", databasesJson);
       }
 
@@ -99,6 +99,16 @@ public class RemoteServer extends RemoteHttpComponent {
     } catch (final Exception e) {
       throw new DatabaseOperationException("Error on creating user", e);
     }
+  }
+
+  public void createUser(final String userName, final String password, final List<String> databases) {
+
+    HashMap<String,String> databasesWithGroups = new HashMap<String, String>();
+
+    for (final String dbName : databases)
+      databasesWithGroups.put(dbName, "admin");
+
+    createUser(userName, password, databasesWithGroups);
   }
 
   public void dropUser(final String userName) {


### PR DESCRIPTION
## What does this PR do?

1. The `RemoteServe` class method `createUser` is overloaded with a variant with the signature
```
public void createUser(final String userName, final String password, final HashMap<String,String> databases)
```
As for the HTTP API server command the `databases` HashMap should have keys being database names and values being a group name. 
The former function with a `List<String>` `databases` argument is still available, but its body changed so that the new method is called by it.

2. The `Console` class method `executeCreateUser` is updated so the new `RemoteServer` `createUser` method is used. However not too robustly, and error handling is defered to the `RemoteServer` or eventually to the `ServerSecurityUser` class.

So now in console the following can be done:
```
CREATE USER user IDENTIFIED BY password GRANT CONNECT TO db:group
```

## Motivation

Missing capability to assign group during user creation in console, even though possibl via HTTP API.

## Additional Notes

It is possible to pass an empty group, but AFAIK this is also allowed in the HTTP server command.

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
