### PR TITLE
Add Docker as dependency to developer guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ the `main` branch of GitHub. All you need is:
 
 - **Java v21** for the runtime or major
 - [**Apache Maven**](https://maven.apache.org/), to build the distribution
+- [**Docker**](https://www.docker.com/), to build the container images
 
 It's super easy, just follow the following steps:
 


### PR DESCRIPTION
## What does this PR do?

Add a note to the developer guide about Docker as dependency

## Motivation

Docker is needed for e2e tests.

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
