### PR TITLE
feat: Add SQL sort method

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/method/DefaultSQLMethodFactory.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/DefaultSQLMethodFactory.java
@@ -25,6 +25,7 @@ import com.arcadedb.query.sql.method.collection.SQLMethodKeys;
 import com.arcadedb.query.sql.method.collection.SQLMethodRemove;
 import com.arcadedb.query.sql.method.collection.SQLMethodRemoveAll;
 import com.arcadedb.query.sql.method.collection.SQLMethodSize;
+import com.arcadedb.query.sql.method.collection.SQLMethodSort;
 import com.arcadedb.query.sql.method.collection.SQLMethodTransform;
 import com.arcadedb.query.sql.method.collection.SQLMethodValues;
 import com.arcadedb.query.sql.method.conversion.SQLMethodAsBoolean;
@@ -89,6 +90,7 @@ public class DefaultSQLMethodFactory implements SQLMethodFactory {
     register(SQLMethodRemove.NAME, new SQLMethodRemove());
     register(SQLMethodRemoveAll.NAME, new SQLMethodRemoveAll());
     register(SQLMethodSize.NAME, new SQLMethodSize());
+    register(SQLMethodSort.NAME, new SQLMethodSort());
     register(SQLMethodTransform.NAME, new SQLMethodTransform());
     register(SQLMethodValues.NAME, new SQLMethodValues());
 

--- a/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodSort.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodSort.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.method.collection;
+
+import com.arcadedb.serializer.BinaryComparator;
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.MultiValue;
+import com.arcadedb.query.sql.method.AbstractSQLMethod;
+
+import java.util.*;
+
+/**
+ * @author Christian Himpe
+ * @author Luca Garulli (l.garulli--(at)--gmail.com)
+ */
+public class SQLMethodSort extends AbstractSQLMethod {
+
+  public static final String NAME = "sort";
+
+  public SQLMethodSort() {
+    super(NAME);
+  }
+
+  @Override
+  public Object execute(final Object iThis, final Identifiable iCurrentRecord, final CommandContext iContext, final Object ioResult, final Object[] iParams) {
+
+    if (ioResult != null && ioResult instanceof List) {
+      List<Object> result = new ArrayList((List) ioResult);
+      if (iParams != null && iParams.length > 0 && iParams[0] != null && iParams[0] instanceof Boolean && !((Boolean) iParams[0]))
+        result.sort((left, right) -> BinaryComparator.compareTo(right, left));
+      else
+        result.sort((left,right) -> BinaryComparator.compareTo(left, right));
+      return result;
+    } else {
+      return ioResult;
+    }
+  }
+
+  @Override
+  public String getSyntax() {
+    return "sort(<bool>)";
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodSortTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodSortTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.method.collection;
+
+import com.arcadedb.query.sql.executor.SQLMethod;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SQLMethodSortTest {
+    private SQLMethod method;
+
+    @BeforeEach
+    void setUp() {
+        method = new SQLMethodSort();
+    }
+
+    @Test
+    void testSortedList() {
+        final List<Number> listin = List.of(1, 2, 3);
+        final Object result = method.execute(null, null, null, listin, null);
+        assertThat(result).isInstanceOf(List.class);
+        assertThat(result).isEqualTo(listin);
+    }
+
+    @Test
+    void testReverseSortedList() {
+        final List<Number> listin = List.of(3, 2, 1);
+        final Object result = method.execute(null, null, null, listin, new Boolean[]{false});
+        assertThat(result).isInstanceOf(List.class);
+        assertThat(result).isEqualTo(listin);
+    }
+
+    @Test
+    void testUnsortedList() {
+        final List<Number> listin = List.of(3, 2, 1);
+        final List<Number> listout = List.of(1, 2, 3);
+        final Object result = method.execute(null, null, null, listin, null);
+        assertThat(result).isInstanceOf(List.class);
+        assertThat(result).isEqualTo(listout);
+    }
+
+    @Test
+    void testCharacterList() {
+        final List<String> listin = List.of("z","A","b");
+        final List<String> listout = List.of("A","b","z");
+        final Object result = method.execute(null, null, null, listin, null);
+        assertThat(result).isInstanceOf(List.class);
+        assertThat(result).isEqualTo(listout);
+    }
+
+    @Test
+    void testWordList() {
+        final List<String> listin = List.of("z1","z2","a");
+        final List<String> listout = List.of("a","z1","z2");
+        final Object result = method.execute(null, null, null, listin, null);
+        assertThat(result).isInstanceOf(List.class);
+        assertThat(result).isEqualTo(listout);
+    }
+
+    @Test
+    void testDoubleList() {
+        final List<Number> listin = List.of(3.0, 2.2, 0.0001);
+        final List<Number> listout = List.of(0.0001, 2.2, 3.0);
+        final Object result = method.execute(null, null, null, listin, null);
+        assertThat(result).isInstanceOf(List.class);
+        assertThat(result).isEqualTo(listout);
+    }
+
+    @Test
+    void testScalar() {
+        final Integer listin = 3;
+        final Integer listout = 3;
+        final Object result = method.execute(null, null, null, listin, null);
+        assertThat(result).isInstanceOf(Number.class);
+        assertThat(result).isEqualTo(listout);
+    }
+}


### PR DESCRIPTION
## What does this PR do?

This adds a SQL `sort` method to the engine which allows to sort a list ascending or descending (controlled by a boolean argument which is by default true ~ ascending). Only caveat is that only list of a single type, ie Integer, Stirng, Double can be sorted, mixed list will produce an error.

## Motivation

Sorting the result of a `unionall` without a subquery.

## Additional Notes

I will add docu for this method once accepted, too.

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
