### PR TITLE
Fix code scanning alert no. 45: Implicit narrowing conversion in compound assignment

### DIFF
--- a/console/src/test/java/com/arcadedb/console/ConsoleTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleTest.java
@@ -321,7 +321,7 @@ public class ConsoleTest {
     newConsole.close();
 
     int vertices = 0;
-    int edges = 0;
+    long edges = 0;
 
     try (final DatabaseFactory factory = new DatabaseFactory("./target/databases/" + DATABASE_PATH)) {
       try (final Database database = factory.open()) {


### PR DESCRIPTION
Fixes [https://github.com/ArcadeData/arcadedb/security/code-scanning/45](https://github.com/ArcadeData/arcadedb/security/code-scanning/45)

To fix the problem, we need to ensure that the type of the left-hand side of the compound assignment statement is at least as wide as the type of the right-hand side. In this case, we should change the type of the `edges` variable from `int` to `long`. This will prevent any implicit narrowing conversion and ensure that the `edges` variable can hold the value returned by `countEdges` without any data loss.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
