### PR TITLE
Remove windows build

### DIFF
--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -11,16 +11,7 @@ on:
 
 jobs:
   build:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        continue-on-error: [false]
-        include:
-          - os: windows-latest
-            continue-on-error: true
-
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
       - uses: xembly/workflow-manager@v1
@@ -33,37 +24,30 @@ jobs:
       - uses: pre-commit/action@v3.0.1
 
       - name: Set up QEMU
-        if: ${{ matrix.os != 'windows-latest' }}
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        if: ${{ matrix.os != 'windows-latest' }}
         uses: docker/setup-buildx-action@v3
 
-      - name: Set up GraalVM 11
-        uses: graalvm/setup-graalvm@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
         with:
-          version: "22.3.2"
-          gds-token: ${{ secrets.GDS_TOKEN }}
-          java-version: "11"
+          distribution: "temurin"
+          java-version: 11
           cache: "maven"
-          components: "native-image,js"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install jars
-        continue-on-error: ${{ matrix.continue-on-error }}
         run: mvn --show-version clean install -DskipTests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test
-        continue-on-error: ${{ matrix.continue-on-error }}
         run: mvn verify  -Pintegration -Pcoverage -Pdocker --batch-mode  --errors --fail-never --show-version  -pl !e2e
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: E2E Test
-        if: ${{ success() && matrix.os != 'windows-latest' }}
+        if: success()
         run: mvn verify -pl e2e
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -79,13 +63,11 @@ jobs:
           reporter: java-junit
 
       - name: Get coverage files
-        if: ${{ matrix.os != 'windows-latest' }}
         id: coverage-files-generator
         run: |
           echo ::set-output name=COVERAGE_FILES::$(find **/jacoco*.xml -printf '%p,')
 
       - name: Codacy coverage reporter
-        if: ${{ matrix.os != 'windows-latest' }}
         uses: codacy/codacy-coverage-reporter-action@v1
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}


### PR DESCRIPTION


## What does this PR do?

remove windows build from the matrix
move to temurin 11 JDK

## Motivation

Windows builds are alway red, it would be better to move it on a dedicated workflow to be triggered on demand, rather than having a consistently red build
