### PR TITLE
Fix missing HTTP Post language guard

### DIFF
--- a/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
@@ -65,6 +65,9 @@ public class PostCommandHandler extends AbstractQueryHandler {
     if (command == null || command.isEmpty())
       return new ExecutionResponse(400, "{ \"error\" : \"Command text is null\"}");
 
+    if (language == null || language.isEmpty())
+      return new ExecutionResponse(400, "{ \"error\" : \"Language is null\"}");
+
     command = command.trim();
 
     Map<String, Object> paramMap = (Map<String, Object>) requestMap.get("params");


### PR DESCRIPTION
## What does this PR do?

This change adds a guard to the HTTP Server POST command handler, sending a 400 status if the language property is missing in the body (in the same way the GET query handler does).

## Motivation

User report in Discord

## Related issues

https://github.com/ArcadeData/arcadedb/issues/1603

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
