### PR TITLE
feat: enhance load testing with increased user and friendship counts

### DIFF
--- a/e2e-perf/src/test/java/com/arcadedb/test/performance/SingleLocalhostServerSimpleLoadTestIT.java
+++ b/e2e-perf/src/test/java/com/arcadedb/test/performance/SingleLocalhostServerSimpleLoadTestIT.java
@@ -1,0 +1,115 @@
+package com.arcadedb.test.performance;
+
+import com.arcadedb.test.support.LocalhostDatabaseWrapper;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.logging.LoggingMeterRegistry;
+import io.micrometer.core.instrument.logging.LoggingRegistryConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+public class SingleLocalhostServerSimpleLoadTestIT {
+  protected LoggingMeterRegistry loggingMeterRegistry;
+  protected Logger               logger = LoggerFactory.getLogger(getClass());
+
+  protected Supplier<Integer> idSupplier = new Supplier<>() {
+
+    private final AtomicInteger id = new AtomicInteger();
+
+    @Override
+    public Integer get() {
+      return id.getAndIncrement();
+    }
+  };
+
+  @BeforeEach
+  void setUp() throws IOException, InterruptedException {
+
+    // METRICS
+    LoggingRegistryConfig config = new LoggingRegistryConfig() {
+      @Override
+      public String get(@NotNull String key) {
+        return null;
+      }
+
+      @Override
+      public @NotNull Duration step() {
+        return Duration.ofSeconds(10);
+      }
+    };
+
+    Metrics.addRegistry(new SimpleMeterRegistry());
+    loggingMeterRegistry = LoggingMeterRegistry.builder(config).build();
+    Metrics.addRegistry(loggingMeterRegistry);
+
+  }
+
+  @AfterEach
+  public void tearDown() {
+
+    Metrics.removeRegistry(loggingMeterRegistry);
+  }
+
+  @Test
+  @DisplayName("Single server load test")
+  void singleServerLoadTest() throws InterruptedException, IOException {
+
+    LocalhostDatabaseWrapper db = new LocalhostDatabaseWrapper(idSupplier);
+    db.createDatabase();
+    db.createSchema();
+
+    final int numOfThreads = 5  ;
+    final int numOfUsers = 1000000;
+    final int numOfPhotos = 0;
+    final int numOfFriendship = 0;
+
+    int expectedUsersCount = numOfUsers * numOfThreads;
+    int expectedFriendshipCount = numOfFriendship * numOfThreads;
+    int expectedPhotoCount = expectedUsersCount * numOfPhotos;
+
+    logger.info("Creating {} users using {} threads", expectedUsersCount, numOfThreads);
+    ExecutorService executor = Executors.newFixedThreadPool(numOfThreads);
+    for (int i = 0; i < numOfThreads; i++) {
+      // Each thread will create users and photos
+      executor.submit(() -> {
+        LocalhostDatabaseWrapper db1 = new LocalhostDatabaseWrapper(idSupplier);
+        db1.addUserAndPhotos(numOfUsers, numOfPhotos);
+        db1.close();
+      });
+    }
+
+    executor.shutdown();
+
+    while (!executor.isTerminated()) {
+      long users = db.countUsers();
+      long friendships = db.countFriendships();
+      long photos = db.countPhotos();
+      logger.info("Current users: {} - photos: {} - friendships: {}", users, photos, friendships);
+      // Wait for 2 seconds before checking again
+      try {
+        TimeUnit.SECONDS.sleep(2);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+
+    db.assertThatUserCountIs(expectedUsersCount);
+    db.assertThatPhotoCountIs(expectedPhotoCount);
+    db.assertThatFriendshipCountIs(expectedFriendshipCount);
+
+  }
+
+}

--- a/e2e-perf/src/test/java/com/arcadedb/test/performance/SingleLocalhostServerSimpleLoadTestIT.java
+++ b/e2e-perf/src/test/java/com/arcadedb/test/performance/SingleLocalhostServerSimpleLoadTestIT.java
@@ -71,7 +71,7 @@ public class SingleLocalhostServerSimpleLoadTestIT {
     db.createDatabase();
     db.createSchema();
 
-    final int numOfThreads = 5  ;
+    final int numOfThreads = 5;
     final int numOfUsers = 1000000;
     final int numOfPhotos = 0;
     final int numOfFriendship = 0;
@@ -94,12 +94,16 @@ public class SingleLocalhostServerSimpleLoadTestIT {
     executor.shutdown();
 
     while (!executor.isTerminated()) {
-      long users = db.countUsers();
-      long friendships = db.countFriendships();
-      long photos = db.countPhotos();
-      logger.info("Current users: {} - photos: {} - friendships: {}", users, photos, friendships);
-      // Wait for 2 seconds before checking again
       try {
+        long users = db.countUsers();
+        long friendships = db.countFriendships();
+        long photos = db.countPhotos();
+        logger.info("Current users: {} - photos: {} - friendships: {}", users, photos, friendships);
+      } catch (Exception e) {
+        logger.error(e.getMessage(), e);
+      }
+      try {
+        // Wait for 2 seconds before checking again
         TimeUnit.SECONDS.sleep(2);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();

--- a/e2e-perf/src/test/java/com/arcadedb/test/performance/SingleLocalhostServerSimpleLoadTestIT.java
+++ b/e2e-perf/src/test/java/com/arcadedb/test/performance/SingleLocalhostServerSimpleLoadTestIT.java
@@ -8,6 +8,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -21,6 +22,19 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
+/**
+ * How to run this test locally
+ * 1 - build the package: mvn clea install -DskipTests
+ * 2 - run the server :
+ * export ARCADEDB_OPTS_MEMORY="-Xms16G -Xmx16G" && \
+ * ./package/target/arcadedb-25.6.1-SNAPSHOT.dir/arcadedb-25.6.1-SNAPSHOT/bin/server.sh \
+ * -Darcadedb.server.rootPassword=playwithdata \
+ * -Darcadedb.serverMetrics=true \
+ * -Darcadedb.typeDefaultBuckets=10 -Darcadedb.bucketReuseSpaceMode=low
+ * 3 - when the server is up and running, remove the Disabled annotation and run the test
+ * <p>
+ * The test uses a fixed size thread pool to execute operations in parallel.
+ */
 public class SingleLocalhostServerSimpleLoadTestIT {
   protected LoggingMeterRegistry loggingMeterRegistry;
   protected Logger               logger = LoggerFactory.getLogger(getClass());
@@ -64,6 +78,7 @@ public class SingleLocalhostServerSimpleLoadTestIT {
   }
 
   @Test
+  @Disabled
   @DisplayName("Single server load test")
   void singleServerLoadTest() throws InterruptedException, IOException {
 
@@ -71,6 +86,7 @@ public class SingleLocalhostServerSimpleLoadTestIT {
     db.createDatabase();
     db.createSchema();
 
+    // Parameters for the test
     final int numOfThreads = 5;
     final int numOfUsers = 1000000;
     final int numOfPhotos = 0;

--- a/e2e-perf/src/test/java/com/arcadedb/test/performance/SingleServerLoadTestIT.java
+++ b/e2e-perf/src/test/java/com/arcadedb/test/performance/SingleServerLoadTestIT.java
@@ -26,7 +26,7 @@ public class SingleServerLoadTestIT extends ContainersTestTemplate {
     db.createSchema();
 
     final int numOfThreads = 5;
-    final int numOfUsers = 100000;
+    final int numOfUsers = 1000;
     final int numOfPhotos = 10;
     final int numOfFriendship = 1000;
 

--- a/e2e-perf/src/test/java/com/arcadedb/test/performance/SingleServerSimpleLoadTestIT.java
+++ b/e2e-perf/src/test/java/com/arcadedb/test/performance/SingleServerSimpleLoadTestIT.java
@@ -11,7 +11,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-public class SingleServerLoadTestIT extends ContainersTestTemplate {
+public class SingleServerSimpleLoadTestIT extends ContainersTestTemplate {
 
   @Test
   @DisplayName("Single server load test")
@@ -25,10 +25,10 @@ public class SingleServerLoadTestIT extends ContainersTestTemplate {
     db.createDatabase();
     db.createSchema();
 
-    final int numOfThreads = 5;
-    final int numOfUsers = 100000;
-    final int numOfPhotos = 10;
-    final int numOfFriendship = 1000;
+    final int numOfThreads = 1;
+    final int numOfUsers = 1000000;
+    final int numOfPhotos = 0;
+    final int numOfFriendship = 0;
 
     int expectedUsersCount = numOfUsers * numOfThreads;
     int expectedFriendshipCount = numOfFriendship * numOfThreads;
@@ -43,17 +43,10 @@ public class SingleServerLoadTestIT extends ContainersTestTemplate {
         db1.addUserAndPhotos(numOfUsers, numOfPhotos);
         db1.close();
       });
-
-      TimeUnit.SECONDS.sleep(2);
-      // Each thread will create friendships
-      executor.submit(() -> {
-        DatabaseWrapper db1 = new DatabaseWrapper(arcadeContainer, idSupplier);
-        db1.createFriendships(numOfFriendship);
-        db1.close();
-      });
     }
 
     executor.shutdown();
+
     while (!executor.isTerminated()) {
       long users = db.countUsers();
       long friendships = db.countFriendships();

--- a/e2e-perf/src/test/java/com/arcadedb/test/performance/SingleServerSimpleLoadTestIT.java
+++ b/e2e-perf/src/test/java/com/arcadedb/test/performance/SingleServerSimpleLoadTestIT.java
@@ -26,7 +26,7 @@ public class SingleServerSimpleLoadTestIT extends ContainersTestTemplate {
     db.createSchema();
 
     final int numOfThreads = 1;
-    final int numOfUsers = 1000000;
+    final int numOfUsers = 10000;
     final int numOfPhotos = 0;
     final int numOfFriendship = 0;
 

--- a/e2e-perf/src/test/java/com/arcadedb/test/support/ContainersTestTemplate.java
+++ b/e2e-perf/src/test/java/com/arcadedb/test/support/ContainersTestTemplate.java
@@ -187,7 +187,7 @@ public abstract class ContainersTestTemplate {
         .withEnv("JAVA_OPTS", String.format("""
             -Darcadedb.server.rootPassword=playwithdata
             -Darcadedb.server.plugins=Postgres:com.arcadedb.postgres.PostgresProtocolPlugin
-            -Darcadedb.server.httpsIoThreads=10
+            -Darcadedb.server.httpsIoThreads=30
             -Darcadedb.bucketReuseSpaceMode=low
             -Darcadedb.server.name=%s
             -Darcadedb.backup.enabled=false
@@ -198,6 +198,7 @@ public abstract class ContainersTestTemplate {
             -Darcadedb.ha.serverList=%s
             -Darcadedb.ha.replicationQueueSize=1024
             """, name, ha, quorum, role, serverList))
+        .withEnv("ARCADEDB_OPTS_MEMORY", "-Xms16G -Xmx16G")
         .waitingFor(Wait.forHttp("/api/v1/ready").forPort(2480).forStatusCode(204));
     containers.add(container);
     return container;

--- a/e2e-perf/src/test/java/com/arcadedb/test/support/LocalhostDatabaseWrapper.java
+++ b/e2e-perf/src/test/java/com/arcadedb/test/support/LocalhostDatabaseWrapper.java
@@ -39,7 +39,7 @@ public class LocalhostDatabaseWrapper {
         2480,
         DATABASE,
         "root",
-        "pippopluto");
+        "playwithdata");
     database.setConnectionStrategy(RemoteHttpComponent.CONNECTION_STRATEGY.FIXED);
     database.setTimeout(30000);
     return database;
@@ -53,7 +53,7 @@ public class LocalhostDatabaseWrapper {
     RemoteServer server = new RemoteServer("localhost",
         2480,
         "root",
-        "pippopluto");
+        "playwithdata");
     server.setConnectionStrategy(RemoteHttpComponent.CONNECTION_STRATEGY.FIXED);
 
     if (server.exists(DATABASE)) {

--- a/e2e-perf/src/test/java/com/arcadedb/test/support/LocalhostDatabaseWrapper.java
+++ b/e2e-perf/src/test/java/com/arcadedb/test/support/LocalhostDatabaseWrapper.java
@@ -39,7 +39,7 @@ public class LocalhostDatabaseWrapper {
         2480,
         DATABASE,
         "root",
-        "playwithdata");
+        PASSWORD);
     database.setConnectionStrategy(RemoteHttpComponent.CONNECTION_STRATEGY.FIXED);
     database.setTimeout(30000);
     return database;
@@ -53,7 +53,7 @@ public class LocalhostDatabaseWrapper {
     RemoteServer server = new RemoteServer("localhost",
         2480,
         "root",
-        "playwithdata");
+        PASSWORD);
     server.setConnectionStrategy(RemoteHttpComponent.CONNECTION_STRATEGY.FIXED);
 
     if (server.exists(DATABASE)) {

--- a/e2e-perf/src/test/resources/logback-test.xml
+++ b/e2e-perf/src/test/resources/logback-test.xml
@@ -8,7 +8,7 @@
 
   <!-- New File Appender -->
   <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>test.log</file>
+    <file>./test.log</file>
     <encoder>
       <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -229,6 +229,9 @@ public enum GlobalConfiguration {
 
   PAGE_FLUSH_QUEUE("arcadedb.pageFlushQueue", SCOPE.DATABASE, "Size of the asynchronous page flush queue", Integer.class, 512),
 
+  EXPLICIT_LOCK_TIMEOUT("arcadedb.explicitLockTimeout", SCOPE.DATABASE, "Timeout in ms to lock resources on explicit lock",
+      Long.class, 5000),
+
   COMMIT_LOCK_TIMEOUT("arcadedb.commitLockTimeout", SCOPE.DATABASE, "Timeout in ms to lock resources during commit", Long.class,
       5000),
 

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -475,7 +475,7 @@ public class TransactionManager {
         if (attemptFileId != null)
           throw new TimeoutException(
               "Timeout on locking file " + attemptFileId + " (" + database.getFileManager().getFile(attemptFileId).getFileName()
-                  + ") during commit (fileIds=" + orderedFilesIds + ")");
+                  + ") during commit (fileIds=" + orderedFilesIds + ", timeout=" + timeout + "ms");
 
         throw new TimeoutException("Timeout on locking files during commit (fileIds=" + orderedFilesIds + ")");
       }

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -102,6 +102,7 @@ public class LocalSchema implements Schema {
   private             boolean                                multipleUpdate                = false;
   private final       AtomicLong                             versionSerial                 = new AtomicLong();
   private final       Map<String, FunctionLibraryDefinition> functionLibraries             = new ConcurrentHashMap<>();
+  private final       Map<Integer, Integer>                  migratedFileIds               = new ConcurrentHashMap<>();
 
   public LocalSchema(final DatabaseInternal database, final String databasePath, final SecurityManager security) {
     this.database = database;
@@ -1280,6 +1281,15 @@ public class LocalSchema implements Schema {
   @Override
   public FunctionDefinition getFunction(final String libraryName, final String functionName) throws IllegalArgumentException {
     return getFunctionLibrary(libraryName).getFunction(functionName);
+  }
+
+  public void setMigratedFileId(final int oldFileId, final int newFileId) {
+    LogManager.instance().log(this, Level.FINE, "Migrating file id %d to %d", null, oldFileId, newFileId);
+    migratedFileIds.put(oldFileId, newFileId);
+  }
+
+  public Integer getMigratedFileId(final int oldFileId) {
+    return migratedFileIds.get(oldFileId);
   }
 
   public boolean isDirty() {

--- a/network/src/main/java/com/arcadedb/remote/RemoteHttpComponent.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteHttpComponent.java
@@ -310,13 +310,11 @@ public class RemoteHttpComponent extends RWLockContext {
     final String authorization = userName + ":" + userPassword;
     String authHeader = "Basic " + Base64.getEncoder().encodeToString(authorization.getBytes(DatabaseFactory.getDefaultCharset()));
 
-    HttpRequest.Builder builder = HttpRequest.newBuilder()
+    return HttpRequest.newBuilder()
         .uri(URI.create(url))
         .timeout(Duration.ofMillis(timeout))
         .header("charset", "utf-8")
         .header("Authorization", authHeader);
-
-    return builder;
   }
 
   void requestClusterConfiguration() {

--- a/server/src/main/java/com/arcadedb/server/http/HttpSession.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpSession.java
@@ -59,6 +59,11 @@ public class HttpSession {
       try {
         LogManager.instance().log(this, Level.FINE, "Executing session %s for user %s", id, user.getName());
         callback.call();
+      } catch (Exception e) {
+        // ROLLBACK SERVER-SIDE TRANSACTION
+        if (transaction != null)
+          transaction.rollback();
+        throw e;
       } finally {
         lock.unlock();
       }

--- a/server/src/test/java/com/arcadedb/remote/RemoteBulk.java
+++ b/server/src/test/java/com/arcadedb/remote/RemoteBulk.java
@@ -1,5 +1,6 @@
 package com.arcadedb.remote;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -17,14 +18,15 @@ public class RemoteBulk {
   };
 
   @Test
+  @Disabled
   void bulkload() {
-    RemoteServer server = new RemoteServer("127.0.0.1", 2480, "root", "pippopluto");
+    RemoteServer server = new RemoteServer("127.0.0.1", 2480, "root", "playwithdata");
     if (server.exists("testBulk"))
       server.drop("testBulk");
     server.create("testBulk");
 
     final RemoteDatabase db = new RemoteDatabase("127.0.0.1", 2480, "testBulk", "root",
-        "pippopluto");
+        "playwithdata");
 
     db.command("sqlscript",
         """

--- a/server/src/test/java/com/arcadedb/remote/RemoteBulk.java
+++ b/server/src/test/java/com/arcadedb/remote/RemoteBulk.java
@@ -1,0 +1,69 @@
+package com.arcadedb.remote;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+public class RemoteBulk {
+  protected Supplier<Integer> idSupplier = new Supplier<>() {
+
+    private final AtomicInteger id = new AtomicInteger();
+
+    @Override
+    public Integer get() {
+      return id.getAndIncrement();
+    }
+  };
+
+  @Test
+  void bulkload() {
+    RemoteServer server = new RemoteServer("127.0.0.1", 2480, "root", "pippopluto");
+    if (server.exists("testBulk"))
+      server.drop("testBulk");
+    server.create("testBulk");
+
+    final RemoteDatabase db = new RemoteDatabase("127.0.0.1", 2480, "testBulk", "root",
+        "pippopluto");
+
+    db.command("sqlscript",
+        """
+            CREATE VERTEX TYPE User;
+            CREATE PROPERTY User.id INTEGER;
+            CREATE INDEX ON User (id) UNIQUE;
+
+            CREATE VERTEX TYPE Photo;
+            CREATE PROPERTY Photo.id INTEGER;
+            CREATE INDEX ON Photo (id) UNIQUE;
+
+            CREATE EDGE TYPE HasUploaded;
+
+            CREATE EDGE TYPE FriendOf;
+
+            CREATE EDGE TYPE Likes;
+            """);
+
+    for (int userIndex = 1; userIndex <= 1000000; userIndex++) {
+      Integer userId = idSupplier.get();
+      try {
+        db.transaction(() ->
+            {
+                db.acquireLock()
+                    .type("User")
+                    .lock();
+              db.command("sql", "CREATE VERTEX User SET id = ?", userId);
+            }
+            , true, 10);
+
+        if (userIndex % 1000 == 0)
+          System.out.println("userId = " + userId);
+      } catch (Exception e) {
+        System.out.printf("Error creating user %s: %s", userId, e.getMessage());
+        e.printStackTrace();
+//        System.exit(1);
+      }
+    }
+    db.close();
+  }
+
+}


### PR DESCRIPTION
This pull request introduces significant updates to performance tests and supporting utilities for the ArcadeDB project. Key changes include the addition of new test classes, enhancements to existing load tests, optimizations in database interaction, and updates to container configurations for improved memory and threading capabilities.

### New Test Classes
* Added `SingleLocalhostServerSimpleLoadTestIT` to test load scenarios with a single server using a fixed-size thread pool for parallel operations. Includes metrics logging and assertions for user, photo, and friendship counts.
* Added `SingleServerSimpleLoadTestIT`, a simplified load test class using TestContainers for containerized server testing. Similar logic to the localhost test but tailored for container-based environments.

### Enhancements to Load Tests
* Updated `SingleServerLoadTestIT` to increase the scale of load testing by modifying parameters: `numOfUsers`, `numOfPhotos`, and `numOfFriendship`. Simplified friendship creation logic by removing iterations and using a single parameter. [[1]](diffhunk://#diff-eba3c81d56ffb7789ec81f4aa902f479c51aa5b0f90cf5e51a65d23728e0dea4L29-R34) [[2]](diffhunk://#diff-eba3c81d56ffb7789ec81f4aa902f479c51aa5b0f90cf5e51a65d23728e0dea4L52-R51)

### Optimizations in Database Interaction
* Enhanced `DatabaseWrapper`:
  - Added a timeout of 30 seconds for remote database connections.
  - Improved error handling in `addUserAndPhotos` by enabling transaction rollback and logging errors with stack traces.
  - Simplified friendship creation logic by introducing `UserIdSupplier`, which fetches user IDs in batches for efficient processing. [[1]](diffhunk://#diff-d0a1e463fdc50ea6aebfc20e179ea0f3a2847c60802612539bf86a5300104138L174-R192) [[2]](diffhunk://#diff-d0a1e463fdc50ea6aebfc20e179ea0f3a2847c60802612539bf86a5300104138R262-R300)
  - Modified `addFriendship` to use `ResultSet` for edge creation commands.

### Updates to Container Configuration
* Increased `httpsIoThreads` from 10 to 30 for better concurrency handling.
* Added `ARCADEDB_OPTS_MEMORY` environment variable to allocate 16GB of memory for containerized servers.



## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
