### PR TITLE
Use only relative paths in studio URLs.

### DIFF
--- a/studio/src/main/resources/static/js/studio-cluster.js
+++ b/studio/src/main/resources/static/js/studio-cluster.js
@@ -4,7 +4,7 @@ function updateCluster(callback) {
   jQuery
     .ajax({
       type: "GET",
-      url: "/api/v1/server?mode=cluster",
+      url: "api/v1/server?mode=cluster",
       beforeSend: function (xhr) {
         xhr.setRequestHeader("Authorization", globalCredentials);
       },
@@ -176,7 +176,7 @@ function connectToCluster() {
       jQuery
         .ajax({
           type: "POST",
-          url: "/api/v1/server",
+          url: "api/v1/server",
           data: "{ 'command': 'connect cluster " + serverAddress + "' }",
           beforeSend: function (xhr) {
             xhr.setRequestHeader("Authorization", globalCredentials);
@@ -201,7 +201,7 @@ function executeServerCommand(command, successMessage) {
   jQuery
     .ajax({
       type: "POST",
-      url: "/api/v1/server",
+      url: "api/v1/server",
       data: JSON.stringify({
         command: command,
       }),

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -45,7 +45,7 @@ function updateDatabases(callback) {
   jQuery
     .ajax({
       type: "POST",
-      url: "/api/v1/server",
+      url: "api/v1/server",
       data: "{ command: 'list databases' }",
       beforeSend: function (xhr) {
         xhr.setRequestHeader("Authorization", globalCredentials);
@@ -107,7 +107,7 @@ function createDatabase() {
       jQuery
         .ajax({
           type: "POST",
-          url: "/api/v1/server",
+          url: "api/v1/server",
           data: "{ 'command': 'create database " + database + "' }",
           beforeSend: function (xhr) {
             xhr.setRequestHeader("Authorization", globalCredentials);
@@ -141,7 +141,7 @@ function dropDatabase() {
       jQuery
         .ajax({
           type: "POST",
-          url: "/api/v1/server",
+          url: "api/v1/server",
           data: "{ 'command': 'drop database " + database + "' }",
           beforeSend: function (xhr) {
             xhr.setRequestHeader("Authorization", globalCredentials);
@@ -172,7 +172,7 @@ function resetDatabase() {
       jQuery
         .ajax({
           type: "POST",
-          url: "/api/v1/server",
+          url: "api/v1/server",
           data: "{ 'command': 'drop database " + database + "' }",
           beforeSend: function (xhr) {
             xhr.setRequestHeader("Authorization", globalCredentials);
@@ -182,7 +182,7 @@ function resetDatabase() {
           jQuery
             .ajax({
               type: "POST",
-              url: "/api/v1/server",
+              url: "api/v1/server",
               data: "{ 'command': 'create database " + database + "' }",
               beforeSend: function (xhr) {
                 xhr.setRequestHeader("Authorization", globalCredentials);
@@ -218,7 +218,7 @@ function backupDatabase() {
       jQuery
         .ajax({
           type: "POST",
-          url: "/api/v1/command/" + database,
+          url: "api/v1/command/" + database,
           data: JSON.stringify({
             language: "sql",
             command: "backup database",
@@ -253,7 +253,7 @@ function dropProperty(type, property) {
       jQuery
         .ajax({
           type: "POST",
-          url: "/api/v1/command/" + database,
+          url: "api/v1/command/" + database,
           data: JSON.stringify({
             language: "sql",
             command: "drop property `" + type + "`.`" + property + "`",
@@ -288,7 +288,7 @@ function dropIndex(indexName) {
       jQuery
         .ajax({
           type: "POST",
-          url: "/api/v1/command/" + database,
+          url: "api/v1/command/" + database,
           data: JSON.stringify({
             language: "sql",
             command: "drop index `" + indexName + "`",
@@ -427,7 +427,7 @@ function executeCommandTable() {
   jQuery
     .ajax({
       type: "POST",
-      url: "/api/v1/command/" + database,
+      url: "api/v1/command/" + database,
       data: JSON.stringify({
         language: language,
         command: command,
@@ -477,7 +477,7 @@ function executeCommandGraph() {
   jQuery
     .ajax({
       type: "POST",
-      url: "/api/v1/command/" + database,
+      url: "api/v1/command/" + database,
       data: JSON.stringify({
         language: language,
         command: command,
@@ -528,7 +528,7 @@ function displaySchema() {
   jQuery
     .ajax({
       type: "POST",
-      url: "/api/v1/query/" + database,
+      url: "api/v1/query/" + database,
       data: JSON.stringify({
         language: "sql",
         command: "select from schema:types",
@@ -776,7 +776,7 @@ function displayDatabaseSettings() {
   jQuery
     .ajax({
       type: "POST",
-      url: "/api/v1/query/" + database,
+      url: "api/v1/query/" + database,
       data: JSON.stringify({
         language: "sql",
         command: "select expand( settings ) from schema:database",
@@ -850,7 +850,7 @@ function updateDatabaseSetting(key, value) {
       jQuery
         .ajax({
           type: "POST",
-          url: "/api/v1/server",
+          url: "api/v1/server",
           data: JSON.stringify({
             language: "sql",
             command: "set database setting " + getCurrentDatabase() + " " + key + " " + $("#updateSettingInput").val(),

--- a/studio/src/main/resources/static/js/studio-graph-widget.js
+++ b/studio/src/main/resources/static/js/studio-graph-widget.js
@@ -397,7 +397,7 @@ function loadNodeNeighbors(direction, rid) {
   jQuery
     .ajax({
       type: "POST",
-      url: "/api/v1/command/" + database,
+      url: "api/v1/command/" + database,
       data: JSON.stringify({
         language: "sql",
         command: "select expand( " + direction + "E() ) from " + rid,
@@ -502,7 +502,7 @@ function addNodeFromRecord(rid) {
     jQuery
       .ajax({
         type: "POST",
-        url: "/api/v1/command/" + escapeHtml($("#schemaInputDatabase").val()),
+        url: "api/v1/command/" + escapeHtml($("#schemaInputDatabase").val()),
         async: false,
         data: JSON.stringify({
           language: "sql",

--- a/studio/src/main/resources/static/js/studio-server.js
+++ b/studio/src/main/resources/static/js/studio-server.js
@@ -24,7 +24,7 @@ function updateServer(callback) {
   jQuery
     .ajax({
       type: "GET",
-      url: "/api/v1/server",
+      url: "api/v1/server",
       beforeSend: function (xhr) {
         xhr.setRequestHeader("Authorization", globalCredentials);
       },
@@ -414,7 +414,7 @@ function updateServerSetting(key, value) {
       jQuery
         .ajax({
           type: "POST",
-          url: "/api/v1/server",
+          url: "api/v1/server",
           data: JSON.stringify({
             language: "sql",
             command: "set server setting " + key + " " + $("#updateSettingInput").val(),
@@ -439,7 +439,7 @@ function getServerEvents(file) {
   jQuery
     .ajax({
       type: "POST",
-      url: "/api/v1/server",
+      url: "api/v1/server",
       data: "{ command: 'get server events" + (file != null ? " " + file : "") + "' }",
       beforeSend: function (xhr) {
         xhr.setRequestHeader("Authorization", globalCredentials);

--- a/studio/src/main/resources/static/popup-login.html
+++ b/studio/src/main/resources/static/popup-login.html
@@ -25,7 +25,7 @@
 
                   <button onclick="login()" class="btn btn-lg btn-primary btn-block" type="submit">
                     Sign in
-                    <img id="loginSpinner" class="ui-loading" src="/images/color-spin-small.svg" style="display: none" />
+                    <img id="loginSpinner" class="ui-loading" src="images/color-spin-small.svg" style="display: none" />
                   </button>
                 </div>
               </div>

--- a/studio/src/main/resources/static/query.html
+++ b/studio/src/main/resources/static/query.html
@@ -34,7 +34,7 @@
       <div class="d-flex">
         <button class="btn btn-primary mx-2" onclick="executeCommand()">
           <i class="fa fa-play"></i>
-          <img id="executeSpinner" class="ui-loading" src="/images/color-spin-small.svg" style="display: none" />
+          <img id="executeSpinner" class="ui-loading" src="images/color-spin-small.svg" style="display: none" />
         </button>
         <select id="inputLanguage" class="px-1 form-control" style="color: #00aeee">
           <option value="sql" selected>SQL</option>


### PR DESCRIPTION
## What does this PR do?

Change absolute URLs in the studio to relative ones.

## Motivation

Relative URLs in the studio eases the task to proxy multiple instances of ArcadeDB. Without this patch, URLs in the HTML and Javascript documents must be rewritten by the proxy. With this patch this is no longer necessary.

As an example the following nginx config snippet proxies 2 ArcadeDB instances:
```
        # This is the production instance.
        location /arcadedb/stable/ {
                rewrite ^/arcadedb/stable(.*)$ $1 break;
                proxy_pass http://10.11.12.13:2480;
        }
        # This is the sandbox server.
        location /arcadedb/sandbox/ {
                rewrite ^/arcadedb/sandbox(.*)$ $1 break;
                proxy_pass http://10.11.12.14:2480;
        }
```

Please note that the configuration example rewrites only the URL in the client's request. It does not change the URLs in the HTML and Javascript files sent by the ArcadeDB server.

## Additional Notes

Unfortunately I'm too dumb to create a unit test for this. :(

## Checklist

- [x] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
