### PR TITLE
Security Fix: Upgraded the commons-beanutils library to version 1.11.0 to resolve a security vulnerability identified by a Meterian security scan

### DIFF
--- a/gremlin/pom.xml
+++ b/gremlin/pom.xml
@@ -68,6 +68,11 @@
             <version>${commons-configuration2.version}</version>
         </dependency>
         <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.11.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.groovy</groupId>
             <artifactId>groovy</artifactId>
             <version>${groovy.version}</version>
@@ -76,6 +81,12 @@
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-core</artifactId>
             <version>${gremlin.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-beanutils</groupId>
+                    <artifactId>commons-beanutils</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>

--- a/gremlin/pom.xml
+++ b/gremlin/pom.xml
@@ -40,6 +40,7 @@
         <netty.version>4.2.2.Final</netty.version>
         <commons-configuration2.version>2.12.0</commons-configuration2.version>
         <groovy.version>4.0.27</groovy.version>
+        <commons-beanutils.version>1.11.0</commons-beanutils.version>
     </properties>
 
     <dependencies>
@@ -70,7 +71,7 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>1.11.0</version>
+            <version>${commons-beanutils.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.groovy</groupId>


### PR DESCRIPTION
This pull request makes updates to the `gremlin/pom.xml` file to manage dependencies more effectively. The changes include adding a new dependency and excluding it from another dependency to avoid conflicts.

Dependency management updates:

* [`gremlin/pom.xml`](diffhunk://#diff-0b18313d2162740105f81ecb341ad369b0032faf5562b0fb6c956c2af47fec69R70-R74): Added `commons-beanutils` as a direct dependency with version `1.11.0`.
* [`gremlin/pom.xml`](diffhunk://#diff-0b18313d2162740105f81ecb341ad369b0032faf5562b0fb6c956c2af47fec69R84-R89): Excluded `commons-beanutils` from the `gremlin-core` dependency to prevent potential issues or conflicts.…rsion


## Motivation

Security scan by Meterian


## Additional Notes

Anything else we should know when reviewing?

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
