### PR TITLE
#2304 feat: add performance testing for single server load in ArcadeDB

### DIFF
--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Run Unit Tests with Coverage
         # verify because it runs the tests and generates the coverage report, ITs are skipped
-        run: ./mvnw verify -Pcoverage --batch-mode --errors --fail-never --show-version -pl !e2e
+        run: ./mvnw verify -Pcoverage --batch-mode --errors --fail-never --show-version -pl !e2e !e2e-perf
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -193,6 +193,50 @@ jobs:
         with:
           name: Java E2E Tests Report
           path: "e2e/target/surefire-reports/TEST*.xml"
+          list-suites: "failed"
+          list-tests: "failed"
+          reporter: java-junit
+
+  java-e2e-perf-tests:
+    runs-on: ubuntu-latest
+    needs: build-and-package
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          distribution: "temurin"
+          java-version: 21
+          cache: "maven"
+
+      - name: Restore Maven artifacts
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.m2/repository
+          key: maven-repo-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Restore Docker image
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: /tmp/arcadedb-image.tar
+          key: docker-image-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Load Docker image
+        run: docker load < /tmp/arcadedb-image.tar
+
+      - name: E2E Perf Tests
+        run: ./mvnw verify -pl e2e-perf
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARCADEDB_DOCKER_IMAGE: ${{ needs.build-and-package.outputs.image-tag }}
+
+      - name: E2E Perf Tests Reporter
+        uses: dorny/test-reporter@890a17cecf52a379fc869ab770a71657660be727 # v2.1.0
+        if: success() || failure()
+        with:
+          name: Java E2E Perf Tests Report
+          path: "e2e-perf/target/failsafe-reports/TEST*.xml"
           list-suites: "failed"
           list-tests: "failed"
           reporter: java-junit

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Run Unit Tests with Coverage
         # verify because it runs the tests and generates the coverage report, ITs are skipped
-        run: ./mvnw verify -Pcoverage --batch-mode --errors --fail-never --show-version -pl !e2e !e2e-perf
+        run: ./mvnw verify -Pcoverage --batch-mode --errors --fail-never --show-version -pl !e2e,!e2e-perf
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -130,7 +130,7 @@ jobs:
           key: maven-repo-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Run Integration Tests with Coverage
-        run: ./mvnw verify -DskipTests -Pintegration -Pcoverage  --batch-mode --errors --fail-never --show-version -pl !e2e !e2e-perf
+        run: ./mvnw verify -DskipTests -Pintegration -Pcoverage  --batch-mode --errors --fail-never --show-version -pl !e2e,!e2e-perf
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -226,7 +226,7 @@ jobs:
         run: docker load < /tmp/arcadedb-image.tar
 
       - name: E2E Perf Tests
-        run: ./mvnw verify -pl e2e-perf
+        run: ./mvnw verify -Pintegration -pl e2e-perf
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARCADEDB_DOCKER_IMAGE: ${{ needs.build-and-package.outputs.image-tag }}

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -130,7 +130,7 @@ jobs:
           key: maven-repo-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Run Integration Tests with Coverage
-        run: ./mvnw verify -DskipTests -Pintegration -Pcoverage  --batch-mode --errors --fail-never --show-version -pl !e2e
+        run: ./mvnw verify -DskipTests -Pintegration -Pcoverage  --batch-mode --errors --fail-never --show-version -pl !e2e !e2e-perf
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/e2e-perf/pom.xml
+++ b/e2e-perf/pom.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+    SPDX-License-Identifier: Apache-2.0
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.arcadedb</groupId>
+        <artifactId>arcadedb-parent</artifactId>
+        <version>25.6.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <properties>
+        <allowIncompleteProjects>true</allowIncompleteProjects>
+    </properties>
+
+    <artifactId>arcadedb-e2e-perf</artifactId>
+    <name>ArcadeDB performance tests</name>
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback-classic.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.arcadedb</groupId>
+            <artifactId>arcadedb-network</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-db</artifactId>
+            <version>${assertj-db.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>toxiproxy</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${postgresql.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>${micrometer.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/e2e-perf/pom.xml
+++ b/e2e-perf/pom.xml
@@ -50,7 +50,6 @@
                     </execution>
                 </executions>
             </plugin>
-
         </plugins>
     </build>
 

--- a/e2e-perf/pom.xml
+++ b/e2e-perf/pom.xml
@@ -74,12 +74,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-db</artifactId>
-            <version>${assertj-db.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <version>${testcontainers.version}</version>
@@ -95,12 +89,6 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${testcontainers.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <version>${postgresql.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/e2e-perf/src/test/java/com/arcadedb/test/performance/SingleServerLoadTestIT.java
+++ b/e2e-perf/src/test/java/com/arcadedb/test/performance/SingleServerLoadTestIT.java
@@ -1,0 +1,77 @@
+package com.arcadedb.test.performance;
+
+import com.arcadedb.test.support.ContainersTestTemplate;
+import com.arcadedb.test.support.DatabaseWrapper;
+import io.micrometer.core.instrument.Metrics;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class SingleServerLoadTestIT extends ContainersTestTemplate {
+
+  @Test
+  @DisplayName("Single server load test")
+  void singleServerLoadTest() throws InterruptedException, IOException {
+
+    GenericContainer<?> arcadeContainer = createArcadeContainer("arcade", "none", "none", "any", false, network);
+
+    startContainers();
+
+    DatabaseWrapper db = new DatabaseWrapper(arcadeContainer, idSupplier);
+    db.createDatabase();
+    db.createSchema();
+
+    final int numOfThreads = 5;
+    final int numOfUsers = 1000;
+    final int numOfPhotos = 5;
+    final int numOfFriendshipIterations = 10;
+    final int numOfFriendshipPerIterations = 10;
+
+    int expectedUsersCount = numOfUsers * numOfThreads;
+    int expectedFriendshipCount = numOfFriendshipIterations * numOfFriendshipPerIterations * numOfThreads;
+    int expectedPhotoCount = expectedUsersCount * numOfPhotos;
+
+    logger.info("Creating {} users using {} threads", expectedUsersCount, numOfThreads);
+    ExecutorService executor = Executors.newFixedThreadPool(numOfThreads);
+    for (int i = 0; i < numOfThreads; i++) {
+      // Each thread will create users and photos
+      executor.submit(() -> {
+        DatabaseWrapper db1 = new DatabaseWrapper(arcadeContainer, idSupplier);
+        db1.addUserAndPhotos(numOfUsers, numOfPhotos);
+        db1.close();
+      });
+
+      TimeUnit.SECONDS.sleep(1);
+      // Each thread will create friendships
+      executor.submit(() -> {
+        DatabaseWrapper db1 = new DatabaseWrapper(arcadeContainer, idSupplier);
+        db1.createFriendships(numOfFriendshipIterations, numOfFriendshipPerIterations);
+        db1.close();
+      });
+    }
+
+    executor.shutdown();
+    while (!executor.isTerminated()) {
+      long users = db.countUsers();
+      long friendships = db.countFriendships();
+      logger.info("Current users: {} - friendships: {}", users, friendships);
+      // Wait for 2 seconds before checking again
+      try {
+        TimeUnit.SECONDS.sleep(2);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+
+    db.assertThatUserCountIs(expectedUsersCount);
+    db.assertThatPhotoCountIs(expectedPhotoCount);
+    db.assertThatFriendshipCountIs(expectedFriendshipCount);
+
+  }
+
+}

--- a/e2e-perf/src/test/java/com/arcadedb/test/performance/SingleServerLoadTestIT.java
+++ b/e2e-perf/src/test/java/com/arcadedb/test/performance/SingleServerLoadTestIT.java
@@ -2,7 +2,6 @@ package com.arcadedb.test.performance;
 
 import com.arcadedb.test.support.ContainersTestTemplate;
 import com.arcadedb.test.support.DatabaseWrapper;
-import io.micrometer.core.instrument.Metrics;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
@@ -46,7 +45,7 @@ public class SingleServerLoadTestIT extends ContainersTestTemplate {
         db1.close();
       });
 
-      TimeUnit.SECONDS.sleep(1);
+      TimeUnit.SECONDS.sleep(2);
       // Each thread will create friendships
       executor.submit(() -> {
         DatabaseWrapper db1 = new DatabaseWrapper(arcadeContainer, idSupplier);
@@ -59,7 +58,8 @@ public class SingleServerLoadTestIT extends ContainersTestTemplate {
     while (!executor.isTerminated()) {
       long users = db.countUsers();
       long friendships = db.countFriendships();
-      logger.info("Current users: {} - friendships: {}", users, friendships);
+      long photos = db.countPhotos();
+      logger.info("Current users: {} - photos: {} - friendships: {}", users, photos, friendships);
       // Wait for 2 seconds before checking again
       try {
         TimeUnit.SECONDS.sleep(2);

--- a/e2e-perf/src/test/java/com/arcadedb/test/support/ContainersTestTemplate.java
+++ b/e2e-perf/src/test/java/com/arcadedb/test/support/ContainersTestTemplate.java
@@ -1,0 +1,214 @@
+package com.arcadedb.test.support;
+
+import com.arcadedb.utility.FileUtils;
+import eu.rekawek.toxiproxy.ToxiproxyClient;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.logging.LoggingMeterRegistry;
+import io.micrometer.core.instrument.logging.LoggingRegistryConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.ContainerState;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.utility.MountableFile;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+public abstract class ContainersTestTemplate {
+  public static final String                    IMAGE      = "arcadedata/arcadedb:latest";
+  public static final String                    PASSWORD   = "playwithdata";
+  protected              LoggingMeterRegistry      loggingMeterRegistry;
+  protected           Logger                    logger     = LoggerFactory.getLogger(getClass());
+  protected           Network                   network;
+  protected           ToxiproxyContainer        toxiproxy;
+  protected           ToxiproxyClient           toxiproxyClient;
+  protected           List<GenericContainer<?>> containers = new ArrayList<>();
+
+  /**
+   * Supplier to generate unique IDs.
+   */
+  protected Supplier<Integer> idSupplier = new Supplier<>() {
+
+    private final AtomicInteger id = new AtomicInteger();
+
+    @Override
+    public Integer get() {
+      return id.getAndIncrement();
+    }
+  };
+
+  @BeforeEach
+  void setUp() throws IOException, InterruptedException {
+    deleteContainersDirectories();
+
+    // METRICS
+    LoggingRegistryConfig config = new LoggingRegistryConfig() {
+      @Override
+      public String get(@NotNull String key) {
+        return null;
+      }
+
+      @Override
+      public @NotNull Duration step() {
+        return Duration.ofSeconds(10);
+      }
+    };
+
+    Metrics.addRegistry(new SimpleMeterRegistry());
+    loggingMeterRegistry = LoggingMeterRegistry.builder(config).build();
+    Metrics.addRegistry(loggingMeterRegistry);
+
+    // NETWORK
+    network = Network.newNetwork();
+
+    // Toxiproxy
+    logger.info("Creating a Toxiproxy container");
+    toxiproxy = new ToxiproxyContainer("ghcr.io/shopify/toxiproxy:2.12.0")
+        .withNetwork(network)
+        .withNetworkAliases("proxy");
+    Startables.deepStart(toxiproxy).join();
+    toxiproxyClient = new ToxiproxyClient(toxiproxy.getHost(), toxiproxy.getControlPort());
+
+  }
+
+  @AfterEach
+  public void tearDown() {
+    stopContainers();
+
+    logger.info("Stopping the Toxiproxy container");
+    toxiproxy.stop();
+
+    deleteContainersDirectories();
+
+    Metrics.removeRegistry(loggingMeterRegistry);
+  }
+
+  private void deleteContainersDirectories() {
+    logger.info("Deleting containers directories");
+    FileUtils.deleteRecursively(Path.of("./target/databases").toFile());
+    FileUtils.deleteRecursively(Path.of("./target/replication").toFile());
+    FileUtils.deleteRecursively(Path.of("./target/logs").toFile());
+  }
+
+  private void makeContainersDirectories(String name) {
+    logger.info("Creating containers directories");
+    Path.of("./target/databases/" + name).toFile().mkdirs();
+    Path.of("./target/databases/" + name).toFile().setWritable(true, false);
+    Path.of("./target/replication/" + name).toFile().mkdirs();
+    Path.of("./target/replication/" + name).toFile().setWritable(true, false);
+    Path.of("./target/logs/" + name).toFile().mkdirs();
+    Path.of("./target/logs/" + name).toFile().setWritable(true, false);
+  }
+
+  /**
+   * Stops all containers and clears the list of containers.
+   */
+  protected void stopContainers() {
+    logger.info("Stopping all containers");
+    containers.stream()
+        .filter(ContainerState::isRunning)
+        .peek(container -> logger.info("Stopping container {}", container.getContainerName()))
+//        .peek(container -> {
+//          try {
+//            container.execInContainer("rm -rf", "/home/arcadedb/databases/*");
+//            container.execInContainer("rm -rf", "/home/arcadedb/replication/*");
+//            container.execInContainer("rm -rf", "/home/arcadedb/logs/*");
+//          } catch (IOException | InterruptedException e) {
+//            logger.error("Error while stopping container {}", container.getContainerName(), e);
+//          }
+//        })
+        .forEach(GenericContainer::stop);
+    containers.clear();
+  }
+
+  /**
+   * Starts all containers that are not already running.
+   */
+  protected void startContainers() {
+    logger.info("Starting all containers");
+    containers.stream()
+        .filter(container -> !container.isRunning())
+        .forEach(container -> Startables.deepStart(container).join());
+  }
+
+  /**
+   * Creates a new ArcadeDB container with the specified name and server list.
+   *
+   * @param name       The name of the container.
+   * @param serverList The server list for HA configuration.
+   * @param quorum     The quorum configuration for HA.
+   * @param network    The network to attach the container to.
+   *
+   * @return A GenericContainer instance representing the ArcadeDB container.
+   */
+  protected GenericContainer<?> createArcadeContainer(String name,
+      String serverList,
+      String quorum,
+      String role,
+      Network network) {
+    return createArcadeContainer(name, serverList, quorum, role, true, network);
+  }
+
+  /**
+   * Creates a new ArcadeDB container with the specified name and server list.
+   *
+   * @param name       The name of the container.
+   * @param serverList The server list for HA configuration.
+   * @param quorum     The quorum configuration for HA.
+   * @param role       The role of the server (e.g., "leader", "follower").
+   * @param ha         Whether to enable HA.
+   * @param network    The network to attach the container to.
+   *
+   * @return A GenericContainer instance representing the ArcadeDB container.
+   */
+  protected GenericContainer<?> createArcadeContainer(String name,
+      String serverList,
+      String quorum,
+      String role,
+      boolean ha,
+      Network network) {
+
+    makeContainersDirectories(name);
+
+    GenericContainer<?> container = new GenericContainer<>(IMAGE)
+        .withExposedPorts(2480, 5432)
+        .withNetwork(network)
+        .withNetworkAliases(name)
+        .withStartupTimeout(Duration.ofSeconds(90))
+        .withCopyToContainer(MountableFile.forHostPath("./target/databases/" + name, 0777), "/home/arcadedb/databases")
+        .withCopyToContainer(MountableFile.forHostPath("./target/replication/" + name, 0777), "/home/arcadedb/replication")
+        .withCopyToContainer(MountableFile.forHostPath("./target/logs/" + name, 0777), "/home/arcadedb/logs")
+
+        .withEnv("JAVA_OPTS", String.format("""
+            -Darcadedb.server.rootPassword=playwithdata
+            -Darcadedb.server.plugins=Postgres:com.arcadedb.postgres.PostgresProtocolPlugin
+            -Darcadedb.server.httpsIoThreads=10
+            -Darcadedb.bucketReuseSpaceMode=low
+            -Darcadedb.server.name=%s
+            -Darcadedb.backup.enabled=false
+            -Darcadedb.typeDefaultBuckets=10
+            -Darcadedb.ha.enabled=%s
+            -Darcadedb.ha.quorum=%s
+            -Darcadedb.ha.serverRole=%s
+            -Darcadedb.ha.serverList=%s
+            -Darcadedb.ha.replicationQueueSize=1024
+            """, name, ha, quorum, role, serverList))
+        .waitingFor(Wait.forHttp("/api/v1/ready").forPort(2480).forStatusCode(204));
+    containers.add(container);
+    return container;
+  }
+
+}

--- a/e2e-perf/src/test/java/com/arcadedb/test/support/ContainersTestTemplate.java
+++ b/e2e-perf/src/test/java/com/arcadedb/test/support/ContainersTestTemplate.java
@@ -30,7 +30,8 @@ import java.util.function.Supplier;
 public abstract class ContainersTestTemplate {
   public static final String                    IMAGE      = "arcadedata/arcadedb:latest";
   public static final String                    PASSWORD   = "playwithdata";
-  protected              LoggingMeterRegistry      loggingMeterRegistry;
+  public static final String                    DATABASE   = "playwithpictures";
+  protected           LoggingMeterRegistry      loggingMeterRegistry;
   protected           Logger                    logger     = LoggerFactory.getLogger(getClass());
   protected           Network                   network;
   protected           ToxiproxyContainer        toxiproxy;
@@ -121,15 +122,6 @@ public abstract class ContainersTestTemplate {
     containers.stream()
         .filter(ContainerState::isRunning)
         .peek(container -> logger.info("Stopping container {}", container.getContainerName()))
-//        .peek(container -> {
-//          try {
-//            container.execInContainer("rm -rf", "/home/arcadedb/databases/*");
-//            container.execInContainer("rm -rf", "/home/arcadedb/replication/*");
-//            container.execInContainer("rm -rf", "/home/arcadedb/logs/*");
-//          } catch (IOException | InterruptedException e) {
-//            logger.error("Error while stopping container {}", container.getContainerName(), e);
-//          }
-//        })
         .forEach(GenericContainer::stop);
     containers.clear();
   }

--- a/e2e-perf/src/test/java/com/arcadedb/test/support/DatabaseWrapper.java
+++ b/e2e-perf/src/test/java/com/arcadedb/test/support/DatabaseWrapper.java
@@ -1,0 +1,258 @@
+package com.arcadedb.test.support;
+
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.remote.RemoteDatabase;
+import com.arcadedb.remote.RemoteHttpComponent;
+import com.arcadedb.remote.RemoteSchema;
+import com.arcadedb.remote.RemoteServer;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import static com.arcadedb.test.support.ContainersTestTemplate.PASSWORD;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DatabaseWrapper {
+  private static final Logger              logger = LoggerFactory.getLogger(DatabaseWrapper.class);
+  private final        RemoteDatabase      db;
+  private final        GenericContainer<?> arcadeServer;
+  private final        Supplier<Integer>   idSupplier;
+  private final        Timer               photosTimer;
+  private final        Timer               usersTimer;
+  private final        Timer               friendshipTimer;
+
+  public DatabaseWrapper(GenericContainer<?> arcadeContainer, Supplier<Integer> idSupplier) {
+    this.arcadeServer = arcadeContainer;
+    this.db = connectToDatabase(arcadeContainer);
+    this.idSupplier = idSupplier;
+    usersTimer = Metrics.timer("arcadedb.test.inserted.users");
+    photosTimer = Metrics.timer("arcadedb.test.inserted.photos");
+    friendshipTimer = Metrics.timer("arcadedb.test.inserted.friendship");
+  }
+
+  private RemoteDatabase connectToDatabase(GenericContainer<?> arcadeContainer) {
+    RemoteDatabase database = new RemoteDatabase(arcadeContainer.getHost(),
+        arcadeContainer.getMappedPort(2480),
+        "ha-test",
+        "root",
+        PASSWORD);
+    database.setConnectionStrategy(RemoteHttpComponent.CONNECTION_STRATEGY.FIXED);
+    return database;
+  }
+
+  public void close() {
+    db.close();
+  }
+
+  public void createDatabase() {
+    RemoteServer server = new RemoteServer(arcadeServer.getHost(),
+        arcadeServer.getMappedPort(2480),
+        "root",
+        PASSWORD);
+    server.setConnectionStrategy(RemoteHttpComponent.CONNECTION_STRATEGY.FIXED);
+
+    if (server.exists("ha-test")) {
+      logger.info("Dropping existing database ha-test");
+      server.drop("ha-test");
+    }
+    if (!server.exists("ha-test"))
+      server.create("ha-test");
+  }
+
+  public void createSchema() {
+    //this is a test-double of HTTPGraphIT.testOneEdgePerTx test
+    db.command("sqlscript",
+        """
+            CREATE VERTEX TYPE User;
+            CREATE PROPERTY User.id INTEGER;
+            CREATE INDEX ON User (id) UNIQUE;
+
+            CREATE VERTEX TYPE Photo;
+            CREATE PROPERTY Photo.id INTEGER;
+            CREATE INDEX ON Photo (id) UNIQUE;
+
+            CREATE EDGE TYPE HasUploaded;
+
+            CREATE EDGE TYPE FriendOf;
+
+            CREATE EDGE TYPE Likes;
+            """);
+  }
+
+  public void checkSchema() {
+    RemoteSchema schema = db.getSchema();
+    assertThat(schema.existsType("Photo")).isTrue();
+    assertThat(schema.existsType("User")).isTrue();
+    assertThat(schema.existsType("HasUploaded")).isTrue();
+    assertThat(schema.existsType("FriendOf")).isTrue();
+    assertThat(schema.existsType("Likes")).isTrue();
+  }
+
+  /**
+   * This method creates a number of users and photos for each user.
+   * The photos are created in a transaction with the user.
+   *
+   * @param numberOfUsers  the number of users to create
+   * @param numberOfPhotos the number of photos to create for each user
+   */
+  public void addUserAndPhotos(int numberOfUsers, int numberOfPhotos) {
+    for (int userIndex = 1; userIndex <= numberOfUsers; userIndex++) {
+      int userId = idSupplier.get();
+      try {
+        usersTimer.record(() -> {
+          db.transaction(() ->
+              {
+//                db.acquireLock()
+//                    .type("User")
+//                    .lock();
+                db.command("sql", "CREATE VERTEX User SET id = ?", userId);
+              }
+              , false, 10);
+        });
+
+        addPhotosOfUser(userId, numberOfPhotos);
+
+      } catch (Exception e) {
+        Metrics.counter("arcadedb.test.inserted.users.error").increment();
+        logger.error("Error creating user {}: {}", userId, e.getMessage());
+      }
+
+    }
+  }
+
+  private void addPhotosOfUser(int userId, int numberOfPhotos) {
+    for (int photoIndex = 1; photoIndex <= numberOfPhotos; photoIndex++) {
+      int photoId = idSupplier.get();
+      String photoName = String.format("download-%s.jpg", photoId);
+      String sqlScript = """
+          BEGIN;
+          LET photo = CREATE VERTEX Photo SET id = ?, name = ?;
+          LET user = SELECT FROM User WHERE id = ?;
+          LET userEdge = CREATE EDGE HasUploaded FROM $user TO $photo;
+          COMMIT RETRY 30;
+          RETURN $photo;""";
+      try {
+        photosTimer.record(() -> {
+          db.transaction(() ->
+                  db.command("sqlscript", sqlScript, photoId, photoName, userId)
+              , true, 20);
+        });
+
+      } catch (Exception e) {
+        Metrics.counter("arcadedb.test.inserted.photos.error").increment();
+        logger.error("Error creating photo {}: {}", photoId, e.getMessage());
+      }
+    }
+  }
+
+  public void createFriendships(int numOfFriendshipIterations, int numOfFriendshipPerIterations) {
+    for (int f = 0; f < numOfFriendshipIterations; f++) {
+      List<Integer> userIds = getUserIds(numOfFriendshipPerIterations, f * 10);
+      for (int j = 0; j < userIds.size(); j++) {
+        addFriendship(userIds.get(j), userIds.get((j + 1) % userIds.size()));
+      }
+    }
+    logger.info("Created {} friendships", numOfFriendshipIterations * numOfFriendshipPerIterations);
+  }
+
+  /**
+   * This method creates a friendship between two users.
+   * The friendship is created in a transaction with the users.
+   *
+   * @param userId1 the id of the first user
+   * @param userId2 the id of the second user
+   */
+  public void addFriendship(int userId1, int userId2) {
+    try {
+      friendshipTimer.record(() -> {
+            db.transaction(() ->
+                {
+//                  db.acquireLock()
+//                      .type("FriendOf")
+//                      .type("User")
+//                      .lock();
+                  db.command("sql",
+                      """
+                          CREATE EDGE FriendOf
+                          FROM (SELECT FROM User WHERE id = ?) TO (SELECT FROM User WHERE id = ?)
+                          """, userId1, userId2);
+
+                }
+                , true, 30);
+
+          }
+      );
+
+    } catch (Exception e) {
+      Metrics.counter("arcadedb.test.inserted.friendship.error").increment();
+      logger.error("Error creating friendship between {} and {}: {}", userId1, userId2, e.getMessage());
+    }
+  }
+
+  /**
+   * This method creates a friendship between two users.
+   * The friendship is created in a transaction with the users.
+   *
+   * @param userId1 the id of the first user
+   * @param userId2 the id of the second user
+   */
+  public void addFriendshipScript(int userId1, int userId2) {
+    try {
+      friendshipTimer.record(() -> {
+        db.transaction(() ->
+            db.command("sqlscript",
+                """
+                    BEGIN;
+                    CREATE EDGE FriendOf
+                    FROM (SELECT FROM User WHERE id = ?) TO (SELECT FROM User WHERE id = ?);
+                    COMMIT RETRY 30;
+                    """, userId1, userId2), true);
+      });
+
+    } catch (Exception e) {
+      Metrics.counter("arcadedb.test.inserted.friendship.error").increment();
+      logger.error("Error creating friendship between {} and {}: {}", userId1, userId2, e.getMessage());
+    }
+  }
+
+  public void assertThatUserCountIs(int expectedCount) {
+    assertThat(countUsers()).isEqualTo(expectedCount);
+  }
+
+  public List<Integer> getUserIds(int numOfUsers, int skip) {
+    ResultSet resultSet = db.query("sql", "SELECT id  FROM User ORDER BY id SKIP ? LIMIT ?", skip, numOfUsers);
+    return resultSet.stream()
+        .map(r -> r.<Integer>getProperty("id"))
+        .toList();
+  }
+
+  public void assertThatFriendshipCountIs(int expectedCount) {
+    assertThat(countFriendships()).isEqualTo(expectedCount);
+  }
+
+  public void assertThatPhotoCountIs(int expectedCount) {
+    assertThat(countPhotos()).isEqualTo(expectedCount);
+  }
+
+  public long countUsers() {
+    return db.countType("User", false);
+  }
+
+  public long countPhotos() {
+    return db.countType("Photo", false);
+  }
+
+  public long countFriendships() {
+    return db.countType("FriendOf", false);
+  }
+
+  public ResultSet command(String command, Object... args) {
+    logger.info("Execute command: {}", command);
+    return db.command("sql", command, args);
+  }
+}

--- a/e2e-perf/src/test/java/com/arcadedb/test/support/DatabaseWrapper.java
+++ b/e2e-perf/src/test/java/com/arcadedb/test/support/DatabaseWrapper.java
@@ -107,9 +107,10 @@ public class DatabaseWrapper {
         usersTimer.record(() -> {
           db.transaction(() ->
               {
-//                db.acquireLock()
-//                    .type("User")
-//                    .lock();
+                //uncomment to see error on server side
+                db.acquireLock()
+                    .type("User")
+                    .lock();
                 db.command("sql", "CREATE VERTEX User SET id = ?", userId);
               }
               , false, 10);
@@ -172,6 +173,7 @@ public class DatabaseWrapper {
       friendshipTimer.record(() -> {
             db.transaction(() ->
                 {
+                  //uncomment to see error on server side
 //                  db.acquireLock()
 //                      .type("FriendOf")
 //                      .type("User")

--- a/e2e-perf/src/test/resources/logback-test.xml
+++ b/e2e-perf/src/test/resources/logback-test.xml
@@ -1,0 +1,27 @@
+<configuration>
+  <!-- Console Appender (existing) -->
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- New File Appender -->
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>test.log</file>
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- Root logger configuration -->
+  <root level="info">
+    <appender-ref ref="STDOUT"/>
+    <appender-ref ref="FILE"/>
+  </root>
+
+  <!-- Specific logger configurations (existing) -->
+  <logger name="org.testcontainers" level="WARN"/>
+  <logger name="com.github.dockerjava" level="WARN"/>
+  <logger name="org.apache.hc" level="WARN"/>
+</configuration>

--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -45,13 +45,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -65,12 +65,14 @@
         <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
+        <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
         <license-maven-plugin.version>5.0.0</license-maven-plugin.version>
         <maven-central-publishing-plugin.version>0.8.0</maven-central-publishing-plugin.version>
 
         <testcontainers.version>1.21.0</testcontainers.version>
         <logback-classic.version>1.5.18</logback-classic.version>
         <micrometer.version>1.14.6</micrometer.version>
+        <postgres.version>42.7.7</postgres.version>
 
         <assertj-core.version>3.27.3</assertj-core.version>
         <junit.jupiter.version>5.13.1</junit.jupiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,10 @@
         <license-maven-plugin.version>5.0.0</license-maven-plugin.version>
         <maven-central-publishing-plugin.version>0.8.0</maven-central-publishing-plugin.version>
 
+        <testcontainers.version>1.21.0</testcontainers.version>
+        <logback-classic.version>1.5.18</logback-classic.version>
+        <micrometer.version>1.14.6</micrometer.version>
+
         <assertj-core.version>3.27.3</assertj-core.version>
         <junit.jupiter.version>5.13.1</junit.jupiter.version>
         <awaitility.version>4.3.0</awaitility.version>
@@ -120,6 +124,7 @@
         <module>studio</module>
         <module>package</module>
         <module>e2e</module>
+        <module>e2e-perf</module>
     </modules>
 
     <build>
@@ -275,7 +280,7 @@
                     <publishingServerId>central</publishingServerId>
                     <autoPublish>true</autoPublish>
                     <excludeArtifacts>
-                        arcadedb-coverage,arcadedb-e2e
+                        arcadedb-coverage,arcadedb-e2e,arcadedb-e2e-perf
                     </excludeArtifacts>
                 </configuration>
             </plugin>

--- a/postgresw/pom.xml
+++ b/postgresw/pom.xml
@@ -34,7 +34,6 @@
     <name>ArcadeDB PostgresW</name>
 
     <properties>
-        <postgres.version>42.7.7</postgres.version>
         <tomcat-jdbc.version>11.0.8</tomcat-jdbc.version>
     </properties>
 

--- a/studio/pom.xml
+++ b/studio/pom.xml
@@ -84,6 +84,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>
+                <version>${maven-clean-plugin.version}</version>
                 <configuration>
                     <filesets>
                         <fileset>


### PR DESCRIPTION
## What does this PR do?

Add initial infra for perfs tests using containers and an initial load test for single node deployment

## Motivation

Even if Some perfomance tests are in place, they spin up Servers inside the same JVM of the test code.

## Related issues

#2304 

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
