### PR TITLE
Initial impl of helm chart

### DIFF
--- a/k8s/helm/Chart.yaml
+++ b/k8s/helm/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: arcadedb
+description: |
+  A Helm chart for ArcadeDB
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "25.2.1"

--- a/k8s/helm/README.md
+++ b/k8s/helm/README.md
@@ -1,0 +1,213 @@
+# ArcadeDB Helm Chart
+
+This Helm chart facilitates the deployment of [ArcadeDB](https://arcadedb.com/), an open-source multi-model database, on a Kubernetes cluster.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.0+
+
+## Installation
+
+To install the chart with the release name `my-arcadedb`:
+
+```bash
+helm install my-arcadedb ./arcadedb
+```
+
+The command deploys ArcadeDB on the Kubernetes cluster using the default configuration. The [Parameters](#parameters) section lists the configurable parameters of this chart and their default values.
+
+## Uninstallation
+
+To uninstall/delete the `my-arcadedb` deployment:
+
+```bash
+helm uninstall my-arcadedb
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Parameters
+
+### arcaddb
+
+| Name                         | Description                                           | Value                                    |
+| ---------------------------- | ----------------------------------------------------- | ---------------------------------------- |
+| `arcadedb.databaseDirectory` | Enable persistence by updating this and volume/Mounts | `/home/arcadedb/databases`               |
+| `arcadedb.defaultDatabases`  | Default databases                                     | `Universe[foo:bar]`                      |
+| `arcadedb.extraCommands`     | Any extra comands to pass to ArcadeDB startup         | `["-Darcadedb.server.mode=development"]` |
+
+### arcadedb.credentials
+
+
+### arcadedb.credentials.rootPassword
+
+
+### arcadedb.credentials.secret
+
+| Name                                            | Description                   | Value |
+| ----------------------------------------------- | ----------------------------- | ----- |
+| `arcadedb.credentials.rootPassword.secret.name` | Name of existing secret       | `nil` |
+| `arcadedb.credentials.rootPassword.secret.key`  | Key to use in existing secret | `nil` |
+
+### image
+
+| Name               | Description                                                                                                                                                                                      | Value          |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- |
+| `image.registry`   | Registry for image                                                                                                                                                                               | `arcadedata`   |
+| `image.repository` | Image repo                                                                                                                                                                                       | `arcadedb`     |
+| `image.pullPolicy` | This sets the pull policy for images.                                                                                                                                                            | `IfNotPresent` |
+| `image.tag`        | Overrides the image tag whose default is the chart appVersion.                                                                                                                                   | `""`           |
+| `imagePullSecrets` | This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ | `[]`           |
+| `nameOverride`     | This is to override the chart name.                                                                                                                                                              | `""`           |
+| `fullnameOverride` |                                                                                                                                                                                                  | `""`           |
+
+### This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+
+| Name                         | Description                                             | Value  |
+| ---------------------------- | ------------------------------------------------------- | ------ |
+| `serviceAccount.create`      | Specifies whether a service account should be created   | `true` |
+| `serviceAccount.automount`   | Automatically mount a ServiceAccount's API credentials? | `true` |
+| `serviceAccount.annotations` | Annotations to add to the service account               | `{}`   |
+| `serviceAccount.name`        | The name of the service account to use.                 | `""`   |
+| `podAnnotations`             | This is for setting Kubernetes Annotations to a Pod.    | `{}`   |
+| `podLabels`                  | This is for setting Kubernetes Labels to a Pod.         | `{}`   |
+| `podSecurityContext`         |                                                         | `{}`   |
+| `securityContext`            |                                                         | `{}`   |
+
+### This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+
+
+### http
+
+| Name                | Description                                                                                                                                                       | Value          |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| `service.http.type` | This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types | `LoadBalancer` |
+| `service.http.port` | This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports                         | `2480`         |
+
+### rpc
+
+| Name               | Description                                                                                                                               | Value  |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `service.rpc.port` | This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports | `2424` |
+
+### ingress This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+
+| Name                  | Description | Value   |
+| --------------------- | ----------- | ------- |
+| `ingress.enabled`     |             | `false` |
+| `ingress.className`   |             | `""`    |
+| `ingress.annotations` |             | `{}`    |
+
+### ingress.hosts
+
+| Name                    | Description | Value                 |
+| ----------------------- | ----------- | --------------------- |
+| `ingress.hosts[0].host` |             | `chart-example.local` |
+
+### ingress.hosts[0].paths
+
+| Name                                 | Description | Value                    |
+| ------------------------------------ | ----------- | ------------------------ |
+| `ingress.hosts[0].paths[0].path`     |             | `/`                      |
+| `ingress.hosts[0].paths[0].pathType` |             | `ImplementationSpecific` |
+| `ingress.tls`                        |             | `[]`                     |
+| `resources`                          |             | `{}`                     |
+
+### This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+
+
+### livenessProbe.httpGet
+
+| Name                         | Description | Value           |
+| ---------------------------- | ----------- | --------------- |
+| `livenessProbe.httpGet.path` |             | `/api/v1/ready` |
+| `livenessProbe.httpGet.port` |             | `http`          |
+
+### This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+
+
+### readinessProbe.httpGet
+
+| Name                          | Description | Value           |
+| ----------------------------- | ----------- | --------------- |
+| `readinessProbe.httpGet.path` |             | `/api/v1/ready` |
+| `readinessProbe.httpGet.port` |             | `http`          |
+
+### This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+
+| Name                                         | Description                                                  | Value   |
+| -------------------------------------------- | ------------------------------------------------------------ | ------- |
+| `autoscaling.enabled`                        |                                                              | `false` |
+| `autoscaling.minReplicas`                    |                                                              | `1`     |
+| `autoscaling.maxReplicas`                    |                                                              | `100`   |
+| `autoscaling.targetCPUUtilizationPercentage` |                                                              | `80`    |
+| `volumes`                                    | Additional volumes on the output Deployment definition.      | `[]`    |
+| `volumeMounts`                               | Additional volumeMounts on the output Deployment definition. | `[]`    |
+| `nodeSelector`                               |                                                              | `{}`    |
+| `tolerations`                                |                                                              | `[]`    |
+
+### affinity
+
+
+### Set the anti-affinity selector scope to arcadedb servers.
+
+
+### preferredDuringSchedulingIgnoredDuringExecution
+
+| Name                                                                                 | Description                                       | Value |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------- | ----- |
+| `affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight` |                                                   | `100` |
+| `extraManifests`                                                                     | - Include any amount of extra arbitrary manifests | `{}`  |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
+
+```bash
+helm install my-arcadedb ./arcadedb --set image.tag=21.11.1
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example:
+
+```bash
+helm install my-arcadedb ./arcadedb -f values.yaml
+```
+
+## Persistence
+
+The ArcadeDB image stores data at the `/opt/arcadedb/databases` path of the container. By default, a PersistentVolumeClaim is created and mounted to this directory. If you want to disable persistence, set `persistence.enabled` to `false`. Data will then be stored in an emptyDir, which is erased when the Pod is terminated.
+
+## Ingress
+
+This chart provides support for Ingress resource. To enable Ingress, set `ingress.enabled` to `true` and configure the `ingress.hosts` parameter. For example:
+
+```yaml
+ingress:
+  enabled: true
+  hosts:
+    - host: arcadedb.local
+      paths: []
+```
+
+## Resources
+
+The resource requests and limits can be set by specifying the `resources` parameter. The default values are:
+
+```yaml
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+```
+
+## Notes
+
+After installing the chart, you can access ArcadeDB by running the following command:
+
+```bash
+kubectl get --namespace default service arcadedb-http
+```
+
+Replace `arcadedb-http` with your release name if it's different. The command retrieves the service details, including the IP address and port, which you can use to connect to ArcadeDB. 

--- a/k8s/helm/index.yaml
+++ b/k8s/helm/index.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+entries: {}
+generated: "2025-03-03T07:54:53.678656559+01:00"

--- a/k8s/helm/templates/NOTES.txt
+++ b/k8s/helm/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.http.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "arcadedb.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.http.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "arcadedb.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "arcadedb.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.http.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "arcadedb.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/k8s/helm/templates/_helpers.tpl
+++ b/k8s/helm/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "arcadedb.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "arcadedb.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "arcadedb.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "arcadedb.labels" -}}
+app: {{ .Chart.Name }}
+helm.sh/chart: {{ include "arcadedb.chart" . }}
+{{ include "arcadedb.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "arcadedb.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "arcadedb.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "arcadedb.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "arcadedb.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/k8s/helm/templates/extra-manifests.yaml
+++ b/k8s/helm/templates/extra-manifests.yaml
@@ -1,0 +1,10 @@
+---
+
+{{- range $_key, $value := .Values.extraManifests }}
+{{- with $value }}
+{{ toYaml . }}
+{{- end }}
+
+---
+
+{{- end }}

--- a/k8s/helm/templates/hpa.yaml
+++ b/k8s/helm/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "arcadedb.fullname" . }}
+  labels:
+    {{- include "arcadedb.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ include "arcadedb.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/k8s/helm/templates/ingress.yaml
+++ b/k8s/helm/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "arcadedb.fullname" . }}
+  labels:
+    {{- include "arcadedb.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "arcadedb.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/k8s/helm/templates/secret.yaml
+++ b/k8s/helm/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.arcadedb.credentials.rootPassword.secret.name }}
+{{ $secret := (lookup "v1" "Secret" .Release.Namespace "arcadedb-credentials-secret") | default dict }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: arcadedb-credentials-secret
+type: Opaque
+data:
+  # retrieve the secret data using lookup function and when not exists, return an empty dictionary / map as result
+  {{- $secretData := (get $secret "data") | default dict }}
+  {{- $rootPassword := (get $secretData "rootPassword") | default (randAlphaNum 32 | b64enc) }}
+  rootPassword: {{ $rootPassword }}
+{{- end }}

--- a/k8s/helm/templates/service.yaml
+++ b/k8s/helm/templates/service.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "arcadedb.fullname" . }}-http
+  labels:
+    {{- include "arcadedb.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.http.type }}
+  ports:
+    - port: {{ .Values.service.http.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "arcadedb.selectorLabels" . | nindent 4 }}
+
+---
+
+{{/*
+This is a "headless" service for the arcadedb which exists to allow discovery of the set of
+member pods (masters). The CNAME of this service points to SRV records - one for each Pod that
+is Running and Ready). Read more in the Kubernetes docs:
+https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/
+*/}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "arcadedb.fullname" . }}
+  labels:
+    {{- include "arcadedb.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  ports:
+    - port: {{ .Values.service.http.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: {{ .Values.service.rpc.port }}
+      targetPort: rpc
+      protocol: TCP
+      name: rpc
+  selector:
+    {{- include "arcadedb.selectorLabels" . | nindent 4 }}
+

--- a/k8s/helm/templates/serviceaccount.yaml
+++ b/k8s/helm/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "arcadedb.serviceAccountName" . }}
+  labels:
+    {{- include "arcadedb.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/k8s/helm/templates/statefulset.yaml
+++ b/k8s/helm/templates/statefulset.yaml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "arcadedb.fullname" . }}
+  labels:
+    {{- include "arcadedb.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "arcadedb.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "arcadedb.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "arcadedb.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.http.port }}
+              protocol: TCP
+          command:
+            - bin/server.sh
+            - -Darcadedb.dumpConfigAtStartup=true
+            - -Darcadedb.server.name=${HOSTNAME}
+            - -Darcadedb.server.rootPassword=${rootPassword}
+            - -Darcadedb.server.databaseDirectory={{ .Values.arcadedb.databaseDirectory }}
+            - -Darcadedb.server.defaultDatabases={{ .Values.arcadedb.defaultDatabases }}
+            - -Darcadedb.ha.enabled=true
+            - -Darcadedb.ha.replicationIncomingHost=0.0.0.0
+            - -Darcadedb.ha.serverList={{ include "arcadedb.fullname" . }}-0.{{ .Chart.Name }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.rpc.port }}
+            - -Darcadedb.ha.k8s=true
+            - -Darcadedb.ha.k8sSuffix=.{{ .Chart.Name }}.{{ .Release.Namespace }}.svc.cluster.local
+            {{- with .Values.arcadedb.extraCommands }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: POD_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: rootPassword
+              {{- if .Values.arcadedb.credentials.rootPassword.secret.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.arcadedb.credentials.rootPassword.secret.name }}
+                  {{- if .Values.arcadedb.credentials.rootPassword.secret.key }}
+                  key: {{ .Values.arcadedb.credentials.rootPassword.secret.key }}
+                  {{- end }}
+                  optional: false
+              {{- else }}  {{/* Use auto generated secret then */}}
+              valueFrom:
+                secretKeyRef:
+                  name: arcadedb-credentials-secret
+                  key: rootPassword
+              {{- end }}
+
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -110,11 +110,11 @@ resources: {}
 # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:
   httpGet:
-    path: /
+    path: /api/v1/ready
     port: http
 readinessProbe:
   httpGet:
-    path: /
+    path: /api/v1/ready
     port: http
 
 # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -1,0 +1,160 @@
+# Default values for arcadedb.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+arcadedb:
+  # Enable persistence by updating this and volume/Mounts
+  databaseDirectory: "/home/arcadedb/databases"
+  defaultDatabases: "Universe[elon:musk]"
+  extraCommands:
+    - -Darcadedb.server.mode=development # development | production
+  credentials:
+    rootPassword:
+      # If the secret is null, a new one called 'arcadedb-credentials-secret' will be created
+      # NOTE: If you are using `helm template` ie like ArgoCD does, each time the generated secret
+      # will be updated! If your auth flow is automated thru the secret name then maybe that's okay.
+      # Otherwise, you may be better off specifying the secret thru other means.
+      secret:
+        name: null
+        key: null
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  registry: arcadedata
+  repository: arcadedb
+  # This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  http:
+    # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+    type: LoadBalancer
+    # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+    port: 2480
+  rpc:
+    port: 2424
+
+# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+# TODO: This is probably broken, a mismatch between selectors in the headless service vs http service.
+# At least it doesn't seem to work correctly when using Traefik annotations.
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity:
+  # Set the anti-affinity selector scope to arcadedb servers.
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - arcadedb
+          topologyKey: kubernetes.io/hostname
+
+# extraManifests - Include any amount of extra arbitrary manifests
+extraManifests: {}

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 arcadedb:
   # Enable persistence by updating this and volume/Mounts
   databaseDirectory: "/home/arcadedb/databases"
-  defaultDatabases: "Universe[elon:musk]"
+  defaultDatabases: "Universe[foo:bar]"
   extraCommands:
     - -Darcadedb.server.mode=development # development | production
   credentials:

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -1,63 +1,74 @@
-# Default values for arcadedb.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
-# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+## @param replicaCount This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+##
 replicaCount: 1
 
+## @section arcaddb
 arcadedb:
-  # Enable persistence by updating this and volume/Mounts
+  ## @param arcadedb.databaseDirectory Enable persistence by updating this and volume/Mounts
   databaseDirectory: "/home/arcadedb/databases"
+  ## @param arcadedb.defaultDatabases Default databases 
   defaultDatabases: "Universe[foo:bar]"
+  ## @param arcadedb.extraCommands Any extra comands to pass to ArcadeDB startup
   extraCommands:
     - -Darcadedb.server.mode=development # development | production
+  ## @section arcadedb.credentials
   credentials:
+  ## @section arcadedb.credentials.rootPassword
     rootPassword:
-      # If the secret is null, a new one called 'arcadedb-credentials-secret' will be created
-      # NOTE: If you are using `helm template` ie like ArgoCD does, each time the generated secret
-      # will be updated! If your auth flow is automated thru the secret name then maybe that's okay.
-      # Otherwise, you may be better off specifying the secret thru other means.
+      ## @section arcadedb.credentials.secret
+      ## If the secret is null, a new one called 'arcadedb-credentials-secret' will be created
+      ## NOTE: If you are using `helm template` ie like ArgoCD does, each time the generated secret
+      ## will be updated! If your auth flow is automated thru the secret name then maybe that's okay.
+      ## Otherwise, you may be better off specifying the secret thru other means.
       secret:
+        ## @param arcadedb.credentials.rootPassword.secret.name Name of existing secret
         name: null
+        ## @param arcadedb.credentials.rootPassword.secret.key Key to use in existing secret
         key: null
 
-# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+## @section image
+## This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
+  ## @param image.registry Registry for image
   registry: arcadedata
+  ## @param image.repository Image repo
   repository: arcadedb
-  # This sets the pull policy for images.
+  ## @param image.pullPolicy This sets the pull policy for images.
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
+  ## @param image.tag Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
-# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+## @param imagePullSecrets This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
-# This is to override the chart name.
+## @param nameOverride This is to override the chart name.
 nameOverride: ""
+## @param fullnameOverride
 fullnameOverride: ""
 
-# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+## @section This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
 serviceAccount:
-  # Specifies whether a service account should be created
+  ## @param serviceAccount.create Specifies whether a service account should be created
   create: true
-  # Automatically mount a ServiceAccount's API credentials?
+  ## @param serviceAccount.automount Automatically mount a ServiceAccount's API credentials?
   automount: true
-  # Annotations to add to the service account
+  ## @param serviceAccount.annotations Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  ## @param serviceAccount.name The name of the service account to use.
+  ## If not set and create is true, a name is generated using the fullname template
   name: ""
 
-# This is for setting Kubernetes Annotations to a Pod.
-# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+## @param podAnnotations This is for setting Kubernetes Annotations to a Pod.
+## For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 podAnnotations: {}
-# This is for setting Kubernetes Labels to a Pod.
-# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+## @param podLabels This is for setting Kubernetes Labels to a Pod.
+## For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
 
+## @param podSecurityContext
 podSecurityContext: {}
   # fsGroup: 2000
 
+## @param securityContext
 securityContext: {}
   # capabilities:
   #   drop:
@@ -66,35 +77,48 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+## @section This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:
+  ## @section http
   http:
-    # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+    ## @param service.http.type This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
     type: LoadBalancer
-    # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+    ## @param service.http.port This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
     port: 2480
+  ## @section rpc
   rpc:
+    ## @param service.rpc.port This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
     port: 2424
 
-# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
-# TODO: This is probably broken, a mismatch between selectors in the headless service vs http service.
-# At least it doesn't seem to work correctly when using Traefik annotations.
+## @section ingress This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+## TODO: This is probably broken, a mismatch between selectors in the headless service vs http service.
+## At least it doesn't seem to work correctly when using Traefik annotations.
 ingress:
+  ## @param ingress.enabled
   enabled: false
+  ## @param ingress.className
   className: ""
+  ## @param ingress.annotations
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  ## @section ingress.hosts
   hosts:
+      ## @param ingress.hosts[0].host
     - host: chart-example.local
+      ## @section ingress.hosts[0].paths
       paths:
+          ## @param ingress.hosts[0].paths[0].path
         - path: /
+          ## @param ingress.hosts[0].paths[0].pathType
           pathType: ImplementationSpecific
+  ## @param ingress.tls
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
 
+## @param resources
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -107,46 +131,63 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+## @section This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:
+  ## @section livenessProbe.httpGet
   httpGet:
+    ## @param livenessProbe.httpGet.path
     path: /api/v1/ready
+    ## @param livenessProbe.httpGet.port
     port: http
+## @section This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 readinessProbe:
+  ## @section readinessProbe.httpGet
   httpGet:
+    ## @param readinessProbe.httpGet.path
     path: /api/v1/ready
+    ## @param readinessProbe.httpGet.port
     port: http
 
-# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+## @section This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:
+  ## @param autoscaling.enabled
   enabled: false
+  ## @param autoscaling.minReplicas
   minReplicas: 1
+  ## @param autoscaling.maxReplicas
   maxReplicas: 100
+  ## @param autoscaling.targetCPUUtilizationPercentage
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
-# Additional volumes on the output Deployment definition.
+## @param volumes Additional volumes on the output Deployment definition.
 volumes: []
 # - name: foo
 #   secret:
 #     secretName: mysecret
 #     optional: false
 
-# Additional volumeMounts on the output Deployment definition.
+## @param volumeMounts Additional volumeMounts on the output Deployment definition.
 volumeMounts: []
 # - name: foo
 #   mountPath: "/etc/foo"
 #   readOnly: true
 
+## @param nodeSelector
 nodeSelector: {}
 
+## @param tolerations
 tolerations: []
 
+## @section affinity
 affinity:
-  # Set the anti-affinity selector scope to arcadedb servers.
+  ## @section Set the anti-affinity selector scope to arcadedb servers.
   podAntiAffinity:
+    ## @section preferredDuringSchedulingIgnoredDuringExecution
     preferredDuringSchedulingIgnoredDuringExecution:
+        ## @param affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight
       - weight: 100
+        ## @skip affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm
         podAffinityTerm:
           labelSelector:
             matchExpressions:
@@ -156,5 +197,5 @@ affinity:
                   - arcadedb
           topologyKey: kubernetes.io/hostname
 
-# extraManifests - Include any amount of extra arbitrary manifests
+## @param extraManifests - Include any amount of extra arbitrary manifests
 extraManifests: {}


### PR DESCRIPTION
## What does this PR do?

This adds an initial Helm chart at `k8s/helm` (maybe a different path is preferred?)

100% organic human generated code; I used `helm create` and tried to follow the [recommended best practices](https://helm.sh/docs/chart_best_practices/). However I doubt it's bug free, in fact, I *think* something is wrong with the `ingress` portion. At least when I use Traefik it seems to keep getting routed to the headless service, resulting in `no available server` from Traefik. I think this has something to do with the selectors getting mixed up, but I'm not sure.  I plan to poke at it a bit more today but unless I find quick success, I see adding a separate [`IngressRoute`](https://doc.traefik.io/traefik-hub/api-gateway/reference/routing/kubernetes/http/routers/ref-httpingressroute) directly works w/o issue so may just use that in the shorter term.

Otherwise, I think it replicates pretty closely to what the existing static manifests accomplish and seems to work nicely on my end. I'm happy to continue to add to this as we use it more.

## Motivation

We have a standard flow of using helm with ArgoCD for base services and would like to give ArcadeDB a go in the same way.

## Related issues

https://github.com/ArcadeData/arcadedb/issues/1465#issuecomment-2692617813

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
