### PR TITLE
Improve console batch mode

### DIFF
--- a/console/pom.xml
+++ b/console/pom.xml
@@ -73,7 +73,7 @@
         </dependency>
         <dependency>
             <groupId>org.jline</groupId>
-            <artifactId>jline-terminal-jansi</artifactId>
+            <artifactId>jline-terminal-jni</artifactId>
             <version>${jline.version}</version>
         </dependency>
         <dependency>

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -612,8 +612,9 @@ public class Console {
       try {
         resultSet = databaseProxy.command(language, line);
       } catch (Exception e) {
-        outputError(e);
-        return;
+//        outputError(e);
+//        return;
+        throw e;
       }
 
     if (transactionBatchSize > 0) {
@@ -764,8 +765,15 @@ public class Console {
             throw e;
         }
       } else {
-        if (!execute(w))
-          return false;
+        try {
+          if (!execute(w))
+            return false;
+        } catch (final Exception e) {
+            return true;
+
+//          throw e;
+        }
+
       }
     }
     return true;

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -54,8 +54,18 @@ import org.jline.reader.impl.history.DefaultHistory;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
 
-import java.io.*;
-import java.util.*;
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 public class Console {
   private static final String               PROMPT                   = "%n%s> ";
@@ -95,7 +105,7 @@ public class Console {
 
     GlobalConfiguration.PROFILE.setValue("low-cpu");
 
-    terminal = TerminalBuilder.builder().system(system).streams(System.in, System.out).jansi(true).build();
+    terminal = TerminalBuilder.builder().system(system).streams(System.in, System.out).jni(true).build();
 
     output(3, "%s Console v.%s - %s (%s)", Constants.PRODUCT, Constants.getRawVersion(), Constants.COPYRIGHT, Constants.URL);
   }
@@ -163,9 +173,9 @@ public class Console {
         final String[] parts = value.substring(2).split("=");
         System.setProperty(parts[0], parts[1]);
         setGlobalConfiguration(parts[0], parts[1], true);
-      } else if (value.equalsIgnoreCase("-b"))
+      } else if (value.equalsIgnoreCase("-b")) {
         batchMode = true;
-      else {
+      } else {
         commands.append(value);
         if (!value.endsWith(";"))
           commands.append(";");
@@ -721,14 +731,15 @@ public class Console {
   }
 
   public boolean parse(final String line) throws IOException, RuntimeException {
-    return parse(line, false, true);
+    return parse(line, false, false);
   }
 
   public boolean parse(final String line, final boolean printCommand) throws IOException, RuntimeException {
-    return parse(line, printCommand, true);
+    return parse(line, printCommand, false);
   }
 
-  public boolean parse(final String line, final boolean printCommand, final boolean batchMode) throws IOException, RuntimeException {
+  public boolean parse(final String line, final boolean printCommand, final boolean batchMode)
+      throws IOException, RuntimeException {
 
     final ParsedLine parsedLine = parser.parse(line, 0);
 

--- a/console/src/test/java/com/arcadedb/console/ConsoleBatchTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleBatchTest.java
@@ -45,7 +45,7 @@ public class ConsoleBatchTest {
 
   @Test
   public void batchModeWithError() throws IOException {
-
+    // This should fail
     assertThatThrownBy(() -> Console.execute(
         new String[] { "-b", """
           create database console;
@@ -53,8 +53,26 @@ public class ConsoleBatchTest {
           create vertex type ConsoleOnlyVertex;
         """ }))
         .isInstanceOf(CommandSQLParsingException.class);
+
     final Database db = new DatabaseFactory("./target/databases/console").open();
+    // the ConsoleOnlyVertex should not be created
     assertThat(db.getSchema().existsType("ConsoleOnlyVertex")).isFalse();
+    db.drop();
+  }
+
+  @Test
+  public void batchModeWithFailAtEnd() throws IOException {
+    // Error is only printed out
+    Console.execute(
+        new String[] { "-b", "-fae", """
+          create database console;
+          create vertex table WRONG_STATEMENT;
+          create vertex type ConsoleOnlyVertex;
+        """ });
+
+    final Database db = new DatabaseFactory("./target/databases/console").open();
+    // the ConsoleOnlyVertex is created
+    assertThat(db.getSchema().existsType("ConsoleOnlyVertex")).isTrue();
     db.drop();
   }
 


### PR DESCRIPTION
## What does this PR do?

Overall, this change alters the console behavior such that if an error occurs in batch mode or during a script, execution is halted and if in batch mode, the console is exited.

In particular these changes are introduced in `Console.java`:

1. Make `parse` method have 3 arguments (see [line 731](https://github.com/ArcadeData/arcadedb/compare/main...gramian:arcadedb:console#diff-a1bb54898c0fb689c4f019cdf0af238dd35cdfad2ba6ec318e5281624745c4cbR731)). The third argument is a `boolean` indicating batch mode, which is true by default.
2. Add wrapper method with 2 arguments to minimize changes (see [line 727](https://github.com/ArcadeData/arcadedb/compare/main...gramian:arcadedb:console#diff-a1bb54898c0fb689c4f019cdf0af238dd35cdfad2ba6ec318e5281624745c4cbR727))
3. New `parse` does not consume exeception anymore, but throws them upwards (see [line 742ff](https://github.com/ArcadeData/arcadedb/compare/main...gramian:arcadedb:console#diff-a1bb54898c0fb689c4f019cdf0af238dd35cdfad2ba6ec318e5281624745c4cbR742)).
4. "Lower" `execute` method now throws also `RuntimeExeception` (see line [line 223](https://github.com/ArcadeData/arcadedb/compare/main...gramian:arcadedb:console#diff-a1bb54898c0fb689c4f019cdf0af238dd35cdfad2ba6ec318e5281624745c4cbR223))
5. "Upper" `execute` method uses new `parse` method depending on if batch mode is set.

## Motivation

Currently console continues to execute commands in scripts or batch even though previous command fails. This can produce unwanted results. Especially tracking errors is complicated since if the last line passes, it seems as if a script or batch is successful.

## Additional Notes

@lvca 

* `ConsoleTest`: `testNotNullProperties` fails, is this test faulty? 
* Need help constructing tests for this.
* The "upper" execute method (line 155) should be renamed so there are not two methods names `execute`.
* Are the exeception-related changes OK?

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
