### PR TITLE
refactor setDatabaseSetting for step-by-step decoding

### DIFF
--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -199,7 +199,7 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
     return httpServer.getServer().getSecurity().authenticate(userName, userPassword, null);
   }
 
-  protected static void checkRootUser(ServerSecurityUser user) {
+  protected void checkRootUser(ServerSecurityUser user) {
     if (!"root".equals(user.getName()))
       throw new ServerSecurityException("Only root user is authorized to execute server commands");
   }

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -50,6 +50,21 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 public class PostServerCommandHandler extends AbstractServerHttpHandler {
+  final String LIST_DATABASES       = "list databases";
+  final String SHUTDOWN             = "shutdown";
+  final String CREATE_DATABASE      = "create database";
+  final String DROP_DATABASE        = "drop database";
+  final String CLOSE_DATABASE       = "close database";
+  final String OPEN_DATABASE        = "open database";
+  final String CREATE_USER          = "create user";
+  final String DROP_USER            = "drop user";
+  final String CONNECT_CLUSTER      = "connect cluster";
+  final String DISCONNECT_CLUSTER   = "disconnect cluster";
+  final String SET_DATABASE_SETTING = "set database setting";
+  final String SET_SERVER_SETTING   = "set server setting";
+  final String GET_SERVER_EVENTS    = "get server events";
+  final String ALIGN_DATABASE       = "align database";
+
   public PostServerCommandHandler(final HttpServer httpServer) {
     super(httpServer);
   }
@@ -62,30 +77,15 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
   @Override
   public ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user) throws IOException {
 
-    final String LIST_DATABASES = "list databases";
-    final String SHUTDOWN = "shutdown";
-    final String CREATE_DATABASE = "create database";
-    final String DROP_DATABASE = "drop database";
-    final String CLOSE_DATABASE = "close database";
-    final String OPEN_DATABASE = "open database";
-    final String CREATE_USER = "create user";
-    final String DROP_USER = "drop user";
-    final String CONNECT_CLUSTER = "connect cluster";
-    final String DISCONNECT_CLUSTER = "disconnect cluster";
-    final String SET_DATABASE_SETTING = "set database setting";
-    final String SET_SERVER_SETTING = "set server setting";
-    final String GET_SERVER_EVENTS = "get server events";
-    final String ALIGN_DATABASE = "align database";
-
     final JSONObject payload = new JSONObject(parseRequestPayload(exchange));
 
-    final String command = payload.has("command") ? payload.getString("command") : null;
+    final String command = payload.has("command") ? payload.getString("command").trim() : null;
     if (command == null)
       return new ExecutionResponse(400, "{ \"error\" : \"Server command is null\"}");
 
     final JSONObject response = createResult(user, null).put("result", "ok");
 
-    final String command_lc = command.toLowerCase(Locale.ENGLISH);
+    final String command_lc = command.toLowerCase(Locale.ENGLISH).trim();
 
     if (command_lc.equals(LIST_DATABASES))
       return listDatabases(user);
@@ -93,34 +93,34 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
       checkRootUser(user);
 
     if (command_lc.startsWith(SHUTDOWN))
-      shutdownServer(command.substring(SHUTDOWN.length()).trim());
+      shutdownServer(extractTarget(command, SHUTDOWN));
     else if (command_lc.startsWith(CREATE_DATABASE))
-      createDatabase(command.substring(CREATE_DATABASE.length()).trim());
+      createDatabase(extractTarget(command, CREATE_DATABASE));
     else if (command_lc.startsWith(DROP_DATABASE))
-      dropDatabase(command.substring(DROP_DATABASE.length()).trim());
+      dropDatabase(extractTarget(command, DROP_DATABASE));
     else if (command_lc.startsWith(CLOSE_DATABASE))
-      closeDatabase(command.substring(CLOSE_DATABASE.length()).trim());
+      closeDatabase(extractTarget(command, CLOSE_DATABASE));
     else if (command_lc.startsWith(OPEN_DATABASE))
-      openDatabase(command.substring(OPEN_DATABASE.length()).trim());
+      openDatabase(extractTarget(command, OPEN_DATABASE));
     else if (command_lc.startsWith(CREATE_USER))
-      createUser(command.substring(CREATE_USER.length()).trim());
+      createUser(extractTarget(command, CREATE_USER));
     else if (command_lc.startsWith(DROP_USER))
-      dropUser(command.substring(DROP_USER.length()).trim());
+      dropUser(extractTarget(command, DROP_USER));
     else if (command_lc.startsWith(CONNECT_CLUSTER)) {
-      if (!connectCluster(command.substring(CONNECT_CLUSTER.length()).trim(), exchange))
+      if (!connectCluster(extractTarget(command, CONNECT_CLUSTER), exchange))
         return null;
     } else if (command_lc.equals(DISCONNECT_CLUSTER))
       disconnectCluster();
     else if (command_lc.startsWith(SET_DATABASE_SETTING))
-      setDatabaseSetting(command.substring(SET_DATABASE_SETTING.length()).trim());
+      setDatabaseSetting(extractTarget(command, SET_DATABASE_SETTING));
     else if (command_lc.startsWith(SET_SERVER_SETTING))
-      setServerSetting(command.substring(SET_SERVER_SETTING.length()).trim());
+      setServerSetting(extractTarget(command, SET_SERVER_SETTING));
     else if (command_lc.startsWith(GET_SERVER_EVENTS))
-      response.put("result", getServerEvents(command.substring(GET_SERVER_EVENTS.length()).trim()));
+      response.put("result", getServerEvents(extractTarget(command, GET_SERVER_EVENTS)));
     else if (command_lc.startsWith(ALIGN_DATABASE))
-      alignDatabase(command.substring(ALIGN_DATABASE.length()).trim());
+      alignDatabase(extractTarget(command, ALIGN_DATABASE));
     else {
-      Metrics.counter("http.server-command.invalid").increment(); ;
+      Metrics.counter("http.server-command.invalid").increment();
 
       return new ExecutionResponse(400, "{ \"error\" : \"Server command not valid\"}");
     }
@@ -128,9 +128,18 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     return new ExecutionResponse(200, response.toString());
   }
 
+  private String extractTarget(String command, String keyword) {
+    final int pos = command.indexOf(keyword);
+    if (pos == -1)
+      return "";
+
+    return command.substring(pos + keyword.length()).trim();
+  }
+
   private ExecutionResponse listDatabases(final ServerSecurityUser user) {
     final ArcadeDBServer server = httpServer.getServer();
-      Metrics.counter("http.list-databases").increment(); ;
+    Metrics.counter("http.list-databases").increment();
+    ;
 
     final Set<String> installedDatabases = new HashSet<>(server.getDatabaseNames());
     final Set<String> allowedDatabases = user.getAuthorizedDatabases();
@@ -144,7 +153,8 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
   }
 
   private void shutdownServer(final String serverName) throws IOException {
-      Metrics.counter("http.server-shutdown").increment(); ;
+    Metrics.counter("http.server-shutdown").increment();
+    ;
 
     if (serverName.isEmpty()) {
       // SHUTDOWN CURRENT SERVER
@@ -174,7 +184,8 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     checkServerIsLeaderIfInHA();
 
     final ArcadeDBServer server = httpServer.getServer();
-      Metrics.counter("http.create-database").increment(); ;
+    Metrics.counter("http.create-database").increment();
+    ;
 
     final ServerDatabase db = server.createDatabase(databaseName, ComponentFile.MODE.READ_WRITE);
 
@@ -190,7 +201,8 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
 
     final ServerDatabase database = httpServer.getServer().getDatabase(databaseName);
 
-      Metrics.counter("http.drop-database").increment(); ;
+    Metrics.counter("http.drop-database").increment();
+    ;
 
     database.getEmbedded().drop();
     httpServer.getServer().removeDatabase(database.getName());
@@ -203,7 +215,8 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     final ServerDatabase database = httpServer.getServer().getDatabase(databaseName);
     database.getEmbedded().close();
 
-      Metrics.counter("http.close-database").increment(); ;
+    Metrics.counter("http.close-database").increment();
+    ;
     httpServer.getServer().removeDatabase(database.getName());
   }
 
@@ -212,7 +225,8 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
       throw new IllegalArgumentException("Database name empty");
 
     httpServer.getServer().getDatabase(databaseName);
-      Metrics.counter("http.open-database").increment(); ;
+    Metrics.counter("http.open-database").increment();
+    ;
   }
 
   private void createUser(final String payload) {
@@ -229,7 +243,8 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
 
     json.put("password", httpServer.getServer().getSecurity().encodePassword(userPassword));
 
-    Metrics.counter("http.create-user").increment(); ;
+    Metrics.counter("http.create-user").increment();
+    ;
 
     httpServer.getServer().getSecurity().createUser(json);
   }
@@ -238,7 +253,8 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     if (userName.isEmpty())
       throw new IllegalArgumentException("User name was missing");
 
-    Metrics.counter("http.drop-user").increment(); ;
+    Metrics.counter("http.drop-user").increment();
+    ;
 
     final boolean result = httpServer.getServer().getSecurity().dropUser(userName);
     if (!result)
@@ -248,7 +264,8 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
   private boolean connectCluster(final String serverAddress, final HttpServerExchange exchange) {
     final HAServer ha = getHA();
 
-    Metrics.counter("http.connect-cluster").increment(); ;
+    Metrics.counter("http.connect-cluster").increment();
+    ;
 
     return ha.connectToLeader(serverAddress, exception -> {
       exchange.setStatusCode(StatusCodes.INTERNAL_SERVER_ERROR);
@@ -258,7 +275,8 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
   }
 
   private void disconnectCluster() {
-    Metrics.counter("http.server-disconnect").increment(); ;
+    Metrics.counter("http.server-disconnect").increment();
+    ;
     final HAServer ha = getHA();
 
     final Replica2LeaderNetworkExecutor leader = ha.getLeader();
@@ -280,8 +298,8 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     if (secondSpace == -1)
       throw new IllegalArgumentException("Expected <database> <key> <value>");
 
-    final String db = tripleTrimmed.substring(0,firstSpace);
-    final String key = pairTrimmed.substring(0,secondSpace);
+    final String db = tripleTrimmed.substring(0, firstSpace);
+    final String key = pairTrimmed.substring(0, secondSpace);
     final String value = pairTrimmed.substring(secondSpace);
 
     final DatabaseInternal database = (DatabaseInternal) httpServer.getServer().getDatabase(db);
@@ -297,7 +315,7 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     if (firstSpace == -1)
       throw new IllegalArgumentException("Expected <key> <value>");
 
-    final String key = pairTrimmed.substring(0,firstSpace);
+    final String key = pairTrimmed.substring(0, firstSpace);
     final String value = pairTrimmed.substring(firstSpace);
 
     httpServer.getServer().getConfiguration().setValue(key, value);
@@ -305,7 +323,8 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
 
   private String getServerEvents(final String fileName) {
     final ArcadeDBServer server = httpServer.getServer();
-    Metrics.counter("http.get-server-events").increment(); ;
+    Metrics.counter("http.get-server-events").increment();
+    ;
 
     final JSONArray events = fileName.isEmpty() ?
         server.getEventLog().getCurrentEvents() :
@@ -321,7 +340,8 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
 
     final Database database = httpServer.getServer().getDatabase(databaseName);
 
-    Metrics.counter("http.align-database").increment(); ;
+    Metrics.counter("http.align-database").increment();
+    ;
 
     database.command("sql", "align database");
   }

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -268,13 +268,24 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
       ha.disconnectAllReplicas();
   }
 
-  private void setDatabaseSetting(final String pair) throws IOException {
-    final String[] dbKeyValue = pair.split(" ");
-    if (dbKeyValue.length != 3)
+  private void setDatabaseSetting(final String triple) throws IOException {
+
+    final String triple_trimmed = triple.trim();
+    final Integer first_space = triple_trimmed.indexOf(" ");
+    if (first_space == -1)
       throw new IllegalArgumentException("Expected <database> <key> <value>");
 
-    final DatabaseInternal database = (DatabaseInternal) httpServer.getServer().getDatabase(dbKeyValue[0]);
-    database.getConfiguration().setValue(dbKeyValue[1], dbKeyValue[2]);
+    final String pair_trimmed = triple_trimmed.substring(first_space).trim();
+    final Integer second_space = pair_trimmed.indexOf(" ");
+    if (second_space == -1)
+      throw new IllegalArgumentException("Expected <database> <key> <value>");
+
+    final String db = triple_trimmed.substring(0,first_space);
+    final String key = pair_trimmed.substring(0,second_space);
+    final String value = pair_trimmed.substring(second_space).trim();
+
+    final DatabaseInternal database = (DatabaseInternal) httpServer.getServer().getDatabase(db);
+    database.getConfiguration().setValue(key, value);
     database.saveConfiguration();
   }
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -270,19 +270,19 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
 
   private void setDatabaseSetting(final String triple) throws IOException {
 
-    final String triple_trimmed = triple.trim();
-    final Integer first_space = triple_trimmed.indexOf(" ");
-    if (first_space == -1)
+    final String tripleTrimmed = triple.trim();
+    final Integer firstSpace = tripleTrimmed.indexOf(" ");
+    if (firstSpace == -1)
       throw new IllegalArgumentException("Expected <database> <key> <value>");
 
-    final String pair_trimmed = triple_trimmed.substring(first_space).trim();
-    final Integer second_space = pair_trimmed.indexOf(" ");
-    if (second_space == -1)
+    final String pairTrimmed = tripleTrimmed.substring(firstSpace).trim();
+    final Integer secondSpace = pairTrimmed.indexOf(" ");
+    if (secondSpace == -1)
       throw new IllegalArgumentException("Expected <database> <key> <value>");
 
-    final String db = triple_trimmed.substring(0,first_space);
-    final String key = pair_trimmed.substring(0,second_space);
-    final String value = pair_trimmed.substring(second_space).trim();
+    final String db = tripleTrimmed.substring(0,firstSpace);
+    final String key = pairTrimmed.substring(0,secondSpace);
+    final String value = pairTrimmed.substring(secondSpace);
 
     final DatabaseInternal database = (DatabaseInternal) httpServer.getServer().getDatabase(db);
     database.getConfiguration().setValue(key, value);
@@ -290,11 +290,17 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
   }
 
   private void setServerSetting(final String pair) {
-    final String[] keyValue = pair.split(" ");
-    if (keyValue.length != 2)
+
+    final String pairTrimmed = pair.trim();
+
+    final Integer firstSpace = pairTrimmed.indexOf(" ");
+    if (firstSpace == -1)
       throw new IllegalArgumentException("Expected <key> <value>");
 
-    httpServer.getServer().getConfiguration().setValue(keyValue[0], keyValue[1]);
+    final String key = pairTrimmed.substring(0,firstSpace);
+    final String value = pairTrimmed.substring(firstSpace);
+
+    httpServer.getServer().getConfiguration().setValue(key, value);
   }
 
   private String getServerEvents(final String fileName) {

--- a/server/src/test/java/com/arcadedb/server/HTTPDocumentIT.java
+++ b/server/src/test/java/com/arcadedb/server/HTTPDocumentIT.java
@@ -37,7 +37,7 @@ import java.util.logging.*;
 
 import static org.assertj.core.api.Assertions.*;
 
-public class HTTPDocumentIT extends BaseGraphServerTest {
+public class  HTTPDocumentIT extends BaseGraphServerTest {
   private final static String DATABASE_NAME = "httpDocument";
 
   @Override
@@ -57,6 +57,8 @@ public class HTTPDocumentIT extends BaseGraphServerTest {
       try {
         connection.connect();
         final String response = readResponse(connection);
+
+        System.out.println("response = " + response);
         LogManager.instance().log(this, Level.FINE, "Response: ", null, response);
         assertThat(connection.getResponseCode()).isEqualTo(200);
         assertThat(connection.getResponseMessage()).isEqualTo("OK");

--- a/server/src/test/java/com/arcadedb/server/http/handler/PostServerCommandHandlerIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/PostServerCommandHandlerIT.java
@@ -1,0 +1,56 @@
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.log.LogManager;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.ProtocolException;
+import java.net.URI;
+import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.logging.Level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PostServerCommandHandlerIT extends BaseGraphServerTest {
+
+  @Test
+  void testSetServerSettingCommnad() throws Exception {
+
+    HttpClient client = HttpClient.newHttpClient();
+    HttpRequest request = HttpRequest.newBuilder()
+        .uri(new URI("http://localhost:2480/api/v1/server"))
+        .POST(HttpRequest.BodyPublishers.ofString(new JSONObject()
+            .put("command", "set database setting graph `arcadedb.dateTimeFormat` \"yyyy-MM-dd HH:mm:ss.SSS\" ")
+            .toString()))
+        .setHeader("Authorization",
+            "Basic " + Base64.getEncoder().encodeToString(("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes()))
+        .build();
+
+
+    HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
+    assertThat(response.statusCode()).isEqualTo(200);
+
+    request = HttpRequest.newBuilder()
+        .uri(new URI("http://localhost:2480/api/v1/server"))
+        .GET()
+        .setHeader("Authorization",
+            "Basic " + Base64.getEncoder().encodeToString(("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes()))
+        .build();
+
+
+     response = client.send(request, BodyHandlers.ofString());
+
+    assertThat(response.statusCode()).isEqualTo(200);
+//    assertThat(JsonPa response.body()).contains("arcadedb.dateTimeFormat");
+    System.out.println("response = " + response.body());
+
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/PostServerCommandHandlerIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/PostServerCommandHandlerIT.java
@@ -1,28 +1,22 @@
 package com.arcadedb.server.http.handler;
 
-import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.BaseGraphServerTest;
 import org.junit.jupiter.api.Test;
 
-import java.net.HttpURLConnection;
-import java.net.ProtocolException;
 import java.net.URI;
-import java.net.URL;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.util.Base64;
-import java.util.HashMap;
-import java.util.logging.Level;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class PostServerCommandHandlerIT extends BaseGraphServerTest {
 
   @Test
-  void testSetServerSettingCommnad() throws Exception {
+  void testSetDatabaseSettingCommand() throws Exception {
 
     HttpClient client = HttpClient.newHttpClient();
     HttpRequest request = HttpRequest.newBuilder()
@@ -34,23 +28,8 @@ class PostServerCommandHandlerIT extends BaseGraphServerTest {
             "Basic " + Base64.getEncoder().encodeToString(("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes()))
         .build();
 
-
     HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
     assertThat(response.statusCode()).isEqualTo(200);
-
-    request = HttpRequest.newBuilder()
-        .uri(new URI("http://localhost:2480/api/v1/server"))
-        .GET()
-        .setHeader("Authorization",
-            "Basic " + Base64.getEncoder().encodeToString(("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes()))
-        .build();
-
-
-     response = client.send(request, BodyHandlers.ofString());
-
-    assertThat(response.statusCode()).isEqualTo(200);
-//    assertThat(JsonPa response.body()).contains("arcadedb.dateTimeFormat");
-    System.out.println("response = " + response.body());
 
   }
 }

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -877,7 +877,6 @@ function updateDatabaseSetting(key, value) {
           type: "POST",
           url: "api/v1/server",
           data: JSON.stringify({
-            language: "sql",
             command: "set database setting " + getCurrentDatabase() + " " + key + " " + $("#updateSettingInput").val(),
           }),
           beforeSend: function (xhr) {


### PR DESCRIPTION
clone of  #2006 
## What does this PR do? 

This change refactors the `setDatabaseSetting` method in a way that it reads for spaces step-by-step instead of `split`ting all at once. Same was done for `setServerSetting` for consistency.

## Motivation

Alter database setting with a value containing a space

## Related issues

https://github.com/ArcadeData/arcadedb/issues/1957

## Additional Notes

Also, I deleted the unnecessary `language` property of the studio server command

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
