### PR TITLE
Add "trimPrefix" and "trimSuffix" SQL Methods

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/method/DefaultSQLMethodFactory.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/DefaultSQLMethodFactory.java
@@ -68,6 +68,8 @@ import com.arcadedb.query.sql.method.string.SQLMethodLeft;
 import com.arcadedb.query.sql.method.string.SQLMethodLength;
 import com.arcadedb.query.sql.method.string.SQLMethodNormalize;
 import com.arcadedb.query.sql.method.string.SQLMethodPrefix;
+import com.arcadedb.query.sql.method.string.SQLMethodTrimPrefix;
+import com.arcadedb.query.sql.method.string.SQLMethodTrimSuffix;
 import com.arcadedb.query.sql.method.string.SQLMethodReplace;
 import com.arcadedb.query.sql.method.string.SQLMethodRight;
 import com.arcadedb.query.sql.method.string.SQLMethodSplit;
@@ -144,6 +146,8 @@ public class DefaultSQLMethodFactory implements SQLMethodFactory {
     register(SQLMethodLength.NAME, new SQLMethodLength());
     register(SQLMethodNormalize.NAME, new SQLMethodNormalize());
     register(SQLMethodPrefix.NAME, new SQLMethodPrefix());
+    register(SQLMethodTrimPrefix.NAME, new SQLMethodTrimPrefix());
+    register(SQLMethodTrimSuffix.NAME, new SQLMethodTrimSuffix());
     register(SQLMethodReplace.NAME, new SQLMethodReplace());
     register(SQLMethodRight.NAME, new SQLMethodRight());
     register(SQLMethodSplit.NAME, new SQLMethodSplit());

--- a/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodTrimPrefix.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodTrimPrefix.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.method.string;
+
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.method.AbstractSQLMethod;
+
+/**
+ * @author Johann Sorel (Geomatys)
+ * @author Luca Garulli (l.garulli--(at)--gmail.com)
+ */
+public class SQLMethodTrimPrefix extends AbstractSQLMethod {
+
+  public static final String NAME = "trimprefix";
+
+  public SQLMethodTrimPrefix() {
+    super(NAME, 1);
+  }
+
+  @Override
+  public Object execute( final Object value, final Identifiable iRecord, final CommandContext iContext, final Object[] iParams) {
+    if (value == null || null == iParams || null == iParams[0])
+      return value;
+
+    final String strval = value.toString();
+    final String prefix = iParams[0].toString();
+
+    if (strval.startsWith(prefix))
+      return strval.substring(prefix.length());
+    else
+      return strval;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodTrimSuffix.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/string/SQLMethodTrimSuffix.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.method.string;
+
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.method.AbstractSQLMethod;
+
+/**
+ * @author Johann Sorel (Geomatys)
+ * @author Luca Garulli (l.garulli--(at)--gmail.com)
+ */
+public class SQLMethodTrimSuffix extends AbstractSQLMethod {
+
+  public static final String NAME = "trimsuffix";
+
+  public SQLMethodTrimSuffix() {
+    super(NAME, 1);
+  }
+
+  @Override
+  public Object execute( final Object value, final Identifiable iRecord, final CommandContext iContext, final Object[] iParams) {
+    if (value == null || null == iParams || null == iParams[0])
+      return value;
+
+    final String strval = value.toString();
+    final String suffix = iParams[0].toString();
+
+    if (strval.endsWith(suffix))
+      return strval.substring(0,strval.length() - suffix.length());
+    else
+      return strval;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/method/string/SQLMethodTrimPrefixTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/string/SQLMethodTrimPrefixTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.method.string;
+
+import com.arcadedb.query.sql.executor.SQLMethod;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SQLMethodTrimPrefoxTest {
+  private SQLMethod method;
+
+  @BeforeEach
+  void setUp() {
+    method = new SQLMethodTrimPrefix();
+  }
+
+  @Test
+  void testAllNullPreservation() {
+    final Object result = method.execute(null, null, null, null);
+    assertThat(result).isNull();
+  }
+
+  @Test
+  void testBaseNullPreservation() {
+    final Object result = method.execute(null, null, null, new Object[] {"Bye"});
+    assertThat(result).isNull();
+  }
+
+  @Test
+  void testArgNullPreservation() {
+    final Object result = method.execute("Hello World", null, null, null);
+    assertThat(result).isEqualTo("Hello World");
+  }
+
+  @Test
+  void testIdentity() {
+    final Object result = method.execute("Hello World", null, null, new Object[] {"Bye"});
+    assertThat(result).isEqualTo("Hello World");
+  }
+
+  @Test
+  void testTrim() {
+    final Object result = method.execute("Hello World", null, null, new Object[] {"Hello"});
+    assertThat(result).isEqualTo(" World");
+  }
+
+  @Test
+  void testEmptyArg() {
+    final Object result = method.execute("Hello World", null, null, new Object[] {""});
+    assertThat(result).isEqualTo("Hello World");
+  }
+
+  @Test
+  void testEmptyBase() {
+    final Object result = method.execute("", null, null, new Object[] {"Bye"});
+    assertThat(result).isEqualTo("");
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/method/string/SQLMethodTrimPrefixTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/string/SQLMethodTrimPrefixTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class SQLMethodTrimPrefoxTest {
+class SQLMethodTrimPrefixTest {
   private SQLMethod method;
 
   @BeforeEach
@@ -63,6 +63,12 @@ class SQLMethodTrimPrefoxTest {
   }
 
   @Test
+  void testFull() {
+    final Object result = method.execute("Hello World", null, null, new Object[] {"Hello World"});
+    assertThat(result).isEqualTo("");
+  }
+
+  @Test
   void testEmptyArg() {
     final Object result = method.execute("Hello World", null, null, new Object[] {""});
     assertThat(result).isEqualTo("Hello World");
@@ -72,5 +78,11 @@ class SQLMethodTrimPrefoxTest {
   void testEmptyBase() {
     final Object result = method.execute("", null, null, new Object[] {"Bye"});
     assertThat(result).isEqualTo("");
+  }
+
+  @Test
+  void testNonString() {
+    final Object result = method.execute(123, null, null, new Object[] {"Bye"});
+    assertThat(result).isEqualTo("123");
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/method/string/SQLMethodTrimSuffixTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/string/SQLMethodTrimSuffixTest.java
@@ -63,6 +63,12 @@ class SQLMethodTrimSuffixTest {
   }
 
   @Test
+  void testFull() {
+    final Object result = method.execute("Hello World", null, null, new Object[] {"Hello World"});
+    assertThat(result).isEqualTo("");
+  }
+
+  @Test
   void testEmptyArg() {
     final Object result = method.execute("Hello World", null, null, new Object[] {""});
     assertThat(result).isEqualTo("Hello World");
@@ -72,5 +78,11 @@ class SQLMethodTrimSuffixTest {
   void testEmptyBase() {
     final Object result = method.execute("", null, null, new Object[] {"Bye"});
     assertThat(result).isEqualTo("");
+  }
+
+  @Test
+  void testNonString() {
+    final Object result = method.execute(123, null, null, new Object[] {"Bye"});
+    assertThat(result).isEqualTo("123");
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/method/string/SQLMethodTrimSuffixTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/string/SQLMethodTrimSuffixTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.method.string;
+
+import com.arcadedb.query.sql.executor.SQLMethod;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SQLMethodTrimSuffixTest {
+  private SQLMethod method;
+
+  @BeforeEach
+  void setUp() {
+    method = new SQLMethodTrimSuffix();
+  }
+
+  @Test
+  void testAllNullPreservation() {
+    final Object result = method.execute(null, null, null, null);
+    assertThat(result).isNull();
+  }
+
+  @Test
+  void testBaseNullPreservation() {
+    final Object result = method.execute(null, null, null, new Object[] {"Bye"});
+    assertThat(result).isNull();
+  }
+
+  @Test
+  void testArgNullPreservation() {
+    final Object result = method.execute("Hello World", null, null, null);
+    assertThat(result).isEqualTo("Hello World");
+  }
+
+  @Test
+  void testIdentity() {
+    final Object result = method.execute("Hello World", null, null, new Object[] {"Bye"});
+    assertThat(result).isEqualTo("Hello World");
+  }
+
+  @Test
+  void testTrim() {
+    final Object result = method.execute("Hello World", null, null, new Object[] {"World"});
+    assertThat(result).isEqualTo("Hello ");
+  }
+
+  @Test
+  void testEmptyArg() {
+    final Object result = method.execute("Hello World", null, null, new Object[] {""});
+    assertThat(result).isEqualTo("Hello World");
+  }
+
+  @Test
+  void testEmptyBase() {
+    final Object result = method.execute("", null, null, new Object[] {"Bye"});
+    assertThat(result).isEqualTo("");
+  }
+}


### PR DESCRIPTION
## What does this PR do?

This change adds two SQL methods aimed at strings:

* `.trimPrefix`
* `.trimSuffix`

These methods remove a string argument from the front or back of the base object respectively if it exists, otherwise returns the (stringified) base object as-is.

## Motivation

Inspired by [Connect](https://docs.redpanda.com/redpanda-connect/guides/bloblang/methods/#trim_prefix) for data cleaning purposes.

## Checklist

- [X] I have run the build using `mvn clean package` command
- [X] My unit tests cover both failure and success scenarios (only success)
