### PR TITLE
#1515 fix date formatting in JSONObject, add tests

### DIFF
--- a/engine/src/main/java/com/arcadedb/serializer/JsonSerializer.java
+++ b/engine/src/main/java/com/arcadedb/serializer/JsonSerializer.java
@@ -26,9 +26,11 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
+import com.google.gson.JsonNull;
 
-import java.lang.reflect.*;
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 public class JsonSerializer {
   private boolean useCollectionSize         = false;
@@ -38,7 +40,9 @@ public class JsonSerializer {
 
   public JSONObject serializeDocument(final Document document) {
     final Database database = document.getDatabase();
-    final JSONObject object = new JSONObject().setDateFormat(database.getSchema().getDateTimeFormat());
+    final JSONObject object = new JSONObject()
+        .setDateFormat(database.getSchema().getDateTimeFormat())
+        .setDateTimeFormat(database.getSchema().getDateTimeFormat());
 
     if (document.getIdentity() != null)
       object.put("@rid", document.getIdentity().toString());
@@ -53,9 +57,9 @@ public class JsonSerializer {
         value = JSONObject.NULL;
       else if (value instanceof Document)
         value = serializeDocument((Document) value);
-      else if (value instanceof Collection) {
+      else if (value instanceof Collection)
         serializeCollection(database, (Collection<?>) value);
-      } else if (value instanceof Map)
+      else if (value instanceof Map)
         value = serializeMap(database, (Map<Object, Object>) value);
 
       value = convertNonNumbers(value);
@@ -69,7 +73,9 @@ public class JsonSerializer {
   }
 
   public JSONObject serializeResult(final Database database, final Result result) {
-    final JSONObject object = new JSONObject().setDateFormat(database.getSchema().getDateTimeFormat());
+    final JSONObject object = new JSONObject()
+        .setDateFormat(database.getSchema().getDateFormat())
+        .setDateTimeFormat(database.getSchema().getDateTimeFormat());
 
     if (result.isElement()) {
       final Document document = result.toElement();
@@ -85,12 +91,12 @@ public class JsonSerializer {
 
       if (value == null)
         value = JSONObject.NULL;
-      else if (value instanceof Document)
-        value = serializeDocument((Document) value);
-      else if (value instanceof Result)
-        value = serializeResult(database, (Result) value);
-      else if (value instanceof Collection)
-        value = serializeCollection(database, (Collection<?>) value);
+      else if (value instanceof Document document)
+        value = serializeDocument(document);
+      else if (value instanceof Result res)
+        value = serializeResult(database, res);
+      else if (value instanceof Collection<?> coll)
+        value = serializeCollection(database, coll);
       else if (value instanceof Map)
         value = serializeMap(database, (Map<Object, Object>) value);
       else if (value.getClass().isArray())
@@ -147,7 +153,9 @@ public class JsonSerializer {
     if (useCollectionSize) {
       result = value.size();
     } else {
-      final JSONObject map = new JSONObject().setDateFormat(database.getSchema().getDateTimeFormat());
+      final JSONObject map = new JSONObject()
+          .setDateFormat(database.getSchema().getDateFormat())
+          .setDateTimeFormat(database.getSchema().getDateTimeFormat());
       for (final Map.Entry<Object, Object> entry : value.entrySet()) {
         Object o = entry.getValue();
         if (o instanceof Document)

--- a/engine/src/main/java/com/arcadedb/serializer/json/JSONFactory.java
+++ b/engine/src/main/java/com/arcadedb/serializer/json/JSONFactory.java
@@ -39,13 +39,11 @@ public class JSONFactory {
   private JSONFactory() {
     gson = new GsonBuilder()//
         .serializeNulls()//
-        //.registerTypeAdapter(Date.class, new DateDeserializer())//
         .create();
 
     gsonPrettyPrint = new GsonBuilder()//
         .serializeNulls()//
         .setPrettyPrinting()//
-        //.registerTypeAdapter(Date.class, new DateDeserializer())
         .create();
   }
 

--- a/server/src/main/java/com/arcadedb/server/ha/HAServer.java
+++ b/server/src/main/java/com/arcadedb/server/ha/HAServer.java
@@ -26,9 +26,9 @@ import com.arcadedb.exception.ConfigurationException;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.exception.TransactionException;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.network.HostUtil;
 import com.arcadedb.network.binary.ChannelBinaryClient;
 import com.arcadedb.network.binary.ConnectionException;
-import com.arcadedb.network.HostUtil;
 import com.arcadedb.network.binary.QuorumNotReachedException;
 import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
 import com.arcadedb.query.sql.executor.InternalResultSet;
@@ -51,12 +51,26 @@ import com.arcadedb.utility.Pair;
 import com.arcadedb.utility.RecordTableFormatter;
 import com.arcadedb.utility.TableFormatter;
 
-import java.io.*;
-import java.net.*;
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.*;
-import java.util.logging.*;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
 
 public class HAServer implements ServerPlugin {
   public static final String                                         DEFAULT_PORT                      = HostUtil.HA_DEFAULT_PORT;
@@ -822,9 +836,11 @@ public class HAServer implements ServerPlugin {
   public JSONObject getStats() {
     final String dateTimeFormat = GlobalConfiguration.DATE_TIME_FORMAT.getValueAsString();
 
-    final JSONObject result = new JSONObject().setDateFormat(dateTimeFormat);
+    final JSONObject result = new JSONObject().setDateTimeFormat(dateTimeFormat)
+        .setDateFormat(GlobalConfiguration.DATE_FORMAT.getValueAsString());
 
-    final JSONObject current = new JSONObject().setDateFormat(dateTimeFormat);
+    final JSONObject current = new JSONObject().setDateTimeFormat(dateTimeFormat)
+        .setDateFormat(GlobalConfiguration.DATE_FORMAT.getValueAsString());
     current.put("name", getServerName());
     current.put("address", getServerAddress());
     current.put("role", isLeader() ? "Leader" : "Replica");

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -207,7 +207,9 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
   protected JSONObject createResult(final SecurityUser user, final Database database) {
     final JSONObject json = new JSONObject();
     if (database != null)
-      json.setDateFormat(database.getSchema().getDateTimeFormat());
+      json.setDateFormat(database.getSchema().getDateFormat())
+          .setDateTimeFormat(database.getSchema().getDateTimeFormat());
+
     json.put("user", user.getName()).put("version", Constants.getVersion())
         .put("serverName", httpServer.getServer().getServerName());
     return json;

--- a/server/src/test/java/com/arcadedb/remote/Issue1515IT.java
+++ b/server/src/test/java/com/arcadedb/remote/Issue1515IT.java
@@ -1,0 +1,48 @@
+package com.arcadedb.remote;
+
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Issue1515IT extends BaseGraphServerTest {
+
+  protected String getDatabaseName() {
+    return "issue1515";
+  }
+
+  @Test
+  void rename_me() {
+    final RemoteDatabase database = new RemoteDatabase("127.0.0.1", 2480, getDatabaseName(), "root",
+        BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
+
+    String script = """
+        alter database `arcadedb.dateImplementation` `java.time.LocalDate`;
+        alter database `arcadedb.dateTimeImplementation` `java.time.LocalDateTime`;
+        alter database `arcadedb.dateFormat` 'dd MM yyyy GG';
+        alter database `arcadedb.dateTimeFormat` 'dd MM yyyy GG HH:mm:ss';
+        create property Person.name if not exists String (mandatory true, notnull true);
+        create index if not exists on Person (name) unique;
+        create property Person.dateOfBirth if not exists Date;
+        create property Person.dateOfDeath if not exists Date;
+        """;
+
+    database.transaction(() ->
+        database.command("sqlscript", script));
+
+    database.transaction(() ->
+        database.command("sql", """
+            insert into Person set name = 'Hannibal',
+            dateOfBirth = date('01 01 0001 BC', 'dd MM yyyy GG'),
+            dateOfDeath = date('01 01 0001 AD', 'dd MM yyyy GG')
+            """));
+
+    ResultSet result = database.query("sql", "select from Person where name = 'Hannibal'");
+    Result doc = result.next();
+    assertThat(doc.<String>getProperty("dateOfBirth")).isEqualTo("01 01 0001 BC");
+    assertThat(doc.<String>getProperty("dateOfDeath")).isEqualTo("01 01 0001 AD");
+
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Add a date formatter for LocalDataTime to JsonObject.
 
## Motivation

The JsonObjet has a single DateTimeFormater dedicated to Date and doen't provide a dedicated formatter for LocalDatetime, but inside the database there are 2 different formatters configurable with properties:

```sql
        alter database `arcadedb.dateImplementation` `java.time.LocalDate`;
        alter database `arcadedb.dateTimeImplementation` `java.time.LocalDateTime`;
        alter database `arcadedb.dateFormat` 'dd MM yyyy GG';
        alter database `arcadedb.dateTimeFormat` 'dd MM yyyy GG HH:mm:ss';
```

## Related issues

#1515 

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
