### PR TITLE
fix: Implement TraverseStatement.refersToParent() exception

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/TraverseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/TraverseStatement.java
@@ -137,7 +137,11 @@ public class TraverseStatement extends Statement {
         throw new IllegalArgumentException("Strategy " + strategy + " not supported");
       }
     }
+  }
 
+  @Override
+  public boolean refersToParent() {
+    return false;
   }
 
   @Override


### PR DESCRIPTION
## What does this PR do?

Fix the UnsupportedOperationException (Implement TraverseStatement.refersToParent()) when using sql traverse

## Motivation

Needed because of migration from orientdb and there it worked.

## Checklist

- [x] I tried to build but tests failed everywhere
