### PR TITLE
Add note about docker image rebuilding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,12 @@ To run additional integration test locally use:
 $ mvn clean install -P integration
 ```
 
+Rebuild Docker images for `e2e` tests:
+
+```shell
+$ mvn clean install -DskipTests -Pdocker
+```
+
 Build and run in fail-at-end mode:
 
 ```shell


### PR DESCRIPTION
## What does this PR do?

Add short note to `CONTRIBUTING` about image rebuilding for tests

## Motivation

Errors during tests due to outdated images

## Additional Notes

Solution by @robfrank 

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
