### PR TITLE
fix: operators in, contains, containsany and containsall

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsAllCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsAllCondition.java
@@ -40,33 +40,31 @@ public class ContainsAllCondition extends BooleanExpression {
   public boolean execute(Object left, Object right) {
     if (left instanceof Collection) {
       if (right instanceof Collection)
-        return ((Collection) left).containsAll((Collection) right);
+        return ((Collection<?>) left).containsAll((Collection<?>) right);
 
       if (right instanceof Iterable)
-        right = ((Iterable) right).iterator();
+        right = ((Iterable<?>) right).iterator();
 
-      if (right instanceof Iterator) {
-        final Iterator iterator = (Iterator) right;
+      if (right instanceof Iterator<?> iterator) {
         while (iterator.hasNext()) {
           final Object next = iterator.next();
-          if (!((Collection) left).contains(next)) {
+          if (!((Collection<?>) left).contains(next))
             return false;
-          }
+
         }
       }
       return ((Collection) left).contains(right);
     }
     if (left instanceof Iterable)
-      left = ((Iterable) left).iterator();
+      left = ((Iterable<?>) left).iterator();
 
-    if (left instanceof Iterator) {
+    if (left instanceof Iterator<?> leftIterator) {
       if (!(right instanceof Iterable))
         right = Collections.singleton(right);
 
-      right = ((Iterable) right).iterator();
+      right = ((Iterable<?>) right).iterator();
 
-      final Iterator leftIterator = (Iterator) left;
-      final Iterator rightIterator = (Iterator) right;
+      final Iterator<?> rightIterator = (Iterator<?>) right;
       while (rightIterator.hasNext()) {
         final Object leftItem = rightIterator.next();
         boolean found = false;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsAnyCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsAnyCondition.java
@@ -40,38 +40,35 @@ public class ContainsAnyCondition extends BooleanExpression {
 
   public boolean execute(Object left, Object right) {
     if (left instanceof Collection) {
-      if (right instanceof Iterable) {
-        right = ((Iterable) right).iterator();
-      }
-      if (right instanceof Iterator) {
-        final Iterator iterator = (Iterator) right;
+      if (right instanceof Iterable)
+        right = ((Iterable<?>) right).iterator();
+
+      if (right instanceof Iterator<?> iterator) {
         while (iterator.hasNext()) {
           final Object next = iterator.next();
-          if (((Collection) left).contains(next)) {
+          if (((Collection<?>) left).contains(next))
             return true;
-          }
         }
       }
-      return false;
+      return ((Collection<?>) left).contains(right);
     }
-    if (left instanceof Iterable) {
-      left = ((Iterable) left).iterator();
-    }
-    if (left instanceof Iterator) {
-      if (!(right instanceof Iterable)) {
-        right = Collections.singleton(right);
-      }
-      right = ((Iterable) right).iterator();
 
-      final Iterator leftIterator = (Iterator) left;
-      final Iterator rightIterator = (Iterator) right;
+    if (left instanceof Iterable)
+      left = ((Iterable<?>) left).iterator();
+
+    if (left instanceof Iterator<?> leftIterator) {
+      if (!(right instanceof Iterable))
+        right = Collections.singleton(right);
+
+      right = ((Iterable<?>) right).iterator();
+
+      final Iterator<?> rightIterator = (Iterator<?>) right;
       while (rightIterator.hasNext()) {
         final Object leftItem = rightIterator.next();
         while (leftIterator.hasNext()) {
           final Object rightItem = leftIterator.next();
-          if (leftItem != null && leftItem.equals(rightItem)) {
+          if (leftItem != null && leftItem.equals(rightItem))
             return true;
-          }
         }
       }
     }
@@ -85,23 +82,20 @@ public class ContainsAnyCondition extends BooleanExpression {
       final Object rightValue = right.execute(currentRecord, context);
       return execute(leftValue, rightValue);
     } else {
-      if (!MultiValue.isMultiValue(leftValue)) {
+      if (!MultiValue.isMultiValue(leftValue))
         return false;
-      }
+
       final Iterator<Object> iter = MultiValue.getMultiValueIterator(leftValue);
       while (iter.hasNext()) {
         final Object item = iter.next();
         if (item instanceof Identifiable) {
-          if (!rightBlock.evaluate((Identifiable) item, context)) {
+          if (!rightBlock.evaluate((Identifiable) item, context))
             return false;
-          }
         } else if (item instanceof Result) {
-          if (!rightBlock.evaluate((Result) item, context)) {
+          if (!rightBlock.evaluate((Result) item, context))
             return false;
-          }
-        } else if (!rightBlock.evaluate(new ResultInternal(item), context)) {
+        } else if (!rightBlock.evaluate(new ResultInternal(item), context))
           return false;
-        }
       }
       return true;
     }
@@ -114,23 +108,20 @@ public class ContainsAnyCondition extends BooleanExpression {
       final Object rightValue = right.execute(currentRecord, context);
       return execute(leftValue, rightValue);
     } else {
-      if (!MultiValue.isMultiValue(leftValue)) {
+      if (!MultiValue.isMultiValue(leftValue))
         return false;
-      }
+
       final Iterator<Object> iter = MultiValue.getMultiValueIterator(leftValue);
       while (iter.hasNext()) {
         final Object item = iter.next();
         if (item instanceof Identifiable) {
-          if (!rightBlock.evaluate((Identifiable) item, context)) {
+          if (!rightBlock.evaluate((Identifiable) item, context))
             return false;
-          }
         } else if (item instanceof Result) {
-          if (!rightBlock.evaluate((Result) item, context)) {
+          if (!rightBlock.evaluate((Result) item, context))
             return false;
-          }
-        } else if (!rightBlock.evaluate(new ResultInternal(item), context)) {
+        } else if (!rightBlock.evaluate(new ResultInternal(item), context))
           return false;
-        }
       }
       return true;
     }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsCondition.java
@@ -167,7 +167,7 @@ public class ContainsCondition extends BooleanExpression {
           return true;
         else if (item instanceof Result && condition.evaluate((Result) item, context))
           return true;
-        else if (item instanceof Map && condition.evaluate(new ResultInternal((Map<?, ?>) item), context))
+        else if (item instanceof Map && condition.evaluate(new ResultInternal((Map) item), context))
           return true;
         else if (condition.evaluate(new ResultInternal(item), context))
           return true;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsCondition.java
@@ -43,59 +43,56 @@ public class ContainsCondition extends BooleanExpression {
   public boolean execute(final Object left, Object right) {
     if (left instanceof Collection) {
       if (right instanceof Collection) {
-        if (((Collection) right).size() == 1) {
-          Object item = ((Collection) right).iterator().next();
+        if (((Collection<?>) right).size() == 1) {
+          Object item = ((Collection<?>) right).iterator().next();
           if (item instanceof Result && ((Result) item).getPropertyNames().size() == 1) {
             final Object propValue = ((Result) item).getProperty(((Result) item).getPropertyNames().iterator().next());
-            if (((Collection) left).contains(propValue)) {
+            if (((Collection<?>) left).contains(propValue))
               return true;
-            }
           }
-          if (((Collection) left).contains(item)) {
+          if (((Collection<?>) left).contains(item))
             return true;
-          }
+
           if (item instanceof Result)
             item = ((Result) item).getElement().orElse(null);
 
-          if (item instanceof Identifiable && ((Collection) left).contains(item))
+          if (item instanceof Identifiable && ((Collection<?>) left).contains(item))
             return true;
         }
 
         return MultiValue.contains(left, right);
       }
-      if (right instanceof Iterable) {
-        right = ((Iterable) right).iterator();
-      }
-      if (right instanceof Iterator) {
-        final Iterator iterator = (Iterator) right;
+
+      if (right instanceof Iterable)
+        right = ((Iterable<?>) right).iterator();
+
+      if (right instanceof Iterator<?> iterator) {
         while (iterator.hasNext()) {
           final Object next = iterator.next();
-          if (!((Collection) left).contains(next)) {
+          if (!((Collection<?>) left).contains(next))
             return false;
-          }
         }
       }
-      for (final Object o : (Collection) left) {
-        if (equalsInContainsSpace(o, right)) {
+      for (final Object o : (Collection<?>) left) {
+        if (equalsInContainsSpace(o, right))
           return true;
-        }
       }
       return false;
     }
 
-    Iterator leftIterator = null;
-    if (left instanceof Iterable) {
-      leftIterator = ((Iterable) left).iterator();
-    } else if (left instanceof Iterator) {
-      leftIterator = (Iterator) left;
-    }
-    if (leftIterator != null) {
-      if (!(right instanceof Iterable)) {
-        right = Collections.singleton(right);
-      }
-      right = ((Iterable) right).iterator();
+    Iterator<?> leftIterator = null;
+    if (left instanceof Iterable)
+      leftIterator = ((Iterable<?>) left).iterator();
+    else if (left instanceof Iterator)
+      leftIterator = (Iterator<?>) left;
 
-      final Iterator rightIterator = (Iterator) right;
+    if (leftIterator != null) {
+      if (!(right instanceof Iterable))
+        right = Collections.singleton(right);
+
+      right = ((Iterable<?>) right).iterator();
+
+      final Iterator<?> rightIterator = (Iterator<?>) right;
       while (rightIterator.hasNext()) {
         final Object leftItem = rightIterator.next();
         boolean found = false;
@@ -107,17 +104,15 @@ public class ContainsCondition extends BooleanExpression {
           }
         }
 
-        if (!found) {
+        if (!found)
           return false;
-        }
 
         // here left iterator should go from beginning, that can be done only for iterable
         // if left at input is iterator result can be invalid
         // TODO what if left is Iterator!!!???, should we make temporary Collection , to be able to
         // iterate from beginning
-        if (left instanceof Iterable) {
-          leftIterator = ((Iterable) left).iterator();
-        }
+        if (left instanceof Iterable)
+          leftIterator = ((Iterable<?>) left).iterator();
       }
       return true;
     }
@@ -125,11 +120,10 @@ public class ContainsCondition extends BooleanExpression {
   }
 
   private boolean equalsInContainsSpace(final Object left, final Object right) {
-    if (left == null && right == null) {
+    if (left == null && right == null)
       return true;
-    } else {
+    else
       return QueryOperatorEquals.equals(left, right);
-    }
   }
 
   @Override
@@ -139,9 +133,9 @@ public class ContainsCondition extends BooleanExpression {
       final Object rightValue = right.execute(currentRecord, context);
       return execute(leftValue, rightValue);
     } else {
-      if (!MultiValue.isMultiValue(leftValue)) {
+      if (!MultiValue.isMultiValue(leftValue))
         return false;
-      }
+
       final Iterator<Object> iter = MultiValue.getMultiValueIterator(leftValue);
       while (iter.hasNext()) {
         final Object item = iter.next();
@@ -163,9 +157,9 @@ public class ContainsCondition extends BooleanExpression {
       final Object rightValue = right.execute(currentRecord, context);
       return execute(leftValue, rightValue);
     } else {
-      if (!MultiValue.isMultiValue(leftValue)) {
+      if (!MultiValue.isMultiValue(leftValue))
         return false;
-      }
+
       final Iterator<Object> iter = MultiValue.getMultiValueIterator(leftValue);
       while (iter.hasNext()) {
         final Object item = iter.next();
@@ -173,7 +167,7 @@ public class ContainsCondition extends BooleanExpression {
           return true;
         else if (item instanceof Result && condition.evaluate((Result) item, context))
           return true;
-        else if (item instanceof Map && condition.evaluate(new ResultInternal((Map) item), context))
+        else if (item instanceof Map && condition.evaluate(new ResultInternal((Map<?, ?>) item), context))
           return true;
         else if (condition.evaluate(new ResultInternal(item), context))
           return true;
@@ -226,7 +220,7 @@ public class ContainsCondition extends BooleanExpression {
     final List<String> rightX = right == null ? null : right.getMatchPatternInvolvedAliases();
     final List<String> conditionX = condition == null ? null : condition.getMatchPatternInvolvedAliases();
 
-    final List<String> result = new ArrayList<String>();
+    final List<String> result = new ArrayList<>();
     if (leftX != null)
       result.addAll(leftX);
 
@@ -247,9 +241,8 @@ public class ContainsCondition extends BooleanExpression {
   public boolean isIndexAware(final IndexSearchInfo info) {
     if (left.isBaseIdentifier()) {
       if (info.getField().equals(left.getDefaultAlias().getStringValue())) {
-        if (right != null) {
+        if (right != null)
           return right.isEarlyCalculated(info.getContext());
-        }
       }
     }
     return false;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/InOperator.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/InOperator.java
@@ -31,36 +31,32 @@ public class InOperator extends SimpleNode implements BinaryCompareOperator {
 
   @Override
   public boolean execute(final DatabaseInternal database, Object left, Object right) {
-    if (left == null) {
-      return false;
-    }
     if (right instanceof Collection) {
-      if (left instanceof Collection) {
-        return ((Collection) right).containsAll((Collection) left);
-      }
-      if (left instanceof Iterable) {
-        left = ((Iterable) left).iterator();
-      }
-      if (left instanceof Iterator) {
-        final Iterator iterator = (Iterator) left;
+      if (left instanceof Collection<?>)
+        return ((Collection<?>) right).containsAll((Collection<?>) left);
+
+      if (left instanceof Iterable)
+        left = ((Iterable<?>) left).iterator();
+
+      if (left instanceof Iterator<?> iterator) {
         while (iterator.hasNext()) {
           final Object next = iterator.next();
-          if (!((Collection) right).contains(next)) {
+          if (!((Collection<?>) right).contains(next)) {
             return false;
           }
         }
       }
-      return ((Collection) right).contains(left);
+      return ((Collection<?>) right).contains(left);
     }
-    if (right instanceof Iterable) {
-      right = ((Iterable) right).iterator();
-    }
-    if (right instanceof Iterator) {
-      if (left instanceof Iterable) {
-        left = ((Iterable) left).iterator();
-      }
-      final Iterator leftIterator = (Iterator) left;
-      final Iterator rightIterator = (Iterator) right;
+
+    if (right instanceof Iterable)
+      right = ((Iterable<?>) right).iterator();
+
+    if (right instanceof Iterator<?> rightIterator) {
+      if (left instanceof Iterable)
+        left = ((Iterable<?>) left).iterator();
+
+      final Iterator<?> leftIterator = (Iterator<?>) left;
       while (leftIterator.hasNext()) {
         final Object leftItem = leftIterator.next();
         boolean found = false;
@@ -71,9 +67,9 @@ public class InOperator extends SimpleNode implements BinaryCompareOperator {
             break;
           }
         }
-        if (!found) {
+        if (!found)
           return false;
-        }
+
       }
       return true;
     }

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsAllConditionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsAllConditionTest.java
@@ -18,8 +18,7 @@
  */
 package com.arcadedb.query.sql.parser.operators;
 
-import com.arcadedb.query.sql.parser.ContainsCondition;
-import com.arcadedb.query.sql.parser.InOperator;
+import com.arcadedb.query.sql.parser.ContainsAllCondition;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
@@ -27,12 +26,12 @@ import java.util.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * @author Luigi Dell'Aquila (luigi.dellaquila-(at)-gmail.com)
+ * @author Luca Garulli (l.garulli-(at)-arcadedata.com)
  */
-public class ContainsConditionTest {
+public class ContainsAllConditionTest {
   @Test
   public void test() {
-    final ContainsCondition op = new ContainsCondition(-1);
+    final ContainsAllCondition op = new ContainsAllCondition(-1);
 
     assertThat(op.execute(null, null)).isFalse();
     assertThat(op.execute(null, "foo")).isFalse();
@@ -50,11 +49,17 @@ public class ContainsConditionTest {
 
     left.add(null);
     assertThat(op.execute(left, null)).isTrue();
+
+    final List<Object> right = new ArrayList<>();
+    left.add("foo");
+    left.add("bar");
+
+    assertThat(op.execute(left, right)).isTrue();
   }
 
   @Test
   public void testIterable() {
-    final Iterable<?> left = new Iterable<>() {
+    final Iterable<Object> left = new Iterable<>() {
       private final List<Integer> ls = Arrays.asList(3, 1, 2);
 
       @Override
@@ -63,7 +68,7 @@ public class ContainsConditionTest {
       }
     };
 
-    final Iterable<?> right = new Iterable<>() {
+    final Iterable<Object> right = new Iterable<>() {
       private final List<Integer> ls = Arrays.asList(2, 3);
 
       @Override
@@ -72,13 +77,13 @@ public class ContainsConditionTest {
       }
     };
 
-    final ContainsCondition op = new ContainsCondition(-1);
-    assertThat(op.execute(left, right)).isTrue();
+    final ContainsAllCondition op = new ContainsAllCondition(-1);
+    assertThat(op.execute(left, right)).isFalse();
   }
 
   @Test
   public void issue1785() {
-    final ContainsCondition op = new ContainsCondition(-1);
+    final ContainsAllCondition op = new ContainsAllCondition(-1);
 
     final List<Object> nullList = new ArrayList<>();
     nullList.add(null);

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsAnyConditionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/ContainsAnyConditionTest.java
@@ -18,8 +18,8 @@
  */
 package com.arcadedb.query.sql.parser.operators;
 
-import com.arcadedb.query.sql.parser.ContainsCondition;
-import com.arcadedb.query.sql.parser.InOperator;
+import com.arcadedb.query.sql.parser.ContainsAnyCondition;
+import com.arcadedb.query.sql.parser.ContainsAnyCondition;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
@@ -27,12 +27,12 @@ import java.util.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * @author Luigi Dell'Aquila (luigi.dellaquila-(at)-gmail.com)
+ * @author Luca Garulli (l.garulli-(at)-arcadedata.com)
  */
-public class ContainsConditionTest {
+public class ContainsAnyConditionTest {
   @Test
   public void test() {
-    final ContainsCondition op = new ContainsCondition(-1);
+    final ContainsAnyCondition op = new ContainsAnyCondition(-1);
 
     assertThat(op.execute(null, null)).isFalse();
     assertThat(op.execute(null, "foo")).isFalse();
@@ -54,7 +54,7 @@ public class ContainsConditionTest {
 
   @Test
   public void testIterable() {
-    final Iterable<?> left = new Iterable<>() {
+    final Iterable left = new Iterable() {
       private final List<Integer> ls = Arrays.asList(3, 1, 2);
 
       @Override
@@ -63,7 +63,7 @@ public class ContainsConditionTest {
       }
     };
 
-    final Iterable<?> right = new Iterable<>() {
+    final Iterable right = new Iterable() {
       private final List<Integer> ls = Arrays.asList(2, 3);
 
       @Override
@@ -72,13 +72,13 @@ public class ContainsConditionTest {
       }
     };
 
-    final ContainsCondition op = new ContainsCondition(-1);
+    final ContainsAnyCondition op = new ContainsAnyCondition(-1);
     assertThat(op.execute(left, right)).isTrue();
   }
 
   @Test
   public void issue1785() {
-    final ContainsCondition op = new ContainsCondition(-1);
+    final ContainsAnyCondition op = new ContainsAnyCondition(-1);
 
     final List<Object> nullList = new ArrayList<>();
     nullList.add(null);

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/operators/InOperatorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/operators/InOperatorTest.java
@@ -49,7 +49,16 @@ public class InOperatorTest {
     assertThat(op.execute(null, "foo", list1)).isFalse();
     assertThat(op.execute(null, "a", list1)).isTrue();
     assertThat(op.execute(null, 1, list1)).isTrue();
+  }
 
-    // TODO
+  @Test
+  public void issue1785() {
+    final InOperator op = new InOperator(-1);
+
+    final List<Object> nullList = new ArrayList<>();
+    nullList.add(null);
+
+    assertThat(op.execute(null, null, nullList)).isTrue();
+    assertThat(op.execute(null, nullList, nullList)).isTrue();
   }
 }


### PR DESCRIPTION
Hi @gramian, this PR fixes https://github.com/ArcadeData/arcadedb/issues/1785.

I've created new test for the missing cases. About your tests, check my comments:

```
(NULL IN [NULL]) -- is FALSE but should be TRUE <-- OK
([NULL] IN [NULL]) -- is TRUE but should be FALSE <-- WHY?

([NULL] CONTAINS [NULL]) -- is TRUE but should be FALSE <-- WHY?

([NULL] CONTAINSANY NULL) -- is FALSE is fine if the right-hand-side has to be a collection, BUT <-- IT SHOULS RETURN TRUE
([NULL] CONTAINSALL NULL) -- is TRUE which is inconsistent with `CONTAINSANY`<-- OK? SEE ABOVE
```

