### PR TITLE
Async rebuild index

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncCompletion.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncCompletion.java
@@ -20,7 +20,13 @@ package com.arcadedb.database.async;
 
 import com.arcadedb.database.DatabaseInternal;
 
+import java.util.concurrent.*;
+
 public class DatabaseAsyncCompletion extends DatabaseAsyncAbstractCallbackTask {
+  public DatabaseAsyncCompletion() {
+    super(new CountDownLatch(1));
+  }
+
   @Override
   public void execute(final DatabaseAsyncExecutorImpl.AsyncThread async, final DatabaseInternal database) {
     try {

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecuteAlone.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecuteAlone.java
@@ -18,20 +18,30 @@
  */
 package com.arcadedb.database.async;
 
+import com.arcadedb.database.DatabaseInternal;
+
 import java.util.concurrent.*;
 
-public abstract class DatabaseAsyncAbstractCallbackTask implements DatabaseAsyncTask {
-  private final CountDownLatch semaphore;
+public class DatabaseAsyncExecuteAlone extends DatabaseAsyncAbstractCallbackTask {
+  private final OkCallback callback;
 
-  protected DatabaseAsyncAbstractCallbackTask(final CountDownLatch semaphore) {
-    this.semaphore = semaphore;
+  public DatabaseAsyncExecuteAlone(final CountDownLatch semaphore, final OkCallback callback) {
+    super(semaphore);
+    this.callback = callback;
   }
 
-  public boolean waitCompletion(final long timeoutInMs) throws InterruptedException {
-    return semaphore.await(timeoutInMs, TimeUnit.MILLISECONDS);
+  @Override
+  public void execute(final DatabaseAsyncExecutorImpl.AsyncThread async, final DatabaseInternal database) {
+    callback.call();
   }
 
-  public void completed() {
-    semaphore.countDown();
+  @Override
+  public boolean requiresActiveTx() {
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return "ExecuteAlone";
   }
 }

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java
@@ -413,4 +413,9 @@ public interface DatabaseAsyncExecutor {
    * Returns true if there is any asynchronous tasks executing or scheduled.
    */
   boolean isProcessing();
+
+  /**
+   * Returns the number of asynchronous threads.
+   */
+  int getThreadCount();
 }

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -296,11 +296,7 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
   }
 
   @Override
-  public boolean waitCompletion(final long timeout) {
-    return waitCompletion(timeout, () -> new DatabaseAsyncCompletion());
-  }
-
-  public boolean waitCompletion(long timeout, final AsyncTaskFactory taskFactoryClass) {
+  public boolean waitCompletion(long timeout) {
     if (executorThreads == null)
       return true;
 
@@ -308,7 +304,7 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
 
     for (int i = 0; i < executorThreads.length; ++i)
       try {
-        semaphores[i] = taskFactoryClass.create();
+        semaphores[i] = new DatabaseAsyncCompletion();
         executorThreads[i].queue.put(semaphores[i]);
       } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();

--- a/engine/src/main/java/com/arcadedb/index/TypeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/TypeIndex.java
@@ -186,7 +186,7 @@ public class TypeIndex implements RangeIndex, IndexInternal {
 
   @Override
   public String getMostRecentFileName() {
-    return indexesOnBuckets.get(0).getMostRecentFileName();
+    return getFirstUnderlyingIndex().getMostRecentFileName();
   }
 
   @Override
@@ -194,7 +194,7 @@ public class TypeIndex implements RangeIndex, IndexInternal {
     checkIsValid();
     if (indexesOnBuckets.isEmpty())
       return null;
-    return indexesOnBuckets.get(0).getType();
+    return getFirstUnderlyingIndex().getType();
   }
 
   @Override
@@ -205,7 +205,7 @@ public class TypeIndex implements RangeIndex, IndexInternal {
   @Override
   public List<String> getPropertyNames() {
     checkIsValid();
-    return indexesOnBuckets.get(0).getPropertyNames();
+    return getFirstUnderlyingIndex().getPropertyNames();
   }
 
   @Override
@@ -217,7 +217,7 @@ public class TypeIndex implements RangeIndex, IndexInternal {
 
   @Override
   public JSONObject toJSON() {
-    return indexesOnBuckets.get(0).toJSON();
+    return getFirstUnderlyingIndex().toJSON();
   }
 
   @Override
@@ -261,25 +261,25 @@ public class TypeIndex implements RangeIndex, IndexInternal {
   @Override
   public LSMTreeIndexAbstract.NULL_STRATEGY getNullStrategy() {
     checkIsValid();
-    return indexesOnBuckets.get(0).getNullStrategy();
+    return getFirstUnderlyingIndex().getNullStrategy();
   }
 
   @Override
   public void setNullStrategy(final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy) {
     checkIsValid();
-    indexesOnBuckets.get(0).setNullStrategy(nullStrategy);
+    getFirstUnderlyingIndex().setNullStrategy(nullStrategy);
   }
 
   @Override
   public boolean isUnique() {
     checkIsValid();
-    return indexesOnBuckets.get(0).isUnique();
+    return getFirstUnderlyingIndex().isUnique();
   }
 
   @Override
   public boolean supportsOrderedIterations() {
     checkIsValid();
-    return indexesOnBuckets.get(0).supportsOrderedIterations();
+    return getFirstUnderlyingIndex().supportsOrderedIterations();
   }
 
   @Override
@@ -290,7 +290,7 @@ public class TypeIndex implements RangeIndex, IndexInternal {
   @Override
   public int getPageSize() {
     checkIsValid();
-    return indexesOnBuckets.get(0).getPageSize();
+    return getFirstUnderlyingIndex().getPageSize();
   }
 
   @Override
@@ -388,13 +388,13 @@ public class TypeIndex implements RangeIndex, IndexInternal {
   @Override
   public Type[] getKeyTypes() {
     checkIsValid();
-    return indexesOnBuckets.get(0).getKeyTypes();
+    return getFirstUnderlyingIndex().getKeyTypes();
   }
 
   @Override
   public byte[] getBinaryKeyTypes() {
     checkIsValid();
-    return indexesOnBuckets.get(0).getBinaryKeyTypes();
+    return getFirstUnderlyingIndex().getBinaryKeyTypes();
   }
 
   @Override
@@ -490,5 +490,12 @@ public class TypeIndex implements RangeIndex, IndexInternal {
   private void checkIsValid() {
     if (!valid)
       throw new IndexException("Index '" + getName() + "' is not valid. Probably has been drop or rebuilt");
+  }
+
+  private IndexInternal getFirstUnderlyingIndex() {
+    checkIsValid();
+    if (indexesOnBuckets.isEmpty())
+      throw new IndexException("Index '" + getName() + "' is not valid. Probably has been drop or rebuilt");
+    return indexesOnBuckets.get(0);
   }
 }

--- a/engine/src/main/java/com/arcadedb/schema/BucketIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/BucketIndexBuilder.java
@@ -19,16 +19,20 @@
 package com.arcadedb.schema;
 
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.async.DatabaseAsyncExecuteAlone;
+import com.arcadedb.database.async.DatabaseAsyncExecutorImpl;
 import com.arcadedb.engine.Bucket;
 import com.arcadedb.exception.DatabaseMetadataException;
-import com.arcadedb.exception.NeedRetryException;
 import com.arcadedb.exception.SchemaException;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexInternal;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.security.SecurityDatabaseUser;
 
 import java.util.*;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
+import java.util.logging.*;
 
 /**
  * Builder class for bucket indexes.
@@ -40,7 +44,8 @@ public class BucketIndexBuilder extends IndexBuilder<Index> {
   final String   bucketName;
   final String[] propertyNames;
 
-  protected BucketIndexBuilder(final DatabaseInternal database, final String typeName, final String bucketName, final String[] propertyNames) {
+  protected BucketIndexBuilder(final DatabaseInternal database, final String typeName, final String bucketName,
+      final String[] propertyNames) {
     super(database, Index.class);
     this.typeName = typeName;
     this.bucketName = bucketName;
@@ -51,55 +56,70 @@ public class BucketIndexBuilder extends IndexBuilder<Index> {
   public Index create() {
     database.checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);
 
-    if (database.isAsyncProcessing())
-      throw new NeedRetryException("Cannot create a new index while asynchronous tasks are running");
+    try {
+      final CountDownLatch semaphore = new CountDownLatch(database.async().getThreadCount());
 
-    final LocalSchema schema = database.getSchema().getEmbedded();
+      ((DatabaseAsyncExecutorImpl) database.async()).waitCompletion(0L, () -> new DatabaseAsyncExecuteAlone(semaphore,
+          () -> {
 
-    if (propertyNames.length == 0)
-      throw new DatabaseMetadataException("Cannot create index on type '" + typeName + "' because there are no property defined");
+          })
+      );
 
-    final LocalDocumentType type = schema.getType(typeName);
+      final LocalSchema schema = database.getSchema().getEmbedded();
 
-    // CHECK ALL THE PROPERTIES EXIST
-    final Type[] keyTypes = new Type[propertyNames.length];
-    int i = 0;
+      if (propertyNames.length == 0)
+        throw new DatabaseMetadataException(
+            "Cannot create index on type '" + typeName + "' because there are no property defined");
 
-    for (final String propertyName : propertyNames) {
-      final Property property = type.getPolymorphicPropertyIfExists(propertyName);
-      if (property == null)
-        throw new SchemaException("Cannot create the index on type '" + typeName + "." + propertyName + "' because the property does not exist");
+      final LocalDocumentType type = schema.getType(typeName);
 
-      keyTypes[i++] = property.getType();
-    }
+      // CHECK ALL THE PROPERTIES EXIST
+      final Type[] keyTypes = new Type[propertyNames.length];
+      int i = 0;
 
-    return schema.recordFileChanges(() -> {
-      final AtomicReference<Index> result = new AtomicReference<>();
-      database.transaction(() -> {
+      for (final String propertyName : propertyNames) {
+        final Property property = type.getPolymorphicPropertyIfExists(propertyName);
+        if (property == null)
+          throw new SchemaException(
+              "Cannot create the index on type '" + typeName + "." + propertyName + "' because the property does not exist");
 
-        Bucket bucket = null;
-        final List<Bucket> buckets = type.getBuckets(true);
-        for (final Bucket b : buckets) {
-          if (bucketName.equals(b.getName())) {
-            bucket = b;
-            break;
+        keyTypes[i++] = property.getType();
+      }
+
+      return schema.recordFileChanges(() -> {
+        final AtomicReference<Index> result1 = new AtomicReference<>();
+        database.transaction(() -> {
+
+          Bucket bucket = null;
+          final List<Bucket> buckets = type.getBuckets(true);
+          for (final Bucket b : buckets) {
+            if (bucketName.equals(b.getName())) {
+              bucket = b;
+              break;
+            }
           }
-        }
 
-        final Index index = schema.createBucketIndex(type, keyTypes, bucket, typeName, indexType, unique, pageSize, nullStrategy, callback, propertyNames, null,
-            batchSize);
-        result.set(index);
+          final Index index = schema.createBucketIndex(type, keyTypes, bucket, typeName, indexType, unique, pageSize,
+              nullStrategy,
+              callback, propertyNames, null,
+              batchSize);
+          result1.set(index);
 
-        schema.saveConfiguration();
+          schema.saveConfiguration();
 
-      }, false, maxAttempts, null, (error) -> {
-        final Index indexToRemove = result.get();
-        if (indexToRemove != null) {
-          ((IndexInternal) indexToRemove).drop();
-        }
+        }, false, maxAttempts, null, (error) -> {
+          final Index indexToRemove = result1.get();
+          if (indexToRemove != null) {
+            ((IndexInternal) indexToRemove).drop();
+          }
+        });
+        return result1.get();
       });
 
-      return result.get();
-    });
+    } finally {
+      // RE-ENABLE THE THREAD POOL
+      LogManager.instance().log(this, Level.INFO, "Resuming asynch threads");
+      ((DatabaseAsyncExecutorImpl) database.async()).pauseThread(false);
+    }
   }
 }


### PR DESCRIPTION
This pull request includes several changes to improve the handling of asynchronous tasks and the management of indexes in the database. The most important changes include refactoring the `DatabaseAsyncAbstractCallbackTask` class, adding a new class `DatabaseAsyncExecuteAlone`, updating the `DatabaseAsyncExecutor` and `DatabaseAsyncExecutorImpl` interfaces, and modifying the `TypeIndex` class to use a helper method for accessing the first underlying index.

### Asynchronous Task Management:

* [`engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncAbstractCallbackTask.java`](diffhunk://#diff-71fbcdd1579c9a543eaddfd531cae140deb0869a9f315e921d87ce45e2bdb774L24-R28): Refactored the class to accept a `CountDownLatch` via a constructor, improving flexibility.
* [`engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncCompletion.java`](diffhunk://#diff-75ef5b473ebfe83de00f7b85f9e576e39d7c25eff6e7e5eeca1cb34845c28125R23-R29): Updated the class to use the new constructor of `DatabaseAsyncAbstractCallbackTask`.
* [`engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecuteAlone.java`](diffhunk://#diff-18184014e3725a15fc2a062e8bee43af0e6303dc5c97760683154930bd5eebc8R1-R47): Added a new class `DatabaseAsyncExecuteAlone` that extends `DatabaseAsyncAbstractCallbackTask` to execute a callback in isolation.
* [`engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutor.java`](diffhunk://#diff-89f320717eadfb2f2a6f1fd0ef45afe16d1767ead2f691f82e5d743f522aad1bR416-R420): Added a method `getThreadCount` to return the number of asynchronous threads.
* [`engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java`](diffhunk://#diff-de9a3171c13bb87ee75dca3339271ec9986fb4ceec2ba0e77f3de5f670ba4da5R61-R64): Implemented the `getThreadCount` method and updated the `waitCompletion` method to use `DatabaseAsyncAbstractCallbackTask`. [[1]](diffhunk://#diff-de9a3171c13bb87ee75dca3339271ec9986fb4ceec2ba0e77f3de5f670ba4da5R61-R64) [[2]](diffhunk://#diff-de9a3171c13bb87ee75dca3339271ec9986fb4ceec2ba0e77f3de5f670ba4da5R298-R303) [[3]](diffhunk://#diff-de9a3171c13bb87ee75dca3339271ec9986fb4ceec2ba0e77f3de5f670ba4da5R666-R670)

### Index Management:

* [`engine/src/main/java/com/arcadedb/index/TypeIndex.java`](diffhunk://#diff-f393d736aa37b37cdbd17d4b16e857f330dbb9bd8a38075ef234d8c28ad0803aL189-R197): Refactored multiple methods to use a new helper method `getFirstUnderlyingIndex` for accessing the first underlying index, improving code readability and maintainability. [[1]](diffhunk://#diff-f393d736aa37b37cdbd17d4b16e857f330dbb9bd8a38075ef234d8c28ad0803aL189-R197) [[2]](diffhunk://#diff-f393d736aa37b37cdbd17d4b16e857f330dbb9bd8a38075ef234d8c28ad0803aL208-R208) [[3]](diffhunk://#diff-f393d736aa37b37cdbd17d4b16e857f330dbb9bd8a38075ef234d8c28ad0803aL220-R220) [[4]](diffhunk://#diff-f393d736aa37b37cdbd17d4b16e857f330dbb9bd8a38075ef234d8c28ad0803aL264-R282) [[5]](diffhunk://#diff-f393d736aa37b37cdbd17d4b16e857f330dbb9bd8a38075ef234d8c28ad0803aL293-R293) [[6]](diffhunk://#diff-f393d736aa37b37cdbd17d4b16e857f330dbb9bd8a38075ef234d8c28ad0803aL391-R397) [[7]](diffhunk://#diff-f393d736aa37b37cdbd17d4b16e857f330dbb9bd8a38075ef234d8c28ad0803aR494-R500)

### Additional Changes:

* [`engine/src/main/java/com/arcadedb/schema/BucketIndexBuilder.java`](diffhunk://#diff-3e5f8601d96de353c8b062c9c939ed46b5b99f21e46f36247656dc34877f4cf4R22-R35): Modified the `create` method to handle asynchronous tasks more effectively by using `DatabaseAsyncExecuteAlone` and `CountDownLatch`. [[1]](diffhunk://#diff-3e5f8601d96de353c8b062c9c939ed46b5b99f21e46f36247656dc34877f4cf4R22-R35) [[2]](diffhunk://#diff-3e5f8601d96de353c8b062c9c939ed46b5b99f21e46f36247656dc34877f4cf4L43-R48) [[3]](diffhunk://#diff-3e5f8601d96de353c8b062c9c939ed46b5b99f21e46f36247656dc34877f4cf4L54-R80) [[4]](diffhunk://#diff-3e5f8601d96de353c8b062c9c939ed46b5b99f21e46f36247656dc34877f4cf4L71-R98) [[5]](diffhunk://#diff-3e5f8601d96de353c8b062c9c939ed46b5b99f21e46f36247656dc34877f4cf4L89-R131)