### PR TITLE
#1956 fix PGSQL when used with JS/npm pg driver

### DIFF
--- a/e2e/src/test/java/com/arcadedb/e2e/JdbcQueriesTest.java
+++ b/e2e/src/test/java/com/arcadedb/e2e/JdbcQueriesTest.java
@@ -129,4 +129,49 @@ public class JdbcQueriesTest extends ArcadeContainerTemplate {
       }
     }
   }
+
+  @Test
+  void createSchemaWithSqlScript() throws SQLException {
+    try (final Statement st = conn.createStatement()) {
+
+      st.execute("""
+          {sqlscript}
+          CREATE Document TYPE article IF NOT EXISTS;
+          CREATE PROPERTY article.created IF NOT EXISTS DATETIME;
+          CREATE PROPERTY article.updated IF NOT EXISTS DATETIME;
+          CREATE PROPERTY article.title IF NOT EXISTS STRING;
+          CREATE PROPERTY article.content IF NOT EXISTS STRING;
+          CREATE PROPERTY article.author IF NOT EXISTS STRING;
+
+          INSERT INTO article CONTENT {"created": "2021-01-01 00:00:00",
+                  "updated": "2021-01-01 00:00:00",
+                  "title": "My first article",
+                  "content": "This is the content of my first article",
+                  "author": "John Doe"};
+          INSERT INTO article CONTENT {"created": "2021-01-02 00:00:00",
+                  "updated": "2021-01-02 00:00:00",
+                  "title": "My second article",
+                  "content": "This is the content of my second article",
+                  "author": "John Doe"};
+          INSERT INTO article CONTENT {"created": "2021-01-03 00:00:00",
+                  "updated": "2021-01-03 00:00:00",
+                  "title": "My third article",
+                  "content": "This is the content of my third article",
+                  "author": "John Doe"};
+          """);
+    }
+
+    try (final Statement st = conn.createStatement()) {
+      try (final ResultSet rs = st.executeQuery("SELECT * FROM article")) {
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("title")).isEqualTo("My first article");
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("title")).isEqualTo("My second article");
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("title")).isEqualTo("My third article");
+        assertThat(rs.next()).isFalse();
+      }
+
+    }
+  }
 }

--- a/e2e/src/test/java/com/arcadedb/e2e/JdbcQueriesTest.java
+++ b/e2e/src/test/java/com/arcadedb/e2e/JdbcQueriesTest.java
@@ -142,6 +142,7 @@ public class JdbcQueriesTest extends ArcadeContainerTemplate {
           CREATE PROPERTY article.title IF NOT EXISTS STRING;
           CREATE PROPERTY article.content IF NOT EXISTS STRING;
           CREATE PROPERTY article.author IF NOT EXISTS STRING;
+          CREATE PROPERTY article.notes IF NOT EXISTS EMBEDDED;
 
           INSERT INTO article CONTENT {"created": "2021-01-01 00:00:00",
                   "updated": "2021-01-01 00:00:00",

--- a/engine/src/main/java/com/arcadedb/database/Binary.java
+++ b/engine/src/main/java/com/arcadedb/database/Binary.java
@@ -644,6 +644,10 @@ public class Binary implements BinaryStructure, Comparable<Binary> {
     return content.length;
   }
 
+  public int limit() {
+    return buffer.limit();
+  }
+
   public void fill(final byte filler, final int size) {
     checkForAllocation(buffer.position(), size);
     for (int i = 0; i < size; ++i)

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -476,17 +476,12 @@ public class PostgresNetworkExecutor extends Thread {
       bufferDescription.putByteArray(columnName.getBytes(DatabaseFactory.getDefaultCharset()));//The field name.
       bufferDescription.putByte((byte) 0);
 
-      bufferDescription.putInt(
-          0); //If the field can be identified as a column of a specific table, the object ID of the table; otherwise zero.
-      bufferDescription.putShort(
-          (short) 0); //If the field can be identified as a column of a specific table, the attribute number of the column; otherwise zero.
+      bufferDescription.putInt(0); //If the field can be identified as a column of a specific table, the object ID of the table; otherwise zero.
+      bufferDescription.putShort((short) 0); //If the field can be identified as a column of a specific table, the attribute number of the column; otherwise zero.
       bufferDescription.putInt(columnType.code);// The object ID of the field's data type.
-      bufferDescription.putShort(
-          (short) columnType.size);// The data type size (see pg_type.typlen). Note that negative values denote variable-width types.
-      bufferDescription.putInt(
-          columnType.modifier);// The type modifier (see pg_attribute.atttypmod). The meaning of the modifier is type-specific.
-      bufferDescription.putShort(
-          (short) 0); // The format code being used for the field. Currently will be zero (text) or one (binary). In a RowDescription returned from the statement variant of Describe, the format code is not yet known and will always be zero.
+      bufferDescription.putShort((short) columnType.size);// The data type size (see pg_type.typlen). Note that negative values denote variable-width types.
+      bufferDescription.putInt(-1);// The type modifier (see pg_attribute.atttypmod). The meaning of the modifier is type-specific.
+      bufferDescription.putShort((short) 0); // The format code being used for the field. Currently will be zero (text) or one (binary). In a RowDescription returned from the statement variant of Describe, the format code is not yet known and will always be zero.
     }
 
     bufferDescription.flip();

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkListener.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkListener.java
@@ -24,9 +24,14 @@ import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.ServerException;
 import com.arcadedb.server.ha.network.ServerSocketFactory;
 
-import java.io.*;
-import java.net.*;
-import java.util.logging.*;
+import java.io.IOException;
+import java.net.BindException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketException;
+import java.util.logging.Level;
 
 public class PostgresNetworkListener extends Thread {
   private final    ArcadeDBServer      server;
@@ -39,7 +44,8 @@ public class PostgresNetworkListener extends Thread {
     void connected();
   }
 
-  public PostgresNetworkListener(final ArcadeDBServer server, final ServerSocketFactory iSocketFactory, final String hostName, final String hostPortRange) {
+  public PostgresNetworkListener(final ArcadeDBServer server, final ServerSocketFactory iSocketFactory, final String hostName,
+      final String hostPortRange) {
     super(server.getServerName() + " PostgresW listening at " + hostName + ":" + hostPortRange);
 
     this.server = server;
@@ -108,7 +114,8 @@ public class PostgresNetworkListener extends Thread {
 
         if (serverSocket.isBound()) {
           LogManager.instance().log(this, Level.INFO,
-              "Listening for incoming connections on $ANSI{green " + inboundAddr.getAddress().getHostAddress() + ":" + inboundAddr.getPort() + "} (protocol v."
+              "Listening for incoming connections on $ANSI{green " + inboundAddr.getAddress().getHostAddress() + ":"
+                  + inboundAddr.getPort() + "} (protocol v."
                   + protocolVersion + ")");
 
           return;
@@ -124,9 +131,12 @@ public class PostgresNetworkListener extends Thread {
       }
     }
 
-    LogManager.instance().log(this, Level.SEVERE, "Unable to listen for connections using the configured ports '%s' on host '%s'", hostPortRange, hostName);
+    LogManager.instance()
+        .log(this, Level.SEVERE, "Unable to listen for connections using the configured ports '%s' on host '%s'", hostPortRange,
+            hostName);
 
-    throw new ServerException("Unable to listen for connections using the configured ports '" + hostPortRange + "' on host '" + hostName + "'");
+    throw new ServerException(
+        "Unable to listen for connections using the configured ports '" + hostPortRange + "' on host '" + hostName + "'");
   }
 
   private static int[] getPorts(final String iHostPortRange) {

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresPortal.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresPortal.java
@@ -21,7 +21,8 @@ package com.arcadedb.postgres;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.parser.Statement;
 
-import java.util.*;
+import java.util.List;
+import java.util.Map;
 
 public class PostgresPortal {
   public String                    query;
@@ -30,16 +31,15 @@ public class PostgresPortal {
   public List<Object>              parameterValues;
   public List<Integer>             resultFormats;
   public Statement                 sqlStatement;
-  public boolean                   ignoreExecution   = false;
+  public boolean                   ignoreExecution = false;
   public List<Result>              cachedResultset;
   public Map<String, PostgresType> columns;
-  public boolean                   isExpectingResult = true;
-  public boolean                   executed          = false;
+  public boolean                   isExpectingResult;
+  public boolean                   executed        = false;
 
   public PostgresPortal(final String query) {
     this.query = query;
-    //final String queryUpperCase = query.toUpperCase();
-    this.isExpectingResult = true;//queryUpperCase.startsWith("SELECT") || queryUpperCase.startsWith("MATCH");
+    this.isExpectingResult = true;
   }
 
   @Override

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -64,7 +64,7 @@ public enum PostgresType {
    * @param typeBuffer The buffer to write to
    * @param value      The value to serialize
    */
-  public void serializeAsText(final long code, final Binary typeBuffer, Object value) {
+  public void serializeAsText(final long code,final Binary typeBuffer, Object value) {
     if (value == null) {
       if (code == BOOLEAN.code) {
         value = "0";
@@ -74,7 +74,7 @@ public enum PostgresType {
       }
     }
 
-    byte[] str = value.toString().getBytes(DatabaseFactory.getDefaultCharset());
+    final byte[] str = value.toString().getBytes(DatabaseFactory.getDefaultCharset());
     typeBuffer.putInt(str.length);
     typeBuffer.putByteArray(str);
   }

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -21,171 +21,120 @@ package com.arcadedb.postgres;
 import com.arcadedb.database.Binary;
 import com.arcadedb.database.DatabaseFactory;
 
-import java.nio.*;
-import java.util.*;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
+/**
+ * Represents PostgreSQL data types and provides serialization/deserialization functionality.
+ */
 public enum PostgresType {
-  SMALLINT(21, Short.class, 2, -1), //
-  INTEGER(23, Integer.class, 4, -1), //
-  LONG(20, Long.class, 8, -1), //
-  REAL(700, Float.class, 4, -1), //
-  DOUBLE(701, Double.class, 8, -1), //
-  CHAR(18, Character.class, 1, -1), //
-  BOOLEAN(16, Boolean.class, 1, -1),  //
-  DATE(1082, Date.class, 8, -1), //
-  VARCHAR(1043, String.class, -1, -1), //
-  ;
+  SMALLINT(21, Short.class, 2, value -> Short.parseShort(value)),
+  INTEGER(23, Integer.class, 4, value -> Integer.parseInt(value)),
+  LONG(20, Long.class, 8, value -> Long.parseLong(value)),
+  REAL(700, Float.class, 4, value -> Float.parseFloat(value)),
+  DOUBLE(701, Double.class, 8, value -> Double.parseDouble(value)),
+  CHAR(18, Character.class, 1, value -> value.charAt(0)),
+  BOOLEAN(16, Boolean.class, 1, value -> value.equalsIgnoreCase("true")),
+  DATE(1082, Date.class, 8, value -> new Date(Long.parseLong(value))),
+  VARCHAR(1043, String.class, -1, value -> value);
 
-  public final int      code;
-  public final Class<?> cls;
-  public final int      size;
-  public final int      modifier;
+  private static final Map<Integer, PostgresType> CODE_MAP = Arrays.stream(values())
+      .collect(Collectors.toMap(type -> type.code, type -> type));
 
-  PostgresType(final int code, final Class<?> cls, final int size, final int modifier) {
+  public final  int                      code;
+  public final  Class<?>                 cls;
+  public final  int                      size;
+  private final Function<String, Object> textParser;
+
+  PostgresType(final int code, final Class<?> cls, final int size, Function<String, Object> textParser) {
     this.code = code;
     this.cls = cls;
     this.size = size;
-    this.modifier = modifier;
+    this.textParser = textParser;
   }
 
-//  public void serialize(final ByteBuffer typeBuffer, final Object value) {
-//    if (value == null) {
-//      typeBuffer.putInt(-1);
-//      return;
-//    }
-//
-//    switch (this) {
-//    case VARCHAR:
-//      final byte[] str = value.toString().getBytes(DatabaseFactory.getDefaultCharset());
-//      typeBuffer.putInt(str.length);
-//      typeBuffer.put(str);
-//      break;
-//
-//    case SMALLINT:
-//      typeBuffer.putInt(Binary.SHORT_SERIALIZED_SIZE);
-//      typeBuffer.putShort(((Number) value).shortValue());
-//      break;
-//
-//    case INTEGER:
-//      typeBuffer.putInt(Binary.INT_SERIALIZED_SIZE);
-//      typeBuffer.putInt(((Number) value).intValue());
-//      break;
-//
-//    case LONG:
-//      typeBuffer.putInt(Binary.LONG_SERIALIZED_SIZE);
-//      typeBuffer.putLong(((Number) value).longValue());
-//      break;
-//
-//    case REAL:
-//      typeBuffer.putInt(Binary.INT_SERIALIZED_SIZE);
-//      typeBuffer.putFloat(((Number) value).floatValue());
-//      break;
-//
-//    case DOUBLE:
-//      typeBuffer.putInt(Binary.LONG_SERIALIZED_SIZE);
-//      typeBuffer.putDouble(((Number) value).doubleValue());
-//      break;
-//
-//    case DATE:
-//      typeBuffer.putInt(Binary.LONG_SERIALIZED_SIZE);
-//      typeBuffer.putLong(((Date) value).getTime());
-//      break;
-//
-//    case CHAR:
-//      typeBuffer.putInt(Binary.BYTE_SERIALIZED_SIZE);
-//      typeBuffer.put((byte) ((Character) value).charValue());
-//      break;
-//
-//    case BOOLEAN:
-//      typeBuffer.putInt(Binary.BYTE_SERIALIZED_SIZE);
-//      typeBuffer.put((byte) (((Boolean) value) ? '1' : '0'));
-//      break;
-////
-////    case ANY:
-////      typeBuffer.putInt(Binary.INT_SERIALIZED_SIZE);
-////      typeBuffer.putInt(((Number) value).intValue());
-////      break;
-//
-//    default:
-//      throw new PostgresProtocolException("Type " + this + " not supported for serializing");
-//    }
-//  }
-
+  /**
+   * Serializes a value as text format into the provided Binary buffer.
+   *
+   * @param code       The PostgreSQL type code
+   * @param typeBuffer The buffer to write to
+   * @param value      The value to serialize
+   */
   public void serializeAsText(final long code, final Binary typeBuffer, Object value) {
     if (value == null) {
-      if (code == BOOLEAN.code)
+      if (code == BOOLEAN.code) {
         value = "0";
-      else {
+      } else {
         typeBuffer.putInt(-1);
         return;
       }
     }
 
-    final byte[] str = value.toString().getBytes(DatabaseFactory.getDefaultCharset());
+    byte[] str = value.toString().getBytes(DatabaseFactory.getDefaultCharset());
     typeBuffer.putInt(str.length);
     typeBuffer.putByteArray(str);
   }
 
+  /**
+   * Deserializes a value based on the PostgreSQL type code and format code.
+   *
+   * @param code         The PostgreSQL type code
+   * @param formatCode   The format code (0 for text, 1 for binary)
+   * @param valueAsBytes The raw byte array to deserialize
+   *
+   * @return The deserialized object
+   *
+   * @throws PostgresProtocolException if the type or format is not supported
+   */
   public static Object deserialize(final long code, final int formatCode, final byte[] valueAsBytes) {
-    switch (formatCode) {
-    case 0:
-      final String str = new String(valueAsBytes, DatabaseFactory.getDefaultCharset());
-      if (code == 0) // UNSPECIFIED
-        return str;
-      else if (code == VARCHAR.code)
-        return str;
-      else if (code == SMALLINT.code)
-        return Short.parseShort(str);
-      else if (code == INTEGER.code)
-        return Integer.parseInt(str);
-      else if (code == LONG.code)
-        return Long.parseLong(str);
-      else if (code == REAL.code)
-        return Float.parseFloat(str);
-      else if (code == DOUBLE.code)
-        return Double.parseDouble(str);
-      else if (code == DATE.code)
-        return new Date(Long.parseLong(str));
-      else if (code == CHAR.code)
-        return str.charAt(0);
-      else if (code == BOOLEAN.code)
-        return str.equalsIgnoreCase("true");
-//      else if (code == ANY.code)
-//        return Integer.parseInt(str);
-      else
-        throw new PostgresProtocolException("Type with code " + code + " not supported for deserializing");
+    return switch (formatCode) {
+      case 0 -> deserializeText(code, valueAsBytes);
+      case 1 -> deserializeBinary(code, valueAsBytes);
+      default -> throw new PostgresProtocolException("Invalid format code " + formatCode);
+    };
+  }
 
-    case 1:
-      final ByteBuffer typeBuffer = ByteBuffer.wrap(valueAsBytes);
-
-      if (code == VARCHAR.code) {
-        final int length = typeBuffer.getInt();
-        final byte[] buffer = new byte[length];
-        typeBuffer.get(buffer);
-        return new String(buffer);
-      } else if (code == SMALLINT.code)
-        return typeBuffer.getShort();
-      else if (code == INTEGER.code)
-        return typeBuffer.getInt();
-      else if (code == LONG.code)
-        return typeBuffer.getLong();
-      else if (code == REAL.code)
-        return typeBuffer.getFloat();
-      else if (code == DOUBLE.code)
-        return typeBuffer.getDouble();
-      else if (code == DATE.code)
-        return new Date(typeBuffer.getLong());
-      else if (code == CHAR.code)
-        return typeBuffer.getChar();
-      else if (code == BOOLEAN.code)
-        return typeBuffer.get() == 1;
-//      else if (code == ANY.code)
-//        return typeBuffer.getInt();
-      else
-        throw new PostgresProtocolException("Type with code " + code + " not supported for deserializing");
-
-    default:
-      throw new PostgresProtocolException("Invalid format code " + formatCode);
+  private static Object deserializeText(final long code, final byte[] valueAsBytes) {
+    String str = new String(valueAsBytes, DatabaseFactory.getDefaultCharset());
+    if (code == 0) { // UNSPECIFIED
+      return str;
     }
+
+    PostgresType type = CODE_MAP.get((int) code);
+    if (type == null) {
+      throw new PostgresProtocolException("Type with code " + code + " not supported for deserializing");
+    }
+
+    return type.textParser.apply(str);
+  }
+
+  private static Object deserializeBinary(final long code, final byte[] valueAsBytes) {
+    ByteBuffer buffer = ByteBuffer.wrap(valueAsBytes);
+    PostgresType type = CODE_MAP.get((int) code);
+
+    if (type == null) {
+      throw new PostgresProtocolException("Type with code " + code + " not supported for deserializing");
+    }
+
+    return switch (type) {
+      case VARCHAR -> {
+        int length = buffer.getInt();
+        byte[] bytes = new byte[length];
+        buffer.get(bytes);
+        yield new String(bytes);
+      }
+      case SMALLINT -> buffer.getShort();
+      case INTEGER -> buffer.getInt();
+      case LONG -> buffer.getLong();
+      case REAL -> buffer.getFloat();
+      case DOUBLE -> buffer.getDouble();
+      case DATE -> new Date(buffer.getLong());
+      case CHAR -> buffer.getChar();
+      case BOOLEAN -> buffer.get() == 1;
+    };
   }
 }

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcTest.java
@@ -94,6 +94,35 @@ public class PostgresWJdbcTest extends BaseGraphServerTest {
   }
 
   @Test
+  void testScript() throws Exception {
+    try (final Connection conn = getConnection()) {
+      conn.setAutoCommit(false);
+      try (final Statement st = conn.createStatement()) {
+        st.execute("""
+            {sqlscript}create vertex type V IF NOT EXISTS;
+            create vertex V set id = 0, name = 'Jay', lastName = 'Miner';
+            create vertex V set id = 1, name = 'Jay', lastName = 'Miner';
+            create vertex V set id = 2, name = 'Jay', lastName = 'Miner';
+            create vertex V set id = 3, name = 'Jay', lastName = 'Miner';
+            create vertex V set id = 4, name = 'Jay', lastName = 'Miner';
+            create vertex V set id = 5, name = 'Jay', lastName = 'Miner';
+            create vertex V set id = 6, name = 'Jay', lastName = 'Miner';
+            create vertex V set id = 7, name = 'Jay', lastName = 'Miner';
+            create vertex V set id = 8, name = 'Jay', lastName = 'Miner';
+            create vertex V set id = 9, name = 'Jay', lastName = 'Miner';
+            create vertex V set id = 10, name = 'Jay', lastName = 'Miner';
+            """);
+
+        final ResultSet rs = st.executeQuery("{gremlin}g.V().hasLabel('V').order().by('id').limit(10)");
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getInt("id")).isEqualTo(0);
+        assertThat(rs.getString("name")).isEqualTo("Jay");
+        assertThat(rs.getString("lastName")).isEqualTo("Miner");
+      }
+    }
+  }
+
+  @Test
   public void queryVertices() throws Exception {
     final int TOTAL = 1000;
     final long now = System.currentTimeMillis();


### PR DESCRIPTION
## What does this PR do?


## Motivation

After replacing ByteBuffer with Binary on the PG plugin, the JS driver is unable to fetch the result of a query.


## Related issues

#1956 


## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
