### PR TITLE
#2119 test: add parameterized query tests for JdbcQueries and psycopg2

### DIFF
--- a/e2e-python/tests/test_arcadedb.py
+++ b/e2e-python/tests/test_arcadedb.py
@@ -207,8 +207,8 @@ def test_psycopg2_with_named_parameterized_query():
 
     try:
         with conn.cursor() as cursor:
-            params = {'name': 'Stout'}
-            cursor.execute('SELECT * FROM Beer WHERE name = %(name)s', params)
+            query_params = {'name': 'Stout'}
+            cursor.execute('SELECT * FROM Beer WHERE name = %(name)s', query_params)
             beer = cursor.fetchall()[0]
             assert 'Stout' in beer
     finally:

--- a/e2e-python/tests/test_arcadedb.py
+++ b/e2e-python/tests/test_arcadedb.py
@@ -197,3 +197,36 @@ def test_psycopg2_return_array_common():
                                    datas), f"For {type_name}: Not all items are of type {type_name}"
     finally:
         conn.close()
+
+
+def test_psycopg2_with_named_parametrized_query():
+    """Check if the driver correctly handles parametrized named queries"""
+
+    params = get_connection_params(arcadedb)
+    conn = psycopg.connect(**params)
+    conn.autocommit = True
+
+    try:
+        with conn.cursor() as cursor:
+            params = {'name': 'Stout'}
+            cursor.execute('SELECT * FROM Beer WHERE name = %(name)s', params)
+            beer = cursor.fetchall()[0]
+            assert 'Stout' in beer
+    finally:
+        conn.close()
+
+
+def test_psycopg2_with_positional_parametrized_query():
+    """Check if the driver correctly handles parametrized positional queries"""
+
+    params = get_connection_params(arcadedb)
+    conn = psycopg.connect(**params)
+    conn.autocommit = True
+
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute('SELECT * FROM Beer WHERE name = %s', ("Stout",))
+            beer = cursor.fetchall()[0]
+            assert 'Stout' in beer
+    finally:
+        conn.close()

--- a/e2e-python/tests/test_arcadedb.py
+++ b/e2e-python/tests/test_arcadedb.py
@@ -199,9 +199,8 @@ def test_psycopg2_return_array_common():
         conn.close()
 
 
-def test_psycopg2_with_named_parametrized_query():
-    """Check if the driver correctly handles parametrized named queries"""
-
+def test_psycopg2_with_named_parameterized_query():
+    """Check if the driver correctly handles parameterized named queries"""
     params = get_connection_params(arcadedb)
     conn = psycopg.connect(**params)
     conn.autocommit = True

--- a/e2e-python/tests/test_arcadedb.py
+++ b/e2e-python/tests/test_arcadedb.py
@@ -215,9 +215,8 @@ def test_psycopg2_with_named_parameterized_query():
         conn.close()
 
 
-def test_psycopg2_with_positional_parametrized_query():
-    """Check if the driver correctly handles parametrized positional queries"""
-
+def test_psycopg2_with_positional_parameterized_query():
+    """Check if the driver correctly handles parameterized positional queries"""
     params = get_connection_params(arcadedb)
     conn = psycopg.connect(**params)
     conn.autocommit = True

--- a/e2e/src/test/java/com/arcadedb/e2e/JdbcQueriesTest.java
+++ b/e2e/src/test/java/com/arcadedb/e2e/JdbcQueriesTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
@@ -76,6 +77,21 @@ public class JdbcQueriesTest extends ArcadeContainerTemplate {
       }
     }
   }
+
+  @Test
+  void preparedStatement() throws Exception {
+
+    try (final PreparedStatement st = conn.prepareStatement("SELECT * FROM Beer where name = ?")) {
+      st.setString(1, "Stout");
+      try (final ResultSet rs = st.executeQuery()) {
+        while (rs.next()) {
+          assertThat(rs.getString("name")).isEqualTo("Stout");
+        }
+      }
+    }
+  }
+
+
 
   @Test
   void bigResultSetSQLQuery() throws Exception {


### PR DESCRIPTION
This pull request includes new tests for parameterized queries in both Python and Java, ensuring that the driver correctly handles named and positional parameters.

### New tests for parameterized queries:

* [`e2e-python/tests/test_arcadedb.py`](diffhunk://#diff-43e0690c67917d4e0065a0d68c2fd8361183c9cab76f3e0162d47b75f0dd0ef4R200-R230): Added `test_psycopg2_with_named_parameterized_query` and `test_psycopg2_with_positional_parameterized_query` to verify correct handling of named and positional parameterized queries in Python.
* [`e2e/src/test/java/com/arcadedb/e2e/JdbcQueriesTest.java`](diffhunk://#diff-f95c0d972953192f8794aa17b676121778126913b51cba1dbf524b0d95c81a98R81-R95): Added `preparedStatement` test to verify correct handling of parameterized queries using `PreparedStatement` in Java.

### Import changes:

* [`e2e/src/test/java/com/arcadedb/e2e/JdbcQueriesTest.java`](diffhunk://#diff-f95c0d972953192f8794aa17b676121778126913b51cba1dbf524b0d95c81a98R30): Added import for `PreparedStatement` to support new parameterized query tests.


## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
