### PR TITLE
fix: graphql support for embedded documents

### DIFF
--- a/graphql/src/test/java/com/arcadedb/graphql/AbstractGraphQLTest.java
+++ b/graphql/src/test/java/com/arcadedb/graphql/AbstractGraphQLTest.java
@@ -20,8 +20,11 @@ package com.arcadedb.graphql;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.MutableEmbeddedDocument;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.schema.VertexType;
 import com.arcadedb.utility.Callable;
 import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -47,14 +50,21 @@ public abstract class AbstractGraphQLTest {
       try {
         database.transaction(() -> {
           final Schema schema = database.getSchema();
+
+          schema.getOrCreateDocumentType("Address");
+
+          final VertexType author = schema.getOrCreateVertexType("Author");
+          author.createProperty("address", Type.EMBEDDED, "Address");
+
           schema.getOrCreateVertexType("Book");
-          schema.getOrCreateVertexType("Author");
           schema.getOrCreateEdgeType("IS_AUTHOR_OF");
 
           final MutableVertex author1 = database.newVertex("Author");
           author1.set("id", "author-1");
           author1.set("firstName", "Joanne");
           author1.set("lastName", "Rowling");
+          final MutableEmbeddedDocument address = author1.newEmbeddedDocument("Address", "address");
+          address.set("city", "Rome");
           author1.save();
 
           final MutableVertex book1 = database.newVertex("Book");


### PR DESCRIPTION
This pull request includes various changes to the `GraphQLResultSet` class and its associated test files to improve handling of embedded documents and enhance code readability. The most important changes include adding support for `EmbeddedDocument` and refining the test cases.

Enhancements to `GraphQLResultSet`:

* Added imports for `EmbeddedDocument` and `RID` in `GraphQLResultSet` to support embedded document handling.
* Updated the `GraphQLResultSet` constructor and methods to improve readability by reformatting the code. [[1]](diffhunk://#diff-b87f04b8297e92e07c39dce0e923ae0768a7fe8afc9ebcfc71d6f5879c088f8eL63-R66) [[2]](diffhunk://#diff-b87f04b8297e92e07c39dce0e923ae0768a7fe8afc9ebcfc71d6f5879c088f8eL97-R101) [[3]](diffhunk://#diff-b87f04b8297e92e07c39dce0e923ae0768a7fe8afc9ebcfc71d6f5879c088f8eL133-R143)
* Enhanced the `mapProjections` method to handle `EmbeddedDocument` types and ensure `RID` is not null before adding to the map. [[1]](diffhunk://#diff-b87f04b8297e92e07c39dce0e923ae0768a7fe8afc9ebcfc71d6f5879c088f8eL153-R161) [[2]](diffhunk://#diff-b87f04b8297e92e07c39dce0e923ae0768a7fe8afc9ebcfc71d6f5879c088f8eL192-R203) [[3]](diffhunk://#diff-b87f04b8297e92e07c39dce0e923ae0768a7fe8afc9ebcfc71d6f5879c088f8eL213-R226)

Improvements to test cases:

* Added a new test case `embeddedAddresses` in `GraphQLBasicTest` to verify the handling of embedded addresses within authors.
* Updated the `executeTest` method in `AbstractGraphQLTest` to create document and vertex types for testing embedded documents.
* Refined existing test cases to improve readability by reformatting the code. [[1]](diffhunk://#diff-6866a7b4c1c09abfd878e3903c87088774751dda6e8bec2791c0fb521a161a0dL90-R91) [[2]](diffhunk://#diff-6866a7b4c1c09abfd878e3903c87088774751dda6e8bec2791c0fb521a161a0dR228-R234) [[3]](diffhunk://#diff-6866a7b4c1c09abfd878e3903c87088774751dda6e8bec2791c0fb521a161a0dR269)
What inspired you to submit this pull request?

## Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.