### PR TITLE
fix: return value of ALTER PROPERTY for DEFAULT attribute

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/AlterPropertyStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/AlterPropertyStatement.java
@@ -72,7 +72,7 @@ public class AlterPropertyStatement extends DDLStatement {
       result.setProperty("newValue", finalValue);
     } else if (settingName != null) {
       final String setting = settingName.getStringValue().toLowerCase(Locale.ENGLISH);
-      final Object finalValue = settingValue.execute((Identifiable) null, context);
+      final Object finalValue = setting.equalsIgnoreCase("default") ? settingValue.toString() : settingValue.execute((Identifiable) null, context);
 
       final Object oldValue;
 
@@ -93,7 +93,7 @@ public class AlterPropertyStatement extends DDLStatement {
         property.setMin("" + finalValue);
       } else if (setting.equalsIgnoreCase("default")) {
         oldValue = property.getDefaultValue();
-        property.setDefaultValue(settingValue.toString());
+        property.setDefaultValue("" + finalValue);
       } else if (setting.equalsIgnoreCase("regexp")) {
         oldValue = property.getRegexp();
         property.setRegexp("" + finalValue);


### PR DESCRIPTION
## What does this PR do?

`ALTER PROPERTY` is returning the evaluated attribute value for attribute type `default`, this is not only inconsistent with the attribute value set but also confusing as it appears to a user as if the attribute was evaluated.

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
