### PR TITLE
Add SQL version function

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/function/DefaultSQLFunctionFactory.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/function/DefaultSQLFunctionFactory.java
@@ -69,6 +69,7 @@ import com.arcadedb.query.sql.function.misc.SQLFunctionEncode;
 import com.arcadedb.query.sql.function.misc.SQLFunctionIf;
 import com.arcadedb.query.sql.function.misc.SQLFunctionIfNull;
 import com.arcadedb.query.sql.function.misc.SQLFunctionUUID;
+import com.arcadedb.query.sql.function.misc.SQLFunctionVersion;
 import com.arcadedb.query.sql.function.text.SQLFunctionConcat;
 import com.arcadedb.query.sql.function.text.SQLFunctionFormat;
 import com.arcadedb.query.sql.function.text.SQLFunctionStrcmpci;
@@ -142,6 +143,7 @@ public final class DefaultSQLFunctionFactory extends SQLFunctionFactoryTemplate 
     register(SQLFunctionIf.NAME, new SQLFunctionIf());
     register(SQLFunctionIfNull.NAME, new SQLFunctionIfNull());
     register(SQLFunctionUUID.NAME, SQLFunctionUUID.class);
+    register(SQLFunctionVersion.NAME, SQLFunctionVersion.class);
 
     // Text
     register(SQLFunctionFormat.NAME, new SQLFunctionFormat());

--- a/engine/src/main/java/com/arcadedb/query/sql/function/misc/SQLFunctionVersion.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/function/misc/SQLFunctionVersion.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.function.misc;
+
+import com.arcadedb.Constants;
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.function.SQLFunctionAbstract;
+
+import java.util.*;
+
+/**
+ * Generates a UUID as a 128-bits value using the Leach-Salz variant. For more information look at:
+ * http://docs.oracle.com/javase/6/docs/api/java/util/UUID.html.
+ *
+ * @author Luca Garulli (l.garulli--(at)--gmail.com)
+ */
+public class SQLFunctionVersion extends SQLFunctionAbstract {
+  public static final String NAME = "version";
+
+  /**
+   * Get the date at construction to have the same date for all the iteration.
+   */
+  public SQLFunctionVersion() {
+    super(NAME);
+  }
+
+  public Object execute(final Object iThis, final Identifiable iCurrentRecord, final Object iCurrentResult, final Object[] iParams,
+      final CommandContext iContext) {
+    return Constants.getVersion();
+  }
+
+  @Override
+  public boolean aggregateResults() {
+    return false;
+  }
+
+  public String getSyntax() {
+    return "version()";
+  }
+
+  @Override
+  public Object getResult() {
+    return null;
+  }
+}


### PR DESCRIPTION
## What does this PR do?

This change adds the Postgres `version` function as SQL function reporting ArcadeDB's version constant.

## Motivation

I am trying to get DBgate to work which reports the version function as missing, see here: https://github.com/dbgate/dbgate/blob/master/plugins/dbgate-plugin-postgres/src/backend/drivers.js#L171

## Related issues

https://github.com/ArcadeData/arcadedb/issues/1444

## Additional Notes

I will add docu for this function once merged.

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
