### PR TITLE
fix: fixed Postgres driver CPU 100%

### DIFF
--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -43,6 +43,7 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.security.ServerSecurityException;
 import com.arcadedb.server.security.ServerSecurityUser;
+import com.arcadedb.utility.CodeUtils;
 import com.arcadedb.utility.DateUtils;
 import com.arcadedb.utility.FileUtils;
 import com.arcadedb.utility.Pair;
@@ -1074,6 +1075,11 @@ public class PostgresNetworkExecutor extends Thread {
 
   private boolean readMessage(final String messageName, final ReadMessageCallback callback, final char... expectedMessageCodes) {
     try {
+      if (!channel.inputHasData()) {
+        CodeUtils.sleep(100);
+        return false;
+      }
+
       final char type = (char) readNextByte();
       final long length = channel.readUnsignedInt();
 

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcTest.java
@@ -55,7 +55,7 @@ public class PostgresWJdbcTest extends BaseGraphServerTest {
     super.setTestConfiguration();
     GlobalConfiguration.SERVER_PLUGINS.setValue(
         "Postgres:com.arcadedb.postgres.PostgresProtocolPlugin,GremlinServer:com.arcadedb.server.gremlin.GremlinServerPlugin");
-    GlobalConfiguration.POSTGRES_DEBUG.setValue("true");
+    GlobalConfiguration.POSTGRES_DEBUG.setValue("false"); // SET THIS TO TRUE TO DEBUG THE PROTOCOL
   }
 
   @AfterEach


### PR DESCRIPTION
This fixes the issue with CPU 100% when the postgres driver has an open connection.

The issue was with the read from the socket: if no data is present, a spin lock like behavior happens inside the read. Now if the data is not present, sleep 100ms and check again. 

The idea would be implementing a multiplexing poll, this is a quick fix.