### PR TITLE
Update and move nightly builds link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ There are three variants of (about monthly) releases:
 - `minimal` - this package excludes the `gremlin`, `redisw`, `mongodbw`, `graphql` modules
 - `headless` - this package excludes the `gremlin`, `redisw`, `mongodbw`, `graphql`, `studio` modules
 
+The nightly builds of the repository head can be found [here](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/arcadedb/arcadedb-package/).
+
 ### Community
 
 Join our growing community around the world, for ideas, discussions and help regarding ArcadeDB.
@@ -145,7 +147,6 @@ Recurrent and One-Time tiers. All the sponsorship received will be distributed t
 
 We would love for you to get involved with ArcadeDB project.
 If you wish to help, you can learn more about how you can contribute to this project in the [contribution guide](CONTRIBUTING.md).
-The nightly builds of the repository head can be found [here](https://s01.oss.sonatype.org/content/repositories/snapshots/com/arcadedb/arcadedb-package/).
 
 Have fun with data!
 


### PR DESCRIPTION
## What does this PR do?

The link for the nightly builds in the README is updated and moved to the more suitable `Releases` section.

## Related issues

https://github.com/ArcadeData/arcadedb/issues/2197

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
