### PR TITLE
feat: add SQL join method

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/method/DefaultSQLMethodFactory.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/DefaultSQLMethodFactory.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.sql.method;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.query.sql.executor.SQLMethod;
 import com.arcadedb.query.sql.method.collection.SQLMethodField;
+import com.arcadedb.query.sql.method.collection.SQLMethodJoin;
 import com.arcadedb.query.sql.method.collection.SQLMethodKeys;
 import com.arcadedb.query.sql.method.collection.SQLMethodRemove;
 import com.arcadedb.query.sql.method.collection.SQLMethodRemoveAll;
@@ -88,6 +89,7 @@ public class DefaultSQLMethodFactory implements SQLMethodFactory {
   public DefaultSQLMethodFactory() {
     // Collections
     register(SQLMethodField.NAME, new SQLMethodField());
+    register(SQLMethodJoin.NAME, new SQLMethodJoin());
     register(SQLMethodKeys.NAME, new SQLMethodKeys());
     register(SQLMethodRemove.NAME, new SQLMethodRemove());
     register(SQLMethodRemoveAll.NAME, new SQLMethodRemoveAll());

--- a/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodJoin.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodJoin.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.method.collection;
+
+import java.util.List;
+
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.method.AbstractSQLMethod;
+
+/**
+ * Splits a string using a delimiter.
+ *
+ * @author Luca Garulli (l.garulli--(at)--gmail.com)
+ */
+public class SQLMethodJoin extends AbstractSQLMethod {
+
+  public static final String NAME = "join";
+
+  public SQLMethodJoin() {
+    super(NAME, 1);
+  }
+
+  @Override
+  public Object execute(final Object value, final Identifiable iRecord, final CommandContext iContext, final Object[] iParams) {
+
+    if (value == null) {
+      return null;
+    } else if (value instanceof List && !((List<?>) value).isEmpty()) {
+
+      final String separator;
+
+      if( null == iParams || iParams.length == 0 || null == iParams[0] )
+        separator = ",";
+      else
+        separator = iParams[0].toString();
+
+      StringBuilder result = new StringBuilder("");
+      Boolean isFirst = true;
+
+      for(Object elem : (List<?>) value) {
+        if(isFirst)
+          isFirst = false;
+        else
+          result.append(separator);
+        result.append(elem.toString());
+      }
+      return result;
+    }
+    else
+      return value.toString();
+  }
+}


### PR DESCRIPTION
## What does this PR do?

This change adds a `join` SQL method which returns its input as string and in case of a list input the list elements are concatenated to a string with a separator supplied by an optional argument that is a comma by default.

## Motivation

A `join` method is available in other DSLs I use.

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
