### PR TITLE
feat: disable backup lock for embedded massive insertion only gaining…

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -125,7 +125,7 @@ public enum GlobalConfiguration {
   }, null, Set.of("default", "high-performance", "low-ram", "low-cpu")),
 
   TEST("arcadedb.test", SCOPE.JVM,
-      "Tells if it is running in test mode. This enables the calling of callbacks for testing purpose ", Boolean.class, false),
+      "Tells if it is running in test mode. This enables the calling of callbacks for testing purpose", Boolean.class, false),
 
   MAX_PAGE_RAM("arcadedb.maxPageRAM", SCOPE.DATABASE, "Maximum amount of pages (in MB) to keep in RAM", Long.class, 4 * 1024, // 4GB
       new Callable<>() {
@@ -234,6 +234,10 @@ public enum GlobalConfiguration {
   TX_RETRY_DELAY("arcadedb.txRetryDelay", SCOPE.DATABASE,
       "Maximum amount of milliseconds to compute a random number to wait for the next retry. This setting is helpful in case of high concurrency on the same pages (multi-thread insertion over the same bucket)",
       Integer.class, 100),
+
+  BACKUP_ENABLED("arcadedb.backup.enabled", SCOPE.DATABASE,
+      "Allow a database to be backup. Disabling backup gives a huge boost in performance because no lock will be used for every operations",
+      Boolean.class, true),
 
   // SQL
   SQL_STATEMENT_CACHE("arcadedb.sqlStatementCache", SCOPE.DATABASE, "Maximum number of parsed statements to keep in cache",

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -1409,7 +1409,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
    */
   @Override
   public <RET> RET executeInReadLock(final Callable<RET> callable) {
-    final ReentrantReadWriteLock.ReadLock stamp = readLock();
+    final ReentrantReadWriteLock.ReadLock readLock = readLock();
     try {
 
       return callable.call();
@@ -1426,7 +1426,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
       throw new DatabaseOperationException("Error during read lock", e);
 
     } finally {
-      readUnlock(stamp);
+      readUnlock(readLock);
     }
   }
 
@@ -1435,7 +1435,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
    */
   @Override
   public <RET> RET executeInWriteLock(final Callable<RET> callable) {
-    final ReentrantReadWriteLock.WriteLock stamp = writeLock();
+    final ReentrantReadWriteLock.WriteLock writeLock = writeLock();
     try {
 
       return callable.call();
@@ -1452,7 +1452,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
       throw new DatabaseOperationException("Error during write lock", e);
 
     } finally {
-      writeUnlock(stamp);
+      writeUnlock(writeLock);
     }
   }
 
@@ -1772,6 +1772,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
   private void openInternal() {
     try {
       DatabaseContext.INSTANCE.init(this);
+      setLockingEnabled(configuration.getValueAsBoolean(GlobalConfiguration.BACKUP_ENABLED));
 
       fileManager = new FileManager(databasePath, mode, SUPPORTED_FILE_EXT);
       transactionManager = new TransactionManager(wrappedDatabaseInstance);
@@ -1854,4 +1855,5 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
       }
     }
   }
+
 }

--- a/engine/src/main/java/com/arcadedb/utility/RWLockContext.java
+++ b/engine/src/main/java/com/arcadedb/utility/RWLockContext.java
@@ -24,9 +24,13 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.locks.*;
 
 public class RWLockContext {
-  private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
+  private final ReentrantReadWriteLock lock          = new ReentrantReadWriteLock(true);
+  private       boolean                enableLocking = true;
 
   protected ReentrantReadWriteLock.ReadLock readLock() {
+    if (!enableLocking)
+      return null;
+
     final ReentrantReadWriteLock.ReadLock rl = lock.readLock();
     rl.lock();
     return rl;
@@ -38,6 +42,9 @@ public class RWLockContext {
   }
 
   protected ReentrantReadWriteLock.WriteLock writeLock() {
+    if (!enableLocking)
+      return null;
+
     final ReentrantReadWriteLock.WriteLock wl = lock.writeLock();
     wl.lock();
     return wl;
@@ -86,5 +93,13 @@ public class RWLockContext {
     } finally {
       writeUnlock(wl);
     }
+  }
+
+  protected void setLockingEnabled(final boolean enabled) {
+    this.enableLocking = enabled;
+  }
+
+  protected boolean isLockingEnabled() {
+    return enableLocking;
   }
 }

--- a/engine/src/test/java/performance/LocalDatabaseBenchmark.java
+++ b/engine/src/test/java/performance/LocalDatabaseBenchmark.java
@@ -62,9 +62,11 @@ public class LocalDatabaseBenchmark {
 
   private void endTest() {
     database.close();
+    GlobalConfiguration.resetAll();
   }
 
   private void beginTest() {
+    GlobalConfiguration.BACKUP_ENABLED.setValue(false);
     if (new DatabaseFactory(DATABASE_NAME).exists())
       new DatabaseFactory(DATABASE_NAME).open().drop();
     database = new DatabaseFactory(DATABASE_NAME).create();
@@ -153,8 +155,8 @@ public class LocalDatabaseBenchmark {
     long begin = System.currentTimeMillis();
     for (int i = 0; i < TOTAL * CONCURRENT_THREADS; i++) {
       assertThat(database.query("sql",
-        "select from User where id = ? and id = ? and id = ? and id = ? and id = ? and id = ? and id = ? and id = ? and id = ? and id = ?",
-        i, i, i, i, i, i, i, i, i, i).toVertices().size()).isEqualTo(1);
+          "select from User where id = ? and id = ? and id = ? and id = ? and id = ? and id = ? and id = ? and id = ? and id = ? and id = ?",
+          i, i, i, i, i, i, i, i, i, i).toVertices().size()).isEqualTo(1);
     }
     System.out.println("SQL " + (System.currentTimeMillis() - begin) + "ms");
   }


### PR DESCRIPTION
… around 30% improvement in speed

Tested LocalDatabaseBenchmark on my MacBook Pro 2019 and it's able to insert 4.3M rec/sec (multi-threads, 1 property only, 1 unique index). With default settings (backup enabled = true) the performance dropped to 3.2M rec/sec

Added new global cfg:

BACKUP_ENABLED("arcadedb.backup.enabled")

