### PR TITLE
[Helm] ArcadeDB chart has serverList hardcoded not allowing multiple replicas

### DIFF
--- a/k8s/helm/templates/_helpers.tpl
+++ b/k8s/helm/templates/_helpers.tpl
@@ -67,7 +67,7 @@ Create the name of the service account to use
 */}}
 {{- define "arcadedb.k8sSuffix" -}}
 {{- $fullname := (include "arcadedb.fullname" .) -}}
-{{- default ""  (printf ".%s.%s.svc.cluster.local" $fullname .Release.Namespace) -}}
+{{- printf ".%s.%s.svc.cluster.local" $fullname .Release.Namespace -}}
 {{- end }}
 
 {{/*
@@ -82,5 +82,5 @@ Create a list of pod names based the number of replica.
 {{- range $i, $_ := until $replicas }}
 {{- $names = append $names (printf "%s-%d%s:%d" $fullname $i $k8sSuffix $rpcPort) }}
 {{- end }}
-{{ join "," $names }}
+{{- join "," $names -}}
 {{- end }}

--- a/k8s/helm/templates/statefulset.yaml
+++ b/k8s/helm/templates/statefulset.yaml
@@ -53,7 +53,7 @@ spec:
             - -Darcadedb.server.defaultDatabases={{ .Values.arcadedb.defaultDatabases }}
             - -Darcadedb.ha.enabled=true
             - -Darcadedb.ha.replicationIncomingHost=0.0.0.0
-            - -Darcadedb.ha.serverList={{ include "arcadedb.nodenames" . | replace "\n" ""}}
+            - -Darcadedb.ha.serverList={{ include "arcadedb.nodenames" . }}
             - -Darcadedb.ha.k8s=true
             - -Darcadedb.ha.k8sSuffix={{ include "arcadedb.k8sSuffix" . }}
             {{- with .Values.arcadedb.extraCommands }}


### PR DESCRIPTION
## What does this PR do?

This PR is meant to fix the `arcadedb.ha.serverList` which is hardcoded and doesn't allow to add multiple replicas on same cluster.

## Motivation

Contributing for evolving this open-source project

## Related issues

https://github.com/ArcadeData/arcadedb/issues/2324

## Additional Notes

For testing the generated manifests:
```
cd k8s/helm
helm template testing . -f values.yaml --namespace arcadium --set replicaCount=3
```
The result must be a `arcadedb.ha.serverList` with 3 nodes.

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
