### PR TITLE
test: add test for postgres driver handling of generic lists and ARRAY_OF_FLOATS

### DIFF
--- a/e2e-python/pyproject.toml
+++ b/e2e-python/pyproject.toml
@@ -9,6 +9,7 @@ license = {text = "Apache-2.0"}
 dependencies = [
     "testcontainers>=4.9.1",
     "pytest>=8.3.4",
+    "pytest-check>=2.5.0",
     "docker>=7.1.0",
     "psycopg>=3.2.5",
     "psycopg-binary>=3.2.5",

--- a/e2e-python/tests/test_arcadedb.py
+++ b/e2e-python/tests/test_arcadedb.py
@@ -98,3 +98,27 @@ def test_psycopg2_basic_queries():
             assert 29.99 in product
     finally:
         conn.close()
+
+
+def test_psycopg2_return_array_floats():
+    """Check if the driver correctly sends the array of floats as a list of floats to the python driver"""
+    # Get connection parameters
+    params = get_connection_params(arcadedb)
+
+    # Connect to the database
+    conn = psycopg.connect(**params)
+    conn.autocommit = True
+
+    try:
+        with conn.cursor() as cursor:
+
+            cursor.execute("create vertex type `TEXT_EMBEDDING` if not exists;")
+
+            cursor.execute("create property TEXT_EMBEDDING.str if not exists STRING;")
+            cursor.execute("create property TEXT_EMBEDDING.embedding if not exists ARRAY_OF_FLOATS;")
+
+            cursor.execute('INSERT INTO `TEXT_EMBEDDING` SET str = "meow", hash = [0.1,0.2,0.3] RETURN hash')
+            embeddings = cursor.fetchone()[0]
+            assert isinstance(embeddings, list) and all(isinstance(item, float) for item in embeddings), f"Type ARRAY_OF_FLOATS is returned as {type(embeddings)} instead of list of floats"
+    finally:
+        conn.close()

--- a/e2e-python/tests/test_arcadedb.py
+++ b/e2e-python/tests/test_arcadedb.py
@@ -1,10 +1,15 @@
 import time
 from time import sleep
-
+import random
 import psycopg
 import pytest
 import requests
 from testcontainers.core.container import DockerContainer
+import json
+import string
+
+import pytest
+from pytest_check import check
 
 arcadedb = (DockerContainer("arcadedata/arcadedb:latest")
             .with_exposed_ports(2480, 2424, 5432)
@@ -109,6 +114,8 @@ def test_psycopg2_return_array_floats():
     conn = psycopg.connect(**params)
     conn.autocommit = True
 
+
+
     try:
         with conn.cursor() as cursor:
 
@@ -120,5 +127,55 @@ def test_psycopg2_return_array_floats():
             cursor.execute('INSERT INTO `TEXT_EMBEDDING` SET str = "meow", embedding = [0.1,0.2,0.3] RETURN embedding')
             embeddings = cursor.fetchone()[0]
             assert isinstance(embeddings, list) and all(isinstance(item, float) for item in embeddings), f"Type ARRAY_OF_FLOATS is returned as {type(embeddings)} instead of list of floats"
+    finally:
+        conn.close()
+
+
+def random_values(_type, size=64):
+    if _type == bool:  # Note: fixed the '=' to '==' for comparison
+        return [random.choice([True, False]) for _ in range(size)]
+    elif _type == float:
+        return [random.uniform(-100, 100) for _ in range(size)]
+    elif _type == int:
+        return [random.randint(-100, 100) for _ in range(size)]
+    elif _type == str:
+        # Generate random strings of length between 5 and 15
+        return [''.join(random.choices(string.ascii_letters + string.digits, k=random.randint(5, 15)))
+                for _ in range(size)]
+    else:
+        raise ValueError(f"Unsupported type: {_type}")
+
+def test_psycopg2_return_array_common():
+    """Check if the driver correctly sends the array of floats as a list of floats to the python driver"""
+    # Get connection parameters
+    params = get_connection_params(arcadedb)
+
+    # Connect to the database
+    conn = psycopg.connect(**params)
+    conn.autocommit = True
+
+    types_to_test = [bool, float, int, str]
+
+    try:
+        for type_to_test in types_to_test:
+            # Extract just the type name from the class representation
+            type_name = type_to_test.__name__
+            arcade_name = f"TEXT_{type_name}"
+
+            with conn.cursor() as cursor:
+                cursor.execute(f"create vertex type `{arcade_name}` if not exists;")
+                cursor.execute(f"create property {arcade_name}.str if not exists STRING;")
+                cursor.execute(f"create property {arcade_name}.data if not exists LIST;")
+
+                cursor.execute(f'INSERT INTO `{arcade_name}` SET str = "meow", data = {json.dumps(random_values(type_to_test))} RETURN data')
+                datas = cursor.fetchone()[0]
+
+                # Use pytest-check to continue even after assertion failures
+                with check:
+                    assert isinstance(datas, list), f"For {type_name}: Type LIST is returned as {type(datas)} instead of list"
+
+                if isinstance(datas, list):
+                    with check:
+                        assert all(isinstance(item, type_to_test) for item in datas), f"For {type_name}: Not all items are of type {type_name}"
     finally:
         conn.close()

--- a/e2e-python/tests/test_arcadedb.py
+++ b/e2e-python/tests/test_arcadedb.py
@@ -117,7 +117,7 @@ def test_psycopg2_return_array_floats():
             cursor.execute("create property TEXT_EMBEDDING.str if not exists STRING;")
             cursor.execute("create property TEXT_EMBEDDING.embedding if not exists ARRAY_OF_FLOATS;")
 
-            cursor.execute('INSERT INTO `TEXT_EMBEDDING` SET str = "meow", hash = [0.1,0.2,0.3] RETURN hash')
+            cursor.execute('INSERT INTO `TEXT_EMBEDDING` SET str = "meow", embedding = [0.1,0.2,0.3] RETURN embedding')
             embeddings = cursor.fetchone()[0]
             assert isinstance(embeddings, list) and all(isinstance(item, float) for item in embeddings), f"Type ARRAY_OF_FLOATS is returned as {type(embeddings)} instead of list of floats"
     finally:


### PR DESCRIPTION
## What does this PR do?

Test checking if the pg driver returns an actual list instead of a string for an ARRAY_OF_FLOATS

## Motivation

test for pr #2017

## Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

## Additional Notes

Anything else we should know when reviewing?

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
