### PR TITLE
Fix: make "size" method also applicable to strings

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodSize.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodSize.java
@@ -42,6 +42,8 @@ public class SQLMethodSize extends AbstractSQLMethod {
     if (ioResult != null) {
       if (ioResult instanceof Identifiable) {
         size = 1;
+      } else if (ioResult instanceof String) {
+        size = ioResult.toString().length();
       } else {
         size = MultiValue.getSize(ioResult);
       }


### PR DESCRIPTION
## What does this PR do?

This change makes the `size` method report the size of strings.

## Additional Notes

This also makes the `length` method redundant. And particularly the `length` method does not work the same way for non-strings.

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
