### PR TITLE
fix: create property default value assignment

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreatePropertyAttributeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreatePropertyAttributeStatement.java
@@ -68,7 +68,7 @@ public class CreatePropertyAttributeStatement extends SimpleNode {
       } else if (attrName.equalsIgnoreCase("default")) {
         if (this.settingValue == null)
           throw new CommandExecutionException("Default value not set");
-        internalProp.setDefaultValue(attrValue);
+        internalProp.setDefaultValue(this.settingValue.toString());
       } else if (attrName.equalsIgnoreCase("regexp")) {
         internalProp.setRegexp("" + attrValue);
       } else {


### PR DESCRIPTION
## What does this PR do?

This change syncs the the assignment of a default value in `CREATE PROPERTY` to the way it is done in `ALTER PROPERTY` (see https://github.com/ArcadeData/arcadedb/blob/main/engine/src/main/java/com/arcadedb/query/sql/parser/AlterPropertyStatement.java#L96 ).

## Motivation

Using `sysdate` in a default value was evaluated at property creation time not at record creation time.

## Related issues

https://github.com/ArcadeData/arcadedb/issues/1609

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
