### PR TITLE
Fix "NULL IN [NULL]" 

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/InCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/InCondition.java
@@ -111,7 +111,7 @@ public class InCondition extends BooleanExpression {
         return ((Set) iRight).contains(iLeft);
 
       for (final Object o : MultiValue.getMultiValueIterable(iRight, false)) {
-        if (QueryOperatorEquals.equals(iLeft, o))
+        if (QueryOperatorEquals.equals(iLeft, o) || (iLeft == null && o == null))
           return true;
         if (MultiValue.isMultiValue(iLeft) && MultiValue.getSize(iLeft) == 1) {
 
@@ -126,7 +126,7 @@ public class InCondition extends BooleanExpression {
       }
     } else if (iRight.getClass().isArray()) {
       for (final Object o : (Object[]) iRight) {
-        if (QueryOperatorEquals.equals(iLeft, o))
+        if (QueryOperatorEquals.equals(iLeft, o) || (iLeft == null && o == null))
           return true;
       }
     } else if (iRight instanceof ResultSet) {


### PR DESCRIPTION
## What does this PR do?

This change makes an `IN`-condition return true if left and right side are null. This is necessary because the existing test with [queryOperatorEquals](https://github.com/ArcadeData/arcadedb/blob/main/engine/src/main/java/com/arcadedb/query/sql/executor/QueryOperatorEquals.java#L31) returns false as soon as one operand is null (which is generally correct in terms of null arithmetic). This solution is likely not the most elegant but it seems to work. @lvca feel free to suggesst better solutions.

## Related issues

https://github.com/ArcadeData/arcadedb/issues/1785

I suspected that `InCondition` could still be a problem even if `InOperator` works: https://github.com/ArcadeData/arcadedb/issues/1785#issuecomment-2448095522

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
