### PR TITLE
Add null check to accumulator to fix csv import

### DIFF
--- a/integration/src/main/java/com/arcadedb/integration/importer/AnalyzedEntity.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/AnalyzedEntity.java
@@ -63,7 +63,10 @@ public class AnalyzedEntity {
 
   public void setRowSize(final String[] row) {
     for (int i = 0; i < row.length; ++i) {
-      totalRowLength += row[i].length() + 1;
+      if (row[i] != null)
+        totalRowLength += row[i].length();
+
+      ++totalRowLength; // Delimiter
     }
     ++totalRowLength; // ADD LF
 


### PR DESCRIPTION
## What does this PR do?

This change adds a `null` check to the `totalRowLength` accumulator attribute of class `AnalyzedEntity`.

## Motivation

Error caused by import of CSV files with empty values.

## Related issues

https://github.com/ArcadeData/arcadedb/issues/1199

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
