### PR TITLE
#1761 fix coverage report: run always

### DIFF
--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -61,10 +61,12 @@ jobs:
 
       - name: Get coverage files
         id: coverage-files-generator
+        if: success() || failure()
         run: echo "COVERAGE_FILES=$(find . -path **/jacoco*.xml -printf '%p,')" >> "$GITHUB_OUTPUT"
 
       - name: Codacy coverage reporter
         uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # v1.3.0
+        if: success() || failure()
         with:
           language: java
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

Should solve the coverage report missing on codacy 

## Motivation

Code coverage is missing even if 1500+ tests are executed

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
