### PR TITLE
Add version number to Studio sidebar

### DIFF
--- a/studio/src/main/resources/static/index.html
+++ b/studio/src/main/resources/static/index.html
@@ -72,7 +72,8 @@
         <div class="row">
           <div class="col-1">
             <ul class="nav nav-tabs flex-column" id="tabs" style="height: 100%; background-color: white">
-              <li class="nav-item text-center" style="height: 85px; padding: 5px"><img src="images/arcadedb-logo-mini.png" style="width: 100%" /></li>
+              <li class="nav-item text-center" style="padding: 5px 0px"><img src="images/arcadedb-logo-mini.png" style="width: 100%" /></li>
+              <li class="nav-item text-center" id="version" style="padding: 5px 0px"></li>
               <li class="nav-item">
                 <a data-toggle="tab" href="#tab-query" class="vertical-tab nav-link active show" id="tab-query-sel">
                   <h3>

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -52,6 +52,14 @@ function updateDatabases(callback) {
       },
     })
     .done(function (data) {
+      let version = data.version;
+      let pos = data.version.indexOf("(build");
+      if (pos > -1) {
+        version = version.substring(0, pos);
+      }
+
+      $("#version").html(version);
+
       let databases = "";
       for (let i in data.result) {
         let dbName = data.result[i];

--- a/studio/src/main/resources/static/resources.html
+++ b/studio/src/main/resources/static/resources.html
@@ -20,7 +20,7 @@
                 <p><a class="link" href="https://docs.arcadedb.com#Open-Cypher">Cypher</a></p>
               </li>
               <li>
-                <p><a class="link" href="https://docs.arcadedb.com#Gremlin-API">Apache Gremlin (Apache Tinkerpop v3.4.x)</a></p>
+                <p><a class="link" href="https://docs.arcadedb.com#Gremlin-API">Apache Gremlin (Apache Tinkerpop v3.7.x)</a></p>
               </li>
               <li>
                 <p><a class="link" href="https://docs.arcadedb.com#MongoDB-API">MongoDB Query Language</a></p>


### PR DESCRIPTION
## What does this PR do?

This change adds the current ArcadeDB version number to the sidebar menu in the studio.

## Motivation

I think it is useful to readily see the version number.

## Additional Notes

I also updated the link label on the resources page to mache the current Gremlin series.

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
