### PR TITLE
Revert "build(deps-dev): bump redis.clients:jedis from 3.7.1 to 5.2.0" (#1970) [skip ci]

### DIFF
--- a/redisw/pom.xml
+++ b/redisw/pom.xml
@@ -33,7 +33,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <jedis.version>5.2.0</jedis.version>
+        <jedis.version>3.10.0</jedis.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Reverts ArcadeData/arcadedb#1733