### PR TITLE
fix: Wait for Gremlin Server to complete shutdown while shutting down the ArcadeDB Server

### DIFF
--- a/gremlin/src/main/java/com/arcadedb/server/gremlin/GremlinServerPlugin.java
+++ b/gremlin/src/main/java/com/arcadedb/server/gremlin/GremlinServerPlugin.java
@@ -93,6 +93,6 @@ public class GremlinServerPlugin implements ServerPlugin {
   @Override
   public void stopService() {
     if (gremlinServer != null)
-      gremlinServer.stop();
+      gremlinServer.stop().join();
   }
 }


### PR DESCRIPTION
## What does this PR do?

Previously, the ArcadeDB server did not wait for the Gremlin Server to complete the shutdown which lead to errors in the log files in case you are running an embedded ArcadeDB Server from within Tomcat which is currently shutting down (more general: any application in which the classloader is going to unload classes). This happens because relevant classes are unloaded before the Gremlin Server is done with the shutdown. This PR does not only fix the issue with the logs but also ensures that the Gremlin Server is shutdown properly.

Tomcat logs which were created previously (but not always, since it's a timing issue):
```
13-Jun-2024 14:22:22.216 INFORMATION [gremlin-server-stop] org.apache.catalina.loader.WebappClassLoaderBase.checkStateForResourceLoading Illegal access: this web application instance has been stopped already. Could not load [groovy.lang.Script]. The following stack trace is thrown for debugging purposes as well as to attempt to terminate the thread which caused the illegal access.
    java.lang.IllegalStateException: Illegal access: this web application instance has been stopped already. Could not load [groovy.lang.Script]. The following stack trace is thrown for debugging purposes as well as to attempt to terminate the thread which caused the illegal access.
        at org.apache.catalina.loader.WebappClassLoaderBase.checkStateForResourceLoading(WebappClassLoaderBase.java:1457)
        at org.apache.catalina.loader.WebappClassLoaderBase.checkStateForClassLoading(WebappClassLoaderBase.java:1445)
        at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1284)
        at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1245)
        at org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinGroovyScriptEngine.getParentLoader(GremlinGroovyScriptEngine.java:794)
        at org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinGroovyScriptEngine.createClassLoader(GremlinGroovyScriptEngine.java:756)
        at org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinGroovyScriptEngine.internalReset(GremlinGroovyScriptEngine.java:338)
        at org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinGroovyScriptEngine.reset(GremlinGroovyScriptEngine.java:309)
        at com.arcadedb.gremlin.ArcadeGraph.close(ArcadeGraph.java:406)
        at org.apache.tinkerpop.gremlin.server.GremlinServer.lambda$stop$8(GremlinServer.java:332)
        at java.base/java.util.concurrent.ConcurrentHashMap$KeySetView.forEach(ConcurrentHashMap.java:4706)
        at org.apache.tinkerpop.gremlin.server.GremlinServer.lambda$stop$9(GremlinServer.java:328)
        at java.base/java.lang.Thread.run(Thread.java:840)
13-Jun-2024 14:22:22.218 INFORMATION [gremlin-server-stop] org.apache.catalina.loader.WebappClassLoaderBase.checkStateForResourceLoading Illegal access: this web application instance has been stopped already. Could not load [com.arcadedb.cypher.ArcadeCypher$1]. The following stack trace is thrown for debugging purposes as well as to attempt to terminate the thread which caused the illegal access.
    java.lang.IllegalStateException: Illegal access: this web application instance has been stopped already. Could not load [com.arcadedb.cypher.ArcadeCypher$1]. The following stack trace is thrown for debugging purposes as well as to attempt to terminate the thread which caused the illegal access.
        at org.apache.catalina.loader.WebappClassLoaderBase.checkStateForResourceLoading(WebappClassLoaderBase.java:1457)
        at org.apache.catalina.loader.WebappClassLoaderBase.checkStateForClassLoading(WebappClassLoaderBase.java:1445)
        at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1284)
        at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1245)
        at com.arcadedb.gremlin.ArcadeGraph.close(ArcadeGraph.java:416)
        at org.apache.tinkerpop.gremlin.server.GremlinServer.lambda$stop$8(GremlinServer.java:332)
        at java.base/java.util.concurrent.ConcurrentHashMap$KeySetView.forEach(ConcurrentHashMap.java:4706)
        at org.apache.tinkerpop.gremlin.server.GremlinServer.lambda$stop$9(GremlinServer.java:328)
        at java.base/java.lang.Thread.run(Thread.java:840)
Exception in thread "gremlin-server-stop" java.lang.NoClassDefFoundError: com/arcadedb/cypher/ArcadeCypher$1
    at com.arcadedb.gremlin.ArcadeGraph.close(ArcadeGraph.java:416)
    at org.apache.tinkerpop.gremlin.server.GremlinServer.lambda$stop$8(GremlinServer.java:332)
    at java.base/java.util.concurrent.ConcurrentHashMap$KeySetView.forEach(ConcurrentHashMap.java:4706)
    at org.apache.tinkerpop.gremlin.server.GremlinServer.lambda$stop$9(GremlinServer.java:328)
    at java.base/java.lang.Thread.run(Thread.java:840)
```

## Motivation

Getting rid of confusing errors in the log files; Make sure that the server and all of it's components are shutdown properly.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
