### PR TITLE
Return exit status from console if error occurs in bulk mode

### DIFF
--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -164,6 +164,8 @@ public class Console {
 
     try {
       execute(args);
+    } catch(Throwable t) {
+      System.exit(1);
     } finally {
       // FORCE EXIT IN CASE OF UNMANAGED ERROR
       System.exit(0);

--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -93,6 +93,7 @@ public class Console {
   private              RemoteServer         remoteServer;
   private              boolean              batchMode                = false;
   private              boolean              failAtEnd                = false;
+  private static       boolean              errored                  = false;
 
   public Console(final DatabaseInternal database) throws IOException {
     this();
@@ -164,11 +165,10 @@ public class Console {
 
     try {
       execute(args);
-    } catch(Throwable t) {
-      System.exit(1);
     } finally {
       // FORCE EXIT IN CASE OF UNMANAGED ERROR
-      System.exit(0);
+      if (errored) System.exit(1);
+      else System.exit(0);
     }
   }
 
@@ -631,6 +631,7 @@ public class Console {
       try {
         resultSet = databaseProxy.command(language, line);
       } catch (Exception e) {
+        errored = true;
         if (batchMode && !failAtEnd)
           throw e;
         else
@@ -778,6 +779,7 @@ public class Console {
           if (!execute(w))
             return false;
         } catch (final Exception e) {
+          errored = true;
           if (!failAtEnd)
             throw e;
         }


### PR DESCRIPTION
## What does this PR do?

This change adds an exit status one for errors during bulk mode that is not fail-at-end.

Note: A static attribute is used to track the error status during console execution.

## Motivation

Using console bulk mode during building of Docker images

## Related issues

https://github.com/ArcadeData/arcadedb/issues/2052

## Additional notes

This could be considered a breaking change (?).

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
