### PR TITLE
Refactor "map2json"

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/BaseDocument.java
+++ b/engine/src/main/java/com/arcadedb/database/BaseDocument.java
@@ -173,6 +173,6 @@ public abstract class BaseDocument extends BaseRecord implements Document, Seria
 
   @Override
   public JSONObject toJSON(final String... includeProperties) {
-    return new JSONSerializer(database).map2json(propertiesAsMap(), includeProperties);
+    return new JSONSerializer(database).map2json(propertiesAsMap(), null, includeProperties);
   }
 }

--- a/engine/src/main/java/com/arcadedb/database/JSONSerializer.java
+++ b/engine/src/main/java/com/arcadedb/database/JSONSerializer.java
@@ -39,15 +39,11 @@ public class JSONSerializer {
     this.database = database;
   }
 
-  public JSONObject map2json(final Map<String, Object> map, final String... includeProperties) {
-    return map2json(map, null, includeProperties);
-  }
-
   public JSONObject map2json(final Map<String, Object> map, final DocumentType type, final String... includeProperties) {
     final JSONObject json = new JSONObject();
 
     final Set<String> includePropertiesSet;
-    if (includeProperties != null && includeProperties.length > 0) {
+    if (includeProperties.length > 0) {
       includePropertiesSet = new HashSet<>();
       for (String p : includeProperties)
         includePropertiesSet.add(p);
@@ -58,9 +54,11 @@ public class JSONSerializer {
       if (includePropertiesSet != null && !includePropertiesSet.contains(entry.getKey()))
         continue;
 
-      Type propertyType = null;
+      final Type propertyType;
       if (type != null && type.existsProperty(entry.getKey()))
         propertyType = type.getProperty(entry.getKey()).getType();
+      else
+        propertyType = null;
 
       final Object value = convertToJSONType(entry.getValue(), propertyType);
 

--- a/engine/src/main/java/com/arcadedb/database/MutableDocument.java
+++ b/engine/src/main/java/com/arcadedb/database/MutableDocument.java
@@ -111,7 +111,7 @@ public class MutableDocument extends BaseDocument implements RecordInternal {
   @Override
   public JSONObject toJSON(final boolean includeMetadata) {
     checkForLazyLoadingProperties();
-    final JSONObject result = new JSONSerializer(database).map2json(map, type, null);
+    final JSONObject result = new JSONSerializer(database).map2json(map, type);
     if (includeMetadata) {
       result.put("@cat", "d");
       result.put("@type", type.getName());


### PR DESCRIPTION
## What does this PR do?

These changes fix warnings by refactoring the causing method `map2json` in the `JSONSerializer` class. The following changes are included:

* Remove the overloaded `map2json` ( https://github.com/ArcadeData/arcadedb/compare/main...gramian:arcadedb:warning?expand=1#diff-4f4613bf216c5c62f61a33c35c5cea977fab05b287e8fdd375c64ec9408ba9c6L42-L45 ). One now has to pass a `null` for the `type` argument but I think this is acceptable as one had to do this for the `includeProperties` arguments too. Also, the `includeProperties` vararg is a `String[]` so I am not sure if forwarding it to the actual `map2json` would have worked.
* The `includeProperties` vararg is now only checked for length ( https://github.com/ArcadeData/arcadedb/compare/main...gramian:arcadedb:warning?expand=1#diff-4f4613bf216c5c62f61a33c35c5cea977fab05b287e8fdd375c64ec9408ba9c6R46 )
* Use `final` for assignment ( https://github.com/ArcadeData/arcadedb/compare/main...gramian:arcadedb:warning?expand=1#diff-4f4613bf216c5c62f61a33c35c5cea977fab05b287e8fdd375c64ec9408ba9c6R57-R61 )

The caller changes were minimal, because previously null was passed to signify no `includeProperties`, which is repurposed to mean `type` is `null` for most cases. Only the calls which use both had to be adapted.

## Motivation

Originally, these warnings:
```
[WARNING] /Users/ch/Projects/arcadedb/engine/src/main/java/com/arcadedb/database/MutableDocument.java:[114,80] non-varargs call of varargs method with inexact argument type for last parameter;
  cast to java.lang.String for a varargs call
  cast to java.lang.String[] for a non-varargs call and to suppress this warning
[WARNING] /Users/ch/Projects/arcadedb/engine/src/main/java/com/arcadedb/database/ImmutableDocument.java:[92,74] non-varargs call of varargs method with inexact argument type for last parameter;
  cast to java.lang.String for a varargs call
  cast to java.lang.String[] for a non-varargs call and to suppress this warning
[WARNING] /Users/ch/Projects/arcadedb/engine/src/main/java/com/arcadedb/database/DetachedDocument.java:[86,74] non-varargs call of varargs method with inexact argument type for last parameter;
  cast to java.lang.String for a varargs call
  cast to java.lang.String[] for a non-varargs call and to suppress this warning
[WARNING] /Users/ch/Projects/arcadedb/network/src/main/java/com/arcadedb/remote/RemoteMutableVertex.java:[97,74] non-varargs call of varargs method with inexact argument type for last parameter;
  cast to java.lang.String for a varargs call
  cast to java.lang.String[] for a non-varargs call and to suppress this warning
[WARNING] /Users/ch/Projects/arcadedb/network/src/main/java/com/arcadedb/remote/RemoteImmutableDocument.java:[98,74] non-varargs call of varargs method with inexact argument type for last parameter;
  cast to java.lang.String for a varargs call
  cast to java.lang.String[] for a non-varargs call and to suppress this warning
[WARNING] /Users/ch/Projects/arcadedb/network/src/main/java/com/arcadedb/remote/RemoteMutableDocument.java:[84,74] non-varargs call of varargs method with inexact argument type for last parameter;
  cast to java.lang.String for a varargs call
  cast to java.lang.String[] for a non-varargs call and to suppress this warning
[WARNING] /Users/ch/Projects/arcadedb/network/src/main/java/com/arcadedb/remote/RemoteMutableEdge.java:[99,74] non-varargs call of varargs method with inexact argument type for last parameter;
  cast to java.lang.String for a varargs call
  cast to java.lang.String[] for a non-varargs call and to suppress this warning
```
motivated the changes.

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
