### PR TITLE
Fix doc links in studio

### DIFF
--- a/studio/src/main/resources/static/api.html
+++ b/studio/src/main/resources/static/api.html
@@ -27,7 +27,7 @@
           <pre>/api/v1/ready</pre>
         </div>
         <div class="col-7">
-          <a class="link" href="https://docs.arcadedb.com/#HTTP-CheckReady">Get server status</a>
+          <a class="link" href="https://docs.arcadedb.com/#http-checkready">Get server status</a>
         </div>
       </div>
 
@@ -37,7 +37,7 @@
           <pre>/api/v1/server</pre>
         </div>
         <div class="col-7">
-          <a class="link" href="https://docs.arcadedb.com/#HTTP-ServerInfo">Get server information</a>
+          <a class="link" href="https://docs.arcadedb.com/#http-serverinfo">Get server information</a>
         </div>
       </div>
 
@@ -47,7 +47,7 @@
           <pre>/api/v1/server</pre>
         </div>
         <div class="col-7">
-          <a class="link" href="https://docs.arcadedb.com/#HTTP-ServerCommand"
+          <a class="link" href="https://docs.arcadedb.com/#http-servercommand"
             >Send server command (create/drop/open/close database, create/drop user, shutdown)</a
           >
         </div>
@@ -59,7 +59,7 @@
           <pre>/api/v1/databases</pre>
         </div>
         <div class="col-7">
-          <a class="link" href="https://docs.arcadedb.com/#HTTP-ListDatabases">List databases</a>
+          <a class="link" href="https://docs.arcadedb.com/#http-listdatabases">List databases</a>
         </div>
       </div>
 
@@ -69,7 +69,7 @@
           <pre>/api/v1/exists/{database}</pre>
         </div>
         <div class="col-7">
-          <a class="link" href="https://docs.arcadedb.com/#HTTP-DatabaseExists">Does database exist?</a>
+          <a class="link" href="https://docs.arcadedb.com/#http-databaseexists">Does database exist?</a>
         </div>
       </div>
 
@@ -79,7 +79,7 @@
           <pre>/api/v1/query/{database}/{language}/{query}</pre>
         </div>
         <div class="col-7">
-          <a class="link" href="https://docs.arcadedb.com/#HTTP-ExecuteQuery">Execute a query (GET)</a>
+          <a class="link" href="https://docs.arcadedb.com/#http-executequery">Execute a query (GET)</a>
         </div>
       </div>
 
@@ -89,7 +89,7 @@
           <pre>/api/v1/query/{database}</pre>
         </div>
         <div class="col-7">
-          <a class="link" href="https://docs.arcadedb.com/#HTTP-ExecuteQuery">Execute a query (POST)</a>
+          <a class="link" href="https://docs.arcadedb.com/#http-executequery">Execute a query (POST)</a>
         </div>
       </div>
 
@@ -99,7 +99,7 @@
           <pre>/api/v1/command/{database}</pre>
         </div>
         <div class="col-7">
-          <a class="link" href="https://docs.arcadedb.com/#HTTP-ExecuteCommand">Execute a command</a>
+          <a class="link" href="https://docs.arcadedb.com/#http-executecommand">Execute a command</a>
         </div>
       </div>
 
@@ -109,7 +109,7 @@
           <pre>/api/v1/begin/{database}</pre>
         </div>
         <div class="col-7">
-          <a class="link" href="https://docs.arcadedb.com/#HTTP-Begin">Begin a new transaction</a>
+          <a class="link" href="https://docs.arcadedb.com/#http-begin">Begin a new transaction</a>
         </div>
       </div>
 
@@ -119,7 +119,7 @@
           <pre>/api/v1/commit/{database}</pre>
         </div>
         <div class="col-7">
-          <a class="link" href="https://docs.arcadedb.com/#HTTP-Commit">Commit a transaction</a>
+          <a class="link" href="https://docs.arcadedb.com/#http-commit">Commit a transaction</a>
         </div>
       </div>
 
@@ -129,7 +129,7 @@
           <pre>/api/v1/rollback/{database}</pre>
         </div>
         <div class="col-7">
-          <a class="link" href="https://docs.arcadedb.com/#HTTP-Rollback">Rollback a transaction</a>
+          <a class="link" href="https://docs.arcadedb.com/#http-rollback">Rollback a transaction</a>
         </div>
       </div>
 

--- a/studio/src/main/resources/static/resources.html
+++ b/studio/src/main/resources/static/resources.html
@@ -13,26 +13,26 @@
             <ul>
               <li>
                 <p>
-                  <a class="link" href="https://docs.arcadedb.com#SQL">SQL</a> (inspired from OrientDB SQL dialect that supports pattern matching on graphs)
+                  <a class="link" href="https://docs.arcadedb.com#sql">SQL</a> (inspired from OrientDB SQL dialect that supports pattern matching on graphs)
                 </p>
               </li>
               <li>
-                <p><a class="link" href="https://docs.arcadedb.com#Open-Cypher">Cypher</a></p>
+                <p><a class="link" href="https://docs.arcadedb.com#open-cypher">Cypher</a></p>
               </li>
               <li>
-                <p><a class="link" href="https://docs.arcadedb.com#Gremlin-API">Apache Gremlin (Apache Tinkerpop v3.7.x)</a></p>
+                <p><a class="link" href="https://docs.arcadedb.com#gremlin-api">Apache Gremlin (Apache Tinkerpop v3.7.x)</a></p>
               </li>
               <li>
-                <p><a class="link" href="https://docs.arcadedb.com#MongoDB-API">MongoDB Query Language</a></p>
+                <p><a class="link" href="https://docs.arcadedb.com#mongodb-api">MongoDB Query Language</a></p>
               </li>
             </ul>
           </div>
         </li>
         <li>
-          <p>Tutorials: <a class="link" href="https://docs.arcadedb.com#Java-Tutorial">Java Tutorial</a></p>
+          <p>Tutorials: <a class="link" href="https://docs.arcadedb.com#java-tutorial">Java Tutorial</a></p>
         </li>
         <li>
-          <p>Tools: <a class="link" href="https://docs.arcadedb.com#Console-Tutorial">Working with the Console Tutorial</a></p>
+          <p>Tools: <a class="link" href="https://docs.arcadedb.com#console-tutorial">Working with the Console Tutorial</a></p>
         </li>
       </ul>
     </div>
@@ -44,26 +44,26 @@
           <div class="ulist">
             <ul>
               <li>
-                <p><a class="link" href="https://docs.arcadedb.com#Java-API">Embedded</a> from any language on top of the Java Virtual Machine</p>
+                <p><a class="link" href="https://docs.arcadedb.com#java-api">Embedded</a> from any language on top of the Java Virtual Machine</p>
               </li>
               <li>
-                <p>Remotely by using <a class="link" href="https://docs.arcadedb.com#HTTP-API">HTTP/JSON</a></p>
+                <p>Remotely by using <a class="link" href="https://docs.arcadedb.com#http-api">HTTP/JSON</a></p>
               </li>
               <li>
                 <p>
-                  Remotely by using a <a class="link" href="https://docs.arcadedb.com#Postgres-Driver">Postgres driver</a> (ArcadeDB implements Postgres Wire
+                  Remotely by using a <a class="link" href="https://docs.arcadedb.com#postgres-driver">Postgres driver</a> (ArcadeDB implements Postgres Wire
                   protocol)
                 </p>
               </li>
               <li>
                 <p>
-                  Remotely by using a <a class="link" href="https://docs.arcadedb.com#MongoDB-API">MongoDB driver</a> (only a subset of the operations are
+                  Remotely by using a <a class="link" href="https://docs.arcadedb.com#mongodb-api">MongoDB driver</a> (only a subset of the operations are
                   implemented)
                 </p>
               </li>
               <li>
                 <p>
-                  Remotely by using a <a class="link" href="https://docs.arcadedb.com#Redis-API">Redis driver</a> (only a subset of the operations are
+                  Remotely by using a <a class="link" href="https://docs.arcadedb.com#redis-api">Redis driver</a> (only a subset of the operations are
                   implemented)
                 </p>
               </li>
@@ -72,7 +72,7 @@
         </li>
         <li>
           <p>
-            Misc: <a class="link" href="https://docs.arcadedb.com#Docker">Docker</a>, <a class="link" href="https://docs.arcadedb.com#Kubernetes">Kubernetes</a>
+            Misc: <a class="link" href="https://docs.arcadedb.com#docker">Docker</a>, <a class="link" href="https://docs.arcadedb.com#kubernetes">Kubernetes</a>
           </p>
         </li>
       </ul>


### PR DESCRIPTION
## What does this PR do?

This change corrects the doc links in studio after the big doc refactoring

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
