### PR TITLE
fix: comparison of empty strings with like

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/QueryHelper.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/QueryHelper.java
@@ -35,7 +35,7 @@ public class QueryHelper {
 
   public static String convertForRegExp(String value) {
 
-    final StringBuilder sb = new StringBuilder("");
+    final StringBuilder sb = new StringBuilder("(?s)");
 
     for (int i = 0; i < value.length();++i) {
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/QueryHelper.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/QueryHelper.java
@@ -23,9 +23,11 @@ public class QueryHelper {
   protected static final char WILDCARD_ANY     = '%';
 
   public static boolean like(String currentValue, String value) {
-    if (currentValue == null || currentValue.isEmpty() || value == null || value.isEmpty())
+    if (currentValue == null || value == null || (currentValue.isEmpty() ^ value.isEmpty()))
       // EMPTY/NULL PARAMETERS
       return false;
+    else if (currentValue.isEmpty() && value.isEmpty())
+      return true;
 
     value = convertForRegExp(value);
     return currentValue.matches(value);

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/QueryHelper.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/QueryHelper.java
@@ -34,73 +34,51 @@ public class QueryHelper {
   }
 
   public static String convertForRegExp(String value) {
-    // TODO: NOT EFFICIENT, IT SHOULD BROWSE ONCE AND BUILD THE FINAL RESULT
-    for (int i = 0; i < value.length(); ) {
-      final char c = value.charAt(i);
 
-      final String replaceWith;
+    final StringBuilder sb = new StringBuilder("");
+
+    for (int i = 0; i < value.length();++i) {
+
+      final char c = value.charAt(i);
       switch (c) {
       case '\\':
         if (i + 1 < value.length()) {
           final char next = value.charAt(i + 1);
-          if (next == '%')
-            replaceWith = "" + next;
-          else
-            replaceWith = "\\\\";
-        } else
-          replaceWith = "\\\\";
-        break;
+          if (next == WILDCARD_ANY) {
+            sb.append(next);
+            ++i;
+            break;
+          } else if (next == WILDCARD_ANYCHAR) {
+            sb.append("\\" + next);
+            ++i;
+            break;
+          }
+        }
       case '[':
-        replaceWith = "\\[";
-        break;
       case ']':
-        replaceWith = "\\]";
-        break;
       case '{':
-        replaceWith = "\\{";
-        break;
       case '}':
-        replaceWith = "\\}";
-        break;
       case '(':
-        replaceWith = "\\(";
-        break;
       case ')':
-        replaceWith = "\\)";
-        break;
       case '|':
-        replaceWith = "\\|";
-        break;
       case '*':
-        replaceWith = "\\*";
-        break;
       case '+':
-        replaceWith = "\\+";
-        break;
       case '$':
-        replaceWith = "\\$";
-        break;
       case '^':
-        replaceWith = "\\^";
-        break;
       case '.':
-        replaceWith = "\\.";
+        sb.append("\\" + c);
         break;
       case WILDCARD_ANYCHAR:
-        replaceWith = ".";
+        sb.append(".");
         break;
       case WILDCARD_ANY:
-        replaceWith = ".*";
+        sb.append(".*");
         break;
-
       default:
-        ++i;
-        continue;
+        sb.append(c);
+        break;
       }
-
-      value = value.substring(0, i) + replaceWith + value.substring(i + 1);
-      i += replaceWith.length();
     }
-    return value;
+    return sb.toString();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ILikeOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ILikeOperatorTest.java
@@ -39,6 +39,8 @@ public class ILikeOperatorTest {
     Assertions.assertTrue(op.execute(null, "100%", "100\\%"));
     Assertions.assertTrue(op.execute(null, "100%", "100%"));
     Assertions.assertTrue(op.execute(null, "", ""));
+    Assertions.assertTrue(op.execute(null, "100?", "100\\?"));
+    Assertions.assertTrue(op.execute(null, "100?", "100?"));
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ILikeOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ILikeOperatorTest.java
@@ -38,6 +38,7 @@ public class ILikeOperatorTest {
     Assertions.assertTrue(op.execute(null, "FOOBAR", "foobar"));
     Assertions.assertTrue(op.execute(null, "100%", "100\\%"));
     Assertions.assertTrue(op.execute(null, "100%", "100%"));
+    Assertions.assertTrue(op.execute(null, "", ""));
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ILikeOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ILikeOperatorTest.java
@@ -41,10 +41,11 @@ public class ILikeOperatorTest {
     Assertions.assertTrue(op.execute(null, "", ""));
     Assertions.assertTrue(op.execute(null, "100?", "100\\?"));
     Assertions.assertTrue(op.execute(null, "100?", "100?"));
+    Assertions.assertTrue(op.execute(null, "abc\ndef", "%E%"));
   }
 
   @Test
   public void replaceSpecialCharacters() {
-    Assertions.assertEquals("\\\\\\[\\]\\{\\}\\(\\)\\|\\*\\+\\$\\^\\...*", QueryHelper.convertForRegExp("\\[]{}()|*+$^.?%"));
+    Assertions.assertEquals("(?s)\\\\\\[\\]\\{\\}\\(\\)\\|\\*\\+\\$\\^\\...*", QueryHelper.convertForRegExp("\\[]{}()|*+$^.?%"));
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/LikeOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/LikeOperatorTest.java
@@ -38,6 +38,7 @@ public class LikeOperatorTest {
     Assertions.assertTrue(op.execute(null, "foobar", "foobar"));
     Assertions.assertTrue(op.execute(null, "100%", "100\\%"));
     Assertions.assertTrue(op.execute(null, "100%", "100%"));
+    Assertions.assertTrue(op.execute(null, "", ""));
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/LikeOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/LikeOperatorTest.java
@@ -41,10 +41,11 @@ public class LikeOperatorTest {
     Assertions.assertTrue(op.execute(null, "", ""));
     Assertions.assertTrue(op.execute(null, "100?", "100\\?"));
     Assertions.assertTrue(op.execute(null, "100?", "100?"));
+    Assertions.assertTrue(op.execute(null, "abc\ndef", "%e%"));
   }
 
   @Test
   public void replaceSpecialCharacters() {
-    Assertions.assertEquals("\\\\\\[\\]\\{\\}\\(\\)\\|\\*\\+\\$\\^\\...*", QueryHelper.convertForRegExp("\\[]{}()|*+$^.?%"));
+    Assertions.assertEquals("(?s)\\\\\\[\\]\\{\\}\\(\\)\\|\\*\\+\\$\\^\\...*", QueryHelper.convertForRegExp("\\[]{}()|*+$^.?%"));
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/LikeOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/LikeOperatorTest.java
@@ -39,6 +39,8 @@ public class LikeOperatorTest {
     Assertions.assertTrue(op.execute(null, "100%", "100\\%"));
     Assertions.assertTrue(op.execute(null, "100%", "100%"));
     Assertions.assertTrue(op.execute(null, "", ""));
+    Assertions.assertTrue(op.execute(null, "100?", "100\\?"));
+    Assertions.assertTrue(op.execute(null, "100?", "100?"));
   }
 
   @Test


### PR DESCRIPTION
## What does this PR do?

This change fixes and tests the case of comparing two empty strings `""` with `LIKE`, ie: `SELECT ("" LIKE "")`,
see https://sqlfiddle.com/postgresql/online-compiler?id=357ca34a-0b9f-428d-8f17-10d3202e8a38 for comparison.

## Related issues

https://github.com/ArcadeData/arcadedb/issues/1580

https://github.com/ArcadeData/arcadedb/issues/1577

## Additional Notes

The `QueryHelper` was refactored using a `StringBuilder` and iterating through the stirng only once.

Also the [regex modifier `(?s)`](https://www.regular-expressions.info/modifiers.html) is prepended to the pattern so that strings with newlines can be compared with `LIKE` and `ILIKE`.

## Checklist

- [X] I have run the build using `mvn clean package` command
- [X] My unit tests cover both failure and success scenarios
