### PR TITLE
fix #2160 (studio login)

### DIFF
--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -44,9 +44,8 @@ function updateDatabases(callback) {
 
   jQuery
     .ajax({
-      type: "POST",
-      url: "api/v1/server",
-      data: "{ command: 'list databases' }",
+      type: "GET",
+      url: "api/v1/databases",
       beforeSend: function (xhr) {
         xhr.setRequestHeader("Authorization", globalCredentials);
       },


### PR DESCRIPTION
## What does this PR do?

Studio Login fails due to use of removed `version` prop from HTTP responses.

## Motivation

https://github.com/ArcadeData/arcadedb/issues/2160

## Additional Notes

This only works because the `databases` endpoint still uses the `createResult` for the JSON response including the version property.

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
