### PR TITLE
Add extra environment variables to helm chart

### DIFF
--- a/k8s/helm/README.md
+++ b/k8s/helm/README.md
@@ -33,11 +33,12 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### arcaddb
 
-| Name                         | Description                                           | Value                                    |
-|------------------------------|-------------------------------------------------------|------------------------------------------|
-| `arcadedb.databaseDirectory` | Enable persistence by updating this and volume/Mounts | `/home/arcadedb/databases`               |
-| `arcadedb.defaultDatabases`  | Default databases                                     | `Universe[foo:bar]`                      |
-| `arcadedb.extraCommands`     | Any extra comands to pass to ArcadeDB startup         | `["-Darcadedb.server.mode=development"]` |
+| Name                         | Description                                                        | Value                                    |
+|------------------------------|--------------------------------------------------------------------|------------------------------------------|
+| `arcadedb.databaseDirectory` | Enable persistence by updating this and volume/Mounts              | `/home/arcadedb/databases`               |
+| `arcadedb.defaultDatabases`  | Default databases                                                  | `Universe[foo:bar]`                      |
+| `arcadedb.extraCommands`     | Any extra commands to pass to ArcadeDB startup                     | `["-Darcadedb.server.mode=development"]` |
+| `arcadedb.extraEnvironment`  | Additional environment variables to pass to the ArcadeDB container | `[]` |
 
 ### arcadedb.credentials
 

--- a/k8s/helm/templates/statefulset.yaml
+++ b/k8s/helm/templates/statefulset.yaml
@@ -95,7 +95,9 @@ spec:
                   name: arcadedb-credentials-secret
                   key: rootPassword
               {{- end }}
-
+              {{- with .Values.arcadedb.extraEnvironment }}
+                {{- toYaml . | nindent 12 }}
+              {{- end }}
       {{- with .Values.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -8,9 +8,11 @@ arcadedb:
   databaseDirectory: "/home/arcadedb/databases"
   ## @param arcadedb.defaultDatabases Default databases
   defaultDatabases: "Universe[foo:bar]"
-  ## @param arcadedb.extraCommands Any extra comands to pass to ArcadeDB startup
+  ## @param arcadedb.extraCommands Any extra commands to pass to ArcadeDB startup
   extraCommands:
     - -Darcadedb.server.mode=development # development | production
+  ## @param arcadedb.extraEnvironment Additional environment variables to pass to the ArcadeDB container
+  extraEnvironment: []
   ## @section arcadedb.credentials
   credentials:
   ## @section arcadedb.credentials.rootPassword


### PR DESCRIPTION
## What does this PR do?

This PR aims to add support for extend environment variables allowing helm chart users to customise server.sh parameters.

## Motivation

As user of arcadedb and identified the limitation, it is fair to share a contribution to evolve the project.

## Related issues

- https://github.com/ArcadeData/arcadedb/issues/2307
- https://github.com/ArcadeData/arcadedb/discussions/2306

## Additional Notes

-

## Checklist

- [x] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
