### PR TITLE
In STUDIO, if there is 4 or less character selected, ignore it and just send the whole editor query

### DIFF
--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -422,7 +422,7 @@ function executeCommandTable() {
   let language = escapeHtml($("#inputLanguage").val());
 
   let command = editor.getSelection();
-  if (command == null || command == "") command = editor.getValue();
+  if (command == null || command.length <=4 ) command = editor.getValue();
   command = escapeHtml(command);
 
   let limit = parseInt($("#inputLimit").val());
@@ -472,7 +472,7 @@ function executeCommandGraph() {
   let language = escapeHtml($("#inputLanguage").val());
 
   let command = editor.getSelection();
-  if (command == null || command == "") command = editor.getValue();
+  if (command == null || command.length <= 4 ) command = editor.getValue();
   command = escapeHtml(command);
 
   let limit = parseInt($("#inputLimit").val());


### PR DESCRIPTION
Long story short, at the office we sometime end up selecting (on purpose or not, by accident) part of code in the editor and it only sends this part, beside this feature being really not intutive it makes little to no sense to send a query with 4 character.

Let's see it as a failsafe just to ignore little selection mistakes 