### PR TITLE
Fix record serializer

### DIFF
--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
@@ -181,7 +181,7 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
       while (qResult.hasNext()) {
         final Result r = qResult.next();
         result.put(serializerImpl.serializeResult(database, r));
-        if (limit > 0 && response.length() >= limit)
+        if (limit > 0 && result.length() >= limit)
           break;
       }
       response.put("result", result);


### PR DESCRIPTION
## What does this PR do?

This changes fixes the record serializer, which before measures the limit against the `response` which us unset at this point. Now the limit is compared to the `result`.

## Related issues

[A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.](https://github.com/ArcadeData/arcadedb/issues/1661)

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
