### PR TITLE
fix: replace Thread.currentThread().getId() with Thread.currentThread…

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -1654,7 +1654,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
             "Database '" + name + "' is locked by another process (path=" + new File(databasePath).getAbsolutePath() + ")");
       }
 
-      //LogManager.instance().log(this, Level.INFO, "LOCKED DATABASE FILE '%s' (thread=%s)", null, lockFile, Thread.currentThread().getId());
+      //LogManager.instance().log(this, Level.INFO, "LOCKED DATABASE FILE '%s' (thread=%s)", null, lockFile, Thread.currentThread().threadId());
 
     } catch (final Exception e) {
       try {
@@ -1750,7 +1750,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
         try {
           if (lockFileLock != null) {
             lockFileLock.release();
-            //LogManager.instance().log(this, Level.INFO, "RELEASED DATABASE FILE '%s' (thread=%s)", null, lockFile, Thread.currentThread().getId());
+            //LogManager.instance().log(this, Level.INFO, "RELEASED DATABASE FILE '%s' (thread=%s)", null, lockFile, Thread.currentThread().threadId());
           }
           if (lockFileIOChannel != null)
             lockFileIOChannel.close();
@@ -1896,7 +1896,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     if (retryDelay > 0) {
       LogManager.instance()
           .log(this, Level.FINE, "Wait %d ms before the next retry for transaction commit (threadId=%d)", retryDelay,
-              Thread.currentThread().getId());
+              Thread.currentThread().threadId());
 
       try {
         Thread.sleep(1 + new Random().nextInt(retryDelay));

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -204,7 +204,7 @@ public class TransactionContext implements Transaction {
   public void rollback() {
     LogManager.instance()
         .log(this, Level.FINE, "Rollback transaction newPages=%s modifiedPages=%s (threadId=%d)", newPages, modifiedPages,
-            Thread.currentThread().getId());
+            Thread.currentThread().threadId());
 
     if (database.isOpen() && database.getSchema().getDictionary() != null) {
       if (modifiedPages != null) {
@@ -613,7 +613,7 @@ public class TransactionContext implements Transaction {
 
       if (useWAL) {
         txId = database.getTransactionManager().getNextTransactionId();
-        //LogManager.instance().log(this, Level.FINE, "Creating buffer for TX %d (threadId=%d)", txId, Thread.currentThread().getId());
+        //LogManager.instance().log(this, Level.FINE, "Creating buffer for TX %d (threadId=%d)", txId, Thread.currentThread().threadId());
         result = database.getTransactionManager().createTransactionBuffer(txId, pages);
       }
 
@@ -624,7 +624,7 @@ public class TransactionContext implements Transaction {
       throw e;
     } catch (final Exception e) {
       LogManager.instance()
-          .log(this, Level.FINE, "Unknown exception during commit (threadId=%d)", e, Thread.currentThread().getId());
+          .log(this, Level.FINE, "Unknown exception during commit (threadId=%d)", e, Thread.currentThread().threadId());
       rollback();
       throw new TransactionException("Transaction error on commit", e);
     }
@@ -651,7 +651,7 @@ public class TransactionContext implements Transaction {
       // UPDATE PAGE COUNTER FIRST
       LogManager.instance()
           .log(this, Level.FINE, "TX committing pages newPages=%s modifiedPages=%s (threadId=%d)", newPages, modifiedPages,
-              Thread.currentThread().getId());
+              Thread.currentThread().threadId());
 
       database.getPageManager().updatePages(newPages, modifiedPages, asyncFlush);
 
@@ -687,7 +687,7 @@ public class TransactionContext implements Transaction {
       throw e;
     } catch (final Exception e) {
       LogManager.instance()
-          .log(this, Level.FINE, "Unknown exception during commit (threadId=%d)", e, Thread.currentThread().getId());
+          .log(this, Level.FINE, "Unknown exception during commit (threadId=%d)", e, Thread.currentThread().threadId());
       throw new TransactionException("Transaction error on commit", e);
     } finally {
       reset();

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncCreateRecord.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncCreateRecord.java
@@ -49,7 +49,7 @@ public class DatabaseAsyncCreateRecord implements DatabaseAsyncTask {
 
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.SEVERE, "Error on executing async create record operation (threadId=%d)", e,
-          Thread.currentThread().getId());
+          Thread.currentThread().threadId());
 
       async.onError(e);
 

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncDeleteRecord.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncDeleteRecord.java
@@ -60,7 +60,7 @@ public class DatabaseAsyncDeleteRecord implements DatabaseAsyncTask {
         onOkCallback.call(record);
 
     } catch (final Exception e) {
-      LogManager.instance().log(this, Level.SEVERE, "Error on executing async delete record operation (threadId=%d)", e, Thread.currentThread().getId());
+      LogManager.instance().log(this, Level.SEVERE, "Error on executing async delete record operation (threadId=%d)", e, Thread.currentThread().threadId());
 
       async.onError(e);
 

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -131,7 +131,7 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
             executingTask.set(true);
             try {
               LogManager.instance()
-                  .log(this, Level.FINE, "Received async message %s (threadId=%d)", message, Thread.currentThread().getId());
+                  .log(this, Level.FINE, "Received async message %s (threadId=%d)", message, Thread.currentThread().threadId());
 
               if (message == FORCE_EXIT) {
                 break;

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncUpdateRecord.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncUpdateRecord.java
@@ -58,7 +58,7 @@ public class DatabaseAsyncUpdateRecord implements DatabaseAsyncTask {
         onOkCallback.call(record);
 
     } catch (final Exception e) {
-      LogManager.instance().log(this, Level.SEVERE, "Error on executing async update record operation (threadId=%d)", e, Thread.currentThread().getId());
+      LogManager.instance().log(this, Level.SEVERE, "Error on executing async update record operation (threadId=%d)", e, Thread.currentThread().threadId());
 
       async.onError(e);
 

--- a/engine/src/main/java/com/arcadedb/database/bucketselectionstrategy/ThreadBucketSelectionStrategy.java
+++ b/engine/src/main/java/com/arcadedb/database/bucketselectionstrategy/ThreadBucketSelectionStrategy.java
@@ -43,7 +43,7 @@ public class ThreadBucketSelectionStrategy implements BucketSelectionStrategy {
 
   @Override
   public int getBucketIdByRecord(final Document record, final boolean async) {
-    return (int) (Thread.currentThread().getId() % total);
+    return (int) (Thread.currentThread().threadId() % total);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -669,7 +669,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
       LogManager.instance()
           .log(this, Level.FINE, "Creating record (%s records=%d threadId=%d)", selectedPage, availablePositionIndex,
-              Thread.currentThread().getId());
+              Thread.currentThread().threadId());
       final RID rid = new RID(database, file.getFileId(),
           ((long) selectedPage.getPageId().getPageNumber()) * maxRecordsInPage + availablePositionIndex);
 
@@ -699,7 +699,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
       LogManager.instance()
           .log(this, Level.FINE, "Created record %s (%s records=%d threadId=%d)", rid, selectedPage, recordCountInPage,
-              Thread.currentThread().getId());
+              Thread.currentThread().threadId());
 
       if (!discardRecordAfter)
         ((RecordInternal) record).setBuffer(buffer.getNotReusable());
@@ -745,7 +745,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         throw new RecordNotFoundException("Record " + rid + " not found", rid);
 
 //      LogManager.instance()
-//          .log(this, Level.SEVERE, "UPDATE %s pageV=%d content %s (threadId=%d)", rid, page.getVersion(), record.toJSON(), Thread.currentThread().getId());
+//          .log(this, Level.SEVERE, "UPDATE %s pageV=%d content %s (threadId=%d)", rid, page.getVersion(), record.toJSON(), Thread.currentThread().threadId());
 
       boolean isPlaceHolder = false;
       if (recordSize[0] == RECORD_PLACEHOLDER_POINTER) {
@@ -844,7 +844,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
           LogManager.instance()
               .log(this, Level.FINE, "Updated record %s by allocating new space on the same page (%s threadId=%d)", null, rid, page,
-                  Thread.currentThread().getId());
+                  Thread.currentThread().threadId());
 
           updatePageStatistics(pageId, spaceAvailableInCurrentPage, -additionalSpaceNeeded);
 
@@ -864,14 +864,14 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
             LogManager.instance()
                 .log(this, Level.FINE, "Updated record %s by allocating new space with a placeholder (%s threadId=%d)", null, rid,
-                    page, Thread.currentThread().getId());
+                    page, Thread.currentThread().threadId());
           } else {
             // SPLIT THE RECORD IN CHUNKS AS LINKED LIST AND STORE THE FIRST PART ON CURRENT PAGE ISSUE https://github.com/ArcadeData/arcadedb/issues/332
             writeMultiPageRecord(rid, buffer, page, recordPositionInPage, availableSpaceForChunk);
 
             LogManager.instance().log(this, Level.FINE,
                 "Updated record %s by splitting it in multiple chunks to be saved in multiple pages (%s threadId=%d)", null, rid,
-                page, Thread.currentThread().getId());
+                page, Thread.currentThread().threadId());
           }
         }
       } else {
@@ -883,7 +883,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
 
         LogManager.instance()
             .log(this, Level.FINE, "Updated record %s with the same size or less as before (%s threadId=%d)", null, rid, page,
-                Thread.currentThread().getId());
+                Thread.currentThread().threadId());
       }
 
       if (!discardRecordAfter)
@@ -1010,7 +1010,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
       }
 
       LogManager.instance()
-          .log(this, Level.FINE, "Deleted record %s (%s threadId=%d)", null, rid, page, Thread.currentThread().getId());
+          .log(this, Level.FINE, "Deleted record %s (%s threadId=%d)", null, rid, page, Thread.currentThread().threadId());
 
     } catch (final RecordNotFoundException e) {
       throw e;

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -211,7 +211,7 @@ public class PageManager extends LockContext {
     if (!fileManager.existsFile(pageId.getFileId()))
       throw new ConcurrentModificationException(
           "Concurrent modification on page " + pageId + ". The file with id " + pageId.getFileId()
-              + " does not exist anymore. Please retry the operation (threadId=" + Thread.currentThread().getId() + ")");
+              + " does not exist anymore. Please retry the operation (threadId=" + Thread.currentThread().threadId() + ")");
 
     final int mostRecentPageVersion = getMostRecentVersionOfPage(pageId, page.getPhysicalSize());
 
@@ -221,7 +221,7 @@ public class PageManager extends LockContext {
       throw new ConcurrentModificationException(
           "Concurrent modification on page " + pageId + " in file '" + fileManager.getFile(pageId.getFileId()).getFileName()
               + "' (current v." + page.getVersion() + " <> database v." + mostRecentPageVersion
-              + "). Please retry the operation (threadId=" + Thread.currentThread().getId() + ")");
+              + "). Please retry the operation (threadId=" + Thread.currentThread().threadId() + ")");
     }
   }
 
@@ -256,7 +256,7 @@ public class PageManager extends LockContext {
       throw new ConcurrentModificationException(
           "Concurrent modification on page " + pageId + " in file '" + fileManager.getFile(pageId.getFileId()).getFileName()
               + "' (current v." + page.getVersion() + " <> database v." + mostRecentPageVersion
-              + "). Please retry the operation (threadId=" + Thread.currentThread().getId() + ")");
+              + "). Please retry the operation (threadId=" + Thread.currentThread().threadId() + ")");
     }
 
     page.incrementVersion();
@@ -264,7 +264,7 @@ public class PageManager extends LockContext {
 
     LogManager.instance()
         .log(this, Level.FINE, "Updated page %s (size=%d records=%d threadId=%d)", null, page, page.getPhysicalSize(),
-            page.readShort(0), Thread.currentThread().getId());
+            page.readShort(0), Thread.currentThread().threadId());
 
     return page;
   }
@@ -275,7 +275,7 @@ public class PageManager extends LockContext {
     flushPage(page);
 
     LogManager.instance().log(this, Level.FINE, "Overwritten page %s (size=%d threadId=%d)", null, page, page.getPhysicalSize(),
-        Thread.currentThread().getId());
+        Thread.currentThread().threadId());
   }
 
   public PPageManagerStats getStats() {
@@ -335,7 +335,7 @@ public class PageManager extends LockContext {
         throw new DatabaseMetadataException("Cannot flush pages on disk because file '" + file.getFileName() + "' is closed");
 
       LogManager.instance()
-          .log(this, Level.FINE, "Flushing page %s to disk (threadId=%d)...", null, page, Thread.currentThread().getId());
+          .log(this, Level.FINE, "Flushing page %s to disk (threadId=%d)...", null, page, Thread.currentThread().threadId());
 
       // ACQUIRE A LOCK ON THE I/O OPERATION TO AVOID PARTIAL READS/WRITES
       concurrentPageAccess(page.pageId, true, () -> {
@@ -350,7 +350,7 @@ public class PageManager extends LockContext {
     } else
       LogManager.instance()
           .log(this, Level.FINE, "Cannot flush page %s because the file has been dropped (threadId=%d)...", null, page,
-              Thread.currentThread().getId());
+              Thread.currentThread().threadId());
   }
 
   private CachedPage loadPage(final PageId pageId, final int size, final boolean createIfNotExists, final boolean cache)
@@ -379,7 +379,7 @@ public class PageManager extends LockContext {
 
       page.loadMetadata();
 
-      LogManager.instance().log(this, Level.FINE, "Loaded page %s (threadId=%d)", null, page, Thread.currentThread().getId());
+      LogManager.instance().log(this, Level.FINE, "Loaded page %s (threadId=%d)", null, page, Thread.currentThread().threadId());
     }
 
     totalPagesRead.incrementAndGet();
@@ -427,7 +427,7 @@ public class PageManager extends LockContext {
 
     LogManager.instance()
         .log(this, Level.FINE, "Reached max RAM for page cache. Freeing pages from cache (target=%d current=%d max=%d threadId=%d)",
-            null, ramToFree, totalRAM, maxRAM, Thread.currentThread().getId());
+            null, ramToFree, totalRAM, maxRAM, Thread.currentThread().threadId());
 
     // GET THE <DISPOSE_PAGES_PER_CYCLE> OLDEST PAGES
     // ORDER PAGES BY LAST ACCESS + SIZE
@@ -464,11 +464,11 @@ public class PageManager extends LockContext {
 
     LogManager.instance()
         .log(this, Level.FINE, "Freed %s RAM (current=%s max=%s threadId=%d)", null, FileUtils.getSizeAsString(freedRAM),
-            FileUtils.getSizeAsString(newTotalRAM), FileUtils.getSizeAsString(maxRAM), Thread.currentThread().getId());
+            FileUtils.getSizeAsString(newTotalRAM), FileUtils.getSizeAsString(maxRAM), Thread.currentThread().threadId());
 
     if (newTotalRAM > maxRAM)
       LogManager.instance().log(this, Level.WARNING, "Cannot free pages in RAM (current=%s > max=%s threadId=%d)", null,
-          FileUtils.getSizeAsString(newTotalRAM), FileUtils.getSizeAsString(maxRAM), Thread.currentThread().getId());
+          FileUtils.getSizeAsString(newTotalRAM), FileUtils.getSizeAsString(maxRAM), Thread.currentThread().threadId());
 
     lastCheckForRAM = System.currentTimeMillis();
   }
@@ -502,7 +502,7 @@ public class PageManager extends LockContext {
 
     if (page == null)
       throw new IllegalArgumentException(
-          "Page id '" + pageId + "' does not exist (threadId=" + Thread.currentThread().getId() + ")");
+          "Page id '" + pageId + "' does not exist (threadId=" + Thread.currentThread().threadId() + ")");
 
     return page;
   }

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -148,7 +148,7 @@ public class TransactionManager {
     final long begin = System.currentTimeMillis();
 
     while (true) {
-      final WALFile file = activeWALFilePool[(int) (Thread.currentThread().getId() % activeWALFilePool.length)];
+      final WALFile file = activeWALFilePool[(int) (Thread.currentThread().threadId() % activeWALFilePool.length)];
 
       if (file != null && file.acquire(() -> {
         file.writeTransactionToFile(database, pages, sync, file, txId, bufferChanges);
@@ -324,7 +324,7 @@ public class TransactionManager {
           throw new ConcurrentModificationException(
               "Concurrent modification on page " + pageId + " in file '" + database.getFileManager().getFile(pageId.getFileId())
                   .getFileName() + "' (current v." + txPage.currentPageVersion + " <= database v." + page.getVersion()
-                  + "). Please retry the operation (threadId=" + Thread.currentThread().getId() + ")");
+                  + "). Please retry the operation (threadId=" + Thread.currentThread().threadId() + ")");
         }
 
         if (txPage.currentPageVersion > page.getVersion() + 1) {
@@ -475,7 +475,7 @@ public class TransactionManager {
 
     // OK: ALL LOCKED
     LogManager.instance()
-        .log(this, Level.FINE, "Locked files %s (threadId=%d)", null, orderedFilesIds, Thread.currentThread().getId());
+        .log(this, Level.FINE, "Locked files %s (threadId=%d)", null, orderedFilesIds, Thread.currentThread().threadId());
     // RETURN ONLY THE LOCKED FILES
     return lockedFiles;
   }
@@ -486,7 +486,7 @@ public class TransactionManager {
         unlockFile(fileId);
 
       LogManager.instance()
-          .log(this, Level.FINE, "Unlocked files %s (threadId=%d)", null, lockedFileIds, Thread.currentThread().getId());
+          .log(this, Level.FINE, "Unlocked files %s (threadId=%d)", null, lockedFileIds, Thread.currentThread().threadId());
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/engine/WALFile.java
+++ b/engine/src/main/java/com/arcadedb/engine/WALFile.java
@@ -255,7 +255,7 @@ public class WALFile extends LockContext {
 
       LogManager.instance()
           .log(WALFile.class, Level.FINE, "Writing page %s v%d range %d-%d into buffer (txId=%d threadId=%d)", null, newPage.getPageId(), newPage.version + 1,
-              deltaRange[0], deltaRange[1], txId, Thread.currentThread().getId());
+              deltaRange[0], deltaRange[1], txId, Thread.currentThread().threadId());
 
       bufferChanges.putInt(newPage.getPageId().getFileId());
       bufferChanges.putInt(newPage.getPageId().getPageNumber());
@@ -284,7 +284,7 @@ public class WALFile extends LockContext {
       final Binary buffer) throws IOException {
 
     LogManager.instance()
-        .log(this, Level.FINE, "Appending WAL for txId=%d (size=%d file=%s threadId=%d)", null, txId, buffer.size(), filePath, Thread.currentThread().getId());
+        .log(this, Level.FINE, "Appending WAL for txId=%d (size=%d file=%s threadId=%d)", null, txId, buffer.size(), filePath, Thread.currentThread().threadId());
 
     file.append(buffer.getByteBuffer());
 

--- a/engine/src/main/java/com/arcadedb/index/CompressedRID2RIDIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/CompressedRID2RIDIndex.java
@@ -287,7 +287,7 @@ public class CompressedRID2RIDIndex {
 
   private void checkThreadAccess() {
     if (!readOnly && lastThreadAccessed != null && lastThreadAccessed != Thread.currentThread())
-      LogManager.instance().log(this, Level.WARNING, "Access by a different thread %d (%s). Previously it was %d (%s)", null, Thread.currentThread().getId(),
+      LogManager.instance().log(this, Level.WARNING, "Access by a different thread %d (%s). Previously it was %d (%s)", null, Thread.currentThread().threadId(),
           Thread.currentThread().getName(), lastThreadAccessed.getId(), lastThreadAccessed.getName());
     lastThreadAccessed = Thread.currentThread();
   }

--- a/engine/src/main/java/com/arcadedb/index/CompressedRID2RIDsIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/CompressedRID2RIDsIndex.java
@@ -358,7 +358,7 @@ public class CompressedRID2RIDsIndex {
 
   private void checkThreadAccess() {
     if (!readOnly && lastThreadAccessed != null && lastThreadAccessed != Thread.currentThread())
-      LogManager.instance().log(this, Level.WARNING, "Access by a different thread %d (%s). Previously it was %d (%s)", null, Thread.currentThread().getId(),
+      LogManager.instance().log(this, Level.WARNING, "Access by a different thread %d (%s). Previously it was %d (%s)", null, Thread.currentThread().threadId(),
           Thread.currentThread().getName(), lastThreadAccessed.getId(), lastThreadAccessed.getName());
     lastThreadAccessed = Thread.currentThread();
   }

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompactor.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompactor.java
@@ -52,7 +52,7 @@ public class LSMTreeIndexCompactor {
     LogManager.instance()
         .log(mainIndex, Level.INFO, "Compacting index '%s' (pages=%d pageSize=%d threadId=%d)...", null, mutableIndex, totalPages,
             mutableIndex.getPageSize(),
-            Thread.currentThread().getId());
+            Thread.currentThread().threadId());
 
     if (totalPages < 2)
       return false;
@@ -67,7 +67,7 @@ public class LSMTreeIndexCompactor {
       LogManager.instance()
           .log(mainIndex, Level.WARNING, "- Creating sub-index '%s' with fileId=%d (threadId=%d)...", null, compactedIndex,
               compactedIndex.getFileId(),
-              Thread.currentThread().getId());
+              Thread.currentThread().threadId());
     }
 
     final byte[] keyTypes = mutableIndex.getBinaryKeyTypes();
@@ -111,7 +111,7 @@ public class LSMTreeIndexCompactor {
     }
 
     LogManager.instance().log(mainIndex, Level.WARNING, "- Compacting pages 0-%d (threadId=%d)", null, lastImmutablePage,
-        Thread.currentThread().getId());
+        Thread.currentThread().threadId());
 
     for (int pageIndex = 0; pageIndex <= lastImmutablePage; ) {
       final long totalRAMNeeded = (lastImmutablePage - pageIndex + 1L) * mutableIndex.getPageSize();
@@ -122,7 +122,7 @@ public class LSMTreeIndexCompactor {
             .log(mainIndex, Level.WARNING, "- Creating partial index with %d pages by using %s (totalRAMNeeded=%s, threadId=%d)",
                 null, pagesToCompact,
                 FileUtils.getSizeAsString(indexCompactionRAM), FileUtils.getSizeAsString(totalRAMNeeded),
-                Thread.currentThread().getId());
+                Thread.currentThread().threadId());
       } else
         pagesToCompact = lastImmutablePage - pageIndex + 1;
 
@@ -134,7 +134,7 @@ public class LSMTreeIndexCompactor {
       LogManager.instance()
           .log(mainIndex, Level.WARNING, "- This turn compacting %d pages using root page %s v.%d (threadId=%d)", null,
               pagesToCompact, rootPage.getPageId(),
-              rootPage.getVersion(), Thread.currentThread().getId());
+              rootPage.getVersion(), Thread.currentThread().threadId());
 
       int compactedPageNumberInSeries = 1;
 
@@ -257,7 +257,7 @@ public class LSMTreeIndexCompactor {
               LogManager.instance()
                   .log(mainIndex, Level.WARNING,
                       "- Creating a new entry in index '%s' root page %s->%d (entry in page=%d threadId=%d)", null, mutableIndex,
-                      Arrays.toString(minorKey), newPageNum, mutableIndex.getCount(rootPage) - 1, Thread.currentThread().getId());
+                      Arrays.toString(minorKey), newPageNum, mutableIndex.getCount(rootPage) - 1, Thread.currentThread().threadId());
 
               if (newRootPage != rootPage) {
                 throw new UnsupportedOperationException("Root index page overflow");
@@ -288,7 +288,7 @@ public class LSMTreeIndexCompactor {
             LogManager.instance()
                 .log(mainIndex, Level.WARNING, "- Keys %d values %d - iterations %d (entriesInRootPage=%d, threadId=%d)", null,
                     totalKeys, totalValues,
-                    iterations, compactedIndex.getCount(rootPage), Thread.currentThread().getId());
+                    iterations, compactedIndex.getCount(rootPage), Thread.currentThread().threadId());
         }
       }
 
@@ -300,7 +300,7 @@ public class LSMTreeIndexCompactor {
         LogManager.instance()
             .log(mainIndex, Level.WARNING, "- Creating last entry in index '%s' root page %s (entriesInRootPage=%d, threadId=%d)",
                 null, mutableIndex,
-                Arrays.toString(lastPageMaxKey), compactedIndex.getCount(rootPage), Thread.currentThread().getId());
+                Arrays.toString(lastPageMaxKey), compactedIndex.getCount(rootPage), Thread.currentThread().threadId());
       }
 
       final List<MutablePage> modifiedPages = new ArrayList<>(1);
@@ -318,7 +318,7 @@ public class LSMTreeIndexCompactor {
           "- compacted %d pages, remaining %d pages (totalKeys=%d totalValues=%d totalMergedKeys=%d totalMergedValues=%d, threadId=%d)",
           null, compactedPages,
           (lastImmutablePage - compactedPages + 1), totalKeys, totalValues, totalMergedKeys, totalMergedValues,
-          Thread.currentThread().getId());
+          Thread.currentThread().threadId());
 
       pageIndex += pagesToCompact;
     }
@@ -333,7 +333,7 @@ public class LSMTreeIndexCompactor {
         compactedIndex.getTotalPages(),
         iterations, oldMutableFileName, oldMutableFileId, mainIndex.getMutableIndex().getName(),
         mainIndex.getMutableIndex().getFileId(),
-        compactedIndex.getName(), compactedIndex.getFileId(), Thread.currentThread().getId()));
+        compactedIndex.getName(), compactedIndex.getFileId(), Thread.currentThread().threadId()));
 
     if (debug) {
       System.out.println("AFTER COMPACTING:");

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
@@ -504,7 +504,7 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
       if (LogManager.instance().isDebugEnabled())
         LogManager.instance().log(this, Level.FINE, "Put entry %s=%s in index '%s' (page=%s countInPage=%d newPage=%s thread=%d)",
             Arrays.toString(keys), Arrays.toString(rids), componentName, currentPage.getPageId(), count + 1, newPage,
-            Thread.currentThread().getId());
+            Thread.currentThread().threadId());
 
     } catch (final IOException e) {
       throw new DatabaseOperationException(

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/RetryStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/RetryStep.java
@@ -110,7 +110,7 @@ public class RetryStep extends AbstractExecutionStep {
     if (retryDelay > 0) {
       LogManager.instance()
           .log(this, Level.FINE, "Wait %d ms before the next retry for transaction commit (threadId=%d)", retryDelay,
-              Thread.currentThread().getId());
+              Thread.currentThread().threadId());
 
       try {
         Thread.sleep(1 + new Random().nextInt(retryDelay));

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -944,7 +944,7 @@ public class LocalSchema implements Schema {
         root = new JSONObject(fileContent);
       }
 
-      if (root.names() == null || root.names().length() == 0)
+      if (root.names() == null || root.names().isEmpty())
         // EMPTY SCHEMA
         return;
 
@@ -975,15 +975,13 @@ public class LocalSchema implements Schema {
         final LocalDocumentType type;
 
         final String kind = (String) schemaType.get("type");
-        if ("v".equals(kind)) {
-          type = new LocalVertexType(this, typeName);
-        } else if ("e".equals(kind)) {
-          type = new LocalEdgeType(this, typeName,
-              schemaType.has("bidirectional") ? schemaType.getBoolean("bidirectional") : true);
-        } else if ("d".equals(kind)) {
-          type = new LocalDocumentType(this, typeName);
-        } else
-          throw new ConfigurationException("Type '" + kind + "' is not supported");
+        type = switch (kind) {
+          case "v" -> new LocalVertexType(this, typeName);
+          case "e" -> new LocalEdgeType(this, typeName,
+              !schemaType.has("bidirectional") || schemaType.getBoolean("bidirectional"));
+          case "d" -> new LocalDocumentType(this, typeName);
+          case null, default -> throw new ConfigurationException("Type '" + kind + "' is not supported");
+        };
 
         this.types.put(typeName, type);
 

--- a/engine/src/test/java/com/arcadedb/index/LSMTreeIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/LSMTreeIndexTest.java
@@ -1059,7 +1059,7 @@ public class LSMTreeIndexTest extends TestHelper {
                   if (threadInserted % 1000 == 0)
                     LogManager.instance()
                         .log(this, Level.INFO, "%s Thread %d inserted record %s, total %d records with key %d (total=%d)", null,
-                            getClass(), Thread.currentThread().getId(), v.getIdentity(), i, threadInserted,
+                            getClass(), Thread.currentThread().threadId(), v.getIdentity(), i, threadInserted,
                             crossThreadsInserted.get());
 
                   keyPresent = true;
@@ -1074,7 +1074,7 @@ public class LSMTreeIndexTest extends TestHelper {
                   assertThat(database.isTransactionActive()).isFalse();
                 } catch (final Exception e) {
                   LogManager.instance()
-                      .log(this, Level.SEVERE, "%s Thread %d Generic Exception", e, getClass(), Thread.currentThread().getId());
+                      .log(this, Level.SEVERE, "%s Thread %d Generic Exception", e, getClass(), Thread.currentThread().threadId());
                   assertThat(database.isTransactionActive()).isFalse();
                   return;
                 }
@@ -1083,16 +1083,16 @@ public class LSMTreeIndexTest extends TestHelper {
               if (!keyPresent)
                 LogManager.instance()
                     .log(this, Level.WARNING, "%s Thread %d Cannot create key %d after %d retries! (total=%d)", null, getClass(),
-                        Thread.currentThread().getId(), i, maxRetries, crossThreadsInserted.get());
+                        Thread.currentThread().threadId(), i, maxRetries, crossThreadsInserted.get());
 
             }
 
             LogManager.instance()
-                .log(this, Level.INFO, "%s Thread %d completed (inserted=%d)", null, getClass(), Thread.currentThread().getId(),
+                .log(this, Level.INFO, "%s Thread %d completed (inserted=%d)", null, getClass(), Thread.currentThread().threadId(),
                     threadInserted);
 
           } catch (final Exception e) {
-            LogManager.instance().log(this, Level.SEVERE, "%s Thread %d Error", e, getClass(), Thread.currentThread().getId());
+            LogManager.instance().log(this, Level.SEVERE, "%s Thread %d Error", e, getClass(), Thread.currentThread().threadId());
           }
         }
 

--- a/engine/src/test/java/com/arcadedb/index/TypeLSMTreeIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/TypeLSMTreeIndexTest.java
@@ -676,7 +676,7 @@ public class TypeLSMTreeIndexTest extends TestHelper {
                   if (threadInserted % 1000 == 0)
                     LogManager.instance()
                         .log(this, Level.FINE, "%s Thread %d inserted %d records with key %d (total=%d)", null, getClass(),
-                            Thread.currentThread().getId(), i, threadInserted, crossThreadsInserted.get());
+                            Thread.currentThread().threadId(), i, threadInserted, crossThreadsInserted.get());
 
                   keyPresent = true;
 
@@ -690,7 +690,7 @@ public class TypeLSMTreeIndexTest extends TestHelper {
                   assertThat(database.isTransactionActive()).isFalse();
                 } catch (final Exception e) {
                   LogManager.instance()
-                      .log(this, Level.SEVERE, "%s Thread %d Generic Exception", e, getClass(), Thread.currentThread().getId());
+                      .log(this, Level.SEVERE, "%s Thread %d Generic Exception", e, getClass(), Thread.currentThread().threadId());
                   assertThat(database.isTransactionActive()).isFalse();
                   return;
                 }
@@ -699,16 +699,16 @@ public class TypeLSMTreeIndexTest extends TestHelper {
               if (!keyPresent)
                 LogManager.instance()
                     .log(this, Level.WARNING, "%s Thread %d Cannot create key %d after %d retries! (total=%d)", null, getClass(),
-                        Thread.currentThread().getId(), i, maxRetries, crossThreadsInserted.get());
+                        Thread.currentThread().threadId(), i, maxRetries, crossThreadsInserted.get());
 
             }
 
             LogManager.instance()
-                .log(this, Level.FINE, "%s Thread %d completed (inserted=%d)", null, getClass(), Thread.currentThread().getId(),
+                .log(this, Level.FINE, "%s Thread %d completed (inserted=%d)", null, getClass(), Thread.currentThread().threadId(),
                     threadInserted);
 
           } catch (final Exception e) {
-            LogManager.instance().log(this, Level.SEVERE, "%s Thread %d Error", e, getClass(), Thread.currentThread().getId());
+            LogManager.instance().log(this, Level.SEVERE, "%s Thread %d Error", e, getClass(), Thread.currentThread().threadId());
           }
         }
 

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/CheckClusterTypeStepTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/CheckClusterTypeStepTest.java
@@ -48,6 +48,7 @@ public class CheckClusterTypeStepTest {
     });
   }
 
+  @Test
   public void shouldThrowExceptionWhenClusterIsWrong() throws Exception {
     try {
       TestHelper.executeInNewDatabase((db) -> {

--- a/engine/src/test/java/performance/LocalDatabaseBenchmark.java
+++ b/engine/src/test/java/performance/LocalDatabaseBenchmark.java
@@ -203,7 +203,7 @@ public class LocalDatabaseBenchmark {
               final MutableVertex user = database.newVertex("User").set("id", id);
               user.save();
 
-              //LogManager.instance().log(this, Level.WARNING, "Saving user id %d as %s (threadId=%d)", id, user.getIdentity(), Thread.currentThread().getId());
+              //LogManager.instance().log(this, Level.WARNING, "Saving user id %d as %s (threadId=%d)", id, user.getIdentity(), Thread.currentThread().threadId());
 
             } catch (Throwable t) {
               incrementError(t);

--- a/integration/src/main/java/com/arcadedb/integration/importer/OrientDBImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/OrientDBImporter.java
@@ -139,14 +139,12 @@ public class OrientDBImporter {
       else if (arg.equals("-v"))
         state = "verboseLevel";
       else if (state != null) {
-        if (state.equals("databasePath"))
-          databasePath = arg;
-        else if (state.equals("inputFile"))
-          inputFile = arg;
-        else if (state.equals("batchSize"))
-          batchSize = Integer.parseInt(arg);
-        else if (state.equals("verboseLevel"))
-          settings.verboseLevel = Integer.parseInt(arg);
+        switch (state) {
+        case "databasePath" -> databasePath = arg;
+        case "inputFile" -> inputFile = arg;
+        case "batchSize" -> batchSize = Integer.parseInt(arg);
+        case "verboseLevel" -> settings.verboseLevel = Integer.parseInt(arg);
+        }
       }
     }
 

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/CreateEdgeFromImportTask.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/CreateEdgeFromImportTask.java
@@ -66,7 +66,7 @@ public class CreateEdgeFromImportTask implements DatabaseAsyncTask {
 
   public void execute(final DatabaseAsyncExecutorImpl.AsyncThread async, final DatabaseInternal database) {
 
-//    LogManager.instance().log(this, Level.INFO, "Using context %s from theadId=%d", null, threadContext, Thread.currentThread().getId());
+//    LogManager.instance().log(this, Level.INFO, "Using context %s from theadId=%d", null, threadContext, Thread.currentThread().threadId());
 
     // TODO: LOAD FROM INDEX
     final RID destinationVertexRID = context.graphImporter.getVertex(threadContext.vertexIndexThreadBuffer, destinationVertexKey);
@@ -101,7 +101,7 @@ public class CreateEdgeFromImportTask implements DatabaseAsyncTask {
           .log(this, Level.INFO, "Creation of back connections, reached %s size (max=%s), flushing %d connections (slots=%d thread=%d)...", null,
               FileUtils.getSizeAsString(threadContext.incomingConnectionsIndexThread.getChunkSize()), FileUtils.getSizeAsString(settings.maxRAMIncomingEdges),
               threadContext.incomingConnectionsIndexThread.size(), threadContext.incomingConnectionsIndexThread.getTotalUsedSlots(),
-              Thread.currentThread().getId());
+              Thread.currentThread().threadId());
 
       createIncomingEdgesInBatch(database, threadContext.incomingConnectionsIndexThread, linked -> context.linkedEdges.addAndGet(linked));
 

--- a/network/src/main/java/com/arcadedb/network/binary/SocketFactory.java
+++ b/network/src/main/java/com/arcadedb/network/binary/SocketFactory.java
@@ -74,10 +74,10 @@ public class SocketFactory {
   protected SSLContext createSSLContext() {
     try {
       if (keyStorePath != null && trustStorePath != null) {
-        if (keyStorePassword == null || keyStorePassword.equals("")) {
+        if (keyStorePassword == null || keyStorePassword.isEmpty()) {
           throw new ConfigurationException("Please provide a keystore password");
         }
-        if (trustStorePassword == null || trustStorePassword.equals("")) {
+        if (trustStorePassword == null || trustStorePassword.isEmpty()) {
           throw new ConfigurationException("Please provide a truststore password");
         }
 
@@ -113,9 +113,9 @@ public class SocketFactory {
     InputStream input;
 
     try {
-      final URL url = new URL(path);
+      final URL url = new URI(path).toURL();
       input = url.openStream();
-    } catch (final MalformedURLException ignore) {
+    } catch (final MalformedURLException | URISyntaxException ignore) {
       input = null;
     }
 

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -217,7 +217,7 @@ public class PostgresNetworkExecutor extends Thread {
 
   private void syncCommand() {
     if (DEBUG)
-      LogManager.instance().log(this, Level.INFO, "PSQL: sync (thread=%s)", Thread.currentThread().getId());
+      LogManager.instance().log(this, Level.INFO, "PSQL: sync (thread=%s)", Thread.currentThread().threadId());
 
     if (errorInTransaction) {
       // DISCARDED PREVIOUS MESSAGES TILL THIS POINT
@@ -232,7 +232,7 @@ public class PostgresNetworkExecutor extends Thread {
 
   private void flushCommand() {
     if (DEBUG)
-      LogManager.instance().log(this, Level.INFO, "PSQL: flush (thread=%s)", Thread.currentThread().getId());
+      LogManager.instance().log(this, Level.INFO, "PSQL: flush (thread=%s)", Thread.currentThread().threadId());
     writeReadyForQueryMessage();
   }
 
@@ -248,7 +248,7 @@ public class PostgresNetworkExecutor extends Thread {
 
     if (DEBUG)
       LogManager.instance().log(this, Level.INFO, "PSQL: close '%s' type=%s (thread=%s)", prepStatementOrPortal, (char) closeType,
-          Thread.currentThread().getId());
+          Thread.currentThread().threadId());
 
     writeMessage("close complete", null, '3', 4);
   }
@@ -260,7 +260,7 @@ public class PostgresNetworkExecutor extends Thread {
     if (DEBUG)
       LogManager.instance()
           .log(this, Level.INFO, "PSQL: describe '%s' type=%s (errorInTransaction=%s thread=%s)", portalName, (char) type,
-              errorInTransaction, Thread.currentThread().getId());
+              errorInTransaction, Thread.currentThread().threadId());
 
     if (errorInTransaction)
       return;
@@ -309,7 +309,7 @@ public class PostgresNetworkExecutor extends Thread {
       if (DEBUG)
         LogManager.instance()
             .log(this, Level.INFO, "PSQL: execute (portal=%s) (limit=%d)-> %s (thread=%s)", portalName, limit, portal,
-                Thread.currentThread().getId());
+                Thread.currentThread().threadId());
 
       if (portal.ignoreExecution)
         writeNoData();
@@ -580,7 +580,7 @@ public class PostgresNetworkExecutor extends Thread {
 
     if (DEBUG)
       LogManager.instance().log(this, Level.INFO, "PSQL:-> %d row data (%s) (thread=%s)", resultSet.size(),
-          FileUtils.getSizeAsString(bufferData.limit()), Thread.currentThread().getId());
+          FileUtils.getSizeAsString(bufferData.limit()), Thread.currentThread().threadId());
   }
 
   private void bindCommand() {
@@ -598,7 +598,7 @@ public class PostgresNetworkExecutor extends Thread {
       if (DEBUG)
         LogManager.instance()
             .log(this, Level.INFO, "PSQL: bind (portal=%s) -> %s (thread=%s)", portalName, sourcePreparedStatement,
-                Thread.currentThread().getId());
+                Thread.currentThread().threadId());
 
       final int paramFormatCount = channel.readShort();
       if (paramFormatCount > 0) {
@@ -661,7 +661,7 @@ public class PostgresNetworkExecutor extends Thread {
       if (DEBUG)
         LogManager.instance()
             .log(this, Level.INFO, "PSQL: parse (portal=%s) -> %s (params=%d) (errorInTransaction=%s thread=%s)", portalName,
-                portal.query, paramCount, errorInTransaction, Thread.currentThread().getId());
+                portal.query, paramCount, errorInTransaction, Thread.currentThread().threadId());
 
       if (errorInTransaction)
         return;
@@ -1039,7 +1039,7 @@ public class PostgresNetworkExecutor extends Thread {
 
       if (DEBUG)
         LogManager.instance().log(this, Level.INFO, "PSQL:-> %s (%s - %s) (thread=%s)", null, messageName, messageCode,
-            FileUtils.getSizeAsString(length), Thread.currentThread().getId());
+            FileUtils.getSizeAsString(length), Thread.currentThread().threadId());
 
     } catch (final IOException e) {
       setErrorInTx();

--- a/server/src/main/java/com/arcadedb/server/ha/Replica2LeaderNetworkExecutor.java
+++ b/server/src/main/java/com/arcadedb/server/ha/Replica2LeaderNetworkExecutor.java
@@ -90,7 +90,7 @@ public class Replica2LeaderNetworkExecutor extends Thread {
 
         if (request == null) {
           LogManager.instance().log(this, Level.SEVERE, "Error on receiving message NULL, reconnecting (threadId=%d)",
-              Thread.currentThread().getId());
+              Thread.currentThread().threadId());
           reconnect(null);
           continue;
         }
@@ -103,10 +103,10 @@ public class Replica2LeaderNetworkExecutor extends Thread {
 
         if (reqId > -1)
           LogManager.instance()
-              .log(this, Level.FINE, "Received request %d from the Leader (threadId=%d)", reqId, Thread.currentThread().getId());
+              .log(this, Level.FINE, "Received request %d from the Leader (threadId=%d)", reqId, Thread.currentThread().threadId());
         else
           LogManager.instance()
-              .log(this, Level.FINE, "Received response %d from the Leader (threadId=%d)", reqId, Thread.currentThread().getId());
+              .log(this, Level.FINE, "Received response %d from the Leader (threadId=%d)", reqId, Thread.currentThread().threadId());
 
         // NUMBERS <0 ARE FORWARD FROM REPLICA TO LEADER WITHOUT A VALID SEQUENCE
         if (reqId > -1) {
@@ -165,7 +165,7 @@ public class Replica2LeaderNetworkExecutor extends Thread {
 
     LogManager.instance()
         .log(this, Level.INFO, "Replica message thread closed (shutdown=%s name=%s threadId=%d lastReqId=%d)", shutdown, getName(),
-            Thread.currentThread().getId(), lastReqId);
+            Thread.currentThread().threadId(), lastReqId);
   }
 
   public String getRemoteServerName() {

--- a/server/src/main/java/com/arcadedb/server/ha/ReplicationLogFile.java
+++ b/server/src/main/java/com/arcadedb/server/ha/ReplicationLogFile.java
@@ -281,14 +281,14 @@ public class ReplicationLogFile extends LockContext {
       if (message.messageNumber < lastMessageNumber) {
         LogManager.instance().log(this, Level.WARNING,
             "Wrong sequence in message numbers. Last was %d and now receiving %d. Skip saving this entry (threadId=%d)",
-            lastMessageNumber, message.messageNumber, Thread.currentThread().getId());
+            lastMessageNumber, message.messageNumber, Thread.currentThread().threadId());
         return false;
       }
 
       if (message.messageNumber != lastMessageNumber + 1) {
         LogManager.instance().log(this, Level.WARNING,
             "Found a jump (%d) in message numbers. Last was %d and now receiving %d. Skip saving this entry (threadId=%d)",
-            (message.messageNumber - lastMessageNumber), lastMessageNumber, message.messageNumber, Thread.currentThread().getId());
+            (message.messageNumber - lastMessageNumber), lastMessageNumber, message.messageNumber, Thread.currentThread().threadId());
 
         return false;
       }

--- a/server/src/test/java/com/arcadedb/server/BaseGraphServerTest.java
+++ b/server/src/test/java/com/arcadedb/server/BaseGraphServerTest.java
@@ -46,6 +46,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -275,14 +276,14 @@ public abstract class BaseGraphServerTest extends StaticBaseServerTest {
 
   protected String getServerAddresses() {
     int port = 2424;
-    String serverURLs = "";
+    StringBuilder serverURLs = new StringBuilder();
     for (int i = 0; i < getServerCount(); ++i) {
       if (i > 0)
-        serverURLs += ",";
+        serverURLs.append(",");
 
-      serverURLs += "localhost:" + (port++);
+      serverURLs.append("localhost:").append(port++);
     }
-    return serverURLs;
+    return serverURLs.toString();
   }
 
   protected void startServers() {
@@ -358,7 +359,7 @@ public abstract class BaseGraphServerTest extends StaticBaseServerTest {
   protected boolean areAllReplicasAreConnected() {
     final int serverCount = getServerCount();
 
-    int lastTotalConnectedReplica = 0;
+    int lastTotalConnectedReplica;
 
     for (int i = 0; i < serverCount; ++i) {
       if (getServerRole(i) == HAServer.SERVER_ROLE.ANY) {
@@ -516,9 +517,9 @@ public abstract class BaseGraphServerTest extends StaticBaseServerTest {
 
   protected void deleteDatabaseFolders() {
     if (databases != null)
-      for (int i = 0; i < databases.length; ++i) {
-        if (databases[i] != null && databases[i].isOpen())
-          ((DatabaseInternal) databases[i]).getEmbedded().drop();
+      for (Database database : databases) {
+        if (database != null && database.isOpen())
+          ((DatabaseInternal) database).getEmbedded().drop();
       }
 
     if (servers != null)
@@ -587,8 +588,10 @@ public abstract class BaseGraphServerTest extends StaticBaseServerTest {
   }
 
   protected String command(final int serverIndex, final String command) throws Exception {
-    final HttpURLConnection initialConnection = (HttpURLConnection) new URL(
-        "http://127.0.0.1:248" + serverIndex + "/api/v1/command/graph").openConnection();
+    final HttpURLConnection initialConnection = (HttpURLConnection) new URI(
+        "http://127.0.0.1:248" + serverIndex + "/api/v1/command/graph")
+        .toURL()
+        .openConnection();
     try {
 
       initialConnection.setRequestMethod("POST");

--- a/server/src/test/java/com/arcadedb/server/HTTPGraphIT.java
+++ b/server/src/test/java/com/arcadedb/server/HTTPGraphIT.java
@@ -583,7 +583,7 @@ public class HTTPGraphIT extends BaseGraphServerTest {
               atomic.incrementAndGet();
 
               if (responseAsJson == null) {
-                LogManager.instance().log(this, Level.SEVERE, "Error on execution from thread %d", Thread.currentThread().getId());
+                LogManager.instance().log(this, Level.SEVERE, "Error on execution from thread %d", Thread.currentThread().threadId());
                 continue;
               }
 

--- a/server/src/test/java/com/arcadedb/server/ha/HTTPGraphConcurrentIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/HTTPGraphConcurrentIT.java
@@ -69,7 +69,7 @@ public class HTTPGraphConcurrentIT extends BaseGraphServerTest {
               atomic.incrementAndGet();
 
               if (responseAsJson == null) {
-                LogManager.instance().log(this, Level.SEVERE, "Error on execution from thread %d", Thread.currentThread().getId());
+                LogManager.instance().log(this, Level.SEVERE, "Error on execution from thread %d", Thread.currentThread().threadId());
                 continue;
               }
 


### PR DESCRIPTION
This pull request updates all instances of `Thread.currentThread().getId()` to `Thread.currentThread().threadId()` across various classes in the codebase. This change ensures compatibility with the updated Java API, which now provides the `threadId()` method as a more modern and standardized way to retrieve the thread ID.

### Updates to Logging Statements:
* Replaced `Thread.currentThread().getId()` with `Thread.currentThread().threadId()` in logging calls across multiple methods in `LocalDatabase.java`, ensuring consistent logging of thread IDs. [[1]](diffhunk://#diff-b44a08af3784675465ad0899e5162ba83f557e41c0c04dffe2adc56f2da7d73cL1657-R1657) [[2]](diffhunk://#diff-b44a08af3784675465ad0899e5162ba83f557e41c0c04dffe2adc56f2da7d73cL1753-R1753) [[3]](diffhunk://#diff-b44a08af3784675465ad0899e5162ba83f557e41c0c04dffe2adc56f2da7d73cL1899-R1899)
* Updated logging statements in `TransactionContext.java` to use `threadId()` for thread ID retrieval during transaction operations. [[1]](diffhunk://#diff-9ece3676d9e63b7b7e2af2d3e78b4c9cfc26b48460f3102b5b15b9a9f5731097L207-R207) [[2]](diffhunk://#diff-9ece3676d9e63b7b7e2af2d3e78b4c9cfc26b48460f3102b5b15b9a9f5731097L616-R616) [[3]](diffhunk://#diff-9ece3676d9e63b7b7e2af2d3e78b4c9cfc26b48460f3102b5b15b9a9f5731097L627-R627) [[4]](diffhunk://#diff-9ece3676d9e63b7b7e2af2d3e78b4c9cfc26b48460f3102b5b15b9a9f5731097L654-R654) [[5]](diffhunk://#diff-9ece3676d9e63b7b7e2af2d3e78b4c9cfc26b48460f3102b5b15b9a9f5731097L690-R690)

### Changes in Async Operations:
* Updated thread ID retrieval in async operation logging within `DatabaseAsyncCreateRecord.java`, `DatabaseAsyncDeleteRecord.java`, `DatabaseAsyncUpdateRecord.java`, and `DatabaseAsyncExecutorImpl.java`. [[1]](diffhunk://#diff-f674f965ba8984f54810ad2d5c5c6e963d85563b4cbb61aa3805bf04ba50e769L52-R52) [[2]](diffhunk://#diff-36fd83893c9764a1ba5e6751cff4e3358367d998c790c0cad9b93b9810990636L63-R63) [[3]](diffhunk://#diff-bcf52ac1f2121588255a27c8995d8d0f860b79c205f17cebf96a9c43bdf826f8L61-R61) [[4]](diffhunk://#diff-de9a3171c13bb87ee75dca3339271ec9986fb4ceec2ba0e77f3de5f670ba4da5L134-R134)

### Modifications in `LocalBucket.java`:
* Replaced `getId()` with `threadId()` in logging statements during record creation, update, and deletion processes to ensure accurate thread ID representation. [[1]](diffhunk://#diff-2a73407a16da61b14f95c4bffdf8dea841e021676277af2a347a1098fff3ae24L672-R672) [[2]](diffhunk://#diff-2a73407a16da61b14f95c4bffdf8dea841e021676277af2a347a1098fff3ae24L702-R702) [[3]](diffhunk://#diff-2a73407a16da61b14f95c4bffdf8dea841e021676277af2a347a1098fff3ae24L748-R748) [[4]](diffhunk://#diff-2a73407a16da61b14f95c4bffdf8dea841e021676277af2a347a1098fff3ae24L847-R847) [[5]](diffhunk://#diff-2a73407a16da61b14f95c4bffdf8dea841e021676277af2a347a1098fff3ae24L867-R874) [[6]](diffhunk://#diff-2a73407a16da61b14f95c4bffdf8dea841e021676277af2a347a1098fff3ae24L886-R886) [[7]](diffhunk://#diff-2a73407a16da61b14f95c4bffdf8dea841e021676277af2a347a1098fff3ae24L1013-R1013)

### Updates in `PageManager.java`:
* Transitioned to `threadId()` for thread ID logging in methods related to page version checks, updates, flushing, and eviction. [[1]](diffhunk://#diff-9fb41a856b564b7ac656bfd7b0f45093b103a5abc3756ce268cc0976ec8f9757L214-R214) [[2]](diffhunk://#diff-9fb41a856b564b7ac656bfd7b0f45093b103a5abc3756ce268cc0976ec8f9757L224-R224) [[3]](diffhunk://#diff-9fb41a856b564b7ac656bfd7b0f45093b103a5abc3756ce268cc0976ec8f9757L259-R267) [[4]](diffhunk://#diff-9fb41a856b564b7ac656bfd7b0f45093b103a5abc3756ce268cc0976ec8f9757L278-R278) [[5]](diffhunk://#diff-9fb41a856b564b7ac656bfd7b0f45093b103a5abc3756ce268cc0976ec8f9757L338-R338) [[6]](diffhunk://#diff-9fb41a856b564b7ac656bfd7b0f45093b103a5abc3756ce268cc0976ec8f9757L353-R353) [[7]](diffhunk://#diff-9fb41a856b564b7ac656bfd7b0f45093b103a5abc3756ce268cc0976ec8f9757L382-R382) [[8]](diffhunk://#diff-9fb41a856b564b7ac656bfd7b0f45093b103a5abc3756ce268cc0976ec8f9757L430-R430)

### Other Updates:
* Updated the `ThreadBucketSelectionStrategy.java` to use `threadId()` for bucket ID calculation, ensuring alignment with the new API.…().threadId() for consistency

## What does this PR do?

some chore

## Motivation

remove compilation warnings

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
