### PR TITLE
fix: return value of CREATE PROPERTY for DEFAULT attribute

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreatePropertyAttributeStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreatePropertyAttributeStatement.java
@@ -53,7 +53,15 @@ public class CreatePropertyAttributeStatement extends SimpleNode {
 
   public Object setOnProperty(final Property internalProp, final CommandContext context) {
     final String attrName = settingName.getStringValue();
-    final Object attrValue = this.settingValue == null ? true : this.settingValue.execute((Identifiable) null, context);
+    final Object attrValue;
+    if (this.settingValue == null) {
+      attrValue = true;
+    } else if (attrName.equalsIgnoreCase("default")) {
+      attrValue = this.settingValue.toString();
+    } else {
+      attrValue = this.settingValue.execute((Identifiable) null, context);
+    }
+
     try {
       if (attrName.equalsIgnoreCase("readonly")) {
         internalProp.setReadonly((boolean) attrValue);
@@ -68,7 +76,7 @@ public class CreatePropertyAttributeStatement extends SimpleNode {
       } else if (attrName.equalsIgnoreCase("default")) {
         if (this.settingValue == null)
           throw new CommandExecutionException("Default value not set");
-        internalProp.setDefaultValue(this.settingValue.toString());
+        internalProp.setDefaultValue("" + attrValue);
       } else if (attrName.equalsIgnoreCase("regexp")) {
         internalProp.setRegexp("" + attrValue);
       } else {


### PR DESCRIPTION
## What does this PR do?

`CREATE PROPERTY` is returning the evaluated attribute value for attribute type `default`, this is not only inconsistent with the attribute value set but also confusing as it appears to a user as if the attribute was evaluated.

## Motivation

Fixing `ALTER PROPERTY`.

## Related issues

https://github.com/ArcadeData/arcadedb/pull/1802

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
