### PR TITLE
NullPointerException when database data directory hasn't the proper permissions

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/FileManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/FileManager.java
@@ -73,8 +73,17 @@ public class FileManager {
 
     final File dbDirectory = new File(path);
     if (!dbDirectory.exists()) {
-      dbDirectory.mkdirs();
+      boolean created = dbDirectory.mkdirs();
+      if (!created) {
+        LogManager.instance().log(this, Level.SEVERE, "Cannot create the directory '%s'", null, dbDirectory);
+        throw new IllegalArgumentException("Cannot create the directory '" + dbDirectory + "'");
+      }
     } else {
+      if (!dbDirectory.canRead()) {
+        LogManager.instance().log(this, Level.SEVERE, "The directory '%s' doesn't have the proper permissions", null, dbDirectory);
+        throw new IllegalArgumentException("The directory '" + dbDirectory + "' doesn't have the proper permissions");
+      }
+
       for (final File f : dbDirectory.listFiles()) {
         final String filePath = f.getAbsolutePath();
         final String fileExt = filePath.substring(filePath.lastIndexOf(".") + 1);

--- a/engine/src/main/java/com/arcadedb/engine/FileManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/FileManager.java
@@ -81,7 +81,7 @@ throw new IllegalArgumentException(String.format("Cannot create the directory '%
     } else {
       if (!dbDirectory.canRead()) {
         LogManager.instance().log(this, Level.SEVERE, "The directory '%s' doesn't have the proper permissions", null, dbDirectory);
-        throw new IllegalArgumentException("The directory '" + dbDirectory + "' doesn't have the proper permissions");
+throw new IllegalArgumentException(String.format("The directory '%s' doesn't have the proper permissions", dbDirectory));
       }
 
       for (final File f : dbDirectory.listFiles()) {

--- a/engine/src/main/java/com/arcadedb/engine/FileManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/FileManager.java
@@ -76,7 +76,7 @@ public class FileManager {
       boolean created = dbDirectory.mkdirs();
       if (!created) {
         LogManager.instance().log(this, Level.SEVERE, "Cannot create the directory '%s'", null, dbDirectory);
-        throw new IllegalArgumentException("Cannot create the directory '" + dbDirectory + "'");
+throw new IllegalArgumentException(String.format("Cannot create the directory '%s'", dbDirectory));
       }
     } else {
       if (!dbDirectory.canRead()) {

--- a/engine/src/test/java/com/arcadedb/engine/FileManagerTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/FileManagerTest.java
@@ -44,7 +44,7 @@ public class  FileManagerTest {
     }
 
     @Test
-    void construtor_failure_parentWithNoPermissionsDirectory() throws IOException {
+    void construtor_failure_parentDirectoryWithNoPermissions() throws IOException {
         // arrange
         Path dir = Files.createTempDirectory("parentNoPermsDir");
         Set<PosixFilePermission> noPerms = EnumSet.noneOf(PosixFilePermission.class);

--- a/engine/src/test/java/com/arcadedb/engine/FileManagerTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/FileManagerTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * @author carlos-rodrigues@8x8.com
  */
-public class  FileManagerTest {
+public class FileManagerTest {
 
 
     @Test

--- a/engine/src/test/java/com/arcadedb/engine/FileManagerTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/FileManagerTest.java
@@ -1,0 +1,96 @@
+package com.arcadedb.engine;
+
+import com.arcadedb.index.lsm.LSMTreeIndexCompacted;
+import com.arcadedb.index.lsm.LSMTreeIndexMutable;
+import com.arcadedb.index.vector.HnswVectorIndex;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.EnumSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author carlos-rodrigues@8x8.com
+ */
+public class  FileManagerTest {
+
+
+    @Test
+    void construtor_failure_noPermissionsDirectory() throws IOException {
+        // arrange
+        Path dir = Files.createTempDirectory("noPermsDir");
+        Set<PosixFilePermission> noPerms = EnumSet.noneOf(PosixFilePermission.class);
+        Files.setPosixFilePermissions(dir, noPerms);
+
+        // act and assert
+        assertThrows(IllegalArgumentException.class, () -> {
+            new FileManager(dir.toFile().getAbsolutePath(), ComponentFile.MODE.READ_WRITE, Set.of(Dictionary.DICT_EXT,
+                    LocalBucket.BUCKET_EXT, LSMTreeIndexMutable.NOTUNIQUE_INDEX_EXT, LSMTreeIndexMutable.UNIQUE_INDEX_EXT,
+                    LSMTreeIndexCompacted.NOTUNIQUE_INDEX_EXT, LSMTreeIndexCompacted.UNIQUE_INDEX_EXT, HnswVectorIndex.FILE_EXT));
+        });
+
+        // cleanup
+        Set<PosixFilePermission> restorePerms = PosixFilePermissions.fromString("rwx------");
+        Files.setPosixFilePermissions(dir, restorePerms);
+
+        Files.deleteIfExists(dir);
+    }
+
+    @Test
+    void construtor_failure_parentWithNoPermissionsDirectory() throws IOException {
+        // arrange
+        Path dir = Files.createTempDirectory("parentNoPermsDir");
+        Set<PosixFilePermission> noPerms = EnumSet.noneOf(PosixFilePermission.class);
+        Files.setPosixFilePermissions(dir, noPerms);
+
+        // act and assert
+        assertThrows(IllegalArgumentException.class, () -> {
+            new FileManager(dir.toFile().getAbsolutePath() + "/child", ComponentFile.MODE.READ_WRITE, Set.of(Dictionary.DICT_EXT,
+                    LocalBucket.BUCKET_EXT, LSMTreeIndexMutable.NOTUNIQUE_INDEX_EXT, LSMTreeIndexMutable.UNIQUE_INDEX_EXT,
+                    LSMTreeIndexCompacted.NOTUNIQUE_INDEX_EXT, LSMTreeIndexCompacted.UNIQUE_INDEX_EXT, HnswVectorIndex.FILE_EXT));
+        });
+
+        // cleanup
+        Set<PosixFilePermission> restorePerms = PosixFilePermissions.fromString("rwx------");
+        Files.setPosixFilePermissions(dir, restorePerms);
+
+        Files.deleteIfExists(dir);
+    }
+
+    @Test
+    void construtor_success_emptyDirectory() throws IOException {
+        // arrange
+        Path dir = Files.createTempDirectory("emptyDir");
+
+        // act
+        FileManager fileManager = new FileManager(dir.toFile().getAbsolutePath(), ComponentFile.MODE.READ_WRITE, Set.of(Dictionary.DICT_EXT,
+                LocalBucket.BUCKET_EXT, LSMTreeIndexMutable.NOTUNIQUE_INDEX_EXT, LSMTreeIndexMutable.UNIQUE_INDEX_EXT));
+
+        // assert
+        assertTrue(fileManager.getFiles().isEmpty());
+        // cleanup
+        Files.deleteIfExists(dir);
+    }
+
+    @Test
+    void construtor_success_noDirectory() throws IOException {
+        // arrange
+        Path dir = Path.of("/tmp","nonExistentDir");
+
+        // act
+        FileManager fileManager = new FileManager(dir.toFile().getAbsolutePath(), ComponentFile.MODE.READ_WRITE, Set.of(Dictionary.DICT_EXT,
+                LocalBucket.BUCKET_EXT, LSMTreeIndexMutable.NOTUNIQUE_INDEX_EXT, LSMTreeIndexMutable.UNIQUE_INDEX_EXT));
+
+        // assert
+        assertTrue(fileManager.getFiles().isEmpty());
+        // cleanup
+        Files.deleteIfExists(dir);
+    }
+}

--- a/engine/src/test/java/com/arcadedb/engine/FileManagerTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/FileManagerTest.java
@@ -82,7 +82,7 @@ public class FileManagerTest {
     @Test
     void construtor_success_noDirectory() throws IOException {
         // arrange
-        Path dir = Path.of("/tmp","nonExistentDir");
+Path dir = Path.of(System.getProperty("java.io.tmpdir"),"nonExistentDir");
 
         // act
         FileManager fileManager = new FileManager(dir.toFile().getAbsolutePath(), ComponentFile.MODE.READ_WRITE, Set.of(Dictionary.DICT_EXT,

--- a/engine/src/test/java/com/arcadedb/engine/FileManagerTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/FileManagerTest.java
@@ -4,6 +4,9 @@ import com.arcadedb.index.lsm.LSMTreeIndexCompacted;
 import com.arcadedb.index.lsm.LSMTreeIndexMutable;
 import com.arcadedb.index.vector.HnswVectorIndex;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -19,74 +22,63 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * @author carlos-rodrigues@8x8.com
  */
+@EnabledOnOs({OS.LINUX, OS.MAC})
 public class FileManagerTest {
 
+    public static final Set<String> FILE_EXT = Set.of(Dictionary.DICT_EXT,
+            LocalBucket.BUCKET_EXT, LSMTreeIndexMutable.NOTUNIQUE_INDEX_EXT, LSMTreeIndexMutable.UNIQUE_INDEX_EXT,
+            LSMTreeIndexCompacted.NOTUNIQUE_INDEX_EXT, LSMTreeIndexCompacted.UNIQUE_INDEX_EXT, HnswVectorIndex.FILE_EXT);
 
     @Test
-    void construtor_failure_noPermissionsDirectory() throws IOException {
+    void construtor_failure_noPermissionsDirectory(@TempDir Path dir) throws IOException {
         // arrange
-        Path dir = Files.createTempDirectory("noPermsDir");
+
         Set<PosixFilePermission> noPerms = EnumSet.noneOf(PosixFilePermission.class);
         Files.setPosixFilePermissions(dir, noPerms);
 
         // act and assert
         assertThrows(IllegalArgumentException.class, () -> {
-            new FileManager(dir.toFile().getAbsolutePath(), ComponentFile.MODE.READ_WRITE, Set.of(Dictionary.DICT_EXT,
-                    LocalBucket.BUCKET_EXT, LSMTreeIndexMutable.NOTUNIQUE_INDEX_EXT, LSMTreeIndexMutable.UNIQUE_INDEX_EXT,
-                    LSMTreeIndexCompacted.NOTUNIQUE_INDEX_EXT, LSMTreeIndexCompacted.UNIQUE_INDEX_EXT, HnswVectorIndex.FILE_EXT));
+            new FileManager(dir.toFile().getAbsolutePath(), ComponentFile.MODE.READ_WRITE, FILE_EXT);
         });
 
-        // cleanup
+        // reset permissions to allow cleanup
         Set<PosixFilePermission> restorePerms = PosixFilePermissions.fromString("rwx------");
         Files.setPosixFilePermissions(dir, restorePerms);
-
-        Files.deleteIfExists(dir);
     }
 
     @Test
-    void construtor_failure_parentDirectoryWithNoPermissions() throws IOException {
+    void construtor_failure_parentDirectoryWithNoPermissions(@TempDir Path dir) throws IOException {
         // arrange
-        Path dir = Files.createTempDirectory("parentNoPermsDir");
         Set<PosixFilePermission> noPerms = EnumSet.noneOf(PosixFilePermission.class);
         Files.setPosixFilePermissions(dir, noPerms);
 
         // act and assert
         assertThrows(IllegalArgumentException.class, () -> {
-            new FileManager(dir.toFile().getAbsolutePath() + "/child", ComponentFile.MODE.READ_WRITE, Set.of(Dictionary.DICT_EXT,
-                    LocalBucket.BUCKET_EXT, LSMTreeIndexMutable.NOTUNIQUE_INDEX_EXT, LSMTreeIndexMutable.UNIQUE_INDEX_EXT,
-                    LSMTreeIndexCompacted.NOTUNIQUE_INDEX_EXT, LSMTreeIndexCompacted.UNIQUE_INDEX_EXT, HnswVectorIndex.FILE_EXT));
+            new FileManager(dir.toFile().getAbsolutePath() + "/child", ComponentFile.MODE.READ_WRITE, FILE_EXT);
         });
 
         // cleanup
         Set<PosixFilePermission> restorePerms = PosixFilePermissions.fromString("rwx------");
         Files.setPosixFilePermissions(dir, restorePerms);
-
-        Files.deleteIfExists(dir);
     }
 
     @Test
-    void construtor_success_emptyDirectory() throws IOException {
+    void construtor_success_emptyDirectory(@TempDir Path dir) throws IOException {
         // arrange
-        Path dir = Files.createTempDirectory("emptyDir");
-
         // act
-        FileManager fileManager = new FileManager(dir.toFile().getAbsolutePath(), ComponentFile.MODE.READ_WRITE, Set.of(Dictionary.DICT_EXT,
-                LocalBucket.BUCKET_EXT, LSMTreeIndexMutable.NOTUNIQUE_INDEX_EXT, LSMTreeIndexMutable.UNIQUE_INDEX_EXT));
+        FileManager fileManager = new FileManager(dir.toFile().getAbsolutePath(), ComponentFile.MODE.READ_WRITE, FILE_EXT);
 
         // assert
         assertTrue(fileManager.getFiles().isEmpty());
-        // cleanup
-        Files.deleteIfExists(dir);
     }
 
     @Test
     void construtor_success_noDirectory() throws IOException {
         // arrange
-Path dir = Path.of(System.getProperty("java.io.tmpdir"),"nonExistentDir");
+        Path dir = Path.of(System.getProperty("java.io.tmpdir"), "nonExistentDir");
 
         // act
-        FileManager fileManager = new FileManager(dir.toFile().getAbsolutePath(), ComponentFile.MODE.READ_WRITE, Set.of(Dictionary.DICT_EXT,
-                LocalBucket.BUCKET_EXT, LSMTreeIndexMutable.NOTUNIQUE_INDEX_EXT, LSMTreeIndexMutable.UNIQUE_INDEX_EXT));
+        FileManager fileManager = new FileManager(dir.toFile().getAbsolutePath(), ComponentFile.MODE.READ_WRITE, FILE_EXT);
 
         // assert
         assertTrue(fileManager.getFiles().isEmpty());


### PR DESCRIPTION
## What does this PR do?

The goal of this PR is adding proper validations on database directory permissions.

## Motivation

Contribute for the community

## Related issues

https://github.com/ArcadeData/arcadedb/issues/2362

## Additional Notes

The code wasn't refactored according the TODO comments. It was the goal.

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
