### PR TITLE
Allow default database with no user

### DIFF
--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -512,7 +512,8 @@ public class ArcadeDBServer {
         final int credentialEnd = db.indexOf(']', credentialBegin);
         final String credentials = db.substring(credentialBegin + 1, credentialEnd);
 
-        parseCredentials(dbName, credentials);
+        if (!credentials.isEmpty())
+          parseCredentials(dbName, credentials);
 
         Database database = existsDatabase(dbName) ? getDatabase(dbName) : null;
 


### PR DESCRIPTION
## What does this PR do?

This change allows default databases with no specific user.

## Motivation

Passing `-Darcadedb.server.defaultDatabases=test[]` failed due to empty credentials.

## Additional Notes

This did work at some point if I remember correctly(?). So this could have been a regression or causing one?

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
