### PR TITLE
Allow root password to be updated using `arcadedb.server.rootPassword` and `arcadedb.server.rootPasswordPath`

### DIFF
--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -125,20 +125,39 @@ public class ServerSecurity implements ServerPlugin, com.arcadedb.security.Secur
         }
       }
 
-      String rootPassword = server != null ?
+      final String rootPasswordFromEnv = server != null ?
         server.getConfiguration().getValueAsString(GlobalConfiguration.SERVER_ROOT_PASSWORD) :
         GlobalConfiguration.SERVER_ROOT_PASSWORD.getValueAsString();
+
+
+
+      final String rootPasswordPath = server != null ?
+        server.getConfiguration().getValueAsString(GlobalConfiguration.SERVER_ROOT_PASSWORD_PATH) :
+        GlobalConfiguration.SERVER_ROOT_PASSWORD_PATH.getValueAsString();
+
+
+      final String rootPasswordFromFile = rootPasswordPath != null ? (Files.isReadable(Path.of(rootPasswordPath)) ? Files.readString(Path.of(rootPasswordPath)) : null) : null;
+
       if (users.isEmpty() || (users.containsKey("root") && users.get("root").getPassword() == null))
       {
         askForRootPassword();
       }
-      else if (rootPassword != null && (users.containsKey("root") && users.get("root").getPassword() != rootPassword))
+      else if ((rootPasswordFromFile != null || rootPasswordFromEnv != null) && (users.containsKey("root")))
       {
-        credentialsValidator.validateCredentials("root", rootPassword);
+        final String curRootPassword = users.get("root").getPassword();
+        if (rootPasswordFromFile != null && rootPasswordFromEnv != null)
+          LogManager.instance().log(this, Level.WARNING, "Both `arcadedb.server.rootPassword` and `arcadedb.server.rootPasswordPath` settings were used, falling back to `arcadedb.server.rootPasswordPath`");
 
-        final String encodedPassword = encodePassword(rootPassword, ServerSecurity.generateRandomSalt());
-        getUser("root").setPassword(encodedPassword);
-        saveUsers();
+        final String pickedNewRootPassword = rootPasswordFromFile == null ? rootPasswordFromEnv : rootPasswordFromFile;
+
+
+        if (curRootPassword != pickedNewRootPassword)
+        {
+            credentialsValidator.validateCredentials("root", pickedNewRootPassword);
+            final String encodedPassword = encodePassword(pickedNewRootPassword, ServerSecurity.generateRandomSalt());
+            getUser("root").setPassword(encodedPassword);
+            saveUsers();
+        }
       }
 
 

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -137,11 +137,8 @@ public class ServerSecurity implements ServerPlugin, com.arcadedb.security.Secur
         credentialsValidator.validateCredentials("root", rootPassword);
 
         final String encodedPassword = encodePassword(rootPassword, ServerSecurity.generateRandomSalt());
-
-        if (existsUser("root")) {
-          getUser("root").setPassword(encodedPassword);
-          saveUsers();
-        }
+        getUser("root").setPassword(encodedPassword);
+        saveUsers();
       }
 
 


### PR DESCRIPTION
## What does this PR do?

When using env variable `arcadedb.server.rootPassword` you can now update root password on each boot and not just on first boot to prevent stdin "listening"

## Motivation

What inspired you to submit this pull request?

## Related issues

#2058 



## Checklist

- [x] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
