### PR TITLE
downgrade junit to 5.11.4

### DIFF
--- a/network/pom.xml
+++ b/network/pom.xml
@@ -56,13 +56,13 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven-surefire-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </build>
+<!--    <build>-->
+<!--        <plugins>-->
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-surefire-plugin</artifactId>-->
+<!--                <version>${maven-surefire-plugin.version}</version>-->
+<!--            </plugin>-->
+<!--        </plugins>-->
+<!--    </build>-->
 </project>

--- a/network/src/test/java/com/arcadedb/remote/RemoteDatabaseHttpIT.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteDatabaseHttpIT.java
@@ -6,10 +6,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.io.*;
-import java.net.*;
-import java.nio.charset.*;
-import java.util.*;
+import java.io.ByteArrayInputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;

--- a/network/src/test/java/com/arcadedb/remote/RemoteServerHttpIT.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteServerHttpIT.java
@@ -6,9 +6,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.io.*;
-import java.net.*;
-import java.nio.charset.*;
+import java.io.ByteArrayInputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <docker.plugin.version>1.2.2</docker.plugin.version>
-        <dockerfile-maven-version>1.4.13</dockerfile-maven-version>
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
@@ -65,19 +64,19 @@
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
         <maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>
+        <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
+        <license-maven-plugin.version>4.6</license-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
 
         <assertj-core.version>3.27.3</assertj-core.version>
-        <junit.jupiter.version>5.12.0</junit.jupiter.version>
+        <junit.jupiter.version>5.11.4</junit.jupiter.version>
         <awaitility.version>4.3.0</awaitility.version>
+        <mockito-core.version>5.15.2</mockito-core.version>
 
         <skipIntegration>true</skipIntegration>
 
         <itCoverageAgent></itCoverageAgent>
         <argLine></argLine>
-        <license-maven-plugin.version>4.6</license-maven-plugin.version>
-        <mockito-core.version>5.15.2</mockito-core.version>
-        <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
     </properties>
 
     <developers>


### PR DESCRIPTION
## What does this PR do?

Downgrades junit to 5.11.4 due to broken compatibility of junit 5.12.0 with mockito
## Motivation

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
