### PR TITLE
Refactor isEmbeddedX in ResultInternal

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ResultInternal.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ResultInternal.java
@@ -199,7 +199,7 @@ public class ResultInternal implements Result {
           return true;
       }
 
-      return false;
+    return false;
   }
 
   private boolean isEmbeddedMap(final Object input) {
@@ -216,7 +216,7 @@ public class ResultInternal implements Result {
           return true;
       }
 
-      return false;
+    return false;
   }
 
   private boolean isEmbeddedList(final Object input) {
@@ -233,7 +233,7 @@ public class ResultInternal implements Result {
           return true;
       }
 
-      return false;
+    return false;
   }
 
   public Set<String> getPropertyNames() {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ResultInternal.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ResultInternal.java
@@ -186,52 +186,54 @@ public class ResultInternal implements Result {
   }
 
   private boolean isEmbeddedSet(final Object input) {
-    if (input instanceof Set) {
-      for (final Object o : (Set) input) {
-        if (o instanceof Record)
+    if (!(input instanceof Set))
+      return false;
+
+      final Set<?> inputSet = (Set<?>) input;
+
+      for (Object value : inputSet) {
+        if (value instanceof Record)
           return false;
 
-        else if (isEmbeddedList(o))
-          return true;
-        else if (isEmbeddedSet(o))
-          return true;
-        else if (isEmbeddedMap(o))
+        if (isEmbeddedList(value) || isEmbeddedSet(value) || isEmbeddedMap(value))
           return true;
       }
-    }
-    return false;
+
+      return false;
   }
 
   private boolean isEmbeddedMap(final Object input) {
-    if (input instanceof Map) {
-      for (final Object o : ((Map) input).values()) {
-        if (o instanceof Record)
-          return false;//TODO
-        else if (isEmbeddedList(o))
-          return true;
-        else if (isEmbeddedSet(o))
-          return true;
-        else if (isEmbeddedMap(o))
+    if (!(input instanceof Map))
+      return false;
+
+      final Map<?, ?> inputMap = (Map<?, ?>) input;
+
+      for (Object value : inputMap.values()) {
+        if (value instanceof Record)
+          return false;
+
+        if (isEmbeddedList(value) || isEmbeddedSet(value) || isEmbeddedMap(value))
           return true;
       }
-    }
-    return false;
+
+      return false;
   }
 
   private boolean isEmbeddedList(final Object input) {
-    if (input instanceof List) {
-      for (final Object o : (List) input) {
-        if (o instanceof Record)
+    if (!(input instanceof List))
+      return false;
+
+      final List<?> inputList = (List<?>) input;
+
+      for (Object value : inputList) {
+        if (value instanceof Record)
           return false;
-        else if (isEmbeddedList(o))
-          return true;
-        else if (isEmbeddedSet(o))
-          return true;
-        else if (isEmbeddedMap(o))
+
+        if (isEmbeddedList(value) || isEmbeddedSet(value) || isEmbeddedMap(value))
           return true;
       }
-    }
-    return false;
+
+      return false;
   }
 
   public Set<String> getPropertyNames() {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ResultInternal.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ResultInternal.java
@@ -189,9 +189,7 @@ public class ResultInternal implements Result {
     if (!(input instanceof Set))
       return false;
 
-    final Set<?> inputSet = (Set<?>) input;
-
-    for (Object value : inputSet) {
+    for (Object value : (Set<?>) input) {
       if (value instanceof Record)
         return false;
 
@@ -206,9 +204,7 @@ public class ResultInternal implements Result {
     if (!(input instanceof Map))
       return false;
 
-    final Map<?, ?> inputMap = (Map<?, ?>) input;
-
-    for (Object value : inputMap.values()) {
+    for (Object value : ((Map<?,?>) input).values()) {
       if (value instanceof Record)
         return false;
 
@@ -223,9 +219,7 @@ public class ResultInternal implements Result {
     if (!(input instanceof List))
       return false;
 
-    final List<?> inputList = (List<?>) input;
-
-    for (Object value : inputList) {
+    for (Object value : (List<?>) input) {
       if (value instanceof Record)
         return false;
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ResultInternal.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ResultInternal.java
@@ -189,15 +189,15 @@ public class ResultInternal implements Result {
     if (!(input instanceof Set))
       return false;
 
-      final Set<?> inputSet = (Set<?>) input;
+    final Set<?> inputSet = (Set<?>) input;
 
-      for (Object value : inputSet) {
-        if (value instanceof Record)
-          return false;
+    for (Object value : inputSet) {
+      if (value instanceof Record)
+        return false;
 
-        if (isEmbeddedList(value) || isEmbeddedSet(value) || isEmbeddedMap(value))
-          return true;
-      }
+      if (isEmbeddedList(value) || isEmbeddedSet(value) || isEmbeddedMap(value))
+        return true;
+    }
 
     return false;
   }
@@ -206,15 +206,15 @@ public class ResultInternal implements Result {
     if (!(input instanceof Map))
       return false;
 
-      final Map<?, ?> inputMap = (Map<?, ?>) input;
+    final Map<?, ?> inputMap = (Map<?, ?>) input;
 
-      for (Object value : inputMap.values()) {
-        if (value instanceof Record)
-          return false;
+    for (Object value : inputMap.values()) {
+      if (value instanceof Record)
+        return false;
 
-        if (isEmbeddedList(value) || isEmbeddedSet(value) || isEmbeddedMap(value))
-          return true;
-      }
+      if (isEmbeddedList(value) || isEmbeddedSet(value) || isEmbeddedMap(value))
+        return true;
+    }
 
     return false;
   }
@@ -223,15 +223,15 @@ public class ResultInternal implements Result {
     if (!(input instanceof List))
       return false;
 
-      final List<?> inputList = (List<?>) input;
+    final List<?> inputList = (List<?>) input;
 
-      for (Object value : inputList) {
-        if (value instanceof Record)
-          return false;
+    for (Object value : inputList) {
+      if (value instanceof Record)
+        return false;
 
-        if (isEmbeddedList(value) || isEmbeddedSet(value) || isEmbeddedMap(value))
-          return true;
-      }
+      if (isEmbeddedList(value) || isEmbeddedSet(value) || isEmbeddedMap(value))
+        return true;
+    }
 
     return false;
   }


### PR DESCRIPTION
## What does this PR do?

This change refactors `isEmbeddedSet`, `isEmbeddedMap`, `isEmbeddedList` in `ResultInternal` to allow early exit and avoid multiple casts.

## Motivation

Benchmarking `isEmbeddedMap` turned out to be the dominant consumer of CPU time, and while the recursive cost cannot be reduced, this refactoring can help reducing overhead.

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
