### PR TITLE
Fix inconsistent naming HSNW to HNSW

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/vector/HnswVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/HnswVectorIndex.java
@@ -1199,7 +1199,7 @@ public class HnswVectorIndex<TId, TVector, TDistance> extends Component implemen
 
   @Override
   public Schema.INDEX_TYPE getType() {
-    return Schema.INDEX_TYPE.HSNW;
+    return Schema.INDEX_TYPE.HNSW;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
@@ -92,8 +92,8 @@ public class CreateIndexStatement extends DDLStatement {
       unique = true;
     } else if (typeAsString.equalsIgnoreCase("NOTUNIQUE")) {
       indexType = Schema.INDEX_TYPE.LSM_TREE;
-    } else if (typeAsString.equalsIgnoreCase("HSNW")) {
-      indexType = Schema.INDEX_TYPE.HSNW;
+    } else if (typeAsString.equalsIgnoreCase("HNSW")) {
+      indexType = Schema.INDEX_TYPE.HNSW;
       unique = true;
     } else
       throw new CommandSQLParsingException("Index type '" + typeAsString + "' is not supported");

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -122,7 +122,7 @@ public class LocalSchema implements Schema {
 
     indexFactory.register(INDEX_TYPE.LSM_TREE.name(), new LSMTreeIndex.IndexFactoryHandler());
     indexFactory.register(INDEX_TYPE.FULL_TEXT.name(), new LSMTreeFullTextIndex.IndexFactoryHandler());
-    indexFactory.register(INDEX_TYPE.HSNW.name(), new HnswVectorIndex.IndexFactoryHandler());
+    indexFactory.register(INDEX_TYPE.HNSW.name(), new HnswVectorIndex.IndexFactoryHandler());
     configurationFile = new File(databasePath + File.separator + SCHEMA_FILE_NAME);
   }
 

--- a/engine/src/main/java/com/arcadedb/schema/Schema.java
+++ b/engine/src/main/java/com/arcadedb/schema/Schema.java
@@ -372,6 +372,6 @@ public interface Schema {
   FunctionDefinition getFunction(String libraryName, String functionName) throws IllegalArgumentException;
 
   enum INDEX_TYPE {
-    LSM_TREE, FULL_TEXT, HSNW
+    LSM_TREE, FULL_TEXT, HNSW
   }
 }

--- a/engine/src/main/java/com/arcadedb/schema/VectorIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/VectorIndexBuilder.java
@@ -68,7 +68,7 @@ public class VectorIndexBuilder extends IndexBuilder<HnswVectorIndex> {
 
   public VectorIndexBuilder(final Database database, final HnswVectorIndexRAM origin) {
     super((DatabaseInternal) database, HnswVectorIndex.class);
-    this.indexType = Schema.INDEX_TYPE.HSNW;
+    this.indexType = Schema.INDEX_TYPE.HNSW;
     this.origin = origin;
     this.dimensions = origin.getDimensions();
     this.distanceFunction = origin.getDistanceFunction();


### PR DESCRIPTION
## What does this PR do?

This change cinverts all occurances in the code base of `HSNW` to `HNSW`.

## Motivation

Consistent and correct naming of vector index

## Related issues

https://github.com/ArcadeData/arcadedb/issues/2002

## Additional Notes

Please assign @ExtReMLapin who should comment here

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
