### PR TITLE
#1764 migrate form Junit5 Assertions to AssertJ

### DIFF
--- a/console/src/test/java/com/arcadedb/console/ConsoleBatchTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleBatchTest.java
@@ -24,18 +24,19 @@ import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.server.TestServerHelper;
 import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConsoleBatchTest {
   @Test
   public void batchMode() throws IOException {
     Console.execute(new String[] { "-b", "create database console; create vertex type ConsoleOnlyVertex;" });
     final Database db = new DatabaseFactory("./target/databases/console").open();
-    Assertions.assertTrue(db.getSchema().existsType("ConsoleOnlyVertex"));
+    assertThat(db.getSchema().existsType("ConsoleOnlyVertex")).isTrue();
     db.drop();
   }
 
@@ -43,7 +44,7 @@ public class ConsoleBatchTest {
   public void interactiveMode() throws IOException {
     Console.execute(new String[] { "create database console; create vertex type ConsoleOnlyVertex;exit" });
     final Database db = new DatabaseFactory("./target/databases/console").open();
-    Assertions.assertTrue(db.getSchema().existsType("ConsoleOnlyVertex"));
+    assertThat(db.getSchema().existsType("ConsoleOnlyVertex")).isTrue();
     db.drop();
   }
 
@@ -52,7 +53,7 @@ public class ConsoleBatchTest {
     FileUtils.deleteRecursively(new File("./console"));
     Console.execute(new String[] { "-Darcadedb.server.databaseDirectory=.", "create database console; create vertex type ConsoleOnlyVertex;exit;" });
     final Database db = new DatabaseFactory("./console").open();
-    Assertions.assertTrue(db.getSchema().existsType("ConsoleOnlyVertex"));
+    assertThat(db.getSchema().existsType("ConsoleOnlyVertex")).isTrue();
     db.drop();
     GlobalConfiguration.resetAll();
   }

--- a/console/src/test/java/com/arcadedb/console/ConsoleTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleTest.java
@@ -33,13 +33,16 @@ import com.arcadedb.schema.Type;
 import com.arcadedb.server.TestServerHelper;
 import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.text.*;
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class ConsoleTest {
   private static final String  DB_NAME = "console";
@@ -53,14 +56,14 @@ public class ConsoleTest {
     FileUtils.deleteRecursively(dbFile);
     GlobalConfiguration.SERVER_ROOT_PATH.setValue("./target");
     console = new Console();
-    Assertions.assertTrue(console.parse("create database " + DB_NAME + "; close"));
+    assertThat(console.parse("create database " + DB_NAME + "; close")).isTrue();
   }
 
   @AfterEach
   public void drop() throws IOException {
     console.close();
     TestServerHelper.checkActiveDatabases();
-    Assertions.assertTrue(console.parse("drop database " + DB_NAME + "; close", false));
+    assertThat(console.parse("drop database " + DB_NAME + "; close", false)).isTrue();
     GlobalConfiguration.resetAll();
   }
 
@@ -70,57 +73,57 @@ public class ConsoleTest {
       return;
 
     String localUrl = "local:/" + absoluteDBPath + "/" + DB_NAME;
-    Assertions.assertTrue(console.parse("drop database " + localUrl + "; close", false));
-    Assertions.assertTrue(console.parse("create database " + localUrl + "; close", false));
+    assertThat(console.parse("drop database " + localUrl + "; close", false)).isTrue();
+    assertThat(console.parse("create database " + localUrl + "; close", false)).isTrue();
   }
 
   @Test
   public void testNull() throws IOException {
-    Assertions.assertTrue(console.parse(null));
+    assertThat(console.parse(null)).isTrue();
   }
 
   @Test
   public void testEmpty() throws IOException {
-    Assertions.assertTrue(console.parse(""));
+    assertThat(console.parse("")).isTrue();
   }
 
   @Test
   public void testEmpty2() throws IOException {
-    Assertions.assertTrue(console.parse(" "));
+    assertThat(console.parse(" ")).isTrue();
   }
 
   @Test
   public void testEmpty3() throws IOException {
-    Assertions.assertTrue(console.parse(";"));
+    assertThat(console.parse(";")).isTrue();
   }
 
   @Test
   public void testComment() throws IOException {
-    Assertions.assertTrue(console.parse("-- This is a comment;"));
+    assertThat(console.parse("-- This is a comment;")).isTrue();
   }
 
   @Test
   public void testListDatabases() throws IOException {
-    Assertions.assertTrue(console.parse("list databases;"));
+    assertThat(console.parse("list databases;")).isTrue();
   }
 
   @Test
   public void testConnect() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + DB_NAME + ";info types"));
+    assertThat(console.parse("connect " + DB_NAME + ";info types")).isTrue();
   }
 
   @Test
   public void testLocalConnect() throws IOException {
     if (System.getProperty("os.name").toLowerCase().contains("windows"))
       return;
-    Assertions.assertTrue(console.parse("connect local:/" + absoluteDBPath + "/" + DB_NAME + ";info types", false));
+    assertThat(console.parse("connect local:/" + absoluteDBPath + "/" + DB_NAME + ";info types", false)).isTrue();
   }
 
   @Test
   public void testSetVerbose() throws IOException {
     try {
       console.parse("set verbose = 2; close; connect " + DB_NAME + "XX");
-      Assertions.fail();
+      fail("");
     } catch (final DatabaseOperationException e) {
       // EXPECTED
     }
@@ -133,59 +136,59 @@ public class ConsoleTest {
 
   @Test
   public void testCreateClass() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + DB_NAME));
-    Assertions.assertTrue(console.parse("create document type Person"));
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+    assertThat(console.parse("create document type Person")).isTrue();
 
     final StringBuilder buffer = new StringBuilder();
     console.setOutput(output -> buffer.append(output));
-    Assertions.assertTrue(console.parse("info types"));
-    Assertions.assertTrue(buffer.toString().contains("Person"));
+    assertThat(console.parse("info types")).isTrue();
+    assertThat(buffer.toString().contains("Person")).isTrue();
 
     buffer.setLength(0);
-    Assertions.assertTrue(console.parse("info type Person"));
-    Assertions.assertTrue(buffer.toString().contains("DOCUMENT TYPE 'Person'"));
+    assertThat(console.parse("info type Person")).isTrue();
+    assertThat(buffer.toString().contains("DOCUMENT TYPE 'Person'")).isTrue();
   }
 
   @Test
   public void testInsertAndSelectRecord() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + DB_NAME));
-    Assertions.assertTrue(console.parse("create document type Person"));
-    Assertions.assertTrue(console.parse("insert into Person set name = 'Jay', lastname='Miner'"));
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+    assertThat(console.parse("create document type Person")).isTrue();
+    assertThat(console.parse("insert into Person set name = 'Jay', lastname='Miner'")).isTrue();
 
     final StringBuilder buffer = new StringBuilder();
     console.setOutput(output -> buffer.append(output));
-    Assertions.assertTrue(console.parse("select from Person"));
-    Assertions.assertTrue(buffer.toString().contains("Jay"));
+    assertThat(console.parse("select from Person")).isTrue();
+    assertThat(buffer.toString().contains("Jay")).isTrue();
   }
 
   @Test
   public void testInsertAndRollback() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + DB_NAME));
-    Assertions.assertTrue(console.parse("begin"));
-    Assertions.assertTrue(console.parse("create document type Person"));
-    Assertions.assertTrue(console.parse("insert into Person set name = 'Jay', lastname='Miner'"));
-    Assertions.assertTrue(console.parse("rollback"));
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+    assertThat(console.parse("begin")).isTrue();
+    assertThat(console.parse("create document type Person")).isTrue();
+    assertThat(console.parse("insert into Person set name = 'Jay', lastname='Miner'")).isTrue();
+    assertThat(console.parse("rollback")).isTrue();
 
     final StringBuilder buffer = new StringBuilder();
     console.setOutput(output -> buffer.append(output));
-    Assertions.assertTrue(console.parse("select from Person"));
-    Assertions.assertFalse(buffer.toString().contains("Jay"));
+    assertThat(console.parse("select from Person")).isTrue();
+    assertThat(buffer.toString().contains("Jay")).isFalse();
   }
 
   @Test
   public void testHelp() throws IOException {
     final StringBuilder buffer = new StringBuilder();
     console.setOutput(output -> buffer.append(output));
-    Assertions.assertTrue(console.parse("?"));
-    Assertions.assertTrue(buffer.toString().contains("quit"));
+    assertThat(console.parse("?")).isTrue();
+    assertThat(buffer.toString().contains("quit")).isTrue();
   }
 
   @Test
   public void testInfoError() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + DB_NAME));
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
     try {
-      Assertions.assertTrue(console.parse("info blablabla"));
-      Assertions.fail();
+      assertThat(console.parse("info blablabla")).isTrue();
+      fail("");
     } catch (final ConsoleException e) {
       // EXPECTED
     }
@@ -193,25 +196,24 @@ public class ConsoleTest {
 
   @Test
   public void testAllRecordTypes() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + DB_NAME));
-    Assertions.assertTrue(console.parse("create document type D"));
-    Assertions.assertTrue(console.parse("create vertex type V"));
-    Assertions.assertTrue(console.parse("create edge type E"));
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+    assertThat(console.parse("create document type D")).isTrue();
+    assertThat(console.parse("create vertex type V")).isTrue();
+    assertThat(console.parse("create edge type E")).isTrue();
 
-    Assertions.assertTrue(console.parse("insert into D set name = 'Jay', lastname='Miner'"));
-    Assertions.assertTrue(console.parse("insert into V set name = 'Jay', lastname='Miner'"));
-    Assertions.assertTrue(console.parse("insert into V set name = 'Elon', lastname='Musk'"));
-    Assertions.assertTrue(
-        console.parse("create edge E from (select from V where name ='Jay') to (select from V where name ='Elon')"));
+    assertThat(console.parse("insert into D set name = 'Jay', lastname='Miner'")).isTrue();
+    assertThat(console.parse("insert into V set name = 'Jay', lastname='Miner'")).isTrue();
+    assertThat(console.parse("insert into V set name = 'Elon', lastname='Musk'")).isTrue();
+    assertThat(console.parse("create edge E from (select from V where name ='Jay') to (select from V where name ='Elon')")).isTrue();
 
     final StringBuilder buffer = new StringBuilder();
     console.setOutput(output -> buffer.append(output));
-    Assertions.assertTrue(console.parse("select from D"));
-    Assertions.assertTrue(buffer.toString().contains("Jay"));
+    assertThat(console.parse("select from D")).isTrue();
+    assertThat(buffer.toString().contains("Jay")).isTrue();
 
-    Assertions.assertTrue(console.parse("select from V"));
-    Assertions.assertTrue(console.parse("select from E"));
-    Assertions.assertTrue(buffer.toString().contains("Elon"));
+    assertThat(console.parse("select from V")).isTrue();
+    assertThat(console.parse("select from E")).isTrue();
+    assertThat(buffer.toString().contains("Elon")).isTrue();
   }
 
   /**
@@ -219,34 +221,34 @@ public class ConsoleTest {
    */
   @Test
   public void testNotStringProperties() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + DB_NAME));
-    Assertions.assertTrue(console.parse("CREATE VERTEX TYPE v"));
-    Assertions.assertTrue(console.parse("CREATE PROPERTY v.s STRING"));
-    Assertions.assertTrue(console.parse("CREATE PROPERTY v.i INTEGER"));
-    Assertions.assertTrue(console.parse("CREATE PROPERTY v.b BOOLEAN"));
-    Assertions.assertTrue(console.parse("CREATE PROPERTY v.sh SHORT"));
-    Assertions.assertTrue(console.parse("CREATE PROPERTY v.d DOUBLE"));
-    Assertions.assertTrue(console.parse("CREATE PROPERTY v.da DATETIME"));
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+    assertThat(console.parse("CREATE VERTEX TYPE v")).isTrue();
+    assertThat(console.parse("CREATE PROPERTY v.s STRING")).isTrue();
+    assertThat(console.parse("CREATE PROPERTY v.i INTEGER")).isTrue();
+    assertThat(console.parse("CREATE PROPERTY v.b BOOLEAN")).isTrue();
+    assertThat(console.parse("CREATE PROPERTY v.sh SHORT")).isTrue();
+    assertThat(console.parse("CREATE PROPERTY v.d DOUBLE")).isTrue();
+    assertThat(console.parse("CREATE PROPERTY v.da DATETIME")).isTrue();
 
     final StringBuilder buffer = new StringBuilder();
     console.setOutput(output -> buffer.append(output));
-    Assertions.assertTrue(console.parse("CREATE VERTEX v SET s=\"abc\", i=1, b=true, sh=2, d=3.5, da=\"2022-12-20 18:00\""));
-    Assertions.assertTrue(buffer.toString().contains("true"));
+    assertThat(console.parse("CREATE VERTEX v SET s=\"abc\", i=1, b=true, sh=2, d=3.5, da=\"2022-12-20 18:00\"")).isTrue();
+    assertThat(buffer.toString().contains("true")).isTrue();
   }
 
   @Test
   public void testUserMgmtLocalError() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + DB_NAME));
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
     try {
-      Assertions.assertTrue(console.parse("create user elon identified by musk"));
-      Assertions.fail("local connection allowed user creation");
+      assertThat(console.parse("create user elon identified by musk")).isTrue();
+      fail("local connection allowed user creation");
     } catch (final Exception e) {
       // EXPECTED
     }
 
     try {
-      Assertions.assertTrue(console.parse("drop user jack"));
-      Assertions.fail("local connection allowed user deletion");
+      assertThat(console.parse("drop user jack")).isTrue();
+      fail("local connection allowed user deletion");
     } catch (final Exception e) {
       // EXPECTED
     }
@@ -265,31 +267,31 @@ public class ConsoleTest {
     try (final DatabaseFactory factory = new DatabaseFactory("./target/databases/" + DATABASE_PATH)) {
       try (final Database database = factory.open()) {
         final DocumentType personType = database.getSchema().getType("User");
-        Assertions.assertNotNull(personType);
-        Assertions.assertEquals(3, database.countType("User", true));
+        assertThat(personType).isNotNull();
+        assertThat(database.countType("User", true)).isEqualTo(3);
 
         final IndexCursor cursor = database.lookupByKey("User", "id", "0");
-        Assertions.assertTrue(cursor.hasNext());
+        assertThat(cursor.hasNext()).isTrue();
         final Vertex v = cursor.next().asVertex();
-        Assertions.assertEquals("Adam", v.get("name"));
-        Assertions.assertEquals("2015-07-04T19:32:24", new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").format(v.getLong("born")));
+        assertThat(v.get("name")).isEqualTo("Adam");
+        assertThat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").format(v.getLong("born"))).isEqualTo("2015-07-04T19:32:24");
 
         final Map<String, Object> place = (Map<String, Object>) v.get("place");
-        Assertions.assertEquals(33.46789, ((Number) place.get("latitude")).doubleValue());
-        Assertions.assertNull(place.get("height"));
+        assertThat(((Number) place.get("latitude")).doubleValue()).isEqualTo(33.46789);
+        assertThat(place.get("height")).isNull();
 
-        Assertions.assertEquals(Arrays.asList("Sam", "Anna", "Grace"), v.get("kids"));
+        assertThat(v.get("kids")).isEqualTo(Arrays.asList("Sam", "Anna", "Grace"));
 
         final DocumentType friendType = database.getSchema().getType("KNOWS");
-        Assertions.assertNotNull(friendType);
-        Assertions.assertEquals(1, database.countType("KNOWS", true));
+        assertThat(friendType).isNotNull();
+        assertThat(database.countType("KNOWS", true)).isEqualTo(1);
 
         final Iterator<Edge> relationships = v.getEdges(Vertex.DIRECTION.OUT, "KNOWS").iterator();
-        Assertions.assertTrue(relationships.hasNext());
+        assertThat(relationships.hasNext()).isTrue();
         final Edge e = relationships.next();
 
-        Assertions.assertEquals(1993, e.get("since"));
-        Assertions.assertEquals("P5M1DT12H", e.get("bffSince"));
+        assertThat(e.get("since")).isEqualTo(1993);
+        assertThat(e.get("bffSince")).isEqualTo("P5M1DT12H");
       }
     }
   }
@@ -333,34 +335,34 @@ public class ConsoleTest {
       }
     }
 
-    Assertions.assertEquals(101, vertices);
-    Assertions.assertEquals(135, edges);
+    assertThat(vertices).isEqualTo(101);
+    assertThat(edges).isEqualTo(135);
   }
 
   @Test
   public void testNullValues() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + DB_NAME));
-    Assertions.assertTrue(console.parse("create document type Person"));
-    Assertions.assertTrue(console.parse("insert into Person set name = 'Jay', lastname='Miner', nothing = null"));
-    Assertions.assertTrue(console.parse("insert into Person set name = 'Thom', lastname='Yorke', nothing = 'something'"));
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+    assertThat(console.parse("create document type Person")).isTrue();
+    assertThat(console.parse("insert into Person set name = 'Jay', lastname='Miner', nothing = null")).isTrue();
+    assertThat(console.parse("insert into Person set name = 'Thom', lastname='Yorke', nothing = 'something'")).isTrue();
 
     {
       final StringBuilder buffer = new StringBuilder();
       console.setOutput(output -> buffer.append(output));
-      Assertions.assertTrue(console.parse("select from Person where nothing is null"));
-      Assertions.assertTrue(buffer.toString().contains("<null>"));
+      assertThat(console.parse("select from Person where nothing is null")).isTrue();
+      assertThat(buffer.toString().contains("<null>")).isTrue();
     }
     {
       final StringBuilder buffer = new StringBuilder();
       console.setOutput(output -> buffer.append(output));
-      Assertions.assertTrue(console.parse("select nothing, lastname, name from Person where nothing is null"));
-      Assertions.assertTrue(buffer.toString().contains("<null>"));
+      assertThat(console.parse("select nothing, lastname, name from Person where nothing is null")).isTrue();
+      assertThat(buffer.toString().contains("<null>")).isTrue();
     }
     {
       final StringBuilder buffer = new StringBuilder();
       console.setOutput(output -> buffer.append(output));
-      Assertions.assertTrue(console.parse("select nothing, lastname, name from Person"));
-      Assertions.assertTrue(buffer.toString().contains("<null>"));
+      assertThat(console.parse("select nothing, lastname, name from Person")).isTrue();
+      assertThat(buffer.toString().contains("<null>")).isTrue();
     }
   }
 
@@ -369,89 +371,89 @@ public class ConsoleTest {
    */
   @Test
   public void testProjectionOrder() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + DB_NAME));
-    Assertions.assertTrue(console.parse("create document type Order"));
-    Assertions.assertTrue(console.parse(
-        "insert into Order set processor = 'SIR1LRM-7.1', vstart = '20220319_002624.404379', vstop = '20220319_002826.525650', status = 'PENDING'"));
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+    assertThat(console.parse("create document type Order")).isTrue();
+    assertThat(console.parse(
+      "insert into Order set processor = 'SIR1LRM-7.1', vstart = '20220319_002624.404379', vstop = '20220319_002826.525650', status = 'PENDING'")).isTrue();
 
     {
       final StringBuilder buffer = new StringBuilder();
       console.setOutput(output -> buffer.append(output));
-      Assertions.assertTrue(console.parse("select processor, vstart, vstop, pstart, pstop, status, node from Order"));
+      assertThat(console.parse("select processor, vstart, vstop, pstart, pstop, status, node from Order")).isTrue();
 
       int pos = buffer.toString().indexOf("processor");
-      Assertions.assertTrue(pos > -1);
+      assertThat(pos > -1).isTrue();
       pos = buffer.toString().indexOf("vstart", pos);
-      Assertions.assertTrue(pos > -1);
+      assertThat(pos > -1).isTrue();
       pos = buffer.toString().indexOf("vstop", pos);
-      Assertions.assertTrue(pos > -1);
+      assertThat(pos > -1).isTrue();
       pos = buffer.toString().indexOf("pstart", pos);
-      Assertions.assertTrue(pos > -1);
+      assertThat(pos > -1).isTrue();
       pos = buffer.toString().indexOf("pstop", pos);
-      Assertions.assertTrue(pos > -1);
+      assertThat(pos > -1).isTrue();
       pos = buffer.toString().indexOf("status", pos);
-      Assertions.assertTrue(pos > -1);
+      assertThat(pos > -1).isTrue();
       pos = buffer.toString().indexOf("node", pos);
-      Assertions.assertTrue(pos > -1);
+      assertThat(pos > -1).isTrue();
     }
   }
 
   @Test
   public void testAsyncMode() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + DB_NAME));
-    Assertions.assertTrue(console.parse("create document type D"));
-    Assertions.assertTrue(console.parse("create vertex type V"));
-    Assertions.assertTrue(console.parse("create edge type E"));
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+    assertThat(console.parse("create document type D")).isTrue();
+    assertThat(console.parse("create vertex type V")).isTrue();
+    assertThat(console.parse("create edge type E")).isTrue();
 
-    Assertions.assertTrue(console.parse("insert into D set name = 'Jay', lastname='Miner'"));
+    assertThat(console.parse("insert into D set name = 'Jay', lastname='Miner'")).isTrue();
 
     int asyncOperations = (int) ((DatabaseAsyncExecutorImpl) ((DatabaseInternal) console.getDatabase()).async()).getStats().scheduledTasks;
-    Assertions.assertEquals(0, asyncOperations);
+    assertThat(asyncOperations).isEqualTo(0);
 
-    Assertions.assertTrue(console.parse("set asyncMode = true"));
+    assertThat(console.parse("set asyncMode = true")).isTrue();
 
-    Assertions.assertTrue(console.parse("insert into V set name = 'Jay', lastname='Miner'"));
-    Assertions.assertTrue(console.parse("insert into V set name = 'Elon', lastname='Musk'"));
+    assertThat(console.parse("insert into V set name = 'Jay', lastname='Miner'")).isTrue();
+    assertThat(console.parse("insert into V set name = 'Elon', lastname='Musk'")).isTrue();
 
-    Assertions.assertTrue(console.parse("set asyncMode = false"));
+    assertThat(console.parse("set asyncMode = false")).isTrue();
 
     asyncOperations = (int) ((DatabaseAsyncExecutorImpl) ((DatabaseInternal) console.getDatabase()).async()).getStats().scheduledTasks;
-    Assertions.assertEquals(2, asyncOperations);
+    assertThat(asyncOperations).isEqualTo(2);
   }
 
   @Test
   public void testBatchMode() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + DB_NAME));
-    Assertions.assertTrue(console.parse("create document type D"));
-    Assertions.assertTrue(console.parse("create vertex type V"));
-    Assertions.assertTrue(console.parse("create edge type E"));
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+    assertThat(console.parse("create document type D")).isTrue();
+    assertThat(console.parse("create vertex type V")).isTrue();
+    assertThat(console.parse("create edge type E")).isTrue();
 
-    Assertions.assertTrue(console.parse("set transactionBatchSize = 2"));
+    assertThat(console.parse("set transactionBatchSize = 2")).isTrue();
 
-    Assertions.assertTrue(console.parse("insert into D set name = 'Jay', lastname='Miner'"));
-    Assertions.assertEquals(1, console.currentOperationsInBatch);
+    assertThat(console.parse("insert into D set name = 'Jay', lastname='Miner'")).isTrue();
+    assertThat(console.currentOperationsInBatch).isEqualTo(1);
 
-    Assertions.assertTrue(((DatabaseInternal) console.getDatabase()).getTransaction().isActive());
-    Assertions.assertTrue(((DatabaseInternal) console.getDatabase()).getTransaction().getModifiedPages() > 0);
+    assertThat(((DatabaseInternal) console.getDatabase()).getTransaction().isActive()).isTrue();
+    assertThat(((DatabaseInternal) console.getDatabase()).getTransaction().getModifiedPages() > 0).isTrue();
 
-    Assertions.assertTrue(console.parse("insert into V set name = 'Jay', lastname='Miner'"));
-    Assertions.assertEquals(2, console.currentOperationsInBatch);
-    Assertions.assertTrue(console.parse("insert into V set name = 'Elon', lastname='Musk'"));
-    Assertions.assertEquals(1, console.currentOperationsInBatch);
+    assertThat(console.parse("insert into V set name = 'Jay', lastname='Miner'")).isTrue();
+    assertThat(console.currentOperationsInBatch).isEqualTo(2);
+    assertThat(console.parse("insert into V set name = 'Elon', lastname='Musk'")).isTrue();
+    assertThat(console.currentOperationsInBatch).isEqualTo(1);
 
-    Assertions.assertTrue(console.parse("set transactionBatchSize = 0"));
+    assertThat(console.parse("set transactionBatchSize = 0")).isTrue();
   }
 
   @Test
   public void testLoad() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + DB_NAME));
-    Assertions.assertTrue(console.parse("load " + new File("src/test/resources/console-batch.sql").toString().replace('\\', '/')));
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+    assertThat(console.parse("load " + new File("src/test/resources/console-batch.sql").toString().replace('\\', '/'))).isTrue();
 
     final String[] urls = new String[] { "http://arcadedb.com", "https://www.arcadedb.com", "file://this/is/myfile.txt" };
 
     // VALIDATE WITH PLAIN JAVA REGEXP FIRST
     for (String url : urls)
-      Assertions.assertTrue(url.matches("^([a-zA-Z]{1,15}:)(\\/\\/)?[^\\s\\/$.?#].[^\\s]*$"), "Cannot validate URL: " + url);
+      assertThat(url.matches("^([a-zA-Z]{1,15}:)(\\/\\/)?[^\\s\\/$.?#].[^\\s]*$")).as("Cannot validate URL: " + url).isTrue();
 
     // VALIDATE WITH DATABASE SCHEMA
     for (String url : urls)
@@ -460,19 +462,17 @@ public class ConsoleTest {
 
   @Test
   public void testCustomPropertyInSchema() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + DB_NAME));
-    Assertions.assertTrue(console.parse("CREATE DOCUMENT TYPE doc;"));
-    Assertions.assertTrue(console.parse("CREATE PROPERTY doc.prop STRING;"));
-    Assertions.assertTrue(console.parse("ALTER PROPERTY doc.prop CUSTOM test = true;"));
-    Assertions.assertEquals(true, console.getDatabase().getSchema().getType("doc").getProperty("prop").getCustomValue("test"));
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+    assertThat(console.parse("CREATE DOCUMENT TYPE doc;")).isTrue();
+    assertThat(console.parse("CREATE PROPERTY doc.prop STRING;")).isTrue();
+    assertThat(console.parse("ALTER PROPERTY doc.prop CUSTOM test = true;")).isTrue();
+    assertThat(console.getDatabase().getSchema().getType("doc").getProperty("prop").getCustomValue("test")).isEqualTo(true);
 
-    Assertions.assertEquals(Type.BOOLEAN.name().toUpperCase(),
-        console.getDatabase().query("sql", "SELECT properties.custom.test[0].type() as type FROM schema:types").next()
-            .getProperty("type"));
+    assertThat(console.getDatabase().query("sql", "SELECT properties.custom.test[0].type() as type FROM schema:types").next()
+      .<String>getProperty("type")).isEqualTo(Type.BOOLEAN.name().toUpperCase());
 
-    Assertions.assertEquals(Type.BOOLEAN.name().toUpperCase(),
-        console.getDatabase().command("sql", "SELECT properties.custom.test[0].type() as type FROM schema:types").next()
-            .getProperty("type"));
+    assertThat(console.getDatabase().command("sql", "SELECT properties.custom.test[0].type() as type FROM schema:types").next()
+      .<String>getProperty("type")).isEqualTo(Type.BOOLEAN.name().toUpperCase());
   }
 
   /**
@@ -480,21 +480,21 @@ public class ConsoleTest {
    */
   @Test
   public void testNotNullProperties() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + DB_NAME));
-    Assertions.assertTrue(console.parse("CREATE DOCUMENT TYPE doc;"));
-    Assertions.assertTrue(console.parse("CREATE PROPERTY doc.prop STRING (notnull);"));
-    Assertions.assertTrue(console.getDatabase().getSchema().getType("doc").getProperty("prop").isNotNull());
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+    assertThat(console.parse("CREATE DOCUMENT TYPE doc;")).isTrue();
+    assertThat(console.parse("CREATE PROPERTY doc.prop STRING (notnull);")).isTrue();
+    assertThat(console.getDatabase().getSchema().getType("doc").getProperty("prop").isNotNull()).isTrue();
 
-    Assertions.assertTrue(console.parse("INSERT INTO doc set a = null;"));
+    assertThat(console.parse("INSERT INTO doc set a = null;")).isTrue();
 
     final StringBuilder buffer = new StringBuilder();
     console.setOutput(output -> buffer.append(output));
-    Assertions.assertTrue(console.parse("INSERT INTO doc set prop = null;"));
+    assertThat(console.parse("INSERT INTO doc set prop = null;")).isTrue();
 
     int pos = buffer.toString().indexOf("ValidationException");
-    Assertions.assertTrue(pos > -1);
+    assertThat(pos > -1).isTrue();
 
-    Assertions.assertNull(console.getDatabase().query("sql", "SELECT FROM doc").nextIfAvailable().getProperty("prop"));
+    assertThat(console.getDatabase().query("sql", "SELECT FROM doc").nextIfAvailable().<String>getProperty("prop")).isNull();
   }
 
   /**
@@ -502,23 +502,23 @@ public class ConsoleTest {
    */
   @Test
   public void testPercentWildcardInQuery() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + DB_NAME));
-    Assertions.assertTrue(console.parse("create document type Person"));
-    Assertions.assertTrue(console.parse("insert into Person set name = 'Jay', lastname='Miner', nothing = null"));
-    Assertions.assertTrue(console.parse("insert into Person set name = 'Thom', lastname='Yorke', nothing = 'something'"));
+    assertThat(console.parse("connect " + DB_NAME)).isTrue();
+    assertThat(console.parse("create document type Person")).isTrue();
+    assertThat(console.parse("insert into Person set name = 'Jay', lastname='Miner', nothing = null")).isTrue();
+    assertThat(console.parse("insert into Person set name = 'Thom', lastname='Yorke', nothing = 'something'")).isTrue();
 
     {
       final StringBuilder buffer = new StringBuilder();
       console.setOutput(output -> buffer.append(output));
-      Assertions.assertTrue(console.parse("select from Person where name like 'Thom%'"));
-      Assertions.assertTrue(buffer.toString().contains("Yorke"));
+      assertThat(console.parse("select from Person where name like 'Thom%'")).isTrue();
+      assertThat(buffer.toString().contains("Yorke")).isTrue();
     }
 
     {
       final StringBuilder buffer = new StringBuilder();
       console.setOutput(output -> buffer.append(output));
-      Assertions.assertTrue(console.parse("select from Person where not ( name like 'Thom%' )"));
-      Assertions.assertTrue(buffer.toString().contains("Miner"));
+      assertThat(console.parse("select from Person where not ( name like 'Thom%' )")).isTrue();
+      assertThat(buffer.toString().contains("Miner")).isTrue();
     }
   }
 }

--- a/console/src/test/java/com/arcadedb/console/RemoteConsoleIT.java
+++ b/console/src/test/java/com/arcadedb/console/RemoteConsoleIT.java
@@ -25,11 +25,13 @@ import com.arcadedb.schema.Type;
 import com.arcadedb.server.BaseGraphServerTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.*;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class RemoteConsoleIT extends BaseGraphServerTest {
   private static final String URL               = "remote:localhost:2480/console root " + DEFAULT_PASSWORD_FOR_TESTS;
@@ -47,24 +49,24 @@ public class RemoteConsoleIT extends BaseGraphServerTest {
 
   @Test
   public void testCreateDatabase() throws IOException {
-    Assertions.assertTrue(console.parse("create database " + URL_NEW_DB));
+    assertThat(console.parse("create database " + URL_NEW_DB)).isTrue();
   }
 
   @Test
   public void testConnect() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + URL));
+    assertThat(console.parse("connect " + URL)).isTrue();
   }
 
   @Test
   public void testConnectShortURL() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + URL_SHORT));
+    assertThat(console.parse("connect " + URL_SHORT)).isTrue();
   }
 
   @Test
   public void testConnectNoCredentials() throws IOException {
     try {
-      Assertions.assertTrue(console.parse("connect " + URL_NOCREDENTIALS + ";create document type VVVV"));
-      Assertions.fail("Security was bypassed!");
+      assertThat(console.parse("connect " + URL_NOCREDENTIALS + ";create document type VVVV")).isTrue();
+      fail("Security was bypassed!");
     } catch (final ConsoleException e) {
       // EXPECTED
     }
@@ -73,8 +75,8 @@ public class RemoteConsoleIT extends BaseGraphServerTest {
   @Test
   public void testConnectWrongPassword() throws IOException {
     try {
-      Assertions.assertTrue(console.parse("connect " + URL_WRONGPASSWD + ";create document type VVVV"));
-      Assertions.fail("Security was bypassed!");
+      assertThat(console.parse("connect " + URL_WRONGPASSWD + ";create document type VVVV")).isTrue();
+      fail("Security was bypassed!");
     } catch (final SecurityException e) {
       // EXPECTED
     }
@@ -82,95 +84,95 @@ public class RemoteConsoleIT extends BaseGraphServerTest {
 
   @Test
   public void testCreateType() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + URL));
-    Assertions.assertTrue(console.parse("create document type Person2"));
+    assertThat(console.parse("connect " + URL)).isTrue();
+    assertThat(console.parse("create document type Person2")).isTrue();
 
     final StringBuilder buffer = new StringBuilder();
     console.setOutput(buffer::append);
-    Assertions.assertTrue(console.parse("info types"));
-    Assertions.assertTrue(buffer.toString().contains("Person2"));
-    Assertions.assertTrue(console.parse("drop type Person2"));
+    assertThat(console.parse("info types")).isTrue();
+    assertThat(buffer.toString().contains("Person2")).isTrue();
+    assertThat(console.parse("drop type Person2")).isTrue();
   }
 
   @Test
   public void testInsertAndSelectRecord() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + URL));
-    Assertions.assertTrue(console.parse("create document type Person2"));
-    Assertions.assertTrue(console.parse("insert into Person2 set name = 'Jay', lastname='Miner'"));
+    assertThat(console.parse("connect " + URL)).isTrue();
+    assertThat(console.parse("create document type Person2")).isTrue();
+    assertThat(console.parse("insert into Person2 set name = 'Jay', lastname='Miner'")).isTrue();
 
     final StringBuilder buffer = new StringBuilder();
     console.setOutput(buffer::append);
-    Assertions.assertTrue(console.parse("select from Person2"));
-    Assertions.assertTrue(buffer.toString().contains("Jay"));
-    Assertions.assertTrue(console.parse("drop type Person2"));
+    assertThat(console.parse("select from Person2")).isTrue();
+    assertThat(buffer.toString().contains("Jay")).isTrue();
+    assertThat(console.parse("drop type Person2")).isTrue();
   }
 
   @Test
   public void testListDatabases() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + URL));
-    Assertions.assertTrue(console.parse("list databases;"));
+    assertThat(console.parse("connect " + URL)).isTrue();
+    assertThat(console.parse("list databases;")).isTrue();
   }
 
   @Test
   public void testInsertAndRollback() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + URL));
-    Assertions.assertTrue(console.parse("begin"));
-    Assertions.assertTrue(console.parse("create document type Person"));
-    Assertions.assertTrue(console.parse("insert into Person set name = 'Jay', lastname='Miner'"));
-    Assertions.assertTrue(console.parse("rollback"));
+    assertThat(console.parse("connect " + URL)).isTrue();
+    assertThat(console.parse("begin")).isTrue();
+    assertThat(console.parse("create document type Person")).isTrue();
+    assertThat(console.parse("insert into Person set name = 'Jay', lastname='Miner'")).isTrue();
+    assertThat(console.parse("rollback")).isTrue();
 
     final StringBuilder buffer = new StringBuilder();
     console.setOutput(buffer::append);
-    Assertions.assertTrue(console.parse("select from Person"));
-    Assertions.assertFalse(buffer.toString().contains("Jay"));
+    assertThat(console.parse("select from Person")).isTrue();
+    assertThat(buffer.toString().contains("Jay")).isFalse();
   }
 
   @Test
   public void testInsertAndCommit() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + URL));
-    Assertions.assertTrue(console.parse("begin"));
-    Assertions.assertTrue(console.parse("create document type Person"));
-    Assertions.assertTrue(console.parse("insert into Person set name = 'Jay', lastname='Miner'"));
-    Assertions.assertTrue(console.parse("commit"));
+    assertThat(console.parse("connect " + URL)).isTrue();
+    assertThat(console.parse("begin")).isTrue();
+    assertThat(console.parse("create document type Person")).isTrue();
+    assertThat(console.parse("insert into Person set name = 'Jay', lastname='Miner'")).isTrue();
+    assertThat(console.parse("commit")).isTrue();
 
     final StringBuilder buffer = new StringBuilder();
     console.setOutput(buffer::append);
-    Assertions.assertTrue(console.parse("select from Person"));
-    Assertions.assertTrue(buffer.toString().contains("Jay"));
+    assertThat(console.parse("select from Person")).isTrue();
+    assertThat(buffer.toString().contains("Jay")).isTrue();
   }
 
   @Test
   public void testTransactionExpired() throws IOException, InterruptedException {
-    Assertions.assertTrue(console.parse("connect " + URL));
-    Assertions.assertTrue(console.parse("begin"));
-    Assertions.assertTrue(console.parse("create document type Person"));
-    Assertions.assertTrue(console.parse("insert into Person set name = 'Jay', lastname='Miner'"));
+    assertThat(console.parse("connect " + URL)).isTrue();
+    assertThat(console.parse("begin")).isTrue();
+    assertThat(console.parse("create document type Person")).isTrue();
+    assertThat(console.parse("insert into Person set name = 'Jay', lastname='Miner'")).isTrue();
     Thread.sleep(5000);
     try {
-      Assertions.assertTrue(console.parse("commit"));
-      Assertions.fail();
+      assertThat(console.parse("commit")).isTrue();
+      fail("");
     } catch (final Exception e) {
       // EXPECTED
     }
 
     final StringBuilder buffer = new StringBuilder();
     console.setOutput(buffer::append);
-    Assertions.assertTrue(console.parse("select from Person"));
-    Assertions.assertFalse(buffer.toString().contains("Jay"));
+    assertThat(console.parse("select from Person")).isTrue();
+    assertThat(buffer.toString().contains("Jay")).isFalse();
   }
 
   @Test
   public void testUserMgmt() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + URL));
+    assertThat(console.parse("connect " + URL)).isTrue();
     try {
-      Assertions.assertTrue(console.parse("drop user elon"));
+      assertThat(console.parse("drop user elon")).isTrue();
     } catch (final Exception e) {
       // EXPECTED IF ALREADY EXISTENT
     }
 
     try {
-      Assertions.assertTrue(console.parse("create user jay identified by m"));
-      Assertions.fail();
+      assertThat(console.parse("create user jay identified by m")).isTrue();
+      fail("");
     } catch (final RuntimeException e) {
       // PASSWORD MUST BE AT LEAST 5 CHARS
     }
@@ -180,34 +182,34 @@ public class RemoteConsoleIT extends BaseGraphServerTest {
       for (int i = 0; i < 257; i++)
         longPassword += "P";
 
-      Assertions.assertTrue(console.parse("create user jay identified by " + longPassword));
-      Assertions.fail();
+      assertThat(console.parse("create user jay identified by " + longPassword)).isTrue();
+      fail("");
     } catch (final RuntimeException e) {
       // PASSWORD MUST BE MAX 256 CHARS LONG
     }
 
-    Assertions.assertTrue(console.parse("create user elon identified by musk"));
-    Assertions.assertTrue(console.parse("drop user elon"));
+    assertThat(console.parse("create user elon identified by musk")).isTrue();
+    assertThat(console.parse("drop user elon")).isTrue();
 
     // TEST SYNTAX ERROR
     try {
-      Assertions.assertTrue(console.parse("create user elon identified by musk grand connect on db1"));
-      Assertions.fail();
+      assertThat(console.parse("create user elon identified by musk grand connect on db1")).isTrue();
+      fail("");
     } catch (final Exception e) {
       // EXPECTED
     }
 
-    Assertions.assertTrue(console.parse("create user elon identified by musk grant connect to db1"));
-    Assertions.assertTrue(console.parse("create user jeff identified by amazon grant connect to db1:readonly"));
-    Assertions.assertTrue(console.parse("drop user elon"));
+    assertThat(console.parse("create user elon identified by musk grant connect to db1")).isTrue();
+    assertThat(console.parse("create user jeff identified by amazon grant connect to db1:readonly")).isTrue();
+    assertThat(console.parse("drop user elon")).isTrue();
   }
 
   @Test
   public void testHelp() throws IOException {
     final StringBuilder buffer = new StringBuilder();
     console.setOutput(buffer::append);
-    Assertions.assertTrue(console.parse("?"));
-    Assertions.assertTrue(buffer.toString().contains("quit"));
+    assertThat(console.parse("?")).isTrue();
+    assertThat(buffer.toString().contains("quit")).isTrue();
   }
 
   /**
@@ -215,84 +217,82 @@ public class RemoteConsoleIT extends BaseGraphServerTest {
    */
   @Test
   public void testProjectionOrder() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + URL));
-    Assertions.assertTrue(console.parse("create document type Order"));
-    Assertions.assertTrue(console.parse(
-        "insert into Order set processor = 'SIR1LRM-7.1', vstart = '20220319_002624.404379', vstop = '20220319_002826.525650', status = 'PENDING'"));
+    assertThat(console.parse("connect " + URL)).isTrue();
+    assertThat(console.parse("create document type Order")).isTrue();
+    assertThat(console.parse(
+      "insert into Order set processor = 'SIR1LRM-7.1', vstart = '20220319_002624.404379', vstop = '20220319_002826.525650', status = 'PENDING'")).isTrue();
 
     {
       final StringBuilder buffer = new StringBuilder();
       console.setOutput(output -> buffer.append(output));
-      Assertions.assertTrue(console.parse("select processor, vstart, vstop, pstart, pstop, status, node from Order"));
+      assertThat(console.parse("select processor, vstart, vstop, pstart, pstop, status, node from Order")).isTrue();
 
       int pos = buffer.toString().indexOf("processor");
-      Assertions.assertTrue(pos > -1);
+      assertThat(pos > -1).isTrue();
       pos = buffer.toString().indexOf("vstart", pos);
-      Assertions.assertTrue(pos > -1);
+      assertThat(pos > -1).isTrue();
       pos = buffer.toString().indexOf("vstop", pos);
-      Assertions.assertTrue(pos > -1);
+      assertThat(pos > -1).isTrue();
       pos = buffer.toString().indexOf("pstart", pos);
-      Assertions.assertTrue(pos > -1);
+      assertThat(pos > -1).isTrue();
       pos = buffer.toString().indexOf("pstop", pos);
-      Assertions.assertTrue(pos > -1);
+      assertThat(pos > -1).isTrue();
       pos = buffer.toString().indexOf("status", pos);
-      Assertions.assertTrue(pos > -1);
+      assertThat(pos > -1).isTrue();
       pos = buffer.toString().indexOf("node", pos);
-      Assertions.assertTrue(pos > -1);
+      assertThat(pos > -1).isTrue();
     }
   }
 
   @Test
   public void testCustomPropertyInSchema() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + URL));
-    Assertions.assertTrue(console.parse("CREATE DOCUMENT TYPE doc;"));
-    Assertions.assertTrue(console.parse("ALTER TYPE doc CUSTOM testType = 444;"));
-    Assertions.assertTrue(console.parse("CREATE PROPERTY doc.prop STRING;"));
-    Assertions.assertTrue(console.parse("ALTER PROPERTY doc.prop CUSTOM test = true;"));
+    assertThat(console.parse("connect " + URL)).isTrue();
+    assertThat(console.parse("CREATE DOCUMENT TYPE doc;")).isTrue();
+    assertThat(console.parse("ALTER TYPE doc CUSTOM testType = 444;")).isTrue();
+    assertThat(console.parse("CREATE PROPERTY doc.prop STRING;")).isTrue();
+    assertThat(console.parse("ALTER PROPERTY doc.prop CUSTOM test = true;")).isTrue();
 
-    Assertions.assertEquals(444, console.getDatabase().getSchema().getType("doc").getCustomValue("testType"));
-    Assertions.assertEquals(true, console.getDatabase().getSchema().getType("doc").getProperty("prop").getCustomValue("test"));
+    assertThat(console.getDatabase().getSchema().getType("doc").getCustomValue("testType")).isEqualTo(444);
+    assertThat(console.getDatabase().getSchema().getType("doc").getProperty("prop").getCustomValue("test")).isEqualTo(true);
 
     console.getDatabase().getSchema().getType("doc").setCustomValue("testType", "555");
-    Assertions.assertEquals("555", console.getDatabase().getSchema().getType("doc").getCustomValue("testType"));
+    assertThat(console.getDatabase().getSchema().getType("doc").getCustomValue("testType")).isEqualTo("555");
 
-    Assertions.assertEquals(Type.BOOLEAN.name().toUpperCase(),
-        console.getDatabase().query("sql", "SELECT properties.custom.test[0].type() as type FROM schema:types").next()
-            .getProperty("type"));
+    assertThat(console.getDatabase().query("sql", "SELECT properties.custom.test[0].type() as type FROM schema:types").next()
+      .<String>getProperty("type")).isEqualTo(Type.BOOLEAN.name().toUpperCase());
 
-    Assertions.assertEquals(Type.BOOLEAN.name().toUpperCase(),
-        console.getDatabase().command("sql", "SELECT properties.custom.test[0].type() as type FROM schema:types").next()
-            .getProperty("type"));
+    assertThat(console.getDatabase().command("sql", "SELECT properties.custom.test[0].type() as type FROM schema:types").next()
+      .<String>getProperty("type")).isEqualTo(Type.BOOLEAN.name().toUpperCase());
   }
 
   @Test
   public void testIfWithSchemaResult() throws IOException {
-    Assertions.assertTrue(console.parse("connect " + URL));
-    Assertions.assertTrue(console.parse("CREATE DOCUMENT TYPE doc;"));
-    Assertions.assertTrue(console.parse("CREATE PROPERTY doc.prop STRING;"));
+    assertThat(console.parse("connect " + URL)).isTrue();
+    assertThat(console.parse("CREATE DOCUMENT TYPE doc;")).isTrue();
+    assertThat(console.parse("CREATE PROPERTY doc.prop STRING;")).isTrue();
 
-    Assertions.assertTrue(console.parse("INSERT INTO doc set name = 'doc'"));
+    assertThat(console.parse("INSERT INTO doc set name = 'doc'")).isTrue();
 
     ResultSet resultSet = console.getDatabase().command("sql",
         "SELECT name, (name = 'doc') as name2, if( (name = 'doc'), true, false) as name3, if( (name IN ['doc','XXX']), true, false) as name4, ifnull( (name = 'doc'), null) as name5 FROM schema:types");
 
-    Assertions.assertTrue(resultSet.hasNext());
+    assertThat(resultSet.hasNext()).isTrue();
 
     Result result = resultSet.next();
 
-    Assertions.assertEquals("doc", result.getProperty("name"));
-    Assertions.assertTrue((boolean) result.getProperty("name2"));
-    Assertions.assertTrue((boolean) result.getProperty("name3"));
-    Assertions.assertTrue((boolean) result.getProperty("name4"));
-    Assertions.assertTrue((boolean) result.getProperty("name5"));
+    assertThat(result.<String>getProperty("name")).isEqualTo("doc");
+    assertThat( result.<Boolean>getProperty("name2")).isTrue();
+    assertThat( result.<Boolean>getProperty("name3")).isTrue();
+    assertThat( result.<Boolean>getProperty("name4")).isTrue();
+    assertThat( result.<Boolean>getProperty("name5")).isTrue();
 
     resultSet = console.getDatabase().command("sql", "SELECT name FROM schema:types WHERE 'a_b' = 'a b'.replace(' ','_')");
 
-    Assertions.assertTrue(resultSet.hasNext());
+    assertThat(resultSet.hasNext()).isTrue();
 
     result = resultSet.next();
 
-    Assertions.assertEquals("doc", result.getProperty("name"));
+    assertThat(result.<String>getProperty("name")).isEqualTo("doc");
   }
 
   @Override
@@ -315,7 +315,7 @@ public class RemoteConsoleIT extends BaseGraphServerTest {
       console = new Console();
       console.parse("close");
     } catch (final IOException e) {
-      Assertions.fail(e);
+      fail("", e);
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/AsyncTest.java
+++ b/engine/src/test/java/com/arcadedb/AsyncTest.java
@@ -25,12 +25,15 @@ import com.arcadedb.index.IndexCursor;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class AsyncTest extends TestHelper {
   private static final int    TOT       = 10000;
@@ -47,7 +50,7 @@ public class AsyncTest extends TestHelper {
         return true;
       });
 
-      Assertions.assertEquals(TOT, callbackInvoked.get());
+      assertThat(callbackInvoked.get()).isEqualTo(TOT);
 
       database.async().waitCompletion();
       database.async().waitCompletion();
@@ -78,13 +81,13 @@ public class AsyncTest extends TestHelper {
       database.commit();
     }
 
-    Assertions.assertEquals(TOT, callbackInvoked.get());
-    Assertions.assertEquals(TOT, updatedRecords.get());
+    assertThat(callbackInvoked.get()).isEqualTo(TOT);
+    assertThat(updatedRecords.get()).isEqualTo(TOT);
 
     final ResultSet resultSet = database.query("sql", "select count(*) as count from " + TYPE_NAME + " where updated = true");
 
-    Assertions.assertTrue(resultSet.hasNext());
-    Assertions.assertEquals(TOT, ((Number) resultSet.next().getProperty("count")).intValue());
+    assertThat(resultSet.hasNext()).isTrue();
+    assertThat(((Number) resultSet.next().getProperty("count")).intValue()).isEqualTo(TOT);
   }
 
   @Test
@@ -102,13 +105,13 @@ public class AsyncTest extends TestHelper {
 
       database.async().waitCompletion();
 
-      Assertions.assertEquals(TOT, callbackInvoked.get());
-      Assertions.assertEquals(TOT, deletedRecords.get());
+      assertThat(callbackInvoked.get()).isEqualTo(TOT);
+      assertThat(deletedRecords.get()).isEqualTo(TOT);
 
       final ResultSet resultSet = database.query("sql", "select count(*) as count from " + TYPE_NAME + " where updated = true");
 
-      Assertions.assertTrue(resultSet.hasNext());
-      Assertions.assertEquals(0, ((Number) resultSet.next().getProperty("count")).intValue());
+      assertThat(resultSet.hasNext()).isTrue();
+      assertThat(((Number) resultSet.next().getProperty("count")).intValue()).isEqualTo(0);
 
       populateDatabase();
 
@@ -130,7 +133,7 @@ public class AsyncTest extends TestHelper {
         return callbackInvoked.getAndIncrement() < 10;
       });
 
-      Assertions.assertTrue(callbackInvoked.get() < 20);
+      assertThat(callbackInvoked.get() < 20).isTrue();
 
     } finally {
       database.commit();
@@ -158,8 +161,8 @@ public class AsyncTest extends TestHelper {
 
       database.async().waitCompletion(5_000);
 
-      Assertions.assertEquals(1, completeCallbackInvoked.get());
-      Assertions.assertEquals(0, errorCallbackInvoked.get());
+      assertThat(completeCallbackInvoked.get()).isEqualTo(1);
+      assertThat(errorCallbackInvoked.get()).isEqualTo(0);
 
     } finally {
       database.commit();
@@ -189,9 +192,9 @@ public class AsyncTest extends TestHelper {
       // WAIT INDEFINITELY
       counter.await();
 
-      Assertions.assertTrue(resultSets[0].hasNext());
-      Assertions.assertTrue(resultSets[1].hasNext());
-      Assertions.assertTrue(resultSets[2].hasNext());
+      assertThat(resultSets[0].hasNext()).isTrue();
+      assertThat(resultSets[1].hasNext()).isTrue();
+      assertThat(resultSets[2].hasNext()).isTrue();
 
     } finally {
       database.commit();
@@ -219,8 +222,8 @@ public class AsyncTest extends TestHelper {
 
       database.async().waitCompletion(5_000);
 
-      Assertions.assertEquals(1, completeCallbackInvoked.get());
-      Assertions.assertEquals(0, errorCallbackInvoked.get());
+      assertThat(completeCallbackInvoked.get()).isEqualTo(1);
+      assertThat(errorCallbackInvoked.get()).isEqualTo(0);
 
     } finally {
       database.commit();
@@ -237,9 +240,9 @@ public class AsyncTest extends TestHelper {
 
       final IndexCursor resultSet = database.lookupByKey(TYPE_NAME, "id", Integer.MAX_VALUE);
 
-      Assertions.assertTrue(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isTrue();
       final Document record = resultSet.next().asDocument();
-      Assertions.assertEquals(Integer.MAX_VALUE, record.get("id"));
+      assertThat(record.get("id")).isEqualTo(Integer.MAX_VALUE);
 
     } finally {
       database.commit();
@@ -268,8 +271,8 @@ public class AsyncTest extends TestHelper {
 
       database.async().waitCompletion(5_000);
 
-      Assertions.assertEquals(1, completeCallbackInvoked.get());
-      Assertions.assertEquals(0, errorCallbackInvoked.get());
+      assertThat(completeCallbackInvoked.get()).isEqualTo(1);
+      assertThat(errorCallbackInvoked.get()).isEqualTo(0);
 
     } finally {
       database.commit();
@@ -297,8 +300,8 @@ public class AsyncTest extends TestHelper {
 
       database.async().waitCompletion(5_000);
 
-      Assertions.assertEquals(1, completeCallbackInvoked.get());
-      Assertions.assertEquals(0, errorCallbackInvoked.get());
+      assertThat(completeCallbackInvoked.get()).isEqualTo(1);
+      assertThat(errorCallbackInvoked.get()).isEqualTo(0);
 
     } finally {
       database.commit();
@@ -326,8 +329,8 @@ public class AsyncTest extends TestHelper {
 
       database.async().waitCompletion(5_000);
 
-      Assertions.assertEquals(0, completeCallbackInvoked.get());
-      Assertions.assertEquals(1, errorCallbackInvoked.get());
+      assertThat(completeCallbackInvoked.get()).isEqualTo(0);
+      assertThat(errorCallbackInvoked.get()).isEqualTo(1);
 
     } finally {
       database.commit();
@@ -338,7 +341,7 @@ public class AsyncTest extends TestHelper {
   protected void beginTest() {
     database.begin();
 
-    Assertions.assertFalse(database.getSchema().existsType(TYPE_NAME));
+    assertThat(database.getSchema().existsType(TYPE_NAME)).isFalse();
 
     final AtomicLong okCallbackInvoked = new AtomicLong();
 
@@ -346,7 +349,7 @@ public class AsyncTest extends TestHelper {
     database.async().setParallelLevel(3);
     database.async().onOk(() -> okCallbackInvoked.incrementAndGet());
 
-    database.async().onError(exception -> Assertions.fail("Error on creating async record", exception));
+    database.async().onError(exception -> fail("Error on creating async record", exception));
 
     final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(3).create();
     type.createProperty("id", Integer.class);
@@ -358,7 +361,7 @@ public class AsyncTest extends TestHelper {
 
     populateDatabase();
 
-    Assertions.assertTrue(okCallbackInvoked.get() > 0);
+    assertThat(okCallbackInvoked.get() > 0).isTrue();
   }
 
   private void populateDatabase() {

--- a/engine/src/test/java/com/arcadedb/BLOBTest.java
+++ b/engine/src/test/java/com/arcadedb/BLOBTest.java
@@ -22,8 +22,11 @@ import com.arcadedb.database.Document;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Type;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class BLOBTest extends TestHelper {
   @Override
@@ -44,7 +47,7 @@ public class BLOBTest extends TestHelper {
 
     database.transaction(() -> {
       final Document blob = database.iterateType("Blob", false).next().asDocument();
-      Assertions.assertEquals("This is a test", new String( blob.getBinary("binary")));
+      assertThat(new String( blob.getBinary("binary"))).isEqualTo("This is a test");
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/CRUDTest.java
+++ b/engine/src/test/java/com/arcadedb/CRUDTest.java
@@ -27,11 +27,15 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.*;
 import java.util.logging.*;
+
+import org.assertj.core.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class CRUDTest extends TestHelper {
   private static final int TOT = ((int) GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.getDefValue()) * 2;
@@ -59,11 +63,11 @@ public class CRUDTest extends TestHelper {
 
       db.begin();
 
-      Assertions.assertEquals(TOT, db.countType("V", true));
+      assertThat(db.countType("V", true)).isEqualTo(TOT);
 
       db.scanType("V", true, record -> {
-        Assertions.assertEquals(true, record.get("update"));
-        Assertions.assertEquals("This is a large field to force the page overlap at some point", record.get("largeField"));
+        assertThat(record.get("update")).isEqualTo(true);
+        assertThat(record.get("largeField")).isEqualTo("This is a large field to force the page overlap at some point");
         return true;
       });
 
@@ -83,16 +87,15 @@ public class CRUDTest extends TestHelper {
         final String largeField = "largeField" + i;
         updateAll(largeField);
 
-        Assertions.assertEquals(TOT, db.countType("V", true));
+        assertThat(db.countType("V", true)).isEqualTo(TOT);
 
-        Assertions.assertEquals(TOT,
-            ((Long) db.query("sql", "select count(*) as count from V where " + largeField + " is not null").nextIfAvailable()
-                .getProperty("count")).intValue(), "Count not expected for field '" + largeField + "'");
+        assertThat(((Long) db.query("sql", "select count(*) as count from V where " + largeField + " is not null").nextIfAvailable()
+          .getProperty("count")).intValue()).as("Count not expected for field '" + largeField + "'").isEqualTo(TOT);
 
         db.commit();
         db.begin();
 
-        Assertions.assertEquals(TOT, db.countType("V", true));
+        assertThat(db.countType("V", true)).isEqualTo(TOT);
 
         LogManager.instance().log(this, Level.FINE, "Completed %d cycle of updates", i);
       }
@@ -111,24 +114,23 @@ public class CRUDTest extends TestHelper {
         final String largeField = "largeField" + i;
         updateAll(largeField);
 
-        Assertions.assertEquals(TOT, db.countType("V", true));
-        Assertions.assertEquals(TOT,
-            ((Long) db.query("sql", "select count(*) as count from V where " + largeField + " is not null").nextIfAvailable()
-                .getProperty("count")).intValue(), "Count not expected for field '" + largeField + "'");
+        assertThat(db.countType("V", true)).isEqualTo(TOT);
+        assertThat(((Long) db.query("sql", "select count(*) as count from V where " + largeField + " is not null").nextIfAvailable()
+          .getProperty("count")).intValue()).as("Count not expected for field '" + largeField + "'").isEqualTo(TOT);
 
         db.commit();
         db.begin();
 
-        Assertions.assertEquals(TOT, db.countType("V", true));
+        assertThat(db.countType("V", true)).isEqualTo(TOT);
 
         LogManager.instance().log(this, Level.FINE, "Completed %d cycle of updates", i);
       }
 
       db.scanType("V", true, record -> {
-        Assertions.assertEquals(true, record.get("update"));
+        assertThat(record.get("update")).isEqualTo(true);
 
         for (int i = 0; i < 10; ++i)
-          Assertions.assertEquals("This is a large field to force the page overlap at some point", record.get("largeField" + i));
+          assertThat(record.get("largeField" + i)).isEqualTo("This is a large field to force the page overlap at some point");
 
         return true;
       });
@@ -184,39 +186,37 @@ public class CRUDTest extends TestHelper {
 
         db.begin();
 
-        Assertions.assertEquals(TOT, db.countType("V", true));
+        assertThat(db.countType("V", true)).isEqualTo(TOT);
 
         updateAll("largeField" + i);
 
-        Assertions.assertEquals(TOT, db.countType("V", true));
+        assertThat(db.countType("V", true)).isEqualTo(TOT);
 
         db.commit();
         db.begin();
 
-        Assertions.assertEquals(TOT, db.countType("V", true));
+        assertThat(db.countType("V", true)).isEqualTo(TOT);
 
         db.scanType("V", true, record -> {
-          Assertions.assertEquals(true, record.get("update"));
+          assertThat(record.get("update")).isEqualTo(true);
 
-          Assertions.assertEquals("This is a large field to force the page overlap at some point",
-              record.get("largeField" + counter), "Unexpected content in record " + record.getIdentity());
-
+          assertThat(record.get("largeField" + counter)).isEqualTo("This is a large field to force the page overlap at some point");
           return true;
         });
 
         deleteAll();
 
-        Assertions.assertEquals(0, db.countType("V", true));
+        assertThat(db.countType("V", true)).isEqualTo(0);
 
         db.commit();
 
-        database.transaction(() -> Assertions.assertEquals(0, db.countType("V", true)));
+        database.transaction(() -> assertThat(db.countType("V", true)).isEqualTo(0));
 
         LogManager.instance().log(this, Level.FINE, "Completed %d cycle of updates+delete", i);
 
         createAll();
 
-        database.transaction(() -> Assertions.assertEquals(TOT, db.countType("V", true)));
+        database.transaction(() -> assertThat(db.countType("V", true)).isEqualTo(TOT));
       }
 
     } finally {

--- a/engine/src/test/java/com/arcadedb/ConcurrentWriteTest.java
+++ b/engine/src/test/java/com/arcadedb/ConcurrentWriteTest.java
@@ -25,12 +25,13 @@ import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.graph.MutableVertex;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.concurrent.atomic.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConcurrentWriteTest {
   private static final int           TOTAL                = 10_000;
@@ -84,11 +85,11 @@ public class ConcurrentWriteTest {
 
     List<Long> allIds = checkRecordSequence(database);
 
-    Assertions.assertEquals(TOTAL * CONCURRENT_THREADS, allIds.size());
+    assertThat(allIds.size()).isEqualTo(TOTAL * CONCURRENT_THREADS);
 
-    Assertions.assertEquals(TOTAL * CONCURRENT_THREADS, totalRecordsOnClusters);
+    assertThat(totalRecordsOnClusters).isEqualTo(TOTAL * CONCURRENT_THREADS);
 
-    Assertions.assertEquals(TOTAL * CONCURRENT_THREADS, database.countType("User", true));
+    assertThat(database.countType("User", true)).isEqualTo(TOTAL * CONCURRENT_THREADS);
   }
 
   private List<Long> checkRecordSequence(final Database database) {

--- a/engine/src/test/java/com/arcadedb/ConfigurationTest.java
+++ b/engine/src/test/java/com/arcadedb/ConfigurationTest.java
@@ -18,41 +18,41 @@
  */
 package com.arcadedb;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
 
 import static com.arcadedb.GlobalConfiguration.TEST;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConfigurationTest {
   @Test
   public void testGlobalExport2Json() {
-    Assertions.assertFalse(TEST.getValueAsBoolean());
+    assertThat(TEST.getValueAsBoolean()).isFalse();
     final String json = GlobalConfiguration.toJSON();
     TEST.setValue(true);
-    Assertions.assertTrue(TEST.getValueAsBoolean());
+    assertThat(TEST.getValueAsBoolean()).isTrue();
     GlobalConfiguration.fromJSON(json);
-    Assertions.assertFalse(TEST.getValueAsBoolean());
+    assertThat(TEST.getValueAsBoolean()).isFalse();
   }
 
   @Test
   public void testContextExport2Json() {
     final ContextConfiguration cfg = new ContextConfiguration();
     cfg.setValue(TEST, false);
-    Assertions.assertFalse(cfg.getValueAsBoolean(TEST));
+    assertThat(cfg.getValueAsBoolean(TEST)).isFalse();
     final String json = cfg.toJSON();
     cfg.setValue(TEST, true);
-    Assertions.assertTrue(cfg.getValueAsBoolean(TEST));
+    assertThat(cfg.getValueAsBoolean(TEST)).isTrue();
     cfg.fromJSON(json);
-    Assertions.assertFalse(cfg.getValueAsBoolean(TEST));
+    assertThat(cfg.getValueAsBoolean(TEST)).isFalse();
   }
 
   @Test
   public void testDump() {
     final ByteArrayOutputStream out = new ByteArrayOutputStream();
     GlobalConfiguration.dumpConfiguration(new PrintStream(out));
-    Assertions.assertTrue(out.size() > 0);
+    assertThat(out.size() > 0).isTrue();
   }
 
 }

--- a/engine/src/test/java/com/arcadedb/ConstantsTest.java
+++ b/engine/src/test/java/com/arcadedb/ConstantsTest.java
@@ -18,53 +18,54 @@
  */
 package com.arcadedb;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class ConstantsTest {
 
   @Test
   void getVersionMajor() {
-    Assertions.assertNotNull(Constants.getVersionMajor());
+    assertThat(Constants.getVersionMajor()).isNotNull();
   }
 
   @Test
   void getVersionMinor() {
-    Assertions.assertNotNull(Constants.getVersionMinor());
+    assertThat(Constants.getVersionMinor()).isNotNull();
   }
 
   @Test
   void getVersionHotfix() {
-    Assertions.assertNotNull(Constants.getVersionHotfix());
+    assertThat(Constants.getVersionHotfix()).isNotNull();
   }
 
   @Test
   void getVersion() {
-    Assertions.assertNotNull(Constants.getVersion());
+    assertThat(Constants.getVersion()).isNotNull();
   }
 
   @Test
   void getRawVersion() {
-    Assertions.assertNotNull(Constants.getRawVersion());
+    assertThat(Constants.getRawVersion()).isNotNull();
   }
 
   @Test
   void getBranch() {
-    Assertions.assertNotNull(Constants.getBranch());
+    assertThat(Constants.getBranch()).isNotNull();
   }
 
   @Test
   void getBuildNumber() {
-    Assertions.assertNotNull(Constants.getBuildNumber());
+    assertThat(Constants.getBuildNumber()).isNotNull();
   }
 
   @Test
   void getTimestamp() {
-    Assertions.assertNotNull(Constants.getTimestamp());
+    assertThat(Constants.getTimestamp()).isNotNull();
   }
 
   @Test
   void isSnapshot() {
-    Assertions.assertNotNull(Constants.isSnapshot());
+    assertThat(Constants.isSnapshot()).isNotNull();
   }
 }

--- a/engine/src/test/java/com/arcadedb/DocumentTest.java
+++ b/engine/src/test/java/com/arcadedb/DocumentTest.java
@@ -23,10 +23,14 @@ import com.arcadedb.database.EmbeddedDocument;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Type;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
 
 public class DocumentTest extends TestHelper {
   @Override
@@ -68,37 +72,37 @@ public class DocumentTest extends TestHelper {
       doc.reload();
       doc.detach();
 
-      Assertions.assertEquals("Tim", detached.getString("name"));
-      Assertions.assertEquals(embeddedObj, detached.get("embeddedObj"));
-      Assertions.assertEquals(embeddedList, detached.get("embeddedList"));
-      Assertions.assertEquals(embeddedMap, detached.get("embeddedMap"));
-      Assertions.assertNull(detached.getString("lastname"));
+      assertThat(detached.getString("name")).isEqualTo("Tim");
+      assertThat(detached.get("embeddedObj")).isEqualTo(embeddedObj);
+      assertThat(detached.get("embeddedList")).isEqualTo(embeddedList);
+      assertThat(detached.get("embeddedMap")).isEqualTo(embeddedMap);
+      assertThat(detached.getString("lastname")).isNull();
 
       final Set<String> props = detached.getPropertyNames();
-      Assertions.assertEquals(4, props.size());
-      Assertions.assertTrue(props.contains("name"));
-      Assertions.assertTrue(props.contains("embeddedObj"));
-      Assertions.assertTrue(props.contains("embeddedList"));
-      Assertions.assertTrue(props.contains("embeddedMap"));
+      assertThat(props).hasSize(4);
+      assertThat(props.contains("name")).isTrue();
+      assertThat(props.contains("embeddedObj")).isTrue();
+      assertThat(props.contains("embeddedList")).isTrue();
+      assertThat(props.contains("embeddedMap")).isTrue();
 
       final Map<String, Object> map = detached.toMap();
-      Assertions.assertEquals(6, map.size());
+      assertThat(map).hasSize(6);
 
-      Assertions.assertEquals("Tim", map.get("name"));
-      Assertions.assertEquals(embeddedObj, map.get("embeddedObj"));
-      Assertions.assertTrue(((DetachedDocument) map.get("embeddedObj")).getBoolean("embeddedObj"));
-      Assertions.assertEquals(embeddedList, map.get("embeddedList"));
-      Assertions.assertTrue(((List<DetachedDocument>) map.get("embeddedList")).get(0).getBoolean("embeddedList"));
-      Assertions.assertEquals(embeddedMap, map.get("embeddedMap"));
-      Assertions.assertTrue(((Map<String, DetachedDocument>) map.get("embeddedMap")).get("first").getBoolean("embeddedMap"));
+      assertThat(map.get("name")).isEqualTo("Tim");
+      assertThat(map.get("embeddedObj")).isEqualTo(embeddedObj);
+      assertThat(((DetachedDocument) map.get("embeddedObj")).getBoolean("embeddedObj")).isTrue();
+      assertThat(map.get("embeddedList")).isEqualTo(embeddedList);
+      assertThat(((List<DetachedDocument>) map.get("embeddedList")).get(0).getBoolean("embeddedList")).isTrue();
+      assertThat(map.get("embeddedMap")).isEqualTo(embeddedMap);
+      assertThat(((Map<String, DetachedDocument>) map.get("embeddedMap")).get("first").getBoolean("embeddedMap")).isTrue();
 
-      Assertions.assertEquals("Tim", detached.toJSON().get("name"));
+      assertThat(detached.toJSON().get("name")).isEqualTo("Tim");
 
       detached.toString();
 
       try {
         detached.modify();
-        Assertions.fail("modify");
+        fail("modify");
       } catch (final UnsupportedOperationException e) {
       }
 
@@ -106,12 +110,12 @@ public class DocumentTest extends TestHelper {
 
       try {
         detached.setBuffer(null);
-        Assertions.fail("setBuffer");
+        fail("setBuffer");
       } catch (final UnsupportedOperationException e) {
       }
 
-      Assertions.assertNull(detached.getString("name"));
-      Assertions.assertNull(detached.getString("lastname"));
+      assertThat(detached.getString("name")).isNull();
+      assertThat(detached.getString("lastname")).isNull();
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/GlobalConfigurationTest.java
+++ b/engine/src/test/java/com/arcadedb/GlobalConfigurationTest.java
@@ -18,8 +18,10 @@
  */
 package com.arcadedb;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class GlobalConfigurationTest extends TestHelper {
   @Test
@@ -27,17 +29,17 @@ public class GlobalConfigurationTest extends TestHelper {
     final String original = GlobalConfiguration.SERVER_MODE.getValueAsString();
 
     GlobalConfiguration.SERVER_MODE.setValue("development");
-    Assertions.assertEquals("development", GlobalConfiguration.SERVER_MODE.getValueAsString());
+    assertThat(GlobalConfiguration.SERVER_MODE.getValueAsString()).isEqualTo("development");
 
     GlobalConfiguration.SERVER_MODE.setValue("test");
-    Assertions.assertEquals("test", GlobalConfiguration.SERVER_MODE.getValueAsString());
+    assertThat(GlobalConfiguration.SERVER_MODE.getValueAsString()).isEqualTo("test");
 
     GlobalConfiguration.SERVER_MODE.setValue("production");
-    Assertions.assertEquals("production", GlobalConfiguration.SERVER_MODE.getValueAsString());
+    assertThat(GlobalConfiguration.SERVER_MODE.getValueAsString()).isEqualTo("production");
 
     try {
       GlobalConfiguration.SERVER_MODE.setValue("notvalid");
-      Assertions.fail();
+      fail("");
     } catch (final IllegalArgumentException e) {
       // EXPECTED
     }
@@ -51,7 +53,7 @@ public class GlobalConfigurationTest extends TestHelper {
 
     try {
       GlobalConfiguration.INITIAL_PAGE_CACHE_SIZE.setValue("notvalid");
-      Assertions.fail();
+      fail("");
     } catch (final NumberFormatException e) {
       // EXPECTED
     }
@@ -64,10 +66,10 @@ public class GlobalConfigurationTest extends TestHelper {
     GlobalConfiguration.INITIAL_PAGE_CACHE_SIZE.reset();
     final int original = GlobalConfiguration.INITIAL_PAGE_CACHE_SIZE.getValueAsInteger();
 
-    Assertions.assertEquals(original, GlobalConfiguration.INITIAL_PAGE_CACHE_SIZE.getDefValue());
-    Assertions.assertFalse(GlobalConfiguration.INITIAL_PAGE_CACHE_SIZE.isChanged());
+    assertThat(GlobalConfiguration.INITIAL_PAGE_CACHE_SIZE.getDefValue()).isEqualTo(original);
+    assertThat(GlobalConfiguration.INITIAL_PAGE_CACHE_SIZE.isChanged()).isFalse();
     GlobalConfiguration.INITIAL_PAGE_CACHE_SIZE.setValue(0);
-    Assertions.assertTrue(GlobalConfiguration.INITIAL_PAGE_CACHE_SIZE.isChanged());
+    assertThat(GlobalConfiguration.INITIAL_PAGE_CACHE_SIZE.isChanged()).isTrue();
 
     GlobalConfiguration.INITIAL_PAGE_CACHE_SIZE.setValue(original);
   }

--- a/engine/src/test/java/com/arcadedb/LargeRecordsTest.java
+++ b/engine/src/test/java/com/arcadedb/LargeRecordsTest.java
@@ -21,10 +21,13 @@ package com.arcadedb;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.engine.LocalBucket;
 import com.arcadedb.schema.DocumentType;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Populate the database with records 3X the page size of buckets.
@@ -47,14 +50,14 @@ public class LargeRecordsTest extends TestHelper {
     final long pageOverSize = ((LocalBucket) type.getBuckets(true).get(0)).getPageSize() * 3;
 
     database.scanType("BigRecords", true, record -> {
-      Assertions.assertNotNull(record);
+      assertThat(record).isNotNull();
       final String buffer = record.asDocument().getString("buffer");
-      Assertions.assertEquals(pageOverSize, buffer.length());
+      assertThat(buffer.length()).isEqualTo(pageOverSize);
       total.incrementAndGet();
       return true;
     });
 
-    Assertions.assertEquals(TOT, total.get());
+    assertThat(total.get()).isEqualTo(TOT);
 
     database.commit();
   }

--- a/engine/src/test/java/com/arcadedb/LoggerTest.java
+++ b/engine/src/test/java/com/arcadedb/LoggerTest.java
@@ -21,10 +21,11 @@ package com.arcadedb;
 import com.arcadedb.log.DefaultLogger;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.log.Logger;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.logging.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class LoggerTest extends TestHelper {
   private boolean logged  = false;
@@ -54,11 +55,11 @@ public class LoggerTest extends TestHelper {
 
       LogManager.instance().log(this, Level.FINE, "This is a test");
 
-      Assertions.assertEquals(true, logged);
+      assertThat(logged).isTrue();
 
       LogManager.instance().flush();
 
-      Assertions.assertEquals(true, flushed);
+      assertThat(flushed).isTrue();
     } finally {
       LogManager.instance().setLogger(new DefaultLogger());
     }

--- a/engine/src/test/java/com/arcadedb/MultipleDatabasesTest.java
+++ b/engine/src/test/java/com/arcadedb/MultipleDatabasesTest.java
@@ -24,13 +24,20 @@ import com.arcadedb.database.EmbeddedDocument;
 import com.arcadedb.exception.DatabaseOperationException;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.utility.FileUtils;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class MultipleDatabasesTest extends TestHelper {
   @Test
@@ -51,7 +58,7 @@ public class MultipleDatabasesTest extends TestHelper {
       final MutableVertex v = database.newVertex("V1").set("db", 1).save();
       try {
         v.newEmbeddedDocument("V1", "embedded").set("db", 1).set("embedded", true).save();
-        Assertions.fail();
+        fail();
       } catch (final IllegalArgumentException e) {
         // EXPECTED
       }
@@ -83,17 +90,17 @@ public class MultipleDatabasesTest extends TestHelper {
     });
 
     // CHECK PRESENCE OF RECORDS IN EACH DATABASE
-    Assertions.assertEquals(1, database.iterateType("V1", true).next().asVertex().get("db"));
-    Assertions.assertEquals(1, database.iterateType("V1", true).next().asVertex().getEmbedded("embedded").get("db"));
-    Assertions.assertEquals(2, database2.iterateType("V1", true).next().asVertex().get("db"));
-    Assertions.assertEquals(2, database2.iterateType("V1", true).next().asVertex().getEmbedded("embedded").get("db"));
-    Assertions.assertEquals(3, database3.iterateType("V1", true).next().asVertex().get("db"));
-    Assertions.assertEquals(3, database3.iterateType("V1", true).next().asVertex().getEmbedded("embedded").get("db"));
+    assertThat(database.iterateType("V1", true).next().asVertex().get("db")).isEqualTo(1);
+    assertThat(database.iterateType("V1", true).next().asVertex().getEmbedded("embedded").get("db")).isEqualTo(1);
+    assertThat(database2.iterateType("V1", true).next().asVertex().get("db")).isEqualTo(2);
+    assertThat(database2.iterateType("V1", true).next().asVertex().getEmbedded("embedded").get("db")).isEqualTo(2);
+    assertThat(database3.iterateType("V1", true).next().asVertex().get("db")).isEqualTo(3);
+    assertThat(database3.iterateType("V1", true).next().asVertex().getEmbedded("embedded").get("db")).isEqualTo(3);
 
     // CHECK COPIED RECORDS TOO
-    Assertions.assertEquals(1, database3.iterateType("V1", true).next().asVertex().getEmbedded("embedded1").get("db"));
-    Assertions.assertEquals(2, ((List<EmbeddedDocument>) database3.iterateType("V1", true).next().asVertex().get("list2")).get(0).get("db"));
-    Assertions.assertEquals(2, ((Map<String, EmbeddedDocument>) database3.iterateType("V1", true).next().asVertex().get("map2")).get("copied2").get("db"));
+    assertThat(database3.iterateType("V1", true).next().asVertex().getEmbedded("embedded1").get("db")).isEqualTo(1);
+    assertThat(((List<EmbeddedDocument>) database3.iterateType("V1", true).next().asVertex().get("list2")).get(0).get("db")).isEqualTo(2);
+    assertThat(((Map<String, EmbeddedDocument>) database3.iterateType("V1", true).next().asVertex().get("map2")).get("copied2").get("db")).isEqualTo(2);
 
     database.close();
     database2.close();
@@ -106,7 +113,7 @@ public class MultipleDatabasesTest extends TestHelper {
   public void testErrorMultipleDatabaseInstancesSamePath() {
     try {
       new DatabaseFactory(getDatabasePath()).open();
-      Assertions.fail();
+      fail("");
     } catch (final DatabaseOperationException e) {
       // EXPECTED
     }

--- a/engine/src/test/java/com/arcadedb/PageManagerStressTest.java
+++ b/engine/src/test/java/com/arcadedb/PageManagerStressTest.java
@@ -26,11 +26,12 @@ import com.arcadedb.engine.PageManager;
 import com.arcadedb.engine.WALFile;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import performance.PerformanceTest;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PageManagerStressTest {
   private static final int    TOT       = 1_000_000;
@@ -100,8 +101,8 @@ public class PageManagerStressTest {
       }
 
       final PageManager.PPageManagerStats stats = ((DatabaseInternal) database).getPageManager().getStats();
-      Assertions.assertTrue(stats.evictionRuns > 0);
-      Assertions.assertTrue(stats.pagesEvicted > 0);
+      assertThat(stats.evictionRuns > 0).isTrue();
+      assertThat(stats.pagesEvicted > 0).isTrue();
 
     } finally {
       database.close();

--- a/engine/src/test/java/com/arcadedb/ProfilerTest.java
+++ b/engine/src/test/java/com/arcadedb/ProfilerTest.java
@@ -19,10 +19,11 @@
 package com.arcadedb;
 
 import com.arcadedb.serializer.json.JSONObject;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ProfilerTest {
 
@@ -30,15 +31,15 @@ public class ProfilerTest {
   public void testDumpProfileMetrics() {
     final ByteArrayOutputStream out = new ByteArrayOutputStream();
     Profiler.INSTANCE.dumpMetrics(new PrintStream(out));
-    Assertions.assertTrue(out.size() > 0);
+    assertThat(out.size() > 0).isTrue();
   }
 
   @Test
   public void testMetricsToJSON() {
     JSONObject json = Profiler.INSTANCE.toJSON();
-    Assertions.assertTrue(json.has("diskFreeSpace"));
-    Assertions.assertTrue(json.has("diskTotalSpace"));
-    Assertions.assertTrue(json.has("updateRecord"));
-    Assertions.assertTrue(json.has("totalDatabases"));
+    assertThat(json.has("diskFreeSpace")).isTrue();
+    assertThat(json.has("diskTotalSpace")).isTrue();
+    assertThat(json.has("updateRecord")).isTrue();
+    assertThat(json.has("totalDatabases")).isTrue();
   }
 }

--- a/engine/src/test/java/com/arcadedb/RandomTestMultiThreadsTest.java
+++ b/engine/src/test/java/com/arcadedb/RandomTestMultiThreadsTest.java
@@ -32,13 +32,14 @@ import com.arcadedb.schema.EdgeType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.VertexType;
 import com.arcadedb.utility.Pair;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.math.*;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 import java.util.logging.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class RandomTestMultiThreadsTest extends TestHelper {
   private static final int CYCLES           = 10000;
@@ -106,7 +107,7 @@ public class RandomTestMultiThreadsTest extends TestHelper {
                   while (result.hasNext()) {
                     final Result record = result.next();
                     record.toJSON();
-                    Assertions.assertEquals(randomId, (Long) record.getProperty("id"));
+                    assertThat((Long) record.getProperty("id")).isEqualTo(randomId);
                   }
 
                 } else if (op >= 40 && op <= 59) {
@@ -123,7 +124,7 @@ public class RandomTestMultiThreadsTest extends TestHelper {
                     if (randomUUID != (Long) record.getProperty("uuid")) {
                       System.out.printf("Looking for %d but found %d%n", randomUUID, (Long) record.getProperty("uuid"));
                     }
-                    Assertions.assertEquals(randomUUID, (Long) record.getProperty("uuid"));
+                    assertThat((Long) record.getProperty("uuid")).isEqualTo(randomUUID);
                   }
                 } else if (op >= 60 && op <= 64) {
                   LogManager.instance().log(this, Level.FINE, "Scanning Account records (thread=%d)...", threadId);

--- a/engine/src/test/java/com/arcadedb/ReusingSpaceTest.java
+++ b/engine/src/test/java/com/arcadedb/ReusingSpaceTest.java
@@ -21,8 +21,9 @@ package com.arcadedb;
 import com.arcadedb.database.Database;
 import com.arcadedb.engine.DatabaseChecker;
 import com.arcadedb.graph.MutableVertex;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ReusingSpaceTest extends TestHelper {
   @Test
@@ -35,7 +36,7 @@ public class ReusingSpaceTest extends TestHelper {
         db.getSchema().dropType("CreateAndDelete");
         db.getSchema().getOrCreateVertexType("CreateAndDelete", 1);
       }
-      Assertions.assertEquals(0, db.countType("CreateAndDelete", true));
+      assertThat(db.countType("CreateAndDelete", true)).isEqualTo(0);
 
       for (int i = 0; i < 3000; i++) {
         final MutableVertex[] v = new MutableVertex[1];
@@ -53,7 +54,7 @@ public class ReusingSpaceTest extends TestHelper {
         });
       }
 
-      Assertions.assertEquals(0, db.countType("CreateAndDelete", true));
+      assertThat(db.countType("CreateAndDelete", true)).isEqualTo(0);
 
     } finally {
       new DatabaseChecker(database).setVerboseLevel(0).check();

--- a/engine/src/test/java/com/arcadedb/TransactionTypeTest.java
+++ b/engine/src/test/java/com/arcadedb/TransactionTypeTest.java
@@ -1,21 +1,3 @@
-/*
- * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
- * SPDX-License-Identifier: Apache-2.0
- */
 package com.arcadedb;
 
 import com.arcadedb.database.Document;
@@ -27,12 +9,14 @@ import com.arcadedb.index.IndexCursor;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.utility.CollectionUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.util.*;
 import java.util.concurrent.atomic.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 public class TransactionTypeTest extends TestHelper {
   private static final int    TOT       = 10000;
@@ -50,21 +34,21 @@ public class TransactionTypeTest extends TestHelper {
     database.begin();
 
     database.scanType(TYPE_NAME, true, record -> {
-      Assertions.assertNotNull(record);
+      assertThat(record).isNotNull();
 
       final Set<String> prop = new HashSet<String>();
       prop.addAll(record.getPropertyNames());
 
-      Assertions.assertEquals(3, record.getPropertyNames().size(), 9);
-      Assertions.assertTrue(prop.contains("id"));
-      Assertions.assertTrue(prop.contains("name"));
-      Assertions.assertTrue(prop.contains("surname"));
+      assertThat(record.getPropertyNames().size()).isEqualTo(3);
+      assertThat(prop.contains("id")).isTrue();
+      assertThat(prop.contains("name")).isTrue();
+      assertThat(prop.contains("surname")).isTrue();
 
       total.incrementAndGet();
       return true;
     });
 
-    Assertions.assertEquals(TOT, total.get());
+    assertThat(total.get()).isEqualTo(TOT);
 
     database.commit();
   }
@@ -77,16 +61,16 @@ public class TransactionTypeTest extends TestHelper {
 
     database.scanType(TYPE_NAME, true, record -> {
       final Document record2 = (Document) database.lookupByRID(record.getIdentity(), false);
-      Assertions.assertNotNull(record2);
-      Assertions.assertEquals(record, record2);
+      assertThat(record2).isNotNull();
+      assertThat(record2).isEqualTo(record);
 
       final Set<String> prop = new HashSet<String>();
       prop.addAll(record2.getPropertyNames());
 
-      Assertions.assertEquals(record2.getPropertyNames().size(), 3);
-      Assertions.assertTrue(prop.contains("id"));
-      Assertions.assertTrue(prop.contains("name"));
-      Assertions.assertTrue(prop.contains("surname"));
+      assertThat(record2.getPropertyNames().size()).isEqualTo(3);
+      assertThat(prop.contains("id")).isTrue();
+      assertThat(prop.contains("name")).isTrue();
+      assertThat(prop.contains("surname")).isTrue();
 
       total.incrementAndGet();
       return true;
@@ -94,7 +78,7 @@ public class TransactionTypeTest extends TestHelper {
 
     database.commit();
 
-    Assertions.assertEquals(TOT, total.get());
+    assertThat(total.get()).isEqualTo(TOT);
   }
 
   @Test
@@ -105,27 +89,27 @@ public class TransactionTypeTest extends TestHelper {
 
     for (int i = 0; i < TOT; i++) {
       final IndexCursor result = database.lookupByKey(TYPE_NAME, new String[] { "id" }, new Object[] { i });
-      Assertions.assertNotNull(result);
-      Assertions.assertTrue(result.hasNext());
+      assertThat(Optional.ofNullable(result)).isNotNull();
+      assertThat(result.hasNext()).isTrue();
 
       final Document record2 = (Document) result.next().getRecord();
 
-      Assertions.assertEquals(i, record2.get("id"));
+      assertThat(record2.get("id")).isEqualTo(i);
 
       final Set<String> prop = new HashSet<String>();
       prop.addAll(record2.getPropertyNames());
 
-      Assertions.assertEquals(record2.getPropertyNames().size(), 3);
-      Assertions.assertTrue(prop.contains("id"));
-      Assertions.assertTrue(prop.contains("name"));
-      Assertions.assertTrue(prop.contains("surname"));
+      assertThat(record2.getPropertyNames().size()).isEqualTo(3);
+      assertThat(prop.contains("id")).isTrue();
+      assertThat(prop.contains("name")).isTrue();
+      assertThat(prop.contains("surname")).isTrue();
 
       total.incrementAndGet();
     }
 
     database.commit();
 
-    Assertions.assertEquals(TOT, total.get());
+    assertThat(total.get()).isEqualTo(TOT);
   }
 
   @Test
@@ -142,22 +126,22 @@ public class TransactionTypeTest extends TestHelper {
 
     database.commit();
 
-    Assertions.assertEquals(TOT, total.get());
+    assertThat(total.get()).isEqualTo(TOT);
 
     database.begin();
 
-    Assertions.assertEquals(0, database.countType(TYPE_NAME, true));
+    assertThat(database.countType(TYPE_NAME, true)).isEqualTo(0);
 
     // GET EACH ITEM TO CHECK IT HAS BEEN DELETED
     final Index[] indexes = database.getSchema().getIndexes();
     for (int i = 0; i < TOT; ++i) {
       for (final Index index : indexes)
-        Assertions.assertFalse(index.get(new Object[] { i }).hasNext(), "Found item with key " + i);
+        assertThat(index.get(new Object[]{i}).hasNext()).as("Found item with key " + i).isFalse();
     }
 
     beginTest();
 
-    database.transaction(() -> Assertions.assertEquals(TOT, database.countType(TYPE_NAME, true)));
+    database.transaction(() -> assertThat(database.countType(TYPE_NAME, true)).isEqualTo(TOT));
   }
 
   @Test
@@ -176,11 +160,11 @@ public class TransactionTypeTest extends TestHelper {
 
     database.commit();
 
-    Assertions.assertEquals(1, total.get());
+    assertThat(total.get()).isEqualTo(1);
 
     database.begin();
 
-    Assertions.assertEquals(originalCount - 1, database.countType(TYPE_NAME, true));
+    assertThat(database.countType(TYPE_NAME, true)).isEqualTo(originalCount - 1);
 
     // COUNT WITH SCAN
     total.set(0);
@@ -188,14 +172,14 @@ public class TransactionTypeTest extends TestHelper {
       total.incrementAndGet();
       return true;
     });
-    Assertions.assertEquals(originalCount - 1, total.get());
+    assertThat(total.get()).isEqualTo(originalCount - 1);
 
     // COUNT WITH ITERATE TYPE
     total.set(0);
     for (final Iterator<Record> it = database.iterateType(TYPE_NAME, true); it.hasNext(); it.next())
       total.incrementAndGet();
 
-    Assertions.assertEquals(originalCount - 1, total.get());
+    assertThat(total.get()).isEqualTo(originalCount - 1);
   }
 
   @Test
@@ -214,11 +198,11 @@ public class TransactionTypeTest extends TestHelper {
 
     database.commit();
 
-    Assertions.assertEquals(1, total.get());
+    assertThat(total.get()).isEqualTo(1);
 
     database.begin();
 
-    Assertions.assertEquals(originalCount, database.countType(TYPE_NAME, true));
+    assertThat(database.countType(TYPE_NAME, true)).isEqualTo(originalCount);
 
     // COUNT WITH SCAN
     total.set(0);
@@ -226,21 +210,21 @@ public class TransactionTypeTest extends TestHelper {
       total.incrementAndGet();
       return true;
     });
-    Assertions.assertEquals(originalCount, total.get());
+    assertThat(total.get()).isEqualTo(originalCount);
 
     // COUNT WITH ITERATE TYPE
     total.set(0);
     for (final Iterator<Record> it = database.iterateType(TYPE_NAME, true); it.hasNext(); it.next())
       total.incrementAndGet();
 
-    Assertions.assertEquals(originalCount, total.get());
+    assertThat(total.get()).isEqualTo(originalCount);
   }
 
   @Test
   public void testDeleteFail() {
     reopenDatabaseInReadOnlyMode();
 
-    Assertions.assertThrows(DatabaseIsReadOnlyException.class, () -> {
+    assertThatExceptionOfType(DatabaseIsReadOnlyException.class).isThrownBy(() -> {
 
       database.begin();
 
@@ -262,9 +246,9 @@ public class TransactionTypeTest extends TestHelper {
       database.transaction(() -> database.newDocument(TYPE_NAME).set("id", -2, "tx", 2).save());
     });
 
-    Assertions.assertEquals(0, CollectionUtils.countEntries(database.query("sql", "select from " + TYPE_NAME + " where tx = 0")));
-    Assertions.assertEquals(1, CollectionUtils.countEntries(database.query("sql", "select from " + TYPE_NAME + " where tx = 1")));
-    Assertions.assertEquals(1, CollectionUtils.countEntries(database.query("sql", "select from " + TYPE_NAME + " where tx = 2")));
+    assertThat(CollectionUtils.countEntries(database.query("sql", "select from " + TYPE_NAME + " where tx = 0"))).isEqualTo(0);
+    assertThat(CollectionUtils.countEntries(database.query("sql", "select from " + TYPE_NAME + " where tx = 1"))).isEqualTo(1);
+    assertThat(CollectionUtils.countEntries(database.query("sql", "select from " + TYPE_NAME + " where tx = 2"))).isEqualTo(1);
   }
 
   @Override

--- a/engine/src/test/java/com/arcadedb/TypeConversionTest.java
+++ b/engine/src/test/java/com/arcadedb/TypeConversionTest.java
@@ -26,7 +26,7 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Type;
 import com.arcadedb.utility.DateUtils;
 import com.arcadedb.utility.NanoClock;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
 
 import java.math.*;
@@ -36,6 +36,10 @@ import java.time.chrono.*;
 import java.time.temporal.*;
 import java.util.*;
 import java.util.concurrent.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TypeConversionTest extends TestHelper {
   @Override
@@ -82,21 +86,21 @@ public class TypeConversionTest extends TestHelper {
       doc.set("localDate", localDate); // SCHEMALESS
       doc.set("localDateTime", localDateTime); // SCHEMALESS
 
-      Assertions.assertEquals(33, doc.get("int"));
-      Assertions.assertEquals(33l, doc.get("long"));
-      Assertions.assertEquals(33.33f, doc.get("float"));
-      Assertions.assertEquals(33.33d, doc.get("double"));
-      Assertions.assertEquals(new BigDecimal("33.33"), doc.get("decimal"));
-      Assertions.assertEquals(now, doc.get("date"));
+      assertThat(doc.get("int")).isEqualTo(33);
+      assertThat(doc.get("long")).isEqualTo(33l);
+      assertThat(doc.get("float")).isEqualTo(33.33f);
+      assertThat(doc.get("double")).isEqualTo(33.33d);
+      assertThat(doc.get("decimal")).isEqualTo(new BigDecimal("33.33"));
+      assertThat(doc.get("date")).isEqualTo(now);
 
-      Assertions.assertEquals(0, ((LocalDateTime) doc.get("datetime_second")).getNano());
-      Assertions.assertEquals(now, doc.get("datetime_millis"));
-      Assertions.assertEquals(ChronoUnit.MILLIS, DateUtils.getPrecision(doc.getLocalDateTime("datetime_millis").getNano()));
-      Assertions.assertEquals(ChronoUnit.MILLIS, DateUtils.getPrecision(((LocalDateTime) doc.get("datetime_micros")).getNano()));
-      Assertions.assertEquals(ChronoUnit.MILLIS, DateUtils.getPrecision(((LocalDateTime) doc.get("datetime_nanos")).getNano()));
+      assertThat(((LocalDateTime) doc.get("datetime_second")).getNano()).isEqualTo(0);
+      assertThat(doc.get("datetime_millis")).isEqualTo(now);
+      assertThat(DateUtils.getPrecision(doc.getLocalDateTime("datetime_millis").getNano())).isEqualTo(ChronoUnit.MILLIS);
+      assertThat(DateUtils.getPrecision(((LocalDateTime) doc.get("datetime_micros")).getNano())).isEqualTo(ChronoUnit.MILLIS);
+      assertThat(DateUtils.getPrecision(((LocalDateTime) doc.get("datetime_nanos")).getNano())).isEqualTo(ChronoUnit.MILLIS);
 
-      Assertions.assertEquals(localDate, doc.get("localDate"));
-      Assertions.assertEquals(localDateTime, doc.get("localDateTime"));
+      assertThat(doc.get("localDate")).isEqualTo(localDate);
+      assertThat(doc.get("localDateTime")).isEqualTo(localDateTime);
     });
   }
 
@@ -108,19 +112,19 @@ public class TypeConversionTest extends TestHelper {
       final Date now = new Date();
 
       doc.set("decimal", "33.33");
-      Assertions.assertEquals(new BigDecimal("33.33"), doc.get("decimal"));
+      assertThat(doc.get("decimal")).isEqualTo(new BigDecimal("33.33"));
 
       doc.set("decimal", 33.33f);
-      Assertions.assertEquals(new BigDecimal("33.33"), doc.get("decimal"));
+      assertThat(doc.get("decimal")).isEqualTo(new BigDecimal("33.33"));
 
       doc.set("decimal", 33.33d);
-      Assertions.assertEquals(new BigDecimal("33.33"), doc.get("decimal"));
+      assertThat(doc.get("decimal")).isEqualTo(new BigDecimal("33.33"));
 
       doc.save();
 
-      Assertions.assertEquals(String.format("%.1f", 33.3F),
+      assertEquals(String.format("%.1f", 33.3F),
           database.query("sql", "select decimal.format('%.1f') as d from " + doc.getIdentity()).nextIfAvailable().getProperty("d"));
-      Assertions.assertEquals(String.format("%.2f", 33.33F),
+      assertEquals(String.format("%.2f", 33.33F),
           database.query("sql", "select decimal.format('%.2f') as d from " + doc.getIdentity()).nextIfAvailable().getProperty("d"));
 
       doc.delete();
@@ -136,30 +140,30 @@ public class TypeConversionTest extends TestHelper {
 
       doc.set("date", now.getTime());
       doc.set("datetime_millis", now.getTime());
-      Assertions.assertEquals(now, doc.get("date"));
-      Assertions.assertEquals(now, doc.get("datetime_millis"));
+      assertThat(doc.get("date")).isEqualTo(now);
+      assertThat(doc.get("datetime_millis")).isEqualTo(now);
 
       doc.set("date", "" + now.getTime());
       doc.set("datetime_millis", "" + now.getTime());
-      Assertions.assertEquals(now, doc.get("date"));
-      Assertions.assertEquals(now, doc.get("datetime_millis"));
+      assertThat(doc.get("date")).isEqualTo(now);
+      assertThat(doc.get("datetime_millis")).isEqualTo(now);
 
       final SimpleDateFormat df = new SimpleDateFormat(database.getSchema().getDateTimeFormat());
 
       doc.set("date", df.format(now));
       doc.set("datetime_millis", df.format(now));
-      Assertions.assertEquals(df.format(now), df.format(doc.get("date")));
-      Assertions.assertEquals(df.format(now), df.format(doc.get("datetime_millis")));
+      assertThat(df.format(doc.get("date"))).isEqualTo(df.format(now));
+      assertThat(df.format(doc.get("datetime_millis"))).isEqualTo(df.format(now));
 
       final LocalDate localDate = LocalDate.now();
       final LocalDateTime localDateTime = LocalDateTime.now();
       doc.set("date", localDate);
       doc.set("datetime_nanos", localDateTime);
-      Assertions.assertEquals(localDate, doc.getLocalDate("date"));
-      Assertions.assertEquals(localDateTime.truncatedTo(DateUtils.getPrecision(localDateTime.getNano())),
+      assertThat(doc.getLocalDate("date")).isEqualTo(localDate);
+      assertEquals(localDateTime.truncatedTo(DateUtils.getPrecision(localDateTime.getNano())),
           doc.getLocalDateTime("datetime_nanos"));
 
-      Assertions.assertEquals(
+      assertEquals(
           TimeUnit.MILLISECONDS.convert(localDateTime.toEpochSecond(ZoneOffset.UTC), TimeUnit.SECONDS) + localDateTime.getLong(
               ChronoField.MILLI_OF_SECOND), doc.getCalendar("datetime_nanos").getTime().getTime());
     });
@@ -170,21 +174,21 @@ public class TypeConversionTest extends TestHelper {
     database.command("sql", "alter database `arcadedb.dateTimeImplementation` `java.time.LocalDateTime`");
     database.command("sql", "alter database `arcadedb.dateImplementation` `java.time.LocalDate`");
 
-    Assertions.assertEquals(LocalDateTime.class, ((DatabaseInternal) database).getSerializer().getDateTimeImplementation());
-    Assertions.assertEquals(LocalDate.class, ((DatabaseInternal) database).getSerializer().getDateImplementation());
+    assertThat(((DatabaseInternal) database).getSerializer().getDateTimeImplementation()).isEqualTo(LocalDateTime.class);
+    assertThat(((DatabaseInternal) database).getSerializer().getDateImplementation()).isEqualTo(LocalDate.class);
 
     database.close();
 
     database = factory.open();
 
-    Assertions.assertEquals(LocalDateTime.class, ((DatabaseInternal) database).getSerializer().getDateTimeImplementation());
-    Assertions.assertEquals(LocalDate.class, ((DatabaseInternal) database).getSerializer().getDateImplementation());
+    assertThat(((DatabaseInternal) database).getSerializer().getDateTimeImplementation()).isEqualTo(LocalDateTime.class);
+    assertThat(((DatabaseInternal) database).getSerializer().getDateImplementation()).isEqualTo(LocalDate.class);
 
     database.command("sql", "alter database `arcadedb.dateTimeImplementation` `java.util.Date`");
     database.command("sql", "alter database `arcadedb.dateImplementation` `java.util.Date`");
 
-    Assertions.assertEquals(Date.class, ((DatabaseInternal) database).getSerializer().getDateTimeImplementation());
-    Assertions.assertEquals(Date.class, ((DatabaseInternal) database).getSerializer().getDateImplementation());
+    assertThat(((DatabaseInternal) database).getSerializer().getDateTimeImplementation()).isEqualTo(Date.class);
+    assertThat(((DatabaseInternal) database).getSerializer().getDateImplementation()).isEqualTo(Date.class);
   }
 
   @Test
@@ -202,7 +206,7 @@ public class TypeConversionTest extends TestHelper {
       });
 
       doc.reload();
-      Assertions.assertEquals(localDateTime.truncatedTo(ChronoUnit.SECONDS), doc.get("datetime_second"));
+      assertThat(doc.get("datetime_second")).isEqualTo(localDateTime.truncatedTo(ChronoUnit.SECONDS));
 
       database.transaction(() -> {
         // TEST MILLISECONDS PRECISION
@@ -211,7 +215,7 @@ public class TypeConversionTest extends TestHelper {
       });
 
       doc.reload();
-      Assertions.assertEquals(localDateTime.truncatedTo(ChronoUnit.MILLIS), doc.get("datetime_millis"));
+      assertThat(doc.get("datetime_millis")).isEqualTo(localDateTime.truncatedTo(ChronoUnit.MILLIS));
 
       // TEST MICROSECONDS PRECISION
       database.transaction(() -> {
@@ -220,7 +224,7 @@ public class TypeConversionTest extends TestHelper {
       });
 
       doc.reload();
-      Assertions.assertEquals(localDateTime.truncatedTo(ChronoUnit.MICROS), doc.get("datetime_micros"));
+      assertThat(doc.get("datetime_micros")).isEqualTo(localDateTime.truncatedTo(ChronoUnit.MICROS));
 
       // TEST NANOSECOND PRECISION
       database.transaction(() -> {
@@ -228,25 +232,21 @@ public class TypeConversionTest extends TestHelper {
         doc.save();
       });
       doc.reload();
-      Assertions.assertEquals(localDateTime.truncatedTo(ChronoUnit.NANOS), doc.get("datetime_nanos"));
+      assertThat(doc.get("datetime_nanos")).isEqualTo(localDateTime.truncatedTo(ChronoUnit.NANOS));
 
-      Assertions.assertNotNull(
-          database.query("sql", "select datetime_second.asLong() as long from ConversionTest").nextIfAvailable()
-              .getProperty("long"));
-      Assertions.assertNotNull(
-          database.query("sql", "select datetime_millis.asLong() as long from ConversionTest").nextIfAvailable()
-              .getProperty("long"));
-      Assertions.assertNotNull(
-          database.query("sql", "select datetime_micros.asLong() as long from ConversionTest").nextIfAvailable()
-              .getProperty("long"));
-      Assertions.assertNotNull(database.query("sql", "select datetime_nanos.asLong() as long from ConversionTest").nextIfAvailable()
-          .getProperty("long"));
+      assertThat((Long) database.query("sql", "select datetime_second.asLong() as long from ConversionTest").nextIfAvailable()
+        .getProperty("long")).isNotNull();
+      assertThat((Long) database.query("sql", "select datetime_millis.asLong() as long from ConversionTest").nextIfAvailable()
+        .getProperty("long")).isNotNull();
+      assertThat((Long) database.query("sql", "select datetime_micros.asLong() as long from ConversionTest").nextIfAvailable()
+        .getProperty("long")).isNotNull();
+      assertThat((Long) database.query("sql", "select datetime_nanos.asLong() as long from ConversionTest").nextIfAvailable()
+        .getProperty("long")).isNotNull();
 
-      Assertions.assertEquals(
-          TimeUnit.MILLISECONDS.convert(localDateTime.toEpochSecond(ZoneOffset.UTC), TimeUnit.SECONDS) + localDateTime.getLong(
-              ChronoField.MILLI_OF_SECOND), doc.getDate("datetime_millis").getTime());
+      assertThat(doc.getDate("datetime_millis").getTime()).isEqualTo(TimeUnit.MILLISECONDS.convert(localDateTime.toEpochSecond(ZoneOffset.UTC), TimeUnit.SECONDS) + localDateTime.getLong(
+        ChronoField.MILLI_OF_SECOND));
 
-      Assertions.assertTrue(localDateTime.isEqual(doc.getLocalDateTime("datetime_nanos")));
+      assertThat(localDateTime.isEqual(doc.getLocalDateTime("datetime_nanos"))).isTrue();
 
     } finally {
       ((DatabaseInternal) database).getSerializer().setDateTimeImplementation(Date.class);
@@ -261,20 +261,20 @@ public class TypeConversionTest extends TestHelper {
     try {
       database.begin();
       ResultSet result = database.command("sql", "insert into ConversionTest set datetime_second = ?", localDateTime);
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertEquals(localDateTime.truncatedTo(ChronoUnit.SECONDS), result.next().toElement().get("datetime_second"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat(result.next().toElement().get("datetime_second")).isEqualTo(localDateTime.truncatedTo(ChronoUnit.SECONDS));
 
       result = database.command("sql", "insert into ConversionTest set datetime_millis = ?", localDateTime);
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertEquals(localDateTime.truncatedTo(ChronoUnit.MILLIS), result.next().toElement().get("datetime_millis"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat(result.next().toElement().get("datetime_millis")).isEqualTo(localDateTime.truncatedTo(ChronoUnit.MILLIS));
 
       result = database.command("sql", "insert into ConversionTest set datetime_micros = ?", localDateTime);
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertEquals(localDateTime.truncatedTo(ChronoUnit.MICROS), result.next().toElement().get("datetime_micros"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat(result.next().toElement().get("datetime_micros")).isEqualTo(localDateTime.truncatedTo(ChronoUnit.MICROS));
 
       result = database.command("sql", "insert into ConversionTest set datetime_nanos = ?", localDateTime);
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertEquals(localDateTime.truncatedTo(ChronoUnit.NANOS), result.next().toElement().get("datetime_nanos"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat(result.next().toElement().get("datetime_nanos")).isEqualTo(localDateTime.truncatedTo(ChronoUnit.NANOS));
 
       database.commit();
     } finally {
@@ -297,8 +297,8 @@ public class TypeConversionTest extends TestHelper {
       });
 
       doc.reload();
-      Assertions.assertEquals(calendar, doc.get("datetime_millis"));
-      Assertions.assertEquals(calendar, doc.getCalendar("datetime_millis"));
+      assertThat(doc.get("datetime_millis")).isEqualTo(calendar);
+      assertThat(doc.getCalendar("datetime_millis")).isEqualTo(calendar);
 
     } finally {
       ((DatabaseInternal) database).getSerializer().setDateTimeImplementation(Date.class);
@@ -320,8 +320,8 @@ public class TypeConversionTest extends TestHelper {
       });
 
       doc.reload();
-      Assertions.assertEquals(localDate, doc.get("date"));
-      Assertions.assertTrue(localDate.isEqual(doc.getLocalDate("date")));
+      assertThat(doc.get("date")).isEqualTo(localDate);
+      assertThat(localDate.isEqual(doc.getLocalDate("date"))).isTrue();
 
     } finally {
       ((DatabaseInternal) database).getSerializer().setDateImplementation(Date.class);
@@ -344,8 +344,7 @@ public class TypeConversionTest extends TestHelper {
       });
 
       doc.reload();
-      Assertions.assertTrue(
-          zonedDateTime.truncatedTo(ChronoUnit.SECONDS).isEqual((ChronoZonedDateTime<?>) doc.get("datetime_second")));
+      assertThat(zonedDateTime.truncatedTo(ChronoUnit.SECONDS).isEqual((ChronoZonedDateTime<?>) doc.get("datetime_second"))).isTrue();
 
       database.transaction(() -> {
         // TEST MILLISECONDS PRECISION
@@ -354,8 +353,7 @@ public class TypeConversionTest extends TestHelper {
       });
 
       doc.reload();
-      Assertions.assertTrue(
-          zonedDateTime.truncatedTo(ChronoUnit.MILLIS).isEqual((ChronoZonedDateTime<?>) doc.get("datetime_millis")));
+      assertThat(zonedDateTime.truncatedTo(ChronoUnit.MILLIS).isEqual((ChronoZonedDateTime<?>) doc.get("datetime_millis"))).isTrue();
 
       if (!System.getProperty("os.name").startsWith("Windows")) {
         // NOTE: ON WINDOWS MICROSECONDS ARE NOT HANDLED CORRECTLY
@@ -367,8 +365,7 @@ public class TypeConversionTest extends TestHelper {
         });
 
         doc.reload();
-        Assertions.assertTrue(
-            zonedDateTime.truncatedTo(ChronoUnit.MICROS).isEqual((ChronoZonedDateTime<?>) doc.get("datetime_micros")));
+        assertThat(zonedDateTime.truncatedTo(ChronoUnit.MICROS).isEqual((ChronoZonedDateTime<?>) doc.get("datetime_micros"))).isTrue();
       }
 
       // TEST NANOSECOND PRECISION
@@ -377,9 +374,8 @@ public class TypeConversionTest extends TestHelper {
         doc.save();
       });
       doc.reload();
-      Assertions.assertTrue(
-          zonedDateTime.truncatedTo(ChronoUnit.NANOS).isEqual((ChronoZonedDateTime<?>) doc.get("datetime_nanos")));
-      Assertions.assertTrue(zonedDateTime.isEqual(doc.getZonedDateTime("datetime_nanos")));
+      assertThat(zonedDateTime.truncatedTo(ChronoUnit.NANOS).isEqual((ChronoZonedDateTime<?>) doc.get("datetime_nanos"))).isTrue();
+      assertThat(zonedDateTime.isEqual(doc.getZonedDateTime("datetime_nanos"))).isTrue();
 
     } finally {
       ((DatabaseInternal) database).getSerializer().setDateTimeImplementation(Date.class);
@@ -401,7 +397,7 @@ public class TypeConversionTest extends TestHelper {
       });
 
       doc.reload();
-      Assertions.assertEquals(instant.truncatedTo(ChronoUnit.SECONDS), doc.get("datetime_second"));
+      assertThat(doc.get("datetime_second")).isEqualTo(instant.truncatedTo(ChronoUnit.SECONDS));
 
       database.transaction(() -> {
         // TEST MILLISECONDS PRECISION
@@ -410,7 +406,7 @@ public class TypeConversionTest extends TestHelper {
       });
 
       doc.reload();
-      Assertions.assertEquals(instant.truncatedTo(ChronoUnit.MILLIS), doc.get("datetime_millis"));
+      assertThat(doc.get("datetime_millis")).isEqualTo(instant.truncatedTo(ChronoUnit.MILLIS));
 
       // TEST MICROSECONDS PRECISION
       database.transaction(() -> {
@@ -421,7 +417,7 @@ public class TypeConversionTest extends TestHelper {
       doc.reload();
       if (!System.getProperty("os.name").startsWith("Windows"))
         // NOTE: ON WINDOWS MICROSECONDS ARE NOT HANDLED CORRECTLY
-        Assertions.assertEquals(instant.truncatedTo(ChronoUnit.MICROS), doc.get("datetime_micros"));
+        assertThat(doc.get("datetime_micros")).isEqualTo(instant.truncatedTo(ChronoUnit.MICROS));
 
       // TEST NANOSECOND PRECISION
       database.transaction(() -> {
@@ -429,8 +425,8 @@ public class TypeConversionTest extends TestHelper {
         doc.save();
       });
       doc.reload();
-      Assertions.assertEquals(instant.truncatedTo(ChronoUnit.NANOS), doc.get("datetime_nanos"));
-      Assertions.assertEquals(instant, doc.getInstant("datetime_nanos"));
+      assertThat(doc.get("datetime_nanos")).isEqualTo(instant.truncatedTo(ChronoUnit.NANOS));
+      assertThat(doc.getInstant("datetime_nanos")).isEqualTo(instant);
 
     } finally {
       ((DatabaseInternal) database).getSerializer().setDateTimeImplementation(Date.class);
@@ -439,25 +435,25 @@ public class TypeConversionTest extends TestHelper {
 
   @Test
   public void testConversion() {
-    Assertions.assertEquals(10, DateUtils.convertTimestamp(10_000_000_000L, ChronoUnit.NANOS, ChronoUnit.SECONDS));
-    Assertions.assertEquals(10_000, DateUtils.convertTimestamp(10_000_000_000L, ChronoUnit.NANOS, ChronoUnit.MILLIS));
-    Assertions.assertEquals(10_000_000, DateUtils.convertTimestamp(10_000_000_000L, ChronoUnit.NANOS, ChronoUnit.MICROS));
-    Assertions.assertEquals(10_000_000_000L, DateUtils.convertTimestamp(10_000_000_000L, ChronoUnit.NANOS, ChronoUnit.NANOS));
+    assertThat(DateUtils.convertTimestamp(10_000_000_000L, ChronoUnit.NANOS, ChronoUnit.SECONDS)).isEqualTo(10);
+    assertThat(DateUtils.convertTimestamp(10_000_000_000L, ChronoUnit.NANOS, ChronoUnit.MILLIS)).isEqualTo(10_000);
+    assertThat(DateUtils.convertTimestamp(10_000_000_000L, ChronoUnit.NANOS, ChronoUnit.MICROS)).isEqualTo(10_000_000);
+    assertThat(DateUtils.convertTimestamp(10_000_000_000L, ChronoUnit.NANOS, ChronoUnit.NANOS)).isEqualTo(10_000_000_000L);
 
-    Assertions.assertEquals(10, DateUtils.convertTimestamp(10_000_000, ChronoUnit.MICROS, ChronoUnit.SECONDS));
-    Assertions.assertEquals(10_000, DateUtils.convertTimestamp(10_000_000, ChronoUnit.MICROS, ChronoUnit.MILLIS));
-    Assertions.assertEquals(10_000_000, DateUtils.convertTimestamp(10_000_000, ChronoUnit.MICROS, ChronoUnit.MICROS));
-    Assertions.assertEquals(10_000_000_000L, DateUtils.convertTimestamp(10_000_000, ChronoUnit.MICROS, ChronoUnit.NANOS));
+    assertThat(DateUtils.convertTimestamp(10_000_000, ChronoUnit.MICROS, ChronoUnit.SECONDS)).isEqualTo(10);
+    assertThat(DateUtils.convertTimestamp(10_000_000, ChronoUnit.MICROS, ChronoUnit.MILLIS)).isEqualTo(10_000);
+    assertThat(DateUtils.convertTimestamp(10_000_000, ChronoUnit.MICROS, ChronoUnit.MICROS)).isEqualTo(10_000_000);
+    assertThat(DateUtils.convertTimestamp(10_000_000, ChronoUnit.MICROS, ChronoUnit.NANOS)).isEqualTo(10_000_000_000L);
 
-    Assertions.assertEquals(10, DateUtils.convertTimestamp(10_000, ChronoUnit.MILLIS, ChronoUnit.SECONDS));
-    Assertions.assertEquals(10_000, DateUtils.convertTimestamp(10_000, ChronoUnit.MILLIS, ChronoUnit.MILLIS));
-    Assertions.assertEquals(10_000_000, DateUtils.convertTimestamp(10_000, ChronoUnit.MILLIS, ChronoUnit.MICROS));
-    Assertions.assertEquals(10_000_000_000L, DateUtils.convertTimestamp(10_000, ChronoUnit.MILLIS, ChronoUnit.NANOS));
+    assertThat(DateUtils.convertTimestamp(10_000, ChronoUnit.MILLIS, ChronoUnit.SECONDS)).isEqualTo(10);
+    assertThat(DateUtils.convertTimestamp(10_000, ChronoUnit.MILLIS, ChronoUnit.MILLIS)).isEqualTo(10_000);
+    assertThat(DateUtils.convertTimestamp(10_000, ChronoUnit.MILLIS, ChronoUnit.MICROS)).isEqualTo(10_000_000);
+    assertThat(DateUtils.convertTimestamp(10_000, ChronoUnit.MILLIS, ChronoUnit.NANOS)).isEqualTo(10_000_000_000L);
 
-    Assertions.assertEquals(10, DateUtils.convertTimestamp(10, ChronoUnit.SECONDS, ChronoUnit.SECONDS));
-    Assertions.assertEquals(10_000, DateUtils.convertTimestamp(10, ChronoUnit.SECONDS, ChronoUnit.MILLIS));
-    Assertions.assertEquals(10_000_000, DateUtils.convertTimestamp(10, ChronoUnit.SECONDS, ChronoUnit.MICROS));
-    Assertions.assertEquals(10_000_000_000L, DateUtils.convertTimestamp(10, ChronoUnit.SECONDS, ChronoUnit.NANOS));
+    assertThat(DateUtils.convertTimestamp(10, ChronoUnit.SECONDS, ChronoUnit.SECONDS)).isEqualTo(10);
+    assertThat(DateUtils.convertTimestamp(10, ChronoUnit.SECONDS, ChronoUnit.MILLIS)).isEqualTo(10_000);
+    assertThat(DateUtils.convertTimestamp(10, ChronoUnit.SECONDS, ChronoUnit.MICROS)).isEqualTo(10_000_000);
+    assertThat(DateUtils.convertTimestamp(10, ChronoUnit.SECONDS, ChronoUnit.NANOS)).isEqualTo(10_000_000_000L);
   }
 
   @Test
@@ -471,20 +467,20 @@ public class TypeConversionTest extends TestHelper {
       database.begin();
       final LocalDateTime date1 = LocalDateTime.now();
       ResultSet resultSet = database.command("sql", "insert into ConversionTest set datetime_micros = ?", date1);
-      Assertions.assertTrue(resultSet.hasNext());
-      Assertions.assertEquals(date1.truncatedTo(ChronoUnit.MICROS), resultSet.next().toElement().get("datetime_micros"));
+      assertThat(resultSet.hasNext()).isTrue();
+      assertThat(resultSet.next().toElement().get("datetime_micros")).isEqualTo(date1.truncatedTo(ChronoUnit.MICROS));
 
       final LocalDateTime date2 = LocalDateTime.now().plusSeconds(1);
       resultSet = database.command("sql", "insert into ConversionTest set datetime_micros = ?", date2);
-      Assertions.assertTrue(resultSet.hasNext());
-      Assertions.assertEquals(date2.truncatedTo(ChronoUnit.MICROS), resultSet.next().toElement().get("datetime_micros"));
+      assertThat(resultSet.hasNext()).isTrue();
+      assertThat(resultSet.next().toElement().get("datetime_micros")).isEqualTo(date2.truncatedTo(ChronoUnit.MICROS));
 
       resultSet = database.command("sql", "select from ConversionTest where datetime_micros between ? and ?", date1, date2);
-      Assertions.assertTrue(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isTrue();
       resultSet.next();
-      Assertions.assertTrue(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isTrue();
       resultSet.next();
-      Assertions.assertFalse(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isFalse();
 
       try {
         Thread.sleep(1001);
@@ -494,68 +490,68 @@ public class TypeConversionTest extends TestHelper {
 
       resultSet = database.command("sql", "select sysdate() - datetime_micros as diff from ConversionTest");
 
-      Assertions.assertTrue(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isTrue();
       Result result = resultSet.next();
-      Assertions.assertFalse(((Duration) result.getProperty("diff")).isNegative(), "Returned " + result.getProperty("diff"));
+      assertThat(((Duration) result.getProperty("diff")).isNegative()).as("Returned " + result.getProperty("diff")).isFalse();
 
-      Assertions.assertTrue(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isTrue();
       result = resultSet.next();
-      Assertions.assertFalse(((Duration) result.getProperty("diff")).isNegative(), "Returned " + result.getProperty("diff"));
+      assertThat(((Duration) result.getProperty("diff")).isNegative()).as("Returned " + result.getProperty("diff")).isFalse();
 
-      Assertions.assertFalse(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isFalse();
 
       resultSet = database.command("sql",
           "select sysdate() - datetime_micros as diff from ConversionTest where sysdate() - datetime_micros < duration(100000000000, 'nanosecond')");
-      Assertions.assertTrue(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isTrue();
       result = resultSet.next();
-      Assertions.assertFalse(((Duration) result.getProperty("diff")).isNegative(), "Returned " + result.getProperty("diff"));
+      assertThat(((Duration) result.getProperty("diff")).isNegative()).as("Returned " + result.getProperty("diff")).isFalse();
 
-      Assertions.assertTrue(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isTrue();
       result = resultSet.next();
-      Assertions.assertFalse(((Duration) result.getProperty("diff")).isNegative(), "Returned " + result.getProperty("diff"));
+      assertThat(((Duration) result.getProperty("diff")).isNegative()).as("Returned " + result.getProperty("diff")).isFalse();
 
-      Assertions.assertFalse(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isFalse();
 
       resultSet = database.command("sql",
           "select datetime_micros - sysdate() as diff from ConversionTest where abs( datetime_micros - sysdate() ) < duration(100000000000, 'nanosecond')");
 
-      Assertions.assertTrue(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isTrue();
       result = resultSet.next();
-      Assertions.assertTrue(((Duration) result.getProperty("diff")).isNegative(), "Returned " + result.getProperty("diff"));
+      assertThat(((Duration) result.getProperty("diff")).isNegative()).as("Returned " + result.getProperty("diff")).isTrue();
 
-      Assertions.assertTrue(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isTrue();
       result = resultSet.next();
-      Assertions.assertTrue(((Duration) result.getProperty("diff")).isNegative(), "Returned " + result.getProperty("diff"));
+      assertThat(((Duration) result.getProperty("diff")).isNegative()).as("Returned " + result.getProperty("diff")).isTrue();
 
-      Assertions.assertFalse(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isFalse();
 
       resultSet = database.command("sql",
           "select datetime_micros - date(?, 'yyyy-MM-dd HH:mm:ss.SSS') as diff from ConversionTest where abs( datetime_micros - sysdate() ) < duration(100000000000, 'nanosecond')",
           DateUtils.getFormatter("yyyy-MM-dd HH:mm:ss.SSS").format(LocalDateTime.now()));
 
-      Assertions.assertTrue(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isTrue();
       result = resultSet.next();
-      Assertions.assertTrue(((Duration) result.getProperty("diff")).isNegative(), "Returned " + result.getProperty("diff"));
+      assertThat(((Duration) result.getProperty("diff")).isNegative()).as("Returned " + result.getProperty("diff")).isTrue();
 
-      Assertions.assertTrue(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isTrue();
       result = resultSet.next();
-      Assertions.assertTrue(((Duration) result.getProperty("diff")).isNegative(), "Returned " + result.getProperty("diff"));
+      assertThat(((Duration) result.getProperty("diff")).isNegative()).as("Returned " + result.getProperty("diff")).isTrue();
 
-      Assertions.assertFalse(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isFalse();
 
       resultSet = database.command("sql",
           "select datetime_micros - date(?, 'yyyy-MM-dd HH:mm:ss.SSS') as diff from ConversionTest where abs( datetime_micros - sysdate() ) < duration(3, \"second\")",
           DateUtils.getFormatter("yyyy-MM-dd HH:mm:ss.SSS").format(LocalDateTime.now()));
 
-      Assertions.assertTrue(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isTrue();
       result = resultSet.next();
-      Assertions.assertTrue(((Duration) result.getProperty("diff")).isNegative(), "Returned " + result.getProperty("diff"));
+      assertThat(((Duration) result.getProperty("diff")).isNegative()).as("Returned " + result.getProperty("diff")).isTrue();
 
-      Assertions.assertTrue(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isTrue();
       result = resultSet.next();
-      Assertions.assertTrue(((Duration) result.getProperty("diff")).isNegative(), "Returned " + result.getProperty("diff"));
+      assertThat(((Duration) result.getProperty("diff")).isNegative()).as("Returned " + result.getProperty("diff")).isTrue();
 
-      Assertions.assertFalse(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isFalse();
 
       database.commit();
     } finally {

--- a/engine/src/test/java/com/arcadedb/compression/CompressionTest.java
+++ b/engine/src/test/java/com/arcadedb/compression/CompressionTest.java
@@ -19,8 +19,9 @@
 package com.arcadedb.compression;
 
 import com.arcadedb.database.Binary;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class CompressionTest {
   @Test
@@ -30,7 +31,7 @@ public class CompressionTest {
     final Binary compressed = CompressionFactory.getDefault().compress(buffer);
     final Binary decompressed = CompressionFactory.getDefault().decompress(compressed, buffer.size());
 
-    Assertions.assertEquals(buffer, decompressed);
+    assertThat(decompressed).isEqualTo(buffer);
   }
 
   @Test
@@ -40,6 +41,6 @@ public class CompressionTest {
     final Binary compressed = CompressionFactory.getDefault().compress(buffer);
     final Binary decompressed = CompressionFactory.getDefault().decompress(compressed, buffer.size());
 
-    Assertions.assertEquals(buffer, decompressed);
+    assertThat(decompressed).isEqualTo(buffer);
   }
 }

--- a/engine/src/test/java/com/arcadedb/database/BucketSQLTest.java
+++ b/engine/src/test/java/com/arcadedb/database/BucketSQLTest.java
@@ -1,21 +1,3 @@
-/*
- * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
- * SPDX-License-Identifier: Apache-2.0
- */
 package com.arcadedb.database;
 
 import com.arcadedb.GlobalConfiguration;
@@ -23,10 +5,11 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.engine.Bucket;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class BucketSQLTest extends TestHelper {
   @Test
@@ -50,31 +33,31 @@ public class BucketSQLTest extends TestHelper {
 
       final DocumentType customer = database.getSchema().getType("Customer");
       final List<Bucket> buckets = customer.getBuckets(true);
-      Assertions.assertEquals(4, buckets.size());
+      assertThat(buckets.size()).isEqualTo(4);
 
       ResultSet resultset = database.command("sql", "INSERT INTO BUCKET:Customer_Europe CONTENT { firstName: 'Enzo', lastName: 'Ferrari' }");
-      Assertions.assertTrue(resultset.hasNext());
+      assertThat(resultset.hasNext()).isTrue();
       final Document enzo = resultset.next().getRecord().get().asDocument();
-      Assertions.assertFalse(resultset.hasNext());
-      Assertions.assertEquals(database.getSchema().getBucketByName("Customer_Europe").getFileId(), enzo.getIdentity().bucketId);
+      assertThat(resultset.hasNext()).isFalse();
+      assertThat(enzo.getIdentity().bucketId).isEqualTo(database.getSchema().getBucketByName("Customer_Europe").getFileId());
 
       resultset = database.command("sql", "INSERT INTO BUCKET:Customer_Americas CONTENT { firstName: 'Jack', lastName: 'Tramiel' }");
-      Assertions.assertTrue(resultset.hasNext());
+      assertThat(resultset.hasNext()).isTrue();
       final Document jack = resultset.next().getRecord().get().asDocument();
-      Assertions.assertFalse(resultset.hasNext());
-      Assertions.assertEquals(database.getSchema().getBucketByName("Customer_Americas").getFileId(), jack.getIdentity().bucketId);
+      assertThat(resultset.hasNext()).isFalse();
+      assertThat(jack.getIdentity().bucketId).isEqualTo(database.getSchema().getBucketByName("Customer_Americas").getFileId());
 
       resultset = database.command("sql", "INSERT INTO BUCKET:Customer_Asia CONTENT { firstName: 'Bruce', lastName: 'Lee' }");
-      Assertions.assertTrue(resultset.hasNext());
+      assertThat(resultset.hasNext()).isTrue();
       final Document bruce = resultset.next().getRecord().get().asDocument();
-      Assertions.assertFalse(resultset.hasNext());
-      Assertions.assertEquals(database.getSchema().getBucketByName("Customer_Asia").getFileId(), bruce.getIdentity().bucketId);
+      assertThat(resultset.hasNext()).isFalse();
+      assertThat(bruce.getIdentity().bucketId).isEqualTo(database.getSchema().getBucketByName("Customer_Asia").getFileId());
 
       resultset = database.command("sql", "INSERT INTO BUCKET:Customer_Other CONTENT { firstName: 'Penguin', lastName: 'Hungry' }");
-      Assertions.assertTrue(resultset.hasNext());
+      assertThat(resultset.hasNext()).isTrue();
       final Document penguin = resultset.next().getRecord().get().asDocument();
-      Assertions.assertFalse(resultset.hasNext());
-      Assertions.assertEquals(database.getSchema().getBucketByName("Customer_Other").getFileId(), penguin.getIdentity().bucketId);
+      assertThat(resultset.hasNext()).isFalse();
+      assertThat(penguin.getIdentity().bucketId).isEqualTo(database.getSchema().getBucketByName("Customer_Other").getFileId());
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/database/CheckDatabaseTest.java
+++ b/engine/src/test/java/com/arcadedb/database/CheckDatabaseTest.java
@@ -31,12 +31,15 @@ import com.arcadedb.graph.VertexInternal;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.util.*;
 import java.util.concurrent.atomic.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class CheckDatabaseTest extends TestHelper {
 
@@ -46,40 +49,40 @@ public class CheckDatabaseTest extends TestHelper {
   @Test
   public void checkDatabase() {
     final ResultSet result = database.command("sql", "check database");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     while (result.hasNext()) {
       final Result row = result.next();
 
-      Assertions.assertEquals("check database", row.getProperty("operation"));
-      Assertions.assertEquals(TOTAL, (Long) row.getProperty("totalActiveVertices"));
-      Assertions.assertEquals(TOTAL - 1, (Long) row.getProperty("totalActiveEdges"));
-      Assertions.assertEquals(0, (Long) row.getProperty("autoFix"));
+      assertThat(row.<String>getProperty("operation")).isEqualTo("check database");
+      assertThat(row.<Long>getProperty("totalActiveVertices")).isEqualTo(TOTAL);
+      assertThat(row.<Long>getProperty("totalActiveEdges")).isEqualTo(TOTAL - 1);
+      assertThat(row.<Long>getProperty("autoFix")).isEqualTo(0L);
     }
   }
 
   @Test
   public void checkTypes() {
     ResultSet result = database.command("sql", "check database type Person");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     while (result.hasNext()) {
       final Result row = result.next();
 
-      Assertions.assertEquals("check database", row.getProperty("operation"));
-      Assertions.assertEquals(TOTAL, (Long) row.getProperty("totalActiveRecords"));
-      Assertions.assertEquals(TOTAL, (Long) row.getProperty("totalActiveVertices"));
-      Assertions.assertEquals(0, (Long) row.getProperty("autoFix"));
+      assertThat(row.<String>getProperty("operation")).isEqualTo("check database");
+      assertThat((Long) row.getProperty("totalActiveRecords")).isEqualTo(TOTAL);
+      assertThat((Long) row.getProperty("totalActiveVertices")).isEqualTo(TOTAL);
+      assertThat((Long) row.getProperty("autoFix")).isEqualTo(0);
     }
 
     result = database.command("sql", "check database type Person, Knows");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     while (result.hasNext()) {
       final Result row = result.next();
 
-      Assertions.assertEquals("check database", row.getProperty("operation"));
-      Assertions.assertEquals(TOTAL * 2 - 1, (Long) row.getProperty("totalActiveRecords"));
-      Assertions.assertEquals(TOTAL, (Long) row.getProperty("totalActiveVertices"));
-      Assertions.assertEquals(TOTAL - 1, (Long) row.getProperty("totalActiveEdges"));
-      Assertions.assertEquals(0, (Long) row.getProperty("autoFix"));
+      assertThat(row.<String>getProperty("operation")).isEqualTo("check database");
+      assertThat((Long) row.getProperty("totalActiveRecords")).isEqualTo(TOTAL * 2 - 1);
+      assertThat((Long) row.getProperty("totalActiveVertices")).isEqualTo(TOTAL);
+      assertThat((Long) row.getProperty("totalActiveEdges")).isEqualTo(TOTAL - 1);
+      assertThat((Long) row.getProperty("autoFix")).isEqualTo(0);
     }
   }
 
@@ -88,20 +91,20 @@ public class CheckDatabaseTest extends TestHelper {
     database.transaction(() -> database.command("sql", "delete from Knows"));
 
     final ResultSet result = database.command("sql", "check database");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     while (result.hasNext()) {
       final Result row = result.next();
 
-      Assertions.assertEquals("check database", row.getProperty("operation"));
-      Assertions.assertEquals(0L, (Long) row.getProperty("autoFix"));
-      Assertions.assertEquals(TOTAL, (Long) row.getProperty("totalActiveVertices"));
-      Assertions.assertEquals(TOTAL - 1, (Long) row.getProperty("totalAllocatedEdges"));
-      Assertions.assertEquals(0L, (Long) row.getProperty("totalActiveEdges"));
-      Assertions.assertEquals(TOTAL - 1, (Long) row.getProperty("totalDeletedRecords"));
-      Assertions.assertEquals(0, ((Collection) row.getProperty("corruptedRecords")).size());
-      Assertions.assertEquals(0L, (Long) row.getProperty("missingReferenceBack"));
-      Assertions.assertEquals(0L, (Long) row.getProperty("invalidLinks"));
-      Assertions.assertEquals(0, ((Collection) row.getProperty("warnings")).size());
+      assertThat(row.<String>getProperty("operation")).isEqualTo("check database");
+      assertThat((Long) row.getProperty("autoFix")).isEqualTo(0L);
+      assertThat((Long) row.getProperty("totalActiveVertices")).isEqualTo(TOTAL);
+      assertThat((Long) row.getProperty("totalAllocatedEdges")).isEqualTo(TOTAL - 1);
+      assertThat((Long) row.getProperty("totalActiveEdges")).isEqualTo(0L);
+      assertThat((Long) row.getProperty("totalDeletedRecords")).isEqualTo(TOTAL - 1);
+      assertThat(((Collection) row.getProperty("corruptedRecords")).size()).isEqualTo(0);
+      assertThat((Long) row.getProperty("missingReferenceBack")).isEqualTo(0L);
+      assertThat((Long) row.getProperty("invalidLinks")).isEqualTo(0L);
+      assertThat(((Collection) row.getProperty("warnings")).size()).isEqualTo(0);
     }
   }
 
@@ -111,76 +114,76 @@ public class CheckDatabaseTest extends TestHelper {
 
     database.transaction(() -> {
       final Iterator<Record> iter = database.iterateType("Knows", false);
-      Assertions.assertTrue(iter.hasNext());
+      assertThat(iter.hasNext()).isTrue();
 
       final Record edge = iter.next();
       deletedEdge.set(edge.getIdentity());
 
-      Assertions.assertEquals(root.getIdentity(), edge.asEdge().getOut());
+      assertThat(edge.asEdge().getOut()).isEqualTo(root.getIdentity());
 
       // DELETE THE EDGE AT LOW LEVEL
       database.getSchema().getBucketById(edge.getIdentity().getBucketId()).deleteRecord(edge.getIdentity());
     });
 
     ResultSet result = database.command("sql", "check database");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     while (result.hasNext()) {
       final Result row = result.next();
 
-      Assertions.assertEquals("check database", row.getProperty("operation"));
-      Assertions.assertEquals(0, (Long) row.getProperty("autoFix"));
-      Assertions.assertEquals(TOTAL, (Long) row.getProperty("totalActiveVertices"));
-      Assertions.assertEquals(TOTAL - 1, (Long) row.getProperty("totalAllocatedEdges"));
-      Assertions.assertEquals(TOTAL - 2, (Long) row.getProperty("totalActiveEdges"));
-      Assertions.assertEquals(1, (Long) row.getProperty("totalDeletedRecords"));
-      Assertions.assertEquals(1, ((Collection) row.getProperty("corruptedRecords")).size());
-      Assertions.assertEquals(0, (Long) row.getProperty("missingReferenceBack"));
-      Assertions.assertEquals(2, (Long) row.getProperty("invalidLinks"));
-      Assertions.assertEquals(1, ((Collection) row.getProperty("warnings")).size());
+      assertThat(row.<String>getProperty("operation")).isEqualTo("check database");
+      assertThat((Long) row.getProperty("autoFix")).isEqualTo(0);
+      assertThat((Long) row.getProperty("totalActiveVertices")).isEqualTo(TOTAL);
+      assertThat((Long) row.getProperty("totalAllocatedEdges")).isEqualTo(TOTAL - 1);
+      assertThat((Long) row.getProperty("totalActiveEdges")).isEqualTo(TOTAL - 2);
+      assertThat((Long) row.getProperty("totalDeletedRecords")).isEqualTo(1);
+      assertThat(((Collection) row.getProperty("corruptedRecords")).size()).isEqualTo(1);
+      assertThat((Long) row.getProperty("missingReferenceBack")).isEqualTo(0);
+      assertThat((Long) row.getProperty("invalidLinks")).isEqualTo(2);
+      assertThat(((Collection) row.getProperty("warnings")).size()).isEqualTo(1);
     }
 
-    Assertions.assertEquals(TOTAL - 2, countEdges(root.getIdentity()));
-    Assertions.assertEquals(TOTAL - 1, countEdgesSegmentList(root.getIdentity()));
+    assertThat(countEdges(root.getIdentity())).isEqualTo(TOTAL - 2);
+    assertThat(countEdgesSegmentList(root.getIdentity())).isEqualTo(TOTAL - 1);
 
     result = database.command("sql", "check database fix");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     while (result.hasNext()) {
       final Result row = result.next();
 
-      Assertions.assertEquals("check database", row.getProperty("operation"));
-      Assertions.assertEquals(1, (Long) row.getProperty("autoFix"));
-      Assertions.assertEquals(TOTAL, (Long) row.getProperty("totalActiveVertices"));
-      Assertions.assertEquals(TOTAL - 1, (Long) row.getProperty("totalAllocatedEdges"));
-      Assertions.assertEquals(TOTAL - 2, (Long) row.getProperty("totalActiveEdges"));
-      Assertions.assertEquals(1, (Long) row.getProperty("totalDeletedRecords"));
-      Assertions.assertEquals(1, ((Collection) row.getProperty("corruptedRecords")).size());
-      Assertions.assertEquals(0, (Long) row.getProperty("missingReferenceBack"));
-      Assertions.assertEquals(2, (Long) row.getProperty("invalidLinks"));
-      Assertions.assertEquals(1, ((Collection) row.getProperty("warnings")).size());
+      assertThat(row.<String>getProperty("operation")).isEqualTo("check database");
+      assertThat((Long) row.getProperty("autoFix")).isEqualTo(1);
+      assertThat((Long) row.getProperty("totalActiveVertices")).isEqualTo(TOTAL);
+      assertThat((Long) row.getProperty("totalAllocatedEdges")).isEqualTo(TOTAL - 1);
+      assertThat((Long) row.getProperty("totalActiveEdges")).isEqualTo(TOTAL - 2);
+      assertThat((Long) row.getProperty("totalDeletedRecords")).isEqualTo(1);
+      assertThat(((Collection) row.getProperty("corruptedRecords")).size()).isEqualTo(1);
+      assertThat((Long) row.getProperty("missingReferenceBack")).isEqualTo(0);
+      assertThat((Long) row.getProperty("invalidLinks")).isEqualTo(2);
+      assertThat(((Collection) row.getProperty("warnings")).size()).isEqualTo(1);
     }
 
-    Assertions.assertEquals(TOTAL - 2, countEdges(root.getIdentity()));
-    Assertions.assertEquals(TOTAL - 2, countEdgesSegmentList(root.getIdentity()));
+    assertThat(countEdges(root.getIdentity())).isEqualTo(TOTAL - 2);
+    assertThat(countEdgesSegmentList(root.getIdentity())).isEqualTo(TOTAL - 2);
 
     result = database.command("sql", "check database fix");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     while (result.hasNext()) {
       final Result row = result.next();
 
-      Assertions.assertEquals("check database", row.getProperty("operation"));
-      Assertions.assertEquals(0, (Long) row.getProperty("autoFix"));
-      Assertions.assertEquals(TOTAL, (Long) row.getProperty("totalActiveVertices"));
-      Assertions.assertEquals(TOTAL - 1, (Long) row.getProperty("totalAllocatedEdges"));
-      Assertions.assertEquals(TOTAL - 2, (Long) row.getProperty("totalActiveEdges"));
-      Assertions.assertEquals(1, (Long) row.getProperty("totalDeletedRecords"));
-      Assertions.assertEquals(0, ((Collection) row.getProperty("corruptedRecords")).size());
-      Assertions.assertEquals(0, (Long) row.getProperty("missingReferenceBack"));
-      Assertions.assertEquals(0, (Long) row.getProperty("invalidLinks"));
-      Assertions.assertEquals(0, ((Collection) row.getProperty("warnings")).size());
+      assertThat(row.<String>getProperty("operation")).isEqualTo("check database");
+      assertThat((Long) row.getProperty("autoFix")).isEqualTo(0);
+      assertThat((Long) row.getProperty("totalActiveVertices")).isEqualTo(TOTAL);
+      assertThat((Long) row.getProperty("totalAllocatedEdges")).isEqualTo(TOTAL - 1);
+      assertThat((Long) row.getProperty("totalActiveEdges")).isEqualTo(TOTAL - 2);
+      assertThat((Long) row.getProperty("totalDeletedRecords")).isEqualTo(1);
+      assertThat(((Collection) row.getProperty("corruptedRecords")).size()).isEqualTo(0);
+      assertThat((Long) row.getProperty("missingReferenceBack")).isEqualTo(0);
+      assertThat((Long) row.getProperty("invalidLinks")).isEqualTo(0);
+      assertThat(((Collection) row.getProperty("warnings")).size()).isEqualTo(0);
     }
 
-    Assertions.assertEquals(TOTAL - 2, countEdges(root.getIdentity()));
-    Assertions.assertEquals(TOTAL - 2, countEdgesSegmentList(root.getIdentity()));
+    assertThat(countEdges(root.getIdentity())).isEqualTo(TOTAL - 2);
+    assertThat(countEdgesSegmentList(root.getIdentity())).isEqualTo(TOTAL - 2);
   }
 
   @Test
@@ -191,52 +194,52 @@ public class CheckDatabaseTest extends TestHelper {
     });
 
     ResultSet result = database.command("sql", "check database");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     while (result.hasNext()) {
       final Result row = result.next();
 
-      Assertions.assertEquals("check database", row.getProperty("operation"));
-      Assertions.assertEquals(0, (Long) row.getProperty("autoFix"));
-      Assertions.assertEquals(TOTAL - 1, (Long) row.getProperty("totalActiveVertices"));
-      Assertions.assertEquals(TOTAL - 1, (Long) row.getProperty("totalAllocatedEdges"));
-      Assertions.assertEquals(TOTAL - 1, (Long) row.getProperty("totalActiveEdges"));
-      Assertions.assertEquals(1, (Long) row.getProperty("totalDeletedRecords"));
-      Assertions.assertEquals(TOTAL, ((Collection) row.getProperty("corruptedRecords")).size()); // ALL THE EDGES + ROOT VERTEX
-      Assertions.assertEquals(0, (Long) row.getProperty("missingReferenceBack"));
-      Assertions.assertEquals((TOTAL - 1) * 2, (Long) row.getProperty("invalidLinks"));
-      Assertions.assertEquals(TOTAL - 1, ((Collection) row.getProperty("warnings")).size());
+      assertThat(row.<String>getProperty("operation")).isEqualTo("check database");
+      assertThat((Long) row.getProperty("autoFix")).isEqualTo(0);
+      assertThat((Long) row.getProperty("totalActiveVertices")).isEqualTo(TOTAL - 1);
+      assertThat((Long) row.getProperty("totalAllocatedEdges")).isEqualTo(TOTAL - 1);
+      assertThat((Long) row.getProperty("totalActiveEdges")).isEqualTo(TOTAL - 1);
+      assertThat((Long) row.getProperty("totalDeletedRecords")).isEqualTo(1);
+      assertThat(((Collection) row.getProperty("corruptedRecords")).size()).isEqualTo(TOTAL); // ALL THE EDGES + ROOT VERTEX
+      assertThat((Long) row.getProperty("missingReferenceBack")).isEqualTo(0);
+      assertThat((Long) row.getProperty("invalidLinks")).isEqualTo((TOTAL - 1) * 2);
+      assertThat(((Collection) row.getProperty("warnings")).size()).isEqualTo(TOTAL - 1);
     }
 
     result = database.command("sql", "check database fix");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result row = result.next();
 
-    Assertions.assertEquals("check database", row.getProperty("operation"));
-    Assertions.assertEquals((TOTAL - 1) * 2, (Long) row.getProperty("autoFix"));
-    Assertions.assertEquals(TOTAL - 1, (Long) row.getProperty("totalActiveVertices"));
-    Assertions.assertEquals(TOTAL - 1, (Long) row.getProperty("totalAllocatedEdges"));
-    Assertions.assertEquals(0, (Long) row.getProperty("totalActiveEdges"));
-    Assertions.assertEquals(TOTAL, (Long) row.getProperty("totalDeletedRecords"));
-    Assertions.assertEquals(TOTAL - 1, ((Collection) row.getProperty("corruptedRecords")).size());
-    Assertions.assertEquals(0, (Long) row.getProperty("missingReferenceBack"));
-    Assertions.assertEquals((TOTAL - 1) * 2, (Long) row.getProperty("invalidLinks"));
-    Assertions.assertEquals((TOTAL - 1) * 2, ((Collection) row.getProperty("warnings")).size());
+    assertThat(row.<String>getProperty("operation")).isEqualTo("check database");
+    assertThat((Long) row.getProperty("autoFix")).isEqualTo((TOTAL - 1) * 2);
+    assertThat((Long) row.getProperty("totalActiveVertices")).isEqualTo(TOTAL - 1);
+    assertThat((Long) row.getProperty("totalAllocatedEdges")).isEqualTo(TOTAL - 1);
+    assertThat((Long) row.getProperty("totalActiveEdges")).isEqualTo(0);
+    assertThat((Long) row.getProperty("totalDeletedRecords")).isEqualTo(TOTAL);
+    assertThat(((Collection) row.getProperty("corruptedRecords")).size()).isEqualTo(TOTAL - 1);
+    assertThat((Long) row.getProperty("missingReferenceBack")).isEqualTo(0);
+    assertThat((Long) row.getProperty("invalidLinks")).isEqualTo((TOTAL - 1) * 2);
+    assertThat(((Collection) row.getProperty("warnings")).size()).isEqualTo((TOTAL - 1) * 2);
 
     result = database.command("sql", "check database");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
 
     row = result.next();
 
-    Assertions.assertEquals("check database", row.getProperty("operation"));
-    Assertions.assertEquals(0, (Long) row.getProperty("autoFix"));
-    Assertions.assertEquals(TOTAL - 1, (Long) row.getProperty("totalActiveVertices"));
-    Assertions.assertEquals(TOTAL - 1, (Long) row.getProperty("totalAllocatedEdges"));
-    Assertions.assertEquals(0, (Long) row.getProperty("totalActiveEdges"));
-    Assertions.assertEquals(TOTAL, (Long) row.getProperty("totalDeletedRecords"));
-    Assertions.assertEquals(0, ((Collection) row.getProperty("corruptedRecords")).size());
-    Assertions.assertEquals(0, (Long) row.getProperty("missingReferenceBack"));
-    Assertions.assertEquals(0, (Long) row.getProperty("invalidLinks"));
-    Assertions.assertEquals(0, ((Collection) row.getProperty("warnings")).size());
+    assertThat(row.<String>getProperty("operation")).isEqualTo("check database");
+    assertThat((Long) row.getProperty("autoFix")).isEqualTo(0);
+    assertThat((Long) row.getProperty("totalActiveVertices")).isEqualTo(TOTAL - 1);
+    assertThat((Long) row.getProperty("totalAllocatedEdges")).isEqualTo(TOTAL - 1);
+    assertThat((Long) row.getProperty("totalActiveEdges")).isEqualTo(0);
+    assertThat((Long) row.getProperty("totalDeletedRecords")).isEqualTo(TOTAL);
+    assertThat(((Collection) row.getProperty("corruptedRecords")).size()).isEqualTo(0);
+    assertThat((Long) row.getProperty("missingReferenceBack")).isEqualTo(0);
+    assertThat((Long) row.getProperty("invalidLinks")).isEqualTo(0);
+    assertThat(((Collection) row.getProperty("warnings")).size()).isEqualTo(0);
   }
 
   @Test
@@ -256,48 +259,48 @@ public class CheckDatabaseTest extends TestHelper {
     });
 
     ResultSet result = database.command("sql", "check database");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
 
     Result row = result.next();
-    Assertions.assertEquals("check database", row.getProperty("operation"));
-    Assertions.assertTrue((Long) row.getProperty("totalErrors") > 0L);
-    Assertions.assertEquals(0L, (Long) row.getProperty("autoFix"));
-    Assertions.assertTrue((Long) row.getProperty("totalActiveVertices") < TOTAL);
-    Assertions.assertEquals(TOTAL - 1, (Long) row.getProperty("totalAllocatedEdges"));
-    Assertions.assertEquals(TOTAL - 1, (Long) row.getProperty("totalActiveEdges"));
-    Assertions.assertEquals(0L, (Long) row.getProperty("totalDeletedRecords"));
-    Assertions.assertEquals(0L, (Long) row.getProperty("missingReferenceBack"));
-    Assertions.assertTrue((Long) row.getProperty("invalidLinks") > 0L);
-    Assertions.assertTrue(((Collection) row.getProperty("warnings")).size() > 0L);
-    Assertions.assertEquals(1, ((Collection<String>) row.getProperty("rebuiltIndexes")).size());
-    Assertions.assertTrue(((Collection) row.getProperty("corruptedRecords")).size() > 0L);
+    assertThat(row.<String>getProperty("operation")).isEqualTo("check database");
+    assertThat((Long) row.getProperty("totalErrors") > 0L).isTrue();
+    assertThat((Long) row.getProperty("autoFix")).isEqualTo(0L);
+    assertThat((Long) row.getProperty("totalActiveVertices") < TOTAL).isTrue();
+    assertThat((Long) row.getProperty("totalAllocatedEdges")).isEqualTo(TOTAL - 1);
+    assertThat((Long) row.getProperty("totalActiveEdges")).isEqualTo(TOTAL - 1);
+    assertThat((Long) row.getProperty("totalDeletedRecords")).isEqualTo(0L);
+    assertThat((Long) row.getProperty("missingReferenceBack")).isEqualTo(0L);
+    assertThat((Long) row.getProperty("invalidLinks") > 0L).isTrue();
+    assertThat(((Collection) row.getProperty("warnings")).size() > 0L).isTrue();
+    assertThat(((Collection<String>) row.getProperty("rebuiltIndexes")).size()).isEqualTo(1);
+    assertThat(((Collection) row.getProperty("corruptedRecords")).size() > 0L).isTrue();
 
     result = database.command("sql", "check database fix");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     row = result.next();
-    Assertions.assertTrue((Long) row.getProperty("autoFix") > 0L);
-    Assertions.assertEquals(0L, (Long) row.getProperty("totalActiveEdges"));
-    Assertions.assertEquals(1, ((Collection<String>) row.getProperty("rebuiltIndexes")).size());
-    Assertions.assertTrue((Long) row.getProperty("totalActiveVertices") < TOTAL);
-    Assertions.assertTrue(((Collection) row.getProperty("corruptedRecords")).size() > 0L);
+    assertThat((Long) row.getProperty("autoFix") > 0L).isTrue();
+    assertThat((Long) row.getProperty("totalActiveEdges")).isEqualTo(0L);
+    assertThat(((Collection<String>) row.getProperty("rebuiltIndexes")).size()).isEqualTo(1);
+    assertThat((Long) row.getProperty("totalActiveVertices") < TOTAL).isTrue();
+    assertThat(((Collection) row.getProperty("corruptedRecords")).size() > 0L).isTrue();
 
     result = database.command("sql", "check database");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     row = result.next();
-    Assertions.assertEquals(0L, (Long) row.getProperty("autoFix"));
-    Assertions.assertEquals(0L, (Long) row.getProperty("totalErrors"));
-    Assertions.assertEquals(0L, (Long) row.getProperty("autoFix"));
-    Assertions.assertEquals(0L, (Long) row.getProperty("missingReferenceBack"));
-    Assertions.assertEquals(0L, (Long) row.getProperty("invalidLinks"));
-    Assertions.assertEquals(0L, ((Collection) row.getProperty("warnings")).size());
-    Assertions.assertEquals(0, ((Collection<String>) row.getProperty("rebuiltIndexes")).size());
-    Assertions.assertEquals(0L, ((Collection) row.getProperty("corruptedRecords")).size());
+    assertThat((Long) row.getProperty("autoFix")).isEqualTo(0L);
+    assertThat((Long) row.getProperty("totalErrors")).isEqualTo(0L);
+    assertThat((Long) row.getProperty("autoFix")).isEqualTo(0L);
+    assertThat((Long) row.getProperty("missingReferenceBack")).isEqualTo(0L);
+    assertThat((Long) row.getProperty("invalidLinks")).isEqualTo(0L);
+    assertThat(((Collection) row.getProperty("warnings")).size()).isEqualTo(0L);
+    assertThat(((Collection<String>) row.getProperty("rebuiltIndexes")).size()).isEqualTo(0);
+    assertThat(((Collection) row.getProperty("corruptedRecords")).size()).isEqualTo(0L);
 
     // CHECK CORRUPTED RECORD ARE NOT INDEXED ANYMORE
     final List<TypeIndex> indexes = database.getSchema().getType("Person").getIndexesByProperties("id");
-    Assertions.assertEquals(1, indexes.size());
+    assertThat(indexes.size()).isEqualTo(1);
 
-    Assertions.assertEquals((Long) row.getProperty("totalActiveVertices"), indexes.get(0).countEntries());
+    assertThat(indexes.get(0).countEntries()).isEqualTo((Long) row.getProperty("totalActiveVertices"));
   }
 
   @Override

--- a/engine/src/test/java/com/arcadedb/database/DataEncryptionTest.java
+++ b/engine/src/test/java/com/arcadedb/database/DataEncryptionTest.java
@@ -18,8 +18,7 @@
  */
 package com.arcadedb.database;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -84,13 +83,13 @@ class DataEncryptionTest extends TestHelper {
 
   private void verify(Vertex p1, Vertex p2, boolean isEquals) {
     if (isEquals) {
-      assertEquals("John", p1.get("name"));
-      assertEquals("Doe", p2.get("name"));
-      assertEquals(2024, p1.getEdges(DIRECTION.OUT, "Knows").iterator().next().get("since"));
+      assertThat(p1.get("name")).isEqualTo("John");
+      assertThat(p2.get("name")).isEqualTo("Doe");
+      assertThat(p1.getEdges(DIRECTION.OUT, "Knows").iterator().next().get("since")).isEqualTo(2024);
     } else {
-      assertFalse(((String) p1.get("name")).contains("John"));
-      assertFalse(((String) p2.get("name")).contains("Doe"));
-      assertFalse(p1.getEdges(DIRECTION.OUT, "Knows").iterator().next().get("since").toString().contains("2024"));
+      assertThat(((String) p1.get("name")).contains("John")).isFalse();
+      assertThat(((String) p2.get("name")).contains("Doe")).isFalse();
+      assertThat(p1.getEdges(DIRECTION.OUT, "Knows").iterator().next().get("since").toString().contains("2024")).isFalse();
     }
   }
 }

--- a/engine/src/test/java/com/arcadedb/database/DatabaseFactoryTest.java
+++ b/engine/src/test/java/com/arcadedb/database/DatabaseFactoryTest.java
@@ -21,8 +21,11 @@ package com.arcadedb.database;
 import com.arcadedb.TestHelper;
 import com.arcadedb.exception.DatabaseOperationException;
 import com.arcadedb.security.SecurityManager;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 /**
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -33,14 +36,14 @@ class DatabaseFactoryTest extends TestHelper {
   void invalidFactories() {
     try {
       new DatabaseFactory(null);
-      Assertions.fail();
+      fail("");
     } catch (final IllegalArgumentException e) {
       // EXPECTED
     }
 
     try {
       new DatabaseFactory("");
-      Assertions.fail();
+      fail("");
     } catch (final IllegalArgumentException e) {
       // EXPECTED
     }
@@ -50,7 +53,7 @@ class DatabaseFactoryTest extends TestHelper {
   void testGetterSetter() {
     final DatabaseFactory f = new DatabaseFactory("test/");
     f.setAutoTransaction(true);
-    Assertions.assertNotNull(f.getContextConfiguration());
+    assertThat(f.getContextConfiguration()).isNotNull();
 
     final SecurityManager security = new SecurityManager() {
       @Override
@@ -58,7 +61,7 @@ class DatabaseFactoryTest extends TestHelper {
       }
     };
     f.setSecurity(security);
-    Assertions.assertEquals(security, f.getSecurity());
+    assertThat(f.getSecurity()).isEqualTo(security);
   }
 
   @Test
@@ -68,7 +71,7 @@ class DatabaseFactoryTest extends TestHelper {
 
     DatabaseFactory.getActiveDatabaseInstances().contains(db);
     DatabaseFactory.removeActiveDatabaseInstance(db.getDatabasePath());
-    Assertions.assertNull(DatabaseFactory.getActiveDatabaseInstance(db.getDatabasePath()));
+    assertThat(DatabaseFactory.getActiveDatabaseInstance(db.getDatabasePath())).isNull();
 
     db.drop();
     f.close();
@@ -79,10 +82,10 @@ class DatabaseFactoryTest extends TestHelper {
     final DatabaseFactory f = new DatabaseFactory("target/path/to/database");
     final Database db = f.exists() ? f.open() : f.create();
 
-    Assertions.assertEquals(db, DatabaseFactory.getActiveDatabaseInstance("target/path/to/database"));
+    assertThat(DatabaseFactory.getActiveDatabaseInstance("target/path/to/database")).isEqualTo(db);
     if (System.getProperty("os.name").toLowerCase().contains("windows"))
-      Assertions.assertEquals(db, DatabaseFactory.getActiveDatabaseInstance("target\\path\\to\\database"));
-    Assertions.assertEquals(db, DatabaseFactory.getActiveDatabaseInstance("./target/path/../../target/path/to/database"));
+      assertThat(DatabaseFactory.getActiveDatabaseInstance("target\\path\\to\\database")).isEqualTo(db);
+    assertThat(DatabaseFactory.getActiveDatabaseInstance("./target/path/../../target/path/to/database")).isEqualTo(db);
 
     db.drop();
     f.close();
@@ -97,7 +100,7 @@ class DatabaseFactoryTest extends TestHelper {
     final Database db = f1.create();
 
     final DatabaseFactory f2 = new DatabaseFactory(".\\path\\to\\database");
-    Assertions.assertThrows(DatabaseOperationException.class, () -> f2.create());
+    assertThatExceptionOfType(DatabaseOperationException.class).isThrownBy(() -> f2.create());
 
     db.drop();
     f1.close();

--- a/engine/src/test/java/com/arcadedb/database/DefaultDataEncryptionTest.java
+++ b/engine/src/test/java/com/arcadedb/database/DefaultDataEncryptionTest.java
@@ -18,7 +18,7 @@
  */
 package com.arcadedb.database;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.ByteBuffer;
 import java.security.NoSuchAlgorithmException;
@@ -50,7 +50,7 @@ class DefaultDataEncryptionTest {
     String data = "data";
     byte[] encryptedData = dde.encrypt(data.getBytes());
     String decryptedData = new String(dde.decrypt(encryptedData));
-    assertEquals(data, decryptedData);
+    assertThat(decryptedData).isEqualTo(data);
   }
 
   @Test
@@ -59,6 +59,6 @@ class DefaultDataEncryptionTest {
     double data = 1000000d;
     byte[] encryptedData = dde.encrypt(ByteBuffer.allocate(8).putLong(Double.doubleToLongBits(data)).array());
     var decryptedData = Double.longBitsToDouble(ByteBuffer.wrap(dde.decrypt(encryptedData)).getLong());
-    assertEquals(data, decryptedData);
+    assertThat(decryptedData).isEqualTo(data);
   }
 }

--- a/engine/src/test/java/com/arcadedb/database/RecordFactoryTest.java
+++ b/engine/src/test/java/com/arcadedb/database/RecordFactoryTest.java
@@ -30,8 +30,10 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.EdgeType;
 import com.arcadedb.schema.VertexType;
 import com.arcadedb.serializer.BinaryTypes;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -44,27 +46,27 @@ class RecordFactoryTest extends TestHelper {
 
     final DocumentType documentType = database.getSchema().createDocumentType("Document");
     final Record document = ((DatabaseInternal) database).getRecordFactory().newImmutableRecord(database, documentType, EMPTY_RID, Document.RECORD_TYPE);
-    Assertions.assertTrue(document instanceof Document);
+    assertThat(document instanceof Document).isTrue();
 
     final VertexType vertexType = database.getSchema().createVertexType("Vertex");
     final Record vertex = ((DatabaseInternal) database).getRecordFactory().newImmutableRecord(database, vertexType, EMPTY_RID, Vertex.RECORD_TYPE);
-    Assertions.assertTrue(vertex instanceof Vertex);
+    assertThat(vertex instanceof Vertex).isTrue();
 
     final EdgeType edgeType = database.getSchema().createEdgeType("Edge");
     final Record edge = ((DatabaseInternal) database).getRecordFactory().newImmutableRecord(database, edgeType, EMPTY_RID, Edge.RECORD_TYPE);
-    Assertions.assertTrue(edge instanceof Edge);
+    assertThat(edge instanceof Edge).isTrue();
 
     final Record edgeSegment = ((DatabaseInternal) database).getRecordFactory().newImmutableRecord(database, null, EMPTY_RID, EdgeSegment.RECORD_TYPE);
-    Assertions.assertTrue(edgeSegment instanceof EdgeSegment);
+    assertThat(edgeSegment instanceof EdgeSegment).isTrue();
 
     final DocumentType embeddedDocumentType = database.getSchema().createDocumentType("EmbeddedDocument");
     final Record embeddedDocument = ((DatabaseInternal) database).getRecordFactory()
         .newImmutableRecord(database, embeddedDocumentType, EMPTY_RID, EmbeddedDocument.RECORD_TYPE);
-    Assertions.assertTrue(embeddedDocument instanceof EmbeddedDocument);
+    assertThat(embeddedDocument instanceof EmbeddedDocument).isTrue();
 
     try {
       ((DatabaseInternal) database).getRecordFactory().newImmutableRecord(database, embeddedDocumentType, EMPTY_RID, (byte) 'Z');
-      Assertions.fail();
+      fail("");
     } catch (final DatabaseMetadataException e) {
       // EXPECTED
     }
@@ -80,7 +82,7 @@ class RecordFactoryTest extends TestHelper {
 
     final DocumentType documentType = database.getSchema().createDocumentType("Document");
     final Record document = ((DatabaseInternal) database).getRecordFactory().newImmutableRecord(database, documentType, EMPTY_RID, binary, null);
-    Assertions.assertTrue(document instanceof Document);
+    assertThat(document instanceof Document).isTrue();
 
     binary.clear();
     binary.putByte(Vertex.RECORD_TYPE);
@@ -92,7 +94,7 @@ class RecordFactoryTest extends TestHelper {
 
     final VertexType vertexType = database.getSchema().createVertexType("Vertex");
     final Record vertex = ((DatabaseInternal) database).getRecordFactory().newImmutableRecord(database, vertexType, EMPTY_RID, binary, null);
-    Assertions.assertTrue(vertex instanceof Vertex);
+    assertThat(vertex instanceof Vertex).isTrue();
 
     binary.clear();
     binary.putByte(Edge.RECORD_TYPE);
@@ -102,14 +104,14 @@ class RecordFactoryTest extends TestHelper {
 
     final EdgeType edgeType = database.getSchema().createEdgeType("Edge");
     final Record edge = ((DatabaseInternal) database).getRecordFactory().newImmutableRecord(database, edgeType, EMPTY_RID, binary, null);
-    Assertions.assertTrue(edge instanceof Edge);
+    assertThat(edge instanceof Edge).isTrue();
 
     binary.clear();
     binary.putByte(EdgeSegment.RECORD_TYPE);
     binary.flip();
 
     final Record edgeSegment = ((DatabaseInternal) database).getRecordFactory().newImmutableRecord(database, null, EMPTY_RID, binary, null);
-    Assertions.assertTrue(edgeSegment instanceof EdgeSegment);
+    assertThat(edgeSegment instanceof EdgeSegment).isTrue();
 
     binary.clear();
     binary.putByte(EmbeddedDocument.RECORD_TYPE);
@@ -118,7 +120,7 @@ class RecordFactoryTest extends TestHelper {
     final DocumentType embeddedDocumentType = database.getSchema().createDocumentType("EmbeddedDocument");
     final Record embeddedDocument = ((DatabaseInternal) database).getRecordFactory()
         .newImmutableRecord(database, embeddedDocumentType, EMPTY_RID, binary, null);
-    Assertions.assertTrue(embeddedDocument instanceof EmbeddedDocument);
+    assertThat(embeddedDocument instanceof EmbeddedDocument).isTrue();
 
     binary.clear();
     binary.putByte((byte) 'Z');
@@ -126,7 +128,7 @@ class RecordFactoryTest extends TestHelper {
 
     try {
       ((DatabaseInternal) database).getRecordFactory().newImmutableRecord(database, embeddedDocumentType, EMPTY_RID, binary, null);
-      Assertions.fail();
+      fail("");
     } catch (final DatabaseMetadataException e) {
       // EXPECTED
     }
@@ -142,7 +144,7 @@ class RecordFactoryTest extends TestHelper {
 
     final DocumentType documentType = database.getSchema().createDocumentType("Document");
     final Record document = ((DatabaseInternal) database).getRecordFactory().newMutableRecord(database, documentType, EMPTY_RID, binary, null);
-    Assertions.assertTrue(document instanceof MutableDocument);
+    assertThat(document instanceof MutableDocument).isTrue();
 
     binary.clear();
     binary.putByte(Vertex.RECORD_TYPE);
@@ -154,7 +156,7 @@ class RecordFactoryTest extends TestHelper {
 
     final VertexType vertexType = database.getSchema().createVertexType("Vertex");
     final Record vertex = ((DatabaseInternal) database).getRecordFactory().newMutableRecord(database, vertexType, EMPTY_RID, binary, null);
-    Assertions.assertTrue(vertex instanceof MutableVertex);
+    assertThat(vertex instanceof MutableVertex).isTrue();
 
     binary.clear();
     binary.putByte(Edge.RECORD_TYPE);
@@ -164,14 +166,14 @@ class RecordFactoryTest extends TestHelper {
 
     final EdgeType edgeType = database.getSchema().createEdgeType("Edge");
     final Record edge = ((DatabaseInternal) database).getRecordFactory().newMutableRecord(database, edgeType, EMPTY_RID, binary, null);
-    Assertions.assertTrue(edge instanceof MutableEdge);
+    assertThat(edge instanceof MutableEdge).isTrue();
 
     binary.clear();
     binary.putByte(EdgeSegment.RECORD_TYPE);
     binary.flip();
 
     final Record edgeSegment = ((DatabaseInternal) database).getRecordFactory().newMutableRecord(database, null, EMPTY_RID, binary, null);
-    Assertions.assertTrue(edgeSegment instanceof MutableEdgeSegment);
+    assertThat(edgeSegment instanceof MutableEdgeSegment).isTrue();
 
     binary.clear();
     binary.putByte(EmbeddedDocument.RECORD_TYPE);
@@ -179,7 +181,7 @@ class RecordFactoryTest extends TestHelper {
 
     final DocumentType embeddedDocumentType = database.getSchema().createDocumentType("EmbeddedDocument");
     final Record embeddedDocument = ((DatabaseInternal) database).getRecordFactory().newMutableRecord(database, embeddedDocumentType, EMPTY_RID, binary, null);
-    Assertions.assertTrue(embeddedDocument instanceof MutableEmbeddedDocument);
+    assertThat(embeddedDocument instanceof MutableEmbeddedDocument).isTrue();
 
     binary.clear();
     binary.putByte((byte) 'Z');
@@ -187,7 +189,7 @@ class RecordFactoryTest extends TestHelper {
 
     try {
       ((DatabaseInternal) database).getRecordFactory().newMutableRecord(database, embeddedDocumentType, EMPTY_RID, binary, null);
-      Assertions.fail();
+      fail("");
     } catch (final DatabaseMetadataException e) {
       // EXPECTED
     }

--- a/engine/src/test/java/com/arcadedb/engine/BloomFilterTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/BloomFilterTest.java
@@ -19,8 +19,9 @@
 package com.arcadedb.engine;
 
 import com.arcadedb.database.Binary;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class BloomFilterTest {
   @Test
@@ -36,12 +37,12 @@ public class BloomFilterTest {
       if (bf.mightContain(i))
         ++might;
 
-    Assertions.assertTrue(might < count);
+    assertThat(might < count).isTrue();
 
     for (int i = 0; i < count; i++)
       bf.add(i);
 
     for (int i = 0; i < count; i++)
-      Assertions.assertTrue(bf.mightContain(i));
+      assertThat(bf.mightContain(i)).isTrue();
   }
 }

--- a/engine/src/test/java/com/arcadedb/engine/DeleteAllTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/DeleteAllTest.java
@@ -5,11 +5,13 @@ import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.utility.FileUtils;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DeleteAllTest {
   private final static int    TOT_RECORDS = 100_000;
@@ -48,13 +50,13 @@ public class DeleteAllTest {
           });
 
           db.transaction(() -> {
-            Assertions.assertEquals(TOT_RECORDS, db.countType(VERTEX_TYPE, true));
-            Assertions.assertEquals(TOT_RECORDS - 1, db.countType(EDGE_TYPE, true));
+            assertThat(db.countType(VERTEX_TYPE, true)).isEqualTo(TOT_RECORDS);
+            assertThat(db.countType(EDGE_TYPE, true)).isEqualTo(TOT_RECORDS - 1);
 
             db.command("sql", "delete from " + VERTEX_TYPE);
 
-            Assertions.assertEquals(0, db.countType(VERTEX_TYPE, true));
-            Assertions.assertEquals(0, db.countType(EDGE_TYPE, true));
+            assertThat(db.countType(VERTEX_TYPE, true)).isEqualTo(0);
+            assertThat(db.countType(EDGE_TYPE, true)).isEqualTo(0);
           });
         }
 

--- a/engine/src/test/java/com/arcadedb/engine/TestInsertAndSelectWithThreadBucketSelectionStrategy.java
+++ b/engine/src/test/java/com/arcadedb/engine/TestInsertAndSelectWithThreadBucketSelectionStrategy.java
@@ -8,11 +8,12 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.time.*;
 import java.time.format.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestInsertAndSelectWithThreadBucketSelectionStrategy {
   @Test
@@ -54,12 +55,12 @@ public class TestInsertAndSelectWithThreadBucketSelectionStrategy {
             database.begin();
             String sqlString = "UPDATE Product SET name = ?, type = ?, start = ?, stop = ?, v = ? UPSERT WHERE name = ?";
             try (ResultSet resultSet = database.command("sql", sqlString, name1, type, validityStart, validityStop, version1, name1)) {
-              Assertions.assertTrue((long) resultSet.nextIfAvailable().getProperty("count", 0) == 1);
+              assertThat((long) resultSet.nextIfAvailable().getProperty("count", 0)).isEqualTo(1);
             }
 //            database.commit();
 //            database.begin();
             try (ResultSet resultSet = database.command("sql", sqlString, name2, type, validityStart, validityStop, version2, name2)) {
-              Assertions.assertTrue((long) resultSet.nextIfAvailable().getProperty("count", 0) == 1);
+              assertThat((long) resultSet.nextIfAvailable().getProperty("count", 0)).isEqualTo(1);
             }
             database.commit();
           } catch (Exception e) {
@@ -73,10 +74,10 @@ public class TestInsertAndSelectWithThreadBucketSelectionStrategy {
           String sqlString = "SELECT name, start, stop FROM Product WHERE type = ? AND start <= ? AND stop >= ? ORDER BY start DESC, stop DESC, v DESC LIMIT 1";
           int total = 0;
           try (ResultSet resultSet = database.query("sql", sqlString, type, queryStart, queryStop)) {
-            Assertions.assertTrue(resultSet.hasNext());
+            assertThat(resultSet.hasNext()).isTrue();
             ++total;
           }
-          Assertions.assertEquals(1, total);
+          assertThat(total).isEqualTo(1);
         } finally {
           database.drop();
         }

--- a/engine/src/test/java/com/arcadedb/event/DatabaseEventsTest.java
+++ b/engine/src/test/java/com/arcadedb/event/DatabaseEventsTest.java
@@ -22,10 +22,13 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * TODO: ADD TESTS FOR DOCUMENTS AND EDGES
@@ -53,16 +56,16 @@ public class DatabaseEventsTest extends TestHelper {
 
       database.transaction(() -> {
         final MutableVertex v1 = database.newVertex("Vertex").set("id", "test");
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
         v1.save();
-        Assertions.assertEquals(1, counter.get());
-        Assertions.assertEquals(1, database.countType("Vertex", true));
+        assertThat(counter.get()).isEqualTo(1);
+        assertThat(database.countType("Vertex", true)).isEqualTo(1);
 
         final MutableVertex v2 = database.newVertex("Vertex").set("id", "test2");
-        Assertions.assertEquals(1, counter.get());
+        assertThat(counter.get()).isEqualTo(1);
         v2.save();
-        Assertions.assertEquals(2, counter.get());
-        Assertions.assertEquals(1, database.countType("Vertex", true));
+        assertThat(counter.get()).isEqualTo(2);
+        assertThat(database.countType("Vertex", true)).isEqualTo(1);
       });
 
     } finally {
@@ -80,16 +83,16 @@ public class DatabaseEventsTest extends TestHelper {
 
       database.transaction(() -> {
         final MutableVertex v1 = database.newVertex("Vertex").set("id", "test");
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
         v1.save();
-        Assertions.assertEquals(1, counter.get());
-        Assertions.assertEquals(1, database.countType("Vertex", true));
+        assertThat(counter.get()).isEqualTo(1);
+        assertThat(database.countType("Vertex", true)).isEqualTo(1);
 
         final MutableVertex v2 = database.newVertex("Vertex").set("id", "test2");
-        Assertions.assertEquals(1, counter.get());
+        assertThat(counter.get()).isEqualTo(1);
         v2.save();
-        Assertions.assertEquals(2, counter.get());
-        Assertions.assertEquals(2, database.countType("Vertex", true));
+        assertThat(counter.get()).isEqualTo(2);
+        assertThat(database.countType("Vertex", true)).isEqualTo(2);
       });
 
     } finally {
@@ -110,16 +113,16 @@ public class DatabaseEventsTest extends TestHelper {
 
       database.transaction(() -> {
         final MutableVertex v1 = database.newVertex("Vertex").set("id", "test");
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
         v1.save();
-        Assertions.assertEquals(0, counter.get());
-        Assertions.assertEquals(1, database.countType("Vertex", true));
+        assertThat(counter.get()).isEqualTo(0);
+        assertThat(database.countType("Vertex", true)).isEqualTo(1);
       });
 
       database.transaction(() -> {
         final MutableVertex v1 = database.iterateType("Vertex", true).next().asVertex().modify();
         v1.set("modified2", true);
-        Assertions.assertEquals(1, counter.get());
+        assertThat(counter.get()).isEqualTo(1);
       });
 
     } finally {
@@ -140,28 +143,28 @@ public class DatabaseEventsTest extends TestHelper {
 
       database.transaction(() -> {
         final MutableVertex v1 = database.newVertex("Vertex").set("id", "test");
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
         v1.save();
-        Assertions.assertEquals(0, counter.get());
-        Assertions.assertEquals(1, database.countType("Vertex", true));
+        assertThat(counter.get()).isEqualTo(0);
+        assertThat(database.countType("Vertex", true)).isEqualTo(1);
 
         v1.set("modified", true);
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
 
         v1.save();
-        Assertions.assertEquals(1, counter.get());
+        assertThat(counter.get()).isEqualTo(1);
       });
 
       database.transaction(() -> {
         final MutableVertex v1 = database.iterateType("Vertex", true).next().asVertex().modify();
         v1.set("modified2", true);
-        Assertions.assertEquals(1, counter.get());
+        assertThat(counter.get()).isEqualTo(1);
 
         v1.save();
-        Assertions.assertEquals(2, counter.get());
+        assertThat(counter.get()).isEqualTo(2);
       });
 
-      Assertions.assertFalse(database.iterateType("Vertex", true).next().asVertex().has("modified2"));
+      assertThat(database.iterateType("Vertex", true).next().asVertex().has("modified2")).isFalse();
 
     } finally {
       database.getEvents().unregisterListener(listener);
@@ -181,16 +184,16 @@ public class DatabaseEventsTest extends TestHelper {
 
       database.transaction(() -> {
         final MutableVertex v1 = database.newVertex("Vertex").set("id", "test");
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
         v1.save();
-        Assertions.assertEquals(0, counter.get());
-        Assertions.assertEquals(1, database.countType("Vertex", true));
+        assertThat(counter.get()).isEqualTo(0);
+        assertThat(database.countType("Vertex", true)).isEqualTo(1);
       });
 
       database.transaction(() -> {
         final MutableVertex v1 = database.iterateType("Vertex", true).next().asVertex().modify();
         v1.set("modified2", true);
-        Assertions.assertEquals(1, counter.get());
+        assertThat(counter.get()).isEqualTo(1);
       });
 
     } finally {
@@ -208,16 +211,16 @@ public class DatabaseEventsTest extends TestHelper {
 
       database.transaction(() -> {
         final MutableVertex v1 = database.newVertex("Vertex").set("id", "test");
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
         v1.save();
-        Assertions.assertEquals(0, counter.get());
-        Assertions.assertEquals(1, database.countType("Vertex", true));
+        assertThat(counter.get()).isEqualTo(0);
+        assertThat(database.countType("Vertex", true)).isEqualTo(1);
 
         v1.set("modified", true);
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
 
         v1.save();
-        Assertions.assertEquals(1, counter.get());
+        assertThat(counter.get()).isEqualTo(1);
       });
 
     } finally {
@@ -238,29 +241,29 @@ public class DatabaseEventsTest extends TestHelper {
 
       database.transaction(() -> {
         final MutableVertex v1 = database.newVertex("Vertex").set("id", "test");
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
         v1.save();
-        Assertions.assertEquals(0, counter.get());
-        Assertions.assertEquals(1, database.countType("Vertex", true));
+        assertThat(counter.get()).isEqualTo(0);
+        assertThat(database.countType("Vertex", true)).isEqualTo(1);
 
         v1.set("modified", true);
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
 
         v1.save();
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
       });
 
       database.transaction(() -> {
         final MutableVertex v1 = database.iterateType("Vertex", true).next().asVertex().modify();
         v1.delete();
-        Assertions.assertEquals(1, counter.get());
+        assertThat(counter.get()).isEqualTo(1);
 
         final MutableVertex v2 = database.newVertex("Vertex").set("id", "test2").save();
         v2.delete();
-        Assertions.assertEquals(2, counter.get());
+        assertThat(counter.get()).isEqualTo(2);
       });
 
-      Assertions.assertEquals(1, database.countType("Vertex", true));
+      assertThat(database.countType("Vertex", true)).isEqualTo(1);
 
     } finally {
       database.getEvents().unregisterListener(listener);
@@ -277,29 +280,29 @@ public class DatabaseEventsTest extends TestHelper {
 
       database.transaction(() -> {
         final MutableVertex v1 = database.newVertex("Vertex").set("id", "test");
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
         v1.save();
-        Assertions.assertEquals(0, counter.get());
-        Assertions.assertEquals(1, database.countType("Vertex", true));
+        assertThat(counter.get()).isEqualTo(0);
+        assertThat(database.countType("Vertex", true)).isEqualTo(1);
 
         v1.set("modified", true);
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
 
         v1.save();
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
       });
 
       database.transaction(() -> {
         final MutableVertex v1 = database.iterateType("Vertex", true).next().asVertex().modify();
         v1.delete();
-        Assertions.assertEquals(1, counter.get());
+        assertThat(counter.get()).isEqualTo(1);
 
         final MutableVertex v2 = database.newVertex("Vertex").set("id", "test2").save();
         v2.delete();
-        Assertions.assertEquals(2, counter.get());
+        assertThat(counter.get()).isEqualTo(2);
       });
 
-      Assertions.assertEquals(0, database.countType("Vertex", true));
+      assertThat(database.countType("Vertex", true)).isEqualTo(0);
 
     } finally {
       database.getEvents().unregisterListener(listener);
@@ -321,21 +324,21 @@ public class DatabaseEventsTest extends TestHelper {
 
       database.transaction(() -> {
         final MutableVertex v1 = database.newVertex("IndexedVertex").set("id", "test");
-        Assertions.assertFalse(v1.has("counter"));
+        assertThat(v1.has("counter")).isFalse();
         v1.save();
-        Assertions.assertEquals(1, v1.get("counter"));
-        Assertions.assertEquals(1, database.countType("IndexedVertex", true));
+        assertThat(v1.get("counter")).isEqualTo(1);
+        assertThat(database.countType("IndexedVertex", true)).isEqualTo(1);
 
         // SHOULD OVERWRITE THIS
         database.newVertex("IndexedVertex").set("id", "test2").set("counter", 1).save();
 
         final MutableVertex v2 = database.newVertex("IndexedVertex").set("id", "test3");
-        Assertions.assertFalse(v2.has("counter"));
+        assertThat(v2.has("counter")).isFalse();
         v2.save();
-        Assertions.assertEquals(3, v2.get("counter"));
-        Assertions.assertEquals(3, database.countType("IndexedVertex", true));
+        assertThat(v2.get("counter")).isEqualTo(3);
+        assertThat(database.countType("IndexedVertex", true)).isEqualTo(3);
 
-        Assertions.assertEquals("test2", database.query("SQL", "select from `IndexedVertex` where counter= 2").nextIfAvailable().getProperty("id"));
+        assertThat(database.query("SQL", "select from `IndexedVertex` where counter= 2").nextIfAvailable().<String>getProperty("id")).isEqualTo("test2");
       });
 
     } finally {

--- a/engine/src/test/java/com/arcadedb/event/RecordEncryptionTest.java
+++ b/engine/src/test/java/com/arcadedb/event/RecordEncryptionTest.java
@@ -24,7 +24,8 @@ import com.arcadedb.database.Record;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.schema.VertexType;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.crypto.BadPaddingException;
@@ -40,6 +41,9 @@ import java.security.*;
 import java.security.spec.*;
 import java.util.*;
 import java.util.concurrent.atomic.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Implements record encryption by using the database events.
@@ -81,30 +85,30 @@ public class RecordEncryptionTest extends TestHelper
           .save();
     });
 
-    Assertions.assertEquals(1, creates.get());
+    assertThat(creates.get()).isEqualTo(1);
 
     database.setTransactionIsolationLevel(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
     database.transaction(() -> {
       final Vertex v1 = database.iterateType("BackAccount", true).next().asVertex();
-      Assertions.assertEquals("Nobody must know Elon and Zuck are brothers", v1.getString("secret"));
+      assertThat(v1.getString("secret")).isEqualTo("Nobody must know Elon and Zuck are brothers");
     });
 
-    Assertions.assertEquals(1, reads.get());
+    assertThat(reads.get()).isEqualTo(1);
 
     database.transaction(() -> {
       final MutableVertex v1 = database.iterateType("BackAccount", true).next().asVertex().modify();
       v1.set("secret", "Tool late, everybody knows it").save();
     });
 
-    Assertions.assertEquals(1, updates.get());
-    Assertions.assertEquals(2, reads.get());
+    assertThat(updates.get()).isEqualTo(1);
+    assertThat(reads.get()).isEqualTo(2);
 
     database.transaction(() -> {
       final Vertex v1 = database.iterateType("BackAccount", true).next().asVertex();
-      Assertions.assertEquals("Tool late, everybody knows it", v1.getString("secret"));
+      assertThat(v1.getString("secret")).isEqualTo("Tool late, everybody knows it");
     });
 
-    Assertions.assertEquals(3, reads.get());
+    assertThat(reads.get()).isEqualTo(3);
   }
 
   @Override

--- a/engine/src/test/java/com/arcadedb/event/TypeEventsTest.java
+++ b/engine/src/test/java/com/arcadedb/event/TypeEventsTest.java
@@ -20,11 +20,14 @@ package com.arcadedb.event;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.graph.MutableVertex;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.*;
 
+import org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -49,16 +52,16 @@ public class TypeEventsTest extends TestHelper {
 
       database.transaction(() -> {
         final MutableVertex v1 = database.newVertex("Vertex").set("id", "test");
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
         v1.save();
-        Assertions.assertEquals(1, counter.get());
-        Assertions.assertEquals(1, database.countType("Vertex", true));
+        assertThat(counter.get()).isEqualTo(1);
+        assertThat(database.countType("Vertex", true)).isEqualTo(1);
 
         final MutableVertex v2 = database.newVertex("Vertex").set("id", "test2");
-        Assertions.assertEquals(1, counter.get());
+        assertThat(counter.get()).isEqualTo(1);
         v2.save();
-        Assertions.assertEquals(2, counter.get());
-        Assertions.assertEquals(1, database.countType("Vertex", true));
+        assertThat(counter.get()).isEqualTo(2);
+        assertThat(database.countType("Vertex", true)).isEqualTo(1);
       });
 
     } finally {
@@ -76,16 +79,16 @@ public class TypeEventsTest extends TestHelper {
 
       database.transaction(() -> {
         final MutableVertex v1 = database.newVertex("Vertex").set("id", "test");
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
         v1.save();
-        Assertions.assertEquals(1, counter.get());
-        Assertions.assertEquals(1, database.countType("Vertex", true));
+        assertThat(counter.get()).isEqualTo(1);
+        assertThat(database.countType("Vertex", true)).isEqualTo(1);
 
         final MutableVertex v2 = database.newVertex("Vertex").set("id", "test2");
-        Assertions.assertEquals(1, counter.get());
+        assertThat(counter.get()).isEqualTo(1);
         v2.save();
-        Assertions.assertEquals(2, counter.get());
-        Assertions.assertEquals(2, database.countType("Vertex", true));
+        assertThat(counter.get()).isEqualTo(2);
+        assertThat(database.countType("Vertex", true)).isEqualTo(2);
       });
 
     } finally {
@@ -106,28 +109,28 @@ public class TypeEventsTest extends TestHelper {
 
       database.transaction(() -> {
         final MutableVertex v1 = database.newVertex("Vertex").set("id", "test");
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
         v1.save();
-        Assertions.assertEquals(0, counter.get());
-        Assertions.assertEquals(1, database.countType("Vertex", true));
+        assertThat(counter.get()).isEqualTo(0);
+        assertThat(database.countType("Vertex", true)).isEqualTo(1);
 
         v1.set("modified", true);
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
 
         v1.save();
-        Assertions.assertEquals(1, counter.get());
+        assertThat(counter.get()).isEqualTo(1);
       });
 
       database.transaction(() -> {
         final MutableVertex v1 = database.iterateType("Vertex", true).next().asVertex().modify();
         v1.set("modified2", true);
-        Assertions.assertEquals(1, counter.get());
+        assertThat(counter.get()).isEqualTo(1);
 
         v1.save();
-        Assertions.assertEquals(2, counter.get());
+        assertThat(counter.get()).isEqualTo(2);
       });
 
-      Assertions.assertFalse(database.iterateType("Vertex", true).next().asVertex().has("modified2"));
+      assertThat(database.iterateType("Vertex", true).next().asVertex().has("modified2")).isFalse();
 
     } finally {
       database.getSchema().getType("Vertex").getEvents().unregisterListener(listener);
@@ -144,16 +147,16 @@ public class TypeEventsTest extends TestHelper {
 
       database.transaction(() -> {
         final MutableVertex v1 = database.newVertex("Vertex").set("id", "test");
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
         v1.save();
-        Assertions.assertEquals(0, counter.get());
-        Assertions.assertEquals(1, database.countType("Vertex", true));
+        assertThat(counter.get()).isEqualTo(0);
+        assertThat(database.countType("Vertex", true)).isEqualTo(1);
 
         v1.set("modified", true);
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
 
         v1.save();
-        Assertions.assertEquals(1, counter.get());
+        assertThat(counter.get()).isEqualTo(1);
       });
 
     } finally {
@@ -174,29 +177,29 @@ public class TypeEventsTest extends TestHelper {
 
       database.transaction(() -> {
         final MutableVertex v1 = database.newVertex("Vertex").set("id", "test");
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
         v1.save();
-        Assertions.assertEquals(0, counter.get());
-        Assertions.assertEquals(1, database.countType("Vertex", true));
+        assertThat(counter.get()).isEqualTo(0);
+        assertThat(database.countType("Vertex", true)).isEqualTo(1);
 
         v1.set("modified", true);
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
 
         v1.save();
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
       });
 
       database.transaction(() -> {
         final MutableVertex v1 = database.iterateType("Vertex", true).next().asVertex().modify();
         v1.delete();
-        Assertions.assertEquals(1, counter.get());
+        assertThat(counter.get()).isEqualTo(1);
 
         final MutableVertex v2 = database.newVertex("Vertex").set("id", "test2").save();
         v2.delete();
-        Assertions.assertEquals(2, counter.get());
+        assertThat(counter.get()).isEqualTo(2);
       });
 
-      Assertions.assertEquals(1, database.countType("Vertex", true));
+      assertThat(database.countType("Vertex", true)).isEqualTo(1);
 
     } finally {
       database.getSchema().getType("Vertex").getEvents().unregisterListener(listener);
@@ -213,29 +216,29 @@ public class TypeEventsTest extends TestHelper {
 
       database.transaction(() -> {
         final MutableVertex v1 = database.newVertex("Vertex").set("id", "test");
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
         v1.save();
-        Assertions.assertEquals(0, counter.get());
-        Assertions.assertEquals(1, database.countType("Vertex", true));
+        assertThat(counter.get()).isEqualTo(0);
+        assertThat(database.countType("Vertex", true)).isEqualTo(1);
 
         v1.set("modified", true);
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
 
         v1.save();
-        Assertions.assertEquals(0, counter.get());
+        assertThat(counter.get()).isEqualTo(0);
       });
 
       database.transaction(() -> {
         final MutableVertex v1 = database.iterateType("Vertex", true).next().asVertex().modify();
         v1.delete();
-        Assertions.assertEquals(1, counter.get());
+        assertThat(counter.get()).isEqualTo(1);
 
         final MutableVertex v2 = database.newVertex("Vertex").set("id", "test2").save();
         v2.delete();
-        Assertions.assertEquals(2, counter.get());
+        assertThat(counter.get()).isEqualTo(2);
       });
 
-      Assertions.assertEquals(0, database.countType("Vertex", true));
+      assertThat(database.countType("Vertex", true)).isEqualTo(0);
 
     } finally {
       database.getSchema().getType("Vertex").getEvents().unregisterListener(listener);

--- a/engine/src/test/java/com/arcadedb/function/java/JavaFunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/java/JavaFunctionTest.java
@@ -4,10 +4,12 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.function.FunctionExecutionException;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.*;
+import java.lang.reflect.InvocationTargetException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class JavaFunctionTest extends TestHelper {
 
@@ -23,13 +25,13 @@ public class JavaFunctionTest extends TestHelper {
 
   @Test
   public void testRegistration()
-      throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+          throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
     // TEST REGISTRATION HERE
     registerClass();
 
     try {
       registerClass();
-      Assertions.fail();
+      fail("");
     } catch (final IllegalArgumentException e) {
       // EXPECTED
     }
@@ -40,13 +42,13 @@ public class JavaFunctionTest extends TestHelper {
 
   @Test
   public void testRegistrationByClassInstance()
-      throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+          throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
     // TEST REGISTRATION HERE
     database.getSchema().registerFunctionLibrary(new JavaClassFunctionLibraryDefinition("math", JavaFunctionTest.Sum.class));
 
     try {
       database.getSchema().registerFunctionLibrary(new JavaClassFunctionLibraryDefinition("math", JavaFunctionTest.Sum.class));
-      Assertions.fail();
+      fail("");
     } catch (final IllegalArgumentException e) {
       // EXPECTED
     }
@@ -57,29 +59,29 @@ public class JavaFunctionTest extends TestHelper {
 
   @Test
   public void testRegistrationSingleMethods()
-      throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+          throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
     // TEST REGISTRATION HERE
     database.getSchema()
-        .registerFunctionLibrary(new JavaMethodFunctionLibraryDefinition("math", JavaFunctionTest.Sum.class.getMethod("sum", Integer.TYPE, Integer.TYPE)));
+            .registerFunctionLibrary(new JavaMethodFunctionLibraryDefinition("math", JavaFunctionTest.Sum.class.getMethod("sum", Integer.TYPE, Integer.TYPE)));
 
     try {
       database.getSchema()
-          .registerFunctionLibrary(new JavaMethodFunctionLibraryDefinition("math", JavaFunctionTest.Sum.class.getMethod("sum", Integer.TYPE, Integer.TYPE)));
-      Assertions.fail();
+              .registerFunctionLibrary(new JavaMethodFunctionLibraryDefinition("math", JavaFunctionTest.Sum.class.getMethod("sum", Integer.TYPE, Integer.TYPE)));
+      fail("");
     } catch (final IllegalArgumentException e) {
       // EXPECTED
     }
 
     database.getSchema().unregisterFunctionLibrary("math");
     database.getSchema()
-        .registerFunctionLibrary(new JavaMethodFunctionLibraryDefinition("math", JavaFunctionTest.Sum.class.getMethod("sum", Integer.TYPE, Integer.TYPE)));
+            .registerFunctionLibrary(new JavaMethodFunctionLibraryDefinition("math", JavaFunctionTest.Sum.class.getMethod("sum", Integer.TYPE, Integer.TYPE)));
   }
 
   @Test
   public void testFunctionNotFound() {
     try {
       database.getSchema().getFunction("math", "sum");
-      Assertions.fail();
+      fail("");
     } catch (final IllegalArgumentException e) {
       // EXPECTED
     }
@@ -87,35 +89,35 @@ public class JavaFunctionTest extends TestHelper {
 
   @Test
   public void testMethodParameterByPosition()
-      throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+          throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
     // TEST REGISTRATION HERE
     registerClass();
 
     final Integer result = (Integer) database.getSchema().getFunction("math", "sum").execute(3, 5);
-    Assertions.assertEquals(8, result);
+    assertThat(result).isEqualTo(8);
   }
 
   @Test
   public void testStaticMethodParameterByPosition()
-      throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+          throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
     registerClass();
 
     final Integer result = (Integer) database.getSchema().getFunction("math", "SUM").execute(3, 5);
-    Assertions.assertEquals(8, result);
+    assertThat(result).isEqualTo(8);
   }
 
   @Test
   public void testExecuteFromSQL()
-      throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+          throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
     registerClass();
 
     database.transaction(() -> {
       final ResultSet rs = database.command("SQL", "SELECT `math.sum`(20,7) as sum");
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       final Result record = rs.next();
-      Assertions.assertNotNull(record);
-      Assertions.assertFalse(record.getIdentity().isPresent());
-      Assertions.assertEquals(27, ((Number) record.getProperty("sum")).intValue());
+      assertThat(record).isNotNull();
+      assertThat(record.getIdentity()).isNotPresent();
+      assertThat(((Number) record.getProperty("sum")).intValue()).isEqualTo(27);
     });
   }
 
@@ -124,7 +126,7 @@ public class JavaFunctionTest extends TestHelper {
     registerClass();
     try {
       database.getSchema().getFunction("math", "NOT_found").execute(3, 5);
-      Assertions.fail();
+      fail("");
     } catch (IllegalArgumentException e) {
       // EXPECTED
     }
@@ -132,11 +134,11 @@ public class JavaFunctionTest extends TestHelper {
 
   @Test
   public void testExecutionError()
-      throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+          throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
     registerClass();
     try {
       database.getSchema().getFunction("math", "SUM").execute("invalid", 5);
-      Assertions.fail();
+      fail("");
     } catch (FunctionExecutionException e) {
       // EXPECTED
     }

--- a/engine/src/test/java/com/arcadedb/function/polyglot/PolyglotFunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/polyglot/PolyglotFunctionTest.java
@@ -2,17 +2,19 @@ package com.arcadedb.function.polyglot;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.function.FunctionExecutionException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.*;
+import java.lang.reflect.InvocationTargetException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class PolyglotFunctionTest extends TestHelper {
   @Test
   public void testEmbeddedFunction() {
     registerFunctions();
     final Integer result = (Integer) database.getSchema().getFunction("math", "sum").execute(3, 5);
-    Assertions.assertEquals(8, result);
+    assertThat(result).isEqualTo(8);
   }
 
   @Test
@@ -20,10 +22,10 @@ public class PolyglotFunctionTest extends TestHelper {
     registerFunctions();
 
     Integer result = (Integer) database.getSchema().getFunction("math", "sum").execute(3, 5);
-    Assertions.assertEquals(8, result);
+    assertThat(result).isEqualTo(8);
 
     result = (Integer) database.getSchema().getFunction("math", "sum").execute(3, 5);
-    Assertions.assertEquals(8, result);
+    assertThat(result).isEqualTo(8);
   }
 
   @Test
@@ -31,11 +33,11 @@ public class PolyglotFunctionTest extends TestHelper {
     registerFunctions();
 
     Integer result = (Integer) database.getSchema().getFunction("math", "sum").execute(100, 50);
-    Assertions.assertEquals(150, result);
+    assertThat(result).isEqualTo(150);
 
     try {
       database.getSchema().getFunctionLibrary("math").registerFunction(new JavascriptFunctionDefinition("sum", "return a - b;", "a", "b"));
-      Assertions.fail();
+      fail("");
     } catch (final IllegalArgumentException e) {
       // EXPECTED
     }
@@ -44,7 +46,7 @@ public class PolyglotFunctionTest extends TestHelper {
     database.getSchema().getFunctionLibrary("math").registerFunction(new JavascriptFunctionDefinition("sum", "return a - b;", "a", "b"));
 
     result = (Integer) database.getSchema().getFunction("math", "sum").execute(50, 100);
-    Assertions.assertEquals(-50, result);
+    assertThat(result).isEqualTo(-50);
   }
 
   @Test
@@ -52,7 +54,7 @@ public class PolyglotFunctionTest extends TestHelper {
     registerFunctions();
     try {
       database.getSchema().getFunction("math", "NOT_found").execute(3, 5);
-      Assertions.fail();
+      fail("");
     } catch (IllegalArgumentException e) {
       // EXPECTED
     }
@@ -66,7 +68,7 @@ public class PolyglotFunctionTest extends TestHelper {
               .registerFunction(new JavascriptFunctionDefinition("sum", "return a ++++ b;", "a", "b")));
 
       database.getSchema().getFunction("math", "sum").execute("invalid", 5);
-      Assertions.fail();
+      fail("");
     } catch (FunctionExecutionException e) {
       // EXPECTED
     }

--- a/engine/src/test/java/com/arcadedb/function/polyglot/SQLDefinedJavascriptFunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/polyglot/SQLDefinedJavascriptFunctionTest.java
@@ -3,22 +3,24 @@ package com.arcadedb.function.polyglot;
 import com.arcadedb.TestHelper;
 import com.arcadedb.function.FunctionLibraryDefinition;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class SQLDefinedJavascriptFunctionTest extends TestHelper {
   @Test
   public void testEmbeddedFunction() {
     registerFunctions();
     final Integer result = (Integer) database.getSchema().getFunction("math", "sum").execute(3, 5);
-    Assertions.assertEquals(8, result);
+    assertThat(result).isEqualTo(8);
   }
 
   @Test
   public void testCallFromSQL() {
     registerFunctions();
     final ResultSet result = database.command("sql", "select `math.sum`(?,?) as result", 3, 5);
-    Assertions.assertEquals(8, (Integer) result.next().getProperty("result"));
+    assertThat((Integer) result.next().getProperty("result")).isEqualTo(8);
   }
 
   @Test
@@ -26,16 +28,16 @@ public class SQLDefinedJavascriptFunctionTest extends TestHelper {
     registerFunctions();
 
     Integer result = (Integer) database.getSchema().getFunction("math", "sum").execute(3, 5);
-    Assertions.assertEquals(8, result);
+    assertThat(result).isEqualTo(8);
 
     result = (Integer) database.getSchema().getFunction("math", "sum").execute(3, 5);
-    Assertions.assertEquals(8, result);
+    assertThat(result).isEqualTo(8);
 
     result = (Integer) database.getSchema().getFunction("util", "sum").execute(3, 5);
-    Assertions.assertEquals(8, result);
+    assertThat(result).isEqualTo(8);
 
     result = (Integer) database.getSchema().getFunction("util", "sum").execute(3, 5);
-    Assertions.assertEquals(8, result);
+    assertThat(result).isEqualTo(8);
   }
 
   @Test
@@ -43,11 +45,11 @@ public class SQLDefinedJavascriptFunctionTest extends TestHelper {
     registerFunctions();
 
     Integer result = (Integer) database.getSchema().getFunction("math", "sum").execute(100, 50);
-    Assertions.assertEquals(150, result);
+    assertThat(result).isEqualTo(150);
 
     try {
       database.getSchema().getFunctionLibrary("math").registerFunction(new JavascriptFunctionDefinition("sum", "return a - b;", "a", "b"));
-      Assertions.fail();
+      fail("");
     } catch (final IllegalArgumentException e) {
       // EXPECTED
     }
@@ -56,7 +58,7 @@ public class SQLDefinedJavascriptFunctionTest extends TestHelper {
     database.getSchema().getFunctionLibrary("math").registerFunction(new JavascriptFunctionDefinition("sum", "return a - b;", "a", "b"));
 
     result = (Integer) database.getSchema().getFunction("math", "sum").execute(50, 100);
-    Assertions.assertEquals(-50, result);
+    assertThat(result).isEqualTo(-50);
   }
 
   private void registerFunctions() {
@@ -64,6 +66,6 @@ public class SQLDefinedJavascriptFunctionTest extends TestHelper {
     database.command("sql", "define function util.sum \"return a + b\" parameters [a,b] language js");
 
     final FunctionLibraryDefinition flib = database.getSchema().getFunctionLibrary("math");
-    Assertions.assertNotNull(flib);
+    assertThat(flib).isNotNull();
   }
 }

--- a/engine/src/test/java/com/arcadedb/function/sql/SQLDefinedSQLFunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/SQLDefinedSQLFunctionTest.java
@@ -4,36 +4,39 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.function.FunctionLibraryDefinition;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class SQLDefinedSQLFunctionTest extends TestHelper {
   @Test
   public void testEmbeddedFunction() {
     registerFunctions();
     final Integer result = (Integer) database.getSchema().getFunction("math", "sum").execute(3, 5);
-    Assertions.assertEquals(8, result);
+    assertThat(result).isEqualTo(8);
   }
 
   @Test
   public void testCallFromSQLWithParams() {
     registerFunctions();
     final ResultSet result = database.command("sql", "select `math.sum`(?,?) as result", 3, 5);
-    Assertions.assertEquals(8, (Integer) result.next().getProperty("result"));
+    assertThat((Integer) result.next().getProperty("result")).isEqualTo(8);
   }
 
   @Test
   public void testCallFromSQLNoParams() {
     database.command("sql", "define function math.hello \"select 'hello'\" language sql");
     final ResultSet result = database.command("sql", "select `math.hello`() as result");
-    Assertions.assertEquals("hello", result.next().getProperty("result"));
+    assertThat(result.next().<String>getProperty("result")).isEqualTo("hello");
   }
 
   @Test
   public void errorTestCallFromSQLEmptyParams() {
     try {
       database.command("sql", "define function math.hello \"select 'hello'\" parameters [] language sql");
-      Assertions.fail();
+      fail("");
     } catch (CommandSQLParsingException e) {
       // EXPECTED
     }
@@ -44,16 +47,16 @@ public class SQLDefinedSQLFunctionTest extends TestHelper {
     registerFunctions();
 
     Integer result = (Integer) database.getSchema().getFunction("math", "sum").execute(3, 5);
-    Assertions.assertEquals(8, result);
+    assertThat(result).isEqualTo(8);
 
     result = (Integer) database.getSchema().getFunction("math", "sum").execute(3, 5);
-    Assertions.assertEquals(8, result);
+    assertThat(result).isEqualTo(8);
 
     result = (Integer) database.getSchema().getFunction("util", "sum").execute(3, 5);
-    Assertions.assertEquals(8, result);
+    assertThat(result).isEqualTo(8);
 
     result = (Integer) database.getSchema().getFunction("util", "sum").execute(3, 5);
-    Assertions.assertEquals(8, result);
+    assertThat(result).isEqualTo(8);
   }
 
   @Test
@@ -61,11 +64,11 @@ public class SQLDefinedSQLFunctionTest extends TestHelper {
     registerFunctions();
 
     Integer result = (Integer) database.getSchema().getFunction("math", "sum").execute(100, 50);
-    Assertions.assertEquals(150, result);
+    assertThat(result).isEqualTo(150);
 
     try {
       database.command("sql", "define function math.sum \"select :a + :b;\" parameters [a,b] language sql");
-      Assertions.fail();
+      fail("");
     } catch (final IllegalArgumentException e) {
       // EXPECTED
     }
@@ -74,7 +77,7 @@ public class SQLDefinedSQLFunctionTest extends TestHelper {
     database.command("sql", "define function math.sum \"select :a + :b;\" parameters [a,b] language sql");
 
     result = (Integer) database.getSchema().getFunction("math", "sum").execute(-350, 150);
-    Assertions.assertEquals(-200, result);
+    assertThat(result).isEqualTo(-200);
   }
 
   private void registerFunctions() {
@@ -82,6 +85,6 @@ public class SQLDefinedSQLFunctionTest extends TestHelper {
     database.command("sql", "define function util.sum \"select :a + :b;\" parameters [a,b] language sql");
 
     final FunctionLibraryDefinition flib = database.getSchema().getFunctionLibrary("math");
-    Assertions.assertNotNull(flib);
+    assertThat(flib).isNotNull();
   }
 }

--- a/engine/src/test/java/com/arcadedb/graph/BaseGraphTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/BaseGraphTest.java
@@ -23,10 +23,14 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
 import com.arcadedb.utility.FileUtils;
-import org.junit.jupiter.api.Assertions;
+import org.assertj.core.api.Assertions;
+
 
 import java.io.*;
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public abstract class BaseGraphTest extends TestHelper {
   protected static final String VERTEX1_TYPE_NAME = "V1";
@@ -43,10 +47,10 @@ public abstract class BaseGraphTest extends TestHelper {
     FileUtils.deleteRecursively(new File(DB_PATH));
 
     database.transaction(() -> {
-      Assertions.assertFalse(database.getSchema().existsType(VERTEX1_TYPE_NAME));
+      assertThat(database.getSchema().existsType(VERTEX1_TYPE_NAME)).isFalse();
       database.getSchema().buildVertexType().withName(VERTEX1_TYPE_NAME).withTotalBuckets(3).create();
 
-      Assertions.assertFalse(database.getSchema().existsType(VERTEX2_TYPE_NAME));
+      assertThat(database.getSchema().existsType(VERTEX2_TYPE_NAME)).isFalse();
       database.getSchema().buildVertexType().withName(VERTEX2_TYPE_NAME).withTotalBuckets(3).create();
 
       database.getSchema().buildEdgeType().withName(EDGE1_TYPE_NAME).create();
@@ -66,24 +70,24 @@ public abstract class BaseGraphTest extends TestHelper {
 
     // CREATION OF EDGE PASSING PARAMS AS VARARGS
     final MutableEdge e1 = v1.newEdge(EDGE1_TYPE_NAME, v2, true, "name", "E1");
-    Assertions.assertEquals(e1.getOut(), v1);
-    Assertions.assertEquals(e1.getIn(), v2);
+    assertThat(v1).isEqualTo(e1.getOut());
+    assertThat(v2).isEqualTo(e1.getIn());
 
     final MutableVertex v3 = db.newVertex(VERTEX2_TYPE_NAME);
     v3.set("name", "V3");
     v3.save();
 
-    Assertions.assertEquals(v3, v3.asVertex());
-    Assertions.assertEquals(v3, v3.asVertex(true));
+    assertThat(v3.asVertex()).isEqualTo(v3);
+    assertThat(v3.asVertex(true)).isEqualTo(v3);
     try {
-      Assertions.assertNotNull(v3.asEdge());
-      Assertions.fail();
+      assertThat(v3.asEdge()).isNotNull();
+      fail("");
     } catch (final ClassCastException e) {
       // EXPECTED
     }
     try {
-      Assertions.assertNotNull(v3.asEdge(true));
-      Assertions.fail();
+      assertThat(v3.asEdge(true)).isNotNull();
+      fail("");
     } catch (final ClassCastException e) {
       // EXPECTED
     }
@@ -93,28 +97,28 @@ public abstract class BaseGraphTest extends TestHelper {
 
     // CREATION OF EDGE PASSING PARAMS AS MAP
     final MutableEdge e2 = v2.newEdge(EDGE2_TYPE_NAME, v3, true, params);
-    Assertions.assertEquals(e2.getOut(), v2);
-    Assertions.assertEquals(e2.getIn(), v3);
+    assertThat(v2).isEqualTo(e2.getOut());
+    assertThat(v3).isEqualTo(e2.getIn());
 
-    Assertions.assertEquals(e2, e2.asEdge());
-    Assertions.assertEquals(e2, e2.asEdge(true));
+    assertThat(e2.asEdge()).isEqualTo(e2);
+    assertThat(e2.asEdge(true)).isEqualTo(e2);
 
     try {
-      Assertions.assertNotNull(e2.asVertex());
-      Assertions.fail();
+      assertThat(e2.asVertex()).isNotNull();
+      fail("");
     } catch (final ClassCastException e) {
       // EXPECTED
     }
     try {
-      Assertions.assertNotNull(e2.asVertex(true));
-      Assertions.fail();
+      assertThat(e2.asVertex(true)).isNotNull();
+      fail("");
     } catch (final ClassCastException e) {
       // EXPECTED
     }
 
     final ImmutableLightEdge e3 = v1.newLightEdge(EDGE2_TYPE_NAME, v3, true);
-    Assertions.assertEquals(e3.getOut(), v1);
-    Assertions.assertEquals(e3.getIn(), v3);
+    assertThat(v1).isEqualTo(e3.getOut());
+    assertThat(v3).isEqualTo(e3.getIn());
 
     db.commit();
 

--- a/engine/src/test/java/com/arcadedb/graph/BasicGraphTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/BasicGraphTest.java
@@ -32,11 +32,16 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.query.sql.function.SQLFunctionAbstract;
 import com.arcadedb.schema.EdgeType;
 import com.arcadedb.schema.Schema;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.concurrent.atomic.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class BasicGraphTest extends BaseGraphTest {
   @Test
@@ -44,53 +49,53 @@ public class BasicGraphTest extends BaseGraphTest {
     database.begin();
     try {
 
-      Assertions.assertEquals(1, database.countType(VERTEX1_TYPE_NAME, false));
-      Assertions.assertEquals(2, database.countType(VERTEX2_TYPE_NAME, false));
+      assertThat(database.countType(VERTEX1_TYPE_NAME, false)).isEqualTo(1);
+      assertThat(database.countType(VERTEX2_TYPE_NAME, false)).isEqualTo(2);
 
       final Vertex v1 = (Vertex) database.lookupByRID(root, false);
-      Assertions.assertNotNull(v1);
+      assertThat(v1).isNotNull();
 
       // TEST CONNECTED VERTICES
-      Assertions.assertEquals(VERTEX1_TYPE_NAME, v1.getTypeName());
-      Assertions.assertEquals(VERTEX1_TYPE_NAME, v1.get("name"));
+      assertThat(v1.getTypeName()).isEqualTo(VERTEX1_TYPE_NAME);
+      assertThat(v1.get("name")).isEqualTo(VERTEX1_TYPE_NAME);
 
       final Iterator<Vertex> vertices2level = v1.getVertices(Vertex.DIRECTION.OUT, new String[] { EDGE1_TYPE_NAME }).iterator();
-      Assertions.assertNotNull(vertices2level);
-      Assertions.assertTrue(vertices2level.hasNext());
+      assertThat(vertices2level).isNotNull();
+      assertThat(vertices2level.hasNext()).isTrue();
 
       final Vertex v2 = vertices2level.next();
 
-      Assertions.assertNotNull(v2);
-      Assertions.assertEquals(VERTEX2_TYPE_NAME, v2.getTypeName());
-      Assertions.assertEquals(VERTEX2_TYPE_NAME, v2.get("name"));
+      assertThat(v2).isNotNull();
+      assertThat(v2.getTypeName()).isEqualTo(VERTEX2_TYPE_NAME);
+      assertThat(v2.get("name")).isEqualTo(VERTEX2_TYPE_NAME);
 
       final Iterator<Vertex> vertices2level2 = v1.getVertices(Vertex.DIRECTION.OUT, new String[] { EDGE2_TYPE_NAME }).iterator();
-      Assertions.assertTrue(vertices2level2.hasNext());
+      assertThat(vertices2level2.hasNext()).isTrue();
 
       final Vertex v3 = vertices2level2.next();
-      Assertions.assertNotNull(v3);
+      assertThat(v3).isNotNull();
 
-      Assertions.assertEquals(VERTEX2_TYPE_NAME, v3.getTypeName());
-      Assertions.assertEquals("V3", v3.get("name"));
+      assertThat(v3.getTypeName()).isEqualTo(VERTEX2_TYPE_NAME);
+      assertThat(v3.get("name")).isEqualTo("V3");
 
       final Iterator<Vertex> vertices3level = v2.getVertices(Vertex.DIRECTION.OUT, new String[] { EDGE2_TYPE_NAME }).iterator();
-      Assertions.assertNotNull(vertices3level);
-      Assertions.assertTrue(vertices3level.hasNext());
+      assertThat(vertices3level).isNotNull();
+      assertThat(vertices3level.hasNext()).isTrue();
 
       final Vertex v32 = vertices3level.next();
 
-      Assertions.assertNotNull(v32);
-      Assertions.assertEquals(VERTEX2_TYPE_NAME, v32.getTypeName());
-      Assertions.assertEquals("V3", v32.get("name"));
+      assertThat(v32).isNotNull();
+      assertThat(v32.getTypeName()).isEqualTo(VERTEX2_TYPE_NAME);
+      assertThat(v32.get("name")).isEqualTo("V3");
 
-      Assertions.assertTrue(v1.isConnectedTo(v2));
-      Assertions.assertTrue(v2.isConnectedTo(v1));
-      Assertions.assertTrue(v1.isConnectedTo(v3));
-      Assertions.assertTrue(v3.isConnectedTo(v1));
-      Assertions.assertTrue(v2.isConnectedTo(v3));
+      assertThat(v1.isConnectedTo(v2)).isTrue();
+      assertThat(v2.isConnectedTo(v1)).isTrue();
+      assertThat(v1.isConnectedTo(v3)).isTrue();
+      assertThat(v3.isConnectedTo(v1)).isTrue();
+      assertThat(v2.isConnectedTo(v3)).isTrue();
 
-      Assertions.assertFalse(v3.isConnectedTo(v1, Vertex.DIRECTION.OUT));
-      Assertions.assertFalse(v3.isConnectedTo(v2, Vertex.DIRECTION.OUT));
+      assertThat(v3.isConnectedTo(v1, Vertex.DIRECTION.OUT)).isFalse();
+      assertThat(v3.isConnectedTo(v2, Vertex.DIRECTION.OUT)).isFalse();
 
     } finally {
       database.commit();
@@ -103,19 +108,19 @@ public class BasicGraphTest extends BaseGraphTest {
     database.begin();
     try {
       final Vertex v1 = (Vertex) database.lookupByRID(root, false);
-      Assertions.assertNotNull(v1);
+      assertThat(v1).isNotNull();
 
       final Iterator<Edge> edges3 = v1.getEdges(Vertex.DIRECTION.OUT, new String[] { EDGE2_TYPE_NAME }).iterator();
-      Assertions.assertNotNull(edges3);
-      Assertions.assertTrue(edges3.hasNext());
+      assertThat(edges3).isNotNull();
+      assertThat(edges3.hasNext()).isTrue();
 
       try {
         final MutableEdge edge = edges3.next().modify();
-        Assertions.fail("Cannot modify lightweight edges");
+        fail("Cannot modify lightweight edges");
 //        edge.set("upgraded", true);
 //        edge.save();
 //
-//        Assertions.assertTrue(edge.getIdentity().getPosition() > -1);
+//        Assertions.assertThat(edge.getIdentity().getPosition() > -1).isTrue();
       } catch (final IllegalStateException e) {
       }
 
@@ -129,50 +134,50 @@ public class BasicGraphTest extends BaseGraphTest {
     database.begin();
     try {
 
-      Assertions.assertEquals(1, database.countType(EDGE1_TYPE_NAME, false));
-      Assertions.assertEquals(1, database.countType(EDGE2_TYPE_NAME, false));
+      assertThat(database.countType(EDGE1_TYPE_NAME, false)).isEqualTo(1);
+      assertThat(database.countType(EDGE2_TYPE_NAME, false)).isEqualTo(1);
 
       final Vertex v1 = (Vertex) database.lookupByRID(root, false);
-      Assertions.assertNotNull(v1);
+      assertThat(v1).isNotNull();
 
       // TEST CONNECTED EDGES
       final Iterator<Edge> edges1 = v1.getEdges(Vertex.DIRECTION.OUT, new String[] { EDGE1_TYPE_NAME }).iterator();
-      Assertions.assertNotNull(edges1);
-      Assertions.assertTrue(edges1.hasNext());
+      assertThat(edges1).isNotNull();
+      assertThat(edges1.hasNext()).isTrue();
 
       final Edge e1 = edges1.next();
 
-      Assertions.assertNotNull(e1);
-      Assertions.assertEquals(EDGE1_TYPE_NAME, e1.getTypeName());
-      Assertions.assertEquals(v1, e1.getOut());
-      Assertions.assertEquals("E1", e1.get("name"));
+      assertThat(e1).isNotNull();
+      assertThat(e1.getTypeName()).isEqualTo(EDGE1_TYPE_NAME);
+      assertThat(e1.getOut()).isEqualTo(v1);
+      assertThat(e1.get("name")).isEqualTo("E1");
 
       final Vertex v2 = e1.getInVertex();
-      Assertions.assertEquals(VERTEX2_TYPE_NAME, v2.get("name"));
+      assertThat(v2.get("name")).isEqualTo(VERTEX2_TYPE_NAME);
 
       final Iterator<Edge> edges2 = v2.getEdges(Vertex.DIRECTION.OUT, new String[] { EDGE2_TYPE_NAME }).iterator();
-      Assertions.assertTrue(edges2.hasNext());
+      assertThat(edges2.hasNext()).isTrue();
 
       final Edge e2 = edges2.next();
-      Assertions.assertNotNull(e2);
+      assertThat(e2).isNotNull();
 
-      Assertions.assertEquals(EDGE2_TYPE_NAME, e2.getTypeName());
-      Assertions.assertEquals(v2, e2.getOut());
-      Assertions.assertEquals("E2", e2.get("name"));
+      assertThat(e2.getTypeName()).isEqualTo(EDGE2_TYPE_NAME);
+      assertThat(e2.getOut()).isEqualTo(v2);
+      assertThat(e2.get("name")).isEqualTo("E2");
 
       final Vertex v3 = e2.getInVertex();
-      Assertions.assertEquals("V3", v3.get("name"));
+      assertThat(v3.get("name")).isEqualTo("V3");
 
       final Iterator<Edge> edges3 = v1.getEdges(Vertex.DIRECTION.OUT, new String[] { EDGE2_TYPE_NAME }).iterator();
-      Assertions.assertNotNull(edges3);
-      Assertions.assertTrue(edges3.hasNext());
+      assertThat(edges3).isNotNull();
+      assertThat(edges3.hasNext()).isTrue();
 
       final Edge e3 = edges3.next();
 
-      Assertions.assertNotNull(e3);
-      Assertions.assertEquals(EDGE2_TYPE_NAME, e3.getTypeName());
-      Assertions.assertEquals(v1, e3.getOutVertex());
-      Assertions.assertEquals(v3, e3.getInVertex());
+      assertThat(e3).isNotNull();
+      assertThat(e3.getTypeName()).isEqualTo(EDGE2_TYPE_NAME);
+      assertThat(e3.getOutVertex()).isEqualTo(v1);
+      assertThat(e3.getInVertex()).isEqualTo(v3);
 
       v2.getEdges();
 
@@ -186,11 +191,11 @@ public class BasicGraphTest extends BaseGraphTest {
     database.begin();
     try {
 
-      Assertions.assertEquals(1, database.countType(EDGE1_TYPE_NAME, false));
-      Assertions.assertEquals(1, database.countType(EDGE2_TYPE_NAME, false));
+      assertThat(database.countType(EDGE1_TYPE_NAME, false)).isEqualTo(1);
+      assertThat(database.countType(EDGE2_TYPE_NAME, false)).isEqualTo(1);
 
       final Vertex v1 = (Vertex) database.lookupByRID(root, false);
-      Assertions.assertNotNull(v1);
+      assertThat(v1).isNotNull();
 
       final MutableVertex v1Copy = v1.modify();
       v1Copy.set("newProperty1", "TestUpdate1");
@@ -198,12 +203,12 @@ public class BasicGraphTest extends BaseGraphTest {
 
       // TEST CONNECTED EDGES
       final Iterator<Edge> edges1 = v1.getEdges(Vertex.DIRECTION.OUT, new String[] { EDGE1_TYPE_NAME }).iterator();
-      Assertions.assertNotNull(edges1);
-      Assertions.assertTrue(edges1.hasNext());
+      assertThat(edges1).isNotNull();
+      assertThat(edges1.hasNext()).isTrue();
 
       final Edge e1 = edges1.next();
 
-      Assertions.assertNotNull(e1);
+      assertThat(e1).isNotNull();
 
       final MutableEdge e1Copy = e1.modify();
       e1Copy.set("newProperty2", "TestUpdate2");
@@ -212,9 +217,9 @@ public class BasicGraphTest extends BaseGraphTest {
       database.commit();
 
       final Vertex v1CopyReloaded = (Vertex) database.lookupByRID(v1Copy.getIdentity(), true);
-      Assertions.assertEquals("TestUpdate1", v1CopyReloaded.get("newProperty1"));
+      assertThat(v1CopyReloaded.get("newProperty1")).isEqualTo("TestUpdate1");
       final Edge e1CopyReloaded = (Edge) database.lookupByRID(e1Copy.getIdentity(), true);
-      Assertions.assertEquals("TestUpdate2", e1CopyReloaded.get("newProperty2"));
+      assertThat(e1CopyReloaded.get("newProperty2")).isEqualTo("TestUpdate2");
 
     } finally {
       new DatabaseChecker(database).setVerboseLevel(0).check();
@@ -227,16 +232,16 @@ public class BasicGraphTest extends BaseGraphTest {
     try {
 
       final Vertex v1 = (Vertex) database.lookupByRID(root, false);
-      Assertions.assertNotNull(v1);
+      assertThat(v1).isNotNull();
 
       Iterator<Vertex> vertices = v1.getVertices(Vertex.DIRECTION.OUT).iterator();
-      Assertions.assertTrue(vertices.hasNext());
+      assertThat(vertices.hasNext()).isTrue();
       Vertex v3 = vertices.next();
-      Assertions.assertNotNull(v3);
+      assertThat(v3).isNotNull();
 
-      Assertions.assertTrue(vertices.hasNext());
+      assertThat(vertices.hasNext()).isTrue();
       Vertex v2 = vertices.next();
-      Assertions.assertNotNull(v2);
+      assertThat(v2).isNotNull();
 
       final long totalVertices = database.countType(v1.getTypeName(), true);
 
@@ -244,41 +249,41 @@ public class BasicGraphTest extends BaseGraphTest {
       // -----------------------
       database.deleteRecord(v1);
 
-      Assertions.assertEquals(totalVertices - 1, database.countType(v1.getTypeName(), true));
+      assertThat(database.countType(v1.getTypeName(), true)).isEqualTo(totalVertices - 1);
 
       vertices = v2.getVertices(Vertex.DIRECTION.IN).iterator();
-      Assertions.assertFalse(vertices.hasNext());
+      assertThat(vertices.hasNext()).isFalse();
 
       vertices = v2.getVertices(Vertex.DIRECTION.OUT).iterator();
-      Assertions.assertTrue(vertices.hasNext());
+      assertThat(vertices.hasNext()).isTrue();
 
       // Expecting 1 edge only: V2 is still connected to V3
       vertices = v3.getVertices(Vertex.DIRECTION.IN).iterator();
-      Assertions.assertTrue(vertices.hasNext());
+      assertThat(vertices.hasNext()).isTrue();
       vertices.next();
-      Assertions.assertFalse(vertices.hasNext());
+      assertThat(vertices.hasNext()).isFalse();
 
       // RELOAD AND CHECK AGAIN
       // -----------------------
       v2 = (Vertex) database.lookupByRID(v2.getIdentity(), true);
 
       vertices = v2.getVertices(Vertex.DIRECTION.IN).iterator();
-      Assertions.assertFalse(vertices.hasNext());
+      assertThat(vertices.hasNext()).isFalse();
 
       vertices = v2.getVertices(Vertex.DIRECTION.OUT).iterator();
-      Assertions.assertTrue(vertices.hasNext());
+      assertThat(vertices.hasNext()).isTrue();
 
       v3 = (Vertex) database.lookupByRID(v3.getIdentity(), true);
 
       // Expecting 1 edge only: V2 is still connected to V3
       vertices = v3.getVertices(Vertex.DIRECTION.IN).iterator();
-      Assertions.assertTrue(vertices.hasNext());
+      assertThat(vertices.hasNext()).isTrue();
       vertices.next();
-      Assertions.assertFalse(vertices.hasNext());
+      assertThat(vertices.hasNext()).isFalse();
 
       try {
         database.lookupByRID(root, true);
-        Assertions.fail("Expected deleted record");
+        fail("Expected deleted record");
       } catch (final RecordNotFoundException e) {
       }
 
@@ -294,16 +299,16 @@ public class BasicGraphTest extends BaseGraphTest {
     try {
 
       final Vertex v1 = (Vertex) database.lookupByRID(root, false);
-      Assertions.assertNotNull(v1);
+      assertThat(v1).isNotNull();
 
       Iterator<Edge> edges = v1.getEdges(Vertex.DIRECTION.OUT).iterator();
-      Assertions.assertTrue(edges.hasNext());
+      assertThat(edges.hasNext()).isTrue();
       final Edge e3 = edges.next();
-      Assertions.assertNotNull(e3);
+      assertThat(e3).isNotNull();
 
-      Assertions.assertTrue(edges.hasNext());
+      assertThat(edges.hasNext()).isTrue();
       final Edge e2 = edges.next();
-      Assertions.assertNotNull(e2);
+      assertThat(e2).isNotNull();
 
       // DELETE THE EDGE
       // -----------------------
@@ -311,33 +316,33 @@ public class BasicGraphTest extends BaseGraphTest {
 
       Vertex vOut = e2.getOutVertex();
       edges = vOut.getEdges(Vertex.DIRECTION.OUT).iterator();
-      Assertions.assertTrue(edges.hasNext());
+      assertThat(edges.hasNext()).isTrue();
 
       edges.next();
-      Assertions.assertFalse(edges.hasNext());
+      assertThat(edges.hasNext()).isFalse();
 
       Vertex vIn = e2.getInVertex();
       edges = vIn.getEdges(Vertex.DIRECTION.IN).iterator();
-      Assertions.assertFalse(edges.hasNext());
+      assertThat(edges.hasNext()).isFalse();
 
       // RELOAD AND CHECK AGAIN
       // -----------------------
       try {
         database.lookupByRID(e2.getIdentity(), true);
-        Assertions.fail("Expected deleted record");
+        fail("Expected deleted record");
       } catch (final RecordNotFoundException e) {
       }
 
       vOut = e2.getOutVertex();
       edges = vOut.getEdges(Vertex.DIRECTION.OUT).iterator();
-      Assertions.assertTrue(edges.hasNext());
+      assertThat(edges.hasNext()).isTrue();
 
       edges.next();
-      Assertions.assertFalse(edges.hasNext());
+      assertThat(edges.hasNext()).isFalse();
 
       vIn = e2.getInVertex();
       edges = vIn.getEdges(Vertex.DIRECTION.IN).iterator();
-      Assertions.assertFalse(edges.hasNext());
+      assertThat(edges.hasNext()).isFalse();
 
     } finally {
       database.commit();
@@ -351,34 +356,34 @@ public class BasicGraphTest extends BaseGraphTest {
     try {
 
       final Vertex v1 = (Vertex) database.lookupByRID(root, false);
-      Assertions.assertNotNull(v1);
+      assertThat(v1).isNotNull();
 
       Iterator<Edge> edges = v1.getEdges(Vertex.DIRECTION.OUT).iterator();
 
-      Assertions.assertTrue(edges.hasNext());
+      assertThat(edges.hasNext()).isTrue();
       final Edge e3 = edges.next();
-      Assertions.assertNotNull(e3);
+      assertThat(e3).isNotNull();
 
-      Assertions.assertTrue(edges.hasNext());
+      assertThat(edges.hasNext()).isTrue();
       final Edge e2 = edges.next();
-      Assertions.assertNotNull(e2);
+      assertThat(e2).isNotNull();
 
       // DELETE THE EDGE
       // -----------------------
       edges.remove();
 
-      Assertions.assertFalse(edges.hasNext());
+      assertThat(edges.hasNext()).isFalse();
 
       try {
         e2.getOutVertex();
-        Assertions.fail();
+        fail("");
       } catch (RecordNotFoundException e) {
         // EXPECTED
       }
 
       try {
         e2.getInVertex();
-        Assertions.fail();
+        fail("");
       } catch (RecordNotFoundException e) {
         // EXPECTED
       }
@@ -387,7 +392,7 @@ public class BasicGraphTest extends BaseGraphTest {
       // -----------------------
       try {
         database.lookupByRID(e2.getIdentity(), true);
-        Assertions.fail("Expected deleted record");
+        fail("Expected deleted record");
       } catch (final RecordNotFoundException e) {
         // EXPECTED
       }
@@ -408,36 +413,36 @@ public class BasicGraphTest extends BaseGraphTest {
 
       database.command("sql", "create edge " + EDGE1_TYPE_NAME + " from ? to ? unidirectional", v1, v1);
 
-      Assertions.assertTrue(v1.getVertices(Vertex.DIRECTION.OUT).iterator().hasNext());
-      Assertions.assertEquals(v1, v1.getVertices(Vertex.DIRECTION.OUT).iterator().next());
-      Assertions.assertFalse(v1.getVertices(Vertex.DIRECTION.IN).iterator().hasNext());
+      assertThat(v1.getVertices(Vertex.DIRECTION.OUT).iterator().hasNext()).isTrue();
+      assertThat(v1.getVertices(Vertex.DIRECTION.OUT).iterator().next()).isEqualTo(v1);
+      assertThat(v1.getVertices(Vertex.DIRECTION.IN).iterator().hasNext()).isFalse();
 
       // BIDIRECTIONAL EDGE
       final Vertex v2 = database.newVertex(VERTEX1_TYPE_NAME).save();
       v2.newEdge(EDGE1_TYPE_NAME, v2, true).save();
 
-      Assertions.assertTrue(v2.getVertices(Vertex.DIRECTION.OUT).iterator().hasNext());
-      Assertions.assertEquals(v2, v2.getVertices(Vertex.DIRECTION.OUT).iterator().next());
+      assertThat(v2.getVertices(Vertex.DIRECTION.OUT).iterator().hasNext()).isTrue();
+      assertThat(v2.getVertices(Vertex.DIRECTION.OUT).iterator().next()).isEqualTo(v2);
 
-      Assertions.assertTrue(v2.getVertices(Vertex.DIRECTION.IN).iterator().hasNext());
-      Assertions.assertEquals(v2, v2.getVertices(Vertex.DIRECTION.IN).iterator().next());
+      assertThat(v2.getVertices(Vertex.DIRECTION.IN).iterator().hasNext()).isTrue();
+      assertThat(v2.getVertices(Vertex.DIRECTION.IN).iterator().next()).isEqualTo(v2);
 
       database.commit();
 
       // UNIDIRECTIONAL EDGE
       final Vertex v1reloaded = (Vertex) database.lookupByRID(v1.getIdentity(), true);
-      Assertions.assertTrue(v1reloaded.getVertices(Vertex.DIRECTION.OUT).iterator().hasNext());
-      Assertions.assertEquals(v1reloaded, v1reloaded.getVertices(Vertex.DIRECTION.OUT).iterator().next());
-      Assertions.assertFalse(v1reloaded.getVertices(Vertex.DIRECTION.IN).iterator().hasNext());
+      assertThat(v1reloaded.getVertices(Vertex.DIRECTION.OUT).iterator().hasNext()).isTrue();
+      assertThat(v1reloaded.getVertices(Vertex.DIRECTION.OUT).iterator().next()).isEqualTo(v1reloaded);
+      assertThat(v1reloaded.getVertices(Vertex.DIRECTION.IN).iterator().hasNext()).isFalse();
 
       // BIDIRECTIONAL EDGE
       final Vertex v2reloaded = (Vertex) database.lookupByRID(v2.getIdentity(), true);
 
-      Assertions.assertTrue(v2reloaded.getVertices(Vertex.DIRECTION.OUT).iterator().hasNext());
-      Assertions.assertEquals(v2reloaded, v2reloaded.getVertices(Vertex.DIRECTION.OUT).iterator().next());
+      assertThat(v2reloaded.getVertices(Vertex.DIRECTION.OUT).iterator().hasNext()).isTrue();
+      assertThat(v2reloaded.getVertices(Vertex.DIRECTION.OUT).iterator().next()).isEqualTo(v2reloaded);
 
-      Assertions.assertTrue(v2reloaded.getVertices(Vertex.DIRECTION.IN).iterator().hasNext());
-      Assertions.assertEquals(v2reloaded, v2reloaded.getVertices(Vertex.DIRECTION.IN).iterator().next());
+      assertThat(v2reloaded.getVertices(Vertex.DIRECTION.IN).iterator().hasNext()).isTrue();
+      assertThat(v2reloaded.getVertices(Vertex.DIRECTION.IN).iterator().next()).isEqualTo(v2reloaded);
 
     } finally {
       new DatabaseChecker(database).setVerboseLevel(0).check();
@@ -460,15 +465,17 @@ public class BasicGraphTest extends BaseGraphTest {
           final Record v2 = v2Iterator.next();
 
           final ResultSet result = database.query("sql", "select shortestPath(?,?) as sp", v1, v2);
-          Assertions.assertTrue(result.hasNext());
+          assertThat(result.hasNext()).isTrue();
           final Result line = result.next();
 
-          Assertions.assertNotNull(line);
-          Assertions.assertTrue(line.getPropertyNames().contains("sp"));
-          Assertions.assertNotNull(line.getProperty("sp"));
-          Assertions.assertEquals(2, ((List) line.getProperty("sp")).size());
-          Assertions.assertEquals(v1, ((List) line.getProperty("sp")).get(0));
-          Assertions.assertEquals(v2, ((List) line.getProperty("sp")).get(1));
+          assertThat(line).isNotNull();
+          assertThat(line.getPropertyNames().contains("sp")).isTrue();
+          List<RID> sp = line.<List<RID>>getProperty("sp");
+          assertThat(sp).isNotNull();
+          assertThat(sp).hasSize(2);
+
+          assertThat(sp.get(0)).isEqualTo(v1);
+          assertThat(sp.get(1)).isEqualTo(v2);
         }
       }
 
@@ -495,12 +502,12 @@ public class BasicGraphTest extends BaseGraphTest {
       });
 
       final ResultSet result = database.query("sql", "select ciao() as ciao");
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result line = result.next();
 
-      Assertions.assertNotNull(line);
-      Assertions.assertTrue(line.getPropertyNames().contains("ciao"));
-      Assertions.assertEquals("Ciao", line.getProperty("ciao"));
+      assertThat(line).isNotNull();
+      assertThat(line.getPropertyNames().contains("ciao")).isTrue();
+      assertThat(line.<String>getProperty("ciao")).isEqualTo("Ciao");
 
     } finally {
       new DatabaseChecker(database).setVerboseLevel(0).check();
@@ -518,12 +525,12 @@ public class BasicGraphTest extends BaseGraphTest {
       ((SQLQueryEngine) database.getQueryEngine("sql")).getFunctionFactory().getReflectionFactory().register("test_", getClass());
 
       final ResultSet result = database.query("sql", "select test_testReflectionMethod() as testReflectionMethod");
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result line = result.next();
 
-      Assertions.assertNotNull(line);
-      Assertions.assertTrue(line.getPropertyNames().contains("testReflectionMethod"));
-      Assertions.assertEquals("reflect on this", line.getProperty("testReflectionMethod"));
+      assertThat(line).isNotNull();
+      assertThat(line.getPropertyNames().contains("testReflectionMethod")).isTrue();
+      assertThat(line.<String>getProperty("testReflectionMethod")).isEqualTo("reflect on this");
 
     } finally {
       new DatabaseChecker(database).setVerboseLevel(0).check();
@@ -563,7 +570,7 @@ public class BasicGraphTest extends BaseGraphTest {
       v2.set("rid", v1RID.get());
       v2.save();
 
-      Assertions.assertFalse(v1a.isConnectedTo(v2));
+      assertThat(v1a.isConnectedTo(v2)).isFalse();
     });
   }
 
@@ -589,13 +596,13 @@ public class BasicGraphTest extends BaseGraphTest {
       v2.set("rid", v1RID.get());
       v2.save();
 
-      Assertions.fail();
+      fail("");
 
     } catch (final RuntimeException e) {
       // EXPECTED
     }
 
-    Assertions.assertFalse(v1a.isConnectedTo(v2));
+    assertThat(v1a.isConnectedTo(v2)).isFalse();
   }
 
   @Test
@@ -613,7 +620,7 @@ public class BasicGraphTest extends BaseGraphTest {
 
     try {
       database.transaction(() -> v1[0].newEdge("OnlyOneBetweenVertices", v2[0], true));
-      Assertions.fail();
+      fail("");
     } catch (final DuplicatedKeyException ex) {
       // EXPECTED
     }
@@ -649,19 +656,19 @@ public class BasicGraphTest extends BaseGraphTest {
       v1[0] = database.newVertex(VERTEX1_TYPE_NAME).set("id", 1001).save();
       v2[0] = database.newVertex(VERTEX1_TYPE_NAME).set("id", 1002).save();
       final ResultSet result = database.command("sql", "create edge OnlyOneBetweenVertices from ? to ?", v1[0], v2[0]);
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
     });
 
     try {
       database.transaction(() -> v1[0].newEdge("OnlyOneBetweenVertices", v2[0], true));
-      Assertions.fail();
+      fail("");
     } catch (final DuplicatedKeyException ex) {
       // EXPECTED
     }
 
     try {
       database.transaction(() -> database.command("sql", "create edge OnlyOneBetweenVertices from ? to ?", v1[0], v2[0]));
-      Assertions.fail();
+      fail("");
     } catch (final DuplicatedKeyException ex) {
       // EXPECTED
     }
@@ -681,19 +688,19 @@ public class BasicGraphTest extends BaseGraphTest {
       v1[0] = database.newVertex(VERTEX1_TYPE_NAME).set("id", 1001).save();
       v2[0] = database.newVertex(VERTEX2_TYPE_NAME).set("id", 1002).save();
       final ResultSet result = database.command("sql", "create edge EdgeConstraint from ? to ?", v1[0], v2[0]);
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
     });
 
     try {
       database.transaction(() -> v2[0].newEdge("EdgeConstraint", v1[0], true));
-      Assertions.fail();
+      fail("");
     } catch (final ValidationException ex) {
       // EXPECTED
     }
 
     try {
       database.transaction(() -> database.command("sql", "create edge EdgeConstraint from ? to ?", v2[0], v1[0]));
-      Assertions.fail();
+      fail("");
     } catch (final ValidationException ex) {
       // EXPECTED
     }
@@ -711,7 +718,7 @@ public class BasicGraphTest extends BaseGraphTest {
 
     try {
       final Edge e1 = v1.newEdge("a-vertex", v2, /*= bidirectional */ true); // <-- expect IllegalArgumentException
-      Assertions.fail("Created an edge of vertex type");
+      fail("Created an edge of vertex type");
     } catch (final ClassCastException e) {
       // EXPECTED
     }
@@ -732,7 +739,7 @@ public class BasicGraphTest extends BaseGraphTest {
 
       final Iterator<Vertex> vertices = v1.getVertices(Vertex.DIRECTION.OUT).iterator();
       for (int i = 10000 - 1; vertices.hasNext(); --i) {
-        Assertions.assertEquals(i, vertices.next().get("id"));
+        assertThat(vertices.next().get("id")).isEqualTo(i);
       }
     });
   }

--- a/engine/src/test/java/com/arcadedb/graph/InsertGraphIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/InsertGraphIndexTest.java
@@ -26,10 +26,11 @@ import com.arcadedb.index.IndexCursor;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.VertexType;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.logging.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class InsertGraphIndexTest extends TestHelper {
   private static final int    VERTICES         = 1_000;
@@ -125,7 +126,7 @@ public class InsertGraphIndexTest extends TestHelper {
       }
     });
 
-    Assertions.assertEquals(VERTICES, cachedVertices.length);
+    assertThat(cachedVertices.length).isEqualTo(VERTICES);
 
     return cachedVertices;
   }
@@ -162,7 +163,7 @@ public class InsertGraphIndexTest extends TestHelper {
 
       database.async().waitCompletion();
 
-      Assertions.assertEquals(VERTICES, database.countType(VERTEX_TYPE_NAME, true));
+      assertThat(database.countType(VERTEX_TYPE_NAME, true)).isEqualTo(VERTICES);
 
     } finally {
       final long elapsed = System.currentTimeMillis() - startOfTest;
@@ -175,7 +176,7 @@ public class InsertGraphIndexTest extends TestHelper {
     vertex.createProperty("id", Integer.class);
     database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, VERTEX_TYPE_NAME, "id");
 
-    Assertions.assertEquals("round-robin", vertex.getBucketSelectionStrategy().getName());
+    assertThat(vertex.getBucketSelectionStrategy().getName()).isEqualTo("round-robin");
 
     database.getSchema().buildEdgeType().withName(EDGE_TYPE_NAME).withTotalBuckets(PARALLEL).create();
 
@@ -183,10 +184,10 @@ public class InsertGraphIndexTest extends TestHelper {
     vertexNotInUse.createProperty("id", Integer.class);
     database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "NotInUse", "id");
 
-    Assertions.assertEquals("round-robin", vertexNotInUse.getBucketSelectionStrategy().getName());
+    assertThat(vertexNotInUse.getBucketSelectionStrategy().getName()).isEqualTo("round-robin");
 
     vertexNotInUse.setBucketSelectionStrategy("partitioned('id')");
-    Assertions.assertEquals("partitioned", vertexNotInUse.getBucketSelectionStrategy().getName());
+    assertThat(vertexNotInUse.getBucketSelectionStrategy().getName()).isEqualTo("partitioned");
 
   }
 
@@ -202,10 +203,10 @@ public class InsertGraphIndexTest extends TestHelper {
       for (; i < VERTICES; ++i) {
         int edges = 0;
         final long outEdges = cachedVertices[i].countEdges(Vertex.DIRECTION.OUT, EDGE_TYPE_NAME);
-        Assertions.assertEquals(expectedEdges, outEdges);
+        assertThat(outEdges).isEqualTo(expectedEdges);
 
         final long inEdges = cachedVertices[i].countEdges(Vertex.DIRECTION.IN, EDGE_TYPE_NAME);
-        Assertions.assertEquals(expectedEdges, inEdges);
+        assertThat(inEdges).isEqualTo(expectedEdges);
 
         if (++edges > EDGES_PER_VERTEX)
           break;

--- a/engine/src/test/java/com/arcadedb/graph/TestVertexDelete.java
+++ b/engine/src/test/java/com/arcadedb/graph/TestVertexDelete.java
@@ -2,12 +2,14 @@ package com.arcadedb.graph;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.nio.file.*;
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestVertexDelete {
   public static class DeleteOnClose implements AutoCloseable {
@@ -58,8 +60,8 @@ public class TestVertexDelete {
         db.transaction(() -> {
           var v1c = db.countType("v1", false);
           var pc = db.countType("hasParent", false);
-          Assertions.assertEquals(0, v1c);
-          Assertions.assertEquals(0, pc);
+          assertThat(v1c).isEqualTo(0);
+          assertThat(pc).isEqualTo(0);
         });
       }
     }

--- a/engine/src/test/java/com/arcadedb/graph/TxGraphTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/TxGraphTest.java
@@ -22,8 +22,13 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.database.RID;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TxGraphTest extends TestHelper {
   protected static final String DB_PATH = "target/databases/graph";
@@ -50,38 +55,38 @@ public class TxGraphTest extends TestHelper {
 
       commodore[0].asVertex(false).newEdge("SELLS", vic20, true).set("date", System.currentTimeMillis()).save();
 
-      Assertions.assertEquals(2, commodore[0].asVertex().countEdges(Vertex.DIRECTION.OUT, "SELLS"));
+      assertThat(commodore[0].asVertex().countEdges(Vertex.DIRECTION.OUT,"SELLS")).isEqualTo(2);
 
       ResultSet result = database.query("sql", "select expand( in().include('name') ) from Good");
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       while (result.hasNext()) {
         final Result next = result.next();
-        Assertions.assertNotNull(next.getProperty("name"));
-        Assertions.assertNull(next.getProperty("date"));
+        assertThat(next.<String>getProperty("name")).isNotNull();
+        assertThat(next.<String>getProperty("date")).isNull();
       }
 
       result = database.query("sql", "select expand( in().include('date') ) from Good");
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       while (result.hasNext()) {
         final Result next = result.next();
-        Assertions.assertNotNull(next.getProperty("date"));
-        Assertions.assertNull(next.getProperty("name"));
+        assertThat(next.<Long>getProperty("date")).isNotNull();
+        assertThat(next.<String>getProperty("name")).isNull();
       }
 
       result = database.query("sql", "select expand( in().exclude('name') ) from Good");
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       while (result.hasNext()) {
         final Result next = result.next();
-        Assertions.assertNotNull(next.getProperty("date"));
-        Assertions.assertNull(next.getProperty("name"));
+        assertThat(next.<Long>getProperty("date")).isNotNull();
+        assertThat(next.<String>getProperty("name")).isNull();
       }
 
       result = database.query("sql", "select expand( in().exclude('date') ) from Good");
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       while (result.hasNext()) {
         final Result next = result.next();
-        Assertions.assertNotNull(next.getProperty("name"));
-        Assertions.assertNull(next.getProperty("date"));
+        assertThat(next.<Long>getProperty("date")).isNull();
+        assertThat(next.<String>getProperty("name")).isNotNull();
       }
     });
   }

--- a/engine/src/test/java/com/arcadedb/index/CompressedRID2RIDIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/CompressedRID2RIDIndexTest.java
@@ -20,8 +20,9 @@ package com.arcadedb.index;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.RID;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class CompressedRID2RIDIndexTest extends TestHelper {
   private static final int TOT = 10_000_000;
@@ -34,21 +35,21 @@ public class CompressedRID2RIDIndexTest extends TestHelper {
       index.put(new RID(database, 3, i), new RID(database, 4, i));
 
     for (int i = 0; i < TOT; i++)
-      Assertions.assertEquals(new RID(database, 4, i), index.get(new RID(database, 3, i)));
+      assertThat(index.get(new RID(database, 3, i))).isEqualTo(new RID(database, 4, i));
 
     int found = 0;
     for (CompressedRID2RIDIndex.EntryIterator it = index.entryIterator(); it.hasNext(); ) {
       final RID key = it.getKeyRID();
       final RID value = it.getValueRID();
 
-      Assertions.assertEquals(3, key.getBucketId());
-      Assertions.assertEquals(4, value.getBucketId());
-      Assertions.assertEquals(key.getPosition(), value.getPosition());
+      assertThat(key.getBucketId()).isEqualTo(3);
+      assertThat(value.getBucketId()).isEqualTo(4);
+      assertThat(value.getPosition()).isEqualTo(key.getPosition());
 
       ++found;
       it.moveNext();
     }
 
-    Assertions.assertEquals(TOT, found);
+    assertThat(found).isEqualTo(TOT);
   }
 }

--- a/engine/src/test/java/com/arcadedb/index/LSMTreeIndexCompositeTest.java
+++ b/engine/src/test/java/com/arcadedb/index/LSMTreeIndexCompositeTest.java
@@ -24,10 +24,12 @@ import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class LSMTreeIndexCompositeTest extends TestHelper {
   private static final int TOT = 100;
@@ -38,8 +40,8 @@ public class LSMTreeIndexCompositeTest extends TestHelper {
       final TypeIndex index = database.getSchema().getType("File").getIndexesByProperties("absoluteId").get(0);
       for (int i = 0; i < TOT * TOT; ++i) {
         final IndexCursor value = index.get(new Object[] { i });
-        Assertions.assertTrue(value.hasNext());
-        Assertions.assertEquals(i, value.next().asVertex().get("absoluteId"));
+        assertThat(value.hasNext()).isTrue();
+        assertThat(value.next().asVertex().get("absoluteId")).isEqualTo(i);
       }
     });
   }
@@ -51,11 +53,11 @@ public class LSMTreeIndexCompositeTest extends TestHelper {
       for (int i = 0; i < TOT; ++i) {
         for (int k = 0; k < TOT; ++k) {
           final IndexCursor value = index.get(new Object[] { i, k });
-          Assertions.assertTrue(value.hasNext(), "id[" + i + "," + k + "]");
+          assertThat(value.hasNext()).withFailMessage("id[" + i + "," + k + "]").isTrue();
 
           final Vertex v = value.next().asVertex();
-          Assertions.assertEquals(i, v.get("directoryId"));
-          Assertions.assertEquals(k, v.get("fileId"));
+          assertThat(v.get("directoryId")).isEqualTo(i);
+          assertThat(v.get("fileId")).isEqualTo(k);
         }
       }
     });
@@ -67,10 +69,10 @@ public class LSMTreeIndexCompositeTest extends TestHelper {
       final TypeIndex index = database.getSchema().getType("File").getIndexesByProperties("directoryId", "fileId").get(0);
       for (int i = 0; i < TOT; ++i) {
         final IndexCursor value = index.get(new Object[] { i, null });
-        Assertions.assertTrue(value.hasNext(), "id[" + i + "]");
+        assertThat(value.hasNext()).withFailMessage( "id[" + i + "]").isTrue();
 
         final Vertex v = value.next().asVertex();
-        Assertions.assertEquals(i, v.get("directoryId"));
+        assertThat(v.get("directoryId")).isEqualTo(i);
       }
     });
   }
@@ -78,7 +80,7 @@ public class LSMTreeIndexCompositeTest extends TestHelper {
   protected void beginTest() {
     // CREATE SIMPLE GRAPH OF 2 LEVELS DIRECTORY FILE SYSTEM
     database.transaction(() -> {
-      Assertions.assertFalse(database.getSchema().existsType("File"));
+      assertThat(database.getSchema().existsType("File")).isFalse();
       final DocumentType file = database.getSchema().createVertexType("File");
       file.createProperty("absoluteId", Integer.class);
       file.createProperty("directoryId", Integer.class);
@@ -88,7 +90,7 @@ public class LSMTreeIndexCompositeTest extends TestHelper {
 
       file.setBucketSelectionStrategy(new RoundRobinBucketSelectionStrategy());
 
-      Assertions.assertFalse(database.getSchema().existsType("HasChildren"));
+      assertThat(database.getSchema().existsType("HasChildren")).isFalse();
       database.getSchema().createEdgeType("HasChildren");
       database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "HasChildren", "@out", "@in");
 

--- a/engine/src/test/java/com/arcadedb/index/LSMTreeIndexPolymorphicTest.java
+++ b/engine/src/test/java/com/arcadedb/index/LSMTreeIndexPolymorphicTest.java
@@ -26,10 +26,16 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class LSMTreeIndexPolymorphicTest extends TestHelper {
 
@@ -44,11 +50,11 @@ public class LSMTreeIndexPolymorphicTest extends TestHelper {
       final MutableDocument docChildDuplicated = database.newDocument("TestChild");
       database.transaction(() -> {
         docChildDuplicated.set("name", "Root");
-        Assertions.assertEquals("Root", docChildDuplicated.get("name"));
+        assertThat(docChildDuplicated.get("name")).isEqualTo("Root");
         docChildDuplicated.save();
       }, true, 0);
 
-      Assertions.fail("Duplicated shouldn't be allowed by unique index on sub type");
+      fail("Duplicated shouldn't be allowed by unique index on sub type");
 
     } catch (final DuplicatedKeyException e) {
       // EXPECTED
@@ -76,15 +82,15 @@ public class LSMTreeIndexPolymorphicTest extends TestHelper {
     testChild2.setSuperTypes(Arrays.asList(typeRoot2));
     final MutableDocument doc = database.newDocument("TestChild2");
     doc.set("name", "Document Name");
-    Assertions.assertEquals("Document Name", doc.get("name"));
+    assertThat(doc.get("name")).isEqualTo("Document Name");
     doc.save();
-    Assertions.assertEquals("Document Name", doc.get("name"));
+    assertThat(doc.get("name")).isEqualTo("Document Name");
     try (final ResultSet rs = database.query("sql", "select from TestChild2 where name = :name",
         Map.of("arg0", "Test2", "name", "Document Name"))) {
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       final Document docRetrieved = rs.next().getElement().orElse(null);
-      Assertions.assertEquals("Document Name", docRetrieved.get("name"));
-      Assertions.assertFalse(rs.hasNext());
+      assertThat(docRetrieved.get("name")).isEqualTo("Document Name");
+      assertThat(rs.hasNext()).isFalse();
     }
     database.commit();
   }
@@ -103,15 +109,15 @@ public class LSMTreeIndexPolymorphicTest extends TestHelper {
     database.setAutoTransaction(true);
     final MutableDocument doc = database.newDocument("TestChild2");
     doc.set("name", "Document Name");
-    Assertions.assertEquals("Document Name", doc.get("name"));
+    assertThat(doc.get("name")).isEqualTo("Document Name");
     doc.save();
-    Assertions.assertEquals("Document Name", doc.get("name"));
+    assertThat(doc.get("name")).isEqualTo("Document Name");
     try (final ResultSet rs = database.query("sql", "select from TestChild2 where name = :name",
         Map.of("arg0", "Test2", "name", "Document Name"))) {
-      Assertions.assertTrue(rs.hasNext());  //<<<<<<----------FAILING HERE
+      assertThat(rs.hasNext()).isTrue();  //<<<<<<----------FAILING HERE
       final Document docRetrieved = rs.next().getElement().orElse(null);
-      Assertions.assertEquals("Document Name", docRetrieved.get("name"));
-      Assertions.assertFalse(rs.hasNext());
+      assertThat(docRetrieved.get("name")).isEqualTo("Document Name");
+      assertThat(rs.hasNext()).isFalse();
     }
   }
 
@@ -127,62 +133,62 @@ public class LSMTreeIndexPolymorphicTest extends TestHelper {
     final MutableDocument docRoot = database.newDocument("TestRoot");
     database.transaction(() -> {
       docRoot.set("name", "Root");
-      Assertions.assertEquals("Root", docRoot.get("name"));
+      assertThat(docRoot.get("name")).isEqualTo("Root");
       docRoot.save();
     });
-    Assertions.assertEquals("Root", docRoot.get("name"));
+    assertThat(docRoot.get("name")).isEqualTo("Root");
 
     final MutableDocument docChild = database.newDocument("TestChild");
     database.transaction(() -> {
       docChild.set("name", "Child");
-      Assertions.assertEquals("Child", docChild.get("name"));
+      assertThat(docChild.get("name")).isEqualTo("Child");
       docChild.save();
     });
-    Assertions.assertEquals("Child", docChild.get("name"));
+    assertThat(docChild.get("name")).isEqualTo("Child");
   }
 
   private void checkQueries() {
     try (final ResultSet rs = database.query("sql", "select from TestRoot where name <> :name",
         Map.of("arg0", "Test2", "name", "Nonsense"))) {
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       final Document doc1Retrieved = rs.next().getElement().orElse(null);
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       final Document doc2Retrieved = rs.next().getElement().orElse(null);
 
       if (doc1Retrieved.getTypeName().equals("TestRoot"))
-        Assertions.assertEquals("Root", doc1Retrieved.get("name"));
+        assertThat(doc1Retrieved.get("name")).isEqualTo("Root");
       else if (doc2Retrieved.getTypeName().equals("TestChild"))
-        Assertions.assertEquals("Child", doc2Retrieved.get("name"));
+        assertThat(doc2Retrieved.get("name")).isEqualTo("Child");
       else
-        Assertions.fail();
+        fail("");
 
-      Assertions.assertFalse(rs.hasNext());
+      assertThat(rs.hasNext()).isFalse();
     }
 
     try (final ResultSet rs = database.query("sql", "select from TestChild where name = :name",
         Map.of("arg0", "Test2", "name", "Child"))) {
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       final Document doc1Retrieved = rs.next().getElement().orElse(null);
-      Assertions.assertEquals("Child", doc1Retrieved.get("name"));
-      Assertions.assertFalse(rs.hasNext());
+      assertThat(doc1Retrieved.get("name")).isEqualTo("Child");
+      assertThat(rs.hasNext()).isFalse();
     }
 
     typeChild.removeSuperType(typeRoot);
 
     try (final ResultSet rs = database.query("sql", "select from TestChild where name = :name",
         Map.of("arg0", "Test2", "name", "Child"))) {
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       final Document doc1Retrieved = rs.next().getElement().orElse(null);
-      Assertions.assertEquals("Child", doc1Retrieved.get("name"));
-      Assertions.assertFalse(rs.hasNext());
+      assertThat(doc1Retrieved.get("name")).isEqualTo("Child");
+      assertThat(rs.hasNext()).isFalse();
     }
 
     try (final ResultSet rs = database.query("sql", "select from TestRoot where name <> :name",
         Map.of("arg0", "Test2", "name", "Nonsense"))) {
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       final Document doc1Retrieved = rs.next().getElement().orElse(null);
-      Assertions.assertEquals("Root", doc1Retrieved.get("name"));
-      Assertions.assertFalse(rs.hasNext());
+      assertThat(doc1Retrieved.get("name")).isEqualTo("Root");
+      assertThat(rs.hasNext()).isFalse();
     }
   }
 }

--- a/engine/src/test/java/com/arcadedb/index/MultipleTypesIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/MultipleTypesIndexTest.java
@@ -25,10 +25,13 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.schema.VertexType;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
 
 public class MultipleTypesIndexTest extends TestHelper {
   private static final int    TOT       = 100000;
@@ -40,38 +43,38 @@ public class MultipleTypesIndexTest extends TestHelper {
       final Index index = database.getSchema().getIndexByName(TYPE_NAME + "[keywords]");
 
       IndexCursor cursor = index.get(new Object[] { List.of("ceo", "tesla", "spacex", "boring", "neuralink", "twitter") });
-      Assertions.assertTrue(cursor.hasNext());
-      Assertions.assertEquals("Musk", cursor.next().asVertex().getString("lastName"));
-      Assertions.assertFalse(cursor.hasNext());
+      assertThat(cursor.hasNext()).isTrue();
+      assertThat(cursor.next().asVertex().getString("lastName")).isEqualTo("Musk");
+      assertThat(cursor.hasNext()).isFalse();
 
       ResultSet resultset = database.query("sql", "select from " + TYPE_NAME + " where keywords CONTAINS ?", "tesla");
-      Assertions.assertTrue(resultset.hasNext());
-      Assertions.assertEquals("Musk", resultset.next().toElement().asVertex().getString("lastName"));
-      Assertions.assertFalse(resultset.hasNext());
+      assertThat(resultset.hasNext()).isTrue();
+      assertThat(resultset.next().toElement().asVertex().getString("lastName")).isEqualTo("Musk");
+      assertThat(resultset.hasNext()).isFalse();
 
       resultset = database.query("sql", "select from " + TYPE_NAME + " where 'tesla' IN  keywords");
-      Assertions.assertTrue(resultset.hasNext());
-      Assertions.assertEquals("Musk", resultset.next().toElement().asVertex().getString("lastName"));
-      Assertions.assertFalse(resultset.hasNext());
+      assertThat(resultset.hasNext()).isTrue();
+      assertThat(resultset.next().toElement().asVertex().getString("lastName")).isEqualTo("Musk");
+      assertThat(resultset.hasNext()).isFalse();
 
       resultset = database.query("sql", "select from " + TYPE_NAME + " where ? IN keywords", "tesla");
-      Assertions.assertTrue(resultset.hasNext());
-      Assertions.assertEquals("Musk", resultset.next().toElement().asVertex().getString("lastName"));
-      Assertions.assertFalse(resultset.hasNext());
+      assertThat(resultset.hasNext()).isTrue();
+      assertThat(resultset.next().toElement().asVertex().getString("lastName")).isEqualTo("Musk");
+      assertThat(resultset.hasNext()).isFalse();
 
       cursor = index.get(new Object[] { List.of("inventor", "commodore", "amiga", "atari", "80s") });
-      Assertions.assertTrue(cursor.hasNext());
-      Assertions.assertEquals("Jay", cursor.next().asVertex().getString("firstName"));
-      Assertions.assertFalse(cursor.hasNext());
+      assertThat(cursor.hasNext()).isTrue();
+      assertThat(cursor.next().asVertex().getString("firstName")).isEqualTo("Jay");
+      assertThat(cursor.hasNext()).isFalse();
 
       cursor = index.get(new Object[] { List.of("writer") });
-      Assertions.assertTrue(cursor.hasNext());
+      assertThat(cursor.hasNext()).isTrue();
 
       int i = 0;
       for (; cursor.hasNext(); i++) {
         cursor.next();
       }
-      Assertions.assertEquals(TOT - 2, i);
+      assertThat(i).isEqualTo(TOT - 2);
     });
   }
 
@@ -92,9 +95,9 @@ public class MultipleTypesIndexTest extends TestHelper {
       v.save();
 
       IndexCursor cursor = index.get(new Object[] { list });
-      Assertions.assertTrue(cursor.hasNext());
-      Assertions.assertEquals("Zuck", cursor.next().asVertex().getString("lastName"));
-      Assertions.assertFalse(cursor.hasNext());
+      assertThat(cursor.hasNext()).isTrue();
+      assertThat(cursor.next().asVertex().getString("lastName")).isEqualTo("Zuck");
+      assertThat(cursor.hasNext()).isFalse();
     });
   }
 
@@ -118,7 +121,7 @@ public class MultipleTypesIndexTest extends TestHelper {
 
   protected void beginTest() {
     database.transaction(() -> {
-      Assertions.assertFalse(database.getSchema().existsType(TYPE_NAME));
+      assertThat(database.getSchema().existsType(TYPE_NAME)).isFalse();
 
       final DocumentType type = database.getSchema().buildVertexType().withName(TYPE_NAME).withTotalBuckets(3).create();
       type.createProperty("id", Integer.class);

--- a/engine/src/test/java/com/arcadedb/index/PlainLuceneFullTextIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/PlainLuceneFullTextIndexTest.java
@@ -34,11 +34,12 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.store.FSDirectory;
-import org.junit.jupiter.api.Assertions;
 
 import java.io.*;
 import java.nio.file.*;
 import java.util.stream.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PlainLuceneFullTextIndexTest {
   public static void main(String[] args) throws IOException, ParseException {
@@ -102,7 +103,7 @@ public class PlainLuceneFullTextIndexTest {
       final Query query = parser.parse("elec*");
       final ScoreDoc[] hits = searcher.search(query, 1000, Sort.RELEVANCE).scoreDocs;
 
-      Assertions.assertEquals(501, hits.length);
+      assertThat(hits.length).isEqualTo(501);
       // Iterate through the results:
       for (int i = 0; i < hits.length; i++) {
         final Document hitDoc = searcher.doc(hits[i].doc);

--- a/engine/src/test/java/com/arcadedb/query/java/JavaQueryTest.java
+++ b/engine/src/test/java/com/arcadedb/query/java/JavaQueryTest.java
@@ -4,10 +4,12 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.query.QueryEngine;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 class JavaMethods {
   public JavaMethods() {
@@ -29,13 +31,13 @@ class JavaMethods {
 public class JavaQueryTest extends TestHelper {
   @Test
   public void testRegisteredMethod() {
-    Assertions.assertEquals("java", database.getQueryEngine("java").getLanguage());
+    assertThat(database.getQueryEngine("java").getLanguage()).isEqualTo("java");
 
     database.getQueryEngine("java").registerFunctions("com.arcadedb.query.java.JavaMethods::sum");
 
     final ResultSet result = database.command("java", "com.arcadedb.query.java.JavaMethods::sum", 5, 3);
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertEquals(8, (Integer) result.next().getProperty("value"));
+    assertThat(result.hasNext()).isTrue();
+    assertThat((Integer) result.next().getProperty("value")).isEqualTo(8);
   }
 
   @Test
@@ -44,12 +46,12 @@ public class JavaQueryTest extends TestHelper {
     database.getQueryEngine("java").registerFunctions("com.arcadedb.query.java.JavaMethods::SUM");
 
     ResultSet result = database.command("java", "com.arcadedb.query.java.JavaMethods::sum", 5, 3);
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertEquals(8, (Integer) result.next().getProperty("value"));
+    assertThat(result.hasNext()).isTrue();
+    assertThat((Integer) result.next().getProperty("value")).isEqualTo(8);
 
     result = database.command("java", "com.arcadedb.query.java.JavaMethods::SUM", 5, 3);
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertEquals(8, (Integer) result.next().getProperty("value"));
+    assertThat(result.hasNext()).isTrue();
+    assertThat((Integer) result.next().getProperty("value")).isEqualTo(8);
 
     database.getQueryEngine("java").unregisterFunctions();
   }
@@ -59,12 +61,12 @@ public class JavaQueryTest extends TestHelper {
     database.getQueryEngine("java").registerFunctions("com.arcadedb.query.java.JavaMethods");
 
     ResultSet result = database.command("java", "com.arcadedb.query.java.JavaMethods::sum", 5, 3);
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertEquals(8, (Integer) result.next().getProperty("value"));
+    assertThat(result.hasNext()).isTrue();
+    assertThat((Integer) result.next().getProperty("value")).isEqualTo(8);
 
     result = database.command("java", "com.arcadedb.query.java.JavaMethods::SUM", 5, 3);
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertEquals(8, (Integer) result.next().getProperty("value"));
+    assertThat(result.hasNext()).isTrue();
+    assertThat((Integer) result.next().getProperty("value")).isEqualTo(8);
 
     database.getQueryEngine("java").unregisterFunctions();
   }
@@ -73,10 +75,10 @@ public class JavaQueryTest extends TestHelper {
   public void testUnRegisteredMethod() {
     try {
       database.command("java", "com.arcadedb.query.java.JavaMethods::sum", 5, 3);
-      Assertions.fail();
+      fail("");
     } catch (final CommandExecutionException e) {
       // EXPECTED
-      Assertions.assertTrue(e.getCause() instanceof SecurityException);
+      assertThat(e.getCause() instanceof SecurityException).isTrue();
     }
   }
 
@@ -85,10 +87,10 @@ public class JavaQueryTest extends TestHelper {
     database.getQueryEngine("java").registerFunctions("com.arcadedb.query.java.JavaMethods");
     try {
       database.command("java", "com.arcadedb.query.java.JavaMethods::totallyInvented", 5, 3);
-      Assertions.fail();
+      fail("");
     } catch (final CommandExecutionException e) {
       // EXPECTED
-      Assertions.assertTrue(e.getCause() instanceof NoSuchMethodException);
+      assertThat(e.getCause() instanceof NoSuchMethodException).isTrue();
     }
   }
 
@@ -96,8 +98,8 @@ public class JavaQueryTest extends TestHelper {
   public void testAnalyzeQuery() {
     database.getQueryEngine("java").registerFunctions("com.arcadedb.query.java.JavaMethods");
     final QueryEngine.AnalyzedQuery analyzed = database.getQueryEngine("java").analyze("com.arcadedb.query.java.JavaMethods::totallyInvented");
-    Assertions.assertFalse(analyzed.isDDL());
-    Assertions.assertFalse(analyzed.isIdempotent());
+    assertThat(analyzed.isDDL()).isFalse();
+    assertThat(analyzed.isIdempotent()).isFalse();
   }
 
   @Test
@@ -105,7 +107,7 @@ public class JavaQueryTest extends TestHelper {
     database.getQueryEngine("java").registerFunctions("com.arcadedb.query.java.JavaMethods");
     try {
       database.query("java", "com.arcadedb.query.java.JavaMethods::sum", 5, 3);
-      Assertions.fail();
+      fail("");
     } catch (final UnsupportedOperationException e) {
       // EXPECTED
     }
@@ -115,7 +117,7 @@ public class JavaQueryTest extends TestHelper {
       final HashMap map = new HashMap();
       map.put("name", 1);
       database.getQueryEngine("java").command("com.arcadedb.query.java.JavaMethods::hello", null, map);
-      Assertions.fail();
+      fail("");
     } catch (final UnsupportedOperationException e) {
       // EXPECTED
     }
@@ -123,7 +125,7 @@ public class JavaQueryTest extends TestHelper {
     database.getQueryEngine("java").registerFunctions("com.arcadedb.query.java.JavaMethods");
     try {
       database.getQueryEngine("java").query("com.arcadedb.query.java.JavaMethods::sum", null, new HashMap<>());
-      Assertions.fail();
+      fail("");
     } catch (final UnsupportedOperationException e) {
       // EXPECTED
     }

--- a/engine/src/test/java/com/arcadedb/query/select/SelectExecutionIT.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectExecutionIT.java
@@ -25,12 +25,17 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.json.JSONObject;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.stream.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -57,8 +62,8 @@ public class SelectExecutionIT extends TestHelper {
 
       for (int i = 1; i < 100; i++) {
         final Vertex root = database.select().fromType("Vertex").where().property("id").eq().value(0).vertices().nextOrNull();
-        Assertions.assertNotNull(root);
-        Assertions.assertEquals(0, root.getInteger("id"));
+        assertNotNull(root);
+        assertEquals(0, root.getInteger("id"));
 
         root.newEdge("Edge", database.select().fromType("Vertex").where().property("id").eq().value(i).vertices().nextOrNull(),
             true).save();
@@ -76,7 +81,7 @@ public class SelectExecutionIT extends TestHelper {
           .and().property("name").eq().value("Elon").compile();
 
       for (int i = 0; i < 100; i++)
-        Assertions.assertEquals(i, select.parameter("value", i).vertices().nextOrNull().getInteger("id"));
+        assertThat(select.parameter("value", i).vertices().nextOrNull().getInteger("id")).isEqualTo(i);
     }
 
     {
@@ -87,7 +92,7 @@ public class SelectExecutionIT extends TestHelper {
           .and().property("name").eq().value("Elon").compile();
 
       for (int i = 0; i < 100; i++)
-        Assertions.assertEquals(i, select.parameter("value", i).vertices().nextOrNull().getInteger("id"));
+        assertThat(select.parameter("value", i).vertices().nextOrNull().getInteger("id")).isEqualTo(i);
     }
   }
 
@@ -99,7 +104,7 @@ public class SelectExecutionIT extends TestHelper {
           .and().property("name").eq().value("Elon").compile();
 
       for (int i = 0; i < 100; i++)
-        Assertions.assertEquals(i, select.parameter("value", i).vertices().nextOrNull().getInteger("id"));
+        assertThat(select.parameter("value", i).vertices().nextOrNull().getInteger("id")).isEqualTo(i);
     }
 
     {
@@ -107,7 +112,7 @@ public class SelectExecutionIT extends TestHelper {
           .where().property("id").eq().parameter("value")//
           .and().property("name").eq().value("Elon2").compile();
 
-      Assertions.assertFalse(select.parameter("value", 3).vertices().hasNext());
+      assertThat(select.parameter("value", 3).vertices().hasNext()).isFalse();
     }
 
     {
@@ -115,7 +120,7 @@ public class SelectExecutionIT extends TestHelper {
           .where().property("id").eq().value(-1)//
           .and().property("name").eq().value("Elon").compile();
 
-      Assertions.assertFalse(select.vertices().hasNext());
+      assertThat(select.vertices().hasNext()).isFalse();
     }
 
     {
@@ -126,7 +131,7 @@ public class SelectExecutionIT extends TestHelper {
           .and().property("name").eq().value("Elon").compile();
 
       for (int i = 0; i < 100; i++)
-        Assertions.assertEquals(i, select.parameter("value", i).vertices().nextOrNull().getInteger("id"));
+        assertThat(select.parameter("value", i).vertices().nextOrNull().getInteger("id")).isEqualTo(i);
     }
   }
 
@@ -139,7 +144,7 @@ public class SelectExecutionIT extends TestHelper {
 
       for (SelectIterator<Vertex> result = select.parameter("value", 3).vertices(); result.hasNext(); ) {
         final Vertex v = result.next();
-        Assertions.assertTrue(v.getInteger("id").equals(3) || v.getString("name").equals("Elon"));
+        assertThat(v.getInteger("id").equals(3) || v.getString("name").equals("Elon")).isTrue();
       }
     }
 
@@ -150,7 +155,7 @@ public class SelectExecutionIT extends TestHelper {
 
       for (SelectIterator<Vertex> result = select.parameter("value", 3).vertices(); result.hasNext(); ) {
         final Vertex v = result.next();
-        Assertions.assertTrue(v.getInteger("id").equals(3) || v.getString("name").equals("Elon2"));
+        assertThat(v.getInteger("id").equals(3) || v.getString("name").equals("Elon2")).isTrue();
       }
     }
 
@@ -161,7 +166,7 @@ public class SelectExecutionIT extends TestHelper {
 
       for (SelectIterator<Vertex> result = select.parameter("value", 3).vertices(); result.hasNext(); ) {
         final Vertex v = result.next();
-        Assertions.assertTrue(v.getInteger("id").equals(-1) || v.getString("name").equals("Elon"));
+        assertThat(v.getInteger("id").equals(-1) || v.getString("name").equals("Elon")).isTrue();
       }
     }
   }
@@ -176,8 +181,8 @@ public class SelectExecutionIT extends TestHelper {
 
       for (SelectIterator<Vertex> result = select.parameter("value", 3).vertices(); result.hasNext(); ) {
         final Vertex v = result.next();
-        Assertions.assertTrue(v.getInteger("id").equals(3) && v.getString("name").equals("Elon2") ||//
-            v.getString("name").equals("Elon"));
+        assertThat(v.getInteger("id").equals(3) && v.getString("name").equals("Elon2") ||//
+          v.getString("name").equals("Elon")).isTrue();
       }
     }
 
@@ -189,8 +194,8 @@ public class SelectExecutionIT extends TestHelper {
 
       for (SelectIterator<Vertex> result = select.parameter("value", 3).vertices(); result.hasNext(); ) {
         final Vertex v = result.next();
-        Assertions.assertTrue(v.getInteger("id").equals(3) ||//
-            v.getString("name").equals("Elon2") && v.getString("name").equals("Elon"));
+        assertThat(v.getInteger("id").equals(3) ||//
+          v.getString("name").equals("Elon2") && v.getString("name").equals("Elon")).isTrue();
       }
     }
   }
@@ -204,10 +209,10 @@ public class SelectExecutionIT extends TestHelper {
     final SelectIterator<Vertex> iter = select.vertices();
     int browsed = 0;
     while (iter.hasNext()) {
-      Assertions.assertTrue(iter.next().getInteger("id") < 10);
+      assertThat(iter.next().getInteger("id") < 10).isTrue();
       ++browsed;
     }
-    Assertions.assertEquals(10, browsed);
+    assertThat(browsed).isEqualTo(10);
   }
 
   @Test
@@ -219,10 +224,10 @@ public class SelectExecutionIT extends TestHelper {
     SelectIterator<Vertex> iter = select.vertices();
     int browsed = 0;
     while (iter.hasNext()) {
-      Assertions.assertTrue(iter.next().getInteger("id") < 10);
+      assertThat(iter.next().getInteger("id") < 10).isTrue();
       ++browsed;
     }
-    Assertions.assertEquals(0, browsed);
+    assertThat(browsed).isEqualTo(0);
 
     select = database.select().fromType("Vertex")//
         .where().property("id").lt().value(10)//
@@ -231,10 +236,10 @@ public class SelectExecutionIT extends TestHelper {
     iter = select.vertices();
     browsed = 0;
     while (iter.hasNext()) {
-      Assertions.assertTrue(iter.next().getInteger("id") < 10);
+      assertThat(iter.next().getInteger("id") < 10).isTrue();
       ++browsed;
     }
-    Assertions.assertEquals(10, browsed);
+    assertThat(browsed).isEqualTo(10);
 
     select = database.select().fromType("Vertex")//
         .where().property("id").lt().value(10)//
@@ -243,10 +248,10 @@ public class SelectExecutionIT extends TestHelper {
     iter = select.vertices();
     browsed = 0;
     while (iter.hasNext()) {
-      Assertions.assertTrue(iter.next().getInteger("id") < 10);
+      assertThat(iter.next().getInteger("id") < 10).isTrue();
       ++browsed;
     }
-    Assertions.assertEquals(8, browsed);
+    assertThat(browsed).isEqualTo(8);
   }
 
   @Test
@@ -262,7 +267,7 @@ public class SelectExecutionIT extends TestHelper {
     database.select().fromType("Vertex")//
         .where().property("id").lt().value(10)//
         .and().property("name").eq().value("Elon").limit(10).vertices()
-        .forEachRemaining(r -> Assertions.assertTrue(r.getInteger("id") < 10 && r.getBoolean("modified")));
+        .forEachRemaining(r -> assertTrue(r.getInteger("id") < 10 && r.getBoolean("modified")));
   }
 
   @Test
@@ -299,8 +304,8 @@ public class SelectExecutionIT extends TestHelper {
       final int finalI = i;
       final SelectIterator<Vertex> result = select.parameter("value", i).vertices();
       final List<Vertex> list = result.toList();
-      Assertions.assertEquals(99, list.size());
-      list.forEach(r -> Assertions.assertTrue(r.getInteger("id") != finalI));
+      assertThat(list.size()).isEqualTo(99);
+      list.forEach(r -> assertTrue(r.getInteger("id") != finalI));
     }
   }
 
@@ -327,8 +332,8 @@ public class SelectExecutionIT extends TestHelper {
 
       final SelectIterator<Vertex> result = select.vertices();
       final List<Vertex> list = result.toList();
-      Assertions.assertEquals(1_000_000, list.size());
-      list.forEach(r -> Assertions.assertTrue(r.getString("name").startsWith("E")));
+      assertThat(list.size()).isEqualTo(1_000_000);
+      list.forEach(r -> assertTrue(r.getString("name").startsWith("E")));
 
       System.out.println(i + " " + (System.currentTimeMillis() - beginTime));
     }
@@ -342,8 +347,8 @@ public class SelectExecutionIT extends TestHelper {
     for (int i = 0; i < 100; i++) {
       final SelectIterator<Vertex> result = select.parameter("value", i).vertices();
       final List<Vertex> list = result.toList();
-      Assertions.assertEquals(100, list.size());
-      list.forEach(r -> Assertions.assertTrue(r.getString("name").startsWith("E")));
+      assertThat(list.size()).isEqualTo(100);
+      list.forEach(r -> assertTrue(r.getString("name").startsWith("E")));
     }
   }
 
@@ -355,8 +360,8 @@ public class SelectExecutionIT extends TestHelper {
     for (int i = 0; i < 100; i++) {
       final SelectIterator<Vertex> result = select.parameter("value", i).vertices();
       final List<Vertex> list = result.toList();
-      Assertions.assertEquals(100, list.size());
-      list.forEach(r -> Assertions.assertTrue(r.getString("name").startsWith("E")));
+      assertThat(list.size()).isEqualTo(100);
+      list.forEach(r -> assertTrue(r.getString("name").startsWith("E")));
     }
   }
 
@@ -373,7 +378,7 @@ public class SelectExecutionIT extends TestHelper {
   public void okReuse() {
     final SelectCompiled select = database.select().fromType("Vertex").where().property("id").eq().parameter("value").compile();
     for (int i = 0; i < 100; i++)
-      Assertions.assertEquals(i, select.parameter("value", i).vertices().nextOrNull().getInteger("id"));
+      assertThat(select.parameter("value", i).vertices().nextOrNull().getInteger("id")).isEqualTo(i);
   }
 
   @Test
@@ -388,7 +393,7 @@ public class SelectExecutionIT extends TestHelper {
 
       final JSONObject json2 = database.select().json(json).compile().json();
 
-      Assertions.assertEquals(json, json2);
+      assertThat(json2).isEqualTo(json);
     }
   }
 
@@ -402,12 +407,11 @@ public class SelectExecutionIT extends TestHelper {
       if (!expectedException.equals(e.getClass()))
         e.printStackTrace();
 
-      Assertions.assertEquals(expectedException, e.getClass());
-      Assertions.assertTrue(e.getMessage().contains(mustContains),
-          "Expected '" + mustContains + "' in the error message. Error message is: " + e.getMessage());
+      assertThat(e.getClass()).isEqualTo(expectedException);
+      assertThat(e.getMessage().contains(mustContains)).as("Expected '" + mustContains + "' in the error message. Error message is: " + e.getMessage()).isTrue();
     }
 
     if (!failed)
-      Assertions.fail("Expected exception " + expectedException);
+      fail("Expected exception " + expectedException);
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/select/SelectIndexExecutionIT.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectIndexExecutionIT.java
@@ -23,10 +23,12 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.schema.VertexType;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -66,13 +68,13 @@ public class SelectIndexExecutionIT extends TestHelper {
         final SelectIterator<Vertex> result = select.parameter("value", i).vertices();
 
         final List<Vertex> list = result.toList();
-        Assertions.assertEquals(i < 100 ? 1 : 0, list.size());
+        assertThat(list.size()).isEqualTo(i < 100 ? 1 : 0);
 
-        list.forEach(r -> Assertions.assertTrue(r.getInteger("id") == finalI && r.getString("name").equals("Elon")));
+        list.forEach(r -> assertThat(r.getInteger("id") == finalI && r.getString("name").equals("Elon")).isTrue());
 
         // CHECK 1 FOR ID = I + 100 FOR NAME = ELON (ALL OF THEM)
-        Assertions.assertEquals(1L, result.getMetrics().get("evaluatedRecords"), "With id " + i);
-        Assertions.assertEquals(1, result.getMetrics().get("usedIndexes"));
+        assertThat(result.getMetrics().get("evaluatedRecords")).as("With id " + i).isEqualTo(1L);
+        assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(1);
       }
     }
   }
@@ -89,11 +91,11 @@ public class SelectIndexExecutionIT extends TestHelper {
         final int finalI = i;
         final SelectIterator<Vertex> result = select.parameter("value", i).vertices();
 
-        result.forEachRemaining(r -> Assertions.assertTrue(r.getInteger("id") == finalI || r.getString("name").equals("Elon")));
+        result.forEachRemaining(r -> assertThat(r.getInteger("id") == finalI || r.getString("name").equals("Elon")).isTrue());
 
         // CHECK 1 FOR ID = I + 100 FOR NAME = ELON (ALL OF THEM)
-        Assertions.assertEquals(i < 100 ? 100L : 101L, result.getMetrics().get("evaluatedRecords"), "" + finalI);
-        Assertions.assertEquals(2, result.getMetrics().get("usedIndexes"));
+        assertThat(result.getMetrics().get("evaluatedRecords")).as("" + finalI).isEqualTo(i < 100 ? 100L : 101L);
+        assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(2);
       }
     }
   }
@@ -110,11 +112,11 @@ public class SelectIndexExecutionIT extends TestHelper {
         final int finalI = i;
         final SelectIterator<Vertex> result = select.parameter("value", i).vertices();
 
-        result.forEachRemaining(r -> Assertions.assertEquals((int) r.getInteger("id"), finalI));
+        result.forEachRemaining(r -> assertThat((int) r.getInteger("id")).isEqualTo(finalI));
 
         // CHECK 1 FOR ID = I + 100 FOR NAME = ELON (ALL OF THEM)
-        Assertions.assertEquals(1L, result.getMetrics().get("evaluatedRecords"));
-        Assertions.assertEquals(1, result.getMetrics().get("usedIndexes"));
+        assertThat(result.getMetrics().get("evaluatedRecords")).isEqualTo(1L);
+        assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(1);
       }
     }
 
@@ -128,11 +130,11 @@ public class SelectIndexExecutionIT extends TestHelper {
         final int finalI = i;
         final SelectIterator<Vertex> result = select.parameter("value", i).vertices();
 
-        result.forEachRemaining(r -> Assertions.assertEquals((int) r.getInteger("id"), finalI));
+        result.forEachRemaining(r -> assertThat((int) r.getInteger("id")).isEqualTo(finalI));
 
         // CHECK 1 FOR ID = I + 100 FOR NAME = ELON (ALL OF THEM)
-        Assertions.assertEquals(1L, result.getMetrics().get("evaluatedRecords"));
-        Assertions.assertEquals(1, result.getMetrics().get("usedIndexes"));
+        assertThat(result.getMetrics().get("evaluatedRecords")).isEqualTo(1L);
+        assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(1);
       }
     }
   }
@@ -150,8 +152,8 @@ public class SelectIndexExecutionIT extends TestHelper {
         result.toList();
 
         // CHECK 1 FOR ID = I + 100 FOR NAME = ELON (ALL OF THEM)
-        Assertions.assertEquals(110L, result.getMetrics().get("evaluatedRecords"));
-        Assertions.assertEquals(0, result.getMetrics().get("usedIndexes"));
+        assertThat(result.getMetrics().get("evaluatedRecords")).isEqualTo(110L);
+        assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(0);
       }
     }
 
@@ -166,8 +168,8 @@ public class SelectIndexExecutionIT extends TestHelper {
         result.toList();
 
         // CHECK 1 FOR ID = I + 100 FOR NAME = ELON (ALL OF THEM)
-        Assertions.assertEquals(110L, result.getMetrics().get("evaluatedRecords"));
-        Assertions.assertEquals(0, result.getMetrics().get("usedIndexes"));
+        assertThat(result.getMetrics().get("evaluatedRecords")).isEqualTo(110L);
+        assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(0);
       }
     }
 
@@ -183,13 +185,13 @@ public class SelectIndexExecutionIT extends TestHelper {
         final SelectIterator<Vertex> result = select.parameter("value", i).vertices();
 
         final List<Vertex> list = result.toList();
-        Assertions.assertEquals(1, list.size());
+        assertThat(list.size()).isEqualTo(1);
 
-        list.forEach(r -> Assertions.assertEquals((int) r.getInteger("id"), finalI));
+        list.forEach(r -> assertThat((int) r.getInteger("id")).isEqualTo(finalI));
 
         // CHECK 1 FOR ID = I + 100 FOR NAME = ELON (ALL OF THEM)
-        Assertions.assertEquals(1L, result.getMetrics().get("evaluatedRecords"));
-        Assertions.assertEquals(2, result.getMetrics().get("usedIndexes"));
+        assertThat(result.getMetrics().get("evaluatedRecords")).isEqualTo(1L);
+        assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(2);
       }
     }
 
@@ -205,9 +207,9 @@ public class SelectIndexExecutionIT extends TestHelper {
         final int finalI = i;
         final SelectIterator<Vertex> result = select.parameter("value", i).vertices();
         final List<Vertex> list = result.toList();
-        Assertions.assertEquals(109 - i, list.size());
-        list.forEach(r -> Assertions.assertTrue(r.getInteger("id") > finalI));
-        Assertions.assertEquals(1, result.getMetrics().get("usedIndexes"));
+        assertThat(list.size()).isEqualTo(109 - i);
+        list.forEach(r -> assertThat(r.getInteger("id")).isGreaterThan(finalI));
+        assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(1);
       }
     }
 
@@ -219,9 +221,9 @@ public class SelectIndexExecutionIT extends TestHelper {
         final int finalI = i;
         final SelectIterator<Vertex> result = select.parameter("value", i).vertices();
         final List<Vertex> list = result.toList();
-        Assertions.assertEquals(110 - i, list.size());
-        list.forEach(r -> Assertions.assertTrue(r.getInteger("id") >= finalI));
-        Assertions.assertEquals(1, result.getMetrics().get("usedIndexes"));
+        assertThat(list.size()).isEqualTo(110 - i);
+        list.forEach(r -> assertThat(r.getInteger("id")).isGreaterThanOrEqualTo(finalI));
+        assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(1);
       }
     }
 
@@ -233,9 +235,9 @@ public class SelectIndexExecutionIT extends TestHelper {
         final int finalI = i;
         final SelectIterator<Vertex> result = select.parameter("value", i).vertices();
         final List<Vertex> list = result.toList();
-        Assertions.assertEquals(i, list.size());
-        list.forEach(r -> Assertions.assertTrue(r.getInteger("id") < finalI));
-        Assertions.assertEquals(1, result.getMetrics().get("usedIndexes"));
+        assertThat(list.size()).isEqualTo(i);
+        list.forEach(r -> assertThat(r.getInteger("id")).isLessThan(finalI));
+        assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(1);
       }
     }
 
@@ -247,9 +249,9 @@ public class SelectIndexExecutionIT extends TestHelper {
         final int finalI = i;
         final SelectIterator<Vertex> result = select.parameter("value", i).vertices();
         final List<Vertex> list = result.toList();
-        Assertions.assertEquals(i + 1, list.size());
-        list.forEach(r -> Assertions.assertTrue(r.getInteger("id") <= finalI));
-        Assertions.assertEquals(1, result.getMetrics().get("usedIndexes"));
+        assertThat(list.size()).isEqualTo(i + 1);
+        list.forEach(r -> assertThat(r.getInteger("id")).isLessThanOrEqualTo(finalI));
+        assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(1);
       }
     }
 
@@ -261,9 +263,9 @@ public class SelectIndexExecutionIT extends TestHelper {
         final int finalI = i;
         final SelectIterator<Vertex> result = select.parameter("value", i).vertices();
         final List<Vertex> list = result.toList();
-        Assertions.assertEquals(109, list.size());
-        list.forEach(r -> Assertions.assertTrue(r.getInteger("id") != finalI));
-        Assertions.assertEquals(0, result.getMetrics().get("usedIndexes"));
+        assertThat(list.size()).isEqualTo(109);
+        list.forEach(r -> assertThat(r.getInteger("id")).isNotEqualTo(finalI));
+        assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(0);
       }
     }
   }

--- a/engine/src/test/java/com/arcadedb/query/select/SelectOrderByIT.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectOrderByIT.java
@@ -23,8 +23,9 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.schema.VertexType;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -61,11 +62,11 @@ public class SelectOrderByIT extends TestHelper {
 
       while (result.hasNext()) {
         final Integer id = result.next().getInteger("notIndexedId");
-        Assertions.assertTrue(id > lastId);
+        assertThat(id > lastId).isTrue();
         lastId = id;
       }
 
-      Assertions.assertEquals(0, result.getMetrics().get("usedIndexes"));
+      assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(0);
     }
 
     // DESCENDING
@@ -76,11 +77,11 @@ public class SelectOrderByIT extends TestHelper {
 
       while (result.hasNext()) {
         final Integer id = result.next().getInteger("notIndexedId");
-        Assertions.assertTrue(id < lastId);
+        assertThat(id < lastId).isTrue();
         lastId = id;
       }
 
-      Assertions.assertEquals(0, result.getMetrics().get("usedIndexes"));
+      assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(0);
 
     }
   }
@@ -95,11 +96,11 @@ public class SelectOrderByIT extends TestHelper {
 
       while (result.hasNext()) {
         final Integer id = result.next().getInteger("id");
-        Assertions.assertTrue(id > lastId);
+        assertThat(id > lastId).isTrue();
         lastId = id;
       }
 
-      Assertions.assertEquals(1, result.getMetrics().get("usedIndexes"));
+      assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(1);
     }
 
     // DESCENDING
@@ -110,11 +111,11 @@ public class SelectOrderByIT extends TestHelper {
 
       while (result.hasNext()) {
         final Integer id = result.next().getInteger("id");
-        Assertions.assertTrue(id < lastId);
+        assertThat(id < lastId).isTrue();
         lastId = id;
       }
 
-      Assertions.assertEquals(1, result.getMetrics().get("usedIndexes"));
+      assertThat(result.getMetrics().get("usedIndexes")).isEqualTo(1);
 
     }
   }

--- a/engine/src/test/java/com/arcadedb/query/sql/BatchTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/BatchTest.java
@@ -22,8 +22,13 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class BatchTest extends TestHelper {
   @Test
@@ -31,16 +36,16 @@ public class BatchTest extends TestHelper {
     database.transaction(() -> {
       final ResultSet rs = database.command("SQLSCRIPT", "let a = select 1 as result;let b = select 2 as result;return [$a,$b];");
 
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       Result record = rs.next();
-      Assertions.assertNotNull(record);
-      Assertions.assertEquals("{\"value\":[{\"result\":1}]}", record.toJSON().toString());
+      assertThat(record).isNotNull();
+      assertThat(record.toJSON().toString()).isEqualTo("{\"value\":[{\"result\":1}]}");
 
       record = rs.next();
-      Assertions.assertEquals("{\"value\":[{\"result\":2}]}", record.toJSON().toString());
-      Assertions.assertNotNull(record);
+      assertThat(record.toJSON().toString()).isEqualTo("{\"value\":[{\"result\":2}]}");
+      assertThat(record).isNotNull();
 
-      Assertions.assertFalse(rs.hasNext());
+      assertThat(rs.hasNext()).isFalse();
     });
   }
 
@@ -49,16 +54,16 @@ public class BatchTest extends TestHelper {
     database.transaction(() -> {
       final ResultSet rs = database.command("SQLScript", "let a = select 1 as result;let b = select 2 as result;return [$a,$b];");
 
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       Result record = rs.next();
-      Assertions.assertNotNull(record);
-      Assertions.assertEquals("{\"value\":[{\"result\":1}]}", record.toJSON().toString());
+      assertThat(record).isNotNull();
+      assertThat(record.toJSON().toString()).isEqualTo("{\"value\":[{\"result\":1}]}");
 
       record = rs.next();
-      Assertions.assertEquals("{\"value\":[{\"result\":2}]}", record.toJSON().toString());
-      Assertions.assertNotNull(record);
+      assertThat(record.toJSON().toString()).isEqualTo("{\"value\":[{\"result\":2}]}");
+      assertThat(record).isNotNull();
 
-      Assertions.assertFalse(rs.hasNext());
+      assertThat(rs.hasNext()).isFalse();
     });
   }
 
@@ -79,7 +84,7 @@ public class BatchTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from TestWhile order by id");
     for (int i = 0; i < 10; i++) {
       final Result record = result.next();
-      Assertions.assertEquals(i, (int) record.getProperty("id"));
+      assertThat((int) record.getProperty("id")).isEqualTo(i);
     }
   }
 
@@ -103,9 +108,9 @@ public class BatchTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from TestWhileWithReturn order by id");
     for (int i = 0; i < 5; i++) {
       final Result record = result.next();
-      Assertions.assertEquals(i, (int) record.getProperty("id"));
+      assertThat((int) record.getProperty("id")).isEqualTo(i);
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
   }
 
   @Test
@@ -123,7 +128,7 @@ public class BatchTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from TestForeach order by id");
     for (int i = 1; i <= 3; i++) {
       final Result record = result.next();
-      Assertions.assertEquals(i, (int) record.getProperty("id"));
+      assertThat((int) record.getProperty("id")).isEqualTo(i);
     }
   }
 
@@ -145,9 +150,9 @@ public class BatchTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from TestForeachWithReturn order by id");
     for (int i = 1; i <= 1; i++) {
       final Result record = result.next();
-      Assertions.assertEquals(i, (int) record.getProperty("id"));
+      assertThat((int) record.getProperty("id")).isEqualTo(i);
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
   }
 
   /**
@@ -171,8 +176,8 @@ public class BatchTest extends TestHelper {
         + "RETURN \"List is empty\";";
 
     final ResultSet result = database.command("sqlscript", script);
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertEquals("List element detected", result.next().getProperty("value"));
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next().<String>getProperty("value")).isEqualTo("List element detected");
   }
 
   /**
@@ -191,8 +196,8 @@ public class BatchTest extends TestHelper {
         + "RETURN $result;";
 
     final ResultSet result = database.command("sqlscript", script);
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertEquals("Return statement 2", result.next().getProperty("value"));
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next().<String>getProperty("value")).isEqualTo("Return statement 2");
   }
 
   // Isue https://github.com/ArcadeData/arcadedb/issues/1673
@@ -222,8 +227,8 @@ public class BatchTest extends TestHelper {
         + "RETURN $counter;";
 
     final ResultSet result = database.command("sqlscript", script);
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertEquals(7, (Integer) result.next().getProperty("value"));
+    assertThat(result.hasNext()).isTrue();
+    assertThat((Integer) result.next().getProperty("value")).isEqualTo(7);
   }
 
   @Test
@@ -243,22 +248,22 @@ public class BatchTest extends TestHelper {
         + "RETURN $counter;";
 
     final ResultSet result = database.command("sqlscript", script);
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertEquals(100, (Integer) result.next().getProperty("value"));
+    assertThat(result.hasNext()).isTrue();
+    assertThat((Integer) result.next().getProperty("value")).isEqualTo(100);
   }
 
   @Test
   public void testUsingReservedVariableNames() {
     try {
       database.command("sqlscript", "FOREACH ($parent IN [1, 2, 3]){\nRETURN;\n}");
-      Assertions.fail();
+      fail("");
     } catch (CommandSQLParsingException e) {
       // EXPECTED
     }
 
     try {
       database.command("sqlscript", "LET parent = 33;");
-      Assertions.fail();
+      fail("");
     } catch (CommandSQLParsingException e) {
       // EXPECTED
     }

--- a/engine/src/test/java/com/arcadedb/query/sql/DDLTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/DDLTest.java
@@ -19,7 +19,7 @@
 package com.arcadedb.query.sql;
 
 import com.arcadedb.TestHelper;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.stream.*;
@@ -62,17 +62,13 @@ public class DDLTest extends TestHelper {
     database.transaction(() -> {
 
       final Long persons = database.command("sql", "SELECT count(*) as persons FROM Person ").next().<Long>getProperty("persons");
-
-      Assertions.assertEquals(numOfElements, persons);
-
+      assertThat(persons).isEqualTo(numOfElements);
       final Long cars = database.command("sql", "SELECT count(*) as cars FROM Car").next().<Long>getProperty("cars");
 
-      Assertions.assertEquals(numOfElements, cars);
-
+      assertThat(cars).isEqualTo(numOfElements);
       final Long vs = database.command("sql", "SELECT count(*) as vs FROM V").next().<Long>getProperty("vs");
 
-      Assertions.assertEquals(numOfElements * 2, vs);
-
+      assertThat(vs).isEqualTo(numOfElements * 2);
       final Long edges = database.command("sql", "SELECT count(*) as edges FROM Drives").next().<Long>getProperty("edges");
 
     });

--- a/engine/src/test/java/com/arcadedb/query/sql/OrderByTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/OrderByTest.java
@@ -29,11 +29,14 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.time.*;
 import java.time.format.*;
+
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * From Issue https://github.com/ArcadeData/arcadedb/issues/839
@@ -81,7 +84,7 @@ public class OrderByTest {
         stop = LocalDateTime.parse("20220320T002323", FILENAME_TIME_FORMAT);
         Object[] parameters1 = { name, type, start, stop };
         try (ResultSet resultSet = database.command("sql", sqlString, parameters1)) {
-          Assertions.assertTrue(resultSet.hasNext());
+          assertThat(resultSet.hasNext()).isTrue();
           result = resultSet.next();
         } catch (Exception e) {
           System.out.println(e.getMessage());
@@ -98,15 +101,17 @@ public class OrderByTest {
 
         try (ResultSet resultSet = database.query("sql", sqlString, parameters3)) {
 
-          Assertions.assertTrue(resultSet.hasNext());
+          assertThat(resultSet.hasNext()).isTrue();
 
           while (resultSet.hasNext()) {
             result = resultSet.next();
 
             start = result.getProperty("start");
 
-            if (lastStart != null)
-              Assertions.assertTrue(start.compareTo(lastStart) <= 0, "" + start + " is greater than " + lastStart);
+            if (lastStart != null) {
+              assertThat(start.compareTo(lastStart)).isLessThanOrEqualTo(0)
+                  .withFailMessage("" + start + " is greater than " + lastStart);
+            }
 
             lastStart = start;
           }
@@ -116,15 +121,19 @@ public class OrderByTest {
 
         sqlString = "SELECT name, start, stop FROM Product WHERE type = ? AND start <= ? AND stop >= ? ORDER BY start ASC";
         try (ResultSet resultSet = database.query("sql", sqlString, parameters3)) {
-          Assertions.assertTrue(resultSet.hasNext());
+
+          assertThat(resultSet.hasNext()).isTrue();
 
           while (resultSet.hasNext()) {
             result = resultSet.next();
 
             start = result.getProperty("start");
 
-            if (lastStart != null)
-              Assertions.assertTrue(start.compareTo(lastStart) >= 0, "" + start + " is smaller than " + lastStart);
+            if (lastStart != null) {
+
+              assertThat(start.compareTo(lastStart)).isGreaterThanOrEqualTo(0)
+                  .withFailMessage("" + start + " is smaller than " + lastStart);
+            }
 
             lastStart = start;
           }

--- a/engine/src/test/java/com/arcadedb/query/sql/QueryAndIndexesTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/QueryAndIndexesTest.java
@@ -24,11 +24,13 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.VertexType;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.concurrent.atomic.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class QueryAndIndexesTest extends TestHelper {
   private static final int TOT = 10000;
@@ -66,20 +68,20 @@ public class QueryAndIndexesTest extends TestHelper {
       final AtomicInteger total = new AtomicInteger();
       while (rs.hasNext()) {
         final Result record = rs.next();
-        Assertions.assertNotNull(record);
+        assertThat(record).isNotNull();
 
         final Set<String> prop = new HashSet<>();
           prop.addAll(record.getPropertyNames());
 
-        Assertions.assertEquals(3, record.getPropertyNames().size(), 9);
-        Assertions.assertEquals(123, (int) record.getProperty("id"));
-        Assertions.assertEquals("Jay", record.getProperty("name"));
-        Assertions.assertEquals("Miner123", record.getProperty("surname"));
+        assertThat(record.getPropertyNames().size()).isEqualTo(3);
+        assertThat((int) record.getProperty("id")).isEqualTo(123);
+        assertThat(record.<String>getProperty("name")).isEqualTo("Jay");
+        assertThat(record.<String>getProperty("surname")).isEqualTo("Miner123");
 
         total.incrementAndGet();
       }
 
-      Assertions.assertEquals(1, total.get());
+      assertThat(total.get()).isEqualTo(1);
     });
   }
 
@@ -95,17 +97,17 @@ public class QueryAndIndexesTest extends TestHelper {
       final AtomicInteger total = new AtomicInteger();
       while (rs.hasNext()) {
         final Result record = rs.next();
-        Assertions.assertNotNull(record);
+        assertThat(record).isNotNull();
 
         final Set<String> prop = new HashSet<>();
           prop.addAll(record.getPropertyNames());
 
-        Assertions.assertEquals("Jay", record.getProperty("name"));
+        assertThat(record.<String>getProperty("name")).isEqualTo("Jay");
 
         total.incrementAndGet();
       }
 
-      Assertions.assertEquals(TOT, total.get());
+      assertThat(total.get()).isEqualTo(TOT);
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/QueryTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/QueryTest.java
@@ -32,6 +32,9 @@ import java.util.*;
 import java.util.concurrent.atomic.*;
 import java.util.logging.*;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+
 public class QueryTest extends TestHelper {
   private static final int TOT = 10000;
 
@@ -62,21 +65,21 @@ public class QueryTest extends TestHelper {
       final AtomicInteger total = new AtomicInteger();
       while (rs.hasNext()) {
         final Result record = rs.next();
-        Assertions.assertNotNull(record);
+        assertThat(record).isNotNull();
 
         final Set<String> prop = new HashSet<>();
         prop.addAll(record.getPropertyNames());
 
-        Assertions.assertEquals(3, record.getPropertyNames().size(), 9);
-        Assertions.assertTrue(prop.contains("id"));
-        Assertions.assertTrue(prop.contains("name"));
-        Assertions.assertTrue(prop.contains("surname"));
+        assertThat(record.getPropertyNames().size()).isEqualTo(3);
+        assertThat(prop).contains("id", "name", "surname");
 
         total.incrementAndGet();
       }
 
-      Assertions.assertEquals(TOT, total.get());
-    });
+      assertThat(total.get()).isEqualTo(TOT);
+
+    }
+    );
   }
 
   @Test
@@ -91,17 +94,16 @@ public class QueryTest extends TestHelper {
       final AtomicInteger total = new AtomicInteger();
       while (rs.hasNext()) {
         final Result record = rs.next();
-        Assertions.assertNotNull(record);
-
-        Assertions.assertEquals(3, record.getPropertyNames().size(), 9);
-        Assertions.assertEquals(123, (int) record.getProperty("id"));
-        Assertions.assertEquals("Jay", record.getProperty("name"));
-        Assertions.assertEquals("Miner123", record.getProperty("surname"));
+        assertThat(record).isNotNull();
+        assertThat(record.getPropertyNames().size()).isEqualTo(3);
+        assertThat((int) record.<Integer>getProperty("id")).isEqualTo(123);
+        assertThat(record.<String>getProperty("name")).isEqualTo("Jay");
+        assertThat(record.<String>getProperty("surname")).isEqualTo("Miner123");
 
         total.incrementAndGet();
       }
 
-      Assertions.assertEquals(1, total.get());
+      assertThat(total.get()).isEqualTo(1);
     });
   }
 
@@ -116,13 +118,12 @@ public class QueryTest extends TestHelper {
       final AtomicInteger total = new AtomicInteger();
       while (rs.hasNext()) {
         final Result record = rs.next();
-        Assertions.assertNotNull(record);
-
-        Assertions.assertEquals(3, record.getPropertyNames().size(), 9);
+        assertThat(record).isNotNull();
+        assertThat(record.getPropertyNames().size()).isEqualTo(3);
         total.incrementAndGet();
       }
 
-      Assertions.assertEquals(TOT, total.get());
+      assertThat(total.get()).isEqualTo(TOT);
     });
   }
 
@@ -138,25 +139,22 @@ public class QueryTest extends TestHelper {
       AtomicInteger total = new AtomicInteger();
       while (rs.hasNext()) {
         final Result record = rs.next();
-        Assertions.assertNotNull(record);
-
-        Assertions.assertEquals(3, record.getPropertyNames().size(), 9);
-        Assertions.assertEquals(123, (int) record.getProperty("id"));
-        Assertions.assertEquals("Jay", record.getProperty("name"));
-        Assertions.assertEquals("Miner123", record.getProperty("surname"));
+        assertThat(record).isNotNull();
+        assertThat(record.getPropertyNames().size()).isEqualTo(3);
+        assertThat((int) record.<Integer>getProperty("id")).isEqualTo(123);
+        assertThat(record.<String>getProperty("name")).isEqualTo("Jay");
+        assertThat(record.<String>getProperty("surname")).isEqualTo("Miner123");
 
         total.incrementAndGet();
       }
 
-      Assertions.assertEquals(1, total.get());
+      assertThat(total.get()).isEqualTo(1);
 
       // CHECK STATEMENT CACHE
-      Assertions.assertTrue(
-          ((DatabaseInternal) database).getStatementCache().contains("SELECT FROM V WHERE name = :name AND surname = :surname"));
+      assertThat(((DatabaseInternal) database).getStatementCache().contains("SELECT FROM V WHERE name = :name AND surname = :surname")).isTrue();
 
       // CHECK EXECUTION PLAN CACHE
-      Assertions.assertTrue(((DatabaseInternal) database).getExecutionPlanCache()
-          .contains("SELECT FROM V WHERE name = :name AND surname = :surname"));
+      assertThat(((DatabaseInternal) database).getExecutionPlanCache().contains("SELECT FROM V WHERE name = :name AND surname = :surname")).isTrue();
 
       // EXECUTE THE 2ND TIME
       rs = database.command("SQL", "SELECT FROM V WHERE name = :name AND surname = :surname", params);
@@ -164,17 +162,17 @@ public class QueryTest extends TestHelper {
       total = new AtomicInteger();
       while (rs.hasNext()) {
         final Result record = rs.next();
-        Assertions.assertNotNull(record);
-
-        Assertions.assertEquals(3, record.getPropertyNames().size(), 9);
-        Assertions.assertEquals(123, (int) record.getProperty("id"));
-        Assertions.assertEquals("Jay", record.getProperty("name"));
-        Assertions.assertEquals("Miner123", record.getProperty("surname"));
+        assertThat(record).isNotNull();
+assertThat(record).isNotNull();
+assertThat(record.getPropertyNames().size()).isEqualTo(3);
+assertThat((int) record.<Integer>getProperty("id")).isEqualTo(123);
+assertThat(record.<String>getProperty("name")).isEqualTo("Jay");
+assertThat(record.<String>getProperty("surname")).isEqualTo("Miner123");
 
         total.incrementAndGet();
       }
 
-      Assertions.assertEquals(1, total.get());
+      assertThat(total.get()).isEqualTo(1);
     });
   }
 
@@ -188,11 +186,11 @@ public class QueryTest extends TestHelper {
       final AtomicInteger total = new AtomicInteger();
       while (rs.hasNext()) {
         final Result record = rs.next();
-        Assertions.assertNotNull(record);
-        Assertions.assertTrue((int) record.getProperty("id") > TOT - 11);
+        assertThat(record).isNotNull();
+        assertThat(record.<Integer>getProperty("id") > TOT - 11).isTrue();
         total.incrementAndGet();
       }
-      Assertions.assertEquals(10, total.get());
+      assertThat(total.get()).isEqualTo(10);
     });
   }
 
@@ -206,11 +204,12 @@ public class QueryTest extends TestHelper {
       final AtomicInteger total = new AtomicInteger();
       while (rs.hasNext()) {
         final Result record = rs.next();
-        Assertions.assertNotNull(record);
-        Assertions.assertTrue((int) record.getProperty("id") >= TOT - 11);
+        assertThat(record).isNotNull();
+        assertThat(record.<Integer>getProperty("id") >= TOT - 11).isTrue();
+
         total.incrementAndGet();
       }
-      Assertions.assertEquals(11, total.get());
+      assertThat(total.get()).isEqualTo(11);
     });
   }
 
@@ -224,11 +223,11 @@ public class QueryTest extends TestHelper {
       final AtomicInteger total = new AtomicInteger();
       while (rs.hasNext()) {
         final Result record = rs.next();
-        Assertions.assertNotNull(record);
-        Assertions.assertTrue((int) record.getProperty("id") < 10);
+        assertThat(record).isNotNull();
+        assertThat( record.<Integer>getProperty("id") < 10).isTrue();
         total.incrementAndGet();
       }
-      Assertions.assertEquals(10, total.get());
+      assertThat(total.get()).isEqualTo(10);
     });
   }
 
@@ -242,11 +241,11 @@ public class QueryTest extends TestHelper {
       final AtomicInteger total = new AtomicInteger();
       while (rs.hasNext()) {
         final Result record = rs.next();
-        Assertions.assertNotNull(record);
-        Assertions.assertTrue((int) record.getProperty("id") <= 10);
+        assertThat(record).isNotNull();
+        assertThat(record.<Integer>getProperty("id") <= 10).isTrue();
         total.incrementAndGet();
       }
-      Assertions.assertEquals(11, total.get());
+      assertThat(total.get()).isEqualTo(11);
     });
   }
 
@@ -260,11 +259,11 @@ public class QueryTest extends TestHelper {
       final AtomicInteger total = new AtomicInteger();
       while (rs.hasNext()) {
         final Result record = rs.next();
-        Assertions.assertNotNull(record);
-        Assertions.assertTrue((int) record.getProperty("id") <= 10);
+        assertThat(record).isNotNull();
+        assertThat(record.<Integer>getProperty("id") <= 10).isTrue();
         total.incrementAndGet();
       }
-      Assertions.assertEquals(11, total.get());
+      assertThat(total.get()).isEqualTo(11);
     });
   }
 
@@ -276,11 +275,11 @@ public class QueryTest extends TestHelper {
       database.command("SQL", "CREATE VERTEX Foo SET name = 'bar'");
 
       final ResultSet rs = database.query("SQL", "SELECT FROM Foo");
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       rs.next();
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       rs.next();
-      Assertions.assertFalse(rs.hasNext());
+      assertThat(rs.hasNext()).isFalse();
 
       rs.close();
     });
@@ -297,9 +296,9 @@ public class QueryTest extends TestHelper {
           "CREATE EDGE TheEdge FROM (SELECT FROM Foo WHERE name ='foo') TO (SELECT FROM Foo WHERE name ='bar')");
 
       final ResultSet rs = database.query("SQL", "SELECT FROM TheEdge");
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       rs.next();
-      Assertions.assertFalse(rs.hasNext());
+      assertThat(rs.hasNext()).isFalse();
 
       rs.close();
     });
@@ -319,18 +318,18 @@ public class QueryTest extends TestHelper {
               + " WHERE name ='bar')");
 
       ResultSet rs = database.query("SQL", "SELECT FROM " + edgeClass);
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       rs.next();
-      Assertions.assertFalse(rs.hasNext());
+      assertThat(rs.hasNext()).isFalse();
 
       rs.close();
 
       rs = database.query("SQL", "SELECT out()[0].name as name from " + vertexClass + " where name = 'foo'");
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       final Result item = rs.next();
       final String name = item.getProperty("name");
-      Assertions.assertTrue(name.contains("bar"));
-      Assertions.assertFalse(rs.hasNext());
+      assertThat(name.contains("bar")).isTrue();
+      assertThat(rs.hasNext()).isFalse();
 
       rs.close();
     });
@@ -340,10 +339,10 @@ public class QueryTest extends TestHelper {
   public void testMethod() {
     database.transaction(() -> {
       final ResultSet rs = database.query("SQL", "SELECT 'bar'.prefix('foo') as name");
-      Assertions.assertTrue(rs.hasNext());
-      Assertions.assertEquals("foobar", rs.next().getProperty("name"));
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<String>getProperty("name")).isEqualTo("foobar");
 
-      Assertions.assertFalse(rs.hasNext());
+      assertThat(rs.hasNext()).isFalse();
 
       rs.close();
     });
@@ -363,17 +362,17 @@ public class QueryTest extends TestHelper {
               + " WHERE name ='bar')");
 
       ResultSet rs = database.query("SQL", "SELECT FROM " + edgeClass);
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       rs.next();
-      Assertions.assertFalse(rs.hasNext());
+      assertThat(rs.hasNext()).isFalse();
 
       rs.close();
 
       rs = database.query("SQL", "MATCH {type:" + vertexClass + ", as:a} -" + edgeClass + "->{}  RETURN $patterns");
       rs.getExecutionPlan().get().prettyPrint(0, 2);
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       final Result item = rs.next();
-      Assertions.assertFalse(rs.hasNext());
+      assertThat(rs.hasNext()).isFalse();
 
       rs.close();
     });
@@ -393,17 +392,17 @@ public class QueryTest extends TestHelper {
               + " WHERE name ='bar')");
 
       ResultSet rs = database.query("SQL", "SELECT FROM " + edgeClass);
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       rs.next();
-      Assertions.assertFalse(rs.hasNext());
+      assertThat(rs.hasNext()).isFalse();
 
       rs.close();
 
       rs = database.query("SQL", "MATCH {type:" + vertexClass + ", as:a} --> {}  RETURN $patterns");
       rs.getExecutionPlan().get().prettyPrint(0, 2);
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       final Result item = rs.next();
-      Assertions.assertFalse(rs.hasNext());
+      assertThat(rs.hasNext()).isFalse();
 
       rs.close();
     });
@@ -413,19 +412,19 @@ public class QueryTest extends TestHelper {
   public void testLike() {
     database.transaction(() -> {
       ResultSet rs = database.command("SQL", "SELECT FROM V WHERE surname LIKE '%in%' LIMIT 1");
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       rs.next();
-      Assertions.assertFalse(rs.hasNext());
+      assertThat(rs.hasNext()).isFalse();
       rs.close();
 
       rs = database.command("SQL", "SELECT FROM V WHERE surname LIKE 'Mi?er%' LIMIT 1");
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       rs.next();
-      Assertions.assertFalse(rs.hasNext());
+      assertThat(rs.hasNext()).isFalse();
       rs.close();
 
       rs = database.command("SQL", "SELECT FROM V WHERE surname LIKE 'baz' LIMIT 1");
-      Assertions.assertFalse(rs.hasNext());
+      assertThat(rs.hasNext()).isFalse();
       rs.close();
 
     });
@@ -439,20 +438,20 @@ public class QueryTest extends TestHelper {
       database.command("SQL", "insert into V set age = '100%'");
 
       ResultSet rs = database.command("SQL", "SELECT FROM V WHERE age LIKE '10\\%'");
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       Result result = rs.next();
-      Assertions.assertEquals("10%", result.getProperty("age"));
-      Assertions.assertFalse(rs.hasNext());
+      assertThat(result.<String>getProperty("age")).isEqualTo("10%");
+      assertThat(rs.hasNext()).isFalse();
       rs.close();
 
       rs = database.command("SQL", "SELECT FROM V WHERE age LIKE \"10%\" ORDER BY age");
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       result = rs.next();
-      Assertions.assertEquals("10%", result.getProperty("age"));
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(result.<String>getProperty("age")).isEqualTo("10%");
+      assertThat(rs.hasNext()).isTrue();
       result = rs.next();
-      Assertions.assertEquals("100%", result.getProperty("age"));
-      Assertions.assertFalse(rs.hasNext());
+      assertThat(result.<String>getProperty("age")).isEqualTo("100%");
+      assertThat(rs.hasNext()).isFalse();
       rs.close();
     });
   }
@@ -475,7 +474,7 @@ public class QueryTest extends TestHelper {
           final Result record = rs.next();
           LogManager.instance().log(this, Level.INFO, "Found record %s", null, record);
         }
-        Assertions.fail("Timeout should be triggered");
+        fail("Timeout should be triggered");
       } catch (final TimeoutException e) {
         // OK
       }
@@ -493,19 +492,19 @@ public class QueryTest extends TestHelper {
       final AtomicInteger total = new AtomicInteger();
       while (rs.hasNext()) {
         final Result record = rs.next();
-        Assertions.assertNotNull(record);
+        assertThat(record).isNotNull();
 
         final Set<String> prop = new HashSet<>();
         prop.addAll(record.getPropertyNames());
 
-        Assertions.assertEquals(2, record.getPropertyNames().size());
-        Assertions.assertTrue(prop.contains("@rid"));
-        Assertions.assertTrue(prop.contains("name"));
+        assertThat(record.getPropertyNames()).hasSize(2);
+        assertThat(prop.contains("@rid")).isTrue();
+        assertThat(prop.contains("name")).isTrue();
 
         total.incrementAndGet();
       }
 
-      Assertions.assertEquals(2, total.get());
+      assertThat(total.get()).isEqualTo(2);
     });
   }
 
@@ -522,7 +521,7 @@ public class QueryTest extends TestHelper {
       query += ")";
 
       try (ResultSet set = database.query("sql", query)) {
-        Assertions.assertEquals(set.stream().count(), 0);
+        assertThat(set.stream().count()).isEqualTo(0);
       }
     });
   }
@@ -530,11 +529,11 @@ public class QueryTest extends TestHelper {
   @Test
   public void testCollectionsInProjections() {
     try (ResultSet set = database.query("sql", "SELECT [\"a\",\"b\",\"c\"] as coll")) {
-      Collection coll = set.nextIfAvailable().getProperty("coll");
-      Assertions.assertEquals(3, coll.size());
-      Assertions.assertTrue(coll.contains("a"));
-      Assertions.assertTrue(coll.contains("b"));
-      Assertions.assertTrue(coll.contains("c"));
+      Collection<String> coll = set.nextIfAvailable().getProperty("coll");
+      assertThat(coll.size()).isEqualTo(3);
+      assertThat(coll.contains("a")).isTrue();
+      assertThat(coll.contains("b")).isTrue();
+      assertThat(coll.contains("c")).isTrue();
     }
   }
 
@@ -542,7 +541,7 @@ public class QueryTest extends TestHelper {
   public void testCollectionsInProjectionsContains() {
     try (ResultSet set = database.query("sql", "SELECT ([\"a\",\"b\",\"c\"] CONTAINS (@this ILIKE \"C\")) as coll")) {
       final Object coll = set.nextIfAvailable().getProperty("coll");
-      Assertions.assertTrue((Boolean) coll);
+      assertThat((Boolean) coll).isTrue();
     }
   }
 
@@ -551,7 +550,7 @@ public class QueryTest extends TestHelper {
     try (ResultSet set = database.query("sql",
         "SELECT ([{\"x\":\"a\"},{\"x\":\"b\"},{\"x\":\"c\"}] CONTAINS (x ILIKE \"C\")) as coll")) {
       final Object coll = set.nextIfAvailable().getProperty("coll");
-      Assertions.assertTrue((Boolean) coll);
+      assertThat((Boolean) coll).isTrue();
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/query/sql/SQLDeleteEdgeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/SQLDeleteEdgeTest.java
@@ -5,10 +5,13 @@ import com.arcadedb.database.Document;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.utility.CollectionUtils;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class SQLDeleteEdgeTest extends TestHelper {
   @Test
@@ -27,12 +30,12 @@ public class SQLDeleteEdgeTest extends TestHelper {
       database.command("sql", "CREATE EDGE testFromToTwoE from " + result.get(1).getIdentity() + " to " + result.get(0).getIdentity());
 
       List<Document> resultTwo = CollectionUtils.resultsetToListOfDocuments(database.query("sql", "select expand(outE()) from " + result.get(1).getIdentity()));
-      Assertions.assertEquals(resultTwo.size(), 2);
+      assertThat(resultTwo.size()).isEqualTo(2);
 
       database.command("sql", "DELETE EDGE testFromToTwoE from " + result.get(1).getIdentity() + " to" + result.get(0).getIdentity());
 
       resultTwo = CollectionUtils.resultsetToListOfDocuments(database.query("sql", "select expand(outE()) from " + result.get(1).getIdentity()));
-      Assertions.assertEquals(resultTwo.size(), 1);
+      assertThat(resultTwo.size()).isEqualTo(1);
 
       database.command("sql", "DELETE FROM testFromToOneE unsafe");
       database.command("sql", "DELETE FROM testFromToTwoE unsafe");
@@ -56,12 +59,12 @@ public class SQLDeleteEdgeTest extends TestHelper {
       database.command("sql", "CREATE EDGE testFromTwoE from " + result.get(1).getIdentity() + " to " + result.get(0).getIdentity());
 
       List<Document> resultTwo = CollectionUtils.resultsetToListOfDocuments(database.query("sql", "select expand(outE()) from " + result.get(1).getIdentity()));
-      Assertions.assertEquals(2, resultTwo.size());
+      assertThat(resultTwo.size()).isEqualTo(2);
 
       database.command("sql", "DELETE EDGE testFromTwoE from " + result.get(1).getIdentity());
 
       resultTwo = CollectionUtils.resultsetToListOfDocuments(database.query("sql", "select expand(outE()) from " + result.get(1).getIdentity()));
-      Assertions.assertEquals(1, resultTwo.size());
+      assertThat(resultTwo.size()).isEqualTo(1);
 
       database.command("sql", "DELETE FROM testFromOneE unsafe");
       database.command("sql", "DELETE FROM testFromTwoE unsafe");
@@ -85,12 +88,12 @@ public class SQLDeleteEdgeTest extends TestHelper {
       database.command("sql", "CREATE EDGE testToTwoE from " + result.get(1).getIdentity() + " to " + result.get(0).getIdentity());
 
       List<Document> resultTwo = CollectionUtils.resultsetToListOfDocuments(database.query("sql", "select expand(outE()) from " + result.get(1).getIdentity()));
-      Assertions.assertEquals(resultTwo.size(), 2);
+      assertThat(resultTwo.size()).isEqualTo(2);
 
       database.command("sql", "DELETE EDGE testToTwoE to " + result.get(0).getIdentity());
 
       resultTwo = CollectionUtils.resultsetToListOfDocuments(database.query("sql", "select expand(outE()) from " + result.get(1).getIdentity()));
-      Assertions.assertEquals(resultTwo.size(), 1);
+      assertThat(resultTwo.size()).isEqualTo(1);
 
       database.command("sql", "DELETE FROM testToOneE unsafe");
       database.command("sql", "DELETE FROM testToTwoE unsafe");
@@ -112,30 +115,30 @@ public class SQLDeleteEdgeTest extends TestHelper {
     database.transaction(() -> {
       try {
         database.command("sql", "DROP TYPE SuperV");
-        Assertions.assertTrue(false);
+        fail("Expected CommandExecutionException");
       } catch (final CommandExecutionException e) {
-        Assertions.assertTrue(true);
+        assertThat(true).isTrue();
       }
 
       try {
         database.command("sql", "DROP TYPE SuperE");
-        Assertions.assertTrue(false);
+        fail("Expected CommandExecutionException");
       } catch (final CommandExecutionException e) {
-        Assertions.assertTrue(true);
+        assertThat(true).isTrue();
       }
 
       try {
         database.command("sql", "DROP TYPE SuperV unsafe");
-        Assertions.assertTrue(true);
+        assertThat(true).isTrue();
       } catch (final CommandExecutionException e) {
-        Assertions.assertTrue(false);
+        fail("Unexpected CommandExecutionException");
       }
 
       try {
         database.command("sql", "DROP TYPE SuperE UNSAFE");
-        Assertions.assertTrue(true);
+        assertThat(true).isTrue();
       } catch (final CommandExecutionException e) {
-        Assertions.assertTrue(false);
+        fail("Unexpected CommandExecutionException");
       }
     });
   }
@@ -152,32 +155,32 @@ public class SQLDeleteEdgeTest extends TestHelper {
 
       try {
         database.command("sql", "DROP TYPE SuperV");
-        Assertions.fail();
+        fail("Expected CommandExecutionException");
       } catch (final CommandExecutionException e) {
-        Assertions.assertTrue(true);
+        assertThat(true).isTrue();
       }
 
       try {
         database.command("sql", "DROP TYPE SuperE");
-        Assertions.fail();
+        fail("Expected CommandExecutionException");
       } catch (final CommandExecutionException e) {
-        Assertions.assertTrue(true);
+        assertThat(true).isTrue();
       }
 
       final long deleted = database.command("sql", "DELETE FROM SuperV").nextIfAvailable().getProperty("count", 0);
 
       try {
         database.command("sql", "DROP TYPE SuperV");
-        Assertions.assertTrue(true);
+        assertThat(true).isTrue();
       } catch (final CommandExecutionException e) {
-        Assertions.assertTrue(false);
+        fail("Unexpected CommandExecutionException");
       }
 
       try {
         database.command("sql", "DROP TYPE SuperE");
-        Assertions.assertTrue(true);
+        assertThat(true).isTrue();
       } catch (final CommandExecutionException e) {
-        Assertions.assertTrue(false);
+        fail("Unexpected CommandExecutionException");
       }
     });
   }
@@ -196,13 +199,13 @@ public class SQLDeleteEdgeTest extends TestHelper {
       database.command("sql", "create edge FromInStringE from " + v1.getIdentity() + " to " + v3.getIdentity());
 
       List<Document> result = CollectionUtils.resultsetToListOfDocuments(database.query("sql", "SELECT expand(out()[name = ' FROM ']) FROM FromInStringV"));
-      Assertions.assertEquals(result.size(), 1);
+      assertThat(result.size()).isEqualTo(1);
 
       result = CollectionUtils.resultsetToListOfDocuments(database.query("sql", "SELECT expand(in()[name = ' from ']) FROM FromInStringV"));
-      Assertions.assertEquals(result.size(), 2);
+      assertThat(result.size()).isEqualTo(2);
 
       result = CollectionUtils.resultsetToListOfDocuments(database.query("sql", "SELECT expand(out()[name = ' TO ']) FROM FromInStringV"));
-      Assertions.assertEquals(result.size(), 1);
+      assertThat(result.size()).isEqualTo(1);
     });
   }
 
@@ -210,13 +213,13 @@ public class SQLDeleteEdgeTest extends TestHelper {
   public void testDeleteVertexWithReturn() {
     database.transaction(() -> {
       database.command("sql", "create vertex type V");
-      final Identifiable v1 = CollectionUtils.getFirstResultAsDocument(database.command("sql", "create vertex V set returning = true"));
+      final Document v1 = CollectionUtils.getFirstResultAsDocument(database.command("sql", "create vertex V set returning = true"));
 
       final List<Document> v2s = CollectionUtils.resultsetToListOfDocuments(
-          database.command("sql", "delete vertex from V return before where returning = true"));
+              database.command("sql", "delete vertex from V return before where returning = true"));
 
-      Assertions.assertEquals(v2s.size(), 1);
-      Assertions.assertTrue(v2s.contains(v1));
+      assertThat(v2s.size()).isEqualTo(1);
+      assertThat(v2s).contains(v1);
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/SQLScriptTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/SQLScriptTest.java
@@ -7,10 +7,12 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.CollectionUtils;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SQLScriptTest extends TestHelper {
   public void beginTest() {
@@ -32,7 +34,7 @@ public class SQLScriptTest extends TestHelper {
     script.append("return $a;\n");
     ResultSet qResult = database.command("sqlscript", script.toString());
 
-    Assertions.assertEquals(3, CollectionUtils.countEntries(qResult));
+    assertThat(CollectionUtils.countEntries(qResult)).isEqualTo(3);
   }
 
   @Test
@@ -44,7 +46,7 @@ public class SQLScriptTest extends TestHelper {
     script.append("return $a;\n");
     ResultSet qResult = database.command("SQLScript", script.toString());
 
-    Assertions.assertEquals(3, CollectionUtils.countEntries(qResult));
+    assertThat(CollectionUtils.countEntries(qResult)).isEqualTo(3);
   }
 
   @Test
@@ -56,7 +58,7 @@ public class SQLScriptTest extends TestHelper {
     script.append("return $a;\n");
     Document qResult = database.command("SQLScript", script.toString()).next().toElement();
 
-    Assertions.assertNotNull(qResult);
+    assertThat(qResult).isNotNull();
   }
 
   @Test
@@ -66,8 +68,7 @@ public class SQLScriptTest extends TestHelper {
       script.append("let $a = insert into V set test = 'sql script test';\n");
       script.append("return $a.asJSON();\n");
       String qResult = database.command("SQLScript", script.toString()).next().getProperty("value").toString();
-      Assertions.assertNotNull(qResult);
-
+      assertThat(qResult).isNotNull();
       // VALIDATE JSON
       new JSONObject(qResult);
 
@@ -76,10 +77,10 @@ public class SQLScriptTest extends TestHelper {
       script.append("return $a.asJSON();\n");
       String result = database.command("SQLScript", script.toString()).next().getProperty("value").toString();
 
-      Assertions.assertNotNull(result);
+
+      assertThat(result).isNotNull();
       result = result.trim();
-      Assertions.assertTrue(result.startsWith("{"));
-      Assertions.assertTrue(result.endsWith("}"));
+      assertThat(result).startsWith("{").endsWith("}");
 
       // VALIDATE JSON
       new JSONObject(result);
@@ -95,7 +96,7 @@ public class SQLScriptTest extends TestHelper {
     script.append("sleep 500");
     database.command("SQLScript", script.toString());
 
-    Assertions.assertTrue(System.currentTimeMillis() - begin >= 500);
+    assertThat(System.currentTimeMillis() - begin >= 500).isTrue();
   }
 
   //@Test
@@ -128,10 +129,10 @@ public class SQLScriptTest extends TestHelper {
     script.append("return [{ a: 'b' }]");
     ResultSet result = database.command("SQLScript", script.toString());
 
-    Assertions.assertNotNull(result);
+    assertThat(Optional.ofNullable(result)).isNotNull();
 
-    Assertions.assertEquals("b", result.next().getProperty("a"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.next().<String>getProperty("a")).isEqualTo("b");
+    assertThat(result.hasNext()).isFalse();
   }
 
   @Test
@@ -145,10 +146,9 @@ public class SQLScriptTest extends TestHelper {
       script.append("UPDATE TestCounter SET weight += $counter[0].count RETURN AfTER @this;\n");
       ResultSet qResult = database.command("SQLScript", script.toString());
 
-      Assertions.assertTrue(qResult.hasNext());
-      final Result result = qResult.next();
-
-      Assertions.assertEquals(4L, (Long) result.getProperty("weight"));
+      assertThat(qResult.hasNext()).isTrue();
+      Result result = qResult.next();
+      assertThat(result.<Long>getProperty("weight")).isEqualTo(4L);
     });
   }
 
@@ -163,8 +163,8 @@ public class SQLScriptTest extends TestHelper {
     script.append("return 'FAIL';\n");
     ResultSet qResult = database.command("SQLScript", script.toString());
 
-    Assertions.assertNotNull(qResult);
-    Assertions.assertEquals(qResult.next().getProperty("value"), "OK");
+    assertThat(Optional.ofNullable(qResult)).isNotNull();
+    assertThat(qResult.next().<String>getProperty("value")).isEqualTo("OK");
   }
 
   @Test
@@ -178,8 +178,8 @@ public class SQLScriptTest extends TestHelper {
     script.append("return 'FAIL';\n");
     ResultSet qResult = database.command("SQLScript", script.toString());
 
-    Assertions.assertNotNull(qResult);
-    Assertions.assertEquals(qResult.next().getProperty("value"), "OK");
+    assertThat(Optional.ofNullable(qResult)).isNotNull();
+    assertThat(qResult.next().<String>getProperty("value")).isEqualTo("OK");
   }
 
   @Test
@@ -187,8 +187,8 @@ public class SQLScriptTest extends TestHelper {
     StringBuilder script = new StringBuilder();
     script.append("let $a = select 1 as one; if($a[0].one = 1){return 'OK';}return 'FAIL';");
     ResultSet qResult = database.command("SQLScript", script.toString());
-    Assertions.assertNotNull(qResult);
-    Assertions.assertEquals(qResult.next().getProperty("value"), "OK");
+    assertThat(Optional.ofNullable(qResult)).isNotNull();
+    assertThat(qResult.next().<String>getProperty("value")).isEqualTo("OK");
   }
 
   @Test
@@ -205,8 +205,8 @@ public class SQLScriptTest extends TestHelper {
     script.append("return 'FAIL';\n");
     ResultSet qResult = database.command("SQLScript", script.toString());
 
-    Assertions.assertNotNull(qResult);
-    Assertions.assertEquals(qResult.next().getProperty("value"), "OK");
+    assertThat(Optional.ofNullable(qResult)).isNotNull();
+    assertThat(qResult.next().<String>getProperty("value")).isEqualTo("OK");
   }
 
   @Test
@@ -223,8 +223,8 @@ public class SQLScriptTest extends TestHelper {
     script.append("return 'OK';\n");
     ResultSet qResult = database.command("SQLScript", script.toString());
 
-    Assertions.assertNotNull(qResult);
-    Assertions.assertEquals(qResult.next().getProperty("value"), "OK");
+    assertThat(Optional.ofNullable(qResult)).isNotNull();
+    assertThat(qResult.next().<String>getProperty("value")).isEqualTo("OK");
   }
 
   @Test
@@ -238,8 +238,8 @@ public class SQLScriptTest extends TestHelper {
     script.append("return 'FAIL';\n");
     ResultSet qResult = database.command("SQLScript", script.toString());
 
-    Assertions.assertNotNull(qResult);
-    Assertions.assertEquals(3, CollectionUtils.countEntries(qResult));
+    assertThat(Optional.ofNullable(qResult)).isNotNull();
+    assertThat(CollectionUtils.countEntries(qResult)).isEqualTo(3);
   }
 
   @Test
@@ -254,8 +254,8 @@ public class SQLScriptTest extends TestHelper {
     script.append("return 'FAIL';\n");
     ResultSet qResult = database.command("SQLScript", script.toString());
 
-    Assertions.assertNotNull(qResult);
-    Assertions.assertEquals(qResult.next().getProperty("value"), "OK");
+    assertThat(Optional.ofNullable(qResult)).isNotNull();
+    assertThat(qResult.next().<String>getProperty("value")).isEqualTo("OK");
   }
 
   @Test
@@ -276,8 +276,10 @@ public class SQLScriptTest extends TestHelper {
 
       ResultSet result = database.query("sql", "SELECT FROM QuotedRegex2");
       Document doc = result.next().toElement();
-      Assertions.assertFalse(result.hasNext());
-      Assertions.assertEquals("'';", doc.get("regexp"));
+
+      assertThat(result.hasNext()).isFalse();
+      assertThat(doc.get("regexp")).isEqualTo("'';");
+
     });
   }
 
@@ -299,7 +301,7 @@ public class SQLScriptTest extends TestHelper {
 
     rs = database.query("sql", "SELECT FROM " + className + " WHERE name = ?", "bozo");
 
-    Assertions.assertTrue(rs.hasNext());
+    assertThat(rs.hasNext()).isTrue();
     rs.next();
     rs.close();
   }
@@ -318,7 +320,7 @@ public class SQLScriptTest extends TestHelper {
 
     rs = database.query("sql", "SELECT FROM " + className + " WHERE name = ?", "bozo");
 
-    Assertions.assertTrue(rs.hasNext());
+    assertThat(rs.hasNext()).isTrue();
     rs.next();
     rs.close();
   }
@@ -327,6 +329,7 @@ public class SQLScriptTest extends TestHelper {
   public void testInsertJsonNewLines() {
     database.transaction(() -> {
       database.getSchema().createDocumentType("doc");
+
       final ResultSet result = database.command("sqlscript", "INSERT INTO doc CONTENT {\n" + //
           "\"head\" : {\n" + //
           "  \"vars\" : [ \"item\", \"itemLabel\" ]\n" + //
@@ -356,10 +359,10 @@ public class SQLScriptTest extends TestHelper {
           "    }\n" + //
           "}");
 
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result res = result.next();
-      Assertions.assertTrue(res.hasProperty("head"));
-      Assertions.assertTrue(res.hasProperty("results"));
+      assertThat(res.hasProperty("head")).isTrue();
+      assertThat(res.hasProperty("results")).isTrue();
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/AlterDatabaseExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/AlterDatabaseExecutionTest.java
@@ -20,8 +20,9 @@ package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -30,18 +31,18 @@ public class AlterDatabaseExecutionTest extends TestHelper {
   @Test
   public void testBasicCreateProperty() {
     final int defPageSize = ((int) GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE.getDefValue());
-    Assertions.assertEquals(defPageSize, database.getConfiguration().getValueAsInteger(GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE));
+    assertThat(database.getConfiguration().getValueAsInteger(GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE)).isEqualTo(defPageSize);
 
     database.command("sql", "ALTER DATABASE `arcadedb.bucketDefaultPageSize` 262144");
 
-    Assertions.assertEquals(262144, database.getConfiguration().getValueAsInteger(GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE));
+    assertThat(database.getConfiguration().getValueAsInteger(GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE)).isEqualTo(262144);
 
     database.command("sql", "ALTER DATABASE `arcadedb.bucketDefaultPageSize` " + defPageSize);
 
-    Assertions.assertEquals(defPageSize, database.getConfiguration().getValueAsInteger(GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE));
+    assertThat(database.getConfiguration().getValueAsInteger(GlobalConfiguration.BUCKET_DEFAULT_PAGE_SIZE)).isEqualTo(defPageSize);
 
     database.command("sql", "ALTER DATABASE `arcadedb.dateTimeFormat` 'yyyy-MM-dd HH:mm:ss.SSS'");
 
-    Assertions.assertEquals("yyyy-MM-dd HH:mm:ss.SSS", database.getSchema().getDateTimeFormat());
+    assertThat(database.getSchema().getDateTimeFormat()).isEqualTo("yyyy-MM-dd HH:mm:ss.SSS");
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/AlterTypeExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/AlterTypeExecutionTest.java
@@ -22,10 +22,11 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.database.bucketselectionstrategy.BucketSelectionStrategy;
 import com.arcadedb.database.bucketselectionstrategy.PartitionedBucketSelectionStrategy;
 import com.arcadedb.serializer.json.JSONObject;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.stream.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -35,40 +36,40 @@ public class AlterTypeExecutionTest extends TestHelper {
   public void sqlAlterTypeInheritanceUsing() {
     database.command("sql", "CREATE VERTEX TYPE Car");
 
-    Assertions.assertTrue(database.getSchema().getType("Car").getSuperTypes().isEmpty());
+    assertThat(database.getSchema().getType("Car").getSuperTypes().isEmpty()).isTrue();
 
     database.command("sql", "CREATE VERTEX TYPE Vehicle");
     database.command("sql", "ALTER TYPE Car SUPERTYPE +Vehicle");
 
-    Assertions.assertEquals(1, database.getSchema().getType("Car").getSuperTypes().size());
-    Assertions.assertTrue(database.getSchema().getType("Car").getSuperTypes().stream().map(x -> x.getName()).collect(Collectors.toSet()).contains("Vehicle"));
-    Assertions.assertEquals(1, database.getSchema().getType("Vehicle").getSubTypes().size());
-    Assertions.assertTrue(database.getSchema().getType("Vehicle").getSubTypes().stream().map(x -> x.getName()).collect(Collectors.toSet()).contains("Car"));
-    Assertions.assertTrue(database.getSchema().getType("Vehicle").isSuperTypeOf("Car"));
+    assertThat(database.getSchema().getType("Car").getSuperTypes().size()).isEqualTo(1);
+    assertThat(database.getSchema().getType("Car").getSuperTypes().stream().map(x -> x.getName()).collect(Collectors.toSet()).contains("Vehicle")).isTrue();
+    assertThat(database.getSchema().getType("Vehicle").getSubTypes().size()).isEqualTo(1);
+    assertThat(database.getSchema().getType("Vehicle").getSubTypes().stream().map(x -> x.getName()).collect(Collectors.toSet()).contains("Car")).isTrue();
+    assertThat(database.getSchema().getType("Vehicle").isSuperTypeOf("Car")).isTrue();
 
     database.command("sql", "CREATE VERTEX TYPE Suv");
-    Assertions.assertTrue(database.getSchema().getType("Suv").getSuperTypes().isEmpty());
+    assertThat(database.getSchema().getType("Suv").getSuperTypes().isEmpty()).isTrue();
 
     database.command("sql", "ALTER TYPE Suv SUPERTYPE +Car");
-    Assertions.assertEquals(1, database.getSchema().getType("Suv").getSuperTypes().size());
-    Assertions.assertTrue(database.getSchema().getType("Car").isSuperTypeOf("Suv"));
-    Assertions.assertEquals(1, database.getSchema().getType("Car").getSubTypes().size());
-    Assertions.assertTrue(database.getSchema().getType("Car").getSubTypes().stream().map(x -> x.getName()).collect(Collectors.toSet()).contains("Suv"));
-    Assertions.assertTrue(database.getSchema().getType("Car").isSuperTypeOf("Suv"));
+    assertThat(database.getSchema().getType("Suv").getSuperTypes().size()).isEqualTo(1);
+    assertThat(database.getSchema().getType("Car").isSuperTypeOf("Suv")).isTrue();
+    assertThat(database.getSchema().getType("Car").getSubTypes().size()).isEqualTo(1);
+    assertThat(database.getSchema().getType("Car").getSubTypes().stream().map(x -> x.getName()).collect(Collectors.toSet()).contains("Suv")).isTrue();
+    assertThat(database.getSchema().getType("Car").isSuperTypeOf("Suv")).isTrue();
 
     database.command("sql", "ALTER TYPE Car SUPERTYPE -Vehicle");
-    Assertions.assertTrue(database.getSchema().getType("Car").getSuperTypes().isEmpty());
-    Assertions.assertTrue(database.getSchema().getType("Vehicle").getSubTypes().isEmpty());
+    assertThat(database.getSchema().getType("Car").getSuperTypes().isEmpty()).isTrue();
+    assertThat(database.getSchema().getType("Vehicle").getSubTypes().isEmpty()).isTrue();
 
     database.command("sql", "ALTER TYPE Suv SUPERTYPE +Vehicle, +Car");
-    Assertions.assertEquals(2, database.getSchema().getType("Suv").getSuperTypes().size());
-    Assertions.assertTrue(database.getSchema().getType("Car").isSuperTypeOf("Suv"));
-    Assertions.assertTrue(database.getSchema().getType("Vehicle").isSuperTypeOf("Suv"));
-    Assertions.assertEquals(1, database.getSchema().getType("Car").getSubTypes().size());
-    Assertions.assertEquals(1, database.getSchema().getType("Vehicle").getSubTypes().size());
-    Assertions.assertTrue(database.getSchema().getType("Car").getSubTypes().stream().map(x -> x.getName()).collect(Collectors.toSet()).contains("Suv"));
-    Assertions.assertTrue(database.getSchema().getType("Car").isSuperTypeOf("Suv"));
-    Assertions.assertTrue(database.getSchema().getType("Vehicle").isSuperTypeOf("Suv"));
+    assertThat(database.getSchema().getType("Suv").getSuperTypes().size()).isEqualTo(2);
+    assertThat(database.getSchema().getType("Car").isSuperTypeOf("Suv")).isTrue();
+    assertThat(database.getSchema().getType("Vehicle").isSuperTypeOf("Suv")).isTrue();
+    assertThat(database.getSchema().getType("Car").getSubTypes().size()).isEqualTo(1);
+    assertThat(database.getSchema().getType("Vehicle").getSubTypes().size()).isEqualTo(1);
+    assertThat(database.getSchema().getType("Car").getSubTypes().stream().map(x -> x.getName()).collect(Collectors.toSet()).contains("Suv")).isTrue();
+    assertThat(database.getSchema().getType("Car").isSuperTypeOf("Suv")).isTrue();
+    assertThat(database.getSchema().getType("Vehicle").isSuperTypeOf("Suv")).isTrue();
   }
 
   @Test
@@ -79,8 +80,8 @@ public class AlterTypeExecutionTest extends TestHelper {
     database.command("sql", "ALTER TYPE Account BucketSelectionStrategy `partitioned('id')`");
 
     final BucketSelectionStrategy strategy = database.getSchema().getType("Account").getBucketSelectionStrategy();
-    Assertions.assertEquals("partitioned", strategy.getName());
-    Assertions.assertEquals("id", ((PartitionedBucketSelectionStrategy) strategy).getProperties().get(0));
+    assertThat(strategy.getName()).isEqualTo("partitioned");
+    assertThat(((PartitionedBucketSelectionStrategy) strategy).getProperties().get(0)).isEqualTo("id");
   }
 
   @Test
@@ -88,18 +89,18 @@ public class AlterTypeExecutionTest extends TestHelper {
     database.command("sql", "CREATE VERTEX TYPE Suv");
 
     database.command("sql", "ALTER TYPE Suv CUSTOM description = 'test'");
-    Assertions.assertEquals("test", database.getSchema().getType("Suv").getCustomValue("description"));
+    assertThat(database.getSchema().getType("Suv").getCustomValue("description")).isEqualTo("test");
 
     database.command("sql", "ALTER TYPE Suv CUSTOM age = 3");
-    Assertions.assertEquals(3, database.getSchema().getType("Suv").getCustomValue("age"));
+    assertThat(database.getSchema().getType("Suv").getCustomValue("age")).isEqualTo(3);
 
     final JSONObject cfg = database.getSchema().getEmbedded().toJSON();
     final JSONObject customMap = cfg.getJSONObject("types").getJSONObject("Suv").getJSONObject("custom");
-    Assertions.assertEquals("test", customMap.getString("description"));
-    Assertions.assertEquals(3, customMap.getInt("age"));
+    assertThat(customMap.getString("description")).isEqualTo("test");
+    assertThat(customMap.getInt("age")).isEqualTo(3);
 
     database.command("sql", "ALTER TYPE Suv CUSTOM age = null");
-    Assertions.assertNull(database.getSchema().getType("Suv").getCustomValue("age"));
-    Assertions.assertFalse(database.getSchema().getType("Suv").getCustomKeys().contains("age"));
+    assertThat(database.getSchema().getType("Suv").getCustomValue("age")).isNull();
+    assertThat(database.getSchema().getType("Suv").getCustomKeys().contains("age")).isFalse();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/BeginStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/BeginStatementExecutionTest.java
@@ -19,8 +19,12 @@
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.TestHelper;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Luigi Dell'Aquila (l.dellaquila-(at)-orientdb.com)
@@ -29,15 +33,15 @@ public class BeginStatementExecutionTest {
   @Test
   public void testBegin() throws Exception {
     TestHelper.executeInNewDatabase("OCommitStatementExecutionTest", (db) -> {
-      Assertions.assertTrue(db.getTransaction() == null || !db.getTransaction().isActive());
+      assertThat(db.getTransaction() == null || !db.getTransaction().isActive()).isTrue();
       final ResultSet result = db.command("sql", "begin");
       //printExecutionPlan(null, result);
-      Assertions.assertNotNull(result);
-      Assertions.assertTrue(result.hasNext());
+      assertThat((Iterator<? extends Result>) result).isNotNull();
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertEquals("begin", item.getProperty("operation"));
-      Assertions.assertFalse(result.hasNext());
-      Assertions.assertFalse(db.getTransaction() == null || !db.getTransaction().isActive());
+      assertThat(item.<String>getProperty("operation")).isEqualTo("begin");
+      assertThat(result.hasNext()).isFalse();
+      assertThat(db.getTransaction() == null || !db.getTransaction().isActive()).isFalse();
       db.commit();
     });
   }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/CheckClusterTypeStepTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/CheckClusterTypeStepTest.java
@@ -21,8 +21,12 @@ package com.arcadedb.query.sql.executor;
 import com.arcadedb.TestHelper;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.schema.DocumentType;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.fail;
 
 public class CheckClusterTypeStepTest {
 
@@ -39,7 +43,8 @@ public class CheckClusterTypeStepTest {
       final CheckClusterTypeStep step = new CheckClusterTypeStep(CLASS_CLUSTER_NAME, clazz.getName(), context);
 
       final ResultSet result = step.syncPull(context, 20);
-      Assertions.assertEquals(0, result.stream().count());
+
+      assertThat(result.stream().count()).isEqualTo(0);
     });
   }
 
@@ -53,7 +58,7 @@ public class CheckClusterTypeStepTest {
 
         step.syncPull(context, 20);
       });
-      Assertions.fail("Expected CommandExecutionException");
+      fail("Expected CommandExecutionException");
     } catch (final CommandExecutionException e) {
       // OK
     }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/CheckRecordTypeStepTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/CheckRecordTypeStepTest.java
@@ -22,8 +22,12 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.schema.DocumentType;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.fail;
 
 public class CheckRecordTypeStepTest {
 
@@ -54,8 +58,8 @@ public class CheckRecordTypeStepTest {
 
       step.setPrevious(previous);
       final ResultSet result = step.syncPull(context, 20);
-      Assertions.assertEquals(10, result.stream().count());
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.stream().count()).isEqualTo(10);
+      assertThat(result.hasNext()).isFalse();
     });
   }
 
@@ -86,8 +90,8 @@ public class CheckRecordTypeStepTest {
 
       step.setPrevious(previous);
       final ResultSet result = step.syncPull(context, 20);
-      Assertions.assertEquals(10, result.stream().count());
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.stream().count()).isEqualTo(10);
+      assertThat(result.hasNext()).isFalse();
     });
   }
 
@@ -123,7 +127,7 @@ public class CheckRecordTypeStepTest {
           result.next();
         }
       });
-      Assertions.fail("Expected CommandExecutionException");
+      fail("Expected CommandExecutionException");
 
     } catch (final CommandExecutionException e) {
       // OK

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/CheckSafeDeleteStepTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/CheckSafeDeleteStepTest.java
@@ -20,8 +20,10 @@ package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.exception.TimeoutException;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class CheckSafeDeleteStepTest {
 
@@ -50,8 +52,8 @@ public class CheckSafeDeleteStepTest {
 
       step.setPrevious(previous);
       final ResultSet result = step.syncPull(context, 10);
-      Assertions.assertEquals(10, result.stream().count());
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.stream().count()).isEqualTo(10);
+      assertThat(result.hasNext()).isFalse();
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/CheckTypeTypeStepTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/CheckTypeTypeStepTest.java
@@ -21,8 +21,12 @@ package com.arcadedb.query.sql.executor;
 import com.arcadedb.TestHelper;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.schema.DocumentType;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.fail;
 
 public class CheckTypeTypeStepTest {
 
@@ -36,7 +40,7 @@ public class CheckTypeTypeStepTest {
       final CheckTypeTypeStep step = new CheckTypeTypeStep(childClass.getName(), parentClass.getName(), context);
 
       final ResultSet result = step.syncPull(context, 20);
-      Assertions.assertEquals(0, result.stream().count());
+      assertThat(result.stream().count()).isEqualTo(0);
     });
   }
 
@@ -49,7 +53,7 @@ public class CheckTypeTypeStepTest {
       final CheckTypeTypeStep step = new CheckTypeTypeStep(className, className, context);
 
       final ResultSet result = step.syncPull(context, 20);
-      Assertions.assertEquals(0, result.stream().count());
+      assertThat(result.stream().count()).isEqualTo(0);
     });
   }
 
@@ -64,7 +68,7 @@ public class CheckTypeTypeStepTest {
 
         step.syncPull(context, 20);
       });
-      Assertions.fail("Expected CommandExecutionException");
+      fail("Expected CommandExecutionException");
     } catch (final CommandExecutionException e) {
       // OK
     }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ConsoleStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ConsoleStatementExecutionTest.java
@@ -2,8 +2,13 @@ package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.exception.CommandExecutionException;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Luigi Dell'Aquila (l.dellaquila-(at)-orientdatabase.com)
@@ -13,34 +18,34 @@ public class ConsoleStatementExecutionTest extends TestHelper {
   @Test
   public void testError() {
     ResultSet result = database.command("sqlscript", "console.`error` 'foo bar'");
-    Assertions.assertNotNull(result);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(Optional.ofNullable(result)).isNotNull();
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals("error", item.getProperty("level"));
-    Assertions.assertEquals("foo bar", item.getProperty("message"));
+    assertThat(item).isNotNull();
+    assertThat(item.<String>getProperty("level")).isEqualTo("error");
+    assertThat(item.<String>getProperty("message")).isEqualTo("foo bar");
   }
 
   @Test
   public void testLog() {
     ResultSet result = database.command("sqlscript", "console.log 'foo bar'");
-    Assertions.assertNotNull(result);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(Optional.ofNullable(result)).isNotNull();
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals("log", item.getProperty("level"));
-    Assertions.assertEquals("foo bar", item.getProperty("message"));
+    assertThat(item).isNotNull();
+    assertThat(item.<String>getProperty("level")).isEqualTo("log");
+    assertThat(item.<String>getProperty("message")).isEqualTo("foo bar");
   }
 
   @Test
   public void testInvalidLevel() {
     try {
       database.command("sqlscript", "console.bla 'foo bar'");
-      Assertions.fail();
+      fail("");
     } catch (CommandExecutionException x) {
       // EXPECTED
     } catch (Exception x2) {
-      Assertions.fail();
+      fail("");
     }
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ConvertToResultInternalStepTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ConvertToResultInternalStepTest.java
@@ -22,10 +22,13 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.exception.TimeoutException;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
 
 public class ConvertToResultInternalStepTest {
 
@@ -68,13 +71,13 @@ public class ConvertToResultInternalStepTest {
       while (result.hasNext()) {
         final Result currentItem = result.next();
         if (!(currentItem.getClass().equals(ResultInternal.class))) {
-          Assertions.fail("There is an item in result set that is not an instance of ResultInternal");
+          fail("There is an item in result set that is not an instance of ResultInternal");
         }
         if (!currentItem.getElement().get().get(STRING_PROPERTY).equals(documents.get(counter).get(STRING_PROPERTY))) {
-          Assertions.fail("String Document property inside Result instance is not preserved");
+          fail("String Document property inside Result instance is not preserved");
         }
         if (!currentItem.getElement().get().get(INTEGER_PROPERTY).equals(documents.get(counter).get(INTEGER_PROPERTY))) {
-          Assertions.fail("Integer Document property inside Result instance is not preserved");
+          fail("Integer Document property inside Result instance is not preserved");
         }
         counter++;
       }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ConvertToUpdatableResultStepTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ConvertToUpdatableResultStepTest.java
@@ -22,10 +22,13 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.exception.TimeoutException;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
 
 public class ConvertToUpdatableResultStepTest {
 
@@ -69,13 +72,13 @@ public class ConvertToUpdatableResultStepTest {
       while (result.hasNext()) {
         final Result currentItem = result.next();
         if (!(currentItem.getClass().equals(UpdatableResult.class))) {
-          Assertions.fail("There is an item in result set that is not an instance of OUpdatableResult");
+          fail("There is an item in result set that is not an instance of OUpdatableResult");
         }
         if (!currentItem.getElement().get().get(STRING_PROPERTY).equals(documents.get(counter).get(STRING_PROPERTY))) {
-          Assertions.fail("String Document property inside Result instance is not preserved");
+          fail("String Document property inside Result instance is not preserved");
         }
         if (!currentItem.getElement().get().get(INTEGER_PROPERTY).equals(documents.get(counter).get(INTEGER_PROPERTY))) {
-          Assertions.fail("Integer Document property inside Result instance is not preserved");
+          fail("Integer Document property inside Result instance is not preserved");
         }
         counter++;
       }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/CountFromIndexStepTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/CountFromIndexStepTest.java
@@ -25,10 +25,13 @@ import com.arcadedb.query.sql.parser.IndexIdentifier;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
 
 public class CountFromIndexStepTest {
 
@@ -75,8 +78,8 @@ public class CountFromIndexStepTest {
       final CountFromIndexStep step = new CountFromIndexStep(identifier, ALIAS, context);
 
       final ResultSet result = step.syncPull(context, 20);
-      Assertions.assertEquals(20, (long) result.next().getProperty(ALIAS));
-      Assertions.assertFalse(result.hasNext());
+      assertThat((long) result.next().getProperty(ALIAS)).isEqualTo(20);
+      assertThat(result.hasNext()).isFalse();
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/CountFromTypeStepTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/CountFromTypeStepTest.java
@@ -20,8 +20,11 @@ package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.MutableDocument;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
 
 public class CountFromTypeStepTest {
 
@@ -41,8 +44,8 @@ public class CountFromTypeStepTest {
       final CountFromTypeStep step = new CountFromTypeStep(className, ALIAS, context);
 
       final ResultSet result = step.syncPull(context, 20);
-      Assertions.assertEquals(20, (long) result.next().getProperty(ALIAS));
-      Assertions.assertFalse(result.hasNext());
+      assertThat((long) result.next().getProperty(ALIAS)).isEqualTo(20);
+      assertThat(result.hasNext()).isFalse();
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/CountStepTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/CountStepTest.java
@@ -19,8 +19,9 @@
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.exception.TimeoutException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 public class CountStepTest {
@@ -55,7 +56,7 @@ public class CountStepTest {
 
     step.setPrevious(previous);
     final ResultSet result = step.syncPull(context, 100);
-    Assertions.assertEquals(100, (long) result.next().getProperty(COUNT_PROPERTY_NAME));
-    Assertions.assertFalse(result.hasNext());
+    assertThat((long) result.next().getProperty(COUNT_PROPERTY_NAME)).isEqualTo(100);
+    assertThat(result.hasNext()).isFalse();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/CreateDocumentTypeStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/CreateDocumentTypeStatementExecutionTest.java
@@ -21,8 +21,11 @@ package com.arcadedb.query.sql.executor;
 import com.arcadedb.TestHelper;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Luigi Dell'Aquila (l.dellaquila-(at)-orientdb.com)
@@ -35,7 +38,7 @@ public class CreateDocumentTypeStatementExecutionTest {
       final ResultSet result = db.command("sql", "create document type " + className);
       final Schema schema = db.getSchema();
       final DocumentType clazz = schema.getType(className);
-      Assertions.assertNotNull(clazz);
+      assertThat(clazz).isNotNull();
       result.close();
     });
   }
@@ -47,8 +50,8 @@ public class CreateDocumentTypeStatementExecutionTest {
       final ResultSet result = db.command("sql", "create document type " + className + " buckets 32");
       final Schema schema = db.getSchema();
       final DocumentType clazz = schema.getType(className);
-      Assertions.assertNotNull(clazz);
-      Assertions.assertEquals(32, clazz.getBuckets(false).size());
+      assertThat(clazz).isNotNull();
+      assertThat(clazz.getBuckets(false)).hasSize(32);
       result.close();
     });
   }
@@ -60,12 +63,12 @@ public class CreateDocumentTypeStatementExecutionTest {
       ResultSet result = db.command("sql", "create document type " + className + " if not exists");
       final Schema schema = db.getSchema();
       DocumentType clazz = schema.getType(className);
-      Assertions.assertNotNull(clazz);
+      assertThat(clazz).isNotNull();
       result.close();
 
       result = db.command("sql", "create document type " + className + " if not exists");
       clazz = schema.getType(className);
-      Assertions.assertNotNull(clazz);
+      assertThat(clazz).isNotNull();
       result.close();
     });
   }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/CreateEdgeStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/CreateEdgeStatementExecutionTest.java
@@ -22,8 +22,10 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.MutableVertex;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -56,17 +58,17 @@ public class CreateEdgeStatementExecutionTest extends TestHelper {
     int count = 0;
     while (result.hasNext()) {
       final Result r = result.next();
-      Assertions.assertTrue(r.isEdge());
+      assertThat(r.isEdge()).isTrue();
 
       Edge edge = r.getEdge().get();
 
-      Assertions.assertEquals(count, edge.getInteger("x"));
+      assertThat(edge.getInteger("x")).isEqualTo(count);
 
       ++count;
     }
     result.close();
 
-    Assertions.assertEquals(1, count);
+    assertThat(count).isEqualTo(1);
   }
 
   @Test
@@ -89,7 +91,7 @@ public class CreateEdgeStatementExecutionTest extends TestHelper {
 
     try {
       ResultSet result = database.command("sql", "create edge " + edgeClassName + " from ? to ? CONTENT " + array, v1, v2);
-      Assertions.fail();
+      fail("");
     } catch (CommandSQLParsingException e) {
       // EXPECTED
     }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/CreatePropertyStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/CreatePropertyStatementExecutionTest.java
@@ -25,10 +25,13 @@ import com.arcadedb.exception.ValidationException;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Property;
 import com.arcadedb.schema.Type;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Luigi Dell'Aquila (l.dellaquila-(at)-orientdb.com)
@@ -47,8 +50,8 @@ public class CreatePropertyStatementExecutionTest extends TestHelper {
     final DocumentType companyClass = database.getSchema().getType("testBasicCreateProperty");
     final Property nameProperty = companyClass.getProperty(PROP_NAME);
 
-    Assertions.assertEquals(nameProperty.getName(), PROP_NAME);
-    Assertions.assertEquals(nameProperty.getType(), Type.STRING);
+    assertThat(nameProperty.getName()).isEqualTo(PROP_NAME);
+    assertThat(nameProperty.getType()).isEqualTo(Type.STRING);
   }
 
   @Test
@@ -59,8 +62,8 @@ public class CreatePropertyStatementExecutionTest extends TestHelper {
     final DocumentType companyClass = database.getSchema().getType("testCreateMandatoryPropertyWithEmbeddedType");
     final Property nameProperty = companyClass.getProperty(PROP_OFFICERS);
 
-    Assertions.assertEquals(nameProperty.getName(), PROP_OFFICERS);
-    Assertions.assertEquals(nameProperty.getType(), Type.LIST);
+    assertThat(nameProperty.getName()).isEqualTo(PROP_OFFICERS);
+    assertThat(nameProperty.getType()).isEqualTo(Type.LIST);
   }
 
   @Test
@@ -71,8 +74,8 @@ public class CreatePropertyStatementExecutionTest extends TestHelper {
     final DocumentType companyClass = database.getSchema().getType("testCreateUnsafePropertyWithEmbeddedType");
     final Property nameProperty = companyClass.getProperty(PROP_OFFICERS);
 
-    Assertions.assertEquals(nameProperty.getName(), PROP_OFFICERS);
-    Assertions.assertEquals(nameProperty.getType(), Type.LIST);
+    assertThat(nameProperty.getName()).isEqualTo(PROP_OFFICERS);
+    assertThat(nameProperty.getType()).isEqualTo(Type.LIST);
   }
 
   @Test
@@ -83,8 +86,8 @@ public class CreatePropertyStatementExecutionTest extends TestHelper {
     final DocumentType companyClass = database.getSchema().getType("testExtraSpaces");
     final Property idProperty = companyClass.getProperty(PROP_ID);
 
-    Assertions.assertEquals(idProperty.getName(), PROP_ID);
-    Assertions.assertEquals(idProperty.getType(), Type.INTEGER);
+    assertThat(idProperty.getName()).isEqualTo(PROP_ID);
+    assertThat(idProperty.getType()).isEqualTo(Type.INTEGER);
   }
 
   @Test
@@ -92,7 +95,7 @@ public class CreatePropertyStatementExecutionTest extends TestHelper {
     try {
       database.command("sql", "create document type CommandExecutionException").close();
       database.command("sql", "CREATE PROPERTY CommandExecutionException.id INTEGER (MANDATORY, INVALID, NOTNULL)  UNSAFE").close();
-      Assertions.fail("Expected CommandSQLParsingException");
+      fail("Expected CommandSQLParsingException");
     } catch (final CommandSQLParsingException e) {
       // OK
     }
@@ -112,29 +115,29 @@ public class CreatePropertyStatementExecutionTest extends TestHelper {
 
     final DocumentType invoiceType = database.getSchema().getType("Invoice");
     final Property productsProperty = invoiceType.getProperty("products");
-    Assertions.assertEquals(productsProperty.getName(), "products");
-    Assertions.assertEquals(productsProperty.getType(), Type.LIST);
-    Assertions.assertEquals(productsProperty.getOfType(), "Product");
+    assertThat(productsProperty.getName()).isEqualTo("products");
+    assertThat(productsProperty.getType()).isEqualTo(Type.LIST);
+    assertThat(productsProperty.getOfType()).isEqualTo("Product");
 
     final Property tagsProperty = invoiceType.getProperty("tags");
-    Assertions.assertEquals(tagsProperty.getName(), "tags");
-    Assertions.assertEquals(tagsProperty.getType(), Type.LIST);
-    Assertions.assertEquals(tagsProperty.getOfType(), "STRING");
+    assertThat(tagsProperty.getName()).isEqualTo("tags");
+    assertThat(tagsProperty.getType()).isEqualTo(Type.LIST);
+    assertThat(tagsProperty.getOfType()).isEqualTo("STRING");
 
     final Property settingsProperty = invoiceType.getProperty("settings");
-    Assertions.assertEquals(settingsProperty.getName(), "settings");
-    Assertions.assertEquals(settingsProperty.getType(), Type.MAP);
-    Assertions.assertEquals(settingsProperty.getOfType(), "STRING");
+    assertThat(settingsProperty.getName()).isEqualTo("settings");
+    assertThat(settingsProperty.getType()).isEqualTo(Type.MAP);
+    assertThat(settingsProperty.getOfType()).isEqualTo("STRING");
 
     final Property mainProductProperty = invoiceType.getProperty("mainProduct");
-    Assertions.assertEquals(mainProductProperty.getName(), "mainProduct");
-    Assertions.assertEquals(mainProductProperty.getType(), Type.LINK);
-    Assertions.assertEquals(mainProductProperty.getOfType(), "Product");
+    assertThat(mainProductProperty.getName()).isEqualTo("mainProduct");
+    assertThat(mainProductProperty.getType()).isEqualTo(Type.LINK);
+    assertThat(mainProductProperty.getOfType()).isEqualTo("Product");
 
     final Property embeddedProperty = invoiceType.getProperty("embedded");
-    Assertions.assertEquals(embeddedProperty.getName(), "embedded");
-    Assertions.assertEquals(embeddedProperty.getType(), Type.EMBEDDED);
-    Assertions.assertEquals(embeddedProperty.getOfType(), "Product");
+    assertThat(embeddedProperty.getName()).isEqualTo("embedded");
+    assertThat(embeddedProperty.getType()).isEqualTo(Type.EMBEDDED);
+    assertThat(embeddedProperty.getOfType()).isEqualTo("Product");
 
     final MutableDocument[] validInvoice = new MutableDocument[1];
     database.transaction(() -> {
@@ -153,21 +156,21 @@ public class CreatePropertyStatementExecutionTest extends TestHelper {
         database.newDocument("Invoice").set("products",//
             List.of(database.newDocument("Invoice").save())).save();
       });
-      Assertions.fail();
+      fail("");
     } catch (ValidationException e) {
       // EXPECTED
     }
 
     try {
       validInvoice[0].set("tags", List.of(3, "hard to close")).save();
-      Assertions.fail();
+      fail("");
     } catch (ValidationException e) {
       // EXPECTED
     }
 
     try {
       validInvoice[0].set("settings", Map.of("test", 10F)).save();
-      Assertions.fail();
+      fail("");
     } catch (ValidationException e) {
       // EXPECTED
     }
@@ -176,7 +179,7 @@ public class CreatePropertyStatementExecutionTest extends TestHelper {
       database.transaction(() -> {
         validInvoice[0].set("mainProduct", database.newDocument("Invoice").save()).save();
       });
-      Assertions.fail();
+      fail("");
     } catch (ValidationException e) {
       // EXPECTED
     }
@@ -185,7 +188,7 @@ public class CreatePropertyStatementExecutionTest extends TestHelper {
       database.transaction(() -> {
         validInvoice[0].newEmbeddedDocument("Invoice", "embedded").save();
       });
-      Assertions.fail();
+      fail("");
     } catch (ValidationException e) {
       // EXPECTED
     }
@@ -199,15 +202,15 @@ public class CreatePropertyStatementExecutionTest extends TestHelper {
     DocumentType clazz = database.getSchema().getType("testIfNotExists");
     Property nameProperty = clazz.getProperty(PROP_NAME);
 
-    Assertions.assertEquals(nameProperty.getName(), PROP_NAME);
-    Assertions.assertEquals(nameProperty.getType(), Type.STRING);
+    assertThat(nameProperty.getName()).isEqualTo(PROP_NAME);
+    assertThat(nameProperty.getType()).isEqualTo(Type.STRING);
 
     database.command("sql", "CREATE property testIfNotExists.name if not exists STRING").close();
 
     clazz = database.getSchema().getType("testIfNotExists");
     nameProperty = clazz.getProperty(PROP_NAME);
 
-    Assertions.assertEquals(nameProperty.getName(), PROP_NAME);
-    Assertions.assertEquals(nameProperty.getType(), Type.STRING);
+    assertThat(nameProperty.getName()).isEqualTo(PROP_NAME);
+    assertThat(nameProperty.getType()).isEqualTo(Type.STRING);
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/CreateVertexStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/CreateVertexStatementExecutionTest.java
@@ -21,10 +21,13 @@ package com.arcadedb.query.sql.executor;
 import com.arcadedb.TestHelper;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.schema.Schema;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Luigi Dell'Aquila (l.dellaquila-(at)-orientdb.com)
@@ -50,25 +53,25 @@ public class CreateVertexStatementExecutionTest extends TestHelper {
     ResultSet result = database.command("sql", "create vertex " + className + " content " + array);
 
     for (int i = 0; i < 1000; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("name" + i, item.getProperty("name").toString());
-      Assertions.assertEquals("surname" + i, item.getProperty("surname").toString());
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name").toString()).isEqualTo("name" + i);
+      assertThat(item.getProperty("surname").toString()).isEqualTo("surname" + i);
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     result = database.query("sql", "select from " + className);
 
     for (int i = 0; i < 1000; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("name" + i, item.getProperty("name").toString());
-      Assertions.assertEquals("surname" + i, item.getProperty("surname").toString());
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name").toString()).isEqualTo("name" + i);
+      assertThat(item.getProperty("surname").toString()).isEqualTo("surname" + i);
     }
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -81,21 +84,21 @@ public class CreateVertexStatementExecutionTest extends TestHelper {
     ResultSet result = database.command("sql", "create vertex " + className + " set name = 'name1'");
 
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("name1", item.getProperty("name"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isEqualTo("name1");
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     result = database.query("sql", "select from " + className);
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("name1", item.getProperty("name"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isEqualTo("name1");
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -107,10 +110,10 @@ public class CreateVertexStatementExecutionTest extends TestHelper {
 
     try {
       final ResultSet result = database.command("sql", "create vertex " + className + " set name = 'name1'");
-      Assertions.fail();
+      fail("");
     } catch (final CommandExecutionException e1) {
     } catch (final Exception e2) {
-      Assertions.fail();
+      fail("");
     }
   }
 
@@ -123,22 +126,22 @@ public class CreateVertexStatementExecutionTest extends TestHelper {
     ResultSet result = database.command("sql", "create vertex " + className + "  (name, surname) values ('name1', 'surname1')");
 
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("name1", item.getProperty("name"));
-      Assertions.assertEquals("surname1", item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isEqualTo("name1");
+      assertThat(item.<String>getProperty("surname")).isEqualTo("surname1");
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     result = database.query("sql", "select from " + className);
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("name1", item.getProperty("name"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isEqualTo("name1");
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -152,28 +155,28 @@ public class CreateVertexStatementExecutionTest extends TestHelper {
         "create vertex " + className + "  (name, surname) values ('name1', 'surname1'), ('name2', 'surname2')");
 
     for (int i = 0; i < 2; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("name" + (i + 1), item.getProperty("name"));
-      Assertions.assertEquals("surname" + (i + 1), item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isEqualTo("name" + (i + 1));
+      assertThat(item.<String>getProperty("surname")).isEqualTo("surname" + (i + 1));
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     final Set<String> names = new HashSet<>();
     names.add("name1");
     names.add("name2");
     result = database.query("sql", "select from " + className);
     for (int i = 0; i < 2; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertNotNull(item.getProperty("name"));
-      names.remove(item.getProperty("name"));
-      Assertions.assertNotNull(item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isNotNull();
+      names.remove(item.<String>getProperty("name"));
+      assertThat(item.<String>getProperty("surname")).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
-    Assertions.assertTrue(names.isEmpty());
+    assertThat(result.hasNext()).isFalse();
+    assertThat(names.isEmpty()).isTrue();
     result.close();
   }
 
@@ -186,22 +189,22 @@ public class CreateVertexStatementExecutionTest extends TestHelper {
     ResultSet result = database.command("sql", "create vertex " + className + " content {'name':'name1', 'surname':'surname1'}");
 
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("name1", item.getProperty("name"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isEqualTo("name1");
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     result = database.query("sql", "select from " + className);
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("name1", item.getProperty("name"));
-      Assertions.assertEquals("surname1", item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isEqualTo("name1");
+      assertThat(item.<String>getProperty("surname")).isEqualTo("surname1");
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/DistinctExecutionStepTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/DistinctExecutionStepTest.java
@@ -19,8 +19,9 @@
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.exception.TimeoutException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by luigidellaquila on 26/07/16.
@@ -52,10 +53,10 @@ public class DistinctExecutionStepTest {
 
     step.setPrevious(prev);
     final ResultSet res = step.syncPull(ctx, 10);
-    Assertions.assertTrue(res.hasNext());
+    assertThat(res.hasNext()).isTrue();
     res.next();
-    Assertions.assertTrue(res.hasNext());
+    assertThat(res.hasNext()).isTrue();
     res.next();
-    Assertions.assertFalse(res.hasNext());
+    assertThat(res.hasNext()).isFalse();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/DropBucketStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/DropBucketStatementExecutionTest.java
@@ -22,8 +22,11 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.engine.Bucket;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.schema.Schema;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -35,12 +38,12 @@ public class DropBucketStatementExecutionTest extends TestHelper {
     final Schema schema = database.getSchema();
     schema.createDocumentType(className);
 
-    Assertions.assertNotNull(schema.getType(className));
+    assertThat(schema.getType(className)).isNotNull();
 
     for (Bucket bucket : database.getSchema().getType(className).getBuckets(false)) {
       try {
         database.command("sql", "drop bucket " + bucket.getName());
-        Assertions.fail();
+        fail("");
       } catch (CommandExecutionException e) {
         // EXPECTED
       }
@@ -48,13 +51,13 @@ public class DropBucketStatementExecutionTest extends TestHelper {
       database.command("sql", "alter type " + className + " bucket -" + bucket.getName());
 
       final ResultSet result = database.command("sql", "drop bucket " + bucket.getName());
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result next = result.next();
-      Assertions.assertEquals("drop bucket", next.getProperty("operation"));
-      Assertions.assertFalse(result.hasNext());
+      assertThat(next.<String>getProperty("operation")).isEqualTo("drop bucket");
+      assertThat(result.hasNext()).isFalse();
       result.close();
 
-      Assertions.assertFalse(schema.existsBucket(bucket.getName()));
+      assertThat(schema.existsBucket(bucket.getName())).isFalse();
     }
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/DropTypeStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/DropTypeStatementExecutionTest.java
@@ -20,8 +20,9 @@ package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.schema.Schema;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luigi Dell'Aquila (l.dellaquila-(at)-orientdb.com)
@@ -33,16 +34,16 @@ public class DropTypeStatementExecutionTest extends TestHelper {
     final Schema schema = database.getSchema();
     schema.createDocumentType(className);
 
-    Assertions.assertNotNull(schema.getType(className));
+    assertThat(schema.getType(className)).isNotNull();
 
     final ResultSet result = database.command("sql", "drop type " + className);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result next = result.next();
-    Assertions.assertEquals("drop type", next.getProperty("operation"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(next.<String>getProperty("operation")).isEqualTo("drop type");
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
-    Assertions.assertFalse(schema.existsType(className));
+    assertThat(schema.existsType(className)).isFalse();
   }
 
   @Test
@@ -51,21 +52,21 @@ public class DropTypeStatementExecutionTest extends TestHelper {
     final Schema schema = database.getSchema();
     schema.createDocumentType(className);
 
-    Assertions.assertNotNull(schema.getType(className));
+    assertThat(schema.getType(className)).isNotNull();
 
     ResultSet result = database.command("sql", "drop type " + className + " if exists");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result next = result.next();
-    Assertions.assertEquals("drop type", next.getProperty("operation"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(next.<String>getProperty("operation")).isEqualTo("drop type");
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
-    Assertions.assertFalse(schema.existsType(className));
+    assertThat(schema.existsType(className)).isFalse();
 
     result = database.command("sql", "drop type " + className + " if exists");
     result.close();
 
-    Assertions.assertFalse(schema.existsType(className));
+    assertThat(schema.existsType(className)).isFalse();
   }
 
   @Test
@@ -74,15 +75,15 @@ public class DropTypeStatementExecutionTest extends TestHelper {
     final Schema schema = database.getSchema();
     schema.createDocumentType(className);
 
-    Assertions.assertNotNull(schema.getType(className));
+    assertThat(schema.getType(className)).isNotNull();
 
     final ResultSet result = database.command("sql", "drop type ?", className);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result next = result.next();
-    Assertions.assertEquals("drop type", next.getProperty("operation"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(next.<String>getProperty("operation")).isEqualTo("drop type");
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
-    Assertions.assertFalse(schema.existsType(className));
+    assertThat(schema.existsType(className)).isFalse();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ExplainStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ExplainStatementExecutionTest.java
@@ -19,10 +19,11 @@
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.TestHelper;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luigi Dell'Aquila (l.dellaquila-(at)-orientdb.com)
@@ -31,14 +32,14 @@ public class ExplainStatementExecutionTest extends TestHelper {
   @Test
   public void testExplainSelectNoTarget() {
     final ResultSet result = database.query("sql", "explain select 1 as one, 2 as two, 2+3");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result next = result.next();
-    Assertions.assertNotNull(next.getProperty("executionPlan"));
-    Assertions.assertNotNull(next.getProperty("executionPlanAsString"));
+    assertThat(next.<ResultInternal>getProperty("executionPlan")).isNotNull();
+    assertThat(next.<String>getProperty("executionPlanAsString")).isNotNull();
 
     final Optional<ExecutionPlan> plan = result.getExecutionPlan();
-    Assertions.assertTrue(plan.isPresent());
-    Assertions.assertTrue(plan.get() instanceof SelectExecutionPlan);
+    assertThat(plan.isPresent()).isTrue();
+    assertThat(plan.get() instanceof SelectExecutionPlan).isTrue();
 
     result.close();
   }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/GroupByExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/GroupByExecutionTest.java
@@ -19,10 +19,11 @@
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.TestHelper;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -50,8 +51,8 @@ public class GroupByExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select address, count(*) as occurrences from InputTx where address is not null group by address limit 10");
     while (result.hasNext()) {
       final Result row = result.next();
-      Assertions.assertNotNull(row.getProperty("address"));
-      Assertions.assertNotNull(row.getProperty("occurrences"));
+      assertThat(row.<String>getProperty("address")).isNotNull();
+      assertThat(row.<Long>getProperty("occurrences")).isNotNull();
     }
     result.close();
   }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/IfStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/IfStatementExecutionTest.java
@@ -19,7 +19,6 @@
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.TestHelper;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,26 +31,26 @@ public class IfStatementExecutionTest extends TestHelper {
   @Test
   public void testPositive() {
     final ResultSet results = database.command("sql", "if(1=1){ select 1 as a; }");
-    Assertions.assertTrue(results.hasNext());
+    assertThat(results.hasNext()).isTrue();
     final Result result = results.next();
     assertThat((Integer) result.getProperty("a")).isEqualTo(1);
-    Assertions.assertFalse(results.hasNext());
+    assertThat(results.hasNext()).isFalse();
     results.close();
   }
 
   @Test
   public void testNegative() {
     final ResultSet results = database.command("sql", "if(1=2){ select 1 as a; }");
-    Assertions.assertFalse(results.hasNext());
+    assertThat(results.hasNext()).isFalse();
     results.close();
   }
 
   @Test
   public void testIfReturn() {
     final ResultSet results = database.command("sql", "if(1=1){ return 'yes'; }");
-    Assertions.assertTrue(results.hasNext());
-    Assertions.assertEquals("yes", results.next().getProperty("value"));
-    Assertions.assertFalse(results.hasNext());
+    assertThat(results.hasNext()).isTrue();
+    assertThat(results.next().<String>getProperty("value")).isEqualTo("yes");
+    assertThat(results.hasNext()).isFalse();
     results.close();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/InsertStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/InsertStatementExecutionTest.java
@@ -22,10 +22,13 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.database.EmbeddedDocument;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.MutableDocument;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Luigi Dell'Aquila (l.dellaquila-(at)-orientdb.com)
@@ -43,21 +46,21 @@ public class InsertStatementExecutionTest extends TestHelper {
     ResultSet result = database.command("sql", "insert into " + className + " set name = 'name1'");
 
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("name1", item.getProperty("name"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isEqualTo("name1");
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     result = database.query("sql", "select from " + className);
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("name1", item.getProperty("name"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isEqualTo("name1");
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -69,22 +72,22 @@ public class InsertStatementExecutionTest extends TestHelper {
     ResultSet result = database.command("sql", "insert into " + className + "  (name, surname) values ('name1', 'surname1')");
 
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("name1", item.getProperty("name"));
-      Assertions.assertEquals("surname1", item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isEqualTo("name1");
+      assertThat(item.<String>getProperty("surname")).isEqualTo("surname1");
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     result = database.query("sql", "select from " + className);
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("name1", item.getProperty("name"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isEqualTo("name1");
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -97,28 +100,28 @@ public class InsertStatementExecutionTest extends TestHelper {
         "insert into " + className + "  (name, surname) values ('name1', 'surname1'), ('name2', 'surname2')");
 
     for (int i = 0; i < 2; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("name" + (i + 1), item.getProperty("name"));
-      Assertions.assertEquals("surname" + (i + 1), item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isEqualTo("name" + (i + 1));
+      assertThat(item.<String>getProperty("surname")).isEqualTo("surname" + (i + 1));
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     final Set<String> names = new HashSet<>();
     names.add("name1");
     names.add("name2");
     result = database.query("sql", "select from " + className);
     for (int i = 0; i < 2; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertNotNull(item.getProperty("name"));
-      names.remove(item.getProperty("name"));
-      Assertions.assertNotNull(item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isNotNull();
+      names.remove(item.<String>getProperty("name"));
+      assertThat(item.<String>getProperty("surname")).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
-    Assertions.assertTrue(names.isEmpty());
+    assertThat(result.hasNext()).isFalse();
+    assertThat(names.isEmpty()).isTrue();
     result.close();
   }
 
@@ -138,13 +141,13 @@ public class InsertStatementExecutionTest extends TestHelper {
     ResultSet result = database.command("sql", "insert into " + className2 + " from select from " + className1);
 
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertNotNull(item.getProperty("name"));
-      Assertions.assertNotNull(item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isNotNull();
+      assertThat(item.<String>getProperty("surname")).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     final Set<String> names = new HashSet<>();
     for (int i = 0; i < 10; i++) {
@@ -152,15 +155,15 @@ public class InsertStatementExecutionTest extends TestHelper {
     }
     result = database.query("sql", "select from " + className2);
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertNotNull(item.getProperty("name"));
-      names.remove(item.getProperty("name"));
-      Assertions.assertNotNull(item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isNotNull();
+      names.remove(item.<String>getProperty("name"));
+      assertThat(item.<String>getProperty("surname")).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
-    Assertions.assertTrue(names.isEmpty());
+    assertThat(result.hasNext()).isFalse();
+    assertThat(names.isEmpty()).isTrue();
     result.close();
   }
 
@@ -180,13 +183,13 @@ public class InsertStatementExecutionTest extends TestHelper {
     ResultSet result = database.command("sql", "insert into " + className2 + " ( select from " + className1 + ")");
 
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertNotNull(item.getProperty("name"));
-      Assertions.assertNotNull(item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isNotNull();
+      assertThat(item.<String>getProperty("surname")).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     final Set<String> names = new HashSet<>();
     for (int i = 0; i < 10; i++) {
@@ -194,15 +197,15 @@ public class InsertStatementExecutionTest extends TestHelper {
     }
     result = database.query("sql", "select from " + className2);
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertNotNull(item.getProperty("name"));
-      names.remove(item.getProperty("name"));
-      Assertions.assertNotNull(item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isNotNull();
+      names.remove(item.<String>getProperty("name"));
+      assertThat(item.<String>getProperty("surname")).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
-    Assertions.assertTrue(names.isEmpty());
+    assertThat(result.hasNext()).isFalse();
+    assertThat(names.isEmpty()).isTrue();
     result.close();
   }
 
@@ -213,13 +216,13 @@ public class InsertStatementExecutionTest extends TestHelper {
 
     ResultSet result = database.command("sql", "insert into " + className1 + " set test = ( select 777 )");
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result item = result.next();
-    Assertions.assertNotNull(item);
+    assertThat(item).isNotNull();
     List<Integer> list = item.getProperty("test");
-    Assertions.assertEquals(1, list.size());
-    Assertions.assertEquals(777, list.get(0));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(list.size()).isEqualTo(1);
+    assertThat(list.get(0)).isEqualTo(777);
+    assertThat(result.hasNext()).isFalse();
   }
 
   @Test
@@ -229,15 +232,15 @@ public class InsertStatementExecutionTest extends TestHelper {
 
     ResultSet result = database.command("sql", "insert into " + className1 + " set test = ( select 777, 888 )");
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result item = result.next();
-    Assertions.assertNotNull(item);
+    assertThat(item).isNotNull();
     List<Map> list = item.getProperty("test");
-    Assertions.assertEquals(1, list.size());
+    assertThat(list.size()).isEqualTo(1);
     Map<String, Integer> map = list.get(0);
-    Assertions.assertEquals(777, map.get("777"));
-    Assertions.assertEquals(888, map.get("888"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(map.get("777")).isEqualTo(777);
+    assertThat(map.get("888")).isEqualTo(888);
+    assertThat(result.hasNext()).isFalse();
   }
 
   @Test
@@ -248,22 +251,22 @@ public class InsertStatementExecutionTest extends TestHelper {
     ResultSet result = database.command("sql", "insert into " + className + " content {'name':'name1', 'surname':'surname1'}");
 
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("name1", item.getProperty("name"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isEqualTo("name1");
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     result = database.query("sql", "select from " + className);
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("name1", item.getProperty("name"));
-      Assertions.assertEquals("surname1", item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isEqualTo("name1");
+      assertThat(item.<String>getProperty("surname")).isEqualTo("surname1");
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -283,25 +286,25 @@ public class InsertStatementExecutionTest extends TestHelper {
     ResultSet result = database.command("sql", "insert into " + className + " content " + array);
 
     for (int i = 0; i < 1000; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("name" + i, item.getProperty("name").toString());
-      Assertions.assertEquals("surname" + i, item.getProperty("surname").toString());
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name").toString()).isEqualTo("name" + i);
+      assertThat(item.getProperty("surname").toString()).isEqualTo("surname" + i);
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     result = database.query("sql", "select from " + className);
 
     for (int i = 0; i < 1000; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("name" + i, item.getProperty("name").toString());
-      Assertions.assertEquals("surname" + i, item.getProperty("surname").toString());
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name").toString()).isEqualTo("name" + i);
+      assertThat(item.getProperty("surname").toString()).isEqualTo("surname" + i);
     }
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -314,14 +317,14 @@ public class InsertStatementExecutionTest extends TestHelper {
         "insert into " + className + " content { 'embedded': { '@type':'testContent', 'name':'name1', 'surname':'surname1'} }");
 
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
       EmbeddedDocument embedded = item.getProperty("embedded");
-      Assertions.assertEquals("name1", embedded.getString("name"));
-      Assertions.assertEquals("surname1", embedded.getString("surname"));
+      assertThat(embedded.getString("name")).isEqualTo("name1");
+      assertThat(embedded.getString("surname")).isEqualTo("surname1");
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
   }
 
   @Test
@@ -337,22 +340,22 @@ public class InsertStatementExecutionTest extends TestHelper {
     ResultSet result = database.command("sql", "insert into " + className + " content :theContent", params);
 
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("name1", item.getProperty("name"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isEqualTo("name1");
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     result = database.query("sql", "select from " + className);
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("name1", item.getProperty("name"));
-      Assertions.assertEquals("surname1", item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isEqualTo("name1");
+      assertThat(item.<String>getProperty("surname")).isEqualTo("surname1");
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -375,11 +378,11 @@ public class InsertStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", "seLECT FROM " + className2);
     for (int i = 0; i < 2; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result row = result.next();
       final Object val = row.getProperty("processingType");
-      Assertions.assertNotNull(val);
-      Assertions.assertTrue(val instanceof Identifiable);
+      assertThat(val).isNotNull();
+      assertThat(val instanceof Identifiable).isTrue();
     }
     result.close();
   }
@@ -398,16 +401,16 @@ public class InsertStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", "seLECT FROM " + className2);
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result row = result.next();
       final Object list = row.getProperty("sub");
-      Assertions.assertNotNull(list);
-      Assertions.assertTrue(list instanceof List);
-      Assertions.assertEquals(1, ((List) list).size());
+      assertThat(list).isNotNull();
+      assertThat(list instanceof List).isTrue();
+      assertThat(((List) list).size()).isEqualTo(1);
 
       final Object o = ((List) list).get(0);
-      Assertions.assertTrue(o instanceof Map);
-      Assertions.assertEquals("foo", ((Map) o).get("name"));
+      assertThat(o instanceof Map).isTrue();
+      assertThat(((Map) o).get("name")).isEqualTo("foo");
     }
     result.close();
   }
@@ -426,16 +429,16 @@ public class InsertStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", "seLECT FROM " + className2);
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result row = result.next();
       final Object list = row.getProperty("sub");
-      Assertions.assertNotNull(list);
-      Assertions.assertTrue(list instanceof List);
-      Assertions.assertEquals(1, ((List) list).size());
+      assertThat(list).isNotNull();
+      assertThat(list instanceof List).isTrue();
+      assertThat(((List) list).size()).isEqualTo(1);
 
       final Object o = ((List) list).get(0);
-      Assertions.assertTrue(o instanceof Map);
-      Assertions.assertEquals("foo", ((Map) o).get("name"));
+      assertThat(o instanceof Map).isTrue();
+      assertThat(((Map) o).get("name")).isEqualTo("foo");
     }
     result.close();
   }
@@ -448,21 +451,21 @@ public class InsertStatementExecutionTest extends TestHelper {
     ResultSet result = database.command("sql", "insert into " + className + " set name = 'name1' RETURN 'OK' as result");
 
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("OK", item.getProperty("result"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("result")).isEqualTo("OK");
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     result = database.query("sql", "select from " + className);
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("name1", item.getProperty("name"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isEqualTo("name1");
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -480,12 +483,12 @@ public class InsertStatementExecutionTest extends TestHelper {
 
     for (int i = 0; i < 2; i++) {
       final Result item = result.next();
-      if (item.getProperty("name").equals("parent")) {
-        Assertions.assertTrue(item.getProperty("children") instanceof Collection);
-        Assertions.assertEquals(1, ((Collection) item.getProperty("children")).size());
+      if (item.<String>getProperty("name").equals("parent")) {
+        assertThat(item.getProperty("children") instanceof Collection).isTrue();
+        assertThat(((Collection) item.getProperty("children")).size()).isEqualTo(1);
       }
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -506,10 +509,10 @@ public class InsertStatementExecutionTest extends TestHelper {
 
     final Result item = result.next();
     final Map theMap = item.getProperty("mymap");
-    Assertions.assertEquals(1, theMap.size());
-    Assertions.assertNotNull(theMap.get("A-1"));
+    assertThat(theMap.size()).isEqualTo(1);
+    assertThat(theMap.get("A-1")).isNotNull();
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -525,9 +528,9 @@ public class InsertStatementExecutionTest extends TestHelper {
 
     final Result item = result.next();
     final String memo = item.getProperty("memo");
-    Assertions.assertEquals("this is a \n multi line text", memo);
+    assertThat(memo).isEqualTo("this is a \n multi line text");
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -537,7 +540,7 @@ public class InsertStatementExecutionTest extends TestHelper {
     database.getSchema().createEdgeType(className);
     try {
       database.command("sql", "insert into " + className + " set `@out` = #1:10, `@in` = #1:11");
-      Assertions.fail();
+      fail("");
     } catch (final IllegalArgumentException e) {
       // EXPECTED
     }
@@ -575,10 +578,10 @@ public class InsertStatementExecutionTest extends TestHelper {
         "    }\n" + //
         "}");
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result res = result.next();
-    Assertions.assertTrue(res.hasProperty("head"));
-    Assertions.assertTrue(res.hasProperty("results"));
+    assertThat(res.hasProperty("head")).isTrue();
+    assertThat(res.hasProperty("results")).isTrue();
   }
 
   @Test
@@ -586,8 +589,8 @@ public class InsertStatementExecutionTest extends TestHelper {
     database.getSchema().createDocumentType("RegInfoDoc");
     final ResultSet result = database.command("sql",
         "insert into RegInfoDoc set payload = \"(Pn/m)*1000kg/kW, with \\\"Pn\\\" being the\\n\\np  and \\\"m\\\" (kg)\"");
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertEquals("(Pn/m)*1000kg/kW, with \"Pn\" being the\n\np  and \"m\" (kg)", result.next().getProperty("payload"));
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next().<String>getProperty("payload")).isEqualTo("(Pn/m)*1000kg/kW, with \"Pn\" being the\n\np  and \"m\" (kg)");
   }
 
   @Test
@@ -607,6 +610,6 @@ public class InsertStatementExecutionTest extends TestHelper {
     for (; result.hasNext(); i++)
       result.next();
 
-    Assertions.assertEquals(3, i);
+    assertThat(i).isEqualTo(3);
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/MatchInheritanceTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/MatchInheritanceTest.java
@@ -2,8 +2,9 @@ package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.graph.Vertex;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MatchInheritanceTest extends TestHelper {
   @Test
@@ -18,7 +19,7 @@ public class MatchInheritanceTest extends TestHelper {
       Result record = result.next();
       ++selectFromServices;
     }
-    Assertions.assertEquals(4, selectFromServices);
+    assertThat(selectFromServices).isEqualTo(4);
 
     sql = "SELECT FROM Attractions";
     result = database.command("SQL", sql);
@@ -27,7 +28,7 @@ public class MatchInheritanceTest extends TestHelper {
       Result record = result.next();
       ++selectFromAttractions;
     }
-    Assertions.assertEquals(4, selectFromAttractions);
+    assertThat(selectFromAttractions).isEqualTo(4);
 
     sql = "SELECT FROM Locations";
 
@@ -37,27 +38,27 @@ public class MatchInheritanceTest extends TestHelper {
       Result record = result.next();
       ++selectFromLocations;
     }
-    Assertions.assertEquals(8, selectFromLocations);
+    assertThat(selectFromLocations).isEqualTo(8);
 
     sql = "MATCH {type: Customers, as: customer, where: (OrderedId=1)}--{type: Monuments} " + "RETURN $pathelements";
     result = database.query("SQL", sql);
 
-    Assertions.assertEquals(2, result.stream().count());
+    assertThat(result.stream().count()).isEqualTo(2);
 
     sql = "MATCH {type: Customers, as: customer, where: (OrderedId=1)}--{type: Services} " + "RETURN $pathelements";
     result = database.query("SQL", sql);
 
-    Assertions.assertEquals(8, result.stream().count());
+    assertThat(result.stream().count()).isEqualTo(8);
 
     sql = "MATCH {type: Customers, as: customer, where: (OrderedId=1)}--{type: Attractions} " + "RETURN $pathelements";
     result = database.query("SQL", sql);
 
-    Assertions.assertEquals(8, result.stream().count());
+    assertThat(result.stream().count()).isEqualTo(8);
 
     sql = "MATCH {type: Customers, as: customer, where: (OrderedId=1)}--{type: Locations} " + "RETURN $pathelements";
     result = database.query("SQL", sql);
 
-    Assertions.assertEquals(16, result.stream().count());
+    assertThat(result.stream().count()).isEqualTo(16);
   }
 
   @Override

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/MatchResultTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/MatchResultTest.java
@@ -3,10 +3,11 @@ package com.arcadedb.query.sql.executor;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.RID;
 import com.arcadedb.graph.Vertex;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MatchResultTest extends TestHelper {
 
@@ -40,6 +41,6 @@ public class MatchResultTest extends TestHelper {
       set.add(next.getIdentity());
     }
 
-    Assertions.assertEquals(3, set.size());
+    assertThat(set.size()).isEqualTo(3);
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/MatchStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/MatchStatementExecutionTest.java
@@ -19,20 +19,19 @@
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.TestHelper;
-import com.arcadedb.database.Database;
-import com.arcadedb.database.Document;
-import com.arcadedb.database.Identifiable;
-import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.*;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.index.TypeIndex;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
-import java.util.stream.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class MatchStatementExecutionTest extends TestHelper {
   public MatchStatementExecutionTest() {
@@ -237,11 +236,11 @@ public class MatchStatementExecutionTest extends TestHelper {
 
     for (int i = 0; i < 6; i++) {
       final Result item = qResult.next();
-      Assertions.assertEquals(1, item.getPropertyNames().size());
+      assertThat(item.getPropertyNames().size()).isEqualTo(1);
       final Document person = item.getProperty("person");
 
       final String name = person.getString("name");
-      Assertions.assertTrue(name.startsWith("n"));
+      assertThat(name.startsWith("n")).isTrue();
     }
     qResult.close();
   }
@@ -253,12 +252,12 @@ public class MatchStatementExecutionTest extends TestHelper {
 
     for (int i = 0; i < 2; i++) {
       final Result item = qResult.next();
-      Assertions.assertTrue(item.getPropertyNames().size() == 1);
+      assertThat(item.getPropertyNames().size()).isEqualTo(1);
       final Document personId = item.getProperty("person");
 
       final MutableDocument person = personId.getRecord().asVertex().modify();
       final String name = person.getString("name");
-      Assertions.assertTrue(name.equals("n1") || name.equals("n2"));
+      assertThat(name.equals("n1") || name.equals("n2")).isTrue();
     }
     qResult.close();
   }
@@ -267,9 +266,9 @@ public class MatchStatementExecutionTest extends TestHelper {
   public void testSimpleLimit() {
     final ResultSet qResult = database.query("sql",
         "match {type:Person, as: person, where: (name = 'n1' or name = 'n2')} return person limit 1");
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     qResult.next();
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
   }
 
@@ -278,7 +277,7 @@ public class MatchStatementExecutionTest extends TestHelper {
     final ResultSet qResult = database.query("sql",
         "match {type:Person, as: person, where: (name = 'n1' or name = 'n2')} return person limit -1");
     for (int i = 0; i < 2; i++) {
-      Assertions.assertTrue(qResult.hasNext());
+      assertThat(qResult.hasNext()).isTrue();
       qResult.next();
     }
     qResult.close();
@@ -290,7 +289,7 @@ public class MatchStatementExecutionTest extends TestHelper {
     final ResultSet qResult = database.query("sql",
         "match {type:Person, as: person, where: (name = 'n1' or name = 'n2')} return person limit 3");
     for (int i = 0; i < 2; i++) {
-      Assertions.assertTrue(qResult.hasNext());
+      assertThat(qResult.hasNext()).isTrue();
       qResult.next();
     }
     qResult.close();
@@ -304,11 +303,11 @@ public class MatchStatementExecutionTest extends TestHelper {
     for (int i = 0; i < 2; i++) {
 
       final Result item = qResult.next();
-      Assertions.assertEquals(1, item.getPropertyNames().size());
+      assertThat(item.getPropertyNames().size()).isEqualTo(1);
       final Document person = item.getProperty("person");
 
       final String name = person.getString("name");
-      Assertions.assertTrue(name.equals("n1") || name.equals("n2"));
+      assertThat(name.equals("n1") || name.equals("n2")).isTrue();
     }
     qResult.close();
   }
@@ -319,10 +318,10 @@ public class MatchStatementExecutionTest extends TestHelper {
     final ResultSet qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1')}.both('Friend'){as:friend}.both('Friend'){type: Person, where:(name = 'n4')} return friend)");
 
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     final Result item = qResult.next();
-    Assertions.assertEquals("n2", item.getProperty("name"));
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(item.<String>getProperty("name")).isEqualTo("n2");
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
   }
 
@@ -332,10 +331,10 @@ public class MatchStatementExecutionTest extends TestHelper {
     final ResultSet qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1')}.both('Friend'){as:friend}.both('Friend'){type: Person, where:(name = 'n4')} return $patterns)");
 
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     final Result item = qResult.next();
-    Assertions.assertEquals("n2", item.getProperty("name"));
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(item.<String>getProperty("name")).isEqualTo("n2");
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
   }
 
@@ -344,11 +343,11 @@ public class MatchStatementExecutionTest extends TestHelper {
     final ResultSet qResult = database.query("sql",
         "match {type:Person, where:(name = 'n1')}.both('Friend'){as:friend}.both('Friend'){type: Person, where:(name = 'n4')} return $patterns");
 
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     final Result item = qResult.next();
-    Assertions.assertEquals(1, item.getPropertyNames().size());
-    Assertions.assertEquals("friend", item.getPropertyNames().iterator().next());
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(item.getPropertyNames().size()).isEqualTo(1);
+    assertThat(item.getPropertyNames().iterator().next()).isEqualTo("friend");
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
   }
 
@@ -357,10 +356,10 @@ public class MatchStatementExecutionTest extends TestHelper {
     final ResultSet qResult = database.query("sql",
         "match {type:Person, where:(name = 'n1')}.both('Friend'){as:friend}.both('Friend'){type: Person, where:(name = 'n4')} return $paths");
 
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     final Result item = qResult.next();
-    Assertions.assertEquals(3, item.getPropertyNames().size());
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(item.getPropertyNames().size()).isEqualTo(3);
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
   }
 
@@ -369,10 +368,10 @@ public class MatchStatementExecutionTest extends TestHelper {
     final ResultSet qResult = database.query("sql",
         "match {type:Person, where:(name = 'n1')}.both('Friend'){as:friend}.both('Friend'){type: Person, where:(name = 'n4')} return $elements");
 
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     final Result item = qResult.next();
-    Assertions.assertEquals("n2", item.getProperty("name"));
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(item.<String>getProperty("name")).isEqualTo("n2");
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
   }
 
@@ -386,12 +385,12 @@ public class MatchStatementExecutionTest extends TestHelper {
     expected.add("n2");
     expected.add("n4");
     for (int i = 0; i < 3; i++) {
-      Assertions.assertTrue(qResult.hasNext());
+      assertThat(qResult.hasNext()).isTrue();
       final Result item = qResult.next();
-      expected.remove(item.getProperty("name"));
+      expected.remove(item.<String>getProperty("name"));
     }
-    Assertions.assertFalse(qResult.hasNext());
-    Assertions.assertTrue(expected.isEmpty());
+    assertThat(qResult.hasNext()).isFalse();
+    assertThat(expected.isEmpty()).isTrue();
     qResult.close();
   }
 
@@ -401,10 +400,10 @@ public class MatchStatementExecutionTest extends TestHelper {
     final ResultSet qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1')}.both('Friend'){as:friend}.both('Friend'){type: Person, where:(name = 'n4')} return $matches)");
 
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     final Result item = qResult.next();
-    Assertions.assertEquals("n2", item.getProperty("name"));
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(item.<String>getProperty("name")).isEqualTo("n2");
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
   }
 
@@ -414,10 +413,10 @@ public class MatchStatementExecutionTest extends TestHelper {
     final ResultSet qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1')}-Friend-{as:friend}-Friend-{type: Person, where:(name = 'n4')} return friend)");
 
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     final Result item = qResult.next();
-    Assertions.assertEquals("n2", item.getProperty("name"));
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(item.<String>getProperty("name")).isEqualTo("n2");
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
   }
 
@@ -427,10 +426,10 @@ public class MatchStatementExecutionTest extends TestHelper {
     final ResultSet qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1')}-Friend-{as:friend}-Friend-{type: Person, where:(name = 'n4')} return $patterns)");
 
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     final Result item = qResult.next();
-    Assertions.assertEquals("n2", item.getProperty("name"));
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(item.<String>getProperty("name")).isEqualTo("n2");
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
   }
 
@@ -440,10 +439,10 @@ public class MatchStatementExecutionTest extends TestHelper {
     final ResultSet qResult = database.query("sql",
         "match {type:Person, where:(name = 'n1')}.both('Friend'){as:friend}.both('Friend'){type: Person, where:(name = 'n4')} return friend.name as name");
 
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     final Result item = qResult.next();
-    Assertions.assertEquals("n2", item.getProperty("name"));
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(item.<String>getProperty("name")).isEqualTo("n2");
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
   }
 
@@ -453,10 +452,10 @@ public class MatchStatementExecutionTest extends TestHelper {
     final ResultSet qResult = database.query("sql",
         "match {type:Person, where:(name = 'n1')}-Friend-{as:friend}-Friend-{type: Person, where:(name = 'n4')} return friend.name as name");
 
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     final Result item = qResult.next();
-    Assertions.assertEquals("n2", item.getProperty("name"));
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(item.<String>getProperty("name")).isEqualTo("n2");
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
   }
 
@@ -464,10 +463,10 @@ public class MatchStatementExecutionTest extends TestHelper {
   public void testReturnMethod() {
     final ResultSet qResult = database.query("sql",
         "match {type:Person, where:(name = 'n1')}.both('Friend'){as:friend}.both('Friend'){type: Person, where:(name = 'n4')} return friend.name.toUpperCase(Locale.ENGLISH) as name");
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     final Result item = qResult.next();
-    Assertions.assertEquals("N2", item.getProperty("name"));
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(item.<String>getProperty("name")).isEqualTo("N2");
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
   }
 
@@ -475,10 +474,10 @@ public class MatchStatementExecutionTest extends TestHelper {
   public void testReturnMethodArrows() {
     final ResultSet qResult = database.query("sql",
         "match {type:Person, where:(name = 'n1')}-Friend-{as:friend}-Friend-{type: Person, where:(name = 'n4')} return friend.name.toUpperCase(Locale.ENGLISH) as name");
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     final Result item = qResult.next();
-    Assertions.assertEquals("N2", item.getProperty("name"));
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(item.<String>getProperty("name")).isEqualTo("N2");
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
   }
 
@@ -487,10 +486,10 @@ public class MatchStatementExecutionTest extends TestHelper {
     final ResultSet qResult = database.query("sql",
         "match {type:Person, where:(name = 'n1')}.both('Friend'){as:friend}.both('Friend'){type: Person, where:(name = 'n4')} return friend.name + ' ' +friend.name as name");
 
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     final Result item = qResult.next();
-    Assertions.assertEquals("n2 n2", item.getProperty("name"));
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(item.<String>getProperty("name")).isEqualTo("n2 n2");
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
   }
 
@@ -499,10 +498,10 @@ public class MatchStatementExecutionTest extends TestHelper {
     final ResultSet qResult = database.query("sql",
         "match {type:Person, where:(name = 'n1')}-Friend-{as:friend}-Friend-{type: Person, where:(name = 'n4')} return friend.name + ' ' +friend.name as name");
 
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     final Result item = qResult.next();
-    Assertions.assertEquals("n2 n2", item.getProperty("name"));
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(item.<String>getProperty("name")).isEqualTo("n2 n2");
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
   }
 
@@ -511,10 +510,10 @@ public class MatchStatementExecutionTest extends TestHelper {
     final ResultSet qResult = database.query("sql",
         "match {type:Person, where:(name = 'n1')}.both('Friend'){as:friend}.both('Friend'){type: Person, where:(name = 'n4')} return friend.name");
 
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     final Result item = qResult.next();
-    Assertions.assertEquals("n2", item.getProperty("friend.name"));
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(item.<String>getProperty("friend.name")).isEqualTo("n2");
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
   }
 
@@ -523,10 +522,10 @@ public class MatchStatementExecutionTest extends TestHelper {
     final ResultSet qResult = database.query("sql",
         "match {type:Person, where:(name = 'n1')}-Friend-{as:friend}-Friend-{type: Person, where:(name = 'n4')} return friend.name");
 
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     final Result item = qResult.next();
-    Assertions.assertEquals("n2", item.getProperty("friend.name"));
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(item.<String>getProperty("friend.name")).isEqualTo("n2");
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
   }
 
@@ -535,10 +534,10 @@ public class MatchStatementExecutionTest extends TestHelper {
     final ResultSet qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1')}.out('Friend').out('Friend'){as:friend} return $matches)");
 
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     final Result item = qResult.next();
-    Assertions.assertEquals("n4", item.getProperty("name"));
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(item.<String>getProperty("name")).isEqualTo("n4");
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
   }
 
@@ -547,10 +546,10 @@ public class MatchStatementExecutionTest extends TestHelper {
     final ResultSet qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1')}-Friend->{}-Friend->{as:friend} return $matches)");
 
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     final Result item = qResult.next();
-    Assertions.assertEquals("n4", item.getProperty("name"));
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(item.<String>getProperty("name")).isEqualTo("n4");
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
   }
 
@@ -559,10 +558,10 @@ public class MatchStatementExecutionTest extends TestHelper {
     final ResultSet qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1'), as: me}.both('Friend').both('Friend'){as:friend, where: ($matched.me != $currentMatch)} return $matches)");
 
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     while (qResult.hasNext()) {
       final Result item = qResult.next();
-      Assertions.assertNotEquals("n1", item.getProperty("name"));
+      assertThat(item.<String>getProperty("name")).isNotEqualTo("n1");
     }
     qResult.close();
   }
@@ -572,9 +571,9 @@ public class MatchStatementExecutionTest extends TestHelper {
     final ResultSet qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1'), as: me}-Friend-{}-Friend-{as:friend, where: ($matched.me != $currentMatch)} return $matches)");
 
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     while (qResult.hasNext()) {
-      Assertions.assertNotEquals("n1", qResult.next().getProperty("name"));
+      assertThat(qResult.next().<String>getProperty("name")).isNotEqualTo("n1");
     }
     qResult.close();
   }
@@ -584,9 +583,9 @@ public class MatchStatementExecutionTest extends TestHelper {
     final ResultSet qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1' and 1 + 1 = 2)}.out('Friend'){as:friend, where:(name = 'n2' and 1 + 1 = 2)} return friend)");
 
-    Assertions.assertTrue(qResult.hasNext());
-    Assertions.assertEquals("n2", qResult.next().getProperty("name"));
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
+    assertThat(qResult.next().<String>getProperty("name")).isEqualTo("n2");
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
   }
 
@@ -594,9 +593,9 @@ public class MatchStatementExecutionTest extends TestHelper {
   public void testFriendsWithNameArrows() {
     final ResultSet qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1' and 1 + 1 = 2)}-Friend->{as:friend, where:(name = 'n2' and 1 + 1 = 2)} return friend)");
-    Assertions.assertTrue(qResult.hasNext());
-    Assertions.assertEquals("n2", qResult.next().getProperty("name"));
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
+    assertThat(qResult.next().<String>getProperty("name")).isEqualTo("n2");
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
   }
 
@@ -605,32 +604,32 @@ public class MatchStatementExecutionTest extends TestHelper {
 
     ResultSet qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1')}.out('Friend'){as:friend, while: ($depth < 1)} return friend)");
-    Assertions.assertEquals(3, size(qResult));
+    assertThat(size(qResult)).isEqualTo(3);
     qResult.close();
 
     qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1')}.out('Friend'){as:friend, while: ($depth < 2), where: ($depth=1) } return friend)");
-    Assertions.assertEquals(2, size(qResult));
+    assertThat(size(qResult)).isEqualTo(2);
     qResult.close();
 
     qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1')}.out('Friend'){as:friend, while: ($depth < 4), where: ($depth=1) } return friend)");
-    Assertions.assertEquals(2, size(qResult));
+    assertThat(size(qResult)).isEqualTo(2);
     qResult.close();
 
     qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1')}.out('Friend'){as:friend, while: (true) } return friend)");
-    Assertions.assertEquals(6, size(qResult));
+    assertThat(size(qResult)).isEqualTo(6);
     qResult.close();
 
     qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1')}.out('Friend'){as:friend, while: (true) } return friend limit 3)");
-    Assertions.assertEquals(3, size(qResult));
+    assertThat(size(qResult)).isEqualTo(3);
     qResult.close();
 
     qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1')}.out('Friend'){as:friend, while: (true) } return friend) limit 3");
-    Assertions.assertEquals(3, size(qResult));
+    assertThat(size(qResult)).isEqualTo(3);
     qResult.close();
   }
 
@@ -647,22 +646,22 @@ public class MatchStatementExecutionTest extends TestHelper {
   public void testWhileArrows() {
     ResultSet qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1')}-Friend->{as:friend, while: ($depth < 1)} return friend)");
-    Assertions.assertEquals(3, size(qResult));
+    assertThat(size(qResult)).isEqualTo(3);
     qResult.close();
 
     qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1')}-Friend->{as:friend, while: ($depth < 2), where: ($depth=1) } return friend)");
-    Assertions.assertEquals(2, size(qResult));
+    assertThat(size(qResult)).isEqualTo(2);
     qResult.close();
 
     qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1')}-Friend->{as:friend, while: ($depth < 4), where: ($depth=1) } return friend)");
-    Assertions.assertEquals(2, size(qResult));
+    assertThat(size(qResult)).isEqualTo(2);
     qResult.close();
 
     qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1')}-Friend->{as:friend, while: (true) } return friend)");
-    Assertions.assertEquals(6, size(qResult));
+    assertThat(size(qResult)).isEqualTo(6);
     qResult.close();
   }
 
@@ -670,22 +669,22 @@ public class MatchStatementExecutionTest extends TestHelper {
   public void testMaxDepth() {
     ResultSet qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1')}.out('Friend'){as:friend, maxDepth: 1, where: ($depth=1) } return friend)");
-    Assertions.assertEquals(2, size(qResult));
+    assertThat(size(qResult)).isEqualTo(2);
     qResult.close();
 
     qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1')}.out('Friend'){as:friend, maxDepth: 1 } return friend)");
-    Assertions.assertEquals(3, size(qResult));
+    assertThat(size(qResult)).isEqualTo(3);
     qResult.close();
 
     qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1')}.out('Friend'){as:friend, maxDepth: 0 } return friend)");
-    Assertions.assertEquals(1, size(qResult));
+    assertThat(size(qResult)).isEqualTo(1);
     qResult.close();
 
     qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1')}.out('Friend'){as:friend, maxDepth: 1, where: ($depth > 0) } return friend)");
-    Assertions.assertEquals(2, size(qResult));
+    assertThat(size(qResult)).isEqualTo(2);
     qResult.close();
   }
 
@@ -693,22 +692,22 @@ public class MatchStatementExecutionTest extends TestHelper {
   public void testMaxDepthArrow() {
     ResultSet qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1')}-Friend->{as:friend, maxDepth: 1, where: ($depth=1) } return friend)");
-    Assertions.assertEquals(2, size(qResult));
+    assertThat(size(qResult)).isEqualTo(2);
     qResult.close();
 
     qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1')}-Friend->{as:friend, maxDepth: 1 } return friend)");
-    Assertions.assertEquals(3, size(qResult));
+    assertThat(size(qResult)).isEqualTo(3);
     qResult.close();
 
     qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1')}-Friend->{as:friend, maxDepth: 0 } return friend)");
-    Assertions.assertEquals(1, size(qResult));
+    assertThat(size(qResult)).isEqualTo(1);
     qResult.close();
 
     qResult = database.query("sql",
         "select friend.name as name from (match {type:Person, where:(name = 'n1')}-Friend->{as:friend, maxDepth: 1, where: ($depth > 0) } return friend)");
-    Assertions.assertEquals(2, size(qResult));
+    assertThat(size(qResult)).isEqualTo(2);
     qResult.close();
   }
 
@@ -716,15 +715,15 @@ public class MatchStatementExecutionTest extends TestHelper {
   public void testManager() {
     // the manager of a person is the manager of the department that person belongs to.
     // if that department does not have a direct manager, climb up the hierarchy until you find one
-    Assertions.assertEquals("c", getManager("p10").get("name"));
-    Assertions.assertEquals("c", getManager("p12").get("name"));
-    Assertions.assertEquals("b", getManager("p6").get("name"));
-    Assertions.assertEquals("b", getManager("p11").get("name"));
+    assertThat(getManager("p10").get("name")).isEqualTo("c");
+    assertThat(getManager("p12").get("name")).isEqualTo("c");
+    assertThat(getManager("p6").get("name")).isEqualTo("b");
+    assertThat(getManager("p11").get("name")).isEqualTo("b");
 
-    Assertions.assertEquals("c", getManagerArrows("p10").get("name"));
-    Assertions.assertEquals("c", getManagerArrows("p12").get("name"));
-    Assertions.assertEquals("b", getManagerArrows("p6").get("name"));
-    Assertions.assertEquals("b", getManagerArrows("p11").get("name"));
+    assertThat(getManagerArrows("p10").get("name")).isEqualTo("c");
+    assertThat(getManagerArrows("p12").get("name")).isEqualTo("c");
+    assertThat(getManagerArrows("p6").get("name")).isEqualTo("b");
+    assertThat(getManagerArrows("p11").get("name")).isEqualTo("b");
   }
 
   @Test
@@ -744,12 +743,12 @@ public class MatchStatementExecutionTest extends TestHelper {
     query.append(")");
 
     final ResultSet qResult = database.query("sql", query.toString());
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     final Result item = qResult.next();
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
 
-    Assertions.assertEquals("Employee", item.getProperty("@type"));
+    assertThat(item.<String>getProperty("@type")).isEqualTo("Employee");
   }
 
   private Document getManager(final String personName) {
@@ -766,9 +765,9 @@ public class MatchStatementExecutionTest extends TestHelper {
     query.append(")");
 
     final ResultSet qResult = database.query("sql", query.toString());
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     final Result item = qResult.next();
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
     return item.getElement().get().getRecord().asVertex();
   }
@@ -786,9 +785,9 @@ public class MatchStatementExecutionTest extends TestHelper {
 
     final ResultSet qResult = database.query("sql", query.toString());
 
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     final Result item = qResult.next();
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
     return item.getElement().get().getRecord().asVertex();
   }
@@ -798,15 +797,15 @@ public class MatchStatementExecutionTest extends TestHelper {
     // the manager of a person is the manager of the department that person belongs to.
     // if that department does not have a direct manager, climb up the hierarchy until you find one
 
-    Assertions.assertEquals("c", getManager2("p10").getProperty("name"));
-    Assertions.assertEquals("c", getManager2("p12").getProperty("name"));
-    Assertions.assertEquals("b", getManager2("p6").getProperty("name"));
-    Assertions.assertEquals("b", getManager2("p11").getProperty("name"));
+    assertThat(getManager2("p10").<String>getProperty("name")).isEqualTo("c");
+    assertThat(getManager2("p12").<String>getProperty("name")).isEqualTo("c");
+    assertThat(getManager2("p6").<String>getProperty("name")).isEqualTo("b");
+    assertThat(getManager2("p11").<String>getProperty("name")).isEqualTo("b");
 
-    Assertions.assertEquals("c", getManager2Arrows("p10").getProperty("name"));
-    Assertions.assertEquals("c", getManager2Arrows("p12").getProperty("name"));
-    Assertions.assertEquals("b", getManager2Arrows("p6").getProperty("name"));
-    Assertions.assertEquals("b", getManager2Arrows("p11").getProperty("name"));
+    assertThat(getManager2Arrows("p10").<String>getProperty("name")).isEqualTo("c");
+    assertThat(getManager2Arrows("p12").<String>getProperty("name")).isEqualTo("c");
+    assertThat(getManager2Arrows("p6").<String>getProperty("name")).isEqualTo("b");
+    assertThat(getManager2Arrows("p11").<String>getProperty("name")).isEqualTo("b");
   }
 
   private Result getManager2(final String personName) {
@@ -824,9 +823,9 @@ public class MatchStatementExecutionTest extends TestHelper {
     query.append(")");
 
     final ResultSet qResult = database.query("sql", query.toString());
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     final Result item = qResult.next();
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
     return item;
   }
@@ -844,9 +843,9 @@ public class MatchStatementExecutionTest extends TestHelper {
     query.append(")");
 
     final ResultSet qResult = database.query("sql", query.toString());
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     final Result item = qResult.next();
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(qResult.hasNext()).isFalse();
     qResult.close();
     return item;
   }
@@ -856,10 +855,10 @@ public class MatchStatementExecutionTest extends TestHelper {
     // people managed by a manager are people who belong to his department or people who belong to
     // sub-departments without a manager
     final ResultSet managedByA = getManagedBy("a");
-    Assertions.assertTrue(managedByA.hasNext());
+    assertThat(managedByA.hasNext()).isTrue();
     final Result item = managedByA.next();
-    Assertions.assertFalse(managedByA.hasNext());
-    Assertions.assertEquals("p1", item.getProperty("name"));
+    assertThat(managedByA.hasNext()).isFalse();
+    assertThat(item.<String>getProperty("name")).isEqualTo("p1");
     managedByA.close();
 
     final ResultSet managedByB = getManagedBy("b");
@@ -872,12 +871,12 @@ public class MatchStatementExecutionTest extends TestHelper {
     expectedNames.add("p11");
     final Set<String> names = new HashSet<String>();
     for (int i = 0; i < 5; i++) {
-      Assertions.assertTrue(managedByB.hasNext());
+      assertThat(managedByB.hasNext()).isTrue();
       final Result id = managedByB.next();
       final String name = id.getProperty("name");
       names.add(name);
     }
-    Assertions.assertEquals(expectedNames, names);
+    assertThat(names).isEqualTo(expectedNames);
     managedByB.close();
   }
 
@@ -902,10 +901,10 @@ public class MatchStatementExecutionTest extends TestHelper {
     // people managed by a manager are people who belong to his department or people who belong to
     // sub-departments without a manager
     final ResultSet managedByA = getManagedByArrows("a");
-    Assertions.assertTrue(managedByA.hasNext());
+    assertThat(managedByA.hasNext()).isTrue();
     final Result item = managedByA.next();
-    Assertions.assertFalse(managedByA.hasNext());
-    Assertions.assertEquals("p1", item.getProperty("name"));
+    assertThat(managedByA.hasNext()).isFalse();
+    assertThat(item.<String>getProperty("name")).isEqualTo("p1");
     managedByA.close();
     final ResultSet managedByB = getManagedByArrows("b");
 
@@ -917,12 +916,12 @@ public class MatchStatementExecutionTest extends TestHelper {
     expectedNames.add("p11");
     final Set<String> names = new HashSet<String>();
     for (int i = 0; i < 5; i++) {
-      Assertions.assertTrue(managedByB.hasNext());
+      assertThat(managedByB.hasNext()).isTrue();
       final Result id = managedByB.next();
       final String name = id.getProperty("name");
       names.add(name);
     }
-    Assertions.assertEquals(expectedNames, names);
+    assertThat(names).isEqualTo(expectedNames);
     managedByB.close();
   }
 
@@ -945,10 +944,10 @@ public class MatchStatementExecutionTest extends TestHelper {
     // people managed by a manager are people who belong to his department or people who belong to
     // sub-departments without a manager
     final ResultSet managedByA = getManagedBy2("a");
-    Assertions.assertTrue(managedByA.hasNext());
+    assertThat(managedByA.hasNext()).isTrue();
     final Result item = managedByA.next();
-    Assertions.assertFalse(managedByA.hasNext());
-    Assertions.assertEquals("p1", item.getProperty("name"));
+    assertThat(managedByA.hasNext()).isFalse();
+    assertThat(item.<String>getProperty("name")).isEqualTo("p1");
     managedByA.close();
     final ResultSet managedByB = getManagedBy2("b");
 
@@ -960,12 +959,12 @@ public class MatchStatementExecutionTest extends TestHelper {
     expectedNames.add("p11");
     final Set<String> names = new HashSet<String>();
     for (int i = 0; i < 5; i++) {
-      Assertions.assertTrue(managedByB.hasNext());
+      assertThat(managedByB.hasNext()).isTrue();
       final Result id = managedByB.next();
       final String name = id.getProperty("name");
       names.add(name);
     }
-    Assertions.assertEquals(expectedNames, names);
+    assertThat(names).isEqualTo(expectedNames);
     managedByB.close();
   }
 
@@ -990,10 +989,10 @@ public class MatchStatementExecutionTest extends TestHelper {
     // people managed by a manager are people who belong to his department or people who belong to
     // sub-departments without a manager
     final ResultSet managedByA = getManagedBy2Arrows("a");
-    Assertions.assertTrue(managedByA.hasNext());
+    assertThat(managedByA.hasNext()).isTrue();
     final Result item = managedByA.next();
-    Assertions.assertFalse(managedByA.hasNext());
-    Assertions.assertEquals("p1", item.getProperty("name"));
+    assertThat(managedByA.hasNext()).isFalse();
+    assertThat(item.<String>getProperty("name")).isEqualTo("p1");
     managedByA.close();
     final ResultSet managedByB = getManagedBy2Arrows("b");
 
@@ -1005,12 +1004,12 @@ public class MatchStatementExecutionTest extends TestHelper {
     expectedNames.add("p11");
     final Set<String> names = new HashSet<String>();
     for (int i = 0; i < 5; i++) {
-      Assertions.assertTrue(managedByB.hasNext());
+      assertThat(managedByB.hasNext()).isTrue();
       final Result id = managedByB.next();
       final String name = id.getProperty("name");
       names.add(name);
     }
-    Assertions.assertEquals(expectedNames, names);
+    assertThat(names).isEqualTo(expectedNames);
     managedByB.close();
   }
 
@@ -1042,9 +1041,9 @@ public class MatchStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", query.toString());
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1057,9 +1056,9 @@ public class MatchStatementExecutionTest extends TestHelper {
     query.append("return $matches");
 
     final ResultSet result = database.query("sql", query.toString());
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1076,14 +1075,14 @@ public class MatchStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", query.toString());
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result doc = result.next();
     final Document friend1 = doc.getProperty("friend1");
     final Document friend2 = doc.getProperty("friend2");
     final Document friend3 = doc.getProperty("friend3");
-    Assertions.assertEquals(0, friend1.getInteger("uid"));
-    Assertions.assertEquals(1, friend2.getInteger("uid"));
-    Assertions.assertEquals(2, friend3.getInteger("uid"));
+    assertThat(friend1.getInteger("uid")).isEqualTo(0);
+    assertThat(friend2.getInteger("uid")).isEqualTo(1);
+    assertThat(friend3.getInteger("uid")).isEqualTo(2);
     result.close();
   }
 
@@ -1099,15 +1098,15 @@ public class MatchStatementExecutionTest extends TestHelper {
     query.append("return $patterns");
 
     final ResultSet result = database.query("sql", query.toString());
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result doc = result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     final Document friend1 = doc.getProperty("friend1");
     final Document friend2 = doc.getProperty("friend2");
     final Document friend3 = doc.getProperty("friend3");
-    Assertions.assertEquals(0, friend1.getInteger("uid"));
-    Assertions.assertEquals(1, friend2.getInteger("uid"));
-    Assertions.assertEquals(2, friend3.getInteger("uid"));
+    assertThat(friend1.getInteger("uid")).isEqualTo(0);
+    assertThat(friend2.getInteger("uid")).isEqualTo(1);
+    assertThat(friend3.getInteger("uid")).isEqualTo(2);
     result.close();
   }
 
@@ -1123,15 +1122,15 @@ public class MatchStatementExecutionTest extends TestHelper {
     query.append("return $matches");
 
     final ResultSet result = database.query("sql", query.toString());
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result doc = result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     final Document friend1 = doc.getProperty("friend1");
     final Document friend2 = doc.getProperty("friend2");
     final Document friend3 = doc.getProperty("friend3");
-    Assertions.assertEquals(0, friend1.getInteger("uid"));
-    Assertions.assertEquals(1, friend2.getInteger("uid"));
-    Assertions.assertEquals(2, friend3.getInteger("uid"));
+    assertThat(friend1.getInteger("uid")).isEqualTo(0);
+    assertThat(friend2.getInteger("uid")).isEqualTo(1);
+    assertThat(friend3.getInteger("uid")).isEqualTo(2);
     result.close();
   }
 
@@ -1147,9 +1146,9 @@ public class MatchStatementExecutionTest extends TestHelper {
     query.append("return $matches");
 
     final ResultSet result = database.query("sql", query.toString());
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result doc = result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1165,9 +1164,9 @@ public class MatchStatementExecutionTest extends TestHelper {
     query.append("return $matches");
 
     final ResultSet result = database.query("sql", query.toString());
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result doc = result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1183,9 +1182,9 @@ public class MatchStatementExecutionTest extends TestHelper {
     query.append("return $matches");
 
     final ResultSet result = database.query("sql", query.toString());
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result doc = result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1202,9 +1201,9 @@ public class MatchStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", query.toString());
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result doc = result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1219,12 +1218,12 @@ public class MatchStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", query.toString());
 
     for (int i = 0; i < 2; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result doc = result.next();
       final Vertex friend1 = doc.getProperty("friend1");
-      Assertions.assertEquals(friend1.getInteger("uid"), 1);
+      assertThat(friend1.getInteger("uid")).isEqualTo(1);
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1241,10 +1240,10 @@ public class MatchStatementExecutionTest extends TestHelper {
         .ifPresent(x -> x.getSteps().stream().filter(y -> y instanceof MatchPrefetchStep).forEach(prefetchStepFound -> fail()));
 
     for (int i = 0; i < 1000; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1258,11 +1257,11 @@ public class MatchStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", query.toString());
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result d = result.next();
     final Document friend1 = d.getProperty("friend1");
-    Assertions.assertEquals(friend1.getInteger("uid"), 1);
-    Assertions.assertFalse(result.hasNext());
+    assertThat(friend1.getInteger("uid")).isEqualTo(1);
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1275,12 +1274,12 @@ public class MatchStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", query.toString());
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
 
     final Result doc = result.next();
     final Object foo = doc.getProperty("foo");
-    Assertions.assertNotNull(foo);
-    Assertions.assertTrue(foo instanceof Vertex);
+    assertThat(foo).isNotNull();
+    assertThat(foo instanceof Vertex).isTrue();
     result.close();
   }
 
@@ -1292,13 +1291,13 @@ public class MatchStatementExecutionTest extends TestHelper {
     query.append("return friend1.out('TriangleE')[0,1] as foo");
 
     final ResultSet result = database.query("sql", query.toString());
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result doc = result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     final Object foo = doc.getProperty("foo");
-    Assertions.assertNotNull(foo);
-    Assertions.assertTrue(foo instanceof List);
-    Assertions.assertEquals(2, ((List) foo).size());
+    assertThat(foo).isNotNull();
+    assertThat(foo instanceof List).isTrue();
+    assertThat(((List) foo).size()).isEqualTo(2);
     result.close();
   }
 
@@ -1310,14 +1309,14 @@ public class MatchStatementExecutionTest extends TestHelper {
     query.append("return friend1.out('TriangleE')[0..1] as foo");
 
     final ResultSet result = database.query("sql", query.toString());
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result doc = result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     final Object foo = doc.getProperty("foo");
-    Assertions.assertNotNull(foo);
-    Assertions.assertTrue(foo instanceof List);
-    Assertions.assertEquals(1, ((List) foo).size());
+    assertThat(foo).isNotNull();
+    assertThat(foo instanceof List).isTrue();
+    assertThat(((List) foo).size()).isEqualTo(1);
     result.close();
   }
 
@@ -1329,14 +1328,14 @@ public class MatchStatementExecutionTest extends TestHelper {
     query.append("return friend1.out('TriangleE')[0..2] as foo");
 
     final ResultSet result = database.query("sql", query.toString());
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result doc = result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     final Object foo = doc.getProperty("foo");
-    Assertions.assertNotNull(foo);
-    Assertions.assertTrue(foo instanceof List);
-    Assertions.assertEquals(2, ((List) foo).size());
+    assertThat(foo).isNotNull();
+    assertThat(foo instanceof List).isTrue();
+    assertThat(((List) foo).size()).isEqualTo(2);
     result.close();
   }
 
@@ -1348,14 +1347,14 @@ public class MatchStatementExecutionTest extends TestHelper {
     query.append("return friend1.out('TriangleE')[0..3] as foo");
 
     final ResultSet result = database.query("sql", query.toString());
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result doc = result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     final Object foo = doc.getProperty("foo");
-    Assertions.assertNotNull(foo);
-    Assertions.assertTrue(foo instanceof List);
-    Assertions.assertEquals(2, ((List) foo).size());
+    assertThat(foo).isNotNull();
+    assertThat(foo instanceof List).isTrue();
+    assertThat(((List) foo).size()).isEqualTo(2);
     result.close();
   }
 
@@ -1367,16 +1366,16 @@ public class MatchStatementExecutionTest extends TestHelper {
     query.append("return friend1.out('TriangleE')[uid = 2] as foo");
 
     final ResultSet result = database.query("sql", query.toString());
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result doc = result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     final Object foo = doc.getProperty("foo");
-    Assertions.assertNotNull(foo);
-    Assertions.assertTrue(foo instanceof List);
-    Assertions.assertEquals(1, ((List) foo).size());
+    assertThat(foo).isNotNull();
+    assertThat(foo instanceof List).isTrue();
+    assertThat(((List) foo).size()).isEqualTo(1);
     final Vertex resultVertex = (Vertex) ((List) foo).get(0);
-    Assertions.assertEquals(2, resultVertex.getInteger("uid"));
+    assertThat(resultVertex.getInteger("uid")).isEqualTo(2);
     result.close();
   }
 
@@ -1390,9 +1389,9 @@ public class MatchStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", query.toString());
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result doc = result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1405,9 +1404,9 @@ public class MatchStatementExecutionTest extends TestHelper {
     query.append("return one, two");
 
     final ResultSet result = database.query("sql", query.toString());
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result doc = result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1419,9 +1418,9 @@ public class MatchStatementExecutionTest extends TestHelper {
     query.append("return {'name':'foo', 'uuid':one.uid}");
 
     final ResultSet result = database.query("sql", query.toString());
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result doc = result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     //    Document doc = result.get(0);
     //    assertEquals("foo", doc.set("name");
@@ -1437,9 +1436,9 @@ public class MatchStatementExecutionTest extends TestHelper {
     query.append("return {'name':'foo', 'sub': {'uuid':one.uid}}");
 
     final ResultSet result = database.query("sql", query.toString());
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result doc = result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     //    Document doc = result.get(0);
     //    assertEquals("foo", doc.set("name");
     //    assertEquals(0, doc.set("sub.uuid");
@@ -1454,9 +1453,9 @@ public class MatchStatementExecutionTest extends TestHelper {
     query.append("return {'name':'foo', 'sub': [{'uuid':one.uid}]}");
 
     final ResultSet result = database.query("sql", query.toString());
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result doc = result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     //    Document doc = result.get(0);
     //    assertEquals("foo", doc.set("name");
     //    assertEquals(0, doc.set("sub[0].uuid");
@@ -1473,9 +1472,9 @@ public class MatchStatementExecutionTest extends TestHelper {
 
     ResultSet result = database.query("sql", query.toString());
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result doc = result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     query = new StringBuilder();
     query.append("match ");
@@ -1485,9 +1484,9 @@ public class MatchStatementExecutionTest extends TestHelper {
     result.close();
 
     result = database.query("sql", query.toString());
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     doc = result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
     //    Document doc = result.get(0);
     //    assertEquals("foo", doc.set("name");
@@ -1503,11 +1502,11 @@ public class MatchStatementExecutionTest extends TestHelper {
 
     ResultSet result = database.query("sql", query.toString());
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result doc = result.next();
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     doc = result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     query = new StringBuilder();
@@ -1516,11 +1515,11 @@ public class MatchStatementExecutionTest extends TestHelper {
     query.append("return one.uid, two.uid");
 
     result = database.query("sql", query.toString());
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     doc = result.next();
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     doc = result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
     //    Document doc = result.get(0);
     //    assertEquals("foo", doc.set("name");
@@ -1540,13 +1539,13 @@ public class MatchStatementExecutionTest extends TestHelper {
     expectedNames.add("p11");
     final Set<String> names = new HashSet<String>();
     for (int i = 0; i < 6; i++) {
-      Assertions.assertTrue(managedByB.hasNext());
+      assertThat(managedByB.hasNext()).isTrue();
       final Result doc = managedByB.next();
       final String name = doc.getProperty("name");
       names.add(name);
     }
-    Assertions.assertFalse(managedByB.hasNext());
-    Assertions.assertEquals(expectedNames, names);
+    assertThat(managedByB.hasNext()).isFalse();
+    assertThat(names).isEqualTo(expectedNames);
     managedByB.close();
   }
 
@@ -1579,13 +1578,13 @@ public class MatchStatementExecutionTest extends TestHelper {
     expectedNames.add("p11");
     final Set<String> names = new HashSet<String>();
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(managedByB.hasNext());
+      assertThat(managedByB.hasNext()).isTrue();
       final Result doc = managedByB.next();
       final String name = doc.getProperty("name");
       names.add(name);
     }
-    Assertions.assertFalse(managedByB.hasNext());
-    Assertions.assertEquals(expectedNames, names);
+    assertThat(managedByB.hasNext()).isFalse();
+    assertThat(names).isEqualTo(expectedNames);
     managedByB.close();
   }
 
@@ -1595,13 +1594,13 @@ public class MatchStatementExecutionTest extends TestHelper {
         "match {type:Person, as: person} -NonExistingEdge-> {as:b, optional:true} return person, b.name");
 
     for (int i = 0; i < 6; i++) {
-      Assertions.assertTrue(qResult.hasNext());
+      assertThat(qResult.hasNext()).isTrue();
       final Result doc = qResult.next();
-      Assertions.assertTrue(doc.getPropertyNames().size() == 2);
+      assertThat(doc.getPropertyNames().size()).isEqualTo(2);
       final Vertex person = doc.getProperty("person");
 
       final String name = person.getString("name");
-      Assertions.assertTrue(name.startsWith("n"));
+      assertThat(name.startsWith("n")).isTrue();
     }
   }
 
@@ -1611,13 +1610,13 @@ public class MatchStatementExecutionTest extends TestHelper {
         "match {type:Person, as: person} --> {as:b, optional:true, where:(nonExisting = 12)} return person, b.name");
 
     for (int i = 0; i < 6; i++) {
-      Assertions.assertTrue(qResult.hasNext());
+      assertThat(qResult.hasNext()).isTrue();
       final Result doc = qResult.next();
-      Assertions.assertTrue(doc.getPropertyNames().size() == 2);
+      assertThat(doc.getPropertyNames().size()).isEqualTo(2);
       final Vertex person = doc.getProperty("person");
 
       final String name = person.getString("name");
-      Assertions.assertTrue(name.startsWith("n"));
+      assertThat(name.startsWith("n")).isTrue();
     }
   }
 
@@ -1628,11 +1627,11 @@ public class MatchStatementExecutionTest extends TestHelper {
         + "{as:a}.out(){as:b, where:(nonExisting = 12), optional:true}," + "{as:friend}.out(){as:b, optional:true}"
         + " return friend, b)");
 
-    Assertions.assertTrue(qResult.hasNext());
+    assertThat(qResult.hasNext()).isTrue();
     final Result doc = qResult.next();
-    Assertions.assertEquals("n2", doc.getProperty("name"));
-    Assertions.assertNull(doc.getProperty("b"));
-    Assertions.assertFalse(qResult.hasNext());
+    assertThat(doc.<String>getProperty("name")).isEqualTo("n2");
+    assertThat(doc.<String>getProperty("b")).isNull();
+    assertThat(qResult.hasNext()).isFalse();
   }
 
   @Test
@@ -1647,15 +1646,15 @@ public class MatchStatementExecutionTest extends TestHelper {
     final String query = "MATCH { type: testOrderByAsc, as:a} RETURN a.name as name order by name asc";
 
     final ResultSet result = database.query("sql", query);
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertEquals("aaa", result.next().getProperty("name"));
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertEquals("bbb", result.next().getProperty("name"));
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertEquals("ccc", result.next().getProperty("name"));
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertEquals("zzz", result.next().getProperty("name"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next().<String>getProperty("name")).isEqualTo("aaa");
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next().<String>getProperty("name")).isEqualTo("bbb");
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next().<String>getProperty("name")).isEqualTo("ccc");
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next().<String>getProperty("name")).isEqualTo("zzz");
+    assertThat(result.hasNext()).isFalse();
   }
 
   @Test
@@ -1670,15 +1669,15 @@ public class MatchStatementExecutionTest extends TestHelper {
     final String query = "MATCH { type: testOrderByDesc, as:a} RETURN a.name as name order by name desc";
 
     final ResultSet result = database.query("sql", query);
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertEquals("zzz", result.next().getProperty("name"));
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertEquals("ccc", result.next().getProperty("name"));
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertEquals("bbb", result.next().getProperty("name"));
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertEquals("aaa", result.next().getProperty("name"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next().<String>getProperty("name")).isEqualTo("zzz");
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next().<String>getProperty("name")).isEqualTo("ccc");
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next().<String>getProperty("name")).isEqualTo("bbb");
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next().<String>getProperty("name")).isEqualTo("aaa");
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1692,12 +1691,12 @@ public class MatchStatementExecutionTest extends TestHelper {
     final String query = "MATCH { type: " + clazz + ", as:a} RETURN a:{name}, 'x' ";
 
     final ResultSet result = database.query("sql", query);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result item = result.next();
     final Result a = item.getProperty("a");
-    Assertions.assertEquals("bbb", a.getProperty("name"));
-    Assertions.assertNull(a.getProperty("surname"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(a.<String>getProperty("name")).isEqualTo("bbb");
+    assertThat(a.<String>getProperty("surname")).isNull();
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1716,14 +1715,14 @@ public class MatchStatementExecutionTest extends TestHelper {
     final String query = "MATCH { type: " + clazz + ", as:a} RETURN a:{*, @rid}, 'x' ";
 
     final ResultSet result = database.query("sql", query);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result item = result.next();
     final Result a = item.getProperty("a");
-    Assertions.assertEquals("bbb", a.getProperty("name"));
-    Assertions.assertEquals("ccc", a.getProperty("surname"));
-    Assertions.assertNotNull(a.getProperty("@rid"));
-    Assertions.assertEquals(4, a.getPropertyNames().size());
-    Assertions.assertFalse(result.hasNext());
+    assertThat(a.<String>getProperty("name")).isEqualTo("bbb");
+    assertThat(a.<String>getProperty("surname")).isEqualTo("ccc");
+    assertThat(a.<RID>getProperty("@rid")).isNotNull();
+    assertThat(a.getPropertyNames().size()).isEqualTo(4);
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1742,11 +1741,11 @@ public class MatchStatementExecutionTest extends TestHelper {
     final String query = "MATCH { type: " + clazz + ", as:a} RETURN expand(a) ";
 
     final ResultSet result = database.query("sql", query);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result a = result.next();
-    Assertions.assertEquals("bbb", a.getProperty("name"));
-    Assertions.assertEquals("ccc", a.getProperty("surname"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(a.<String>getProperty("name")).isEqualTo("bbb");
+    assertThat(a.<String>getProperty("surname")).isEqualTo("ccc");
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1766,17 +1765,17 @@ public class MatchStatementExecutionTest extends TestHelper {
         "MATCH { type: " + clazz + ", as:a} RETURN a.name as a, max(a.num) as maxNum group by a.name order by a.name";
 
     final ResultSet result = database.query("sql", query);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertEquals("aaa", item.getProperty("a"));
-    Assertions.assertEquals(3, (int) item.getProperty("maxNum"));
+    assertThat(item.<String>getProperty("a")).isEqualTo("aaa");
+    assertThat((int) item.getProperty("maxNum")).isEqualTo(3);
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     item = result.next();
-    Assertions.assertEquals("bbb", item.getProperty("a"));
-    Assertions.assertEquals(6, (int) item.getProperty("maxNum"));
+    assertThat(item.<String>getProperty("a")).isEqualTo("bbb");
+    assertThat((int) item.getProperty("maxNum")).isEqualTo(6);
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1793,13 +1792,13 @@ public class MatchStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", query);
     for (int i = 0; i < 3; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertEquals("aaa", item.getProperty("name"));
-      Assertions.assertEquals(i, (int) item.getProperty("num"));
+      assertThat(item.<String>getProperty("name")).isEqualTo("aaa");
+      assertThat((int) item.getProperty("num")).isEqualTo(i);
     }
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1817,13 +1816,13 @@ public class MatchStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", query);
 
     for (int i = 2; i >= 0; i--) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertEquals("aaa", item.getProperty("name"));
-      Assertions.assertEquals(i, (int) item.getProperty("num"));
+      assertThat(item.<String>getProperty("name")).isEqualTo("aaa");
+      assertThat((int) item.getProperty("num")).isEqualTo(i);
     }
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1840,15 +1839,15 @@ public class MatchStatementExecutionTest extends TestHelper {
     int sum = 0;
     final ResultSet result = database.query("sql", query);
     for (int i = 0; i < 4; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      sum += (Integer) item.getProperty("num");
+      sum +=  item.<Integer>getProperty("num");
     }
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     result.close();
-    Assertions.assertEquals(10, sum);
+    assertThat(sum).isEqualTo(10);
   }
 
   @Test
@@ -1865,15 +1864,15 @@ public class MatchStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", query);
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertEquals("bbb", item.getProperty("name"));
+    assertThat(item.<String>getProperty("name")).isEqualTo("bbb");
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     item = result.next();
-    Assertions.assertEquals("ccc", item.getProperty("name"));
+    assertThat(item.<String>getProperty("name")).isEqualTo("ccc");
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     result.close();
   }
@@ -1902,31 +1901,31 @@ public class MatchStatementExecutionTest extends TestHelper {
 
     int sum = 0;
     for (int i = 0; i < 4; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
       final Object depth = item.getProperty("xy");
-      Assertions.assertTrue(depth instanceof Integer);
-      Assertions.assertEquals("aaa", item.getProperty("name"));
+      assertThat(depth instanceof Integer).isTrue();
+      assertThat(item.<String>getProperty("name")).isEqualTo("aaa");
       switch ((int) depth) {
       case 0:
-        Assertions.assertEquals("aaa", item.getProperty("bname"));
+        assertThat(item.<String>getProperty("bname")).isEqualTo("aaa");
         break;
       case 1:
-        Assertions.assertEquals("bbb", item.getProperty("bname"));
+        assertThat(item.<String>getProperty("bname")).isEqualTo("bbb");
         break;
       case 2:
-        Assertions.assertEquals("ccc", item.getProperty("bname"));
+        assertThat(item.<String>getProperty("bname")).isEqualTo("ccc");
         break;
       case 3:
-        Assertions.assertEquals("ddd", item.getProperty("bname"));
+        assertThat(item.<String>getProperty("bname")).isEqualTo("ddd");
         break;
       default:
-        fail();
+        fail("");
       }
       sum += (int) depth;
     }
-    Assertions.assertEquals(sum, 6);
-    Assertions.assertFalse(result.hasNext());
+    assertThat(sum).isEqualTo(6);
+    assertThat(result.hasNext()).isFalse();
 
     result.close();
   }
@@ -1954,30 +1953,30 @@ public class MatchStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", query);
 
     for (int i = 0; i < 4; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
       final Object path = item.getProperty("xy");
-      Assertions.assertTrue(path instanceof List);
+      assertThat(path instanceof List).isTrue();
       final List<Identifiable> thePath = (List<Identifiable>) path;
 
       final String bname = item.getProperty("bname");
       if (bname.equals("aaa")) {
-        Assertions.assertEquals(0, thePath.size());
+        assertThat(thePath.size()).isEqualTo(0);
       } else if (bname.equals("aaa")) {
-        Assertions.assertEquals(1, thePath.size());
-        Assertions.assertEquals("bbb", ((Document) thePath.get(0).getRecord()).getString("name"));
+        assertThat(thePath.size()).isEqualTo(1);
+        assertThat(((Document) thePath.get(0).getRecord()).getString("name")).isEqualTo("bbb");
       } else if (bname.equals("ccc")) {
-        Assertions.assertEquals(2, thePath.size());
-        Assertions.assertEquals("bbb", ((Document) thePath.get(0).getRecord()).getString("name"));
-        Assertions.assertEquals("ccc", ((Document) thePath.get(1).getRecord()).getString("name"));
+        assertThat(thePath.size()).isEqualTo(2);
+        assertThat(((Document) thePath.get(0).getRecord()).getString("name")).isEqualTo("bbb");
+        assertThat(((Document) thePath.get(1).getRecord()).getString("name")).isEqualTo("ccc");
       } else if (bname.equals("ddd")) {
-        Assertions.assertEquals(3, thePath.size());
-        Assertions.assertEquals("bbb", ((Document) thePath.get(0).getRecord()).getString("name"));
-        Assertions.assertEquals("ccc", ((Document) thePath.get(1).getRecord()).getString("name"));
-        Assertions.assertEquals("ddd", ((Document) thePath.get(2).getRecord()).getString("name"));
+        assertThat(thePath.size()).isEqualTo(3);
+        assertThat(((Document) thePath.get(0).getRecord()).getString("name")).isEqualTo("bbb");
+        assertThat(((Document) thePath.get(1).getRecord()).getString("name")).isEqualTo("ccc");
+        assertThat(((Document) thePath.get(2).getRecord()).getString("name")).isEqualTo("ddd");
       }
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     result.close();
   }
@@ -2018,59 +2017,56 @@ public class MatchStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("SQL", query);
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result item = result.next();
-    Assertions.assertEquals("one", item.getProperty("aname"));
-    Assertions.assertEquals("two", item.getProperty("bname"));
+    assertThat(item.<String>getProperty("aname")).isEqualTo("one");
+    assertThat(item.<String>getProperty("bname")).isEqualTo("two");
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
-    Assertions.assertTrue(database.getSchema().getIndexByName(clazz + "[name]").get(new String[] { "one" }).hasNext());
-    Assertions.assertTrue(database.getSchema().getIndexByName(clazz + "[name]").get(new String[] { "onex" }).hasNext());
-    Assertions.assertTrue(database.getSchema().getIndexByName(clazz + "[name]").get(new String[] { "two" }).hasNext());
-    Assertions.assertTrue(database.getSchema().getIndexByName(clazz + "[name]").get(new String[] { "three" }).hasNext());
+    assertThat(database.getSchema().getIndexByName(clazz + "[name]").get(new String[]{"one"}).hasNext()).isTrue();
+    assertThat(database.getSchema().getIndexByName(clazz + "[name]").get(new String[]{"onex"}).hasNext()).isTrue();
+    assertThat(database.getSchema().getIndexByName(clazz + "[name]").get(new String[]{"two"}).hasNext()).isTrue();
+    assertThat(database.getSchema().getIndexByName(clazz + "[name]").get(new String[]{"three"}).hasNext()).isTrue();
 
     //--------------------------------------------------------------------------------------------------------
     // CHECK THE SUB-INDEX EXISTS
-    Assertions.assertTrue(Set.of(((TypeIndex) database.getSchema().getIndexByName(clazz + "[name]")).getIndexesOnBuckets()).stream()
-        .map((r) -> r.getAssociatedBucketId()).collect(Collectors.toSet())
-        .contains(database.getSchema().getBucketByName(clazz + "_one").getFileId()));
+    assertThat(Set.of(((TypeIndex) database.getSchema().getIndexByName(clazz + "[name]")).getIndexesOnBuckets()).stream()
+      .map((r) -> r.getAssociatedBucketId()).collect(Collectors.toSet())
+      .contains(database.getSchema().getBucketByName(clazz + "_one").getFileId())).isTrue();
 
     database.command("SQL", "ALTER TYPE " + clazz + " BUCKET -" + clazz + "_one").close();
 
     // CHECK THE SUB-INDEX HAS BEN REMOVED
-    Assertions.assertFalse(
-        Set.of(((TypeIndex) database.getSchema().getIndexByName(clazz + "[name]")).getIndexesOnBuckets()).stream()
-            .map((r) -> r.getAssociatedBucketId()).collect(Collectors.toSet())
-            .contains(database.getSchema().getBucketByName(clazz + "_one").getFileId()));
+    assertThat(Set.of(((TypeIndex) database.getSchema().getIndexByName(clazz + "[name]")).getIndexesOnBuckets()).stream()
+      .map((r) -> r.getAssociatedBucketId()).collect(Collectors.toSet())
+      .contains(database.getSchema().getBucketByName(clazz + "_one").getFileId())).isFalse();
 
     //--------------------------------------------------------------------------------------------------------
     // CHECK THE SUB-INDEX EXISTS
-    Assertions.assertTrue(Set.of(((TypeIndex) database.getSchema().getIndexByName(clazz + "[name]")).getIndexesOnBuckets()).stream()
-        .map((r) -> r.getAssociatedBucketId()).collect(Collectors.toSet())
-        .contains(database.getSchema().getBucketByName(clazz + "_two").getFileId()));
+    assertThat(Set.of(((TypeIndex) database.getSchema().getIndexByName(clazz + "[name]")).getIndexesOnBuckets()).stream()
+      .map((r) -> r.getAssociatedBucketId()).collect(Collectors.toSet())
+      .contains(database.getSchema().getBucketByName(clazz + "_two").getFileId())).isTrue();
 
     database.command("SQL", "ALTER TYPE " + clazz + " BUCKET -" + clazz + "_two").close();
 
     // CHECK THE SUB-INDEX HAS BEN REMOVED
-    Assertions.assertFalse(
-        Set.of(((TypeIndex) database.getSchema().getIndexByName(clazz + "[name]")).getIndexesOnBuckets()).stream()
-            .map((r) -> r.getAssociatedBucketId()).collect(Collectors.toSet())
-            .contains(database.getSchema().getBucketByName(clazz + "_two").getFileId()));
+    assertThat(Set.of(((TypeIndex) database.getSchema().getIndexByName(clazz + "[name]")).getIndexesOnBuckets()).stream()
+      .map((r) -> r.getAssociatedBucketId()).collect(Collectors.toSet())
+      .contains(database.getSchema().getBucketByName(clazz + "_two").getFileId())).isFalse();
 
     //--------------------------------------------------------------------------------------------------------
     // CHECK THE SUB-INDEX EXISTS
-    Assertions.assertTrue(Set.of(((TypeIndex) database.getSchema().getIndexByName(clazz + "[name]")).getIndexesOnBuckets()).stream()
-        .map((r) -> r.getAssociatedBucketId()).collect(Collectors.toSet())
-        .contains(database.getSchema().getBucketByName(clazz + "_three").getFileId()));
+    assertThat(Set.of(((TypeIndex) database.getSchema().getIndexByName(clazz + "[name]")).getIndexesOnBuckets()).stream()
+      .map((r) -> r.getAssociatedBucketId()).collect(Collectors.toSet())
+      .contains(database.getSchema().getBucketByName(clazz + "_three").getFileId())).isTrue();
 
     database.command("SQL", "ALTER TYPE " + clazz + " BUCKET -" + clazz + "_three").close();
 
     // CHECK THE SUB-INDEX HAS BEN REMOVED
-    Assertions.assertFalse(
-        Set.of(((TypeIndex) database.getSchema().getIndexByName(clazz + "[name]")).getIndexesOnBuckets()).stream()
-            .map((r) -> r.getAssociatedBucketId()).collect(Collectors.toSet())
-            .contains(database.getSchema().getBucketByName(clazz + "_three").getFileId()));
+    assertThat(Set.of(((TypeIndex) database.getSchema().getIndexByName(clazz + "[name]")).getIndexesOnBuckets()).stream()
+      .map((r) -> r.getAssociatedBucketId()).collect(Collectors.toSet())
+      .contains(database.getSchema().getBucketByName(clazz + "_three").getFileId())).isFalse();
 
     result.close();
   }
@@ -2100,9 +2096,9 @@ public class MatchStatementExecutionTest extends TestHelper {
     query += " RETURN $patterns";
 
     final ResultSet result = database.query("SQL", query);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     result.close();
   }
@@ -2133,7 +2129,7 @@ public class MatchStatementExecutionTest extends TestHelper {
     query += " RETURN $patterns";
 
     final ResultSet result = database.query("SQL", query);
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     result.close();
   }
@@ -2164,9 +2160,9 @@ public class MatchStatementExecutionTest extends TestHelper {
     query += " RETURN $patterns";
 
     final ResultSet result = database.query("SQL", query);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     result.close();
   }
@@ -2198,12 +2194,12 @@ public class MatchStatementExecutionTest extends TestHelper {
     query += " RETURN a.name as a, b.name as b";
 
     ResultSet result = database.query("SQL", query);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertEquals("a", item.getProperty("a"));
-    Assertions.assertEquals("b", item.getProperty("b"));
+    assertThat(item.<String>getProperty("a")).isEqualTo("a");
+    assertThat(item.<String>getProperty("b")).isEqualTo("b");
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     result.close();
 
@@ -2211,12 +2207,12 @@ public class MatchStatementExecutionTest extends TestHelper {
     query += " RETURN a.name as a, b.name as b";
 
     result = database.query("SQL", query);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     item = result.next();
-    Assertions.assertEquals("a", item.getProperty("a"));
-    Assertions.assertEquals("b", item.getProperty("b"));
+    assertThat(item.<String>getProperty("a")).isEqualTo("a");
+    assertThat(item.<String>getProperty("b")).isEqualTo("b");
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     result.close();
   }
@@ -2242,7 +2238,7 @@ public class MatchStatementExecutionTest extends TestHelper {
     final String query = "MATCH {type: `" + className + "`, as:foo} RETURN $elements";
 
     try (final ResultSet rs = database.query("SQL", query)) {
-      Assertions.assertEquals(1L, rs.stream().count());
+      assertThat(rs.stream().count()).isEqualTo(1L);
     }
   }
 
@@ -2250,7 +2246,7 @@ public class MatchStatementExecutionTest extends TestHelper {
   public void testMatchInSubQuery() {
     try (final ResultSet rs = database.query("SQL",
         "SELECT $a LET $a=(MATCH{type:Person,as:Person_0}RETURN expand(Person_0))")) {
-      Assertions.assertEquals(1L, rs.stream().count());
+      assertThat(rs.stream().count()).isEqualTo(1L);
     }
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/MoveVertexStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/MoveVertexStatementExecutionTest.java
@@ -1,8 +1,9 @@
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.TestHelper;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * original @author Luigi Dell'Aquila (l.dellaquila-(at)-orientdatabase.com)
@@ -37,27 +38,27 @@ public class MoveVertexStatementExecutionTest extends TestHelper {
             + vertexClassName1
             + " where name = 'a') to type:" + vertexClassName2);
     ResultSet rs = database.query("sql", "select from " + vertexClassName1);
-    Assertions.assertTrue(rs.hasNext());
+    assertThat(rs.hasNext()).isTrue();
     rs.next();
-    Assertions.assertFalse(rs.hasNext());
+    assertThat(rs.hasNext()).isFalse();
     rs.close();
 
     rs = database.query("sql", "select from " + vertexClassName2);
-    Assertions.assertTrue(rs.hasNext());
+    assertThat(rs.hasNext()).isTrue();
     rs.next();
-    Assertions.assertFalse(rs.hasNext());
+    assertThat(rs.hasNext()).isFalse();
     rs.close();
 
     rs = database.query("sql", "select expand(out()) from " + vertexClassName2);
-    Assertions.assertTrue(rs.hasNext());
+    assertThat(rs.hasNext()).isTrue();
     rs.next();
-    Assertions.assertFalse(rs.hasNext());
+    assertThat(rs.hasNext()).isFalse();
     rs.close();
 
     rs = database.query("sql", "select expand(in()) from " + vertexClassName1);
-    Assertions.assertTrue(rs.hasNext());
+    assertThat(rs.hasNext()).isTrue();
     rs.next();
-    Assertions.assertFalse(rs.hasNext());
+    assertThat(rs.hasNext()).isFalse();
     rs.close();
   }
 
@@ -88,27 +89,27 @@ public class MoveVertexStatementExecutionTest extends TestHelper {
             + vertexClassName1
             + " where name = 'a') to type:" + vertexClassName2 + " BATCH 2");
     ResultSet rs = database.query("sql", "select from " + vertexClassName1);
-    Assertions.assertTrue(rs.hasNext());
+    assertThat(rs.hasNext()).isTrue();
     rs.next();
-    Assertions.assertFalse(rs.hasNext());
+    assertThat(rs.hasNext()).isFalse();
     rs.close();
 
     rs = database.query("sql", "select from " + vertexClassName2);
-    Assertions.assertTrue(rs.hasNext());
+    assertThat(rs.hasNext()).isTrue();
     rs.next();
-    Assertions.assertFalse(rs.hasNext());
+    assertThat(rs.hasNext()).isFalse();
     rs.close();
 
     rs = database.query("sql", "select expand(out()) from " + vertexClassName2);
-    Assertions.assertTrue(rs.hasNext());
+    assertThat(rs.hasNext()).isTrue();
     rs.next();
-    Assertions.assertFalse(rs.hasNext());
+    assertThat(rs.hasNext()).isFalse();
     rs.close();
 
     rs = database.query("sql", "select expand(in()) from " + vertexClassName1);
-    Assertions.assertTrue(rs.hasNext());
+    assertThat(rs.hasNext()).isTrue();
     rs.next();
-    Assertions.assertFalse(rs.hasNext());
+    assertThat(rs.hasNext()).isFalse();
     rs.close();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ProfileStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ProfileStatementExecutionTest.java
@@ -19,8 +19,11 @@
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.TestHelper;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Luigi Dell'Aquila (l.dellaquila-(at)-orientdb.com)
@@ -34,7 +37,7 @@ public class ProfileStatementExecutionTest {
       db.command("sql", "insert into testProfile set name ='bar'");
 
       final ResultSet result = db.query("sql", "PROFILE SELECT FROM testProfile WHERE name ='bar'");
-      Assertions.assertTrue(result.getExecutionPlan().get().prettyPrint(0, 2).contains("μs"));
+      assertThat(result.getExecutionPlan().get().prettyPrint(0, 2).contains("μs")).isTrue();
 
       result.close();
     });

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ResultSetTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ResultSetTest.java
@@ -18,10 +18,11 @@
  */
 package com.arcadedb.query.sql.executor;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by luigidellaquila on 04/11/16.
@@ -36,8 +37,8 @@ public class ResultSetTest {
       rs.add(item);
     }
     final Optional<Integer> result = rs.stream().map(x -> (int) x.getProperty("i")).reduce((a, b) -> a + b);
-    Assertions.assertTrue(result.isPresent());
-    Assertions.assertEquals(45, result.get().intValue());
+    assertThat(result.isPresent()).isTrue();
+    assertThat(result.get().intValue()).isEqualTo(45);
   }
 
   @Test
@@ -49,7 +50,7 @@ public class ResultSetTest {
       rs.add(item);
     }
     final Optional<Integer> result = rs.vertexStream().map(x -> (int) x.get("i")).reduce((a, b) -> a + b);
-    Assertions.assertFalse(result.isPresent());
+    assertThat(result.isPresent()).isFalse();
   }
 
   @Test
@@ -61,7 +62,7 @@ public class ResultSetTest {
       rs.add(item);
     }
     final Optional<Integer> result = rs.vertexStream().map(x -> (int) x.get("i")).reduce((a, b) -> a + b);
-    Assertions.assertFalse(result.isPresent());
+    assertThat(result.isPresent()).isFalse();
   }
 
   @Test
@@ -71,13 +72,13 @@ public class ResultSetTest {
     item.setProperty("long", 10L);
     item.setProperty("short", (short) 10);
 
-    Assertions.assertEquals(10, (int) item.getProperty("int", 10));
-    Assertions.assertEquals(10L, (int) item.getProperty("int", 10L));
+    assertThat((int) item.getProperty("int", 10)).isEqualTo(10);
+    assertThat((int) item.getProperty("int", 10L)).isEqualTo(10L);
 
-    Assertions.assertEquals(10L, (long) item.getProperty("long", 10));
-    Assertions.assertEquals(10L, (long) item.getProperty("long", 10L));
+    assertThat((long) item.getProperty("long", 10)).isEqualTo(10L);
+    assertThat((long) item.getProperty("long", 10L)).isEqualTo(10L);
 
-    Assertions.assertEquals(10, (int) item.getProperty("absent", 10));
-    Assertions.assertEquals(10L, (long) item.getProperty("absent", 10L));
+    assertThat((int) item.getProperty("absent", 10)).isEqualTo(10);
+    assertThat((long) item.getProperty("absent", 10L)).isEqualTo(10L);
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ScriptExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ScriptExecutionTest.java
@@ -11,10 +11,13 @@ import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.query.sql.SQLQueryEngine;
 import com.arcadedb.query.sql.function.SQLFunctionAbstract;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luigi Dell'Aquila (l.dellaquila-(at)-orientdatabase.com)
@@ -54,7 +57,7 @@ public class ScriptExecutionTest extends TestHelper {
           "INSERT INTO " + className + " SET name = 'foo';INSERT INTO " + className + " SET name = 'bar';");
     });
     ResultSet rs = database.query("sql", "SELECT count(*) as count from " + className);
-    Assertions.assertEquals((Object) 2L, rs.next().getProperty("count"));
+    assertThat(rs.next().<Long>getProperty("count")).isEqualTo((Object) 2L);
   }
 
   @Test
@@ -76,7 +79,7 @@ public class ScriptExecutionTest extends TestHelper {
       database.command("sqlscript", script);
     });
     ResultSet rs = database.query("sql", "SELECT count(*) as count from " + className);
-    Assertions.assertEquals((Object) 2L, rs.next().getProperty("count"));
+    assertThat(rs.next().<Long>getProperty("count")).isEqualTo( 2L);
   }
 
   @Test
@@ -97,7 +100,7 @@ public class ScriptExecutionTest extends TestHelper {
     });
 
     final ResultSet rs = database.query("sql", "SELECT count(*) as count from " + className);
-    Assertions.assertEquals((Object) 2L, rs.next().getProperty("count"));
+    assertThat(rs.next().<Long>getProperty("count")).isEqualTo(2L);
   }
 
   @Test
@@ -117,7 +120,7 @@ public class ScriptExecutionTest extends TestHelper {
 
       Result item = result.next();
 
-      Assertions.assertEquals("OK", item.getProperty("value"));
+      assertThat(item.<String>getProperty("value")).isEqualTo("OK");
       result.close();
     });
   }
@@ -139,7 +142,7 @@ public class ScriptExecutionTest extends TestHelper {
 
       Result item = result.next();
 
-      Assertions.assertEquals("OK", item.getProperty("value"));
+      assertThat(item.<String>getProperty("value")).isEqualTo("OK");
       result.close();
     });
   }
@@ -158,7 +161,7 @@ public class ScriptExecutionTest extends TestHelper {
 
       Result item = result.next();
 
-      Assertions.assertEquals("OK", item.getProperty("value"));
+      assertThat(item.<String>getProperty("value")).isEqualTo("OK");
       result.close();
     });
   }
@@ -184,10 +187,10 @@ public class ScriptExecutionTest extends TestHelper {
     });
 
     ResultSet result = database.query("sql", "select from " + className);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertEquals(4, (int) item.getProperty("attempt"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat((int) item.getProperty("attempt")).isEqualTo(4);
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -215,10 +218,10 @@ public class ScriptExecutionTest extends TestHelper {
     database.async().waitCompletion();
 
     ResultSet result = database.query("sql", "select from " + className + " where id = 0");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    //Assertions.assertTrue((Integer) item.getProperty("attempt") < TOTAL);
-    Assertions.assertFalse(result.hasNext());
+    //Assertions.assertThat((Integer).isTrue() item.getProperty("attempt") < TOTAL);
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     // USE RETRY, EXPECTING NO MISS OF UPDATES
@@ -243,7 +246,7 @@ public class ScriptExecutionTest extends TestHelper {
     ImmutablePage page = ((LocalDatabase) database).getPageManager().getImmutablePage(new PageId(2, 0),
         ((PaginatedComponentFile) ((LocalDatabase) database).getFileManager().getFile(2)).getPageSize(), false, false);
 
-    Assertions.assertEquals(TOTAL + 1, page.getVersion(), "Page v." + page.getVersion());
+    assertThat(page.getVersion()).as("Page v." + page.getVersion()).isEqualTo(TOTAL + 1);
   }
 
   @Test
@@ -270,10 +273,10 @@ public class ScriptExecutionTest extends TestHelper {
     database.async().waitCompletion();
 
     ResultSet result = database.query("sql", "select from " + className + " where id = 0");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertTrue((Integer) item.getProperty("attempt") < TOTAL, "Found attempts = " + item.getProperty("attempt"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat((Integer) item.getProperty("attempt") < TOTAL).as("Found attempts = " + item.getProperty("attempt")).isTrue();
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     // USE RETRY, EXPECTING NO MISS OF UPDATES
@@ -298,13 +301,13 @@ public class ScriptExecutionTest extends TestHelper {
     ImmutablePage page = ((LocalDatabase) database).getPageManager().getImmutablePage(new PageId(2, 0),
         ((PaginatedComponentFile) ((LocalDatabase) database).getFileManager().getFile(2)).getPageSize(), false, false);
 
-    Assertions.assertEquals(TOTAL + 1, page.getVersion(), "Page v." + page.getVersion());
+    assertThat(page.getVersion()).as("Page v." + page.getVersion()).isEqualTo(TOTAL + 1);
 
     result = database.query("sql", "select from " + className + " where id = 1");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     item = result.next();
-    Assertions.assertEquals(TOTAL, (Integer) item.getProperty("attempt"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat((Integer) item.getProperty("attempt")).isEqualTo(TOTAL);
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -329,7 +332,7 @@ public class ScriptExecutionTest extends TestHelper {
       }
 
       ResultSet result = database.query("sql", "select from " + className);
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
       result.close();
     });
   }
@@ -354,10 +357,10 @@ public class ScriptExecutionTest extends TestHelper {
       database.command("sqlscript", script);
 
       ResultSet result = database.query("sql", "select from " + className);
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       Result item = result.next();
-      Assertions.assertEquals("foo", item.getProperty("name"));
-      Assertions.assertFalse(result.hasNext());
+      assertThat(item.<String>getProperty("name")).isEqualTo("foo");
+      assertThat(result.hasNext()).isFalse();
       result.close();
     });
   }
@@ -384,10 +387,10 @@ public class ScriptExecutionTest extends TestHelper {
     });
 
     ResultSet result = database.query("sql", "select from " + className);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertEquals("foo", item.getProperty("name"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item.<String>getProperty("name")).isEqualTo("foo");
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -417,10 +420,10 @@ public class ScriptExecutionTest extends TestHelper {
     });
 
     ResultSet result = database.query("sql", "select from " + className);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertEquals("foo", item.getProperty("name"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item.<String>getProperty("name")).isEqualTo("foo");
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -450,10 +453,10 @@ public class ScriptExecutionTest extends TestHelper {
       }
 
       ResultSet result = database.query("sql", "select from " + className);
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       Result item = result.next();
-      Assertions.assertEquals("foo", item.getProperty("name"));
-      Assertions.assertFalse(result.hasNext());
+      assertThat(item.<String>getProperty("name")).isEqualTo("foo");
+      assertThat(result.hasNext()).isFalse();
       result.close();
     });
   }
@@ -471,10 +474,10 @@ public class ScriptExecutionTest extends TestHelper {
       }
 
       ResultSet rs = database.command("sqlscript", script);
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       Result item = rs.next();
-      Assertions.assertEquals(8, (Integer) item.getProperty("result"));
-      Assertions.assertFalse(rs.hasNext());
+      assertThat((Integer) item.getProperty("result")).isEqualTo(8);
+      assertThat(rs.hasNext()).isFalse();
 
       rs.close();
     });
@@ -510,9 +513,9 @@ public class ScriptExecutionTest extends TestHelper {
     database.command("sqlscript", script).close();
 
     try (ResultSet rs = database.query("sql", "select from IndirectEdge")) {
-      Assertions.assertTrue(rs.hasNext());
-      Assertions.assertEquals("foo2", rs.next().getProperty("Source"));
-      Assertions.assertFalse(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<String>getProperty("Source")).isEqualTo("foo2");
+      assertThat(rs.hasNext()).isFalse();
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/SelectStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/SelectStatementExecutionTest.java
@@ -34,23 +34,26 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Property;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.*;
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class SelectStatementExecutionTest extends TestHelper {
 
   @Test
   public void testSelectNoTarget() {
     final ResultSet result = database.query("sql", "select 1 as one, 2 as two, 2+3");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals(1, item.<Object>getProperty("one"));
-    Assertions.assertEquals(2, item.<Object>getProperty("two"));
-    Assertions.assertEquals(5, item.<Object>getProperty("2 + 3"));
+    assertThat(item).isNotNull();
+    assertThat(item.<Object>getProperty("one")).isEqualTo(1);
+    assertThat(item.<Object>getProperty("two")).isEqualTo(2);
+    assertThat(item.<Object>getProperty("2 + 3")).isEqualTo(5);
 
     result.close();
   }
@@ -76,8 +79,8 @@ public class SelectStatementExecutionTest extends TestHelper {
         "select address, count(*) as occurrences from InputTx where address is not null group by address limit 10");
     while (result.hasNext()) {
       final Result row = result.next();
-      Assertions.assertNotNull(row.getProperty("address")); // <== FALSE!
-      Assertions.assertNotNull(row.getProperty("occurrences"));
+      assertThat(row.<String>getProperty("address")).isNotNull(); // <== FALSE!
+      assertThat(row.<Long>getProperty("occurrences")).isNotNull();
     }
     result.close();
   }
@@ -85,7 +88,7 @@ public class SelectStatementExecutionTest extends TestHelper {
   @Test
   public void testSelectNoTargetSkip() {
     final ResultSet result = database.query("sql", "select 1 as one, 2 as two, 2+3 skip 1");
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     result.close();
   }
@@ -93,12 +96,12 @@ public class SelectStatementExecutionTest extends TestHelper {
   @Test
   public void testSelectNoTargetSkipZero() {
     final ResultSet result = database.query("sql", "select 1 as one, 2 as two, 2+3 skip 0");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals(1, item.<Object>getProperty("one"));
-    Assertions.assertEquals(2, item.<Object>getProperty("two"));
-    Assertions.assertEquals(5, item.<Object>getProperty("2 + 3"));
+    assertThat(item).isNotNull();
+    assertThat(item.<Integer>getProperty("one")).isEqualTo(1);
+    assertThat(item.<Integer>getProperty("two")).isEqualTo(2);
+    assertThat(item.<Integer>getProperty("2 + 3")).isEqualTo(5);
 
     result.close();
   }
@@ -106,7 +109,7 @@ public class SelectStatementExecutionTest extends TestHelper {
   @Test
   public void testSelectNoTargetLimit0() {
     final ResultSet result = database.query("sql", "select 1 as one, 2 as two, 2+3 limit 0");
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     result.close();
   }
@@ -114,12 +117,12 @@ public class SelectStatementExecutionTest extends TestHelper {
   @Test
   public void testSelectNoTargetLimit1() {
     final ResultSet result = database.query("sql", "select 1 as one, 2 as two, 2+3 limit 1");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals(1, item.<Object>getProperty("one"));
-    Assertions.assertEquals(2, item.<Object>getProperty("two"));
-    Assertions.assertEquals(5, item.<Object>getProperty("2 + 3"));
+    assertThat(item).isNotNull();
+    assertThat(item.<Object>getProperty("one")).isEqualTo(1);
+    assertThat(item.<Object>getProperty("two")).isEqualTo(2);
+    assertThat(item.<Object>getProperty("2 + 3")).isEqualTo(5);
 
     result.close();
   }
@@ -144,12 +147,12 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.commit();
     final ResultSet result = database.query("sql", "select from " + className);
     for (int i = 0; i < 100000; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertTrue(("" + item.getProperty("name")).startsWith("name"));
+      assertThat(item).isNotNull();
+      assertThat(("" + item.getProperty("name")).startsWith("name")).isTrue();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -168,16 +171,16 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from " + className + " ORDER BY @rid ASC");
     Document lastItem = null;
     for (int i = 0; i < 100000; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertTrue(("" + item.getProperty("name")).startsWith("name"));
+      assertThat(item).isNotNull();
+      assertThat(("" + item.getProperty("name")).startsWith("name")).isTrue();
       if (lastItem != null) {
-        Assertions.assertTrue(lastItem.getIdentity().compareTo(item.getElement().get().getIdentity()) < 0);
+        assertThat(lastItem.getIdentity().compareTo(item.getElement().get().getIdentity()) < 0).isTrue();
       }
       lastItem = item.getElement().get();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     result.close();
   }
@@ -197,16 +200,16 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from " + className + " ORDER BY @rid DESC");
     Document lastItem = null;
     for (int i = 0; i < 100000; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertTrue(("" + item.getProperty("name")).startsWith("name"));
+      assertThat(item).isNotNull();
+      assertThat(("" + item.getProperty("name")).startsWith("name")).isTrue();
       if (lastItem != null) {
-        Assertions.assertTrue(lastItem.getIdentity().compareTo(item.getElement().get().getIdentity()) > 0);
+        assertThat(lastItem.getIdentity().compareTo(item.getElement().get().getIdentity()) > 0).isTrue();
       }
       lastItem = item.getElement().get();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     result.close();
   }
@@ -227,12 +230,12 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from " + className + " limit 10");
 
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertTrue(("" + item.getProperty("name")).startsWith("name"));
+      assertThat(item).isNotNull();
+      assertThat(("" + item.getProperty("name")).startsWith("name")).isTrue();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -252,12 +255,12 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from " + className + " skip 100 limit 10");
 
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertTrue(("" + item.getProperty("name")).startsWith("name"));
+      assertThat(item).isNotNull();
+      assertThat(("" + item.getProperty("name")).startsWith("name")).isTrue();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -278,16 +281,16 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     String lastSurname = null;
     for (int i = 0; i < 30; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      final String thisSurname = item.getProperty("surname");
+      assertThat(item).isNotNull();
+      final String thisSurname = item.<String>getProperty("surname");
       if (lastSurname != null) {
-        Assertions.assertTrue(lastSurname.compareTo(thisSurname) >= 0);
+        assertThat(lastSurname.compareTo(thisSurname) >= 0).isTrue();
       }
       lastSurname = thisSurname;
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -307,16 +310,16 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     String lastSurname = null;
     for (int i = 0; i < 30; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      final String thisSurname = item.getProperty("surname");
+      assertThat(item).isNotNull();
+      final String thisSurname = item.<String>getProperty("surname");
       if (lastSurname != null) {
-        Assertions.assertTrue(lastSurname.compareTo(thisSurname) <= 0);
+        assertThat(lastSurname.compareTo(thisSurname) <= 0).isTrue();
       }
       lastSurname = thisSurname;
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -337,12 +340,12 @@ public class SelectStatementExecutionTest extends TestHelper {
     //    System.out.println("elapsed: " + (System.nanoTime() - begin));
 
     for (int i = 0; i < 100; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("surname0", item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("surname")).isEqualTo("surname0");
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -364,17 +367,17 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     String lastName = null;
     for (int i = 0; i < 100; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
       final String name = item.getProperty("name");
-      Assertions.assertNotNull(name);
+      assertThat(name).isNotNull();
       if (i > 0) {
-        Assertions.assertTrue(name.compareTo(lastName) >= 0);
+        assertThat(name.compareTo(lastName) >= 0).isTrue();
       }
       lastName = name;
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -396,17 +399,17 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     String lastName = null;
     for (int i = 0; i < 100; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
       final String name = item.getProperty("name");
-      Assertions.assertNotNull(name);
+      assertThat(name).isNotNull();
       if (i > 0) {
-        Assertions.assertTrue(name.compareTo(lastName) >= 0);
+        assertThat(name.compareTo(lastName) >= 0).isTrue();
       }
       lastName = name;
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -425,13 +428,13 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from " + className + " where name = 'name1' or name = 'name7' ");
 
     for (int i = 0; i < 2; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
       final Object name = item.getProperty("name");
-      Assertions.assertTrue("name1".equals(name) || "name7".equals(name));
+      assertThat("name1".equals(name) || "name7".equals(name)).isTrue();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -450,13 +453,13 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from " + className + " where name <> 'name1' ");
 
     for (int i = 0; i < 299; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
       final Object name = item.getProperty("name");
-      Assertions.assertFalse("name1".equals(name));
+      assertThat(name).isNotEqualTo("name1");
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -475,17 +478,17 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select name from " + className);
 
     for (int i = 0; i < 300; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
       final String name = item.getProperty("name");
-      final String surname = item.getProperty("surname");
-      Assertions.assertNotNull(name);
-      Assertions.assertTrue(name.startsWith("name"));
-      Assertions.assertNull(surname);
-      Assertions.assertFalse(item.getElement().isPresent());
+      final String surname = item.<String>getProperty("surname");
+      assertThat(name).isNotNull();
+      assertThat(name.startsWith("name")).isTrue();
+      assertThat(surname).isNull();
+      assertThat(item.getElement().isPresent()).isFalse();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -503,16 +506,16 @@ public class SelectStatementExecutionTest extends TestHelper {
     try {
       final ResultSet result = database.query("sql", "select count(*) from " + className);
 
-      Assertions.assertNotNull(result);
-      Assertions.assertTrue(result.hasNext());
+      assertThat(Optional.ofNullable(result)).isNotNull();
+      assertThat(result.hasNext()).isTrue();
       final Result next = result.next();
-      Assertions.assertNotNull(next);
-      Assertions.assertEquals(7L, (Object) next.getProperty("count(*)"));
-      Assertions.assertFalse(result.hasNext());
+      assertThat(next).isNotNull();
+      assertThat((Object) next.getProperty("count(*)")).isEqualTo(7L);
+      assertThat(result.hasNext()).isFalse();
       result.close();
     } catch (final Exception e) {
       e.printStackTrace();
-      Assertions.fail();
+      fail("");
     }
   }
 
@@ -531,18 +534,18 @@ public class SelectStatementExecutionTest extends TestHelper {
     try {
       final ResultSet result = database.query("sql", "select count(*), name from " + className + " group by name");
 
-      Assertions.assertNotNull(result);
+      assertThat(Optional.ofNullable(result)).isNotNull();
       for (int i = 0; i < 5; i++) {
-        Assertions.assertTrue(result.hasNext());
+        assertThat(result.hasNext()).isTrue();
         final Result next = result.next();
-        Assertions.assertNotNull(next);
-        Assertions.assertEquals(2L, (Object) next.getProperty("count(*)"));
+        assertThat(next).isNotNull();
+        assertThat((Object) next.getProperty("count(*)")).isEqualTo(2L);
       }
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
       result.close();
     } catch (final Exception e) {
       e.printStackTrace();
-      Assertions.fail();
+      fail("");
     }
   }
 
@@ -560,16 +563,16 @@ public class SelectStatementExecutionTest extends TestHelper {
     try {
       final ResultSet result = database.query("sql", "select count(*) from " + className + " where name = 'foo'");
 
-      Assertions.assertNotNull(result);
-      Assertions.assertTrue(result.hasNext());
+      assertThat(Optional.ofNullable(result)).isNotNull();
+      assertThat(result.hasNext()).isTrue();
       final Result next = result.next();
-      Assertions.assertNotNull(next);
-      Assertions.assertEquals(0L, (Object) next.getProperty("count(*)"));
-      Assertions.assertFalse(result.hasNext());
+      assertThat(next).isNotNull();
+      assertThat((Object) next.getProperty("count(*)")).isEqualTo(0L);
+      assertThat(result.hasNext()).isFalse();
       result.close();
     } catch (final Exception e) {
       e.printStackTrace();
-      Assertions.fail();
+      fail("");
     }
   }
 
@@ -587,16 +590,16 @@ public class SelectStatementExecutionTest extends TestHelper {
     try {
       final ResultSet result = database.query("sql", "select count(*) as a from " + className + " where name = 'foo'");
 
-      Assertions.assertNotNull(result);
-      Assertions.assertTrue(result.hasNext());
+      assertThat(Optional.ofNullable(result)).isNotNull();
+      assertThat(result.hasNext()).isTrue();
       final Result next = result.next();
-      Assertions.assertNotNull(next);
-      Assertions.assertEquals(0L, (Object) next.getProperty("a"));
-      Assertions.assertFalse(result.hasNext());
+      assertThat(next).isNotNull();
+      assertThat((Object) next.getProperty("a")).isEqualTo(0L);
+      assertThat(result.hasNext()).isFalse();
       result.close();
     } catch (final Exception e) {
       e.printStackTrace();
-      Assertions.fail();
+      fail("");
     }
   }
 
@@ -607,11 +610,11 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     try {
       database.query("sql", "select max(a) + max(b) + pippo + pluto as foo, max(d) + max(e), f from " + className).close();
-      Assertions.fail();
+      fail("");
     } catch (final CommandExecutionException x) {
 
     } catch (final Exception e) {
-      Assertions.fail();
+      fail("");
     }
   }
 
@@ -622,11 +625,11 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     try {
       database.query("sql", "select [max(a), max(b), foo] from " + className).close();
-      Assertions.fail();
+      fail("");
     } catch (final CommandExecutionException x) {
 
     } catch (final Exception e) {
-      Assertions.fail();
+      fail("");
     }
   }
 
@@ -640,7 +643,7 @@ public class SelectStatementExecutionTest extends TestHelper {
       final ResultSet result = database.query("sql", query);
       result.close();
     } catch (final Exception x) {
-      Assertions.fail();
+      fail("");
     }
   }
 
@@ -656,7 +659,7 @@ public class SelectStatementExecutionTest extends TestHelper {
       result.close();
     } catch (final Exception e) {
       e.printStackTrace();
-      Assertions.fail();
+      fail("");
     }
   }
 
@@ -673,10 +676,10 @@ public class SelectStatementExecutionTest extends TestHelper {
     }
     database.commit();
     final ResultSet result = database.query("sql", "select sum(val) from " + className);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals(45, (Object) item.getProperty("sum(val)"));
+    assertThat(item).isNotNull();
+    assertThat((Object) item.getProperty("sum(val)")).isEqualTo(45);
 
     result.close();
   }
@@ -697,20 +700,20 @@ public class SelectStatementExecutionTest extends TestHelper {
     boolean evenFound = false;
     boolean oddFound = false;
     for (int i = 0; i < 2; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
       if ("even".equals(item.getProperty("type"))) {
-        Assertions.assertEquals(20, item.<Object>getProperty("sum(val)"));
+        assertThat(item.<Object>getProperty("sum(val)")).isEqualTo(20);
         evenFound = true;
       } else if ("odd".equals(item.getProperty("type"))) {
-        Assertions.assertEquals(25, item.<Object>getProperty("sum(val)"));
+        assertThat(item.<Object>getProperty("sum(val)")).isEqualTo(25);
         oddFound = true;
       }
     }
-    Assertions.assertFalse(result.hasNext());
-    Assertions.assertTrue(evenFound);
-    Assertions.assertTrue(oddFound);
+    assertThat(result.hasNext()).isFalse();
+    assertThat(evenFound).isTrue();
+    assertThat(oddFound).isTrue();
     result.close();
   }
 
@@ -731,24 +734,24 @@ public class SelectStatementExecutionTest extends TestHelper {
     boolean evenFound = false;
     boolean oddFound = false;
     for (int i = 0; i < 2; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
       if ("even".equals(item.getProperty("type"))) {
-        Assertions.assertEquals(20, item.<Object>getProperty("sum(val)"));
-        Assertions.assertEquals(8, item.<Object>getProperty("max(val)"));
-        Assertions.assertEquals(0, item.<Object>getProperty("min(val)"));
+        assertThat(item.<Object>getProperty("sum(val)")).isEqualTo(20);
+        assertThat(item.<Object>getProperty("max(val)")).isEqualTo(8);
+        assertThat(item.<Object>getProperty("min(val)")).isEqualTo(0);
         evenFound = true;
       } else if ("odd".equals(item.getProperty("type"))) {
-        Assertions.assertEquals(25, item.<Object>getProperty("sum(val)"));
-        Assertions.assertEquals(9, item.<Object>getProperty("max(val)"));
-        Assertions.assertEquals(1, item.<Object>getProperty("min(val)"));
+        assertThat(item.<Object>getProperty("sum(val)")).isEqualTo(25);
+        assertThat(item.<Object>getProperty("max(val)")).isEqualTo(9);
+        assertThat(item.<Object>getProperty("min(val)")).isEqualTo(1);
         oddFound = true;
       }
     }
-    Assertions.assertFalse(result.hasNext());
-    Assertions.assertTrue(evenFound);
-    Assertions.assertTrue(oddFound);
+    assertThat(result.hasNext()).isFalse();
+    assertThat(evenFound).isTrue();
+    assertThat(oddFound).isTrue();
     result.close();
   }
 
@@ -768,9 +771,9 @@ public class SelectStatementExecutionTest extends TestHelper {
     boolean evenFound = false;
     boolean oddFound = false;
     for (int i = 0; i < 2; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
       final Object sum = item.getProperty("sum(val)");
       if (sum.equals(20)) {
         evenFound = true;
@@ -778,9 +781,9 @@ public class SelectStatementExecutionTest extends TestHelper {
         oddFound = true;
       }
     }
-    Assertions.assertFalse(result.hasNext());
-    Assertions.assertTrue(evenFound);
-    Assertions.assertTrue(oddFound);
+    assertThat(result.hasNext()).isFalse();
+    assertThat(evenFound).isTrue();
+    assertThat(oddFound).isTrue();
     result.close();
   }
 
@@ -798,13 +801,13 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.commit();
     final ResultSet result = database.query("sql", "select sum(val) from " + className + " group by type.substring(0,1)");
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
       final Object sum = item.getProperty("sum(val)");
-      Assertions.assertEquals(45, sum);
+      assertThat(sum).isEqualTo(45);
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -825,14 +828,14 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from bucket:" + targetClusterName);
     int sum = 0;
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
       final Integer val = item.getProperty("val");
-      Assertions.assertNotNull(val);
+      assertThat(val).isNotNull();
       sum += val;
     }
-    Assertions.assertEquals(45, sum);
-    Assertions.assertFalse(result.hasNext());
+    assertThat(sum).isEqualTo(45);
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -854,13 +857,13 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from bucket:" + targetBucketName + " order by @rid desc");
     final int sum = 0;
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
       final Integer val = item.getProperty("val");
-      Assertions.assertEquals(i, 9 - val);
+      assertThat(9 - val).isEqualTo(i);
     }
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -882,13 +885,13 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from bucket:" + targetClusterName + " order by @rid asc");
     final int sum = 0;
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
       final Integer val = item.getProperty("val");
-      Assertions.assertEquals((Object) i, val);
+      assertThat(val).isEqualTo((Object) i);
     }
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -922,13 +925,13 @@ public class SelectStatementExecutionTest extends TestHelper {
         "select from bucket:[" + targetClusterName + ", " + targetClusterName2 + "] order by @rid asc");
 
     for (int i = 0; i < 20; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
       final Integer val = item.getProperty("val");
-      Assertions.assertEquals((Object) (i % 10), val);
+      assertThat(val).isEqualTo((Object) (i % 10));
     }
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -948,13 +951,13 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from (select from " + className + " where val > 2)  where val < 8");
 
     for (int i = 0; i < 5; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
       final Integer val = item.getProperty("val");
-      Assertions.assertTrue(val > 2);
-      Assertions.assertTrue(val < 8);
+      assertThat(val > 2).isTrue();
+      assertThat(val < 8).isTrue();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -965,17 +968,17 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", "select from schema:types");
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result item = result.next();
-    Assertions.assertEquals("testQuerySchema", item.getProperty("name"));
+    assertThat(item.<String>getProperty("name")).isEqualTo("testQuerySchema");
 
     final Map<String, Object> customType = item.getProperty("custom");
-    Assertions.assertNotNull(customType);
-    Assertions.assertEquals(1, customType.size());
+    assertThat(customType).isNotNull();
+    assertThat(customType.size()).isEqualTo(1);
 
-    Assertions.assertEquals("this is just a test", customType.get("description"));
+    assertThat(customType.get("description")).isEqualTo("this is just a test");
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -988,13 +991,13 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from schema:indexes");
 
     while (result.hasNext()) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item.getProperty("name"));
-      Assertions.assertEquals("STRING", ((List<String>) item.getProperty("keyTypes")).get(0));
-      Assertions.assertFalse((Boolean) item.getProperty("unique"));
+      assertThat(item.<String>getProperty("name")).isNotNull();
+      assertThat( item.<List<String>>getProperty("keyTypes")).first().isEqualTo("STRING");
+      assertThat( item.<Boolean>getProperty("unique")).isFalse();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1002,10 +1005,10 @@ public class SelectStatementExecutionTest extends TestHelper {
   public void testQueryMetadataDatabase() {
     final ResultSet result = database.query("sql", "select from schema:database");
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result item = result.next();
-    Assertions.assertNotNull(item.getProperty("name"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item.<String>getProperty("name")).isNotNull();
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1013,7 +1016,7 @@ public class SelectStatementExecutionTest extends TestHelper {
   public void testNonExistingRids() {
     final int bucketId = database.getSchema().createDocumentType("testNonExistingRids").getBuckets(false).get(0).getFileId();
     final ResultSet result = database.query("sql", "select from #" + bucketId + ":100000000");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
 
     try {
       result.next();
@@ -1031,9 +1034,9 @@ public class SelectStatementExecutionTest extends TestHelper {
     doc.save();
     database.commit();
     final ResultSet result = database.query("sql", "select from #1:0");
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertNotNull(result.next());
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next()).isNotNull();
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1045,9 +1048,9 @@ public class SelectStatementExecutionTest extends TestHelper {
     doc.save();
     database.commit();
     final ResultSet result = database.query("sql", "select from [#1:0]");
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertNotNull(result.next());
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next()).isNotNull();
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1059,9 +1062,9 @@ public class SelectStatementExecutionTest extends TestHelper {
     doc.save();
     database.commit();
     final ResultSet result = database.query("sql", "select from ?", new RID(database, 1, 0));
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertNotNull(result.next());
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next()).isNotNull();
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1076,11 +1079,11 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.commit();
 
     final ResultSet result = database.query("sql", "select from [#1:0, #2:0]");
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertNotNull(result.next());
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertNotNull(result.next());
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next()).isNotNull();
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next()).isNotNull();
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1095,12 +1098,12 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.commit();
 
     final ResultSet result = database.query("sql", "select from [#1:0, #2:0, #1:100000]");
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertNotNull(result.next());
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertNotNull(result.next());
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next()).isNotNull();
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next()).isNotNull();
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     try {
       result.next();
     } catch (RecordNotFoundException e) {
@@ -1124,19 +1127,19 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", "select from " + className + " where name = 'name2'");
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result next = result.next();
-    Assertions.assertNotNull(next);
-    Assertions.assertEquals("name2", next.getProperty("name"));
+    assertThat(next).isNotNull();
+    assertThat(next.<String>getProperty("name")).isEqualTo("name2");
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     final Optional<ExecutionPlan> p = result.getExecutionPlan();
-    Assertions.assertTrue(p.isPresent());
+    assertThat(p.isPresent()).isTrue();
     final ExecutionPlan p2 = p.get();
-    Assertions.assertTrue(p2 instanceof SelectExecutionPlan);
+    assertThat(p2 instanceof SelectExecutionPlan).isTrue();
     final SelectExecutionPlan plan = (SelectExecutionPlan) p2;
-    Assertions.assertEquals(FetchFromIndexStep.class, plan.getSteps().get(0).getClass());
+    assertThat(plan.getSteps().get(0).getClass()).isEqualTo(FetchFromIndexStep.class);
     result.close();
   }
 
@@ -1158,18 +1161,18 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", "select from index:`" + indexName + "` where key = 'name2'");
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result next = result.next();
-    Assertions.assertNotNull(next);
+    assertThat(next).isNotNull();
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     final Optional<ExecutionPlan> p = result.getExecutionPlan();
-    Assertions.assertTrue(p.isPresent());
+    assertThat(p.isPresent()).isTrue();
     final ExecutionPlan p2 = p.get();
-    Assertions.assertTrue(p2 instanceof SelectExecutionPlan);
+    assertThat(p2 instanceof SelectExecutionPlan).isTrue();
     final SelectExecutionPlan plan = (SelectExecutionPlan) p2;
-    Assertions.assertEquals(FetchFromIndexStep.class, plan.getSteps().get(0).getClass());
+    assertThat(plan.getSteps().get(0).getClass()).isEqualTo(FetchFromIndexStep.class);
     result.close();
   }
 
@@ -1193,23 +1196,23 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", "select from " + className + " where name = 'name2' or surname = 'surname3'");
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     for (int i = 0; i < 2; i++) {
       final Result next = result.next();
-      Assertions.assertNotNull(next);
-      Assertions.assertTrue("name2".equals(next.getProperty("name")) || ("surname3".equals(next.getProperty("surname"))));
+      assertThat(next).isNotNull();
+      assertThat("name2".equals(next.getProperty("name")) || ("surname3".equals(next.getProperty("surname")))).isTrue();
     }
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     final Optional<ExecutionPlan> p = result.getExecutionPlan();
-    Assertions.assertTrue(p.isPresent());
+    assertThat(p.isPresent()).isTrue();
     final ExecutionPlan p2 = p.get();
-    Assertions.assertTrue(p2 instanceof SelectExecutionPlan);
+    assertThat(p2 instanceof SelectExecutionPlan).isTrue();
     final SelectExecutionPlan plan = (SelectExecutionPlan) p2;
-    Assertions.assertEquals(ParallelExecStep.class, plan.getSteps().get(0).getClass());
+    assertThat(plan.getSteps().get(0).getClass()).isEqualTo(ParallelExecStep.class);
     final ParallelExecStep parallel = (ParallelExecStep) plan.getSteps().get(0);
-    Assertions.assertEquals(2, parallel.getSubExecutionPlans().size());
+    assertThat(parallel.getSubExecutionPlans().size()).isEqualTo(2);
     result.close();
   }
 
@@ -1234,7 +1237,7 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql",
         "select from " + className + " where foo is not null and (name = 'name2' or surname = 'surname3')");
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1260,14 +1263,14 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql",
         "select from " + className + " where foo < 100 and (name = 'name2' or surname = 'surname3')");
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     for (int i = 0; i < 2; i++) {
       final Result next = result.next();
-      Assertions.assertNotNull(next);
-      Assertions.assertTrue("name2".equals(next.getProperty("name")) || ("surname3".equals(next.getProperty("surname"))));
+      assertThat(next).isNotNull();
+      assertThat("name2".equals(next.getProperty("name")) || ("surname3".equals(next.getProperty("surname")))).isTrue();
     }
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1293,14 +1296,14 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from " + className
         + " where foo < 100 and ((name = 'name2' and foo < 20) or surname = 'surname3') and ( 4<5 and foo < 50)");
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     for (int i = 0; i < 2; i++) {
       final Result next = result.next();
-      Assertions.assertNotNull(next);
-      Assertions.assertTrue("name2".equals(next.getProperty("name")) || ("surname3".equals(next.getProperty("surname"))));
+      assertThat(next).isNotNull();
+      assertThat("name2".equals(next.getProperty("name")) || ("surname3".equals(next.getProperty("surname")))).isTrue();
     }
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1324,14 +1327,14 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", "select from " + className + " where name = 'name3' and surname >= 'surname1'");
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     for (int i = 0; i < 1; i++) {
       final Result next = result.next();
-      Assertions.assertNotNull(next);
-      Assertions.assertEquals("name3", next.getProperty("name"));
+      assertThat(next).isNotNull();
+      assertThat(next.<String>getProperty("name")).isEqualTo("name3");
     }
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1355,7 +1358,7 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", "select from " + className + " where name = 'name3' and surname > 'surname3'");
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1380,10 +1383,10 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from " + className + " where name = 'name3' and surname >= 'surname3'");
     for (int i = 0; i < 1; i++) {
       final Result next = result.next();
-      Assertions.assertNotNull(next);
-      Assertions.assertEquals("name3", next.getProperty("name"));
+      assertThat(next).isNotNull();
+      assertThat(next.<String>getProperty("name")).isEqualTo("name3");
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1407,7 +1410,7 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", "select from " + className + " where name = 'name3' and surname < 'surname3'");
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1432,10 +1435,10 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from " + className + " where name = 'name3' and surname <= 'surname3'");
     for (int i = 0; i < 1; i++) {
       final Result next = result.next();
-      Assertions.assertNotNull(next);
-      Assertions.assertEquals("name3", next.getProperty("name"));
+      assertThat(next).isNotNull();
+      assertThat(next.<String>getProperty("name")).isEqualTo("name3");
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1459,11 +1462,11 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", "select from " + className + " where name > 'name3' ");
     for (int i = 0; i < 6; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result next = result.next();
-      Assertions.assertNotNull(next);
+      assertThat(next).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1488,9 +1491,9 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from " + className + " where name >= 'name3' ");
     for (int i = 0; i < 7; i++) {
       final Result next = result.next();
-      Assertions.assertNotNull(next);
+      assertThat(next).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1515,9 +1518,9 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from " + className + " where name < 'name3' ");
     for (int i = 0; i < 3; i++) {
       final Result next = result.next();
-      Assertions.assertNotNull(next);
+      assertThat(next).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1542,9 +1545,9 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from " + className + " where name <= 'name3' ");
     for (int i = 0; i < 4; i++) {
       final Result next = result.next();
-      Assertions.assertNotNull(next);
+      assertThat(next).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1569,11 +1572,11 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from " + className + " where name > 'name3' and name < 'name5'");
     for (int i = 0; i < 1; i++) {
       final Result next = result.next();
-      Assertions.assertNotNull(next);
+      assertThat(next).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     final SelectExecutionPlan plan = (SelectExecutionPlan) result.getExecutionPlan().get();
-    Assertions.assertEquals(1, plan.getSteps().stream().filter(step -> step instanceof FetchFromIndexStep).count());
+    assertThat(plan.getSteps().stream().filter(step -> step instanceof FetchFromIndexStep).count()).isEqualTo(1);
     result.close();
   }
 
@@ -1597,9 +1600,9 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql",
         "select from " + className + " where name > 'name6' and name = 'name3' and surname > 'surname2' and surname < 'surname5' ");
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     final SelectExecutionPlan plan = (SelectExecutionPlan) result.getExecutionPlan().get();
-    Assertions.assertEquals(1, plan.getSteps().stream().filter(step -> step instanceof FetchFromIndexStep).count());
+    assertThat(plan.getSteps().stream().filter(step -> step instanceof FetchFromIndexStep).count()).isEqualTo(1);
     result.close();
   }
 
@@ -1625,11 +1628,11 @@ public class SelectStatementExecutionTest extends TestHelper {
 //
 //
 //        for (int i = 0; i < 1; i++) {
-//            Assertions.assertTrue(result.hasNext());
+//            Assertions.assertThat(result.hasNext()).isTrue();
 //            Result next = result.next();
-//            Assertions.assertNotNull(next);
+//            Assertions.assertThat(next).isNotNull();
 //        }
-//        Assertions.assertFalse(result.hasNext());
+//        Assertions.assertThat(result.hasNext()).isFalse();
 //        SelectExecutionPlan plan = (SelectExecutionPlan) result.getExecutionPlan().get();
 //        Assertions.assertEquals(
 //                1, plan.getSteps().stream().filter(step -> step instanceof FetchFromIndexStep).count());
@@ -1658,11 +1661,11 @@ public class SelectStatementExecutionTest extends TestHelper {
 //
 //
 //        for (int i = 0; i < 1; i++) {
-//            Assertions.assertTrue(result.hasNext());
+//            Assertions.assertThat(result.hasNext()).isTrue();
 //            Result next = result.next();
-//            Assertions.assertNotNull(next);
+//            Assertions.assertThat(next).isNotNull();
 //        }
-//        Assertions.assertFalse(result.hasNext());
+//        Assertions.assertThat(result.hasNext()).isFalse();
 //        SelectExecutionPlan plan = (SelectExecutionPlan) result.getExecutionPlan().get();
 //        Assertions.assertEquals(
 //                FetchFromClassExecutionStep.class, plan.getSteps().get(0).getClass()); // index not used
@@ -1693,22 +1696,22 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     ResultSet result = database.query("sql", "select expand(linked) from " + parentClassName);
     for (int i = 0; i < count; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result next = result.next();
-      Assertions.assertNotNull(next);
+      assertThat(next).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
 
     try {
       result = database.query("sql", "select expand(linked).asString() from " + parentClassName);
-      Assertions.fail();
+      fail("");
     } catch (CommandSQLParsingException e) {
       // EXPECTED
     }
 
     try {
       result = database.query("sql", "SELECT expand([{'name':2},2,3,4]).name from " + parentClassName);
-      Assertions.fail();
+      fail("");
     } catch (CommandSQLParsingException e) {
       // EXPECTED
     }
@@ -1744,11 +1747,11 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select expand(linked) from " + parentClassName);
 
     for (int i = 0; i < count * collSize; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result next = result.next();
-      Assertions.assertNotNull(next);
+      assertThat(next).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1781,15 +1784,15 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     String last = null;
     for (int i = 0; i < count * collSize; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result next = result.next();
       if (i > 0) {
-        Assertions.assertTrue(last.compareTo(next.getProperty("name")) <= 0);
+        assertThat(last.compareTo(next.getProperty("name")) <= 0).isTrue();
       }
       last = next.getProperty("name");
-      Assertions.assertNotNull(next);
+      assertThat(next).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1811,11 +1814,11 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select distinct name, surname from " + className);
 
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result next = result.next();
-      Assertions.assertNotNull(next);
+      assertThat(next).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1838,59 +1841,59 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select distinct(name) from " + className);
 
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result next = result.next();
-      Assertions.assertNotNull(next);
+      assertThat(next).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
   @Test
   public void testLet1() {
     final ResultSet result = database.query("sql", "select $a as one, $b as two let $a = 1, $b = 1+1");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals(1, item.<Object>getProperty("one"));
-    Assertions.assertEquals(2, item.<Object>getProperty("two"));
+    assertThat(item).isNotNull();
+    assertThat(item.<Object>getProperty("one")).isEqualTo(1);
+    assertThat(item.<Object>getProperty("two")).isEqualTo(2);
     result.close();
   }
 
   @Test
   public void testLet1Long() {
     final ResultSet result = database.query("sql", "select $a as one, $b as two let $a = 1L, $b = 1L+1");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals(1l, item.<Object>getProperty("one"));
-    Assertions.assertEquals(2l, item.<Object>getProperty("two"));
+    assertThat(item).isNotNull();
+    assertThat(item.<Object>getProperty("one")).isEqualTo(1l);
+    assertThat(item.<Object>getProperty("two")).isEqualTo(2l);
     result.close();
   }
 
   @Test
   public void testLet2() {
     final ResultSet result = database.query("sql", "select $a as one let $a = (select 1 as a)");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result item = result.next();
-    Assertions.assertNotNull(item);
+    assertThat(item).isNotNull();
     final Object one = item.getProperty("one");
-    Assertions.assertTrue(one instanceof List);
-    Assertions.assertEquals(1, ((List) one).size());
+    assertThat(one instanceof List).isTrue();
+    assertThat(((List) one).size()).isEqualTo(1);
     final Object x = ((List) one).get(0);
-    Assertions.assertTrue(x instanceof Result);
-    Assertions.assertEquals(1, (Object) ((Result) x).getProperty("a"));
+    assertThat(x instanceof Result).isTrue();
+    assertThat((Object) ((Result) x).getProperty("a")).isEqualTo(1);
     result.close();
   }
 
   @Test
   public void testLet3() {
     final ResultSet result = database.query("sql", "select $a[0].foo as one let $a = (select 1 as foo)");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result item = result.next();
-    Assertions.assertNotNull(item);
+    assertThat(item).isNotNull();
     final Object one = item.getProperty("one");
-    Assertions.assertEquals(1, one);
+    assertThat(one).isEqualTo(1);
     result.close();
   }
 
@@ -1911,12 +1914,12 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql",
         "select name, surname, $nameAndSurname as fullname from " + className + " let $nameAndSurname = name + ' ' + surname");
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals(item.getProperty("fullname"), item.getProperty("name") + " " + item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.getProperty("name") + " " + item.<String>getProperty("surname")).isEqualTo(item.getProperty("fullname"));
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1937,12 +1940,12 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql",
         "select from " + className + " where name in (select name from " + className + " where name = 'name1')");
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("name1", item.getProperty("name"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isEqualTo("name1");
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1964,13 +1967,13 @@ public class SelectStatementExecutionTest extends TestHelper {
         "select $foo as name from " + className + " let $foo = (select name from " + className
             + " where name = $parent.$current.name)");
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertNotNull(item.getProperty("name"));
-      Assertions.assertTrue(item.getProperty("name") instanceof Collection);
+      assertThat(item).isNotNull();
+      assertThat(item.<List<String>>getProperty("name")).isNotNull();
+      assertThat(item.getProperty("name") instanceof Collection).isTrue();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -1992,13 +1995,13 @@ public class SelectStatementExecutionTest extends TestHelper {
         "select $bar as name from " + className + " " + "let $foo = (select name from " + className
             + " where name = $parent.$current.name)," + "$bar = $foo[0].name");
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertNotNull(item.getProperty("name"));
-      Assertions.assertTrue(item.getProperty("name") instanceof String);
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isNotNull();
+      assertThat(item.getProperty("name") instanceof String).isTrue();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -2038,7 +2041,7 @@ public class SelectStatementExecutionTest extends TestHelper {
         }
       }
     }
-    Assertions.assertEquals(1, counter);
+    assertThat(counter).isEqualTo(1);
     resultSet.close();
   }
 
@@ -2058,16 +2061,16 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", "select i, iSeq from " + className + " unwind iSeq");
     for (int i = 0; i < 30; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertNotNull(item.getProperty("i"));
-      Assertions.assertNotNull(item.getProperty("iSeq"));
+      assertThat(item).isNotNull();
+      assertThat(item.<Object>getProperty("i")).isNotNull();
+      assertThat(item.<Object>getProperty("iSeq")).isNotNull();
       final Integer first = item.getProperty("i");
       final Integer second = item.getProperty("iSeq");
-      Assertions.assertTrue(first + second == 0 || second % first == 0);
+      assertThat(first + second == 0 || second % first == 0).isTrue();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -2091,16 +2094,16 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", "select i, iSeq from " + className + " unwind iSeq");
     for (int i = 0; i < 30; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertNotNull(item.getProperty("i"));
-      Assertions.assertNotNull(item.getProperty("iSeq"));
+      assertThat(item).isNotNull();
+      assertThat(item.<Object>getProperty("i")).isNotNull();
+      assertThat(item.<Object>getProperty("iSeq")).isNotNull();
       final Integer first = item.getProperty("i");
       final Integer second = item.getProperty("iSeq");
-      Assertions.assertTrue(first + second == 0 || second % first == 0);
+      assertThat(first + second == 0 || second % first == 0).isTrue();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -2141,13 +2144,13 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", "select from " + parent + " where name = 'name1'");
     final InternalExecutionPlan plan = (InternalExecutionPlan) result.getExecutionPlan().get();
-    Assertions.assertTrue(plan.getSteps().get(0) instanceof ParallelExecStep);
+    assertThat(plan.getSteps().get(0) instanceof ParallelExecStep).isTrue();
     for (int i = 0; i < 2; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -2186,13 +2189,13 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", "select from " + parent + " where name = 'name1' and surname = 'surname1'");
     final InternalExecutionPlan plan = (InternalExecutionPlan) result.getExecutionPlan().get();
-    Assertions.assertTrue(plan.getSteps().get(0) instanceof ParallelExecStep);
+    assertThat(plan.getSteps().get(0) instanceof ParallelExecStep).isTrue();
     for (int i = 0; i < 2; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -2230,13 +2233,13 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", "select from " + parent + " where name = 'name1' and surname = 'surname1'");
     final InternalExecutionPlan plan = (InternalExecutionPlan) result.getExecutionPlan().get();
-    Assertions.assertTrue(plan.getSteps().get(0) instanceof FetchFromTypeExecutionStep); // no index used
+    assertThat(plan.getSteps().get(0) instanceof FetchFromTypeExecutionStep).isTrue(); // no index used
     for (int i = 0; i < 2; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -2279,14 +2282,13 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", "select from " + parent + " where name = 'name1' and surname = 'surname1'");
     final InternalExecutionPlan plan = (InternalExecutionPlan) result.getExecutionPlan().get();
-    Assertions.assertTrue(
-        plan.getSteps().get(0) instanceof FetchFromTypeExecutionStep); // no index, because the superclass is not empty
+    assertThat(plan.getSteps().get(0) instanceof FetchFromTypeExecutionStep).isTrue(); // no index, because the superclass is not empty
     for (int i = 0; i < 2; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -2342,13 +2344,13 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", "select from " + parent + " where name = 'name1' and surname = 'surname1'");
     final InternalExecutionPlan plan = (InternalExecutionPlan) result.getExecutionPlan().get();
-    Assertions.assertTrue(plan.getSteps().get(0) instanceof ParallelExecStep);
+    assertThat(plan.getSteps().get(0) instanceof ParallelExecStep).isTrue();
     for (int i = 0; i < 3; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -2401,13 +2403,13 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", "select from " + parent + " where name = 'name1' and surname = 'surname1'");
     final InternalExecutionPlan plan = (InternalExecutionPlan) result.getExecutionPlan().get();
-    Assertions.assertTrue(plan.getSteps().get(0) instanceof FetchFromTypeExecutionStep);
+    assertThat(plan.getSteps().get(0) instanceof FetchFromTypeExecutionStep).isTrue();
     for (int i = 0; i < 3; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -2431,21 +2433,21 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from " + className + " where name = 'name1' order by surname ASC");
     String lastSurname = null;
     for (int i = 0; i < 3; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertNotNull(item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("surname")).isNotNull();
 
-      final String surname = item.getProperty("surname");
+      final String surname = item.<String>getProperty("surname");
       if (i > 0) {
-        Assertions.assertTrue(surname.compareTo(lastSurname) > 0);
+        assertThat(surname.compareTo(lastSurname) > 0).isTrue();
       }
       lastSurname = surname;
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     final ExecutionPlan plan = result.getExecutionPlan().get();
-    Assertions.assertEquals(1, plan.getSteps().stream().filter(step -> step instanceof FetchFromIndexStep).count());
-    Assertions.assertEquals(0, plan.getSteps().stream().filter(step -> step instanceof OrderByStep).count());
+    assertThat(plan.getSteps().stream().filter(step -> step instanceof FetchFromIndexStep).count()).isEqualTo(1);
+    assertThat(plan.getSteps().stream().filter(step -> step instanceof OrderByStep).count()).isEqualTo(0);
     result.close();
   }
 
@@ -2471,21 +2473,21 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from " + className + " where name = 'name1' order by surname DESC");
     String lastSurname = null;
     for (int i = 0; i < 3; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertNotNull(item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("surname")).isNotNull();
 
-      final String surname = item.getProperty("surname");
+      final String surname = item.<String>getProperty("surname");
       if (i > 0) {
-        Assertions.assertTrue(surname.compareTo(lastSurname) < 0);
+        assertThat(surname.compareTo(lastSurname) < 0).isTrue();
       }
       lastSurname = surname;
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     final ExecutionPlan plan = result.getExecutionPlan().get();
-    Assertions.assertEquals(1, plan.getSteps().stream().filter(step -> step instanceof FetchFromIndexStep).count());
-    Assertions.assertEquals(0, plan.getSteps().stream().filter(step -> step instanceof OrderByStep).count());
+    assertThat(plan.getSteps().stream().filter(step -> step instanceof FetchFromIndexStep).count()).isEqualTo(1);
+    assertThat(plan.getSteps().stream().filter(step -> step instanceof OrderByStep).count()).isEqualTo(0);
     result.close();
   }
 
@@ -2510,21 +2512,21 @@ public class SelectStatementExecutionTest extends TestHelper {
         "select from " + className + " where name = 'name1' order by name DESC, surname DESC");
     String lastSurname = null;
     for (int i = 0; i < 3; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertNotNull(item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("surname")).isNotNull();
 
-      final String surname = item.getProperty("surname");
+      final String surname = item.<String>getProperty("surname");
       if (i > 0) {
-        Assertions.assertTrue(((String) item.getProperty("surname")).compareTo(lastSurname) < 0);
+        assertThat(((String) item.<String>getProperty("surname")).compareTo(lastSurname) < 0).isTrue();
       }
       lastSurname = surname;
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     final ExecutionPlan plan = result.getExecutionPlan().get();
-    Assertions.assertEquals(1, plan.getSteps().stream().filter(step -> step instanceof FetchFromIndexStep).count());
-    Assertions.assertEquals(0, plan.getSteps().stream().filter(step -> step instanceof OrderByStep).count());
+    assertThat(plan.getSteps().stream().filter(step -> step instanceof FetchFromIndexStep).count()).isEqualTo(1);
+    assertThat(plan.getSteps().stream().filter(step -> step instanceof OrderByStep).count()).isEqualTo(0);
     result.close();
   }
 
@@ -2549,21 +2551,21 @@ public class SelectStatementExecutionTest extends TestHelper {
         "select from " + className + " where name = 'name1' order by name ASC, surname ASC");
     String lastSurname = null;
     for (int i = 0; i < 3; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertNotNull(item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("surname")).isNotNull();
 
-      final String surname = item.getProperty("surname");
+      final String surname = item.<String>getProperty("surname");
       if (i > 0) {
-        Assertions.assertTrue(surname.compareTo(lastSurname) > 0);
+        assertThat(surname.compareTo(lastSurname) > 0).isTrue();
       }
       lastSurname = surname;
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     final ExecutionPlan plan = result.getExecutionPlan().get();
-    Assertions.assertEquals(1, plan.getSteps().stream().filter(step -> step instanceof FetchFromIndexStep).count());
-    Assertions.assertEquals(0, plan.getSteps().stream().filter(step -> step instanceof OrderByStep).count());
+    assertThat(plan.getSteps().stream().filter(step -> step instanceof FetchFromIndexStep).count()).isEqualTo(1);
+    assertThat(plan.getSteps().stream().filter(step -> step instanceof OrderByStep).count()).isEqualTo(0);
     result.close();
   }
 
@@ -2589,20 +2591,20 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from " + className + " where name = 'name1' order by surname ASC");
     String lastSurname = null;
     for (int i = 0; i < 3; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertNotNull(item.getProperty("surname"));
-      final String surname = item.getProperty("surname");
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("surname")).isNotNull();
+      final String surname = item.<String>getProperty("surname");
       if (i > 0) {
-        Assertions.assertTrue(surname.compareTo(lastSurname) > 0);
+        assertThat(surname.compareTo(lastSurname) > 0).isTrue();
       }
       lastSurname = surname;
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     final ExecutionPlan plan = result.getExecutionPlan().get();
-    Assertions.assertEquals(1, plan.getSteps().stream().filter(step -> step instanceof FetchFromIndexStep).count());
-    Assertions.assertEquals(0, plan.getSteps().stream().filter(step -> step instanceof OrderByStep).count());
+    assertThat(plan.getSteps().stream().filter(step -> step instanceof FetchFromIndexStep).count()).isEqualTo(1);
+    assertThat(plan.getSteps().stream().filter(step -> step instanceof OrderByStep).count()).isEqualTo(0);
     result.close();
   }
 
@@ -2628,20 +2630,20 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from " + className + " where name = 'name1' order by surname DESC");
     String lastSurname = null;
     for (int i = 0; i < 3; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertNotNull(item.getProperty("surname"));
-      final String surname = item.getProperty("surname");
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("surname")).isNotNull();
+      final String surname = item.<String>getProperty("surname");
       if (i > 0) {
-        Assertions.assertTrue(surname.compareTo(lastSurname) < 0);
+        assertThat(surname.compareTo(lastSurname) < 0).isTrue();
       }
       lastSurname = surname;
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     final ExecutionPlan plan = result.getExecutionPlan().get();
-    Assertions.assertEquals(1, plan.getSteps().stream().filter(step -> step instanceof FetchFromIndexStep).count());
-    Assertions.assertEquals(0, plan.getSteps().stream().filter(step -> step instanceof OrderByStep).count());
+    assertThat(plan.getSteps().stream().filter(step -> step instanceof FetchFromIndexStep).count()).isEqualTo(1);
+    assertThat(plan.getSteps().stream().filter(step -> step instanceof OrderByStep).count()).isEqualTo(0);
     result.close();
   }
 
@@ -2667,12 +2669,12 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from " + className + " where name = 'name1' order by address DESC");
 
     for (int i = 0; i < 3; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertNotNull(item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("surname")).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     boolean orderStepFound = false;
     for (final ExecutionStep step : result.getExecutionPlan().get().getSteps()) {
       if (step instanceof OrderByStep) {
@@ -2680,7 +2682,7 @@ public class SelectStatementExecutionTest extends TestHelper {
         break;
       }
     }
-    Assertions.assertTrue(orderStepFound);
+    assertThat(orderStepFound).isTrue();
     result.close();
   }
 
@@ -2704,13 +2706,13 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql",
         "select from " + className + " where name = 'name1' order by name ASC, surname DESC");
     for (int i = 0; i < 3; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertNotNull(item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("surname")).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
+    assertThat(result.hasNext()).isFalse();
     boolean orderStepFound = false;
     for (final ExecutionStep step : result.getExecutionPlan().get().getSteps()) {
       if (step instanceof OrderByStep) {
@@ -2718,7 +2720,7 @@ public class SelectStatementExecutionTest extends TestHelper {
         break;
       }
     }
-    Assertions.assertTrue(orderStepFound);
+    assertThat(orderStepFound).isTrue();
     result.close();
   }
 
@@ -2741,13 +2743,13 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", "select from " + className + " order by name , surname ASC");
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertNotNull(item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("surname")).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
+    assertThat(result.hasNext()).isFalse();
     boolean orderStepFound = false;
     for (final ExecutionStep step : result.getExecutionPlan().get().getSteps()) {
       if (step instanceof OrderByStep) {
@@ -2755,7 +2757,7 @@ public class SelectStatementExecutionTest extends TestHelper {
         break;
       }
     }
-    Assertions.assertFalse(orderStepFound);
+    assertThat(orderStepFound).isFalse();
     result.close();
   }
 
@@ -2778,13 +2780,13 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", "select from " + className + " order by name desc, surname desc");
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertNotNull(item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("surname")).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
+    assertThat(result.hasNext()).isFalse();
     boolean orderStepFound = false;
     for (final ExecutionStep step : result.getExecutionPlan().get().getSteps()) {
       if (step instanceof OrderByStep) {
@@ -2792,7 +2794,7 @@ public class SelectStatementExecutionTest extends TestHelper {
         break;
       }
     }
-    Assertions.assertFalse(orderStepFound);
+    assertThat(orderStepFound).isFalse();
     result.close();
   }
 
@@ -2815,13 +2817,13 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", "select from " + className + " order by name asc, surname desc");
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertNotNull(item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("surname")).isNotNull();
     }
-    Assertions.assertFalse(result.hasNext());
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
+    assertThat(result.hasNext()).isFalse();
     boolean orderStepFound = false;
     for (final ExecutionStep step : result.getExecutionPlan().get().getSteps()) {
       if (step instanceof OrderByStep) {
@@ -2829,7 +2831,7 @@ public class SelectStatementExecutionTest extends TestHelper {
         break;
       }
     }
-    Assertions.assertTrue(orderStepFound);
+    assertThat(orderStepFound).isTrue();
     result.close();
   }
 
@@ -2853,19 +2855,19 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from " + className + " order by name");
     String last = null;
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertNotNull(item.getProperty("name"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isNotNull();
       final String name = item.getProperty("name");
       //System.out.println(name);
       if (i > 0) {
-        Assertions.assertTrue(name.compareTo(last) >= 0);
+        assertThat(name.compareTo(last) >= 0).isTrue();
       }
       last = name;
     }
-    Assertions.assertFalse(result.hasNext());
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
+    assertThat(result.hasNext()).isFalse();
     boolean orderStepFound = false;
     for (final ExecutionStep step : result.getExecutionPlan().get().getSteps()) {
       if (step instanceof OrderByStep) {
@@ -2873,7 +2875,7 @@ public class SelectStatementExecutionTest extends TestHelper {
         break;
       }
     }
-    Assertions.assertFalse(orderStepFound);
+    assertThat(orderStepFound).isFalse();
     result.close();
   }
 
@@ -2891,12 +2893,12 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from ?", className);
 
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertTrue(("" + item.getProperty("name")).startsWith("name"));
+      assertThat(item).isNotNull();
+      assertThat(("" + item.getProperty("name")).startsWith("name")).isTrue();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -2916,12 +2918,12 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from :target", params);
 
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertTrue(("" + item.getProperty("name")).startsWith("name"));
+      assertThat(item).isNotNull();
+      assertThat(("" + item.getProperty("name")).startsWith("name")).isTrue();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -2939,12 +2941,12 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from " + className + " where name matches 'name1'");
 
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals(item.getProperty("name"), "name1");
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isEqualTo("name1");
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -2962,26 +2964,26 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select name[0..3] as names from " + className);
 
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
       final Object names = item.getProperty("names");
       if (names == null) {
-        Assertions.fail();
+        fail("");
       }
       if (names instanceof Collection) {
-        Assertions.assertEquals(3, ((Collection) names).size());
+        assertThat(((Collection) names).size()).isEqualTo(3);
         final Iterator iter = ((Collection) names).iterator();
-        Assertions.assertEquals("a", iter.next());
-        Assertions.assertEquals("b", iter.next());
-        Assertions.assertEquals("c", iter.next());
+        assertThat(iter.next()).isEqualTo("a");
+        assertThat(iter.next()).isEqualTo("b");
+        assertThat(iter.next()).isEqualTo("c");
       } else if (names.getClass().isArray()) {
-        Assertions.assertEquals(3, Array.getLength(names));
+        assertThat(Array.getLength(names)).isEqualTo(3);
       } else {
-        Assertions.fail();
+        fail("");
       }
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -2999,26 +3001,26 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select name[?..?] as names from " + className, 0, 3);
 
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
       final Object names = item.getProperty("names");
       if (names == null) {
-        Assertions.fail();
+        fail("");
       }
       if (names instanceof Collection) {
-        Assertions.assertEquals(3, ((Collection) names).size());
+        assertThat(((Collection) names).size()).isEqualTo(3);
         final Iterator iter = ((Collection) names).iterator();
-        Assertions.assertEquals("a", iter.next());
-        Assertions.assertEquals("b", iter.next());
-        Assertions.assertEquals("c", iter.next());
+        assertThat(iter.next()).isEqualTo("a");
+        assertThat(iter.next()).isEqualTo("b");
+        assertThat(iter.next()).isEqualTo("c");
       } else if (names.getClass().isArray()) {
-        Assertions.assertEquals(3, Array.getLength(names));
+        assertThat(Array.getLength(names)).isEqualTo(3);
       } else {
-        Assertions.fail();
+        fail("");
       }
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -3039,26 +3041,26 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select name[:a..:b] as names from " + className, params);
 
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
       final Object names = item.getProperty("names");
       if (names == null) {
-        Assertions.fail();
+        fail("");
       }
       if (names instanceof Collection) {
-        Assertions.assertEquals(3, ((Collection) names).size());
+        assertThat(((Collection) names).size()).isEqualTo(3);
         final Iterator iter = ((Collection) names).iterator();
-        Assertions.assertEquals("a", iter.next());
-        Assertions.assertEquals("b", iter.next());
-        Assertions.assertEquals("c", iter.next());
+        assertThat(iter.next()).isEqualTo("a");
+        assertThat(iter.next()).isEqualTo("b");
+        assertThat(iter.next()).isEqualTo("c");
       } else if (names.getClass().isArray()) {
-        Assertions.assertEquals(3, Array.getLength(names));
+        assertThat(Array.getLength(names)).isEqualTo(3);
       } else {
-        Assertions.fail();
+        fail("");
       }
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -3076,43 +3078,43 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select name[0...2] as names from " + className);
 
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
       final Object names = item.getProperty("names");
       if (names == null) {
-        Assertions.fail();
+        fail("");
       }
       if (names instanceof Collection) {
-        Assertions.assertEquals(3, ((Collection) names).size());
+        assertThat(((Collection) names).size()).isEqualTo(3);
         final Iterator iter = ((Collection) names).iterator();
-        Assertions.assertEquals("a", iter.next());
-        Assertions.assertEquals("b", iter.next());
-        Assertions.assertEquals("c", iter.next());
+        assertThat(iter.next()).isEqualTo("a");
+        assertThat(iter.next()).isEqualTo("b");
+        assertThat(iter.next()).isEqualTo("c");
       } else if (names.getClass().isArray()) {
-        Assertions.assertEquals(3, Array.getLength(names));
-        Assertions.assertEquals("a", Array.get(names, 0));
-        Assertions.assertEquals("b", Array.get(names, 1));
-        Assertions.assertEquals("c", Array.get(names, 2));
+        assertThat(Array.getLength(names)).isEqualTo(3);
+        assertThat(Array.get(names, 0)).isEqualTo("a");
+        assertThat(Array.get(names, 1)).isEqualTo("b");
+        assertThat(Array.get(names, 2)).isEqualTo("c");
       } else {
-        Assertions.fail();
+        fail("");
       }
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
   @Test
   public void testNewRid() {
     final ResultSet result = database.query("sql", "select {\"@rid\":\"#12:0\"} as theRid ");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result item = result.next();
     final Object rid = item.getProperty("theRid");
-    Assertions.assertTrue(rid instanceof Identifiable);
+    assertThat(rid instanceof Identifiable).isTrue();
     final Identifiable id = (Identifiable) rid;
-    Assertions.assertEquals(12, id.getIdentity().getBucketId());
-    Assertions.assertEquals(0L, id.getIdentity().getPosition());
-    Assertions.assertFalse(result.hasNext());
+    assertThat(id.getIdentity().getBucketId()).isEqualTo(12);
+    assertThat(id.getIdentity().getPosition()).isEqualTo(0L);
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -3144,20 +3146,20 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.commit();
     final ResultSet result = database.query("sql",
         "select name, elem1:{*}, elem2:{!surname} from " + className + " where name = 'd'");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result item = result.next();
-    Assertions.assertNotNull(item);
+    assertThat(item).isNotNull();
 
     final Result elem1Result = item.getProperty("elem1");
-    Assertions.assertEquals("a", elem1Result.getProperty("name"));
-    Assertions.assertEquals(elem1.getIdentity(), elem1Result.getProperty("@rid"));
-    Assertions.assertEquals(elem1.getTypeName(), elem1Result.getProperty("@type"));
+    assertThat(elem1Result.<String>getProperty("name")).isEqualTo("a");
+    assertThat(elem1Result.<RID>getProperty("@rid")).isEqualTo(elem1.getIdentity());
+    assertThat(elem1Result.<String>getProperty("@type")).isEqualTo(elem1.getTypeName());
 
     final Result elem2Result = item.getProperty("elem2");
-    Assertions.assertEquals("b", elem2Result.getProperty("name"));
-    Assertions.assertNull(elem2Result.getProperty("surname"));
-    Assertions.assertEquals(elem2.getIdentity(), elem2Result.getProperty("@rid"));
-    Assertions.assertEquals(elem2.getTypeName(), elem2Result.getProperty("@type"));
+    assertThat(elem2Result.<String>getProperty("name")).isEqualTo("b");
+    assertThat(elem2Result.<String>getProperty("surname")).isNull();
+    assertThat(elem2Result.<RID>getProperty("@rid")).isEqualTo(elem2.getIdentity());
+    assertThat(elem2Result.<String>getProperty("@type")).isEqualTo(elem2.getTypeName());
 
     result.close();
   }
@@ -3177,33 +3179,33 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.commit();
 
     ResultSet result = database.query("sql", "select coll[='foo'] as filtered from " + className);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
     List res = item.getProperty("filtered");
-    Assertions.assertEquals(1, res.size());
-    Assertions.assertEquals("foo", res.get(0));
+    assertThat(res.size()).isEqualTo(1);
+    assertThat(res.get(0)).isEqualTo("foo");
     result.close();
 
     result = database.query("sql", "select coll[<'ccc'] as filtered from " + className);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     item = result.next();
     res = item.getProperty("filtered");
-    Assertions.assertEquals(2, res.size());
+    assertThat(res.size()).isEqualTo(2);
     result.close();
 
     result = database.query("sql", "select coll[LIKE 'ba%'] as filtered from " + className);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     item = result.next();
     res = item.getProperty("filtered");
-    Assertions.assertEquals(2, res.size());
+    assertThat(res.size()).isEqualTo(2);
     result.close();
 
     result = database.query("sql", "select coll[in ['bar']] as filtered from " + className);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     item = result.next();
     res = item.getProperty("filtered");
-    Assertions.assertEquals(1, res.size());
-    Assertions.assertEquals("bar", res.get(0));
+    assertThat(res.size()).isEqualTo(1);
+    assertThat(res.get(0)).isEqualTo("bar");
     result.close();
   }
 
@@ -3230,19 +3232,19 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     database.commit();
     ResultSet result = database.query("sql", "select from " + className + " where coll contains 1");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     result = database.query("sql", "select from " + className + " where coll contains 1L");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     result = database.query("sql", "select from " + className + " where coll contains 12L");
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -3277,12 +3279,12 @@ public class SelectStatementExecutionTest extends TestHelper {
       for (final EmbeddedDocument d : embeddedList)
         valueMatches.add(d.getInteger("value"));
 
-      Assertions.assertTrue(valueMatches.contains(3));
+      assertThat(valueMatches.contains(3)).isTrue();
 
       ++totalFound;
     }
 
-    Assertions.assertEquals(3, totalFound);
+    assertThat(totalFound).isEqualTo(3);
   }
 
   @Test
@@ -3316,12 +3318,12 @@ public class SelectStatementExecutionTest extends TestHelper {
       for (final EmbeddedDocument d : embeddedList)
         valueMatches.add(d.getString("value"));
 
-      Assertions.assertTrue(valueMatches.contains("3"));
+      assertThat(valueMatches.contains("3")).isTrue();
 
       ++totalFound;
     }
 
-    Assertions.assertEquals(3, totalFound);
+    assertThat(totalFound).isEqualTo(3);
   }
 
   @Test
@@ -3357,12 +3359,12 @@ public class SelectStatementExecutionTest extends TestHelper {
       for (final Map d : embeddedList)
         valueMatches.add((String) d.get("value"));
 
-      Assertions.assertTrue(valueMatches.contains("3"));
+      assertThat(valueMatches.contains("3")).isTrue();
 
       ++totalFound;
     }
 
-    Assertions.assertEquals(3, totalFound);
+    assertThat(totalFound).isEqualTo(3);
   }
 
   @Test
@@ -3378,9 +3380,9 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     database.commit();
     final ResultSet result = database.query("sql", "select from " + className + " where name = 'Bar'");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -3397,9 +3399,9 @@ public class SelectStatementExecutionTest extends TestHelper {
     params.put("p1", "Foo");
     params.put("p2", "Fox");
     final ResultSet result = database.query("sql", "select from " + className + " where name = :p1 and surname = :p2", params);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -3417,9 +3419,9 @@ public class SelectStatementExecutionTest extends TestHelper {
     final Map<String, Object> params = new HashMap<>();
     params.put("p1", "Foo");
     final ResultSet result = database.query("sql", "select from " + className + " where name = :p1", params);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -3434,9 +3436,9 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.commit();
 
     final ResultSet result = database.query("sql", "select from " + className + " where name is defined");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -3451,9 +3453,9 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.commit();
 
     final ResultSet result = database.query("sql", "select from " + className + " where name is not defined");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -3480,7 +3482,7 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ExecutionPlan execPlan = result.getExecutionPlan().get();
     for (final ExecutionStep ExecutionStep : execPlan.getSteps()) {
       if (ExecutionStep instanceof FetchFromTypeExecutionStep) {
-        Assertions.assertEquals(clusterIds.length - 1, ExecutionStep.getSubSteps().size());
+        assertThat(ExecutionStep.getSubSteps().size()).isEqualTo(clusterIds.length - 1);
         // clusters - 1 + fetch from tx...
       }
     }
@@ -3490,7 +3492,7 @@ public class SelectStatementExecutionTest extends TestHelper {
       result.next();
     }
     result.close();
-    Assertions.assertEquals(clusterIds.length - 1, count);
+    assertThat(count).isEqualTo(clusterIds.length - 1);
   }
 
   @Test
@@ -3518,7 +3520,7 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ExecutionPlan execPlan = result.getExecutionPlan().get();
     for (final ExecutionStep ExecutionStep : execPlan.getSteps()) {
       if (ExecutionStep instanceof FetchFromTypeExecutionStep) {
-        Assertions.assertEquals(clusterIds.length - 1, ExecutionStep.getSubSteps().size());
+        assertThat(ExecutionStep.getSubSteps().size()).isEqualTo(clusterIds.length - 1);
         // clusters - 1 + fetch from tx...
       }
     }
@@ -3528,7 +3530,7 @@ public class SelectStatementExecutionTest extends TestHelper {
       result.next();
     }
     result.close();
-    Assertions.assertEquals(clusterIds.length - 1, count);
+    assertThat(count).isEqualTo(clusterIds.length - 1);
   }
 
   @Test
@@ -3549,11 +3551,11 @@ public class SelectStatementExecutionTest extends TestHelper {
     try (final ResultSet result = database.query("sql",
         "select from " + className + 2 + " where tags contains (select from " + className + 1 + " where name = 'foo')")) {
 
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
     }
   }
 
@@ -3575,11 +3577,11 @@ public class SelectStatementExecutionTest extends TestHelper {
     try (final ResultSet result = database.query("sql",
         "select from " + className + 2 + " where (select from " + className + 1 + " where name = 'foo') in tags")) {
 
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
     }
   }
 
@@ -3596,31 +3598,31 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.commit();
 
     try (final ResultSet result = database.query("sql", "select from " + className + " where tags containsany ['foo','baz']")) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
     }
 
     try (final ResultSet result = database.query("sql", "select from " + className + " where tags containsany ['foo','bar']")) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
     }
 
     try (final ResultSet result = database.query("sql", "select from " + className + " where tags containsany ['foo','bbb']")) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
     }
 
     try (final ResultSet result = database.query("sql", "select from " + className + " where tags containsany ['xx','baz']")) {
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
     }
 
     try (final ResultSet result = database.query("sql", "select from " + className + " where tags containsany []")) {
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
     }
   }
 
@@ -3638,36 +3640,36 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.commit();
 
     try (final ResultSet result = database.query("sql", "select from " + className + " where tags containsany ['foo','baz']")) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertFalse(result.hasNext());
-      Assertions.assertTrue(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep));
+      assertThat(result.hasNext()).isFalse();
+      assertThat(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep)).isTrue();
     }
 
     try (final ResultSet result = database.query("sql", "select from " + className + " where tags containsany ['foo','bar']")) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertFalse(result.hasNext());
-      Assertions.assertTrue(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep));
+      assertThat(result.hasNext()).isFalse();
+      assertThat(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep)).isTrue();
     }
 
     try (final ResultSet result = database.query("sql", "select from " + className + " where tags containsany ['foo','bbb']")) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertFalse(result.hasNext());
-      Assertions.assertTrue(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep));
+      assertThat(result.hasNext()).isFalse();
+      assertThat(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep)).isTrue();
     }
 
     try (final ResultSet result = database.query("sql", "select from " + className + " where tags containsany ['xx','baz']")) {
-      Assertions.assertFalse(result.hasNext());
-      Assertions.assertTrue(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep));
+      assertThat(result.hasNext()).isFalse();
+      assertThat(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep)).isTrue();
     }
 
     try (final ResultSet result = database.query("sql", "select from " + className + " where tags containsany []")) {
-      Assertions.assertFalse(result.hasNext());
-      Assertions.assertTrue(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep));
+      assertThat(result.hasNext()).isFalse();
+      assertThat(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep)).isTrue();
     }
   }
 
@@ -3683,17 +3685,17 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.commit();
 
     try (final ResultSet result = database.query("sql", "select from " + className + " where tags containsall ['foo','bar']")) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
     }
 
     try (final ResultSet result = database.query("sql", "select from " + className + " where tags containsall ['foo']")) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
     }
   }
 
@@ -3710,11 +3712,11 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.commit();
 
     try (final ResultSet result = database.query("sql", "select from " + className + " where val between 2 and 3")) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
     }
   }
 
@@ -3731,36 +3733,36 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.commit();
 
     try (final ResultSet result = database.query("sql", "select from " + className + " where tag in ['foo','baz']")) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertFalse(result.hasNext());
-      Assertions.assertTrue(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep));
+      assertThat(result.hasNext()).isFalse();
+      assertThat(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep)).isTrue();
     }
 
     try (final ResultSet result = database.query("sql", "select from " + className + " where tag in ['foo','bar']")) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertFalse(result.hasNext());
-      Assertions.assertTrue(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep));
+      assertThat(result.hasNext()).isFalse();
+      assertThat(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep)).isTrue();
     }
 
     try (final ResultSet result = database.query("sql", "select from " + className + " where tag in []")) {
-      Assertions.assertFalse(result.hasNext());
-      Assertions.assertTrue(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep));
+      assertThat(result.hasNext()).isFalse();
+      assertThat(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep)).isTrue();
     }
 
     final List<String> params = new ArrayList<>();
     params.add("foo");
     params.add("bar");
     try (final ResultSet result = database.query("sql", "select from " + className + " where tag in (?)", params)) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertFalse(result.hasNext());
-      Assertions.assertTrue(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep));
+      assertThat(result.hasNext()).isFalse();
+      assertThat(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep)).isTrue();
     }
   }
 
@@ -3776,36 +3778,36 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.commit();
 
     try (final ResultSet result = database.query("sql", "select from " + className + " where tag in ['foo','baz']")) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertFalse(result.hasNext());
-      Assertions.assertFalse(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep));
+      assertThat(result.hasNext()).isFalse();
+      assertThat(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep)).isFalse();
     }
 
     try (final ResultSet result = database.query("sql", "select from " + className + " where tag in ['foo','bar']")) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertFalse(result.hasNext());
-      Assertions.assertFalse(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep));
+      assertThat(result.hasNext()).isFalse();
+      assertThat(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep)).isFalse();
     }
 
     try (final ResultSet result = database.query("sql", "select from " + className + " where tag in []")) {
-      Assertions.assertFalse(result.hasNext());
-      Assertions.assertFalse(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep));
+      assertThat(result.hasNext()).isFalse();
+      assertThat(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep)).isFalse();
     }
 
     final List<String> params = new ArrayList<>();
     params.add("foo");
     params.add("bar");
     try (final ResultSet result = database.query("sql", "select from " + className + " where tag in (?)", params)) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertFalse(result.hasNext());
-      Assertions.assertFalse(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep));
+      assertThat(result.hasNext()).isFalse();
+      assertThat(result.getExecutionPlan().get().getSteps().stream().anyMatch(x -> x instanceof FetchFromIndexStep)).isFalse();
     }
   }
 
@@ -3823,9 +3825,9 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     try (final ResultSet result = database.query("sql", "select from " + className + " where thelist CONTAINS ( name = ?)",
         "Jack")) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
     }
   }
 
@@ -3872,8 +3874,8 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     try (final ResultSet result = database.query("sql", TEST_QUERY)) {
       final Result row = result.nextIfAvailable();
-      Assertions.assertEquals("21087591856", row.getProperty("cuij"));
-      Assertions.assertEquals(1L, (Long) row.getProperty("count"));
+      assertThat(row.<String>getProperty("cuij")).isEqualTo("21087591856");
+      assertThat((Long) row.getProperty("count")).isEqualTo(1L);
     }
   }
 
@@ -3893,9 +3895,9 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     database.commit();
     try (final ResultSet result = database.query("sql", "select from " + className + " where test contains []")) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
     }
   }
 
@@ -3915,9 +3917,9 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.commit();
 
     try (final ResultSet result = database.query("sql", "select from " + className + " where test contains [1]")) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
     }
   }
 
@@ -3942,7 +3944,7 @@ public class SelectStatementExecutionTest extends TestHelper {
         try (final ResultSet result = database.query("sql", "select from " + className + " ORDER BY name")) {
           result.forEachRemaining(x -> x.getProperty("name"));
         }
-        Assertions.fail();
+        fail("");
       } catch (final CommandExecutionException ex) {
       }
     } finally {
@@ -3953,10 +3955,10 @@ public class SelectStatementExecutionTest extends TestHelper {
   @Test
   public void testXor() {
     try (final ResultSet result = database.query("sql", "select 15 ^ 4 as foo")) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertEquals(11, (int) item.getProperty("foo"));
-      Assertions.assertFalse(result.hasNext());
+      assertThat((int) item.getProperty("foo")).isEqualTo(11);
+      assertThat(result.hasNext()).isFalse();
     }
   }
 
@@ -3973,35 +3975,35 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.commit();
 
     try (final ResultSet result = database.query("sql", "select from " + className + " where name LIKE 'foo%'")) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
     }
     try (final ResultSet result = database.query("sql", "select from " + className + " where name LIKE '%foo%baz%'")) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
     }
     try (final ResultSet result = database.query("sql", "select from " + className + " where name LIKE '%bar%'")) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
     }
 
     try (final ResultSet result = database.query("sql", "select from " + className + " where name LIKE 'bar%'")) {
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
     }
 
     try (final ResultSet result = database.query("sql", "select from " + className + " where name LIKE '%bar'")) {
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
     }
 
     final String specialChars = "[]{}()|*^.";
     for (final char c : specialChars.toCharArray()) {
       try (final ResultSet result = database.query("sql", "select from " + className + " where name LIKE '%" + c + "%'")) {
-        Assertions.assertTrue(result.hasNext());
+        assertThat(result.hasNext()).isTrue();
         result.next();
-        Assertions.assertFalse(result.hasNext());
+        assertThat(result.hasNext()).isFalse();
       }
     }
   }
@@ -4021,10 +4023,10 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.commit();
     final ResultSet result = database.query("sql", "select count(val) as count from " + className + " limit 3");
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result item = result.next();
-    Assertions.assertEquals(10L, (long) item.getProperty("count"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat((long) item.getProperty("count")).isEqualTo(10L);
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -4147,10 +4149,10 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from " + className + " WHERE name >= 'name5'");
 
     for (int i = 0; i < 5; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -4171,10 +4173,10 @@ public class SelectStatementExecutionTest extends TestHelper {
     final ResultSet result = database.query("sql", "select from " + className + " WHERE name <= 'name5'");
 
     for (int i = 0; i < 6; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -4205,11 +4207,11 @@ public class SelectStatementExecutionTest extends TestHelper {
     try (final ResultSet rs = database.query("sql",
         "select from " + classNamePrefix + "Report where id in (select out('" + classNamePrefix + "hasOwnership').id from "
             + classNamePrefix + "User where id = 'admin');")) {
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       rs.next();
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       rs.next();
-      Assertions.assertFalse(rs.hasNext());
+      assertThat(rs.hasNext()).isFalse();
     }
 
     database.command("sql", "create index ON " + classNamePrefix + "Report(id) unique;").close();
@@ -4217,11 +4219,11 @@ public class SelectStatementExecutionTest extends TestHelper {
     try (final ResultSet rs = database.query("sql",
         "select from " + classNamePrefix + "Report where id in (select out('" + classNamePrefix + "hasOwnership').id from "
             + classNamePrefix + "User where id = 'admin');")) {
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       rs.next();
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       rs.next();
-      Assertions.assertFalse(rs.hasNext());
+      assertThat(rs.hasNext()).isFalse();
     }
   }
 
@@ -4237,11 +4239,11 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.commit();
 
     final ResultSet result = database.query("sql", "select *, !surname from " + className);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals("foo", item.getProperty("name"));
-    Assertions.assertNull(item.getProperty("surname"));
+    assertThat(item).isNotNull();
+    assertThat(item.<String>getProperty("name")).isEqualTo("foo");
+    assertThat(item.<String>getProperty("surname")).isNull();
 
     result.close();
   }
@@ -4261,17 +4263,17 @@ public class SelectStatementExecutionTest extends TestHelper {
 
     try (final ResultSet result = database.query("sql",
         "select from " + className + " LET $order = name.substring(1) ORDER BY $order ASC LIMIT 1")) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("baaa", item.getProperty("name"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isEqualTo("baaa");
     }
     try (final ResultSet result = database.query("sql",
         "select from " + className + " LET $order = name.substring(1) ORDER BY $order DESC LIMIT 1")) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("abbb", item.getProperty("name"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isEqualTo("abbb");
     }
   }
 
@@ -4281,14 +4283,14 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.command("sql", "ALTER TYPE SchemaMap CUSTOM label = 'Document'");
     final ResultSet result = database.query("sql", "SELECT map(name,custom.label) as map FROM schema:types");
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result item = result.next();
-    Assertions.assertNotNull(item);
+    assertThat(item).isNotNull();
 
     Object map = item.getProperty("map");
-    Assertions.assertTrue(map instanceof Map);
+    assertThat(map instanceof Map).isTrue();
 
-    Assertions.assertEquals("Document", ((Map<?, ?>) map).get("SchemaMap"));
+    assertThat(((Map<?, ?>) map).get("SchemaMap")).isEqualTo("Document");
 
     result.close();
   }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/SelectStatementExecutionTestIT.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/SelectStatementExecutionTestIT.java
@@ -20,8 +20,9 @@ package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.MutableDocument;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by tglman on 09/06/17.
@@ -51,9 +52,9 @@ public class SelectStatementExecutionTestIT extends TestHelper {
         final Result item = result.next();
         //        Assertions.assertNotNull(item);
         final Object name = item.getProperty("name");
-        Assertions.assertFalse("name1".equals(name));
+        assertThat(name).isNotEqualTo("name1");
       }
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
       result.close();
       final long end = System.nanoTime();
     }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/SleepStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/SleepStatementExecutionTest.java
@@ -19,8 +19,9 @@
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.TestHelper;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luigi Dell'Aquila (l.dellaquila-(at)-orientdb.com)
@@ -30,12 +31,12 @@ public class SleepStatementExecutionTest extends TestHelper {
   public void testBasic() {
     final long begin = System.currentTimeMillis();
     final ResultSet result = database.command("sql", "sleep 1000");
-    Assertions.assertTrue(System.currentTimeMillis() - begin >= 1000);
+    assertThat(System.currentTimeMillis() - begin >= 1000).isTrue();
     //printExecutionPlan(null, result);
-    Assertions.assertNotNull(result);
-    Assertions.assertTrue(result.hasNext());
+//    assertThat(result).isNotNull();
+    assertThat(result.hasNext()).isTrue();
     final Result item = result.next();
-    Assertions.assertEquals("sleep", item.getProperty("operation"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item.<String>getProperty("operation")).isEqualTo("sleep");
+    assertThat(result.hasNext()).isFalse();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/TraverseStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/TraverseStatementExecutionTest.java
@@ -20,10 +20,13 @@ package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.RID;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Luigi Dell'Aquila (l.dellaquila-(at)-orientdb.com)
@@ -53,11 +56,11 @@ public class TraverseStatementExecutionTest extends TestHelper {
       final ResultSet result = database.query("sql", "traverse out() from (select from " + classPrefix + "V where name = 'a')");
 
       for (int i = 0; i < 4; i++) {
-        Assertions.assertTrue(result.hasNext());
+        assertThat(result.hasNext()).isTrue();
         final Result item = result.next();
-        Assertions.assertEquals(i, item.getMetadata("$depth"));
+        assertThat(item.getMetadata("$depth")).isEqualTo(i);
       }
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
       result.close();
     });
   }
@@ -87,11 +90,11 @@ public class TraverseStatementExecutionTest extends TestHelper {
           "traverse out() from (select from " + classPrefix + "V where name = 'a') WHILE $depth < 2");
 
       for (int i = 0; i < 2; i++) {
-        Assertions.assertTrue(result.hasNext());
+        assertThat(result.hasNext()).isTrue();
         final Result item = result.next();
-        Assertions.assertEquals(i, item.getMetadata("$depth"));
+        assertThat(item.getMetadata("$depth")).isEqualTo(i);
       }
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
       result.close();
     });
   }
@@ -121,21 +124,21 @@ public class TraverseStatementExecutionTest extends TestHelper {
           "traverse out() from (select from " + classPrefix + "V where name = 'a') MAXDEPTH 1");
 
       for (int i = 0; i < 2; i++) {
-        Assertions.assertTrue(result.hasNext());
+        assertThat(result.hasNext()).isTrue();
         final Result item = result.next();
-        Assertions.assertEquals(i, item.getMetadata("$depth"));
+        assertThat(item.getMetadata("$depth")).isEqualTo(i);
       }
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
       result.close();
 
       result = database.query("sql", "traverse out() from (select from " + classPrefix + "V where name = 'a') MAXDEPTH 2");
 
       for (int i = 0; i < 3; i++) {
-        Assertions.assertTrue(result.hasNext());
+        assertThat(result.hasNext()).isTrue();
         final Result item = result.next();
-        Assertions.assertEquals(i, item.getMetadata("$depth"));
+        assertThat(item.getMetadata("$depth")).isEqualTo(i);
       }
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
       result.close();
     });
   }
@@ -165,11 +168,11 @@ public class TraverseStatementExecutionTest extends TestHelper {
           "traverse out() from (select from " + classPrefix + "V where name = 'a') STRATEGY BREADTH_FIRST");
 
       for (int i = 0; i < 4; i++) {
-        Assertions.assertTrue(result.hasNext());
+        assertThat(result.hasNext()).isTrue();
         final Result item = result.next();
-        Assertions.assertEquals(i, item.getMetadata("$depth"));
+        assertThat(item.getMetadata("$depth")).isEqualTo(i);
       }
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
       result.close();
     });
   }
@@ -195,9 +198,9 @@ public class TraverseStatementExecutionTest extends TestHelper {
       script += "return $top;";
 
       final ResultSet result = database.command("sqlscript", script);
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
-      Assertions.assertFalse(result.hasNext());
+      assertThat(result.hasNext()).isFalse();
       result.close();
     });
   }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/TruncateClassStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/TruncateClassStatementExecutionTest.java
@@ -23,10 +23,11 @@ import com.arcadedb.index.Index;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luigi Dell'Aquila (l.dellaquila-(at)-orientdb.com)
@@ -54,14 +55,14 @@ public class TruncateClassStatementExecutionTest extends TestHelper {
     database.newDocument(testClass.getName()).set("name", "y").set("data", Arrays.asList(8, 9, -1)).save();
 
     final ResultSet result = database.query("sql", "SElect from test_class");
-    //    Assertions.assertEquals(result.size(), 2);
+    //    Assertions.assertThat(2).isEqualTo(result.size());
 
     final Set<Integer> set = new HashSet<Integer>();
     while (result.hasNext()) {
       set.addAll(result.next().getProperty("data"));
     }
     result.close();
-    Assertions.assertTrue(set.containsAll(Arrays.asList(5, 6, 7, 8, 9, -1)));
+    assertThat(set.containsAll(Arrays.asList(5, 6, 7, 8, 9, -1))).isTrue();
 
     schema.dropType("test_class");
     database.commit();
@@ -79,22 +80,22 @@ public class TruncateClassStatementExecutionTest extends TestHelper {
 
     ResultSet result = database.query("sql", "SElect from TestTruncateVertexClassSuperclass");
     for (int i = 0; i < 2; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       result.next();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     database.command("sql", "truncate type TestTruncateVertexClassSuperclass ");
     result = database.query("sql", "SElect from TestTruncateVertexClassSubclass");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     result.next();
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     database.command("sql", "truncate type TestTruncateVertexClassSuperclass polymorphic");
     result = database.query("sql", "SElect from TestTruncateVertexClassSubclass");
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
     database.commit();
   }
@@ -130,13 +131,13 @@ public class TruncateClassStatementExecutionTest extends TestHelper {
     database.newDocument(testClass.getName()).set("name", "y").set("data", Arrays.asList(3, 0)).save();
 
     ResultSet result = database.query("sql", "SElect from test_class");
-    Assertions.assertEquals(toList(result).size(), 2);
+    assertThat(toList(result).size()).isEqualTo(2);
 
     result.close();
     database.command("sql", "truncate type test_class");
 
     result = database.query("sql", "SElect from test_class");
-    Assertions.assertEquals(toList(result).size(), 0);
+    assertThat(toList(result).size()).isEqualTo(0);
     result.close();
 
     schema.dropType("test_class");

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateStatementExecutionTest.java
@@ -32,12 +32,15 @@ import com.arcadedb.index.TypeIndex;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.time.*;
 import java.time.format.*;
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luigi Dell'Aquila (l.dellaquila-(at)-orientdb.com)
@@ -87,22 +90,22 @@ public class UpdateStatementExecutionTest extends TestHelper {
   @Test
   public void testSetString() {
     ResultSet result = database.command("sql", "update " + className + " set surname = 'foo'");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals((Object) 10L, item.getProperty("count"));
+    assertThat(item).isNotNull();
+    assertThat(item.<Long>getProperty("count")).isEqualTo((Object) 10L);
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     result = database.query("sql", "SElect from " + className);
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("foo", item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("surname")).isEqualTo("foo");
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -110,117 +113,114 @@ public class UpdateStatementExecutionTest extends TestHelper {
   public void testCopyField() {
     ResultSet result = database.command("sql", "update " + className + " set surname = name");
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals((Object) 10L, item.getProperty("count"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item).isNotNull();
+    assertThat(item.<Long>getProperty("count")).isEqualTo(10L);
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     result = database.query("sql", "SElect from " + className);
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals((Object) item.getProperty("name"), item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("surname")).isEqualTo( item.getProperty("name"));
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
   @Test
   public void testSetExpression() {
     ResultSet result = database.command("sql", "update " + className + " set surname = 'foo'+name ");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals((Object) 10L, item.getProperty("count"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item).isNotNull();
+    assertThat(item.<Long>getProperty("count")).isEqualTo(10L);
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     result = database.query("sql", "SElect from " + className);
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("foo" + item.getProperty("name"), item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("surname")).isEqualTo("foo" + item.getProperty("name"));
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
   @Test
   public void testConditionalSet() {
     ResultSet result = database.command("sql", "update " + className + " set surname = 'foo' where name = 'name3'");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals((Object) 1L, item.getProperty("count"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item).isNotNull();
+    assertThat(item.<Long>getProperty("count")).isEqualTo(1L);
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     result = database.query("sql", "SElect from " + className);
     boolean found = false;
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
       if ("name3".equals(item.getProperty("name"))) {
-        Assertions.assertEquals("foo", item.getProperty("surname"));
+        assertThat(item.<String>getProperty("surname")).isEqualTo("foo");
         found = true;
       }
     }
-    Assertions.assertTrue(found);
-    Assertions.assertFalse(result.hasNext());
+    assertThat(found).isTrue();
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
   @Test
   public void testSetOnList() {
     ResultSet result = database.command("sql", "update " + className + " set tagsList[0] = 'abc' where name = 'name3'");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals((Object) 1L, item.getProperty("count"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item).isNotNull();
+    assertThat(item.<Long>getProperty("count")).isEqualTo( 1L);
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     result = database.query("sql", "SElect from " + className);
     boolean found = false;
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
       if ("name3".equals(item.getProperty("name"))) {
-        final List<String> tags = new ArrayList<>();
-        tags.add("abc");
-        tags.add("bar");
-        tags.add("baz");
-        Assertions.assertEquals(tags, item.getProperty("tagsList"));
+        final List<String> tags = List.of("abc", "bar", "baz");
+        assertThat(item.<List<String>>getProperty("tagsList")).isEqualTo(tags);
         found = true;
       }
     }
-    Assertions.assertTrue(found);
-    Assertions.assertFalse(result.hasNext());
+    assertThat(found).isTrue();
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
   @Test
   public void testSetOnList2() {
     ResultSet result = database.command("sql", "update " + className + " set tagsList[6] = 'abc' where name = 'name3'");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals((Object) 1L, item.getProperty("count"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item).isNotNull();
+    assertThat(item.<Long>getProperty("count")).isEqualTo((Object) 1L);
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     result = database.query("sql", "SElect from " + className);
     boolean found = false;
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
       if ("name3".equals(item.getProperty("name"))) {
         final List<String> tags = new ArrayList<>();
         tags.add("foo");
@@ -230,48 +230,48 @@ public class UpdateStatementExecutionTest extends TestHelper {
         tags.add(null);
         tags.add(null);
         tags.add("abc");
-        Assertions.assertEquals(tags, item.getProperty("tagsList"));
+        assertThat(item.<List<String>>getProperty("tagsList")).isEqualTo(tags);
         found = true;
       }
     }
-    Assertions.assertTrue(found);
-    Assertions.assertFalse(result.hasNext());
+    assertThat(found).isTrue();
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
   @Test
   public void testSetOnMap() {
     ResultSet result = database.command("sql", "update " + className + " set tagsMap['foo'] = 'abc' where name = 'name3'");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals((Object) 1L, item.getProperty("count"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item).isNotNull();
+    assertThat(item.<Long>getProperty("count")).isEqualTo((Object) 1L);
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     result = database.query("sql", "SElect from " + className);
     boolean found = false;
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
       if ("name3".equals(item.getProperty("name"))) {
         final Map<String, String> tags = new HashMap<>();
         tags.put("foo", "abc");
         tags.put("bar", "bar");
         tags.put("baz", "baz");
-        Assertions.assertEquals(tags, item.getProperty("tagsMap"));
+        assertThat(item.<Map<String, String>>getProperty("tagsMap")).isEqualTo(tags);
         found = true;
       } else {
         final Map<String, String> tags = new HashMap<>();
         tags.put("foo", "foo");
         tags.put("bar", "bar");
         tags.put("baz", "baz");
-        Assertions.assertEquals(tags, item.getProperty("tagsMap"));
+        assertThat(item.<Map<String, String>>getProperty("tagsMap")).isEqualTo(tags);
       }
     }
-    Assertions.assertTrue(found);
-    Assertions.assertFalse(result.hasNext());
+    assertThat(found).isTrue();
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -281,21 +281,21 @@ public class UpdateStatementExecutionTest extends TestHelper {
         "insert into " + className + " set listStrings = ['this', 'is', 'a', 'test'], listNumbers = [1,2,3]");
     final RID rid = result.next().getIdentity().get();
     result = database.command("sql", "update " + rid + " set listStrings += '!', listNumbers += 9");
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertNotNull(result.next());
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next()).isNotNull();
 
     result = database.command("sql", "select from " + rid);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
+    assertThat(item).isNotNull();
 
     List<String> listStrings = item.getProperty("listStrings");
-    Assertions.assertEquals(5, listStrings.size());
-    Assertions.assertEquals("!", listStrings.get(4));
+    assertThat(listStrings.size()).isEqualTo(5);
+    assertThat(listStrings.get(4)).isEqualTo("!");
 
     List<Number> listNumbers = item.getProperty("listNumbers");
-    Assertions.assertEquals(4, listNumbers.size());
-    Assertions.assertEquals(9, listNumbers.get(3));
+    assertThat(listNumbers.size()).isEqualTo(4);
+    assertThat(listNumbers.get(3)).isEqualTo(9);
   }
 
   @Test
@@ -303,23 +303,23 @@ public class UpdateStatementExecutionTest extends TestHelper {
     ResultSet result = database.command("sql", "insert into " + className + " set map1 = {'name':'Jay'}, map2 = {'name':'Jay'}");
     final RID rid = result.next().getIdentity().get();
     result = database.command("sql", "update " + rid + " set map1 += { 'last': 'Miner'}, map2 += [ 'last', 'Miner']");
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertNotNull(result.next());
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next()).isNotNull();
 
     result = database.command("sql", "select from " + rid);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
+    assertThat(item).isNotNull();
 
     Map<String, String> map1 = item.getProperty("map1");
-    Assertions.assertEquals(2, map1.size());
-    Assertions.assertEquals("Jay", map1.get("name"));
-    Assertions.assertEquals("Miner", map1.get("last"));
+    assertThat(map1.size()).isEqualTo(2);
+    assertThat(map1.get("name")).isEqualTo("Jay");
+    assertThat(map1.get("last")).isEqualTo("Miner");
 
     Map<String, String> map2 = item.getProperty("map2");
-    Assertions.assertEquals(2, map2.size());
-    Assertions.assertEquals("Jay", map2.get("name"));
-    Assertions.assertEquals("Miner", map2.get("last"));
+    assertThat(map2.size()).isEqualTo(2);
+    assertThat(map2.get("name")).isEqualTo("Jay");
+    assertThat(map2.get("last")).isEqualTo("Miner");
   }
 
   /**
@@ -333,68 +333,68 @@ public class UpdateStatementExecutionTest extends TestHelper {
     database.command("sql", "update " + rid + " set bars = map( \"23-03-24\" , { \"volume\": 100 } )");
 
     result = database.command("sql", "update " + rid + " set bars += { \"2023-03-08\": { \"volume\": 134 }}");
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertNotNull(result.next());
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next()).isNotNull();
 
     result = database.command("sql", "select from " + rid);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
+    assertThat(item).isNotNull();
 
     Map<String, Object> map1 = item.getProperty("bars");
-    Assertions.assertEquals(2, map1.size());
+    assertThat(map1.size()).isEqualTo(2);
 
     Map nestedMap = (Map) map1.get("23-03-24");
-    Assertions.assertNotNull(nestedMap);
-    Assertions.assertEquals(100, nestedMap.get("volume"));
+    assertThat(nestedMap).isNotNull();
+    assertThat(nestedMap.get("volume")).isEqualTo(100);
 
     nestedMap = (Map) map1.get("2023-03-08");
-    Assertions.assertNotNull(nestedMap);
-    Assertions.assertEquals(134, nestedMap.get("volume"));
+    assertThat(nestedMap).isNotNull();
+    assertThat(nestedMap.get("volume")).isEqualTo(134);
   }
 
   @Test
   public void testPlusAssign() {
     ResultSet result = database.command("sql", "update " + className + " set name += 'foo', newField += 'bar', number += 5");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals((Object) 10L, item.getProperty("count"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item).isNotNull();
+    assertThat(item.<Long>getProperty("count")).isEqualTo((Object) 10L);
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     result = database.query("sql", "SElect from " + className);
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertTrue(item.getProperty("name").toString().endsWith("foo")); // test concatenate string to string
-      Assertions.assertEquals(8, item.getProperty("name").toString().length());
-      Assertions.assertEquals("bar", item.getProperty("newField")); // test concatenate null to string
-      Assertions.assertEquals((Object) 9L, item.getProperty("number")); // test sum numbers
+      assertThat(item).isNotNull();
+      assertThat(item.getProperty("name").toString().endsWith("foo")).isTrue(); // test concatenate string to string
+      assertThat(item.getProperty("name").toString().length()).isEqualTo(8);
+      assertThat(item.<String>getProperty("newField")).isEqualTo("bar"); // test concatenate null to string
+      assertThat(item.<Long>getProperty("number")).isEqualTo( 9L); // test sum numbers
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
   @Test
   public void testMinusAssign() {
     ResultSet result = database.command("sql", "update " + className + " set number -= 5");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals((Object) 10L, item.getProperty("count"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item).isNotNull();
+    assertThat(item.<Long>getProperty("count")).isEqualTo((Object) 10L);
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     result = database.query("sql", "SElect from " + className);
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals((Object) (-1L), item.getProperty("number"));
+      assertThat(item).isNotNull();
+      assertThat(item.<Long>getProperty("number")).isEqualTo((Object) (-1L));
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -404,21 +404,21 @@ public class UpdateStatementExecutionTest extends TestHelper {
         "insert into " + className + " set listStrings = ['this', 'is', 'a', 'test'], listNumbers = [1,2,3]");
     final RID rid = result.next().getIdentity().get();
     result = database.command("sql", "update " + rid + " set listStrings -= 'a', listNumbers -= 2");
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertNotNull(result.next());
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next()).isNotNull();
 
     result = database.command("sql", "select from " + rid);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
+    assertThat(item).isNotNull();
 
     List<String> listStrings = item.getProperty("listStrings");
-    Assertions.assertEquals(3, listStrings.size());
-    Assertions.assertFalse(listStrings.contains("!"));
+    assertThat(listStrings.size()).isEqualTo(3);
+    assertThat(listStrings.contains("!")).isFalse();
 
     List<Number> listNumbers = item.getProperty("listNumbers");
-    Assertions.assertEquals(2, listNumbers.size());
-    Assertions.assertFalse(listNumbers.contains(2));
+    assertThat(listNumbers.size()).isEqualTo(2);
+    assertThat(listNumbers.contains(2)).isFalse();
   }
 
   @Test
@@ -426,60 +426,60 @@ public class UpdateStatementExecutionTest extends TestHelper {
     ResultSet result = database.command("sql", "insert into " + className + " set map1 = {'name':'Jay'}, map2 = {'name':'Jay'}");
     final RID rid = result.next().getIdentity().get();
     result = database.command("sql", "update " + rid + " set map1 -= {'name':'Jay'}, map2 -= [ 'name' ]");
-    Assertions.assertTrue(result.hasNext());
-    Assertions.assertNotNull(result.next());
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next()).isNotNull();
 
     result = database.command("sql", "select from " + rid);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
+    assertThat(item).isNotNull();
 
     Map<String, String> map1 = item.getProperty("map1");
-    Assertions.assertEquals(0, map1.size());
+    assertThat(map1.size()).isEqualTo(0);
 
     Map<String, String> map2 = item.getProperty("map2");
-    Assertions.assertEquals(0, map2.size());
+    assertThat(map2.size()).isEqualTo(0);
   }
 
   @Test
   public void testStarAssign() {
     ResultSet result = database.command("sql", "update " + className + " set number *= 5");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals((Object) 10L, item.getProperty("count"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item).isNotNull();
+    assertThat(item.<Long>getProperty("count")).isEqualTo((Object) 10L);
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     result = database.query("sql", "SElect from " + className);
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals((Object) 20L, item.getProperty("number"));
+      assertThat(item).isNotNull();
+      assertThat(item.<Long>getProperty("number")).isEqualTo(20L);
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
   @Test
   public void testSlashAssign() {
     ResultSet result = database.command("sql", "update " + className + " set number /= 2");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals((Object) 10L, item.getProperty("count"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item).isNotNull();
+    assertThat(item.<Long>getProperty("count")).isEqualTo((Object) 10L);
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     result = database.query("sql", "SElect from " + className);
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals((Object) 2L, item.getProperty("number"));
+      assertThat(item).isNotNull();
+      assertThat(item.<Long>getProperty("number")).isEqualTo(2L);
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -487,31 +487,31 @@ public class UpdateStatementExecutionTest extends TestHelper {
   public void testRemove() {
     ResultSet result = database.query("sql", "SElect from " + className);
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertNotNull(item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("surname")).isNotNull();
     }
 
     result.close();
     result = database.command("sql", "update " + className + " remove surname");
     for (int i = 0; i < 1; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals((Object) 10L, item.getProperty("count"));
+      assertThat(item).isNotNull();
+      assertThat(item.<Long>getProperty("count")).isEqualTo((Object) 10L);
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     result = database.query("sql", "SElect from " + className);
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertFalse(item.toElement().has("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.toElement().has("surname")).isFalse();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -519,23 +519,23 @@ public class UpdateStatementExecutionTest extends TestHelper {
   public void testContent() {
 
     ResultSet result = database.command("sql", "update " + className + " content {'name': 'foo', 'secondName': 'bar'}");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals((Object) 10L, item.getProperty("count"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item).isNotNull();
+    assertThat(item.<Long>getProperty("count")).isEqualTo((Object) 10L);
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     result = database.query("sql", "SElect from " + className);
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("foo", item.getProperty("name"));
-      Assertions.assertEquals("bar", item.getProperty("secondName"));
-      Assertions.assertNull(item.getProperty("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isEqualTo("foo");
+      assertThat(item.<String>getProperty("secondName")).isEqualTo("bar");
+      assertThat(item.<String>getProperty("surname")).isNull();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -543,23 +543,23 @@ public class UpdateStatementExecutionTest extends TestHelper {
   public void testMerge() {
 
     ResultSet result = database.command("sql", "update " + className + " merge {'name': 'foo', 'secondName': 'bar'}");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals((Object) 10L, item.getProperty("count"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item).isNotNull();
+    assertThat(item.<Long>getProperty("count")).isEqualTo((Object) 10L);
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     result = database.query("sql", "SElect from " + className);
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals("foo", item.getProperty("name"));
-      Assertions.assertEquals("bar", item.getProperty("secondName"));
-      Assertions.assertTrue(item.getProperty("surname").toString().startsWith("surname"));
+      assertThat(item).isNotNull();
+      assertThat(item.<String>getProperty("name")).isEqualTo("foo");
+      assertThat(item.<String>getProperty("secondName")).isEqualTo("bar");
+      assertThat(item.<String>getProperty("surname").toString().startsWith("surname")).isTrue();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -580,21 +580,21 @@ public class UpdateStatementExecutionTest extends TestHelper {
     doc.save();
 
     ResultSet result = database.command("sql", "update " + className + " remove theProperty[0]");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item).isNotNull();
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     result = database.query("sql", "SElect from " + className);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     item = result.next();
-    Assertions.assertNotNull(item);
+    assertThat(item).isNotNull();
     final List ls = item.getProperty("theProperty");
-    Assertions.assertNotNull(ls);
-    Assertions.assertEquals(9, ls.size());
-    Assertions.assertFalse(ls.contains("n0"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(ls).isNotNull();
+    assertThat(ls.size()).isEqualTo(9);
+    assertThat(ls.contains("n0")).isFalse();
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -614,27 +614,27 @@ public class UpdateStatementExecutionTest extends TestHelper {
     doc.save();
 
     ResultSet result = database.command("sql", "update " + className + " remove theProperty[0, 1, 3]");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item).isNotNull();
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     result = database.query("sql", "SElect from " + className);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     item = result.next();
-    Assertions.assertNotNull(item);
+    assertThat(item).isNotNull();
     final List ls = item.getProperty("theProperty");
 
-    Assertions.assertNotNull(ls);
-    Assertions.assertEquals(ls.size(), 7);
-    Assertions.assertFalse(ls.contains("n0"));
-    Assertions.assertFalse(ls.contains("n1"));
-    Assertions.assertTrue(ls.contains("n2"));
-    Assertions.assertFalse(ls.contains("n3"));
-    Assertions.assertTrue(ls.contains("n4"));
+    assertThat(ls).isNotNull();
+    assertThat(ls.size()).isEqualTo(7);
+    assertThat(ls.contains("n0")).isFalse();
+    assertThat(ls.contains("n1")).isFalse();
+    assertThat(ls.contains("n2")).isTrue();
+    assertThat(ls.contains("n3")).isFalse();
+    assertThat(ls.contains("n4")).isTrue();
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -653,21 +653,21 @@ public class UpdateStatementExecutionTest extends TestHelper {
     doc.save();
 
     ResultSet result = database.command("sql", "update " + className + " remove theProperty.sub");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item).isNotNull();
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     result = database.query("sql", "SElect from " + className);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     item = result.next();
-    Assertions.assertNotNull(item);
+    assertThat(item).isNotNull();
     final EmbeddedDocument ls = item.getProperty("theProperty");
-    Assertions.assertNotNull(ls);
-    Assertions.assertFalse(ls.getPropertyNames().contains("sub"));
-    Assertions.assertEquals("bar", ls.getString("aaa"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(ls).isNotNull();
+    assertThat(ls.getPropertyNames().contains("sub")).isFalse();
+    assertThat(ls.getString("aaa")).isEqualTo("bar");
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -678,13 +678,13 @@ public class UpdateStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", "SELECT tagsMap FROM " + className);
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals(2, ((Map) item.getProperty("tagsMap")).size());
-      Assertions.assertFalse(((Map) item.getProperty("tagsMap")).containsKey("bar"));
+      assertThat(item).isNotNull();
+      assertThat(((Map) item.getProperty("tagsMap")).size()).isEqualTo(2);
+      assertThat(((Map) item.getProperty("tagsMap")).containsKey("bar")).isFalse();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -695,13 +695,13 @@ public class UpdateStatementExecutionTest extends TestHelper {
 
     final ResultSet result = database.query("sql", "SELECT tagsMap FROM " + className);
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result item = result.next();
-      Assertions.assertNotNull(item);
-      Assertions.assertEquals(2, ((Map) item.getProperty("tagsMap")).size());
-      Assertions.assertFalse(((Map) item.getProperty("tagsMap")).containsKey("bar"));
+      assertThat(item).isNotNull();
+      assertThat(((Map) item.getProperty("tagsMap")).size()).isEqualTo(2);
+      assertThat(((Map) item.getProperty("tagsMap")).containsKey("bar")).isFalse();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -709,12 +709,12 @@ public class UpdateStatementExecutionTest extends TestHelper {
   public void testReturnBefore() {
     final ResultSet result = database.command("sql",
         "update " + className + " set name = 'foo' RETURN BEFORE where name = 'name1'");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals("name1", item.getProperty("name"));
+    assertThat(item).isNotNull();
+    assertThat(item.<String>getProperty("name")).isEqualTo("name1");
 
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -762,12 +762,12 @@ public class UpdateStatementExecutionTest extends TestHelper {
       try (ResultSet resultSet = database.query("sql",
           "SELECT start, stop FROM Product WHERE start <= ? AND stop >= ? ORDER BY start DESC, stop DESC LIMIT 1", start, stop)) {
 
-        Assertions.assertTrue(resultSet.hasNext());
+        assertThat(resultSet.hasNext()).isTrue();
 
         while (resultSet.hasNext()) {
           result = resultSet.next();
-          Assertions.assertNotNull(result.getProperty("start"));
-          Assertions.assertNotNull(result.getProperty("stop"));
+          assertThat(result.<LocalDateTime>getProperty("start")).isNotNull();
+          assertThat(result.<LocalDateTime>getProperty("stop")).isNotNull();
         }
       }
     });
@@ -813,8 +813,8 @@ public class UpdateStatementExecutionTest extends TestHelper {
       String sqlString = "SELECT id, processor, status FROM Order WHERE status = ?";
       try (ResultSet resultSet1 = database.query("sql", sqlString, parameters2)) {
         final Result record = resultSet1.next();
-        Assertions.assertEquals("PENDING", record.getProperty("status"));
-        Assertions.assertEquals("2", record.getProperty("id"));
+        assertThat(record.<String>getProperty("status")).isEqualTo("PENDING");
+        assertThat(record.<String>getProperty("id")).isEqualTo("2");
       }
     });
     // drop index
@@ -825,7 +825,7 @@ public class UpdateStatementExecutionTest extends TestHelper {
       Object[] parameters2 = { "PENDING" };
       String sqlString = "SELECT id, processor, status FROM Order WHERE status = ?";
       try (ResultSet resultSet1 = database.query("sql", sqlString, parameters2)) {
-        Assertions.assertEquals("PENDING", resultSet1.next().getProperty("status"));
+        assertThat(resultSet1.next().<String>getProperty("status")).isEqualTo("PENDING");
       }
     });
 
@@ -833,7 +833,7 @@ public class UpdateStatementExecutionTest extends TestHelper {
       Object[] parameters2 = { "PENDING" };
       try (ResultSet resultSet1 = database.query("sql",
           "SELECT id, status FROM Order WHERE status = 'PENDING' OR status = 'READY' ORDER BY id ASC LIMIT 1")) {
-        Assertions.assertEquals("PENDING", resultSet1.next().getProperty("status"));
+        assertThat(resultSet1.next().<String>getProperty("status")).isEqualTo("PENDING");
       }
     });
   }
@@ -853,14 +853,14 @@ public class UpdateStatementExecutionTest extends TestHelper {
     String INSERT_ORDER = "INSERT INTO Order SET id = ?, status = ?";
     database.begin();
     try (ResultSet resultSet = database.command("sql", INSERT_ORDER, 1, "PENDING")) {
-      Assertions.assertTrue(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isTrue();
     }
     database.commit();
     // update order
     database.begin();
     String UPDATE_ORDER = "UPDATE Order SET status = ? RETURN AFTER WHERE id = ?";
     try (ResultSet resultSet = database.command("sql", UPDATE_ORDER, "ERROR", 1)) {
-      Assertions.assertTrue(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isTrue();
     }
     database.commit();
     // resubmit order 1
@@ -868,17 +868,17 @@ public class UpdateStatementExecutionTest extends TestHelper {
     // "UPDATE Order SET status = ? WHERE (status != ? AND status != ?) AND id = ?";
     String RESUBMIT_ORDER = "UPDATE Order SET status = ? RETURN AFTER WHERE (status != ? AND status != ?) AND id = ?";
     try (ResultSet resultSet = database.command("sql", RESUBMIT_ORDER, "PENDING", "PENDING", "PROCESSING", 1)) {
-      Assertions.assertTrue(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isTrue();
     }
     database.commit();
     // retrieve order 1 by id
     try (ResultSet resultSet = database.query("sql", "SELECT FROM Order WHERE id = 1")) {
-      Assertions.assertTrue(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isTrue();
     }
     // retrieve order 1 by status
     String RETRIEVE_NEXT_ELIGIBLE_ORDERS = "SELECT id, status FROM Order WHERE status = 'PENDING' OR status = 'READY' ORDER BY id ASC LIMIT 1";
     try (ResultSet resultSet = database.query("sql", RETRIEVE_NEXT_ELIGIBLE_ORDERS)) {
-      Assertions.assertTrue(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isTrue();
     }
   }
 
@@ -900,9 +900,9 @@ public class UpdateStatementExecutionTest extends TestHelper {
             "return $e;");
 
         ResultSet resultSet = database.query("sql", "SELECT from Account where name = 'bob'");
-        Assertions.assertTrue(resultSet.hasNext());
+        assertThat(resultSet.hasNext()).isTrue();
         while (resultSet.hasNext())
-          Assertions.assertEquals("bob", resultSet.next().getProperty("name"));
+          assertThat(resultSet.next().<String>getProperty("name")).isEqualTo("bob");
       });
     }
   }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/UpsertStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/UpsertStatementExecutionTest.java
@@ -29,12 +29,15 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.schema.VertexType;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.time.*;
 import java.time.format.*;
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -90,7 +93,7 @@ public class UpsertStatementExecutionTest extends TestHelper {
     final List<Document> resultSet = database.select().fromType(className).where().property("name").eq().value("name1").documents()
         .toList();
 
-    Assertions.assertEquals(1, resultSet.size());
+    assertThat(resultSet.size()).isEqualTo(1);
     final Document record = resultSet.get(0);
 
     final String bucketName = database.getSchema().getBucketById(record.getIdentity().getBucketId()).getName();
@@ -98,86 +101,86 @@ public class UpsertStatementExecutionTest extends TestHelper {
     // BY BUCKET NAME
     ResultSet result = database.command("sql",
         "update bucket:" + bucketName + " set foo = 'bar' upsert where name = 'name1'");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals((Object) 1L, item.getProperty("count"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item).isNotNull();
+    assertThat(item.<Long>getProperty("count")).isEqualTo( 1L);
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     // BY BUCKET ID
     result = database.command("sql",
         "update bucket:" + record.getIdentity().getBucketId() + " set foo = 'bar' upsert where name = 'name1'");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals((Object) 1L, item.getProperty("count"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item).isNotNull();
+    assertThat(item.<Long>getProperty("count")).isEqualTo( 1L);
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     result = database.query("sql", "SElect from bucket:" + buckets.get(0).getName());
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
 
     while (result.hasNext()) {
       item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
       final String name = item.getProperty("name");
-      Assertions.assertNotNull(name);
+      assertThat(name).isNotNull();
       if ("name1".equals(name)) {
-        Assertions.assertEquals("bar", item.getProperty("foo"));
+        assertThat(item.<String>getProperty("foo")).isEqualTo("bar");
       } else {
-        Assertions.assertNull(item.getProperty("foo"));
+        assertThat(item.<String>getProperty("foo")).isNull();
       }
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     result = database.command("sql", "update bucket:" + bucketName + " remove foo upsert where name = 'name1'");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals((Object) 1L, item.getProperty("count"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item).isNotNull();
+    assertThat(item.<Long>getProperty("count")).isEqualTo((Object) 1L);
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     result = database.query("sql", "SElect from bucket:" + bucketName);
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
 
     while (result.hasNext()) {
       item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
       final String name = item.getProperty("name");
-      Assertions.assertNotNull(name);
-      Assertions.assertNull(item.getProperty("foo"));
+      assertThat(name).isNotNull();
+      assertThat(item.<String>getProperty("foo")).isNull();
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
   @Test
   public void testUpsert1() {
     ResultSet result = database.command("sql", "update " + className + " set foo = 'bar' upsert where name = 'name1'");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals((Object) 1L, item.getProperty("count"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item).isNotNull();
+    assertThat(item.<Long>getProperty("count")).isEqualTo((Object) 1L);
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     result = database.query("sql", "SElect from " + className);
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
       final String name = item.getProperty("name");
-      Assertions.assertNotNull(name);
+      assertThat(name).isNotNull();
       if ("name1".equals(name)) {
-        Assertions.assertEquals("bar", item.getProperty("foo"));
+        assertThat(item.<String>getProperty("foo")).isEqualTo("bar");
       } else {
-        Assertions.assertNull(item.getProperty("foo"));
+        assertThat(item.<String>getProperty("foo")).isNull();
       }
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -192,12 +195,12 @@ public class UpsertStatementExecutionTest extends TestHelper {
     final ResultSet result = database.command("sql",
         "update extra_node set extraitem = 'Hugo2' upsert return after $current where extraitem = 'Hugo'");
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result item = result.next();
-    Assertions.assertNotNull(item);
+    assertThat(item).isNotNull();
     final Vertex current = item.getProperty("$current");
-    Assertions.assertEquals("Hugo2", current.getString("extraitem"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(current.getString("extraitem")).isEqualTo("Hugo2");
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -206,11 +209,11 @@ public class UpsertStatementExecutionTest extends TestHelper {
     final ResultSet result = database.command("sql",
         "update " + className + " set foo = 'bar' upsert  return after  where name = 'name1' ");
 
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     final Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals("bar", item.getProperty("foo"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item).isNotNull();
+    assertThat(item.<String>getProperty("foo")).isEqualTo("bar");
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -218,27 +221,27 @@ public class UpsertStatementExecutionTest extends TestHelper {
   public void testUpsert2() {
 
     ResultSet result = database.command("sql", "update " + className + " set foo = 'bar' upsert where name = 'name11'");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals((Object) 1L, item.getProperty("count"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item).isNotNull();
+    assertThat(item.<Long>getProperty("count")).isEqualTo((Object) 1L);
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     result = database.query("sql", "SElect from " + className);
     for (int i = 0; i < 11; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
       final String name = item.getProperty("name");
-      Assertions.assertNotNull(name);
+      assertThat(name).isNotNull();
       if ("name11".equals(name)) {
-        Assertions.assertEquals("bar", item.getProperty("foo"));
+        assertThat(item.<String>getProperty("foo")).isEqualTo("bar");
       } else {
-        Assertions.assertNull(item.getProperty("foo"));
+        assertThat(item.<String>getProperty("foo")).isNull();
       }
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -270,27 +273,27 @@ public class UpsertStatementExecutionTest extends TestHelper {
     }
 
     ResultSet result = database.command("sql", "update UpsertableVertex set foo = 'bar' upsert where name = 'name1'");
-    Assertions.assertTrue(result.hasNext());
+    assertThat(result.hasNext()).isTrue();
     Result item = result.next();
-    Assertions.assertNotNull(item);
-    Assertions.assertEquals((Object) 1L, item.getProperty("count"));
-    Assertions.assertFalse(result.hasNext());
+    assertThat(item).isNotNull();
+    assertThat(item.<Long>getProperty("count")).isEqualTo(1L);
+    assertThat(result.hasNext()).isFalse();
     result.close();
 
     result = database.query("sql", "SElect from UpsertableVertex");
     for (int i = 0; i < 10; i++) {
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       item = result.next();
-      Assertions.assertNotNull(item);
+      assertThat(item).isNotNull();
       final String name = item.getProperty("name");
-      Assertions.assertNotNull(name);
+      assertThat(name).isNotNull();
       if ("name1".equals(name)) {
-        Assertions.assertEquals("bar", item.getProperty("foo"));
+        assertThat(item.<String>getProperty("foo")).isEqualTo("bar");
       } else {
-        Assertions.assertNull(item.getProperty("foo"));
+        assertThat(item.<String>getProperty("foo")).isNull();
       }
     }
-    Assertions.assertFalse(result.hasNext());
+    assertThat(result.hasNext()).isFalse();
     result.close();
   }
 
@@ -325,8 +328,8 @@ public class UpsertStatementExecutionTest extends TestHelper {
         ResultSet resultSet = database.query("sql", "SELECT from Product");
         while (resultSet.hasNext()) {
           result = resultSet.next();
-          Assertions.assertNotNull(result.getProperty("start"));
-          Assertions.assertNotNull(result.getProperty("stop"));
+          assertThat(result.<LocalDateTime>getProperty("start")).isNotNull();
+          assertThat(result.<LocalDateTime>getProperty("stop")).isNotNull();
         }
       });
     }
@@ -376,12 +379,12 @@ public class UpsertStatementExecutionTest extends TestHelper {
       try (ResultSet resultSet = database.query("sql",
           "SELECT start, stop FROM Product WHERE start <= ? AND stop >= ? ORDER BY start DESC, stop DESC LIMIT 1", start, stop)) {
 
-        Assertions.assertTrue(resultSet.hasNext());
+        assertThat(resultSet.hasNext()).isTrue();
 
         while (resultSet.hasNext()) {
           result = resultSet.next();
-          Assertions.assertNotNull(result.getProperty("start"));
-          Assertions.assertNotNull(result.getProperty("stop"));
+          assertThat(result.<LocalDateTime>getProperty("start")).isNotNull();
+          assertThat(result.<LocalDateTime>getProperty("stop")).isNotNull();
         }
       }
     });

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/WhileBlockExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/WhileBlockExecutionTest.java
@@ -19,8 +19,9 @@
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.TestHelper;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luigi Dell'Aquila (l.dellaquila-(at)-orientdb.com)
@@ -51,11 +52,11 @@ public class WhileBlockExecutionTest extends TestHelper {
     int sum = 0;
     while (results.hasNext()) {
       final Result item = results.next();
-      sum += (Integer) item.getProperty("value");
+      sum +=  item.<Integer>getProperty("value");
       tot++;
     }
-    Assertions.assertEquals(3, tot);
-    Assertions.assertEquals(3, sum);
+    assertThat(tot).isEqualTo(3);
+    assertThat(sum).isEqualTo(3);
     results.close();
   }
 
@@ -83,11 +84,11 @@ public class WhileBlockExecutionTest extends TestHelper {
     int sum = 0;
     while (results.hasNext()) {
       final Result item = results.next();
-      sum += (Integer) item.getProperty("value");
+      sum +=  item.<Integer>getProperty("value");
       tot++;
     }
-    Assertions.assertEquals(2, tot);
-    Assertions.assertEquals(1, sum);
+    assertThat(tot).isEqualTo(2);
+    assertThat(sum).isEqualTo(1);
     results.close();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/functions/coll/SQLFunctionIntersectTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/functions/coll/SQLFunctionIntersectTest.java
@@ -20,10 +20,11 @@ package com.arcadedb.query.sql.functions.coll;
 
 import com.arcadedb.query.sql.executor.BasicCommandContext;
 import com.arcadedb.query.sql.function.coll.SQLFunctionIntersect;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -39,7 +40,7 @@ public class SQLFunctionIntersectTest {
 
     final ArrayList<Object> result = (ArrayList<Object>) function.execute(null, null, null, new Object[] { coll1, coll2 }, new BasicCommandContext());
 
-    Assertions.assertEquals(new HashSet<>(result), new HashSet<>(Arrays.asList(1, 3, 0)));
+    assertThat(new HashSet<>(Arrays.asList(1, 3, 0))).isEqualTo(new HashSet<>(result));
   }
 
   @Test
@@ -52,6 +53,6 @@ public class SQLFunctionIntersectTest {
     function.execute(null, null, null, new Object[] { coll1 }, new BasicCommandContext());
     function.execute(null, null, null, new Object[] { coll2 }, new BasicCommandContext());
 
-    Assertions.assertEquals(function.getResult(), new HashSet<>(Arrays.asList(1, 3, 0)));
+    assertThat(new HashSet<>(Arrays.asList(1, 3, 0))).isEqualTo(function.getResult());
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/functions/coll/SQLFunctionSymmetricDifferenceTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/functions/coll/SQLFunctionSymmetricDifferenceTest.java
@@ -20,10 +20,11 @@ package com.arcadedb.query.sql.functions.coll;
 
 import com.arcadedb.query.sql.executor.BasicCommandContext;
 import com.arcadedb.query.sql.function.coll.SQLFunctionSymmetricDifference;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author edegtyarenko
@@ -62,9 +63,9 @@ public class SQLFunctionSymmetricDifferenceTest {
   }
 
   private void assertSetEquals(final Set<Object> actualResult, final Set<Object> expectedResult) {
-    Assertions.assertEquals(actualResult.size(), expectedResult.size());
+    assertThat(expectedResult.size()).isEqualTo(actualResult.size());
     for (final Object o : actualResult) {
-      Assertions.assertTrue(expectedResult.contains(o));
+      assertThat(expectedResult.contains(o)).isTrue();
     }
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/functions/geo/SQLGeoFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/functions/geo/SQLGeoFunctionsTest.java
@@ -26,13 +26,16 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.locationtech.spatial4j.io.GeohashUtils;
 import org.locationtech.spatial4j.shape.Circle;
 import org.locationtech.spatial4j.shape.Point;
 import org.locationtech.spatial4j.shape.Rectangle;
 import org.locationtech.spatial4j.shape.Shape;
+
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -43,9 +46,9 @@ public class SQLGeoFunctionsTest {
   public void testPoint() throws Exception {
     TestHelper.executeInNewDatabase("GeoDatabase", (db) -> {
       ResultSet result = db.query("sql", "select point(11,11) as point");
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       Point point = result.next().getProperty("point");
-      Assertions.assertNotNull(point);
+      assertThat(point).isNotNull();
     });
   }
 
@@ -53,9 +56,9 @@ public class SQLGeoFunctionsTest {
   public void testRectangle() throws Exception {
     TestHelper.executeInNewDatabase("GeoDatabase", (db) -> {
       ResultSet result = db.query("sql", "select rectangle(10,10,20,20) as shape");
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       Rectangle rectangle = result.next().getProperty("shape");
-      Assertions.assertNotNull(rectangle);
+      assertThat(rectangle).isNotNull();
     });
   }
 
@@ -63,24 +66,25 @@ public class SQLGeoFunctionsTest {
   public void testCircle() throws Exception {
     TestHelper.executeInNewDatabase("GeoDatabase", (db) -> {
       ResultSet result = db.query("sql", "select circle(10,10,10) as circle");
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       Circle circle = result.next().getProperty("circle");
-      Assertions.assertNotNull(circle);
+      assertThat(circle).isNotNull();
     });
   }
 
   @Test
   public void testPolygon() throws Exception {
     TestHelper.executeInNewDatabase("GeoDatabase", (db) -> {
-      ResultSet result = db.query("sql", "select polygon( [ point(10,10), point(20,10), point(20,20), point(10,20), point(10,10) ] ) as polygon");
-      Assertions.assertTrue(result.hasNext());
+      ResultSet result = db.query("sql",
+          "select polygon( [ point(10,10), point(20,10), point(20,20), point(10,20), point(10,10) ] ) as polygon");
+      assertThat(result.hasNext()).isTrue();
       Shape polygon = result.next().getProperty("polygon");
-      Assertions.assertNotNull(polygon);
+      assertThat(polygon).isNotNull();
 
       result = db.query("sql", "select polygon( [ [10,10], [20,10], [20,20], [10,20], [10,10] ] ) as polygon");
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       polygon = result.next().getProperty("polygon");
-      Assertions.assertNotNull(polygon);
+      assertThat(polygon).isNotNull();
     });
   }
 
@@ -88,12 +92,12 @@ public class SQLGeoFunctionsTest {
   public void testPointIsWithinRectangle() throws Exception {
     TestHelper.executeInNewDatabase("GeoDatabase", (db) -> {
       ResultSet result = db.query("sql", "select point(11,11).isWithin( rectangle(10,10,20,20) ) as isWithin");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertTrue((Boolean) result.next().getProperty("isWithin"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("isWithin")).isTrue();
 
       result = db.query("sql", "select point(11,21).isWithin( rectangle(10,10,20,20) ) as isWithin");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertFalse((Boolean) result.next().getProperty("isWithin"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("isWithin")).isFalse();
     });
   }
 
@@ -101,12 +105,12 @@ public class SQLGeoFunctionsTest {
   public void testPointIsWithinCircle() throws Exception {
     TestHelper.executeInNewDatabase("GeoDatabase", (db) -> {
       ResultSet result = db.query("sql", "select point(11,11).isWithin( circle(10,10,10) ) as isWithin");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertTrue((Boolean) result.next().getProperty("isWithin"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("isWithin")).isTrue();
 
       result = db.query("sql", "select point(10,21).isWithin( circle(10,10,10) ) as isWithin");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertFalse((Boolean) result.next().getProperty("isWithin"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("isWithin")).isFalse();
     });
   }
 
@@ -114,12 +118,12 @@ public class SQLGeoFunctionsTest {
   public void testPointIntersectWithRectangle() throws Exception {
     TestHelper.executeInNewDatabase("GeoDatabase", (db) -> {
       ResultSet result = db.query("sql", "select rectangle(9,9,11,11).intersectsWith( rectangle(10,10,20,20) ) as intersectsWith");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertTrue((Boolean) result.next().getProperty("intersectsWith"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("intersectsWith")).isTrue();
 
       result = db.query("sql", "select rectangle(9,9,9.9,9.9).intersectsWith( rectangle(10,10,20,20) ) as intersectsWith");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertFalse((Boolean) result.next().getProperty("intersectsWith"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("intersectsWith")).isFalse();
     });
   }
 
@@ -128,12 +132,13 @@ public class SQLGeoFunctionsTest {
     TestHelper.executeInNewDatabase("GeoDatabase", (db) -> {
       ResultSet result = db.query("sql",
           "select polygon( [ [10,10], [20,10], [20,20], [10,20], [10,10] ] ).intersectsWith( rectangle(10,10,20,20) ) as intersectsWith");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertTrue((Boolean) result.next().getProperty("intersectsWith"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("intersectsWith")).isTrue();
 
-      result = db.query("sql", "select polygon( [ [10,10], [20,10], [20,20], [10,20], [10,10] ] ).intersectsWith( rectangle(21,21,22,22) ) as intersectsWith");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertFalse((Boolean) result.next().getProperty("intersectsWith"));
+      result = db.query("sql",
+          "select polygon( [ [10,10], [20,10], [20,20], [10,20], [10,10] ] ).intersectsWith( rectangle(21,21,22,22) ) as intersectsWith");
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("intersectsWith")).isFalse();
     });
   }
 
@@ -142,13 +147,13 @@ public class SQLGeoFunctionsTest {
     TestHelper.executeInNewDatabase("GeoDatabase", (db) -> {
       ResultSet result = db.query("sql",
           "select linestring( [ [10,10], [20,10], [20,20], [10,20], [10,10] ] ).intersectsWith( rectangle(10,10,20,20) ) as intersectsWith");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertTrue((Boolean) result.next().getProperty("intersectsWith"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("intersectsWith")).isTrue();
 
       result = db.query("sql",
           "select linestring( [ [10,10], [20,10], [20,20], [10,20], [10,10] ] ).intersectsWith( rectangle(21,21,22,22) ) as intersectsWith");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertFalse((Boolean) result.next().getProperty("intersectsWith"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("intersectsWith")).isFalse();
     });
   }
 
@@ -183,12 +188,12 @@ public class SQLGeoFunctionsTest {
 
         begin = System.currentTimeMillis();
 
-        Assertions.assertTrue(result.hasNext());
+        assertThat(result.hasNext()).isTrue();
         int returned = 0;
         while (result.hasNext()) {
           final Document record = result.next().toElement();
-          Assertions.assertTrue(record.getDouble("lat") >= 10.5);
-          Assertions.assertTrue(record.getDouble("long") <= 10.55);
+          assertThat(record.getDouble("lat")).isGreaterThanOrEqualTo(10.5);
+          assertThat(record.getDouble("long")).isLessThanOrEqualTo(10.55);
 //          System.out.println(record.toJSON());
 
           ++returned;
@@ -196,7 +201,7 @@ public class SQLGeoFunctionsTest {
 
         //System.out.println("Elapsed browsing: " + (System.currentTimeMillis() - begin));
 
-        Assertions.assertEquals(6, returned);
+        assertThat(returned).isEqualTo(6);
       });
     });
   }
@@ -226,7 +231,7 @@ public class SQLGeoFunctionsTest {
         }
 
         for (Index idx : type.getAllIndexes(false)) {
-          Assertions.assertEquals(TOTAL, idx.countEntries());
+          assertThat(idx.countEntries()).isEqualTo(TOTAL);
         }
 
         //System.out.println("Elapsed insert: " + (System.currentTimeMillis() - begin));
@@ -243,14 +248,14 @@ public class SQLGeoFunctionsTest {
 
         begin = System.currentTimeMillis();
 
-        Assertions.assertTrue(result.hasNext());
+        assertThat(result.hasNext()).isTrue();
         int returned = 0;
         while (result.hasNext()) {
           final Document record = result.next().toElement();
-          Assertions.assertTrue(record.getDouble("x1") >= 10.0001D, "x1: " + record.getDouble("x1"));
-          Assertions.assertTrue(record.getDouble("y1") >= 10.0001D, "y1: " + record.getDouble("y1"));
-          Assertions.assertTrue(record.getDouble("x2") <= 10.020D, "x2: " + record.getDouble("x2"));
-          Assertions.assertTrue(record.getDouble("y2") <= 10.020D, "y2: " + record.getDouble("y2"));
+          assertThat(record.getDouble("x1")).isGreaterThanOrEqualTo(10.0001D).withFailMessage("x1: " + record.getDouble("x1"));
+          assertThat(record.getDouble("y1")).isGreaterThanOrEqualTo(10.0001D).withFailMessage("y1: " + record.getDouble("y1"));
+          assertThat(record.getDouble("x2")).isLessThanOrEqualTo(10.020D).withFailMessage("x2: " + record.getDouble("x2"));
+          assertThat(record.getDouble("y2")).isLessThanOrEqualTo(10.020D).withFailMessage("y2: " + record.getDouble("y2"));
           //System.out.println(record.toJSON());
 
           ++returned;
@@ -258,7 +263,7 @@ public class SQLGeoFunctionsTest {
 
         //System.out.println("Elapsed browsing: " + (System.currentTimeMillis() - begin));
 
-        Assertions.assertEquals(20, returned);
+        assertThat(returned).isEqualTo(20);
       });
     });
   }

--- a/engine/src/test/java/com/arcadedb/query/sql/functions/graph/SQLFunctionAdjacencyTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/functions/graph/SQLFunctionAdjacencyTest.java
@@ -36,10 +36,13 @@ import com.arcadedb.query.sql.function.graph.SQLFunctionInV;
 import com.arcadedb.query.sql.function.graph.SQLFunctionOut;
 import com.arcadedb.query.sql.function.graph.SQLFunctionOutE;
 import com.arcadedb.query.sql.function.graph.SQLFunctionOutV;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
 
 public class SQLFunctionAdjacencyTest {
 
@@ -57,14 +60,14 @@ public class SQLFunctionAdjacencyTest {
       final Set<RID> result = new HashSet<>();
       while (iterator.hasNext()) {
         final Edge edge = iterator.next().asEdge(true);
-        Assertions.assertNotNull(edge);
+        assertThat(edge).isNotNull();
         result.add(edge.getIdentity());
       }
 
-      Assertions.assertTrue(result.contains(edges.get(3).getIdentity()));
-      Assertions.assertTrue(result.contains(edges.get(4).getIdentity()));
+      assertThat(result.contains(edges.get(3).getIdentity())).isTrue();
+      assertThat(result.contains(edges.get(4).getIdentity())).isTrue();
 
-      Assertions.assertEquals(2, result.size());
+      assertThat(result).hasSize(2);
     });
   }
 
@@ -79,13 +82,13 @@ public class SQLFunctionAdjacencyTest {
       final Set<RID> result = new HashSet<>();
       while (iterator.hasNext()) {
         final Edge edge = iterator.next().asEdge(true);
-        Assertions.assertNotNull(edge);
+        assertThat(edge).isNotNull();
         result.add(edge.getIdentity());
       }
 
-      Assertions.assertTrue(result.contains(edges.get(2).getIdentity()));
+      assertThat(result.contains(edges.get(2).getIdentity())).isTrue();
 
-      Assertions.assertEquals(1, result.size());
+      assertThat(result).hasSize(1);
     });
   }
 
@@ -100,15 +103,15 @@ public class SQLFunctionAdjacencyTest {
       final Set<RID> result = new HashSet<>();
       while (iterator.hasNext()) {
         final Edge edge = iterator.next().asEdge(true);
-        Assertions.assertNotNull(edge);
+        assertThat(edge).isNotNull();
         result.add(edge.getIdentity());
       }
 
-      Assertions.assertTrue(result.contains(edges.get(2).getIdentity()));
-      Assertions.assertTrue(result.contains(edges.get(3).getIdentity()));
-      Assertions.assertTrue(result.contains(edges.get(4).getIdentity()));
+      assertThat(result.contains(edges.get(2).getIdentity())).isTrue();
+      assertThat(result.contains(edges.get(3).getIdentity())).isTrue();
+      assertThat(result.contains(edges.get(4).getIdentity())).isTrue();
 
-      Assertions.assertEquals(3, result.size());
+      assertThat(result).hasSize(3);
     });
   }
 
@@ -123,15 +126,15 @@ public class SQLFunctionAdjacencyTest {
       final Set<RID> result = new HashSet<>();
       while (iterator.hasNext()) {
         final Vertex vertex = iterator.next().asVertex(true);
-        Assertions.assertNotNull(vertex);
+        assertThat(vertex).isNotNull();
         result.add(vertex.getIdentity());
       }
 
-      Assertions.assertTrue(result.contains(vertices.get(2).getIdentity()));
-      Assertions.assertTrue(result.contains(vertices.get(1).getIdentity()));
-      Assertions.assertTrue(result.contains(vertices.get(4).getIdentity()));
+      assertThat(result.contains(vertices.get(2).getIdentity())).isTrue();
+      assertThat(result.contains(vertices.get(1).getIdentity())).isTrue();
+      assertThat(result.contains(vertices.get(4).getIdentity())).isTrue();
 
-      Assertions.assertEquals(3, result.size());
+      assertThat(result).hasSize(3);
     });
   }
 
@@ -146,14 +149,14 @@ public class SQLFunctionAdjacencyTest {
       final Set<RID> result = new HashSet<>();
       while (iterator.hasNext()) {
         final Vertex vertex = iterator.next().asVertex(true);
-        Assertions.assertNotNull(vertex);
+        assertThat(vertex).isNotNull();
         result.add(vertex.getIdentity());
       }
 
-      Assertions.assertTrue(result.contains(vertices.get(1).getIdentity()));
-      Assertions.assertTrue(result.contains(vertices.get(4).getIdentity()));
+      assertThat(result.contains(vertices.get(1).getIdentity())).isTrue();
+      assertThat(result.contains(vertices.get(4).getIdentity())).isTrue();
 
-      Assertions.assertEquals(2, result.size());
+      assertThat(result).hasSize(2);
     });
   }
 
@@ -168,13 +171,13 @@ public class SQLFunctionAdjacencyTest {
       final Set<RID> result = new HashSet<>();
       while (iterator.hasNext()) {
         final Vertex vertex = iterator.next().asVertex(true);
-        Assertions.assertNotNull(vertex);
+        assertThat(vertex).isNotNull();
         result.add(vertex.getIdentity());
       }
 
-      Assertions.assertTrue(result.contains(vertices.get(2).getIdentity()));
+      assertThat(result.contains(vertices.get(2).getIdentity())).isTrue();
 
-      Assertions.assertEquals(1, result.size());
+      assertThat(result).hasSize(1);
     });
   }
 
@@ -185,7 +188,7 @@ public class SQLFunctionAdjacencyTest {
 
       final Vertex v = (Vertex) new SQLFunctionOutV().execute(edges.get(3), null, null, new Object[] {}, new BasicCommandContext().setDatabase(graph));
 
-      Assertions.assertEquals(v.getIdentity(), vertices.get(3).getIdentity());
+      assertThat(vertices.get(3).getIdentity()).isEqualTo(v.getIdentity());
     });
   }
 
@@ -196,7 +199,7 @@ public class SQLFunctionAdjacencyTest {
 
       final Vertex v = (Vertex) new SQLFunctionInV().execute(edges.get(3), null, null, new Object[] {}, new BasicCommandContext().setDatabase(graph));
 
-      Assertions.assertEquals(v.getIdentity(), vertices.get(1).getIdentity());
+      assertThat(vertices.get(1).getIdentity()).isEqualTo(v.getIdentity());
     });
   }
 
@@ -208,10 +211,10 @@ public class SQLFunctionAdjacencyTest {
       final ArrayList<Identifiable> iterator = (ArrayList<Identifiable>) new SQLFunctionBothV().execute(edges.get(3), null, null, new Object[] {},
           new BasicCommandContext().setDatabase(graph));
 
-      Assertions.assertTrue(iterator.contains(vertices.get(3).getIdentity()));
-      Assertions.assertTrue(iterator.contains(vertices.get(1).getIdentity()));
+      assertThat(iterator.contains(vertices.get(3).getIdentity())).isTrue();
+      assertThat(iterator.contains(vertices.get(1).getIdentity())).isTrue();
 
-      Assertions.assertEquals(2, iterator.size());
+      assertThat(iterator).hasSize(2);
     });
   }
 

--- a/engine/src/test/java/com/arcadedb/query/sql/functions/graph/SQLFunctionAstarTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/functions/graph/SQLFunctionAstarTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import java.util.*;
 import java.util.stream.*;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /*
@@ -195,14 +196,14 @@ public class SQLFunctionAstarTest {
       ctx.setDatabase(graph);
       final List<Vertex> result = functionAstar.execute(null, null, null, new Object[] { v1, v4, "'weight'", options }, ctx);
       try (final ResultSet rs = graph.query("sql", "select count(*) as count from has_path")) {
-        assertEquals((Object) 16L, rs.next().getProperty("count"));
+        assertThat(rs.next().<Long>getProperty("count")).isEqualTo((Object) 16L);
       }
 
-      assertEquals(4, result.size());
-      assertEquals(v1, result.get(0));
-      assertEquals(v2, result.get(1));
-      assertEquals(v3, result.get(2));
-      assertEquals(v4, result.get(3));
+      assertThat(result).hasSize(4);
+      assertThat(result.get(0)).isEqualTo(v1);
+      assertThat(result.get(1)).isEqualTo(v2);
+      assertThat(result.get(2)).isEqualTo(v3);
+      assertThat(result.get(3)).isEqualTo(v4);
     });
   }
 
@@ -220,12 +221,12 @@ public class SQLFunctionAstarTest {
       ctx.setDatabase(graph);
       final List<Vertex> result = functionAstar.execute(null, null, null, new Object[] { v1, v6, "'weight'", options }, ctx);
       try (final ResultSet rs = graph.query("sql", "select count(*) as count from has_path")) {
-        assertEquals((Object) 16L, rs.next().getProperty("count"));
+        assertThat(rs.next().<Long>getProperty("count")).isEqualTo((Object) 16L);
       }
-      assertEquals(3, result.size());
-      assertEquals(v1, result.get(0));
-      assertEquals(v5, result.get(1));
-      assertEquals(v6, result.get(2));
+      assertThat(result).hasSize(3);
+      assertThat(result.get(0)).isEqualTo(v1);
+      assertThat(result.get(1)).isEqualTo(v5);
+      assertThat(result.get(2)).isEqualTo(v6);
     });
   }
 
@@ -244,13 +245,13 @@ public class SQLFunctionAstarTest {
       ctx.setDatabase(graph);
       final List<Vertex> result = functionAstar.execute(null, null, null, new Object[] { v1, v6, "'weight'", options }, ctx);
       try (final ResultSet rs = graph.query("sql", "select count(*) as count from has_path")) {
-        assertEquals((Object) 16L, rs.next().getProperty("count"));
+        assertThat(rs.next().<Long>getProperty("count")).isEqualTo((Object) 16L);
       }
 
-      assertEquals(3, result.size());
-      assertEquals(v1, result.get(0));
-      assertEquals(v5, result.get(1));
-      assertEquals(v6, result.get(2));
+      assertThat(result).hasSize(3);
+      assertThat(result.get(0)).isEqualTo(v1);
+      assertThat(result.get(1)).isEqualTo(v5);
+      assertThat(result.get(2)).isEqualTo(v6);
     });
   }
 
@@ -269,13 +270,13 @@ public class SQLFunctionAstarTest {
       ctx.setDatabase(graph);
       final List<Vertex> result = functionAstar.execute(null, null, null, new Object[] { v1, v6, "'weight'", options }, ctx);
       try (final ResultSet rs = graph.query("sql", "select count(*) as count from has_path")) {
-        assertEquals((Object) 16L, rs.next().getProperty("count"));
+        assertThat(rs.next().<Long>getProperty("count")).isEqualTo((Object) 16L);
       }
 
-      assertEquals(3, result.size());
-      assertEquals(v1, result.get(0));
-      assertEquals(v5, result.get(1));
-      assertEquals(v6, result.get(2));
+      assertThat(result).hasSize(3);
+      assertThat(result.get(0)).isEqualTo(v1);
+      assertThat(result.get(1)).isEqualTo(v5);
+      assertThat(result.get(2)).isEqualTo(v6);
     });
   }
 
@@ -294,13 +295,13 @@ public class SQLFunctionAstarTest {
       ctx.setDatabase(graph);
       final List<Vertex> result = functionAstar.execute(null, null, null, new Object[] { v3, v5, "'weight'", options }, ctx);
       try (final ResultSet rs = graph.query("sql", "select count(*) as count from has_path")) {
-        assertEquals((Object) 16L, rs.next().getProperty("count"));
+        assertThat(rs.next().<Long>getProperty("count")).isEqualTo((Object) 16L);
       }
 
-      assertEquals(3, result.size());
-      assertEquals(v3, result.get(0));
-      assertEquals(v6, result.get(1));
-      assertEquals(v5, result.get(2));
+      assertThat(result).hasSize(3);
+      assertThat(result.get(0)).isEqualTo(v3);
+      assertThat(result.get(1)).isEqualTo(v6);
+      assertThat(result.get(2)).isEqualTo(v5);
     });
   }
 
@@ -319,16 +320,16 @@ public class SQLFunctionAstarTest {
       ctx.setDatabase(graph);
       final List<Vertex> result = functionAstar.execute(null, null, null, new Object[] { v6, v1, "'weight'", options }, ctx);
       try (final ResultSet rs = graph.query("sql", "select count(*) as count from has_path")) {
-        assertEquals((Object) 16L, rs.next().getProperty("count"));
+        assertThat(rs.next().<Long>getProperty("count")).isEqualTo((Object) 16L);
       }
 
-      assertEquals(6, result.size());
-      assertEquals(v6, result.get(0));
-      assertEquals(v5, result.get(1));
-      assertEquals(v2, result.get(2));
-      assertEquals(v3, result.get(3));
-      assertEquals(v4, result.get(4));
-      assertEquals(v1, result.get(5));
+      assertThat(result).hasSize(6);
+      assertThat(result.get(0)).isEqualTo(v6);
+      assertThat(result.get(1)).isEqualTo(v5);
+      assertThat(result.get(2)).isEqualTo(v2);
+      assertThat(result.get(3)).isEqualTo(v3);
+      assertThat(result.get(4)).isEqualTo(v4);
+      assertThat(result.get(5)).isEqualTo(v1);
     });
   }
 
@@ -348,16 +349,16 @@ public class SQLFunctionAstarTest {
       ctx.setDatabase(graph);
       final List<Vertex> result = functionAstar.execute(null, null, null, new Object[] { v6, v1, "'weight'", options }, ctx);
       try (final ResultSet rs = graph.query("sql", "select count(*) as count from has_path")) {
-        assertEquals((Object) 16L, rs.next().getProperty("count"));
+        assertThat(rs.next().<Long>getProperty("count")).isEqualTo((Object) 16L);
       }
 
-      assertEquals(6, result.size());
-      assertEquals(v6, result.get(0));
-      assertEquals(v5, result.get(1));
-      assertEquals(v2, result.get(2));
-      assertEquals(v3, result.get(3));
-      assertEquals(v4, result.get(4));
-      assertEquals(v1, result.get(5));
+      assertThat(result).hasSize(6);
+      assertThat(result.get(0)).isEqualTo(v6);
+      assertThat(result.get(1)).isEqualTo(v5);
+      assertThat(result.get(2)).isEqualTo(v2);
+      assertThat(result.get(3)).isEqualTo(v3);
+      assertThat(result.get(4)).isEqualTo(v4);
+      assertThat(result.get(5)).isEqualTo(v1);
     });
   }
 
@@ -378,15 +379,15 @@ public class SQLFunctionAstarTest {
       ctx.setDatabase(graph);
       final List<Vertex> result = functionAstar.execute(null, null, null, new Object[] { v6, v1, "'weight'", options }, ctx);
       try (final ResultSet rs = graph.query("sql", "select count(*) as count from has_path")) {
-        assertEquals((Object) 16L, rs.next().getProperty("count"));
+        assertThat(rs.next().<Long>getProperty("count")).isEqualTo((Object) 16L);
       }
 
-      assertEquals(5, result.size());
-      assertEquals(v6, result.get(0));
-      assertEquals(v5, result.get(1));
-      assertEquals(v2, result.get(2));
-      assertEquals(v4, result.get(3));
-      assertEquals(v1, result.get(4));
+      assertThat(result).hasSize(5);
+      assertThat(result.get(0)).isEqualTo(v6);
+      assertThat(result.get(1)).isEqualTo(v5);
+      assertThat(result.get(2)).isEqualTo(v2);
+      assertThat(result.get(3)).isEqualTo(v4);
+      assertThat(result.get(4)).isEqualTo(v1);
     });
   }
 
@@ -407,13 +408,13 @@ public class SQLFunctionAstarTest {
       ctx.setDatabase(graph);
       final List<Vertex> result = functionAstar.execute(null, null, null, new Object[] { v6, v1, "'weight'", options }, ctx);
       try (final ResultSet rs = graph.query("sql", "select count(*) as count from has_path")) {
-        assertEquals((Object) 16L, rs.next().getProperty("count"));
+        assertThat(rs.next().<Long>getProperty("count")).isEqualTo((Object) 16L);
       }
 
-      assertEquals(3, result.size());
-      assertEquals(v6, result.get(0));
-      assertEquals(v5, result.get(1));
-      assertEquals(v1, result.get(2));
+      assertThat(result).hasSize(3);
+      assertThat(result.get(0)).isEqualTo(v6);
+      assertThat(result.get(1)).isEqualTo(v5);
+      assertThat(result.get(2)).isEqualTo(v1);
     });
   }
 
@@ -429,14 +430,14 @@ public class SQLFunctionAstarTest {
       final List result = new ArrayList();
       result.addAll(r.stream().map(Result::toElement).collect(Collectors.toList()));
       try (final ResultSet rs = graph.query("sql", "select count(*) as count from has_path")) {
-        assertEquals((Object) 16L, rs.next().getProperty("count"));
+        assertThat(rs.next().<Long>getProperty("count")).isEqualTo((Object) 16L);
       }
 
-      assertEquals(4, result.size());
-      assertEquals(v1.getIdentity(), result.get(0));
-      assertEquals(v2.getIdentity(), result.get(1));
-      assertEquals(v3.getIdentity(), result.get(2));
-      assertEquals(v4.getIdentity(), result.get(3));
+      assertThat(result).hasSize(4);
+      assertThat(result.get(0)).isEqualTo(v1.getIdentity());
+      assertThat(result.get(1)).isEqualTo(v2.getIdentity());
+      assertThat(result.get(2)).isEqualTo(v3.getIdentity());
+      assertThat(result.get(3)).isEqualTo(v4.getIdentity());
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/functions/graph/SQLFunctionDijkstraTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/functions/graph/SQLFunctionDijkstraTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SQLFunctionDijkstraTest {
@@ -80,11 +81,11 @@ public class SQLFunctionDijkstraTest {
       setUp(graph);
       final List<Vertex> result = functionDijkstra.execute(null, null, null, new Object[] { v1, v4, "'weight'" }, new BasicCommandContext());
 
-      assertEquals(4, result.size());
-      assertEquals(v1, result.get(0));
-      assertEquals(v2, result.get(1));
-      assertEquals(v3, result.get(2));
-      assertEquals(v4, result.get(3));
+      assertThat(result).hasSize(4);
+      assertThat(result.get(0)).isEqualTo(v1);
+      assertThat(result.get(1)).isEqualTo(v2);
+      assertThat(result.get(2)).isEqualTo(v3);
+      assertThat(result.get(3)).isEqualTo(v4);
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/functions/graph/SQLFunctionShortestPathTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/functions/graph/SQLFunctionShortestPathTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import java.util.*;
 
 import static java.util.Arrays.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SQLFunctionShortestPathTest {
@@ -43,10 +44,10 @@ public class SQLFunctionShortestPathTest {
       function = new SQLFunctionShortestPath();
 
       final List<RID> result = function.execute(null, null, null, new Object[] { vertices.get(1), vertices.get(4) }, new BasicCommandContext());
-      assertEquals(3, result.size());
-      assertEquals(vertices.get(1).getIdentity(), result.get(0));
-      assertEquals(vertices.get(3).getIdentity(), result.get(1));
-      assertEquals(vertices.get(4).getIdentity(), result.get(2));
+      assertThat(result).hasSize(3);
+      assertThat(result.get(0)).isEqualTo(vertices.get(1).getIdentity());
+      assertThat(result.get(1)).isEqualTo(vertices.get(3).getIdentity());
+      assertThat(result.get(2)).isEqualTo(vertices.get(4).getIdentity());
     });
   }
 
@@ -58,11 +59,11 @@ public class SQLFunctionShortestPathTest {
 
       final List<RID> result = function.execute(null, null, null, new Object[] { vertices.get(1), vertices.get(4), "out", null }, new BasicCommandContext());
 
-      assertEquals(4, result.size());
-      assertEquals(vertices.get(1).getIdentity(), result.get(0));
-      assertEquals(vertices.get(2).getIdentity(), result.get(1));
-      assertEquals(vertices.get(3).getIdentity(), result.get(2));
-      assertEquals(vertices.get(4).getIdentity(), result.get(3));
+      assertThat(result).hasSize(4);
+      assertThat(result.get(0)).isEqualTo(vertices.get(1).getIdentity());
+      assertThat(result.get(1)).isEqualTo(vertices.get(2).getIdentity());
+      assertThat(result.get(2)).isEqualTo(vertices.get(3).getIdentity());
+      assertThat(result.get(3)).isEqualTo(vertices.get(4).getIdentity());
     });
   }
 
@@ -74,11 +75,11 @@ public class SQLFunctionShortestPathTest {
 
       final List<RID> result = function.execute(null, null, null, new Object[] { vertices.get(1), vertices.get(4), null, "Edge1" }, new BasicCommandContext());
 
-      assertEquals(4, result.size());
-      assertEquals(vertices.get(1).getIdentity(), result.get(0));
-      assertEquals(vertices.get(2).getIdentity(), result.get(1));
-      assertEquals(vertices.get(3).getIdentity(), result.get(2));
-      assertEquals(vertices.get(4).getIdentity(), result.get(3));
+      assertThat(result).hasSize(4);
+      assertThat(result.get(0)).isEqualTo(vertices.get(1).getIdentity());
+      assertThat(result.get(1)).isEqualTo(vertices.get(2).getIdentity());
+      assertThat(result.get(2)).isEqualTo(vertices.get(3).getIdentity());
+      assertThat(result.get(3)).isEqualTo(vertices.get(4).getIdentity());
     });
   }
 
@@ -91,10 +92,10 @@ public class SQLFunctionShortestPathTest {
       final List<RID> result = function
           .execute(null, null, null, new Object[] { vertices.get(1), vertices.get(4), "BOTH", asList("Edge1", "Edge2") }, new BasicCommandContext());
 
-      assertEquals(3, result.size());
-      assertEquals(vertices.get(1).getIdentity(), result.get(0));
-      assertEquals(vertices.get(3).getIdentity(), result.get(1));
-      assertEquals(vertices.get(4).getIdentity(), result.get(2));
+      assertThat(result).hasSize(3);
+      assertThat(result.get(0)).isEqualTo(vertices.get(1).getIdentity());
+      assertThat(result.get(1)).isEqualTo(vertices.get(3).getIdentity());
+      assertThat(result.get(2)).isEqualTo(vertices.get(4).getIdentity());
     });
   }
 
@@ -106,12 +107,12 @@ public class SQLFunctionShortestPathTest {
 
       final List<RID> result = function.execute(null, null, null, new Object[] { vertices.get(1), vertices.get(20) }, new BasicCommandContext());
 
-      assertEquals(11, result.size());
-      assertEquals(vertices.get(1).getIdentity(), result.get(0));
-      assertEquals(vertices.get(3).getIdentity(), result.get(1));
+      assertThat(result).hasSize(11);
+      assertThat(result.get(0)).isEqualTo(vertices.get(1).getIdentity());
+      assertThat(result.get(1)).isEqualTo(vertices.get(3).getIdentity());
       int next = 2;
       for (int i = 4; i <= 20; i += 2) {
-        assertEquals(vertices.get(i).getIdentity(), result.get(next++));
+        assertThat(result.get(next++)).isEqualTo(vertices.get(i).getIdentity());
       }
     });
   }
@@ -127,7 +128,7 @@ public class SQLFunctionShortestPathTest {
       final List<RID> result = function
           .execute(null, null, null, new Object[] { vertices.get(1), vertices.get(20), null, null, additionalParams }, new BasicCommandContext());
 
-      assertEquals(11, result.size());
+      assertThat(result).hasSize(11);
     });
   }
 
@@ -142,7 +143,7 @@ public class SQLFunctionShortestPathTest {
       final List<RID> result = function
           .execute(null, null, null, new Object[] { vertices.get(1), vertices.get(20), null, null, additionalParams }, new BasicCommandContext());
 
-      assertEquals(11, result.size());
+      assertThat(result).hasSize(11);
     });
   }
 
@@ -157,7 +158,7 @@ public class SQLFunctionShortestPathTest {
       final List<RID> result = function
           .execute(null, null, null, new Object[] { vertices.get(1), vertices.get(20), null, null, additionalParams }, new BasicCommandContext());
 
-      assertEquals(0, result.size());
+      assertThat(result).isEmpty();
     });
   }
 
@@ -172,7 +173,7 @@ public class SQLFunctionShortestPathTest {
       final List<RID> result = function
           .execute(null, null, null, new Object[] { vertices.get(1), vertices.get(20), null, null, additionalParams }, new BasicCommandContext());
 
-      assertEquals(0, result.size());
+      assertThat(result).isEmpty();
     });
   }
 

--- a/engine/src/test/java/com/arcadedb/query/sql/functions/math/SQLFunctionAbsoluteValueTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/functions/math/SQLFunctionAbsoluteValueTest.java
@@ -21,15 +21,15 @@ package com.arcadedb.query.sql.functions.math;
 import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.query.sql.function.math.SQLFunctionAbsoluteValue;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.math.*;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests the absolute value function. The key is that the mathematical abs function is correctly
@@ -49,133 +49,133 @@ public class SQLFunctionAbsoluteValueTest {
     @Test
     public void testEmpty() {
         final Object result = function.getResult();
-        assertNull(result);
+      assertThat(result).isNull();
     }
 
     @Test
     public void testNull() {
         function.execute(null, null, null, new Object[]{null}, null);
         final Object result = function.getResult();
-        assertNull(result);
+      assertThat(result).isNull();
     }
 
     @Test
     public void testPositiveInteger() {
         function.execute(null, null, null, new Object[]{10}, null);
         final Object result = function.getResult();
-        assertTrue(result instanceof Integer);
-        assertEquals(result, 10);
+      assertThat(result instanceof Integer).isTrue();
+      assertThat(result).isEqualTo(10);
     }
 
     @Test
     public void testNegativeInteger() {
         function.execute(null, null, null, new Object[]{-10}, null);
         final Object result = function.getResult();
-        assertTrue(result instanceof Integer);
-        assertEquals(result, 10);
+      assertThat(result instanceof Integer).isTrue();
+      assertThat(result).isEqualTo(10);
     }
 
     @Test
     public void testPositiveLong() {
         function.execute(null, null, null, new Object[]{10L}, null);
         final Object result = function.getResult();
-        assertTrue(result instanceof Long);
-        assertEquals(result, 10L);
+      assertThat(result instanceof Long).isTrue();
+      assertThat(result).isEqualTo(10L);
     }
 
     @Test
     public void testNegativeLong() {
         function.execute(null, null, null, new Object[]{-10L}, null);
         final Object result = function.getResult();
-        assertTrue(result instanceof Long);
-        assertEquals(result, 10L);
+      assertThat(result instanceof Long).isTrue();
+      assertThat(result).isEqualTo(10L);
     }
 
     @Test
     public void testPositiveShort() {
         function.execute(null, null, null, new Object[]{(short) 10}, null);
         final Object result = function.getResult();
-        assertTrue(result instanceof Short);
-        assertEquals(result, (short) 10);
+      assertThat(result instanceof Short).isTrue();
+      assertThat((short) 10).isEqualTo(result);
     }
 
     @Test
     public void testNegativeShort() {
         function.execute(null, null, null, new Object[]{(short) -10}, null);
         final Object result = function.getResult();
-        assertTrue(result instanceof Short);
-        assertEquals(result, (short) 10);
+      assertThat(result instanceof Short).isTrue();
+      assertThat((short) 10).isEqualTo(result);
     }
 
     @Test
     public void testPositiveDouble() {
         function.execute(null, null, null, new Object[]{10.5D}, null);
         final Object result = function.getResult();
-        assertTrue(result instanceof Double);
-        assertEquals(result, 10.5D);
+      assertThat(result instanceof Double).isTrue();
+      assertThat(result).isEqualTo(10.5D);
     }
 
     @Test
     public void testNegativeDouble() {
         function.execute(null, null, null, new Object[]{-10.5D}, null);
         final Object result = function.getResult();
-        assertTrue(result instanceof Double);
-        assertEquals(result, 10.5D);
+      assertThat(result instanceof Double).isTrue();
+      assertThat(result).isEqualTo(10.5D);
     }
 
     @Test
     public void testPositiveFloat() {
         function.execute(null, null, null, new Object[]{10.5F}, null);
         final Object result = function.getResult();
-        assertTrue(result instanceof Float);
-        assertEquals(result, 10.5F);
+      assertThat(result instanceof Float).isTrue();
+      assertThat(result).isEqualTo(10.5F);
     }
 
     @Test
     public void testNegativeFloat() {
         function.execute(null, null, null, new Object[]{-10.5F}, null);
         final Object result = function.getResult();
-        assertTrue(result instanceof Float);
-        assertEquals(result, 10.5F);
+      assertThat(result instanceof Float).isTrue();
+      assertThat(result).isEqualTo(10.5F);
     }
 
     @Test
     public void testPositiveBigDecimal() {
         function.execute(null, null, null, new Object[]{new BigDecimal("10.5")}, null);
         final Object result = function.getResult();
-        assertTrue(result instanceof BigDecimal);
-        assertEquals(result, new BigDecimal("10.5"));
+      assertThat(result instanceof BigDecimal).isTrue();
+      assertThat(new BigDecimal("10.5")).isEqualTo(result);
     }
 
     @Test
     public void testNegativeBigDecimal() {
         function.execute(null, null, null, new Object[]{BigDecimal.valueOf(-10.5D)}, null);
         final Object result = function.getResult();
-        assertTrue(result instanceof BigDecimal);
-        assertEquals(result, new BigDecimal("10.5"));
+      assertThat(result instanceof BigDecimal).isTrue();
+      assertThat(new BigDecimal("10.5")).isEqualTo(result);
     }
 
     @Test
     public void testPositiveBigInteger() {
         function.execute(null, null, null, new Object[]{new BigInteger("10")}, null);
         final Object result = function.getResult();
-        assertTrue(result instanceof BigInteger);
-        assertEquals(result, new BigInteger("10"));
+      assertThat(result instanceof BigInteger).isTrue();
+      assertThat(new BigInteger("10")).isEqualTo(result);
     }
 
     @Test
     public void testNegativeBigInteger() {
         function.execute(null, null, null, new Object[]{new BigInteger("-10")}, null);
         final Object result = function.getResult();
-        assertTrue(result instanceof BigInteger);
-        assertEquals(result, new BigInteger("10"));
+      assertThat(result instanceof BigInteger).isTrue();
+      assertThat(new BigInteger("10")).isEqualTo(result);
     }
 
     @Test
     public void testNonNumber() {
         try {
             function.execute(null, null, null, new Object[]{"abc"}, null);
-            Assertions.fail("Expected  IllegalArgumentException");
+          fail("Expected  IllegalArgumentException");
         } catch (final IllegalArgumentException e) {
             // OK
         }
@@ -185,7 +185,7 @@ public class SQLFunctionAbsoluteValueTest {
     public void testFromQuery() throws Exception {
         TestHelper.executeInNewDatabase("./target/databases/testAbsFunction", (db) -> {
             final ResultSet result = db.query("sql", "select abs(-45.4) as abs");
-            assertEquals(45.4F, ((Number) result.next().getProperty("abs")).floatValue());
+            assertThat(((Number) result.next().getProperty("abs")).floatValue()).isEqualTo(45.4F);
         });
     }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/functions/math/SQLFunctionModeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/functions/math/SQLFunctionModeTest.java
@@ -24,9 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SQLFunctionModeTest {
 
@@ -40,7 +38,7 @@ public class SQLFunctionModeTest {
     @Test
     public void testEmpty() {
         final Object result = mode.getResult();
-        assertNull(result);
+      assertThat(result).isNull();
     }
 
     @Test
@@ -52,7 +50,7 @@ public class SQLFunctionModeTest {
         }
 
         final Object result = mode.getResult();
-        assertEquals(3, (int) ((List<Integer>) result).get(0));
+      assertThat((int) ((List<Integer>) result).get(0)).isEqualTo(3);
     }
 
     @Test
@@ -65,9 +63,9 @@ public class SQLFunctionModeTest {
 
         final Object result = mode.getResult();
         final List<Integer> modes = (List<Integer>) result;
-        assertEquals(2, modes.size());
-        assertTrue(modes.contains(2));
-        assertTrue(modes.contains(3));
+      assertThat(modes.size()).isEqualTo(2);
+      assertThat(modes.contains(2)).isTrue();
+      assertThat(modes.contains(3)).isTrue();
     }
 
     @Test
@@ -81,6 +79,6 @@ public class SQLFunctionModeTest {
         }
 
         final Object result = mode.getResult();
-        assertEquals(1, (int) ((List<Integer>) result).get(0));
+      assertThat((int) ((List<Integer>) result).get(0)).isEqualTo(1);
     }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/functions/math/SQLFunctionPercentileTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/functions/math/SQLFunctionPercentileTest.java
@@ -24,8 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 public class SQLFunctionPercentileTest {
@@ -41,19 +40,19 @@ public class SQLFunctionPercentileTest {
   @Test
   public void testEmpty() {
     final Object result = percentile.getResult();
-    assertNull(result);
+    assertThat(result).isNull();
   }
 
   @Test
   public void testSingleValueLower() {
     percentile.execute(null, null, null, new Object[] {10, .25}, null);
-    assertEquals(10, percentile.getResult());
+    assertThat(percentile.getResult()).isEqualTo(10);
   }
 
   @Test
   public void testSingleValueUpper() {
     percentile.execute(null, null, null, new Object[] {10, .75}, null);
-    assertEquals(10, percentile.getResult());
+    assertThat(percentile.getResult()).isEqualTo(10);
   }
 
   @Test
@@ -65,7 +64,7 @@ public class SQLFunctionPercentileTest {
     }
 
     final Object result = percentile.getResult();
-    assertEquals(3.0, result);
+    assertThat(result).isEqualTo(3.0);
   }
 
   @Test
@@ -77,7 +76,7 @@ public class SQLFunctionPercentileTest {
     }
 
     final Object result = percentile.getResult();
-    assertEquals(3.0, result);
+    assertThat(result).isEqualTo(3.0);
   }
 
   @Test
@@ -89,7 +88,7 @@ public class SQLFunctionPercentileTest {
     }
 
     final Object result = percentile.getResult();
-    assertEquals(3.0, result);
+    assertThat(result).isEqualTo(3.0);
   }
 
   @Test
@@ -101,7 +100,7 @@ public class SQLFunctionPercentileTest {
     }
 
     final Object result = percentile.getResult();
-    assertEquals(1.5, result);
+    assertThat(result).isEqualTo(1.5);
   }
 
   @Test
@@ -113,7 +112,7 @@ public class SQLFunctionPercentileTest {
     }
 
     final Object result = percentile.getResult();
-    assertEquals(4.5, result);
+    assertThat(result).isEqualTo(4.5);
   }
 
   @Test
@@ -125,7 +124,7 @@ public class SQLFunctionPercentileTest {
     }
 
     final List<Number> result = (List<Number>) percentile.getResult();
-    assertEquals(1.5, result.get(0).doubleValue(), 0);
-    assertEquals(4.5, result.get(1).doubleValue(), 0);
+    assertThat(result.get(0).doubleValue()).isEqualTo(1.5);
+    assertThat(result.get(1).doubleValue()).isEqualTo(4.5);
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/functions/math/SQLFunctionRandomIntTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/functions/math/SQLFunctionRandomIntTest.java
@@ -19,13 +19,16 @@
 package com.arcadedb.query.sql.functions.math;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.query.sql.function.math.SQLFunctionRandomInt;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -41,27 +44,27 @@ public class SQLFunctionRandomIntTest {
   @Test
   public void testEmpty() {
     final Object result = random.getResult();
-    assertNull(result);
+    assertThat(result).isNull();
   }
 
   @Test
   public void testResultWithIntParameter() {
     final Integer result = (Integer) random.execute(null, null, null, new Integer[] { 1000 }, null);
-    assertNotNull(result);
+    assertThat(result).isNotNull();
   }
 
   @Test
   public void testResultWithStringParameter() {
     final Integer result = (Integer) random.execute(null, null, null, new Object[] { "1000" }, null);
-    assertNotNull(result);
+    assertThat(result).isNotNull();
   }
 
   @Test
   public void testQuery() throws Exception {
     TestHelper.executeInNewDatabase("SQLFunctionRandomInt", (db) -> {
       final ResultSet result = db.query("sql", "select randomInt(1000) as random");
-      assertNotNull(result);
-      assertNotNull(result.next().getProperty("random"));
+      assertThat((Iterator<? extends Result>) result).isNotNull();
+      assertThat(result.next().<Integer>getProperty("random")).isNotNull();
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/functions/math/SQLFunctionSquareRootTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/functions/math/SQLFunctionSquareRootTest.java
@@ -21,15 +21,15 @@ package com.arcadedb.query.sql.functions.math;
 import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.query.sql.function.math.SQLFunctionSquareRoot;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.math.*;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SQLFunctionSquareRootTest {
 
@@ -43,126 +43,126 @@ public class SQLFunctionSquareRootTest {
     @Test
     public void testEmpty() {
         final Object result = function.getResult();
-        assertNull(result);
+      assertThat(result).isNull();
     }
 
     @Test
     public void testNull() {
         function.execute(null, null, null, new Object[]{null}, null);
         final Object result = function.getResult();
-        assertNull(result);
+      assertThat(result).isNull();
     }
 
     @Test
     public void testPositiveInteger() {
         function.execute(null, null, null, new Object[]{4}, null);
         final Object result = function.getResult();
-        assertTrue(result instanceof Integer);
-        assertEquals(result, 2);
+      assertThat(result instanceof Integer).isTrue();
+      assertThat(result).isEqualTo(2);
     }
 
     @Test
     public void testNegativeInteger() {
         function.execute(null, null, null, new Object[]{-4}, null);
         final Object result = function.getResult();
-        assertNull(result);
+      assertThat(result).isNull();
     }
 
     @Test
     public void testPositiveLong() {
         function.execute(null, null, null, new Object[]{4L}, null);
         final Object result = function.getResult();
-        assertTrue(result instanceof Long);
-        assertEquals(result, 2L);
+      assertThat(result instanceof Long).isTrue();
+      assertThat(result).isEqualTo(2L);
     }
 
     @Test
     public void testNegativeLong() {
         function.execute(null, null, null, new Object[]{-4L}, null);
         final Object result = function.getResult();
-        assertNull(result);
+      assertThat(result).isNull();
     }
 
     @Test
     public void testPositiveShort() {
         function.execute(null, null, null, new Object[]{(short) 4}, null);
         final Object result = function.getResult();
-        assertTrue(result instanceof Short);
-        assertEquals(result, (short) 2);
+      assertThat(result instanceof Short).isTrue();
+      assertThat((short) 2).isEqualTo(result);
     }
 
     @Test
     public void testNegativeShort() {
         function.execute(null, null, null, new Object[]{(short) -4}, null);
         final Object result = function.getResult();
-        assertNull(result);
+      assertThat(result).isNull();
     }
 
     @Test
     public void testPositiveDouble() {
         function.execute(null, null, null, new Object[]{4.0D}, null);
         final Object result = function.getResult();
-        assertTrue(result instanceof Double);
-        assertEquals(result, 2.0D);
+      assertThat(result instanceof Double).isTrue();
+      assertThat(result).isEqualTo(2.0D);
     }
 
     @Test
     public void testNegativeDouble() {
         function.execute(null, null, null, new Object[]{-4.0D}, null);
         final Object result = function.getResult();
-        assertNull(result);
+      assertThat(result).isNull();
     }
 
     @Test
     public void testPositiveFloat() {
         function.execute(null, null, null, new Object[]{4.0F}, null);
         final Object result = function.getResult();
-        assertTrue(result instanceof Float);
-        assertEquals(result, 2.0F);
+      assertThat(result instanceof Float).isTrue();
+      assertThat(result).isEqualTo(2.0F);
     }
 
     @Test
     public void testNegativeFloat() {
         function.execute(null, null, null, new Object[]{-4.0F}, null);
         final Object result = function.getResult();
-        assertNull(result);
+      assertThat(result).isNull();
     }
 
     @Test
     public void testPositiveBigDecimal() {
         function.execute(null, null, null, new Object[]{new BigDecimal("4.0")}, null);
         final Object result = function.getResult();
-        assertTrue(result instanceof BigDecimal);
-        assertEquals(result, new BigDecimal("2"));
+      assertThat(result instanceof BigDecimal).isTrue();
+      assertThat(new BigDecimal("2")).isEqualTo(result);
     }
 
     @Test
     public void testNegativeBigDecimal() {
         function.execute(null, null, null, new Object[]{BigDecimal.valueOf(-4.0D)}, null);
         final Object result = function.getResult();
-        assertNull(result);
+      assertThat(result).isNull();
     }
 
     @Test
     public void testPositiveBigInteger() {
         function.execute(null, null, null, new Object[]{new BigInteger("4")}, null);
         final Object result = function.getResult();
-        assertTrue(result instanceof BigInteger);
-        assertEquals(result, new BigInteger("2"));
+      assertThat(result instanceof BigInteger).isTrue();
+      assertThat(new BigInteger("2")).isEqualTo(result);
     }
 
     @Test
     public void testNegativeBigInteger() {
         function.execute(null, null, null, new Object[]{new BigInteger("-4")}, null);
         final Object result = function.getResult();
-        assertNull(result);
+      assertThat(result).isNull();
     }
 
     @Test
     public void testNonNumber() {
         try {
             function.execute(null, null, null, new Object[]{"abc"}, null);
-            Assertions.fail("Expected  IllegalArgumentException");
+          fail("Expected  IllegalArgumentException");
         } catch (final IllegalArgumentException e) {
             // OK
         }
@@ -172,7 +172,7 @@ public class SQLFunctionSquareRootTest {
     public void testFromQuery() throws Exception {
         TestHelper.executeInNewDatabase("./target/databases/testSqrtFunction", (db) -> {
             final ResultSet result = db.query("sql", "select sqrt(4.0) as sqrt");
-            assertEquals(2.0F, ((Number) result.next().getProperty("sqrt")).floatValue());
+            assertThat(((Number) result.next().getProperty("sqrt")).floatValue()).isEqualTo(2.0F);
         });
     }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/functions/math/SQLFunctionVarianceTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/functions/math/SQLFunctionVarianceTest.java
@@ -19,11 +19,10 @@
 package com.arcadedb.query.sql.functions.math;
 
 import com.arcadedb.query.sql.function.math.SQLFunctionVariance;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SQLFunctionVarianceTest {
 
@@ -37,7 +36,7 @@ public class SQLFunctionVarianceTest {
     @Test
     public void testEmpty() {
         final Object result = variance.getResult();
-        assertNull(result);
+      assertThat(result).isNull();
     }
 
     @Test
@@ -49,7 +48,7 @@ public class SQLFunctionVarianceTest {
         }
 
         final Object result = variance.getResult();
-        Assertions.assertEquals(22.1875, result);
+      assertThat(result).isEqualTo(22.1875);
     }
 
     @Test
@@ -61,7 +60,7 @@ public class SQLFunctionVarianceTest {
         }
 
         final Object result = variance.getResult();
-        Assertions.assertEquals(2.25, result);
+      assertThat(result).isEqualTo(2.25);
     }
 
     @Test
@@ -73,6 +72,6 @@ public class SQLFunctionVarianceTest {
         }
 
         final Object result = variance.getResult();
-        Assertions.assertEquals(36.0, result);
+      assertThat(result).isEqualTo(36.0);
     }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/functions/misc/FunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/functions/misc/FunctionTest.java
@@ -23,11 +23,15 @@ import com.arcadedb.database.MutableDocument;
 import com.arcadedb.query.sql.SQLQueryEngine;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.concurrent.atomic.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FunctionTest extends TestHelper {
   private static final int TOT = 10000;
@@ -59,12 +63,12 @@ public class FunctionTest extends TestHelper {
       final AtomicInteger counter = new AtomicInteger();
       while (rs.hasNext()) {
         final Result record = rs.next();
-        Assertions.assertNotNull(record);
-        Assertions.assertFalse(record.getIdentity().isPresent());
-        Assertions.assertEquals(10, ((Number) record.getProperty("count")).intValue());
+        assertThat(record).isNotNull();
+        assertThat(record.getIdentity().isPresent()).isFalse();
+        assertThat(((Number) record.getProperty("count")).intValue()).isEqualTo(10);
         counter.incrementAndGet();
       }
-      Assertions.assertEquals(1, counter.get());
+      assertThat(counter.get()).isEqualTo(1);
     });
   }
 
@@ -73,17 +77,17 @@ public class FunctionTest extends TestHelper {
     database.transaction(() -> {
       final ResultSet rs = database.command("SQL", "SELECT id, if( eval( 'id > 3' ), 'high', 'low') as value FROM V");
 
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       while (rs.hasNext()) {
         final Result record = rs.next();
-        Assertions.assertNotNull(record);
-        Assertions.assertFalse(record.getIdentity().isPresent());
+        assertThat(record).isNotNull();
+        assertThat(record.getIdentity().isPresent()).isFalse();
 
         final Object value = record.getProperty("value");
         if ((Integer) record.getProperty("id") > 3)
-          Assertions.assertEquals("high", value);
+          assertThat(value).isEqualTo("high");
         else
-          Assertions.assertEquals("low", value);
+          assertThat(value).isEqualTo("low");
       }
     });
   }
@@ -93,17 +97,17 @@ public class FunctionTest extends TestHelper {
     database.transaction(() -> {
       final ResultSet rs = database.command("SQL", "SELECT id, if( ( id > 3 ), 'high', 'low') as value FROM V");
 
-      Assertions.assertTrue(rs.hasNext());
+      assertThat(rs.hasNext()).isTrue();
       while (rs.hasNext()) {
         final Result record = rs.next();
-        Assertions.assertNotNull(record);
-        Assertions.assertFalse(record.getIdentity().isPresent());
+        assertThat(record).isNotNull();
+        assertThat(record.getIdentity().isPresent()).isFalse();
 
         final Object value = record.getProperty("value");
         if ((Integer) record.getProperty("id") > 3)
-          Assertions.assertEquals("high", value);
+          assertThat(value).isEqualTo("high");
         else
-          Assertions.assertEquals("low", value);
+          assertThat(value).isEqualTo("low");
       }
     });
   }
@@ -118,12 +122,12 @@ public class FunctionTest extends TestHelper {
       final AtomicInteger counter = new AtomicInteger();
       while (rs.hasNext()) {
         final Result record = rs.next();
-        Assertions.assertNotNull(record);
-        Assertions.assertFalse(record.getIdentity().isPresent());
-        Assertions.assertEquals(4, ((Number) record.getProperty("avg")).intValue());
+        assertThat(record).isNotNull();
+        assertThat(record.getIdentity().isPresent()).isFalse();
+        assertThat(((Number) record.getProperty("avg")).intValue()).isEqualTo(4);
         counter.incrementAndGet();
       }
-      Assertions.assertEquals(1, counter.get());
+      assertThat(counter.get()).isEqualTo(1);
     });
   }
 
@@ -136,12 +140,12 @@ public class FunctionTest extends TestHelper {
       final AtomicInteger counter = new AtomicInteger();
       while (rs.hasNext()) {
         final Result record = rs.next();
-        Assertions.assertNotNull(record);
-        Assertions.assertFalse(record.getIdentity().isPresent());
-        Assertions.assertEquals(TOT - 1, ((Number) record.getProperty("max")).intValue());
+        assertThat(record).isNotNull();
+        assertThat(record.getIdentity().isPresent()).isFalse();
+        assertThat(((Number) record.getProperty("max")).intValue()).isEqualTo(TOT - 1);
         counter.incrementAndGet();
       }
-      Assertions.assertEquals(1, counter.get());
+      assertThat(counter.get()).isEqualTo(1);
     });
   }
 
@@ -154,12 +158,12 @@ public class FunctionTest extends TestHelper {
       final AtomicInteger counter = new AtomicInteger();
       while (rs.hasNext()) {
         final Result record = rs.next();
-        Assertions.assertNotNull(record);
-        Assertions.assertFalse(record.getIdentity().isPresent());
-        Assertions.assertEquals(0, ((Number) record.getProperty("min")).intValue());
+        assertThat(record).isNotNull();
+        assertThat(record.getIdentity().isPresent()).isFalse();
+        assertThat(((Number) record.getProperty("min")).intValue()).isEqualTo(0);
         counter.incrementAndGet();
       }
-      Assertions.assertEquals(1, counter.get());
+      assertThat(counter.get()).isEqualTo(1);
     });
   }
 
@@ -167,8 +171,8 @@ public class FunctionTest extends TestHelper {
   public void testAllFunctionsHaveSyntax() {
     final SQLQueryEngine sqlEngine = (SQLQueryEngine) database.getQueryEngine("sql");
     for (final String name : sqlEngine.getFunctionFactory().getFunctionNames()) {
-      Assertions.assertNotNull(sqlEngine.getFunction(name).getName());
-      Assertions.assertNotNull(sqlEngine.getFunction(name).getSyntax());
+      assertThat(sqlEngine.getFunction(name).getName()).isNotNull();
+      assertThat(sqlEngine.getFunction(name).getSyntax()).isNotNull();
     }
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/functions/misc/SQLFunctionBoolAndTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/functions/misc/SQLFunctionBoolAndTest.java
@@ -20,8 +20,11 @@ package com.arcadedb.query.sql.functions.misc;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -35,8 +38,8 @@ public class SQLFunctionBoolAndTest extends TestHelper {
       database.command("sql", "create property doc0.bool boolean;");
       database.command("sql", "insert into doc0 set bool = null;");
       ResultSet result = database.query("sql", "select bool_and(bool) as bool_and from doc0;");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertTrue((Boolean) result.next().getProperty("bool_and"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("bool_and")).isTrue();
     });
   }
 
@@ -47,8 +50,8 @@ public class SQLFunctionBoolAndTest extends TestHelper {
       database.command("sql", "create property doc1.bool boolean;");
       database.command("sql", "insert into doc1 set bool = true;");
       ResultSet result = database.query("sql", "select bool_and(bool) as bool_and from doc1;");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertTrue((Boolean) result.next().getProperty("bool_and"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("bool_and")).isTrue();
     });
   }
 
@@ -59,8 +62,8 @@ public class SQLFunctionBoolAndTest extends TestHelper {
       database.command("sql", "create property doc2.bool boolean;");
       database.command("sql", "insert into doc2 set bool = false;");
       ResultSet result = database.query("sql", "select bool_and(bool) as bool_and from doc2;");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertFalse((Boolean) result.next().getProperty("bool_and"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("bool_and")).isFalse();
     });
   }
 
@@ -71,8 +74,8 @@ public class SQLFunctionBoolAndTest extends TestHelper {
       database.command("sql", "create property doc3.bool boolean;");
       database.command("sql", "insert into doc3 (bool) values (null), (null), (null);");
       ResultSet result = database.query("sql", "select bool_and(bool) as bool_and from doc3;");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertTrue((Boolean) result.next().getProperty("bool_and"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("bool_and")).isTrue();
     });
   }
 
@@ -83,8 +86,8 @@ public class SQLFunctionBoolAndTest extends TestHelper {
       database.command("sql", "create property doc4.bool boolean;");
       database.command("sql", "insert into doc4 (bool) values (true), (true), (true);");
       ResultSet result = database.query("sql", "select bool_and(bool) as bool_and from doc4;");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertTrue((Boolean) result.next().getProperty("bool_and"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("bool_and")).isTrue();
     });
   }
 
@@ -95,8 +98,8 @@ public class SQLFunctionBoolAndTest extends TestHelper {
       database.command("sql", "create property doc5.bool boolean;");
       database.command("sql", "insert into doc5 (bool) values (true), (true), (false);");
       ResultSet result = database.query("sql", "select bool_and(bool) as bool_and from doc5;");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertFalse((Boolean) result.next().getProperty("bool_and"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("bool_and")).isFalse();
     });
   }
 
@@ -107,8 +110,8 @@ public class SQLFunctionBoolAndTest extends TestHelper {
       database.command("sql", "create property doc6.bool boolean;");
       database.command("sql", "insert into doc6 (bool) values (true), (null), (true);");
       ResultSet result = database.query("sql", "select bool_and(bool) as bool_and from doc6;");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertTrue((Boolean) result.next().getProperty("bool_and"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("bool_and")).isTrue();
     });
   }
 
@@ -119,8 +122,8 @@ public class SQLFunctionBoolAndTest extends TestHelper {
       database.command("sql", "create property doc7.bool boolean;");
       database.command("sql", "insert into doc7 (bool) values (true), (null), (false);");
       ResultSet result = database.query("sql", "select bool_and(bool) as bool_and from doc7;");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertFalse((Boolean) result.next().getProperty("bool_and"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("bool_and")).isFalse();
     });
   }
 
@@ -131,8 +134,8 @@ public class SQLFunctionBoolAndTest extends TestHelper {
       database.command("sql", "create property doc8.bool boolean;");
       database.command("sql", "insert into doc8 (bool) values (null), (null), (null);");
       ResultSet result = database.query("sql", "select bool_and((bool is null)) as bool_and from doc8;");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertTrue((Boolean) result.next().getProperty("bool_and"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("bool_and")).isTrue();
     });
   }
 
@@ -143,8 +146,8 @@ public class SQLFunctionBoolAndTest extends TestHelper {
       database.command("sql", "create property doc9.bool boolean;");
       database.command("sql", "insert into doc9 (bool) values (true), (null), (false);");
       ResultSet result = database.query("sql", "select bool_and((bool is not null)) as bool_and from doc9;");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertFalse((Boolean) result.next().getProperty("bool_and"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("bool_and")).isFalse();
     });
   }
 
@@ -152,28 +155,28 @@ public class SQLFunctionBoolAndTest extends TestHelper {
   public void testBoolAndNull() {
     database.transaction(() -> {
       ResultSet result = database.query("sql", "SELECT (true AND null) as result");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertNull(result.next().getProperty("result"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat(result.next().<Boolean>getProperty("result")).isNull();
 
       result = database.query("sql", "SELECT (false AND null) as result");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertFalse((Boolean)result.next().getProperty("result"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean)result.next().getProperty("result")).isFalse();
 
       result = database.query("sql", "SELECT (null AND null) as result");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertNull(result.next().getProperty("result"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat(result.next().<Boolean>getProperty("result")).isNull();
 
       result = database.query("sql", "SELECT (true OR null) as result");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertTrue((Boolean)result.next().getProperty("result"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean)result.next().getProperty("result")).isTrue();
 
       result = database.query("sql", "SELECT (false OR null) as result");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertNull(result.next().getProperty("result"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat(result.next().<Boolean>getProperty("result")).isNull();
 
       result = database.query("sql", "SELECT (null OR null) as result");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertNull(result.next().getProperty("result"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat(result.next().<Boolean>getProperty("result")).isNull();
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/functions/misc/SQLFunctionBoolOrTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/functions/misc/SQLFunctionBoolOrTest.java
@@ -20,8 +20,11 @@ package com.arcadedb.query.sql.functions.misc;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -35,8 +38,8 @@ public class SQLFunctionBoolOrTest extends TestHelper {
       database.command("sql", "create property doc0.bool boolean;");
       database.command("sql", "insert into doc0 set bool = null;");
       ResultSet result = database.query("sql","select bool_or(bool) as bool_or from doc0;");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertFalse((Boolean) result.next().getProperty("bool_or"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("bool_or")).isFalse();
     });
   }
 
@@ -47,8 +50,8 @@ public class SQLFunctionBoolOrTest extends TestHelper {
       database.command("sql", "create property doc1.bool boolean;");
       database.command("sql", "insert into doc1 set bool = true;");
       ResultSet result = database.query("sql","select bool_or(bool) as bool_or from doc1;");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertTrue((Boolean) result.next().getProperty("bool_or"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("bool_or")).isTrue();
     });
   }
 
@@ -59,8 +62,8 @@ public class SQLFunctionBoolOrTest extends TestHelper {
       database.command("sql", "create property doc2.bool boolean;");
       database.command("sql", "insert into doc2 set bool = false;");
       ResultSet result = database.query("sql","select bool_or(bool) as bool_or from doc2;");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertFalse((Boolean) result.next().getProperty("bool_or"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("bool_or")).isFalse();
     });
   }
 
@@ -71,8 +74,8 @@ public class SQLFunctionBoolOrTest extends TestHelper {
       database.command("sql", "create property doc3.bool boolean;");
       database.command("sql", "insert into doc3 (bool) values (null), (null), (null);");
       ResultSet result = database.query("sql","select bool_or(bool) as bool_or from doc3;");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertFalse((Boolean) result.next().getProperty("bool_or"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("bool_or")).isFalse();
     });
   }
 
@@ -83,8 +86,8 @@ public class SQLFunctionBoolOrTest extends TestHelper {
       database.command("sql", "create property doc4.bool boolean;");
       database.command("sql", "insert into doc4 (bool) values (false), (false), (true);");
       ResultSet result = database.query("sql","select bool_or(bool) as bool_or from doc4;");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertTrue((Boolean) result.next().getProperty("bool_or"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("bool_or")).isTrue();
     });
   }
 
@@ -95,8 +98,8 @@ public class SQLFunctionBoolOrTest extends TestHelper {
       database.command("sql", "create property doc5.bool boolean;");
       database.command("sql", "insert into doc5 (bool) values (false), (false), (false);");
       ResultSet result = database.query("sql","select bool_or(bool) as bool_or from doc5;");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertFalse((Boolean) result.next().getProperty("bool_or"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("bool_or")).isFalse();
     });
   }
 
@@ -107,8 +110,8 @@ public class SQLFunctionBoolOrTest extends TestHelper {
       database.command("sql", "create property doc6.bool boolean;");
       database.command("sql", "insert into doc6 (bool) values (false), (null), (true);");
       ResultSet result = database.query("sql","select bool_or(bool) as bool_or from doc6;");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertTrue((Boolean) result.next().getProperty("bool_or"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("bool_or")).isTrue();
     });
   }
 
@@ -119,8 +122,8 @@ public class SQLFunctionBoolOrTest extends TestHelper {
       database.command("sql", "create property doc7.bool boolean;");
       database.command("sql", "insert into doc7 (bool) values (false), (null), (false);");
       ResultSet result = database.query("sql","select bool_or(bool) as bool_or from doc7;");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertFalse((Boolean) result.next().getProperty("bool_or"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("bool_or")).isFalse();
     });
   }
 
@@ -131,8 +134,8 @@ public class SQLFunctionBoolOrTest extends TestHelper {
       database.command("sql", "create property doc8.bool boolean;");
       database.command("sql", "insert into doc8 (bool) values (null), (null), (null);");
       ResultSet result = database.query("sql","select bool_or((bool is not null)) as bool_or from doc8;");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertFalse((Boolean) result.next().getProperty("bool_or"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("bool_or")).isFalse();
     });
   }
 
@@ -143,8 +146,8 @@ public class SQLFunctionBoolOrTest extends TestHelper {
       database.command("sql", "create property doc9.bool boolean;");
       database.command("sql", "insert into doc9 (bool) values (true), (null), (false);");
       ResultSet result = database.query("sql","select bool_or((bool is null)) as bool_or from doc9;");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertTrue((Boolean) result.next().getProperty("bool_or"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Boolean) result.next().getProperty("bool_or")).isTrue();
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/functions/misc/SQLFunctionCoalesceTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/functions/misc/SQLFunctionCoalesceTest.java
@@ -20,10 +20,13 @@ package com.arcadedb.query.sql.functions.misc;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -36,19 +39,19 @@ public class SQLFunctionCoalesceTest extends TestHelper {
       database.command("sql", "CREATE DOCUMENT TYPE doc");
       database.command("sql", "INSERT INTO doc (num) VALUES (1),(3),(5),(2),(4)");
 
-      Assertions.assertEquals(5, database.countType("doc", true));
+      assertThat(database.countType("doc", true)).isEqualTo(5);
 
       ResultSet result = database.query("sql", "SELECT coalesce((SELECT num FROM doc)) as coal");
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
 
       List coal = result.next().getProperty("coal");
-      Assertions.assertEquals(5, coal.size());
+      assertThat(coal).hasSize(5);
 
       result = database.query("sql", "SELECT coalesce((SELECT num FROM doc ORDER BY num)) as coal");
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
 
       coal = result.next().getProperty("coal");
-      Assertions.assertEquals(5, coal.size());
+      assertThat(coal).hasSize(5);
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/functions/misc/SQLFunctionConvertTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/functions/misc/SQLFunctionConvertTest.java
@@ -21,12 +21,14 @@ package com.arcadedb.query.sql.functions.misc;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.Document;
+import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
 
 import java.math.*;
 import java.util.*;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -52,80 +54,80 @@ public class SQLFunctionConvertTest {
       db.command("sql", "update TestConversion set selfrid = 'foo" + doc.getIdentity() + "'");
 
       ResultSet results = db.query("sql", "select string.asString() as convert from TestConversion");
-      assertNotNull(results);
+      assertThat((Iterator<? extends Result>) results).isNotNull();
       Object convert = results.next().getProperty("convert");
-      assertTrue(convert instanceof String, "Found " + convert.getClass() + " instead");
+      assertThat(convert instanceof String).as("Found " + convert.getClass() + " instead").isTrue();
 
       results = db.query("sql", "select number.asDate() as convert from TestConversion");
-      assertNotNull(results);
+      assertThat((Iterator<? extends Result>) results).isNotNull();
       convert = results.next().getProperty("convert");
-      assertTrue(convert instanceof Date, "Found " + convert.getClass() + " instead");
+      assertThat(convert instanceof Date).as("Found " + convert.getClass() + " instead").isTrue();
 
       results = db.query("sql", "select dateAsString.asDate(\"yyyy-MM-dd'T'HH:mm:ss.SSS\") as convert from TestConversion");
-      assertNotNull(results);
+      assertThat((Iterator<? extends Result>) results).isNotNull();
       convert = results.next().getProperty("convert");
-      assertTrue(convert instanceof Date, "Found " + convert.getClass() + " instead");
+      assertThat(convert instanceof Date).as("Found " + convert.getClass() + " instead").isTrue();
 
       results = db.query("sql", "select number.asDateTime() as convert from TestConversion");
-      assertNotNull(results);
+      assertThat((Iterator<? extends Result>) results).isNotNull();
       convert = results.next().getProperty("convert");
-      assertTrue(convert instanceof Date, "Found " + convert.getClass() + " instead");
+      assertThat(convert instanceof Date).as("Found " + convert.getClass() + " instead").isTrue();
 
       results = db.query("sql", "select dateAsString.asDateTime(\"yyyy-MM-dd'T'HH:mm:ss.SSS\") as convert from TestConversion");
-      assertNotNull(results);
+      assertThat((Iterator<? extends Result>) results).isNotNull();
       convert = results.next().getProperty("convert");
-      assertTrue(convert instanceof Date, "Found " + convert.getClass() + " instead");
+      assertThat(convert instanceof Date).as("Found " + convert.getClass() + " instead").isTrue();
 
       results = db.query("sql", "select number.asInteger() as convert from TestConversion");
-      assertNotNull(results);
+      assertThat((Iterator<? extends Result>) results).isNotNull();
       convert = results.next().getProperty("convert");
-      assertTrue(convert instanceof Integer, "Found " + convert.getClass() + " instead");
+      assertThat(convert instanceof Integer).as("Found " + convert.getClass() + " instead").isTrue();
 
       results = db.query("sql", "select number.asLong() as convert from TestConversion");
-      assertNotNull(results);
+      assertThat((Iterator<? extends Result>) results).isNotNull();
       convert = results.next().getProperty("convert");
-      assertTrue(convert instanceof Long, "Found " + convert.getClass() + " instead");
+      assertThat(convert instanceof Long).as("Found " + convert.getClass() + " instead").isTrue();
 
       results = db.query("sql", "select number.asFloat() as convert from TestConversion");
-      assertNotNull(results);
+      assertThat((Iterator<? extends Result>) results).isNotNull();
       convert = results.next().getProperty("convert");
-      assertTrue(convert instanceof Float, "Found " + convert.getClass() + " instead");
+      assertThat(convert instanceof Float).as("Found " + convert.getClass() + " instead").isTrue();
 
       results = db.query("sql", "select number.asDecimal() as convert from TestConversion");
-      assertNotNull(results);
+      assertThat((Iterator<? extends Result>) results).isNotNull();
       convert = results.next().getProperty("convert");
-      assertTrue(convert instanceof BigDecimal, "Found " + convert.getClass() + " instead");
+      assertThat(convert instanceof BigDecimal).as("Found " + convert.getClass() + " instead").isTrue();
 
       results = db.query("sql", "select \"100000.123\".asDecimal()*1000 as convert");
-      assertNotNull(results);
+      assertThat((Iterator<? extends Result>) results).isNotNull();
       convert = results.next().getProperty("convert");
-      assertTrue(convert instanceof BigDecimal, "Found " + convert.getClass() + " instead");
+      assertThat(convert instanceof BigDecimal).as("Found " + convert.getClass() + " instead").isTrue();
 
       results = db.query("sql", "select number.convert('LONG') as convert from TestConversion");
-      assertNotNull(results);
+      assertThat((Iterator<? extends Result>) results).isNotNull();
       convert = results.next().getProperty("convert");
-      assertTrue(convert instanceof Long, "Found " + convert.getClass() + " instead");
+      assertThat(convert instanceof Long).as("Found " + convert.getClass() + " instead").isTrue();
 
       results = db.query("sql", "select number.convert('SHORT') as convert from TestConversion");
-      assertNotNull(results);
+      assertThat((Iterator<? extends Result>) results).isNotNull();
       convert = results.next().getProperty("convert");
-      assertTrue(convert instanceof Short, "Found " + convert.getClass() + " instead");
+      assertThat(convert instanceof Short).as("Found " + convert.getClass() + " instead").isTrue();
 
       results = db.query("sql", "select number.convert('DOUBLE') as convert from TestConversion");
-      assertNotNull(results);
+      assertThat((Iterator<? extends Result>) results).isNotNull();
       convert = results.next().getProperty("convert");
-      assertTrue(convert instanceof Double, "Found " + convert.getClass() + " instead");
+      assertThat(convert instanceof Double).as("Found " + convert.getClass() + " instead").isTrue();
 
       results = db.query("sql", "select selfrid.substring(3).convert('LINK').string as convert from TestConversion");
-      assertNotNull(results);
+      assertThat((Iterator<? extends Result>) results).isNotNull();
       convert = results.next().getProperty("convert");
-      assertEquals(convert, "Jay");
+      assertThat(convert).isEqualTo("Jay");
 
       results = db.query("sql", "select list.transform('toLowerCase') as list from TestConversion");
-      assertNotNull(results);
+      assertThat((Iterator<? extends Result>) results).isNotNull();
       convert = results.next().getProperty("list");
       final List list = (List) convert;
-      assertTrue(list.containsAll(List.of("a", "b")));
+      assertThat(list.containsAll(List.of("a", "b"))).isTrue();
     }));
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/functions/misc/SQLFunctionEncodeDecodeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/functions/misc/SQLFunctionEncodeDecodeTest.java
@@ -19,15 +19,18 @@
 package com.arcadedb.query.sql.functions.misc;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.query.sql.function.misc.SQLFunctionDecode;
 import com.arcadedb.query.sql.function.misc.SQLFunctionEncode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class SQLFunctionEncodeDecodeTest {
 
@@ -43,22 +46,22 @@ public class SQLFunctionEncodeDecodeTest {
   @Test
   public void testEmpty() {
     final Object result = encode.getResult();
-    assertNull(result);
+    assertThat(result).isNull();
   }
 
   @Test
   public void testResult() {
     final String result = (String) encode.execute(null, null, null, new Object[] { "abc123", "base64" }, null);
-    assertNotNull(result);
+    assertThat(result).isNotNull();
   }
 
   @Test
   public void testQuery() throws Exception {
     TestHelper.executeInNewDatabase("SQLFunctionEncodeTest", (db) -> {
       final ResultSet result = db.query("sql", "select decode( encode('abc123', 'base64'), 'base64' ).asString() as encode");
-      assertNotNull(result);
+      assertThat((Iterator<? extends Result>) result).isNotNull();
       final Object prop = result.next().getProperty("encode");
-      assertEquals("abc123", prop);
+      assertThat(prop).isEqualTo("abc123");
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/functions/misc/SQLFunctionUUIDTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/functions/misc/SQLFunctionUUIDTest.java
@@ -19,13 +19,16 @@
 package com.arcadedb.query.sql.functions.misc;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.query.sql.function.misc.SQLFunctionUUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class SQLFunctionUUIDTest {
 
@@ -39,21 +42,21 @@ public class SQLFunctionUUIDTest {
   @Test
   public void testEmpty() {
     final Object result = uuid.getResult();
-    assertNull(result);
+    assertThat(result).isNull();
   }
 
   @Test
   public void testResult() {
     final String result = (String) uuid.execute(null, null, null, null, null);
-    assertNotNull(result);
+    assertThat(result).isNotNull();
   }
 
   @Test
   public void testQuery() throws Exception {
     TestHelper.executeInNewDatabase("SQLFunctionUUIDTest", (db) -> {
       final ResultSet result = db.query("sql", "select uuid() as uuid");
-      assertNotNull(result);
-      assertNotNull(result.next().getProperty("uuid"));
+      assertThat((Iterator<? extends Result>) result).isNotNull();
+      assertThat(result.next().<String>getProperty("uuid")).isNotNull();
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/functions/sql/CustomSQLFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/functions/sql/CustomSQLFunctionsTest.java
@@ -21,10 +21,13 @@ package com.arcadedb.query.sql.functions.sql;
 import com.arcadedb.TestHelper;
 import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.query.sql.executor.ResultSet;
+import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.api.AssertionsForClassTypes.within;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CustomSQLFunctionsTest {
@@ -32,7 +35,7 @@ public class CustomSQLFunctionsTest {
   public void testRandom() throws Exception {
     TestHelper.executeInNewDatabase("testRandom", (db) -> {
       final ResultSet result = db.query("sql", "select math_random() as random");
-      assertTrue((Double) result.next().getProperty("random") > 0);
+      assertThat(result.next().<Double>getProperty("random")).isGreaterThan(0);
     });
   }
 
@@ -40,7 +43,7 @@ public class CustomSQLFunctionsTest {
   public void testLog10() throws Exception {
     TestHelper.executeInNewDatabase("testRandom", (db) -> {
       final ResultSet result = db.query("sql", "select math_log10(10000) as log10");
-      assertEquals(result.next().getProperty("log10"), 4.0, 0.0001);
+      assertThat(result.next().<Double>getProperty("log10")).isCloseTo(4.0, within(0.0001));
     });
   }
 
@@ -48,7 +51,7 @@ public class CustomSQLFunctionsTest {
   public void testAbsInt() throws Exception {
     TestHelper.executeInNewDatabase("testRandom", (db) -> {
       final ResultSet result = db.query("sql", "select math_abs(-5) as abs");
-      assertTrue((Integer) result.next().getProperty("abs") == 5);
+      assertThat(result.next().<Integer>getProperty("abs")).isEqualTo(5);
     });
   }
 
@@ -56,7 +59,7 @@ public class CustomSQLFunctionsTest {
   public void testAbsDouble() throws Exception {
     TestHelper.executeInNewDatabase("testRandom", (db) -> {
       final ResultSet result = db.query("sql", "select math_abs(-5.0d) as abs");
-      assertTrue((Double) result.next().getProperty("abs") == 5.0);
+      assertThat(result.next().<Double>getProperty("abs")).isEqualTo(5.0);
     });
   }
 
@@ -64,15 +67,16 @@ public class CustomSQLFunctionsTest {
   public void testAbsFloat() throws Exception {
     TestHelper.executeInNewDatabase("testRandom", (db) -> {
       final ResultSet result = db.query("sql", "select math_abs(-5.0f) as abs");
-      assertTrue((Float) result.next().getProperty("abs") == 5.0);
+      assertThat(result.next().<Float>getProperty("abs")).isEqualTo(5.0f);
     });
   }
 
   @Test
   public void testNonExistingFunction() {
-    assertThrows(CommandParsingException.class, () -> TestHelper.executeInNewDatabase("testRandom", (db) -> {
-      final ResultSet result = db.query("sql", "select math_min('boom', 'boom') as boom");
-      result.next();
-    }));
+    assertThatExceptionOfType(CommandParsingException.class).isThrownBy(
+        () -> TestHelper.executeInNewDatabase("testRandom", (db) -> {
+          final ResultSet result = db.query("sql", "select math_min('boom', 'boom') as boom");
+          result.next();
+        }));
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/functions/text/SQLFunctionStrcmpciTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/functions/text/SQLFunctionStrcmpciTest.java
@@ -21,9 +21,13 @@ package com.arcadedb.query.sql.functions.text;
 import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.query.sql.function.text.SQLFunctionStrcmpci;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -40,44 +44,44 @@ public class SQLFunctionStrcmpciTest {
   @Test
   public void testEmpty() {
     final Object result = function.getResult();
-    Assertions.assertNull(result);
+    assertThat(result).isNull();
   }
 
   @Test
   public void testResult() {
-    Assertions.assertEquals(0, function.execute(null, null, null, new String[] { "ThisIsATest", "THISISATEST" }, null));
+    assertThat(function.execute(null, null, null, new String[]{"ThisIsATest", "THISISATEST"}, null)).isEqualTo(0);
   }
 
   @Test
   public void testQuery() throws Exception {
     TestHelper.executeInNewDatabase("SQLFunctionStrcmpci", (db) -> {
       ResultSet result = db.query("sql", "select strcmpci('ThisIsATest', 'THISISATEST') as strcmpci");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertEquals(0, (Integer) result.next().getProperty("strcmpci"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Integer) result.next().getProperty("strcmpci")).isEqualTo(0);
 
       result = db.query("sql", "select strcmpci(null, null) as strcmpci");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertEquals(0, (Integer) result.next().getProperty("strcmpci"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Integer) result.next().getProperty("strcmpci")).isEqualTo(0);
 
       result = db.query("sql", "select strcmpci('ThisIsATest', null) as strcmpci");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertEquals(1, (Integer) result.next().getProperty("strcmpci"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Integer) result.next().getProperty("strcmpci")).isEqualTo(1);
 
       result = db.query("sql", "select strcmpci(null, 'ThisIsATest') as strcmpci");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertEquals(-1, (Integer) result.next().getProperty("strcmpci"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Integer) result.next().getProperty("strcmpci")).isEqualTo(-1);
 
       result = db.query("sql", "select strcmpci('ThisIsATest', 'THISISATESTO') as strcmpci");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertEquals(-1, (Integer) result.next().getProperty("strcmpci"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Integer) result.next().getProperty("strcmpci")).isEqualTo(-1);
 
       result = db.query("sql", "select strcmpci('ThisIsATestO', 'THISISATEST') as strcmpci");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertEquals(+1, (Integer) result.next().getProperty("strcmpci"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Integer) result.next().getProperty("strcmpci")).isEqualTo(+1);
 
       result = db.query("sql", "select strcmpci('ThisIsATestO', 'THISISATESTE') as strcmpci");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertEquals(+1, (Integer) result.next().getProperty("strcmpci"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((Integer) result.next().getProperty("strcmpci")).isEqualTo(+1);
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodJoinTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodJoinTest.java
@@ -9,7 +9,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 
 class SQLMethodJoinTest {
 

--- a/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodKeysTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodKeysTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SQLMethodKeysTest {
 
@@ -43,6 +43,6 @@ public class SQLMethodKeysTest {
     resultInternal.setProperty("surname", "Bar");
 
     final Object result = function.execute(resultInternal, null, null, null);
-    assertEquals(new LinkedHashSet(Arrays.asList("name", "surname")), result);
+    assertThat(result).isEqualTo(new LinkedHashSet(Arrays.asList("name", "surname")));
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodValuesTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodValuesTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SQLMethodValuesTest {
   private SQLMethod function;
@@ -43,6 +43,6 @@ public class SQLMethodValuesTest {
     resultInternal.setProperty("surname", "Bar");
 
     final Object result = function.execute(resultInternal, null, null, null);
-    assertEquals(Arrays.asList("Foo", "Bar"), new ArrayList<>((Collection<String>) result));
+    assertThat(new ArrayList<>((Collection<String>) result)).isEqualTo(Arrays.asList("Foo", "Bar"));
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsJSONTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsJSONTest.java
@@ -21,11 +21,11 @@ package com.arcadedb.query.sql.method.conversion;
 import com.arcadedb.query.sql.executor.SQLMethod;
 import com.arcadedb.serializer.json.JSONException;
 import com.arcadedb.serializer.json.JSONObject;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 class SQLMethodAsJSONTest {
 
@@ -39,28 +39,28 @@ class SQLMethodAsJSONTest {
   @Test
   void testNull() {
     final Object result = method.execute(null, null, null, null);
-    Assertions.assertNull(result);
+    assertThat(result).isNull();
   }
 
   @Test
   void testEmptyJsonIsReturned() {
     final Object result = method.execute("", null, null, null);
-    Assertions.assertTrue(result instanceof JSONObject);
-    Assertions.assertTrue(((JSONObject) result).isEmpty());
+    assertThat(result instanceof JSONObject).isTrue();
+    assertThat(((JSONObject) result).isEmpty()).isTrue();
   }
 
   @Test
   void testStringIsReturnedAsString() {
     final Object result = method.execute(new JSONObject().put("name", "robot").toString(), null, null, null);
-    Assertions.assertTrue(result instanceof JSONObject);
-    Assertions.assertEquals("robot", ((JSONObject) result).getString("name"));
+    assertThat(result instanceof JSONObject).isTrue();
+    assertThat(((JSONObject) result).getString("name")).isEqualTo("robot");
   }
 
   @Test
   void testErrorJsonParsing() {
     try {
       final Object result = method.execute("{\"name\"]", null, null, null);
-      Assertions.fail();
+      fail("");
     } catch (JSONException e) {
       //EXPECTED
     }

--- a/engine/src/test/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsListTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsListTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests the "asList()" method implemented by the OSQLMethodAsList class. Note that the only input
@@ -49,7 +49,7 @@ public class SQLMethodAsListTest {
   public void testNull() {
     // The expected behavior is to return an empty list.
     final Object result = function.execute(null, null, null, null);
-    assertEquals(result, new ArrayList<Object>());
+    assertThat(new ArrayList<Object>()).isEqualTo(result);
   }
 
   @Test
@@ -59,7 +59,7 @@ public class SQLMethodAsListTest {
     aList.add(1);
     aList.add("2");
     final Object result = function.execute(aList, null, null, null);
-    assertEquals(result, aList);
+    assertThat(aList).isEqualTo(result);
   }
 
   @Test
@@ -74,7 +74,7 @@ public class SQLMethodAsListTest {
     final ArrayList<Object> expected = new ArrayList<Object>();
     expected.add(1);
     expected.add("2");
-    assertEquals(result, expected);
+    assertThat(expected).isEqualTo(result);
   }
 
   @Test
@@ -88,7 +88,7 @@ public class SQLMethodAsListTest {
     final TestIterable<Object> anIterable = new TestIterable<Object>(expected);
     final Object result = function.execute(anIterable, null, null, null);
 
-    assertEquals(result, expected);
+    assertThat(expected).isEqualTo(result);
   }
 
   @Test
@@ -102,7 +102,7 @@ public class SQLMethodAsListTest {
     final TestIterable<Object> anIterable = new TestIterable<Object>(expected);
     final Object result = function.execute(anIterable.iterator(), null, null, null);
 
-    assertEquals(result, expected);
+    assertThat(expected).isEqualTo(result);
   }
 
   @Test
@@ -121,7 +121,7 @@ public class SQLMethodAsListTest {
     final ArrayList<Object> expected = new ArrayList<Object>();
     expected.add(doc);
 
-    assertEquals(result, expected);
+    assertThat(expected).isEqualTo(result);
   }
 
   @Test
@@ -132,6 +132,6 @@ public class SQLMethodAsListTest {
     final Object result = function.execute(Integer.valueOf(4), null, null, null);
     final ArrayList<Object> expected = new ArrayList<Object>();
     expected.add(Integer.valueOf(4));
-    assertEquals(result, expected);
+    assertThat(expected).isEqualTo(result);
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsMapTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsMapTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests the "asMap()" method implemented by the OSQLMethodAsMap class. Note that the only input to
@@ -48,7 +48,7 @@ public class SQLMethodAsMapTest {
   public void testNull() {
     // The expected behavior is to return an empty map.
     final Object result = function.execute(null, null, null, null);
-    assertEquals(result, new HashMap<Object, Object>());
+    assertThat(new HashMap<Object, Object>()).isEqualTo(result);
   }
 
   @Test
@@ -58,7 +58,7 @@ public class SQLMethodAsMapTest {
     aMap.put("p1", 1);
     aMap.put("p2", 2);
     final Object result = function.execute(aMap, null, null, null);
-    assertEquals(result, aMap);
+    assertThat(aMap).isEqualTo(result);
   }
 
   @Test
@@ -73,7 +73,7 @@ public class SQLMethodAsMapTest {
 
     final Object result = function.execute(doc, null, null, null);
 
-    assertEquals(doc.toMap(false), result);
+    assertThat(result).isEqualTo(doc.toMap(false));
   }
 
   @Test
@@ -92,7 +92,7 @@ public class SQLMethodAsMapTest {
     final HashMap<Object, Object> expected = new HashMap<Object, Object>();
     expected.put("p1", 1);
     expected.put("p2", 2);
-    assertEquals(result, expected);
+    assertThat(expected).isEqualTo(result);
   }
 
   @Test
@@ -111,13 +111,13 @@ public class SQLMethodAsMapTest {
     final HashMap<Object, Object> expected = new HashMap<Object, Object>();
     expected.put("p1", 1);
     expected.put("p2", 2);
-    assertEquals(result, expected);
+    assertThat(expected).isEqualTo(result);
   }
 
   @Test
   public void testOtherValue() {
     // The expected behavior is to return null.
     final Object result = function.execute(Integer.valueOf(4), null, null, null);
-    assertEquals(result, null);
+    assertThat(result).isNull();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsSetTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsSetTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests the "asSet()" method implemented by the OSQLMethodAsSet class. Note that the only input to
@@ -51,14 +51,14 @@ public class SQLMethodAsSetTest {
     aSet.add(1);
     aSet.add("2");
     final Object result = function.execute(aSet, null, null, null);
-    assertEquals(result, aSet);
+    assertThat(aSet).isEqualTo(result);
   }
 
   @Test
   public void testNull() {
     // The expected behavior is to return an empty set.
     final Object result = function.execute(null, null, null, null);
-    assertEquals(result, new HashSet<Object>());
+    assertThat(new HashSet<Object>()).isEqualTo(result);
   }
 
   @Test
@@ -73,7 +73,7 @@ public class SQLMethodAsSetTest {
     final HashSet<Object> expected = new HashSet<Object>();
     expected.add(1);
     expected.add("2");
-    assertEquals(result, expected);
+    assertThat(expected).isEqualTo(result);
   }
 
   @Test
@@ -91,7 +91,7 @@ public class SQLMethodAsSetTest {
     expected.add(1);
     expected.add("2");
 
-    assertEquals(result, expected);
+    assertThat(expected).isEqualTo(result);
   }
 
   @Test
@@ -109,7 +109,7 @@ public class SQLMethodAsSetTest {
     expected.add(1);
     expected.add("2");
 
-    assertEquals(result, expected);
+    assertThat(expected).isEqualTo(result);
   }
 
   @Test
@@ -127,7 +127,7 @@ public class SQLMethodAsSetTest {
     final HashSet<Object> expected = new HashSet<Object>();
     expected.add(doc);
 
-    assertEquals(result, expected);
+    assertThat(expected).isEqualTo(result);
   }
 
   @Test
@@ -138,6 +138,6 @@ public class SQLMethodAsSetTest {
     final Object result = function.execute(Integer.valueOf(4), null, null, null);
     final HashSet<Object> expected = new HashSet<Object>();
     expected.add(Integer.valueOf(4));
-    assertEquals(result, expected);
+    assertThat(expected).isEqualTo(result);
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/method/misc/SQLMethodExcludeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/misc/SQLMethodExcludeTest.java
@@ -22,11 +22,12 @@ package com.arcadedb.query.sql.method.misc;
 
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.SQLMethod;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class SQLMethodExcludeTest {
 
@@ -45,9 +46,9 @@ class SQLMethodExcludeTest {
     resultInternal.setProperty("surname", "Bar");
 
     final Object result = method.execute(resultInternal, null, null, new Object[] { "name" });
-    Assertions.assertNotNull(result);
-    Assertions.assertTrue(((Map) result).containsKey("surname"));
-    Assertions.assertFalse(((Map) result).containsKey("name"));
-    Assertions.assertEquals("Bar", ((Map) result).get("surname"));
+    assertThat(result).isNotNull();
+    assertThat(((Map) result).containsKey("surname")).isTrue();
+    assertThat(((Map) result).containsKey("name")).isFalse();
+    assertThat(((Map) result).get("surname")).isEqualTo("Bar");
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/method/misc/SQLMethodIncludeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/misc/SQLMethodIncludeTest.java
@@ -22,11 +22,12 @@ package com.arcadedb.query.sql.method.misc;
 
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.SQLMethod;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class SQLMethodIncludeTest {
 
@@ -45,9 +46,9 @@ class SQLMethodIncludeTest {
     resultInternal.setProperty("surname", "Bar");
 
     final Object result = method.execute(resultInternal, null, null, new Object[] { "name" });
-    Assertions.assertNotNull(result);
-    Assertions.assertTrue(((Map) result).containsKey("name"));
-    Assertions.assertFalse(((Map) result).containsKey("surname"));
-    Assertions.assertEquals("Foo", ((Map) result).get("name"));
+    assertThat(result).isNotNull();
+    assertThat(((Map) result).containsKey("name")).isTrue();
+    assertThat(((Map) result).containsKey("surname")).isFalse();
+    assertThat(((Map) result).get("name")).isEqualTo("Foo");
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/method/misc/SQLMethodPrecisionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/misc/SQLMethodPrecisionTest.java
@@ -21,16 +21,17 @@ package com.arcadedb.query.sql.method.misc;
 import com.arcadedb.query.sql.executor.SQLMethod;
 import com.arcadedb.utility.DateUtils;
 import com.arcadedb.utility.NanoClock;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.time.*;
-import java.time.temporal.*;
-import java.util.*;
-import java.util.concurrent.*;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.concurrent.Callable;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 class SQLMethodPrecisionTest {
   private SQLMethod method;
@@ -44,7 +45,7 @@ class SQLMethodPrecisionTest {
   void testRequiredArgs() {
     try {
       method.execute(null, null, null, new Object[] { null });
-      Assertions.fail();
+      fail("");
     } catch (IllegalArgumentException e) {
       // EXPECTED
     }
@@ -74,7 +75,7 @@ class SQLMethodPrecisionTest {
     final Date now = new Date();
     Object result = method.execute(now, null, null, new String[] { "millisecond" });
     assertThat(result).isInstanceOf(Date.class);
-    Assertions.assertEquals(now, result);
+    assertThat(result).isEqualTo(now);
   }
 
   private void testPrecision(final String precisionAsString, final Callable<Object> getNow) throws Exception {
@@ -91,6 +92,6 @@ class SQLMethodPrecisionTest {
       if (DateUtils.getPrecision(DateUtils.getNanos(result)) == precision)
         break;
     }
-    Assertions.assertEquals(precision, DateUtils.getPrecision(DateUtils.getNanos(result)));
+    assertThat(DateUtils.getPrecision(DateUtils.getNanos(result))).isEqualTo(precision);
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/method/string/SQLMethodSplitTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/string/SQLMethodSplitTest.java
@@ -20,7 +20,6 @@ package com.arcadedb.query.sql.method.string;
 
 import com.arcadedb.query.sql.executor.SQLMethod;
 import com.arcadedb.utility.CodeUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -85,7 +84,7 @@ class SQLMethodSplitTest {
     final String rid = "#12:23231";
     for (int i = 0; i < 10_000_000; i++) {
       final String[] parts = rid.split(":", 2);
-      Assertions.assertEquals(2, parts.length);
+      assertThat(parts.length).isEqualTo(2);
     }
   }
 
@@ -93,7 +92,7 @@ class SQLMethodSplitTest {
     final String rid = "#12:23231";
     for (int i = 0; i < 10_000_000; i++) {
       final List<String> parts = CodeUtils.split(rid, ':', 2);
-      Assertions.assertEquals(2, parts.size());
+      assertThat(parts.size()).isEqualTo(2);
     }
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/method/string/SQLMethodSubStringTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/string/SQLMethodSubStringTest.java
@@ -20,11 +20,10 @@
  */
 package com.arcadedb.query.sql.method.string;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests the "asList()" method implemented by the OSQLMethodAsList class. Note that the only input
@@ -46,49 +45,49 @@ public class SQLMethodSubStringTest {
   public void testRange() {
 
     Object result = function.execute("foobar", null, null, new Object[] { 1, 3 });
-    assertEquals(result, "foobar".substring(1, 3));
+    assertThat("foobar".substring(1, 3)).isEqualTo(result);
 
     result = function.execute("foobar", null, null, new Object[] { 0, 0 });
-    assertEquals(result, "foobar".substring(0, 0));
+    assertThat("foobar".substring(0, 0)).isEqualTo(result);
 
     result = function.execute("foobar", null, null, new Object[] { 0, 1000 });
-    assertEquals(result, "foobar");
+    assertThat(result).isEqualTo("foobar");
 
     result = function.execute("foobar", null, null, new Object[] { 0, -1 });
-    assertEquals(result, "");
+    assertThat(result).isEqualTo("");
 
     result = function.execute("foobar", null, null, new Object[] { 6, 6 });
-    assertEquals(result, "foobar".substring(6, 6));
+    assertThat("foobar".substring(6, 6)).isEqualTo(result);
 
     result = function.execute("foobar", null, null, new Object[] { 1, 9 });
-    assertEquals(result, "foobar".substring(1, 6));
+    assertThat("foobar".substring(1, 6)).isEqualTo(result);
 
     result = function.execute("foobar", null, null, new Object[] { -7, 4 });
-    assertEquals(result, "foobar".substring(0, 4));
+    assertThat("foobar".substring(0, 4)).isEqualTo(result);
   }
 
   @Test
   public void testFrom() {
     Object result = function.execute("foobar", null, null, new Object[] { 1 });
-    assertEquals(result, "foobar".substring(1));
+    assertThat("foobar".substring(1)).isEqualTo(result);
 
     result = function.execute("foobar", null, null, new Object[] { 0 });
-    assertEquals(result, "foobar");
+    assertThat(result).isEqualTo("foobar");
 
     result = function.execute("foobar", null, null, new Object[] { 6 });
-    assertEquals(result, "foobar".substring(6));
+    assertThat("foobar".substring(6)).isEqualTo(result);
 
     result = function.execute("foobar", null, null, new Object[] { 12 });
-    assertEquals(result, "");
+    assertThat(result).isEqualTo("");
 
     result = function.execute("foobar", null, null, new Object[] { -7 });
-    assertEquals(result, "foobar");
+    assertThat(result).isEqualTo("foobar");
   }
 
   @Test
   public void testNull() {
 
     final Object result = function.execute(null, null, null, null);
-    Assertions.assertNull(result);
+    assertThat(result).isNull();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/AbstractParserTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/AbstractParserTest.java
@@ -18,7 +18,7 @@
  */
 package com.arcadedb.query.sql.parser;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 public abstract class AbstractParserTest {
 
@@ -54,14 +54,14 @@ public abstract class AbstractParserTest {
       result.validate();
 
       if (!isCorrect)
-        fail();
+        fail("");
 
       return result;
     } catch (final Exception e) {
       if (isCorrect) {
         System.out.println(query);
         e.printStackTrace();
-        fail();
+        fail("");
       }
     }
     return null;
@@ -72,14 +72,14 @@ public abstract class AbstractParserTest {
     try {
       final SimpleNode result = osql.Parse();
       if (!isCorrect)
-        fail();
+        fail("");
 
       return result;
     } catch (final Exception e) {
       if (isCorrect) {
         System.out.println(query);
         e.printStackTrace();
-        fail();
+        fail("");
       }
     }
     return null;

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/BatchScriptTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/BatchScriptTest.java
@@ -20,10 +20,11 @@ package com.arcadedb.query.sql.parser;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.*;
-import java.util.*;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 public class BatchScriptTest {
 
@@ -99,14 +100,14 @@ public class BatchScriptTest {
       //        System.out.println(stm.toString()+";");
       //      }
       if (!isCorrect) {
-        fail();
+        fail("");
       }
 
       return result;
     } catch (final Exception e) {
       if (isCorrect) {
         e.printStackTrace();
-        fail();
+        fail("");
       }
     }
     return null;

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/CreateEdgeStatementTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/CreateEdgeStatementTest.java
@@ -20,9 +20,10 @@ package com.arcadedb.query.sql.parser;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 public class CreateEdgeStatementTest {
 
@@ -40,13 +41,13 @@ public class CreateEdgeStatementTest {
     try {
       final SimpleNode result = osql.Parse();
       if (!isCorrect) {
-        fail();
+        fail("");
       }
       return result;
     } catch (final Exception e) {
       if (isCorrect) {
         e.printStackTrace();
-        fail();
+        fail("");
       }
     }
     return null;

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/CreateVertexStatementTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/CreateVertexStatementTest.java
@@ -20,9 +20,10 @@ package com.arcadedb.query.sql.parser;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 public class CreateVertexStatementTest {
 
@@ -39,13 +40,13 @@ public class CreateVertexStatementTest {
     try {
       final SimpleNode result = osql.Parse();
       if (!isCorrect) {
-        fail();
+        fail("");
       }
       return result;
     } catch (final Exception e) {
       if (isCorrect) {
         e.printStackTrace();
-        fail();
+        fail("");
       }
     }
     return null;

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/DeleteEdgeStatementTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/DeleteEdgeStatementTest.java
@@ -20,9 +20,10 @@ package com.arcadedb.query.sql.parser;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 public class DeleteEdgeStatementTest {
 
@@ -39,13 +40,13 @@ public class DeleteEdgeStatementTest {
     try {
       final SimpleNode result = osql.Parse();
       if (!isCorrect) {
-        fail();
+        fail("");
       }
       return result;
     } catch (final Exception e) {
       if (isCorrect) {
         e.printStackTrace();
-        fail();
+        fail("");
       }
     }
     return null;

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/DeleteStatementTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/DeleteStatementTest.java
@@ -23,13 +23,13 @@ import com.arcadedb.database.Document;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.utility.CollectionUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.util.*;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class DeleteStatementTest extends TestHelper {
 
@@ -59,11 +59,11 @@ public class DeleteStatementTest extends TestHelper {
     database.command("sql", "delete from (select expand(arr) from Bar) where k = 'key2'");
 
     final ResultSet result = database.query("sql", "select from Foo");
-    Assertions.assertNotNull(result);
-    Assertions.assertEquals(CollectionUtils.countEntries(result), 2);
+    assertThat(Optional.ofNullable(result)).isNotNull();
+    assertThat(CollectionUtils.countEntries(result)).isEqualTo(2);
     for (final ResultSet it = result; it.hasNext(); ) {
       final Document doc = it.next().toElement();
-      Assertions.assertNotEquals(doc.getString("k"), "key2");
+      assertThat(doc.getString("k")).isNotEqualTo("key2");
     }
     database.commit();
   }
@@ -87,13 +87,13 @@ public class DeleteStatementTest extends TestHelper {
     try {
       final SimpleNode result = osql.Parse();
       if (!isCorrect) {
-        fail();
+        fail("");
       }
       return result;
     } catch (final Exception e) {
       if (isCorrect) {
         e.printStackTrace();
-        fail();
+        fail("");
       }
     }
     return null;

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/ExecutionPlanCacheTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/ExecutionPlanCacheTest.java
@@ -25,8 +25,9 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Property;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ExecutionPlanCacheTest {
 
@@ -57,30 +58,30 @@ public class ExecutionPlanCacheTest {
       // schema changes
       db.query("sql", stm).close();
       cache = ExecutionPlanCache.instance(db);
-      Assertions.assertTrue(cache.contains(stm));
+      assertThat(cache.contains(stm)).isTrue();
 
       final DocumentType clazz = db.getSchema().createDocumentType(testName);
-      Assertions.assertFalse(cache.contains(stm));
+      assertThat(cache.contains(stm)).isFalse();
 
       Thread.sleep(2);
 
       // schema changes 2
       db.query("sql", stm).close();
       cache = ExecutionPlanCache.instance(db);
-      Assertions.assertTrue(cache.contains(stm));
+      assertThat(cache.contains(stm)).isTrue();
 
       final Property prop = clazz.createProperty("name", Type.STRING);
-      Assertions.assertFalse(cache.contains(stm));
+      assertThat(cache.contains(stm)).isFalse();
 
       Thread.sleep(2);
 
       // index changes
       db.query("sql", stm).close();
       cache = ExecutionPlanCache.instance(db);
-      Assertions.assertTrue(cache.contains(stm));
+      assertThat(cache.contains(stm)).isTrue();
 
       db.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, testName, "name");
-      Assertions.assertFalse(cache.contains(stm));
+      assertThat(cache.contains(stm)).isFalse();
 
     } finally {
       db.drop();

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/IdentifierTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/IdentifierTest.java
@@ -18,8 +18,9 @@
  */
 package com.arcadedb.query.sql.parser;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by luigidellaquila on 26/04/16.
@@ -30,8 +31,8 @@ public class IdentifierTest {
   public void testBackTickQuoted() {
     final Identifier identifier = new Identifier("foo`bar");
 
-    //Assertions.assertEquals(identifier.getStringValue(), "foo`bar");
-    Assertions.assertEquals("foo\\`bar", identifier.getStringValue());
-    Assertions.assertEquals("foo\\`bar", identifier.getValue());
+    //Assertions.assertThat("foo`bar").isEqualTo(identifier.getStringValue());
+    assertThat(identifier.getStringValue()).isEqualTo("foo\\`bar");
+    assertThat(identifier.getValue()).isEqualTo("foo\\`bar");
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/InsertStatementTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/InsertStatementTest.java
@@ -20,9 +20,10 @@ package com.arcadedb.query.sql.parser;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 public class InsertStatementTest {
 
@@ -39,13 +40,13 @@ public class InsertStatementTest {
     try {
       final SimpleNode result = osql.Parse();
       if (!isCorrect) {
-        fail();
+        fail("");
       }
       return result;
     } catch (final Exception e) {
       if (isCorrect) {
         e.printStackTrace();
-        fail();
+        fail("");
       }
     }
     return null;

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/MatchStatementTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/MatchStatementTest.java
@@ -20,9 +20,10 @@ package com.arcadedb.query.sql.parser;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 public class MatchStatementTest {
 
@@ -42,13 +43,13 @@ public class MatchStatementTest {
     try {
       final SimpleNode result = osql.Parse();
       if (!isCorrect) {
-        fail();
+        fail("");
       }
       return result;
     } catch (final Exception e) {
       if (isCorrect) {
         e.printStackTrace();
-        fail();
+        fail("");
       }
     }
     return null;

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/MathExpressionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/MathExpressionTest.java
@@ -19,11 +19,12 @@
 package com.arcadedb.query.sql.parser;
 
 import com.arcadedb.query.sql.executor.Result;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.math.*;
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by luigidellaquila on 02/07/15.
@@ -39,28 +40,28 @@ public class MathExpressionTest {
         MathExpression.Operator.STAR, MathExpression.Operator.SLASH, MathExpression.Operator.REM };
 
     for (final MathExpression.Operator op : basicOps) {
-      Assertions.assertEquals(op.apply(1, 1).getClass(), Integer.class);
+      assertThat(op.apply(1, 1).getClass()).isEqualTo(Integer.class);
 
-      Assertions.assertEquals(op.apply((short) 1, (short) 1).getClass(), Integer.class);
+      assertThat(op.apply((short) 1, (short) 1).getClass()).isEqualTo(Integer.class);
 
-      Assertions.assertEquals(op.apply(1l, 1l).getClass(), Long.class);
-      Assertions.assertEquals(op.apply(1f, 1f).getClass(), Float.class);
-      Assertions.assertEquals(op.apply(1d, 1d).getClass(), Double.class);
-      Assertions.assertEquals(op.apply(BigDecimal.ONE, BigDecimal.ONE).getClass(), BigDecimal.class);
+      assertThat(op.apply(1l, 1l).getClass()).isEqualTo(Long.class);
+      assertThat(op.apply(1f, 1f).getClass()).isEqualTo(Float.class);
+      assertThat(op.apply(1d, 1d).getClass()).isEqualTo(Double.class);
+      assertThat(op.apply(BigDecimal.ONE, BigDecimal.ONE).getClass()).isEqualTo(BigDecimal.class);
 
-      Assertions.assertEquals(op.apply(1l, 1).getClass(), Long.class);
-      Assertions.assertEquals(op.apply(1f, 1).getClass(), Float.class);
-      Assertions.assertEquals(op.apply(1d, 1).getClass(), Double.class);
-      Assertions.assertEquals(op.apply(BigDecimal.ONE, 1).getClass(), BigDecimal.class);
+      assertThat(op.apply(1l, 1).getClass()).isEqualTo(Long.class);
+      assertThat(op.apply(1f, 1).getClass()).isEqualTo(Float.class);
+      assertThat(op.apply(1d, 1).getClass()).isEqualTo(Double.class);
+      assertThat(op.apply(BigDecimal.ONE, 1).getClass()).isEqualTo(BigDecimal.class);
 
-      Assertions.assertEquals(op.apply(1, 1l).getClass(), Long.class);
-      Assertions.assertEquals(op.apply(1, 1f).getClass(), Float.class);
-      Assertions.assertEquals(op.apply(1, 1d).getClass(), Double.class);
-      Assertions.assertEquals(op.apply(1, BigDecimal.ONE).getClass(), BigDecimal.class);
+      assertThat(op.apply(1, 1l).getClass()).isEqualTo(Long.class);
+      assertThat(op.apply(1, 1f).getClass()).isEqualTo(Float.class);
+      assertThat(op.apply(1, 1d).getClass()).isEqualTo(Double.class);
+      assertThat(op.apply(1, BigDecimal.ONE).getClass()).isEqualTo(BigDecimal.class);
     }
 
-    Assertions.assertEquals(MathExpression.Operator.PLUS.apply(Integer.MAX_VALUE, 1).getClass(), Long.class);
-    Assertions.assertEquals(MathExpression.Operator.MINUS.apply(Integer.MIN_VALUE, 1).getClass(), Long.class);
+    assertThat(MathExpression.Operator.PLUS.apply(Integer.MAX_VALUE, 1).getClass()).isEqualTo(Long.class);
+    assertThat(MathExpression.Operator.MINUS.apply(Integer.MIN_VALUE, 1).getClass()).isEqualTo(Long.class);
   }
 
   @Test
@@ -79,8 +80,8 @@ public class MathExpressionTest {
     exp.childExpressions.add(integer(1));
 
     final Object result = exp.execute((Result) null, null);
-    Assertions.assertTrue(result instanceof Integer);
-    Assertions.assertEquals(208, result);
+    assertThat(result instanceof Integer).isTrue();
+    assertThat(result).isEqualTo(208);
   }
 
   @Test
@@ -105,8 +106,8 @@ public class MathExpressionTest {
     exp.childExpressions.add(integer(1));
 
     final Object result = exp.execute((Result) null, null);
-    Assertions.assertTrue(result instanceof Integer);
-    Assertions.assertEquals(16, result);
+    assertThat(result instanceof Integer).isTrue();
+    assertThat(result).isEqualTo(16);
   }
 
   @Test
@@ -119,8 +120,8 @@ public class MathExpressionTest {
     exp.childExpressions.add(integer(1));
 
     final Object result = exp.execute((Result) null, null);
-    Assertions.assertTrue(result instanceof Integer);
-    Assertions.assertEquals(2, result);
+    assertThat(result instanceof Integer).isTrue();
+    assertThat(result).isEqualTo(2);
   }
 
   @Test
@@ -133,8 +134,8 @@ public class MathExpressionTest {
     exp.childExpressions.add(integer(1));
 
     final Object result = exp.execute((Result) null, null);
-    Assertions.assertTrue(result instanceof Integer);
-    Assertions.assertEquals(3, result);
+    assertThat(result instanceof Integer).isTrue();
+    assertThat(result).isEqualTo(3);
   }
 
   @Test
@@ -145,8 +146,8 @@ public class MathExpressionTest {
     exp.childExpressions.add(integer(1));
 
     final Object result = exp.execute((Result) null, null);
-    Assertions.assertTrue(result instanceof Integer);
-    Assertions.assertEquals(1, result);
+    assertThat(result instanceof Integer).isTrue();
+    assertThat(result).isEqualTo(1);
   }
 
   @Test
@@ -157,8 +158,8 @@ public class MathExpressionTest {
     exp.childExpressions.add(integer(4));
 
     final Object result = exp.execute((Result) null, null);
-    Assertions.assertTrue(result instanceof Integer);
-    Assertions.assertEquals(4, result);
+    assertThat(result instanceof Integer).isTrue();
+    assertThat(result).isEqualTo(4);
   }
 
   @Test
@@ -169,8 +170,8 @@ public class MathExpressionTest {
     exp.childExpressions.add(integer(4));
 
     final Object result = exp.execute((Result) null, null);
-    Assertions.assertTrue(result instanceof Integer);
-    Assertions.assertEquals(5, result);
+    assertThat(result instanceof Integer).isTrue();
+    assertThat(result).isEqualTo(5);
   }
 
   @Test
@@ -181,7 +182,7 @@ public class MathExpressionTest {
     exp.childExpressions.add(nullValue());
 
     final Object result = exp.execute((Result) null, null);
-    Assertions.assertNull(result);
+    assertThat(result).isNull();
   }
 
   @Test
@@ -192,8 +193,8 @@ public class MathExpressionTest {
     exp.childExpressions.add(integer(1));
 
     final Object result = exp.execute((Result) null, null);
-    Assertions.assertTrue(result instanceof Integer);
-    Assertions.assertEquals(5, result);
+    assertThat(result instanceof Integer).isTrue();
+    assertThat(result).isEqualTo(5);
   }
 
   @Test
@@ -213,8 +214,8 @@ public class MathExpressionTest {
     exp.childExpressions.add(integer(5));
 
     final Object result = exp.execute((Result) null, null);
-    Assertions.assertTrue(result instanceof List<?>);
-    Assertions.assertEquals(5, ((List<Object>) result).get(3));
+    assertThat(result instanceof List<?>).isTrue();
+    assertThat(((List<Object>) result).get(3)).isEqualTo(5);
   }
 
   @Test
@@ -225,8 +226,8 @@ public class MathExpressionTest {
     exp.childExpressions.add(str("test"));
 
     final Object result = exp.execute((Result) null, null);
-    Assertions.assertTrue(result instanceof List<?>);
-    Assertions.assertEquals("test", ((List<Object>) result).get(3));
+    assertThat(result instanceof List<?>).isTrue();
+    assertThat(((List<Object>) result).get(3)).isEqualTo("test");
   }
 
   @Test
@@ -237,9 +238,9 @@ public class MathExpressionTest {
     exp.childExpressions.add(str("a"));
 
     final Object result = exp.execute((Result) null, null);
-    Assertions.assertTrue(result instanceof List<?>);
-    Assertions.assertEquals(3, ((List<?>) result).size());
-    Assertions.assertFalse(((List<Object>) result).contains("a"));
+    assertThat(result instanceof List<?>).isTrue();
+    assertThat(((List<?>) result).size()).isEqualTo(3);
+    assertThat(((List<Object>) result).contains("a")).isFalse();
   }
 
   private void testNullCoalescingGeneric(final MathExpression left, final MathExpression right, final Object expected) {
@@ -249,8 +250,8 @@ public class MathExpressionTest {
     exp.childExpressions.add(right);
 
     final Object result = exp.execute((Result) null, null);
-    //    Assertions.assertTrue(result instanceof Integer);
-    Assertions.assertEquals(expected, result);
+    //    Assertions.assertThat(result instanceof Integer).isTrue();
+    assertThat(result).isEqualTo(expected);
   }
 
   private MathExpression integer(final Number i) {

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/PatternTestParserTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/PatternTestParserTest.java
@@ -18,10 +18,13 @@
  */
 package com.arcadedb.query.sql.parser;
 
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /** Created by luigidellaquila on 11/10/16. */
 public class PatternTestParserTest extends AbstractParserTest {
@@ -34,12 +37,12 @@ public class PatternTestParserTest extends AbstractParserTest {
       final MatchStatement stm = (MatchStatement) parser.Parse();
       stm.buildPatterns();
       final Pattern pattern = stm.pattern;
-      Assertions.assertEquals(0, pattern.getNumOfEdges());
-      Assertions.assertEquals(1, pattern.getAliasToNode().size());
-      Assertions.assertNotNull(pattern.getAliasToNode().get("a"));
-      Assertions.assertEquals(1, pattern.getDisjointPatterns().size());
+      assertThat(pattern.getNumOfEdges()).isEqualTo(0);
+      assertThat(pattern.getAliasToNode().size()).isEqualTo(1);
+      assertThat(pattern.getAliasToNode().get("a")).isNotNull();
+      assertThat(pattern.getDisjointPatterns().size()).isEqualTo(1);
     } catch (final ParseException e) {
-      Assertions.fail();
+      fail("");
     }
   }
 
@@ -51,25 +54,25 @@ public class PatternTestParserTest extends AbstractParserTest {
       final MatchStatement stm = (MatchStatement) parser.Parse();
       stm.buildPatterns();
       final Pattern pattern = stm.pattern;
-      Assertions.assertEquals(0, pattern.getNumOfEdges());
-      Assertions.assertEquals(2, pattern.getAliasToNode().size());
-      Assertions.assertNotNull(pattern.getAliasToNode().get("a"));
+      assertThat(pattern.getNumOfEdges()).isEqualTo(0);
+      assertThat(pattern.getAliasToNode().size()).isEqualTo(2);
+      assertThat(pattern.getAliasToNode().get("a")).isNotNull();
       final List<Pattern> subPatterns = pattern.getDisjointPatterns();
-      Assertions.assertEquals(2, subPatterns.size());
-      Assertions.assertEquals(0, subPatterns.get(0).getNumOfEdges());
-      Assertions.assertEquals(1, subPatterns.get(0).getAliasToNode().size());
-      Assertions.assertEquals(0, subPatterns.get(1).getNumOfEdges());
-      Assertions.assertEquals(1, subPatterns.get(1).getAliasToNode().size());
+      assertThat(subPatterns.size()).isEqualTo(2);
+      assertThat(subPatterns.get(0).getNumOfEdges()).isEqualTo(0);
+      assertThat(subPatterns.get(0).getAliasToNode().size()).isEqualTo(1);
+      assertThat(subPatterns.get(1).getNumOfEdges()).isEqualTo(0);
+      assertThat(subPatterns.get(1).getAliasToNode().size()).isEqualTo(1);
 
       final Set<String> aliases = new HashSet<>();
       aliases.add("a");
       aliases.add("b");
       aliases.remove(subPatterns.get(0).getAliasToNode().keySet().iterator().next());
       aliases.remove(subPatterns.get(1).getAliasToNode().keySet().iterator().next());
-      Assertions.assertEquals(0, aliases.size());
+      assertThat(aliases.size()).isEqualTo(0);
 
     } catch (final ParseException e) {
-      Assertions.fail();
+      fail("");
     }
   }
 
@@ -82,11 +85,11 @@ public class PatternTestParserTest extends AbstractParserTest {
       final MatchStatement stm = (MatchStatement) parser.Parse();
       stm.buildPatterns();
       final Pattern pattern = stm.pattern;
-      Assertions.assertEquals(4, pattern.getNumOfEdges());
-      Assertions.assertEquals(6, pattern.getAliasToNode().size());
-      Assertions.assertNotNull(pattern.getAliasToNode().get("a"));
+      assertThat(pattern.getNumOfEdges()).isEqualTo(4);
+      assertThat(pattern.getAliasToNode().size()).isEqualTo(6);
+      assertThat(pattern.getAliasToNode().get("a")).isNotNull();
       final List<Pattern> subPatterns = pattern.getDisjointPatterns();
-      Assertions.assertEquals(2, subPatterns.size());
+      assertThat(subPatterns.size()).isEqualTo(2);
 
       final Set<String> aliases = new HashSet<>();
       aliases.add("a");
@@ -97,10 +100,10 @@ public class PatternTestParserTest extends AbstractParserTest {
       aliases.add("f");
       aliases.removeAll(subPatterns.get(0).getAliasToNode().keySet());
       aliases.removeAll(subPatterns.get(1).getAliasToNode().keySet());
-      Assertions.assertEquals(0, aliases.size());
+      assertThat(aliases.size()).isEqualTo(0);
 
     } catch (final ParseException e) {
-      Assertions.fail();
+      fail("");
     }
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/ProjectionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/ProjectionTest.java
@@ -19,10 +19,13 @@
 package com.arcadedb.query.sql.parser;
 
 import com.arcadedb.exception.CommandSQLParsingException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Created by luigidellaquila on 02/07/15.
@@ -33,15 +36,15 @@ public class ProjectionTest {
   public void testIsExpand() throws ParseException {
     final SqlParser parser = getParserFor("select expand(foo)  from V");
     final SelectStatement stm = (SelectStatement) parser.Parse();
-    Assertions.assertTrue(stm.getProjection().isExpand());
+    assertThat(stm.getProjection().isExpand()).isTrue();
 
     final SqlParser parser2 = getParserFor("select foo  from V");
     final SelectStatement stm2 = (SelectStatement) parser2.Parse();
-    Assertions.assertFalse(stm2.getProjection().isExpand());
+    assertThat(stm2.getProjection().isExpand()).isFalse();
 
     final SqlParser parser3 = getParserFor("select expand  from V");
     final SelectStatement stm3 = (SelectStatement) parser3.Parse();
-    Assertions.assertFalse(stm3.getProjection().isExpand());
+    assertThat(stm3.getProjection().isExpand()).isFalse();
   }
 
   @Test
@@ -53,11 +56,11 @@ public class ProjectionTest {
     try {
       getParserFor("select expand(foo), bar  from V").Parse();
 
-      Assertions.fail();
+      fail("");
     } catch (final CommandSQLParsingException ex) {
 
     } catch (final Exception x) {
-      Assertions.fail();
+      fail("");
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/SelectStatementTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/SelectStatementTest.java
@@ -25,12 +25,8 @@ import org.junit.jupiter.api.Test;
 import java.io.*;
 import java.util.*;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class SelectStatementTest {
 
@@ -58,7 +54,7 @@ public class SelectStatementTest {
         //          System.out.println(builder.toString());
         //          System.out.println("............");
         //        }
-        fail();
+        fail("");
       }
 
       return result;
@@ -66,7 +62,7 @@ public class SelectStatementTest {
       if (isCorrect) {
         //System.out.println(query);
         e.printStackTrace();
-        fail();
+        fail("");
       }
     }
     return null;
@@ -75,23 +71,23 @@ public class SelectStatementTest {
   @Test
   public void testParserSimpleSelect1() {
     final SimpleNode stm = checkRightSyntax("select from Foo");
-    assertTrue(stm instanceof SelectStatement);
+    assertThat(stm instanceof SelectStatement).isTrue();
     final SelectStatement select = (SelectStatement) stm;
-    assertNull(select.getProjection());
-    assertNotNull(select.getTarget());
-    assertNull(select.getWhereClause());
+    assertThat(select.getProjection()).isNull();
+    assertThat(select.getTarget()).isNotNull();
+    assertThat(select.getWhereClause()).isNull();
   }
 
   @Test
   public void testParserSimpleSelect2() {
     final SimpleNode stm = checkRightSyntax("select bar from Foo");
-    assertTrue(stm instanceof SelectStatement);
+    assertThat(stm instanceof SelectStatement).isTrue();
     final SelectStatement select = (SelectStatement) stm;
-    assertNotNull(select.getProjection());
-    assertNotNull(select.getProjection().getItems());
-    assertEquals(select.getProjection().getItems().size(), 1);
-    assertNotNull(select.getTarget());
-    assertNull(select.getWhereClause());
+    assertThat(select.getProjection()).isNotNull();
+    assertThat(select.getProjection().getItems()).isNotNull();
+    assertThat(select.getProjection().getItems().size()).isEqualTo(1);
+    assertThat(select.getTarget()).isNotNull();
+    assertThat(select.getWhereClause()).isNull();
   }
 
   @Test
@@ -165,7 +161,7 @@ public class SelectStatementTest {
   public void testIn() {
     final SimpleNode result = checkRightSyntax("select count(*) from OFunction where name in [\"a\"]");
     // result.dump("    ");
-    assertTrue(result instanceof SelectStatement);
+    assertThat(result instanceof SelectStatement).isTrue();
 
   }
 
@@ -173,7 +169,7 @@ public class SelectStatementTest {
   public void testNotIn() {
     final SimpleNode result = checkRightSyntax("select count(*) from OFunction where name not in [\"a\"]");
     // result.dump("    ");
-    assertTrue(result instanceof Statement);
+    assertThat(result instanceof Statement).isTrue();
 
   }
 
@@ -181,7 +177,7 @@ public class SelectStatementTest {
   public void testMath1() {
     final SimpleNode result = checkRightSyntax("" + "select * from sqlSelectIndexReuseTestClass where prop1 = 1 + 1");
     // result.dump("    ");
-    assertTrue(result instanceof SelectStatement);
+    assertThat(result instanceof SelectStatement).isTrue();
 
   }
 
@@ -189,7 +185,7 @@ public class SelectStatementTest {
   public void testMath2() {
     final SimpleNode result = checkRightSyntax("" + "select * from sqlSelectIndexReuseTestClass where prop1 = foo + 1");
     // result.dump("    ");
-    assertTrue(result instanceof SelectStatement);
+    assertThat(result instanceof SelectStatement).isTrue();
 
   }
 
@@ -197,7 +193,7 @@ public class SelectStatementTest {
   public void testMath5() {
     final SimpleNode result = checkRightSyntax("" + "select * from sqlSelectIndexReuseTestClass where prop1 = foo + 1 * bar - 5");
 
-    assertTrue(result instanceof SelectStatement);
+    assertThat(result instanceof SelectStatement).isTrue();
 
   }
 
@@ -205,7 +201,7 @@ public class SelectStatementTest {
   public void testContainsWithCondition() {
     final SimpleNode result = checkRightSyntax("select from Profile where customReferences.values() CONTAINS 'a'");
 
-    assertTrue(result instanceof SelectStatement);
+    assertThat(result instanceof SelectStatement).isTrue();
 
   }
 
@@ -213,7 +209,7 @@ public class SelectStatementTest {
   public void testNamedParam() {
     final SimpleNode result = checkRightSyntax("select from JavaComplexTestClass where enumField = :enumItem");
 
-    assertTrue(result instanceof SelectStatement);
+    assertThat(result instanceof SelectStatement).isTrue();
 
   }
 
@@ -221,7 +217,7 @@ public class SelectStatementTest {
   public void testBoolean() {
     final SimpleNode result = checkRightSyntax("select from Foo where bar = true");
     // result.dump("    ");
-    assertTrue(result instanceof SelectStatement);
+    assertThat(result instanceof SelectStatement).isTrue();
 
   }
 
@@ -229,14 +225,14 @@ public class SelectStatementTest {
   public void testDottedAtField() {
     final SimpleNode result = checkRightSyntax("select from City where country.@type = 'Country'");
     // result.dump("    ");
-    assertTrue(result instanceof SelectStatement);
+    assertThat(result instanceof SelectStatement).isTrue();
 
   }
 
   @Test
   public void testQuotedFieldNameFrom() {
     final SimpleNode result = checkRightSyntax("select `from` from City where country.@type = 'Country'");
-    assertTrue(result instanceof SelectStatement);
+    assertThat(result instanceof SelectStatement).isTrue();
 
   }
 
@@ -257,7 +253,7 @@ public class SelectStatementTest {
   public void testLongDotted() {
     final SimpleNode result = checkRightSyntax("select from Profile where location.city.country.name = 'Spain'");
     // result.dump("    ");
-    assertTrue(result instanceof SelectStatement);
+    assertThat(result instanceof SelectStatement).isTrue();
 
   }
 
@@ -265,7 +261,7 @@ public class SelectStatementTest {
   public void testInIsNotAReservedWord() {
     final SimpleNode result = checkRightSyntax("select count(*) from TRVertex where in.type() not in [\"LINKSET\"] ");
     // result.dump("    ");
-    assertTrue(result instanceof SelectStatement);
+    assertThat(result instanceof SelectStatement).isTrue();
 
   }
 
@@ -273,13 +269,13 @@ public class SelectStatementTest {
   public void testSelectFunction() {
     final SimpleNode result = checkRightSyntax("select max(1,2,7,0,-2,3), 'pluto'");
     // result.dump("    ");
-    assertTrue(result instanceof SelectWithoutTargetStatement);
+    assertThat(result instanceof SelectWithoutTargetStatement).isTrue();
   }
 
   @Test
   public void testEscape1() {
     final SimpleNode result = checkRightSyntax("select from bucket:internal where \"\\u005C\\u005C\" = \"\\u005C\\u005C\" ");
-    assertTrue(result instanceof SelectStatement);
+    assertThat(result instanceof SelectStatement).isTrue();
   }
 
   @Test
@@ -299,9 +295,9 @@ public class SelectStatementTest {
 
       final StringBuilder parsed = new StringBuilder();
       stm.toString(params, parsed);
-      assertEquals(parsed.toString(), "SELECT FROM bar WHERE name NOT IN []");
+      assertThat(parsed.toString()).isEqualTo("SELECT FROM bar WHERE name NOT IN []");
     } catch (final Exception e) {
-      fail();
+      fail("");
     }
   }
 
@@ -309,7 +305,7 @@ public class SelectStatementTest {
   public void testEscape2() {
     try {
       checkWrongSyntax("select from bucket:internal where \"\\u005C\" = \"\\u005C\" ");
-      fail();
+      fail("");
     } catch (final Error e) {
       // EXPECTED
     }
@@ -548,10 +544,10 @@ public class SelectStatementTest {
   public void testFlatten() {
     final SelectStatement stm = (SelectStatement) checkRightSyntax("select from ouser where name = 'foo'");
     final List<AndBlock> flattened = stm.whereClause.flatten();
-    assertTrue(((BinaryCondition) flattened.get(0).subBlocks.get(0)).left.isBaseIdentifier());
-    assertFalse(((BinaryCondition) flattened.get(0).subBlocks.get(0)).right.isBaseIdentifier());
-    assertFalse(((BinaryCondition) flattened.get(0).subBlocks.get(0)).left.isEarlyCalculated(new BasicCommandContext()));
-    assertTrue(((BinaryCondition) flattened.get(0).subBlocks.get(0)).right.isEarlyCalculated(new BasicCommandContext()));
+    assertThat(((BinaryCondition) flattened.get(0).subBlocks.get(0)).left.isBaseIdentifier()).isTrue();
+    assertThat(((BinaryCondition) flattened.get(0).subBlocks.get(0)).right.isBaseIdentifier()).isFalse();
+    assertThat(((BinaryCondition) flattened.get(0).subBlocks.get(0)).left.isEarlyCalculated(new BasicCommandContext())).isFalse();
+    assertThat(((BinaryCondition) flattened.get(0).subBlocks.get(0)).right.isEarlyCalculated(new BasicCommandContext())).isTrue();
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/StatementCacheTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/StatementCacheTest.java
@@ -18,8 +18,9 @@
  */
 package com.arcadedb.query.sql.parser;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class StatementCacheTest {
 
@@ -30,15 +31,15 @@ public class StatementCacheTest {
     cache.get("select from bar");
     cache.get("select from baz");
 
-    Assertions.assertTrue(cache.contains("select from bar"));
-    Assertions.assertTrue(cache.contains("select from baz"));
-    Assertions.assertFalse(cache.contains("select from foo"));
+    assertThat(cache.contains("select from bar")).isTrue();
+    assertThat(cache.contains("select from baz")).isTrue();
+    assertThat(cache.contains("select from foo")).isFalse();
 
     cache.get("select from bar");
     cache.get("select from foo");
 
-    Assertions.assertTrue(cache.contains("select from bar"));
-    Assertions.assertTrue(cache.contains("select from foo"));
-    Assertions.assertFalse(cache.contains("select from baz"));
+    assertThat(cache.contains("select from bar")).isTrue();
+    assertThat(cache.contains("select from foo")).isTrue();
+    assertThat(cache.contains("select from baz")).isFalse();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/TraverseStatementTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/TraverseStatementTest.java
@@ -20,9 +20,10 @@ package com.arcadedb.query.sql.parser;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 public class TraverseStatementTest {
 
@@ -45,7 +46,7 @@ public class TraverseStatementTest {
         //          System.out.println(result.toString());
         //          System.out.println("............");
         //        }
-        fail();
+        fail("");
       }
 
       return result;
@@ -53,7 +54,7 @@ public class TraverseStatementTest {
       if (isCorrect) {
         System.out.println(query);
         e.printStackTrace();
-        fail();
+        fail("");
       }
     }
     return null;

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/UpdateEdgeStatementTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/UpdateEdgeStatementTest.java
@@ -20,9 +20,10 @@ package com.arcadedb.query.sql.parser;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 public class UpdateEdgeStatementTest {
   protected SimpleNode checkRightSyntax(final String query) {
@@ -39,14 +40,14 @@ public class UpdateEdgeStatementTest {
     try {
       final SimpleNode result = osql.Parse();
       if (!isCorrect) {
-        fail();
+        fail("");
       }
 
       return result;
     } catch (final Exception e) {
       if (isCorrect) {
         e.printStackTrace();
-        fail();
+        fail("");
       }
     }
     return null;

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/UpdateStatementTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/UpdateStatementTest.java
@@ -20,9 +20,10 @@ package com.arcadedb.query.sql.parser;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 public class UpdateStatementTest {
 
@@ -46,7 +47,7 @@ public class UpdateStatementTest {
         //          System.out.println(result.toString());
         //          System.out.println("............");
         //        }
-        fail();
+        fail("");
       }
       //      System.out.println(query);
       //      System.out.println("->");
@@ -58,7 +59,7 @@ public class UpdateStatementTest {
       if (isCorrect) {
         //System.out.println(query);
         e.printStackTrace();
-        fail();
+        fail("");
       }
     }
     return null;

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsConditionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsConditionTest.java
@@ -23,8 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luigi Dell'Aquila (luigi.dellaquila-(at)-gmail.com)
@@ -34,22 +33,22 @@ public class ContainsConditionTest {
   public void test() {
     final ContainsCondition op = new ContainsCondition(-1);
 
-    assertFalse(op.execute(null, null));
-    assertFalse(op.execute(null, "foo"));
+    assertThat(op.execute(null, null)).isFalse();
+    assertThat(op.execute(null, "foo")).isFalse();
 
     final List<Object> left = new ArrayList<Object>();
-    assertFalse(op.execute(left, "foo"));
-    assertFalse(op.execute(left, null));
+    assertThat(op.execute(left, "foo")).isFalse();
+    assertThat(op.execute(left, null)).isFalse();
 
     left.add("foo");
     left.add("bar");
 
-    assertTrue(op.execute(left, "foo"));
-    assertTrue(op.execute(left, "bar"));
-    assertFalse(op.execute(left, "fooz"));
+    assertThat(op.execute(left, "foo")).isTrue();
+    assertThat(op.execute(left, "bar")).isTrue();
+    assertThat(op.execute(left, "fooz")).isFalse();
 
     left.add(null);
-    assertTrue(op.execute(left, null));
+    assertThat(op.execute(left, null)).isTrue();
   }
 
   @Test
@@ -73,6 +72,6 @@ public class ContainsConditionTest {
     };
 
     final ContainsCondition op = new ContainsCondition(-1);
-    assertTrue(op.execute(left, right));
+    assertThat(op.execute(left, right)).isTrue();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsKeyOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsKeyOperatorTest.java
@@ -23,8 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luigi Dell'Aquila (luigi.dellaquila-(at)-gmail.com)
@@ -35,18 +34,18 @@ public class ContainsKeyOperatorTest {
     public void test() {
         final ContainsKeyOperator op = new ContainsKeyOperator(-1);
 
-        assertFalse(op.execute(null, null, null));
-        assertFalse(op.execute(null, null, "foo"));
+      assertThat(op.execute(null, null, null)).isFalse();
+      assertThat(op.execute(null, null, "foo")).isFalse();
 
         final Map<Object, Object> originMap = new HashMap<Object, Object>();
-        assertFalse(op.execute(null, originMap, "foo"));
-        assertFalse(op.execute(null, originMap, null));
+      assertThat(op.execute(null, originMap, "foo")).isFalse();
+      assertThat(op.execute(null, originMap, null)).isFalse();
 
         originMap.put("foo", "bar");
         originMap.put(1, "baz");
 
-        assertTrue(op.execute(null, originMap, "foo"));
-        assertTrue(op.execute(null, originMap, 1));
-        assertFalse(op.execute(null, originMap, "fooz"));
+      assertThat(op.execute(null, originMap, "foo")).isTrue();
+      assertThat(op.execute(null, originMap, 1)).isTrue();
+      assertThat(op.execute(null, originMap, "fooz")).isFalse();
     }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsValueOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsValueOperatorTest.java
@@ -19,10 +19,11 @@
 package com.arcadedb.query.sql.parser.operators;
 
 import com.arcadedb.query.sql.parser.ContainsValueOperator;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** @author Luigi Dell'Aquila (luigi.dellaquila-(at)-gmail.com) */
 public class ContainsValueOperatorTest {
@@ -30,20 +31,20 @@ public class ContainsValueOperatorTest {
   public void test() {
     final ContainsValueOperator op = new ContainsValueOperator(-1);
 
-    Assertions.assertFalse(op.execute(null,null, null));
-    Assertions.assertFalse(op.execute(null,null, "foo"));
+    assertThat(op.execute(null, null, null)).isFalse();
+    assertThat(op.execute(null, null, "foo")).isFalse();
 
     final Map<Object, Object> originMap = new HashMap<Object, Object>();
-    Assertions.assertFalse(op.execute(null,originMap, "bar"));
-    Assertions.assertFalse(op.execute(null,originMap, null));
+    assertThat(op.execute(null, originMap, "bar")).isFalse();
+    assertThat(op.execute(null, originMap, null)).isFalse();
 
     originMap.put("foo", "bar");
     originMap.put(1, "baz");
     originMap.put(2, 12);
 
-    Assertions.assertTrue(op.execute(null,originMap, "bar"));
-    Assertions.assertTrue(op.execute(null,originMap, "baz"));
-    Assertions.assertTrue(op.execute(null,originMap, 12));
-    Assertions.assertFalse(op.execute(null,originMap, "asdfafsd"));
+    assertThat(op.execute(null, originMap, "bar")).isTrue();
+    assertThat(op.execute(null, originMap, "baz")).isTrue();
+    assertThat(op.execute(null, originMap, 12)).isTrue();
+    assertThat(op.execute(null, originMap, "asdfafsd")).isFalse();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/EqualsCompareOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/EqualsCompareOperatorTest.java
@@ -20,11 +20,12 @@ package com.arcadedb.query.sql.parser.operators;
 
 import com.arcadedb.database.RID;
 import com.arcadedb.query.sql.parser.EqualsCompareOperator;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.math.*;
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luigi Dell'Aquila (luigi.dellaquila-(at)-gmail.com)
@@ -34,42 +35,42 @@ public class EqualsCompareOperatorTest {
   public void test() {
     final EqualsCompareOperator op = new EqualsCompareOperator(-1);
 
-    Assertions.assertFalse(op.execute(null, null, 1));
-    Assertions.assertFalse(op.execute(null, 1, null));
-    Assertions.assertFalse(op.execute(null, null, null));
+    assertThat(op.execute(null, null, 1)).isFalse();
+    assertThat(op.execute(null, 1, null)).isFalse();
+    assertThat(op.execute(null, null, null)).isFalse();
 
-    Assertions.assertTrue(op.execute(null, 1, 1));
-    Assertions.assertFalse(op.execute(null, 1, 0));
-    Assertions.assertFalse(op.execute(null, 0, 1));
+    assertThat(op.execute(null, 1, 1)).isTrue();
+    assertThat(op.execute(null, 1, 0)).isFalse();
+    assertThat(op.execute(null, 0, 1)).isFalse();
 
-    Assertions.assertFalse(op.execute(null, "aaa", "zzz"));
-    Assertions.assertFalse(op.execute(null, "zzz", "aaa"));
-    Assertions.assertTrue(op.execute(null, "aaa", "aaa"));
+    assertThat(op.execute(null, "aaa", "zzz")).isFalse();
+    assertThat(op.execute(null, "zzz", "aaa")).isFalse();
+    assertThat(op.execute(null, "aaa", "aaa")).isTrue();
 
-    Assertions.assertFalse(op.execute(null, 1, 1.1));
-    Assertions.assertFalse(op.execute(null, 1.1, 1));
+    assertThat(op.execute(null, 1, 1.1)).isFalse();
+    assertThat(op.execute(null, 1.1, 1)).isFalse();
 
-    Assertions.assertTrue(op.execute(null, BigDecimal.ONE, 1));
-    Assertions.assertTrue(op.execute(null, 1, BigDecimal.ONE));
+    assertThat(op.execute(null, BigDecimal.ONE, 1)).isTrue();
+    assertThat(op.execute(null, 1, BigDecimal.ONE)).isTrue();
 
-    Assertions.assertFalse(op.execute(null, 1.1, BigDecimal.ONE));
-    Assertions.assertFalse(op.execute(null, 2, BigDecimal.ONE));
+    assertThat(op.execute(null, 1.1, BigDecimal.ONE)).isFalse();
+    assertThat(op.execute(null, 2, BigDecimal.ONE)).isFalse();
 
-    Assertions.assertFalse(op.execute(null, BigDecimal.ONE, 0.999999));
-    Assertions.assertFalse(op.execute(null, BigDecimal.ONE, 0));
+    assertThat(op.execute(null, BigDecimal.ONE, 0.999999)).isFalse();
+    assertThat(op.execute(null, BigDecimal.ONE, 0)).isFalse();
 
-    Assertions.assertFalse(op.execute(null, BigDecimal.ONE, 2));
-    Assertions.assertFalse(op.execute(null, BigDecimal.ONE, 1.0001));
+    assertThat(op.execute(null, BigDecimal.ONE, 2)).isFalse();
+    assertThat(op.execute(null, BigDecimal.ONE, 1.0001)).isFalse();
 
-    Assertions.assertTrue(op.execute(null, new RID( 1, 10), new RID( (short) 1, 10)));
-    Assertions.assertFalse(op.execute(null, new RID( 1, 10), new RID( (short) 1, 20)));
+    assertThat(op.execute(null, new RID( 1, 10), new RID( (short) 1, 10))).isTrue();
+    assertThat(op.execute(null, new RID( 1, 10), new RID( (short) 1, 20))).isFalse();
 
-    Assertions.assertFalse(op.execute(null, new Object(), new Object()));
+    assertThat(op.execute(null, new Object(), new Object())).isFalse();
 
     // MAPS
-    Assertions.assertTrue(op.execute(null, Map.of("a", "b"), Map.of("a", "b")));
+    assertThat(op.execute(null, Map.of("a", "b"), Map.of("a", "b"))).isTrue();
 
-    Assertions.assertTrue(op.execute(null, Map.of("a", "b", "c", 3), Map.of("a", "b", "c", 3)));
-    Assertions.assertFalse(op.execute(null, Map.of("a", "b", "c", 3), Map.of("a", "b")));
+    assertThat(op.execute(null, Map.of("a", "b", "c", 3), Map.of("a", "b", "c", 3))).isTrue();
+    assertThat(op.execute(null, Map.of("a", "b", "c", 3), Map.of("a", "b"))).isFalse();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/GeOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/GeOperatorTest.java
@@ -19,10 +19,12 @@
 package com.arcadedb.query.sql.parser.operators;
 
 import com.arcadedb.query.sql.parser.GeOperator;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.math.*;
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Luigi Dell'Aquila (luigi.dellaquila-(at)-gmail.com)
@@ -31,32 +33,32 @@ public class GeOperatorTest {
   @Test
   public void test() {
     final GeOperator op = new GeOperator(-1);
-    Assertions.assertTrue(op.execute(null, 1, 1));
-    Assertions.assertTrue(op.execute(null, 1, 0));
-    Assertions.assertFalse(op.execute(null, 0, 1));
+    assertThat(op.execute(null, 1, 1)).isTrue();
+    assertThat(op.execute(null, 1, 0)).isTrue();
+    assertThat(op.execute(null, 0, 1)).isFalse();
 
-    Assertions.assertFalse(op.execute(null, "aaa", "zzz"));
-    Assertions.assertTrue(op.execute(null, "zzz", "aaa"));
+    assertThat(op.execute(null, "aaa", "zzz")).isFalse();
+    assertThat(op.execute(null, "zzz", "aaa")).isTrue();
 
-    Assertions.assertFalse(op.execute(null, 1, 1.1));
-    Assertions.assertTrue(op.execute(null, 1.1, 1));
+    assertThat(op.execute(null, 1, 1.1)).isFalse();
+    assertThat(op.execute(null, 1.1, 1)).isTrue();
 
-    Assertions.assertTrue(op.execute(null, BigDecimal.ONE, 1));
-    Assertions.assertTrue(op.execute(null, 1, BigDecimal.ONE));
+    assertThat(op.execute(null, BigDecimal.ONE, 1)).isTrue();
+    assertThat(op.execute(null, 1, BigDecimal.ONE)).isTrue();
 
-    Assertions.assertTrue(op.execute(null, 1.1, BigDecimal.ONE));
-    Assertions.assertTrue(op.execute(null, 2, BigDecimal.ONE));
+    assertThat(op.execute(null, 1.1, BigDecimal.ONE)).isTrue();
+    assertThat(op.execute(null, 2, BigDecimal.ONE)).isTrue();
 
-    Assertions.assertTrue(op.execute(null, BigDecimal.ONE, 0.999999));
-    Assertions.assertTrue(op.execute(null, BigDecimal.ONE, 0));
+    assertThat(op.execute(null, BigDecimal.ONE, 0.999999)).isTrue();
+    assertThat(op.execute(null, BigDecimal.ONE, 0)).isTrue();
 
-    Assertions.assertFalse(op.execute(null, BigDecimal.ONE, 2));
-    Assertions.assertFalse(op.execute(null, BigDecimal.ONE, 1.0001));
+    assertThat(op.execute(null, BigDecimal.ONE, 2)).isFalse();
+    assertThat(op.execute(null, BigDecimal.ONE, 1.0001)).isFalse();
     try {
-      Assertions.assertFalse(op.execute(null, new Object(), new Object()));
-      Assertions.fail();
+      assertThat(op.execute(null, new Object(), new Object())).isFalse();
+      fail("");
     } catch (final Exception e) {
-      Assertions.assertTrue(e instanceof ClassCastException);
+      assertThat(e instanceof ClassCastException).isTrue();
     }
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/GtOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/GtOperatorTest.java
@@ -19,10 +19,11 @@
 package com.arcadedb.query.sql.parser.operators;
 
 import com.arcadedb.query.sql.parser.GtOperator;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.math.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luigi Dell'Aquila (luigi.dellaquila-(at)-gmail.com)
@@ -31,33 +32,33 @@ public class GtOperatorTest {
   @Test
   public void test() {
     final GtOperator op = new GtOperator(-1);
-    Assertions.assertFalse(op.execute(null, 1, 1));
-    Assertions.assertTrue(op.execute(null, 1, 0));
-    Assertions.assertFalse(op.execute(null, 0, 1));
+    assertThat(op.execute(null, 1, 1)).isFalse();
+    assertThat(op.execute(null, 1, 0)).isTrue();
+    assertThat(op.execute(null, 0, 1)).isFalse();
 
-    Assertions.assertFalse(op.execute(null, "aaa", "zzz"));
-    Assertions.assertTrue(op.execute(null, "zzz", "aaa"));
+    assertThat(op.execute(null, "aaa", "zzz")).isFalse();
+    assertThat(op.execute(null, "zzz", "aaa")).isTrue();
 
-    Assertions.assertFalse(op.execute(null, "aaa", "aaa"));
+    assertThat(op.execute(null, "aaa", "aaa")).isFalse();
 
-    Assertions.assertFalse(op.execute(null, 1, 1.1));
-    Assertions.assertTrue(op.execute(null, 1.1, 1));
+    assertThat(op.execute(null, 1, 1.1)).isFalse();
+    assertThat(op.execute(null, 1.1, 1)).isTrue();
 
-    Assertions.assertFalse(op.execute(null, BigDecimal.ONE, 1));
-    Assertions.assertFalse(op.execute(null, 1, BigDecimal.ONE));
+    assertThat(op.execute(null, BigDecimal.ONE, 1)).isFalse();
+    assertThat(op.execute(null, 1, BigDecimal.ONE)).isFalse();
 
-    Assertions.assertFalse(op.execute(null, 1.1, 1.1));
-    Assertions.assertFalse(op.execute(null, new BigDecimal(15), new BigDecimal(15)));
+    assertThat(op.execute(null, 1.1, 1.1)).isFalse();
+    assertThat(op.execute(null, new BigDecimal(15), new BigDecimal(15))).isFalse();
 
-    Assertions.assertTrue(op.execute(null, 1.1, BigDecimal.ONE));
-    Assertions.assertTrue(op.execute(null, 2, BigDecimal.ONE));
+    assertThat(op.execute(null, 1.1, BigDecimal.ONE)).isTrue();
+    assertThat(op.execute(null, 2, BigDecimal.ONE)).isTrue();
 
-    Assertions.assertTrue(op.execute(null, BigDecimal.ONE, 0.999999));
-    Assertions.assertTrue(op.execute(null, BigDecimal.ONE, 0));
+    assertThat(op.execute(null, BigDecimal.ONE, 0.999999)).isTrue();
+    assertThat(op.execute(null, BigDecimal.ONE, 0)).isTrue();
 
-    Assertions.assertFalse(op.execute(null, BigDecimal.ONE, 2));
-    Assertions.assertFalse(op.execute(null, BigDecimal.ONE, 1.0001));
+    assertThat(op.execute(null, BigDecimal.ONE, 2)).isFalse();
+    assertThat(op.execute(null, BigDecimal.ONE, 1.0001)).isFalse();
 
-    Assertions.assertFalse(op.execute(null, new Object(), new Object()));
+    assertThat(op.execute(null, new Object(), new Object())).isFalse();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ILikeOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ILikeOperatorTest.java
@@ -20,8 +20,9 @@ package com.arcadedb.query.sql.parser.operators;
 
 import com.arcadedb.query.sql.executor.QueryHelper;
 import com.arcadedb.query.sql.parser.ILikeOperator;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luigi Dell'Aquila (luigi.dellaquila-(at)-gmail.com)
@@ -30,22 +31,22 @@ public class ILikeOperatorTest {
   @Test
   public void test() {
     final ILikeOperator op = new ILikeOperator(-1);
-    Assertions.assertTrue(op.execute(null, "FOOBAR", "%ooba%"));
-    Assertions.assertTrue(op.execute(null, "FOOBAR", "%oo%"));
-    Assertions.assertFalse(op.execute(null, "FOOBAR", "oo%"));
-    Assertions.assertFalse(op.execute(null, "FOOBAR", "%oo"));
-    Assertions.assertFalse(op.execute(null, "FOOBAR", "%fff%"));
-    Assertions.assertTrue(op.execute(null, "FOOBAR", "foobar"));
-    Assertions.assertTrue(op.execute(null, "100%", "100\\%"));
-    Assertions.assertTrue(op.execute(null, "100%", "100%"));
-    Assertions.assertTrue(op.execute(null, "", ""));
-    Assertions.assertTrue(op.execute(null, "100?", "100\\?"));
-    Assertions.assertTrue(op.execute(null, "100?", "100?"));
-    Assertions.assertTrue(op.execute(null, "abc\ndef", "%E%"));
+    assertThat(op.execute(null, "FOOBAR", "%ooba%")).isTrue();
+    assertThat(op.execute(null, "FOOBAR", "%oo%")).isTrue();
+    assertThat(op.execute(null, "FOOBAR", "oo%")).isFalse();
+    assertThat(op.execute(null, "FOOBAR", "%oo")).isFalse();
+    assertThat(op.execute(null, "FOOBAR", "%fff%")).isFalse();
+    assertThat(op.execute(null, "FOOBAR", "foobar")).isTrue();
+    assertThat(op.execute(null, "100%", "100\\%")).isTrue();
+    assertThat(op.execute(null, "100%", "100%")).isTrue();
+    assertThat(op.execute(null, "", "")).isTrue();
+    assertThat(op.execute(null, "100?", "100\\?")).isTrue();
+    assertThat(op.execute(null, "100?", "100?")).isTrue();
+    assertThat(op.execute(null, "abc\ndef", "%E%")).isTrue();
   }
 
   @Test
   public void replaceSpecialCharacters() {
-    Assertions.assertEquals("(?s)\\\\\\[\\]\\{\\}\\(\\)\\|\\*\\+\\$\\^\\...*", QueryHelper.convertForRegExp("\\[]{}()|*+$^.?%"));
+    assertThat(QueryHelper.convertForRegExp("\\[]{}()|*+$^.?%")).isEqualTo("(?s)\\\\\\[\\]\\{\\}\\(\\)\\|\\*\\+\\$\\^\\...*");
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/InOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/InOperatorTest.java
@@ -19,10 +19,11 @@
 package com.arcadedb.query.sql.parser.operators;
 
 import com.arcadedb.query.sql.parser.InOperator;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luigi Dell'Aquila (luigi.dellaquila-(at)-gmail.com)
@@ -32,22 +33,22 @@ public class InOperatorTest {
   public void test() {
     final InOperator op = new InOperator(-1);
 
-    Assertions.assertFalse(op.execute(null, null, null));
-    Assertions.assertFalse(op.execute(null, null, "foo"));
-    Assertions.assertFalse(op.execute(null, "foo", null));
-    Assertions.assertFalse(op.execute(null, "foo", "foo"));
+    assertThat(op.execute(null, null, null)).isFalse();
+    assertThat(op.execute(null, null, "foo")).isFalse();
+    assertThat(op.execute(null, "foo", null)).isFalse();
+    assertThat(op.execute(null, "foo", "foo")).isFalse();
 
     final List<Object> list1 = new ArrayList<Object>();
-    Assertions.assertFalse(op.execute(null, "foo", list1));
-    Assertions.assertFalse(op.execute(null, null, list1));
-    Assertions.assertTrue(op.execute(null, list1, list1));
+    assertThat(op.execute(null, "foo", list1)).isFalse();
+    assertThat(op.execute(null, null, list1)).isFalse();
+    assertThat(op.execute(null, list1, list1)).isTrue();
 
     list1.add("a");
     list1.add(1);
 
-    Assertions.assertFalse(op.execute(null, "foo", list1));
-    Assertions.assertTrue(op.execute(null, "a", list1));
-    Assertions.assertTrue(op.execute(null, 1, list1));
+    assertThat(op.execute(null, "foo", list1)).isFalse();
+    assertThat(op.execute(null, "a", list1)).isTrue();
+    assertThat(op.execute(null, 1, list1)).isTrue();
 
     // TODO
   }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/LeOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/LeOperatorTest.java
@@ -19,10 +19,12 @@
 package com.arcadedb.query.sql.parser.operators;
 
 import com.arcadedb.query.sql.parser.LeOperator;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.math.*;
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Luigi Dell'Aquila (luigi.dellaquila-(at)-gmail.com)
@@ -31,32 +33,32 @@ public class LeOperatorTest {
   @Test
   public void test() {
     final LeOperator op = new LeOperator(-1);
-    Assertions.assertTrue(op.execute(null, 1, 1));
-    Assertions.assertFalse(op.execute(null, 1, 0));
-    Assertions.assertTrue(op.execute(null, 0, 1));
+    assertThat(op.execute(null, 1, 1)).isTrue();
+    assertThat(op.execute(null, 1, 0)).isFalse();
+    assertThat(op.execute(null, 0, 1)).isTrue();
 
-    Assertions.assertTrue(op.execute(null, "aaa", "zzz"));
-    Assertions.assertFalse(op.execute(null, "zzz", "aaa"));
+    assertThat(op.execute(null, "aaa", "zzz")).isTrue();
+    assertThat(op.execute(null, "zzz", "aaa")).isFalse();
 
-    Assertions.assertTrue(op.execute(null, 1, 1.1));
-    Assertions.assertFalse(op.execute(null, 1.1, 1));
+    assertThat(op.execute(null, 1, 1.1)).isTrue();
+    assertThat(op.execute(null, 1.1, 1)).isFalse();
 
-    Assertions.assertTrue(op.execute(null, BigDecimal.ONE, 1));
-    Assertions.assertTrue(op.execute(null, 1, BigDecimal.ONE));
+    assertThat(op.execute(null, BigDecimal.ONE, 1)).isTrue();
+    assertThat(op.execute(null, 1, BigDecimal.ONE)).isTrue();
 
-    Assertions.assertFalse(op.execute(null, 1.1, BigDecimal.ONE));
-    Assertions.assertFalse(op.execute(null, 2, BigDecimal.ONE));
+    assertThat(op.execute(null, 1.1, BigDecimal.ONE)).isFalse();
+    assertThat(op.execute(null, 2, BigDecimal.ONE)).isFalse();
 
-    Assertions.assertFalse(op.execute(null, BigDecimal.ONE, 0.999999));
-    Assertions.assertFalse(op.execute(null, BigDecimal.ONE, 0));
+    assertThat(op.execute(null, BigDecimal.ONE, 0.999999)).isFalse();
+    assertThat(op.execute(null, BigDecimal.ONE, 0)).isFalse();
 
-    Assertions.assertTrue(op.execute(null, BigDecimal.ONE, 2));
-    Assertions.assertTrue(op.execute(null, BigDecimal.ONE, 1.0001));
+    assertThat(op.execute(null, BigDecimal.ONE, 2)).isTrue();
+    assertThat(op.execute(null, BigDecimal.ONE, 1.0001)).isTrue();
     try {
-      Assertions.assertFalse(op.execute(null, new Object(), new Object()));
-      Assertions.fail();
+      assertThat(op.execute(null, new Object(), new Object())).isFalse();
+      fail("");
     } catch (final Exception e) {
-      Assertions.assertTrue(e instanceof ClassCastException);
+      assertThat(e instanceof ClassCastException).isTrue();
     }
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/LikeOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/LikeOperatorTest.java
@@ -20,8 +20,9 @@ package com.arcadedb.query.sql.parser.operators;
 
 import com.arcadedb.query.sql.executor.QueryHelper;
 import com.arcadedb.query.sql.parser.LikeOperator;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luigi Dell'Aquila (luigi.dellaquila-(at)-gmail.com)
@@ -30,22 +31,22 @@ public class LikeOperatorTest {
   @Test
   public void test() {
     final LikeOperator op = new LikeOperator(-1);
-    Assertions.assertTrue(op.execute(null, "foobar", "%ooba%"));
-    Assertions.assertTrue(op.execute(null, "foobar", "%oo%"));
-    Assertions.assertFalse(op.execute(null, "foobar", "oo%"));
-    Assertions.assertFalse(op.execute(null, "foobar", "%oo"));
-    Assertions.assertFalse(op.execute(null, "foobar", "%fff%"));
-    Assertions.assertTrue(op.execute(null, "foobar", "foobar"));
-    Assertions.assertTrue(op.execute(null, "100%", "100\\%"));
-    Assertions.assertTrue(op.execute(null, "100%", "100%"));
-    Assertions.assertTrue(op.execute(null, "", ""));
-    Assertions.assertTrue(op.execute(null, "100?", "100\\?"));
-    Assertions.assertTrue(op.execute(null, "100?", "100?"));
-    Assertions.assertTrue(op.execute(null, "abc\ndef", "%e%"));
+    assertThat(op.execute(null, "foobar", "%ooba%")).isTrue();
+    assertThat(op.execute(null, "foobar", "%oo%")).isTrue();
+    assertThat(op.execute(null, "foobar", "oo%")).isFalse();
+    assertThat(op.execute(null, "foobar", "%oo")).isFalse();
+    assertThat(op.execute(null, "foobar", "%fff%")).isFalse();
+    assertThat(op.execute(null, "foobar", "foobar")).isTrue();
+    assertThat(op.execute(null, "100%", "100\\%")).isTrue();
+    assertThat(op.execute(null, "100%", "100%")).isTrue();
+    assertThat(op.execute(null, "", "")).isTrue();
+    assertThat(op.execute(null, "100?", "100\\?")).isTrue();
+    assertThat(op.execute(null, "100?", "100?")).isTrue();
+    assertThat(op.execute(null, "abc\ndef", "%e%")).isTrue();
   }
 
   @Test
   public void replaceSpecialCharacters() {
-    Assertions.assertEquals("(?s)\\\\\\[\\]\\{\\}\\(\\)\\|\\*\\+\\$\\^\\...*", QueryHelper.convertForRegExp("\\[]{}()|*+$^.?%"));
+    assertThat(QueryHelper.convertForRegExp("\\[]{}()|*+$^.?%")).isEqualTo("(?s)\\\\\\[\\]\\{\\}\\(\\)\\|\\*\\+\\$\\^\\...*");
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/LtOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/LtOperatorTest.java
@@ -19,11 +19,13 @@
 package com.arcadedb.query.sql.parser.operators;
 
 import com.arcadedb.query.sql.parser.LtOperator;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.math.*;
-import java.util.*;
+import java.math.BigDecimal;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Luigi Dell'Aquila (luigi.dellaquila-(at)-gmail.com)
@@ -32,45 +34,45 @@ public class LtOperatorTest {
   @Test
   public void test() {
     final LtOperator op = new LtOperator(-1);
-    Assertions.assertFalse(op.execute(null, 1, 1));
-    Assertions.assertFalse(op.execute(null, 1, 0));
-    Assertions.assertTrue(op.execute(null, 0, 1));
+    assertThat(op.execute(null, 1, 1)).isFalse();
+    assertThat(op.execute(null, 1, 0)).isFalse();
+    assertThat(op.execute(null, 0, 1)).isTrue();
 
-    Assertions.assertTrue(op.execute(null, "aaa", "zzz"));
-    Assertions.assertFalse(op.execute(null, "zzz", "aaa"));
+    assertThat(op.execute(null, "aaa", "zzz")).isTrue();
+    assertThat(op.execute(null, "zzz", "aaa")).isFalse();
 
-    Assertions.assertFalse(op.execute(null, "aaa", "aaa"));
+    assertThat(op.execute(null, "aaa", "aaa")).isFalse();
 
-    Assertions.assertTrue(op.execute(null, 1, 1.1));
-    Assertions.assertFalse(op.execute(null, 1.1, 1));
+    assertThat(op.execute(null, 1, 1.1)).isTrue();
+    assertThat(op.execute(null, 1.1, 1)).isFalse();
 
-    Assertions.assertFalse(op.execute(null, BigDecimal.ONE, 1));
-    Assertions.assertFalse(op.execute(null, 1, BigDecimal.ONE));
+    assertThat(op.execute(null, BigDecimal.ONE, 1)).isFalse();
+    assertThat(op.execute(null, 1, BigDecimal.ONE)).isFalse();
 
-    Assertions.assertFalse(op.execute(null, 1.1, 1.1));
-    Assertions.assertFalse(op.execute(null, new BigDecimal(15), new BigDecimal(15)));
+    assertThat(op.execute(null, 1.1, 1.1)).isFalse();
+    assertThat(op.execute(null, new BigDecimal(15), new BigDecimal(15))).isFalse();
 
-    Assertions.assertFalse(op.execute(null, 1.1, BigDecimal.ONE));
-    Assertions.assertFalse(op.execute(null, 2, BigDecimal.ONE));
+    assertThat(op.execute(null, 1.1, BigDecimal.ONE)).isFalse();
+    assertThat(op.execute(null, 2, BigDecimal.ONE)).isFalse();
 
-    Assertions.assertFalse(op.execute(null, BigDecimal.ONE, 0.999999));
-    Assertions.assertFalse(op.execute(null, BigDecimal.ONE, 0));
+    assertThat(op.execute(null, BigDecimal.ONE, 0.999999)).isFalse();
+    assertThat(op.execute(null, BigDecimal.ONE, 0)).isFalse();
 
-    Assertions.assertTrue(op.execute(null, BigDecimal.ONE, 2));
-    Assertions.assertTrue(op.execute(null, BigDecimal.ONE, 1.0001));
+    assertThat(op.execute(null, BigDecimal.ONE, 2)).isTrue();
+    assertThat(op.execute(null, BigDecimal.ONE, 1.0001)).isTrue();
     try {
-      Assertions.assertTrue(op.execute(null, new Object(), new Object()));
-      Assertions.fail();
+      assertThat(op.execute(null, new Object(), new Object())).isTrue();
+      fail("");
     } catch (final Exception e) {
-      Assertions.assertTrue(e instanceof ClassCastException);
+      assertThat(e instanceof ClassCastException).isTrue();
     }
 
     // MAPS
-    Assertions.assertFalse(op.execute(null, Map.of("a", "b"), Map.of("a", "b")));
+    assertThat(op.execute(null, Map.of("a", "b"), Map.of("a", "b"))).isFalse();
 
-    Assertions.assertFalse(op.execute(null, Map.of("a", "b", "c", 3), Map.of("a", "b", "c", 3)));
-    Assertions.assertFalse(op.execute(null, Map.of("a", "b", "c", 3), Map.of("a", "b")));
+    assertThat(op.execute(null, Map.of("a", "b", "c", 3), Map.of("a", "b", "c", 3))).isFalse();
+    assertThat(op.execute(null, Map.of("a", "b", "c", 3), Map.of("a", "b"))).isFalse();
 
-    Assertions.assertTrue(op.execute(null, Map.of("a", "b"), Map.of("a", "b", "c", 3)));
+    assertThat(op.execute(null, Map.of("a", "b"), Map.of("a", "b", "c", 3))).isTrue();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/NeOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/NeOperatorTest.java
@@ -20,10 +20,11 @@ package com.arcadedb.query.sql.parser.operators;
 
 import com.arcadedb.database.RID;
 import com.arcadedb.query.sql.parser.NeOperator;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.math.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luigi Dell'Aquila (luigi.dellaquila-(at)-gmail.com)
@@ -33,36 +34,36 @@ public class NeOperatorTest {
   public void test() {
     final NeOperator op = new NeOperator(-1);
 
-    Assertions.assertTrue(op.execute(null, null, 1));
-    Assertions.assertTrue(op.execute(null, 1, null));
-    Assertions.assertTrue(op.execute(null, null, null));
+    assertThat(op.execute(null, null, 1)).isTrue();
+    assertThat(op.execute(null, 1, null)).isTrue();
+    assertThat(op.execute(null, null, null)).isTrue();
 
-    Assertions.assertFalse(op.execute(null, 1, 1));
-    Assertions.assertTrue(op.execute(null, 1, 0));
-    Assertions.assertTrue(op.execute(null, 0, 1));
+    assertThat(op.execute(null, 1, 1)).isFalse();
+    assertThat(op.execute(null, 1, 0)).isTrue();
+    assertThat(op.execute(null, 0, 1)).isTrue();
 
-    Assertions.assertTrue(op.execute(null, "aaa", "zzz"));
-    Assertions.assertTrue(op.execute(null, "zzz", "aaa"));
-    Assertions.assertFalse(op.execute(null, "aaa", "aaa"));
+    assertThat(op.execute(null, "aaa", "zzz")).isTrue();
+    assertThat(op.execute(null, "zzz", "aaa")).isTrue();
+    assertThat(op.execute(null, "aaa", "aaa")).isFalse();
 
-    Assertions.assertTrue(op.execute(null, 1, 1.1));
-    Assertions.assertTrue(op.execute(null, 1.1, 1));
+    assertThat(op.execute(null, 1, 1.1)).isTrue();
+    assertThat(op.execute(null, 1.1, 1)).isTrue();
 
-    Assertions.assertFalse(op.execute(null, BigDecimal.ONE, 1));
-    Assertions.assertFalse(op.execute(null, 1, BigDecimal.ONE));
+    assertThat(op.execute(null, BigDecimal.ONE, 1)).isFalse();
+    assertThat(op.execute(null, 1, BigDecimal.ONE)).isFalse();
 
-    Assertions.assertTrue(op.execute(null, 1.1, BigDecimal.ONE));
-    Assertions.assertTrue(op.execute(null, 2, BigDecimal.ONE));
+    assertThat(op.execute(null, 1.1, BigDecimal.ONE)).isTrue();
+    assertThat(op.execute(null, 2, BigDecimal.ONE)).isTrue();
 
-    Assertions.assertTrue(op.execute(null, BigDecimal.ONE, 0.999999));
-    Assertions.assertTrue(op.execute(null, BigDecimal.ONE, 0));
+    assertThat(op.execute(null, BigDecimal.ONE, 0.999999)).isTrue();
+    assertThat(op.execute(null, BigDecimal.ONE, 0)).isTrue();
 
-    Assertions.assertTrue(op.execute(null, BigDecimal.ONE, 2));
-    Assertions.assertTrue(op.execute(null, BigDecimal.ONE, 1.0001));
+    assertThat(op.execute(null, BigDecimal.ONE, 2)).isTrue();
+    assertThat(op.execute(null, BigDecimal.ONE, 1.0001)).isTrue();
 
-    Assertions.assertFalse(op.execute(null, new RID( 1, 10), new RID( (short) 1, 10)));
-    Assertions.assertTrue(op.execute(null, new RID( 1, 10), new RID( (short) 1, 20)));
+    assertThat(op.execute(null, new RID( 1, 10), new RID( (short) 1, 10))).isFalse();
+    assertThat(op.execute(null, new RID( 1, 10), new RID( (short) 1, 20))).isTrue();
 
-    Assertions.assertTrue(op.execute(null, new Object(), new Object()));
+    assertThat(op.execute(null, new Object(), new Object())).isTrue();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/NeqOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/NeqOperatorTest.java
@@ -20,10 +20,11 @@ package com.arcadedb.query.sql.parser.operators;
 
 import com.arcadedb.database.RID;
 import com.arcadedb.query.sql.parser.NeqOperator;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.math.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luigi Dell'Aquila (luigi.dellaquila-(at)-gmail.com)
@@ -32,36 +33,36 @@ public class NeqOperatorTest {
   @Test
   public void test() {
     final NeqOperator op = new NeqOperator(-1);
-    Assertions.assertTrue(op.execute(null, null, 1));
-    Assertions.assertTrue(op.execute(null, 1, null));
-    Assertions.assertTrue(op.execute(null, null, null));
+    assertThat(op.execute(null, null, 1)).isTrue();
+    assertThat(op.execute(null, 1, null)).isTrue();
+    assertThat(op.execute(null, null, null)).isTrue();
 
-    Assertions.assertFalse(op.execute(null, 1, 1));
-    Assertions.assertTrue(op.execute(null, 1, 0));
-    Assertions.assertTrue(op.execute(null, 0, 1));
+    assertThat(op.execute(null, 1, 1)).isFalse();
+    assertThat(op.execute(null, 1, 0)).isTrue();
+    assertThat(op.execute(null, 0, 1)).isTrue();
 
-    Assertions.assertTrue(op.execute(null, "aaa", "zzz"));
-    Assertions.assertTrue(op.execute(null, "zzz", "aaa"));
-    Assertions.assertFalse(op.execute(null, "aaa", "aaa"));
+    assertThat(op.execute(null, "aaa", "zzz")).isTrue();
+    assertThat(op.execute(null, "zzz", "aaa")).isTrue();
+    assertThat(op.execute(null, "aaa", "aaa")).isFalse();
 
-    Assertions.assertTrue(op.execute(null, 1, 1.1));
-    Assertions.assertTrue(op.execute(null, 1.1, 1));
+    assertThat(op.execute(null, 1, 1.1)).isTrue();
+    assertThat(op.execute(null, 1.1, 1)).isTrue();
 
-    Assertions.assertFalse(op.execute(null, BigDecimal.ONE, 1));
-    Assertions.assertFalse(op.execute(null, 1, BigDecimal.ONE));
+    assertThat(op.execute(null, BigDecimal.ONE, 1)).isFalse();
+    assertThat(op.execute(null, 1, BigDecimal.ONE)).isFalse();
 
-    Assertions.assertTrue(op.execute(null, 1.1, BigDecimal.ONE));
-    Assertions.assertTrue(op.execute(null, 2, BigDecimal.ONE));
+    assertThat(op.execute(null, 1.1, BigDecimal.ONE)).isTrue();
+    assertThat(op.execute(null, 2, BigDecimal.ONE)).isTrue();
 
-    Assertions.assertTrue(op.execute(null, BigDecimal.ONE, 0.999999));
-    Assertions.assertTrue(op.execute(null, BigDecimal.ONE, 0));
+    assertThat(op.execute(null, BigDecimal.ONE, 0.999999)).isTrue();
+    assertThat(op.execute(null, BigDecimal.ONE, 0)).isTrue();
 
-    Assertions.assertTrue(op.execute(null, BigDecimal.ONE, 2));
-    Assertions.assertTrue(op.execute(null, BigDecimal.ONE, 1.0001));
+    assertThat(op.execute(null, BigDecimal.ONE, 2)).isTrue();
+    assertThat(op.execute(null, BigDecimal.ONE, 1.0001)).isTrue();
 
-    Assertions.assertFalse(op.execute(null, new RID( 1, 10), new RID( (short) 1, 10)));
-    Assertions.assertTrue(op.execute(null, new RID( 1, 10), new RID( (short) 1, 20)));
+    assertThat(op.execute(null, new RID( 1, 10), new RID( (short) 1, 10))).isFalse();
+    assertThat(op.execute(null, new RID( 1, 10), new RID( (short) 1, 20))).isTrue();
 
-    Assertions.assertTrue(op.execute(null, new Object(), new Object()));
+    assertThat(op.execute(null, new Object(), new Object())).isTrue();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/NullSafeEqualsCompareOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/NullSafeEqualsCompareOperatorTest.java
@@ -20,10 +20,11 @@ package com.arcadedb.query.sql.parser.operators;
 
 import com.arcadedb.database.RID;
 import com.arcadedb.query.sql.parser.NullSafeEqualsCompareOperator;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.math.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luca Garulli
@@ -33,36 +34,36 @@ public class NullSafeEqualsCompareOperatorTest {
   public void test() {
     final NullSafeEqualsCompareOperator op = new NullSafeEqualsCompareOperator(-1);
 
-    Assertions.assertFalse(op.execute(null, null, 1));
-    Assertions.assertFalse(op.execute(null, 1, null));
-    Assertions.assertTrue(op.execute(null, null, null));
+    assertThat(op.execute(null, null, 1)).isFalse();
+    assertThat(op.execute(null, 1, null)).isFalse();
+    assertThat(op.execute(null, null, null)).isTrue();
 
-    Assertions.assertTrue(op.execute(null, 1, 1));
-    Assertions.assertFalse(op.execute(null, 1, 0));
-    Assertions.assertFalse(op.execute(null, 0, 1));
+    assertThat(op.execute(null, 1, 1)).isTrue();
+    assertThat(op.execute(null, 1, 0)).isFalse();
+    assertThat(op.execute(null, 0, 1)).isFalse();
 
-    Assertions.assertFalse(op.execute(null, "aaa", "zzz"));
-    Assertions.assertFalse(op.execute(null, "zzz", "aaa"));
-    Assertions.assertTrue(op.execute(null, "aaa", "aaa"));
+    assertThat(op.execute(null, "aaa", "zzz")).isFalse();
+    assertThat(op.execute(null, "zzz", "aaa")).isFalse();
+    assertThat(op.execute(null, "aaa", "aaa")).isTrue();
 
-    Assertions.assertFalse(op.execute(null, 1, 1.1));
-    Assertions.assertFalse(op.execute(null, 1.1, 1));
+    assertThat(op.execute(null, 1, 1.1)).isFalse();
+    assertThat(op.execute(null, 1.1, 1)).isFalse();
 
-    Assertions.assertTrue(op.execute(null, BigDecimal.ONE, 1));
-    Assertions.assertTrue(op.execute(null, 1, BigDecimal.ONE));
+    assertThat(op.execute(null, BigDecimal.ONE, 1)).isTrue();
+    assertThat(op.execute(null, 1, BigDecimal.ONE)).isTrue();
 
-    Assertions.assertFalse(op.execute(null, 1.1, BigDecimal.ONE));
-    Assertions.assertFalse(op.execute(null, 2, BigDecimal.ONE));
+    assertThat(op.execute(null, 1.1, BigDecimal.ONE)).isFalse();
+    assertThat(op.execute(null, 2, BigDecimal.ONE)).isFalse();
 
-    Assertions.assertFalse(op.execute(null, BigDecimal.ONE, 0.999999));
-    Assertions.assertFalse(op.execute(null, BigDecimal.ONE, 0));
+    assertThat(op.execute(null, BigDecimal.ONE, 0.999999)).isFalse();
+    assertThat(op.execute(null, BigDecimal.ONE, 0)).isFalse();
 
-    Assertions.assertFalse(op.execute(null, BigDecimal.ONE, 2));
-    Assertions.assertFalse(op.execute(null, BigDecimal.ONE, 1.0001));
+    assertThat(op.execute(null, BigDecimal.ONE, 2)).isFalse();
+    assertThat(op.execute(null, BigDecimal.ONE, 1.0001)).isFalse();
 
-    Assertions.assertTrue(op.execute(null, new RID( 1, 10), new RID( (short) 1, 10)));
-    Assertions.assertFalse(op.execute(null, new RID( 1, 10), new RID( (short) 1, 20)));
+    assertThat(op.execute(null, new RID( 1, 10), new RID( (short) 1, 10))).isTrue();
+    assertThat(op.execute(null, new RID( 1, 10), new RID( (short) 1, 20))).isFalse();
 
-    Assertions.assertFalse(op.execute(null, new Object(), new Object()));
+    assertThat(op.execute(null, new Object(), new Object())).isFalse();
   }
 }

--- a/engine/src/test/java/com/arcadedb/schema/DictionaryTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/DictionaryTest.java
@@ -25,16 +25,20 @@ import com.arcadedb.database.Record;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.Iterator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class DictionaryTest extends TestHelper {
   @Test
   public void updateName() {
     database.transaction(() -> {
-      Assertions.assertFalse(database.getSchema().existsType("V"));
+      Assertions.assertThat(database.getSchema().existsType("V")).isFalse();
 
       final DocumentType type = database.getSchema().buildDocumentType().withName("V").withTotalBuckets(3).create();
       type.createProperty("id", Integer.class);
@@ -49,10 +53,10 @@ public class DictionaryTest extends TestHelper {
       }
     });
 
-    Assertions.assertEquals(4, database.getSchema().getDictionary().getDictionaryMap().size());
+    assertThat(database.getSchema().getDictionary().getDictionaryMap().size()).isEqualTo(4);
 
     database.transaction(() -> {
-      Assertions.assertTrue(database.getSchema().existsType("V"));
+      Assertions.assertThat(database.getSchema().existsType("V")).isTrue();
 
       final MutableDocument v = database.newDocument("V");
       v.set("id", 10);
@@ -62,14 +66,14 @@ public class DictionaryTest extends TestHelper {
       v.save();
     });
 
-    Assertions.assertEquals(5, database.getSchema().getDictionary().getDictionaryMap().size());
+    assertThat(database.getSchema().getDictionary().getDictionaryMap().size()).isEqualTo(5);
 
     database.transaction(() -> {
-      Assertions.assertTrue(database.getSchema().existsType("V"));
+      Assertions.assertThat(database.getSchema().existsType("V")).isTrue();
       database.getSchema().getDictionary().updateName("name", "firstName");
     });
 
-    Assertions.assertEquals(5, database.getSchema().getDictionary().getDictionaryMap().size());
+    assertThat(database.getSchema().getDictionary().getDictionaryMap().size()).isEqualTo(5);
 
     database.transaction(() -> {
       final ResultSet iter = database.query("sql", "select from V order by id asc");
@@ -78,29 +82,29 @@ public class DictionaryTest extends TestHelper {
       while (iter.hasNext()) {
         final Document d = (Document) iter.next().getRecord().get();
 
-        Assertions.assertEquals(i, d.getInteger("id"));
-        Assertions.assertEquals("Jay", d.getString("firstName"));
-        Assertions.assertEquals("Miner", d.getString("surname"));
+        Assertions.assertThat(d.getInteger("id")).isEqualTo(i);
+        Assertions.assertThat(d.getString("firstName")).isEqualTo("Jay");
+        Assertions.assertThat(d.getString("surname")).isEqualTo("Miner");
 
         if (i == 10)
-          Assertions.assertEquals("newProperty", d.getString("newProperty"));
+          Assertions.assertThat(d.getString("newProperty")).isEqualTo("newProperty");
         else
-          Assertions.assertNull(d.getString("newProperty"));
+          Assertions.assertThat(d.getString("newProperty")).isNull();
 
-        Assertions.assertNull(d.getString("name"));
+        Assertions.assertThat(d.getString("name")).isNull();
 
         ++i;
       }
 
-      Assertions.assertEquals(11, i);
+      Assertions.assertThat(i).isEqualTo(11);
     });
 
     try {
       database.transaction(() -> {
-        Assertions.assertTrue(database.getSchema().existsType("V"));
+        Assertions.assertThat(database.getSchema().existsType("V")).isTrue();
         database.getSchema().getDictionary().updateName("V", "V2");
       });
-      Assertions.fail();
+      fail("");
     } catch (final Exception e) {
     }
   }
@@ -123,13 +127,13 @@ public class DictionaryTest extends TestHelper {
 
     for (final Iterator<Record> iterator = database.iterateType("Babylonia", true); iterator.hasNext(); ) {
       final Vertex v = iterator.next().asVertex();
-      Assertions.assertEquals(11, v.getPropertyNames().size());
+      assertThat(v.getPropertyNames().size()).isEqualTo(11);
 
       final int origin = v.getInteger("origin");
 
       for (int k = 0; k < 10; k++) {
         final Integer value = v.getInteger("p" + ((origin * 10) + k));
-        Assertions.assertEquals((origin * 10) + k, value);
+        assertThat(value).isEqualTo((origin * 10) + k);
       }
     }
   }
@@ -156,13 +160,13 @@ public class DictionaryTest extends TestHelper {
 
     for (final Iterator<Record> iterator = database.iterateType("Babylonia", true); iterator.hasNext(); ) {
       final Vertex v = iterator.next().asVertex();
-      Assertions.assertEquals(11, v.getPropertyNames().size());
+      assertThat(v.getPropertyNames().size()).isEqualTo(11);
 
       final int origin = v.getInteger("origin");
 
       for (int k = 0; k < 10; k++) {
         final Integer value = v.getInteger("p" + ((origin * 10) + k));
-        Assertions.assertEquals((origin * 10) + k, value);
+        assertThat(value).isEqualTo((origin * 10) + k);
       }
     }
   }
@@ -189,13 +193,13 @@ public class DictionaryTest extends TestHelper {
 
     for (final Iterator<Record> iterator = database.iterateType("Babylonia", true); iterator.hasNext(); ) {
       final Vertex v = iterator.next().asVertex();
-      Assertions.assertEquals(11, v.getPropertyNames().size());
+      assertThat(v.getPropertyNames().size()).isEqualTo(11);
 
       final int origin = v.getInteger("origin");
 
       for (int k = 0; k < 10; k++) {
         final Integer value = v.getInteger("p" + ((origin * 10) + k));
-        Assertions.assertEquals((origin * 10) + k, value);
+        assertThat(value).isEqualTo((origin * 10) + k);
       }
     }
   }
@@ -224,13 +228,13 @@ public class DictionaryTest extends TestHelper {
 
     for (final Iterator<Record> iterator = database.iterateType("Babylonia", true); iterator.hasNext(); ) {
       final Vertex v = iterator.next().asVertex();
-      Assertions.assertEquals(11, v.getPropertyNames().size());
+      assertThat(v.getPropertyNames().size()).isEqualTo(11);
 
       final int origin = v.getInteger("origin");
 
       for (int k = 0; k < 10; k++) {
         final Integer value = v.getInteger("p" + ((origin * 10) + k));
-        Assertions.assertEquals((origin * 10) + k, value);
+        assertThat(value).isEqualTo((origin * 10) + k);
       }
     }
   }

--- a/engine/src/test/java/com/arcadedb/schema/DocumentValidationTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/DocumentValidationTest.java
@@ -10,11 +10,15 @@ import com.arcadedb.graph.MutableEdge;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.text.*;
+import java.text.SimpleDateFormat;
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class DocumentValidationTest extends TestHelper {
 
@@ -176,16 +180,16 @@ public class DocumentValidationTest extends TestHelper {
     database.command("sql", "create property Validation.string STRING (default \"1\")");
     database.command("sql", "create property Validation.dat DATETIME (default sysdate('YYYY-MM-DD HH:MM:SS'))");
 
-    Assertions.assertEquals(1L, clazz.getProperty("long").getDefaultValue());
-    Assertions.assertEquals("1", clazz.getProperty("string").getDefaultValue());
-    Assertions.assertTrue(clazz.getProperty("dat").getDefaultValue() instanceof Date);
+    assertThat(clazz.getProperty("long").getDefaultValue()).isEqualTo(1L);
+    assertThat(clazz.getProperty("string").getDefaultValue()).isEqualTo("1");
+    assertThat(clazz.getProperty("dat").getDefaultValue() instanceof Date).isTrue();
 
     database.transaction(() -> {
       final MutableDocument d = database.newDocument("Validation");
       d.save();
-      Assertions.assertEquals(1L, d.get("long"));
-      Assertions.assertEquals("1", d.get("string"));
-      Assertions.assertTrue(d.get("dat") instanceof Date);
+      assertThat(d.get("long")).isEqualTo(1L);
+      assertThat(d.get("string")).isEqualTo("1");
+      assertThat(d.get("dat") instanceof Date);
     });
   }
 
@@ -195,12 +199,12 @@ public class DocumentValidationTest extends TestHelper {
 
     database.command("sql", "create property Validation.string STRING (notnull, default \"1\")");
 
-    Assertions.assertEquals("1", clazz.getProperty("string").getDefaultValue());
+    assertThat(clazz.getProperty("string").getDefaultValue()).isEqualTo("1");
 
     database.transaction(() -> {
       final MutableDocument d = database.newDocument("Validation");
       d.save();
-      Assertions.assertEquals("1", d.get("string"));
+      assertThat(d.get("string")).isEqualTo("1");
     });
   }
 
@@ -211,23 +215,23 @@ public class DocumentValidationTest extends TestHelper {
     database.command("sql", "create property Validation.string STRING (mandatory true, notnull true, default \"Hi\")");
     database.command("sql", "create property Validation.dat DATETIME (mandatory true, default null)");
 
-    Assertions.assertEquals("Hi", clazz.getProperty("string").getDefaultValue());
-    Assertions.assertNull(clazz.getProperty("dat").getDefaultValue());
+    assertThat(clazz.getProperty("string").getDefaultValue()).isEqualTo("Hi");
+    assertThat(clazz.getProperty("dat").getDefaultValue()).isNull();
 
     database.transaction(() -> {
       final MutableDocument d = database.newDocument("Validation");
       d.save();
-      Assertions.assertEquals("Hi", d.get("string"));
-      Assertions.assertNull(d.get("dat"));
+      assertThat(d.get("string")).isEqualTo("Hi");
+      assertThat(d.get("dat")).isNull();
 
       final ResultSet resultSet = database.command("sql", "insert into Validation set string = null");
 
-      Assertions.assertTrue(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isTrue();
       final Result result = resultSet.next();
 
-      Assertions.assertEquals("Hi", result.getProperty("string"));
-      Assertions.assertTrue(result.hasProperty("dat"));
-      Assertions.assertNull(result.getProperty("dat"));
+      assertThat(result.<String>getProperty("string")).isEqualTo("Hi");
+      assertThat(result.hasProperty("dat")).isTrue();
+      assertThat(result.<String>getProperty("dat")).isNull();
     });
   }
 
@@ -237,7 +241,7 @@ public class DocumentValidationTest extends TestHelper {
 
     database.command("sql", "create property Validation.int INTEGER (mandatory true)");
 
-    Assertions.assertTrue(clazz.getProperty("int").isMandatory());
+    assertThat(clazz.getProperty("int").isMandatory()).isTrue();
 
     final MutableDocument d = database.newDocument("Validation");
     d.set("int", 10);
@@ -265,7 +269,7 @@ public class DocumentValidationTest extends TestHelper {
       }
 
       final MutableEdge e = v1.newEdge("E", v2, true, "id", "12345");
-      Assertions.assertEquals("12345", e.getString("id"));
+      assertThat(e.getString("id")).isEqualTo("12345");
     });
   }
 
@@ -303,9 +307,9 @@ public class DocumentValidationTest extends TestHelper {
       }
 
       final Edge e = database.command("sql", "create edge E from ? to ? set a = '12345', b = '4444', c = '2222'", v1, v2).nextIfAvailable().getEdge().get();
-      Assertions.assertEquals("12345", e.getString("a"));
-      Assertions.assertEquals("4444", e.getString("b"));
-      Assertions.assertEquals("2222", e.getString("c"));
+      assertThat(e.getString("a")).isEqualTo("12345");
+      assertThat(e.getString("b")).isEqualTo("4444");
+      assertThat(e.getString("c")).isEqualTo("2222");
     });
   }
 
@@ -327,9 +331,9 @@ public class DocumentValidationTest extends TestHelper {
     embedded.set("test", "test");
     try {
       d.validate();
-      Assertions.fail("Validation doesn't throw exception");
+      fail("Validation doesn't throw exception");
     } catch (final ValidationException e) {
-      Assertions.assertTrue(e.toString().contains("int"));
+      assertThat(e.toString().contains("int")).isTrue();
     }
   }
 
@@ -360,9 +364,9 @@ public class DocumentValidationTest extends TestHelper {
 
     try {
       d.validate();
-      Assertions.fail("Validation doesn't throw exception");
+      fail("Validation doesn't throw exception");
     } catch (final ValidationException e) {
-      Assertions.assertTrue(e.toString().contains("long"));
+      assertThat(e.toString().contains("long")).isTrue();
     }
   }
 
@@ -394,9 +398,9 @@ public class DocumentValidationTest extends TestHelper {
 
     try {
       d.validate();
-      Assertions.fail("Validation doesn't throw exception");
+      fail("Validation doesn't throw exception");
     } catch (final ValidationException e) {
-      Assertions.assertTrue(e.toString().contains("long"));
+      assertThat(e.toString().contains("long")).isTrue();
     }
   }
 
@@ -705,9 +709,9 @@ public class DocumentValidationTest extends TestHelper {
     final DocumentType clazzLoaded = database.getSchema().getType("Validation");
     final Property property = clazzLoaded.getPropertyIfExists("string");
 
-    Assertions.assertTrue(property.isMandatory());
-    Assertions.assertTrue(property.isReadonly());
-    Assertions.assertTrue(property.isNotNull());
+    assertThat(property.isMandatory()).isTrue();
+    assertThat(property.isReadonly()).isTrue();
+    assertThat(property.isNotNull()).isTrue();
   }
 
   @Test
@@ -715,14 +719,14 @@ public class DocumentValidationTest extends TestHelper {
     final DocumentType clazz = database.getSchema().getOrCreateDocumentType("Validation");
     try {
       clazz.createProperty("invString", Type.STRING).setMin("-1");
-      Assertions.fail();
+      fail("");
     } catch (IllegalArgumentException e) {
       // EXPECTED
     }
 
     try {
       clazz.createProperty("invBinary", Type.LIST).setMax("-1");
-      Assertions.fail();
+      fail("");
     } catch (IllegalArgumentException e) {
       // EXPECTED
     }
@@ -733,7 +737,7 @@ public class DocumentValidationTest extends TestHelper {
       final MutableDocument newD = database.newDocument(toCheck.getTypeName()).fromMap(toCheck.toMap());
       newD.set(field, newValue);
       newD.validate();
-      Assertions.fail();
+      fail("");
     } catch (final ValidationException v) {
     }
   }
@@ -743,7 +747,7 @@ public class DocumentValidationTest extends TestHelper {
       final MutableDocument newD = database.newDocument(toCheck.getTypeName()).fromMap(toCheck.toMap());
       newD.remove(fieldName);
       newD.validate();
-      Assertions.fail();
+      fail("");
     } catch (final ValidationException v) {
     }
   }
@@ -752,7 +756,7 @@ public class DocumentValidationTest extends TestHelper {
     try {
       toCheck.remove(fieldName);
       toCheck.validate();
-      Assertions.fail();
+      fail("");
     } catch (final ValidationException v) {
     }
   }

--- a/engine/src/test/java/com/arcadedb/schema/DropBucketTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/DropBucketTest.java
@@ -1,16 +1,17 @@
 package com.arcadedb.schema;
 
 import com.arcadedb.TestHelper;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DropBucketTest extends TestHelper {
 
   @Test
   public void createDropCluster() {
     database.getSchema().createBucket("test");
-    Assertions.assertNotNull(database.getSchema().getBucketByName("test"));
+    assertThat(database.getSchema().getBucketByName("test")).isNotNull();
     database.getSchema().dropBucket("test");
-    Assertions.assertFalse(database.getSchema().existsBucket("test"));
+    assertThat(database.getSchema().existsBucket("test")).isFalse();
   }
 }

--- a/engine/src/test/java/com/arcadedb/schema/DropTypeTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/DropTypeTest.java
@@ -22,10 +22,13 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.engine.Bucket;
 import com.arcadedb.exception.SchemaException;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
 
 public class DropTypeTest extends TestHelper {
   private static final int    TOT        = 10;
@@ -36,7 +39,7 @@ public class DropTypeTest extends TestHelper {
   @Test
   public void testDropAndRecreateType() {
     database.transaction(() -> {
-      Assertions.assertFalse(database.getSchema().existsType(TYPE_NAME));
+      assertThat(database.getSchema().existsType(TYPE_NAME)).isFalse();
 
       final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(3).create();
 
@@ -71,57 +74,57 @@ public class DropTypeTest extends TestHelper {
       for (final Bucket b : buckets) {
         try {
           database.getSchema().getBucketById(b.getFileId());
-          Assertions.fail();
+          fail();
         } catch (final SchemaException e) {
         }
 
         try {
           database.getSchema().getBucketByName(b.getName());
-          Assertions.fail();
+          fail();
         } catch (final SchemaException e) {
         }
 
         try {
           database.getSchema().getFileById(b.getFileId());
-          Assertions.fail();
+          fail();
         } catch (final SchemaException e) {
         }
       }
 
       // CHECK TYPE HAS BEEN REMOVED FROM INHERITANCE
       for (final DocumentType parent : type2.getSuperTypes())
-        Assertions.assertFalse(parent.getSubTypes().contains(type2));
+        assertThat(parent.getSubTypes().contains(type2)).isFalse();
 
       for (final DocumentType sub : type2.getSubTypes()) {
-        Assertions.assertFalse(sub.getSuperTypes().contains(type2));
-        Assertions.assertTrue(sub.getSuperTypes().contains(type));
+        assertThat(sub.getSuperTypes().contains(type2)).isFalse();
+        assertThat(sub.getSuperTypes().contains(type)).isTrue();
       }
 
       // CHECK INHERITANCE CHAIN IS CONSISTENT
-      Assertions.assertTrue(type.getSuperTypes().isEmpty());
+      assertThat(type.getSuperTypes().isEmpty()).isTrue();
 
       for (final DocumentType sub : type.getSubTypes())
-        Assertions.assertTrue(sub.getSuperTypes().contains(type));
+        assertThat(sub.getSuperTypes().contains(type)).isTrue();
 
-      Assertions.assertEquals(1, database.countType(TYPE_NAME, true));
+      assertThat(database.countType(TYPE_NAME, true)).isEqualTo(1);
 
       final DocumentType newType = database.getSchema().getOrCreateDocumentType(TYPE_NAME2);
-      Assertions.assertEquals(1, database.countType(TYPE_NAME, true));
-      Assertions.assertEquals(0, database.countType(TYPE_NAME2, true));
-      Assertions.assertEquals(0, database.countType(TYPE_NAME2, false));
+      assertThat(database.countType(TYPE_NAME, true)).isEqualTo(1);
+      assertThat(database.countType(TYPE_NAME2, true)).isEqualTo(0);
+      assertThat(database.countType(TYPE_NAME2, false)).isEqualTo(0);
 
       newType.addSuperType(TYPE_NAME);
 
       // CHECK INHERITANCE CHAIN IS CONSISTENT AGAIN
       for (final DocumentType parent : newType.getSuperTypes())
-        Assertions.assertTrue(parent.getSubTypes().contains(newType));
+        assertThat(parent.getSubTypes().contains(newType)).isTrue();
 
       for (final DocumentType sub : newType.getSubTypes())
-        Assertions.assertTrue(sub.getSuperTypes().contains(newType));
+        assertThat(sub.getSuperTypes().contains(newType)).isTrue();
 
-      Assertions.assertEquals(1, database.countType(TYPE_NAME, true));
-      Assertions.assertEquals(0, database.countType(TYPE_NAME2, true));
-      Assertions.assertEquals(0, database.countType(TYPE_NAME2, false));
+      assertThat(database.countType(TYPE_NAME, true)).isEqualTo(1);
+      assertThat(database.countType(TYPE_NAME2, true)).isEqualTo(0);
+      assertThat(database.countType(TYPE_NAME2, false)).isEqualTo(0);
 
       database.begin();
 
@@ -137,9 +140,9 @@ public class DropTypeTest extends TestHelper {
       v3.set("id", TOT);
       v3.save();
 
-      Assertions.assertEquals(TOT + 2, database.countType(TYPE_NAME, true));
-      Assertions.assertEquals(TOT, database.countType(TYPE_NAME2, false));
-      Assertions.assertEquals(2, database.countType(TYPE_NAME, false));
+      assertThat(database.countType(TYPE_NAME, true)).isEqualTo(TOT + 2);
+      assertThat(database.countType(TYPE_NAME2, false)).isEqualTo(TOT);
+      assertThat(database.countType(TYPE_NAME, false)).isEqualTo(2);
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/schema/SchemaTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/SchemaTest.java
@@ -19,11 +19,14 @@
 package com.arcadedb.schema;
 
 import com.arcadedb.TestHelper;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.time.*;
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SchemaTest extends TestHelper {
 
@@ -31,29 +34,29 @@ public class SchemaTest extends TestHelper {
   public void tesSchemaSettings() {
     database.transaction(() -> {
       final ZoneId zoneId = database.getSchema().getZoneId();
-      Assertions.assertNotNull(zoneId);
+      assertThat(zoneId).isNotNull();
       database.getSchema().setZoneId(ZoneId.of("America/New_York"));
-      Assertions.assertEquals(ZoneId.of("America/New_York"), database.getSchema().getZoneId());
+      assertThat(database.getSchema().getZoneId()).isEqualTo(ZoneId.of("America/New_York"));
 
       final TimeZone timeZone = database.getSchema().getTimeZone();
-      Assertions.assertNotNull(timeZone);
+      assertThat(timeZone).isNotNull();
       database.getSchema().setTimeZone(TimeZone.getTimeZone("UK"));
-      Assertions.assertEquals(TimeZone.getTimeZone("UK"), database.getSchema().getTimeZone());
+      assertThat(database.getSchema().getTimeZone()).isEqualTo(TimeZone.getTimeZone("UK"));
 
       final String dateFormat = database.getSchema().getDateFormat();
-      Assertions.assertNotNull(dateFormat);
+      assertThat(dateFormat).isNotNull();
       database.getSchema().setDateFormat("yyyy-MMM-dd");
-      Assertions.assertEquals("yyyy-MMM-dd", database.getSchema().getDateFormat());
+      assertThat(database.getSchema().getDateFormat()).isEqualTo("yyyy-MMM-dd");
 
       final String dateTimeFormat = database.getSchema().getDateTimeFormat();
-      Assertions.assertNotNull(dateTimeFormat);
+      assertThat(dateTimeFormat).isNotNull();
       database.getSchema().setDateTimeFormat("yyyy-MMM-dd HH:mm:ss");
-      Assertions.assertEquals("yyyy-MMM-dd HH:mm:ss", database.getSchema().getDateTimeFormat());
+      assertThat(database.getSchema().getDateTimeFormat()).isEqualTo("yyyy-MMM-dd HH:mm:ss");
 
       final String encoding = database.getSchema().getEncoding();
-      Assertions.assertNotNull(encoding);
+      assertThat(encoding).isNotNull();
       database.getSchema().setEncoding("UTF-8");
-      Assertions.assertEquals("UTF-8", database.getSchema().getEncoding());
+      assertThat(database.getSchema().getEncoding()).isEqualTo("UTF-8");
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/serializer/JavaBinarySerializerTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/JavaBinarySerializerTest.java
@@ -26,10 +26,11 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.EdgeType;
 import com.arcadedb.schema.Type;
 import com.arcadedb.schema.VertexType;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JavaBinarySerializerTest extends TestHelper {
 
@@ -43,14 +44,14 @@ public class JavaBinarySerializerTest extends TestHelper {
       doc1.writeExternal(buffer);
       buffer.flush();
 
-      Assertions.assertTrue(arrayOut.size() > 0);
+      assertThat(arrayOut.size() > 0).isTrue();
 
       final MutableDocument doc2 = database.newDocument("Doc");
 
       try (final ByteArrayInputStream arrayIn = new ByteArrayInputStream(arrayOut.toByteArray()); final ObjectInput in = new ObjectInputStream(arrayIn)) {
         doc2.readExternal(in);
-        Assertions.assertEquals(doc1, doc2);
-        Assertions.assertEquals(doc1.toMap(), doc2.toMap());
+        assertThat(doc2).isEqualTo(doc1);
+        assertThat(doc2.toMap()).isEqualTo(doc1.toMap());
       }
     }
   }
@@ -68,14 +69,14 @@ public class JavaBinarySerializerTest extends TestHelper {
       doc1.writeExternal(buffer);
       buffer.flush();
 
-      Assertions.assertTrue(arrayOut.size() > 0);
+      assertThat(arrayOut.size() > 0).isTrue();
 
       final MutableDocument doc2 = database.newDocument("Doc");
 
       try (final ByteArrayInputStream arrayIn = new ByteArrayInputStream(arrayOut.toByteArray()); final ObjectInput in = new ObjectInputStream(arrayIn)) {
         doc2.readExternal(in);
-        Assertions.assertEquals(doc1, doc2);
-        Assertions.assertEquals(doc1.toMap(), doc2.toMap());
+        assertThat(doc2).isEqualTo(doc1);
+        assertThat(doc2.toMap()).isEqualTo(doc1.toMap());
       }
     }
   }
@@ -90,14 +91,14 @@ public class JavaBinarySerializerTest extends TestHelper {
       doc1.writeExternal(buffer);
       buffer.flush();
 
-      Assertions.assertTrue(arrayOut.size() > 0);
+      assertThat(arrayOut.size() > 0).isTrue();
 
       final MutableVertex docTest = database.newVertex("Doc");
 
       try (final ByteArrayInputStream arrayIn = new ByteArrayInputStream(arrayOut.toByteArray()); final ObjectInput in = new ObjectInputStream(arrayIn)) {
         docTest.readExternal(in);
-        Assertions.assertEquals(doc1, docTest);
-        Assertions.assertEquals(doc1.toMap(), docTest.toMap());
+        assertThat(docTest).isEqualTo(doc1);
+        assertThat(docTest.toMap()).isEqualTo(doc1.toMap());
       }
     }
   }
@@ -119,16 +120,16 @@ public class JavaBinarySerializerTest extends TestHelper {
       v1.writeExternal(buffer);
       buffer.flush();
 
-      Assertions.assertTrue(arrayOut.size() > 0);
+      assertThat(arrayOut.size() > 0).isTrue();
 
       final MutableVertex vTest = database.newVertex("Doc");
 
       try (final ByteArrayInputStream arrayIn = new ByteArrayInputStream(arrayOut.toByteArray()); final ObjectInput in = new ObjectInputStream(arrayIn)) {
         vTest.readExternal(in);
-        Assertions.assertEquals(v1, vTest);
-        Assertions.assertEquals(v1.toMap(), vTest.toMap());
-        Assertions.assertEquals(v1.getOutEdgesHeadChunk(), vTest.getOutEdgesHeadChunk());
-        Assertions.assertEquals(v1.getInEdgesHeadChunk(), vTest.getInEdgesHeadChunk());
+        assertThat(vTest).isEqualTo(v1);
+        assertThat(vTest.toMap()).isEqualTo(v1.toMap());
+        assertThat(vTest.getOutEdgesHeadChunk()).isEqualTo(v1.getOutEdgesHeadChunk());
+        assertThat(vTest.getInEdgesHeadChunk()).isEqualTo(v1.getInEdgesHeadChunk());
       }
     }
   }
@@ -149,16 +150,16 @@ public class JavaBinarySerializerTest extends TestHelper {
       edge1.writeExternal(buffer);
       buffer.flush();
 
-      Assertions.assertTrue(arrayOut.size() > 0);
+      assertThat(arrayOut.size() > 0).isTrue();
 
       final MutableEdge edgeTest = new MutableEdge(database, type, null);
 
       try (final ByteArrayInputStream arrayIn = new ByteArrayInputStream(arrayOut.toByteArray()); final ObjectInput in = new ObjectInputStream(arrayIn)) {
         edgeTest.readExternal(in);
-        Assertions.assertEquals(edge1, edgeTest);
-        Assertions.assertEquals(edge1.toMap(), edgeTest.toMap());
-        Assertions.assertEquals(edge1.getOut(), edgeTest.getOut());
-        Assertions.assertEquals(edge1.getIn(), edgeTest.getIn());
+        assertThat(edgeTest).isEqualTo(edge1);
+        assertThat(edgeTest.toMap()).isEqualTo(edge1.toMap());
+        assertThat(edgeTest.getOut()).isEqualTo(edge1.getOut());
+        assertThat(edgeTest.getIn()).isEqualTo(edge1.getIn());
       }
     }
   }

--- a/engine/src/test/java/com/arcadedb/serializer/SerializerTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/SerializerTest.java
@@ -29,12 +29,14 @@ import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.MutableEmbeddedDocument;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Type;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
 
 import java.math.*;
 import java.nio.*;
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SerializerTest extends TestHelper {
 
@@ -80,66 +82,66 @@ public class SerializerTest extends TestHelper {
     binary.rewind();
     buffer.rewind();
 
-    Assertions.assertEquals(0, binary.getUnsignedNumber());
-    Assertions.assertEquals(0, buffer.getUnsignedNumber());
-    Assertions.assertEquals(3, binary.getUnsignedNumber());
-    Assertions.assertEquals(3, buffer.getUnsignedNumber());
-    Assertions.assertEquals(Short.MIN_VALUE, binary.getUnsignedNumber());
-    Assertions.assertEquals(Short.MIN_VALUE, buffer.getUnsignedNumber());
-    Assertions.assertEquals(Short.MAX_VALUE, binary.getUnsignedNumber());
-    Assertions.assertEquals(Short.MAX_VALUE, buffer.getUnsignedNumber());
-    Assertions.assertEquals(Integer.MIN_VALUE, binary.getUnsignedNumber());
-    Assertions.assertEquals(Integer.MIN_VALUE, buffer.getUnsignedNumber());
-    Assertions.assertEquals(Integer.MAX_VALUE, binary.getUnsignedNumber());
-    Assertions.assertEquals(Integer.MAX_VALUE, buffer.getUnsignedNumber());
-    Assertions.assertEquals(Long.MIN_VALUE, binary.getUnsignedNumber());
-    Assertions.assertEquals(Long.MIN_VALUE, buffer.getUnsignedNumber());
-    Assertions.assertEquals(Long.MAX_VALUE, binary.getUnsignedNumber());
-    Assertions.assertEquals(Long.MAX_VALUE, buffer.getUnsignedNumber());
+    assertThat(binary.getUnsignedNumber()).isEqualTo(0);
+    assertThat(buffer.getUnsignedNumber()).isEqualTo(0);
+    assertThat(binary.getUnsignedNumber()).isEqualTo(3);
+    assertThat(buffer.getUnsignedNumber()).isEqualTo(3);
+    assertThat(binary.getUnsignedNumber()).isEqualTo(Short.MIN_VALUE);
+    assertThat(buffer.getUnsignedNumber()).isEqualTo(Short.MIN_VALUE);
+    assertThat(binary.getUnsignedNumber()).isEqualTo(Short.MAX_VALUE);
+    assertThat(buffer.getUnsignedNumber()).isEqualTo(Short.MAX_VALUE);
+    assertThat(binary.getUnsignedNumber()).isEqualTo(Integer.MIN_VALUE);
+    assertThat(buffer.getUnsignedNumber()).isEqualTo(Integer.MIN_VALUE);
+    assertThat(binary.getUnsignedNumber()).isEqualTo(Integer.MAX_VALUE);
+    assertThat(buffer.getUnsignedNumber()).isEqualTo(Integer.MAX_VALUE);
+    assertThat(binary.getUnsignedNumber()).isEqualTo(Long.MIN_VALUE);
+    assertThat(buffer.getUnsignedNumber()).isEqualTo(Long.MIN_VALUE);
+    assertThat(binary.getUnsignedNumber()).isEqualTo(Long.MAX_VALUE);
+    assertThat(buffer.getUnsignedNumber()).isEqualTo(Long.MAX_VALUE);
 
-    Assertions.assertEquals(0, binary.getNumber());
-    Assertions.assertEquals(0, buffer.getNumber());
-    Assertions.assertEquals(3, binary.getNumber());
-    Assertions.assertEquals(3, buffer.getNumber());
-    Assertions.assertEquals(Short.MIN_VALUE, binary.getNumber());
-    Assertions.assertEquals(Short.MIN_VALUE, buffer.getNumber());
-    Assertions.assertEquals(Short.MAX_VALUE, binary.getNumber());
-    Assertions.assertEquals(Short.MAX_VALUE, buffer.getNumber());
-    Assertions.assertEquals(Integer.MIN_VALUE, binary.getNumber());
-    Assertions.assertEquals(Integer.MIN_VALUE, buffer.getNumber());
-    Assertions.assertEquals(Integer.MAX_VALUE, binary.getNumber());
-    Assertions.assertEquals(Integer.MAX_VALUE, buffer.getNumber());
-    Assertions.assertEquals(Long.MIN_VALUE, binary.getNumber());
-    Assertions.assertEquals(Long.MIN_VALUE, buffer.getNumber());
-    Assertions.assertEquals(Long.MAX_VALUE, binary.getNumber());
-    Assertions.assertEquals(Long.MAX_VALUE, buffer.getNumber());
+    assertThat(binary.getNumber()).isEqualTo(0);
+    assertThat(buffer.getNumber()).isEqualTo(0);
+    assertThat(binary.getNumber()).isEqualTo(3);
+    assertThat(buffer.getNumber()).isEqualTo(3);
+    assertThat(binary.getNumber()).isEqualTo(Short.MIN_VALUE);
+    assertThat(buffer.getNumber()).isEqualTo(Short.MIN_VALUE);
+    assertThat(binary.getNumber()).isEqualTo(Short.MAX_VALUE);
+    assertThat(buffer.getNumber()).isEqualTo(Short.MAX_VALUE);
+    assertThat(binary.getNumber()).isEqualTo(Integer.MIN_VALUE);
+    assertThat(buffer.getNumber()).isEqualTo(Integer.MIN_VALUE);
+    assertThat(binary.getNumber()).isEqualTo(Integer.MAX_VALUE);
+    assertThat(buffer.getNumber()).isEqualTo(Integer.MAX_VALUE);
+    assertThat(binary.getNumber()).isEqualTo(Long.MIN_VALUE);
+    assertThat(buffer.getNumber()).isEqualTo(Long.MIN_VALUE);
+    assertThat(binary.getNumber()).isEqualTo(Long.MAX_VALUE);
+    assertThat(buffer.getNumber()).isEqualTo(Long.MAX_VALUE);
 
-    Assertions.assertEquals(0, binary.getShort());
-    Assertions.assertEquals(0, buffer.getShort());
+    assertThat(binary.getShort()).isEqualTo((short) 0);
+    assertThat(buffer.getShort()).isEqualTo((short) 0);
 
-    Assertions.assertEquals(Short.MIN_VALUE, binary.getShort());
-    Assertions.assertEquals(Short.MIN_VALUE, buffer.getShort());
+    assertThat(binary.getShort()).isEqualTo(Short.MIN_VALUE);
+    assertThat(buffer.getShort()).isEqualTo(Short.MIN_VALUE);
 
-    Assertions.assertEquals(Short.MAX_VALUE, binary.getShort());
-    Assertions.assertEquals(Short.MAX_VALUE, buffer.getShort());
+    assertThat(binary.getShort()).isEqualTo(Short.MAX_VALUE);
+    assertThat(buffer.getShort()).isEqualTo(Short.MAX_VALUE);
 
-    Assertions.assertEquals(0, binary.getInt());
-    Assertions.assertEquals(0, buffer.getInt());
+    assertThat(binary.getInt()).isEqualTo(0);
+    assertThat(buffer.getInt()).isEqualTo(0);
 
-    Assertions.assertEquals(Integer.MIN_VALUE, binary.getInt());
-    Assertions.assertEquals(Integer.MIN_VALUE, buffer.getInt());
+    assertThat(binary.getInt()).isEqualTo(Integer.MIN_VALUE);
+    assertThat(buffer.getInt()).isEqualTo(Integer.MIN_VALUE);
 
-    Assertions.assertEquals(Integer.MAX_VALUE, binary.getInt());
-    Assertions.assertEquals(Integer.MAX_VALUE, buffer.getInt());
+    assertThat(binary.getInt()).isEqualTo(Integer.MAX_VALUE);
+    assertThat(buffer.getInt()).isEqualTo(Integer.MAX_VALUE);
 
-    Assertions.assertEquals(0l, binary.getLong());
-    Assertions.assertEquals(0l, buffer.getLong());
+    assertThat(binary.getLong()).isEqualTo(0l);
+    assertThat(buffer.getLong()).isEqualTo(0l);
 
-    Assertions.assertEquals(Long.MIN_VALUE, binary.getLong());
-    Assertions.assertEquals(Long.MIN_VALUE, buffer.getLong());
+    assertThat(binary.getLong()).isEqualTo(Long.MIN_VALUE);
+    assertThat(buffer.getLong()).isEqualTo(Long.MIN_VALUE);
 
-    Assertions.assertEquals(Long.MAX_VALUE, binary.getLong());
-    Assertions.assertEquals(Long.MAX_VALUE, buffer.getLong());
+    assertThat(binary.getLong()).isEqualTo(Long.MAX_VALUE);
+    assertThat(buffer.getLong()).isEqualTo(Long.MAX_VALUE);
   }
 
   @Test
@@ -174,21 +176,21 @@ public class SerializerTest extends TestHelper {
       buffer3.getByte(); // SKIP RECORD TYPE
       final Map<String, Object> record2 = serializer.deserializeProperties(database, buffer3, null, null);
 
-      Assertions.assertEquals(Integer.MIN_VALUE, record2.get("minInt"));
-      Assertions.assertEquals(Integer.MAX_VALUE, record2.get("maxInt"));
+      assertThat(record2.get("minInt")).isEqualTo(Integer.MIN_VALUE);
+      assertThat(record2.get("maxInt")).isEqualTo(Integer.MAX_VALUE);
 
-      Assertions.assertEquals(Long.MIN_VALUE, record2.get("minLong"));
-      Assertions.assertEquals(Long.MAX_VALUE, record2.get("maxLong"));
+      assertThat(record2.get("minLong")).isEqualTo(Long.MIN_VALUE);
+      assertThat(record2.get("maxLong")).isEqualTo(Long.MAX_VALUE);
 
-      Assertions.assertEquals(Short.MIN_VALUE, record2.get("minShort"));
-      Assertions.assertEquals(Short.MAX_VALUE, record2.get("maxShort"));
+      assertThat(record2.get("minShort")).isEqualTo(Short.MIN_VALUE);
+      assertThat(record2.get("maxShort")).isEqualTo(Short.MAX_VALUE);
 
-      Assertions.assertEquals(Byte.MIN_VALUE, record2.get("minByte"));
-      Assertions.assertEquals(Byte.MAX_VALUE, record2.get("maxByte"));
+      assertThat(record2.get("minByte")).isEqualTo(Byte.MIN_VALUE);
+      assertThat(record2.get("maxByte")).isEqualTo(Byte.MAX_VALUE);
 
-      Assertions.assertTrue(record2.get("decimal") instanceof BigDecimal);
-      Assertions.assertEquals(new BigDecimal("9876543210.0123456789"), record2.get("decimal"));
-      Assertions.assertEquals("Miner", record2.get("string"));
+      assertThat(record2.get("decimal") instanceof BigDecimal).isTrue();
+      assertThat(record2.get("decimal")).isEqualTo(new BigDecimal("9876543210.0123456789"));
+      assertThat(record2.get("string")).isEqualTo("Miner");
     });
   }
 
@@ -271,29 +273,29 @@ public class SerializerTest extends TestHelper {
       buffer3.getByte(); // SKIP RECORD TYPE
       final Map<String, Object> record2 = serializer.deserializeProperties(database, buffer3, null, null);
 
-      Assertions.assertIterableEquals(listOfBooleans, (Iterable<?>) record2.get("listOfBooleans"));
-      Assertions.assertIterableEquals(listOfBooleans, (Iterable<?>) record2.get("arrayOfBooleans"));
+      assertThat(record2.get("listOfBooleans")).isEqualTo(listOfBooleans);
+      assertThat(record2.get("arrayOfBooleans")).isEqualTo(listOfBooleans);
 
-      Assertions.assertIterableEquals(listOfIntegers, (Iterable<?>) record2.get("listOfIntegers"));
-      Assertions.assertIterableEquals(listOfIntegers, (Iterable<?>) record2.get("arrayOfIntegers"));
+      assertThat(record2.get("listOfIntegers")).isEqualTo(listOfIntegers);
+      assertThat(record2.get("arrayOfIntegers")).isEqualTo(listOfIntegers);
 
-      Assertions.assertIterableEquals(listOfLongs, (Iterable<?>) record2.get("listOfLongs"));
-      Assertions.assertIterableEquals(listOfLongs, (Iterable<?>) record2.get("arrayOfLongs"));
+      assertThat(record2.get("listOfLongs")).isEqualTo(listOfLongs);
+      assertThat(record2.get("arrayOfLongs")).isEqualTo(listOfLongs);
 
-      Assertions.assertIterableEquals(listOfShorts, (Iterable<?>) record2.get("listOfShorts"));
-      Assertions.assertIterableEquals(listOfShorts, (Iterable<?>) record2.get("arrayOfShorts"));
+      assertThat(record2.get("listOfShorts")).isEqualTo(listOfShorts);
+      assertThat(record2.get("arrayOfShorts")).isEqualTo(listOfShorts);
 
-      Assertions.assertIterableEquals(listOfFloats, (Iterable<?>) record2.get("listOfFloats"));
-      Assertions.assertIterableEquals(listOfFloats, (Iterable<?>) record2.get("arrayOfFloats"));
+      assertThat(record2.get("listOfFloats")).isEqualTo(listOfFloats);
+      assertThat(record2.get("arrayOfFloats")).isEqualTo(listOfFloats);
 
-      Assertions.assertIterableEquals(listOfDoubles, (Iterable<?>) record2.get("listOfDoubles"));
-      Assertions.assertIterableEquals(listOfDoubles, (Iterable<?>) record2.get("arrayOfDoubles"));
+      assertThat(record2.get("listOfDoubles")).isEqualTo(listOfDoubles);
+      assertThat(record2.get("arrayOfDoubles")).isEqualTo(listOfDoubles);
 
-      Assertions.assertIterableEquals(listOfStrings, (Iterable<?>) record2.get("listOfStrings"));
-      Assertions.assertIterableEquals(listOfStrings, (Iterable<?>) record2.get("arrayOfStrings"));
+      assertThat(record2.get("listOfStrings")).isEqualTo(listOfStrings);
+      assertThat(record2.get("arrayOfStrings")).isEqualTo(listOfStrings);
 
-      Assertions.assertIterableEquals(listOfMixed, (Iterable<?>) record2.get("listOfMixed"));
-      Assertions.assertIterableEquals(listOfMixed, (Iterable<?>) record2.get("arrayOfMixed"));
+      assertThat(record2.get("listOfMixed")).isEqualTo(listOfMixed);
+      assertThat(record2.get("arrayOfMixed")).isEqualTo(listOfMixed);
     });
   }
 
@@ -344,11 +346,11 @@ public class SerializerTest extends TestHelper {
       buffer3.getByte(); // SKIP RECORD TYPE
       final Map<String, Object> record2 = serializer.deserializeProperties(database, buffer3, null, null);
 
-      Assertions.assertArrayEquals(arrayOfIntegers, (int[]) record2.get("arrayOfIntegers"));
-      Assertions.assertArrayEquals(arrayOfLongs, (long[]) record2.get("arrayOfLongs"));
-      Assertions.assertArrayEquals(arrayOfShorts, (short[]) record2.get("arrayOfShorts"));
-      Assertions.assertArrayEquals(arrayOfFloats, (float[]) record2.get("arrayOfFloats"));
-      Assertions.assertArrayEquals(arrayOfDoubles, (double[]) record2.get("arrayOfDoubles"));
+      assertThat((int[]) record2.get("arrayOfIntegers")).isEqualTo(arrayOfIntegers);
+      assertThat((long[]) record2.get("arrayOfLongs")).isEqualTo(arrayOfLongs);
+      assertThat((short[]) record2.get("arrayOfShorts")).isEqualTo(arrayOfShorts);
+      assertThat((float[]) record2.get("arrayOfFloats")).isEqualTo(arrayOfFloats);
+      assertThat((double[]) record2.get("arrayOfDoubles")).isEqualTo(arrayOfDoubles);
     });
   }
 
@@ -416,14 +418,14 @@ public class SerializerTest extends TestHelper {
       buffer3.getByte(); // SKIP RECORD TYPE
       final Map<String, Object> record2 = serializer.deserializeProperties(database, buffer3, null, null);
 
-      Assertions.assertEquals(mapOfStringsBooleans, record2.get("mapOfStringsBooleans"));
-      Assertions.assertEquals(mapOfIntegers, record2.get("mapOfIntegers"));
-      Assertions.assertEquals(mapOfLongs, record2.get("mapOfLongs"));
-      Assertions.assertEquals(mapOfShorts, record2.get("mapOfShorts"));
-      Assertions.assertEquals(mapOfFloats, record2.get("mapOfFloats"));
-      Assertions.assertEquals(mapOfDoubles, record2.get("mapOfDoubles"));
-      Assertions.assertEquals(mapOfStrings, record2.get("mapOfStrings"));
-      Assertions.assertEquals(mapOfMixed, record2.get("mapOfMixed"));
+      assertThat(record2.get("mapOfStringsBooleans")).isEqualTo(mapOfStringsBooleans);
+      assertThat(record2.get("mapOfIntegers")).isEqualTo(mapOfIntegers);
+      assertThat(record2.get("mapOfLongs")).isEqualTo(mapOfLongs);
+      assertThat(record2.get("mapOfShorts")).isEqualTo(mapOfShorts);
+      assertThat(record2.get("mapOfFloats")).isEqualTo(mapOfFloats);
+      assertThat(record2.get("mapOfDoubles")).isEqualTo(mapOfDoubles);
+      assertThat(record2.get("mapOfStrings")).isEqualTo(mapOfStrings);
+      assertThat(record2.get("mapOfMixed")).isEqualTo(mapOfMixed);
     });
   }
 
@@ -456,11 +458,11 @@ public class SerializerTest extends TestHelper {
       buffer3.getByte(); // SKIP RECORD TYPE
       final Map<String, Object> record2 = serializer.deserializeProperties(database, buffer3, new EmbeddedModifierProperty(testDocument, "embedded"), null);
 
-      Assertions.assertEquals(0, record2.get("id"));
+      assertThat(record2.get("id")).isEqualTo(0);
 
       final EmbeddedDocument embeddedDoc = (EmbeddedDocument) record2.get("embedded");
 
-      Assertions.assertEquals(1, embeddedDoc.get("id"));
+      assertThat(embeddedDoc.get("id")).isEqualTo(1);
     });
   }
 
@@ -500,14 +502,14 @@ public class SerializerTest extends TestHelper {
       buffer3.getByte(); // SKIP RECORD TYPE
       final Map<String, Object> record2 = serializer.deserializeProperties(database, buffer3, new EmbeddedModifierProperty(testDocument, "embedded"), null);
 
-      Assertions.assertEquals(0, record2.get("id"));
+      assertThat(record2.get("id")).isEqualTo(0);
 
       final List<Document> embeddedList2 = (List<Document>) record2.get("embedded");
 
-      Assertions.assertIterableEquals(embeddedList, embeddedList2);
+      assertThat(embeddedList).isEqualTo(embeddedList2);
 
       for (final Document d : embeddedList2)
-        Assertions.assertTrue(d instanceof EmbeddedDocument);
+        assertThat(d instanceof EmbeddedDocument).isTrue();
     });
   }
 
@@ -550,15 +552,16 @@ public class SerializerTest extends TestHelper {
       buffer3.getByte(); // SKIP RECORD TYPE
       final Map<String, Object> record2 = serializer.deserializeProperties(database, buffer3, null, null);
 
-      Assertions.assertEquals(0, record2.get("id"));
+      assertThat(record2.get("id")).isEqualTo(0);
 
       final Map<Integer, Document> embeddedMap2 = (Map<Integer, Document>) record2.get("embedded");
 
-      Assertions.assertIterableEquals(embeddedMap.entrySet(), embeddedMap2.entrySet());
+      assertThat(embeddedMap).isEqualTo(embeddedMap2);
+//      Assertions.assertIterableEquals(embeddedMap.entrySet(), embeddedMap2.entrySet());
 
       for (final Map.Entry<Integer, Document> d : embeddedMap2.entrySet()) {
-        Assertions.assertTrue(d.getKey() instanceof Integer);
-        Assertions.assertTrue(d.getValue() instanceof EmbeddedDocument);
+        assertThat(d.getKey() instanceof Integer).isTrue();
+        assertThat(d.getValue() instanceof EmbeddedDocument).isTrue();
       }
     });
   }

--- a/engine/src/test/java/com/arcadedb/serializer/json/JSONTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/json/JSONTest.java
@@ -19,10 +19,11 @@
 package com.arcadedb.serializer.json;
 
 import com.arcadedb.TestHelper;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test JSON parser and it support for types.
@@ -36,7 +37,7 @@ public class JSONTest extends TestHelper {
     JSONObject json = new JSONObject().put("date", date);
     final String serialized = json.toString();
     JSONObject deserialized = new JSONObject(serialized);
-    Assertions.assertEquals(json, deserialized);
+    assertThat(deserialized).isEqualTo(json);
   }
 
   @Test
@@ -44,7 +45,7 @@ public class JSONTest extends TestHelper {
     JSONObject json = new JSONObject().put("list", Collections.unmodifiableList(List.of(1, 2, 3)));
     final String serialized = json.toString();
     JSONObject deserialized = new JSONObject(serialized);
-    Assertions.assertEquals(json, deserialized);
+    assertThat(deserialized).isEqualTo(json);
   }
 
   @Test
@@ -54,7 +55,7 @@ public class JSONTest extends TestHelper {
     JSONObject json = new JSONObject().put("list", list);
     final String serialized = json.toString();
     JSONObject deserialized = new JSONObject(serialized);
-    Assertions.assertEquals(json, deserialized);
+    assertThat(deserialized).isEqualTo(json);
   }
 
   @Test
@@ -65,7 +66,7 @@ public class JSONTest extends TestHelper {
     final String serialized = json.toString();
     JSONObject deserialized = new JSONObject(serialized);
 
-    Assertions.assertEquals(json, deserialized);
+    assertThat(deserialized).isEqualTo(json);
   }
 
   @Test
@@ -78,19 +79,19 @@ public class JSONTest extends TestHelper {
     final String serialized = json.toString();
     JSONObject deserialized = new JSONObject(serialized);
 
-    Assertions.assertEquals(json, deserialized);
+    assertThat(deserialized).isEqualTo(json);
   }
 
   @Test
   public void testMalformedTrailingCommas() {
     JSONObject json = new JSONObject("{'array':[1,2,3,]}");
-    Assertions.assertEquals(4, json.getJSONArray("array").length());
+    assertThat(json.getJSONArray("array").length()).isEqualTo(4);
 
     json = new JSONObject("{'array':[{'a':3},]}");
-    Assertions.assertEquals(2, json.getJSONArray("array").length());
+    assertThat(json.getJSONArray("array").length()).isEqualTo(2);
 // NOT SUPPORTED BY GSON LIBRARY
 //    json = new JSONObject("{'map':{'a':3,}");
-//    Assertions.assertEquals(2, json.getJSONArray("map").length());
+//    Assertions.assertThat(json.getJSONArray("map").length()).isEqualTo(2);
   }
 
   @Test
@@ -100,9 +101,9 @@ public class JSONTest extends TestHelper {
     json.put("arrayNan", new JSONArray().put(0).put(Double.NaN).put(5));
     json.validate();
 
-    Assertions.assertEquals(json.getInt("nan"), 0);
-    Assertions.assertEquals(json.getJSONArray("arrayNan").get(0), 0);
-    Assertions.assertEquals(json.getJSONArray("arrayNan").get(1), 0);
-    Assertions.assertEquals(json.getJSONArray("arrayNan").get(2), 5);
+    assertThat(json.getInt("nan")).isEqualTo(0);
+    assertThat(json.getJSONArray("arrayNan").get(0)).isEqualTo(0);
+    assertThat(json.getJSONArray("arrayNan").get(1)).isEqualTo(0);
+    assertThat(json.getJSONArray("arrayNan").get(2)).isEqualTo(5);
   }
 }

--- a/engine/src/test/java/performance/LocalDatabaseBenchmark.java
+++ b/engine/src/test/java/performance/LocalDatabaseBenchmark.java
@@ -26,10 +26,11 @@ import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.query.select.SelectCompiled;
-import org.junit.jupiter.api.Assertions;
 
 import java.util.*;
 import java.util.concurrent.atomic.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class LocalDatabaseBenchmark {
   private static final int TOTAL    = 1_000;
@@ -115,11 +116,11 @@ public class LocalDatabaseBenchmark {
 
     List<Long> allIds = checkRecordSequence(database);
 
-    Assertions.assertEquals(TOTAL * CONCURRENT_THREADS, allIds.size());
+    assertThat(allIds.size()).isEqualTo(TOTAL * CONCURRENT_THREADS);
 
-    Assertions.assertEquals(TOTAL * CONCURRENT_THREADS, totalRecordsOnClusters);
+    assertThat(totalRecordsOnClusters).isEqualTo(TOTAL * CONCURRENT_THREADS);
 
-    Assertions.assertEquals(TOTAL * CONCURRENT_THREADS, database.countType("User", true));
+    assertThat(database.countType("User", true)).isEqualTo(TOTAL * CONCURRENT_THREADS);
 
 //    queryNative();
 //    querySQL();
@@ -143,7 +144,7 @@ public class LocalDatabaseBenchmark {
         .property("id").eq().parameter("id")//
         .compile();
     for (int i = 0; i < TOTAL * CONCURRENT_THREADS; i++) {
-      Assertions.assertEquals(1, cached.parameter("id", i).vertices().toList().size());
+      assertThat(cached.parameter("id", i).vertices().toList().size()).isEqualTo(1);
     }
     System.out.println("NATIVE " + (System.currentTimeMillis() - begin) + "ms");
   }
@@ -151,9 +152,9 @@ public class LocalDatabaseBenchmark {
   private void querySQL() {
     long begin = System.currentTimeMillis();
     for (int i = 0; i < TOTAL * CONCURRENT_THREADS; i++) {
-      Assertions.assertEquals(1, database.query("sql",
-          "select from User where id = ? and id = ? and id = ? and id = ? and id = ? and id = ? and id = ? and id = ? and id = ? and id = ?",
-          i, i, i, i, i, i, i, i, i, i).toVertices().size());
+      assertThat(database.query("sql",
+        "select from User where id = ? and id = ? and id = ? and id = ? and id = ? and id = ? and id = ? and id = ? and id = ? and id = ?",
+        i, i, i, i, i, i, i, i, i, i).toVertices().size()).isEqualTo(1);
     }
     System.out.println("SQL " + (System.currentTimeMillis() - begin) + "ms");
   }

--- a/engine/src/test/java/performance/PerformanceComplexIndexTest.java
+++ b/engine/src/test/java/performance/PerformanceComplexIndexTest.java
@@ -114,11 +114,11 @@ public class PerformanceComplexIndexTest {
 //      System.out.println("Lookup all the keys...");
 //      for (long id = 0; id < TOT; ++id) {
 //        final Cursor<RID> records = database.lookupByKey(TYPE_NAME, new String[] { "id" }, new Object[] { id });
-//        Assertions.assertNotNull(records);
-//        Assertions.assertEquals(1, records.size(), "Wrong result for lookup of key " + id);
+//        Assertions.assertThat(records).isNotNull();
+//        Assertions.assertThat(records.size().isEqualTo(1), "Wrong result for lookup of key " + id);
 //
 //        final Document record = (Document) records.next().getRecord();
-//        Assertions.assertEquals(id, record.get("id"));
+//        Assertions.assertThat(record.get("id")).isEqualTo(id);
 //
 //        if (id % 100000 == 0)
 //          System.out.println("Checked " + id + " lookups in " + (System.currentTimeMillis() - begin) + "ms");

--- a/engine/src/test/java/performance/PerformanceIndexCompaction.java
+++ b/engine/src/test/java/performance/PerformanceIndexCompaction.java
@@ -27,10 +27,11 @@ import com.arcadedb.index.IndexCursor;
 import com.arcadedb.index.IndexInternal;
 import com.arcadedb.index.RangeIndex;
 import com.arcadedb.log.LogManager;
-import org.junit.jupiter.api.Assertions;
 
 import java.io.*;
 import java.util.logging.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PerformanceIndexCompaction {
   public static void main(final String[] args) throws Exception {
@@ -51,12 +52,12 @@ public class PerformanceIndexCompaction {
       LogManager.instance().log(this, Level.INFO, "Total indexes items %d", totalIndexed);
 
       for (final Index index : database.getSchema().getIndexes())
-        Assertions.assertTrue(((IndexInternal) index).compact());
+        assertThat(((IndexInternal) index).compact()).isTrue();
 
       final long totalIndexed2 = countIndexedItems(database);
 
-      Assertions.assertEquals(total, totalIndexed);
-      Assertions.assertEquals(totalIndexed, totalIndexed2);
+      assertThat(totalIndexed).isEqualTo(total);
+      assertThat(totalIndexed2).isEqualTo(totalIndexed);
 
       System.out.println("Compaction done");
 

--- a/engine/src/test/java/performance/PerformanceInsertGraphIndexTest.java
+++ b/engine/src/test/java/performance/PerformanceInsertGraphIndexTest.java
@@ -33,11 +33,12 @@ import com.arcadedb.schema.EdgeType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.VertexType;
 import com.arcadedb.utility.FileUtils;
-import org.junit.jupiter.api.Assertions;
 
 import java.io.*;
 import java.util.*;
 import java.util.logging.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Inserts a graph. Configurations:
@@ -261,10 +262,10 @@ public class PerformanceInsertGraphIndexTest extends TestHelper {
       int j = 0;
       for (; j < expectedTotalEdges; j++) {
         final IndexCursor edgeCursor = index.get(new Object[] { j });
-        Assertions.assertTrue(edgeCursor.hasNext());
+        assertThat(edgeCursor.hasNext()).isTrue();
         final Edge e = edgeCursor.next().asEdge(true);
-        Assertions.assertNotNull(e);
-        Assertions.assertEquals(j, e.get("id"));
+        assertThat(e).isNotNull();
+        assertThat(e.get("id")).isEqualTo(j);
 
         if (j % 1_000_000 == 0) {
           final long elapsed = System.currentTimeMillis() - begin;
@@ -294,13 +295,13 @@ public class PerformanceInsertGraphIndexTest extends TestHelper {
       for (; i < VERTICES; ++i) {
         for (final Edge e : cachedVertices[i].getEdges(Vertex.DIRECTION.OUT, EDGE_TYPE_NAME)) {
           if (EDGE_IDS)
-            Assertions.assertNotNull(e.get("id"));
+            assertThat(e.get("id")).isNotNull();
           ++outEdges;
         }
 
         for (final Edge e : cachedVertices[i].getEdges(Vertex.DIRECTION.IN, EDGE_TYPE_NAME)) {
           if (EDGE_IDS)
-            Assertions.assertNotNull(e.get("id"));
+            assertThat(e.get("id")).isNotNull();
           ++inEdges;
         }
 
@@ -322,8 +323,8 @@ public class PerformanceInsertGraphIndexTest extends TestHelper {
 
       final int expectedTotalEdges = VERTICES * EDGES_PER_VERTEX;
 
-      Assertions.assertEquals(expectedTotalEdges, inEdges);
-      Assertions.assertEquals(expectedTotalEdges, outEdges);
+      assertThat(inEdges).isEqualTo(expectedTotalEdges);
+      assertThat(outEdges).isEqualTo(expectedTotalEdges);
 
     } finally {
       database.commit();

--- a/engine/src/test/java/performance/PerformanceParsing.java
+++ b/engine/src/test/java/performance/PerformanceParsing.java
@@ -24,9 +24,11 @@ import com.arcadedb.database.async.AsyncResultsetCallback;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.Assertions;
+
 
 import java.util.concurrent.atomic.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PerformanceParsing {
   private static final String TYPE_NAME = "Person";
@@ -64,7 +66,7 @@ public class PerformanceParsing {
 
             while (rs.hasNext()) {
               final Result record = rs.next();
-              Assertions.assertNotNull(record);
+              assertThat(record).isNotNull();
             }
           }
 
@@ -80,8 +82,8 @@ public class PerformanceParsing {
     } finally {
       database.close();
 
-      Assertions.assertEquals(MAX_LOOPS, ok.get());
-      Assertions.assertEquals(0, error.get());
+      assertThat(ok.get()).isEqualTo(MAX_LOOPS);
+      assertThat(error.get()).isEqualTo(0);
     }
   }
 }

--- a/engine/src/test/java/performance/PerformanceSQLSelect.java
+++ b/engine/src/test/java/performance/PerformanceSQLSelect.java
@@ -21,9 +21,10 @@ package performance;
 import com.arcadedb.TestHelper;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.Assertions;
 
 import java.util.concurrent.atomic.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PerformanceSQLSelect extends TestHelper {
   private static final String TYPE_NAME = "Person";
@@ -50,8 +51,8 @@ public class PerformanceSQLSelect extends TestHelper {
         final ResultSet rs = database.command("SQL", "select from " + TYPE_NAME + " where id < 1l");
         while (rs.hasNext()) {
           final Result record = rs.next();
-          Assertions.assertNotNull(record);
-          Assertions.assertTrue((long) record.getProperty("id") < 1);
+          assertThat(record).isNotNull();
+          assertThat((long) record.getProperty("id") < 1).isTrue();
           row.incrementAndGet();
         }
 

--- a/engine/src/test/java/performance/PerformanceVertexIndexTest.java
+++ b/engine/src/test/java/performance/PerformanceVertexIndexTest.java
@@ -32,11 +32,14 @@ import com.arcadedb.index.IndexInternal;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
-import org.junit.jupiter.api.Assertions;
+
 
 import java.io.*;
 import java.util.*;
 import java.util.logging.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
 
 public class PerformanceVertexIndexTest {
   private static final int    TOT               = 10_000_000;
@@ -59,7 +62,7 @@ public class PerformanceVertexIndexTest {
         try {
           compaction();
         } catch (final Exception e) {
-          Assertions.fail(e);
+          fail(e);
         }
       }
     }, 0);
@@ -70,7 +73,7 @@ public class PerformanceVertexIndexTest {
   private void compaction() throws IOException, InterruptedException {
     try (final Database database = new DatabaseFactory(PerformanceTest.DATABASE_PATH).open()) {
       for (final Index index : database.getSchema().getIndexes())
-        Assertions.assertTrue(((IndexInternal) index).compact());
+        assertThat(((IndexInternal) index).compact()).isTrue();
     }
   }
 
@@ -133,7 +136,7 @@ public class PerformanceVertexIndexTest {
         public void call(final Throwable exception) {
           LogManager.instance().log(this, Level.INFO, "TEST: ERROR: " + exception);
           exception.printStackTrace();
-          Assertions.fail(exception);
+          fail(exception);
         }
       });
 
@@ -198,11 +201,12 @@ public class PerformanceVertexIndexTest {
 
       for (long id = 0; id < TOT; id += step) {
         final IndexCursor records = database.lookupByKey(TYPE_NAME, new String[] { "id" }, new Object[] { id });
-        Assertions.assertNotNull(records);
-        Assertions.assertTrue(records.hasNext(), "Wrong result for lookup of key " + id);
+        assertThat(records.hasNext())
+                .as("Wrong result for lookup of key " + id)
+                .isTrue();
 
         final Document record = (Document) records.next().getRecord();
-        Assertions.assertEquals("" + id, record.get("id"));
+        assertThat(record.get("id")).isEqualTo("" + id);
 
         checked++;
 

--- a/graphql/src/test/java/com/arcadedb/graphql/AbstractGraphQLNativeLanguageDirectivesTest.java
+++ b/graphql/src/test/java/com/arcadedb/graphql/AbstractGraphQLNativeLanguageDirectivesTest.java
@@ -20,10 +20,11 @@ package com.arcadedb.graphql;
 
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class AbstractGraphQLNativeLanguageDirectivesTest extends AbstractGraphQLTest {
   protected int getExpectedPropertiesMetadata() {
@@ -35,22 +36,23 @@ public abstract class AbstractGraphQLNativeLanguageDirectivesTest extends Abstra
     executeTest((database) -> {
       defineTypes(database);
 
-      try (final ResultSet resultSet = database.query("graphql", "{ bookByName(bookNameParameter: \"Harry Potter and the Philosopher's Stone\")}")) {
-        Assertions.assertTrue(resultSet.hasNext());
+      try (final ResultSet resultSet = database.query("graphql",
+          "{ bookByName(bookNameParameter: \"Harry Potter and the Philosopher's Stone\")}")) {
+        assertThat(resultSet.hasNext()).isTrue();
         final Result record = resultSet.next();
-        Assertions.assertEquals(4 + getExpectedPropertiesMetadata(), record.getPropertyNames().size());
-        Assertions.assertEquals(1, ((Collection) record.getProperty("authors")).size());
-        Assertions.assertEquals("Harry Potter and the Philosopher's Stone", record.getProperty("name"));
-        Assertions.assertFalse(resultSet.hasNext());
+        assertThat(record.getPropertyNames().size()).isEqualTo(4 + getExpectedPropertiesMetadata());
+        assertThat(record.<Collection<?>>getProperty("authors")).hasSize(1);
+        assertThat(record.<String>getProperty("name")).isEqualTo("Harry Potter and the Philosopher's Stone");
+        assertThat(resultSet.hasNext()).isFalse();
       }
 
       try (final ResultSet resultSet = database.query("graphql", "{ bookByName(bookNameParameter: \"Mr. brain\") }")) {
-        Assertions.assertTrue(resultSet.hasNext());
+        assertThat(resultSet.hasNext()).isTrue();
         final Result record = resultSet.next();
-        Assertions.assertEquals(4 + getExpectedPropertiesMetadata(), record.getPropertyNames().size());
-        Assertions.assertEquals(1, ((Collection) record.getProperty("authors")).size());
-        Assertions.assertEquals("Mr. brain", record.getProperty("name"));
-        Assertions.assertFalse(resultSet.hasNext());
+        assertThat(record.getPropertyNames().size()).isEqualTo(4 + getExpectedPropertiesMetadata());
+        assertThat(record.<Collection<?>>getProperty("authors")).hasSize(1);
+        assertThat(record.<String>getProperty("name")).isEqualTo("Mr. brain");
+        assertThat(resultSet.hasNext()).isFalse();
       }
 
       return null;
@@ -64,19 +66,20 @@ public abstract class AbstractGraphQLNativeLanguageDirectivesTest extends Abstra
 
       try (final ResultSet resultSet = database.query("graphql",
           "{ bookByName(bookNameParameter: \"Harry Potter and the Philosopher's Stone\"){ id name pageCount } }")) {
-        Assertions.assertTrue(resultSet.hasNext());
+        assertThat(resultSet.hasNext()).isTrue();
         final Result record = resultSet.next();
-        Assertions.assertEquals(3 + getExpectedPropertiesMetadata(), record.getPropertyNames().size());
-        Assertions.assertEquals("Harry Potter and the Philosopher's Stone", record.getProperty("name"));
-        Assertions.assertFalse(resultSet.hasNext());
+        assertThat(record.getPropertyNames().size()).isEqualTo(3 + getExpectedPropertiesMetadata());
+        assertThat(record.<String>getProperty("name")).isEqualTo("Harry Potter and the Philosopher's Stone");
+        assertThat(resultSet.hasNext()).isFalse();
       }
 
-      try (final ResultSet resultSet = database.query("graphql", "{ bookByName(bookNameParameter: \"Mr. brain\"){ id name pageCount } }")) {
-        Assertions.assertTrue(resultSet.hasNext());
+      try (final ResultSet resultSet = database.query("graphql",
+          "{ bookByName(bookNameParameter: \"Mr. brain\"){ id name pageCount } }")) {
+        assertThat(resultSet.hasNext()).isTrue();
         final Result record = resultSet.next();
-        Assertions.assertEquals(3 + getExpectedPropertiesMetadata(), record.getPropertyNames().size());
-        Assertions.assertEquals("Mr. brain", record.getProperty("name"));
-        Assertions.assertFalse(resultSet.hasNext());
+        assertThat(record.getPropertyNames().size()).isEqualTo(3 + getExpectedPropertiesMetadata());
+        assertThat(record.<String>getProperty("name")).isEqualTo("Mr. brain");
+        assertThat(resultSet.hasNext()).isFalse();
       }
 
       return null;

--- a/graphql/src/test/java/com/arcadedb/graphql/GraphQLBasicTest.java
+++ b/graphql/src/test/java/com/arcadedb/graphql/GraphQLBasicTest.java
@@ -22,10 +22,13 @@ import com.arcadedb.database.RID;
 import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
 
 public class GraphQLBasicTest extends AbstractGraphQLTest {
 
@@ -61,18 +64,18 @@ public class GraphQLBasicTest extends AbstractGraphQLTest {
           "  }" +//
           "}" +//
           "}")) {
-        Assertions.assertTrue(resultSet.hasNext());
+        assertThat(resultSet.hasNext()).isTrue();
         final Result record = resultSet.next();
 
         record.toJSON();
 
         rid = record.getIdentity().get();
-        Assertions.assertNotNull(rid);
+        assertThat(rid).isNotNull();
 
-        Assertions.assertEquals(8, record.getPropertyNames().size());
-        Assertions.assertEquals(1, ((Collection) record.getProperty("authors")).size());
+        assertThat(record.getPropertyNames()).hasSize(8);
+        assertThat(((Collection) record.getProperty("authors"))).hasSize(1);
 
-        Assertions.assertFalse(resultSet.hasNext());
+        assertThat(resultSet.hasNext()).isFalse();
       }
 
       return null;
@@ -85,21 +88,21 @@ public class GraphQLBasicTest extends AbstractGraphQLTest {
       defineTypes(database);
 
       try (final ResultSet resultSet = database.query("graphql", "{ bookByName(name: \"Harry Potter and the Philosopher's Stone\")}")) {
-        Assertions.assertTrue(resultSet.hasNext());
+        assertThat(resultSet.hasNext()).isTrue();
         final Result record = resultSet.next();
-        Assertions.assertEquals(7, record.getPropertyNames().size());
-        Assertions.assertEquals(1, ((Collection) record.getProperty("authors")).size());
-        Assertions.assertEquals("Harry Potter and the Philosopher's Stone", record.getProperty("name"));
-        Assertions.assertFalse(resultSet.hasNext());
+        assertThat(record.getPropertyNames()).hasSize(7);
+        assertThat(((Collection) record.getProperty("authors"))).hasSize(1);
+        assertThat(record.<String>getProperty("name")).isEqualTo("Harry Potter and the Philosopher's Stone");
+        assertThat(resultSet.hasNext()).isFalse();
       }
 
       try (final ResultSet resultSet = database.query("graphql", "{ bookByName(name: \"Mr. brain\") }")) {
-        Assertions.assertTrue(resultSet.hasNext());
+        assertThat(resultSet.hasNext()).isTrue();
         final Result record = resultSet.next();
-        Assertions.assertEquals(7, record.getPropertyNames().size());
-        Assertions.assertEquals(1, ((Collection) record.getProperty("authors")).size());
-        Assertions.assertEquals("Mr. brain", record.getProperty("name"));
-        Assertions.assertFalse(resultSet.hasNext());
+        assertThat(record.getPropertyNames()).hasSize(7);
+        assertThat(((Collection) record.getProperty("authors"))).hasSize(1);
+        assertThat(record.<String>getProperty("name")).isEqualTo("Mr. brain");
+        assertThat(resultSet.hasNext()).isFalse();
       }
 
       return null;
@@ -113,7 +116,7 @@ public class GraphQLBasicTest extends AbstractGraphQLTest {
 
       try {
         database.query("graphql", "{ bookByName(wrong: \"Mr. brain\") }");
-        Assertions.fail();
+        fail();
       } catch (final CommandParsingException e) {
         // EXPECTED
       }
@@ -144,17 +147,17 @@ public class GraphQLBasicTest extends AbstractGraphQLTest {
       database.command("graphql", types);
 
       try (final ResultSet resultSet = database.query("graphql", "{ books }")) {
-        Assertions.assertTrue(resultSet.hasNext());
+        assertThat(resultSet.hasNext()).isTrue();
         Result record = resultSet.next();
-        Assertions.assertEquals(7, record.getPropertyNames().size());
-        Assertions.assertEquals(1, ((Collection) record.getProperty("authors")).size());
+        assertThat(record.getPropertyNames()).hasSize(7);
+        assertThat(((Collection) record.getProperty("authors"))).hasSize(1);
 
-        Assertions.assertTrue(resultSet.hasNext());
+        assertThat(resultSet.hasNext()).isTrue();
         record = resultSet.next();
-        Assertions.assertEquals(7, record.getPropertyNames().size());
-        Assertions.assertEquals(1, ((Collection) record.getProperty("authors")).size());
+        assertThat(record.getPropertyNames()).hasSize(7);
+        assertThat(((Collection) record.getProperty("authors"))).hasSize(1);
 
-        Assertions.assertFalse(resultSet.hasNext());
+        assertThat(resultSet.hasNext()).isFalse();
       }
 
       return null;
@@ -183,17 +186,17 @@ public class GraphQLBasicTest extends AbstractGraphQLTest {
       database.command("graphql", types);
 
       try (final ResultSet resultSet = database.query("graphql", "{ books { id\n name\n pageCount\n authors @relationship(type: \"WRONG\", direction: IN)} }")) {
-        Assertions.assertTrue(resultSet.hasNext());
+        assertThat(resultSet.hasNext()).isTrue();
         Result record = resultSet.next();
-        Assertions.assertEquals(7, record.getPropertyNames().size());
-        Assertions.assertEquals(0, countIterable(record.getProperty("authors")));
+        assertThat(record.getPropertyNames()).hasSize(7);
+        assertThat(countIterable(record.getProperty("authors"))).isEqualTo(0);
 
-        Assertions.assertTrue(resultSet.hasNext());
+        assertThat(resultSet.hasNext()).isTrue();
         record = resultSet.next();
-        Assertions.assertEquals(7, record.getPropertyNames().size());
-        Assertions.assertEquals(0, countIterable(record.getProperty("authors")));
+        assertThat(record.getPropertyNames()).hasSize(7);
+        assertThat(countIterable(record.getProperty("authors"))).isEqualTo(0);
 
-        Assertions.assertFalse(resultSet.hasNext());
+        assertThat(resultSet.hasNext()).isFalse();
       }
 
       return null;
@@ -222,17 +225,17 @@ public class GraphQLBasicTest extends AbstractGraphQLTest {
       database.command("graphql", types);
 
       try (final ResultSet resultSet = database.query("graphql", "{ books( where: \"name = 'Mr. brain'\" ) }")) {
-        Assertions.assertTrue(resultSet.hasNext());
+        assertThat(resultSet.hasNext()).isTrue();
         final Result record = resultSet.next();
-        Assertions.assertEquals(7, record.getPropertyNames().size());
+        assertThat(record.getPropertyNames()).hasSize(7);
 
-        Assertions.assertEquals("book-2", record.getProperty("id"));
-        Assertions.assertEquals("Mr. brain", record.getProperty("name"));
-        Assertions.assertEquals(422, (Integer) record.getProperty("pageCount"));
+        assertThat(record.<String>getProperty("id")).isEqualTo("book-2");
+        assertThat(record.<String>getProperty("name")).isEqualTo("Mr. brain");
+        assertThat((Integer) record.getProperty("pageCount")).isEqualTo(422);
 
-        Assertions.assertEquals(1, ((Collection) record.getProperty("authors")).size());
+        assertThat(((Collection) record.getProperty("authors"))).hasSize(1);
 
-        Assertions.assertFalse(resultSet.hasNext());
+        assertThat(resultSet.hasNext()).isFalse();
       }
 
       return null;

--- a/graphql/src/test/java/com/arcadedb/graphql/parser/GraphQLParserSchemaTest.java
+++ b/graphql/src/test/java/com/arcadedb/graphql/parser/GraphQLParserSchemaTest.java
@@ -18,8 +18,10 @@
  */
 package com.arcadedb.graphql.parser;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class GraphQLParserSchemaTest {
   @Test
@@ -40,7 +42,7 @@ public class GraphQLParserSchemaTest {
         "  lastName: String\n" +//
         "}");
 
-    Assertions.assertTrue(ast.children.length > 0);
+    assertThat(ast.children.length > 0).isTrue();
   }
 
   @Test
@@ -62,7 +64,7 @@ public class GraphQLParserSchemaTest {
           "  lastName: String\n" +//
           "  wrote: [Book] @relationship(type: \"IS_AUTHOR_OF\", direction: OUT)\n" +//
           "} dsfjsd fjsdkjf sdk");
-      Assertions.fail(ast.treeToString(""));
+      fail(ast.treeToString(""));
     } catch (final ParseException e) {
       // EXPECTED
     }
@@ -87,7 +89,7 @@ public class GraphQLParserSchemaTest {
           "  lastName: String\n" +//
           "  wrote: [Book] @relationship(type: \"IS_AUTHOR_OF\", direction: OUT)\n" +//
           "} dsfjsd fjsdkjf sdk");
-      Assertions.fail(ast.treeToString(""));
+      fail(ast.treeToString(""));
     } catch (final ParseException e) {
       // EXPECTED
     }

--- a/graphql/src/test/java/com/arcadedb/graphql/parser/GraphQLParserTest.java
+++ b/graphql/src/test/java/com/arcadedb/graphql/parser/GraphQLParserTest.java
@@ -18,8 +18,9 @@
  */
 package com.arcadedb.graphql.parser;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class GraphQLParserTest {
   @Test
@@ -40,7 +41,7 @@ public class GraphQLParserTest {
         "}" +//
         "}");
 
-    Assertions.assertTrue(ast.children.length > 0);
+    assertThat(ast.children.length > 0).isTrue();
 
     //ast.dump("-");
   }

--- a/gremlin/src/test/java/com/arcadedb/gremlin/CypherTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/CypherTest.java
@@ -29,11 +29,14 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -58,19 +61,19 @@ public class CypherTest {
       int lastAge = 0;
       for (; result.hasNext(); ++i) {
         final Result row = result.next();
-        Assertions.assertEquals("Jay", row.getProperty("p.name"));
-        Assertions.assertTrue(row.getProperty("p.age") instanceof Number);
-        Assertions.assertTrue((int) row.getProperty("p.age") > lastAge);
+        assertThat(row.<String>getProperty("p.name")).isEqualTo("Jay");
+        assertThat(row.getProperty("p.age") instanceof Number).isTrue();
+        assertThat((int) row.getProperty("p.age") > lastAge).isTrue();
 
         lastAge = row.getProperty("p.age");
       }
 
-      Assertions.assertEquals(25, i);
+      assertThat(i).isEqualTo(25);
 
     } finally {
       graph.drop();
-      Assertions.assertNull(graph.getGremlinJavaEngine());
-      Assertions.assertNull(graph.getGremlinGroovyEngine());
+      assertThat(graph.getGremlinJavaEngine()).isNull();
+      assertThat(graph.getGremlinGroovyEngine()).isNull();
     }
   }
 
@@ -84,15 +87,15 @@ public class CypherTest {
       try {
         graph.cypher("MATCH (p::Person) WHERE p.age >= $p1 RETURN p.name, p.age ORDER BY p.age")//
             .setParameter("p1", 25).execute();
-        Assertions.fail();
+        fail("");
       } catch (final CommandParsingException e) {
         // EXPECTED
       }
 
     } finally {
       graph.drop();
-      Assertions.assertNull(graph.getGremlinJavaEngine());
-      Assertions.assertNull(graph.getGremlinGroovyEngine());
+      assertThat(graph.getGremlinJavaEngine()).isNull();
+      assertThat(graph.getGremlinGroovyEngine()).isNull();
     }
   }
 
@@ -115,14 +118,14 @@ public class CypherTest {
       int lastAge = 0;
       for (; result.hasNext(); ++i) {
         final Result row = result.next();
-        Assertions.assertEquals("Jay", row.getProperty("p.name"));
-        Assertions.assertTrue(row.getProperty("p.age") instanceof Number);
-        Assertions.assertTrue((int) row.getProperty("p.age") > lastAge);
+        assertThat(row.<String>getProperty("p.name")).isEqualTo("Jay");
+        assertThat(row.getProperty("p.age") instanceof Number).isTrue();
+        assertThat((int) row.getProperty("p.age") > lastAge).isTrue();
 
         lastAge = row.getProperty("p.age");
       }
 
-      Assertions.assertEquals(25, i);
+      assertThat(i).isEqualTo(25);
 
     } finally {
       if (database.isTransactionActive())
@@ -139,18 +142,18 @@ public class CypherTest {
 
       final ArcadeCypher cypherReadOnly = graph.cypher("MATCH (p:Person) WHERE p.age >= 25 RETURN p.name, p.age ORDER BY p.age");
 
-      Assertions.assertTrue(cypherReadOnly.parse().isIdempotent());
-      Assertions.assertFalse(cypherReadOnly.parse().isDDL());
+      assertThat(cypherReadOnly.parse().isIdempotent()).isTrue();
+      assertThat(cypherReadOnly.parse().isDDL()).isFalse();
 
       final ArcadeGremlin cypherWrite = graph.cypher("CREATE (n:Person)");
 
-      Assertions.assertFalse(cypherWrite.parse().isIdempotent());
-      Assertions.assertFalse(cypherWrite.parse().isDDL());
+      assertThat(cypherWrite.parse().isIdempotent()).isFalse();
+      assertThat(cypherWrite.parse().isDDL()).isFalse();
 
     } finally {
       graph.drop();
-      Assertions.assertNull(graph.getGremlinJavaEngine());
-      Assertions.assertNull(graph.getGremlinGroovyEngine());
+      assertThat(graph.getGremlinJavaEngine()).isNull();
+      assertThat(graph.getGremlinGroovyEngine()).isNull();
     }
   }
 
@@ -161,19 +164,19 @@ public class CypherTest {
 
       final ArcadeCypher cypherReadOnly = graph.cypher("CREATE (i:User {name: 'RAMS'}) return i");
 
-      Assertions.assertFalse(cypherReadOnly.parse().isIdempotent());
-      Assertions.assertFalse(cypherReadOnly.parse().isDDL());
+      assertThat(cypherReadOnly.parse().isIdempotent()).isFalse();
+      assertThat(cypherReadOnly.parse().isDDL()).isFalse();
 
       final ResultSet result = cypherReadOnly.execute();
 
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result row = result.next();
-      Assertions.assertNotNull(row.getIdentity().get());
+      assertThat(row.getIdentity().get()).isNotNull();
 
     } finally {
       graph.drop();
-      Assertions.assertNull(graph.getGremlinJavaEngine());
-      Assertions.assertNull(graph.getGremlinGroovyEngine());
+      assertThat(graph.getGremlinJavaEngine()).isNull();
+      assertThat(graph.getGremlinGroovyEngine()).isNull();
     }
   }
 
@@ -188,27 +191,27 @@ public class CypherTest {
       graph.getDatabase().getSchema().getOrCreateVertexType("Person");
 
       final ResultSet p1 = graph.cypher("CREATE (p:Person {label:\"First\"}) return p").execute();
-      Assertions.assertTrue(p1.hasNext());
+      assertThat(p1.hasNext()).isTrue();
       final RID p1RID = p1.next().getIdentity().get();
 
       final ResultSet p2 = graph.cypher("CREATE (p:Person {label:\"Second\"}) return p").execute();
-      Assertions.assertTrue(p2.hasNext());
+      assertThat(p2.hasNext()).isTrue();
       final RID p2RID = p2.next().getIdentity().get();
 
       final ArcadeCypher query = graph.cypher("MATCH (a),(b) WHERE a.label = \"First\" AND b.label = \"Second\" RETURN a,b");
       final ResultSet result = query.execute();
 
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result row = result.next();
-      Assertions.assertNotNull(row.getProperty("a"));
-      Assertions.assertEquals(p1RID, ((Result) row.getProperty("a")).getIdentity().get());
-      Assertions.assertNotNull(row.getProperty("b"));
-      Assertions.assertEquals(p2RID, ((Result) row.getProperty("b")).getIdentity().get());
+      assertThat(row.<Object>getProperty("a")).isNotNull();
+      assertThat(((Result) row.getProperty("a")).getIdentity().get()).isEqualTo(p1RID);
+      assertThat(row.<Object>getProperty("b")).isNotNull();
+      assertThat(((Result) row.getProperty("b")).getIdentity().get()).isEqualTo(p2RID);
 
     } finally {
       graph.drop();
-      Assertions.assertNull(graph.getGremlinJavaEngine());
-      Assertions.assertNull(graph.getGremlinGroovyEngine());
+      assertThat(graph.getGremlinJavaEngine()).isNull();
+      assertThat(graph.getGremlinGroovyEngine()).isNull();
     }
   }
 
@@ -222,15 +225,15 @@ public class CypherTest {
     try {
 
       final ResultSet p1 = graph.cypher("CREATE (p:Person) RETURN p").execute();
-      Assertions.assertTrue(p1.hasNext());
+      assertThat(p1.hasNext()).isTrue();
       p1.next().getIdentity().get();
 
       graph.cypher("MATCH (p) DELETE p").execute();
 
     } finally {
       graph.drop();
-      Assertions.assertNull(graph.getGremlinJavaEngine());
-      Assertions.assertNull(graph.getGremlinGroovyEngine());
+      assertThat(graph.getGremlinJavaEngine()).isNull();
+      assertThat(graph.getGremlinGroovyEngine()).isNull();
     }
   }
 

--- a/gremlin/src/test/java/com/arcadedb/gremlin/GremlinTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/GremlinTest.java
@@ -35,14 +35,18 @@ import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import java.io.*;
-import java.math.*;
-import java.util.*;
+import java.io.File;
+import java.io.PrintStream;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Tests execution of gremlin queries as text.
@@ -74,14 +78,14 @@ public class GremlinTest {
       int lastAge = 0;
       for (; result.hasNext(); ++i) {
         final Result row = result.next();
-        Assertions.assertEquals("Jay", row.getProperty("p.name"));
-        Assertions.assertTrue(row.getProperty("p.age") instanceof Number);
-        Assertions.assertTrue((int) row.getProperty("p.age") > lastAge);
+        assertThat(row.<String>getProperty("p.name")).isEqualTo("Jay");
+        assertThat(row.getProperty("p.age") instanceof Number).isTrue();
+        assertThat((int) row.getProperty("p.age") > lastAge).isTrue();
 
         lastAge = row.getProperty("p.age");
       }
 
-      Assertions.assertEquals(25, i);
+      assertThat(i).isEqualTo(25);
 
     } finally {
       graph.drop();
@@ -120,13 +124,13 @@ public class GremlinTest {
       int total = 0;
       for (; result.hasNext(); ++total)
         result.next();
-      Assertions.assertEquals(10, total);
+      assertThat(total).isEqualTo(10);
 
       result = graph.gremlin("g.E().hasLabel('bucket:LinkedTo_1')").execute();
       total = 0;
       for (; result.hasNext(); ++total)
         result.next();
-      Assertions.assertEquals(9, total);
+      assertThat(total).isEqualTo(9);
 
     } finally {
       graph.drop();
@@ -137,11 +141,9 @@ public class GremlinTest {
   public void testGremlinCountNotDefinedTypes() {
     final ArcadeGraph graph = ArcadeGraph.open("./target/testgremlin");
     try {
-      Assertions.assertEquals(0,
-          (Long) graph.gremlin("g.V().hasLabel ( 'foo-label' ).count ()").execute().nextIfAvailable().getProperty("result"));
+      assertThat((Long) graph.gremlin("g.V().hasLabel ( 'foo-label' ).count ()").execute().nextIfAvailable().getProperty("result")).isEqualTo(0);
 
-      Assertions.assertEquals(0,
-          (Long) graph.gremlin("g.E().hasLabel ( 'foo-label' ).count ()").execute().nextIfAvailable().getProperty("result"));
+      assertThat((Long) graph.gremlin("g.E().hasLabel ( 'foo-label' ).count ()").execute().nextIfAvailable().getProperty("result")).isEqualTo(0);
 
     } finally {
       graph.drop();
@@ -171,11 +173,11 @@ public class GremlinTest {
       int total = 0;
       for (; result.hasNext(); ++total) {
         EmbeddedDocument address = result.next().getProperty("residence");
-        Assertions.assertEquals("Via Roma, 10", address.getString("street"));
-        Assertions.assertEquals("Rome", address.getString("city"));
-        Assertions.assertEquals("Italy", address.getString("country"));
+        assertThat(address.getString("street")).isEqualTo("Via Roma, 10");
+        assertThat(address.getString("city")).isEqualTo("Rome");
+        assertThat(address.getString("country")).isEqualTo("Italy");
       }
-      Assertions.assertEquals(10, total);
+      assertThat(total).isEqualTo(10);
 
     } finally {
       graph.drop();
@@ -195,14 +197,14 @@ public class GremlinTest {
       graph.addVertex("vl3").property("vp1", 1);
 
       ResultSet result = graph.gremlin("g.V().has('vl1','vp1',lt(2)).count()").execute();
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       Result row = result.next();
-      Assertions.assertEquals(1L, (Long) row.getProperty("result"));
+      assertThat((Long) row.getProperty("result")).isEqualTo(1L);
 
       result = graph.gremlin("g.V().has('vl1','vp1',lt(2)).hasLabel('vl1','vl2','vl3').count()").execute();
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       row = result.next();
-      Assertions.assertEquals(1L, (Long) row.getProperty("result"));
+      assertThat((Long) row.getProperty("result")).isEqualTo(1L);
 
     } finally {
       graph.drop();
@@ -218,15 +220,15 @@ public class GremlinTest {
       ArcadeVertex v2 = graph.addVertex("vl2");
 
       ResultSet result = graph.gremlin("g.V('" + v1.id() + "').addE('FriendOf').to( V('" + v2.id() + "') )").execute();
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       Result row = result.next();
 
-      Assertions.assertTrue(row.isEdge());
+      assertThat(row.isEdge()).isTrue();
 
       final Edge edge = row.getEdge().get();
 
-      Assertions.assertEquals(v1.id(), edge.getOut().getIdentity().toString());
-      Assertions.assertEquals(v2.id(), edge.getIn().getIdentity().toString());
+      assertThat(edge.getOut().getIdentity().toString()).isEqualTo(v1.id());
+      assertThat(edge.getIn().getIdentity().toString()).isEqualTo(v2.id());
 
     } finally {
       graph.drop();
@@ -253,15 +255,15 @@ public class GremlinTest {
       int lastAge = 0;
       for (; result.hasNext(); ++i) {
         final Result row = result.next();
-        Assertions.assertFalse(row.isElement());
-        Assertions.assertEquals("Jay", row.getProperty("p.name"));
-        Assertions.assertTrue(row.getProperty("p.age") instanceof Number);
-        Assertions.assertTrue((int) row.getProperty("p.age") > lastAge);
+        assertThat(row.isElement()).isFalse();
+        assertThat(row.<String>getProperty("p.name")).isEqualTo("Jay");
+        assertThat(row.getProperty("p.age") instanceof Number).isTrue();
+        assertThat((int) row.getProperty("p.age") > lastAge).isTrue();
 
         lastAge = row.getProperty("p.age");
       }
 
-      Assertions.assertEquals(25, i);
+      assertThat(i).isEqualTo(25);
 
     } finally {
       if (database.isTransactionActive())
@@ -281,7 +283,7 @@ public class GremlinTest {
         graph.getDatabase().query("gremlin",
             "g.V().as('p').hasLabel22222('Person').where(__.choose(__.constant(p1), __.constant(p1), __.constant('  cypher.null')).is(neq('  cypher.null')).as('  GENERATED1').select('p').values('age').where(gte('  GENERATED1'))).select('p').project('p.name', 'p.age').by(__.choose(neq('  cypher.null'), __.choose(__.values('name'), __.values('name'), __.constant('  cypher.null')))).by(__.choose(neq('  cypher.null'), __.choose(__.values('age'), __.values('age'), __.constant('  cypher.null')))).order().by(__.select('p.age'), asc)",
             "p1", 25);
-        Assertions.fail();
+        fail("");
       } catch (final CommandParsingException e) {
         // EXPECTED
       }
@@ -299,13 +301,13 @@ public class GremlinTest {
       final ArcadeGremlin gremlinReadOnly = graph.gremlin(
           "g.V().as('p').hasLabel('Person').where(__.choose(__.constant(25), __.constant(25), __.constant('  cypher.null')).is(neq('  cypher.null')).as('  GENERATED1').select('p').values('age').where(gte('  GENERATED1'))).select('p').project('p.name', 'p.age').by(__.choose(neq('  cypher.null'), __.choose(__.values('name'), __.values('name'), __.constant('  cypher.null')))).by(__.choose(neq('  cypher.null'), __.choose(__.values('age'), __.values('age'), __.constant('  cypher.null')))).order().by(__.select('p.age'), asc)");
 
-      Assertions.assertTrue(gremlinReadOnly.parse().isIdempotent());
-      Assertions.assertFalse(gremlinReadOnly.parse().isDDL());
+      assertThat(gremlinReadOnly.parse().isIdempotent()).isTrue();
+      assertThat(gremlinReadOnly.parse().isDDL()).isFalse();
 
       final ArcadeGremlin gremlinWrite = graph.gremlin("g.V().addV('Person')");
 
-      Assertions.assertFalse(gremlinWrite.parse().isIdempotent());
-      Assertions.assertFalse(gremlinWrite.parse().isDDL());
+      assertThat(gremlinWrite.parse().isIdempotent()).isFalse();
+      assertThat(gremlinWrite.parse().isDDL()).isFalse();
 
     } finally {
       graph.drop();
@@ -318,13 +320,13 @@ public class GremlinTest {
     try {
       final ResultSet result = graph.gremlin("g.addV('Person').property( 'list', ['a', 'b'] )").execute();
 
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result v = result.next();
-      Assertions.assertTrue(v.isVertex());
+      assertThat(v.isVertex()).isTrue();
       final List list = (List) v.getVertex().get().get("list");
-      Assertions.assertEquals(2, list.size());
-      Assertions.assertTrue(list.contains("a"));
-      Assertions.assertTrue(list.contains("b"));
+      assertThat(list.size()).isEqualTo(2);
+      assertThat(list.contains("a")).isTrue();
+      assertThat(list.contains("b")).isTrue();
 
     } finally {
       graph.drop();
@@ -345,7 +347,7 @@ public class GremlinTest {
       final ArcadeGremlin gremlinReadOnly = graph.gremlin("g.V().as('p').hasLabel('Person').has( 'id', eq('" + uuid + "'))");
       final ResultSet result = gremlinReadOnly.execute();
 
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
     } finally {
       graph.drop();
     }
@@ -376,7 +378,7 @@ public class GremlinTest {
       final ArcadeGremlin gremlinReadOnly = graph.gremlin("g.V().has('hair', 500.00)");
       final ResultSet result = gremlinReadOnly.execute();
 
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
 
     } finally {
       graph.drop();
@@ -395,7 +397,7 @@ public class GremlinTest {
       final ArcadeGremlin gremlinReadOnly = graph.gremlin("g.addV('ChipID').property('name', 'a').property('uid', 'b')");
       final ResultSet result = gremlinReadOnly.execute();
 
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
 
     } finally {
       graph.drop();
@@ -421,7 +423,7 @@ public class GremlinTest {
       final ArcadeGremlin gremlinReadOnly = graph.gremlin("g.V().order().by('name', asc)");
       final ResultSet result = gremlinReadOnly.execute();
 
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
 
     } finally {
       graph.drop();
@@ -434,14 +436,13 @@ public class GremlinTest {
     final ArcadeGraph graph = ArcadeGraph.open("./target/testgremlin");
     try {
       Result value = graph.gremlin("g.inject(Long.MAX_VALUE, 0).sum()").execute().nextIfAvailable();
-      Assertions.assertEquals(Long.MAX_VALUE, (long) value.getProperty("result"));
+      assertThat((long) value.getProperty("result")).isEqualTo(Long.MAX_VALUE);
 
       value = graph.gremlin("g.inject(Long.MAX_VALUE, 1).sum()").execute().nextIfAvailable();
-      Assertions.assertEquals(Long.MAX_VALUE + 1, (long) value.getProperty("result"));
+      assertThat((long) value.getProperty("result")).isEqualTo(Long.MAX_VALUE + 1);
 
       value = graph.gremlin("g.inject(BigInteger.valueOf(Long.MAX_VALUE), 1).sum()").execute().nextIfAvailable();
-      Assertions.assertEquals(BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.valueOf(1L)),
-          (BigInteger) value.getProperty("result"));
+      assertThat((BigInteger) value.getProperty("result")).isEqualTo(BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.valueOf(1L)));
     } finally {
       graph.drop();
     }
@@ -453,7 +454,7 @@ public class GremlinTest {
     final ArcadeGraph graph = ArcadeGraph.open("./target/testgremlin");
     try {
       Result value = graph.gremlin("g.inject(1).size()").execute().nextIfAvailable();
-      Assertions.assertEquals(1, (int) value.getProperty("result"));
+      assertThat((int) value.getProperty("result")).isEqualTo(1);
     } finally {
       graph.drop();
     }
@@ -476,9 +477,9 @@ public class GremlinTest {
 
       ResultSet resultSet = graph.gremlin("g.V().hasLabel('Person').group().by('name')").execute();
       Result result = resultSet.nextIfAvailable();
-      Assertions.assertNotNull(result.getProperty("Alice"));
-      Assertions.assertNotNull(result.getProperty("Bob"));
-      Assertions.assertNotNull(result.getProperty("Steve"));
+      assertThat(result.<Object>getProperty("Alice")).isNotNull();
+      assertThat(result.<Object>getProperty("Bob")).isNotNull();
+      assertThat(result.<Object>getProperty("Steve")).isNotNull();
     } finally {
       graph.drop();
     }
@@ -515,10 +516,9 @@ public class GremlinTest {
       graph.gremlin("g.addV('A').property('b', true)").execute().nextIfAvailable();
       graph.gremlin("g.addV('A').property('b', false)").execute().nextIfAvailable();
       graph.gremlin("g.addV('A')").execute().nextIfAvailable();
-      Assertions.assertEquals(4, graph.gremlin("g.V().hasLabel('A')").execute().toVertices().size());
-      Assertions.assertEquals(2, graph.gremlin("g.V().hasLabel('A').has('b',true)").execute().toVertices().size());
-      Assertions.assertEquals(2,
-          (Long) graph.gremlin("g.V().hasLabel('A').has('b',true).count()").execute().nextIfAvailable().getProperty("result"));
+      assertThat(graph.gremlin("g.V().hasLabel('A')").execute().toVertices().size()).isEqualTo(4);
+      assertThat(graph.gremlin("g.V().hasLabel('A').has('b',true)").execute().toVertices().size()).isEqualTo(2);
+      assertThat((Long) graph.gremlin("g.V().hasLabel('A').has('b',true).count()").execute().nextIfAvailable().getProperty("result")).isEqualTo(2);
 
     } finally {
       graph.drop();

--- a/gremlin/src/test/java/com/arcadedb/gremlin/SQLFromGremlinTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/SQLFromGremlinTest.java
@@ -24,11 +24,12 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -53,14 +54,14 @@ public class SQLFromGremlinTest {
       int lastAge = 0;
       for (; result.hasNext(); ++i) {
         final Result row = result.next();
-        Assertions.assertEquals("Jay", row.getProperty("p.name"));
-        Assertions.assertTrue(row.getProperty("p.age") instanceof Number);
-        Assertions.assertTrue((int) row.getProperty("p.age") > lastAge);
+        assertThat(row.<String>getProperty("p.name")).isEqualTo("Jay");
+        assertThat(row.getProperty("p.age") instanceof Number).isTrue();
+        assertThat((int) row.getProperty("p.age") > lastAge).isTrue();
 
         lastAge = row.getProperty("p.age");
       }
 
-      Assertions.assertEquals(25, i);
+      assertThat(i).isEqualTo(25);
 
     } finally {
       graph.drop();

--- a/gremlin/src/test/java/com/arcadedb/gremlin/integration/exporter/GraphSONExporterIT.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/integration/exporter/GraphSONExporterIT.java
@@ -31,13 +31,14 @@ import com.arcadedb.server.TestServerHelper;
 import com.arcadedb.utility.FileUtils;
 import org.apache.tinkerpop.gremlin.structure.io.IoCore;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.util.stream.*;
 import java.util.zip.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class GraphSONExporterIT {
   private final static String DATABASE_PATH = "target/databases/performance";
@@ -54,30 +55,26 @@ public class GraphSONExporterIT {
     final var importer = new OrientDBImporter(("-i " + inputFile.getFile() + " -d " + DATABASE_PATH + " -o").split(" "));
     importer.run().close();
 
-    Assertions.assertFalse(importer.isError());
-    Assertions.assertTrue(databaseDirectory.exists());
+    assertThat(importer.isError()).isFalse();
+    assertThat(databaseDirectory.exists()).isTrue();
 
     new Exporter(("-f " + FILE + " -d " + DATABASE_PATH + " -o -format graphson").split(" ")).exportDatabase();
 
-    Assertions.assertTrue(file.exists());
-    Assertions.assertTrue(file.length() > 0);
+    assertThat(file.exists()).isTrue();
+    assertThat(file.length() > 0).isTrue();
 
     try (final ArcadeGraph graph = ArcadeGraph.open(importedDatabaseDirectory.getAbsolutePath())) {
       try (final GZIPInputStream is = new GZIPInputStream(new FileInputStream(file))) {
         graph.io(IoCore.graphson()).reader().create().readGraph(is, graph);
       }
 
-      Assertions.assertTrue(importedDatabaseDirectory.exists());
+      assertThat(importedDatabaseDirectory.exists()).isTrue();
 
       try (final Database originalDatabase = new DatabaseFactory(DATABASE_PATH).open(ComponentFile.MODE.READ_ONLY)) {
-        Assertions.assertEquals(//
-            originalDatabase.getSchema().getTypes().stream().map(DocumentType::getName).collect(Collectors.toSet()),//
-            graph.getDatabase().getSchema().getTypes().stream().map(DocumentType::getName).collect(Collectors.toSet()));
+        assertThat(graph.getDatabase().getSchema().getTypes().stream().map(DocumentType::getName).collect(Collectors.toSet())).isEqualTo(originalDatabase.getSchema().getTypes().stream().map(DocumentType::getName).collect(Collectors.toSet()));
 
         for (final DocumentType type : originalDatabase.getSchema().getTypes()) {
-          Assertions.assertEquals(//
-              originalDatabase.countType(type.getName(), true),//
-              graph.getDatabase().countType(type.getName(), true));
+          assertThat(graph.getDatabase().countType(type.getName(), true)).isEqualTo(originalDatabase.countType(type.getName(), true));
         }
       }
     }

--- a/gremlin/src/test/java/com/arcadedb/gremlin/integration/importer/GraphMLImporterIT.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/integration/importer/GraphMLImporterIT.java
@@ -27,7 +27,6 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.server.TestServerHelper;
 import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +35,8 @@ import java.net.*;
 import java.util.*;
 import java.util.stream.*;
 import java.util.zip.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class GraphMLImporterIT {
   private final static String DATABASE_PATH     = "target/databases/performance";
@@ -53,14 +54,12 @@ public class GraphMLImporterIT {
       final Importer importer = new Importer(database, inputFile.getFile());
       importer.load();
 
-      Assertions.assertTrue(databaseDirectory.exists());
+      assertThat(databaseDirectory.exists()).isTrue();
 
-      Assertions.assertEquals(//
-          new HashSet<>(Arrays.asList("Friend", "Person")),//
-          database.getSchema().getTypes().stream().map(DocumentType::getName).collect(Collectors.toSet()));
+      assertThat(database.getSchema().getTypes().stream().map(DocumentType::getName).collect(Collectors.toSet())).isEqualTo(new HashSet<>(Arrays.asList("Friend", "Person")));
 
       for (final DocumentType type : database.getSchema().getTypes()) {
-        Assertions.assertTrue(database.countType(type.getName(), true) > 0);
+        assertThat(database.countType(type.getName(), true) > 0).isTrue();
       }
     }
   }
@@ -83,14 +82,12 @@ public class GraphMLImporterIT {
       final Importer importer = new Importer(database, UNCOMPRESSED_FILE);
       importer.load();
 
-      Assertions.assertTrue(databaseDirectory.exists());
+      assertThat(databaseDirectory.exists()).isTrue();
 
-      Assertions.assertEquals(//
-          new HashSet<>(Arrays.asList("Friend", "Person")),//
-          database.getSchema().getTypes().stream().map(DocumentType::getName).collect(Collectors.toSet()));
+      assertThat(database.getSchema().getTypes().stream().map(DocumentType::getName).collect(Collectors.toSet())).isEqualTo(new HashSet<>(Arrays.asList("Friend", "Person")));
 
       for (final DocumentType type : database.getSchema().getTypes()) {
-        Assertions.assertTrue(database.countType(type.getName(), true) > 0);
+        assertThat(database.countType(type.getName(), true) > 0).isTrue();
       }
     }
   }
@@ -103,17 +100,15 @@ public class GraphMLImporterIT {
 
       database.command("sql", "import database file://" + inputFile.getFile() + " WITH commitEvery = 1000");
 
-      Assertions.assertTrue(databaseDirectory.exists());
+      assertThat(databaseDirectory.exists()).isTrue();
 
-      Assertions.assertEquals(//
-          new HashSet<>(Arrays.asList("Friend", "Person")),//
-          database.getSchema().getTypes().stream().map(DocumentType::getName).collect(Collectors.toSet()));
+      assertThat(database.getSchema().getTypes().stream().map(DocumentType::getName).collect(Collectors.toSet())).isEqualTo(new HashSet<>(Arrays.asList("Friend", "Person")));
 
       for (final DocumentType type : database.getSchema().getTypes()) {
-        Assertions.assertTrue(database.countType(type.getName(), true) > 0);
+        assertThat(database.countType(type.getName(), true) > 0).isTrue();
       }
     }
-    Assertions.assertNull(DatabaseFactory.getActiveDatabaseInstance(DATABASE_PATH));
+    assertThat(DatabaseFactory.getActiveDatabaseInstance(DATABASE_PATH)).isNull();
   }
 
   @BeforeEach

--- a/gremlin/src/test/java/com/arcadedb/gremlin/integration/importer/GraphSONImporterIT.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/integration/importer/GraphSONImporterIT.java
@@ -27,7 +27,6 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.server.TestServerHelper;
 import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +35,8 @@ import java.net.*;
 import java.util.*;
 import java.util.stream.*;
 import java.util.zip.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class GraphSONImporterIT {
   private final static String DATABASE_PATH     = "target/databases/performance";
@@ -53,14 +54,12 @@ public class GraphSONImporterIT {
       final Importer importer = new Importer(database, inputFile.getFile());
       importer.load();
 
-      Assertions.assertTrue(databaseDirectory.exists());
+      assertThat(databaseDirectory.exists()).isTrue();
 
-      Assertions.assertEquals(//
-          new HashSet<>(Arrays.asList("Friend", "Person")),//
-          database.getSchema().getTypes().stream().map(DocumentType::getName).collect(Collectors.toSet()));
+      assertThat(database.getSchema().getTypes().stream().map(DocumentType::getName).collect(Collectors.toSet())).isEqualTo(new HashSet<>(Arrays.asList("Friend", "Person")));
 
       for (final DocumentType type : database.getSchema().getTypes()) {
-        Assertions.assertTrue(database.countType(type.getName(), true) > 0);
+        assertThat(database.countType(type.getName(), true) > 0).isTrue();
       }
     }
   }
@@ -83,14 +82,12 @@ public class GraphSONImporterIT {
       final Importer importer = new Importer(database, UNCOMPRESSED_FILE);
       importer.load();
 
-      Assertions.assertTrue(databaseDirectory.exists());
+      assertThat(databaseDirectory.exists()).isTrue();
 
-      Assertions.assertEquals(//
-          new HashSet<>(Arrays.asList("Friend", "Person")),//
-          database.getSchema().getTypes().stream().map(DocumentType::getName).collect(Collectors.toSet()));
+      assertThat(database.getSchema().getTypes().stream().map(DocumentType::getName).collect(Collectors.toSet())).isEqualTo(new HashSet<>(Arrays.asList("Friend", "Person")));
 
       for (final DocumentType type : database.getSchema().getTypes()) {
-        Assertions.assertTrue(database.countType(type.getName(), true) > 0);
+        assertThat(database.countType(type.getName(), true) > 0).isTrue();
       }
     }
   }
@@ -103,17 +100,15 @@ public class GraphSONImporterIT {
 
       database.command("sql", "import database file://" + inputFile.getFile() + " WITH commitEvery = 1000");
 
-      Assertions.assertTrue(databaseDirectory.exists());
+      assertThat(databaseDirectory.exists()).isTrue();
 
-      Assertions.assertEquals(//
-          new HashSet<>(Arrays.asList("Friend", "Person")),//
-          database.getSchema().getTypes().stream().map(DocumentType::getName).collect(Collectors.toSet()));
+      assertThat(database.getSchema().getTypes().stream().map(DocumentType::getName).collect(Collectors.toSet())).isEqualTo(new HashSet<>(Arrays.asList("Friend", "Person")));
 
       for (final DocumentType type : database.getSchema().getTypes()) {
-        Assertions.assertTrue(database.countType(type.getName(), true) > 0);
+        assertThat(database.countType(type.getName(), true) > 0).isTrue();
       }
     }
-    Assertions.assertNull(DatabaseFactory.getActiveDatabaseInstance(DATABASE_PATH));
+    assertThat(DatabaseFactory.getActiveDatabaseInstance(DATABASE_PATH)).isNull();
   }
 
   @BeforeEach

--- a/gremlin/src/test/java/com/arcadedb/server/gremlin/AbstractGremlinServerIT.java
+++ b/gremlin/src/test/java/com/arcadedb/server/gremlin/AbstractGremlinServerIT.java
@@ -21,21 +21,19 @@
 package com.arcadedb.server.gremlin;
 
 import com.arcadedb.GlobalConfiguration;
-import com.arcadedb.gremlin.ArcadeGraph;
-import com.arcadedb.query.sql.executor.ResultSet;
-import com.arcadedb.remote.RemoteDatabase;
 import com.arcadedb.remote.RemoteServer;
 import com.arcadedb.server.BaseGraphServerTest;
 import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
 
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.in;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.select;
+import static org.assertj.core.api.Assertions.fail;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.fail;
 
 public abstract class AbstractGremlinServerIT extends BaseGraphServerTest {
 
@@ -59,7 +57,7 @@ public abstract class AbstractGremlinServerIT extends BaseGraphServerTest {
       GlobalConfiguration.SERVER_PLUGINS.setValue("GremlinServer:com.arcadedb.server.gremlin.GremlinServerPlugin");
 
     } catch (final IOException e) {
-      Assertions.fail(e);
+      fail("", e);
     }
   }
 

--- a/gremlin/src/test/java/com/arcadedb/server/gremlin/ConnectRemoteGremlinServerIT.java
+++ b/gremlin/src/test/java/com/arcadedb/server/gremlin/ConnectRemoteGremlinServerIT.java
@@ -27,11 +27,12 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSo
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.WithOptions;
 import org.apache.tinkerpop.gremlin.structure.io.binary.TypeSerializerRegistry;
 import org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Manual test against a Gremlin Server.
@@ -47,7 +48,7 @@ public class ConnectRemoteGremlinServerIT {
     final List<Map<Object, Object>> vertices = g.V().valueMap().with(WithOptions.tokens)
         .toList(); // verifies that the vertex created with properties is returned
 
-    Assertions.assertFalse(vertices.isEmpty());
+    assertThat(vertices.isEmpty()).isFalse();
   }
 
   private Cluster createCluster() {

--- a/gremlin/src/test/java/com/arcadedb/server/gremlin/GremlinServerSecurityTest.java
+++ b/gremlin/src/test/java/com/arcadedb/server/gremlin/GremlinServerSecurityTest.java
@@ -18,34 +18,20 @@
  */
 package com.arcadedb.server.gremlin;
 
-import com.arcadedb.GlobalConfiguration;
-import com.arcadedb.gremlin.ArcadeGraph;
-import com.arcadedb.gremlin.io.ArcadeIoRegistry;
 import com.arcadedb.remote.RemoteDatabase;
-import com.arcadedb.server.BaseGraphServerTest;
-import com.arcadedb.server.security.ServerSecurityException;
-import com.arcadedb.utility.CodeUtils;
-import com.arcadedb.utility.FileUtils;
-import org.apache.tinkerpop.gremlin.driver.Cluster;
-import org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteConnection;
-import org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
-import org.apache.tinkerpop.gremlin.structure.io.binary.TypeSerializerRegistry;
-import org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.io.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class GremlinServerSecurityTest extends AbstractGremlinServerIT {
 
   @Test
   public void getAllVertices() {
     try (final RemoteDatabase database = new RemoteDatabase("127.0.0.1", 2480, getDatabaseName(), "root", "test")) {
-      Assertions.fail("Expected security exception");
+      fail("Expected security exception");
     } catch (final SecurityException e) {
-      Assertions.assertTrue(e.getMessage().contains("User/Password"));
+      assertThat(e.getMessage().contains("User/Password")).isTrue();
     }
   }
 

--- a/gremlin/src/test/java/com/arcadedb/server/gremlin/GremlinServerTest.java
+++ b/gremlin/src/test/java/com/arcadedb/server/gremlin/GremlinServerTest.java
@@ -29,10 +29,11 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSo
 import org.apache.tinkerpop.gremlin.structure.io.binary.TypeSerializerRegistry;
 import org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class GremlinServerTest extends AbstractGremlinServerIT {
 
@@ -40,7 +41,7 @@ public class GremlinServerTest extends AbstractGremlinServerIT {
   public void getAllVertices() {
     final GraphTraversalSource g = traversal();
     final var vertices = g.V().limit(3).toList();
-    Assertions.assertEquals(3, vertices.size());
+    assertThat(vertices.size()).isEqualTo(3);
   }
 
   @AfterEach

--- a/gremlin/src/test/java/com/arcadedb/server/gremlin/LocalGremlinFactoryIT.java
+++ b/gremlin/src/test/java/com/arcadedb/server/gremlin/LocalGremlinFactoryIT.java
@@ -28,10 +28,13 @@ import com.arcadedb.remote.RemoteServer;
 import com.arcadedb.server.BaseGraphServerTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class LocalGremlinFactoryIT {
   private static final String DATABASE_NAME = "local-database-factory";
@@ -41,11 +44,11 @@ public class LocalGremlinFactoryIT {
     try (ArcadeGraphFactory pool = ArcadeGraphFactory.withLocal(DATABASE_NAME)) {
       for (int i = 0; i < 1_000; i++) {
         final ArcadeGraph instance = pool.get();
-        Assertions.assertNotNull(instance);
+        assertThat(instance).isNotNull();
         instance.close();
       }
 
-      Assertions.assertEquals(1, pool.getTotalInstancesCreated());
+      assertThat(pool.getTotalInstancesCreated()).isEqualTo(1);
     }
   }
 
@@ -54,17 +57,17 @@ public class LocalGremlinFactoryIT {
     try (ArcadeGraphFactory pool = ArcadeGraphFactory.withLocal(DATABASE_NAME)) {
       for (int i = 0; i < pool.getMaxInstances(); i++) {
         final ArcadeGraph instance = pool.get();
-        Assertions.assertNotNull(instance);
+        assertThat(instance).isNotNull();
       }
 
       try {
         pool.get();
-        Assertions.fail();
+        fail("");
       } catch (IllegalArgumentException e) {
         // EXPECTED
       }
 
-      Assertions.assertEquals(pool.getMaxInstances(), pool.getTotalInstancesCreated());
+      assertThat(pool.getTotalInstancesCreated()).isEqualTo(pool.getMaxInstances());
     }
   }
 

--- a/gremlin/src/test/java/com/arcadedb/server/gremlin/RemoteGremlinIT.java
+++ b/gremlin/src/test/java/com/arcadedb/server/gremlin/RemoteGremlinIT.java
@@ -25,20 +25,22 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.remote.RemoteDatabase;
 import com.arcadedb.remote.RemoteServer;
 import com.arcadedb.server.BaseGraphServerTest;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.in;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.select;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class RemoteGremlinIT extends AbstractGremlinServerIT {
 
   @Test
   public void insert() throws Exception {
     testEachServer((serverIndex) -> {
-      Assertions.assertTrue(
+      assertThat(
           new RemoteServer("127.0.0.1", 2480 + serverIndex, "root", BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).exists(
-              getDatabaseName()));
+              getDatabaseName())).isTrue();
 
       final RemoteDatabase database = new RemoteDatabase("127.0.0.1", 2480 + serverIndex, getDatabaseName(), "root",
           BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
@@ -50,16 +52,17 @@ public class RemoteGremlinIT extends AbstractGremlinServerIT {
           graph.addVertex(org.apache.tinkerpop.gremlin.structure.T.label, "inputstructure", "json", "{\"name\": \"Elon\"}");
 
         try (final ResultSet list = graph.gremlin("g.V().hasLabel(\"inputstructure\")").execute()) {
-          Assertions.assertEquals(1_000, list.stream().count());
+          assertThat(list.stream().count()).isEqualTo(1_000);
         }
 
         try (final ResultSet list = graph.gremlin("g.V().hasLabel(\"inputstructure\").count()").execute()) {
-          Assertions.assertEquals(1_000, (Integer) list.nextIfAvailable().getProperty("result"));
+          assertThat(list.nextIfAvailable().<Integer>getProperty("result")).isEqualTo(1_000);
         }
 
         graph.tx().commit();
 
-        Assertions.assertEquals(1_000L, graph.traversal().V().hasLabel("inputstructure").count().next());
+        assertThat(graph.traversal().V().hasLabel("inputstructure").count().next()).isEqualTo(1_000L);
+
       }
     });
   }

--- a/integration/src/test/java/com/arcadedb/integration/TestHelper.java
+++ b/integration/src/test/java/com/arcadedb/integration/TestHelper.java
@@ -3,10 +3,11 @@ package com.arcadedb.integration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.log.LogManager;
-import org.junit.jupiter.api.Assertions;
 
 import java.util.*;
 import java.util.logging.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class TestHelper {
   public static void checkActiveDatabases() {
@@ -18,6 +19,6 @@ public abstract class TestHelper {
     for (final Database db : activeDatabases)
       db.close();
 
-    Assertions.assertTrue(activeDatabases.isEmpty(), "Found active databases: " + activeDatabases);
+    assertThat(activeDatabases.isEmpty()).as("Found active databases: " + activeDatabases).isTrue();
   }
 }

--- a/integration/src/test/java/com/arcadedb/integration/exporter/JsonlExporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/exporter/JsonlExporterIT.java
@@ -26,13 +26,15 @@ import com.arcadedb.integration.importer.OrientDBImporterIT;
 import com.arcadedb.utility.FileUtils;
 import com.arcadedb.serializer.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
-import java.net.*;
-import java.util.zip.*;
+import java.net.URL;
+import java.util.zip.GZIPInputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class JsonlExporterIT {
   private final static String DATABASE_PATH = "target/databases/performance";
@@ -50,13 +52,13 @@ public class JsonlExporterIT {
       final OrientDBImporter importer = new OrientDBImporter(("-i " + inputFile.getFile() + " -d " + DATABASE_PATH + " -o").split(" "));
       importer.run().close();
 
-      Assertions.assertFalse(importer.isError());
-      Assertions.assertTrue(databaseDirectory.exists());
+      assertThat(importer.isError()).isFalse();
+      assertThat(databaseDirectory.exists()).isTrue();
 
       new Exporter(("-f " + FILE + " -d " + DATABASE_PATH + " -o -format jsonl").split(" ")).exportDatabase();
 
-      Assertions.assertTrue(file.exists());
-      Assertions.assertTrue(file.length() > 0);
+      assertThat(file.exists()).isTrue();
+      assertThat(file.length() > 0).isTrue();
 
       int lines = 0;
       try (final BufferedReader in = new BufferedReader(new InputStreamReader(new GZIPInputStream(new FileInputStream(file))))) {
@@ -67,7 +69,7 @@ public class JsonlExporterIT {
         }
       }
 
-      Assertions.assertTrue(lines > 10);
+      assertThat(lines > 10).isTrue();
 
     } finally {
       FileUtils.deleteRecursively(databaseDirectory);
@@ -80,7 +82,7 @@ public class JsonlExporterIT {
     try {
       emptyDatabase().close();
       new Exporter(("-f " + FILE + " -d " + DATABASE_PATH + " -o -format unknown").split(" ")).exportDatabase();
-      Assertions.fail();
+      fail("");
     } catch (final ExportException e) {
       // EXPECTED
     }
@@ -92,7 +94,7 @@ public class JsonlExporterIT {
       emptyDatabase().close();
       new File(FILE).createNewFile();
       new Exporter(("-f " + FILE + " -d " + DATABASE_PATH + " -format jsonl").split(" ")).exportDatabase();
-      Assertions.fail();
+      fail("");
     } catch (final ExportException e) {
       // EXPECTED
     }

--- a/integration/src/test/java/com/arcadedb/integration/exporter/SQLLocalExporterTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/exporter/SQLLocalExporterTest.java
@@ -26,11 +26,12 @@ import com.arcadedb.integration.importer.OrientDBImporterIT;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.utility.FileUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.net.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SQLLocalExporterTest {
   @Test
@@ -45,19 +46,19 @@ public class SQLLocalExporterTest {
 
       database.command("sql", "import database file://" + inputFile.getFile());
 
-      Assertions.assertEquals(500, database.countType("Person", false));
-      Assertions.assertEquals(10000, database.countType("Friend", false));
+      assertThat(database.countType("Person", false)).isEqualTo(500);
+      assertThat(database.countType("Friend", false)).isEqualTo(10000);
 
       final ResultSet result = database.command("sql", "export database file://export.jsonl.tgz with `overwrite` = true");
 
       final Result stats = result.next();
-      Assertions.assertEquals(500L, (long) stats.getProperty("vertices"));
-      Assertions.assertEquals(10000L, (long) stats.getProperty("edges"));
-      Assertions.assertNull(stats.getProperty("documents"));
+      assertThat((long) stats.getProperty("vertices")).isEqualTo(500L);
+      assertThat((long) stats.getProperty("edges")).isEqualTo(10000L);
+      assertThat(stats.<Object>getProperty("documents")).isNull();
 
       final File exportFile = new File("./exports/export.jsonl.tgz");
-      Assertions.assertTrue(exportFile.exists());
-      Assertions.assertTrue(exportFile.length() > 50_000);
+      assertThat(exportFile.exists()).isTrue();
+      assertThat(exportFile.length() > 50_000).isTrue();
       exportFile.delete();
     }
 
@@ -78,19 +79,19 @@ public class SQLLocalExporterTest {
 
       database.command("sql", "import database file://" + inputFile.getFile());
 
-      Assertions.assertEquals(500, database.countType("Person", false));
-      Assertions.assertEquals(10000, database.countType("Friend", false));
+      assertThat(database.countType("Person", false)).isEqualTo(500);
+      assertThat(database.countType("Friend", false)).isEqualTo(10000);
 
       final ResultSet result = database.command("sql", "export database file://export.jsonl.tgz with `overwrite` = true, includeTypes = Person");
 
       final Result stats = result.next();
-      Assertions.assertEquals(500L, (long) stats.getProperty("vertices"));
-      Assertions.assertNull(stats.getProperty("edges"));
-      Assertions.assertNull(stats.getProperty("documents"));
+      assertThat((long) stats.getProperty("vertices")).isEqualTo(500L);
+      assertThat(stats.<Object>getProperty("edges")).isNull();
+      assertThat(stats.<Object>getProperty("documents")).isNull();
 
       final File exportFile = new File("./exports/export.jsonl.tgz");
-      Assertions.assertTrue(exportFile.exists());
-      Assertions.assertTrue(exportFile.length() > 50_000);
+      assertThat(exportFile.exists()).isTrue();
+      assertThat(exportFile.length() > 50_000).isTrue();
       exportFile.delete();
     }
 

--- a/integration/src/test/java/com/arcadedb/integration/importer/CSVImporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/CSVImporterIT.java
@@ -21,8 +21,9 @@ package com.arcadedb.integration.importer;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.integration.TestHelper;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class CSVImporterIT {
   @Test
@@ -36,7 +37,7 @@ public class CSVImporterIT {
     final Database db = databaseFactory.create();
     try {
       db.command("sql", "import database file://src/test/resources/importer-vertices.csv");
-      Assertions.assertEquals(6, db.countType("Document", true));
+      assertThat(db.countType("Document", true)).isEqualTo(6);
     } finally {
       db.drop();
     }
@@ -56,7 +57,7 @@ public class CSVImporterIT {
     importer.load();
 
     try (final Database db = databaseFactory.open()) {
-      Assertions.assertEquals(6, db.countType("Node", true));
+      assertThat(db.countType("Node", true)).isEqualTo(6);
     }
 
     importer = new Importer(("-edges src/test/resources/importer-edges.csv -database " + databasePath
@@ -64,8 +65,8 @@ public class CSVImporterIT {
     importer.load();
 
     try (final Database db = databaseFactory.open()) {
-      Assertions.assertEquals(6, db.countType("Node", true));
-      Assertions.assertEquals("Jay", db.lookupByKey("Node", "Id", 0).next().getRecord().asVertex().get("First Name"));
+      assertThat(db.countType("Node", true)).isEqualTo(6);
+      assertThat(db.lookupByKey("Node", "Id", 0).next().getRecord().asVertex().get("First Name")).isEqualTo("Jay");
     }
 
     databaseFactory.open().drop();

--- a/integration/src/test/java/com/arcadedb/integration/importer/GloVeImporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/GloVeImporterIT.java
@@ -26,11 +26,12 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.utility.FileUtils;
 import com.arcadedb.utility.Pair;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class GloVeImporterIT {
   @Test
@@ -50,12 +51,12 @@ public class GloVeImporterIT {
           + "vertexType = Word, edgeType = Proximity, vectorProperty = vector, idProperty = name" //
       );
 
-      Assertions.assertEquals(10, db.countType("Word", true));
+      assertThat(db.countType("Word", true)).isEqualTo(10);
 
       final float[] key = new float[100];
 
       ResultSet resultSet = db.query("sql", "select vectorNeighbors('Word[name,vector]', ?,?) as neighbors", key, 10);
-      Assertions.assertTrue(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isTrue();
       final List<Pair<Identifiable, Float>> approximateResults = new ArrayList<>();
       while (resultSet.hasNext()) {
         final Result row = resultSet.next();

--- a/integration/src/test/java/com/arcadedb/integration/importer/JSONImporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/JSONImporterIT.java
@@ -26,11 +26,14 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.integration.TestHelper;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.FileUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.IOException;
+import java.util.Iterator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class JSONImporterIT {
   @Test
@@ -43,13 +46,13 @@ public class JSONImporterIT {
     importer.load();
 
     try (final Database db = new DatabaseFactory(databasePath).open()) {
-      Assertions.assertEquals(1, db.countType("Food", true));
+      assertThat(db.countType("Food", true)).isEqualTo(1);
 
       final Document food = db.iterateType("Food", true).next().asDocument(true);
       JSONObject json = new JSONObject(FileUtils.readFileAsString(new File("src/test/resources/importer-one-object.json")));
 
       for (Object name : json.names())
-        Assertions.assertTrue(food.has(name.toString()));
+        assertThat(food.has(name.toString())).isTrue();
     }
 
     TestHelper.checkActiveDatabases();
@@ -64,7 +67,7 @@ public class JSONImporterIT {
     importer.load();
 
     try (final Database db = new DatabaseFactory(databasePath).open()) {
-      Assertions.assertEquals(2, db.countType("Food", true));
+      assertThat(db.countType("Food", true)).isEqualTo(2);
     }
 
     TestHelper.checkActiveDatabases();
@@ -115,26 +118,26 @@ public class JSONImporterIT {
         final String name = vertex.getString("Name");
 
         if ("Marcus".equalsIgnoreCase(name)) {
-          Assertions.assertEquals("1234", vertex.getString("id"));
-          Assertions.assertEquals(0, vertex.countEdges(Vertex.DIRECTION.OUT, "HAS_MANAGER"));
-          Assertions.assertEquals(2, vertex.countEdges(Vertex.DIRECTION.IN, "HAS_MANAGER"));
+          assertThat(vertex.getString("id")).isEqualTo("1234");
+          assertThat(vertex.countEdges(Vertex.DIRECTION.OUT, "HAS_MANAGER")).isEqualTo(0);
+          assertThat(vertex.countEdges(Vertex.DIRECTION.IN, "HAS_MANAGER")).isEqualTo(2);
         } else if ("Win".equals(name)) {
-          Assertions.assertEquals("1230", vertex.getString("id"));
-          Assertions.assertEquals(1, vertex.countEdges(Vertex.DIRECTION.OUT, "HAS_MANAGER"));
-          Assertions.assertEquals(0, vertex.countEdges(Vertex.DIRECTION.IN, "HAS_MANAGER"));
+          assertThat(vertex.getString("id")).isEqualTo("1230");
+          assertThat(vertex.countEdges(Vertex.DIRECTION.OUT, "HAS_MANAGER")).isEqualTo(1);
+          assertThat(vertex.countEdges(Vertex.DIRECTION.IN, "HAS_MANAGER")).isEqualTo(0);
         } else if ("Dave".equals(name)) {
-          Assertions.assertEquals("1232", vertex.getString("id"));
-          Assertions.assertEquals(1, vertex.countEdges(Vertex.DIRECTION.OUT, "HAS_MANAGER"));
-          Assertions.assertEquals(1, vertex.countEdges(Vertex.DIRECTION.IN, "HAS_MANAGER"));
+          assertThat(vertex.getString("id")).isEqualTo("1232");
+          assertThat(vertex.countEdges(Vertex.DIRECTION.OUT, "HAS_MANAGER")).isEqualTo(1);
+          assertThat(vertex.countEdges(Vertex.DIRECTION.IN, "HAS_MANAGER")).isEqualTo(1);
         } else if ("Albert".equals(name)) {
-          Assertions.assertEquals("1239", vertex.getString("id"));
-          Assertions.assertEquals(1, vertex.countEdges(Vertex.DIRECTION.OUT, "HAS_MANAGER"));
-          Assertions.assertEquals(0, vertex.countEdges(Vertex.DIRECTION.IN, "HAS_MANAGER"));
+          assertThat(vertex.getString("id")).isEqualTo("1239");
+          assertThat(vertex.countEdges(Vertex.DIRECTION.OUT, "HAS_MANAGER")).isEqualTo(1);
+          assertThat(vertex.countEdges(Vertex.DIRECTION.IN, "HAS_MANAGER")).isEqualTo(0);
         } else
-          Assertions.fail();
+          fail("");
       }
 
-      Assertions.assertEquals(4, db.countType("User", true));
+      assertThat(db.countType("User", true)).isEqualTo(4);
     }
 
     TestHelper.checkActiveDatabases();

--- a/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterIT.java
@@ -30,7 +30,7 @@ import com.arcadedb.integration.TestHelper;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.utility.FileUtils;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
@@ -39,6 +39,9 @@ import java.text.*;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 import java.util.logging.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class Neo4jImporterIT {
   private final static String DATABASE_PATH = "target/databases/neo4j";
@@ -54,38 +57,38 @@ public class Neo4jImporterIT {
           ("-i " + inputFile.getFile() + " -d " + DATABASE_PATH + " -o -decimalType double").split(" "));
       importer.run();
 
-      Assertions.assertFalse(importer.isError());
+      assertThat(importer.isError()).isFalse();
 
-      Assertions.assertTrue(databaseDirectory.exists());
+      assertThat(databaseDirectory.exists()).isTrue();
 
       try (final DatabaseFactory factory = new DatabaseFactory(DATABASE_PATH)) {
         try (final Database database = factory.open()) {
           final DocumentType personType = database.getSchema().getType("User");
-          Assertions.assertNotNull(personType);
-          Assertions.assertEquals(3, database.countType("User", true));
+          assertThat(personType).isNotNull();
+          assertThat(database.countType("User", true)).isEqualTo(3);
 
           final IndexCursor cursor = database.lookupByKey("User", "id", "0");
-          Assertions.assertTrue(cursor.hasNext());
+          assertThat(cursor.hasNext()).isTrue();
           final Vertex v = cursor.next().asVertex();
-          Assertions.assertEquals("Adam", v.get("name"));
-          Assertions.assertEquals("2015-07-04T19:32:24", new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").format(v.getLong("born")));
+          assertThat(v.get("name")).isEqualTo("Adam");
+          assertThat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").format(v.getLong("born"))).isEqualTo("2015-07-04T19:32:24");
 
           final Map<String, Object> place = (Map<String, Object>) v.get("place");
-          Assertions.assertEquals(33.46789, place.get("latitude"));
-          Assertions.assertNull(place.get("height"));
+          assertThat(place.get("latitude")).isEqualTo(33.46789);
+          assertThat(place.get("height")).isNull();
 
-          Assertions.assertEquals(Arrays.asList("Sam", "Anna", "Grace"), v.get("kids"));
+          assertThat(v.get("kids")).isEqualTo(Arrays.asList("Sam", "Anna", "Grace"));
 
           final DocumentType friendType = database.getSchema().getType("KNOWS");
-          Assertions.assertNotNull(friendType);
-          Assertions.assertEquals(1, database.countType("KNOWS", true));
+          assertThat(friendType).isNotNull();
+          assertThat(database.countType("KNOWS", true)).isEqualTo(1);
 
           final Iterator<Edge> relationships = v.getEdges(Vertex.DIRECTION.OUT, "KNOWS").iterator();
-          Assertions.assertTrue(relationships.hasNext());
+          assertThat(relationships.hasNext()).isTrue();
           final Edge e = relationships.next();
 
-          Assertions.assertEquals(1993, e.get("since"));
-          Assertions.assertEquals("P5M1DT12H", e.get("bffSince"));
+          assertThat(e.get("since")).isEqualTo(1993);
+          assertThat(e.get("bffSince")).isEqualTo("P5M1DT12H");
         }
       }
       TestHelper.checkActiveDatabases();
@@ -100,10 +103,10 @@ public class Neo4jImporterIT {
     final Neo4jImporter importer = new Neo4jImporter(("-i " + inputFile.getFile() + "2 -d " + DATABASE_PATH + " -o").split(" "));
     try {
       importer.run();
-      Assertions.fail("Expected File Not Found Exception");
+      fail("Expected File Not Found Exception");
     } catch (final IllegalArgumentException e) {
     }
-    Assertions.assertTrue(importer.isError());
+    assertThat(importer.isError()).isTrue();
   }
 
   @Test
@@ -170,38 +173,38 @@ public class Neo4jImporterIT {
 
       t.get().join();
 
-      Assertions.assertFalse(importer.isError());
+      assertThat(importer.isError()).isFalse();
 
-      Assertions.assertTrue(databaseDirectory.exists());
+      assertThat(databaseDirectory.exists()).isTrue();
 
       try (final DatabaseFactory factory = new DatabaseFactory(DATABASE_PATH)) {
         try (final Database database = factory.open()) {
           final DocumentType personType = database.getSchema().getType("User");
-          Assertions.assertNotNull(personType);
-          Assertions.assertEquals(TOTAL, database.countType("User", true));
+          assertThat(personType).isNotNull();
+          assertThat(database.countType("User", true)).isEqualTo(TOTAL);
 
           final IndexCursor cursor = database.lookupByKey("User", "id", "0");
-          Assertions.assertTrue(cursor.hasNext());
+          assertThat(cursor.hasNext()).isTrue();
           final Vertex v = cursor.next().asVertex();
-          Assertions.assertEquals("Adam", v.get("name"));
-          Assertions.assertEquals("2015-07-04T19:32:24", new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").format(v.getLong("born")));
+          assertThat(v.get("name")).isEqualTo("Adam");
+          assertThat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").format(v.getLong("born"))).isEqualTo("2015-07-04T19:32:24");
 
           final Map<String, Object> place = (Map<String, Object>) v.get("place");
-          Assertions.assertEquals(33.46789, place.get("latitude"));
-          Assertions.assertNull(place.get("height"));
+          assertThat(place.get("latitude")).isEqualTo(33.46789);
+          assertThat(place.get("height")).isNull();
 
-          Assertions.assertEquals(Arrays.asList("Sam", "Anna", "Grace"), v.get("kids"));
+          assertThat(v.get("kids")).isEqualTo(Arrays.asList("Sam", "Anna", "Grace"));
 
           final DocumentType friendType = database.getSchema().getType("KNOWS");
-          Assertions.assertNotNull(friendType);
-          Assertions.assertEquals(TOTAL / 2, database.countType("KNOWS", true));
+          assertThat(friendType).isNotNull();
+          assertThat(database.countType("KNOWS", true)).isEqualTo(TOTAL / 2);
 
           final Iterator<Edge> relationships = v.getEdges(Vertex.DIRECTION.OUT, "KNOWS").iterator();
-          Assertions.assertTrue(relationships.hasNext());
+          assertThat(relationships.hasNext()).isTrue();
           final Edge e = relationships.next();
 
-          Assertions.assertEquals(1993, e.get("since"));
-          Assertions.assertEquals("P5M1DT12H", e.get("bffSince"));
+          assertThat(e.get("since")).isEqualTo(1993);
+          assertThat(e.get("bffSince")).isEqualTo("P5M1DT12H");
         }
       }
       TestHelper.checkActiveDatabases();
@@ -223,24 +226,24 @@ public class Neo4jImporterIT {
       final Neo4jImporter importer = new Neo4jImporter(("-i " + inputFile.getFile() + " -d " + DATABASE_PATH).split(" "));
       importer.run();
 
-      Assertions.assertFalse(importer.isError());
+      assertThat(importer.isError()).isFalse();
 
-      Assertions.assertTrue(databaseDirectory.exists());
+      assertThat(databaseDirectory.exists()).isTrue();
 
       try (final DatabaseFactory factory = new DatabaseFactory(DATABASE_PATH)) {
         try (final Database database = factory.open()) {
           final DocumentType placeType = database.getSchema().getType("Place");
-          Assertions.assertNotNull(placeType);
-          Assertions.assertEquals(1, database.countType("Place", true));
+          assertThat(placeType).isNotNull();
+          assertThat(database.countType("Place", true)).isEqualTo(1);
 
           final DocumentType cityType = database.getSchema().getType("City");
-          Assertions.assertNotNull(cityType);
-          Assertions.assertEquals(1, database.countType("City", true));
+          assertThat(cityType).isNotNull();
+          assertThat(database.countType("City", true)).isEqualTo(1);
 
           IndexCursor cursor = database.lookupByKey("City_Place", "id", "0");
-          Assertions.assertTrue(cursor.hasNext());
+          assertThat(cursor.hasNext()).isTrue();
           Vertex v = cursor.next().asVertex();
-          Assertions.assertEquals("Test", v.get("name"));
+          assertThat(v.get("name")).isEqualTo("Test");
         }
       }
       TestHelper.checkActiveDatabases();

--- a/integration/src/test/java/com/arcadedb/integration/importer/OrientDBImporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/OrientDBImporterIT.java
@@ -26,11 +26,14 @@ import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.utility.FileUtils;
 import com.arcadedb.serializer.json.JSONObject;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.net.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class OrientDBImporterIT {
   private final static String DATABASE_PATH = "target/databases/performance";
@@ -45,29 +48,29 @@ public class OrientDBImporterIT {
       final OrientDBImporter importer = new OrientDBImporter(("-i " + inputFile.getFile() + " -d " + DATABASE_PATH + " -s -o").split(" "));
       importer.run().close();
 
-      Assertions.assertFalse(importer.isError());
-      Assertions.assertTrue(databaseDirectory.exists());
+      assertThat(importer.isError()).isFalse();
+      assertThat(databaseDirectory.exists()).isTrue();
 
       try (final DatabaseFactory factory = new DatabaseFactory(DATABASE_PATH)) {
         try (final Database database = factory.open()) {
           final DocumentType personType = database.getSchema().getType("Person");
-          Assertions.assertNotNull(personType);
-          Assertions.assertEquals(Type.INTEGER, personType.getProperty("id").getType());
-          Assertions.assertEquals(500, database.countType("Person", true));
-          Assertions.assertEquals(Schema.INDEX_TYPE.LSM_TREE, database.getSchema().getIndexByName("Person[id]").getType());
+          assertThat(personType).isNotNull();
+          assertThat(personType.getProperty("id").getType()).isEqualTo(Type.INTEGER);
+          assertThat(database.countType("Person", true)).isEqualTo(500);
+          assertThat(database.getSchema().getIndexByName("Person[id]").getType()).isEqualTo(Schema.INDEX_TYPE.LSM_TREE);
 
           final DocumentType friendType = database.getSchema().getType("Friend");
-          Assertions.assertNotNull(friendType);
-          Assertions.assertEquals(Type.INTEGER, friendType.getProperty("id").getType());
-          Assertions.assertEquals(10_000, database.countType("Friend", true));
-          Assertions.assertEquals(Schema.INDEX_TYPE.LSM_TREE, database.getSchema().getIndexByName("Friend[id]").getType());
+          assertThat(friendType).isNotNull();
+          assertThat(friendType.getProperty("id").getType()).isEqualTo(Type.INTEGER);
+          assertThat(database.countType("Friend", true)).isEqualTo(10_000);
+          assertThat(database.getSchema().getIndexByName("Friend[id]").getType()).isEqualTo(Schema.INDEX_TYPE.LSM_TREE);
 
           final File securityFile = new File("./server-users.jsonl");
-          Assertions.assertTrue(securityFile.exists());
+          assertThat(securityFile.exists()).isTrue();
 
           final String fileContent = FileUtils.readFileAsString(securityFile);
           final JSONObject security = new JSONObject(fileContent.substring(0, fileContent.indexOf("\n")));
-          Assertions.assertEquals("admin", security.getString("name"));
+          assertThat(security.getString("name")).isEqualTo("admin");
         }
       }
     } finally {
@@ -82,9 +85,9 @@ public class OrientDBImporterIT {
     final OrientDBImporter importer = new OrientDBImporter(("-i " + inputFile.getFile() + "2 -d " + DATABASE_PATH + " -s -o").split(" "));
     try {
       importer.run();
-      Assertions.fail("Expected File Not Found Exception");
+      fail("Expected File Not Found Exception");
     } catch (final IllegalArgumentException e) {
     }
-    Assertions.assertTrue(importer.isError());
+    assertThat(importer.isError()).isTrue();
   }
 }

--- a/integration/src/test/java/com/arcadedb/integration/importer/SQLLocalImporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/SQLLocalImporterIT.java
@@ -23,11 +23,12 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.integration.TestHelper;
 import com.arcadedb.utility.FileUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.net.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SQLLocalImporterIT {
   @Test
@@ -43,8 +44,8 @@ public class SQLLocalImporterIT {
       //database.command("sql", "import database " + "file:///Users/luca/Downloads/Reactome.gz");
       database.command("sql", "import database file://" + inputFile.getFile());
 
-      Assertions.assertEquals(500, database.countType("Person", false));
-      Assertions.assertEquals(10000, database.countType("Friend", false));
+      assertThat(database.countType("Person", false)).isEqualTo(500);
+      assertThat(database.countType("Friend", false)).isEqualTo(10000);
     }
 
     TestHelper.checkActiveDatabases();

--- a/integration/src/test/java/com/arcadedb/integration/importer/SQLRemoteImporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/SQLRemoteImporterIT.java
@@ -22,10 +22,11 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.integration.TestHelper;
 import com.arcadedb.utility.FileUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SQLRemoteImporterIT {
   @Test
@@ -37,10 +38,10 @@ public class SQLRemoteImporterIT {
       //database.command("sql", "import database https://github.com/ArcadeData/arcadedb-datasets/raw/main/orientdb/MovieRatings.gz");
       database.command("sql", "import database https://github.com/ArcadeData/arcadedb-datasets/raw/main/orientdb/GratefulDeadConcerts.gz");
 
-      Assertions.assertEquals(809, database.countType("V", false));
-      Assertions.assertEquals(7047, database.countType("followed_by", false));
-      Assertions.assertEquals(501, database.countType("sung_by", false));
-      Assertions.assertEquals(501, database.countType("written_by", false));
+      assertThat(database.countType("V", false)).isEqualTo(809);
+      assertThat(database.countType("followed_by", false)).isEqualTo(7047);
+      assertThat(database.countType("sung_by", false)).isEqualTo(501);
+      assertThat(database.countType("written_by", false)).isEqualTo(501);
     }
 
     TestHelper.checkActiveDatabases();

--- a/integration/src/test/java/com/arcadedb/integration/importer/Word2VecImporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Word2VecImporterIT.java
@@ -22,10 +22,11 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.integration.TestHelper;
 import com.arcadedb.utility.FileUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class Word2VecImporterIT {
   @Test
@@ -44,7 +45,7 @@ public class Word2VecImporterIT {
           + "with distanceFunction = cosine, m = 16, ef = 128, efConstruction = 128, " //
           + "vertexType = Word, edgeType = Proximity, vectorProperty = vector, idProperty = name" //
       );
-      Assertions.assertEquals(10, db.countType("Word", true));
+      assertThat(db.countType("Word", true)).isEqualTo(10);
     } finally {
       db.drop();
       TestHelper.checkActiveDatabases();

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBQueryTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBQueryTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.*;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MongoDBQueryTest {
 
@@ -65,14 +65,14 @@ public class MongoDBQueryTest {
     for (final ResultSet resultset = database.query("mongo",
         "{ collection: 'MongoDBCollection', query: { $and: [ { name: { $eq: 'Jay' } }, { lastName: { $exists: true } }, { lastName: { $eq: 'Miner' } }, { lastName: { $ne: 'Miner22' } } ], $orderBy: { id: 1 } } }"); resultset.hasNext(); ++i) {
       final Result doc = resultset.next();
-      assertEquals(i, (Integer) doc.getProperty("id"));
+      assertThat((Integer) doc.getProperty("id")).isEqualTo(i);
     }
 
     i = 9;
     for (final ResultSet resultset = database.query("mongo",
         "{ collection: 'MongoDBCollection', query: { $and: [ { name: { $eq: 'Jay' } }, { lastName: { $exists: true } }, { lastName: { $eq: 'Miner' } }, { lastName: { $ne: 'Miner22' } } ], $orderBy: { id: -1 } } }"); resultset.hasNext(); --i) {
       final Result doc = resultset.next();
-      assertEquals(i, (Integer) doc.getProperty("id"));
+      assertThat((Integer) doc.getProperty("id")).isEqualTo(i);
     }
   }
 }

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBServerTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBServerTest.java
@@ -36,8 +36,7 @@ import static com.mongodb.client.model.Filters.exists;
 import static com.mongodb.client.model.Filters.gt;
 import static com.mongodb.client.model.Filters.lte;
 import static com.mongodb.client.model.Filters.ne;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MongoDBServerTest extends BaseGraphServerTest {
 
@@ -63,7 +62,7 @@ public class MongoDBServerTest extends BaseGraphServerTest {
     client.getDatabase(getDatabaseName()).createCollection("MongoDBCollection");
 
     collection = client.getDatabase(getDatabaseName()).getCollection("MongoDBCollection");
-    assertEquals(0, collection.countDocuments());
+    assertThat(collection.countDocuments()).isEqualTo(0);
 
     obj = new Document("id", 0).append("name", "Jay").append("lastName", "Miner").append("id", 0);
     collection.insertOne(obj);
@@ -88,24 +87,24 @@ public class MongoDBServerTest extends BaseGraphServerTest {
 
   @Test
   public void testSimpleInsertQuery() {
-    assertEquals(10, collection.countDocuments());
-    assertEquals(obj, stripMetadata(collection.find().first()));
-    assertEquals(obj, stripMetadata(collection.find(BsonDocument.parse("{ name: \"Jay\" } ")).first()));
-    assertNull(collection.find(BsonDocument.parse("{ name: \"Jay2\" } ")).first());
-    assertEquals(obj, stripMetadata(collection.find(BsonDocument.parse("{ name: { $eq: \"Jay\" } } ")).first()));
-    assertEquals(obj, stripMetadata(collection.find(BsonDocument.parse("{ name: { $ne: \"Jay2\" } } ")).first()));
-    assertEquals(obj, stripMetadata(collection.find(BsonDocument.parse("{ name: { $in: [ \"Jay\", \"John\" ] } } ")).first()));
-    assertEquals(obj, stripMetadata(collection.find(BsonDocument.parse("{ name: { $nin: [ \"Jay2\", \"John\" ] } } ")).first()));
-    assertEquals(obj, stripMetadata(collection.find(BsonDocument.parse("{ name: { $lt: \"Jay2\" } } ")).first()));
-    assertEquals(obj, stripMetadata(collection.find(BsonDocument.parse("{ name: { $lte: \"Jay2\" } } ")).first()));
-    assertEquals(obj, stripMetadata(collection.find(BsonDocument.parse("{ name: { $gt: \"A\" } } ")).first()));
-    assertEquals(obj, stripMetadata(collection.find(BsonDocument.parse("{ name: { $gte: \"A\" } } ")).first()));
-    assertEquals(obj, stripMetadata(collection.find(and(gt("name", "A"), lte("name", "Jay"))).first()));
-    assertEquals(obj, stripMetadata(collection.find(BsonDocument.parse("{ $or: [ { name: { $eq: 'Jay' } }, { lastName: 'Miner222'} ] }")).first()));
-    assertEquals(obj, stripMetadata(collection.find(BsonDocument.parse("{ $not: { name: { $eq: 'Jay2' } } }")).first()));
-    assertEquals(obj, stripMetadata(collection.find(BsonDocument.parse(
-        "{ $and: [ { name: { $eq: 'Jay' } }, { lastName: { $exists: true } }, { lastName: { $eq: 'Miner' } }, { lastName: { $ne: 'Miner22' } } ] }")).first()));
-    assertEquals(obj, stripMetadata(collection.find(and(eq("name", "Jay"), exists("lastName"), eq("lastName", "Miner"), ne("lastName", "Miner22"))).first()));
+    assertThat(collection.countDocuments()).isEqualTo(10);
+    assertThat(stripMetadata(collection.find().first())).isEqualTo(obj);
+    assertThat(stripMetadata(collection.find(BsonDocument.parse("{ name: \"Jay\" } ")).first())).isEqualTo(obj);
+    assertThat(collection.find(BsonDocument.parse("{ name: \"Jay2\" } ")).first()).isNull();
+    assertThat(stripMetadata(collection.find(BsonDocument.parse("{ name: { $eq: \"Jay\" } } ")).first())).isEqualTo(obj);
+    assertThat(stripMetadata(collection.find(BsonDocument.parse("{ name: { $ne: \"Jay2\" } } ")).first())).isEqualTo(obj);
+    assertThat(stripMetadata(collection.find(BsonDocument.parse("{ name: { $in: [ \"Jay\", \"John\" ] } } ")).first())).isEqualTo(obj);
+    assertThat(stripMetadata(collection.find(BsonDocument.parse("{ name: { $nin: [ \"Jay2\", \"John\" ] } } ")).first())).isEqualTo(obj);
+    assertThat(stripMetadata(collection.find(BsonDocument.parse("{ name: { $lt: \"Jay2\" } } ")).first())).isEqualTo(obj);
+    assertThat(stripMetadata(collection.find(BsonDocument.parse("{ name: { $lte: \"Jay2\" } } ")).first())).isEqualTo(obj);
+    assertThat(stripMetadata(collection.find(BsonDocument.parse("{ name: { $gt: \"A\" } } ")).first())).isEqualTo(obj);
+    assertThat(stripMetadata(collection.find(BsonDocument.parse("{ name: { $gte: \"A\" } } ")).first())).isEqualTo(obj);
+    assertThat(stripMetadata(collection.find(and(gt("name", "A"), lte("name", "Jay"))).first())).isEqualTo(obj);
+    assertThat(stripMetadata(collection.find(BsonDocument.parse("{ $or: [ { name: { $eq: 'Jay' } }, { lastName: 'Miner222'} ] }")).first())).isEqualTo(obj);
+    assertThat(stripMetadata(collection.find(BsonDocument.parse("{ $not: { name: { $eq: 'Jay2' } } }")).first())).isEqualTo(obj);
+    assertThat(stripMetadata(collection.find(BsonDocument.parse(
+      "{ $and: [ { name: { $eq: 'Jay' } }, { lastName: { $exists: true } }, { lastName: { $eq: 'Miner' } }, { lastName: { $ne: 'Miner22' } } ] }")).first())).isEqualTo(obj);
+    assertThat(stripMetadata(collection.find(and(eq("name", "Jay"), exists("lastName"), eq("lastName", "Miner"), ne("lastName", "Miner22"))).first())).isEqualTo(obj);
   }
 
   @Test
@@ -115,7 +114,7 @@ public class MongoDBServerTest extends BaseGraphServerTest {
             "{ $and: [ { name: { $eq: 'Jay' } }, { lastName: { $exists: true } }, { lastName: { $eq: 'Miner' } }, { lastName: { $ne: 'Miner22' } } ], $orderBy: { id: 1 } }"))
         .iterator(); it.hasNext(); ++i) {
       final Document doc = it.next();
-      assertEquals(i, doc.get("id"));
+      assertThat(doc.get("id")).isEqualTo(i);
     }
 
     i = 9;
@@ -123,7 +122,7 @@ public class MongoDBServerTest extends BaseGraphServerTest {
             "{ $and: [ { name: { $eq: 'Jay' } }, { lastName: { $exists: true } }, { lastName: { $eq: 'Miner' } }, { lastName: { $ne: 'Miner22' } } ], $orderBy: { id: -1 } }"))
         .iterator(); it.hasNext(); --i) {
       final Document doc = it.next();
-      assertEquals(i, doc.get("id"));
+      assertThat(doc.get("id")).isEqualTo(i);
     }
   }
 }

--- a/network/src/test/java/com/arcadedb/remote/RemoteDatabaseHttpIT.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteDatabaseHttpIT.java
@@ -11,9 +11,8 @@ import java.net.*;
 import java.nio.charset.*;
 import java.util.*;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
@@ -58,7 +57,7 @@ class RemoteDatabaseHttpIT {
     verify(outputStream).write(payloadAsByteArray, 0, payloadAsByteArray.length);
 
     verify(connection).getHeaderField(RemoteDatabase.ARCADEDB_SESSION_ID);
-    assertTrue(database.isTransactionActive());
+    assertThat(database.isTransactionActive()).isTrue();
   }
 
   @Test
@@ -103,7 +102,7 @@ class RemoteDatabaseHttpIT {
     }, false, 1);
     verify(database).begin();
     verify(database).commit();
-    assertTrue(createdNewTx);
+    assertThat(createdNewTx).isTrue();
   }
 
   @Test
@@ -115,7 +114,7 @@ class RemoteDatabaseHttpIT {
     }, true, 1);
     verify(database, never()).begin();
     verify(database, never()).commit();
-    assertFalse(createdNewTx);
+    assertThat(createdNewTx).isFalse();
   }
 
   @Test
@@ -124,7 +123,7 @@ class RemoteDatabaseHttpIT {
     doNothing().when(database).begin();
     doThrow(new RuntimeException()).when(database).commit();
 
-    assertThrows(RuntimeException.class, () -> database.transaction(() -> {
+    assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> database.transaction(() -> {
     }, false, 1));
     verify(database).begin();
   }

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
 
         <assertj-core.version>3.26.3</assertj-core.version>
         <junit.jupiter.version>5.11.2</junit.jupiter.version>
+        <awaitility.version>4.2.2</awaitility.version>
 
         <skipIntegration>true</skipIntegration>
 
@@ -353,6 +354,12 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito-core.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/postgresw/pom.xml
+++ b/postgresw/pom.xml
@@ -67,6 +67,8 @@
             <groupId>com.arcadedb</groupId>
             <artifactId>arcadedb-gremlin</artifactId>
             <version>${project.parent.version}</version>
+            <classifier>shaded</classifier>
+
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcTest.java
@@ -20,19 +20,17 @@ package com.arcadedb.postgres;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.server.BaseGraphServerTest;
-import com.arcadedb.utility.DateUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.postgresql.util.PSQLException;
 
 import java.sql.*;
-import java.time.*;
-import java.time.temporal.*;
-import java.util.*;
+import java.time.LocalDate;
+import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class PostgresWJdbcTest extends BaseGraphServerTest {
   @Override
@@ -55,7 +53,7 @@ public class PostgresWJdbcTest extends BaseGraphServerTest {
       try (final Statement st = conn.createStatement()) {
         try {
           st.executeQuery("SELECT * FROM V");
-          Assertions.fail("The query should go in error");
+          fail("The query should go in error");
         } catch (final PSQLException e) {
         }
       }
@@ -68,9 +66,9 @@ public class PostgresWJdbcTest extends BaseGraphServerTest {
       try (final Statement st = conn.createStatement()) {
         try {
           st.executeQuery("SELECT 'abc \\u30 def';");
-          Assertions.fail("The query should go in error");
+          fail("The query should go in error");
         } catch (final PSQLException e) {
-          Assertions.assertTrue(e.toString().contains("Syntax error"));
+          assertThat(e.toString().contains("Syntax error")).isTrue();
         }
       }
     }
@@ -121,51 +119,51 @@ public class PostgresWJdbcTest extends BaseGraphServerTest {
         ResultSet rs = st.executeQuery(
             "SELECT name, lastName, short, int, long, float, double, boolean, date, timestamp FROM V order by id");
 
-        Assertions.assertTrue(!rs.isAfterLast());
+        assertThat(rs.isAfterLast()).isFalse();
 
         int i = 0;
         while (rs.next()) {
           if (rs.getString(1).equalsIgnoreCase("Jay")) {
-            Assertions.assertEquals("Jay", rs.getString(1));
-            Assertions.assertEquals("Miner", rs.getString(2));
+            assertThat(rs.getString(1)).isEqualTo("Jay");
+            assertThat(rs.getString(2)).isEqualTo("Miner");
             ++i;
           } else if (rs.getString(1).equalsIgnoreCase("Rocky")) {
-            Assertions.assertEquals("Balboa", rs.getString(2));
-            Assertions.assertEquals((short) 3, rs.getShort(3));
-            Assertions.assertEquals(4, rs.getInt(4));
-            Assertions.assertEquals(5L, rs.getLong(5));
-            Assertions.assertEquals(6F, rs.getFloat(6));
-            Assertions.assertEquals(7D, rs.getDouble(7));
-            Assertions.assertEquals(false, rs.getBoolean(8));
-            Assertions.assertEquals(LocalDate.now(), rs.getDate(9).toLocalDate());
-            Assertions.assertEquals(now, rs.getTimestamp(10).getTime());
+            assertThat(rs.getString(2)).isEqualTo("Balboa");
+            assertThat(rs.getShort(3)).isEqualTo((short) 3);
+            assertThat(rs.getInt(4)).isEqualTo(4);
+            assertThat(rs.getLong(5)).isEqualTo(5L);
+            assertThat(rs.getFloat(6)).isEqualTo(6F);
+            assertThat(rs.getDouble(7)).isEqualTo(7D);
+            assertThat(rs.getBoolean(8)).isFalse();
+            assertThat(rs.getDate(9).toLocalDate()).isEqualTo(LocalDate.now());
+            assertThat(rs.getTimestamp(10).getTime()).isEqualTo(now);
             ++i;
           } else
-            Assertions.fail("Unknown value");
+            fail("Unknown value");
         }
 
-        Assertions.assertEquals(TOTAL + 1, i);
+        assertThat(i).isEqualTo(TOTAL + 1);
 
         rs.close();
 
         rs = st.executeQuery("SELECT FROM V order by id");
 
-        Assertions.assertTrue(!rs.isAfterLast());
+        assertThat(rs.isAfterLast()).isFalse();
 
         i = 0;
         while (rs.next()) {
-          Assertions.assertTrue(rs.findColumn("@rid") > -1);
-          Assertions.assertTrue(rs.findColumn("@type") > -1);
-          Assertions.assertTrue(rs.findColumn("@cat") > -1);
+          assertThat(rs.findColumn("@rid") > -1).isTrue();
+          assertThat(rs.findColumn("@type") > -1).isTrue();
+          assertThat(rs.findColumn("@cat") > -1).isTrue();
 
-          Assertions.assertTrue(rs.getString(rs.findColumn("@rid")).startsWith("#"));
-          Assertions.assertEquals("V", rs.getString(rs.findColumn("@type")));
-          Assertions.assertEquals("v", rs.getString(rs.findColumn("@cat")));
+          assertThat(rs.getString(rs.findColumn("@rid")).startsWith("#")).isTrue();
+          assertThat(rs.getString(rs.findColumn("@type"))).isEqualTo("V");
+          assertThat(rs.getString(rs.findColumn("@cat"))).isEqualTo("v");
 
           ++i;
         }
 
-        Assertions.assertEquals(TOTAL + 1, i);
+        assertThat(i).isEqualTo(TOTAL + 1);
 
       }
     }
@@ -188,25 +186,25 @@ public class PostgresWJdbcTest extends BaseGraphServerTest {
 
         final ResultSet rs = st.executeQuery("SELECT * FROM V");
 
-        Assertions.assertTrue(!rs.isAfterLast());
+        assertThat(rs.isAfterLast()).isFalse();
 
         int i = 0;
         while (rs.next()) {
           if (rs.getString(1).equalsIgnoreCase("Jay")) {
-            Assertions.assertEquals("Jay", rs.getString(1));
-            Assertions.assertEquals("Miner", rs.getString(2));
+            assertThat(rs.getString(1)).isEqualTo("Jay");
+            assertThat(rs.getString(2)).isEqualTo("Miner");
             ++i;
           } else if (rs.getString(1).equalsIgnoreCase("Rocky")) {
-            Assertions.assertEquals("Rocky", rs.getString(1));
-            Assertions.assertEquals("Balboa", rs.getString(2));
+            assertThat(rs.getString(1)).isEqualTo("Rocky");
+            assertThat(rs.getString(2)).isEqualTo("Balboa");
             ++i;
           } else
-            Assertions.fail("Unknown value");
+            fail("Unknown value");
         }
 
         st.execute("commit");
 
-        Assertions.assertEquals(2, i);
+        assertThat(i).isEqualTo(2);
 
         rs.close();
       }
@@ -230,19 +228,19 @@ public class PostgresWJdbcTest extends BaseGraphServerTest {
 
           int numberOfPeople = 0;
           while (rs.next()) {
-            Assertions.assertNotNull(rs.getString(1));
+            assertThat(rs.getString(1)).isNotNull();
 
             if (rs.getString(1).equals("James"))
-              Assertions.assertEquals(1.9F, rs.getFloat(2));
+              assertThat(rs.getFloat(2)).isEqualTo(1.9F);
             else if (rs.getString(1).equals("Henry"))
-              Assertions.assertNull(rs.getString(2));
+              assertThat(rs.getString(2)).isNull();
             else
-              Assertions.fail();
+              fail("");
 
             ++numberOfPeople;
           }
 
-          Assertions.assertEquals(2, numberOfPeople);
+          assertThat(numberOfPeople).isEqualTo(2);
           st.execute("commit");
         }
       }

--- a/postgresw/src/test/java/com/arcadedb/postgres/TomcatConnectionPoolPostgresWJdbcTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/TomcatConnectionPoolPostgresWJdbcTest.java
@@ -23,13 +23,14 @@ import com.arcadedb.server.BaseGraphServerTest;
 import org.apache.tomcat.jdbc.pool.DataSource;
 import org.apache.tomcat.jdbc.pool.PoolProperties;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.postgresql.util.PSQLException;
 
 import java.sql.*;
-import java.util.*;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.fail;
 
 public class TomcatConnectionPoolPostgresWJdbcTest extends BaseGraphServerTest {
   @Override
@@ -99,7 +100,7 @@ public class TomcatConnectionPoolPostgresWJdbcTest extends BaseGraphServerTest {
       try (final Statement st = conn.createStatement()) {
         try {
           st.executeQuery("SELECT * FROM V");
-          Assertions.fail("The query should go in error");
+          fail("The query should go in error");
         } catch (final PSQLException e) {
         }
       }

--- a/server/src/test/java/com/arcadedb/remote/RemoteDatabaseIT.java
+++ b/server/src/test/java/com/arcadedb/remote/RemoteDatabaseIT.java
@@ -35,12 +35,15 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.BaseGraphServerTest;
 import org.junit.jupiter.api.AfterEach;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.concurrent.atomic.*;
+
+import static org.assertj.core.api.Assertions.*;
 
 public class RemoteDatabaseIT extends BaseGraphServerTest {
   private static final String DATABASE_NAME = "remote-database";
@@ -53,9 +56,9 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
   @Test
   public void simpleTxDocuments() throws Exception {
     testEachServer((serverIndex) -> {
-      Assertions.assertTrue(
+      assertThat(
           new RemoteServer("127.0.0.1", 2480 + serverIndex, "root", BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).exists(
-              DATABASE_NAME));
+              DATABASE_NAME)).isTrue();
 
       final RemoteDatabase database = new RemoteDatabase("127.0.0.1", 2480 + serverIndex, DATABASE_NAME, "root",
           BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
@@ -66,44 +69,44 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
       database.transaction(() -> {
         // CREATE DOCUMENT VIA API
         final MutableDocument jay = database.newDocument("Person").set("name", "Jay").save();
-        Assertions.assertNotNull(jay);
-        Assertions.assertEquals("Jay", jay.getString("name"));
-        Assertions.assertNotNull(jay.getIdentity());
+        assertThat(jay).isNotNull();
+        assertThat(jay.getString("name")).isEqualTo("Jay");
+        assertThat(jay.getIdentity()).isNotNull();
         jay.save();
 
         // TEST DELETION AND LOOKUP
         jay.delete();
         try {
           jay.reload();
-          Assertions.fail();
+          fail();
         } catch (RecordNotFoundException e) {
           // EXPECTED
         }
 
         // CREATE DOCUMENT VIA SQL
         ResultSet result = database.command("SQL", "insert into Person set name = 'Elon'");
-        Assertions.assertNotNull(result);
-        Assertions.assertTrue(result.hasNext());
+        assertThat((Iterator<? extends Result>) result).isNotNull();
+        assertThat(result.hasNext()).isTrue();
         final Result rec = result.next();
-        Assertions.assertTrue(rec.toJSON().toString().contains("Elon"));
-        Assertions.assertEquals("Elon", rec.toElement().toMap().get("name"));
+        assertThat(rec.toJSON().toString().contains("Elon")).isTrue();
+        assertThat(rec.toElement().toMap().get("name")).isEqualTo("Elon");
         final RID rid = rec.toElement().getIdentity();
 
         // RETRIEVE DOCUMENT WITH QUERY
         result = database.query("SQL", "select from Person where name = 'Elon'");
-        Assertions.assertTrue(result.hasNext());
+        assertThat(result.hasNext()).isTrue();
 
         // UPDATE DOCUMENT WITH COMMAND
         result = database.command("SQL", "update Person set lastName = 'Musk' where name = 'Elon'");
-        Assertions.assertTrue(result.hasNext());
-        Assertions.assertEquals(1, result.next().toJSON().getInt("count"));
+        assertThat(result.hasNext()).isTrue();
+        assertThat(result.next().toJSON().getInt("count")).isEqualTo(1);
 
         final Document record = (Document) database.lookupByRID(rid);
-        Assertions.assertNotNull(result);
-        Assertions.assertEquals("Musk", record.getString("lastName"));
+        assertThat((Iterator<? extends Result>) result).isNotNull();
+        assertThat(record.getString("lastName")).isEqualTo("Musk");
 
-        Assertions.assertEquals(1L, database.countType("Person", true));
-        Assertions.assertEquals(1L, database.countType("Person", false));
+        assertThat(database.countType("Person", true)).isEqualTo(1L);
+        assertThat(database.countType("Person", false)).isEqualTo(1L);
 
         long totalInBuckets = 0L;
         for (int i = 0; i < 100; i++) {
@@ -114,13 +117,13 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
             break;
           }
         }
-        Assertions.assertEquals(1L, totalInBuckets);
+        assertThat(totalInBuckets).isEqualTo(1L);
       });
 
       // RETRIEVE DOCUMENT WITH QUERY AFTER COMMIT
       final ResultSet result = database.query("SQL", "select from Person where name = 'Elon'");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertEquals("Musk", result.next().getProperty("lastName"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat(result.next().<String>getProperty("lastName")).isEqualTo("Musk");
     });
   }
 
@@ -142,91 +145,91 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
       database.transaction(() -> {
         // CREATE VERTEX TYPE
         ResultSet result = database.command("SQL", "create vertex type Character");
-        Assertions.assertNotNull(result);
-        Assertions.assertTrue(result.hasNext());
+        assertThat((Iterator<? extends Result>) result).isNotNull();
+        assertThat(result.hasNext()).isTrue();
 
         // CREATE DOCUMENT VIA API
         final MutableVertex jay = database.newVertex("Character").set("name", "Jay").save();
-        Assertions.assertTrue(jay instanceof RemoteMutableVertex);
+        assertThat(jay instanceof RemoteMutableVertex).isTrue();
 
-        Assertions.assertNotNull(jay);
-        Assertions.assertEquals("Jay", jay.getString("name"));
-        Assertions.assertNotNull(jay.getIdentity());
+        assertThat(jay).isNotNull();
+        assertThat(jay.getString("name")).isEqualTo("Jay");
+        assertThat(jay.getIdentity()).isNotNull();
         jay.save();
 
-        Assertions.assertNotNull(jay);
-        Assertions.assertEquals("Jay", jay.getString("name"));
-        Assertions.assertNotNull(jay.getIdentity());
+        assertThat(jay).isNotNull();
+        assertThat(jay.getString("name")).isEqualTo("Jay");
+        assertThat(jay.getIdentity()).isNotNull();
         jay.save();
 
         // CREATE DOCUMENT VIA API
         final Map<String, Object> map = Map.of("on", "today", "for", "5 days");
         Edge edge = jay.newEdge(EDGE1_TYPE_NAME, jay, true, map).save();
-        Assertions.assertTrue(edge instanceof RemoteMutableEdge);
-        Assertions.assertEquals("today", edge.get("on"));
-        Assertions.assertEquals("5 days", edge.get("for"));
+        assertThat(edge instanceof RemoteMutableEdge).isTrue();
+        assertThat(edge.get("on")).isEqualTo("today");
+        assertThat(edge.get("for")).isEqualTo("5 days");
 
         // TEST DELETION AND LOOKUP
         jay.delete();
         try {
           jay.reload();
-          Assertions.fail();
+          fail();
         } catch (RecordNotFoundException e) {
           // EXPECTED
         }
 
         // CREATE VERTEX 1
         result = database.command("SQL", "insert into Character set name = 'Elon'");
-        Assertions.assertNotNull(result);
-        Assertions.assertTrue(result.hasNext());
+        assertThat((Iterator<? extends Result>) result).isNotNull();
+        assertThat(result.hasNext()).isTrue();
         Result rec = result.next();
-        Assertions.assertTrue(rec.toJSON().toString().contains("Elon"));
-        Assertions.assertEquals("Elon", rec.toElement().toMap().get("name"));
+        assertThat(rec.toJSON().toString().contains("Elon")).isTrue();
+        assertThat(rec.toElement().toMap().get("name")).isEqualTo("Elon");
         final RID rid1 = rec.getIdentity().get();
 
         // CREATE VERTEX 2
         result = database.command("SQL", "create vertex Character set name = 'Kimbal'");
-        Assertions.assertNotNull(result);
-        Assertions.assertTrue(result.hasNext());
+        assertThat((Iterator<? extends Result>) result).isNotNull();
+        assertThat(result.hasNext()).isTrue();
         rec = result.next();
-        Assertions.assertTrue(rec.toJSON().toString().contains("Kimbal"));
-        Assertions.assertEquals("Kimbal", rec.toElement().toMap().get("name"));
+        assertThat(rec.toJSON().toString().contains("Kimbal")).isTrue();
+        assertThat(rec.toElement().toMap().get("name")).isEqualTo("Kimbal");
         final RID rid2 = rec.getIdentity().get();
 
         // RETRIEVE VERTEX WITH QUERY
         result = database.query("SQL", "select from Character where name = 'Elon'");
-        Assertions.assertTrue(result.hasNext());
-        Assertions.assertTrue(result.next().isVertex());
+        assertThat(result.hasNext()).isTrue();
+        assertThat(result.next().isVertex()).isTrue();
 
         // UPDATE VERTEX WITH COMMAND
         result = database.command("SQL", "update Character set lastName = 'Musk' where name = 'Elon' or name = 'Kimbal'");
-        Assertions.assertTrue(result.hasNext());
-        Assertions.assertEquals(2, result.next().toJSON().getInt("count"));
+        assertThat(result.hasNext()).isTrue();
+        assertThat(result.next().toJSON().getInt("count")).isEqualTo(2);
 
         // CREATE EDGE WITH COMMAND
         result = database.command("SQL", "create edge " + EDGE1_TYPE_NAME + " from " + rid1 + " to " + rid2);
-        Assertions.assertTrue(result.hasNext());
+        assertThat(result.hasNext()).isTrue();
         edge = result.next().getEdge().get();
 
         edge.toMap();
         edge.toJSON();
 
-        Assertions.assertEquals(EDGE1_TYPE_NAME, edge.getTypeName());
-        Assertions.assertEquals(rid1, edge.getOut());
-        Assertions.assertEquals(rid2, edge.getIn());
+        assertThat(edge.getTypeName()).isEqualTo(EDGE1_TYPE_NAME);
+        assertThat(edge.getOut()).isEqualTo(rid1);
+        assertThat(edge.getIn()).isEqualTo(rid2);
 
         Vertex record = (Vertex) database.lookupByRID(rid1);
-        Assertions.assertNotNull(record);
-        Assertions.assertEquals("Elon", record.getString("name"));
-        Assertions.assertEquals("Musk", record.getString("lastName"));
+        assertThat(record).isNotNull();
+        assertThat(record.getString("name")).isEqualTo("Elon");
+        assertThat(record.getString("lastName")).isEqualTo("Musk");
 
         record.toMap();
         record.toJSON();
 
         record = (Vertex) database.lookupByRID(rid2);
-        Assertions.assertNotNull(record);
-        Assertions.assertEquals("Kimbal", record.getString("name"));
-        Assertions.assertEquals("Musk", record.getString("lastName"));
+        assertThat(record).isNotNull();
+        assertThat(record.getString("name")).isEqualTo("Kimbal");
+        assertThat(record.getString("lastName")).isEqualTo("Musk");
 
         final MutableDocument mutable = record.modify();
         mutable.set("extra", 100);
@@ -235,81 +238,81 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
 
       // RETRIEVE VERTEX WITH QUERY AFTER COMMIT
       final ResultSet result = database.query("SQL", "select from Character where name = 'Kimbal'");
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result record = result.next();
-      Assertions.assertTrue(record.isVertex());
+      assertThat(record.isVertex()).isTrue();
 
       final Vertex kimbal = record.getVertex().get();
-      Assertions.assertEquals("Musk", kimbal.getString("lastName"));
-      Assertions.assertEquals(100, kimbal.getInteger("extra"));
+      assertThat(kimbal.getString("lastName")).isEqualTo("Musk");
+      assertThat(kimbal.getInteger("extra")).isEqualTo(100);
 
-      Assertions.assertTrue(kimbal.toMap().containsKey("@cat"));
-      Assertions.assertTrue(kimbal.toMap().containsKey("@type"));
-      Assertions.assertFalse(kimbal.toMap().containsKey("@out"));
-      Assertions.assertFalse(kimbal.toMap().containsKey("@in"));
+      assertThat(kimbal.toMap().containsKey("@cat")).isTrue();
+      assertThat(kimbal.toMap().containsKey("@type")).isTrue();
+      assertThat(kimbal.toMap().containsKey("@out")).isFalse();
+      assertThat(kimbal.toMap().containsKey("@in")).isFalse();
 
       kimbal.toJSON();
 
       final Iterator<Vertex> connected = kimbal.getVertices(Vertex.DIRECTION.IN).iterator();
-      Assertions.assertTrue(connected.hasNext());
+      assertThat(connected.hasNext()).isTrue();
       final Vertex elon = connected.next();
-      Assertions.assertEquals("Musk", elon.getString("lastName"));
+      assertThat(elon.getString("lastName")).isEqualTo("Musk");
 
-      Assertions.assertEquals(1L, kimbal.countEdges(Vertex.DIRECTION.IN, null));
-      Assertions.assertEquals(1L, kimbal.countEdges(Vertex.DIRECTION.IN, EDGE1_TYPE_NAME));
-      Assertions.assertEquals(0L, kimbal.countEdges(Vertex.DIRECTION.IN, EDGE2_TYPE_NAME));
-      Assertions.assertEquals(0, kimbal.countEdges(Vertex.DIRECTION.OUT, null));
-      Assertions.assertEquals(0, kimbal.countEdges(Vertex.DIRECTION.OUT, EDGE1_TYPE_NAME));
-      Assertions.assertEquals(0L, kimbal.countEdges(Vertex.DIRECTION.OUT, EDGE2_TYPE_NAME));
+      assertThat(kimbal.countEdges(Vertex.DIRECTION.IN, null)).isEqualTo(1L);
+      assertThat(kimbal.countEdges(Vertex.DIRECTION.IN, EDGE1_TYPE_NAME)).isEqualTo(1L);
+      assertThat(kimbal.countEdges(Vertex.DIRECTION.IN, EDGE2_TYPE_NAME)).isEqualTo(0L);
+      assertThat(kimbal.countEdges(Vertex.DIRECTION.OUT, null)).isEqualTo(0);
+      assertThat(kimbal.countEdges(Vertex.DIRECTION.OUT, EDGE1_TYPE_NAME)).isEqualTo(0);
+      assertThat(kimbal.countEdges(Vertex.DIRECTION.OUT, EDGE2_TYPE_NAME)).isEqualTo(0L);
 
-      Assertions.assertEquals(1L, elon.countEdges(Vertex.DIRECTION.OUT, null));
-      Assertions.assertEquals(1L, elon.countEdges(Vertex.DIRECTION.OUT, EDGE1_TYPE_NAME));
-      Assertions.assertEquals(0L, elon.countEdges(Vertex.DIRECTION.OUT, EDGE2_TYPE_NAME));
-      Assertions.assertEquals(0, elon.countEdges(Vertex.DIRECTION.IN, null));
-      Assertions.assertEquals(0, elon.countEdges(Vertex.DIRECTION.IN, EDGE1_TYPE_NAME));
-      Assertions.assertEquals(0L, elon.countEdges(Vertex.DIRECTION.IN, EDGE2_TYPE_NAME));
+      assertThat(elon.countEdges(Vertex.DIRECTION.OUT, null)).isEqualTo(1L);
+      assertThat(elon.countEdges(Vertex.DIRECTION.OUT, EDGE1_TYPE_NAME)).isEqualTo(1L);
+      assertThat(elon.countEdges(Vertex.DIRECTION.OUT, EDGE2_TYPE_NAME)).isEqualTo(0L);
+      assertThat(elon.countEdges(Vertex.DIRECTION.IN, null)).isEqualTo(0);
+      assertThat(elon.countEdges(Vertex.DIRECTION.IN, EDGE1_TYPE_NAME)).isEqualTo(0);
+      assertThat(elon.countEdges(Vertex.DIRECTION.IN, EDGE2_TYPE_NAME)).isEqualTo(0);
 
-      Assertions.assertTrue(kimbal.isConnectedTo(elon.getIdentity()));
-      Assertions.assertTrue(kimbal.isConnectedTo(elon.getIdentity(), Vertex.DIRECTION.IN));
-      Assertions.assertFalse(kimbal.isConnectedTo(elon.getIdentity(), Vertex.DIRECTION.OUT));
+      assertThat(kimbal.isConnectedTo(elon.getIdentity())).isTrue();
+      assertThat(kimbal.isConnectedTo(elon.getIdentity(), Vertex.DIRECTION.IN)).isTrue();
+      assertThat(kimbal.isConnectedTo(elon.getIdentity(), Vertex.DIRECTION.OUT)).isFalse();
 
-      Assertions.assertTrue(elon.isConnectedTo(kimbal.getIdentity()));
-      Assertions.assertTrue(elon.isConnectedTo(kimbal.getIdentity(), Vertex.DIRECTION.OUT));
-      Assertions.assertFalse(elon.isConnectedTo(kimbal.getIdentity(), Vertex.DIRECTION.IN));
+      assertThat(elon.isConnectedTo(kimbal.getIdentity())).isTrue();
+      assertThat(elon.isConnectedTo(kimbal.getIdentity(), Vertex.DIRECTION.OUT)).isTrue();
+      assertThat(elon.isConnectedTo(kimbal.getIdentity(), Vertex.DIRECTION.IN)).isFalse();
 
       final MutableEdge newEdge = elon.newEdge(EDGE2_TYPE_NAME, kimbal, true, "since", "today");
-      Assertions.assertEquals(newEdge.getOut(), elon.getIdentity());
-      Assertions.assertEquals(newEdge.getOutVertex(), elon);
-      Assertions.assertEquals(newEdge.getIn(), kimbal.getIdentity());
-      Assertions.assertEquals(newEdge.getInVertex(), kimbal);
+      assertThat(elon.getIdentity()).isEqualTo(newEdge.getOut());
+      assertThat(elon).isEqualTo(newEdge.getOutVertex());
+      assertThat(kimbal.getIdentity()).isEqualTo(newEdge.getIn());
+      assertThat(kimbal).isEqualTo(newEdge.getInVertex());
 
       newEdge.set("updated", true);
       newEdge.save();
 
       // SAME BUT FROM A MUTABLE INSTANCE
       final MutableEdge newEdge2 = elon.modify().newEdge(EDGE2_TYPE_NAME, kimbal, true, "since", "today");
-      Assertions.assertEquals(newEdge2.getOut(), elon.getIdentity());
-      Assertions.assertEquals(newEdge2.getOutVertex(), elon);
-      Assertions.assertEquals(newEdge2.getIn(), kimbal.getIdentity());
-      Assertions.assertEquals(newEdge2.getInVertex(), kimbal);
+      assertThat(elon.getIdentity()).isEqualTo(newEdge2.getOut());
+      assertThat(elon).isEqualTo(newEdge2.getOutVertex());
+      assertThat(kimbal.getIdentity()).isEqualTo(newEdge2.getIn());
+      assertThat(kimbal).isEqualTo(newEdge2.getInVertex());
       newEdge2.delete();
 
       final Edge edge = elon.getEdges(Vertex.DIRECTION.OUT, EDGE2_TYPE_NAME).iterator().next();
-      Assertions.assertEquals(edge.getOut(), elon.getIdentity());
-      Assertions.assertEquals(edge.getOutVertex(), elon);
-      Assertions.assertEquals(edge.getIn(), kimbal.getIdentity());
-      Assertions.assertEquals(edge.getInVertex(), kimbal);
-      Assertions.assertTrue(edge.getBoolean("updated"));
+      assertThat(elon.getIdentity()).isEqualTo(edge.getOut());
+      assertThat(elon).isEqualTo(edge.getOutVertex());
+      assertThat(kimbal.getIdentity()).isEqualTo(edge.getIn());
+      assertThat(kimbal).isEqualTo(edge.getInVertex());
+      assertThat(edge.getBoolean("updated")).isTrue();
 
       // DELETE THE EDGE
       edge.delete();
-      Assertions.assertFalse(elon.getEdges(Vertex.DIRECTION.OUT, EDGE2_TYPE_NAME).iterator().hasNext());
+      assertThat(elon.getEdges(Vertex.DIRECTION.OUT, EDGE2_TYPE_NAME).iterator().hasNext()).isFalse();
 
       // DELETE ONE VERTEX
       elon.delete();
       try {
         database.lookupByRID(elon.getIdentity());
-        Assertions.fail();
+        fail();
       } catch (final RecordNotFoundException e) {
         // EXPECTED
       }
@@ -322,9 +325,9 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
       final int TOTAL_TRANSACTIONS = 100;
       final int BATCH_SIZE = 100;
 
-      Assertions.assertTrue(
+      assertThat(
           new RemoteServer("127.0.0.1", 2480 + serverIndex, "root", BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).exists(
-              DATABASE_NAME));
+              DATABASE_NAME)).isTrue();
 
       final RemoteDatabase database = new RemoteDatabase("127.0.0.1", 2480 + serverIndex, DATABASE_NAME, "root",
           BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
@@ -341,10 +344,10 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
           while (checkThreadRunning.get()) {
             Thread.sleep(1000);
             ResultSet result = database.query("SQL", "select from Person");
-            Assertions.assertTrue(result.hasNext());
+            assertThat(result.hasNext()).isTrue();
             int total = 0;
             while (result.hasNext()) {
-              Assertions.assertNotNull(result.next().getProperty("name"));
+              assertThat(result.next().<String>getProperty("name")).isNotNull();
               ++total;
             }
             //System.out.println("Parallel thread browsed " + total + " records (limit 20,000)");
@@ -362,22 +365,22 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
           database.transaction(() -> {
             for (int j = 0; j < BATCH_SIZE; j++) {
               final MutableDocument jay = database.newDocument("Person").set("name", "Jay").save();
-              Assertions.assertNotNull(jay);
-              Assertions.assertEquals("Jay", jay.getString("name"));
-              Assertions.assertNotNull(jay.getIdentity());
+              assertThat(jay).isNotNull();
+              assertThat(jay.getString("name")).isEqualTo("Jay");
+              assertThat(jay.getIdentity()).isNotNull();
               jay.save();
             }
 
             // TEST ISOLATION: COUNT SHOULD SEE THE MOST RECENT CHANGES BEFORE THE COMMIT
             ResultSet result = database.query("SQL", "select count(*) as total from Person");
-            Assertions.assertTrue(result.hasNext());
-            Assertions.assertEquals(executedBatches * BATCH_SIZE, (int) result.next().getProperty("total"));
+            assertThat(result.hasNext()).isTrue();
+            assertThat((int) result.next().getProperty("total")).isEqualTo(executedBatches * BATCH_SIZE);
 
             // CHECK ON A PARALLEL CONNECTION THE TX ISOLATION (RECORDS LESS THEN INSERTED)
             result = database2.query("SQL", "select count(*) as total from Person");
-            Assertions.assertTrue(result.hasNext());
+            assertThat(result.hasNext()).isTrue();
             final int totalRecord = result.next().getProperty("total");
-            Assertions.assertTrue(totalRecord < executedBatches * BATCH_SIZE,
+            assertThat(totalRecord).isLessThan(executedBatches * BATCH_SIZE).withFailMessage(
                 "Found total " + totalRecord + " records but should be less than " + (executedBatches * BATCH_SIZE));
 
             //System.out.println("BATCH " + executedBatches + "/" + TOTAL_TRANSACTIONS);
@@ -394,17 +397,17 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
 
       // RETRIEVE DOCUMENT WITH QUERY AFTER COMMIT
       final ResultSet result = database.query("SQL", "select count(*) as total from Person");
-      Assertions.assertTrue(result.hasNext());
-      Assertions.assertEquals(TOTAL_TRANSACTIONS * BATCH_SIZE, (int) result.next().getProperty("total"));
+      assertThat(result.hasNext()).isTrue();
+      assertThat((int) result.next().getProperty("total")).isEqualTo(TOTAL_TRANSACTIONS * BATCH_SIZE);
     });
   }
 
   @Test
   public void testRIDAsParametersInSQL() throws Exception {
     testEachServer((serverIndex) -> {
-      Assertions.assertTrue(
+      assertThat(
           new RemoteServer("127.0.0.1", 2480 + serverIndex, "root", BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).exists(
-              DATABASE_NAME));
+              DATABASE_NAME)).isTrue();
 
       final RemoteDatabase database = new RemoteDatabase("127.0.0.1", 2480 + serverIndex, DATABASE_NAME, "root",
           BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
@@ -446,9 +449,9 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
   @Test
   public void testTransactionWrongSessionId() throws Exception {
     testEachServer((serverIndex) -> {
-      Assertions.assertTrue(
+      assertThat(
           new RemoteServer("127.0.0.1", 2480 + serverIndex, "root", BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).exists(
-              DATABASE_NAME));
+              DATABASE_NAME)).isTrue();
 
       final RemoteDatabase database1 = new RemoteDatabase("127.0.0.1", 2480 + serverIndex, DATABASE_NAME, "root",
           BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
@@ -458,9 +461,9 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
       database1.begin();
 
       final MutableDocument jay = database1.newDocument("Person").set("name", "Jay").save();
-      Assertions.assertNotNull(jay);
-      Assertions.assertEquals("Jay", jay.getString("name"));
-      Assertions.assertNotNull(jay.getIdentity());
+      assertThat(jay).isNotNull();
+      assertThat(jay.getString("name")).isEqualTo("Jay");
+      assertThat(jay.getIdentity()).isNotNull();
       jay.save();
 
       final String sessionId = database1.getSessionId();
@@ -468,7 +471,7 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
 
       try {
         final MutableDocument elon = database1.newDocument("Person").set("name", "Elon").save();
-        Assertions.fail();
+        fail();
       } catch (TransactionException e) {
         // EXPECTED
       }
@@ -484,12 +487,12 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
     testEachServer((serverIndex) -> {
       final RemoteDatabase database = new RemoteDatabase("127.0.0.1", 2480 + serverIndex, DATABASE_NAME, "root",
           BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
-      Assertions.assertTrue(database.isOpen());
+      assertThat(database.isOpen()).isTrue();
       database.close();
-      Assertions.assertFalse(database.isOpen());
+      assertThat(database.isOpen()).isFalse();
       try {
         database.countType("aaa", true);
-        Assertions.fail();
+        fail();
       } catch (DatabaseIsClosedException e) {
         //EXPECTED
       }

--- a/server/src/test/java/com/arcadedb/remote/RemoteSchemaIT.java
+++ b/server/src/test/java/com/arcadedb/remote/RemoteSchemaIT.java
@@ -26,10 +26,13 @@ import com.arcadedb.schema.Property;
 import com.arcadedb.schema.Type;
 import com.arcadedb.schema.VertexType;
 import com.arcadedb.server.BaseGraphServerTest;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class RemoteSchemaIT extends BaseGraphServerTest {
   private static final String DATABASE_NAME = "remote-database";
@@ -45,18 +48,18 @@ public class RemoteSchemaIT extends BaseGraphServerTest {
       final RemoteDatabase database = new RemoteDatabase("127.0.0.1", 2480 + serverIndex, DATABASE_NAME, "root",
           BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
 
-      Assertions.assertFalse(database.getSchema().existsType("Document"));
+      assertThat(database.getSchema().existsType("Document")).isFalse();
       DocumentType type = database.getSchema().createDocumentType("Document");
-      Assertions.assertNotNull(type);
-      Assertions.assertEquals(type.getName(), "Document");
-      Assertions.assertTrue(database.getSchema().existsType("Document"));
+      assertThat(type).isNotNull();
+      assertThat(type.getName()).isEqualTo("Document");
+      assertThat(database.getSchema().existsType("Document")).isTrue();
 
       type.createProperty("a", Type.STRING);
-      Assertions.assertTrue(type.existsProperty("a"));
-      Assertions.assertFalse(type.existsProperty("zz"));
+      assertThat(type.existsProperty("a")).isTrue();
+      assertThat(type.existsProperty("zz")).isFalse();
 
       type.createProperty("b", Type.LIST, "STRING");
-      Assertions.assertTrue(type.existsProperty("b"));
+      assertThat(type.existsProperty("b")).isTrue();
 
       database.getSchema().dropType("Document");
     });
@@ -68,37 +71,37 @@ public class RemoteSchemaIT extends BaseGraphServerTest {
       final RemoteDatabase database = new RemoteDatabase("127.0.0.1", 2480 + serverIndex, DATABASE_NAME, "root",
           BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
 
-      Assertions.assertFalse(database.getSchema().existsType("Vertex"));
+      assertThat(database.getSchema().existsType("Vertex")).isFalse();
       VertexType type = database.getSchema().createVertexType("Vertex");
-      Assertions.assertNotNull(type);
-      Assertions.assertEquals(type.getName(), "Vertex");
-      Assertions.assertTrue(database.getSchema().existsType("Vertex"));
+      assertThat(type).isNotNull();
+      assertThat(type.getName()).isEqualTo("Vertex");
+      assertThat(database.getSchema().existsType("Vertex")).isTrue();
 
       VertexType type2 = database.getSchema().createVertexType("Vertex2");
 
       Property prop2 = type2.createProperty("b", Type.LIST, "STRING");
-      Assertions.assertEquals("b", prop2.getName());
-      Assertions.assertEquals(Type.LIST, prop2.getType());
-      Assertions.assertEquals("STRING", prop2.getOfType());
+      assertThat(prop2.getName()).isEqualTo("b");
+      assertThat(prop2.getType()).isEqualTo(Type.LIST);
+      assertThat(prop2.getOfType()).isEqualTo("STRING");
 
       type2.addSuperType("Vertex");
-      Assertions.assertTrue(type2.isSubTypeOf("Vertex"));
+      assertThat(type2.isSubTypeOf("Vertex")).isTrue();
 
       VertexType type3 = database.getSchema().createVertexType("Vertex3");
       Property prop3 = type3.createProperty("c", Type.LIST, "INTEGER");
-      Assertions.assertEquals("c", prop3.getName());
-      Assertions.assertEquals(Type.LIST, prop3.getType());
-      Assertions.assertEquals("INTEGER", prop3.getOfType());
+      assertThat(prop3.getName()).isEqualTo("c");
+      assertThat(prop3.getType()).isEqualTo(Type.LIST);
+      assertThat(prop3.getOfType()).isEqualTo("INTEGER");
 
       type3.addSuperType("Vertex2");
-      Assertions.assertTrue(type3.isSubTypeOf("Vertex"));
-      Assertions.assertTrue(type3.isSubTypeOf("Vertex2"));
+      assertThat(type3.isSubTypeOf("Vertex")).isTrue();
+      assertThat(type3.isSubTypeOf("Vertex2")).isTrue();
 
-      Assertions.assertEquals(3, database.getSchema().getTypes().size());
+      assertThat(database.getSchema().getTypes()).hasSize(3);
 
-      Assertions.assertNotNull(database.getSchema().getType("Vertex"));
-      Assertions.assertNotNull(database.getSchema().getType("Vertex2"));
-      Assertions.assertNotNull(database.getSchema().getType("Vertex3"));
+      assertThat(database.getSchema().getType("Vertex")).isNotNull();
+      assertThat(database.getSchema().getType("Vertex2")).isNotNull();
+      assertThat(database.getSchema().getType("Vertex3")).isNotNull();
 
       database.getSchema().dropType("Vertex3");
       database.getSchema().dropType("Vertex2");
@@ -112,11 +115,11 @@ public class RemoteSchemaIT extends BaseGraphServerTest {
       final RemoteDatabase database = new RemoteDatabase("127.0.0.1", 2480 + serverIndex, DATABASE_NAME, "root",
           BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
 
-      Assertions.assertFalse(database.getSchema().existsType("Edge"));
+      assertThat(database.getSchema().existsType("Edge")).isFalse();
       EdgeType type = database.getSchema().createEdgeType("Edge");
-      Assertions.assertNotNull(type);
-      Assertions.assertEquals(type.getName(), "Edge");
-      Assertions.assertTrue(database.getSchema().existsType("Edge"));
+      assertThat(type).isNotNull();
+      assertThat(type.getName()).isEqualTo("Edge");
+      assertThat(database.getSchema().existsType("Edge")).isTrue();
       database.getSchema().dropType("Edge");
     });
   }

--- a/server/src/test/java/com/arcadedb/server/AsyncInsertTest.java
+++ b/server/src/test/java/com/arcadedb/server/AsyncInsertTest.java
@@ -35,7 +35,6 @@ import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,6 +43,7 @@ import java.util.*;
 import java.util.concurrent.atomic.*;
 
 import static com.arcadedb.server.BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * From Issue https://github.com/ArcadeData/arcadedb/issues/1126
@@ -78,8 +78,7 @@ public class AsyncInsertTest {
 
     database.async().onError(exception -> errCount.incrementAndGet());
 
-    Assertions.assertNotEquals(database.async().getParallelLevel(),
-        database.getSchema().getType("Product").getBuckets(false).size());
+    assertThat(database.getSchema().getType("Product").getBuckets(false).size()).isNotEqualTo(database.async().getParallelLevel());
     for (int i = 0; i < N; i++) {
       name = UUID.randomUUID().toString();
       database.async().command("sql", sqlString, new AsyncResultsetCallback() {
@@ -95,14 +94,14 @@ public class AsyncInsertTest {
       }, name, name);
     }
 
-    Assertions.assertTrue(database.async().waitCompletion(3000));
+    assertThat(database.async().waitCompletion(3000)).isTrue();
 
-    Assertions.assertEquals(N, okCount.get());
-    Assertions.assertNotEquals(0, errCount.get());
+    assertThat(okCount.get()).isEqualTo(N);
+    assertThat(errCount.get()).isNotEqualTo(0);
 
     try (ResultSet resultSet = database.query("sql", "SELECT count(*) as total FROM Product")) {
       Result result = resultSet.next();
-      Assertions.assertNotEquals(N, (Long) result.getProperty("total"));
+      assertThat((Long) result.getProperty("total")).isNotEqualTo(N);
     }
   }
 
@@ -131,7 +130,7 @@ public class AsyncInsertTest {
     database.async().setParallelLevel(4);
     database.async().onError(exception -> errCount.incrementAndGet());
 
-    Assertions.assertEquals(database.async().getParallelLevel(), database.getSchema().getType("Product").getBuckets(false).size());
+    assertThat(database.getSchema().getType("Product").getBuckets(false).size()).isEqualTo(database.async().getParallelLevel());
     for (int i = 0; i < N; i++) {
       name = UUID.randomUUID().toString();
       database.async().command("sql", sqlString, new AsyncResultsetCallback() {
@@ -147,14 +146,14 @@ public class AsyncInsertTest {
       }, name, name);
     }
 
-    Assertions.assertTrue(database.async().waitCompletion(3000));
+    assertThat(database.async().waitCompletion(3000)).isTrue();
 
-    Assertions.assertEquals(N, okCount.get());
-    Assertions.assertEquals(0, errCount.get());
+    assertThat(okCount.get()).isEqualTo(N);
+    assertThat(errCount.get()).isEqualTo(0);
 
     try (ResultSet resultSet = database.query("sql", "SELECT count(*) as total FROM Product")) {
       Result result = resultSet.next();
-      Assertions.assertEquals(N, (Long) result.getProperty("total"));
+      assertThat((Long) result.getProperty("total")).isEqualTo(N);
     }
   }
 

--- a/server/src/test/java/com/arcadedb/server/BatchInsertUpdateTest.java
+++ b/server/src/test/java/com/arcadedb/server/BatchInsertUpdateTest.java
@@ -35,7 +35,6 @@ import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -45,6 +44,7 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
 import static com.arcadedb.server.BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * From Issue https://github.com/ArcadeData/arcadedb/discussion/1129
@@ -131,8 +131,8 @@ public class BatchInsertUpdateTest {
           else if (status.equals("updated"))
             ++updated;
         }
-        Assertions.assertEquals(TOTAL, created);
-        Assertions.assertEquals(TOTAL / 2, updated);
+        assertThat(created).isEqualTo(TOTAL);
+        assertThat(updated).isEqualTo(TOTAL / 2);
 
       } finally {
         arcadeDBServer.stop();

--- a/server/src/test/java/com/arcadedb/server/CompositeIndexTest.java
+++ b/server/src/test/java/com/arcadedb/server/CompositeIndexTest.java
@@ -34,7 +34,6 @@ import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -43,6 +42,7 @@ import java.time.*;
 import java.time.format.*;
 
 import static com.arcadedb.server.BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * From Issue https://github.com/ArcadeData/arcadedb/issues/741
@@ -91,14 +91,14 @@ public class CompositeIndexTest {
       vstop = LocalDateTime.parse("2019-05-05T00:07:57.423797", DateTimeFormatter.ofPattern(dateTimePattern));
       try (ResultSet resultSet = database.command("sql", sqlString, 1, processor, vstart, vstop, status, processor, vstart,
           vstop)) {
-        Assertions.assertTrue(resultSet.hasNext());
+        assertThat(resultSet.hasNext()).isTrue();
         resultSet.next().toJSON();
       }
       vstart = LocalDateTime.parse("2019-05-05T00:10:37.288211", DateTimeFormatter.ofPattern(dateTimePattern));
       vstop = LocalDateTime.parse("2019-05-05T00:12:38.236835", DateTimeFormatter.ofPattern(dateTimePattern));
       try (ResultSet resultSet = database.command("sql", sqlString, 2, processor, vstart, vstop, status, processor, vstart,
           vstop)) {
-        Assertions.assertTrue(resultSet.hasNext());
+        assertThat(resultSet.hasNext()).isTrue();
         resultSet.next().toJSON();
       }
       database.commit();
@@ -113,17 +113,17 @@ public class CompositeIndexTest {
       // select orders
       sqlString = "SELECT FROM Order WHERE status = ?";
       try (ResultSet resultSet = database.query("sql", sqlString, "COMPLETED")) {
-        Assertions.assertTrue(resultSet.hasNext());
+        assertThat(resultSet.hasNext()).isTrue();
         resultSet.next().toJSON();
       }
       try (ResultSet resultSet = database.query("sql", "SELECT FROM Order WHERE id = 2")) {
-        Assertions.assertTrue(resultSet.hasNext());
+        assertThat(resultSet.hasNext()).isTrue();
         Result result = resultSet.next();
-        Assertions.assertTrue(result.getProperty("status").equals("PENDING"));
+        assertThat(result.<String>getProperty("status")).isEqualTo("PENDING");
         result.toJSON();
       }
       try (ResultSet resultSet = database.query("sql", sqlString, "PENDING")) {
-        Assertions.assertTrue(resultSet.hasNext());
+        assertThat(resultSet.hasNext()).isTrue();
         resultSet.next().toJSON();
       }
     } catch (Exception e) {

--- a/server/src/test/java/com/arcadedb/server/HTTPGraphIT.java
+++ b/server/src/test/java/com/arcadedb/server/HTTPGraphIT.java
@@ -3,7 +3,7 @@ package com.arcadedb.server;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
-import org.junit.jupiter.api.Assertions;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
@@ -11,6 +11,10 @@ import java.net.*;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 import java.util.logging.*;
+
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class HTTPGraphIT extends BaseGraphServerTest {
   @Test
@@ -24,9 +28,9 @@ public class HTTPGraphIT extends BaseGraphServerTest {
       try {
         connection.connect();
         readResponse(connection);
-        Assertions.fail("Authentication was bypassed!");
+        fail("Authentication was bypassed!");
       } catch (final IOException e) {
-        Assertions.assertTrue(e.toString().contains("403"));
+        assertThat(e.toString()).contains("403");
       } finally {
         connection.disconnect();
       }
@@ -43,9 +47,9 @@ public class HTTPGraphIT extends BaseGraphServerTest {
       try {
         connection.connect();
         readResponse(connection);
-        Assertions.fail("Authentication was bypassed!");
+        fail("Authentication was bypassed!");
       } catch (final IOException e) {
-        Assertions.assertTrue(e.toString().contains("401"));
+        assertThat(e.toString()).contains("401");
       } finally {
         connection.disconnect();
       }
@@ -66,9 +70,9 @@ public class HTTPGraphIT extends BaseGraphServerTest {
       try {
         final String response = readResponse(connection);
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
-        Assertions.assertEquals(200, connection.getResponseCode());
-        Assertions.assertEquals("OK", connection.getResponseMessage());
-        Assertions.assertTrue(response.contains("V1"));
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getResponseMessage()).isEqualTo("OK");
+        assertThat(response.contains("V1")).isTrue();
 
       } finally {
         connection.disconnect();
@@ -91,9 +95,9 @@ public class HTTPGraphIT extends BaseGraphServerTest {
       try {
         final String response = readResponse(connection);
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
-        Assertions.assertEquals(200, connection.getResponseCode());
-        Assertions.assertEquals("OK", connection.getResponseMessage());
-        Assertions.assertTrue(response.contains("V1"));
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getResponseMessage()).isEqualTo("OK");
+        assertThat(response.contains("V1")).isTrue();
       } finally {
         connection.disconnect();
       }
@@ -115,9 +119,9 @@ public class HTTPGraphIT extends BaseGraphServerTest {
       try {
         final String response = readResponse(connection);
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
-        Assertions.assertEquals(200, connection.getResponseCode());
-        Assertions.assertEquals("OK", connection.getResponseMessage());
-        Assertions.assertTrue(response.contains("V1"));
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getResponseMessage()).isEqualTo("OK");
+        assertThat(response.contains("V1")).isTrue();
       } finally {
         connection.disconnect();
       }
@@ -139,9 +143,9 @@ public class HTTPGraphIT extends BaseGraphServerTest {
       try {
         final String response = readResponse(connection);
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
-        Assertions.assertEquals(200, connection.getResponseCode());
-        Assertions.assertEquals("OK", connection.getResponseMessage());
-        Assertions.assertTrue(response.contains("V1"));
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getResponseMessage()).isEqualTo("OK");
+        assertThat(response.contains("V1")).isTrue();
       } finally {
         connection.disconnect();
       }
@@ -164,9 +168,9 @@ public class HTTPGraphIT extends BaseGraphServerTest {
       try {
         final String response = readResponse(connection);
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
-        Assertions.assertEquals(200, connection.getResponseCode());
-        Assertions.assertEquals("OK", connection.getResponseMessage());
-        Assertions.assertTrue(response.contains("V1"));
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getResponseMessage()).isEqualTo("OK");
+        assertThat(response.contains("V1")).isTrue();
       } finally {
         connection.disconnect();
       }
@@ -191,9 +195,9 @@ public class HTTPGraphIT extends BaseGraphServerTest {
       try {
         final String response = readResponse(connection);
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
-        Assertions.assertEquals(200, connection.getResponseCode());
-        Assertions.assertEquals("OK", connection.getResponseMessage());
-        Assertions.assertTrue(response.contains("V1"));
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getResponseMessage()).isEqualTo("OK");
+        assertThat(response.contains("V1")).isTrue();
       } finally {
         connection.disconnect();
       }
@@ -220,9 +224,9 @@ public class HTTPGraphIT extends BaseGraphServerTest {
       try {
         final String response = readResponse(connection);
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
-        Assertions.assertEquals(200, connection.getResponseCode());
-        Assertions.assertEquals("OK", connection.getResponseMessage());
-        Assertions.assertTrue(response.contains("#1:0"), response);
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getResponseMessage()).isEqualTo("OK");
+        assertThat(response).contains("#1:0");
       } finally {
         connection.disconnect();
       }
@@ -235,20 +239,22 @@ public class HTTPGraphIT extends BaseGraphServerTest {
       final JSONObject responseAsJson = executeCommand(serverIndex, "sql", "SELECT FROM E1");
 
       final List<Object> vertices = responseAsJson.getJSONObject("result").getJSONArray("vertices").toList();
-      Assertions.assertEquals(2, vertices.size());
+      assertThat(vertices).hasSize(2);
       for (final Object o : vertices)
-        Assertions.assertTrue(((Map) o).get("t").equals("V1") || ((Map) o).get("t").equals("V2"));
+        assertThat(((Map) o).get("t").equals("V1") || ((Map) o).get("t").equals("V2")).isTrue();
 
       final List<Object> records = responseAsJson.getJSONObject("result").getJSONArray("records").toList();
-      Assertions.assertEquals(1, records.size());
+      assertThat(records).hasSize(1);
       for (final Object o : records)
-        Assertions.assertTrue(
-            ((Map) o).get("@type").equals("V1") || ((Map) o).get("@type").equals("V2") || ((Map) o).get("@type").equals("E1"));
+//        Assertions.assertTrue(
+//            ((Map) o).get("@type").equals("V1") || ((Map) o).get("@type").equals("V2") || ((Map) o).get("@type").equals("E1"));
 
+        assertThat(((Map) o).get("@type").equals("V1") || ((Map) o).get("@type").equals("V2") || ((Map) o).get("@type")
+            .equals("E1")).isTrue();
       final List<Object> edges = responseAsJson.getJSONObject("result").getJSONArray("edges").toList();
-      Assertions.assertEquals(1, edges.size());
+      assertThat(edges).hasSize(1);
       for (final Object o : edges)
-        Assertions.assertTrue(((Map) o).get("t").equals("E1"));
+        assertThat(((Map) o).get("t")).isEqualTo("E1");
     });
   }
 
@@ -266,9 +272,9 @@ public class HTTPGraphIT extends BaseGraphServerTest {
       try {
         final String response = readResponse(connection);
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
-        Assertions.assertEquals(200, connection.getResponseCode());
-        Assertions.assertEquals("OK", connection.getResponseMessage());
-        Assertions.assertTrue(new JSONObject(response).getBoolean("result"));
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getResponseMessage()).isEqualTo("OK");
+        assertThat(new JSONObject(response).getBoolean("result")).isTrue();
       } finally {
         connection.disconnect();
       }
@@ -289,10 +295,10 @@ public class HTTPGraphIT extends BaseGraphServerTest {
       try {
         final String response = readResponse(connection);
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
-        Assertions.assertEquals(200, connection.getResponseCode());
-        Assertions.assertEquals("OK", connection.getResponseMessage());
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getResponseMessage()).isEqualTo("OK");
         final JSONArray databases = new JSONObject(response).getJSONArray("result");
-        Assertions.assertEquals(1, databases.length(), "Found the following databases: " + databases);
+        assertThat(databases.length()).isEqualTo(1).withFailMessage("Found the following databases: " + databases);
       } finally {
         connection.disconnect();
       }
@@ -314,9 +320,9 @@ public class HTTPGraphIT extends BaseGraphServerTest {
       try {
         final String response = readResponse(connection);
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
-        Assertions.assertEquals(200, connection.getResponseCode());
-        Assertions.assertEquals("OK", connection.getResponseMessage());
-        Assertions.assertEquals("ok", new JSONObject(response).getString("result"));
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getResponseMessage()).isEqualTo("OK");
+        assertThat(new JSONObject(response).getString("result")).isEqualTo("ok");
 
       } finally {
         connection.disconnect();
@@ -332,9 +338,9 @@ public class HTTPGraphIT extends BaseGraphServerTest {
       try {
         final String response = readResponse(connection);
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
-        Assertions.assertEquals(200, connection.getResponseCode());
-        Assertions.assertEquals("OK", connection.getResponseMessage());
-        Assertions.assertTrue(new JSONObject(response).getBoolean("result"));
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getResponseMessage()).isEqualTo("OK");
+        assertThat(new JSONObject(response).getBoolean("result")).isTrue();
 
       } finally {
         connection.disconnect();
@@ -351,9 +357,9 @@ public class HTTPGraphIT extends BaseGraphServerTest {
       try {
         final String response = readResponse(connection);
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
-        Assertions.assertEquals(200, connection.getResponseCode());
-        Assertions.assertEquals("OK", connection.getResponseMessage());
-        Assertions.assertEquals("ok", new JSONObject(response).getString("result"));
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getResponseMessage()).isEqualTo("OK");
+        assertThat(new JSONObject(response).getString("result")).isEqualTo("ok");
 
       } finally {
         connection.disconnect();
@@ -369,9 +375,9 @@ public class HTTPGraphIT extends BaseGraphServerTest {
       try {
         final String response = readResponse(connection);
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
-        Assertions.assertEquals(200, connection.getResponseCode());
-        Assertions.assertEquals("OK", connection.getResponseMessage());
-        Assertions.assertFalse(new JSONObject(response).getBoolean("result"));
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getResponseMessage()).isEqualTo("OK");
+        assertThat(new JSONObject(response).getBoolean("result")).isFalse();
 
       } finally {
         connection.disconnect();
@@ -394,9 +400,9 @@ public class HTTPGraphIT extends BaseGraphServerTest {
       try {
         final String response = readResponse(connection);
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
-        Assertions.assertEquals(200, connection.getResponseCode());
-        Assertions.assertEquals("OK", connection.getResponseMessage());
-        Assertions.assertEquals("ok", new JSONObject(response).getString("result"));
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getResponseMessage()).isEqualTo("OK");
+        assertThat(new JSONObject(response).getString("result")).isEqualTo("ok");
 
       } finally {
         connection.disconnect();
@@ -413,9 +419,9 @@ public class HTTPGraphIT extends BaseGraphServerTest {
       try {
         final String response = readResponse(connection);
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
-        Assertions.assertEquals(200, connection.getResponseCode());
-        Assertions.assertEquals("OK", connection.getResponseMessage());
-        Assertions.assertEquals("ok", new JSONObject(response).getString("result"));
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getResponseMessage()).isEqualTo("OK");
+        assertThat(new JSONObject(response).getString("result")).isEqualTo("ok");
 
       } finally {
         connection.disconnect();
@@ -432,9 +438,9 @@ public class HTTPGraphIT extends BaseGraphServerTest {
       try {
         final String response = readResponse(connection);
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
-        Assertions.assertEquals(200, connection.getResponseCode());
-        Assertions.assertEquals("OK", connection.getResponseMessage());
-        Assertions.assertEquals("ok", new JSONObject(response).getString("result"));
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getResponseMessage()).isEqualTo("OK");
+        assertThat(new JSONObject(response).getString("result")).isEqualTo("ok");
 
       } finally {
         connection.disconnect();
@@ -451,9 +457,9 @@ public class HTTPGraphIT extends BaseGraphServerTest {
       try {
         final String response = readResponse(connection);
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
-        Assertions.assertEquals(200, connection.getResponseCode());
-        Assertions.assertEquals("OK", connection.getResponseMessage());
-        Assertions.assertTrue(new JSONObject(response).getBoolean("result"));
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getResponseMessage()).isEqualTo("OK");
+        assertThat(new JSONObject(response).getBoolean("result")).isTrue();
 
       } finally {
         connection.disconnect();
@@ -475,9 +481,9 @@ public class HTTPGraphIT extends BaseGraphServerTest {
 
       try {
         readResponse(connection);
-        Assertions.fail("Empty database should be an error");
+        fail("Empty database should be an error");
       } catch (final Exception e) {
-        Assertions.assertEquals(400, connection.getResponseCode());
+        assertThat(connection.getResponseCode()).isEqualTo(400);
 
       } finally {
         connection.disconnect();
@@ -515,7 +521,7 @@ public class HTTPGraphIT extends BaseGraphServerTest {
       final JSONObject responseAsJsonSelect = executeCommand(serverIndex, "sql", //
           "SELECT id FROM ( SELECT expand( outE('HasUploaded') ) FROM Users WHERE id = \"u1111\" )");
 
-      Assertions.assertEquals(3, responseAsJsonSelect.getJSONObject("result").getJSONArray("records").length());
+      assertThat(responseAsJsonSelect.getJSONObject("result").getJSONArray("records").length()).isEqualTo(3);
     });
   }
 
@@ -549,7 +555,7 @@ public class HTTPGraphIT extends BaseGraphServerTest {
                 continue;
               }
 
-              Assertions.assertNotNull(responseAsJson.getJSONObject("result").getJSONArray("records"));
+              assertThat(responseAsJson.getJSONObject("result").getJSONArray("records")).isNotNull();
 
             } catch (Exception e) {
               throw new RuntimeException(e);
@@ -562,12 +568,12 @@ public class HTTPGraphIT extends BaseGraphServerTest {
       for (int i = 0; i < THREADS; i++)
         threads[i].join(60 * 1_000);
 
-      Assertions.assertEquals(THREADS * SCRIPTS, atomic.get());
+      assertThat(atomic.get()).isEqualTo(THREADS * SCRIPTS);
 
       final JSONObject responseAsJsonSelect = executeCommand(serverIndex, "sql", //
           "SELECT id FROM ( SELECT expand( outE('HasUploaded') ) FROM Users WHERE id = \"u1111\" )");
 
-      Assertions.assertEquals(THREADS * SCRIPTS, responseAsJsonSelect.getJSONObject("result").getJSONArray("records").length());
+      assertThat(responseAsJsonSelect.getJSONObject("result").getJSONArray("records").length()).isEqualTo(THREADS * SCRIPTS);
     });
   }
 }

--- a/server/src/test/java/com/arcadedb/server/HTTPSSLIT.java
+++ b/server/src/test/java/com/arcadedb/server/HTTPSSLIT.java
@@ -21,7 +21,8 @@ package com.arcadedb.server;
 import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.log.LogManager;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.HttpsURLConnection;
@@ -76,8 +77,8 @@ public class HTTPSSLIT extends BaseGraphServerTest {
         connection.connect();
         final String response = readResponse(connection);
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
-        Assertions.assertEquals(200, connection.getResponseCode());
-        Assertions.assertEquals("OK", connection.getResponseMessage());
+        Assertions.assertThat(connection.getResponseCode()).isEqualTo(200);
+        Assertions.assertThat(connection.getResponseMessage()).isEqualTo("OK");
       } finally {
         connection.disconnect();
       }

--- a/server/src/test/java/com/arcadedb/server/HTTPTransactionIT.java
+++ b/server/src/test/java/com/arcadedb/server/HTTPTransactionIT.java
@@ -20,7 +20,8 @@ package com.arcadedb.server;
 
 import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONObject;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
@@ -29,6 +30,8 @@ import java.util.*;
 import java.util.logging.*;
 
 import static com.arcadedb.server.http.HttpSessionManager.ARCADEDB_SESSION_ID;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class HTTPTransactionIT extends BaseGraphServerTest {
 
@@ -50,10 +53,10 @@ public class HTTPTransactionIT extends BaseGraphServerTest {
       try {
         final String response = readResponse(connection);
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
-        Assertions.assertEquals(204, connection.getResponseCode());
+        assertThat(connection.getResponseCode()).isEqualTo(204);
         sessionId = connection.getHeaderField(ARCADEDB_SESSION_ID).trim();
 
-        Assertions.assertNotNull(sessionId);
+        assertThat(sessionId).isNotNull();
 
       } finally {
         connection.disconnect();
@@ -75,13 +78,13 @@ public class HTTPTransactionIT extends BaseGraphServerTest {
       try {
         final String response = readResponse(connection);
 
-        Assertions.assertEquals(200, connection.getResponseCode());
-        Assertions.assertEquals("OK", connection.getResponseMessage());
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getResponseMessage()).isEqualTo("OK");
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
         final JSONObject responseAsJson = new JSONObject(response);
-        Assertions.assertTrue(responseAsJson.has("result"));
+        assertThat(responseAsJson.has("result")).isTrue();
         rid = responseAsJson.getJSONArray("result").getJSONObject(0).getString("@rid");
-        Assertions.assertTrue(rid.contains("#"));
+        assertThat(rid.contains("#")).isTrue();
       } finally {
         connection.disconnect();
       }
@@ -89,7 +92,7 @@ public class HTTPTransactionIT extends BaseGraphServerTest {
       // CANNOT RETRIEVE DOCUMENT OUTSIDE A TX
       try {
         checkDocumentWasCreated(DATABASE_NAME, serverIndex, payload, rid, null);
-        Assertions.fail();
+        fail();
       } catch (final Exception e) {
         // EXPECTED
       }
@@ -110,9 +113,9 @@ public class HTTPTransactionIT extends BaseGraphServerTest {
       try {
         final String response = readResponse(connection);
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
-        Assertions.assertEquals(200, connection.getResponseCode());
-        Assertions.assertEquals("OK", connection.getResponseMessage());
-        Assertions.assertTrue(response.contains("Person"));
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getResponseMessage()).isEqualTo("OK");
+        assertThat(response.contains("Person")).isTrue();
 
       } finally {
         connection.disconnect();
@@ -131,9 +134,9 @@ public class HTTPTransactionIT extends BaseGraphServerTest {
       try {
         final String response = readResponse(connection);
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
-        Assertions.assertEquals(200, connection.getResponseCode());
-        Assertions.assertEquals("OK", connection.getResponseMessage());
-        Assertions.assertTrue(response.contains("Person"));
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getResponseMessage()).isEqualTo("OK");
+        assertThat(response.contains("Person")).isTrue();
       } finally {
         connection.disconnect();
       }
@@ -150,8 +153,8 @@ public class HTTPTransactionIT extends BaseGraphServerTest {
       try {
         final String response = readResponse(connection);
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
-        Assertions.assertEquals(204, connection.getResponseCode());
-        Assertions.assertNull(connection.getHeaderField(ARCADEDB_SESSION_ID));
+        assertThat(connection.getResponseCode()).isEqualTo(204);
+        assertThat(connection.getHeaderField(ARCADEDB_SESSION_ID)).isNull();
 
       } finally {
         connection.disconnect();
@@ -178,10 +181,10 @@ public class HTTPTransactionIT extends BaseGraphServerTest {
       try {
         final String response = readResponse(connection);
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
-        Assertions.assertEquals(204, connection.getResponseCode());
+        assertThat(connection.getResponseCode()).isEqualTo(204);
         sessionId = connection.getHeaderField(ARCADEDB_SESSION_ID).trim();
 
-        Assertions.assertNotNull(sessionId);
+        assertThat(sessionId).isNotNull();
 
       } finally {
         connection.disconnect();
@@ -215,12 +218,12 @@ public class HTTPTransactionIT extends BaseGraphServerTest {
       String response = null;
       try {
         response = readResponse(connection);
-        Assertions.fail();
+        fail();
       } catch (final IOException e) {
         response = readError(connection);
-        Assertions.assertEquals(503, connection.getResponseCode());
+        assertThat(connection.getResponseCode()).isEqualTo(503);
         connection.disconnect();
-        Assertions.assertTrue(response.contains("DuplicatedKeyException"));
+        assertThat(response.contains("DuplicatedKeyException")).isTrue();
       }
     });
   }
@@ -243,13 +246,13 @@ public class HTTPTransactionIT extends BaseGraphServerTest {
     try {
       final String response = readResponse(connection);
       final JSONObject responseAsJson = new JSONObject(response);
-      Assertions.assertTrue(responseAsJson.has("result"));
+      assertThat(responseAsJson.has("result")).isTrue();
       final JSONObject object = responseAsJson.getJSONArray("result").getJSONObject(0);
-      Assertions.assertEquals(200, connection.getResponseCode());
-      Assertions.assertEquals("OK", connection.getResponseMessage());
-      Assertions.assertEquals(rid, object.remove("@rid").toString());
-      Assertions.assertEquals("d", object.remove("@cat"));
-      Assertions.assertEquals(payload.toMap(), object.toMap());
+      assertThat(connection.getResponseCode()).isEqualTo(200);
+      assertThat(connection.getResponseMessage()).isEqualTo("OK");
+      assertThat(object.remove("@rid").toString()).isEqualTo(rid);
+      assertThat(object.remove("@cat")).isEqualTo("d");
+      assertThat(object.toMap()).isEqualTo(payload.toMap());
 
     } finally {
       connection.disconnect();
@@ -272,10 +275,10 @@ public class HTTPTransactionIT extends BaseGraphServerTest {
       try {
         readResponse(connection);
 
-        Assertions.fail();
+        fail();
 
       } catch (Exception e) {
-        Assertions.assertTrue(e.getMessage().contains("400"));
+        assertThat(e.getMessage().contains("400")).isTrue();
       } finally {
         connection.disconnect();
       }

--- a/server/src/test/java/com/arcadedb/server/RemoteDateIT.java
+++ b/server/src/test/java/com/arcadedb/server/RemoteDateIT.java
@@ -34,7 +34,6 @@ import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.DateUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -42,6 +41,7 @@ import java.time.*;
 import java.time.temporal.*;
 
 import static com.arcadedb.server.BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests dates by using server and/or remote connection.
@@ -77,17 +77,16 @@ public class RemoteDateIT {
       database.begin();
       sqlString = "INSERT INTO Order SET vstart = ?";
       try (ResultSet resultSet = database.command("sql", sqlString, vstart)) {
-        Assertions.assertEquals(DateUtils.dateTimeToTimestamp(vstart, ChronoUnit.MICROS),
-            resultSet.next().toJSON().getLong("vstart"));
+        assertThat(resultSet.next().toJSON().getLong("vstart")).isEqualTo(DateUtils.dateTimeToTimestamp(vstart, ChronoUnit.MICROS));
       }
       sqlString = "select from Order";
       System.out.println(sqlString);
       Result result = null;
       try (ResultSet resultSet = database.query("sql", sqlString)) {
         result = resultSet.next();
-        Assertions.assertEquals(vstart, result.toElement().get("vstart"));
+        assertThat(result.toElement().get("vstart")).isEqualTo(vstart);
       }
-      Assertions.assertNotNull(result);
+      assertThat(result).isNotNull();
 
       database.commit();
 
@@ -96,9 +95,9 @@ public class RemoteDateIT {
       result = null;
       try (ResultSet resultSet = remote.query("sql", sqlString)) {
         result = resultSet.next();
-        Assertions.assertEquals(vstart.toString(), result.toElement().get("vstart"));
+        assertThat(result.toElement().get("vstart")).isEqualTo(vstart.toString());
       }
-      Assertions.assertNotNull(result);
+      assertThat(result).isNotNull();
 
     } finally {
       arcadeDBServer.stop();

--- a/server/src/test/java/com/arcadedb/server/RemoteQueriesIT.java
+++ b/server/src/test/java/com/arcadedb/server/RemoteQueriesIT.java
@@ -36,7 +36,7 @@ import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -45,6 +45,7 @@ import java.time.*;
 import java.time.format.*;
 
 import static com.arcadedb.server.BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luca Garulli (l.garulli@arcadedata.com)
@@ -85,10 +86,10 @@ public class RemoteQueriesIT {
     Vertex toVtx = database.command("sql", "CREATE VERTEX ToVtx").next().getVertex().get();
     Edge conEdg = fromVtx.newEdge("ConEdge", toVtx, true);
 
-    Assertions.assertEquals(1, fromVtx.countEdges(Vertex.DIRECTION.OUT, "ConEdge"));
-    Assertions.assertEquals(0, fromVtx.countEdges(Vertex.DIRECTION.IN, "ConEdge"));
-    Assertions.assertTrue(fromVtx.getEdges(Vertex.DIRECTION.OUT, "ConEdge").iterator().hasNext());
-    Assertions.assertFalse(fromVtx.getEdges(Vertex.DIRECTION.IN, "ConEdge").iterator().hasNext());
+    assertThat(fromVtx.countEdges(Vertex.DIRECTION.OUT, "ConEdge")).isEqualTo(1);
+    assertThat(fromVtx.countEdges(Vertex.DIRECTION.IN, "ConEdge")).isEqualTo(0);
+    assertThat(fromVtx.getEdges(Vertex.DIRECTION.OUT, "ConEdge").iterator().hasNext()).isTrue();
+    assertThat(fromVtx.getEdges(Vertex.DIRECTION.IN, "ConEdge").iterator().hasNext()).isFalse();
   }
 
   @Test
@@ -128,7 +129,7 @@ public class RemoteQueriesIT {
       database.transaction(() -> {
         String sqlString = "INSERT INTO Order SET id = ?, status = ?, processor = ?";
         try (ResultSet resultSet1 = database.command("sql", sqlString, id, status, processor)) {
-          Assertions.assertEquals("" + id, resultSet1.next().getProperty("id"));
+          assertThat(resultSet1.next().<String>getProperty("id")).isEqualTo("" + id);
         }
       });
     }
@@ -137,7 +138,7 @@ public class RemoteQueriesIT {
       Object[] parameters2 = { "ERROR", 1 };
       String sqlString = "UPDATE Order SET status = ? RETURN AFTER WHERE id = ?";
       try (ResultSet resultSet1 = database.command("sql", sqlString, parameters2)) {
-        Assertions.assertEquals("1", resultSet1.next().getProperty("id"));
+          assertThat(resultSet1.next().<String>getProperty("id")).isEqualTo("1");
       } catch (Exception e) {
         System.out.println(e.getMessage());
         e.printStackTrace();
@@ -151,7 +152,7 @@ public class RemoteQueriesIT {
       Object[] parameters2 = { "PENDING" };
       String sqlString = "SELECT id, processor, status FROM Order WHERE status = ?";
       try (ResultSet resultSet1 = database.query("sql", sqlString, parameters2)) {
-        Assertions.assertEquals("PENDING", resultSet1.next().getProperty("status"));
+        assertThat(resultSet1.next().<String>getProperty("status")).isEqualTo("PENDING");
       } catch (Exception e) {
         System.out.println(e.getMessage());
         e.printStackTrace();
@@ -165,7 +166,7 @@ public class RemoteQueriesIT {
       Object[] parameters2 = { "PENDING" };
       String sqlString = "SELECT id, processor, status FROM Order WHERE status = ?";
       try (ResultSet resultSet1 = database.query("sql", sqlString, parameters2)) {
-        Assertions.assertEquals("PENDING", resultSet1.next().getProperty("status"));
+        assertThat(resultSet1.next().<String>getProperty("status")).isEqualTo("PENDING");
       } catch (Exception e) {
         System.out.println(e.getMessage());
         e.printStackTrace();
@@ -194,7 +195,7 @@ public class RemoteQueriesIT {
     ContextConfiguration configuration = new ContextConfiguration();
     GlobalConfiguration.DATE_TIME_IMPLEMENTATION.setValue(java.time.LocalDateTime.class);
     GlobalConfiguration.DATE_TIME_FORMAT.setValue("yyyy-MM-dd'T'HH:mm:ss.SSSSSS");
-    Assertions.assertTrue(configuration.getValue(GlobalConfiguration.DATE_TIME_IMPLEMENTATION) == java.time.LocalDateTime.class);
+    assertThat(configuration.getValue(GlobalConfiguration.DATE_TIME_IMPLEMENTATION) == java.time.LocalDateTime.class).isTrue();
 
     arcadeDBServer = new ArcadeDBServer(configuration);
     arcadeDBServer.start();
@@ -211,9 +212,9 @@ public class RemoteQueriesIT {
     stop = LocalDateTime.parse("20220320T002323", FILENAME_TIME_FORMAT);
     Object[] parameters1 = { name, type, start, stop };
     try (ResultSet resultSet = database.command("sql", sqlString, parameters1)) {
-      Assertions.assertTrue(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isTrue();
       result = resultSet.next();
-      Assertions.assertTrue(result.getProperty("start").equals(start), "start value retrieved does not match start value inserted");
+      assertThat(start).as("start value retrieved does not match start value inserted").isEqualTo(result.getProperty("start"));
     } catch (Exception e) {
       e.printStackTrace();
     }
@@ -223,10 +224,10 @@ public class RemoteQueriesIT {
     stop = LocalDateTime.parse("2022-03-19T00:28:26.525650", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS"));
     Object[] parameters2 = { type, start, stop };
     try (ResultSet resultSet = database.query("sql", sqlString, parameters2)) {
-      Assertions.assertTrue(resultSet.hasNext());
+      assertThat(resultSet.hasNext()).isTrue();
       while (resultSet.hasNext()) {
         result = resultSet.next();
-        //Assertions.assertTrue(result.getProperty("start").equals(start), "start value retrieved does not match start value inserted");
+        //Assertions.assertThat(result.getProperty("start").equals(start)).as("start value retrieved does not match start value inserted").isTrue();
       }
     }
   }

--- a/server/src/test/java/com/arcadedb/server/SelectOrderTest.java
+++ b/server/src/test/java/com/arcadedb/server/SelectOrderTest.java
@@ -34,8 +34,9 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.utility.FileUtils;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,6 +45,8 @@ import java.time.*;
 import java.time.format.*;
 
 import static com.arcadedb.server.BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * From Issue https://github.com/ArcadeData/arcadedb/issues/741
@@ -109,7 +112,7 @@ public class SelectOrderTest {
         database.begin();
         try (ResultSet resultSet = database.query("sql", sqlString, parameter)) {
           while (resultSet.hasNext()) {
-            Assertions.assertEquals(rids[0], resultSet.next().getIdentity().get());
+            assertThat(resultSet.next().getIdentity().get()).isEqualTo(rids[0]);
           }
         }
         database.commit();
@@ -120,7 +123,7 @@ public class SelectOrderTest {
         database.begin();
         try (ResultSet resultSet = database.query("sql", sqlString, parameter)) {
           while (resultSet.hasNext()) {
-            Assertions.assertEquals(rids[1], resultSet.next().getIdentity().get());
+            assertThat(resultSet.next().getIdentity().get()).isEqualTo(rids[1]);
           }
         }
         database.commit();
@@ -131,7 +134,7 @@ public class SelectOrderTest {
         database.begin();
         try (ResultSet resultSet = database.query("sql", sqlString, parameter)) {
           while (resultSet.hasNext()) {
-            Assertions.assertEquals(rids[0], resultSet.next().getIdentity().get());
+            assertThat(resultSet.next().getIdentity().get()).isEqualTo(rids[0]);
           }
         }
         database.commit();
@@ -141,7 +144,7 @@ public class SelectOrderTest {
         database.begin();
         try (ResultSet resultSet = database.query("sql", sqlString)) {
           while (resultSet.hasNext()) {
-            Assertions.assertEquals(rids[0], resultSet.next().getIdentity().get());
+            assertThat(resultSet.next().getIdentity().get()).isEqualTo(rids[0]);
           }
         }
         database.commit();
@@ -151,7 +154,7 @@ public class SelectOrderTest {
         database.begin();
         try (ResultSet resultSet = database.query("sql", sqlString)) {
           while (resultSet.hasNext()) {
-            Assertions.assertEquals(rids[0], resultSet.next().getIdentity().get());
+            assertThat(resultSet.next().getIdentity().get()).isEqualTo(rids[0]);
           }
         }
         database.commit();
@@ -162,7 +165,7 @@ public class SelectOrderTest {
         database.begin();
         try (ResultSet resultSet = database.query("sql", sqlString, parameter)) {
           while (resultSet.hasNext()) {
-            Assertions.assertEquals(rids[0], resultSet.next().getIdentity().get());
+            assertThat(resultSet.next().getIdentity().get()).isEqualTo(rids[0]);
           }
         }
         database.commit();
@@ -216,7 +219,8 @@ public class SelectOrderTest {
             stop = LocalDateTime.parse("20220320T002323", FILENAME_TIME_FORMAT);
             Object[] parameters1 = { name, type, start, stop };
             try (ResultSet resultSet = database.command("sql", sqlString, parameters1)) {
-              Assertions.assertTrue(resultSet.hasNext());
+
+              assertThat(resultSet.hasNext()).isTrue();
               result = resultSet.next();
             } catch (Exception e) {
               System.out.println(e.getMessage());
@@ -233,7 +237,7 @@ public class SelectOrderTest {
 
             try (ResultSet resultSet = database.query("sql", sqlString, parameters3)) {
 
-              Assertions.assertTrue(resultSet.hasNext());
+              assertThat(resultSet.hasNext()).isTrue();
 
               while (resultSet.hasNext()) {
                 result = resultSet.next();
@@ -241,7 +245,8 @@ public class SelectOrderTest {
                 start = result.getProperty("start");
 
                 if (lastStart != null)
-                  Assertions.assertTrue(start.compareTo(lastStart) <= 0, "" + start + " is greater than " + lastStart);
+                  assertThat(start.compareTo(lastStart)).isLessThanOrEqualTo(0)
+                      .withFailMessage("" + start + " is greater than " + lastStart);
 
                 lastStart = start;
               }
@@ -251,7 +256,7 @@ public class SelectOrderTest {
 
             sqlString = "SELECT name, start, stop FROM Product WHERE type = ? AND start <= ? AND stop >= ? ORDER BY start ASC";
             try (ResultSet resultSet = database.query("sql", sqlString, parameters3)) {
-              Assertions.assertTrue(resultSet.hasNext());
+              assertThat(resultSet.hasNext()).isTrue();
 
               while (resultSet.hasNext()) {
                 result = resultSet.next();
@@ -259,7 +264,8 @@ public class SelectOrderTest {
                 start = result.getProperty("start");
 
                 if (lastStart != null)
-                  Assertions.assertTrue(start.compareTo(lastStart) >= 0, "" + start + " is smaller than " + lastStart);
+                  assertThat(start.compareTo(lastStart)).isGreaterThanOrEqualTo(0)
+                      .withFailMessage("" + start + " is smaller than " + lastStart);
 
                 lastStart = start;
               }

--- a/server/src/test/java/com/arcadedb/server/ServerBackupDatabaseIT.java
+++ b/server/src/test/java/com/arcadedb/server/ServerBackupDatabaseIT.java
@@ -19,10 +19,11 @@
 package com.arcadedb.server;
 
 import com.arcadedb.database.Database;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ServerBackupDatabaseIT extends BaseGraphServerTest {
 
@@ -40,7 +41,7 @@ public class ServerBackupDatabaseIT extends BaseGraphServerTest {
     final Database database = getServer(0).getDatabase(getDatabaseName());
     database.command("sql", "backup database file://" + backupFile.getName());
 
-    Assertions.assertTrue(backupFile.exists());
+    assertThat(backupFile.exists()).isTrue();
     backupFile.delete();
   }
 }

--- a/server/src/test/java/com/arcadedb/server/ServerConfigurationIT.java
+++ b/server/src/test/java/com/arcadedb/server/ServerConfigurationIT.java
@@ -20,23 +20,23 @@ package com.arcadedb.server;
 
 import com.arcadedb.ContextConfiguration;
 import com.arcadedb.utility.FileUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
 
 import static com.arcadedb.GlobalConfiguration.TX_WAL;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ServerConfigurationIT extends BaseGraphServerTest {
   @Test
   public void testServerLoadConfiguration() throws IOException {
     final ContextConfiguration cfg = new ContextConfiguration();
 
-    Assertions.assertTrue(cfg.getValueAsBoolean(TX_WAL));
+    assertThat(cfg.getValueAsBoolean(TX_WAL)).isTrue();
 
     cfg.setValue(TX_WAL, false);
 
-    Assertions.assertFalse(cfg.getValueAsBoolean(TX_WAL));
+    assertThat(cfg.getValueAsBoolean(TX_WAL)).isFalse();
 
     final File file = new File(getServer(0).getRootPath() + File.separator + ArcadeDBServer.CONFIG_SERVER_CONFIGURATION_FILENAME);
     if (file.exists())
@@ -49,7 +49,7 @@ public class ServerConfigurationIT extends BaseGraphServerTest {
     try {
       server.start();
 
-      Assertions.assertFalse(server.getConfiguration().getValueAsBoolean(TX_WAL));
+      assertThat(server.getConfiguration().getValueAsBoolean(TX_WAL)).isFalse();
     } finally {
       if (file.exists())
         file.delete();

--- a/server/src/test/java/com/arcadedb/server/ServerDefaultDatabasesIT.java
+++ b/server/src/test/java/com/arcadedb/server/ServerDefaultDatabasesIT.java
@@ -22,12 +22,14 @@ import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.server.security.ServerSecurityException;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
 
 import static com.arcadedb.engine.ComponentFile.MODE.READ_WRITE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class ServerDefaultDatabasesIT extends BaseGraphServerTest {
 
@@ -57,30 +59,30 @@ public class ServerDefaultDatabasesIT extends BaseGraphServerTest {
 
     try {
       getServer(0).getSecurity().authenticate("elon", "musk", "Amiga");
-      Assertions.fail();
+      fail("");
     } catch (final ServerSecurityException e) {
       // EXPECTED
     }
 
     try {
       getServer(0).getSecurity().authenticate("Jack", "Tramiel", "Universe");
-      Assertions.fail();
+      fail("");
     } catch (final ServerSecurityException e) {
       // EXPECTED
     }
 
     try {
       getServer(0).getSecurity().authenticate("Jack", "Tramiel", "RandomName");
-      Assertions.fail();
+      fail("");
     } catch (final ServerSecurityException e) {
       // EXPECTED
     }
 
-    Assertions.assertTrue(getServer(0).existsDatabase("Universe"));
-    Assertions.assertTrue(getServer(0).existsDatabase("Amiga"));
+    assertThat(getServer(0).existsDatabase("Universe")).isTrue();
+    assertThat(getServer(0).existsDatabase("Amiga")).isTrue();
 
-    Assertions.assertTrue(READ_WRITE.equals(getServer(0).getDatabase("Universe").getMode()));
-    Assertions.assertTrue(READ_WRITE.equals(getServer(0).getDatabase("Amiga").getMode()));
+    assertThat(getServer(0).getDatabase("Universe").getMode()).isEqualTo(READ_WRITE);
+    assertThat(getServer(0).getDatabase("Amiga").getMode()).isEqualTo(READ_WRITE);
 
     ((DatabaseInternal) getServer(0).getDatabase("Universe")).getEmbedded().drop();
     ((DatabaseInternal) getServer(0).getDatabase("Amiga")).getEmbedded().drop();

--- a/server/src/test/java/com/arcadedb/server/ServerImportDatabaseIT.java
+++ b/server/src/test/java/com/arcadedb/server/ServerImportDatabaseIT.java
@@ -23,10 +23,11 @@ import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ServerImportDatabaseIT extends BaseGraphServerTest {
   public ServerImportDatabaseIT() {
@@ -61,7 +62,7 @@ public class ServerImportDatabaseIT extends BaseGraphServerTest {
   public void checkDefaultDatabases() {
     getServer(0).getSecurity().authenticate("elon", "musk", "Movies");
     final Database database = getServer(0).getDatabase("Movies");
-    Assertions.assertEquals(500, database.countType("Person", true));
+    assertThat(database.countType("Person", true)).isEqualTo(500);
     FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + "0/Movies"));
   }
 }

--- a/server/src/test/java/com/arcadedb/server/ServerReadOnlyDatabasesIT.java
+++ b/server/src/test/java/com/arcadedb/server/ServerReadOnlyDatabasesIT.java
@@ -20,12 +20,12 @@ package com.arcadedb.server;
 
 import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
 
 import static com.arcadedb.engine.ComponentFile.MODE.READ_ONLY;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ServerReadOnlyDatabasesIT extends BaseGraphServerTest {
 
@@ -50,10 +50,10 @@ public class ServerReadOnlyDatabasesIT extends BaseGraphServerTest {
 
   @Test
   public void checkDefaultDatabases() throws IOException {
-    Assertions.assertTrue(getServer(0).existsDatabase("Universe"));
-    Assertions.assertTrue(getServer(0).existsDatabase("Amiga"));
+    assertThat(getServer(0).existsDatabase("Universe")).isTrue();
+    assertThat(getServer(0).existsDatabase("Amiga")).isTrue();
 
-    Assertions.assertTrue(READ_ONLY.equals(getServer(0).getDatabase("Universe").getMode()));
-    Assertions.assertTrue(READ_ONLY.equals(getServer(0).getDatabase("Amiga").getMode()));
+    assertThat(getServer(0).getDatabase("Universe").getMode()).isEqualTo(READ_ONLY);
+    assertThat(getServer(0).getDatabase("Amiga").getMode()).isEqualTo(READ_ONLY);
   }
 }

--- a/server/src/test/java/com/arcadedb/server/TestServerHelper.java
+++ b/server/src/test/java/com/arcadedb/server/TestServerHelper.java
@@ -28,11 +28,13 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.utility.CallableNoReturn;
 import com.arcadedb.utility.CallableParameterNoReturn;
 import com.arcadedb.utility.FileUtils;
-import org.junit.jupiter.api.Assertions;
 
-import java.io.*;
-import java.util.*;
-import java.util.logging.*;
+import java.io.File;
+import java.util.Collection;
+import java.util.logging.Level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Executes all the tests while the server is up and running.
@@ -106,7 +108,7 @@ public abstract class TestServerHelper {
       throws Exception {
     try {
       callback.call();
-      Assertions.fail();
+      fail("");
     } catch (final Throwable e) {
       if (e.getClass().equals(expectedException))
         // EXPECTED
@@ -139,7 +141,7 @@ public abstract class TestServerHelper {
       } else
         db.close();
 
-    Assertions.assertTrue(activeDatabases.isEmpty(), "Found active databases: " + activeDatabases);
+    assertThat(activeDatabases.isEmpty()).as("Found active databases: " + activeDatabases).isTrue();
   }
 
   public static void deleteDatabaseFolders(final int totalServers) {

--- a/server/src/test/java/com/arcadedb/server/ha/HAConfigurationIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/HAConfigurationIT.java
@@ -20,8 +20,10 @@ package com.arcadedb.server.ha;
 
 import com.arcadedb.server.BaseGraphServerTest;
 import com.arcadedb.server.ServerException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class HAConfigurationIT extends BaseGraphServerTest {
   protected int getServerCount() {
@@ -40,10 +42,10 @@ public class HAConfigurationIT extends BaseGraphServerTest {
   public void testReplication() {
     try {
       super.beginTest();
-      Assertions.fail();
+      fail("");
     } catch (ServerException e) {
       // EXPECTED
-      Assertions.assertTrue(e.getMessage().contains("Found a localhost"));
+      assertThat(e.getMessage().contains("Found a localhost")).isTrue();
     }
   }
 }

--- a/server/src/test/java/com/arcadedb/server/ha/HARandomCrashIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/HARandomCrashIT.java
@@ -31,11 +31,12 @@ import com.arcadedb.remote.RemoteException;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.BaseGraphServerTest;
 import com.arcadedb.utility.CodeUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.logging.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class HARandomCrashIT extends ReplicationServerIT {
   private          int  restarts = 0;
@@ -151,15 +152,15 @@ public class HARandomCrashIT extends ReplicationServerIT {
             final ResultSet resultSet = db.command("SQL", "CREATE VERTEX " + VERTEX1_TYPE_NAME + " SET id = ?, name = ?", ++counter,
                 "distributed-test");
 
-            Assertions.assertTrue(resultSet.hasNext());
+            assertThat(resultSet.hasNext()).isTrue();
             final Result result = resultSet.next();
-            Assertions.assertNotNull(result);
+            assertThat(result).isNotNull();
             final Set<String> props = result.getPropertyNames();
-            Assertions.assertEquals(2, props.size(), "Found the following properties " + props);
-            Assertions.assertTrue(props.contains("id"));
-            Assertions.assertEquals(counter, (int) result.getProperty("id"));
-            Assertions.assertTrue(props.contains("name"));
-            Assertions.assertEquals("distributed-test", result.getProperty("name"));
+            assertThat(props.size()).as("Found the following properties " + props).isEqualTo(2);
+            assertThat(props.contains("id")).isTrue();
+            assertThat((int) result.getProperty("id")).isEqualTo(counter);
+            assertThat(props.contains("name")).isTrue();
+            assertThat(result.<String>getProperty("name")).isEqualTo("distributed-test");
           }
 
           CodeUtils.sleep(delay);
@@ -222,7 +223,7 @@ public class HARandomCrashIT extends ReplicationServerIT {
 
     onAfterTest();
 
-    Assertions.assertTrue(restarts >= getServerCount(), "Restarts " + restarts + " times");
+    assertThat(restarts >= getServerCount()).as("Restarts " + restarts + " times").isTrue();
   }
 
   private static Level getLogLevel() {

--- a/server/src/test/java/com/arcadedb/server/ha/HASplitBrainIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/HASplitBrainIT.java
@@ -23,12 +23,13 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.ReplicationCallback;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 
 import java.io.*;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 import java.util.logging.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Simulates a split brain on 5 nodes, by isolating nodes 4th and 5th in a separate network. After 10 seconds, allows the 2 networks to see
@@ -55,7 +56,7 @@ public class HASplitBrainIT extends ReplicationServerIT {
   @Override
   protected void onAfterTest() {
     timer.cancel();
-    Assertions.assertEquals(firstLeader, getLeaderServer().getServerName());
+    assertThat(getLeaderServer().getServerName()).isEqualTo(firstLeader);
   }
 
   @Override

--- a/server/src/test/java/com/arcadedb/server/ha/HTTP2ServersIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/HTTP2ServersIT.java
@@ -23,13 +23,17 @@ import com.arcadedb.remote.RemoteDatabase;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.BaseGraphServerTest;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.net.*;
 import java.util.*;
 import java.util.logging.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class HTTP2ServersIT extends BaseGraphServerTest {
   @Override
@@ -50,8 +54,8 @@ public class HTTP2ServersIT extends BaseGraphServerTest {
         connection.connect();
         final String response = readResponse(connection);
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
-        Assertions.assertEquals(200, connection.getResponseCode());
-        Assertions.assertEquals("OK", connection.getResponseMessage());
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getResponseMessage()).isEqualTo("OK");
       } finally {
         connection.disconnect();
       }
@@ -63,8 +67,9 @@ public class HTTP2ServersIT extends BaseGraphServerTest {
     testEachServer((serverIndex) -> {
       // CREATE THE SCHEMA ON BOTH SERVER, ONE TYPE PER SERVER
       final String response = command(serverIndex, "create vertex type VertexType" + serverIndex);
-      Assertions.assertTrue(response.contains("VertexType" + serverIndex),
-          "Type " + (("VertexType" + serverIndex) + " not found on server " + serverIndex));
+      assertThat(response).contains("VertexType" + serverIndex)
+          .withFailMessage("Type " + (("VertexType" + serverIndex) + " not found on server " + serverIndex));
+
     });
 
     Thread.sleep(300);
@@ -87,9 +92,9 @@ public class HTTP2ServersIT extends BaseGraphServerTest {
       try {
         final String response = readResponse(connection);
         LogManager.instance().log(this, Level.FINE, "TEST: Response: %s", null, response);
-        Assertions.assertEquals(200, connection.getResponseCode());
-        Assertions.assertEquals("OK", connection.getResponseMessage());
-        Assertions.assertTrue(response.contains("V1"));
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getResponseMessage()).isEqualTo("OK");
+        assertThat(response.contains("V1")).isTrue();
 
       } finally {
         connection.disconnect();
@@ -114,8 +119,8 @@ public class HTTP2ServersIT extends BaseGraphServerTest {
 
       testEachServer((checkServer) -> {
         try {
-          Assertions.assertFalse(new JSONObject(command(checkServer, "select from " + v1)).getJSONArray("result").isEmpty(),
-              "executed on server " + serverIndex + " checking on server " + serverIndex);
+          assertThat(new JSONObject(command(checkServer, "select from " + v1)).getJSONArray("result")).isNotEmpty().
+              withFailMessage("executed on server " + serverIndex + " checking on server " + serverIndex);
         } catch (final Exception e) {
           LogManager.instance().log(this, Level.SEVERE, "Error on checking for V1 on server " + checkServer);
           throw e;
@@ -131,8 +136,9 @@ public class HTTP2ServersIT extends BaseGraphServerTest {
 
       testEachServer((checkServer) -> {
         try {
-          Assertions.assertFalse(new JSONObject(command(checkServer, "select from " + v2)).getJSONArray("result").isEmpty(),
-              "executed on server " + serverIndex + " checking on server " + serverIndex);
+
+          assertThat(new JSONObject(command(checkServer, "select from " + v2)).getJSONArray("result")).isNotEmpty()
+              .withFailMessage("executed on server " + serverIndex + " checking on server " + serverIndex);
         } catch (final Exception e) {
           LogManager.instance().log(this, Level.SEVERE, "Error on checking for V2 on server " + checkServer);
           throw e;
@@ -147,8 +153,8 @@ public class HTTP2ServersIT extends BaseGraphServerTest {
 
       testEachServer((checkServer) -> {
         try {
-          Assertions.assertFalse(new JSONObject(command(checkServer, "select from " + e1)).getJSONArray("result").isEmpty(),
-              "executed on server " + serverIndex + " checking on server " + serverIndex);
+          assertThat(new JSONObject(command(checkServer, "select from " + e1)).getJSONArray("result")).isNotEmpty()
+              .withFailMessage("executed on server " + serverIndex + " checking on server " + serverIndex);
         } catch (final Exception e) {
           LogManager.instance().log(this, Level.SEVERE, "Error on checking on E1 on server " + checkServer);
           throw e;
@@ -164,8 +170,8 @@ public class HTTP2ServersIT extends BaseGraphServerTest {
 
       testEachServer((checkServer) -> {
         try {
-          Assertions.assertFalse(new JSONObject(command(checkServer, "select from " + v3)).getJSONArray("result").isEmpty(),
-              "executed on server " + serverIndex + " checking on server " + serverIndex);
+          assertThat(new JSONObject(command(checkServer, "select from " + v3)).getJSONArray("result")).isNotEmpty()
+              .withFailMessage("executed on server " + serverIndex + " checking on server " + serverIndex);
         } catch (final Exception e) {
           LogManager.instance().log(this, Level.SEVERE, "Error on checking for V3 on server " + checkServer);
           throw e;
@@ -180,8 +186,8 @@ public class HTTP2ServersIT extends BaseGraphServerTest {
 
       testEachServer((checkServer) -> {
         try {
-          Assertions.assertFalse(new JSONObject(command(checkServer, "select from " + e2)).getJSONArray("result").isEmpty(),
-              "executed on server " + serverIndex + " checking on server " + serverIndex);
+          assertThat(new JSONObject(command(checkServer, "select from " + e2)).getJSONArray("result")).isNotEmpty()
+              .withFailMessage("executed on server " + serverIndex + " checking on server " + serverIndex);
         } catch (final Exception e) {
           LogManager.instance().log(this, Level.SEVERE, "Error on checking for E2 on server " + checkServer);
           throw e;
@@ -196,14 +202,14 @@ public class HTTP2ServersIT extends BaseGraphServerTest {
       testEachServer((checkServer) -> {
         try {
           new JSONObject(command(checkServer, "select from " + v1)).getJSONArray("result");
-          Assertions.fail("executed on server " + serverIndex + " checking on server " + serverIndex);
+          fail("executed on server " + serverIndex + " checking on server " + serverIndex);
         } catch (FileNotFoundException e) {
           //  EXPECTED
         }
 
         try {
           new JSONObject(command(checkServer, "select from " + e1)).getJSONArray("result");
-          Assertions.fail("executed on server " + serverIndex + " checking on server " + serverIndex);
+          fail("executed on server " + serverIndex + " checking on server " + serverIndex);
         } catch (FileNotFoundException e) {
           //  EXPECTED
         }
@@ -216,8 +222,8 @@ public class HTTP2ServersIT extends BaseGraphServerTest {
     for (ArcadeDBServer server : getServers()) {
       final RemoteDatabase database = new RemoteDatabase("127.0.0.1", 2480, getDatabaseName(), "root",
           BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
-      Assertions.assertNotNull(database.getLeaderAddress());
-      Assertions.assertFalse(database.getReplicaAddresses().isEmpty());
+      assertThat(database.getLeaderAddress()).isNotNull();
+      assertThat(database.getReplicaAddresses().isEmpty()).isFalse();
     }
   }
 }

--- a/server/src/test/java/com/arcadedb/server/ha/HTTPGraphConcurrentIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/HTTPGraphConcurrentIT.java
@@ -21,11 +21,14 @@ package com.arcadedb.server.ha;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.BaseGraphServerTest;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.*;
 import java.util.logging.*;
+
+import static org.assertj.core.api.Assertions.*;
 
 public class HTTPGraphConcurrentIT extends BaseGraphServerTest {
   @Override
@@ -70,10 +73,10 @@ public class HTTPGraphConcurrentIT extends BaseGraphServerTest {
                 continue;
               }
 
-              Assertions.assertNotNull(responseAsJson.getJSONObject("result").getJSONArray("records"));
+              assertThat(responseAsJson.getJSONObject("result").getJSONArray("records")).isNotNull();
 
             } catch (Exception e) {
-              Assertions.fail(e);
+              fail(e);
             }
           }
         });
@@ -83,14 +86,15 @@ public class HTTPGraphConcurrentIT extends BaseGraphServerTest {
       for (int i = 0; i < THREADS; i++)
         threads[i].join(60 * 1_000);
 
-      Assertions.assertEquals(THREADS * SCRIPTS, atomic.get());
+      assertThat(atomic.get()).isEqualTo(THREADS * SCRIPTS);
 
       final JSONObject responseAsJsonSelect = executeCommand(serverIndex, "sql", //
           "SELECT id FROM ( SELECT expand( outE('HasUploaded" + serverIndex + "') ) FROM Users" + serverIndex
               + " WHERE id = \"u1111\" )");
 
-      Assertions.assertEquals(THREADS * SCRIPTS, responseAsJsonSelect.getJSONObject("result").getJSONArray("records").length(),
-          "Some edges was missing when executing from server " + serverIndex);
+      assertThat(responseAsJsonSelect.getJSONObject("result").getJSONArray("records").length())
+          .isEqualTo(THREADS * SCRIPTS)
+          .withFailMessage("Some edges was missing when executing from server " + serverIndex);
     });
   }
 }

--- a/server/src/test/java/com/arcadedb/server/ha/IndexOperations3ServersIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/IndexOperations3ServersIT.java
@@ -28,6 +28,7 @@ import com.arcadedb.schema.VertexType;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.BaseGraphServerTest;
 import com.arcadedb.server.TestServerHelper;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/server/src/test/java/com/arcadedb/server/ha/ReplicationServerLeaderChanges3TimesIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/ReplicationServerLeaderChanges3TimesIT.java
@@ -33,13 +33,14 @@ import com.arcadedb.server.ReplicationCallback;
 import com.arcadedb.server.ha.message.TxRequest;
 import com.arcadedb.utility.CodeUtils;
 import com.arcadedb.utility.Pair;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 import java.util.logging.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ReplicationServerLeaderChanges3TimesIT extends ReplicationServerIT {
   private final AtomicInteger                       messagesInTotal    = new AtomicInteger();
@@ -82,15 +83,15 @@ public class ReplicationServerLeaderChanges3TimesIT extends ReplicationServerIT 
             final ResultSet resultSet = db.command("SQL", "CREATE VERTEX " + VERTEX1_TYPE_NAME + " SET id = ?, name = ?", ++counter,
                 "distributed-test");
 
-            Assertions.assertTrue(resultSet.hasNext());
+            assertThat(resultSet.hasNext()).isTrue();
             final Result result = resultSet.next();
-            Assertions.assertNotNull(result);
+            assertThat(result).isNotNull();
             final Set<String> props = result.getPropertyNames();
-            Assertions.assertEquals(2, props.size(), "Found the following properties " + props);
-            Assertions.assertTrue(props.contains("id"));
-            Assertions.assertEquals(counter, (int) result.getProperty("id"));
-            Assertions.assertTrue(props.contains("name"));
-            Assertions.assertEquals("distributed-test", result.getProperty("name"));
+            assertThat(props.size()).as("Found the following properties " + props).isEqualTo(2);
+            assertThat(props.contains("id")).isTrue();
+            assertThat((int) result.getProperty("id")).isEqualTo(counter);
+            assertThat(props.contains("name")).isTrue();
+            assertThat(result.<String>getProperty("name")).isEqualTo("distributed-test");
 
             if (counter % 100 == 0) {
               LogManager.instance().log(this, Level.SEVERE, "- Progress %d/%d", null, counter, (getTxs() * getVerticesPerTx()));
@@ -135,7 +136,7 @@ public class ReplicationServerLeaderChanges3TimesIT extends ReplicationServerIT 
     onAfterTest();
 
     LogManager.instance().log(this, Level.FINE, "TEST Restart = %d", null, restarts);
-    Assertions.assertTrue(restarts.get() >= getServerCount(), "Restarted " + restarts.get() + " times");
+    assertThat(restarts.get() >= getServerCount()).as("Restarted " + restarts.get() + " times").isTrue();
   }
 
   @Override

--- a/server/src/test/java/com/arcadedb/server/ha/ReplicationServerLeaderDownIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/ReplicationServerLeaderDownIT.java
@@ -28,12 +28,13 @@ import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.BaseGraphServerTest;
 import com.arcadedb.server.ReplicationCallback;
 import com.arcadedb.utility.CodeUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.concurrent.atomic.*;
 import java.util.logging.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ReplicationServerLeaderDownIT extends ReplicationServerIT {
   private final AtomicInteger messages = new AtomicInteger();
@@ -76,15 +77,15 @@ public class ReplicationServerLeaderDownIT extends ReplicationServerIT {
             final ResultSet resultSet = db.command("SQL", "CREATE VERTEX " + VERTEX1_TYPE_NAME + " SET id = ?, name = ?", ++counter,
                 "distributed-test");
 
-            Assertions.assertTrue(resultSet.hasNext());
+            assertThat(resultSet.hasNext()).isTrue();
             final Result result = resultSet.next();
-            Assertions.assertNotNull(result);
+            assertThat(result).isNotNull();
             final Set<String> props = result.getPropertyNames();
-            Assertions.assertEquals(2, props.size(), "Found the following properties " + props);
-            Assertions.assertTrue(props.contains("id"));
-            Assertions.assertEquals(counter, (int) result.getProperty("id"));
-            Assertions.assertTrue(props.contains("name"));
-            Assertions.assertEquals("distributed-test", result.getProperty("name"));
+            assertThat(props.size()).as("Found the following properties " + props).isEqualTo(2);
+            assertThat(props.contains("id")).isTrue();
+            assertThat((int) result.getProperty("id")).isEqualTo(counter);
+            assertThat(props.contains("name")).isTrue();
+            assertThat(result.<String>getProperty("name")).isEqualTo("distributed-test");
             break;
           } catch (final RemoteException e) {
             // IGNORE IT

--- a/server/src/test/java/com/arcadedb/server/ha/ReplicationServerLeaderDownNoTransactionsToForwardIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/ReplicationServerLeaderDownNoTransactionsToForwardIT.java
@@ -28,12 +28,13 @@ import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.BaseGraphServerTest;
 import com.arcadedb.server.ReplicationCallback;
 import com.arcadedb.utility.CodeUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.concurrent.atomic.*;
 import java.util.logging.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ReplicationServerLeaderDownNoTransactionsToForwardIT extends ReplicationServerIT {
   private final AtomicInteger messages = new AtomicInteger();
@@ -73,15 +74,15 @@ public class ReplicationServerLeaderDownNoTransactionsToForwardIT extends Replic
             final ResultSet resultSet = db.command("SQL", "CREATE VERTEX " + VERTEX1_TYPE_NAME + " SET id = ?, name = ?", ++counter,
                 "distributed-test");
 
-            Assertions.assertTrue(resultSet.hasNext());
+            assertThat(resultSet.hasNext()).isTrue();
             final Result result = resultSet.next();
-            Assertions.assertNotNull(result);
+            assertThat(result).isNotNull();
             final Set<String> props = result.getPropertyNames();
-            Assertions.assertEquals(2, props.size(), "Found the following properties " + props);
-            Assertions.assertTrue(props.contains("id"));
-            Assertions.assertEquals(counter, (int) result.getProperty("id"));
-            Assertions.assertTrue(props.contains("name"));
-            Assertions.assertEquals("distributed-test", result.getProperty("name"));
+            assertThat(props.size()).as("Found the following properties " + props).isEqualTo(2);
+            assertThat(props.contains("id")).isTrue();
+            assertThat((int) result.getProperty("id")).isEqualTo(counter);
+            assertThat(props.contains("name")).isTrue();
+            assertThat(result.<String>getProperty("name")).isEqualTo("distributed-test");
             break;
           } catch (final RemoteException e) {
             // IGNORE IT

--- a/server/src/test/java/com/arcadedb/server/ha/ReplicationServerQuorumMajority2ServersOutIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/ReplicationServerQuorumMajority2ServersOutIT.java
@@ -24,11 +24,13 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.network.binary.QuorumNotReachedException;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.ReplicationCallback;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.atomic.*;
-import java.util.logging.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class ReplicationServerQuorumMajority2ServersOutIT extends ReplicationServerIT {
   private final AtomicInteger messages = new AtomicInteger();
@@ -70,7 +72,7 @@ public class ReplicationServerQuorumMajority2ServersOutIT extends ReplicationSer
   public void testReplication() throws Exception {
     try {
       super.testReplication();
-      Assertions.fail("Replication is supposed to fail without enough online servers");
+      fail("Replication is supposed to fail without enough online servers");
     } catch (final QuorumNotReachedException e) {
       // CATCH IT
     }
@@ -84,11 +86,11 @@ public class ReplicationServerQuorumMajority2ServersOutIT extends ReplicationSer
     final Database db = getServerDatabase(serverIndex, getDatabaseName());
     db.begin();
     try {
-      Assertions.assertTrue(1 + getTxs() * getVerticesPerTx() > db.countType(VERTEX1_TYPE_NAME, true), "Check for vertex count for server" + serverIndex);
+      assertThat(1 + getTxs() * getVerticesPerTx() > db.countType(VERTEX1_TYPE_NAME, true)).as("Check for vertex count for server" + serverIndex).isTrue();
 
     } catch (final Exception e) {
       e.printStackTrace();
-      Assertions.fail("Error on checking on server" + serverIndex);
+      fail("Error on checking on server" + serverIndex);
     }
   }
 

--- a/server/src/test/java/com/arcadedb/server/ha/ReplicationServerReplicaHotResyncIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/ReplicationServerReplicaHotResyncIT.java
@@ -23,10 +23,11 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.ReplicationCallback;
 import com.arcadedb.utility.CodeUtils;
-import org.junit.jupiter.api.Assertions;
 
 import java.util.concurrent.atomic.*;
 import java.util.logging.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ReplicationServerReplicaHotResyncIT extends ReplicationServerIT {
   private final    AtomicLong totalMessages = new AtomicLong();
@@ -42,12 +43,13 @@ public class ReplicationServerReplicaHotResyncIT extends ReplicationServerIT {
 
   @Override
   protected void onAfterTest() {
-    Assertions.assertTrue(hotResync);
-    Assertions.assertFalse(fullResync);
+    assertThat(hotResync).isTrue();
+    assertThat(fullResync).isFalse();
   }
 
   @Override
   protected void onBeforeStarting(final ArcadeDBServer server) {
+
     if (server.getServerName().equals("ArcadeDB_2"))
       server.registerTestEventListener(new ReplicationCallback() {
         @Override
@@ -58,15 +60,15 @@ public class ReplicationServerReplicaHotResyncIT extends ReplicationServerIT {
           if (slowDown) {
             // SLOW DOWN A SERVER AFTER 5TH MESSAGE
             if (totalMessages.incrementAndGet() > 5) {
-              LogManager.instance().log(this, Level.FINE, "TEST: Slowing down response from replica server 2...");
-              CodeUtils.sleep(10_000);
+              LogManager.instance().log(this, Level.INFO, "TEST: Slowing down response from replica server 2...");
+              CodeUtils.sleep(5_000);
             }
           } else {
             if (type == TYPE.REPLICA_HOT_RESYNC) {
-              LogManager.instance().log(this, Level.FINE, "TEST: Received hot resync request");
+              LogManager.instance().log(this, Level.INFO, "TEST: Received hot resync request");
               hotResync = true;
             } else if (type == TYPE.REPLICA_FULL_RESYNC) {
-              LogManager.instance().log(this, Level.FINE, "TEST: Received full resync request");
+              LogManager.instance().log(this, Level.INFO, "TEST: Received full resync request");
               fullResync = true;
             }
           }
@@ -82,7 +84,7 @@ public class ReplicationServerReplicaHotResyncIT extends ReplicationServerIT {
             return;
 
           if ("ArcadeDB_2".equals(object) && type == TYPE.REPLICA_OFFLINE) {
-            LogManager.instance().log(this, Level.FINE, "TEST: Replica 2 is offline removing latency...");
+            LogManager.instance().log(this, Level.INFO, "TEST: Replica 2 is offline removing latency...");
             slowDown = false;
           }
         }

--- a/server/src/test/java/com/arcadedb/server/ha/ReplicationServerReplicaRestartForceDbInstallIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/ReplicationServerReplicaRestartForceDbInstallIT.java
@@ -22,11 +22,13 @@ import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.ReplicationCallback;
-import org.junit.jupiter.api.Assertions;
+
 
 import java.io.*;
 import java.util.concurrent.atomic.*;
 import java.util.logging.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ReplicationServerReplicaRestartForceDbInstallIT extends ReplicationServerIT {
   private final    AtomicLong totalMessages           = new AtomicLong();
@@ -41,8 +43,8 @@ public class ReplicationServerReplicaRestartForceDbInstallIT extends Replication
 
   @Override
   protected void onAfterTest() {
-    Assertions.assertFalse(hotResync);
-    Assertions.assertTrue(fullResync);
+    assertThat(hotResync).isFalse();
+    assertThat(fullResync).isTrue();
   }
 
   @Override
@@ -97,7 +99,7 @@ public class ReplicationServerReplicaRestartForceDbInstallIT extends Replication
               getServer(2).stop();
               GlobalConfiguration.HA_REPLICATION_QUEUE_SIZE.reset();
 
-              Assertions.assertTrue(new File("./target/replication/replication_ArcadeDB_2.rlog.0").exists());
+              assertThat(new File("./target/replication/replication_ArcadeDB_2.rlog.0").exists()).isTrue();
               new File("./target/replication/replication_ArcadeDB_2.rlog.0").delete();
 
               LogManager.instance().log(this, Level.SEVERE, "TEST: Restarting Replica 2...");

--- a/server/src/test/java/com/arcadedb/server/ha/ServerDatabaseBackupIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/ServerDatabaseBackupIT.java
@@ -25,10 +25,11 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.server.BaseGraphServerTest;
 import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ServerDatabaseBackupIT extends BaseGraphServerTest {
   @Override
@@ -57,14 +58,14 @@ public class ServerDatabaseBackupIT extends BaseGraphServerTest {
       final Database database = getServer(i).getDatabase(getDatabaseName());
 
       final ResultSet result = database.command("sql", "backup database");
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result response = result.next();
 
       final String backupFile = response.getProperty("backupFile");
-      Assertions.assertNotNull(backupFile);
+      assertThat(backupFile).isNotNull();
 
       final File file = new File("target/backups/graph/" + backupFile);
-      Assertions.assertTrue(file.exists());
+      assertThat(file.exists()).isTrue();
       file.delete();
     }
   }
@@ -75,14 +76,14 @@ public class ServerDatabaseBackupIT extends BaseGraphServerTest {
       final Database database = getServer(i).getDatabase(getDatabaseName());
 
       final ResultSet result = database.command("sqlscript", "backup database");
-      Assertions.assertTrue(result.hasNext());
+      assertThat(result.hasNext()).isTrue();
       final Result response = result.next();
 
       final String backupFile = response.getProperty("backupFile");
-      Assertions.assertNotNull(backupFile);
+      assertThat(backupFile).isNotNull();
 
       final File file = new File("target/backups/graph/" + backupFile);
-      Assertions.assertTrue(file.exists());
+      assertThat(file.exists()).isTrue();
       file.delete();
     }
   }

--- a/server/src/test/java/com/arcadedb/server/ha/ServerDatabaseSqlScriptIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/ServerDatabaseSqlScriptIT.java
@@ -24,11 +24,14 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.server.BaseGraphServerTest;
 import com.arcadedb.utility.FileUtils;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
+
+import static org.assertj.core.api.Assertions.*;
 
 public class ServerDatabaseSqlScriptIT extends BaseGraphServerTest {
   @Override
@@ -64,9 +67,9 @@ public class ServerDatabaseSqlScriptIT extends BaseGraphServerTest {
             "LET photo1 = CREATE vertex Photos SET id = \"3778f235a52d\", name = \"beach.jpg\", status = \"\";\n"
                 + "LET photo2 = CREATE vertex Photos SET id = \"23kfkd23223\", name = \"luca.jpg\", status = \"\";\n"
                 + "LET connected = Create edge Connected FROM $photo1 to $photo2 set type = \"User_Photos\";return $photo1;");
-        Assertions.assertTrue(result.hasNext());
+        assertThat(result.hasNext()).isTrue();
         final Result response = result.next();
-        Assertions.assertEquals("beach.jpg", response.getProperty("name"));
+        assertThat(response.<String>getProperty("name")).isEqualTo("beach.jpg");
       });
     }
   }

--- a/server/src/test/java/com/arcadedb/server/ws/WebSocketClientHelper.java
+++ b/server/src/test/java/com/arcadedb/server/ws/WebSocketClientHelper.java
@@ -32,7 +32,8 @@ import io.undertow.websockets.core.CloseMessage;
 import io.undertow.websockets.core.WebSocketChannel;
 import io.undertow.websockets.core.WebSocketFrameType;
 import io.undertow.websockets.core.WebSockets;
-import org.junit.jupiter.api.Assertions;
+
+import org.assertj.core.api.Assertions;
 import org.xnio.OptionMap;
 import org.xnio.Options;
 import org.xnio.Xnio;
@@ -45,6 +46,7 @@ import java.util.concurrent.*;
 import java.util.logging.*;
 
 import static org.apache.lucene.store.BufferedIndexInput.BUFFER_SIZE;
+import static org.assertj.core.api.Assertions.fail;
 
 public class WebSocketClientHelper implements AutoCloseable {
   private final XnioWorker                 worker;
@@ -84,7 +86,7 @@ public class WebSocketClientHelper implements AutoCloseable {
       protected void onError(final WebSocketChannel channel, final Throwable error) {
         LogManager.instance().log(this, Level.SEVERE, "WS client error: " + error);
         super.onError(channel, error);
-        Assertions.fail(error.getMessage());
+        fail(error.getMessage());
       }
     });
     this.channel.resumeReceives();

--- a/server/src/test/java/performance/BasePerformanceTest.java
+++ b/server/src/test/java/performance/BasePerformanceTest.java
@@ -28,12 +28,12 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.TestServerHelper;
 import com.arcadedb.utility.FileUtils;
-import org.junit.jupiter.api.Assertions;
 
 import java.io.*;
 import java.util.logging.*;
 
 import static com.arcadedb.server.BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class BasePerformanceTest {
   protected static RID              root;
@@ -82,7 +82,7 @@ public abstract class BasePerformanceTest {
     new Exception().printStackTrace(output);
     output.flush();
     final String out = os.toString();
-    Assertions.assertFalse(out.contains("ArcadeDB"), "Some thread is still up & running: \n" + out);
+    assertThat(out.contains("ArcadeDB")).as("Some thread is still up & running: \n" + out).isFalse();
   }
 
   protected void startServers() {

--- a/server/src/test/java/performance/RemoteDatabaseBenchmark.java
+++ b/server/src/test/java/performance/RemoteDatabaseBenchmark.java
@@ -25,10 +25,11 @@ import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.remote.RemoteDatabase;
 import com.arcadedb.remote.RemoteServer;
 import com.arcadedb.server.BaseGraphServerTest;
-import org.junit.jupiter.api.Assertions;
 
 import java.util.*;
 import java.util.concurrent.atomic.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class RemoteDatabaseBenchmark extends BaseGraphServerTest {
   private static final int TOTAL              = 10_000;
@@ -107,11 +108,11 @@ public class RemoteDatabaseBenchmark extends BaseGraphServerTest {
       last = allIds.get(i);
     }
 
-    Assertions.assertEquals(TOTAL * CONCURRENT_THREADS, allIds.size());
+    assertThat(allIds.size()).isEqualTo(TOTAL * CONCURRENT_THREADS);
 
-    Assertions.assertEquals(TOTAL * CONCURRENT_THREADS, totalRecordsOnClusters);
+    assertThat(totalRecordsOnClusters).isEqualTo(TOTAL * CONCURRENT_THREADS);
 
-    Assertions.assertEquals(TOTAL * CONCURRENT_THREADS, database.countType("User", true));
+    assertThat(database.countType("User", true)).isEqualTo(TOTAL * CONCURRENT_THREADS);
 
     database.close();
   }

--- a/server/src/test/java/performance/ReplicationSpeedQuorumMajorityIT.java
+++ b/server/src/test/java/performance/ReplicationSpeedQuorumMajorityIT.java
@@ -26,10 +26,11 @@ import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.VertexType;
-import org.junit.jupiter.api.Assertions;
 
 import java.util.*;
 import java.util.logging.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ReplicationSpeedQuorumMajorityIT extends BasePerformanceTest {
   public static void main(final String[] args) {
@@ -158,7 +159,7 @@ public class ReplicationSpeedQuorumMajorityIT extends BasePerformanceTest {
   }
 
   protected void populateDatabase(final int parallel, final Database database) {
-    Assertions.assertFalse(database.getSchema().existsType("Device"));
+    assertThat(database.getSchema().existsType("Device")).isFalse();
 
     final VertexType v = database.getSchema().buildVertexType().withName("Device").withTotalBuckets(parallel).create();
 


### PR DESCRIPTION
## What does this PR do?

This PR migrates all the Junit5 assertions to AssertJ's 

## Motivation

The main motivation is to modernize the code base while increasing the readability of test code.

## Additional Notes

To fix some flaky tests,  Awaitility (https://github.com/awaitility/awaitility) is now used 

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
