### PR TITLE
override versions of groovy and netty to solve security issues

### DIFF
--- a/gremlin/pom.xml
+++ b/gremlin/pom.xml
@@ -36,6 +36,9 @@
         <gremlin.version>3.7.3</gremlin.version>
         <translation.version>1.0.4</translation.version>
         <snakeyaml.version>2.3</snakeyaml.version>
+        <netty.version>4.1.117.Final</netty.version>
+        <commons-configuration2.version>2.11.0</commons-configuration2.version>
+        <groovy.version>4.0.24</groovy.version>
     </properties>
 
     <dependencies>
@@ -54,6 +57,21 @@
         </dependency>
 
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
+            <version>${commons-configuration2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>${groovy.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-core</artifactId>
             <version>${gremlin.version}</version>
@@ -68,6 +86,7 @@
             <artifactId>gremlin-driver</artifactId>
             <version>${gremlin.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-util</artifactId>


### PR DESCRIPTION
## What does this PR do?

Overrides the provided versions of groovy, commons-config  and netty to solve security issues

## Motivation

to resolve security issues highlighted by Meterian


## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
