### PR TITLE
remove npe on closing in TomcatConnectionPoolPostgresWJdbcTest

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/DatabaseContext.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseContext.java
@@ -115,7 +115,7 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
           super.remove();
           CONTEXTS.remove(Thread.currentThread());
         }
-        result.add(tl);
+        Optional.ofNullable(tl).ifPresent(result::add);
       }
     }
     return result;


### PR DESCRIPTION
## What does this PR do?

Remove the NPE while closing the DB in the TomcatConnectionPoolPostgresWJdbcTest and probably in other cases

## Motivation

NPEs are always bad

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
