### PR TITLE
Fix code scanning alert no. 108: Incomplete string escaping or encoding

### DIFF
--- a/studio/src/main/resources/static/components/DataTables/DataTables-1.10.20/js/jquery.dataTables.js
+++ b/studio/src/main/resources/static/components/DataTables/DataTables-1.10.20/js/jquery.dataTables.js
@@ -4022,7 +4022,7 @@
           word = m ? m[1] : word;
         }
 
-        return word.replace('"', "");
+        return word.replace(/"/g, "");
       });
 
       search = "^(?=.*?" + a.join(")(?=.*?") + ").*$";


### PR DESCRIPTION
Fixes [https://github.com/ArcadeData/arcadedb/security/code-scanning/108](https://github.com/ArcadeData/arcadedb/security/code-scanning/108)

To fix the problem, we need to ensure that all occurrences of the double-quote character (`"`) are replaced, not just the first one. This can be achieved by using a regular expression with the global flag (`g`). This change will ensure that every instance of the double-quote character in the string is replaced, thus providing complete escaping.

- Modify the `replace` method call on line 4025 to use a regular expression with the global flag.
- No additional imports or dependencies are required for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
