### PR TITLE
fix: improve root user password check logic in ServerSecurity

### DIFF
--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -125,7 +125,7 @@ public class ServerSecurity implements ServerPlugin, com.arcadedb.security.Secur
         }
       }
 
-      if (users.isEmpty() || (users.containsKey("root") && users.get("root").getPassword() == null))
+      if (users.isEmpty() || !users.containsKey("root") || (users.containsKey("root") && users.get("root").getPassword() == null))
         askForRootPassword();
 
       final long fileLastModified = usersRepository.getFileLastModified();


### PR DESCRIPTION
as proposed there : https://github.com/ArcadeData/arcadedb/issues/2058#issuecomment-2718427974

Issue is that is we have at least one user registered it will not try to recreate root because the current contition doesn't allow it

this pr fixes it