### PR TITLE
fix: retain multiple command-line args for console script

### DIFF
--- a/package/src/main/scripts/console.sh
+++ b/package/src/main/scripts/console.sh
@@ -57,7 +57,7 @@ if [ $# -gt 0 ] ; then
         $JAVA_OPTS_SCRIPT \
         $ARCADEDB_SETTINGS \
         -cp "$ARCADEDB_HOME/lib/*" \
-        $ARGS com.arcadedb.console.Console "$*"
+        $ARGS com.arcadedb.console.Console "$@"
 else
     exec "$JAVA" $JAVA_OPTS \
         $ARCADEDB_OPTS_MEMORY \


### PR DESCRIPTION
## What does this PR do?

This changes the way command-line arguments are passed from the console script to java (Linux and MacOS) from using `$*` (all arguments as one string) to `$@` (arguments as array of strings), see https://tldp.org/LDP/abs/html/refcards.html .

## Motivation

The change is necessary to be able to pass multiple arguments, otherwise the console cannot detect switches.

## Additional Notes

I do not know and cannot test if this problem is also present on Windows.

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
