### PR TITLE
fix e2e jdbc test

### DIFF
--- a/e2e/src/test/java/com/arcadedb/e2e/JdbcQueriesTest.java
+++ b/e2e/src/test/java/com/arcadedb/e2e/JdbcQueriesTest.java
@@ -136,7 +136,7 @@ public class JdbcQueriesTest extends ArcadeContainerTemplate {
 
       st.execute("""
           {sqlscript}
-          CREATE Document TYPE article IF NOT EXISTS;
+          CREATE DOCUMENT TYPE article IF NOT EXISTS;
           CREATE PROPERTY article.created IF NOT EXISTS DATETIME;
           CREATE PROPERTY article.updated IF NOT EXISTS DATETIME;
           CREATE PROPERTY article.title IF NOT EXISTS STRING;


### PR DESCRIPTION
## What does this PR do?

This change fixes the e2e `JdbcQueriesTest` which fails weirdly because it seems to need capitalized SQL commands.

So `CREATE Document TYPE ...` failed, now `CREATE DOCUMENT TYPE ...` passes.

The error then is

```
JdbcQueriesTest.createSchemaWithSqlScript:137 » PSQL ERROR: Syntax error on parsing query: Encountered "{" "{" at line 1, column 1.
```

## Motivation

Local tests did not pass

## Additional Notes

@robfrank does a bug need to be filed for that?

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
