### PR TITLE
Centralized page manager

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb;
 
+import com.arcadedb.engine.PageManager;
 import com.arcadedb.exception.ConfigurationException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.BinaryComparator;
@@ -112,6 +113,8 @@ public enum GlobalConfiguration {
         HA_REPLICATION_QUEUE_SIZE.setValue(8);
         ASYNC_OPERATIONS_QUEUE_IMPL.setValue("standard");
         SERVER_HTTP_IO_THREADS.setValue(cores > 8 ? 4 : 2);
+
+        PageManager.INSTANCE.configure();
 
       } else if (v.equalsIgnoreCase("low-cpu")) {
         ASYNC_WORKER_THREADS.setValue(1);

--- a/engine/src/main/java/com/arcadedb/Profiler.java
+++ b/engine/src/main/java/com/arcadedb/Profiler.java
@@ -51,7 +51,6 @@ public class Profiler {
     final JSONObject json = new JSONObject();
 
     long readCacheUsed = 0;
-    long writeCacheUsed = 0;
     long cacheMax = 0;
     long pagesRead = 0;
     long pagesWritten = 0;
@@ -109,7 +108,6 @@ public class Profiler {
 
       final PageManager.PPageManagerStats pStats = db.getPageManager().getStats();
       readCacheUsed += pStats.readCacheRAM;
-      writeCacheUsed += pStats.writeCacheRAM;
       cacheMax += pStats.maxRAM;
       pagesRead += pStats.pagesRead;
       pagesReadSize += pStats.pagesReadSize;
@@ -138,7 +136,6 @@ public class Profiler {
     }
 
     json.put("readCacheUsed", new JSONObject().put("space", readCacheUsed));
-    json.put("writeCacheUsed", new JSONObject().put("space", writeCacheUsed));
     json.put("cacheMax", new JSONObject().put("space", cacheMax));
     json.put("pagesRead", new JSONObject().put("count", pagesRead));
     json.put("pagesWritten", new JSONObject().put("count", pagesWritten));
@@ -243,7 +240,6 @@ public class Profiler {
     final long totalSpaceInMB = new File(".").getTotalSpace();
 
     long readCacheUsed = 0;
-    long writeCacheUsed = 0;
     long cacheMax = 0;
     long pagesRead = 0;
     long pagesWritten = 0;
@@ -278,7 +274,6 @@ public class Profiler {
     long evictionRuns = 0;
     long pagesEvicted = 0;
     int readCachePages = 0;
-    int writeCachePages = 0;
     long indexCompactions = 0;
 
     try {
@@ -302,7 +297,6 @@ public class Profiler {
 
         final PageManager.PPageManagerStats pStats = db.getPageManager().getStats();
         readCacheUsed += pStats.readCacheRAM;
-        writeCacheUsed += pStats.writeCacheRAM;
         cacheMax += pStats.maxRAM;
         pagesRead += pStats.pagesRead;
         pagesReadSize += pStats.pagesReadSize;
@@ -361,8 +355,8 @@ public class Profiler {
             String.format("%n JVM heap=%s/%s gc=%dms", FileUtils.getSizeAsString(runtime.totalMemory() - runtime.freeMemory()),
                 FileUtils.getSizeAsString(runtime.maxMemory()), gcTime));
 
-      buffer.append(String.format("%n PAGE-CACHE read=%s (pages=%d) write=%s (pages=%d) max=%s readOps=%d (%s) writeOps=%d (%s)",
-          FileUtils.getSizeAsString(readCacheUsed), readCachePages, FileUtils.getSizeAsString(writeCacheUsed), writeCachePages,
+      buffer.append(String.format("%n PAGE-CACHE read=%s (pages=%d) max=%s readOps=%d (%s) writeOps=%d (%s)",
+          FileUtils.getSizeAsString(readCacheUsed), readCachePages,
           FileUtils.getSizeAsString(cacheMax), pagesRead, FileUtils.getSizeAsString(pagesReadSize), pagesWritten,
           FileUtils.getSizeAsString(pagesWrittenSize)));
 

--- a/engine/src/main/java/com/arcadedb/database/DatabaseComparator.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseComparator.java
@@ -86,22 +86,23 @@ public class DatabaseComparator {
       // AT THIS POINT BOTH BUCKETS HAVE THE SAME PAGES
       final int pageSize = bucket1.getPageSize();
       for (int i = 0; i < bucket1.getTotalPages(); ++i) {
-        final PageId pageId = new PageId(bucket1.getFileId(), i);
+        final PageId pageId1 = new PageId(bucket1.getDatabase(), bucket1.getFileId(), i);
+        final PageId pageId2 = new PageId(bucket2.getDatabase(), bucket2.getFileId(), i);
 
         final ImmutablePage page1;
         final ImmutablePage page2;
 
         try {
-          page1 = db1.getPageManager().getImmutablePage(pageId, pageSize, false, true);
+          page1 = db1.getPageManager().getImmutablePage(pageId1, pageSize, false, true);
         } catch (final IOException e) {
-          throw new DatabaseAreNotIdentical("Error on reading page %s from bucket '%s' DB1 (cause=%s)", pageId, bucket1.getName(),
+          throw new DatabaseAreNotIdentical("Error on reading page %s from bucket '%s' DB1 (cause=%s)", pageId1, bucket1.getName(),
               e.toString());
         }
 
         try {
-          page2 = db2.getPageManager().getImmutablePage(pageId, pageSize, false, true);
+          page2 = db2.getPageManager().getImmutablePage(pageId2, pageSize, false, true);
         } catch (final IOException e) {
-          throw new DatabaseAreNotIdentical("Error on reading page %s from bucket '%s' DB2 (cause=%s)", pageId, bucket2.getName(),
+          throw new DatabaseAreNotIdentical("Error on reading page %s from bucket '%s' DB2 (cause=%s)", pageId2, bucket2.getName(),
               e.toString());
         }
 
@@ -109,10 +110,10 @@ public class DatabaseComparator {
 
         if (page1.getVersion() != page2.getVersion())
           throw new DatabaseAreNotIdentical("Page %s has different versions on databases. DB1 %d <> DB2 %d (sameContent=%s)",
-              pageId, page1.getVersion(), page2.getVersion(), sameContent);
+              pageId1, page1.getVersion(), page2.getVersion(), sameContent);
 
         if (!sameContent)
-          throw new DatabaseAreNotIdentical("Page %s has different content on databases", pageId);
+          throw new DatabaseAreNotIdentical("Page %s has different content on databases", pageId1);
 
         db2.getPageManager().removePageFromCache(page2.getPageId());
       }

--- a/engine/src/main/java/com/arcadedb/database/RID.java
+++ b/engine/src/main/java/com/arcadedb/database/RID.java
@@ -216,7 +216,7 @@ public class RID implements Identifiable, Comparable<Object>, Serializable {
   }
 
   public PageId getPageId() {
-    return new PageId(bucketId,
+    return new PageId(database, bucketId,
         (int) (getPosition() / ((LocalBucket) database.getSchema().getBucketById(bucketId)).getMaxRecordsInPage()));
   }
 }

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -359,7 +359,7 @@ public class TransactionContext implements Transaction {
     assureIsActive();
 
     // CREATE A PAGE ID BASED ON NEW PAGES IN TX. IN CASE OF ROLLBACK THEY ARE SIMPLY REMOVED AND THE GLOBAL PAGE COUNT IS UNCHANGED
-    final MutablePage page = new MutablePage(database.getPageManager(), pageId, pageSize);
+    final MutablePage page = new MutablePage(pageId, pageSize);
     newPages.put(pageId, page);
 
     final Integer indexCounter = newPageCounters.get(pageId.getFileId());

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -492,7 +492,7 @@ public class TransactionContext implements Transaction {
         final PaginatedComponentFile file = (PaginatedComponentFile) database.getFileManager().getFile(p.fileId);
         final int pageSize = file.getPageSize();
 
-        final PageId pageId = new PageId(p.fileId, p.pageNumber);
+        final PageId pageId = new PageId(database, p.fileId, p.pageNumber);
 
         final boolean isNew = p.pageNumber >= file.getTotalPages();
 

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -86,8 +86,10 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       super("AsyncExecutor-" + database.getName() + "-" + id);
       this.database = database;
 
-      final int queueSize =
+      int queueSize =
           database.getConfiguration().getValueAsInteger(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE) / parallelLevel;
+      if (queueSize < 1)
+        queueSize = 1;
 
       final String cfgQueueImpl = database.getConfiguration().getValueAsString(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_IMPL);
       if ("fast".equalsIgnoreCase(cfgQueueImpl))

--- a/engine/src/main/java/com/arcadedb/engine/BasePage.java
+++ b/engine/src/main/java/com/arcadedb/engine/BasePage.java
@@ -36,15 +36,13 @@ public abstract class BasePage {
   protected static final int PAGE_CONTENTSIZE_OFFSET = Binary.INT_SERIALIZED_SIZE;
   public static final    int PAGE_HEADER_SIZE        = Binary.INT_SERIALIZED_SIZE + Binary.INT_SERIALIZED_SIZE;
 
-  protected final PageManager manager;
-
   protected final PageId pageId;
   protected       Binary content;
   protected final int    size;
   protected       int    version;
 
-  protected BasePage(final PageManager manager, final PageId pageId, final int size, final byte[] buffer, final int version, final int contentSize) {
-    this.manager = manager;
+  protected BasePage(final PageId pageId, final int size, final byte[] buffer, final int version,
+      final int contentSize) {
     this.pageId = pageId;
     this.size = size;
     this.content = new Binary(buffer, contentSize);

--- a/engine/src/main/java/com/arcadedb/engine/BucketIterator.java
+++ b/engine/src/main/java/com/arcadedb/engine/BucketIterator.java
@@ -34,9 +34,9 @@ import static com.arcadedb.database.Binary.INT_SERIALIZED_SIZE;
 
 public class BucketIterator implements Iterator<Record> {
   private final static int              PREFETCH_SIZE = 1_024;
-  private final DatabaseInternal database;
-  private final LocalBucket      bucket;
-  final         Record[]         nextBatch     = new Record[PREFETCH_SIZE];
+  private final        DatabaseInternal database;
+  private final        LocalBucket      bucket;
+  final                Record[]         nextBatch     = new Record[PREFETCH_SIZE];
   private              int              prefetchIndex = 0;
   final                long             limit;
   int      nextPageNumber      = 0;
@@ -67,7 +67,7 @@ public class BucketIterator implements Iterator<Record> {
     nextBatch[prefetchIndex] = position.getRecord();
     nextPageNumber = (int) (position.getPosition() / bucket.getMaxRecordsInPage());
     currentRecordInPage = (int) (position.getPosition() % bucket.getMaxRecordsInPage()) + 1;
-    currentPage = database.getTransaction().getPage(new PageId(position.getBucketId(), nextPageNumber), bucket.pageSize);
+    currentPage = database.getTransaction().getPage(new PageId(database, position.getBucketId(), nextPageNumber), bucket.pageSize);
     recordCountInCurrentPage = currentPage.readShort(LocalBucket.PAGE_RECORD_COUNT_IN_PAGE_OFFSET);
   }
 
@@ -104,7 +104,8 @@ public class BucketIterator implements Iterator<Record> {
           if (nextPageNumber > totalPages) {
             return null;
           }
-          currentPage = database.getTransaction().getPage(new PageId(bucket.file.getFileId(), nextPageNumber), bucket.pageSize);
+          currentPage = database.getTransaction()
+              .getPage(new PageId(database, bucket.file.getFileId(), nextPageNumber), bucket.pageSize);
           recordCountInCurrentPage = currentPage.readShort(LocalBucket.PAGE_RECORD_COUNT_IN_PAGE_OFFSET);
         }
 

--- a/engine/src/main/java/com/arcadedb/engine/CachedPage.java
+++ b/engine/src/main/java/com/arcadedb/engine/CachedPage.java
@@ -29,15 +29,13 @@ import java.util.*;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class CachedPage {
-  private final PageManager pageManager;
-  private final PageId      pageId;
-  private final Binary      content;
-  private final int         size;
-  private       int         version;
-  private       long        lastAccessed = System.currentTimeMillis();
+  private final PageId pageId;
+  private final Binary content;
+  private final int    size;
+  private       int    version;
+  private       long   lastAccessed = System.currentTimeMillis();
 
   public CachedPage(final MutablePage page, final boolean copyBuffer) {
-    this.pageManager = page.manager;
     this.pageId = page.pageId;
     this.content = copyBuffer ? page.content.copy() : page.content;
     this.size = page.size;
@@ -45,7 +43,6 @@ public class CachedPage {
   }
 
   public CachedPage(final PageManager pageManager, final PageId pageId, final int size) {
-    this.pageManager = pageManager;
     this.pageId = pageId;
     this.content = new Binary(size).setAutoResizable(false);
     this.size = size;
@@ -57,13 +54,13 @@ public class CachedPage {
   }
 
   public ImmutablePage useAsImmutable() {
-    return new ImmutablePage(pageManager, pageId, size, content.getContent(), version, content.size());
+    return new ImmutablePage(pageId, size, content.getContent(), version, content.size());
   }
 
   public MutablePage useAsMutable() {
     final byte[] array = this.content.getByteBuffer().array();
     // COPY THE CONTENT, SO CHANGES DOES NOT AFFECT IMMUTABLE COPY
-    return new MutablePage(pageManager, pageId, size, Arrays.copyOf(array, array.length), version, content.size());
+    return new MutablePage(pageId, size, Arrays.copyOf(array, array.length), version, content.size());
   }
 
   public long getLastAccessed() {

--- a/engine/src/main/java/com/arcadedb/engine/Dictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/Dictionary.java
@@ -47,7 +47,8 @@ public class Dictionary extends PaginatedComponent {
 
   public static class PaginatedComponentFactoryHandler implements ComponentFactory.PaginatedComponentFactoryHandler {
     @Override
-    public PaginatedComponent createOnLoad(final DatabaseInternal database, final String name, final String filePath, final int fileId,
+    public PaginatedComponent createOnLoad(final DatabaseInternal database, final String name, final String filePath,
+        final int fileId,
         final ComponentFile.MODE mode, final int pageSize, final int version) throws IOException {
       return new Dictionary(database, name, filePath, fileId, mode, pageSize, version);
     }
@@ -56,12 +57,13 @@ public class Dictionary extends PaginatedComponent {
   /**
    * Called at creation time.
    */
-  public Dictionary(final DatabaseInternal database, final String name, final String filePath, final ComponentFile.MODE mode, final int pageSize)
+  public Dictionary(final DatabaseInternal database, final String name, final String filePath, final ComponentFile.MODE mode,
+      final int pageSize)
       throws IOException {
     super(database, name, filePath, DICT_EXT, mode, pageSize, CURRENT_VERSION);
     if (file.getSize() == 0) {
       // NEW FILE, CREATE HEADER PAGE
-      final MutablePage header = database.getTransaction().addPage(new PageId(file.getFileId(), 0), pageSize);
+      final MutablePage header = database.getTransaction().addPage(new PageId(database, file.getFileId(), 0), pageSize);
       updateCounters(header);
     }
   }
@@ -69,7 +71,8 @@ public class Dictionary extends PaginatedComponent {
   /**
    * Called at load time.
    */
-  public Dictionary(final DatabaseInternal database, final String name, final String filePath, final int id, final ComponentFile.MODE mode, final int pageSize,
+  public Dictionary(final DatabaseInternal database, final String name, final String filePath, final int id,
+      final ComponentFile.MODE mode, final int pageSize,
       final int version) throws IOException {
     super(database, name, filePath, id, mode, pageSize, version);
     reload();
@@ -165,9 +168,11 @@ public class Dictionary extends PaginatedComponent {
 
       for (final DocumentType t : database.getSchema().getTypes())
         if (oldName.equals(t.getName()))
-          throw new IllegalArgumentException("Cannot rename the item '" + oldName + "' in the dictionary because it has been used as a type name");
+          throw new IllegalArgumentException(
+              "Cannot rename the item '" + oldName + "' in the dictionary because it has been used as a type name");
 
-      final MutablePage header = database.getTransaction().getPageToModify(new PageId(file.getFileId(), 0), pageSize, false);
+      final MutablePage header = database.getTransaction()
+          .getPageToModify(new PageId(database, file.getFileId(), 0), pageSize, false);
 
       header.clearContent();
       updateCounters(header);
@@ -203,7 +208,7 @@ public class Dictionary extends PaginatedComponent {
 
     final MutablePage header;
     try {
-      header = database.getTransaction().getPageToModify(new PageId(file.getFileId(), 0), pageSize, false);
+      header = database.getTransaction().getPageToModify(new PageId(database, file.getFileId(), 0), pageSize, false);
 
       if (header.getAvailableContentSize() < Binary.SHORT_SERIALIZED_SIZE + property.length)
         throw new DatabaseMetadataException("No space left in dictionary file (items=" + dictionary.size() + ")");
@@ -224,12 +229,12 @@ public class Dictionary extends PaginatedComponent {
     if (file.getSize() == 0) {
       // NEW FILE, CREATE HEADER PAGE
       database.transaction(() -> {
-        final MutablePage header = database.getTransaction().addPage(new PageId(file.getFileId(), 0), pageSize);
+        final MutablePage header = database.getTransaction().addPage(new PageId(database, file.getFileId(), 0), pageSize);
         updateCounters(header);
       });
 
     } else {
-      final BasePage header = database.getTransaction().getPage(new PageId(file.getFileId(), 0), pageSize);
+      final BasePage header = database.getTransaction().getPage(new PageId(database, file.getFileId(), 0), pageSize);
 
       final List<String> newDictionary = new CopyOnWriteArrayList<>();
 

--- a/engine/src/main/java/com/arcadedb/engine/ImmutablePage.java
+++ b/engine/src/main/java/com/arcadedb/engine/ImmutablePage.java
@@ -34,8 +34,8 @@ import java.util.*;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class ImmutablePage extends BasePage {
-  public ImmutablePage(final PageManager manager, final PageId pageId, final int size, final byte[] content, final int version, final int contentSize) {
-    super(manager, pageId, size, content, version, contentSize);
+  public ImmutablePage(final PageId pageId, final int size, final byte[] content, final int version, final int contentSize) {
+    super(pageId, size, content, version, contentSize);
   }
 
   /**
@@ -52,6 +52,6 @@ public class ImmutablePage extends BasePage {
   public MutablePage modify() {
     final byte[] array = this.content.getByteBuffer().array();
     // COPY THE CONTENT, SO CHANGES DOES NOT AFFECT IMMUTABLE COPY
-    return new MutablePage(manager, pageId, size, Arrays.copyOf(array, array.length), version, content.size());
+    return new MutablePage(pageId, size, Arrays.copyOf(array, array.length), version, content.size());
   }
 }

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -150,7 +150,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     }
 
     try {
-      final BasePage page = database.getTransaction().getPage(new PageId(file.getFileId(), pageId), pageSize);
+      final BasePage page = database.getTransaction().getPage(new PageId(database, file.getFileId(), pageId), pageSize);
 
       final short recordCountInPage = page.readShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET);
       if (positionInPage >= recordCountInPage)
@@ -184,7 +184,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
     try {
       for (int pageId = 0; pageId < txPageCount; ++pageId) {
-        final BasePage page = database.getTransaction().getPage(new PageId(file.getFileId(), pageId), pageSize);
+        final BasePage page = database.getTransaction().getPage(new PageId(database, file.getFileId(), pageId), pageSize);
         final short recordCountInPage = page.readShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET);
 
         if (recordCountInPage > 0) {
@@ -254,7 +254,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
       }
     }
 
-    database.getTransaction().getPageToModify(new PageId(file.getFileId(), pageId), pageSize, false);
+    database.getTransaction().getPageToModify(new PageId(database, file.getFileId(), pageId), pageSize, false);
   }
 
   @Override
@@ -297,7 +297,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
     try {
       for (int pageId = 0; pageId < txPageCount; ++pageId) {
-        final BasePage page = transaction.getPage(new PageId(file.getFileId(), pageId), pageSize);
+        final BasePage page = transaction.getPage(new PageId(database, file.getFileId(), pageId), pageSize);
         final short recordCountInPage = page.readShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET);
 
         if (recordCountInPage > 0) {
@@ -350,7 +350,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
     for (int pageId = 0; pageId < totalPages; ++pageId) {
       try {
-        final BasePage page = database.getTransaction().getPage(new PageId(file.getFileId(), pageId), pageSize);
+        final BasePage page = database.getTransaction().getPage(new PageId(database, file.getFileId(), pageId), pageSize);
         final short recordCountInPage = page.readShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET);
 
         int pageActiveRecords = 0;
@@ -519,7 +519,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     }
 
     try {
-      final BasePage page = database.getTransaction().getPage(new PageId(file.getFileId(), pageId), pageSize);
+      final BasePage page = database.getTransaction().getPage(new PageId(database, file.getFileId(), pageId), pageSize);
 
       final short recordCountInPage = page.readShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET);
       if (positionInPage >= recordCountInPage)
@@ -604,7 +604,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
       final MutablePage selectedPage;
       if (createNewPage) {
-        selectedPage = database.getTransaction().addPage(new PageId(file.getFileId(), txPageCounter), pageSize);
+        selectedPage = database.getTransaction().addPage(new PageId(database, file.getFileId(), txPageCounter), pageSize);
         newPosition = contentHeaderSize;
         recordCountInPage = 0;
       } else
@@ -661,7 +661,8 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     }
 
     try {
-      final MutablePage page = database.getTransaction().getPageToModify(new PageId(file.getFileId(), pageId), pageSize, false);
+      final MutablePage page = database.getTransaction()
+          .getPageToModify(new PageId(database, file.getFileId(), pageId), pageSize, false);
       final short recordCountInPage = page.readShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET);
       if (positionInPage >= recordCountInPage)
         throw new RecordNotFoundException("Record " + rid + " not found", rid);
@@ -828,7 +829,8 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     }
 
     try {
-      final MutablePage page = database.getTransaction().getPageToModify(new PageId(file.getFileId(), pageId), pageSize, false);
+      final MutablePage page = database.getTransaction()
+          .getPageToModify(new PageId(database, file.getFileId(), pageId), pageSize, false);
       final short recordCountInPage = page.readShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET);
       if (positionInPage >= recordCountInPage)
         throw new RecordNotFoundException("Record " + rid + " not found", rid);
@@ -865,7 +867,8 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
             final int chunkPageId = (int) (nextChunkPointer / maxRecordsInPage);
             final int chunkPositionInPage = (int) (nextChunkPointer % maxRecordsInPage);
 
-            chunkPage = database.getTransaction().getPageToModify(new PageId(file.getFileId(), chunkPageId), pageSize, false);
+            chunkPage = database.getTransaction()
+                .getPageToModify(new PageId(database, file.getFileId(), chunkPageId), pageSize, false);
             chunkRecordPositionInPage = getRecordPositionInPage(chunkPage, chunkPositionInPage);
             recordSize = chunkPage.readNumberAndSize(chunkRecordPositionInPage);
 
@@ -943,7 +946,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
       final int chunkPageId = (int) (nextChunkPointer / maxRecordsInPage);
       final int chunkPositionInPage = (int) (nextChunkPointer % maxRecordsInPage);
 
-      page = database.getTransaction().getPage(new PageId(file.getFileId(), chunkPageId), pageSize);
+      page = database.getTransaction().getPage(new PageId(database, file.getFileId(), chunkPageId), pageSize);
       recordPositionInPage = getRecordPositionInPage(page, chunkPositionInPage);
       recordSize = page.readNumberAndSize(recordPositionInPage);
 
@@ -1010,7 +1013,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
       if (nextPage == null) {
         // CREATE A NEW PAGE
-        nextPage = database.getTransaction().addPage(new PageId(file.getFileId(), txPageCounter++), pageSize);
+        nextPage = database.getTransaction().addPage(new PageId(database, file.getFileId(), txPageCounter++), pageSize);
         newPosition = contentHeaderSize;
         nextPage.writeUnsignedInt(PAGE_RECORD_TABLE_OFFSET, newPosition);
         nextPage.writeShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET, (short) 1);
@@ -1090,7 +1093,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         final int chunkPageId = (int) (nextChunkPointer / maxRecordsInPage);
         final int chunkPositionInPage = (int) (nextChunkPointer % maxRecordsInPage);
 
-        nextPage = database.getTransaction().getPageToModify(new PageId(file.getFileId(), chunkPageId), pageSize, false);
+        nextPage = database.getTransaction().getPageToModify(new PageId(database, file.getFileId(), chunkPageId), pageSize, false);
         final int recordPositionInPage = getRecordPositionInPage(nextPage, chunkPositionInPage);
         final long[] recordSize = nextPage.readNumberAndSize(recordPositionInPage);
 
@@ -1120,7 +1123,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
         if (nextPage == null) {
           // CREATE A NEW PAGE
-          nextPage = database.getTransaction().addPage(new PageId(file.getFileId(), txPageCounter++), pageSize);
+          nextPage = database.getTransaction().addPage(new PageId(database, file.getFileId(), txPageCounter++), pageSize);
           newPosition = contentHeaderSize;
           nextPage.writeUnsignedInt(PAGE_RECORD_TABLE_OFFSET, newPosition);
           nextPage.writeShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET, (short) 1);
@@ -1166,7 +1169,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
       throws IOException {
     final AvailableSpace result = new AvailableSpace();
 
-    result.page = database.getTransaction().getPage(new PageId(file.getFileId(), pageNumber), pageSize);
+    result.page = database.getTransaction().getPage(new PageId(database, file.getFileId(), pageNumber), pageSize);
 
     result.recordCountInPage = result.page.readShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET);
     if (result.recordCountInPage >= maxRecordsInPage)

--- a/engine/src/main/java/com/arcadedb/engine/MutablePage.java
+++ b/engine/src/main/java/com/arcadedb/engine/MutablePage.java
@@ -37,14 +37,14 @@ public class MutablePage extends BasePage implements TrackableContent {
   private int     modifiedRangeTo   = -1;
   private WALFile walFile;
 
-  public MutablePage(final PageManager manager, final PageId pageId, final int size) {
-    this(manager, pageId, size, new byte[size], 0, 0);
+  public MutablePage(final PageId pageId, final int size) {
+    this(pageId, size, new byte[size], 0, 0);
     updateModifiedRange(0, size - 1);
   }
 
-  public MutablePage(final PageManager manager, final PageId pageId, final int size, final byte[] array, final int version,
+  public MutablePage(final PageId pageId, final int size, final byte[] array, final int version,
       final int contentSize) {
-    super(manager, pageId, size, array, version, contentSize);
+    super(pageId, size, array, version, contentSize);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/engine/PageId.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageId.java
@@ -18,16 +18,28 @@
  */
 package com.arcadedb.engine;
 
+import com.arcadedb.database.BasicDatabase;
+
+import java.util.*;
+
 /**
  * Immutable.
  */
 public class PageId implements Comparable<PageId> {
-  private final int fileId;
-  private final int pageNumber;
+  private final BasicDatabase database;
+  private final int           fileId;
+  private final int           pageNumber;
 
-  public PageId(final int fileId, final int pageNumber) {
+  public PageId(final BasicDatabase database, final int fileId, final int pageNumber) {
+    if (database == null)
+      throw new IllegalArgumentException("database is null");
+    this.database = database;
     this.fileId = fileId;
     this.pageNumber = pageNumber;
+  }
+
+  public BasicDatabase getDatabase() {
+    return database;
   }
 
   public int getFileId() {
@@ -39,35 +51,32 @@ public class PageId implements Comparable<PageId> {
   }
 
   @Override
-  public boolean equals(final Object o) {
-    if (this == o)
+  public boolean equals(final Object value) {
+    if (this == value)
       return true;
-    if (o == null || getClass() != o.getClass())
+    if (!(value instanceof PageId pageId))
       return false;
-
-    final PageId pageId = (PageId) o;
-
-    if (fileId != pageId.fileId)
-      return false;
-    return pageNumber == pageId.pageNumber;
+    return fileId == pageId.fileId && pageNumber == pageId.pageNumber && Objects.equals(database, pageId.database);
   }
 
   @Override
   public int hashCode() {
-    int result = fileId;
-    result = 31 * result + pageNumber;
-    return result;
+    return Objects.hash(database, fileId, pageNumber);
   }
 
   @Override
   public String toString() {
-    return "PageId(" + fileId + "/" + pageNumber + ")";
+    return "PageId(" + database.getName() + "/" + fileId + "/" + pageNumber + ")";
   }
 
   @Override
   public int compareTo(final PageId o) {
     if (o == this)
       return 0;
+
+    final int cmp = database.getName().compareTo(o.database.getName());
+    if (cmp != 0)
+      return cmp;
 
     if (fileId > o.fileId)
       return 1;

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -83,7 +83,7 @@ public class PageManager extends LockContext {
 
   private PageManager() {
     configure();
-    Runtime.getRuntime().addShutdownHook(new Thread(() -> close()));
+    Runtime.getRuntime().addShutdownHook(new Thread(this::close));
   }
 
   public void configure() {
@@ -123,9 +123,14 @@ public class PageManager extends LockContext {
     }
   }
 
-  public void flushAllPagesOfDatabase(final Database database) {
+  public void flushModifiedPagesOfDatabase(final Database database) {
     if (flushThread != null)
-      flushThread.flushAllPagesOfDatabase(database);
+      flushThread.flushModifiedPagesOfDatabase(database);
+  }
+
+  public void removeModifiedPagesOfDatabase(final Database database) {
+    if (flushThread != null)
+      flushThread.removeAllPagesOfDatabase(database);
   }
 
   public void suspendFlushAndExecute(final Database database, final CallableNoReturn callback)

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -20,6 +20,8 @@ package com.arcadedb.engine;
 
 import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.exception.ConfigurationException;
 import com.arcadedb.exception.DatabaseMetadataException;
@@ -39,14 +41,13 @@ import java.util.logging.*;
  * Manages pages from disk to RAM. Each page can have different size.
  */
 public class PageManager extends LockContext {
-  private final    FileManager                       fileManager;
+  public static final PageManager INSTANCE = new PageManager();
+
   private final    ConcurrentMap<PageId, CachedPage> readCache;
-  private final    TransactionManager                txManager;
   // MANAGE CONCURRENT ACCESS TO THE PAGES. THE VALUE IS TRUE FOR WRITE OPERATION AND FALSE FOR READ
   private final    ConcurrentMap<PageId, Boolean>    pendingFlushPages                     = new ConcurrentHashMap<>();
   private final    long                              maxRAM;
   private final    AtomicLong                        totalReadCacheRAM                     = new AtomicLong();
-  private final    AtomicLong                        totalWriteCacheRAM                    = new AtomicLong();
   private final    AtomicLong                        totalPagesRead                        = new AtomicLong();
   private final    AtomicLong                        totalPagesReadSize                    = new AtomicLong();
   private final    AtomicLong                        totalPagesWritten                     = new AtomicLong();
@@ -67,7 +68,6 @@ public class PageManager extends LockContext {
   public static class PPageManagerStats {
     public long maxRAM;
     public long readCacheRAM;
-    public long writeCacheRAM;
     public long pagesRead;
     public long pagesReadSize;
     public long pagesWritten;
@@ -81,10 +81,8 @@ public class PageManager extends LockContext {
     public int  readCachePages;
   }
 
-  public PageManager(final FileManager fileManager, final TransactionManager txManager, final ContextConfiguration configuration,
-      final String databaseName) {
-    this.fileManager = fileManager;
-    this.txManager = txManager;
+  private PageManager() {
+    final ContextConfiguration configuration = new ContextConfiguration();
 
     this.freePageRAM = configuration.getValueAsInteger(GlobalConfiguration.FREE_PAGE_RAM);
     this.readCache = new ConcurrentHashMap<>(configuration.getValueAsInteger(GlobalConfiguration.INITIAL_PAGE_CACHE_SIZE));
@@ -93,8 +91,10 @@ public class PageManager extends LockContext {
     if (maxRAM < 0)
       throw new ConfigurationException(GlobalConfiguration.MAX_PAGE_RAM.getKey() + " configuration is invalid (" + maxRAM + " MB)");
 
-    flushThread = new PageManagerFlushThread(this, configuration, databaseName);
+    flushThread = new PageManagerFlushThread(this, configuration);
     flushThread.start();
+
+    Runtime.getRuntime().addShutdownHook(new Thread(() -> close()));
   }
 
   public void close() {
@@ -105,53 +105,55 @@ public class PageManager extends LockContext {
         Thread.currentThread().interrupt();
       }
     }
-
-    readCache.clear();
-    totalReadCacheRAM.set(0);
-    totalWriteCacheRAM.set(0);
   }
 
-  public void suspendFlushAndExecute(final CallableNoReturn callback) throws IOException, InterruptedException {
-    flushThread.flushPagesFromQueueToDisk(0L);
-    flushThread.setSuspended(true);
-    try {
-      CodeUtils.executeIgnoringExceptions(callback, "Error during suspend flush", true);
-    } finally {
-      flushThread.setSuspended(false);
+  public void removeAllPagesOfDatabase(final Database database) {
+    for (final Iterator<CachedPage> it = readCache.values().iterator(); it.hasNext(); ) {
+      final CachedPage p = it.next();
+      final PageId pageId = p.getPageId();
+      if (pageId.getDatabase().equals(database)) {
+        totalReadCacheRAM.addAndGet(-1L * p.getPhysicalSize());
+        it.remove();
+      }
     }
   }
 
-  public boolean isPageFlushingSuspended() {
-    return flushThread.isSuspended();
+  public void flushAllPagesOfDatabase(final Database database) {
+    if (flushThread != null)
+      flushThread.flushAllPagesOfDatabase(database);
+    removeAllPagesOfDatabase(database);
+  }
+
+  public void suspendFlushAndExecute(final Database database, final CallableNoReturn callback)
+      throws IOException, InterruptedException {
+    if (flushThread.setSuspended(database, true)) {
+      flushThread.flushPagesFromQueueToDisk(database, 0L);
+      try {
+        CodeUtils.executeIgnoringExceptions(callback, "Error during suspend flush", true);
+      } finally {
+        flushThread.setSuspended(database, false);
+      }
+    }
+  }
+
+  public boolean isPageFlushingSuspended(final Database database) {
+    return flushThread.isSuspended(database);
   }
 
   /**
    * Test only API.
    */
-  public void kill() {
-    if (flushThread != null) {
-      try {
-        flushThread.interrupt();
-        flushThread.closeAndJoin();
-      } catch (final InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
-    }
-
-    readCache.clear();
-    totalReadCacheRAM.set(0);
-    totalWriteCacheRAM.set(0);
+  public void simulateKillOfDatabase(final Database database) {
+    removeAllPagesOfDatabase(database);
+    if (flushThread != null)
+      flushThread.removeAllPagesOfDatabase(database);
   }
 
-  public void clear() {
-    readCache.clear();
-    totalReadCacheRAM.set(0);
-  }
-
-  public void deleteFile(final int fileId) {
+  public void deleteFile(final Database database, final int fileId) {
     for (final Iterator<CachedPage> it = readCache.values().iterator(); it.hasNext(); ) {
       final CachedPage p = it.next();
-      if (p.getPageId().getFileId() == fileId) {
+      final PageId pageId = p.getPageId();
+      if (pageId.getDatabase().equals(database) && pageId.getFileId() == fileId) {
         totalReadCacheRAM.addAndGet(-1L * p.getPhysicalSize());
         it.remove();
       }
@@ -190,6 +192,8 @@ public class PageManager extends LockContext {
 
   public void checkPageVersion(final MutablePage page, final boolean isNew) throws IOException {
     final PageId pageId = page.getPageId();
+
+    final FileManager fileManager = ((DatabaseInternal) pageId.getDatabase()).getFileManager();
 
     if (!fileManager.existsFile(pageId.getFileId()))
       throw new ConcurrentModificationException(
@@ -234,6 +238,8 @@ public class PageManager extends LockContext {
     final int mostRecentPageVersion = getMostRecentVersionOfPage(pageId, page.getPhysicalSize());
     if (mostRecentPageVersion != page.getVersion()) {
       totalConcurrentModificationExceptions.incrementAndGet();
+
+      final FileManager fileManager = ((DatabaseInternal) pageId.getDatabase()).getFileManager();
       throw new ConcurrentModificationException(
           "Concurrent modification on page " + pageId + " in file '" + fileManager.getFile(pageId.getFileId()).getFileName()
               + "' (current v." + page.getVersion() + " <> database v." + mostRecentPageVersion
@@ -263,7 +269,6 @@ public class PageManager extends LockContext {
     final PPageManagerStats stats = new PPageManagerStats();
     stats.maxRAM = maxRAM;
     stats.readCacheRAM = totalReadCacheRAM.get();
-    stats.writeCacheRAM = totalWriteCacheRAM.get();
     stats.readCachePages = readCache.size();
     stats.pagesRead = totalPagesRead.get();
     stats.pagesReadSize = totalPagesReadSize.get();
@@ -303,6 +308,14 @@ public class PageManager extends LockContext {
   }
 
   protected void flushPage(final MutablePage page) throws IOException {
+    final DatabaseInternal database = (DatabaseInternal) page.getPageId().getDatabase();
+
+    if (!database.isOpen()) {
+      LogManager.instance().log(this, Level.SEVERE, "Cannot flush page %s because the database is closed", page);
+      return;
+    }
+
+    final FileManager fileManager = database.getFileManager();
     if (fileManager.existsFile(page.pageId.getFileId())) {
       final PaginatedComponentFile file = (PaginatedComponentFile) fileManager.getFile(page.pageId.getFileId());
       if (!file.isOpen())
@@ -319,7 +332,7 @@ public class PageManager extends LockContext {
 
       totalPagesWritten.incrementAndGet();
 
-      txManager.notifyPageFlushed(page);
+      database.getTransactionManager().notifyPageFlushed(page);
 
     } else
       LogManager.instance()
@@ -329,10 +342,12 @@ public class PageManager extends LockContext {
 
   private CachedPage loadPage(final PageId pageId, final int size, final boolean createIfNotExists, final boolean cache)
       throws IOException {
+    final DatabaseInternal database = (DatabaseInternal) pageId.getDatabase();
+
     // ASSURE THE PAGE IS NOT IN THE FLUSHING QUEUE
     CachedPage page = flushThread.getCachedPageFromMutablePageInQueue(pageId);
     if (page == null) {
-      final PaginatedComponentFile file = (PaginatedComponentFile) fileManager.getFile(pageId.getFileId());
+      final PaginatedComponentFile file = (PaginatedComponentFile) database.getFileManager().getFile(pageId.getFileId());
 
       final boolean isNewPage = pageId.getPageNumber() >= file.getTotalPages();
       if (!createIfNotExists && isNewPage)

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -82,7 +82,6 @@ public class PageManager extends LockContext {
   }
 
   private PageManager() {
-    configure();
     Runtime.getRuntime().addShutdownHook(new Thread(this::close));
   }
 
@@ -106,10 +105,14 @@ public class PageManager extends LockContext {
     if (flushThread != null) {
       try {
         flushThread.closeAndJoin();
+        flushThread = null;
       } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();
       }
     }
+
+    readCache.clear();
+    totalReadCacheRAM.set(0L);
   }
 
   public void removeAllReadPagesOfDatabase(final Database database) {
@@ -125,7 +128,7 @@ public class PageManager extends LockContext {
 
   public void flushModifiedPagesOfDatabase(final Database database) {
     if (flushThread != null)
-      flushThread.flushModifiedPagesOfDatabase(database);
+      flushThread.flushAllPagesOfDatabase(database);
   }
 
   public void removeModifiedPagesOfDatabase(final Database database) {

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -284,7 +284,7 @@ public class TransactionManager {
     for (final WALFile.WALPage txPage : tx.pages) {
       final PaginatedComponentFile file;
 
-      final PageId pageId = new PageId(txPage.fileId, txPage.pageNumber);
+      final PageId pageId = new PageId(database, txPage.fileId, txPage.pageNumber);
 
       if (!database.getFileManager().existsFile(txPage.fileId)) {
         LogManager.instance()

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -247,7 +247,7 @@ public class TransactionManager {
           }
         }
         createWALFilePool();
-        database.getPageManager().removeAllPagesOfDatabase(database);
+        database.getPageManager().removeAllReadPagesOfDatabase(database);
       }
     } finally {
       LogManager.instance().log(this, Level.WARNING, "Recovery of database '%s' completed", null, database);

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -247,7 +247,7 @@ public class TransactionManager {
           }
         }
         createWALFilePool();
-        database.getPageManager().clear();
+        database.getPageManager().removeAllPagesOfDatabase(database);
       }
     } finally {
       LogManager.instance().log(this, Level.WARNING, "Recovery of database '%s' completed", null, database);

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
@@ -547,9 +547,9 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
 
         for (int i = 0; i < mutable.getTotalPages() - startingFromPage; ++i) {
           final BasePage currentPage = database.getTransaction()
-              .getPage(new PageId(mutable.getFileId(), i + startingFromPage), pageSize);
+              .getPage(new PageId(database, mutable.getFileId(), i + startingFromPage), pageSize);
 
-// COPY THE ENTIRE PAGE TO THE NEW INDEX
+          // COPY THE ENTIRE PAGE TO THE NEW INDEX
           final MutablePage newPage = newMutableIndex.createNewPage();
 
           final ByteBuffer pageContent = currentPage.getContent();

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
@@ -128,7 +128,7 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
 
   public boolean scheduleCompaction() {
     checkIsValid();
-    if (getDatabase().getPageManager().isPageFlushingSuspended())
+    if (getDatabase().getPageManager().isPageFlushingSuspended(getDatabase()))
       return false;
     return status.compareAndSet(INDEX_STATUS.AVAILABLE, INDEX_STATUS.COMPACTION_SCHEDULED);
   }
@@ -216,10 +216,12 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
   @Override
   public boolean compact() throws IOException, InterruptedException {
     checkIsValid();
-    if (getDatabase().getMode() == ComponentFile.MODE.READ_ONLY)
+    final DatabaseInternal database = getDatabase();
+
+    if (database.getMode() == ComponentFile.MODE.READ_ONLY)
       throw new DatabaseIsReadOnlyException("Cannot update the index '" + getName() + "'");
 
-    if (getDatabase().getPageManager().isPageFlushingSuspended())
+    if (database.getPageManager().isPageFlushingSuspended(database))
       // POSTPONE COMPACTING (DATABASE BACKUP IN PROGRESS?)
       return false;
 

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
@@ -203,7 +203,7 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
 
   public void drop() throws IOException {
     if (database.isOpen()) {
-      database.getPageManager().deleteFile(file.getFileId());
+      database.getPageManager().deleteFile(database, file.getFileId());
       database.getFileManager().dropFile(file.getFileId());
       database.getSchema().getEmbedded().removeFile(file.getFileId());
     } else {

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
@@ -173,8 +173,7 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
     // NEW FILE, CREATE HEADER PAGE
     final int txPageCounter = getTotalPages();
 
-    final MutablePage currentPage = new MutablePage(database.getPageManager(), new PageId(database, getFileId(), txPageCounter),
-        pageSize);
+    final MutablePage currentPage = new MutablePage(new PageId(database, getFileId(), txPageCounter), pageSize);
 
     int pos = 0;
     currentPage.writeInt(pos, currentPage.getMaxContentSize());

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCursor.java
@@ -19,6 +19,7 @@
 package com.arcadedb.index.lsm;
 
 import com.arcadedb.database.Binary;
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.TransactionContext;
@@ -76,7 +77,8 @@ public class LSMTreeIndexCursor implements IndexCursor {
     this.serializedToKeys = index.convertKeys(this.toKeys, binaryKeyTypes);
     this.toKeysInclusive = endKeysInclusive;
 
-    final BinarySerializer serializer = index.getDatabase().getSerializer();
+    final DatabaseInternal database = index.getDatabase();
+    final BinarySerializer serializer = database.getSerializer();
     this.comparator = serializer.getComparator();
 
     final LSMTreeIndexCompacted compacted = index.getSubIndex();
@@ -118,8 +120,8 @@ public class LSMTreeIndexCursor implements IndexCursor {
 
       if (serializedFromKeys != null) {
         // SEEK FOR THE FROM RANGE
-        final BasePage currentPage = index.getDatabase().getTransaction()
-            .getPage(new PageId(index.getFileId(), pageId), index.getPageSize());
+        final BasePage currentPage = database.getTransaction()
+            .getPage(new PageId(database, index.getFileId(), pageId), index.getPageSize());
         final Binary currentPageBuffer = new Binary(currentPage.slice());
         final int count = index.getCount(currentPage);
 
@@ -149,8 +151,8 @@ public class LSMTreeIndexCursor implements IndexCursor {
         if (ascendingOrder) {
           pageCursors[cursorIdx] = index.newPageIterator(pageId, -1, true);
         } else {
-          final BasePage currentPage = index.getDatabase().getTransaction()
-              .getPage(new PageId(index.getFileId(), pageId), index.getPageSize());
+          final BasePage currentPage = database.getTransaction()
+              .getPage(new PageId(database, index.getFileId(), pageId), index.getPageSize());
           pageCursors[cursorIdx] = index.newPageIterator(pageId, index.getCount(currentPage), false);
         }
 

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexDebugger.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexDebugger.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.index.lsm;
 
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.engine.BasePage;
 import com.arcadedb.engine.ImmutablePage;
 import com.arcadedb.engine.PageId;
@@ -41,10 +42,12 @@ public class LSMTreeIndexDebugger {
     final int totalPages = index.getTotalPages();
 
     int lastImmutablePage = totalPages - 1;
+    final DatabaseInternal database = index.getDatabase();
     for (int pageIndex = totalPages - 1; pageIndex > -1; --pageIndex) {
       final BasePage page;
       try {
-        page = index.getDatabase().getPageManager().getImmutablePage(new PageId(index.getFileId(), pageIndex), index.getPageSize(), false, true);
+        page = database.getPageManager()
+            .getImmutablePage(new PageId(database, index.getFileId(), pageIndex), index.getPageSize(), false, true);
         if (!index.isMutable(page)) {
           lastImmutablePage = pageIndex;
           break;
@@ -54,11 +57,13 @@ public class LSMTreeIndexDebugger {
       }
     }
 
-    out(0, "MUTABLE INDEX " + index.getName() + " fileId=" + index.getFileId() + " lastImmutablePage = " + lastImmutablePage + "/" + totalPages);
+    out(0, "MUTABLE INDEX " + index.getName() + " fileId=" + index.getFileId() + " lastImmutablePage = " + lastImmutablePage + "/"
+        + totalPages);
     for (int pageIndex = 0; pageIndex < totalPages; ++pageIndex) {
       final BasePage page;
       try {
-        page = index.getDatabase().getPageManager().getImmutablePage(new PageId(index.getFileId(), pageIndex), index.getPageSize(), false, true);
+        page = database.getPageManager()
+            .getImmutablePage(new PageId(database, index.getFileId(), pageIndex), index.getPageSize(), false, true);
         LSMTreeIndexDebugger.out(1, LSMTreeIndexDebugger.printMutableIndexPage(index, page));
       } catch (IOException e) {
         throw new RuntimeException(e);
@@ -75,10 +80,12 @@ public class LSMTreeIndexDebugger {
     final int totalPages = index.getTotalPages();
 
     int lastImmutablePage = totalPages - 1;
+    final DatabaseInternal database = index.getDatabase();
     for (int pageIndex = totalPages - 1; pageIndex > -1; --pageIndex) {
       final ImmutablePage page;
       try {
-        page = index.getDatabase().getPageManager().getImmutablePage(new PageId(index.getFileId(), pageIndex), index.getPageSize(), false, true);
+        page = database.getPageManager()
+            .getImmutablePage(new PageId(database, index.getFileId(), pageIndex), index.getPageSize(), false, true);
         if (!index.isMutable(page)) {
           lastImmutablePage = pageIndex;
           break;
@@ -88,11 +95,13 @@ public class LSMTreeIndexDebugger {
       }
     }
 
-    out(0, "COMPACTED INDEX " + index.getName() + " fileId=" + index.getFileId() + " lastImmutablePage=" + lastImmutablePage + "/" + totalPages);
+    out(0, "COMPACTED INDEX " + index.getName() + " fileId=" + index.getFileId() + " lastImmutablePage=" + lastImmutablePage + "/"
+        + totalPages);
     for (int pageIndex = 0; pageIndex < totalPages; ++pageIndex) {
       final ImmutablePage page;
       try {
-        page = index.getDatabase().getPageManager().getImmutablePage(new PageId(index.getFileId(), pageIndex), index.getPageSize(), false, true);
+        page = database.getPageManager()
+            .getImmutablePage(new PageId(database, index.getFileId(), pageIndex), index.getPageSize(), false, true);
         LSMTreeIndexDebugger.out(1, LSMTreeIndexDebugger.printMutableIndexPage(index, page));
       } catch (IOException e) {
         throw new RuntimeException(e);
@@ -103,7 +112,8 @@ public class LSMTreeIndexDebugger {
   public static String printMutableIndexPage(final LSMTreeIndexAbstract index, final BasePage page) {
     String buffer = "";
     buffer +=
-        "MUTABLE INDEX - PAGE " + page.getPageId() + " v" + page.getVersion() + " mutable=" + index.isMutable(page) + " size=" + page.getPhysicalSize() + " "
+        "MUTABLE INDEX - PAGE " + page.getPageId() + " v" + page.getVersion() + " mutable=" + index.isMutable(page) + " size="
+            + page.getPhysicalSize() + " "
             + Arrays.toString(index.getKeyTypes());
     final Object[] pageKeyRange = index.getPageKeyRange(page);
     final int headerSize = index.getHeaderSize(page.getPageId().getPageNumber());
@@ -111,7 +121,8 @@ public class LSMTreeIndexDebugger {
     int availableSpace = index.getValuesFreePosition(page) - (headerSize + (totalEntries * INT_SERIALIZED_SIZE));
 
     buffer +=
-        " Keys: " + totalEntries + Arrays.toString((Object[]) pageKeyRange[0]) + "-" + Arrays.toString((Object[]) pageKeyRange[1]) + " - header: " + headerSize
+        " Keys: " + totalEntries + Arrays.toString((Object[]) pageKeyRange[0]) + "-" + Arrays.toString((Object[]) pageKeyRange[1])
+            + " - header: " + headerSize
             + " - availableSpace: " + availableSpace;
     return buffer;
   }

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
@@ -103,7 +103,7 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
   public void onAfterLoad() {
     // RELOAD THE PAGE. THIS CAN BE CALLED AT CREATION OF THE OBJECT (CONSTRUCTOR) OR IN A TX WHEN DATABASE STRUCTURE CHANGES
     try {
-      final BasePage currentPage = this.database.getTransaction().getPage(new PageId(file.getFileId(), 0), pageSize);
+      final BasePage currentPage = this.database.getTransaction().getPage(new PageId(database, file.getFileId(), 0), pageSize);
 
       int pos = INT_SERIALIZED_SIZE + INT_SERIALIZED_SIZE + BYTE_SERIALIZED_SIZE + INT_SERIALIZED_SIZE;
 
@@ -203,7 +203,7 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
 
   public LSMTreeIndexUnderlyingPageCursor newPageIterator(final int pageId, final int currentEntryInPage,
       final boolean ascendingOrder) throws IOException {
-    final BasePage page = database.getTransaction().getPage(new PageId(file.getFileId(), pageId), pageSize);
+    final BasePage page = database.getTransaction().getPage(new PageId(database, file.getFileId(), pageId), pageSize);
     return new LSMTreeIndexUnderlyingPageCursor(this, page, currentEntryInPage, getHeaderSize(pageId), binaryKeyTypes,
         getCount(page), ascendingOrder);
   }
@@ -366,10 +366,10 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
     // NEW FILE, CREATE HEADER PAGE
     final int txPageCounter = getTotalPages();
 
-    final PageId pageId = new PageId(file.getFileId(), txPageCounter);
+    final PageId pageId = new PageId(database, file.getFileId(), txPageCounter);
     final MutablePage currentPage = database.isTransactionActive() ?
         database.getTransaction().addPage(pageId, pageSize) :
-        new MutablePage(database.getPageManager(), new PageId(getFileId(), txPageCounter), pageSize);
+        new MutablePage(database.getPageManager(), new PageId(database, getFileId(), txPageCounter), pageSize);
 
     int pos = 0;
     currentPage.writeInt(pos, currentPage.getMaxContentSize());
@@ -404,7 +404,7 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
     final int totalPages = getTotalPages();
 
     for (int p = totalPages - 1; p > -1; --p) {
-      final BasePage currentPage = database.getTransaction().getPage(new PageId(file.getFileId(), p), pageSize);
+      final BasePage currentPage = database.getTransaction().getPage(new PageId(database, file.getFileId(), p), pageSize);
       final Binary currentPageBuffer = new Binary(currentPage.slice());
       final int count = getCount(currentPage);
 
@@ -447,7 +447,8 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
     int pageNum = txPageCounter - 1;
 
     try {
-      MutablePage currentPage = database.getTransaction().getPageToModify(new PageId(file.getFileId(), pageNum), pageSize, false);
+      MutablePage currentPage = database.getTransaction()
+          .getPageToModify(new PageId(database, file.getFileId(), pageNum), pageSize, false);
 
       TrackableBinary currentPageBuffer = currentPage.getTrackable();
 
@@ -539,7 +540,8 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
     int pageNum = txPageCounter - 1;
 
     try {
-      MutablePage currentPage = database.getTransaction().getPageToModify(new PageId(file.getFileId(), pageNum), pageSize, false);
+      MutablePage currentPage = database.getTransaction()
+          .getPageToModify(new PageId(database, file.getFileId(), pageNum), pageSize, false);
 
       assert isMutable(currentPage);
 

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
@@ -369,7 +369,7 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
     final PageId pageId = new PageId(database, file.getFileId(), txPageCounter);
     final MutablePage currentPage = database.isTransactionActive() ?
         database.getTransaction().addPage(pageId, pageSize) :
-        new MutablePage(database.getPageManager(), new PageId(database, getFileId(), txPageCounter), pageSize);
+        new MutablePage(new PageId(database, getFileId(), txPageCounter), pageSize);
 
     int pos = 0;
     currentPage.writeInt(pos, currentPage.getMaxContentSize());

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexUnderlyingCompactedSeriesCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexUnderlyingCompactedSeriesCursor.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.index.lsm;
 
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
 import com.arcadedb.engine.BasePage;
 import com.arcadedb.engine.PageId;
@@ -29,7 +30,8 @@ public class LSMTreeIndexUnderlyingCompactedSeriesCursor extends LSMTreeIndexUnd
   private final int                              lastPageNumber;
   private       LSMTreeIndexUnderlyingPageCursor pageCursor;
 
-  public LSMTreeIndexUnderlyingCompactedSeriesCursor(final LSMTreeIndexCompacted index, final int firstPageNumber, final int lastPageNumber,
+  public LSMTreeIndexUnderlyingCompactedSeriesCursor(final LSMTreeIndexCompacted index, final int firstPageNumber,
+      final int lastPageNumber,
       final byte[] keyTypes, final boolean ascendingOrder, final int posInPage) {
     super(index, keyTypes, keyTypes.length, ascendingOrder);
     this.lastPageNumber = lastPageNumber;
@@ -58,7 +60,9 @@ public class LSMTreeIndexUnderlyingCompactedSeriesCursor extends LSMTreeIndexUnd
         currentPageNumber <= lastPageNumber :
         currentPageNumber >= lastPageNumber; currentPageNumber += ascendingOrder ? 1 : -1) {
       try {
-        final BasePage page = index.getDatabase().getTransaction().getPage(new PageId(index.getFileId(), currentPageNumber), index.getPageSize());
+        final DatabaseInternal database = index.getDatabase();
+        final BasePage page = database.getTransaction()
+            .getPage(new PageId(database, index.getFileId(), currentPageNumber), index.getPageSize());
         final int count = index.getCount(page);
 
         pageCursor = new LSMTreeIndexUnderlyingPageCursor(index, page, posInPage == -1 ? ascendingOrder ? -1 : count : posInPage,

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -741,7 +741,7 @@ public class LocalSchema implements Schema {
                   + "'. Remove the association first");
       }
 
-      database.getPageManager().deleteFile(bucket.getFileId());
+      database.getPageManager().deleteFile(database, bucket.getFileId());
       try {
         database.getFileManager().dropFile(bucket.getFileId());
       } catch (final IOException e) {

--- a/engine/src/test/java/com/arcadedb/LargeRecordsTest.java
+++ b/engine/src/test/java/com/arcadedb/LargeRecordsTest.java
@@ -21,8 +21,6 @@ package com.arcadedb;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.engine.LocalBucket;
 import com.arcadedb.schema.DocumentType;
-
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.*;
@@ -66,7 +64,7 @@ public class LargeRecordsTest extends TestHelper {
     database.transaction(() -> {
       final DocumentType type = database.getSchema().getOrCreateDocumentType("BigRecords");
 
-      final long pageOverSize = ((LocalBucket) type.getBuckets(true).get(0)).getPageSize() * 3;
+      final long pageOverSize = ((LocalBucket) type.getBuckets(true).get(0)).getPageSize() * 3L;
 
       final StringBuilder buffer = new StringBuilder();
       for (int k = 0; k < pageOverSize; ++k)

--- a/engine/src/test/java/com/arcadedb/PageManagerStressTest.java
+++ b/engine/src/test/java/com/arcadedb/PageManagerStressTest.java
@@ -39,8 +39,7 @@ public class PageManagerStressTest {
 
   @Test
   public void stressPageManagerFlush() {
-    GlobalConfiguration.PROFILE.setValue("low-ram");
-    PerformanceTest.clean();
+    PerformanceTest.clean("low-ram");
 
     final int parallel = 2;
 

--- a/engine/src/test/java/com/arcadedb/database/CheckDatabaseTest.java
+++ b/engine/src/test/java/com/arcadedb/database/CheckDatabaseTest.java
@@ -31,7 +31,6 @@ import com.arcadedb.graph.VertexInternal;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
-
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -249,7 +248,7 @@ public class CheckDatabaseTest extends TestHelper {
 
       try {
         final MutablePage page = ((DatabaseInternal) database).getTransaction()
-            .getPageToModify(new PageId(bucket.getFileId(), 0), bucket.getPageSize(), false);
+            .getPageToModify(new PageId(database, bucket.getFileId(), 0), bucket.getPageSize(), false);
         for (int i = 0; i < page.getAvailableContentSize(); i++) {
           page.writeByte(i, (byte) 4);
         }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ScriptExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ScriptExecutionTest.java
@@ -2,8 +2,8 @@ package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.Database;
-import com.arcadedb.database.LocalDatabase;
 import com.arcadedb.database.Identifiable;
+import com.arcadedb.database.LocalDatabase;
 import com.arcadedb.engine.ImmutablePage;
 import com.arcadedb.engine.PageId;
 import com.arcadedb.engine.PaginatedComponentFile;
@@ -11,7 +11,6 @@ import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.query.sql.SQLQueryEngine;
 import com.arcadedb.query.sql.function.SQLFunctionAbstract;
-
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -250,7 +249,7 @@ public class ScriptExecutionTest extends TestHelper {
 
     database.async().waitCompletion();
 
-    ImmutablePage page = ((LocalDatabase) database).getPageManager().getImmutablePage(new PageId(2, 0),
+    ImmutablePage page = ((LocalDatabase) database).getPageManager().getImmutablePage(new PageId(database, 2, 0),
         ((PaginatedComponentFile) ((LocalDatabase) database).getFileManager().getFile(2)).getPageSize(), false, false);
 
     assertThat(page.getVersion()).as("Page v." + page.getVersion()).isEqualTo(TOTAL + 1);
@@ -309,7 +308,7 @@ public class ScriptExecutionTest extends TestHelper {
 
     database.async().waitCompletion();
 
-    ImmutablePage page = ((LocalDatabase) database).getPageManager().getImmutablePage(new PageId(2, 0),
+    ImmutablePage page = ((LocalDatabase) database).getPageManager().getImmutablePage(new PageId(database, 2, 0),
         ((PaginatedComponentFile) ((LocalDatabase) database).getFileManager().getFile(2)).getPageSize(), false, false);
 
     assertThat(page.getVersion()).as("Page v." + page.getVersion()).isEqualTo(TOTAL + 1);

--- a/engine/src/test/java/performance/PerformanceTest.java
+++ b/engine/src/test/java/performance/PerformanceTest.java
@@ -33,7 +33,11 @@ public abstract class PerformanceTest {
   }
 
   public static void clean() {
-    GlobalConfiguration.PROFILE.setValue("high-performance");
+    clean("high-performance");
+  }
+
+  public static void clean(final String profile) {
+    GlobalConfiguration.PROFILE.setValue(profile);
 
     LogManager.instance().setLogger(NullLogger.INSTANCE);
 

--- a/server/src/main/java/com/arcadedb/server/ha/ReplicatedDatabase.java
+++ b/server/src/main/java/com/arcadedb/server/ha/ReplicatedDatabase.java
@@ -819,7 +819,7 @@ public class ReplicatedDatabase implements DatabaseInternal {
     // ACQUIRE A READ LOCK. TRANSACTION CAN STILL RUN, BUT CREATION OF NEW FILES (BUCKETS, TYPES, INDEXES) WILL BE PUT ON PAUSE UNTIL THIS LOCK IS RELEASED
     executeInReadLock(() -> {
       // AVOID FLUSHING OF DATA PAGES TO DISK
-      proxied.getPageManager().suspendFlushAndExecute(() -> {
+      proxied.getPageManager().suspendFlushAndExecute(this, () -> {
         final List<ComponentFile> files = proxied.getFileManager().getFiles();
 
         for (final ComponentFile file : files)

--- a/server/src/main/java/com/arcadedb/server/ha/message/DatabaseAlignRequest.java
+++ b/server/src/main/java/com/arcadedb/server/ha/message/DatabaseAlignRequest.java
@@ -92,7 +92,7 @@ public class DatabaseAlignRequest extends HAAbstractCommand {
     // ACQUIRE A READ LOCK. TRANSACTION CAN STILL RUN, BUT CREATION OF NEW FILES (BUCKETS, TYPES, INDEXES) WILL BE PUT ON PAUSE UNTIL THIS LOCK IS RELEASED
     database.executeInReadLock(() -> {
       // AVOID FLUSHING OF DATA PAGES TO DISK
-      database.getPageManager().suspendFlushAndExecute(() -> {
+      database.getPageManager().suspendFlushAndExecute(database, () -> {
 
         for (final Map.Entry<Integer, Long> entry : fileSizes.entrySet()) {
           final Integer fileId = entry.getKey();

--- a/server/src/main/java/com/arcadedb/server/ha/message/DatabaseChangeStructureRequest.java
+++ b/server/src/main/java/com/arcadedb/server/ha/message/DatabaseChangeStructureRequest.java
@@ -127,7 +127,7 @@ public class DatabaseChangeStructureRequest extends HAAbstractCommand {
 
     // REMOVE FILES
     for (final Map.Entry<Integer, String> entry : filesToRemove.entrySet()) {
-      db.getPageManager().deleteFile(entry.getKey());
+      db.getPageManager().deleteFile(db, entry.getKey());
       db.getFileManager().dropFile(entry.getKey());
       db.getSchema().getEmbedded().removeFile(entry.getKey());
     }

--- a/server/src/main/java/com/arcadedb/server/ha/message/FileContentRequest.java
+++ b/server/src/main/java/com/arcadedb/server/ha/message/FileContentRequest.java
@@ -69,13 +69,13 @@ public class FileContentRequest extends HAAbstractCommand {
           toPageInclusive = totalPages - 1;
 
 //        db.getPageManager().suspendFlushAndExecute(() -> {
-          for (int i = fromPageInclusive; i <= toPageInclusive && pages.get() < CHUNK_MAX_PAGES; ++i) {
-            final PageId pageId = new PageId(fileId, i);
-            final ImmutablePage page = db.getPageManager().getImmutablePage(pageId, pageSize, false, false);
-            pagesContent.putByteArray(page.getContent().array(), pageSize);
+        for (int i = fromPageInclusive; i <= toPageInclusive && pages.get() < CHUNK_MAX_PAGES; ++i) {
+          final PageId pageId = new PageId(db, fileId, i);
+          final ImmutablePage page = db.getPageManager().getImmutablePage(pageId, pageSize, false, false);
+          pagesContent.putByteArray(page.getContent().array(), pageSize);
 
-            pages.incrementAndGet();
-          }
+          pages.incrementAndGet();
+        }
 //        });
 
         final boolean last = pages.get() > toPageInclusive;

--- a/server/src/main/java/com/arcadedb/server/ha/message/FileContentResponse.java
+++ b/server/src/main/java/com/arcadedb/server/ha/message/FileContentResponse.java
@@ -100,7 +100,7 @@ public class FileContentResponse extends HAAbstractCommand {
         for (int i = 0; i < totalPages; ++i) {
           final PageId pageId = new PageId(database, file.getFileId(), pageFromInclusive + i);
 
-          final MutablePage page = new MutablePage(pageManager, pageId, pageSize);
+          final MutablePage page = new MutablePage(pageId, pageSize);
           System.arraycopy(pagesContent.getContent(), i * pageSize, page.getTrackable().getContent(), 0, pageSize);
           page.loadMetadata();
           pageManager.overwritePage(page);

--- a/server/src/main/java/com/arcadedb/server/ha/message/FileContentResponse.java
+++ b/server/src/main/java/com/arcadedb/server/ha/message/FileContentResponse.java
@@ -98,7 +98,7 @@ public class FileContentResponse extends HAAbstractCommand {
         }
 
         for (int i = 0; i < totalPages; ++i) {
-          final PageId pageId = new PageId(file.getFileId(), pageFromInclusive + i);
+          final PageId pageId = new PageId(database, file.getFileId(), pageFromInclusive + i);
 
           final MutablePage page = new MutablePage(pageManager, pageId, pageSize);
           System.arraycopy(pagesContent.getContent(), i * pageSize, page.getTrackable().getContent(), 0, pageSize);


### PR DESCRIPTION
Page Manager now is centralized across all the databases. This allows to have only 1 FlushThread per JVM, 1 Map for the ReadCache and 1 setting for all database about RAM. This means having 1,000 database open on a server shouldn't be a problem anymore.