### PR TITLE
#1756 migrate build and runtime in docker file to java 17

### DIFF
--- a/.github/workflows/mvn-deploy.yml
+++ b/.github/workflows/mvn-deploy.yml
@@ -29,11 +29,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: 11
+          java-version: 17
           cache: "maven"
           server-id: ossrh
           server-username: MAVEN_USERNAME

--- a/.github/workflows/mvn-release.yml
+++ b/.github/workflows/mvn-release.yml
@@ -26,11 +26,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: 11
+          java-version: 17
           cache: "maven"
           server-id: ossrh
           server-username: MAVEN_USERNAME

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -26,11 +26,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: 11
+          java-version: 17
           cache: "maven"
 
       - name: Install jars

--- a/package/src/main/docker/Dockerfile
+++ b/package/src/main/docker/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 
-FROM eclipse-temurin:11
+FROM eclipse-temurin:17
 
 LABEL maintainer="Arcade Data LTD (info@arcadedb.com)"
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     </licenses>
 
     <properties>
-        <maven-compiler-plugin.release>11</maven-compiler-plugin.release>
+        <maven-compiler-plugin.release>17</maven-compiler-plugin.release>
         <exclude.tests></exclude.tests>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 

--- a/studio/pom.xml
+++ b/studio/pom.xml
@@ -7,6 +7,7 @@
         <groupId>com.arcadedb</groupId>
         <artifactId>arcadedb-parent</artifactId>
         <version>24.11.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>arcadedb-studio</artifactId>


### PR DESCRIPTION
## What does this PR do?
Migrates the build system and the runtime (docker) to java 17


## Motivation

We want to move to a modern version of Java and JVM 


## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
