### PR TITLE
[WIP] Add "hidden" property attribute

### DIFF
--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -836,6 +836,7 @@ public class Console {
           row.setField("MANDATORY", property.hasProperty("mandatory") ? property.getProperty("mandatory") : "false");
           row.setField("READONLY", property.hasProperty("readOnly") ? property.getProperty("readOnly") : "false");
           row.setField("NOT NULL", property.hasProperty("notNull") ? property.getProperty("notNull") : "false");
+          row.setField("HIDDEN", property.hasProperty("hidden") ? property.getProperty("hidden") : "false");
           row.setField("DEFAULT", property.hasProperty("default") ? property.getProperty("default") : null);
           row.setField("MIN", property.hasProperty("min") ? property.getProperty("min") : "");
           row.setField("MAX", property.hasProperty("max") ? property.getProperty("max") : "");

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromSchemaTypesStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromSchemaTypesStep.java
@@ -95,6 +95,8 @@ public class FetchFromSchemaTypesStep extends AbstractExecutionStep {
                   propRes.setProperty("readOnly", property.isReadonly());
                 if (property.isNotNull())
                   propRes.setProperty("notNull", property.isNotNull());
+                if (property.isHidden())
+                  propRes.setProperty("hidden", property.isHidden());
                 if (property.getMin() != null)
                   propRes.setProperty("min", property.getMin());
                 if (property.getMax() != null)

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/AlterPropertyStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/AlterPropertyStatement.java
@@ -87,7 +87,7 @@ public class AlterPropertyStatement extends DDLStatement {
         property.setNotNull((boolean) finalValue);
       } else if (setting.equalsIgnoreCase("hidden")) {
         oldValue = property.isHidden();
-        property.setNotNull((boolean) finalValue);
+        property.setHidden((boolean) finalValue);
       } else if (setting.equalsIgnoreCase("max")) {
         oldValue = property.getMax();
         property.setMax("" + finalValue);

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/AlterPropertyStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/AlterPropertyStatement.java
@@ -85,6 +85,9 @@ public class AlterPropertyStatement extends DDLStatement {
       } else if (setting.equalsIgnoreCase("notnull")) {
         oldValue = property.isNotNull();
         property.setNotNull((boolean) finalValue);
+      } else if (setting.equalsIgnoreCase("hidden")) {
+        oldValue = property.isHidden();
+        property.setNotNull((boolean) finalValue);
       } else if (setting.equalsIgnoreCase("max")) {
         oldValue = property.getMax();
         property.setMax("" + finalValue);

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreatePropertyAttributeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreatePropertyAttributeStatement.java
@@ -61,6 +61,8 @@ public class CreatePropertyAttributeStatement extends SimpleNode {
         internalProp.setMandatory((boolean) attrValue);
       } else if (attrName.equalsIgnoreCase("notnull")) {
         internalProp.setNotNull((boolean) attrValue);
+      } else if (attrName.equalsIgnoreCase("hidden")) {
+        internalProp.setHidden((boolean) attrValue);
       } else if (attrName.equalsIgnoreCase("max")) {
         internalProp.setMax("" + attrValue);
       } else if (attrName.equalsIgnoreCase("min")) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Projection.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Projection.java
@@ -39,8 +39,17 @@ public class Projection extends SimpleNode {
 
   public Projection(final List<ProjectionItem> items, final boolean distinct) {
     super(-1);
-    this.items = items;
+
+    if (items.size() > 0) {
+      this.items = items;
+    } else {
+      final ProjectionItem all = new ProjectionItem(null,null,null);
+      all.setAll(true);
+      this.items.add(all);
+    }
+
     this.distinct = distinct;
+
     //TODO make the whole class immutable!
   }
 
@@ -93,11 +102,6 @@ public class Projection extends SimpleNode {
     initExcludes();
     if (isExpand())
       throw new IllegalStateException("This is an expand projection, it cannot be calculated as a single result" + this);
-
-    if (items.size() == 0 ||//
-        (items.size() == 1 && (/*items.get(0).isAll() ||*/ items.get(0).getExpression().toString().equals("@this")))//
-            && items.get(0).nestedProjection == null)
-      return iRecord;
 
     final ResultInternal result = new ResultInternal();
     for (final ProjectionItem item : items) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Projection.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Projection.java
@@ -39,15 +39,7 @@ public class Projection extends SimpleNode {
 
   public Projection(final List<ProjectionItem> items, final boolean distinct) {
     super(-1);
-
-    if (items.size() > 0) {
-      this.items = items;
-    } else {
-      final ProjectionItem all = new ProjectionItem(null,null,null);
-      all.setAll(true);
-      this.items.add(all);
-    }
-
+    this.items = items;
     this.distinct = distinct;
 
     //TODO make the whole class immutable!

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Projection.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Projection.java
@@ -95,10 +95,14 @@ public class Projection extends SimpleNode {
     if (isExpand())
       throw new IllegalStateException("This is an expand projection, it cannot be calculated as a single result" + this);
 
-    if (items.isEmpty() ||//
-        (items.size() == 1 && (items.get(0).isAll() || items.get(0).getExpression().toString().equals("@this")))//
-            && items.get(0).nestedProjection == null)
-      return iRecord;
+    if (items.size() == 1 && items.get(0).getExpression().toString().equals("@this"))
+      items.clear();
+
+    if (items.isEmpty()) {
+      final ProjectionItem star = new ProjectionItem(new Expression(new Identifier("*")),null,null);
+      star.setAll(true);
+      items.add(star);
+    }
 
     final ResultInternal result = new ResultInternal(context.getDatabase());
     for (final ProjectionItem item : items) {
@@ -106,7 +110,7 @@ public class Projection extends SimpleNode {
         continue;
 
       if (item.isAll()) {
-        // result.setElement(iRecord.toElement()); // TODO: Can this be removed?
+        result.setElement(iRecord.toElement());
         final Document doc = iRecord.getElement().get();
         for (final String alias : iRecord.getPropertyNames()) {
           if (this.excludes.contains(alias) || doc.getType().getProperty(alias).isHidden()) {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Projection.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Projection.java
@@ -95,7 +95,7 @@ public class Projection extends SimpleNode {
       throw new IllegalStateException("This is an expand projection, it cannot be calculated as a single result" + this);
 
     if (items.size() == 0 ||//
-        (items.size() == 1 && (/*items.get(0).isAll()*/ || items.get(0).getExpression().toString().equals("@this")))//
+        (items.size() == 1 && (/*items.get(0).isAll() ||*/ items.get(0).getExpression().toString().equals("@this")))//
             && items.get(0).nestedProjection == null)
       return iRecord;
 

--- a/engine/src/main/java/com/arcadedb/schema/AbstractProperty.java
+++ b/engine/src/main/java/com/arcadedb/schema/AbstractProperty.java
@@ -40,6 +40,7 @@ public abstract class AbstractProperty implements Property {
   protected              boolean             readonly        = false;
   protected              boolean             mandatory       = false;
   protected              boolean             notNull         = false;
+  protected              boolean             hidden          = false;
   protected              String              max             = null;
   protected              String              min             = null;
   protected              String              regexp          = null;
@@ -139,6 +140,11 @@ public abstract class AbstractProperty implements Property {
   }
 
   @Override
+  public boolean isHidden() {
+    return hidden;
+  }
+
+  @Override
   public String getMax() {
     return max;
   }
@@ -182,6 +188,8 @@ public abstract class AbstractProperty implements Property {
       json.put("mandatory", mandatory);
     if (notNull)
       json.put("notNull", notNull);
+    if (hidden)
+      json.put("hidden", hidden);
     if (max != null)
       json.put("max", max);
     if (min != null)

--- a/engine/src/main/java/com/arcadedb/schema/DocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/DocumentType.java
@@ -87,6 +87,8 @@ public interface DocumentType {
       p.setMandatory(prop.getBoolean("mandatory"));
     if (prop.has("notNull"))
       p.setNotNull(prop.getBoolean("notNull"));
+    if (prop.has("hidden"))
+      p.setNotNull(prop.getBoolean("hidden"));
     if (prop.has("max"))
       p.setMax(prop.getString("max"));
     if (prop.has("min"))

--- a/engine/src/main/java/com/arcadedb/schema/DocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/DocumentType.java
@@ -88,7 +88,7 @@ public interface DocumentType {
     if (prop.has("notNull"))
       p.setNotNull(prop.getBoolean("notNull"));
     if (prop.has("hidden"))
-      p.setNotNull(prop.getBoolean("hidden"));
+      p.setHidden(prop.getBoolean("hidden"));
     if (prop.has("max"))
       p.setMax(prop.getString("max"));
     if (prop.has("min"))

--- a/engine/src/main/java/com/arcadedb/schema/LocalProperty.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalProperty.java
@@ -113,6 +113,16 @@ public class LocalProperty extends AbstractProperty {
   }
 
   @Override
+  public Property setHidden(final boolean hidden) {
+    final boolean changed = !Objects.equals(this.hidden, hidden);
+    if (changed) {
+      this.hidden = hidden;
+      owner.getSchema().getEmbedded().saveConfiguration();
+    }
+    return this;
+  }
+
+  @Override
   public Property setMax(final String max) {
     final boolean changed = !Objects.equals(this.max, max);
     if (changed) {

--- a/engine/src/main/java/com/arcadedb/schema/Property.java
+++ b/engine/src/main/java/com/arcadedb/schema/Property.java
@@ -55,6 +55,10 @@ public interface Property {
 
   boolean isNotNull();
 
+  Property setHidden(boolean hidden);
+
+  boolean isHidden();
+
   Property setMax(String max);
 
   String getMax();

--- a/network/src/main/java/com/arcadedb/remote/RemoteProperty.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteProperty.java
@@ -67,6 +67,11 @@ public class RemoteProperty extends AbstractProperty {
   }
 
   @Override
+  public Property setHidden(boolean hidden) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public Property setMax(String max) {
     throw new UnsupportedOperationException();
   }

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -632,6 +632,7 @@ function displaySchema() {
         panelHtml += "<th scope='col'>Mandatory</th>";
         panelHtml += "<th scope='col'>Not Null</th>";
         panelHtml += "<th scope='col'>Read Only</th>";
+        panelHtml += "<th scope='col'>Hidden</th>";
         panelHtml += "<th scope='col'>Default Value</th>";
         panelHtml += "<th scope='col'>Min</th>";
         panelHtml += "<th scope='col'>Max</th>";
@@ -712,6 +713,7 @@ function renderProperties(row, results) {
     panelHtml += "<td>" + (property.mandatory ? true : false) + "</td>";
     panelHtml += "<td>" + (property.notNull ? true : false) + "</td>";
     panelHtml += "<td>" + (property.readOnly ? true : false) + "</td>";
+    panelHtml += "<td>" + (property.hidden ? true : false) + "</td>";
     panelHtml += "<td>" + (property["default"] != null ? property["default"] : "") + "</td>";
     panelHtml += "<td>" + (property.min != null ? property.min : "") + "</td>";
     panelHtml += "<td>" + (property.max != null ? property.max : "") + "</td>";


### PR DESCRIPTION
## What does this PR do?

This new boolean property attribute called `hidden` excludes properties from a projection containing a `*` (star).

## Motivation

[ZetaSQL](https://github.com/google/zetasql/blob/master/docs/data-definition-language.md?plain=1#L204)

## Related issues

https://github.com/ArcadeData/arcadedb/discussions/1439

## Additional Notes

This is the interesting change set: https://github.com/ArcadeData/arcadedb/pull/1503/files#diff-1ebfff8995bc54eab127a05a7f09d799b215972c6aa872635f37d86e824fb0b3

* Basically now the any projection with a `*` (`isAll`) gets parsed property by property not by copy any more.
* Particularly I don't understand why the argument record is copied into the result as whole (see https://github.com/ArcadeData/arcadedb/pull/1503/files#diff-1ebfff8995bc54eab127a05a7f09d799b215972c6aa872635f37d86e824fb0b3R108 )?
* `SELECT * FROM x` works, but `SELECT FROM x` does not.

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
