### PR TITLE
#2376 refactor: rename enum constants for consistency 

### DIFF
--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -442,9 +442,9 @@ public class Console {
 
       checkDatabaseIsLocked(localUrl);
 
-      ComponentFile.MODE mode = ComponentFile.MODE.READ_WRITE;
+      ComponentFile.Mode mode = ComponentFile.Mode.READ_WRITE;
       if (urlParts.length > 1)
-        mode = ComponentFile.MODE.valueOf(urlParts[1].toUpperCase(Locale.ENGLISH));
+        mode = ComponentFile.Mode.valueOf(urlParts[1].toUpperCase(Locale.ENGLISH));
 
       databaseFactory = new DatabaseFactory(localUrl);
       databaseProxy = databaseFactory.setAutoTransaction(true).open(mode);
@@ -1029,7 +1029,7 @@ public class Console {
   private static boolean setGlobalConfiguration(final String key, final String value, final boolean printError) {
     final GlobalConfiguration cfg = GlobalConfiguration.findByKey(key);
     if (cfg != null) {
-      if (cfg.getScope() == GlobalConfiguration.SCOPE.SERVER) {
+      if (cfg.getScope() == GlobalConfiguration.Scope.SERVER) {
         if (printError)
           System.err.println("Global configuration '" + key + "' is not available for console. The setting will be ignored");
       } else {

--- a/console/src/test/java/com/arcadedb/console/CompositeIndexUpdateTest.java
+++ b/console/src/test/java/com/arcadedb/console/CompositeIndexUpdateTest.java
@@ -43,7 +43,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
-import java.io.PrintStream;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -131,8 +130,8 @@ public class CompositeIndexUpdateTest {
         dtOrders.createProperty("vstop", Type.DATETIME_MICROS);
         dtOrders.createProperty("status", Type.STRING);
         dtOrders.createProperty("node", Type.STRING);
-        dtOrders.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "id");
-        dtOrders.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "status", "id");
+        dtOrders.createTypeIndex(Schema.IndexType.LSM_TREE, true, "id");
+        dtOrders.createTypeIndex(Schema.IndexType.LSM_TREE, true, "status", "id");
         dtOrders.setBucketSelectionStrategy(new ThreadBucketSelectionStrategy());
       }
     }
@@ -222,7 +221,7 @@ public class CompositeIndexUpdateTest {
     final AtomicInteger totalRows = new AtomicInteger();
     final int[] firstOrderId = new int[1];
     TypeIndex insertOrdersIndex = database.getSchema().getType("Order")
-        .createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "processor", "vstart", "vstop");
+        .createTypeIndex(Schema.IndexType.LSM_TREE, true, "processor", "vstart", "vstop");
     for (CandidateOrder order : orders) {
       indexCursor = database.lookupByKey("Order", new String[] { "processor", "vstart", "vstop" },
           new Object[] { order.getProcessor(), order.getStart(), order.getStop() });

--- a/console/src/test/java/com/arcadedb/console/ConsoleAsyncInsertTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleAsyncInsertTest.java
@@ -165,8 +165,8 @@ public class ConsoleAsyncInsertTest {
           dtProducts.createProperty("start", Type.DATETIME_MICROS);
           dtProducts.createProperty("stop", Type.DATETIME_MICROS);
           dtProducts.createProperty("v", Type.STRING);
-          dtProducts.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "name");
-          dtProducts.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "type", "start", "stop");
+          dtProducts.createTypeIndex(Schema.IndexType.LSM_TREE, true, "name");
+          dtProducts.createTypeIndex(Schema.IndexType.LSM_TREE, false, "type", "start", "stop");
 
           dtProducts.setBucketSelectionStrategy(new ThreadBucketSelectionStrategy());
 
@@ -241,8 +241,8 @@ public class ConsoleAsyncInsertTest {
           dtProducts.createProperty("start", Type.DATETIME_MICROS);
           dtProducts.createProperty("stop", Type.DATETIME_MICROS);
           dtProducts.createProperty("v", Type.STRING);
-          dtProducts.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "name");
-          dtProducts.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "type", "start", "stop");
+          dtProducts.createTypeIndex(Schema.IndexType.LSM_TREE, true, "name");
+          dtProducts.createTypeIndex(Schema.IndexType.LSM_TREE, false, "type", "start", "stop");
 
           //dtProducts.setBucketSelectionStrategy(new ThreadBucketSelectionStrategy());
           dtProducts.setBucketSelectionStrategy(new PartitionedBucketSelectionStrategy(List.of("name")));
@@ -320,8 +320,8 @@ public class ConsoleAsyncInsertTest {
         dtOrders.createProperty("vstop", Type.DATETIME_MICROS);
         dtOrders.createProperty("status", Type.STRING);
         dtOrders.createProperty("node", Type.STRING);
-        dtOrders.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "id");
-        dtOrders.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "status", "id");
+        dtOrders.createTypeIndex(Schema.IndexType.LSM_TREE, true, "id");
+        dtOrders.createTypeIndex(Schema.IndexType.LSM_TREE, true, "status", "id");
         dtOrders.setBucketSelectionStrategy(new ThreadBucketSelectionStrategy());
         DocumentType dtProducts = db.getSchema().buildDocumentType().withName("Product").withTotalBuckets(PARALLEL_LEVEL).create();
         dtProducts.createProperty("name", Type.STRING);
@@ -329,8 +329,8 @@ public class ConsoleAsyncInsertTest {
         dtProducts.createProperty("start", Type.DATETIME_MICROS);
         dtProducts.createProperty("stop", Type.DATETIME_MICROS);
         dtProducts.createProperty("v", Type.STRING);
-        dtProducts.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "name");
-        dtProducts.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "type", "start", "stop");
+        dtProducts.createTypeIndex(Schema.IndexType.LSM_TREE, true, "name");
+        dtProducts.createTypeIndex(Schema.IndexType.LSM_TREE, false, "type", "start", "stop");
         dtProducts.setBucketSelectionStrategy(new ThreadBucketSelectionStrategy());
       }
     }
@@ -489,7 +489,7 @@ public class ConsoleAsyncInsertTest {
     final AtomicInteger totalRows = new AtomicInteger();
     final int[] firstOrderId = new int[1];
     TypeIndex insertOrdersIndex = database.getSchema().getType("Order")
-        .createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "processor", "vstart", "vstop");
+        .createTypeIndex(Schema.IndexType.LSM_TREE, true, "processor", "vstart", "vstop");
     for (CandidateOrder order : orders) {
       indexCursor = database.lookupByKey("Order", new String[] { "processor", "vstart", "vstop" },
           new Object[] { order.getProcessor(), order.getStart(), order.getStop() });

--- a/console/src/test/java/com/arcadedb/console/ConsoleTest.java
+++ b/console/src/test/java/com/arcadedb/console/ConsoleTest.java
@@ -288,7 +288,7 @@ public class ConsoleTest {
         assertThat(friendType).isNotNull();
         assertThat(database.countType("KNOWS", true)).isEqualTo(1);
 
-        final Iterator<Edge> relationships = v.getEdges(Vertex.DIRECTION.OUT, "KNOWS").iterator();
+        final Iterator<Edge> relationships = v.getEdges(Vertex.Direction.OUT, "KNOWS").iterator();
         assertThat(relationships.hasNext()).isTrue();
         final Edge e = relationships.next();
 
@@ -332,7 +332,7 @@ public class ConsoleTest {
         for (Iterator<Record> it = database.iterateType("Page", true); it.hasNext(); ) {
           final Vertex rec = it.next().asVertex();
           ++vertices;
-          edges += rec.countEdges(Vertex.DIRECTION.OUT, "Links");
+          edges += rec.countEdges(Vertex.Direction.OUT, "Links");
         }
       }
     }

--- a/console/src/test/java/com/arcadedb/console/DumpCfgApp.java
+++ b/console/src/test/java/com/arcadedb/console/DumpCfgApp.java
@@ -25,7 +25,7 @@ import java.util.stream.*;
 
 public class DumpCfgApp {
   public static void main(final String[] args) {
-    for (GlobalConfiguration.SCOPE scope : GlobalConfiguration.SCOPE.values())
+    for (GlobalConfiguration.Scope scope : GlobalConfiguration.Scope.values())
       tableByScope(scope);
 
 //    System.out.printf("\n|Name|Java API ENUM name|Description|Type|Default Value");
@@ -35,7 +35,7 @@ public class DumpCfgApp {
 //    }
   }
 
-  private static void tableByScope(final GlobalConfiguration.SCOPE scope) {
+  private static void tableByScope(final GlobalConfiguration.Scope scope) {
     System.out.printf("\n===== " + scope + "\n");
 
     System.out.printf("\n[%%header,cols=\"20%%,55%%,10%%,15%%\",stripes=even]");

--- a/e2e-perf/src/test/java/com/arcadedb/test/support/DatabaseWrapper.java
+++ b/e2e-perf/src/test/java/com/arcadedb/test/support/DatabaseWrapper.java
@@ -46,7 +46,7 @@ public class DatabaseWrapper {
         DATABASE,
         "root",
         PASSWORD);
-    database.setConnectionStrategy(RemoteHttpComponent.CONNECTION_STRATEGY.FIXED);
+    database.setConnectionStrategy(RemoteHttpComponent.ConnectionStrategy.FIXED);
     database.setTimeout(30000);
     return database;
   }
@@ -60,7 +60,7 @@ public class DatabaseWrapper {
         port,
         "root",
         PASSWORD);
-    server.setConnectionStrategy(RemoteHttpComponent.CONNECTION_STRATEGY.FIXED);
+    server.setConnectionStrategy(RemoteHttpComponent.ConnectionStrategy.FIXED);
 
     if (server.exists(DATABASE)) {
       logger.info("Dropping existing database {}", DATABASE);

--- a/e2e/src/test/java/com/arcadedb/e2e/RemoteDatabaseJavaApiTest.java
+++ b/e2e/src/test/java/com/arcadedb/e2e/RemoteDatabaseJavaApiTest.java
@@ -94,7 +94,7 @@ public class RemoteDatabaseJavaApiTest extends ArcadeContainerTemplate {
     assertThat(friendOf.getOut()).isEqualTo(me);
     assertThat(friendOf.getIn()).isEqualTo(you);
 
-    me.getEdges(Vertex.DIRECTION.OUT, "FriendOf").forEach(e -> {
+    me.getEdges(Vertex.Direction.OUT, "FriendOf").forEach(e -> {
       assertThat(e).isEqualTo(friendOf);
     });
 

--- a/engine/src/main/grammar/SQLGrammar.jjt
+++ b/engine/src/main/grammar/SQLGrammar.jjt
@@ -3595,9 +3595,9 @@ CreateIndexStatement CreateIndexStatement():
 
     [ <NULL_STRATEGY>
       (
-        <SKIP2> { jjtThis.nullStrategy = LSMTreeIndexAbstract.NULL_STRATEGY.SKIP; }
+        <SKIP2> { jjtThis.nullStrategy = LSMTreeIndexAbstract.NullStrategy.SKIP; }
         |
-        <ERROR2> { jjtThis.nullStrategy = LSMTreeIndexAbstract.NULL_STRATEGY.ERROR; }
+        <ERROR2> { jjtThis.nullStrategy = LSMTreeIndexAbstract.NullStrategy.ERROR; }
       )
     ]
   )

--- a/engine/src/main/java/com/arcadedb/database/BasicDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/BasicDatabase.java
@@ -139,7 +139,7 @@ public interface BasicDatabase extends AutoCloseable {
    *
    * @param isolationLevel Isolation level between the following: READ_COMMITTED, REPEATABLE_READ, SERIALIZABLE
    */
-  public void begin(Database.TRANSACTION_ISOLATION_LEVEL isolationLevel);
+  public void begin(Database.TransactionIsolationLevel isolationLevel);
 
   /**
    * Commits the current transaction. If it was a sub-transaction, then the previous in the stack becomes active again.

--- a/engine/src/main/java/com/arcadedb/database/Database.java
+++ b/engine/src/main/java/com/arcadedb/database/Database.java
@@ -38,13 +38,13 @@ import java.util.concurrent.*;
 
 @ExcludeFromJacocoGeneratedReport
 public interface Database extends BasicDatabase {
-  enum TRANSACTION_ISOLATION_LEVEL {
+  enum TransactionIsolationLevel {
     READ_COMMITTED, REPEATABLE_READ
   }
 
   ContextConfiguration getConfiguration();
 
-  ComponentFile.MODE getMode();
+  ComponentFile.Mode getMode();
 
   DatabaseAsyncExecutor async();
 
@@ -262,7 +262,7 @@ public interface Database extends BasicDatabase {
    *
    * @return Current Database instance to execute setter methods in chain.
    */
-  Database setTransactionIsolationLevel(TRANSACTION_ISOLATION_LEVEL level);
+  Database setTransactionIsolationLevel(TransactionIsolationLevel level);
 
   /**
    * returns the transaction isolation level between the available ones:
@@ -275,7 +275,7 @@ public interface Database extends BasicDatabase {
    * @return Current isolation level.
    */
 
-  TRANSACTION_ISOLATION_LEVEL getTransactionIsolationLevel();
+  TransactionIsolationLevel getTransactionIsolationLevel();
 
   /**
    * Returns the current default edge list initial size to hold and store edges.

--- a/engine/src/main/java/com/arcadedb/database/DatabaseFactory.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseFactory.java
@@ -37,8 +37,8 @@ public class DatabaseFactory implements AutoCloseable {
   private final static Charset                                                    DEFAULT_CHARSET      = StandardCharsets.UTF_8;
   private static final Map<Path, Database>                                        ACTIVE_INSTANCES     = new ConcurrentHashMap<>();
   private final        ContextConfiguration                                       contextConfiguration = new ContextConfiguration();
-  private final        String                                                     databasePath;
-  private final        Map<DatabaseInternal.CALLBACK_EVENT, List<Callable<Void>>> callbacks            = new HashMap<>();
+  private final        String                                                    databasePath;
+  private final        Map<DatabaseInternal.CallbackEvent, List<Callable<Void>>> callbacks = new HashMap<>();
 
   public DatabaseFactory(final String path) {
     if (path == null || path.trim().isEmpty())
@@ -67,10 +67,10 @@ public class DatabaseFactory implements AutoCloseable {
   }
 
   public Database open() {
-    return open(ComponentFile.MODE.READ_WRITE);
+    return open(ComponentFile.Mode.READ_WRITE);
   }
 
-  public synchronized Database open(final ComponentFile.MODE mode) {
+  public synchronized Database open(final ComponentFile.Mode mode) {
     checkForActiveInstance(databasePath);
 
     if (ACTIVE_INSTANCES.isEmpty())
@@ -91,7 +91,7 @@ public class DatabaseFactory implements AutoCloseable {
     if (ACTIVE_INSTANCES.isEmpty())
       PageManager.INSTANCE.configure();
 
-    final LocalDatabase database = new LocalDatabase(databasePath, ComponentFile.MODE.READ_WRITE, contextConfiguration, security,
+    final LocalDatabase database = new LocalDatabase(databasePath, ComponentFile.Mode.READ_WRITE, contextConfiguration, security,
         callbacks);
     database.setAutoTransaction(autoTransaction);
     database.create();
@@ -126,7 +126,7 @@ public class DatabaseFactory implements AutoCloseable {
   /**
    * Test only API
    */
-  public void registerCallback(final DatabaseInternal.CALLBACK_EVENT event, final Callable<Void> callback) {
+  public void registerCallback(final DatabaseInternal.CallbackEvent event, final Callable<Void> callback) {
     final List<Callable<Void>> callbacks = this.callbacks.computeIfAbsent(event, k -> new ArrayList<>());
     callbacks.add(callback);
   }

--- a/engine/src/main/java/com/arcadedb/database/DatabaseInternal.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseInternal.java
@@ -18,7 +18,6 @@
  */
 package com.arcadedb.database;
 
-import com.arcadedb.database.Record;
 import com.arcadedb.engine.FileManager;
 import com.arcadedb.engine.PageManager;
 import com.arcadedb.engine.TransactionManager;
@@ -40,7 +39,7 @@ import java.util.concurrent.*;
  */
 @ExcludeFromJacocoGeneratedReport
 public interface DatabaseInternal extends Database {
-  enum CALLBACK_EVENT {
+  enum CallbackEvent {
     TX_AFTER_WAL_WRITE, DB_NOT_CLOSED
   }
 
@@ -73,9 +72,9 @@ public interface DatabaseInternal extends Database {
 
   void setWrapper(final String name, final Object instance);
 
-  void checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS access);
+  void checkPermissionsOnDatabase(SecurityDatabaseUser.DatabaseAccess access);
 
-  void checkPermissionsOnFile(int fileId, SecurityDatabaseUser.ACCESS access);
+  void checkPermissionsOnFile(int fileId, SecurityDatabaseUser.Access access);
 
   boolean checkTransactionIsActive(boolean createTx);
 
@@ -85,11 +84,11 @@ public interface DatabaseInternal extends Database {
 
   long getReadTimeout();
 
-  void registerCallback(CALLBACK_EVENT event, Callable<Void> callback);
+  void registerCallback(CallbackEvent event, Callable<Void> callback);
 
-  void unregisterCallback(CALLBACK_EVENT event, Callable<Void> callback);
+  void unregisterCallback(CallbackEvent event, Callable<Void> callback);
 
-  void executeCallbacks(CALLBACK_EVENT event) throws IOException;
+  void executeCallbacks(CallbackEvent event) throws IOException;
 
   GraphEngine getGraphEngine();
 

--- a/engine/src/main/java/com/arcadedb/database/Transaction.java
+++ b/engine/src/main/java/com/arcadedb/database/Transaction.java
@@ -23,7 +23,7 @@ import com.arcadedb.utility.ExcludeFromJacocoGeneratedReport;
 
 @ExcludeFromJacocoGeneratedReport
 public interface Transaction {
-  void begin(Database.TRANSACTION_ISOLATION_LEVEL isolationLevel);
+  void begin(Database.TransactionIsolationLevel isolationLevel);
 
   Binary commit();
 

--- a/engine/src/main/java/com/arcadedb/database/TransactionIndexContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionIndexContext.java
@@ -257,7 +257,7 @@ public class TransactionIndexContext {
 
   public void addIndexKeyLock(final IndexInternal index, IndexKey.IndexKeyOperation operation, final Object[] keysValues,
       final RID rid) {
-    if (index.getNullStrategy() == LSMTreeIndexAbstract.NULL_STRATEGY.SKIP && LSMTreeIndexAbstract.isKeyNull(keysValues))
+    if (index.getNullStrategy() == LSMTreeIndexAbstract.NullStrategy.SKIP && LSMTreeIndexAbstract.isKeyNull(keysValues))
       // NULL VALUES AND SKIP NUL VALUES
       return;
 

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -122,7 +122,7 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       DatabaseContext.INSTANCE.getContext(database.getDatabasePath()).asyncMode = true;
       database.getTransaction().setUseWAL(transactionUseWAL);
       database.setWALFlush(transactionSync);
-      database.getTransaction().begin(Database.TRANSACTION_ISOLATION_LEVEL.READ_COMMITTED); // FORCE THE LOWEST LEVEL OF ISOLATION
+      database.getTransaction().begin(Database.TransactionIsolationLevel.READ_COMMITTED); // FORCE THE LOWEST LEVEL OF ISOLATION
 
       while (!forceShutdown) {
         try {

--- a/engine/src/main/java/com/arcadedb/engine/BucketIterator.java
+++ b/engine/src/main/java/com/arcadedb/engine/BucketIterator.java
@@ -49,7 +49,7 @@ public class BucketIterator implements Iterator<Record> {
 
   BucketIterator(final LocalBucket bucket, final boolean forwardDirection) {
     final DatabaseInternal db = bucket.getDatabase();
-    db.checkPermissionsOnFile(bucket.fileId, SecurityDatabaseUser.ACCESS.READ_RECORD);
+    db.checkPermissionsOnFile(bucket.fileId, SecurityDatabaseUser.Access.READ_RECORD);
 
     this.database = db;
     this.bucket = bucket;

--- a/engine/src/main/java/com/arcadedb/engine/ComponentFactory.java
+++ b/engine/src/main/java/com/arcadedb/engine/ComponentFactory.java
@@ -28,7 +28,7 @@ public class ComponentFactory {
   private final DatabaseInternal                              database;
 
   public interface PaginatedComponentFactoryHandler {
-    Component createOnLoad(final DatabaseInternal database, final String name, final String filePath, final int id, final ComponentFile.MODE mode,
+    Component createOnLoad(final DatabaseInternal database, final String name, final String filePath, final int id, final ComponentFile.Mode mode,
         final int pageSize, final int version) throws IOException;
   }
 
@@ -40,7 +40,7 @@ public class ComponentFactory {
     map.put(fileExt, handler);
   }
 
-  public Component createComponent(final ComponentFile file, final ComponentFile.MODE mode) throws IOException {
+  public Component createComponent(final ComponentFile file, final ComponentFile.Mode mode) throws IOException {
     final String fileName = file.getComponentName();
     final int fileId = file.getFileId();
     final String fileExt = file.getFileExtension();

--- a/engine/src/main/java/com/arcadedb/engine/ComponentFile.java
+++ b/engine/src/main/java/com/arcadedb/engine/ComponentFile.java
@@ -21,18 +21,20 @@ package com.arcadedb.engine;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.utility.FileUtils;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.logging.*;
-import java.util.zip.*;
+import java.util.logging.Level;
+import java.util.zip.CRC32;
 
 public class ComponentFile {
-  public enum MODE {
+  public enum Mode {
     READ_ONLY, READ_WRITE
   }
 
-  protected final MODE    mode;
+  protected final Mode    mode;
   protected       String  filePath;
   protected       String  fileName;
   protected       File    osFile;
@@ -43,10 +45,10 @@ public class ComponentFile {
   protected       boolean open;
 
   public ComponentFile() {
-    this.mode = MODE.READ_ONLY;
+    this.mode = Mode.READ_ONLY;
   }
 
-  protected ComponentFile(final String filePath, final MODE mode) throws FileNotFoundException {
+  protected ComponentFile(final String filePath, final Mode mode) throws FileNotFoundException {
     this.mode = mode;
     open(filePath, mode);
   }
@@ -58,7 +60,7 @@ public class ComponentFile {
     return osFile.length();
   }
 
-  protected void open(final String filePath, final MODE mode) throws FileNotFoundException {
+  protected void open(final String filePath, final Mode mode) throws FileNotFoundException {
     this.filePath = filePath;
 
     final int lastDotPos = filePath.lastIndexOf(".");

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -90,12 +90,12 @@ public class DatabaseChecker {
     if (fix)
       for (final Index idx : affectedIndexes) {
         final String bucketName = database.getSchema().getBucketById(idx.getAssociatedBucketId()).getName();
-        final Schema.INDEX_TYPE indexType = idx.getType();
+        final Schema.IndexType indexType = idx.getType();
         final boolean unique = idx.isUnique();
         final List<String> propNames = idx.getPropertyNames();
         final String typeName = idx.getTypeName();
         final int pageSize = ((IndexInternal) idx).getPageSize();
-        final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy = idx.getNullStrategy();
+        final LSMTreeIndexAbstract.NullStrategy nullStrategy = idx.getNullStrategy();
 
         database.getSchema().dropIndex(idx.getName());
 

--- a/engine/src/main/java/com/arcadedb/engine/Dictionary.java
+++ b/engine/src/main/java/com/arcadedb/engine/Dictionary.java
@@ -49,7 +49,7 @@ public class Dictionary extends PaginatedComponent {
     @Override
     public PaginatedComponent createOnLoad(final DatabaseInternal database, final String name, final String filePath,
         final int fileId,
-        final ComponentFile.MODE mode, final int pageSize, final int version) throws IOException {
+        final ComponentFile.Mode mode, final int pageSize, final int version) throws IOException {
       return new Dictionary(database, name, filePath, fileId, mode, pageSize, version);
     }
   }
@@ -57,7 +57,7 @@ public class Dictionary extends PaginatedComponent {
   /**
    * Called at creation time.
    */
-  public Dictionary(final DatabaseInternal database, final String name, final String filePath, final ComponentFile.MODE mode,
+  public Dictionary(final DatabaseInternal database, final String name, final String filePath, final ComponentFile.Mode mode,
       final int pageSize)
       throws IOException {
     super(database, name, filePath, DICT_EXT, mode, pageSize, CURRENT_VERSION);
@@ -72,7 +72,7 @@ public class Dictionary extends PaginatedComponent {
    * Called at load time.
    */
   public Dictionary(final DatabaseInternal database, final String name, final String filePath, final int id,
-      final ComponentFile.MODE mode, final int pageSize,
+      final ComponentFile.Mode mode, final int pageSize,
       final int version) throws IOException {
     super(database, name, filePath, id, mode, pageSize, version);
     reload();

--- a/engine/src/main/java/com/arcadedb/engine/FileManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/FileManager.java
@@ -28,8 +28,8 @@ import java.util.concurrent.atomic.*;
 import java.util.logging.*;
 
 public class FileManager {
-  private final        ComponentFile.MODE                        mode;
-  private final        List<ComponentFile>                       files           = new ArrayList<>();
+  private final ComponentFile.Mode  mode;
+  private final List<ComponentFile> files           = new ArrayList<>();
   private final        ConcurrentHashMap<String, ComponentFile>  fileNameMap     = new ConcurrentHashMap<>();
   private final        ConcurrentHashMap<Integer, ComponentFile> fileIdMap       = new ConcurrentHashMap<>();
   private final        AtomicLong                                maxFilesOpened  = new AtomicLong();
@@ -68,7 +68,7 @@ public class FileManager {
     public long totalOpenFiles;
   }
 
-  public FileManager(final String path, final ComponentFile.MODE mode, final Set<String> supportedFileExt) {
+  public FileManager(final String path, final ComponentFile.Mode mode, final Set<String> supportedFileExt) {
     this.mode = mode;
 
     final File dbDirectory = new File(path);
@@ -176,7 +176,7 @@ throw new IllegalArgumentException(String.format("The directory '%s' doesn't hav
     return f;
   }
 
-  public ComponentFile getOrCreateFile(final String fileName, final String filePath, final ComponentFile.MODE mode)
+  public ComponentFile getOrCreateFile(final String fileName, final String filePath, final ComponentFile.Mode mode)
       throws IOException {
     ComponentFile file = fileNameMap.get(fileName);
     if (file != null)

--- a/engine/src/main/java/com/arcadedb/engine/PaginatedComponent.java
+++ b/engine/src/main/java/com/arcadedb/engine/PaginatedComponent.java
@@ -37,19 +37,19 @@ public abstract class PaginatedComponent extends Component {
   protected final AtomicInteger          pageCount = new AtomicInteger();
 
   protected PaginatedComponent(final DatabaseInternal database, final String name, final String filePath, final String ext,
-      final ComponentFile.MODE mode,
+      final ComponentFile.Mode mode,
       final int pageSize, final int version) throws IOException {
     this(database, name, filePath, ext, database.getFileManager().newFileId(), mode, pageSize, version);
   }
 
   private PaginatedComponent(final DatabaseInternal database, final String name, final String filePath, final String ext,
       final int id,
-      final ComponentFile.MODE mode, final int pageSize, final int version) throws IOException {
+      final ComponentFile.Mode mode, final int pageSize, final int version) throws IOException {
     this(database, name, filePath + "." + id + "." + pageSize + ".v" + version + "." + ext, id, mode, pageSize, version);
   }
 
   protected PaginatedComponent(final DatabaseInternal database, final String name, final String filePath, final int id,
-      final ComponentFile.MODE mode,
+      final ComponentFile.Mode mode,
       final int pageSize, final int version) throws IOException {
     super(database, name, id, version, filePath);
     if (pageSize <= 0)

--- a/engine/src/main/java/com/arcadedb/engine/PaginatedComponentFile.java
+++ b/engine/src/main/java/com/arcadedb/engine/PaginatedComponentFile.java
@@ -46,7 +46,7 @@ public class PaginatedComponentFile extends ComponentFile {
   public PaginatedComponentFile() {
   }
 
-  protected PaginatedComponentFile(final String filePath, final MODE mode) throws FileNotFoundException {
+  protected PaginatedComponentFile(final String filePath, final Mode mode) throws FileNotFoundException {
     super(filePath, mode);
   }
 
@@ -170,7 +170,7 @@ public class PaginatedComponentFile extends ComponentFile {
   }
 
   @Override
-  protected void open(final String filePath, final MODE mode) throws FileNotFoundException {
+  protected void open(final String filePath, final Mode mode) throws FileNotFoundException {
     this.filePath = filePath;
 
     final int lastDotPos = filePath.lastIndexOf(".");
@@ -206,7 +206,7 @@ public class PaginatedComponentFile extends ComponentFile {
       fileName = filePath;
 
     this.osFile = new File(filePath);
-    this.file = new RandomAccessFile(osFile, mode == MODE.READ_WRITE ? "rw" : "r");
+    this.file = new RandomAccessFile(osFile, mode == Mode.READ_WRITE ? "rw" : "r");
     this.channel = this.file.getChannel();
     doNotCloseOnInterrupt(this.channel);
     this.open = true;

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -57,7 +57,7 @@ public class TransactionManager {
 
     this.logContext = LogManager.instance().getContext();
 
-    if (database.getMode() == ComponentFile.MODE.READ_WRITE) {
+    if (database.getMode() == ComponentFile.Mode.READ_WRITE) {
       createWALFilePool();
 
       task = new Timer("ArcadeDB TransactionManager " + database.getName());
@@ -461,11 +461,11 @@ public class TransactionManager {
     for (final Integer fileId : orderedFilesIds) {
       attemptFileId = fileId;
 
-      final LockManager.LOCK_STATUS lock = tryLockFile(fileId, timeout, requester);
+      final LockManager.LockStatus lock = tryLockFile(fileId, timeout, requester);
 
-      if (lock == LockManager.LOCK_STATUS.YES)
+      if (lock == LockManager.LockStatus.YES)
         lockedFiles.add(fileId);
-      else if (lock == LockManager.LOCK_STATUS.NO) {
+      else if (lock == LockManager.LockStatus.NO) {
         // ERROR: UNLOCK LOCKED FILES
         unlockFilesInOrder(lockedFiles, requester);
 
@@ -495,7 +495,7 @@ public class TransactionManager {
     }
   }
 
-  public LockManager.LOCK_STATUS tryLockFile(final Integer fileId, final long timeout, final Object requester) {
+  public LockManager.LockStatus tryLockFile(final Integer fileId, final long timeout, final Object requester) {
     return fileIdsLockManager.tryLock(fileId, requester, timeout);
   }
 

--- a/engine/src/main/java/com/arcadedb/engine/WALFile.java
+++ b/engine/src/main/java/com/arcadedb/engine/WALFile.java
@@ -304,7 +304,7 @@ public class WALFile extends LockContext {
     else if (sync == FlushType.YES_FULL)
       channel.force(true);
 
-    database.executeCallbacks(DatabaseInternal.CALLBACK_EVENT.TX_AFTER_WAL_WRITE);
+    database.executeCallbacks(DatabaseInternal.CallbackEvent.TX_AFTER_WAL_WRITE);
   }
 
   public void notifyPageFlushed() {

--- a/engine/src/main/java/com/arcadedb/graph/Edge.java
+++ b/engine/src/main/java/com/arcadedb/graph/Edge.java
@@ -44,7 +44,7 @@ public interface Edge extends Document {
 
   Vertex getInVertex();
 
-  Vertex getVertex(Vertex.DIRECTION iDirection);
+  Vertex getVertex(Vertex.Direction iDirection);
 
   @Override
   default Edge asEdge() {

--- a/engine/src/main/java/com/arcadedb/graph/EdgeIterator.java
+++ b/engine/src/main/java/com/arcadedb/graph/EdgeIterator.java
@@ -29,12 +29,12 @@ import java.util.logging.*;
 
 public class EdgeIterator extends ResettableIteratorBase<Edge> {
   private final RID              vertex;
-  private final Vertex.DIRECTION direction;
+  private final Vertex.Direction direction;
   private       int              lastElementPosition = currentPosition.get();
   private       RID              nextEdgeRID;
   private       RID              nextVertexRID;
 
-  public EdgeIterator(final EdgeSegment current, final RID vertex, final Vertex.DIRECTION direction) {
+  public EdgeIterator(final EdgeSegment current, final RID vertex, final Vertex.Direction direction) {
     super(null, current);
     this.vertex = vertex;
     this.direction = direction;
@@ -74,7 +74,7 @@ public class EdgeIterator extends ResettableIteratorBase<Edge> {
         // CREATE LIGHTWEIGHT EDGE
         final DocumentType edgeType = currentContainer.getDatabase().getSchema().getTypeByBucketId(nextEdgeRID.getBucketId());
 
-        if (direction == Vertex.DIRECTION.OUT)
+        if (direction == Vertex.Direction.OUT)
           return new ImmutableLightEdge(currentContainer.getDatabase(), edgeType, nextEdgeRID, vertex, nextVertexRID);
         else
           return new ImmutableLightEdge(currentContainer.getDatabase(), edgeType, nextEdgeRID, nextVertexRID, vertex);
@@ -101,7 +101,7 @@ public class EdgeIterator extends ResettableIteratorBase<Edge> {
         // CREATE LIGHTWEIGHT EDGE
         final DocumentType edgeType = currentContainer.getDatabase().getSchema().getTypeByBucketId(nextEdgeRID.getBucketId());
 
-        if (direction == Vertex.DIRECTION.OUT)
+        if (direction == Vertex.Direction.OUT)
           new ImmutableLightEdge(currentContainer.getDatabase(), edgeType, nextEdgeRID, vertex, nextVertexRID).delete();
         else
           new ImmutableLightEdge(currentContainer.getDatabase(), edgeType, nextEdgeRID, nextVertexRID, vertex).delete();

--- a/engine/src/main/java/com/arcadedb/graph/EdgeIteratorFilter.java
+++ b/engine/src/main/java/com/arcadedb/graph/EdgeIteratorFilter.java
@@ -31,9 +31,9 @@ import java.util.logging.*;
 
 public class EdgeIteratorFilter extends IteratorFilterBase<Edge> {
   private final Vertex           vertex;
-  private final Vertex.DIRECTION direction;
+  private final Vertex.Direction direction;
 
-  public EdgeIteratorFilter(final DatabaseInternal database, final Vertex vertex, final Vertex.DIRECTION direction, final EdgeSegment current,
+  public EdgeIteratorFilter(final DatabaseInternal database, final Vertex vertex, final Vertex.Direction direction, final EdgeSegment current,
       final String[] edgeTypes) {
     super(database, current, edgeTypes);
     this.direction = direction;
@@ -57,7 +57,7 @@ public class EdgeIteratorFilter extends IteratorFilterBase<Edge> {
         // LIGHTWEIGHT EDGE
         final DocumentType edgeType = currentContainer.getDatabase().getSchema().getTypeByBucketId(nextEdge.getBucketId());
 
-        if (direction == Vertex.DIRECTION.OUT)
+        if (direction == Vertex.Direction.OUT)
           return new ImmutableLightEdge(currentContainer.getDatabase(), edgeType, nextEdge, vertex.getIdentity(), nextVertex);
         else
           return new ImmutableLightEdge(currentContainer.getDatabase(), edgeType, nextEdge, nextVertex, vertex.getIdentity());
@@ -87,7 +87,7 @@ public class EdgeIteratorFilter extends IteratorFilterBase<Edge> {
   @Override
   protected void handleCorruption(final Exception e, final RID edge, final RID vertex) {
     if ((e instanceof RecordNotFoundException || e instanceof SchemaException) &&//
-        database.getMode() == ComponentFile.MODE.READ_WRITE) {
+        database.getMode() == ComponentFile.Mode.READ_WRITE) {
 
       LogManager.instance().log(this, Level.WARNING, "Error on loading edge %s %s. Fixing it...", e, edge, vertex != null ? "vertex " + vertex : "");
 

--- a/engine/src/main/java/com/arcadedb/graph/EdgeLinkedList.java
+++ b/engine/src/main/java/com/arcadedb/graph/EdgeLinkedList.java
@@ -35,10 +35,10 @@ import java.util.*;
  */
 public class EdgeLinkedList {
   private final Vertex           vertex;
-  private final Vertex.DIRECTION direction;
+  private final Vertex.Direction direction;
   private       EdgeSegment      lastSegment;
 
-  public EdgeLinkedList(final Vertex vertex, final Vertex.DIRECTION direction, final EdgeSegment lastSegment) {
+  public EdgeLinkedList(final Vertex vertex, final Vertex.Direction direction, final EdgeSegment lastSegment) {
     this.vertex = vertex;
     this.direction = direction;
     this.lastSegment = lastSegment;
@@ -154,7 +154,7 @@ public class EdgeLinkedList {
 
       final MutableVertex modifiableV = vertex.modify();
 
-      if (direction == Vertex.DIRECTION.OUT)
+      if (direction == Vertex.Direction.OUT)
         modifiableV.setOutEdgesHeadChunk(newChunk.getIdentity());
       else
         modifiableV.setInEdgesHeadChunk(newChunk.getIdentity());
@@ -192,7 +192,7 @@ public class EdgeLinkedList {
         final MutableVertex modifiableV = currentVertex.modify();
         currentVertex = modifiableV;
 
-        if (direction == Vertex.DIRECTION.OUT)
+        if (direction == Vertex.Direction.OUT)
           modifiableV.setOutEdgesHeadChunk(newChunk.getIdentity());
         else
           modifiableV.setInEdgesHeadChunk(newChunk.getIdentity());
@@ -219,7 +219,7 @@ public class EdgeLinkedList {
         deleted = current.removeEdge(rid);
       else
         // DELETE BY VERTEX RID
-        deleted = current.removeVertex(direction == Vertex.DIRECTION.OUT ? edge.getIn() : edge.getOut());
+        deleted = current.removeVertex(direction == Vertex.Direction.OUT ? edge.getIn() : edge.getOut());
 
       if (deleted > 0) {
         updateSegment(current, prevBrowsed);

--- a/engine/src/main/java/com/arcadedb/graph/EdgeToVertexIterable.java
+++ b/engine/src/main/java/com/arcadedb/graph/EdgeToVertexIterable.java
@@ -25,9 +25,9 @@ import java.util.*;
  */
 public class EdgeToVertexIterable implements Iterable<Vertex> {
   private final Iterable<Edge>   edges;
-  private final Vertex.DIRECTION direction;
+  private final Vertex.Direction direction;
 
-  public EdgeToVertexIterable(final Iterable<Edge> edges, final Vertex.DIRECTION direction) {
+  public EdgeToVertexIterable(final Iterable<Edge> edges, final Vertex.Direction direction) {
     this.edges = edges;
     this.direction = direction;
   }

--- a/engine/src/main/java/com/arcadedb/graph/EdgeToVertexIterator.java
+++ b/engine/src/main/java/com/arcadedb/graph/EdgeToVertexIterator.java
@@ -25,10 +25,10 @@ import com.arcadedb.utility.ResettableIterator;
  */
 public class EdgeToVertexIterator implements ResettableIterator<Vertex> {
   private final EdgeIterator     edgeIterator;
-  private final Vertex.DIRECTION direction;
+  private final Vertex.Direction direction;
 
-  public EdgeToVertexIterator(final EdgeIterator iterator, final Vertex.DIRECTION direction) {
-    if (direction == Vertex.DIRECTION.BOTH)
+  public EdgeToVertexIterator(final EdgeIterator iterator, final Vertex.Direction direction) {
+    if (direction == Vertex.Direction.BOTH)
       throw new IllegalArgumentException("edge to vertex iterator does not support BOTH as direction");
 
     this.edgeIterator = iterator;

--- a/engine/src/main/java/com/arcadedb/graph/EdgeVertexIterator.java
+++ b/engine/src/main/java/com/arcadedb/graph/EdgeVertexIterator.java
@@ -30,12 +30,12 @@ import java.util.logging.*;
 
 public class EdgeVertexIterator extends ResettableIteratorBase<Pair<RID, RID>> {
   private final RID              vertex;
-  private final Vertex.DIRECTION direction;
+  private final Vertex.Direction direction;
   private       int              lastElementPosition = currentPosition.get();
   private       RID              nextEdgeRID;
   private       RID              nextVertexRID;
 
-  public EdgeVertexIterator(final EdgeSegment current, final RID vertex, final Vertex.DIRECTION direction) {
+  public EdgeVertexIterator(final EdgeSegment current, final RID vertex, final Vertex.Direction direction) {
     super(null, current);
     this.vertex = vertex;
     this.direction = direction;
@@ -81,7 +81,7 @@ public class EdgeVertexIterator extends ResettableIteratorBase<Pair<RID, RID>> {
         // CREATE LIGHTWEIGHT EDGE
         final DocumentType edgeType = currentContainer.getDatabase().getSchema().getTypeByBucketId(nextEdgeRID.getBucketId());
 
-        if (direction == Vertex.DIRECTION.OUT)
+        if (direction == Vertex.Direction.OUT)
           new ImmutableLightEdge(currentContainer.getDatabase(), edgeType, nextEdgeRID, vertex, nextVertexRID).delete();
         else
           new ImmutableLightEdge(currentContainer.getDatabase(), edgeType, nextEdgeRID, nextVertexRID, vertex).delete();

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -159,7 +159,7 @@ public class GraphDatabaseChecker {
       for (Edge e : outEdgesToReconnect) {
         final MutableVertex vertex = e.getOutVertex().modify();
         final EdgeSegment outChunk = graphEngine.createOutEdgeChunk(vertex);
-        final EdgeLinkedList outLinkedList = new EdgeLinkedList(vertex, Vertex.DIRECTION.OUT, outChunk);
+        final EdgeLinkedList outLinkedList = new EdgeLinkedList(vertex, Vertex.Direction.OUT, outChunk);
         outLinkedList.add(e.getIdentity(), e.getIn());
       }
       warnings.add("reconnected " + outEdgesToReconnect.size() + " outgoing edges");
@@ -170,7 +170,7 @@ public class GraphDatabaseChecker {
       for (Edge e : inEdgesToReconnect) {
         final MutableVertex vertex = e.getInVertex().modify();
         final EdgeSegment inChunk = graphEngine.createInEdgeChunk(vertex);
-        final EdgeLinkedList inLinkedList = new EdgeLinkedList(vertex, Vertex.DIRECTION.IN, inChunk);
+        final EdgeLinkedList inLinkedList = new EdgeLinkedList(vertex, Vertex.Direction.IN, inChunk);
         inLinkedList.add(e.getIdentity(), e.getOut());
       }
       warnings.add("reconnected " + inEdgesToReconnect.size() + " incoming edges");
@@ -183,7 +183,7 @@ public class GraphDatabaseChecker {
     if (((VertexInternal) vertex).getInEdgesHeadChunk() != null) {
       EdgeLinkedList inEdges = null;
       try {
-        inEdges = graphEngine.getEdgeHeadChunk((VertexInternal) vertex, Vertex.DIRECTION.IN);
+        inEdges = graphEngine.getEdgeHeadChunk((VertexInternal) vertex, Vertex.Direction.IN);
       } catch (Exception e) {
         // IGNORE IT
       }
@@ -312,7 +312,7 @@ public class GraphDatabaseChecker {
                 }
 
                 if (((EdgeType) edge.getType()).isBidirectional()) {
-                  if (inVertex != null && !inVertex.isConnectedTo(vertexIdentity, Vertex.DIRECTION.OUT, edge.getTypeName())) {
+                  if (inVertex != null && !inVertex.isConnectedTo(vertexIdentity, Vertex.Direction.OUT, edge.getTypeName())) {
                     warnings.add(
                         "edge " + edgeRID + " was not connected from the incoming vertex " + edge.getOut() + " to the vertex " +
                             vertexIdentity);
@@ -364,7 +364,7 @@ public class GraphDatabaseChecker {
     if (((VertexInternal) vertex).getOutEdgesHeadChunk() != null) {
       EdgeLinkedList outEdges = null;
       try {
-        outEdges = graphEngine.getEdgeHeadChunk((VertexInternal) vertex, Vertex.DIRECTION.OUT);
+        outEdges = graphEngine.getEdgeHeadChunk((VertexInternal) vertex, Vertex.Direction.OUT);
       } catch (Exception e) {
         // IGNORE IT
       }
@@ -494,7 +494,7 @@ public class GraphDatabaseChecker {
 
                 if (((EdgeType) edge.getType()).isBidirectional()) {
                   // CHECK THE EDGE IS CONNECTED FROM THE OTHER SIDE
-                  if (outVertex != null && !outVertex.isConnectedTo(vertexIdentity, Vertex.DIRECTION.IN, edge.getTypeName())) {
+                  if (outVertex != null && !outVertex.isConnectedTo(vertexIdentity, Vertex.Direction.IN, edge.getTypeName())) {
                     warnings.add(
                         "edge " + edgeRID + " was not connected from the outgoing vertex " + edge.getIn()
                             + " back to the vertex "
@@ -595,7 +595,7 @@ public class GraphDatabaseChecker {
             try {
               final Vertex vertex = edge.getInVertex().asVertex(true);
 
-              final EdgeLinkedList inEdges = graphEngine.getEdgeHeadChunk((VertexInternal) vertex, Vertex.DIRECTION.IN);
+              final EdgeLinkedList inEdges = graphEngine.getEdgeHeadChunk((VertexInternal) vertex, Vertex.Direction.IN);
               if (inEdges == null || !inEdges.containsEdge(edgeRID))
                 // UNI DIRECTIONAL EDGE
                 missingReferenceBack.incrementAndGet();
@@ -616,7 +616,7 @@ public class GraphDatabaseChecker {
             try {
               final Vertex vertex = edge.getOutVertex().asVertex(true);
 
-              final EdgeLinkedList outEdges = graphEngine.getEdgeHeadChunk((VertexInternal) vertex, Vertex.DIRECTION.OUT);
+              final EdgeLinkedList outEdges = graphEngine.getEdgeHeadChunk((VertexInternal) vertex, Vertex.Direction.OUT);
               if (outEdges == null || !outEdges.containsEdge(edgeRID))
                 // UNI DIRECTIONAL EDGE
                 missingReferenceBack.incrementAndGet();

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -161,7 +161,7 @@ public class GraphEngine {
 
     final EdgeSegment outChunk = createOutEdgeChunk((MutableVertex) fromVertex);
 
-    final EdgeLinkedList outLinkedList = new EdgeLinkedList(fromVertex, Vertex.DIRECTION.OUT, outChunk);
+    final EdgeLinkedList outLinkedList = new EdgeLinkedList(fromVertex, Vertex.Direction.OUT, outChunk);
 
     outLinkedList.add(edge.getIdentity(), toVertex.getIdentity());
   }
@@ -200,7 +200,7 @@ public class GraphEngine {
 
     final EdgeSegment outChunk = createOutEdgeChunk((MutableVertex) sourceVertex);
 
-    final EdgeLinkedList outLinkedList = new EdgeLinkedList(sourceVertex, Vertex.DIRECTION.OUT, outChunk);
+    final EdgeLinkedList outLinkedList = new EdgeLinkedList(sourceVertex, Vertex.Direction.OUT, outChunk);
     outLinkedList.addAll(outEdgePairs);
 
     if (bidirectional) {
@@ -218,7 +218,7 @@ public class GraphEngine {
 
     final EdgeSegment inChunk = createInEdgeChunk(toVertexRecord);
 
-    final EdgeLinkedList inLinkedList = new EdgeLinkedList(toVertexRecord, Vertex.DIRECTION.IN, inChunk);
+    final EdgeLinkedList inLinkedList = new EdgeLinkedList(toVertexRecord, Vertex.Direction.IN, inChunk);
     inLinkedList.add(edgeRID, fromVertexRID);
   }
 
@@ -238,7 +238,7 @@ public class GraphEngine {
 
     if (inEdgesHeadChunk == null) {
       inChunk = new MutableEdgeSegment(database, database.getNewEdgeListSize(0));
-      database.createRecord(inChunk, getEdgesBucketName(toVertex.getIdentity().getBucketId(), Vertex.DIRECTION.IN));
+      database.createRecord(inChunk, getEdgesBucketName(toVertex.getIdentity().getBucketId(), Vertex.Direction.IN));
       inEdgesHeadChunk = inChunk.getIdentity();
 
       toVertex.setInEdgesHeadChunk(inEdgesHeadChunk);
@@ -264,7 +264,7 @@ public class GraphEngine {
 
     if (outEdgesHeadChunk == null) {
       outChunk = new MutableEdgeSegment(database, database.getNewEdgeListSize(0));
-      database.createRecord(outChunk, getEdgesBucketName(fromVertex.getIdentity().getBucketId(), Vertex.DIRECTION.OUT));
+      database.createRecord(outChunk, getEdgesBucketName(fromVertex.getIdentity().getBucketId(), Vertex.Direction.OUT));
       outEdgesHeadChunk = outChunk.getIdentity();
 
       fromVertex.setOutEdgesHeadChunk(outEdgesHeadChunk);
@@ -274,7 +274,7 @@ public class GraphEngine {
     return outChunk;
   }
 
-  public long countEdges(final VertexInternal vertex, final Vertex.DIRECTION direction, final String edgeType) {
+  public long countEdges(final VertexInternal vertex, final Vertex.Direction direction, final String edgeType) {
     if (direction == null)
       throw new IllegalArgumentException("Direction is null");
 
@@ -282,22 +282,22 @@ public class GraphEngine {
 
     switch (direction) {
     case BOTH: {
-      final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.OUT);
+      final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.Direction.OUT);
       total += (outEdges != null) ? outEdges.count(edgeType) : 0L;
 
-      final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.IN);
+      final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.Direction.IN);
       total += (inEdges != null) ? inEdges.count(edgeType) : 0L;
       break;
     }
 
     case OUT: {
-      final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.OUT);
+      final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.Direction.OUT);
       total += (outEdges != null) ? outEdges.count(edgeType) : 0L;
       break;
     }
 
     case IN: {
-      final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.IN);
+      final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.Direction.IN);
       total += (inEdges != null) ? inEdges.count(edgeType) : 0L;
       break;
     }
@@ -316,7 +316,7 @@ public class GraphEngine {
       if (database.existsRecord(edge.getOut())) {
         final VertexInternal vOut = (VertexInternal) edge.getOutVertex();
         if (vOut != null) {
-          final EdgeLinkedList outEdges = getEdgeHeadChunk(vOut, Vertex.DIRECTION.OUT);
+          final EdgeLinkedList outEdges = getEdgeHeadChunk(vOut, Vertex.Direction.OUT);
           if (outEdges != null)
             outEdges.removeEdge(edge);
         }
@@ -330,7 +330,7 @@ public class GraphEngine {
       if (database.existsRecord(edge.getIn())) {
         final VertexInternal vIn = (VertexInternal) edge.getInVertex();
         if (vIn != null) {
-          final EdgeLinkedList inEdges = getEdgeHeadChunk(vIn, Vertex.DIRECTION.IN);
+          final EdgeLinkedList inEdges = getEdgeHeadChunk(vIn, Vertex.Direction.IN);
           if (inEdges != null)
             inEdges.removeEdge(edge);
         }
@@ -356,7 +356,7 @@ public class GraphEngine {
 
     EdgeLinkedList outEdges = null;
     try {
-      outEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.OUT);
+      outEdges = getEdgeHeadChunk(vertex, Vertex.Direction.OUT);
       if (outEdges != null) {
         final EdgeIterator outIterator = (EdgeIterator) outEdges.edgeIterator();
 
@@ -382,7 +382,7 @@ public class GraphEngine {
 
     EdgeLinkedList inEdges = null;
     try {
-      inEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.IN);
+      inEdges = getEdgeHeadChunk(vertex, Vertex.Direction.IN);
       if (inEdges != null) {
         final EdgeIterator inIterator = (EdgeIterator) inEdges.edgeIterator();
 
@@ -414,7 +414,7 @@ public class GraphEngine {
 
     if (outEdges != null) {
       // RELOAD LINKED LISTS
-      outEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.OUT);
+      outEdges = getEdgeHeadChunk(vertex, Vertex.Direction.OUT);
       if (outEdges != null)
         try {
           outEdges.deleteAll();
@@ -425,7 +425,7 @@ public class GraphEngine {
     }
 
     if (inEdges != null) {
-      inEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.IN);
+      inEdges = getEdgeHeadChunk(vertex, Vertex.Direction.IN);
       if (inEdges != null)
         try {
           inEdges.deleteAll();
@@ -442,18 +442,18 @@ public class GraphEngine {
   public IterableGraph<Edge> getEdges(final VertexInternal vertex) {
     final MultiIterator<Edge> result = new MultiIterator<>();
 
-    final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.OUT);
+    final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.Direction.OUT);
     if (outEdges != null)
       result.addIterator(outEdges.edgeIterator());
 
-    final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.IN);
+    final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.Direction.IN);
     if (inEdges != null)
       result.addIterator(inEdges.edgeIterator());
 
     return result;
   }
 
-  public IterableGraph<Edge> getEdges(final VertexInternal vertex, final Vertex.DIRECTION direction, final String... edgeTypes) {
+  public IterableGraph<Edge> getEdges(final VertexInternal vertex, final Vertex.Direction direction, final String... edgeTypes) {
     if (direction == null)
       throw new IllegalArgumentException("Direction is null");
 
@@ -461,24 +461,24 @@ public class GraphEngine {
     case BOTH: {
       final MultiIterator<Edge> result = new MultiIterator<>();
 
-      final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.OUT);
+      final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.Direction.OUT);
       if (outEdges != null)
         result.addIterator(outEdges.edgeIterator(edgeTypes));
 
-      final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.IN);
+      final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.Direction.IN);
       if (inEdges != null)
         result.addIterator(inEdges.edgeIterator(edgeTypes));
       return result;
     }
 
     case OUT:
-      final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.OUT);
+      final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.Direction.OUT);
       if (outEdges != null)
         return () -> outEdges.edgeIterator(edgeTypes);
       break;
 
     case IN:
-      final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.IN);
+      final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.Direction.IN);
       if (inEdges != null)
         return () -> inEdges.edgeIterator(edgeTypes);
       break;
@@ -497,11 +497,11 @@ public class GraphEngine {
   public IterableGraph<Vertex> getVertices(final VertexInternal vertex) {
     final MultiIterator<Vertex> result = new MultiIterator<>();
 
-    final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.OUT);
+    final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.Direction.OUT);
     if (outEdges != null)
       result.addIterator(outEdges.vertexIterator());
 
-    final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.IN);
+    final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.Direction.IN);
     if (inEdges != null)
       result.addIterator(inEdges.vertexIterator());
 
@@ -516,7 +516,7 @@ public class GraphEngine {
    *
    * @return An iterator of PVertex instances
    */
-  public IterableGraph<Vertex> getVertices(final VertexInternal vertex, final Vertex.DIRECTION direction, final String... edgeTypes) {
+  public IterableGraph<Vertex> getVertices(final VertexInternal vertex, final Vertex.Direction direction, final String... edgeTypes) {
     if (direction == null)
       throw new IllegalArgumentException("Direction is null");
 
@@ -524,24 +524,24 @@ public class GraphEngine {
     case BOTH: {
       final MultiIterator<Vertex> result = new MultiIterator<>();
 
-      final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.OUT);
+      final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.Direction.OUT);
       if (outEdges != null)
         result.addIterator(outEdges.vertexIterator(edgeTypes));
 
-      final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.IN);
+      final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.Direction.IN);
       if (inEdges != null)
         result.addIterator(inEdges.vertexIterator(edgeTypes));
       return result;
     }
 
     case OUT:
-      final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.OUT);
+      final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.Direction.OUT);
       if (outEdges != null)
         return () -> outEdges.vertexIterator(edgeTypes);
       break;
 
     case IN:
-      final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.IN);
+      final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.Direction.IN);
       if (inEdges != null)
         return () -> inEdges.vertexIterator(edgeTypes);
       break;
@@ -556,36 +556,36 @@ public class GraphEngine {
     if (toVertex == null)
       throw new IllegalArgumentException("Destination vertex is null");
 
-    final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.OUT);
+    final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.Direction.OUT);
     if (outEdges != null && outEdges.containsVertex(toVertex.getIdentity(), null))
       return true;
 
-    final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.IN);
+    final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.Direction.IN);
     return inEdges != null && inEdges.containsVertex(toVertex.getIdentity(), null);
   }
 
-  public boolean isVertexConnectedTo(final VertexInternal vertex, final Identifiable toVertex, final Vertex.DIRECTION direction) {
+  public boolean isVertexConnectedTo(final VertexInternal vertex, final Identifiable toVertex, final Vertex.Direction direction) {
     if (toVertex == null)
       throw new IllegalArgumentException("Destination vertex is null");
 
     if (direction == null)
       throw new IllegalArgumentException("Direction is null");
 
-    if (direction == Vertex.DIRECTION.OUT || direction == Vertex.DIRECTION.BOTH) {
-      final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.OUT);
+    if (direction == Vertex.Direction.OUT || direction == Vertex.Direction.BOTH) {
+      final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.Direction.OUT);
       if (outEdges != null && outEdges.containsVertex(toVertex.getIdentity(), null))
         return true;
     }
 
-    if (direction == Vertex.DIRECTION.IN || direction == Vertex.DIRECTION.BOTH) {
-      final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.IN);
+    if (direction == Vertex.Direction.IN || direction == Vertex.Direction.BOTH) {
+      final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.Direction.IN);
       return inEdges != null && inEdges.containsVertex(toVertex.getIdentity(), null);
     }
 
     return false;
   }
 
-  public boolean isVertexConnectedTo(final VertexInternal vertex, final Identifiable toVertex, final Vertex.DIRECTION direction,
+  public boolean isVertexConnectedTo(final VertexInternal vertex, final Identifiable toVertex, final Vertex.Direction direction,
       final String edgeType) {
     if (toVertex == null)
       throw new IllegalArgumentException("Destination vertex is null");
@@ -599,26 +599,26 @@ public class GraphEngine {
     final int[] bucketFilter = vertex.getDatabase().getSchema().getType(edgeType).getBuckets(true).stream()
         .mapToInt(x -> x.getFileId()).toArray();
 
-    if (direction == Vertex.DIRECTION.OUT || direction == Vertex.DIRECTION.BOTH) {
-      final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.OUT);
+    if (direction == Vertex.Direction.OUT || direction == Vertex.Direction.BOTH) {
+      final EdgeLinkedList outEdges = getEdgeHeadChunk(vertex, Vertex.Direction.OUT);
       if (outEdges != null && outEdges.containsVertex(toVertex.getIdentity(), bucketFilter))
         return true;
     }
 
-    if (direction == Vertex.DIRECTION.IN || direction == Vertex.DIRECTION.BOTH) {
-      final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.DIRECTION.IN);
+    if (direction == Vertex.Direction.IN || direction == Vertex.Direction.BOTH) {
+      final EdgeLinkedList inEdges = getEdgeHeadChunk(vertex, Vertex.Direction.IN);
       return inEdges != null && inEdges.containsVertex(toVertex.getIdentity(), bucketFilter);
     }
 
     return false;
   }
 
-  public String getEdgesBucketName(final int bucketId, final Vertex.DIRECTION direction) {
+  public String getEdgesBucketName(final int bucketId, final Vertex.Direction direction) {
     final Bucket vertexBucket = database.getSchema().getBucketById(bucketId);
 
-    if (direction == Vertex.DIRECTION.OUT)
+    if (direction == Vertex.Direction.OUT)
       return vertexBucket.getName() + OUT_EDGES_SUFFIX;
-    else if (direction == Vertex.DIRECTION.IN)
+    else if (direction == Vertex.Direction.IN)
       return vertexBucket.getName() + IN_EDGES_SUFFIX;
 
     throw new IllegalArgumentException("Invalid direction");
@@ -639,24 +639,24 @@ public class GraphEngine {
       }
   }
 
-  public EdgeLinkedList getEdgeHeadChunk(final VertexInternal vertex, final Vertex.DIRECTION direction) {
-    if (direction == Vertex.DIRECTION.OUT) {
+  public EdgeLinkedList getEdgeHeadChunk(final VertexInternal vertex, final Vertex.Direction direction) {
+    if (direction == Vertex.Direction.OUT) {
       RID rid = null;
       try {
         rid = vertex.getOutEdgesHeadChunk();
         if (rid != null) {
-          return new EdgeLinkedList(vertex, Vertex.DIRECTION.OUT, (EdgeSegment) vertex.getDatabase().lookupByRID(rid, true));
+          return new EdgeLinkedList(vertex, Vertex.Direction.OUT, (EdgeSegment) vertex.getDatabase().lookupByRID(rid, true));
         }
       } catch (final RecordNotFoundException e) {
         LogManager.instance()
             .log(this, Level.WARNING, "Cannot load OUT edge list chunk (%s) for vertex %s", e, rid, vertex.getIdentity());
       }
-    } else if (direction == Vertex.DIRECTION.IN) {
+    } else if (direction == Vertex.Direction.IN) {
       RID rid = null;
       try {
         rid = vertex.getInEdgesHeadChunk();
         if (rid != null) {
-          return new EdgeLinkedList(vertex, Vertex.DIRECTION.IN, (EdgeSegment) vertex.getDatabase().lookupByRID(rid, true));
+          return new EdgeLinkedList(vertex, Vertex.Direction.IN, (EdgeSegment) vertex.getDatabase().lookupByRID(rid, true));
         }
       } catch (final RecordNotFoundException e) {
         LogManager.instance()
@@ -685,10 +685,10 @@ public class GraphEngine {
       // SAVE OLD VERTEX PROPERTIES AND EDGES
       final Map<String, Object> properties = vertex.propertiesAsMap();
       final List<Edge> outEdges = new ArrayList<>();
-      for (Edge edge : vertex.getEdges(Vertex.DIRECTION.OUT))
+      for (Edge edge : vertex.getEdges(Vertex.Direction.OUT))
         outEdges.add(edge.asEdge(true));
       final List<Edge> inEdges = new ArrayList<>();
-      for (Edge edge : vertex.getEdges(Vertex.DIRECTION.IN))
+      for (Edge edge : vertex.getEdges(Vertex.Direction.IN))
         inEdges.add(edge.asEdge(true));
 
       // DELETE THE OLD RECORD FIRST TO AVOID ISSUES WITH UNIQUE CONSTRAINTS

--- a/engine/src/main/java/com/arcadedb/graph/ImmutableEdge.java
+++ b/engine/src/main/java/com/arcadedb/graph/ImmutableEdge.java
@@ -122,9 +122,9 @@ public class ImmutableEdge extends ImmutableDocument implements Edge {
   }
 
   @Override
-  public synchronized Vertex getVertex(final Vertex.DIRECTION iDirection) {
+  public synchronized Vertex getVertex(final Vertex.Direction iDirection) {
     checkForLazyLoading();
-    if (iDirection == Vertex.DIRECTION.OUT)
+    if (iDirection == Vertex.Direction.OUT)
       return out.asVertex();
     else
       return in.asVertex();

--- a/engine/src/main/java/com/arcadedb/graph/ImmutableLightEdge.java
+++ b/engine/src/main/java/com/arcadedb/graph/ImmutableLightEdge.java
@@ -71,9 +71,9 @@ public class ImmutableLightEdge extends ImmutableDocument implements LightEdge {
   }
 
   @Override
-  public Vertex getVertex(final Vertex.DIRECTION iDirection) {
+  public Vertex getVertex(final Vertex.Direction iDirection) {
     checkForLazyLoading();
-    if (iDirection == Vertex.DIRECTION.OUT)
+    if (iDirection == Vertex.Direction.OUT)
       return (Vertex) out.getRecord();
     else
       return (Vertex) in.getRecord();

--- a/engine/src/main/java/com/arcadedb/graph/ImmutableVertex.java
+++ b/engine/src/main/java/com/arcadedb/graph/ImmutableVertex.java
@@ -148,7 +148,7 @@ public class ImmutableVertex extends ImmutableDocument implements VertexInternal
   }
 
   @Override
-  public long countEdges(final DIRECTION direction, final String edgeType) {
+  public long countEdges(final Direction direction, final String edgeType) {
     return database.getGraphEngine().countEdges(getMostUpdatedVertex(this), direction, edgeType);
   }
 
@@ -158,7 +158,7 @@ public class ImmutableVertex extends ImmutableDocument implements VertexInternal
   }
 
   @Override
-  public IterableGraph<Edge> getEdges(final DIRECTION direction, final String... edgeTypes) {
+  public IterableGraph<Edge> getEdges(final Direction direction, final String... edgeTypes) {
     return database.getGraphEngine().getEdges(getMostUpdatedVertex(this), direction, edgeTypes);
   }
 
@@ -168,7 +168,7 @@ public class ImmutableVertex extends ImmutableDocument implements VertexInternal
   }
 
   @Override
-  public IterableGraph<Vertex> getVertices(final DIRECTION direction, final String... edgeTypes) {
+  public IterableGraph<Vertex> getVertices(final Direction direction, final String... edgeTypes) {
     return database.getGraphEngine().getVertices(getMostUpdatedVertex(this), direction, edgeTypes);
   }
 
@@ -178,12 +178,12 @@ public class ImmutableVertex extends ImmutableDocument implements VertexInternal
   }
 
   @Override
-  public boolean isConnectedTo(final Identifiable toVertex, final DIRECTION direction) {
+  public boolean isConnectedTo(final Identifiable toVertex, final Direction direction) {
     return database.getGraphEngine().isVertexConnectedTo(getMostUpdatedVertex(this), toVertex, direction);
   }
 
   @Override
-  public boolean isConnectedTo(final Identifiable toVertex, final DIRECTION direction, final String edgeType) {
+  public boolean isConnectedTo(final Identifiable toVertex, final Direction direction, final String edgeType) {
     return database.getGraphEngine().isVertexConnectedTo(getMostUpdatedVertex(this), toVertex, direction, edgeType);
   }
 

--- a/engine/src/main/java/com/arcadedb/graph/MutableEdge.java
+++ b/engine/src/main/java/com/arcadedb/graph/MutableEdge.java
@@ -108,8 +108,8 @@ public class MutableEdge extends MutableDocument implements Edge {
   }
 
   @Override
-  public Vertex getVertex(final Vertex.DIRECTION iDirection) {
-    if (iDirection == Vertex.DIRECTION.OUT)
+  public Vertex getVertex(final Vertex.Direction iDirection) {
+    if (iDirection == Vertex.Direction.OUT)
       return out.asVertex();
     else
       return in.asVertex();

--- a/engine/src/main/java/com/arcadedb/graph/MutableVertex.java
+++ b/engine/src/main/java/com/arcadedb/graph/MutableVertex.java
@@ -163,7 +163,7 @@ public class MutableVertex extends MutableDocument implements VertexInternal {
   }
 
   @Override
-  public long countEdges(final DIRECTION direction, final String edgeType) {
+  public long countEdges(final Direction direction, final String edgeType) {
     return database.getGraphEngine().countEdges(this, direction, edgeType);
   }
 
@@ -173,7 +173,7 @@ public class MutableVertex extends MutableDocument implements VertexInternal {
   }
 
   @Override
-  public IterableGraph<Edge> getEdges(final DIRECTION direction, final String... edgeTypes) {
+  public IterableGraph<Edge> getEdges(final Direction direction, final String... edgeTypes) {
     return database.getGraphEngine().getEdges(this, direction, edgeTypes);
   }
 
@@ -183,7 +183,7 @@ public class MutableVertex extends MutableDocument implements VertexInternal {
   }
 
   @Override
-  public IterableGraph<Vertex> getVertices(final DIRECTION direction, final String... edgeTypes) {
+  public IterableGraph<Vertex> getVertices(final Direction direction, final String... edgeTypes) {
     return database.getGraphEngine().getVertices(this, direction, edgeTypes);
   }
 
@@ -193,12 +193,12 @@ public class MutableVertex extends MutableDocument implements VertexInternal {
   }
 
   @Override
-  public boolean isConnectedTo(final Identifiable toVertex, final DIRECTION direction) {
+  public boolean isConnectedTo(final Identifiable toVertex, final Direction direction) {
     return database.getGraphEngine().isVertexConnectedTo(this, toVertex, direction);
   }
 
   @Override
-  public boolean isConnectedTo(final Identifiable toVertex, final DIRECTION direction, final String edgeTypes) {
+  public boolean isConnectedTo(final Identifiable toVertex, final Direction direction, final String edgeTypes) {
     return database.getGraphEngine().isVertexConnectedTo(this, toVertex, direction, edgeTypes);
   }
 

--- a/engine/src/main/java/com/arcadedb/graph/SynchronizedVertex.java
+++ b/engine/src/main/java/com/arcadedb/graph/SynchronizedVertex.java
@@ -85,7 +85,7 @@ public class SynchronizedVertex implements Vertex {
   }
 
   @Override
-  public synchronized long countEdges(final DIRECTION direction, final String edgeType) {
+  public synchronized long countEdges(final Direction direction, final String edgeType) {
     return delegate.countEdges(direction, edgeType);
   }
 
@@ -95,7 +95,7 @@ public class SynchronizedVertex implements Vertex {
   }
 
   @Override
-  public synchronized IterableGraph<Edge> getEdges(final DIRECTION direction, final String... edgeTypes) {
+  public synchronized IterableGraph<Edge> getEdges(final Direction direction, final String... edgeTypes) {
     return delegate.getEdges(direction, edgeTypes);
   }
 
@@ -105,7 +105,7 @@ public class SynchronizedVertex implements Vertex {
   }
 
   @Override
-  public synchronized IterableGraph<Vertex> getVertices(final DIRECTION direction, final String... edgeTypes) {
+  public synchronized IterableGraph<Vertex> getVertices(final Direction direction, final String... edgeTypes) {
     return delegate.getVertices(direction, edgeTypes);
   }
 
@@ -115,12 +115,12 @@ public class SynchronizedVertex implements Vertex {
   }
 
   @Override
-  public synchronized boolean isConnectedTo(final Identifiable toVertex, final DIRECTION direction) {
+  public synchronized boolean isConnectedTo(final Identifiable toVertex, final Direction direction) {
     return delegate.isConnectedTo(toVertex, direction);
   }
 
   @Override
-  public synchronized boolean isConnectedTo(final Identifiable toVertex, final DIRECTION direction, final String edgeType) {
+  public synchronized boolean isConnectedTo(final Identifiable toVertex, final Direction direction, final String edgeType) {
     return delegate.isConnectedTo(toVertex, direction, edgeType);
   }
 

--- a/engine/src/main/java/com/arcadedb/graph/Vertex.java
+++ b/engine/src/main/java/com/arcadedb/graph/Vertex.java
@@ -33,7 +33,7 @@ import com.arcadedb.utility.ExcludeFromJacocoGeneratedReport;
 public interface Vertex extends Document {
   byte RECORD_TYPE = 1;
 
-  enum DIRECTION {
+  enum Direction {
     OUT, IN, BOTH
   }
 
@@ -55,11 +55,11 @@ public interface Vertex extends Document {
   @Deprecated
   ImmutableLightEdge newLightEdge(String edgeType, Identifiable toVertex, boolean bidirectional);
 
-  long countEdges(DIRECTION direction, String edgeType);
+  long countEdges(Direction direction, String edgeType);
 
   IterableGraph<Edge> getEdges();
 
-  IterableGraph<Edge> getEdges(DIRECTION direction, String... edgeTypes);
+  IterableGraph<Edge> getEdges(Direction direction, String... edgeTypes);
 
   /**
    * Returns all the connected vertices, both directions, any edge type.
@@ -75,13 +75,13 @@ public interface Vertex extends Document {
    *
    * @return An iterator of PIndexCursorEntry entries
    */
-  IterableGraph<Vertex> getVertices(DIRECTION direction, String... edgeTypes);
+  IterableGraph<Vertex> getVertices(Direction direction, String... edgeTypes);
 
   boolean isConnectedTo(Identifiable toVertex);
 
-  boolean isConnectedTo(Identifiable toVertex, DIRECTION direction);
+  boolean isConnectedTo(Identifiable toVertex, Direction direction);
 
-  boolean isConnectedTo(Identifiable toVertex, DIRECTION direction, String edgeType);
+  boolean isConnectedTo(Identifiable toVertex, Direction direction, String edgeType);
 
   RID moveToType(String targetType);
 

--- a/engine/src/main/java/com/arcadedb/index/Index.java
+++ b/engine/src/main/java/com/arcadedb/index/Index.java
@@ -68,7 +68,7 @@ public interface Index {
 
   long countEntries();
 
-  Schema.INDEX_TYPE getType();
+  Schema.IndexType getType();
 
   String getTypeName();
 
@@ -76,9 +76,9 @@ public interface Index {
 
   String getName();
 
-  LSMTreeIndexAbstract.NULL_STRATEGY getNullStrategy();
+  LSMTreeIndexAbstract.NullStrategy getNullStrategy();
 
-  void setNullStrategy(LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy);
+  void setNullStrategy(LSMTreeIndexAbstract.NullStrategy nullStrategy);
 
   boolean isUnique();
 

--- a/engine/src/main/java/com/arcadedb/index/IndexInternal.java
+++ b/engine/src/main/java/com/arcadedb/index/IndexInternal.java
@@ -23,15 +23,16 @@ import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.ExcludeFromJacocoGeneratedReport;
 
-import java.io.*;
-import java.util.*;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Internal Index interface.
  */
 @ExcludeFromJacocoGeneratedReport
 public interface IndexInternal extends Index {
-  public enum INDEX_STATUS {UNAVAILABLE, AVAILABLE, COMPACTION_SCHEDULED, COMPACTION_IN_PROGRESS}
+  enum IndexStatus {UNAVAILABLE, AVAILABLE, COMPACTION_SCHEDULED, COMPACTION_IN_PROGRESS}
 
   long build(int buildIndexBatchSize, BuildIndexCallback callback);
 
@@ -39,7 +40,7 @@ public interface IndexInternal extends Index {
 
   void setMetadata(String name, String[] propertyNames, int associatedBucketId);
 
-  boolean setStatus(INDEX_STATUS[] expectedStatuses, INDEX_STATUS newStatus);
+  boolean setStatus(IndexStatus[] expectedStatuses, IndexStatus newStatus);
 
   void close();
 

--- a/engine/src/main/java/com/arcadedb/index/TypeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/TypeIndex.java
@@ -190,7 +190,7 @@ public class TypeIndex implements RangeIndex, IndexInternal {
   }
 
   @Override
-  public Schema.INDEX_TYPE getType() {
+  public Schema.IndexType getType() {
     checkIsValid();
     if (indexesOnBuckets.isEmpty())
       return null;
@@ -226,12 +226,12 @@ public class TypeIndex implements RangeIndex, IndexInternal {
 
     final List<IndexInternal> acquired = new ArrayList<>(indexesOnBuckets.size());
     for (final IndexInternal index : new ArrayList<>(indexesOnBuckets))
-      if (index.setStatus(new INDEX_STATUS[] { INDEX_STATUS.AVAILABLE, INDEX_STATUS.UNAVAILABLE }, INDEX_STATUS.UNAVAILABLE))
+      if (index.setStatus(new IndexStatus[] { IndexStatus.AVAILABLE, IndexStatus.UNAVAILABLE }, IndexStatus.UNAVAILABLE))
         acquired.add(index);
       else {
         // NOT AVAILABLE, RESET ACQUIRED STATUSES
         for (IndexInternal i : acquired)
-          i.setStatus(new INDEX_STATUS[] { INDEX_STATUS.UNAVAILABLE }, INDEX_STATUS.AVAILABLE);
+          i.setStatus(new IndexStatus[] { IndexStatus.UNAVAILABLE }, IndexStatus.AVAILABLE);
         throw new NeedRetryException(
             "Cannot drop index '" + getName() + "' because one or more underlying files are not available");
       }
@@ -259,13 +259,13 @@ public class TypeIndex implements RangeIndex, IndexInternal {
   }
 
   @Override
-  public LSMTreeIndexAbstract.NULL_STRATEGY getNullStrategy() {
+  public LSMTreeIndexAbstract.NullStrategy getNullStrategy() {
     checkIsValid();
     return getFirstUnderlyingIndex().getNullStrategy();
   }
 
   @Override
-  public void setNullStrategy(final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy) {
+  public void setNullStrategy(final LSMTreeIndexAbstract.NullStrategy nullStrategy) {
     checkIsValid();
     getFirstUnderlyingIndex().setNullStrategy(nullStrategy);
   }
@@ -371,7 +371,7 @@ public class TypeIndex implements RangeIndex, IndexInternal {
   }
 
   @Override
-  public boolean setStatus(INDEX_STATUS[] expectedStatuses, INDEX_STATUS newStatus) {
+  public boolean setStatus(IndexStatus[] expectedStatuses, IndexStatus newStatus) {
     return false;
   }
 

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeFullTextIndex.java
@@ -21,7 +21,6 @@ package com.arcadedb.index.lsm;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
-import com.arcadedb.engine.ComponentFactory;
 import com.arcadedb.engine.ComponentFile;
 import com.arcadedb.engine.PaginatedComponent;
 import com.arcadedb.index.Index;
@@ -40,9 +39,12 @@ import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 
-import java.io.*;
-import java.util.*;
-import java.util.concurrent.atomic.*;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Full Text index implementation based on LSM-Tree index.
@@ -82,7 +84,7 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
             "Full text index can only be defined on a '" + builder.getKeyTypes()[0] + "' property, only string");
 
       return new LSMTreeFullTextIndex(builder.getDatabase(), builder.getIndexName(), builder.getFilePath(),
-          ComponentFile.MODE.READ_WRITE, builder.getPageSize(), builder.getNullStrategy());
+          ComponentFile.Mode.READ_WRITE, builder.getPageSize(), builder.getNullStrategy());
     }
   }
 
@@ -98,7 +100,7 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    * Creation time.
    */
   public LSMTreeFullTextIndex(final DatabaseInternal database, final String name, final String filePath,
-      final ComponentFile.MODE mode, final int pageSize, final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy) {
+      final ComponentFile.Mode mode, final int pageSize, final LSMTreeIndexAbstract.NullStrategy nullStrategy) {
     analyzer = new StandardAnalyzer();
     underlyingIndex = new LSMTreeIndex(database, name, false, filePath, mode, new Type[] { Type.STRING }, pageSize, nullStrategy);
   }
@@ -107,7 +109,7 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    * Loading time.
    */
   public LSMTreeFullTextIndex(final DatabaseInternal database, final String name, final String filePath, final int fileId,
-      final ComponentFile.MODE mode, final int pageSize, final int version) {
+      final ComponentFile.Mode mode, final int pageSize, final int version) {
     try {
       underlyingIndex = new LSMTreeIndex(database, name, false, filePath, fileId, mode, pageSize, version);
     } catch (final IOException e) {
@@ -226,7 +228,7 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
   }
 
   @Override
-  public boolean setStatus(final INDEX_STATUS[] expectedStatuses, final INDEX_STATUS newStatus) {
+  public boolean setStatus(final IndexStatus[] expectedStatuses, final IndexStatus newStatus) {
     return underlyingIndex.setStatus(expectedStatuses, newStatus);
   }
 
@@ -261,13 +263,13 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
   }
 
   @Override
-  public LSMTreeIndexAbstract.NULL_STRATEGY getNullStrategy() {
-    return LSMTreeIndexAbstract.NULL_STRATEGY.ERROR;
+  public LSMTreeIndexAbstract.NullStrategy getNullStrategy() {
+    return LSMTreeIndexAbstract.NullStrategy.ERROR;
   }
 
   @Override
-  public void setNullStrategy(final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy) {
-    if (nullStrategy != LSMTreeIndexAbstract.NULL_STRATEGY.ERROR)
+  public void setNullStrategy(final LSMTreeIndexAbstract.NullStrategy nullStrategy) {
+    if (nullStrategy != LSMTreeIndexAbstract.NullStrategy.ERROR)
       throw new IllegalArgumentException("Unsupported null strategy '" + nullStrategy + "'");
   }
 
@@ -337,8 +339,8 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
   }
 
   @Override
-  public Schema.INDEX_TYPE getType() {
-    return Schema.INDEX_TYPE.FULL_TEXT;
+  public Schema.IndexType getType() {
+    return Schema.IndexType.FULL_TEXT;
   }
 
   public Analyzer getAnalyzer() {

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
@@ -62,7 +62,7 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
    */
   protected LSMTreeIndexCompacted(final LSMTreeIndex mainIndex, final DatabaseInternal database, final String name,
       final boolean unique, final String filePath,
-      final int id, final ComponentFile.MODE mode, final int pageSize, final int version) throws IOException {
+      final int id, final ComponentFile.Mode mode, final int pageSize, final int version) throws IOException {
     super(mainIndex, database, name, unique, filePath, id, mode, pageSize, version);
   }
 
@@ -70,7 +70,7 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
     checkForNulls(keys);
 
     final Object[] convertedKeys = convertKeys(keys, binaryKeyTypes);
-    if (convertedKeys == null && nullStrategy == NULL_STRATEGY.SKIP)
+    if (convertedKeys == null && nullStrategy == NullStrategy.SKIP)
       return Collections.emptySet();
 
     try {

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCursor.java
@@ -429,7 +429,7 @@ public class LSMTreeIndexCursor implements IndexCursor {
 
   private void getClosestEntryInTx(final Object[] keys, final boolean inclusive) {
     txCursor = null;
-    if (index.getDatabase().getTransaction().getStatus() == TransactionContext.STATUS.BEGUN) {
+    if (index.getDatabase().getTransaction().getStatus() == TransactionContext.Status.BEGUN) {
       Set<IndexCursorEntry> txChanges = null;
 
       final TreeMap<TransactionIndexContext.ComparableKey, Map<TransactionIndexContext.IndexKey, TransactionIndexContext.IndexKey>> indexChanges = index.getDatabase()

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
@@ -60,8 +60,8 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
    * Called at creation time.
    */
   protected LSMTreeIndexMutable(final LSMTreeIndex mainIndex, final DatabaseInternal database, final String name,
-      final boolean unique, final String filePath, final ComponentFile.MODE mode, final Type[] keyTypes, final int pageSize,
-      final NULL_STRATEGY nullStrategy) throws IOException {
+      final boolean unique, final String filePath, final ComponentFile.Mode mode, final Type[] keyTypes, final int pageSize,
+      final NullStrategy nullStrategy) throws IOException {
     super(mainIndex, database, name, unique, filePath, unique ? UNIQUE_INDEX_EXT : NOTUNIQUE_INDEX_EXT, mode, keyTypes, pageSize,
         CURRENT_VERSION, nullStrategy);
     database.checkTransactionIsActive(database.isAutoTransaction());
@@ -87,7 +87,7 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
    * Called at load time (1st page only).
    */
   protected LSMTreeIndexMutable(final LSMTreeIndex mainIndex, final DatabaseInternal database, final String name,
-      final boolean unique, final String filePath, final int id, final ComponentFile.MODE mode, final int pageSize,
+      final boolean unique, final String filePath, final int id, final ComponentFile.Mode mode, final int pageSize,
       final int version) throws IOException {
     super(mainIndex, database, name, unique, filePath, id, mode, pageSize, version);
     onAfterLoad();
@@ -217,7 +217,7 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
     checkForNulls(keys);
 
     final Object[] convertedKeys = convertKeys(keys, binaryKeyTypes);
-    if (convertedKeys == null && nullStrategy == NULL_STRATEGY.SKIP)
+    if (convertedKeys == null && nullStrategy == NullStrategy.SKIP)
       return new TempIndexCursor(Collections.emptyList());
 
     final Set<IndexCursorEntry> set = new HashSet<>();
@@ -424,7 +424,7 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
     if (keys == null)
       throw new IllegalArgumentException("Keys parameter is null");
 
-    if (database.getMode() == ComponentFile.MODE.READ_ONLY)
+    if (database.getMode() == ComponentFile.Mode.READ_ONLY)
       throw new DatabaseIsReadOnlyException("Cannot update the index '" + componentName + "'");
 
     if (keys.length != binaryKeyTypes.length)
@@ -433,7 +433,7 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
     checkForNulls(keys);
 
     final Object[] convertedKeys = convertKeys(keys, binaryKeyTypes);
-    if (convertedKeys == null && nullStrategy == NULL_STRATEGY.SKIP)
+    if (convertedKeys == null && nullStrategy == NullStrategy.SKIP)
       // SKIP THIS RECORD
       return;
 
@@ -517,7 +517,7 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
     if (keys == null)
       throw new IllegalArgumentException("Keys parameter is null");
 
-    if (database.getMode() == ComponentFile.MODE.READ_ONLY)
+    if (database.getMode() == ComponentFile.Mode.READ_ONLY)
       throw new DatabaseIsReadOnlyException("Cannot update the index '" + componentName + "'");
 
     if (keys.length != binaryKeyTypes.length)

--- a/engine/src/main/java/com/arcadedb/index/vector/HnswVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/HnswVectorIndex.java
@@ -119,7 +119,7 @@ public class HnswVectorIndex<TId, TVector, TDistance> extends Component implemen
   public static class PaginatedComponentFactoryHandlerUnique implements ComponentFactory.PaginatedComponentFactoryHandler {
     @Override
     public Component createOnLoad(final DatabaseInternal database, final String name, final String filePath, final int id,
-        final ComponentFile.MODE mode, final int pageSize, final int version) throws IOException {
+        final ComponentFile.Mode mode, final int pageSize, final int version) throws IOException {
       return new HnswVectorIndex(database, name, filePath, id, version);
     }
   }
@@ -151,7 +151,7 @@ public class HnswVectorIndex<TId, TVector, TDistance> extends Component implemen
 
     this.underlyingIndex = builder.getDatabase().getSchema()
         .buildTypeIndex(builder.getVertexType(), new String[] { idPropertyName }).withUnique(true).withIgnoreIfExists(true)
-        .withType(Schema.INDEX_TYPE.LSM_TREE).create();
+        .withType(Schema.IndexType.LSM_TREE).create();
 
     this.underlyingIndex.setAssociatedIndex(this);
 
@@ -207,7 +207,7 @@ public class HnswVectorIndex<TId, TVector, TDistance> extends Component implemen
   public void onAfterSchemaLoad() {
     try {
       this.underlyingIndex = database.getSchema().buildTypeIndex(vertexType, new String[] { idPropertyName })
-          .withIgnoreIfExists(true).withUnique(true).withType(Schema.INDEX_TYPE.LSM_TREE).create();
+          .withIgnoreIfExists(true).withUnique(true).withType(Schema.IndexType.LSM_TREE).create();
 
       this.underlyingIndex.setAssociatedIndex(this);
 
@@ -328,7 +328,7 @@ public class HnswVectorIndex<TId, TVector, TDistance> extends Component implemen
         ((MutableVertex) vertex).save();
       }
 
-      final long totalEdges = vertex.countEdges(Vertex.DIRECTION.OUT, getEdgeType(0));
+      final long totalEdges = vertex.countEdges(Vertex.Direction.OUT, getEdgeType(0));
       if (totalEdges > 0)
         // ALREADY INSERTED
         return true;
@@ -429,11 +429,11 @@ public class HnswVectorIndex<TId, TVector, TDistance> extends Component implemen
   }
 
   private Iterator<Vertex> getConnectionsFromVertex(final Vertex vertex, final int level) {
-    return vertex.getVertices(Vertex.DIRECTION.OUT, edgeType + level).iterator();
+    return vertex.getVertices(Vertex.Direction.OUT, edgeType + level).iterator();
   }
 
   private int countConnectionsFromVertex(final Vertex vertex, final int level) {
-    return (int) vertex.countEdges(Vertex.DIRECTION.OUT, edgeType + level);
+    return (int) vertex.countEdges(Vertex.Direction.OUT, edgeType + level);
   }
 
   private int getMaxLevelFromVertex(final Vertex vertex) {
@@ -845,7 +845,7 @@ public class HnswVectorIndex<TId, TVector, TDistance> extends Component implemen
                 final Vertex vertex = next.asVertex();
                 for (int level = 0; level <= getMaxLevelFromVertex(vertex); level++) {
                   try {
-                    for (Edge e : vertex.getEdges(Vertex.DIRECTION.BOTH, getEdgeType(level)))
+                    for (Edge e : vertex.getEdges(Vertex.Direction.BOTH, getEdgeType(level)))
                       e.delete();
                   } catch (RecordNotFoundException | SchemaException e) {
                     // IGNORE IT
@@ -873,12 +873,12 @@ public class HnswVectorIndex<TId, TVector, TDistance> extends Component implemen
   }
 
   @Override
-  public LSMTreeIndexAbstract.NULL_STRATEGY getNullStrategy() {
+  public LSMTreeIndexAbstract.NullStrategy getNullStrategy() {
     return underlyingIndex.getNullStrategy();
   }
 
   @Override
-  public void setNullStrategy(final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy) {
+  public void setNullStrategy(final LSMTreeIndexAbstract.NullStrategy nullStrategy) {
     underlyingIndex.setNullStrategy(nullStrategy);
   }
 
@@ -1044,7 +1044,7 @@ public class HnswVectorIndex<TId, TVector, TDistance> extends Component implemen
   }
 
   @Override
-  public boolean setStatus(INDEX_STATUS[] expectedStatuses, INDEX_STATUS newStatus) {
+  public boolean setStatus(IndexStatus[] expectedStatuses, IndexStatus newStatus) {
     return false;
   }
 
@@ -1198,8 +1198,8 @@ public class HnswVectorIndex<TId, TVector, TDistance> extends Component implemen
   }
 
   @Override
-  public Schema.INDEX_TYPE getType() {
-    return Schema.INDEX_TYPE.HNSW;
+  public Schema.IndexType getType() {
+    return Schema.IndexType.HNSW;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/select/SelectWhereBaseBlock.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectWhereBaseBlock.java
@@ -37,7 +37,7 @@ public abstract class SelectWhereBaseBlock {
     select.checkNotCompiled();
     if (select.property != null)
       throw new IllegalArgumentException("Property has already been set");
-    if (select.state != Select.STATE.WHERE)
+    if (select.state != Select.State.WHERE)
       throw new IllegalArgumentException("No context was provided for the parameter");
     select.property = new SelectPropertyValue(name);
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CreateEdgesStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CreateEdgesStep.java
@@ -119,10 +119,10 @@ public class CreateEdgesStep extends AbstractExecutionStep {
 
           if (ifNotExists) {
             if (context.getDatabase().getGraphEngine()
-                .isVertexConnectedTo((VertexInternal) currentFrom, currentTo, Vertex.DIRECTION.OUT, targetClass.getStringValue())) {
+                .isVertexConnectedTo((VertexInternal) currentFrom, currentTo, Vertex.Direction.OUT, targetClass.getStringValue())) {
 
               for (Edge existingEdge : context.getDatabase().getGraphEngine()
-                  .getEdges((VertexInternal) currentFrom, Vertex.DIRECTION.OUT, targetClass.getStringValue())) {
+                  .getEdges((VertexInternal) currentFrom, Vertex.Direction.OUT, targetClass.getStringValue())) {
 
                 if (existingEdge.getIn().equals(currentTo)) {
                   currentTo = null;

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchEdgesFromToVerticesStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchEdgesFromToVerticesStep.java
@@ -161,7 +161,7 @@ public class FetchEdgesFromToVerticesStep extends AbstractExecutionStep {
           if (from instanceof Vertex vertex) {
 
             // TODO: SUPPORT GET EDGE WITH 'TO' AS PARAMETER
-            currentFromEdgesIter = vertex.getEdges(Vertex.DIRECTION.OUT).iterator();
+            currentFromEdgesIter = vertex.getEdges(Vertex.Direction.OUT).iterator();
           } else {
             throw new CommandExecutionException("Invalid vertex: " + from);
           }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchEdgesToVerticesStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchEdgesToVerticesStep.java
@@ -124,7 +124,7 @@ public class FetchEdgesToVerticesStep extends AbstractExecutionStep {
             from = identifiable.getRecord();
           }
           if (from instanceof Vertex vertex) {
-            currentToEdgesIter = vertex.getEdges(Vertex.DIRECTION.IN).iterator();
+            currentToEdgesIter = vertex.getEdges(Vertex.Direction.IN).iterator();
           } else {
             throw new CommandExecutionException("Invalid vertex: " + from);
           }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromSchemaDatabaseStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromSchemaDatabaseStep.java
@@ -68,7 +68,7 @@ public class FetchFromSchemaDatabaseStep extends AbstractExecutionStep {
 
             final List<Map<String, Object>> settings = new ArrayList<>();
             for (GlobalConfiguration cfg : GlobalConfiguration.values()) {
-              if (cfg.getScope() == GlobalConfiguration.SCOPE.DATABASE) {
+              if (cfg.getScope() == GlobalConfiguration.Scope.DATABASE) {
                 final Map<String, Object> map = new LinkedHashMap<>();
                 map.put("key", cfg.getKey());
                 map.put("value", convertValue(cfg.getKey(), dbCfg.getValue(cfg)));

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -76,7 +76,7 @@ import java.util.*;
 import java.util.stream.*;
 
 import static com.arcadedb.schema.Property.RID_PROPERTY;
-import static com.arcadedb.schema.Schema.INDEX_TYPE.FULL_TEXT;
+import static com.arcadedb.schema.Schema.IndexType.FULL_TEXT;
 
 /**
  * @author Luigi Dell'Aquila (luigi.dellaquila-(at)-gmail.com)

--- a/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionAstar.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionAstar.java
@@ -240,10 +240,10 @@ public class SQLFunctionAstar extends SQLFunctionHeuristicPathFinderAbstract {
       context.paramVertexAxisNames = stringArray(mapParams.get(SQLFunctionAstar.PARAM_VERTEX_AXIS_NAMES));
       if (mapParams.get(SQLFunctionAstar.PARAM_DIRECTION) != null) {
         if (mapParams.get(SQLFunctionAstar.PARAM_DIRECTION) instanceof String) {
-          context.paramDirection = Vertex.DIRECTION.valueOf(
+          context.paramDirection = Vertex.Direction.valueOf(
               stringOrDefault(mapParams.get(SQLFunctionAstar.PARAM_DIRECTION), "OUT").toUpperCase(Locale.ENGLISH));
         } else {
-          context.paramDirection = (Vertex.DIRECTION) mapParams.get(SQLFunctionAstar.PARAM_DIRECTION);
+          context.paramDirection = (Vertex.Direction) mapParams.get(SQLFunctionAstar.PARAM_DIRECTION);
         }
       }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionBoth.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionBoth.java
@@ -34,6 +34,6 @@ public class SQLFunctionBoth extends SQLFunctionMove {
 
   @Override
   protected Object move(final Database graph, final Identifiable iRecord, final String[] iLabels) {
-    return v2v(graph, iRecord, Vertex.DIRECTION.BOTH, iLabels);
+    return v2v(graph, iRecord, Vertex.Direction.BOTH, iLabels);
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionBothE.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionBothE.java
@@ -34,6 +34,6 @@ public class SQLFunctionBothE extends SQLFunctionMove {
 
   @Override
   protected Object move(final Database graph, final Identifiable iRecord, final String[] iLabels) {
-    return v2e(graph, iRecord, Vertex.DIRECTION.BOTH, iLabels);
+    return v2e(graph, iRecord, Vertex.Direction.BOTH, iLabels);
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionBothV.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionBothV.java
@@ -34,6 +34,6 @@ public class SQLFunctionBothV extends SQLFunctionMove {
 
   @Override
   protected Object move(final Database graph, final Identifiable iRecord, final String[] iLabels) {
-    return e2v(graph, iRecord, Vertex.DIRECTION.BOTH, iLabels);
+    return e2v(graph, iRecord, Vertex.Direction.BOTH, iLabels);
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionHeuristicPathFinderAbstract.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionHeuristicPathFinderAbstract.java
@@ -49,9 +49,9 @@ public abstract class SQLFunctionHeuristicPathFinderAbstract extends SQLFunction
   protected String[]            paramVertexAxisNames        = new String[] {};
   protected Vertex              paramSourceVertex;
   protected Vertex              paramDestinationVertex;
-  protected SQLHeuristicFormula paramHeuristicFormula       = SQLHeuristicFormula.MANHATTAN;
-  protected Vertex.DIRECTION    paramDirection              = Vertex.DIRECTION.OUT;
-  protected long                paramMaxDepth               = Long.MAX_VALUE;
+  protected SQLHeuristicFormula paramHeuristicFormula = SQLHeuristicFormula.MANHATTAN;
+  protected Vertex.Direction    paramDirection        = Vertex.Direction.OUT;
+  protected long                paramMaxDepth         = Long.MAX_VALUE;
   protected double              paramDFactor                = 1.0;
   protected String              paramCustomHeuristicFormula = "";
 

--- a/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionIn.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionIn.java
@@ -36,17 +36,17 @@ public class SQLFunctionIn extends SQLFunctionMoveFiltered {
 
   @Override
   protected Object move(final Database graph, final Identifiable iRecord, final String[] iLabels) {
-    return v2v(graph, iRecord, Vertex.DIRECTION.IN, iLabels);
+    return v2v(graph, iRecord, Vertex.Direction.IN, iLabels);
   }
 
   protected Object move(final Database graph, final Identifiable iRecord, final String[] iLabels,
       final Iterable<Identifiable> iPossibleResults) {
     if (iPossibleResults == null)
-      return v2v(graph, iRecord, Vertex.DIRECTION.IN, iLabels);
+      return v2v(graph, iRecord, Vertex.Direction.IN, iLabels);
 
     if (!iPossibleResults.iterator().hasNext())
       return Collections.emptyList();
 
-    return v2v(graph, iRecord, Vertex.DIRECTION.IN, iLabels);
+    return v2v(graph, iRecord, Vertex.Direction.IN, iLabels);
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionInE.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionInE.java
@@ -34,7 +34,7 @@ public class SQLFunctionInE extends SQLFunctionMove {
 
   @Override
   protected Object move(final Database graph, final Identifiable iRecord, final String[] iLabels) {
-    return v2e(graph, iRecord, Vertex.DIRECTION.IN, iLabels);
+    return v2e(graph, iRecord, Vertex.Direction.IN, iLabels);
   }
 
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionInV.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionInV.java
@@ -34,6 +34,6 @@ public class SQLFunctionInV extends SQLFunctionMove {
 
   @Override
   protected Object move(final Database graph, final Identifiable iRecord, final String[] iLabels) {
-    return e2v(graph, iRecord, Vertex.DIRECTION.IN, iLabels);
+    return e2v(graph, iRecord, Vertex.Direction.IN, iLabels);
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionMove.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionMove.java
@@ -57,7 +57,7 @@ public abstract class SQLFunctionMove extends SQLFunctionConfigurableAbstract {
     return SQLQueryEngine.foreachRecord(iArgument -> move(context.getDatabase(), iArgument, labels), self, context);
   }
 
-  protected Object v2v(final Database graph, final Identifiable iRecord, final Vertex.DIRECTION iDirection,
+  protected Object v2v(final Database graph, final Identifiable iRecord, final Vertex.Direction iDirection,
       final String[] iLabels) {
     if (iRecord != null) {
       final Document rec = (Document) iRecord.getRecord();
@@ -67,7 +67,7 @@ public abstract class SQLFunctionMove extends SQLFunctionConfigurableAbstract {
     return null;
   }
 
-  protected Object v2e(final Database graph, final Identifiable iRecord, final Vertex.DIRECTION iDirection,
+  protected Object v2e(final Database graph, final Identifiable iRecord, final Vertex.Direction iDirection,
       final String[] iLabels) {
     final Document rec = (Document) iRecord.getRecord();
     if (rec instanceof Vertex vertex)
@@ -76,11 +76,11 @@ public abstract class SQLFunctionMove extends SQLFunctionConfigurableAbstract {
 
   }
 
-  protected Object e2v(final Database graph, final Identifiable iRecord, final Vertex.DIRECTION iDirection,
+  protected Object e2v(final Database graph, final Identifiable iRecord, final Vertex.Direction iDirection,
       final String[] iLabels) {
     final Document rec = (Document) iRecord.getRecord();
     if (rec instanceof Edge edge) {
-      if (iDirection == Vertex.DIRECTION.BOTH) {
+      if (iDirection == Vertex.Direction.BOTH) {
         var results = new ArrayList<Vertex>();
         results.add(edge.getOutVertex());
         results.add(edge.getInVertex());

--- a/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionOut.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionOut.java
@@ -36,17 +36,17 @@ public class SQLFunctionOut extends SQLFunctionMoveFiltered {
 
   @Override
   protected Object move(final Database graph, final Identifiable iRecord, final String[] iLabels) {
-    return v2v(graph, iRecord, Vertex.DIRECTION.OUT, iLabels);
+    return v2v(graph, iRecord, Vertex.Direction.OUT, iLabels);
   }
 
   protected Object move(final Database graph, final Identifiable iRecord, final String[] iLabels,
       final Iterable<Identifiable> iPossibleResults) {
     if (iPossibleResults == null)
-      return v2v(graph, iRecord, Vertex.DIRECTION.OUT, iLabels);
+      return v2v(graph, iRecord, Vertex.Direction.OUT, iLabels);
 
     if (!iPossibleResults.iterator().hasNext())
       return Collections.emptyList();
 
-    return v2v(graph, iRecord, Vertex.DIRECTION.OUT, iLabels);
+    return v2v(graph, iRecord, Vertex.Direction.OUT, iLabels);
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionOutE.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionOutE.java
@@ -34,6 +34,6 @@ public class SQLFunctionOutE extends SQLFunctionMove {
 
   @Override
   protected Object move(final Database graph, final Identifiable iRecord, final String[] iLabels) {
-    return v2e(graph, iRecord, Vertex.DIRECTION.OUT, iLabels);
+    return v2e(graph, iRecord, Vertex.Direction.OUT, iLabels);
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionOutV.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionOutV.java
@@ -34,6 +34,6 @@ public class SQLFunctionOutV extends SQLFunctionMove {
 
   @Override
   protected Object move(final Database graph, final Identifiable iRecord, final String[] iLabels) {
-    return e2v(graph, iRecord, Vertex.DIRECTION.OUT, iLabels);
+    return e2v(graph, iRecord, Vertex.Direction.OUT, iLabels);
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionPathFinder.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionPathFinder.java
@@ -42,7 +42,7 @@ public abstract class SQLFunctionPathFinder extends SQLFunctionMathAbstract {
 
   protected       Vertex           paramSourceVertex;
   protected       Vertex           paramDestinationVertex;
-  protected final Vertex.DIRECTION paramDirection = Vertex.DIRECTION.OUT;
+  protected final Vertex.Direction paramDirection = Vertex.Direction.OUT;
   protected       CommandContext   context;
 
   protected static final float MIN = 0f;

--- a/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionShortestPath.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/function/graph/SQLFunctionShortestPath.java
@@ -58,8 +58,8 @@ public class SQLFunctionShortestPath extends SQLFunctionMathAbstract {
   private static class ShortestPathContext {
     Vertex           sourceVertex;
     Vertex           destinationVertex;
-    Vertex.DIRECTION directionLeft  = Vertex.DIRECTION.BOTH;
-    Vertex.DIRECTION directionRight = Vertex.DIRECTION.BOTH;
+    Vertex.Direction directionLeft  = Vertex.Direction.BOTH;
+    Vertex.Direction directionRight = Vertex.Direction.BOTH;
 
     String   edgeType;
     String[] edgeTypeParam;
@@ -138,12 +138,12 @@ public class SQLFunctionShortestPath extends SQLFunctionMathAbstract {
     }
 
     if (params.length > 2 && params[2] != null) {
-      shortestPathContext.directionLeft = Vertex.DIRECTION.valueOf(params[2].toString().toUpperCase(Locale.ENGLISH));
+      shortestPathContext.directionLeft = Vertex.Direction.valueOf(params[2].toString().toUpperCase(Locale.ENGLISH));
     }
-    if (shortestPathContext.directionLeft == Vertex.DIRECTION.OUT) {
-      shortestPathContext.directionRight = Vertex.DIRECTION.IN;
-    } else if (shortestPathContext.directionLeft == Vertex.DIRECTION.IN) {
-      shortestPathContext.directionRight = Vertex.DIRECTION.OUT;
+    if (shortestPathContext.directionLeft == Vertex.Direction.OUT) {
+      shortestPathContext.directionRight = Vertex.Direction.IN;
+    } else if (shortestPathContext.directionLeft == Vertex.Direction.IN) {
+      shortestPathContext.directionRight = Vertex.Direction.OUT;
     }
 
     shortestPathContext.edgeType = null;
@@ -288,13 +288,13 @@ public class SQLFunctionShortestPath extends SQLFunctionMathAbstract {
    *
    * @author Thomas Young (YJJThomasYoung@hotmail.com)
    */
-  private Pair<Iterable<Vertex>, Iterable<Edge>> getVerticesAndEdges(final Vertex srcVertex, final Vertex.DIRECTION direction,
+  private Pair<Iterable<Vertex>, Iterable<Edge>> getVerticesAndEdges(final Vertex srcVertex, final Vertex.Direction direction,
       final String... types) {
-    if (direction == Vertex.DIRECTION.BOTH) {
+    if (direction == Vertex.Direction.BOTH) {
       final MultiIterator<Vertex> vertexIterator = new MultiIterator<>();
       final MultiIterator<Edge> edgeIterator = new MultiIterator<>();
-      final Pair<Iterable<Vertex>, Iterable<Edge>> pair1 = getVerticesAndEdges(srcVertex, Vertex.DIRECTION.OUT, types);
-      final Pair<Iterable<Vertex>, Iterable<Edge>> pair2 = getVerticesAndEdges(srcVertex, Vertex.DIRECTION.IN, types);
+      final Pair<Iterable<Vertex>, Iterable<Edge>> pair1 = getVerticesAndEdges(srcVertex, Vertex.Direction.OUT, types);
+      final Pair<Iterable<Vertex>, Iterable<Edge>> pair2 = getVerticesAndEdges(srcVertex, Vertex.Direction.IN, types);
       vertexIterator.addIterator(pair1.getFirst());
       vertexIterator.addIterator(pair2.getFirst());
       edgeIterator.addIterator(pair1.getSecond());
@@ -317,7 +317,7 @@ public class SQLFunctionShortestPath extends SQLFunctionMathAbstract {
    *
    * @author Thomas Young (YJJThomasYoung@hotmail.com)
    */
-  private Pair<Iterable<Vertex>, Iterable<Edge>> getVerticesAndEdges(final Vertex srcVertex, final Vertex.DIRECTION direction) {
+  private Pair<Iterable<Vertex>, Iterable<Edge>> getVerticesAndEdges(final Vertex srcVertex, final Vertex.Direction direction) {
     return getVerticesAndEdges(srcVertex, direction, (String[]) null);
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/AlterDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/AlterDatabaseStatement.java
@@ -55,7 +55,7 @@ public class AlterDatabaseStatement extends DDLStatement {
 
   private Result executeSimpleAlter(final Identifier settingName, final Expression settingValue, final CommandContext context) {
     final DatabaseInternal db = context.getDatabase();
-    db.checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_DATABASE_SETTINGS);
+    db.checkPermissionsOnDatabase(SecurityDatabaseUser.DatabaseAccess.UPDATE_DATABASE_SETTINGS);
 
     final String settingNameAsString = settingName.getStringValue();
     final GlobalConfiguration cfg = GlobalConfiguration.findByKey(settingNameAsString);

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BeginStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BeginStatement.java
@@ -41,7 +41,7 @@ public class BeginStatement extends SimpleExecStatement {
     final DatabaseInternal database = context.getDatabase();
 
     if (isolation != null)
-      database.begin(Database.TRANSACTION_ISOLATION_LEVEL.valueOf(isolation.getStringValue().toUpperCase(Locale.ENGLISH)));
+      database.begin(Database.TransactionIsolationLevel.valueOf(isolation.getStringValue().toUpperCase(Locale.ENGLISH)));
     else
       // USE THE STANDARD ISOLATION LEVEL
       database.begin();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
@@ -42,9 +42,9 @@ public class CreateIndexStatement extends DDLStatement {
   protected Identifier                         type;
   protected boolean                            ifNotExists  = false;
   protected Identifier                         engine;
-  protected Json                               metadata;
-  protected LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy = LSMTreeIndexAbstract.NULL_STRATEGY.SKIP;
-  protected List<Identifier>                   keyTypes     = new ArrayList<Identifier>();
+  protected Json                              metadata;
+  protected LSMTreeIndexAbstract.NullStrategy nullStrategy = LSMTreeIndexAbstract.NullStrategy.SKIP;
+  protected List<Identifier>                  keyTypes     = new ArrayList<Identifier>();
 
   public CreateIndexStatement(final int id) {
     super(id);
@@ -81,19 +81,19 @@ public class CreateIndexStatement extends DDLStatement {
 
     final String[] fields = calculateProperties(context);
 
-    final Schema.INDEX_TYPE indexType;
+    final Schema.IndexType indexType;
     boolean unique = false;
 
     final String typeAsString = type.getStringValue();
     if (typeAsString.equalsIgnoreCase("FULL_TEXT"))
-      indexType = Schema.INDEX_TYPE.FULL_TEXT;
+      indexType = Schema.IndexType.FULL_TEXT;
     else if (typeAsString.equalsIgnoreCase("UNIQUE")) {
-      indexType = Schema.INDEX_TYPE.LSM_TREE;
+      indexType = Schema.IndexType.LSM_TREE;
       unique = true;
     } else if (typeAsString.equalsIgnoreCase("NOTUNIQUE")) {
-      indexType = Schema.INDEX_TYPE.LSM_TREE;
+      indexType = Schema.IndexType.LSM_TREE;
     } else if (typeAsString.equalsIgnoreCase("HNSW")) {
-      indexType = Schema.INDEX_TYPE.HNSW;
+      indexType = Schema.IndexType.HNSW;
       unique = true;
     } else
       throw new CommandSQLParsingException("Index type '" + typeAsString + "' is not supported");

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -142,12 +142,12 @@ public class RebuildIndexStatement extends DDLStatement {
         if (((IndexInternal) idx).isCompacting())
           throw new NeedRetryException("Cannot rebuild the index '" + idx.getName() + "' while is compacting");
 
-        final Schema.INDEX_TYPE type = idx.getType();
+        final Schema.IndexType type = idx.getType();
         final String typeName = idx.getTypeName();
         final boolean unique = idx.isUnique();
         final List<String> propertyNames = idx.getPropertyNames();
         final int pageSize = ((IndexInternal) idx).getPageSize();
-        final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy = idx.getNullStrategy();
+        final LSMTreeIndexAbstract.NullStrategy nullStrategy = idx.getNullStrategy();
 
         ((DatabaseInternal) database).executeLockingFiles(((IndexInternal) idx).getFileIds(), () -> {
           database.getSchema().dropIndex(idx.getName());

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/SqlParser.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/SqlParser.java
@@ -14770,12 +14770,12 @@ jjtn000.keyTypes.add(lastIdentifier);
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
         case SKIP2:{
           jj_consume_token(SKIP2);
-jjtn000.nullStrategy = LSMTreeIndexAbstract.NULL_STRATEGY.SKIP;
+jjtn000.nullStrategy = LSMTreeIndexAbstract.NullStrategy.SKIP;
           break;
           }
         case ERROR2:{
           jj_consume_token(ERROR2);
-jjtn000.nullStrategy = LSMTreeIndexAbstract.NULL_STRATEGY.ERROR;
+jjtn000.nullStrategy = LSMTreeIndexAbstract.NullStrategy.ERROR;
           break;
           }
         default:

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/WhereClause.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/WhereClause.java
@@ -103,7 +103,7 @@ public class WhereClause extends SimpleNode {
         final Map<String, Object> conditions = getEqualityOperations(condition, context);
 
         for (final Index index : indexes) {
-          if (index.getType().equals(Schema.INDEX_TYPE.FULL_TEXT))
+          if (index.getType().equals(Schema.IndexType.FULL_TEXT))
             continue;
 
           final List<String> indexedFields = index.getPropertyNames();

--- a/engine/src/main/java/com/arcadedb/schema/AbstractProperty.java
+++ b/engine/src/main/java/com/arcadedb/schema/AbstractProperty.java
@@ -63,7 +63,7 @@ public abstract class AbstractProperty implements Property {
    * @return The index instance
    */
   @Override
-  public Index createIndex(final Schema.INDEX_TYPE type, final boolean unique) {
+  public Index createIndex(final Schema.IndexType type, final boolean unique) {
     return owner.createTypeIndex(type, unique, name);
   }
 
@@ -76,7 +76,7 @@ public abstract class AbstractProperty implements Property {
    * @return The index instance
    */
   @Override
-  public Index getOrCreateIndex(final Schema.INDEX_TYPE type, final boolean unique) {
+  public Index getOrCreateIndex(final Schema.IndexType type, final boolean unique) {
     return owner.getSchema().buildTypeIndex(owner.getName(), new String[] { name }).withType(type).withUnique(unique)
         .withIgnoreIfExists(true).create();
   }

--- a/engine/src/main/java/com/arcadedb/schema/BucketIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/BucketIndexBuilder.java
@@ -54,7 +54,7 @@ public class BucketIndexBuilder extends IndexBuilder<Index> {
 
   @Override
   public Index create() {
-    database.checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);
+    database.checkPermissionsOnDatabase(SecurityDatabaseUser.DatabaseAccess.UPDATE_SCHEMA);
 
     final int totalThreads = database.async().getThreadCount();
     final CountDownLatch semaphoreToStart = new CountDownLatch(totalThreads);

--- a/engine/src/main/java/com/arcadedb/schema/DocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/DocumentType.java
@@ -122,25 +122,25 @@ public interface DocumentType {
 
   Property dropProperty(String propertyName);
 
-  TypeIndex createTypeIndex(Schema.INDEX_TYPE indexType, boolean unique, String... propertyNames);
+  TypeIndex createTypeIndex(Schema.IndexType indexType, boolean unique, String... propertyNames);
 
-  TypeIndex createTypeIndex(Schema.INDEX_TYPE indexType, boolean unique, String[] propertyNames, int pageSize);
+  TypeIndex createTypeIndex(Schema.IndexType indexType, boolean unique, String[] propertyNames, int pageSize);
 
-  TypeIndex createTypeIndex(Schema.INDEX_TYPE indexType, boolean unique, String[] propertyNames, int pageSize,
+  TypeIndex createTypeIndex(Schema.IndexType indexType, boolean unique, String[] propertyNames, int pageSize,
       Index.BuildIndexCallback callback);
 
-  TypeIndex createTypeIndex(Schema.INDEX_TYPE indexType, boolean unique, String[] propertyNames, int pageSize,
-      LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy, Index.BuildIndexCallback callback);
+  TypeIndex createTypeIndex(Schema.IndexType indexType, boolean unique, String[] propertyNames, int pageSize,
+      LSMTreeIndexAbstract.NullStrategy nullStrategy, Index.BuildIndexCallback callback);
 
-  TypeIndex getOrCreateTypeIndex(Schema.INDEX_TYPE indexType, boolean unique, String... propertyNames);
+  TypeIndex getOrCreateTypeIndex(Schema.IndexType indexType, boolean unique, String... propertyNames);
 
-  TypeIndex getOrCreateTypeIndex(Schema.INDEX_TYPE indexType, boolean unique, String[] propertyNames, int pageSize);
+  TypeIndex getOrCreateTypeIndex(Schema.IndexType indexType, boolean unique, String[] propertyNames, int pageSize);
 
-  TypeIndex getOrCreateTypeIndex(Schema.INDEX_TYPE indexType, boolean unique, String[] propertyNames, int pageSize,
+  TypeIndex getOrCreateTypeIndex(Schema.IndexType indexType, boolean unique, String[] propertyNames, int pageSize,
       Index.BuildIndexCallback callback);
 
-  TypeIndex getOrCreateTypeIndex(Schema.INDEX_TYPE indexType, boolean unique, String[] propertyNames, int pageSize,
-      LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy, Index.BuildIndexCallback callback);
+  TypeIndex getOrCreateTypeIndex(Schema.IndexType indexType, boolean unique, String[] propertyNames, int pageSize,
+      LSMTreeIndexAbstract.NullStrategy nullStrategy, Index.BuildIndexCallback callback);
 
   List<Bucket> getInvolvedBuckets();
 

--- a/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
@@ -33,11 +33,11 @@ public abstract class IndexBuilder<T extends Index> {
   public static final int                    BUILD_BATCH_SIZE = 5_000;
   final               DatabaseInternal       database;
   final               Class<? extends Index> indexImplementation;
-  Schema.INDEX_TYPE                  indexType;
-  boolean                            unique;
-  int                                pageSize       = LSMTreeIndexAbstract.DEF_PAGE_SIZE;
-  LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy   = LSMTreeIndexAbstract.NULL_STRATEGY.SKIP;
-  Index.BuildIndexCallback           callback;
+  Schema.IndexType indexType;
+  boolean          unique;
+  int                               pageSize     = LSMTreeIndexAbstract.DEF_PAGE_SIZE;
+  LSMTreeIndexAbstract.NullStrategy nullStrategy = LSMTreeIndexAbstract.NullStrategy.SKIP;
+  Index.BuildIndexCallback          callback;
   boolean                            ignoreIfExists = false;
   String                             indexName      = null;
   String                             filePath       = null;
@@ -52,7 +52,7 @@ public abstract class IndexBuilder<T extends Index> {
 
   public abstract T create();
 
-  public IndexBuilder<T> withType(final Schema.INDEX_TYPE indexType) {
+  public IndexBuilder<T> withType(final Schema.IndexType indexType) {
     this.indexType = indexType;
     return this;
   }
@@ -72,7 +72,7 @@ public abstract class IndexBuilder<T extends Index> {
     return this;
   }
 
-  public IndexBuilder<T> withNullStrategy(final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy) {
+  public IndexBuilder<T> withNullStrategy(final LSMTreeIndexAbstract.NullStrategy nullStrategy) {
     this.nullStrategy = nullStrategy;
     return this;
   }
@@ -86,7 +86,7 @@ public abstract class IndexBuilder<T extends Index> {
     return database;
   }
 
-  public LSMTreeIndexAbstract.NULL_STRATEGY getNullStrategy() {
+  public LSMTreeIndexAbstract.NullStrategy getNullStrategy() {
     return nullStrategy;
   }
 
@@ -94,7 +94,7 @@ public abstract class IndexBuilder<T extends Index> {
     return pageSize;
   }
 
-  public Schema.INDEX_TYPE getIndexType() {
+  public Schema.IndexType getIndexType() {
     return indexType;
   }
 

--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -423,52 +423,52 @@ public class LocalDocumentType implements DocumentType {
   }
 
   @Override
-  public TypeIndex createTypeIndex(final Schema.INDEX_TYPE indexType, final boolean unique, final String... propertyNames) {
+  public TypeIndex createTypeIndex(final Schema.IndexType indexType, final boolean unique, final String... propertyNames) {
     return schema.buildTypeIndex(name, propertyNames).withType(indexType).withUnique(unique).create();
   }
 
   @Override
-  public TypeIndex createTypeIndex(final Schema.INDEX_TYPE indexType, final boolean unique, final String[] propertyNames,
+  public TypeIndex createTypeIndex(final Schema.IndexType indexType, final boolean unique, final String[] propertyNames,
       final int pageSize) {
     return schema.buildTypeIndex(name, propertyNames).withType(indexType).withUnique(unique).withPageSize(pageSize).create();
   }
 
   @Override
-  public TypeIndex createTypeIndex(final Schema.INDEX_TYPE indexType, final boolean unique, final String[] propertyNames,
+  public TypeIndex createTypeIndex(final Schema.IndexType indexType, final boolean unique, final String[] propertyNames,
       final int pageSize, final Index.BuildIndexCallback callback) {
     return schema.buildTypeIndex(name, propertyNames).withType(indexType).withUnique(unique).withPageSize(pageSize)
         .withCallback(callback).create();
   }
 
   @Override
-  public TypeIndex createTypeIndex(final Schema.INDEX_TYPE indexType, final boolean unique, final String[] propertyNames,
-      final int pageSize, final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy, final Index.BuildIndexCallback callback) {
+  public TypeIndex createTypeIndex(final Schema.IndexType indexType, final boolean unique, final String[] propertyNames,
+      final int pageSize, final LSMTreeIndexAbstract.NullStrategy nullStrategy, final Index.BuildIndexCallback callback) {
     return schema.buildTypeIndex(name, propertyNames).withType(indexType).withUnique(unique).withPageSize(pageSize)
         .withNullStrategy(nullStrategy).withCallback(callback).create();
   }
 
   @Override
-  public TypeIndex getOrCreateTypeIndex(final Schema.INDEX_TYPE indexType, final boolean unique, final String... propertyNames) {
+  public TypeIndex getOrCreateTypeIndex(final Schema.IndexType indexType, final boolean unique, final String... propertyNames) {
     return schema.buildTypeIndex(name, propertyNames).withType(indexType).withUnique(unique).withIgnoreIfExists(true).create();
   }
 
   @Override
-  public TypeIndex getOrCreateTypeIndex(final Schema.INDEX_TYPE indexType, final boolean unique, final String[] propertyNames,
+  public TypeIndex getOrCreateTypeIndex(final Schema.IndexType indexType, final boolean unique, final String[] propertyNames,
       final int pageSize) {
     return schema.buildTypeIndex(name, propertyNames).withType(indexType).withUnique(unique).withPageSize(pageSize)
         .withIgnoreIfExists(true).create();
   }
 
   @Override
-  public TypeIndex getOrCreateTypeIndex(final Schema.INDEX_TYPE indexType, final boolean unique, final String[] propertyNames,
+  public TypeIndex getOrCreateTypeIndex(final Schema.IndexType indexType, final boolean unique, final String[] propertyNames,
       final int pageSize, final Index.BuildIndexCallback callback) {
     return schema.buildTypeIndex(name, propertyNames).withType(indexType).withUnique(unique).withPageSize(pageSize)
         .withCallback(callback).withIgnoreIfExists(true).create();
   }
 
   @Override
-  public TypeIndex getOrCreateTypeIndex(final Schema.INDEX_TYPE indexType, final boolean unique, final String[] propertyNames,
-      final int pageSize, final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy, final Index.BuildIndexCallback callback) {
+  public TypeIndex getOrCreateTypeIndex(final Schema.IndexType indexType, final boolean unique, final String[] propertyNames,
+      final int pageSize, final LSMTreeIndexAbstract.NullStrategy nullStrategy, final Index.BuildIndexCallback callback) {
     return schema.buildTypeIndex(name, propertyNames).withType(indexType).withUnique(unique).withPageSize(pageSize)
         .withNullStrategy(nullStrategy).withCallback(callback).withIgnoreIfExists(true).create();
   }

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -122,9 +122,9 @@ public class LocalSchema implements Schema {
         new LSMTreeIndex.PaginatedComponentFactoryHandlerNotUnique());
     componentFactory.registerComponent(HnswVectorIndex.FILE_EXT, new HnswVectorIndex.PaginatedComponentFactoryHandlerUnique());
 
-    indexFactory.register(INDEX_TYPE.LSM_TREE.name(), new LSMTreeIndex.IndexFactoryHandler());
-    indexFactory.register(INDEX_TYPE.FULL_TEXT.name(), new LSMTreeFullTextIndex.IndexFactoryHandler());
-    indexFactory.register(INDEX_TYPE.HNSW.name(), new HnswVectorIndex.IndexFactoryHandler());
+    indexFactory.register(IndexType.LSM_TREE.name(), new LSMTreeIndex.IndexFactoryHandler());
+    indexFactory.register(IndexType.FULL_TEXT.name(), new LSMTreeFullTextIndex.IndexFactoryHandler());
+    indexFactory.register(IndexType.HNSW.name(), new HnswVectorIndex.IndexFactoryHandler());
     configurationFile = new File(databasePath + File.separator + SCHEMA_FILE_NAME);
   }
 
@@ -133,7 +133,7 @@ public class LocalSchema implements Schema {
     return this;
   }
 
-  public void create(final ComponentFile.MODE mode) {
+  public void create(final ComponentFile.Mode mode) {
     loadInRamCompleted = true;
     database.begin();
     try {
@@ -149,7 +149,7 @@ public class LocalSchema implements Schema {
     }
   }
 
-  public void load(final ComponentFile.MODE mode, final boolean initialize) throws IOException {
+  public void load(final ComponentFile.Mode mode, final boolean initialize) throws IOException {
     files.clear();
     types.clear();
     bucketMap.clear();
@@ -312,7 +312,7 @@ public class LocalSchema implements Schema {
   }
 
   public LocalBucket createBucket(final String bucketName, final int pageSize) {
-    database.checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);
+    database.checkPermissionsOnDatabase(SecurityDatabaseUser.DatabaseAccess.UPDATE_SCHEMA);
 
     if (bucketMap.containsKey(bucketName))
       throw new SchemaException("Cannot create bucket '" + bucketName + "' because already exists");
@@ -320,7 +320,7 @@ public class LocalSchema implements Schema {
     return recordFileChanges(() -> {
       try {
         final LocalBucket bucket = new LocalBucket(database, bucketName, databasePath + File.separator + bucketName,
-            ComponentFile.MODE.READ_WRITE, pageSize, LocalBucket.CURRENT_VERSION);
+            ComponentFile.Mode.READ_WRITE, pageSize, LocalBucket.CURRENT_VERSION);
         registerFile((Component) bucket);
         bucketMap.put(bucketName, bucket);
 
@@ -344,7 +344,7 @@ public class LocalSchema implements Schema {
   @Override
   public DocumentType copyType(final String typeName, final String newTypeName, final Class<? extends DocumentType> newTypeClass,
       final int buckets, final int pageSize, final int transactionBatchSize) {
-    database.checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);
+    database.checkPermissionsOnDatabase(SecurityDatabaseUser.DatabaseAccess.UPDATE_SCHEMA);
 
     if (existsType(newTypeName))
       throw new IllegalArgumentException("Type '" + newTypeName + "' already exists");
@@ -440,7 +440,7 @@ public class LocalSchema implements Schema {
 
   @Override
   public void dropIndex(final String indexName) {
-    database.checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);
+    database.checkPermissionsOnDatabase(SecurityDatabaseUser.DatabaseAccess.UPDATE_SCHEMA);
 
     recordFileChanges(() -> {
       boolean setMultipleUpdate = !multipleUpdate;
@@ -520,21 +520,21 @@ public class LocalSchema implements Schema {
   }
 
   @Override
-  public TypeIndex createTypeIndex(final INDEX_TYPE indexType, final boolean unique, final String typeName,
+  public TypeIndex createTypeIndex(final IndexType indexType, final boolean unique, final String typeName,
       final String... propertyNames) {
     return buildTypeIndex(typeName, propertyNames).withType(indexType).withUnique(unique).create();
   }
 
   @Override
   @Deprecated
-  public TypeIndex createTypeIndex(final INDEX_TYPE indexType, final boolean unique, final String typeName,
+  public TypeIndex createTypeIndex(final IndexType indexType, final boolean unique, final String typeName,
       final String[] propertyNames, final int pageSize) {
     return buildTypeIndex(typeName, propertyNames).withType(indexType).withUnique(unique).withPageSize(pageSize).create();
   }
 
   @Override
   @Deprecated
-  public TypeIndex createTypeIndex(final INDEX_TYPE indexType, final boolean unique, final String typeName,
+  public TypeIndex createTypeIndex(final IndexType indexType, final boolean unique, final String typeName,
       final String[] propertyNames, final int pageSize, final Index.BuildIndexCallback callback) {
     return buildTypeIndex(typeName, propertyNames).withType(indexType).withUnique(unique).withPageSize(pageSize)
         .withCallback(callback).create();
@@ -542,22 +542,22 @@ public class LocalSchema implements Schema {
 
   @Override
   @Deprecated
-  public TypeIndex createTypeIndex(final INDEX_TYPE indexType, final boolean unique, final String typeName,
-      final String[] propertyNames, final int pageSize, final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy,
+  public TypeIndex createTypeIndex(final IndexType indexType, final boolean unique, final String typeName,
+      final String[] propertyNames, final int pageSize, final LSMTreeIndexAbstract.NullStrategy nullStrategy,
       final Index.BuildIndexCallback callback) {
     return buildTypeIndex(typeName, propertyNames).withType(indexType).withUnique(unique).withPageSize(pageSize)
         .withCallback(callback).withNullStrategy(nullStrategy).create();
   }
 
   @Override
-  public TypeIndex getOrCreateTypeIndex(final INDEX_TYPE indexType, final boolean unique, final String typeName,
+  public TypeIndex getOrCreateTypeIndex(final IndexType indexType, final boolean unique, final String typeName,
       final String... propertyNames) {
     return buildTypeIndex(typeName, propertyNames).withType(indexType).withUnique(unique).withIgnoreIfExists(true).create();
   }
 
   @Override
   @Deprecated
-  public TypeIndex getOrCreateTypeIndex(final INDEX_TYPE indexType, final boolean unique, final String typeName,
+  public TypeIndex getOrCreateTypeIndex(final IndexType indexType, final boolean unique, final String typeName,
       final String[] propertyNames, final int pageSize) {
     return buildTypeIndex(typeName, propertyNames).withType(indexType).withUnique(unique).withPageSize(pageSize)
         .withIgnoreIfExists(true).create();
@@ -565,7 +565,7 @@ public class LocalSchema implements Schema {
 
   @Override
   @Deprecated
-  public TypeIndex getOrCreateTypeIndex(final INDEX_TYPE indexType, final boolean unique, final String typeName,
+  public TypeIndex getOrCreateTypeIndex(final IndexType indexType, final boolean unique, final String typeName,
       final String[] propertyNames, final int pageSize, final Index.BuildIndexCallback callback) {
     return buildTypeIndex(typeName, propertyNames).withType(indexType).withUnique(unique).withPageSize(pageSize)
         .withCallback(callback).withIgnoreIfExists(true).create();
@@ -573,8 +573,8 @@ public class LocalSchema implements Schema {
 
   @Override
   @Deprecated
-  public TypeIndex getOrCreateTypeIndex(final INDEX_TYPE indexType, final boolean unique, final String typeName,
-      final String[] propertyNames, final int pageSize, final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy,
+  public TypeIndex getOrCreateTypeIndex(final IndexType indexType, final boolean unique, final String typeName,
+      final String[] propertyNames, final int pageSize, final LSMTreeIndexAbstract.NullStrategy nullStrategy,
       final Index.BuildIndexCallback callback) {
     return buildTypeIndex(typeName, propertyNames).withType(indexType).withUnique(unique).withPageSize(pageSize)
         .withNullStrategy(nullStrategy).withCallback(callback).withIgnoreIfExists(true).create();
@@ -582,8 +582,8 @@ public class LocalSchema implements Schema {
 
   @Override
   @Deprecated
-  public Index createBucketIndex(final INDEX_TYPE indexType, final boolean unique, final String typeName, final String bucketName,
-      final String[] propertyNames, final int pageSize, final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy,
+  public Index createBucketIndex(final IndexType indexType, final boolean unique, final String typeName, final String bucketName,
+      final String[] propertyNames, final int pageSize, final LSMTreeIndexAbstract.NullStrategy nullStrategy,
       final Index.BuildIndexCallback callback) {
     return buildBucketIndex(typeName, bucketName, propertyNames).withType(indexType).withUnique(unique).withPageSize(pageSize)
         .withNullStrategy(nullStrategy).withCallback(callback).create();
@@ -591,8 +591,8 @@ public class LocalSchema implements Schema {
 
   @Override
   @Deprecated
-  public Index createManualIndex(final INDEX_TYPE indexType, final boolean unique, final String indexName, final Type[] keyTypes,
-      final int pageSize, final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy) {
+  public Index createManualIndex(final IndexType indexType, final boolean unique, final String indexName, final Type[] keyTypes,
+      final int pageSize, final LSMTreeIndexAbstract.NullStrategy nullStrategy) {
     return buildManualIndex(indexName, keyTypes).withUnique(unique).withPageSize(pageSize).withNullStrategy(nullStrategy).create();
   }
 
@@ -709,7 +709,7 @@ public class LocalSchema implements Schema {
   }
 
   public void dropType(final String typeName) {
-    database.checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);
+    database.checkPermissionsOnDatabase(SecurityDatabaseUser.DatabaseAccess.UPDATE_SCHEMA);
 
     recordFileChanges(() -> {
       multipleUpdate = true;
@@ -755,7 +755,7 @@ public class LocalSchema implements Schema {
 
   @Override
   public void dropBucket(final String bucketName) {
-    database.checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);
+    database.checkPermissionsOnDatabase(SecurityDatabaseUser.DatabaseAccess.UPDATE_SCHEMA);
 
     final Bucket bucket = getBucketByName(bucketName);
 
@@ -1061,9 +1061,9 @@ public class LocalSchema implements Schema {
 
             IndexInternal index = indexMap.get(indexName);
             if (index != null) {
-              final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy = indexJSON.has("nullStrategy") ?
-                  LSMTreeIndexAbstract.NULL_STRATEGY.valueOf(indexJSON.getString("nullStrategy")) :
-                  LSMTreeIndexAbstract.NULL_STRATEGY.ERROR;
+              final LSMTreeIndexAbstract.NullStrategy nullStrategy = indexJSON.has("nullStrategy") ?
+                  LSMTreeIndexAbstract.NullStrategy.valueOf(indexJSON.getString("nullStrategy")) :
+                  LSMTreeIndexAbstract.NullStrategy.ERROR;
 
               index.setNullStrategy(nullStrategy);
 
@@ -1071,7 +1071,7 @@ public class LocalSchema implements Schema {
                 final String configuredIndexType = indexJSON.getString("type");
 
                 if (!index.getType().toString().equals(configuredIndexType)) {
-                  if (configuredIndexType.equalsIgnoreCase(Schema.INDEX_TYPE.FULL_TEXT.toString())) {
+                  if (configuredIndexType.equalsIgnoreCase(IndexType.FULL_TEXT.toString())) {
                     index = new LSMTreeFullTextIndex((LSMTreeIndex) index);
                     indexMap.put(indexName, index);
                   } else {
@@ -1131,9 +1131,9 @@ public class LocalSchema implements Schema {
                     for (int i = 0; i < properties.length; ++i)
                       properties[i] = schemaIndexProperties.getString(i);
 
-                    final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy = entry.getValue().has("nullStrategy") ?
-                        LSMTreeIndexAbstract.NULL_STRATEGY.valueOf(entry.getValue().getString("nullStrategy")) :
-                        LSMTreeIndexAbstract.NULL_STRATEGY.ERROR;
+                    final LSMTreeIndexAbstract.NullStrategy nullStrategy = entry.getValue().has("nullStrategy") ?
+                        LSMTreeIndexAbstract.NullStrategy.valueOf(entry.getValue().getString("nullStrategy")) :
+                        LSMTreeIndexAbstract.NullStrategy.ERROR;
 
                     index.setNullStrategy(nullStrategy);
                     type.addIndexInternal(index, bucket.getFileId(), properties, null);
@@ -1359,9 +1359,9 @@ public class LocalSchema implements Schema {
   }
 
   protected Index createBucketIndex(final LocalDocumentType type, final Type[] keyTypes, final Bucket bucket, final String typeName,
-      final INDEX_TYPE indexType, final boolean unique, final int pageSize, final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy,
+      final IndexType indexType, final boolean unique, final int pageSize, final LSMTreeIndexAbstract.NullStrategy nullStrategy,
       final Index.BuildIndexCallback callback, final String[] propertyNames, final TypeIndex propIndex, final int batchSize) {
-    database.checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);
+    database.checkPermissionsOnDatabase(SecurityDatabaseUser.DatabaseAccess.UPDATE_SCHEMA);
 
     if (bucket == null)
       throw new IllegalArgumentException("bucket is null");

--- a/engine/src/main/java/com/arcadedb/schema/ManualIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/ManualIndexBuilder.java
@@ -42,7 +42,7 @@ public class ManualIndexBuilder extends IndexBuilder<Index> {
   }
 
   public Index create() {
-    database.checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);
+    database.checkPermissionsOnDatabase(SecurityDatabaseUser.DatabaseAccess.UPDATE_SCHEMA);
 
     if (database.isAsyncProcessing())
       throw new NeedRetryException("Cannot create a new index while asynchronous tasks are running");

--- a/engine/src/main/java/com/arcadedb/schema/Property.java
+++ b/engine/src/main/java/com/arcadedb/schema/Property.java
@@ -38,9 +38,9 @@ public interface Property {
   Set<String> METADATA_PROPERTIES = Set.of(RID_PROPERTY, TYPE_PROPERTY, IN_PROPERTY, OUT_PROPERTY, CAT_PROPERTY,
       PROPERTY_TYPES_PROPERTY);
 
-  Index createIndex(Schema.INDEX_TYPE type, boolean unique);
+  Index createIndex(Schema.IndexType type, boolean unique);
 
-  Index getOrCreateIndex(Schema.INDEX_TYPE type, boolean unique);
+  Index getOrCreateIndex(Schema.IndexType type, boolean unique);
 
   String getName();
 

--- a/engine/src/main/java/com/arcadedb/schema/Schema.java
+++ b/engine/src/main/java/com/arcadedb/schema/Schema.java
@@ -36,6 +36,10 @@ import java.util.TimeZone;
 @ExcludeFromJacocoGeneratedReport
 public interface Schema {
 
+  enum IndexType {
+    LSM_TREE, FULL_TEXT, HNSW
+  }
+
   Component getFileById(int id);
 
   boolean existsBucket(String bucketName);
@@ -67,64 +71,64 @@ public interface Schema {
 
   VectorIndexBuilder buildVectorIndex();
 
-  TypeIndex createTypeIndex(Schema.INDEX_TYPE indexType, boolean unique, String typeName, String... propertyNames);
+  TypeIndex createTypeIndex(IndexType indexType, boolean unique, String typeName, String... propertyNames);
 
   /**
    * @Deprecated. Use `buildTypeIndex(typeName, propertyNames).withUnique(unique).withPageSize(pageSize).create()` instead.
    */
   @Deprecated
-  TypeIndex createTypeIndex(Schema.INDEX_TYPE indexType, boolean unique, String typeName, String[] propertyNames, int pageSize);
+  TypeIndex createTypeIndex(IndexType indexType, boolean unique, String typeName, String[] propertyNames, int pageSize);
 
   /**
    * @Deprecated. Use `buildTypeIndex(typeName, propertyNames).withUnique(unique).withPageSize(pageSize).withCallback(callback).create()` instead.
    */
   @Deprecated
-  TypeIndex createTypeIndex(Schema.INDEX_TYPE indexType, boolean unique, String typeName, String[] propertyNames, int pageSize,
+  TypeIndex createTypeIndex(IndexType indexType, boolean unique, String typeName, String[] propertyNames, int pageSize,
       Index.BuildIndexCallback callback);
 
   /**
    * @Deprecated. Use `buildTypeIndex(typeName, propertyNames).withUnique(unique).withPageSize(pageSize).withCallback(callback).withNullStrategy(nullStrategy).create()` instead.
    */
   @Deprecated
-  TypeIndex createTypeIndex(Schema.INDEX_TYPE indexType, boolean unique, String typeName, String[] propertyNames, int pageSize,
-      LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy, Index.BuildIndexCallback callback);
+  TypeIndex createTypeIndex(IndexType indexType, boolean unique, String typeName, String[] propertyNames, int pageSize,
+      LSMTreeIndexAbstract.NullStrategy nullStrategy, Index.BuildIndexCallback callback);
 
-  TypeIndex getOrCreateTypeIndex(Schema.INDEX_TYPE indexType, boolean unique, String typeName, String... propertyNames);
+  TypeIndex getOrCreateTypeIndex(IndexType indexType, boolean unique, String typeName, String... propertyNames);
 
   /**
    * @Deprecated. Use `buildTypeIndex(typeName, propertyNames).withUnique(unique).withPageSize(pageSize).withIgnoreIfExists(true).create()` instead.
    */
   @Deprecated
-  TypeIndex getOrCreateTypeIndex(Schema.INDEX_TYPE indexType, boolean unique, String typeName, String[] propertyNames,
+  TypeIndex getOrCreateTypeIndex(IndexType indexType, boolean unique, String typeName, String[] propertyNames,
       int pageSize);
 
   /**
    * @Deprecated. Use `buildTypeIndex(typeName, propertyNames).withUnique(unique).withPageSize(pageSize).withCallback(callback).withIgnoreIfExists(true).create()` instead.
    */
   @Deprecated
-  TypeIndex getOrCreateTypeIndex(Schema.INDEX_TYPE indexType, boolean unique, String typeName, String[] propertyNames, int pageSize,
+  TypeIndex getOrCreateTypeIndex(IndexType indexType, boolean unique, String typeName, String[] propertyNames, int pageSize,
       Index.BuildIndexCallback callback);
 
   /**
    * @Deprecated. Use `buildTypeIndex(typeName, propertyNames).withUnique(unique).withPageSize(pageSize).withCallback(callback).withNullStrategy(nullStrategy).withIgnoreIfExists(true).create()` instead.
    */
   @Deprecated
-  TypeIndex getOrCreateTypeIndex(Schema.INDEX_TYPE indexType, boolean unique, String typeName, String[] propertyNames, int pageSize,
-      LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy, Index.BuildIndexCallback callback);
+  TypeIndex getOrCreateTypeIndex(IndexType indexType, boolean unique, String typeName, String[] propertyNames, int pageSize,
+      LSMTreeIndexAbstract.NullStrategy nullStrategy, Index.BuildIndexCallback callback);
 
   /**
    * @Deprecated. Use `buildBucketIndex(typeName, propertyNames).withUnique(unique).withPageSize(pageSize).withCallback(callback).withNullStrategy(nullStrategy).create()` instead.
    */
   @Deprecated
-  Index createBucketIndex(Schema.INDEX_TYPE indexType, boolean unique, String typeName, String bucketName, String[] propertyNames,
-      int pageSize, LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy, Index.BuildIndexCallback callback);
+  Index createBucketIndex(IndexType indexType, boolean unique, String typeName, String bucketName, String[] propertyNames,
+      int pageSize, LSMTreeIndexAbstract.NullStrategy nullStrategy, Index.BuildIndexCallback callback);
 
   /**
    * @Deprecated. Use `buildManualIndex(indexName, keyTypes).withType(indexType).withUnique(unique).withPageSize(pageSize).withNullStrategy(nullStrategy).create()` instead.
    */
   @Deprecated
-  Index createManualIndex(Schema.INDEX_TYPE indexType, boolean unique, String indexName, Type[] keyTypes, int pageSize,
-      LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy);
+  Index createManualIndex(IndexType indexType, boolean unique, String indexName, Type[] keyTypes, int pageSize,
+      LSMTreeIndexAbstract.NullStrategy nullStrategy);
 
   Dictionary getDictionary();
 
@@ -371,7 +375,4 @@ public interface Schema {
    */
   FunctionDefinition getFunction(String libraryName, String functionName) throws IllegalArgumentException;
 
-  enum INDEX_TYPE {
-    LSM_TREE, FULL_TEXT, HNSW
-  }
 }

--- a/engine/src/main/java/com/arcadedb/schema/TypeBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeBuilder.java
@@ -53,7 +53,7 @@ public class TypeBuilder<T> {
   }
 
   public T create() {
-    database.checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);
+    database.checkPermissionsOnDatabase(SecurityDatabaseUser.DatabaseAccess.UPDATE_SCHEMA);
 
     if (typeName == null || typeName.isEmpty())
       throw new IllegalArgumentException("Missing type");

--- a/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
@@ -51,7 +51,7 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
 
   @Override
   public TypeIndex create() {
-    database.checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);
+    database.checkPermissionsOnDatabase(SecurityDatabaseUser.DatabaseAccess.UPDATE_SCHEMA);
 
     if (database.isAsyncProcessing())
       throw new NeedRetryException("Cannot create a new index while asynchronous tasks are running");

--- a/engine/src/main/java/com/arcadedb/schema/VectorIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/VectorIndexBuilder.java
@@ -68,7 +68,7 @@ public class VectorIndexBuilder extends IndexBuilder<HnswVectorIndex> {
 
   public VectorIndexBuilder(final Database database, final HnswVectorIndexRAM origin) {
     super((DatabaseInternal) database, HnswVectorIndex.class);
-    this.indexType = Schema.INDEX_TYPE.HNSW;
+    this.indexType = Schema.IndexType.HNSW;
     this.origin = origin;
     this.dimensions = origin.getDimensions();
     this.distanceFunction = origin.getDistanceFunction();
@@ -80,7 +80,7 @@ public class VectorIndexBuilder extends IndexBuilder<HnswVectorIndex> {
   }
 
   public HnswVectorIndex create() {
-    database.checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);
+    database.checkPermissionsOnDatabase(SecurityDatabaseUser.DatabaseAccess.UPDATE_SCHEMA);
 
     if (database.isAsyncProcessing())
       throw new NeedRetryException("Cannot create a new index while asynchronous tasks are running");

--- a/engine/src/main/java/com/arcadedb/security/SecurityDatabaseUser.java
+++ b/engine/src/main/java/com/arcadedb/security/SecurityDatabaseUser.java
@@ -27,7 +27,7 @@ import com.arcadedb.utility.ExcludeFromJacocoGeneratedReport;
  */
 @ExcludeFromJacocoGeneratedReport
 public interface SecurityDatabaseUser {
-  enum ACCESS {
+  enum Access {
     CREATE_RECORD("createRecord", "create records"),//
     READ_RECORD("readRecord", "read records"),//
     UPDATE_RECORD("updateRecord", "update records"),//
@@ -36,13 +36,13 @@ public interface SecurityDatabaseUser {
     public final String name;
     public final String fullName;
 
-    ACCESS(final String name, final String fullName) {
+    Access(final String name, final String fullName) {
       this.name = name;
       this.fullName = fullName;
     }
   }
 
-  enum DATABASE_ACCESS {
+  enum DatabaseAccess {
     UPDATE_SECURITY("updateSecurity", "update security"),//
     UPDATE_SCHEMA("updateSchema", "update schema"),//
     UPDATE_DATABASE_SETTINGS("updateDatabaseSettings", "update database settings");
@@ -50,22 +50,22 @@ public interface SecurityDatabaseUser {
     public final String name;
     public final String fullName;
 
-    DATABASE_ACCESS(final String name, final String fullName) {
+    DatabaseAccess(final String name, final String fullName) {
       this.name = name;
       this.fullName = fullName;
     }
 
-    public static DATABASE_ACCESS getByName(final String name) {
-      for (final DATABASE_ACCESS v : DATABASE_ACCESS.values())
+    public static DatabaseAccess getByName(final String name) {
+      for (final DatabaseAccess v : DatabaseAccess.values())
         if (v.name.equals(name))
           return v;
       return null;
     }
   }
 
-  boolean requestAccessOnDatabase(DATABASE_ACCESS access);
+  boolean requestAccessOnDatabase(DatabaseAccess access);
 
-  boolean requestAccessOnFile(int fileId, ACCESS access);
+  boolean requestAccessOnFile(int fileId, Access access);
 
   String getName();
 

--- a/engine/src/main/java/com/arcadedb/serializer/JsonGraphSerializer.java
+++ b/engine/src/main/java/com/arcadedb/serializer/JsonGraphSerializer.java
@@ -105,17 +105,17 @@ public class JsonGraphSerializer extends JsonSerializer {
 
       if (expandVertexEdges) {
         final JSONArray outEdges = new JSONArray();
-        for (final Edge e : vertex.getEdges(Vertex.DIRECTION.OUT))
+        for (final Edge e : vertex.getEdges(Vertex.Direction.OUT))
           outEdges.put(e.getIdentity().toString());
         object.put("o", outEdges);
 
         final JSONArray inEdges = new JSONArray();
-        for (final Edge e : vertex.getEdges(Vertex.DIRECTION.IN))
+        for (final Edge e : vertex.getEdges(Vertex.Direction.IN))
           inEdges.put(e.getIdentity().toString());
         object.put("i", inEdges);
       } else {
-        object.put("i", vertex.countEdges(Vertex.DIRECTION.IN, null));
-        object.put("o", vertex.countEdges(Vertex.DIRECTION.OUT, null));
+        object.put("i", vertex.countEdges(Vertex.Direction.IN, null));
+        object.put("o", vertex.countEdges(Vertex.Direction.OUT, null));
       }
 
     } else if (document instanceof Edge edge1) {

--- a/engine/src/main/java/com/arcadedb/serializer/JsonSerializer.java
+++ b/engine/src/main/java/com/arcadedb/serializer/JsonSerializer.java
@@ -260,17 +260,17 @@ public class JsonSerializer {
       object.put(CAT_PROPERTY, "v");
       if (includeVertexEdges) {
         if (useVertexEdgeSize) {
-          object.put(OUT_PROPERTY, vertex.countEdges(Vertex.DIRECTION.OUT, null));
-          object.put(IN_PROPERTY, vertex.countEdges(Vertex.DIRECTION.IN, null));
+          object.put(OUT_PROPERTY, vertex.countEdges(Vertex.Direction.OUT, null));
+          object.put(IN_PROPERTY, vertex.countEdges(Vertex.Direction.IN, null));
 
         } else {
           final JSONArray outEdges = new JSONArray();
-          for (final Edge e : vertex.getEdges(Vertex.DIRECTION.OUT))
+          for (final Edge e : vertex.getEdges(Vertex.Direction.OUT))
             outEdges.put(e.getIdentity().toString());
           object.put(OUT_PROPERTY, outEdges);
 
           final JSONArray inEdges = new JSONArray();
-          for (final Edge e : vertex.getEdges(Vertex.DIRECTION.IN))
+          for (final Edge e : vertex.getEdges(Vertex.Direction.IN))
             inEdges.put(e.getIdentity().toString());
           object.put(IN_PROPERTY, inEdges);
         }

--- a/engine/src/main/java/com/arcadedb/utility/LockManager.java
+++ b/engine/src/main/java/com/arcadedb/utility/LockManager.java
@@ -29,7 +29,7 @@ import java.util.logging.*;
  * Lock manager implementation.
  */
 public class LockManager<RESOURCE, REQUESTER> {
-  public enum LOCK_STATUS {NO, YES, ALREADY_ACQUIRED}
+  public enum LockStatus {NO, YES, ALREADY_ACQUIRED}
 
   private final ConcurrentHashMap<RESOURCE, DistributedLock> lockManager = new ConcurrentHashMap<>(256);
 
@@ -45,7 +45,7 @@ public class LockManager<RESOURCE, REQUESTER> {
     }
   }
 
-  public LOCK_STATUS tryLock(final RESOURCE resource, final REQUESTER requester, final long timeout) {
+  public LockStatus tryLock(final RESOURCE resource, final REQUESTER requester, final long timeout) {
     if (resource == null)
       throw new IllegalArgumentException("Resource to lock is null");
 
@@ -59,7 +59,7 @@ public class LockManager<RESOURCE, REQUESTER> {
       if (currentLock.owner.equals(requester)) {
         // SAME RESOURCE/SERVER, ALREADY LOCKED
         LogManager.instance().log(this, Level.FINE, "Resource '%s' already locked by requester '%s'", resource, currentLock.owner);
-        return LOCK_STATUS.ALREADY_ACQUIRED;
+        return LockStatus.ALREADY_ACQUIRED;
       } else {
         // TRY TO RE-LOCK IT UNTIL TIMEOUT IS EXPIRED
         final long startTime = System.currentTimeMillis();
@@ -81,7 +81,7 @@ public class LockManager<RESOURCE, REQUESTER> {
       }
     }
 
-    return currentLock == null ? LOCK_STATUS.YES : LOCK_STATUS.NO;
+    return currentLock == null ? LockStatus.YES : LockStatus.NO;
   }
 
   public void unlock(final RESOURCE resource, final REQUESTER requester) {

--- a/engine/src/main/java/com/arcadedb/utility/TableFormatter.java
+++ b/engine/src/main/java/com/arcadedb/utility/TableFormatter.java
@@ -44,31 +44,29 @@ import static com.arcadedb.schema.Property.RID_PROPERTY;
 import static com.arcadedb.schema.Property.TYPE_PROPERTY;
 
 public class TableFormatter {
-  public static final  int    DEFAULT_MAX_WIDTH = 150;
-  private static final String TYPE_COLUMN       = "@TYPE";
-  private static final String RID_COLUMN        = "@RID";
+  public static final    int                              DEFAULT_MAX_WIDTH    = 150;
+  private static final   String                           TYPE_COLUMN          = "@TYPE";
+  private static final   String                           RID_COLUMN           = "@RID";
+  protected final static String                           MORE                 = "...";
+  protected final static SimpleDateFormat                 DEF_DATEFORMAT       = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+  protected final        Map<String, Alignment>           columnAlignment      = new LinkedHashMap<String, Alignment>();
+  protected final        Map<String, Map<String, String>> columnMetadata       = new LinkedHashMap<String, Map<String, String>>();
+  protected final        Set<String>                      columnHidden         = new HashSet<String>();
+  protected final        TableOutput                      out;
+  protected final        int                              minColumnSize        = 4;
+  protected              Set<String>                      prefixedColumns      = new LinkedHashSet<>();
+  protected              int                              maxMultiValueEntries = 10;
+  protected              Pair<String, Boolean>            columnSorting        = null;
+  protected              int                              maxWidthSize         = DEFAULT_MAX_WIDTH;
+  protected              String                           nullValue            = "";
+  protected              boolean                          leftBorder           = true;
+  protected              boolean                          rightBorder          = true;
+  protected              TableRow                         footer;
+  protected              boolean                          lastResultShrunk     = false;
 
-  public enum ALIGNMENT {
+  public enum Alignment {
     LEFT, CENTER, RIGHT
   }
-
-  protected final static String           MORE           = "...";
-  protected final static SimpleDateFormat DEF_DATEFORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
-
-  protected       Pair<String, Boolean>            columnSorting        = null;
-  protected final Map<String, ALIGNMENT>           columnAlignment      = new LinkedHashMap<String, ALIGNMENT>();
-  protected final Map<String, Map<String, String>> columnMetadata       = new LinkedHashMap<String, Map<String, String>>();
-  protected final Set<String>                      columnHidden         = new HashSet<String>();
-  protected       Set<String>                      prefixedColumns      = new LinkedHashSet<>();
-  protected final TableOutput                      out;
-  protected       int                              maxMultiValueEntries = 10;
-  protected final int                              minColumnSize        = 4;
-  protected       int                              maxWidthSize         = DEFAULT_MAX_WIDTH;
-  protected       String                           nullValue            = "";
-  protected       boolean                          leftBorder           = true;
-  protected       boolean                          rightBorder          = true;
-  protected       TableRow                         footer;
-  protected       boolean                          lastResultShrunk     = false;
 
   @ExcludeFromJacocoGeneratedReport
   public interface TableOutput {
@@ -182,7 +180,7 @@ public class TableFormatter {
     }
   }
 
-  public void setColumnAlignment(final String column, final ALIGNMENT alignment) {
+  public void setColumnAlignment(final String column, final Alignment alignment) {
     columnAlignment.put(column, alignment);
   }
 
@@ -269,7 +267,7 @@ public class TableFormatter {
     if (strippedValue == null)
       strippedValue = nullValue;
 
-    final ALIGNMENT alignment = columnAlignment.get(columnName);
+    final Alignment alignment = columnAlignment.get(columnName);
     if (alignment != null) {
       switch (alignment) {
       case LEFT: {

--- a/engine/src/test/java/com/arcadedb/ACIDTransactionTest.java
+++ b/engine/src/test/java/com/arcadedb/ACIDTransactionTest.java
@@ -113,7 +113,7 @@ public class ACIDTransactionTest extends TestHelper {
 
       // creating the index should throw exception because there's an aync creation ongoing: sometimes it doesn't happen, the async is finished
       try {
-        database.getSchema().getType("V").createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "id");
+        database.getSchema().getType("V").createTypeIndex(Schema.IndexType.LSM_TREE, true, "id");
       } catch (NeedRetryException e) {
         //no action
       }
@@ -175,7 +175,7 @@ public class ACIDTransactionTest extends TestHelper {
       v.set("surname", "Test");
       v.save();
 
-      ((DatabaseInternal) db).registerCallback(DatabaseInternal.CALLBACK_EVENT.TX_AFTER_WAL_WRITE, callback);
+      ((DatabaseInternal) db).registerCallback(DatabaseInternal.CallbackEvent.TX_AFTER_WAL_WRITE, callback);
 
       db.commit();
 
@@ -192,7 +192,7 @@ public class ACIDTransactionTest extends TestHelper {
 
     database.transaction(() -> assertThat(database.countType("V", true)).isEqualTo(1));
 
-    ((DatabaseInternal) db).unregisterCallback(DatabaseInternal.CALLBACK_EVENT.TX_AFTER_WAL_WRITE, callback);
+    ((DatabaseInternal) db).unregisterCallback(DatabaseInternal.CallbackEvent.TX_AFTER_WAL_WRITE, callback);
   }
 
   @Test
@@ -212,7 +212,7 @@ public class ACIDTransactionTest extends TestHelper {
     final AtomicInteger commits = new AtomicInteger(0);
 
     try {
-      ((DatabaseInternal) db).registerCallback(DatabaseInternal.CALLBACK_EVENT.TX_AFTER_WAL_WRITE, new Callable<>() {
+      ((DatabaseInternal) db).registerCallback(DatabaseInternal.CallbackEvent.TX_AFTER_WAL_WRITE, new Callable<>() {
         @Override
         public Void call() throws IOException {
           if (commits.incrementAndGet() > TOT - 1) {
@@ -286,7 +286,7 @@ public class ACIDTransactionTest extends TestHelper {
 
     try {
 
-      ((DatabaseInternal) db).registerCallback(DatabaseInternal.CALLBACK_EVENT.TX_AFTER_WAL_WRITE, callback);
+      ((DatabaseInternal) db).registerCallback(DatabaseInternal.CallbackEvent.TX_AFTER_WAL_WRITE, callback);
 
       for (; total.get() < TOT; total.incrementAndGet()) {
         final MutableDocument v = db.newDocument("V");
@@ -306,7 +306,7 @@ public class ACIDTransactionTest extends TestHelper {
     }
     ((DatabaseInternal) db).kill();
 
-    ((DatabaseInternal) db).unregisterCallback(DatabaseInternal.CALLBACK_EVENT.TX_AFTER_WAL_WRITE, callback);
+    ((DatabaseInternal) db).unregisterCallback(DatabaseInternal.CallbackEvent.TX_AFTER_WAL_WRITE, callback);
 
     verifyWALFilesAreStillPresent();
 
@@ -322,7 +322,7 @@ public class ACIDTransactionTest extends TestHelper {
       type.createProperty("symbol", Type.STRING);
       type.createProperty("date", Type.DATETIME);
       type.createProperty("history", Type.LIST);
-      type.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "symbol", "date");
+      type.createTypeIndex(Schema.IndexType.LSM_TREE, true, "symbol", "date");
 
       final DocumentType type2 = database.getSchema().buildDocumentType().withName("Aggregate").withTotalBuckets(1).create();
       type2.createProperty("volume", Type.LONG);
@@ -420,7 +420,7 @@ public class ACIDTransactionTest extends TestHelper {
     db.async().onError(exception -> errors.incrementAndGet());
 
     final VertexType type = database.getSchema().getOrCreateVertexType("Node");
-    type.getOrCreateProperty("id", Type.STRING).getOrCreateIndex(Schema.INDEX_TYPE.LSM_TREE, true);
+    type.getOrCreateProperty("id", Type.STRING).getOrCreateIndex(Schema.IndexType.LSM_TREE, true);
     type.setBucketSelectionStrategy(new ThreadBucketSelectionStrategy());
 
     database.getSchema().getOrCreateEdgeType("Arc");
@@ -554,7 +554,7 @@ public class ACIDTransactionTest extends TestHelper {
     final AtomicBoolean dbNotClosedCaught = new AtomicBoolean(false);
 
     database.close();
-    factory.registerCallback(DatabaseInternal.CALLBACK_EVENT.DB_NOT_CLOSED, () -> {
+    factory.registerCallback(DatabaseInternal.CallbackEvent.DB_NOT_CLOSED, () -> {
       dbNotClosedCaught.set(true);
       return null;
     });

--- a/engine/src/test/java/com/arcadedb/AsyncTest.java
+++ b/engine/src/test/java/com/arcadedb/AsyncTest.java
@@ -359,7 +359,7 @@ public class AsyncTest extends TestHelper {
     type.createProperty("id", Integer.class);
     type.createProperty("name", String.class);
     type.createProperty("surname", String.class);
-    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, TYPE_NAME, new String[] { "id" }, 20000);
+    database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, TYPE_NAME, new String[] { "id" }, 20000);
 
     database.commit();
 

--- a/engine/src/test/java/com/arcadedb/CRUDTest.java
+++ b/engine/src/test/java/com/arcadedb/CRUDTest.java
@@ -19,11 +19,9 @@
 package com.arcadedb;
 
 import com.arcadedb.database.Database;
-import com.arcadedb.database.Document;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.RID;
 import com.arcadedb.engine.DatabaseChecker;
-import com.arcadedb.graph.Vertex;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
@@ -32,8 +30,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.*;
 import java.util.logging.*;
-
-import org.assertj.core.api.Assertions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -146,7 +142,7 @@ public class CRUDTest extends TestHelper {
 
     try {
       db.getSchema().getType("V").createProperty("id", Type.STRING);
-      db.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "V", "id");
+      db.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, "V", "id");
 
       // ALL IN THE SAME TX
       db.transaction(() -> {

--- a/engine/src/test/java/com/arcadedb/ExplicitLockingTransactionTest.java
+++ b/engine/src/test/java/com/arcadedb/ExplicitLockingTransactionTest.java
@@ -328,7 +328,7 @@ public class ExplicitLockingTransactionTest extends TestHelper {
     }
 
     try {
-      database.begin(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
+      database.begin(Database.TransactionIsolationLevel.REPEATABLE_READ);
       database.query("sql", "select from Node").close();
       database.acquireLock().type("Node").lock();
       fail("This must fail because the tx is not empty");
@@ -339,7 +339,7 @@ public class ExplicitLockingTransactionTest extends TestHelper {
     database.getSchema().getOrCreateVertexType("Node2");
 
     try {
-      database.begin(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
+      database.begin(Database.TransactionIsolationLevel.REPEATABLE_READ);
       database.acquireLock().type("Node").lock();
 
       final MutableVertex v = db.newVertex("Node2");

--- a/engine/src/test/java/com/arcadedb/MVCCTest.java
+++ b/engine/src/test/java/com/arcadedb/MVCCTest.java
@@ -199,14 +199,14 @@ public class MVCCTest extends TestHelper {
       accountType.createProperty("surname", String.class);
       accountType.createProperty("registered", Date.class);
 
-      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Account", new String[] { "id" }, 5000000);
+      database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, "Account", new String[] { "id" }, 5000000);
 
       final VertexType txType = database.getSchema().buildVertexType().withName("Transaction").withTotalBuckets(PARALLEL).create();
       txType.createProperty("uuid", String.class);
       txType.createProperty("date", Date.class);
       txType.createProperty("amount", BigDecimal.class);
 
-      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Transaction", new String[] { "uuid" }, 5000000);
+      database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, "Transaction", new String[] { "uuid" }, 5000000);
 
       final EdgeType edgeType = database.getSchema().buildEdgeType().withName("PurchasedBy").withTotalBuckets(PARALLEL).create();
       edgeType.createProperty("date", Date.class);

--- a/engine/src/test/java/com/arcadedb/PageManagerStressTest.java
+++ b/engine/src/test/java/com/arcadedb/PageManagerStressTest.java
@@ -58,7 +58,7 @@ public class PageManagerStressTest {
         v.createProperty("locali", Integer.class);
         v.createProperty("notes1", String.class);
 
-        database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, TYPE_NAME, new String[] { "id" }, 5000000);
+        database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, false, TYPE_NAME, new String[] { "id" }, 5000000);
 
         database.commit();
       }

--- a/engine/src/test/java/com/arcadedb/RandomTestMultiThreadsTest.java
+++ b/engine/src/test/java/com/arcadedb/RandomTestMultiThreadsTest.java
@@ -52,9 +52,9 @@ public class RandomTestMultiThreadsTest extends TestHelper {
   private final AtomicLong                           mvccErrors              = new AtomicLong();
   private final Random                               rnd                     = new Random();
   private final AtomicLong                           uuid                    = new AtomicLong();
-  private final List<Pair<Integer, Exception>>       otherErrors             = Collections.synchronizedList(new ArrayList<>());
-  private final Database.TRANSACTION_ISOLATION_LEVEL txType                  = Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ;
-  private final boolean                              explicitLocks           = true;
+  private final List<Pair<Integer, Exception>>     otherErrors   = Collections.synchronizedList(new ArrayList<>());
+  private final Database.TransactionIsolationLevel txType        = Database.TransactionIsolationLevel.REPEATABLE_READ;
+  private final boolean                            explicitLocks = true;
   private final boolean                              debug                   = false;
 
   @Test
@@ -392,7 +392,7 @@ public class RandomTestMultiThreadsTest extends TestHelper {
       accountType.createProperty("surname", String.class);
       accountType.createProperty("registered", Date.class);
 
-      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Account", new String[] { "id" }, 500000);
+      database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, "Account", new String[] { "id" }, 500000);
 
       final VertexType txType = database.getSchema().buildVertexType().withName("Transaction").withTotalBuckets(BUCKETS).create();
       txType.createProperty("uuid", Long.class);
@@ -401,7 +401,7 @@ public class RandomTestMultiThreadsTest extends TestHelper {
       txType.createProperty("updated", Integer.class);
       txType.createProperty("longFieldUpdated", String.class);
 
-      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Transaction", new String[] { "uuid" }, 500000);
+      database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, "Transaction", new String[] { "uuid" }, 500000);
 
       final EdgeType edgeType = database.getSchema().buildEdgeType().withName("PurchasedBy").withTotalBuckets(BUCKETS).create();
       edgeType.createProperty("date", Date.class);

--- a/engine/src/test/java/com/arcadedb/RandomTestSingleThread.java
+++ b/engine/src/test/java/com/arcadedb/RandomTestSingleThread.java
@@ -172,14 +172,14 @@ public class RandomTestSingleThread extends TestHelper {
       accountType.createProperty("surname", String.class);
       accountType.createProperty("registered", Date.class);
 
-      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Account", "id");
+      database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, "Account", "id");
 
       final VertexType txType = database.getSchema().buildVertexType().withName("Transaction").withTotalBuckets(PARALLEL).create();
       txType.createProperty("uuid", String.class);
       txType.createProperty("date", Date.class);
       txType.createProperty("amount", BigDecimal.class);
 
-      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Transaction", "uuid");
+      database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, "Transaction", "uuid");
 
       final EdgeType edgeType = database.getSchema().buildEdgeType().withName("PurchasedBy").withTotalBuckets(PARALLEL).create();
       edgeType.createProperty("date", Date.class);

--- a/engine/src/test/java/com/arcadedb/TestHelper.java
+++ b/engine/src/test/java/com/arcadedb/TestHelper.java
@@ -130,7 +130,7 @@ public abstract class TestHelper {
       assertThat(DatabaseFactory.getActiveDatabaseInstance(database.getDatabasePath())).isNull();
     }
 
-    database = factory.open(ComponentFile.MODE.READ_ONLY);
+    database = factory.open(ComponentFile.Mode.READ_ONLY);
     assertThat(DatabaseFactory.getActiveDatabaseInstance(database.getDatabasePath())).isEqualTo(database);
   }
 
@@ -165,7 +165,7 @@ public abstract class TestHelper {
       if (isCheckingDatabaseIntegrity())
         checkDatabaseIntegrity();
 
-      if (database.getMode() == ComponentFile.MODE.READ_ONLY)
+      if (database.getMode() == ComponentFile.Mode.READ_ONLY)
         reopenDatabase();
 
       ((DatabaseInternal) database).getEmbedded().drop();

--- a/engine/src/test/java/com/arcadedb/TransactionIsolationTest.java
+++ b/engine/src/test/java/com/arcadedb/TransactionIsolationTest.java
@@ -2,7 +2,6 @@ package com.arcadedb;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.graph.MutableVertex;
-import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -166,7 +165,7 @@ public class TransactionIsolationTest extends TestHelper {
 
   @Test
   public void testRepeatableRead() throws InterruptedException {
-    database.setTransactionIsolationLevel(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
+    database.setTransactionIsolationLevel(Database.TransactionIsolationLevel.REPEATABLE_READ);
     try {
 
       final CountDownLatch sem1 = new CountDownLatch(1);
@@ -257,7 +256,7 @@ public class TransactionIsolationTest extends TestHelper {
       thread1.join(3000);
       thread2.join(3000);
     } finally {
-      database.setTransactionIsolationLevel(Database.TRANSACTION_ISOLATION_LEVEL.READ_COMMITTED);
+      database.setTransactionIsolationLevel(Database.TransactionIsolationLevel.READ_COMMITTED);
     }
   }
 }

--- a/engine/src/test/java/com/arcadedb/TransactionTypeTest.java
+++ b/engine/src/test/java/com/arcadedb/TransactionTypeTest.java
@@ -257,7 +257,7 @@ public class TransactionTypeTest extends TestHelper {
       if (!database.getSchema().existsType(TYPE_NAME)) {
         final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(3).create();
         type.createProperty("id", Integer.class);
-        database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, TYPE_NAME, "id");
+        database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, TYPE_NAME, "id");
       }
 
       for (int i = 0; i < TOT; ++i) {

--- a/engine/src/test/java/com/arcadedb/database/CheckDatabaseTest.java
+++ b/engine/src/test/java/com/arcadedb/database/CheckDatabaseTest.java
@@ -19,7 +19,6 @@
 package com.arcadedb.database;
 
 import com.arcadedb.TestHelper;
-import com.arcadedb.database.Record;
 import com.arcadedb.engine.LocalBucket;
 import com.arcadedb.engine.MutablePage;
 import com.arcadedb.engine.PageId;
@@ -319,7 +318,7 @@ public class CheckDatabaseTest extends TestHelper {
   }
 
   private int countEdges(final RID rootVertex) {
-    final Iterable<Edge> iter = rootVertex.asVertex().getEdges(Vertex.DIRECTION.OUT);
+    final Iterable<Edge> iter = rootVertex.asVertex().getEdges(Vertex.Direction.OUT);
     int totalEdges = 0;
     try {
       for (final Edge e : iter) {
@@ -340,7 +339,7 @@ public class CheckDatabaseTest extends TestHelper {
 
   private int countEdgesSegmentList(final RID rootVertex) {
     final EdgeLinkedList outEdges = ((DatabaseInternal) database).getGraphEngine()
-        .getEdgeHeadChunk((VertexInternal) rootVertex.asVertex(), Vertex.DIRECTION.OUT);
+        .getEdgeHeadChunk((VertexInternal) rootVertex.asVertex(), Vertex.Direction.OUT);
 
     return (int) outEdges.count(null);
   }

--- a/engine/src/test/java/com/arcadedb/database/DataEncryptionTest.java
+++ b/engine/src/test/java/com/arcadedb/database/DataEncryptionTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.graph.Vertex;
-import com.arcadedb.graph.Vertex.DIRECTION;
+import com.arcadedb.graph.Vertex.Direction;
 
 /**
  * @author Pawel Maslej
@@ -85,11 +85,11 @@ class DataEncryptionTest extends TestHelper {
     if (isEquals) {
       assertThat(p1.get("name")).isEqualTo("John");
       assertThat(p2.get("name")).isEqualTo("Doe");
-      assertThat(p1.getEdges(DIRECTION.OUT, "Knows").iterator().next().get("since")).isEqualTo(2024);
+      assertThat(p1.getEdges(Direction.OUT, "Knows").iterator().next().get("since")).isEqualTo(2024);
     } else {
       assertThat(((String) p1.get("name")).contains("John")).isFalse();
       assertThat(((String) p2.get("name")).contains("Doe")).isFalse();
-      assertThat(p1.getEdges(DIRECTION.OUT, "Knows").iterator().next().get("since").toString().contains("2024")).isFalse();
+      assertThat(p1.getEdges(Direction.OUT, "Knows").iterator().next().get("since").toString().contains("2024")).isFalse();
     }
   }
 }

--- a/engine/src/test/java/com/arcadedb/engine/FileManagerTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/FileManagerTest.java
@@ -38,7 +38,7 @@ public class FileManagerTest {
 
         // act and assert
         assertThrows(IllegalArgumentException.class, () -> {
-            new FileManager(dir.toFile().getAbsolutePath(), ComponentFile.MODE.READ_WRITE, FILE_EXT);
+            new FileManager(dir.toFile().getAbsolutePath(), ComponentFile.Mode.READ_WRITE, FILE_EXT);
         });
 
         // reset permissions to allow cleanup
@@ -54,7 +54,7 @@ public class FileManagerTest {
 
         // act and assert
         assertThrows(IllegalArgumentException.class, () -> {
-            new FileManager(dir.toFile().getAbsolutePath() + "/child", ComponentFile.MODE.READ_WRITE, FILE_EXT);
+            new FileManager(dir.toFile().getAbsolutePath() + "/child", ComponentFile.Mode.READ_WRITE, FILE_EXT);
         });
 
         // cleanup
@@ -66,7 +66,7 @@ public class FileManagerTest {
     void construtor_success_emptyDirectory(@TempDir Path dir) throws IOException {
         // arrange
         // act
-        FileManager fileManager = new FileManager(dir.toFile().getAbsolutePath(), ComponentFile.MODE.READ_WRITE, FILE_EXT);
+        FileManager fileManager = new FileManager(dir.toFile().getAbsolutePath(), ComponentFile.Mode.READ_WRITE, FILE_EXT);
 
         // assert
         assertTrue(fileManager.getFiles().isEmpty());
@@ -78,7 +78,7 @@ public class FileManagerTest {
         Path dir = Path.of(System.getProperty("java.io.tmpdir"), "nonExistentDir");
 
         // act
-        FileManager fileManager = new FileManager(dir.toFile().getAbsolutePath(), ComponentFile.MODE.READ_WRITE, FILE_EXT);
+        FileManager fileManager = new FileManager(dir.toFile().getAbsolutePath(), ComponentFile.Mode.READ_WRITE, FILE_EXT);
 
         // assert
         assertTrue(fileManager.getFiles().isEmpty());

--- a/engine/src/test/java/com/arcadedb/engine/RecordRecyclingTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/RecordRecyclingTest.java
@@ -4,7 +4,6 @@ import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.RID;
-import com.arcadedb.graph.MutableEdge;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.select.SelectIterator;
@@ -209,7 +208,7 @@ public class RecordRecyclingTest {
     db.transaction(() -> {
       for (int i = 0; i < deleteRecords; i++) {
         Vertex root = db.select().fromType(VERTEX_TYPE).limit(1).vertices().next();
-        Vertex connected = root.getVertices(Vertex.DIRECTION.OUT, EDGE_TYPE).iterator().next();
+        Vertex connected = root.getVertices(Vertex.Direction.OUT, EDGE_TYPE).iterator().next();
         connected.delete();
       }
     });

--- a/engine/src/test/java/com/arcadedb/engine/TestInsertAndSelectWithThreadBucketSelectionStrategy.java
+++ b/engine/src/test/java/com/arcadedb/engine/TestInsertAndSelectWithThreadBucketSelectionStrategy.java
@@ -45,8 +45,8 @@ public class TestInsertAndSelectWithThreadBucketSelectionStrategy {
           dtProducts.createProperty("start", Type.DATETIME_MICROS);
           dtProducts.createProperty("stop", Type.DATETIME_MICROS);
           dtProducts.createProperty("v", Type.STRING);
-          dtProducts.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "name");
-          dtProducts.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "type", "start", "stop");
+          dtProducts.createTypeIndex(Schema.IndexType.LSM_TREE, true, "name");
+          dtProducts.createTypeIndex(Schema.IndexType.LSM_TREE, false, "type", "start", "stop");
           dtProducts.setBucketSelectionStrategy(new ThreadBucketSelectionStrategy());
         });
       }

--- a/engine/src/test/java/com/arcadedb/event/DatabaseEventsTest.java
+++ b/engine/src/test/java/com/arcadedb/event/DatabaseEventsTest.java
@@ -23,7 +23,6 @@ import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.*;
@@ -320,7 +319,7 @@ public class DatabaseEventsTest extends TestHelper {
 
     database.getEvents().registerListener(listener);
     try {
-      database.getSchema().createVertexType("IndexedVertex").createProperty("counter", Type.INTEGER).createIndex(Schema.INDEX_TYPE.LSM_TREE, true);
+      database.getSchema().createVertexType("IndexedVertex").createProperty("counter", Type.INTEGER).createIndex(Schema.IndexType.LSM_TREE, true);
 
       database.transaction(() -> {
         final MutableVertex v1 = database.newVertex("IndexedVertex").set("id", "test");

--- a/engine/src/test/java/com/arcadedb/event/RecordEncryptionTest.java
+++ b/engine/src/test/java/com/arcadedb/event/RecordEncryptionTest.java
@@ -92,7 +92,7 @@ public class RecordEncryptionTest extends TestHelper
 
     assertThat(creates.get()).isEqualTo(1);
 
-    database.setTransactionIsolationLevel(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
+    database.setTransactionIsolationLevel(Database.TransactionIsolationLevel.REPEATABLE_READ);
     database.transaction(() -> {
       final Vertex v1 = database.iterateType("BackAccount", true).next().asVertex();
       assertThat(v1.getString("secret")).isEqualTo("Nobody must know John and Zuck are brothers");

--- a/engine/src/test/java/com/arcadedb/graph/BasicGraphTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/BasicGraphTest.java
@@ -56,7 +56,7 @@ public class BasicGraphTest extends BaseGraphTest {
       assertThat(v1.getTypeName()).isEqualTo(VERTEX1_TYPE_NAME);
       assertThat(v1.get("name")).isEqualTo(VERTEX1_TYPE_NAME);
 
-      final Iterator<Vertex> vertices2level = v1.getVertices(Vertex.DIRECTION.OUT, new String[] { EDGE1_TYPE_NAME }).iterator();
+      final Iterator<Vertex> vertices2level = v1.getVertices(Vertex.Direction.OUT, new String[] { EDGE1_TYPE_NAME }).iterator();
       assertThat(vertices2level).isNotNull();
       assertThat(vertices2level.hasNext()).isTrue();
 
@@ -66,7 +66,7 @@ public class BasicGraphTest extends BaseGraphTest {
       assertThat(v2.getTypeName()).isEqualTo(VERTEX2_TYPE_NAME);
       assertThat(v2.get("name")).isEqualTo(VERTEX2_TYPE_NAME);
 
-      final Iterator<Vertex> vertices2level2 = v1.getVertices(Vertex.DIRECTION.OUT, new String[] { EDGE2_TYPE_NAME }).iterator();
+      final Iterator<Vertex> vertices2level2 = v1.getVertices(Vertex.Direction.OUT, new String[] { EDGE2_TYPE_NAME }).iterator();
       assertThat(vertices2level2.hasNext()).isTrue();
 
       final Vertex v3 = vertices2level2.next();
@@ -75,7 +75,7 @@ public class BasicGraphTest extends BaseGraphTest {
       assertThat(v3.getTypeName()).isEqualTo(VERTEX2_TYPE_NAME);
       assertThat(v3.get("name")).isEqualTo("V3");
 
-      final Iterator<Vertex> vertices3level = v2.getVertices(Vertex.DIRECTION.OUT, new String[] { EDGE2_TYPE_NAME }).iterator();
+      final Iterator<Vertex> vertices3level = v2.getVertices(Vertex.Direction.OUT, new String[] { EDGE2_TYPE_NAME }).iterator();
       assertThat(vertices3level).isNotNull();
       assertThat(vertices3level.hasNext()).isTrue();
 
@@ -91,8 +91,8 @@ public class BasicGraphTest extends BaseGraphTest {
       assertThat(v3.isConnectedTo(v1)).isTrue();
       assertThat(v2.isConnectedTo(v3)).isTrue();
 
-      assertThat(v3.isConnectedTo(v1, Vertex.DIRECTION.OUT)).isFalse();
-      assertThat(v3.isConnectedTo(v2, Vertex.DIRECTION.OUT)).isFalse();
+      assertThat(v3.isConnectedTo(v1, Vertex.Direction.OUT)).isFalse();
+      assertThat(v3.isConnectedTo(v2, Vertex.Direction.OUT)).isFalse();
 
     } finally {
       database.commit();
@@ -107,7 +107,7 @@ public class BasicGraphTest extends BaseGraphTest {
       final Vertex v1 = (Vertex) database.lookupByRID(root, false);
       assertThat(v1).isNotNull();
 
-      final Iterator<Edge> edges3 = v1.getEdges(Vertex.DIRECTION.OUT, new String[] { EDGE2_TYPE_NAME }).iterator();
+      final Iterator<Edge> edges3 = v1.getEdges(Vertex.Direction.OUT, new String[] { EDGE2_TYPE_NAME }).iterator();
       assertThat(edges3).isNotNull();
       assertThat(edges3.hasNext()).isTrue();
 
@@ -138,7 +138,7 @@ public class BasicGraphTest extends BaseGraphTest {
       assertThat(v1).isNotNull();
 
       // TEST CONNECTED EDGES
-      final Iterator<Edge> edges1 = v1.getEdges(Vertex.DIRECTION.OUT, new String[] { EDGE1_TYPE_NAME }).iterator();
+      final Iterator<Edge> edges1 = v1.getEdges(Vertex.Direction.OUT, new String[] { EDGE1_TYPE_NAME }).iterator();
       assertThat(edges1).isNotNull();
       assertThat(edges1.hasNext()).isTrue();
 
@@ -152,7 +152,7 @@ public class BasicGraphTest extends BaseGraphTest {
       final Vertex v2 = e1.getInVertex();
       assertThat(v2.get("name")).isEqualTo(VERTEX2_TYPE_NAME);
 
-      final Iterator<Edge> edges2 = v2.getEdges(Vertex.DIRECTION.OUT, new String[] { EDGE2_TYPE_NAME }).iterator();
+      final Iterator<Edge> edges2 = v2.getEdges(Vertex.Direction.OUT, new String[] { EDGE2_TYPE_NAME }).iterator();
       assertThat(edges2.hasNext()).isTrue();
 
       final Edge e2 = edges2.next();
@@ -165,7 +165,7 @@ public class BasicGraphTest extends BaseGraphTest {
       final Vertex v3 = e2.getInVertex();
       assertThat(v3.get("name")).isEqualTo("V3");
 
-      final Iterator<Edge> edges3 = v1.getEdges(Vertex.DIRECTION.OUT, new String[] { EDGE2_TYPE_NAME }).iterator();
+      final Iterator<Edge> edges3 = v1.getEdges(Vertex.Direction.OUT, new String[] { EDGE2_TYPE_NAME }).iterator();
       assertThat(edges3).isNotNull();
       assertThat(edges3.hasNext()).isTrue();
 
@@ -199,7 +199,7 @@ public class BasicGraphTest extends BaseGraphTest {
       v1Copy.save();
 
       // TEST CONNECTED EDGES
-      final Iterator<Edge> edges1 = v1.getEdges(Vertex.DIRECTION.OUT, new String[] { EDGE1_TYPE_NAME }).iterator();
+      final Iterator<Edge> edges1 = v1.getEdges(Vertex.Direction.OUT, new String[] { EDGE1_TYPE_NAME }).iterator();
       assertThat(edges1).isNotNull();
       assertThat(edges1.hasNext()).isTrue();
 
@@ -231,7 +231,7 @@ public class BasicGraphTest extends BaseGraphTest {
       final Vertex v1 = (Vertex) database.lookupByRID(root, false);
       assertThat(v1).isNotNull();
 
-      Iterator<Vertex> vertices = v1.getVertices(Vertex.DIRECTION.OUT).iterator();
+      Iterator<Vertex> vertices = v1.getVertices(Vertex.Direction.OUT).iterator();
       assertThat(vertices.hasNext()).isTrue();
       Vertex v3 = vertices.next();
       assertThat(v3).isNotNull();
@@ -248,14 +248,14 @@ public class BasicGraphTest extends BaseGraphTest {
 
       assertThat(database.countType(v1.getTypeName(), true)).isEqualTo(totalVertices - 1);
 
-      vertices = v2.getVertices(Vertex.DIRECTION.IN).iterator();
+      vertices = v2.getVertices(Vertex.Direction.IN).iterator();
       assertThat(vertices.hasNext()).isFalse();
 
-      vertices = v2.getVertices(Vertex.DIRECTION.OUT).iterator();
+      vertices = v2.getVertices(Vertex.Direction.OUT).iterator();
       assertThat(vertices.hasNext()).isTrue();
 
       // Expecting 1 edge only: V2 is still connected to V3
-      vertices = v3.getVertices(Vertex.DIRECTION.IN).iterator();
+      vertices = v3.getVertices(Vertex.Direction.IN).iterator();
       assertThat(vertices.hasNext()).isTrue();
       vertices.next();
       assertThat(vertices.hasNext()).isFalse();
@@ -264,16 +264,16 @@ public class BasicGraphTest extends BaseGraphTest {
       // -----------------------
       v2 = (Vertex) database.lookupByRID(v2.getIdentity(), true);
 
-      vertices = v2.getVertices(Vertex.DIRECTION.IN).iterator();
+      vertices = v2.getVertices(Vertex.Direction.IN).iterator();
       assertThat(vertices.hasNext()).isFalse();
 
-      vertices = v2.getVertices(Vertex.DIRECTION.OUT).iterator();
+      vertices = v2.getVertices(Vertex.Direction.OUT).iterator();
       assertThat(vertices.hasNext()).isTrue();
 
       v3 = (Vertex) database.lookupByRID(v3.getIdentity(), true);
 
       // Expecting 1 edge only: V2 is still connected to V3
-      vertices = v3.getVertices(Vertex.DIRECTION.IN).iterator();
+      vertices = v3.getVertices(Vertex.Direction.IN).iterator();
       assertThat(vertices.hasNext()).isTrue();
       vertices.next();
       assertThat(vertices.hasNext()).isFalse();
@@ -298,7 +298,7 @@ public class BasicGraphTest extends BaseGraphTest {
       final Vertex v1 = (Vertex) database.lookupByRID(root, false);
       assertThat(v1).isNotNull();
 
-      Iterator<Edge> edges = v1.getEdges(Vertex.DIRECTION.OUT).iterator();
+      Iterator<Edge> edges = v1.getEdges(Vertex.Direction.OUT).iterator();
       assertThat(edges.hasNext()).isTrue();
       final Edge e3 = edges.next();
       assertThat(e3).isNotNull();
@@ -312,14 +312,14 @@ public class BasicGraphTest extends BaseGraphTest {
       database.deleteRecord(e2);
 
       Vertex vOut = e2.getOutVertex();
-      edges = vOut.getEdges(Vertex.DIRECTION.OUT).iterator();
+      edges = vOut.getEdges(Vertex.Direction.OUT).iterator();
       assertThat(edges.hasNext()).isTrue();
 
       edges.next();
       assertThat(edges.hasNext()).isFalse();
 
       Vertex vIn = e2.getInVertex();
-      edges = vIn.getEdges(Vertex.DIRECTION.IN).iterator();
+      edges = vIn.getEdges(Vertex.Direction.IN).iterator();
       assertThat(edges.hasNext()).isFalse();
 
       // RELOAD AND CHECK AGAIN
@@ -331,14 +331,14 @@ public class BasicGraphTest extends BaseGraphTest {
       }
 
       vOut = e2.getOutVertex();
-      edges = vOut.getEdges(Vertex.DIRECTION.OUT).iterator();
+      edges = vOut.getEdges(Vertex.Direction.OUT).iterator();
       assertThat(edges.hasNext()).isTrue();
 
       edges.next();
       assertThat(edges.hasNext()).isFalse();
 
       vIn = e2.getInVertex();
-      edges = vIn.getEdges(Vertex.DIRECTION.IN).iterator();
+      edges = vIn.getEdges(Vertex.Direction.IN).iterator();
       assertThat(edges.hasNext()).isFalse();
 
     } finally {
@@ -355,7 +355,7 @@ public class BasicGraphTest extends BaseGraphTest {
       final Vertex v1 = (Vertex) database.lookupByRID(root, false);
       assertThat(v1).isNotNull();
 
-      Iterator<Edge> edges = v1.getEdges(Vertex.DIRECTION.OUT).iterator();
+      Iterator<Edge> edges = v1.getEdges(Vertex.Direction.OUT).iterator();
 
       assertThat(edges.hasNext()).isTrue();
       final Edge e3 = edges.next();
@@ -412,36 +412,36 @@ public class BasicGraphTest extends BaseGraphTest {
 
       database.command("sql", "create edge " + EDGE3_TYPE_NAME + " from ? to ? unidirectional", v1, v1);
 
-      assertThat(v1.getVertices(Vertex.DIRECTION.OUT).iterator().hasNext()).isTrue();
-      assertThat(v1.getVertices(Vertex.DIRECTION.OUT).iterator().next()).isEqualTo(v1);
-      assertThat(v1.getVertices(Vertex.DIRECTION.IN).iterator().hasNext()).isFalse();
+      assertThat(v1.getVertices(Vertex.Direction.OUT).iterator().hasNext()).isTrue();
+      assertThat(v1.getVertices(Vertex.Direction.OUT).iterator().next()).isEqualTo(v1);
+      assertThat(v1.getVertices(Vertex.Direction.IN).iterator().hasNext()).isFalse();
 
       // BIDIRECTIONAL EDGE
       final Vertex v2 = database.newVertex(VERTEX1_TYPE_NAME).save();
       v2.newEdge(EDGE1_TYPE_NAME, v2).save();
 
-      assertThat(v2.getVertices(Vertex.DIRECTION.OUT).iterator().hasNext()).isTrue();
-      assertThat(v2.getVertices(Vertex.DIRECTION.OUT).iterator().next()).isEqualTo(v2);
+      assertThat(v2.getVertices(Vertex.Direction.OUT).iterator().hasNext()).isTrue();
+      assertThat(v2.getVertices(Vertex.Direction.OUT).iterator().next()).isEqualTo(v2);
 
-      assertThat(v2.getVertices(Vertex.DIRECTION.IN).iterator().hasNext()).isTrue();
-      assertThat(v2.getVertices(Vertex.DIRECTION.IN).iterator().next()).isEqualTo(v2);
+      assertThat(v2.getVertices(Vertex.Direction.IN).iterator().hasNext()).isTrue();
+      assertThat(v2.getVertices(Vertex.Direction.IN).iterator().next()).isEqualTo(v2);
 
       database.commit();
 
       // UNIDIRECTIONAL EDGE
       final Vertex v1reloaded = (Vertex) database.lookupByRID(v1.getIdentity(), true);
-      assertThat(v1reloaded.getVertices(Vertex.DIRECTION.OUT).iterator().hasNext()).isTrue();
-      assertThat(v1reloaded.getVertices(Vertex.DIRECTION.OUT).iterator().next()).isEqualTo(v1reloaded);
-      assertThat(v1reloaded.getVertices(Vertex.DIRECTION.IN).iterator().hasNext()).isFalse();
+      assertThat(v1reloaded.getVertices(Vertex.Direction.OUT).iterator().hasNext()).isTrue();
+      assertThat(v1reloaded.getVertices(Vertex.Direction.OUT).iterator().next()).isEqualTo(v1reloaded);
+      assertThat(v1reloaded.getVertices(Vertex.Direction.IN).iterator().hasNext()).isFalse();
 
       // BIDIRECTIONAL EDGE
       final Vertex v2reloaded = (Vertex) database.lookupByRID(v2.getIdentity(), true);
 
-      assertThat(v2reloaded.getVertices(Vertex.DIRECTION.OUT).iterator().hasNext()).isTrue();
-      assertThat(v2reloaded.getVertices(Vertex.DIRECTION.OUT).iterator().next()).isEqualTo(v2reloaded);
+      assertThat(v2reloaded.getVertices(Vertex.Direction.OUT).iterator().hasNext()).isTrue();
+      assertThat(v2reloaded.getVertices(Vertex.Direction.OUT).iterator().next()).isEqualTo(v2reloaded);
 
-      assertThat(v2reloaded.getVertices(Vertex.DIRECTION.IN).iterator().hasNext()).isTrue();
-      assertThat(v2reloaded.getVertices(Vertex.DIRECTION.IN).iterator().next()).isEqualTo(v2reloaded);
+      assertThat(v2reloaded.getVertices(Vertex.Direction.IN).iterator().hasNext()).isTrue();
+      assertThat(v2reloaded.getVertices(Vertex.Direction.IN).iterator().next()).isEqualTo(v2reloaded);
 
     } finally {
       new DatabaseChecker(database).setVerboseLevel(0).check();
@@ -611,7 +611,7 @@ public class BasicGraphTest extends BaseGraphTest {
     final MutableVertex[] v2 = new MutableVertex[1];
     database.transaction(() -> {
       final EdgeType e = database.getSchema().createEdgeType("OnlyOneBetweenVertices");
-      e.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "@out", "@in");
+      e.createTypeIndex(Schema.IndexType.LSM_TREE, true, "@out", "@in");
 
       v1[0] = database.newVertex(VERTEX1_TYPE_NAME).set("id", 1001).save();
       v2[0] = database.newVertex(VERTEX1_TYPE_NAME).set("id", 1002).save();
@@ -628,7 +628,7 @@ public class BasicGraphTest extends BaseGraphTest {
     database.transaction(() -> v2[0].newEdge("OnlyOneBetweenVertices", v1[0]));
 
     database.transaction(() -> {
-      final Iterable<Edge> edges = v1[0].getEdges(Vertex.DIRECTION.OUT, "OnlyOneBetweenVertices");
+      final Iterable<Edge> edges = v1[0].getEdges(Vertex.Direction.OUT, "OnlyOneBetweenVertices");
       for (final Edge e : edges)
         e.delete();
     });
@@ -636,7 +636,7 @@ public class BasicGraphTest extends BaseGraphTest {
     database.transaction(() -> v1[0].newEdge("OnlyOneBetweenVertices", v2[0]));
 
     database.transaction(() -> {
-      final Iterable<Edge> edges = v2[0].getEdges(Vertex.DIRECTION.OUT, "OnlyOneBetweenVertices");
+      final Iterable<Edge> edges = v2[0].getEdges(Vertex.Direction.OUT, "OnlyOneBetweenVertices");
       for (final Edge e : edges)
         e.delete();
     });
@@ -739,7 +739,7 @@ public class BasicGraphTest extends BaseGraphTest {
         v1.newEdge("testEdgeDescendantOrderEdge", v2);
       }
 
-      final Iterator<Vertex> vertices = v1.getVertices(Vertex.DIRECTION.OUT).iterator();
+      final Iterator<Vertex> vertices = v1.getVertices(Vertex.Direction.OUT).iterator();
       for (int i = 10000 - 1; vertices.hasNext(); --i) {
         assertThat(vertices.next().get("id")).isEqualTo(i);
       }

--- a/engine/src/test/java/com/arcadedb/graph/InsertGraphIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/InsertGraphIndexTest.java
@@ -179,7 +179,7 @@ public class InsertGraphIndexTest extends TestHelper {
   private void createSchema() {
     final VertexType vertex = database.getSchema().buildVertexType().withName(VERTEX_TYPE_NAME).withTotalBuckets(PARALLEL).create();
     vertex.createProperty("id", Integer.class);
-    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, VERTEX_TYPE_NAME, "id");
+    database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, VERTEX_TYPE_NAME, "id");
 
     assertThat(vertex.getBucketSelectionStrategy().getName()).isEqualTo("round-robin");
 
@@ -187,7 +187,7 @@ public class InsertGraphIndexTest extends TestHelper {
 
     final VertexType vertexNotInUse = database.getSchema().createVertexType("NotInUse");
     vertexNotInUse.createProperty("id", Integer.class);
-    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "NotInUse", "id");
+    database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, "NotInUse", "id");
 
     assertThat(vertexNotInUse.getBucketSelectionStrategy().getName()).isEqualTo("round-robin");
 
@@ -207,10 +207,10 @@ public class InsertGraphIndexTest extends TestHelper {
       int i = 0;
       for (; i < VERTICES; ++i) {
         int edges = 0;
-        final long outEdges = cachedVertices[i].countEdges(Vertex.DIRECTION.OUT, EDGE_TYPE_NAME);
+        final long outEdges = cachedVertices[i].countEdges(Vertex.Direction.OUT, EDGE_TYPE_NAME);
         assertThat(outEdges).isEqualTo(expectedEdges);
 
-        final long inEdges = cachedVertices[i].countEdges(Vertex.DIRECTION.IN, EDGE_TYPE_NAME);
+        final long inEdges = cachedVertices[i].countEdges(Vertex.Direction.IN, EDGE_TYPE_NAME);
         assertThat(inEdges).isEqualTo(expectedEdges);
 
         if (++edges > EDGES_PER_VERTEX)

--- a/engine/src/test/java/com/arcadedb/graph/TxGraphTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/TxGraphTest.java
@@ -52,7 +52,7 @@ public class TxGraphTest extends TestHelper {
 
       commodore[0].asVertex(false).newEdge("SELLS", vic20).set("date", System.currentTimeMillis()).save();
 
-      assertThat(commodore[0].asVertex().countEdges(Vertex.DIRECTION.OUT, "SELLS")).isEqualTo(2);
+      assertThat(commodore[0].asVertex().countEdges(Vertex.Direction.OUT, "SELLS")).isEqualTo(2);
 
       ResultSet result = database.query("sql", "select expand( in().include('name') ) from Good");
       assertThat(result.hasNext()).isTrue();

--- a/engine/src/test/java/com/arcadedb/index/DropIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/DropIndexTest.java
@@ -53,10 +53,10 @@ public class DropIndexTest extends TestHelper {
     type.createProperty("name", String.class);
 
     final Index typeIndex = database.getSchema()
-        .createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, TYPE_NAME, new String[] { "id" }, PAGE_SIZE);
+        .createTypeIndex(Schema.IndexType.LSM_TREE, true, TYPE_NAME, new String[] { "id" }, PAGE_SIZE);
     final Index typeIndex2 = database.getSchema()
-        .createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, TYPE_NAME, new String[] { "name" }, PAGE_SIZE,
-            LSMTreeIndexAbstract.NULL_STRATEGY.SKIP, null);
+        .createTypeIndex(Schema.IndexType.LSM_TREE, false, TYPE_NAME, new String[] { "name" }, PAGE_SIZE,
+            LSMTreeIndexAbstract.NullStrategy.SKIP, null);
 
     database.transaction(() -> {
       for (int i = 0; i < TOT; ++i) {
@@ -99,7 +99,7 @@ public class DropIndexTest extends TestHelper {
         }
 
       final Index typeIndex3 = database.getSchema()
-          .createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, TYPE_NAME, new String[] { "id" }, PAGE_SIZE);
+          .createTypeIndex(Schema.IndexType.LSM_TREE, true, TYPE_NAME, new String[] { "id" }, PAGE_SIZE);
 
       Assertions.assertThat(database.countType(TYPE_NAME, true)).isEqualTo(TOT + 1);
       Assertions.assertThat(database.countType(TYPE_NAME2, false)).isEqualTo(TOT);
@@ -142,10 +142,10 @@ public class DropIndexTest extends TestHelper {
     type.createProperty("name", String.class);
 
     final Index typeIndex = database.getSchema()
-        .createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, TYPE_NAME, new String[] { "id" }, PAGE_SIZE);
+        .createTypeIndex(Schema.IndexType.LSM_TREE, true, TYPE_NAME, new String[] { "id" }, PAGE_SIZE);
     final Index typeIndex2 = database.getSchema()
-        .createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, TYPE_NAME, new String[] { "name" }, PAGE_SIZE,
-            LSMTreeIndexAbstract.NULL_STRATEGY.SKIP, null);
+        .createTypeIndex(Schema.IndexType.LSM_TREE, false, TYPE_NAME, new String[] { "name" }, PAGE_SIZE,
+            LSMTreeIndexAbstract.NullStrategy.SKIP, null);
 
     type.setBucketSelectionStrategy(new RoundRobinBucketSelectionStrategy());
     type2.setBucketSelectionStrategy(new RoundRobinBucketSelectionStrategy());
@@ -231,7 +231,7 @@ public class DropIndexTest extends TestHelper {
 
       database.getSchema().dropIndex(typeIndex.getName());
       final Index typeIndex3 = database.getSchema()
-          .createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, TYPE_NAME, new String[] { "id" }, PAGE_SIZE);
+          .createTypeIndex(Schema.IndexType.LSM_TREE, true, TYPE_NAME, new String[] { "id" }, PAGE_SIZE);
 
       for (int i = 0; i < TOT; ++i) {
         final MutableDocument v2 = database.newDocument(TYPE_NAME2);

--- a/engine/src/test/java/com/arcadedb/index/LSMTreeFullTextIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/LSMTreeFullTextIndexTest.java
@@ -28,7 +28,6 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
@@ -48,7 +47,7 @@ public class LSMTreeFullTextIndexTest extends TestHelper {
     final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(1).create();
     type.createProperty("text", String.class);
     final Index typeIndex = database.getSchema()
-        .createTypeIndex(Schema.INDEX_TYPE.FULL_TEXT, false, TYPE_NAME, new String[] { "text" }, PAGE_SIZE);
+        .createTypeIndex(Schema.IndexType.FULL_TEXT, false, TYPE_NAME, new String[] { "text" }, PAGE_SIZE);
 
     assertThat(database.getSchema().existsType(TYPE_NAME)).isTrue();
 
@@ -111,7 +110,7 @@ public class LSMTreeFullTextIndexTest extends TestHelper {
 
     reopenDatabase();
 
-    assertThat(database.getSchema().getIndexes()[0].getType()).isEqualTo(Schema.INDEX_TYPE.FULL_TEXT);
+    assertThat(database.getSchema().getIndexes()[0].getType()).isEqualTo(Schema.IndexType.FULL_TEXT);
 
     database.getSchema().dropIndex(typeIndex.getName());
   }
@@ -125,7 +124,7 @@ public class LSMTreeFullTextIndexTest extends TestHelper {
     type.createProperty("type", String.class);
     try {
       database.getSchema()
-          .createTypeIndex(Schema.INDEX_TYPE.FULL_TEXT, false, TYPE_NAME, new String[] { "text", "type" }, PAGE_SIZE);
+          .createTypeIndex(Schema.IndexType.FULL_TEXT, false, TYPE_NAME, new String[] { "text", "type" }, PAGE_SIZE);
       fail("");
     } catch (IndexException e) {
       // EXPECTED
@@ -140,7 +139,7 @@ public class LSMTreeFullTextIndexTest extends TestHelper {
       final DocumentType type = database.getSchema().createDocumentType("Docs");
       type.createProperty("text", String.class);
       final Index typeIndex = database.getSchema()
-          .createTypeIndex(Schema.INDEX_TYPE.FULL_TEXT, false, "Docs", new String[] { "text" });
+          .createTypeIndex(Schema.IndexType.FULL_TEXT, false, "Docs", new String[] { "text" });
 
       assertThat(database.getSchema().existsType("Docs")).isTrue();
 

--- a/engine/src/test/java/com/arcadedb/index/LSMTreeIndexCompactionTest.java
+++ b/engine/src/test/java/com/arcadedb/index/LSMTreeIndexCompactionTest.java
@@ -144,9 +144,9 @@ public class LSMTreeIndexCompactionTest extends TestHelper {
 
         v.createProperty("Name", String.class);
 
-        database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "Device", new String[] { "id" }, INDEX_PAGE_SIZE);
-        database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "Device", new String[] { "number" }, INDEX_PAGE_SIZE);
-        database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "Device", new String[] { "relativeName" }, INDEX_PAGE_SIZE);
+        database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, false, "Device", new String[] { "id" }, INDEX_PAGE_SIZE);
+        database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, false, "Device", new String[] { "number" }, INDEX_PAGE_SIZE);
+        database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, false, "Device", new String[] { "relativeName" }, INDEX_PAGE_SIZE);
       }
     });
 

--- a/engine/src/test/java/com/arcadedb/index/LSMTreeIndexCompositeTest.java
+++ b/engine/src/test/java/com/arcadedb/index/LSMTreeIndexCompositeTest.java
@@ -85,14 +85,14 @@ public class LSMTreeIndexCompositeTest extends TestHelper {
       file.createProperty("absoluteId", Integer.class);
       file.createProperty("directoryId", Integer.class);
       file.createProperty("fileId", Integer.class);
-      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "File", "absoluteId");
-      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "File", "directoryId", "fileId");
+      database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, "File", "absoluteId");
+      database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, "File", "directoryId", "fileId");
 
       file.setBucketSelectionStrategy(new RoundRobinBucketSelectionStrategy());
 
       assertThat(database.getSchema().existsType("HasChildren")).isFalse();
       database.getSchema().createEdgeType("HasChildren");
-      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "HasChildren", "@out", "@in");
+      database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, "HasChildren", "@out", "@in");
 
       int fileId = 0;
       for (int i = 0; i < TOT; ++i) {

--- a/engine/src/test/java/com/arcadedb/index/LSMTreeIndexPolymorphicTest.java
+++ b/engine/src/test/java/com/arcadedb/index/LSMTreeIndexPolymorphicTest.java
@@ -27,13 +27,11 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -44,7 +42,7 @@ public class LSMTreeIndexPolymorphicTest extends TestHelper {
 
   @Test
   public void testPolymorphic() {
-    populate(Schema.INDEX_TYPE.LSM_TREE);
+    populate(Schema.IndexType.LSM_TREE);
 
     try {
       final MutableDocument docChildDuplicated = database.newDocument("TestChild");
@@ -65,7 +63,7 @@ public class LSMTreeIndexPolymorphicTest extends TestHelper {
 
   @Test
   public void testPolymorphicFullText() {
-    populate(Schema.INDEX_TYPE.FULL_TEXT);
+    populate(Schema.IndexType.FULL_TEXT);
     checkQueries();
   }
 
@@ -75,7 +73,7 @@ public class LSMTreeIndexPolymorphicTest extends TestHelper {
     final DocumentType typeRoot2 = database.getSchema().getOrCreateDocumentType("TestRoot2");
     typeRoot2.getOrCreateProperty("name", String.class);
     typeRoot2.getOrCreateProperty("parent", Type.LINK);
-    typeRoot2.getOrCreateTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "name", "parent");
+    typeRoot2.getOrCreateTypeIndex(Schema.IndexType.LSM_TREE, true, "name", "parent");
     database.command("sql", "delete from TestRoot2");
     database.begin();
     final DocumentType testChild2 = database.getSchema().getOrCreateDocumentType("TestChild2");
@@ -101,7 +99,7 @@ public class LSMTreeIndexPolymorphicTest extends TestHelper {
     final DocumentType typeRoot2 = database.getSchema().getOrCreateDocumentType("TestRoot2");
     typeRoot2.getOrCreateProperty("name", String.class);
     typeRoot2.getOrCreateProperty("parent", Type.LINK);
-    typeRoot2.getOrCreateTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "name", "parent");
+    typeRoot2.getOrCreateTypeIndex(Schema.IndexType.LSM_TREE, true, "name", "parent");
     database.command("sql", "delete from TestRoot2");
     final DocumentType typeChild2 = database.getSchema().getOrCreateDocumentType("TestChild2");
     typeChild2.setSuperTypes(Arrays.asList(typeRoot2));
@@ -121,10 +119,10 @@ public class LSMTreeIndexPolymorphicTest extends TestHelper {
     }
   }
 
-  private void populate(final Schema.INDEX_TYPE indexType) {
+  private void populate(final Schema.IndexType indexType) {
     typeRoot = database.getSchema().getOrCreateDocumentType("TestRoot");
     typeRoot.getOrCreateProperty("name", String.class);
-    typeRoot.getOrCreateTypeIndex(indexType, indexType == Schema.INDEX_TYPE.LSM_TREE, "name");
+    typeRoot.getOrCreateTypeIndex(indexType, indexType == Schema.IndexType.LSM_TREE, "name");
     database.command("sql", "delete from TestRoot");
 
     typeChild = database.getSchema().getOrCreateDocumentType("TestChild");

--- a/engine/src/test/java/com/arcadedb/index/LSMTreeIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/LSMTreeIndexTest.java
@@ -1157,7 +1157,7 @@ public class LSMTreeIndexTest extends TestHelper {
       final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(3).create();
       type.createProperty("id", Integer.class);
       final TypeIndex typeIndex = database.getSchema()
-          .createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, TYPE_NAME, new String[] { "id" }, PAGE_SIZE);
+          .createTypeIndex(Schema.IndexType.LSM_TREE, true, TYPE_NAME, new String[] { "id" }, PAGE_SIZE);
 
       for (int i = 0; i < TOT; ++i) {
         final MutableDocument v = database.newDocument(TYPE_NAME);

--- a/engine/src/test/java/com/arcadedb/index/MultipleTypesIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/MultipleTypesIndexTest.java
@@ -26,7 +26,6 @@ import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.schema.VertexType;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
@@ -107,7 +106,7 @@ public class MultipleTypesIndexTest extends TestHelper {
     VertexType type = database.getSchema().createVertexType("IndexedVertex");
     type.createProperty("counter", Type.INTEGER);
     type.createProperty("status", Type.STRING);
-    type.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "status", "counter");
+    type.createTypeIndex(Schema.IndexType.LSM_TREE, true, "status", "counter");
 
     database.transaction(() -> {
       database.newVertex("IndexedVertex").set("id", "test1").set("status", "on").set("counter", 1).save();
@@ -125,12 +124,12 @@ public class MultipleTypesIndexTest extends TestHelper {
 
       final DocumentType type = database.getSchema().buildVertexType().withName(TYPE_NAME).withTotalBuckets(3).create();
       type.createProperty("id", Integer.class);
-      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, TYPE_NAME, new String[] { "id" });
+      database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, TYPE_NAME, new String[] { "id" });
       type.createProperty("firstName", String.class);
       type.createProperty("lastName", String.class);
-      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, TYPE_NAME, new String[] { "firstName", "lastName" });
+      database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, false, TYPE_NAME, new String[] { "firstName", "lastName" });
       type.createProperty("keywords", List.class);
-      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, TYPE_NAME, new String[] { "keywords" });
+      database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, false, TYPE_NAME, new String[] { "keywords" });
 
       MutableVertex v = database.newVertex(TYPE_NAME);
       v.set("id", 0);

--- a/engine/src/test/java/com/arcadedb/index/NullValuesIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/NullValuesIndexTest.java
@@ -27,7 +27,6 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.VertexType;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,10 +45,10 @@ public class NullValuesIndexTest extends TestHelper {
     type.createProperty("id", Integer.class);
     type.createProperty("name", String.class);
     final Index indexes = database.getSchema()
-        .createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, TYPE_NAME, new String[] { "id" }, PAGE_SIZE);
+        .createTypeIndex(Schema.IndexType.LSM_TREE, true, TYPE_NAME, new String[] { "id" }, PAGE_SIZE);
     final Index indexes2 = database.getSchema()
-        .createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, TYPE_NAME, new String[] { "name" }, PAGE_SIZE,
-            LSMTreeIndexAbstract.NULL_STRATEGY.ERROR, null);
+        .createTypeIndex(Schema.IndexType.LSM_TREE, false, TYPE_NAME, new String[] { "name" }, PAGE_SIZE,
+            LSMTreeIndexAbstract.NullStrategy.ERROR, null);
 
     try {
       database.transaction(() -> {
@@ -87,10 +86,10 @@ public class NullValuesIndexTest extends TestHelper {
     type.createProperty("id", Integer.class);
     type.createProperty("name", String.class);
     final Index indexes = database.getSchema()
-        .createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, TYPE_NAME, new String[] { "id" }, PAGE_SIZE);
+        .createTypeIndex(Schema.IndexType.LSM_TREE, true, TYPE_NAME, new String[] { "id" }, PAGE_SIZE);
     final Index indexes2 = database.getSchema()
-        .createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, TYPE_NAME, new String[] { "name" }, PAGE_SIZE,
-            LSMTreeIndexAbstract.NULL_STRATEGY.SKIP, null);
+        .createTypeIndex(Schema.IndexType.LSM_TREE, false, TYPE_NAME, new String[] { "name" }, PAGE_SIZE,
+            LSMTreeIndexAbstract.NullStrategy.SKIP, null);
 
     database.transaction(() -> {
       for (int i = 0; i < TOT; ++i) {
@@ -147,10 +146,10 @@ public class NullValuesIndexTest extends TestHelper {
     final VertexType type = database.getSchema().buildVertexType().withName(TYPE_NAME).withTotalBuckets(3).create();
     type.createProperty("id", Integer.class);
     type.createProperty("absent", String.class);
-    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, TYPE_NAME, new String[] { "id" }, PAGE_SIZE);
+    database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, TYPE_NAME, new String[] { "id" }, PAGE_SIZE);
     database.getSchema()
-        .createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, TYPE_NAME, new String[] { "absent" }, PAGE_SIZE,
-            LSMTreeIndexAbstract.NULL_STRATEGY.SKIP, null);
+        .createTypeIndex(Schema.IndexType.LSM_TREE, true, TYPE_NAME, new String[] { "absent" }, PAGE_SIZE,
+            LSMTreeIndexAbstract.NullStrategy.SKIP, null);
 
     database.transaction(() -> {
       for (int i = 0; i < TOT; ++i) {

--- a/engine/src/test/java/com/arcadedb/index/TypeLSMTreeIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/TypeLSMTreeIndexTest.java
@@ -41,7 +41,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 
@@ -792,7 +791,7 @@ public class TypeLSMTreeIndexTest extends TestHelper {
     while (true) {
       database.async().waitCompletion();
       try {
-        final TypeIndex idx = type.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "other.special:property");
+        final TypeIndex idx = type.createTypeIndex(Schema.IndexType.LSM_TREE, true, "other.special:property");
         database.command("sql", "rebuild index `" + idx.getName() + "`");
         break;
       } catch (NeedRetryException e) {
@@ -842,7 +841,7 @@ public class TypeLSMTreeIndexTest extends TestHelper {
       final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(3).create();
       type.createProperty("id", Integer.class);
       final Index typeIndex = database.getSchema()
-          .createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, TYPE_NAME, new String[] { "id" }, PAGE_SIZE);
+          .createTypeIndex(Schema.IndexType.LSM_TREE, true, TYPE_NAME, new String[] { "id" }, PAGE_SIZE);
 
       for (int i = 0; i < TOT; ++i) {
         final MutableDocument v = database.newDocument(TYPE_NAME);

--- a/engine/src/test/java/com/arcadedb/query/select/SelectExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectExecutionTest.java
@@ -49,7 +49,7 @@ public class SelectExecutionTest extends TestHelper {
     database.getSchema().createDocumentType("Document");
     database.getSchema().createVertexType("Vertex")//
         .createProperty("id", Type.INTEGER)//
-        .createIndex(Schema.INDEX_TYPE.LSM_TREE, true);
+        .createIndex(Schema.IndexType.LSM_TREE, true);
     database.getSchema().createEdgeType("Edge");
 
     database.transaction(() -> {

--- a/engine/src/test/java/com/arcadedb/query/select/SelectIndexExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectIndexExecutionTest.java
@@ -43,9 +43,9 @@ public class SelectIndexExecutionTest extends TestHelper {
   protected void beginTest() {
     final VertexType v = database.getSchema().createVertexType("Vertex");
     v.createProperty("id", Type.INTEGER)//
-        .createIndex(Schema.INDEX_TYPE.LSM_TREE, true);
+        .createIndex(Schema.IndexType.LSM_TREE, true);
     v.createProperty("name", Type.STRING)//
-        .createIndex(Schema.INDEX_TYPE.LSM_TREE, false);
+        .createIndex(Schema.IndexType.LSM_TREE, false);
 
     database.transaction(() -> {
       for (int i = 0; i < 100; i++)

--- a/engine/src/test/java/com/arcadedb/query/select/SelectOrderByTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectOrderByTest.java
@@ -40,9 +40,9 @@ public class SelectOrderByTest extends TestHelper {
   protected void beginTest() {
     final VertexType v = database.getSchema().createVertexType("Vertex");
     v.createProperty("id", Type.INTEGER)//
-        .createIndex(Schema.INDEX_TYPE.LSM_TREE, true);
+        .createIndex(Schema.IndexType.LSM_TREE, true);
     v.createProperty("name", Type.STRING)//
-        .createIndex(Schema.INDEX_TYPE.LSM_TREE, false);
+        .createIndex(Schema.IndexType.LSM_TREE, false);
 
     database.transaction(() -> {
       for (int i = 0; i < 100; i++)

--- a/engine/src/test/java/com/arcadedb/query/sql/OrderByTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/OrderByTest.java
@@ -30,7 +30,6 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -70,8 +69,8 @@ public class OrderByTest {
         dtProduct.createProperty("type", Type.STRING);
         dtProduct.createProperty("start", Type.DATETIME_MICROS);
         dtProduct.createProperty("stop", Type.DATETIME_MICROS);
-        dtProduct.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "name");
-        dtProduct.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "type", "start", "stop");
+        dtProduct.createTypeIndex(Schema.IndexType.LSM_TREE, true, "name");
+        dtProduct.createTypeIndex(Schema.IndexType.LSM_TREE, true, "type", "start", "stop");
       });
     }
 

--- a/engine/src/test/java/com/arcadedb/query/sql/QueryAndIndexesTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/QueryAndIndexesTest.java
@@ -42,7 +42,7 @@ public class QueryAndIndexesTest extends TestHelper {
         final VertexType t = database.getSchema().createVertexType("V");
         t.createProperty("name", String.class);
         t.createProperty("surname", String.class);
-        database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "V", "name", "surname");
+        database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, "V", "name", "surname");
       }
 
       for (int i = 0; i < TOT; ++i) {

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/CountFromIndexStepTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/CountFromIndexStepTest.java
@@ -26,7 +26,6 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
@@ -58,7 +57,7 @@ public class CountFromIndexStepTest {
       clazz.createProperty(PROPERTY_NAME, Type.STRING);
       String className = clazz.getName();
       indexName = className + "[" + PROPERTY_NAME + "]";
-      clazz.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, PROPERTY_NAME);
+      clazz.createTypeIndex(Schema.IndexType.LSM_TREE, false, PROPERTY_NAME);
 
       for (int i = 0; i < 20; i++) {
         final MutableDocument document = db.newDocument(className);

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ScriptExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ScriptExecutionTest.java
@@ -291,7 +291,7 @@ public class ScriptExecutionTest extends TestHelper {
       database.newDocument(typeName).set("id", 1).save();
     });
 
-    database.setTransactionIsolationLevel(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
+    database.setTransactionIsolationLevel(Database.TransactionIsolationLevel.REPEATABLE_READ);
 
     script = """
         LET $retries = 0;

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/SelectStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/SelectStatementExecutionTest.java
@@ -987,7 +987,7 @@ public class SelectStatementExecutionTest extends TestHelper {
   public void testQueryMetadataIndexManager() {
     final DocumentType type = database.getSchema().createDocumentType("testQuerySchema");
     database.begin();
-    type.createProperty("name", Type.STRING).createIndex(Schema.INDEX_TYPE.LSM_TREE, false);
+    type.createProperty("name", Type.STRING).createIndex(Schema.IndexType.LSM_TREE, false);
     database.commit();
     final ResultSet result = database.query("sql", "select from schema:indexes");
 
@@ -1117,7 +1117,7 @@ public class SelectStatementExecutionTest extends TestHelper {
     final String className = "testFetchFromClassWithIndex";
     final DocumentType clazz = database.getSchema().createDocumentType(className);
     database.begin();
-    clazz.createProperty("name", Type.STRING).createIndex(Schema.INDEX_TYPE.LSM_TREE, false);
+    clazz.createProperty("name", Type.STRING).createIndex(Schema.IndexType.LSM_TREE, false);
 
     for (int i = 0; i < 10; i++) {
       final MutableDocument doc = database.newDocument(className);
@@ -1151,7 +1151,7 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.begin();
     clazz.createProperty("name", Type.STRING);
     final String indexName;
-    final Index idx = clazz.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name");
+    final Index idx = clazz.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name");
     indexName = idx.getName();
     for (int i = 0; i < 10; i++) {
       final MutableDocument doc = database.newDocument(className);
@@ -1184,8 +1184,8 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.begin();
     clazz.createProperty("name", Type.STRING);
     clazz.createProperty("surname", Type.STRING);
-    clazz.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name");
-    clazz.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "surname");
+    clazz.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name");
+    clazz.createTypeIndex(Schema.IndexType.LSM_TREE, false, "surname");
 
     for (int i = 0; i < 10; i++) {
       final MutableDocument doc = database.newDocument(className);
@@ -1224,8 +1224,8 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.begin();
     clazz.createProperty("name", Type.STRING);
     clazz.createProperty("surname", Type.STRING);
-    clazz.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name");
-    clazz.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "surname");
+    clazz.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name");
+    clazz.createTypeIndex(Schema.IndexType.LSM_TREE, false, "surname");
 
     for (int i = 0; i < 10; i++) {
       final MutableDocument doc = database.newDocument(className);
@@ -1249,8 +1249,8 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.begin();
     clazz.createProperty("name", Type.STRING);
     clazz.createProperty("surname", Type.STRING);
-    clazz.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name");
-    clazz.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "surname");
+    clazz.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name");
+    clazz.createTypeIndex(Schema.IndexType.LSM_TREE, false, "surname");
 
     for (int i = 0; i < 10; i++) {
       final MutableDocument doc = database.newDocument(className);
@@ -1282,8 +1282,8 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.begin();
     clazz.createProperty("name", Type.STRING);
     clazz.createProperty("surname", Type.STRING);
-    clazz.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name");
-    clazz.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "surname");
+    clazz.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name");
+    clazz.createTypeIndex(Schema.IndexType.LSM_TREE, false, "surname");
 
     for (int i = 0; i < 10; i++) {
       final MutableDocument doc = database.newDocument(className);
@@ -1315,7 +1315,7 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.begin();
     clazz.createProperty("name", Type.STRING);
     clazz.createProperty("surname", Type.STRING);
-    clazz.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name", "surname");
+    clazz.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name", "surname");
 
     for (int i = 0; i < 10; i++) {
       final MutableDocument doc = database.newDocument(className);
@@ -1346,7 +1346,7 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.begin();
     clazz.createProperty("name", Type.STRING);
     clazz.createProperty("surname", Type.STRING);
-    clazz.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name", "surname");
+    clazz.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name", "surname");
 
     for (int i = 0; i < 10; i++) {
       final MutableDocument doc = database.newDocument(className);
@@ -1370,7 +1370,7 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.begin();
     clazz.createProperty("name", Type.STRING);
     clazz.createProperty("surname", Type.STRING);
-    clazz.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name", "surname");
+    clazz.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name", "surname");
 
     for (int i = 0; i < 10; i++) {
       final MutableDocument doc = database.newDocument(className);
@@ -1398,7 +1398,7 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.begin();
     clazz.createProperty("name", Type.STRING);
     clazz.createProperty("surname", Type.STRING);
-    clazz.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name", "surname");
+    clazz.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name", "surname");
 
     for (int i = 0; i < 10; i++) {
       final MutableDocument doc = database.newDocument(className);
@@ -1422,7 +1422,7 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.begin();
     clazz.createProperty("name", Type.STRING);
     clazz.createProperty("surname", Type.STRING);
-    clazz.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name", "surname");
+    clazz.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name", "surname");
 
     for (int i = 0; i < 10; i++) {
       final MutableDocument doc = database.newDocument(className);
@@ -1450,7 +1450,7 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.begin();
     clazz.createProperty("name", Type.STRING);
     clazz.createProperty("surname", Type.STRING);
-    clazz.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name", "surname");
+    clazz.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name", "surname");
 
     for (int i = 0; i < 10; i++) {
       final MutableDocument doc = database.newDocument(className);
@@ -1478,7 +1478,7 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.begin();
     clazz.createProperty("name", Type.STRING);
     clazz.createProperty("surname", Type.STRING);
-    clazz.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name", "surname");
+    clazz.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name", "surname");
 
     for (int i = 0; i < 10; i++) {
       final MutableDocument doc = database.newDocument(className);
@@ -1505,7 +1505,7 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.begin();
     clazz.createProperty("name", Type.STRING);
     clazz.createProperty("surname", Type.STRING);
-    clazz.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name", "surname");
+    clazz.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name", "surname");
 
     for (int i = 0; i < 10; i++) {
       final MutableDocument doc = database.newDocument(className);
@@ -1532,7 +1532,7 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.begin();
     clazz.createProperty("name", Type.STRING);
     clazz.createProperty("surname", Type.STRING);
-    clazz.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name", "surname");
+    clazz.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name", "surname");
 
     for (int i = 0; i < 10; i++) {
       final MutableDocument doc = database.newDocument(className);
@@ -1559,7 +1559,7 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.begin();
     clazz.createProperty("name", Type.STRING);
     clazz.createProperty("surname", Type.STRING);
-    clazz.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name", "surname");
+    clazz.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name", "surname");
 
     for (int i = 0; i < 10; i++) {
       final MutableDocument doc = database.newDocument(className);
@@ -1588,7 +1588,7 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.begin();
     clazz.createProperty("name", Type.STRING);
     clazz.createProperty("surname", Type.STRING);
-    clazz.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name", "surname");
+    clazz.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name", "surname");
 
     for (int i = 0; i < 10; i++) {
       final MutableDocument doc = database.newDocument(className);
@@ -2170,8 +2170,8 @@ public class SelectStatementExecutionTest extends TestHelper {
     childClass2.addSuperType(parentClass);
 
     parentClass.createProperty("name", Type.STRING);
-    childClass1.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name");
-    childClass2.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name");
+    childClass1.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name");
+    childClass2.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name");
 
     for (int i = 0; i < 10; i++) {
       final MutableDocument doc = database.newDocument(child1);
@@ -2215,7 +2215,7 @@ public class SelectStatementExecutionTest extends TestHelper {
     childClass2.addSuperType(parentClass);
 
     parentClass.createProperty("name", Type.STRING);
-    childClass1.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name");
+    childClass1.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name");
 
     for (int i = 0; i < 10; i++) {
       final MutableDocument doc = database.newDocument(child1);
@@ -2259,8 +2259,8 @@ public class SelectStatementExecutionTest extends TestHelper {
     childClass2.addSuperType(parent);
 
     parentClass.createProperty("name", Type.STRING);
-    childClass1.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name");
-    childClass2.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name");
+    childClass1.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name");
+    childClass2.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name");
 
     final MutableDocument parentdoc = database.newDocument(parent);
     parentdoc.set("name", "foo");
@@ -2317,9 +2317,9 @@ public class SelectStatementExecutionTest extends TestHelper {
     final DocumentType childClass2_2 = database.getSchema().createDocumentType(child2_2);
     childClass2_2.addSuperType(child2);
 
-    childClass1.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name");
-    childClass2_1.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name");
-    childClass2_2.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name");
+    childClass1.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name");
+    childClass2_1.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name");
+    childClass2_2.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name");
 
     for (int i = 0; i < 10; i++) {
       final MutableDocument doc = database.newDocument(child1);
@@ -2378,8 +2378,8 @@ public class SelectStatementExecutionTest extends TestHelper {
     childClass12.addSuperType(childClass2);
 
     parentClass.createProperty("name", Type.STRING);
-    childClass1.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name");
-    childClass2.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "name");
+    childClass1.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name");
+    childClass2.createTypeIndex(Schema.IndexType.LSM_TREE, false, "name");
 
     for (int i = 0; i < 10; i++) {
       final MutableDocument doc = database.newDocument(child1);
@@ -3635,7 +3635,7 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.begin();
 //        Property prop = clazz.createProperty("tags", Type.LIST, Type.STRING);
     final Property prop = clazz.createProperty("tags", Type.LIST);
-    prop.createIndex(Schema.INDEX_TYPE.LSM_TREE, false);
+    prop.createIndex(Schema.IndexType.LSM_TREE, false);
 
     database.command("sql", "insert into " + className + "  set tags = ['foo', 'bar']");
     database.command("sql", "insert into " + className + "  set tags = ['bbb', 'FFF']");
@@ -3728,7 +3728,7 @@ public class SelectStatementExecutionTest extends TestHelper {
     database.begin();
     final DocumentType clazz = database.getSchema().getOrCreateDocumentType(className);
     final Property prop = clazz.createProperty("tag", Type.STRING);
-    prop.createIndex(Schema.INDEX_TYPE.LSM_TREE, false);
+    prop.createIndex(Schema.IndexType.LSM_TREE, false);
 
     database.command("sql", "insert into " + className + "  set tag = 'foo'");
     database.command("sql", "insert into " + className + "  set tag = 'bar'");
@@ -4140,7 +4140,7 @@ public class SelectStatementExecutionTest extends TestHelper {
     final DocumentType clazz = database.getSchema().getOrCreateDocumentType(className);
     database.begin();
     final Property prop = clazz.createProperty("name", Type.STRING);
-    prop.createIndex(Schema.INDEX_TYPE.LSM_TREE, false);
+    prop.createIndex(Schema.IndexType.LSM_TREE, false);
 
     for (int i = 0; i < 10; i++) {
       final MutableDocument doc = database.newDocument(className);
@@ -4164,7 +4164,7 @@ public class SelectStatementExecutionTest extends TestHelper {
     final DocumentType clazz = database.getSchema().getOrCreateDocumentType(className);
     database.begin();
     final Property prop = clazz.createProperty("name", Type.STRING);
-    prop.createIndex(Schema.INDEX_TYPE.LSM_TREE, false);
+    prop.createIndex(Schema.IndexType.LSM_TREE, false);
 
     for (int i = 0; i < 10; i++) {
       final MutableDocument doc = database.newDocument(className);

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/TruncateClassStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/TruncateClassStatementExecutionTest.java
@@ -158,7 +158,7 @@ public class TruncateClassStatementExecutionTest extends TestHelper {
       return database.getSchema().getIndexByName("test_class_by_data");
 
     testClass.createProperty("data", Type.LIST);
-    return testClass.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "data");
+    return testClass.createTypeIndex(Schema.IndexType.LSM_TREE, true, "data");
   }
 
   private DocumentType getOrcreateDocumentType(final Schema schema) {

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/UpdateStatementExecutionTest.java
@@ -26,14 +26,11 @@ import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.MutableEmbeddedDocument;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.bucketselectionstrategy.ThreadBucketSelectionStrategy;
-import com.arcadedb.engine.Bucket;
-import com.arcadedb.graph.Vertex;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.time.*;
@@ -728,7 +725,7 @@ public class UpdateStatementExecutionTest extends TestHelper {
       DocumentType dtProduct = database.getSchema().createDocumentType("Product");
       dtProduct.createProperty("start", Type.DATETIME_MICROS);
       dtProduct.createProperty("stop", Type.DATETIME_MICROS);
-      dtProduct.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "start", "stop");
+      dtProduct.createTypeIndex(Schema.IndexType.LSM_TREE, true, "start", "stop");
     });
 
     GlobalConfiguration.DATE_TIME_IMPLEMENTATION.setValue(java.time.LocalDateTime.class);
@@ -788,7 +785,7 @@ public class UpdateStatementExecutionTest extends TestHelper {
       dtOrders.createProperty("id", Type.STRING);
       dtOrders.createProperty("processor", Type.STRING);
       dtOrders.createProperty("status", Type.STRING);
-      typeIndex[0] = dtOrders.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "status", "id");
+      typeIndex[0] = dtOrders.createTypeIndex(Schema.IndexType.LSM_TREE, true, "status", "id");
     });
 
     String processor = "SIR1LRM-7.1";
@@ -845,8 +842,8 @@ public class UpdateStatementExecutionTest extends TestHelper {
       dtOrders.createProperty("id", Type.INTEGER);
       dtOrders.createProperty("processor", Type.STRING);
       dtOrders.createProperty("status", Type.STRING);
-      dtOrders.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "id");
-      dtOrders.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "status", "id");
+      dtOrders.createTypeIndex(Schema.IndexType.LSM_TREE, true, "id");
+      dtOrders.createTypeIndex(Schema.IndexType.LSM_TREE, true, "status", "id");
       dtOrders.setBucketSelectionStrategy(new ThreadBucketSelectionStrategy());
     });
 

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/UpsertStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/UpsertStatementExecutionTest.java
@@ -30,7 +30,6 @@ import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.schema.VertexType;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.time.*;
@@ -54,7 +53,7 @@ public class UpsertStatementExecutionTest extends TestHelper {
   public void beginTest() {
     final DocumentType clazz = database.getSchema().createDocumentType("UpsertStatementExecutionTest");
     clazz.createProperty("name", Type.STRING);
-    clazz.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "name");
+    clazz.createTypeIndex(Schema.IndexType.LSM_TREE, true, "name");
     className = clazz.getName();
 
     for (int i = 0; i < 10; i++) {
@@ -249,7 +248,7 @@ public class UpsertStatementExecutionTest extends TestHelper {
   public void testUpsertVertices2() {
     final VertexType clazz = database.getSchema().createVertexType("UpsertableVertex");
     clazz.createProperty("name", Type.STRING);
-    clazz.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "name");
+    clazz.createTypeIndex(Schema.IndexType.LSM_TREE, true, "name");
 
     for (int i = 0; i < 10; i++) {
       final MutableDocument doc = database.newVertex("UpsertableVertex");
@@ -310,7 +309,7 @@ public class UpsertStatementExecutionTest extends TestHelper {
       DocumentType dtProduct = database.getSchema().createDocumentType("Product");
       dtProduct.createProperty("start", Type.DATETIME_MICROS);
       dtProduct.createProperty("stop", Type.DATETIME_MICROS);
-      dtProduct.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "start", "stop");
+      dtProduct.createTypeIndex(Schema.IndexType.LSM_TREE, true, "start", "stop");
     });
 
     GlobalConfiguration.DATE_TIME_IMPLEMENTATION.setValue(LocalDateTime.class);
@@ -344,7 +343,7 @@ public class UpsertStatementExecutionTest extends TestHelper {
       DocumentType dtProduct = database.getSchema().createDocumentType("Product");
       dtProduct.createProperty("start", Type.DATETIME_MICROS);
       dtProduct.createProperty("stop", Type.DATETIME_MICROS);
-      dtProduct.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "start", "stop");
+      dtProduct.createTypeIndex(Schema.IndexType.LSM_TREE, true, "start", "stop");
     });
 
     GlobalConfiguration.DATE_TIME_IMPLEMENTATION.setValue(LocalDateTime.class);

--- a/engine/src/test/java/com/arcadedb/query/sql/function/geo/SQLGeoFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/function/geo/SQLGeoFunctionsTest.java
@@ -163,7 +163,7 @@ public class SQLGeoFunctionsTest {
 
       db.transaction(() -> {
         final DocumentType type = db.getSchema().createDocumentType("Restaurant");
-        type.createProperty("coords", Type.STRING).createIndex(Schema.INDEX_TYPE.LSM_TREE, false);
+        type.createProperty("coords", Type.STRING).createIndex(Schema.IndexType.LSM_TREE, false);
 
         long begin = System.currentTimeMillis();
 
@@ -212,8 +212,8 @@ public class SQLGeoFunctionsTest {
 
       db.transaction(() -> {
         final DocumentType type = db.getSchema().createDocumentType("Restaurant");
-        type.createProperty("bboxTL", Type.STRING).createIndex(Schema.INDEX_TYPE.LSM_TREE, false);
-        type.createProperty("bboxBR", Type.STRING).createIndex(Schema.INDEX_TYPE.LSM_TREE, false);
+        type.createProperty("bboxTL", Type.STRING).createIndex(Schema.IndexType.LSM_TREE, false);
+        type.createProperty("bboxBR", Type.STRING).createIndex(Schema.IndexType.LSM_TREE, false);
 
         long begin = System.currentTimeMillis();
 

--- a/engine/src/test/java/com/arcadedb/query/sql/function/sql/SQLFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/function/sql/SQLFunctionsTest.java
@@ -18,7 +18,6 @@
  */
 package com.arcadedb.query.sql.function.sql;
 
-import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.Identifiable;
@@ -44,17 +43,14 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.security.NoSuchAlgorithmException;
-import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static com.arcadedb.TestHelper.checkActiveDatabases;
@@ -182,7 +178,7 @@ public class SQLFunctionsTest {
     indexed.createProperty("key", Type.STRING);
 
     database.transaction(() -> {
-      indexed.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "key");
+      indexed.createTypeIndex(Schema.IndexType.LSM_TREE, false, "key");
 
       database.newDocument("Indexed").set("key", "one").save();
       database.newDocument("Indexed").set("key", "two").save();

--- a/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodTransformTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodTransformTest.java
@@ -192,11 +192,11 @@ class SQLMethodTransformTest {
       }
 
       @Override
-      public void checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS access) {
+      public void checkPermissionsOnDatabase(SecurityDatabaseUser.DatabaseAccess access) {
       }
 
       @Override
-      public void checkPermissionsOnFile(int fileId, SecurityDatabaseUser.ACCESS access) {
+      public void checkPermissionsOnFile(int fileId, SecurityDatabaseUser.Access access) {
       }
 
       @Override
@@ -220,17 +220,17 @@ class SQLMethodTransformTest {
       }
 
       @Override
-      public void registerCallback(CALLBACK_EVENT event, Callable<Void> callback) {
+      public void registerCallback(CallbackEvent event, Callable<Void> callback) {
 
       }
 
       @Override
-      public void unregisterCallback(CALLBACK_EVENT event, Callable<Void> callback) {
+      public void unregisterCallback(CallbackEvent event, Callable<Void> callback) {
 
       }
 
       @Override
-      public void executeCallbacks(CALLBACK_EVENT event) throws IOException {
+      public void executeCallbacks(CallbackEvent event) throws IOException {
 
       }
 
@@ -345,7 +345,7 @@ class SQLMethodTransformTest {
       }
 
       @Override
-      public ComponentFile.MODE getMode() {
+      public ComponentFile.Mode getMode() {
         return null;
       }
 
@@ -502,12 +502,12 @@ class SQLMethodTransformTest {
       }
 
       @Override
-      public Database setTransactionIsolationLevel(TRANSACTION_ISOLATION_LEVEL level) {
+      public Database setTransactionIsolationLevel(TransactionIsolationLevel level) {
         return null;
       }
 
       @Override
-      public TRANSACTION_ISOLATION_LEVEL getTransactionIsolationLevel() {
+      public TransactionIsolationLevel getTransactionIsolationLevel() {
         return null;
       }
 
@@ -608,7 +608,7 @@ class SQLMethodTransformTest {
       }
 
       @Override
-      public void begin(TRANSACTION_ISOLATION_LEVEL isolationLevel) {
+      public void begin(TransactionIsolationLevel isolationLevel) {
 
       }
 

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/ExecutionPlanCacheTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/ExecutionPlanCacheTest.java
@@ -80,7 +80,7 @@ public class ExecutionPlanCacheTest {
       cache = ExecutionPlanCache.instance(db);
       assertThat(cache.contains(stm)).isTrue();
 
-      db.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, testName, "name");
+      db.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, false, testName, "name");
       assertThat(cache.contains(stm)).isFalse();
 
     } finally {

--- a/engine/src/test/java/performance/PerformanceComplexIndexTest.java
+++ b/engine/src/test/java/performance/PerformanceComplexIndexTest.java
@@ -55,7 +55,7 @@ public class PerformanceComplexIndexTest {
         v.createProperty("locali", Integer.class);
         v.createProperty("notes1", String.class);
 
-        database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, TYPE_NAME, new String[] { "id" }, 5000000);
+        database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, false, TYPE_NAME, new String[] { "id" }, 5000000);
 
         database.commit();
       }

--- a/engine/src/test/java/performance/PerformanceIndexCompaction.java
+++ b/engine/src/test/java/performance/PerformanceIndexCompaction.java
@@ -41,7 +41,7 @@ public class PerformanceIndexCompaction {
   private void run() throws IOException, InterruptedException {
     GlobalConfiguration.INDEX_COMPACTION_RAM_MB.setValue(5);
 
-    final Database database = new DatabaseFactory(PerformanceTest.DATABASE_PATH).open(ComponentFile.MODE.READ_WRITE);
+    final Database database = new DatabaseFactory(PerformanceTest.DATABASE_PATH).open(ComponentFile.Mode.READ_WRITE);
 
     final long begin = System.currentTimeMillis();
     try {

--- a/engine/src/test/java/performance/PerformanceInsertGraphIndexTest.java
+++ b/engine/src/test/java/performance/PerformanceInsertGraphIndexTest.java
@@ -239,13 +239,13 @@ public class PerformanceInsertGraphIndexTest extends TestHelper {
   private void createSchema() {
     final VertexType vertex = database.getSchema().buildVertexType().withName(VERTEX_TYPE_NAME).withTotalBuckets(PARALLEL).create();
     vertex.createProperty("id", Integer.class);
-    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, VERTEX_TYPE_NAME, "id");
+    database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, VERTEX_TYPE_NAME, "id");
     vertex.setBucketSelectionStrategy(new PartitionedBucketSelectionStrategy(List.of("id")));
 
     final EdgeType edge = database.getSchema().buildEdgeType().withName(EDGE_TYPE_NAME).withTotalBuckets(PARALLEL).create();
     if (EDGE_IDS) {
       edge.createProperty("id", Integer.class);
-      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, EDGE_TYPE_NAME, "id");
+      database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, EDGE_TYPE_NAME, "id");
       edge.setBucketSelectionStrategy(new PartitionedBucketSelectionStrategy(List.of("id")));
     }
   }
@@ -297,13 +297,13 @@ public class PerformanceInsertGraphIndexTest extends TestHelper {
       int outEdges = 0;
       int inEdges = 0;
       for (; i < VERTICES; ++i) {
-        for (final Edge e : cachedVertices[i].getEdges(Vertex.DIRECTION.OUT, EDGE_TYPE_NAME)) {
+        for (final Edge e : cachedVertices[i].getEdges(Vertex.Direction.OUT, EDGE_TYPE_NAME)) {
           if (EDGE_IDS)
             assertThat(e.get("id")).isNotNull();
           ++outEdges;
         }
 
-        for (final Edge e : cachedVertices[i].getEdges(Vertex.DIRECTION.IN, EDGE_TYPE_NAME)) {
+        for (final Edge e : cachedVertices[i].getEdges(Vertex.Direction.IN, EDGE_TYPE_NAME)) {
           if (EDGE_IDS)
             assertThat(e.get("id")).isNotNull();
           ++inEdges;

--- a/engine/src/test/java/performance/PerformanceInsertIndexTest.java
+++ b/engine/src/test/java/performance/PerformanceInsertIndexTest.java
@@ -69,7 +69,7 @@ public class PerformanceInsertIndexTest extends TestHelper {
       type.createProperty("age", Byte.class);
       type.createProperty("active", Byte.class);
 
-      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, TYPE_NAME, new String[] { "id" }, 5000000);
+      database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, false, TYPE_NAME, new String[] { "id" }, 5000000);
 
       database.commit();
 

--- a/engine/src/test/java/performance/PerformanceInsertMTStressTest.java
+++ b/engine/src/test/java/performance/PerformanceInsertMTStressTest.java
@@ -78,7 +78,7 @@ public class PerformanceInsertMTStressTest {
     resourceType.setBucketSelectionStrategy(new ThreadBucketSelectionStrategy());
     resourceType.createProperty("identifier", Type.STRING);
     resourceType.createProperty("value", Type.LONG);
-    resourceType.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, resourceTypeName, "value");
+    resourceType.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, false, resourceTypeName, "value");
     db.commit();
   }
 

--- a/engine/src/test/java/performance/PerformanceVertexIndexTest.java
+++ b/engine/src/test/java/performance/PerformanceVertexIndexTest.java
@@ -107,9 +107,9 @@ public class PerformanceVertexIndexTest {
         v.createProperty("operationalStatus", String.class);
         v.createProperty("supplierName", String.class);
 
-        database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "Device", new String[] { "id" }, 2 * 1024 * 1024, null);
-        database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "Device", new String[] { "number" }, 2 * 1024 * 1024, null);
-        database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "Device", new String[] { "relativeName" }, 2 * 1024 * 1024, null);
+        database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, false, "Device", new String[] { "id" }, 2 * 1024 * 1024, null);
+        database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, false, "Device", new String[] { "number" }, 2 * 1024 * 1024, null);
+        database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, false, "Device", new String[] { "relativeName" }, 2 * 1024 * 1024, null);
 //        database.getSchema().createClassIndexes(SchemaImpl.INDEX_TYPE.LSM_TREE, false, "Device", new String[] { "HolderSpec_Name" }, 2 * 1024 * 1024, null);
 //        database.getSchema().createClassIndexes(SchemaImpl.INDEX_TYPE.LSM_TREE, false, "Device", new String[] { "Name" }, 2 * 1024 * 1024, null);
 
@@ -189,7 +189,7 @@ public class PerformanceVertexIndexTest {
   }
 
   private void checkLookups(final int step) {
-    final Database database = new DatabaseFactory(PerformanceTest.DATABASE_PATH).open(ComponentFile.MODE.READ_ONLY);
+    final Database database = new DatabaseFactory(PerformanceTest.DATABASE_PATH).open(ComponentFile.Mode.READ_ONLY);
     long begin = System.currentTimeMillis();
 
     try {

--- a/engine/src/test/java/performance/TraversalTest.java
+++ b/engine/src/test/java/performance/TraversalTest.java
@@ -94,12 +94,12 @@ public class TraversalTest {
     Vertex v = db.lookupByRID(firstRid, false).asVertex();
     tot += v.getInteger("val");
 
-    Iterator<Vertex> vertices = v.getVertices(Vertex.DIRECTION.OUT).iterator();
+    Iterator<Vertex> vertices = v.getVertices(Vertex.Direction.OUT).iterator();
 
     while (vertices.hasNext()) {
       v = vertices.next();
       tot += v.getInteger("val");
-      vertices = v.getVertices(Vertex.DIRECTION.OUT).iterator();
+      vertices = v.getVertices(Vertex.Direction.OUT).iterator();
     }
 
     db.commit();

--- a/graphql/src/main/java/com/arcadedb/graphql/schema/GraphQLResultSet.java
+++ b/graphql/src/main/java/com/arcadedb/graphql/schema/GraphQLResultSet.java
@@ -127,12 +127,12 @@ public class GraphQLResultSet implements ResultSet {
           if ("relationship".equals(directive.getName())) {
             if (directive.getArguments() != null) {
               String type = null;
-              Vertex.DIRECTION direction = Vertex.DIRECTION.BOTH;
+              Vertex.Direction direction = Vertex.Direction.BOTH;
               for (final Argument argument : directive.getArguments().getList()) {
                 if ("type".equals(argument.getName())) {
                   type = argument.getValueWithVariable().getValue().getValue().toString();
                 } else if ("direction".equals(argument.getName())) {
-                  direction = Vertex.DIRECTION.valueOf(argument.getValueWithVariable().getValue().getValue().toString());
+                  direction = Vertex.Direction.valueOf(argument.getValueWithVariable().getValue().getValue().toString());
                 }
               }
 

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
@@ -479,11 +479,11 @@ public class ArcadeGraph implements Graph, Closeable {
     return StringFactory.graphString(this, database.getName());
   }
 
-  public static com.arcadedb.graph.Vertex.DIRECTION mapDirection(final Direction direction) {
+  public static com.arcadedb.graph.Vertex.Direction mapDirection(final Direction direction) {
     return switch (direction) {
-      case OUT -> com.arcadedb.graph.Vertex.DIRECTION.OUT;
-      case IN -> com.arcadedb.graph.Vertex.DIRECTION.IN;
-      case BOTH -> com.arcadedb.graph.Vertex.DIRECTION.BOTH;
+      case OUT -> com.arcadedb.graph.Vertex.Direction.OUT;
+      case IN -> com.arcadedb.graph.Vertex.Direction.IN;
+      case BOTH -> com.arcadedb.graph.Vertex.Direction.BOTH;
     };
   }
 

--- a/gremlin/src/test/java/com/arcadedb/gremlin/GremlinTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/GremlinTest.java
@@ -40,7 +40,6 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
-import java.io.PrintStream;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.UUID;
@@ -338,7 +337,7 @@ public class GremlinTest {
     final ArcadeGraph graph = ArcadeGraph.open("./target/testgremlin");
     try {
       graph.getDatabase().getSchema().getOrCreateVertexType("Person").getOrCreateProperty("id", Type.STRING)
-          .getOrCreateIndex(Schema.INDEX_TYPE.LSM_TREE, true);
+          .getOrCreateIndex(Schema.IndexType.LSM_TREE, true);
 
       final String uuid = UUID.randomUUID().toString();
       final Vertex v = graph.addVertex("Person");

--- a/gremlin/src/test/java/com/arcadedb/gremlin/integration/exporter/GraphMLExporterIT.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/integration/exporter/GraphMLExporterIT.java
@@ -70,7 +70,7 @@ public class GraphMLExporterIT {
 
       assertThat(importedDatabaseDirectory.exists()).isTrue();
 
-      try (final Database originalDatabase = new DatabaseFactory(DATABASE_PATH).open(ComponentFile.MODE.READ_ONLY)) {
+      try (final Database originalDatabase = new DatabaseFactory(DATABASE_PATH).open(ComponentFile.Mode.READ_ONLY)) {
         assertThat(graph.getDatabase().getSchema().getTypes().stream().map(DocumentType::getName).collect(Collectors.toSet())).isEqualTo(originalDatabase.getSchema().getTypes().stream().map(DocumentType::getName).collect(Collectors.toSet()));
 
         for (final DocumentType type : originalDatabase.getSchema().getTypes()) {

--- a/gremlin/src/test/java/com/arcadedb/gremlin/integration/exporter/GraphSONExporterIT.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/integration/exporter/GraphSONExporterIT.java
@@ -70,7 +70,7 @@ public class GraphSONExporterIT {
 
       assertThat(importedDatabaseDirectory.exists()).isTrue();
 
-      try (final Database originalDatabase = new DatabaseFactory(DATABASE_PATH).open(ComponentFile.MODE.READ_ONLY)) {
+      try (final Database originalDatabase = new DatabaseFactory(DATABASE_PATH).open(ComponentFile.Mode.READ_ONLY)) {
         assertThat(graph.getDatabase().getSchema().getTypes().stream().map(DocumentType::getName).collect(Collectors.toSet())).isEqualTo(originalDatabase.getSchema().getTypes().stream().map(DocumentType::getName).collect(Collectors.toSet()));
 
         for (final DocumentType type : originalDatabase.getSchema().getTypes()) {

--- a/gremlin/src/test/java/com/arcadedb/server/gremlin/RemoteGraphOrderIT.java
+++ b/gremlin/src/test/java/com/arcadedb/server/gremlin/RemoteGraphOrderIT.java
@@ -26,10 +26,7 @@ import com.arcadedb.remote.RemoteDatabase;
 import com.arcadedb.remote.RemoteServer;
 import com.arcadedb.server.BaseGraphServerTest;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -72,27 +69,27 @@ public class RemoteGraphOrderIT extends AbstractGremlinServerIT {
 
         //Correct result - Returns one vertex/edge
 // Vertices with outgoing "EdgType0" edge
-        Iterable<Vertex> connectedVertices = rootVtx.getVertices(Vertex.DIRECTION.OUT, "EdgType0");
+        Iterable<Vertex> connectedVertices = rootVtx.getVertices(Vertex.Direction.OUT, "EdgType0");
 
         assertThat(connectedVertices)
             .extracting(Vertex::getTypeName) // extract type names of vertices
             .containsExactly("ConnectedVtx"); // assert all extracted names are "ConnectedVtx"
 
         // Edges with type "EdgType0"
-        Iterable<Edge> outgoingEdges = rootVtx.getEdges(Vertex.DIRECTION.OUT, "EdgType0");
+        Iterable<Edge> outgoingEdges = rootVtx.getEdges(Vertex.Direction.OUT, "EdgType0");
 
         assertThat(outgoingEdges)
             .extracting(Edge::getTypeName) // extract edge types
             .containsExactly("EdgType0"); // assert all extracted types are "EdgType0"
 
         // Incoming edge counts
-        assertThat(rootVtx.countEdges(Vertex.DIRECTION.IN, "EdgType0")).isEqualTo(0);
-        assertThat(rootVtx.countEdges(Vertex.DIRECTION.IN, "EdgType1")).isEqualTo(0);
-        assertThat(rootVtx.countEdges(Vertex.DIRECTION.OUT, "EdgType0")).isEqualTo(1);
-        assertThat(rootVtx.countEdges(Vertex.DIRECTION.OUT, "EdgType1")).isEqualTo(1);
+        assertThat(rootVtx.countEdges(Vertex.Direction.IN, "EdgType0")).isEqualTo(0);
+        assertThat(rootVtx.countEdges(Vertex.Direction.IN, "EdgType1")).isEqualTo(0);
+        assertThat(rootVtx.countEdges(Vertex.Direction.OUT, "EdgType0")).isEqualTo(1);
+        assertThat(rootVtx.countEdges(Vertex.Direction.OUT, "EdgType1")).isEqualTo(1);
 
         // Counting outgoing "EdgType1" edges
-        Iterable<Vertex> vertices = rootVtx.getVertices(Vertex.DIRECTION.OUT, "EdgType1");
+        Iterable<Vertex> vertices = rootVtx.getVertices(Vertex.Direction.OUT, "EdgType1");
 
         assertThat(vertices).hasSize(1);
       }

--- a/integration/src/main/java/com/arcadedb/integration/importer/AbstractImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/AbstractImporter.java
@@ -156,7 +156,7 @@ public abstract class AbstractImporter {
       final DocumentType type = database.getSchema().buildDocumentType().withName(name).withTotalBuckets(settings.parallel).create();
       if (settings.typeIdProperty != null) {
         type.createProperty(settings.typeIdProperty, Type.getTypeByName(settings.typeIdType));
-        database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, settings.typeIdPropertyIsUnique, name, settings.typeIdProperty);
+        database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, settings.typeIdPropertyIsUnique, name, settings.typeIdProperty);
         LogManager.instance().log(this, Level.INFO, "- Creating indexed property '%s' of type '%s'", settings.typeIdProperty, settings.typeIdType);
       }
       return type;
@@ -172,7 +172,7 @@ public abstract class AbstractImporter {
       final VertexType type = database.getSchema().buildVertexType().withName(name).withTotalBuckets(settings.parallel).create();
       if (settings.typeIdProperty != null) {
         type.createProperty(settings.typeIdProperty, Type.getTypeByName(settings.typeIdType));
-        database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, settings.typeIdPropertyIsUnique, name, settings.typeIdProperty);
+        database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, settings.typeIdPropertyIsUnique, name, settings.typeIdProperty);
         LogManager.instance().log(this, Level.INFO, "- Creating indexed property '%s' of type '%s'", settings.typeIdProperty, settings.typeIdType);
       }
       return type;

--- a/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
@@ -200,7 +200,7 @@ public class Neo4jImporter {
     final VertexType rootNodeType = database.getSchema().buildVertexType().withName("Node")
         .withTotalBuckets(bucketsPerType).withIgnoreIfExists(true).create();
     rootNodeType.getOrCreateProperty("id", Type.STRING);
-    rootNodeType.getOrCreateTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, new String[] { "id" }, indexPageSize);
+    rootNodeType.getOrCreateTypeIndex(Schema.IndexType.LSM_TREE, true, new String[] { "id" }, indexPageSize);
 
     readFile(json -> {
       switch (json.getString("type")) {

--- a/integration/src/main/java/com/arcadedb/integration/importer/OrientDBImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/OrientDBImporter.java
@@ -1036,12 +1036,12 @@ public class OrientDBImporter {
       // PATCH TO ALWAYS USE SKIP BECAUSE IN ORIENTDB AN INDEX WITHOUT THE IGNORE SETTINGS CAN STILL HAVE NULL PROPERTIES INDEXES.
       nullValuesIgnored = true;
 
-      final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy = nullValuesIgnored ?
-          LSMTreeIndexAbstract.NULL_STRATEGY.SKIP :
-          LSMTreeIndexAbstract.NULL_STRATEGY.ERROR;
+      final LSMTreeIndexAbstract.NullStrategy nullStrategy = nullValuesIgnored ?
+          LSMTreeIndexAbstract.NullStrategy.SKIP :
+          LSMTreeIndexAbstract.NullStrategy.ERROR;
 
       database.getSchema()
-          .getOrCreateTypeIndex(Schema.INDEX_TYPE.LSM_TREE, unique, className, properties, LSMTreeIndexAbstract.DEF_PAGE_SIZE,
+          .getOrCreateTypeIndex(Schema.IndexType.LSM_TREE, unique, className, properties, LSMTreeIndexAbstract.DEF_PAGE_SIZE,
               nullStrategy, null);
 
       logger.logLine(2, "- Created index %s on %s%s", unique ? "UNIQUE" : "NOTUNIQUE", className, Arrays.toString(properties));
@@ -1272,7 +1272,7 @@ public class OrientDBImporter {
     boolean valid = true;
     final Collection<TypeIndex> indexes = type.getAllIndexes(true);
     for (final Index index : indexes) {
-      if (index.getNullStrategy() == LSMTreeIndexAbstract.NULL_STRATEGY.ERROR) {
+      if (index.getNullStrategy() == LSMTreeIndexAbstract.NullStrategy.ERROR) {
         final String indexedPropName = index.getPropertyNames().getFirst();
         final Object value = properties.get(indexedPropName);
         if (value == null) {

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JSONImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JSONImporterFormat.java
@@ -334,7 +334,7 @@ public class JSONImporterFormat implements FormatImporter {
         prop = type.createProperty(id, propType);
       }
 
-      prop.getOrCreateIndex(Schema.INDEX_TYPE.LSM_TREE, true);
+      prop.getOrCreateIndex(Schema.IndexType.LSM_TREE, true);
 
       IndexCursor existent = database.lookupByKey(typeName, id, idValue);
       if (existent.hasNext()) {
@@ -551,7 +551,7 @@ public class JSONImporterFormat implements FormatImporter {
         final String cardinality = mappingObject.optString("@cardinality");
         if ("no-duplicates".equalsIgnoreCase(cardinality)) {
           boolean duplicates = false;
-          for (Iterator<Vertex> connectedVertices = ((Vertex) record).getVertices(Vertex.DIRECTION.OUT, subTypeName)
+          for (Iterator<Vertex> connectedVertices = ((Vertex) record).getVertices(Vertex.Direction.OUT, subTypeName)
               .iterator(); connectedVertices.hasNext(); ) {
             final RID connectedVertex = connectedVertices.next().getIdentity();
             if (destVertex.getIdentity().equals(connectedVertex)) {

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/JsonlImporterFormat.java
@@ -9,7 +9,7 @@ import com.arcadedb.graph.MutableEdge;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.index.CompressedRID2RIDIndex;
-import com.arcadedb.index.lsm.LSMTreeIndexAbstract.NULL_STRATEGY;
+import com.arcadedb.index.lsm.LSMTreeIndexAbstract.NullStrategy;
 import com.arcadedb.integration.importer.AnalyzedEntity.EntityType;
 import com.arcadedb.integration.importer.AnalyzedSchema;
 import com.arcadedb.integration.importer.ConsoleLogger;
@@ -156,10 +156,10 @@ public class JsonlImporterFormat extends AbstractImporterFormat {
           indexes.keySet()
               .forEach(index -> {
                 var idx = indexes.getJSONObject(index);
-                var idxType = Schema.INDEX_TYPE.valueOf(idx.getString("type"));
+                var idxType = Schema.IndexType.valueOf(idx.getString("type"));
                 var idxFields = idx.getJSONArray("properties").toList().stream().map(Object::toString).toArray(String[]::new);
                 var typeIndex = docType.getOrCreateTypeIndex(idxType, idx.getBoolean("unique"), idxFields);
-                typeIndex.setNullStrategy(NULL_STRATEGY.valueOf(idx.getString("nullStrategy")));
+                typeIndex.setNullStrategy(NullStrategy.valueOf(idx.getString("nullStrategy")));
               });
 
         });

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/CreateEdgeFromImportTask.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/CreateEdgeFromImportTask.java
@@ -225,7 +225,7 @@ public class CreateEdgeFromImportTask implements DatabaseAsyncTask {
 
     final EdgeSegment inChunk = database.getGraphEngine().createInEdgeChunk(toVertexRecord);
 
-    final EdgeLinkedList inLinkedList = new EdgeLinkedList(toVertexRecord, Vertex.DIRECTION.IN, inChunk);
+    final EdgeLinkedList inLinkedList = new EdgeLinkedList(toVertexRecord, Vertex.Direction.IN, inChunk);
     inLinkedList.addAll(connections);
 
     if (callback != null)

--- a/integration/src/main/java/com/arcadedb/integration/importer/graph/LinkEdgeFromImportTask.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/graph/LinkEdgeFromImportTask.java
@@ -53,7 +53,7 @@ public class LinkEdgeFromImportTask implements DatabaseAsyncTask {
 
     final EdgeSegment inChunk = database.getGraphEngine().createInEdgeChunk(toVertexRecord);
 
-    final EdgeLinkedList inLinkedList = new EdgeLinkedList(toVertexRecord, Vertex.DIRECTION.IN, inChunk);
+    final EdgeLinkedList inLinkedList = new EdgeLinkedList(toVertexRecord, Vertex.Direction.IN, inChunk);
     inLinkedList.addAll(connections);
 
     if (callback != null)

--- a/integration/src/test/java/com/arcadedb/integration/backup/FullBackupIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/backup/FullBackupIT.java
@@ -65,9 +65,9 @@ public class FullBackupIT {
 
     new Restore(("-f " + FILE + " -d " + restoredDirectory + " -o").split(" ")).restoreDatabase();
 
-    try (final Database originalDatabase = new DatabaseFactory(DATABASE_PATH).open(ComponentFile.MODE.READ_ONLY)) {
+    try (final Database originalDatabase = new DatabaseFactory(DATABASE_PATH).open(ComponentFile.Mode.READ_ONLY)) {
       try (final Database restoredDatabase = new DatabaseFactory(restoredDirectory.getAbsolutePath()).open(
-          ComponentFile.MODE.READ_ONLY)) {
+          ComponentFile.Mode.READ_ONLY)) {
         new DatabaseComparator().compare(originalDatabase, restoredDatabase);
       }
     }
@@ -85,9 +85,9 @@ public class FullBackupIT {
 
     new Restore(("-f " + FILE + " -d " + restoredDirectory + " -o -encryptionKey AnotherTestWithHard2GuessPassword").split(" ")).restoreDatabase();
 
-    try (final Database originalDatabase = new DatabaseFactory(DATABASE_PATH).open(ComponentFile.MODE.READ_ONLY)) {
+    try (final Database originalDatabase = new DatabaseFactory(DATABASE_PATH).open(ComponentFile.Mode.READ_ONLY)) {
       try (final Database restoredDatabase = new DatabaseFactory(restoredDirectory.getAbsolutePath()).open(
-          ComponentFile.MODE.READ_ONLY)) {
+          ComponentFile.Mode.READ_ONLY)) {
         new DatabaseComparator().compare(originalDatabase, restoredDatabase);
       }
     }
@@ -106,7 +106,7 @@ public class FullBackupIT {
       new Restore(FILE, restoredDirectory.getAbsolutePath()).restoreDatabase();
 
       try (final Database restoredDatabase = new DatabaseFactory(restoredDirectory.getAbsolutePath()).open(
-          ComponentFile.MODE.READ_ONLY)) {
+          ComponentFile.Mode.READ_ONLY)) {
         new DatabaseComparator().compare(importedDatabase, restoredDatabase);
       }
     }
@@ -141,7 +141,7 @@ public class FullBackupIT {
       importedDatabase.transaction(() -> {
         type.createProperty("thread", Type.INTEGER);
         type.createProperty("id", Type.INTEGER);
-        type.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "thread", "id");
+        type.createTypeIndex(Schema.IndexType.LSM_TREE, false, "thread", "id");
         type.setBucketSelectionStrategy(new ThreadBucketSelectionStrategy() {
           @Override
           public int getBucketIdByRecord(final Document record, final boolean async) {
@@ -199,7 +199,7 @@ public class FullBackupIT {
 
         new Restore(FILE + "_" + i, databasePath).setVerboseLevel(1).restoreDatabase();
         logger.logLine(1, "Checking restored database %s", databasePath);
-        try (final Database restoredDatabase = new DatabaseFactory(databasePath).open(ComponentFile.MODE.READ_ONLY)) {
+        try (final Database restoredDatabase = new DatabaseFactory(databasePath).open(ComponentFile.Mode.READ_ONLY)) {
           // VERIFY ONLY WHOLE TRANSACTION ARE WRITTEN
           assertThat(restoredDatabase.countType("BackupTest", true) % 500).isEqualTo(0);
         }

--- a/integration/src/test/java/com/arcadedb/integration/importer/JSONImporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/JSONImporterIT.java
@@ -128,20 +128,20 @@ public class JSONImporterIT {
 
         if ("Marcus".equalsIgnoreCase(name)) {
           assertThat(vertex.getString("id")).isEqualTo("1234");
-          assertThat(vertex.countEdges(Vertex.DIRECTION.OUT, "HAS_MANAGER")).isEqualTo(0);
-          assertThat(vertex.countEdges(Vertex.DIRECTION.IN, "HAS_MANAGER")).isEqualTo(2);
+          assertThat(vertex.countEdges(Vertex.Direction.OUT, "HAS_MANAGER")).isEqualTo(0);
+          assertThat(vertex.countEdges(Vertex.Direction.IN, "HAS_MANAGER")).isEqualTo(2);
         } else if ("Win".equals(name)) {
           assertThat(vertex.getString("id")).isEqualTo("1230");
-          assertThat(vertex.countEdges(Vertex.DIRECTION.OUT, "HAS_MANAGER")).isEqualTo(1);
-          assertThat(vertex.countEdges(Vertex.DIRECTION.IN, "HAS_MANAGER")).isEqualTo(0);
+          assertThat(vertex.countEdges(Vertex.Direction.OUT, "HAS_MANAGER")).isEqualTo(1);
+          assertThat(vertex.countEdges(Vertex.Direction.IN, "HAS_MANAGER")).isEqualTo(0);
         } else if ("Dave".equals(name)) {
           assertThat(vertex.getString("id")).isEqualTo("1232");
-          assertThat(vertex.countEdges(Vertex.DIRECTION.OUT, "HAS_MANAGER")).isEqualTo(1);
-          assertThat(vertex.countEdges(Vertex.DIRECTION.IN, "HAS_MANAGER")).isEqualTo(1);
+          assertThat(vertex.countEdges(Vertex.Direction.OUT, "HAS_MANAGER")).isEqualTo(1);
+          assertThat(vertex.countEdges(Vertex.Direction.IN, "HAS_MANAGER")).isEqualTo(1);
         } else if ("Albert".equals(name)) {
           assertThat(vertex.getString("id")).isEqualTo("1239");
-          assertThat(vertex.countEdges(Vertex.DIRECTION.OUT, "HAS_MANAGER")).isEqualTo(1);
-          assertThat(vertex.countEdges(Vertex.DIRECTION.IN, "HAS_MANAGER")).isEqualTo(0);
+          assertThat(vertex.countEdges(Vertex.Direction.OUT, "HAS_MANAGER")).isEqualTo(1);
+          assertThat(vertex.countEdges(Vertex.Direction.IN, "HAS_MANAGER")).isEqualTo(0);
         } else
           fail("");
       }

--- a/integration/src/test/java/com/arcadedb/integration/importer/JsonLImporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/JsonLImporterIT.java
@@ -1,11 +1,8 @@
 package com.arcadedb.integration.importer;
 
-import com.arcadedb.database.DatabaseComparator;
 import com.arcadedb.database.DatabaseFactory;
-import com.arcadedb.database.DatabaseInternal;
-import com.arcadedb.index.lsm.LSMTreeIndexAbstract.NULL_STRATEGY;
+import com.arcadedb.index.lsm.LSMTreeIndexAbstract.NullStrategy;
 import com.arcadedb.integration.TestHelper;
-import com.arcadedb.integration.exporter.Exporter;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.utility.FileUtils;
@@ -80,8 +77,8 @@ public class JsonLImporterIT {
             assertThat(type.getProperty("id").getType()).isEqualTo(Type.INTEGER);
             assertThat(type.getIndexesByProperties("id").getFirst())
                 .satisfies(index -> {
-                  assertThat(index.getType()).isEqualTo(Schema.INDEX_TYPE.LSM_TREE);
-                  assertThat(index.getNullStrategy()).isEqualTo(NULL_STRATEGY.SKIP);
+                  assertThat(index.getType()).isEqualTo(Schema.IndexType.LSM_TREE);
+                  assertThat(index.getNullStrategy()).isEqualTo(NullStrategy.SKIP);
                   assertThat(index.isUnique()).isTrue();
                 });
           });
@@ -90,8 +87,8 @@ public class JsonLImporterIT {
             assertThat(type.getProperty("id").getType()).isEqualTo(Type.INTEGER);
             assertThat(type.getIndexesByProperties("id").getFirst())
                 .satisfies(index -> {
-                  assertThat(index.getType()).isEqualTo(Schema.INDEX_TYPE.LSM_TREE);
-                  assertThat(index.getNullStrategy()).isEqualTo(NULL_STRATEGY.SKIP);
+                  assertThat(index.getType()).isEqualTo(Schema.IndexType.LSM_TREE);
+                  assertThat(index.getNullStrategy()).isEqualTo(NullStrategy.SKIP);
                   assertThat(index.isUnique()).isTrue();
                 });
           });

--- a/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterIT.java
@@ -87,7 +87,7 @@ public class Neo4jImporterIT {
           assertThat(friendType).isNotNull();
           assertThat(database.countType("KNOWS", true)).isEqualTo(1);
 
-          final Iterator<Edge> relationships = v.getEdges(Vertex.DIRECTION.OUT, "KNOWS").iterator();
+          final Iterator<Edge> relationships = v.getEdges(Vertex.Direction.OUT, "KNOWS").iterator();
           assertThat(relationships.hasNext()).isTrue();
           final Edge e = relationships.next();
 
@@ -203,7 +203,7 @@ public class Neo4jImporterIT {
           assertThat(friendType).isNotNull();
           assertThat(database.countType("KNOWS", true)).isEqualTo(TOTAL / 2);
 
-          final Iterator<Edge> relationships = v.getEdges(Vertex.DIRECTION.OUT, "KNOWS").iterator();
+          final Iterator<Edge> relationships = v.getEdges(Vertex.Direction.OUT, "KNOWS").iterator();
           assertThat(relationships.hasNext()).isTrue();
           final Edge e = relationships.next();
 

--- a/integration/src/test/java/com/arcadedb/integration/importer/OrientDBImporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/OrientDBImporterIT.java
@@ -67,13 +67,13 @@ public class OrientDBImporterIT {
         assertThat(personType).isNotNull();
         assertThat(personType.getProperty("id").getType()).isEqualTo(Type.INTEGER);
         assertThat(database.countType("Person", true)).isEqualTo(500);
-        assertThat(database.getSchema().getIndexByName("Person[id]").getType()).isEqualTo(Schema.INDEX_TYPE.LSM_TREE);
+        assertThat(database.getSchema().getIndexByName("Person[id]").getType()).isEqualTo(Schema.IndexType.LSM_TREE);
 
         final DocumentType friendType = database.getSchema().getType("Friend");
         assertThat(friendType).isNotNull();
         assertThat(friendType.getProperty("id").getType()).isEqualTo(Type.INTEGER);
         assertThat(database.countType("Friend", true)).isEqualTo(10_000);
-        assertThat(database.getSchema().getIndexByName("Friend[id]").getType()).isEqualTo(Schema.INDEX_TYPE.LSM_TREE);
+        assertThat(database.getSchema().getIndexByName("Friend[id]").getType()).isEqualTo(Schema.IndexType.LSM_TREE);
 
         final File securityFile = new File("./server-users.jsonl");
         assertThat(securityFile.exists()).isTrue();

--- a/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteDatabase.java
@@ -60,9 +60,9 @@ public class RemoteDatabase extends RemoteHttpComponent implements BasicDatabase
 
   private final String                               databaseName;
   private       BinarySerializer                     serializer;
-  private       String                               sessionId;
-  private       Database.TRANSACTION_ISOLATION_LEVEL transactionIsolationLevel = Database.TRANSACTION_ISOLATION_LEVEL.READ_COMMITTED;
-  private final RemoteSchema                         schema                    = new RemoteSchema(this);
+  private       String                             sessionId;
+  private       Database.TransactionIsolationLevel transactionIsolationLevel = Database.TransactionIsolationLevel.READ_COMMITTED;
+  private final RemoteSchema                       schema                    = new RemoteSchema(this);
   private       boolean                              open                      = true;
   private       RemoteTransactionExplicitLock        explicitLock;
 
@@ -239,7 +239,7 @@ public class RemoteDatabase extends RemoteHttpComponent implements BasicDatabase
   }
 
   @Override
-  public void begin(final Database.TRANSACTION_ISOLATION_LEVEL isolationLevel) {
+  public void begin(final Database.TransactionIsolationLevel isolationLevel) {
     checkDatabaseIsOpen();
     if (getSessionId() != null)
       throw new TransactionException("Transaction already begun");
@@ -482,11 +482,11 @@ public class RemoteDatabase extends RemoteHttpComponent implements BasicDatabase
         (connection, response) -> createResultSet(response));
   }
 
-  public Database.TRANSACTION_ISOLATION_LEVEL getTransactionIsolationLevel() {
+  public Database.TransactionIsolationLevel getTransactionIsolationLevel() {
     return transactionIsolationLevel;
   }
 
-  public void setTransactionIsolationLevel(final Database.TRANSACTION_ISOLATION_LEVEL transactionIsolationLevel) {
+  public void setTransactionIsolationLevel(final Database.TransactionIsolationLevel transactionIsolationLevel) {
     this.transactionIsolationLevel = transactionIsolationLevel;
   }
 

--- a/network/src/main/java/com/arcadedb/remote/RemoteDocumentType.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteDocumentType.java
@@ -28,7 +28,6 @@ import com.arcadedb.index.IndexInternal;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
 import com.arcadedb.query.sql.executor.Result;
-import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Property;
 import com.arcadedb.schema.Schema;
@@ -211,14 +210,14 @@ public class RemoteDocumentType implements DocumentType {
   }
 
   @Override
-  public TypeIndex createTypeIndex(final Schema.INDEX_TYPE indexType, final boolean unique, final String... propertyNames) {
+  public TypeIndex createTypeIndex(final Schema.IndexType indexType, final boolean unique, final String... propertyNames) {
     remoteDatabase.getSchema().createTypeIndex(indexType, unique, name, propertyNames);
     remoteDatabase.getSchema().invalidateSchema();
     return null;
   }
 
   @Override
-  public TypeIndex getOrCreateTypeIndex(final Schema.INDEX_TYPE indexType, final boolean unique, final String... propertyNames) {
+  public TypeIndex getOrCreateTypeIndex(final Schema.IndexType indexType, final boolean unique, final String... propertyNames) {
     remoteDatabase.getSchema().getOrCreateTypeIndex(indexType, unique, name, propertyNames);
     remoteDatabase.getSchema().invalidateSchema();
     return null;
@@ -346,38 +345,38 @@ public class RemoteDocumentType implements DocumentType {
   }
 
   @Override
-  public TypeIndex getOrCreateTypeIndex(final Schema.INDEX_TYPE indexType, final boolean unique, final String[] propertyNames,
+  public TypeIndex getOrCreateTypeIndex(final Schema.IndexType indexType, final boolean unique, final String[] propertyNames,
       final int pageSize) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public TypeIndex getOrCreateTypeIndex(final Schema.INDEX_TYPE indexType, final boolean unique, final String[] propertyNames,
+  public TypeIndex getOrCreateTypeIndex(final Schema.IndexType indexType, final boolean unique, final String[] propertyNames,
       final int pageSize, Index.BuildIndexCallback callback) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public TypeIndex getOrCreateTypeIndex(Schema.INDEX_TYPE indexType, boolean unique, String[] propertyNames, int pageSize,
-      LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy, Index.BuildIndexCallback callback) {
+  public TypeIndex getOrCreateTypeIndex(Schema.IndexType indexType, boolean unique, String[] propertyNames, int pageSize,
+      LSMTreeIndexAbstract.NullStrategy nullStrategy, Index.BuildIndexCallback callback) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public TypeIndex createTypeIndex(final Schema.INDEX_TYPE indexType, final boolean unique, final String[] propertyNames,
+  public TypeIndex createTypeIndex(final Schema.IndexType indexType, final boolean unique, final String[] propertyNames,
       final int pageSize) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public TypeIndex createTypeIndex(final Schema.INDEX_TYPE indexType, final boolean unique, final String[] propertyNames,
+  public TypeIndex createTypeIndex(final Schema.IndexType indexType, final boolean unique, final String[] propertyNames,
       final int pageSize, final Index.BuildIndexCallback callback) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public TypeIndex createTypeIndex(final Schema.INDEX_TYPE indexType, final boolean unique, final String[] propertyNames,
-      final int pageSize, final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy, final Index.BuildIndexCallback callback) {
+  public TypeIndex createTypeIndex(final Schema.IndexType indexType, final boolean unique, final String[] propertyNames,
+      final int pageSize, final LSMTreeIndexAbstract.NullStrategy nullStrategy, final Index.BuildIndexCallback callback) {
     throw new UnsupportedOperationException();
   }
 

--- a/network/src/main/java/com/arcadedb/remote/RemoteImmutableEdge.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteImmutableEdge.java
@@ -62,8 +62,8 @@ public class RemoteImmutableEdge extends RemoteImmutableDocument implements Edge
   }
 
   @Override
-  public Vertex getVertex(final Vertex.DIRECTION iDirection) {
-    if (iDirection == Vertex.DIRECTION.OUT)
+  public Vertex getVertex(final Vertex.Direction iDirection) {
+    if (iDirection == Vertex.Direction.OUT)
       return getOutVertex();
     else
       return getInVertex();

--- a/network/src/main/java/com/arcadedb/remote/RemoteImmutableVertex.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteImmutableVertex.java
@@ -57,27 +57,27 @@ public class RemoteImmutableVertex extends RemoteImmutableDocument implements Ve
   }
 
   @Override
-  public long countEdges(final DIRECTION direction, final String edgeType) {
+  public long countEdges(final Direction direction, final String edgeType) {
     return internal.countEdges(direction, edgeType);
   }
 
   @Override
   public IterableGraph<Edge> getEdges() {
-    return internal.getEdges(DIRECTION.BOTH);
+    return internal.getEdges(Direction.BOTH);
   }
 
   @Override
-  public IterableGraph<Edge> getEdges(final DIRECTION direction, final String... edgeTypes) {
+  public IterableGraph<Edge> getEdges(final Direction direction, final String... edgeTypes) {
     return internal.getEdges(direction, edgeTypes);
   }
 
   @Override
   public IterableGraph<Vertex> getVertices() {
-    return internal.getVertices(DIRECTION.BOTH);
+    return internal.getVertices(Direction.BOTH);
   }
 
   @Override
-  public IterableGraph<Vertex> getVertices(final DIRECTION direction, final String... edgeTypes) {
+  public IterableGraph<Vertex> getVertices(final Direction direction, final String... edgeTypes) {
     return internal.getVertices(direction, edgeTypes);
   }
 
@@ -87,12 +87,12 @@ public class RemoteImmutableVertex extends RemoteImmutableDocument implements Ve
   }
 
   @Override
-  public boolean isConnectedTo(final Identifiable toVertex, final DIRECTION direction) {
+  public boolean isConnectedTo(final Identifiable toVertex, final Direction direction) {
     return internal.isConnectedTo(toVertex, direction);
   }
 
   @Override
-  public boolean isConnectedTo(final Identifiable toVertex, final DIRECTION direction, final String edgeType) {
+  public boolean isConnectedTo(final Identifiable toVertex, final Direction direction, final String edgeType) {
     return internal.isConnectedTo(toVertex, direction, edgeType);
   }
 

--- a/network/src/main/java/com/arcadedb/remote/RemoteMutableVertex.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteMutableVertex.java
@@ -154,27 +154,27 @@ public class RemoteMutableVertex extends MutableVertex {
   }
 
   @Override
-  public long countEdges(final DIRECTION direction, final String edgeType) {
+  public long countEdges(final Direction direction, final String edgeType) {
     return internal.countEdges(direction, edgeType);
   }
 
   @Override
   public IterableGraph<Edge> getEdges() {
-    return internal.getEdges(DIRECTION.BOTH);
+    return internal.getEdges(Direction.BOTH);
   }
 
   @Override
-  public IterableGraph<Edge> getEdges(final DIRECTION direction, final String... edgeTypes) {
-    return internal.getEdges(DIRECTION.BOTH, edgeTypes);
+  public IterableGraph<Edge> getEdges(final Direction direction, final String... edgeTypes) {
+    return internal.getEdges(Direction.BOTH, edgeTypes);
   }
 
   @Override
   public IterableGraph<Vertex> getVertices() {
-    return internal.getVertices(DIRECTION.BOTH);
+    return internal.getVertices(Direction.BOTH);
   }
 
   @Override
-  public IterableGraph<Vertex> getVertices(final DIRECTION direction, final String... edgeTypes) {
+  public IterableGraph<Vertex> getVertices(final Direction direction, final String... edgeTypes) {
     return internal.getVertices(direction, edgeTypes);
   }
 
@@ -184,12 +184,12 @@ public class RemoteMutableVertex extends MutableVertex {
   }
 
   @Override
-  public boolean isConnectedTo(final Identifiable toVertex, final DIRECTION direction) {
+  public boolean isConnectedTo(final Identifiable toVertex, final Direction direction) {
     return internal.isConnectedTo(toVertex, direction);
   }
 
   @Override
-  public boolean isConnectedTo(final Identifiable toVertex, final DIRECTION direction, final String edgeType) {
+  public boolean isConnectedTo(final Identifiable toVertex, final Direction direction, final String edgeType) {
     return internal.isConnectedTo(toVertex, direction, edgeType);
   }
 

--- a/network/src/main/java/com/arcadedb/remote/RemoteSchema.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteSchema.java
@@ -103,7 +103,7 @@ public class RemoteSchema implements Schema {
   }
 
   @Override
-  public TypeIndex createTypeIndex(final INDEX_TYPE indexType, final boolean unique, final String typeName,
+  public TypeIndex createTypeIndex(final IndexType indexType, final boolean unique, final String typeName,
       final String... propertyNames) {
     final String propList = Arrays.stream(propertyNames).collect(Collectors.joining(","));
     remoteDatabase.command("sql", "create index on `" + typeName +//
@@ -114,7 +114,7 @@ public class RemoteSchema implements Schema {
   }
 
   @Override
-  public TypeIndex getOrCreateTypeIndex(final INDEX_TYPE indexType, final boolean unique, final String typeName,
+  public TypeIndex getOrCreateTypeIndex(final IndexType indexType, final boolean unique, final String typeName,
       final String... propertyNames) {
     final String propList = Arrays.stream(propertyNames).collect(Collectors.joining(","));
     remoteDatabase.command("sql", "create index if not exists on `" + typeName +//
@@ -508,53 +508,53 @@ public class RemoteSchema implements Schema {
 
   @Deprecated
   @Override
-  public TypeIndex createTypeIndex(final INDEX_TYPE indexType, final boolean unique, final String typeName,
+  public TypeIndex createTypeIndex(final IndexType indexType, final boolean unique, final String typeName,
       final String[] propertyNames, final int pageSize) {
     throw new UnsupportedOperationException();
   }
 
   @Deprecated
   @Override
-  public TypeIndex createTypeIndex(final INDEX_TYPE indexType, final boolean unique, final String typeName,
+  public TypeIndex createTypeIndex(final IndexType indexType, final boolean unique, final String typeName,
       final String[] propertyNames, final int pageSize, Index.BuildIndexCallback callback) {
     throw new UnsupportedOperationException();
   }
 
   @Deprecated
   @Override
-  public TypeIndex createTypeIndex(final INDEX_TYPE indexType, final boolean unique, final String typeName,
-      final String[] propertyNames, final int pageSize, final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy,
+  public TypeIndex createTypeIndex(final IndexType indexType, final boolean unique, final String typeName,
+      final String[] propertyNames, final int pageSize, final LSMTreeIndexAbstract.NullStrategy nullStrategy,
       final Index.BuildIndexCallback callback) {
     throw new UnsupportedOperationException();
   }
 
   @Deprecated
   @Override
-  public TypeIndex getOrCreateTypeIndex(final INDEX_TYPE indexType, final boolean unique, final String typeName,
+  public TypeIndex getOrCreateTypeIndex(final IndexType indexType, final boolean unique, final String typeName,
       final String[] propertyNames, final int pageSize, final Index.BuildIndexCallback callback) {
     throw new UnsupportedOperationException();
   }
 
   @Deprecated
   @Override
-  public TypeIndex getOrCreateTypeIndex(final INDEX_TYPE indexType, final boolean unique, final String typeName,
-      final String[] propertyNames, final int pageSize, LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy,
+  public TypeIndex getOrCreateTypeIndex(final IndexType indexType, final boolean unique, final String typeName,
+      final String[] propertyNames, final int pageSize, LSMTreeIndexAbstract.NullStrategy nullStrategy,
       Index.BuildIndexCallback callback) {
     throw new UnsupportedOperationException();
   }
 
   @Deprecated
   @Override
-  public Index createBucketIndex(final INDEX_TYPE indexType, final boolean unique, final String typeName, final String bucketName,
-      final String[] propertyNames, final int pageSize, final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy,
+  public Index createBucketIndex(final IndexType indexType, final boolean unique, final String typeName, final String bucketName,
+      final String[] propertyNames, final int pageSize, final LSMTreeIndexAbstract.NullStrategy nullStrategy,
       final Index.BuildIndexCallback callback) {
     throw new UnsupportedOperationException();
   }
 
   @Deprecated
   @Override
-  public Index createManualIndex(final INDEX_TYPE indexType, final boolean unique, final String indexName, final Type[] keyTypes,
-      final int pageSize, final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy) {
+  public Index createManualIndex(final IndexType indexType, final boolean unique, final String indexName, final Type[] keyTypes,
+      final int pageSize, final LSMTreeIndexAbstract.NullStrategy nullStrategy) {
     throw new UnsupportedOperationException();
   }
 
@@ -592,7 +592,7 @@ public class RemoteSchema implements Schema {
 
   @Deprecated
   @Override
-  public TypeIndex getOrCreateTypeIndex(final INDEX_TYPE indexType, final boolean unique, final String typeName,
+  public TypeIndex getOrCreateTypeIndex(final IndexType indexType, final boolean unique, final String typeName,
       final String[] propertyNames, int pageSize) {
     throw new UnsupportedOperationException();
   }

--- a/network/src/main/java/com/arcadedb/remote/RemoteVertex.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteVertex.java
@@ -50,7 +50,7 @@ public class RemoteVertex {
     this.remoteDatabase = remoteDatabase;
   }
 
-  public long countEdges(final Vertex.DIRECTION direction, final String edgeType) {
+  public long countEdges(final Vertex.Direction direction, final String edgeType) {
     StringBuilder query = new StringBuilder("select " + direction.toString().toLowerCase(Locale.ENGLISH) + "(");
     if (edgeType != null)
       query.append("'").append(edgeType).append("'");
@@ -61,10 +61,10 @@ public class RemoteVertex {
   }
 
   public IterableGraph<Edge> getEdges() {
-    return getEdges(Vertex.DIRECTION.BOTH);
+    return getEdges(Vertex.Direction.BOTH);
   }
 
-  public IterableGraph<Edge> getEdges(final Vertex.DIRECTION direction, final String... edgeTypes) {
+  public IterableGraph<Edge> getEdges(final Vertex.Direction direction, final String... edgeTypes) {
     final ResultSet resultSet = fetch("E", direction, edgeTypes);
     return () -> new Iterator<>() {
       @Override
@@ -80,10 +80,10 @@ public class RemoteVertex {
   }
 
   public IterableGraph<Vertex> getVertices() {
-    return getVertices(Vertex.DIRECTION.BOTH);
+    return getVertices(Vertex.Direction.BOTH);
   }
 
-  public IterableGraph<Vertex> getVertices(final Vertex.DIRECTION direction, final String... edgeTypes) {
+  public IterableGraph<Vertex> getVertices(final Vertex.Direction direction, final String... edgeTypes) {
     final ResultSet resultSet = fetch("", direction, edgeTypes);
     return () -> new Iterator<>() {
       @Override
@@ -105,7 +105,7 @@ public class RemoteVertex {
     return resultSet.hasNext();
   }
 
-  public boolean isConnectedTo(final Identifiable toVertex, final Vertex.DIRECTION direction) {
+  public boolean isConnectedTo(final Identifiable toVertex, final Vertex.Direction direction) {
     final String query =
         "select from ( select " + direction.toString().toLowerCase(Locale.ENGLISH) + "() as vertices from " + vertex.getIdentity()
             + " ) where vertices contains " + toVertex;
@@ -113,7 +113,7 @@ public class RemoteVertex {
     return resultSet.hasNext();
   }
 
-  public boolean isConnectedTo(final Identifiable toVertex, final Vertex.DIRECTION direction, final String edgeType) {
+  public boolean isConnectedTo(final Identifiable toVertex, final Vertex.Direction direction, final String edgeType) {
     final String query =
         "select from ( select " + direction.toString().toLowerCase(Locale.ENGLISH) + "('" + edgeType + "') as vertices from "
             + vertex.getIdentity() + " ) where vertices contains " + toVertex;
@@ -224,7 +224,7 @@ public class RemoteVertex {
     remoteDatabase.command("sql", "delete from " + vertex.getIdentity());
   }
 
-  private ResultSet fetch(final String suffix, final Vertex.DIRECTION direction, final String[] types) {
+  private ResultSet fetch(final String suffix, final Vertex.Direction direction, final String[] types) {
     StringBuilder query = new StringBuilder("select expand( " + direction.toString().toLowerCase(Locale.ENGLISH) + suffix + "(");
     for (int i = 0; i < types.length; ++i) {
       if (i > 0)

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -79,7 +79,7 @@ import static com.arcadedb.schema.Property.TYPE_PROPERTY;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class PostgresNetworkExecutor extends Thread {
-  public enum ERROR_SEVERITY {FATAL, ERROR}
+  public enum ErrorSeverity {FATAL, ERROR}
 
   public static final String PG_SERVER_VERSION = "12.0";
 
@@ -344,10 +344,10 @@ public class PostgresNetworkExecutor extends Thread {
       }
     } catch (final CommandParsingException e) {
       setErrorInTx();
-      writeError(ERROR_SEVERITY.ERROR, "Syntax error on executing query: " + e.getCause().getMessage(), "42601");
+      writeError(ErrorSeverity.ERROR, "Syntax error on executing query: " + e.getCause().getMessage(), "42601");
     } catch (final Exception e) {
       setErrorInTx();
-      writeError(ERROR_SEVERITY.ERROR, "Error on executing query: " + e.getMessage(), "XX000");
+      writeError(ErrorSeverity.ERROR, "Error on executing query: " + e.getMessage(), "XX000");
     }
   }
 
@@ -402,10 +402,10 @@ public class PostgresNetworkExecutor extends Thread {
 
     } catch (final CommandParsingException e) {
       setErrorInTx();
-      writeError(ERROR_SEVERITY.ERROR, "Syntax error on executing query: " + e.getCause().getMessage(), "42601");
+      writeError(ErrorSeverity.ERROR, "Syntax error on executing query: " + e.getCause().getMessage(), "42601");
     } catch (final Exception e) {
       setErrorInTx();
-      writeError(ERROR_SEVERITY.ERROR, "Error on executing query: " + e.getMessage(), "XX000");
+      writeError(ErrorSeverity.ERROR, "Error on executing query: " + e.getMessage(), "XX000");
     } finally {
       writeReadyForQueryMessage();
     }
@@ -559,7 +559,7 @@ public class PostgresNetworkExecutor extends Thread {
             if (row.isElement()) {
               final Document record = row.getElement().get();
               if (record instanceof Vertex vertex)
-                yield vertex.countEdges(Vertex.DIRECTION.OUT, null);
+                yield vertex.countEdges(Vertex.Direction.OUT, null);
               else if (record instanceof Edge edge)
                 yield edge.getOut();
             }
@@ -569,7 +569,7 @@ public class PostgresNetworkExecutor extends Thread {
             if (row.isElement()) {
               final Document record = row.getElement().get();
               if (record instanceof Vertex vertex)
-                yield vertex.countEdges(Vertex.DIRECTION.IN, null);
+                yield vertex.countEdges(Vertex.Direction.IN, null);
               else if (record instanceof Edge edge)
                 yield edge.getIn();
             }
@@ -668,7 +668,7 @@ public class PostgresNetworkExecutor extends Thread {
 
     } catch (final Exception e) {
       setErrorInTx();
-      writeError(ERROR_SEVERITY.ERROR, "Error on parsing bind message: " + e.getMessage(), "XX000");
+      writeError(ErrorSeverity.ERROR, "Error on parsing bind message: " + e.getMessage(), "XX000");
     }
   }
 
@@ -723,7 +723,7 @@ public class PostgresNetworkExecutor extends Thread {
         createResultSet(portal, "CURRENT_SCHEMA", database.getName());
 
       } else if (upperCaseText.equals("SHOW TRANSACTION ISOLATION LEVEL")) {
-        final Database.TRANSACTION_ISOLATION_LEVEL dbIsolationLevel = database.getTransactionIsolationLevel();
+        final Database.TransactionIsolationLevel dbIsolationLevel = database.getTransactionIsolationLevel();
         final String level = dbIsolationLevel.name().replace('_', ' ');
         createResultSet(portal, "LEVEL", level);
 
@@ -879,10 +879,10 @@ public class PostgresNetworkExecutor extends Thread {
 
     } catch (final CommandParsingException e) {
       setErrorInTx();
-      writeError(ERROR_SEVERITY.ERROR, "Syntax error on parsing query: " + e.getCause().getMessage(), "42601");
+      writeError(ErrorSeverity.ERROR, "Syntax error on parsing query: " + e.getCause().getMessage(), "42601");
     } catch (final Exception e) {
       setErrorInTx();
-      writeError(ERROR_SEVERITY.ERROR, "Error on parsing query: " + e.getMessage(), "XX000");
+      writeError(ErrorSeverity.ERROR, "Error on parsing query: " + e.getMessage(), "XX000");
     }
   }
 
@@ -929,7 +929,7 @@ public class PostgresNetworkExecutor extends Thread {
 
   private boolean openDatabase() {
     if (databaseName == null) {
-      writeError(ERROR_SEVERITY.FATAL, "Database not selected", "HV00Q");
+      writeError(ErrorSeverity.FATAL, "Database not selected", "HV00Q");
       return false;
     }
 
@@ -943,10 +943,10 @@ public class PostgresNetworkExecutor extends Thread {
       database.setAutoTransaction(true);
 
     } catch (final ServerSecurityException e) {
-      writeError(ERROR_SEVERITY.FATAL, "Credentials not valid", "28P01");
+      writeError(ErrorSeverity.FATAL, "Credentials not valid", "28P01");
       return false;
     } catch (final DatabaseOperationException e) {
-      writeError(ERROR_SEVERITY.FATAL, "Database does not exist", "HV00Q");
+      writeError(ErrorSeverity.FATAL, "Database does not exist", "HV00Q");
       return false;
     }
 
@@ -1024,7 +1024,7 @@ public class PostgresNetworkExecutor extends Thread {
     return true;
   }
 
-  private void writeError(final ERROR_SEVERITY severity, final String errorMessage, final String errorCode) {
+  private void writeError(final ErrorSeverity severity, final String errorMessage, final String errorCode) {
     try {
       final String sev = severity.toString();
 

--- a/server/src/main/java/com/arcadedb/server/ReplicationCallback.java
+++ b/server/src/main/java/com/arcadedb/server/ReplicationCallback.java
@@ -19,19 +19,19 @@
 package com.arcadedb.server;
 
 public interface ReplicationCallback {
-    enum TYPE {
-        SERVER_STARTING,
-        SERVER_UP,
-        SERVER_SHUTTING_DOWN,
-        SERVER_DOWN,
-        LEADER_ELECTED,
-        REPLICA_MSG_RECEIVED,
-        REPLICA_ONLINE,
-        REPLICA_OFFLINE,
-        REPLICA_HOT_RESYNC,
-        REPLICA_FULL_RESYNC,
-        NETWORK_CONNECTION
-    }
+  enum Type {
+    SERVER_STARTING,
+    SERVER_UP,
+    SERVER_SHUTTING_DOWN,
+    SERVER_DOWN,
+    LEADER_ELECTED,
+    REPLICA_MSG_RECEIVED,
+    REPLICA_ONLINE,
+    REPLICA_OFFLINE,
+    REPLICA_HOT_RESYNC,
+    REPLICA_FULL_RESYNC,
+    NETWORK_CONNECTION
+  }
 
-    void onEvent(TYPE type, Object object, ArcadeDBServer server) throws Exception;
+  void onEvent(Type type, Object object, ArcadeDBServer server) throws Exception;
 }

--- a/server/src/main/java/com/arcadedb/server/ServerDatabase.java
+++ b/server/src/main/java/com/arcadedb/server/ServerDatabase.java
@@ -136,7 +136,7 @@ public class ServerDatabase implements DatabaseInternal {
   }
 
   @Override
-  public void begin(final TRANSACTION_ISOLATION_LEVEL isolationLevel) {
+  public void begin(final TransactionIsolationLevel isolationLevel) {
     wrapped.begin(isolationLevel);
   }
 
@@ -196,11 +196,11 @@ public class ServerDatabase implements DatabaseInternal {
     return wrapped.iterateBucket(bucketName);
   }
 
-  public void checkPermissionsOnDatabase(final SecurityDatabaseUser.DATABASE_ACCESS access) {
+  public void checkPermissionsOnDatabase(final SecurityDatabaseUser.DatabaseAccess access) {
     wrapped.checkPermissionsOnDatabase(access);
   }
 
-  public void checkPermissionsOnFile(final int fileId, final SecurityDatabaseUser.ACCESS access) {
+  public void checkPermissionsOnFile(final int fileId, final SecurityDatabaseUser.Access access) {
     wrapped.checkPermissionsOnFile(fileId, access);
   }
 
@@ -232,11 +232,11 @@ public class ServerDatabase implements DatabaseInternal {
     return wrapped.lookupByKey(type, keyNames, keyValues);
   }
 
-  public void registerCallback(final DatabaseInternal.CALLBACK_EVENT event, final Callable<Void> callback) {
+  public void registerCallback(final CallbackEvent event, final Callable<Void> callback) {
     wrapped.registerCallback(event, callback);
   }
 
-  public void unregisterCallback(final DatabaseInternal.CALLBACK_EVENT event, final Callable<Void> callback) {
+  public void unregisterCallback(final CallbackEvent event, final Callable<Void> callback) {
     wrapped.unregisterCallback(event, callback);
   }
 
@@ -260,12 +260,12 @@ public class ServerDatabase implements DatabaseInternal {
   }
 
   @Override
-  public Database setTransactionIsolationLevel(final TRANSACTION_ISOLATION_LEVEL level) {
+  public Database setTransactionIsolationLevel(final TransactionIsolationLevel level) {
     return wrapped.setTransactionIsolationLevel(level);
   }
 
   @Override
-  public TRANSACTION_ISOLATION_LEVEL getTransactionIsolationLevel() {
+  public TransactionIsolationLevel getTransactionIsolationLevel() {
     return wrapped.getTransactionIsolationLevel();
   }
 
@@ -438,7 +438,7 @@ public class ServerDatabase implements DatabaseInternal {
   }
 
   @Override
-  public ComponentFile.MODE getMode() {
+  public ComponentFile.Mode getMode() {
     return wrapped.getMode();
   }
 
@@ -550,7 +550,7 @@ public class ServerDatabase implements DatabaseInternal {
     return wrapped.hashCode();
   }
 
-  public void executeCallbacks(final DatabaseInternal.CALLBACK_EVENT event) throws IOException {
+  public void executeCallbacks(final CallbackEvent event) throws IOException {
     wrapped.executeCallbacks(event);
   }
 

--- a/server/src/main/java/com/arcadedb/server/ServerPlugin.java
+++ b/server/src/main/java/com/arcadedb/server/ServerPlugin.java
@@ -22,10 +22,10 @@ import com.arcadedb.ContextConfiguration;
 import com.arcadedb.server.http.HttpServer;
 import io.undertow.server.handlers.PathHandler;
 
-import static com.arcadedb.server.ServerPlugin.INSTALLATION_PRIORITY.BEFORE_HTTP_ON;
+import static com.arcadedb.server.ServerPlugin.InstallationPriority.BEFORE_HTTP_ON;
 
 public interface ServerPlugin {
-  enum INSTALLATION_PRIORITY {BEFORE_HTTP_ON, AFTER_HTTP_ON, AFTER_DATABASES_OPEN}
+  enum InstallationPriority {BEFORE_HTTP_ON, AFTER_HTTP_ON, AFTER_DATABASES_OPEN}
 
   default void configure(ArcadeDBServer arcadeDBServer, ContextConfiguration configuration) {
     // DEFAULT IMPLEMENTATION
@@ -41,7 +41,7 @@ public interface ServerPlugin {
     // DEFAULT IMPLEMENTATION
   }
 
-  default INSTALLATION_PRIORITY getInstallationPriority() {
+  default InstallationPriority getInstallationPriority() {
     return BEFORE_HTTP_ON;
   }
 }

--- a/server/src/main/java/com/arcadedb/server/event/FileServerEventLog.java
+++ b/server/src/main/java/com/arcadedb/server/event/FileServerEventLog.java
@@ -110,7 +110,7 @@ public class FileServerEventLog implements ServerEventLog {
   }
 
   @Override
-  public void reportEvent(final EVENT_TYPE eventType, final String component, final String databaseName, final String message) {
+  public void reportEvent(final EventType eventType, final String component, final String databaseName, final String message) {
     if (newFileName == null)
       return;
 

--- a/server/src/main/java/com/arcadedb/server/event/ServerEventLog.java
+++ b/server/src/main/java/com/arcadedb/server/event/ServerEventLog.java
@@ -23,9 +23,9 @@ package com.arcadedb.server.event;
 import com.arcadedb.serializer.json.JSONArray;
 
 public interface ServerEventLog {
-  enum EVENT_TYPE {CRITICAL, WARNING, INFO, HINT}
+  enum EventType {CRITICAL, WARNING, INFO, HINT}
 
-  void reportEvent(EVENT_TYPE eventType, String component, String databaseName, String message);
+  void reportEvent(EventType eventType, String component, String databaseName, String message);
 
   JSONArray getCurrentEvents();
 

--- a/server/src/main/java/com/arcadedb/server/ha/LeaderNetworkListener.java
+++ b/server/src/main/java/com/arcadedb/server/ha/LeaderNetworkListener.java
@@ -212,9 +212,9 @@ public class LeaderNetworkListener extends Thread {
 
     if (ha.connectToLeader(remoteServerAddress, null)) {
       // ELECTION FINISHED, THE SERVER IS A REPLICA
-      ha.setElectionStatus(HAServer.ELECTION_STATUS.DONE);
+      ha.setElectionStatus(HAServer.ElectionStatus.DONE);
       try {
-        ha.getServer().lifecycleEvent(ReplicationCallback.TYPE.LEADER_ELECTED, remoteServerName);
+        ha.getServer().lifecycleEvent(ReplicationCallback.Type.LEADER_ELECTED, remoteServerName);
       } catch (final Exception e) {
         throw new ArcadeDBException("Error on propagating election status", e);
       }
@@ -249,7 +249,7 @@ public class LeaderNetworkListener extends Thread {
               remoteServerName, lastReplicationMessage, localServerLastMessageNumber, voteTurn);
       channel.writeByte((byte) 0);
       ha.lastElectionVote = new Pair<>(voteTurn, remoteServerName);
-      ha.setElectionStatus(HAServer.ELECTION_STATUS.VOTING_FOR_OTHERS);
+      ha.setElectionStatus(HAServer.ElectionStatus.VOTING_FOR_OTHERS);
     } else {
       LogManager.instance().log(this, Level.INFO,
           "Server '%s' asked for election (lastReplicationMessage=%d my=%d) on turn %d, but cannot give my vote (votedFor='%s' on turn %d)",

--- a/server/src/main/java/com/arcadedb/server/ha/Replica2LeaderNetworkExecutor.java
+++ b/server/src/main/java/com/arcadedb/server/ha/Replica2LeaderNetworkExecutor.java
@@ -145,7 +145,7 @@ public class Replica2LeaderNetworkExecutor extends Thread {
           }
         }
 
-        server.getServer().lifecycleEvent(ReplicationCallback.TYPE.REPLICA_MSG_RECEIVED, request);
+        server.getServer().lifecycleEvent(ReplicationCallback.Type.REPLICA_MSG_RECEIVED, request);
 
         if (response != null)
           sendCommandToLeader(buffer, response, reqId);
@@ -412,7 +412,7 @@ public class Replica2LeaderNetworkExecutor extends Thread {
       if (response instanceof ReplicaConnectFullResyncResponse fullSync) {
         LogManager.instance().log(this, Level.INFO, "Asking for a full resync...");
 
-        server.getServer().lifecycleEvent(ReplicationCallback.TYPE.REPLICA_FULL_RESYNC, null);
+        server.getServer().lifecycleEvent(ReplicationCallback.Type.REPLICA_FULL_RESYNC, null);
 
         final Set<String> databases = fullSync.getDatabases();
 
@@ -421,7 +421,7 @@ public class Replica2LeaderNetworkExecutor extends Thread {
 
       } else {
         LogManager.instance().log(this, Level.INFO, "Receiving hot resync (from=%d)...", lastLogNumber);
-        server.getServer().lifecycleEvent(ReplicationCallback.TYPE.REPLICA_HOT_RESYNC, null);
+        server.getServer().lifecycleEvent(ReplicationCallback.Type.REPLICA_HOT_RESYNC, null);
       }
 
       sendCommandToLeader(buffer, new ReplicaReadyRequest(), -1);
@@ -471,7 +471,7 @@ public class Replica2LeaderNetworkExecutor extends Thread {
     // RELOAD THE SCHEMA
     database.getSchema().getEmbedded().close();
     DatabaseContext.INSTANCE.init(database);
-    database.getSchema().getEmbedded().load(ComponentFile.MODE.READ_WRITE, true);
+    database.getSchema().getEmbedded().load(ComponentFile.Mode.READ_WRITE, true);
 
     LogManager.instance()
         .log(this, Level.INFO, "Database '%s' installed from the cluster (%s - %d files lastLogNumber=%d)", null, db,

--- a/server/src/main/java/com/arcadedb/server/ha/ReplicatedDatabase.java
+++ b/server/src/main/java/com/arcadedb/server/ha/ReplicatedDatabase.java
@@ -198,12 +198,12 @@ public class ReplicatedDatabase implements DatabaseInternal {
   }
 
   @Override
-  public void checkPermissionsOnDatabase(final SecurityDatabaseUser.DATABASE_ACCESS access) {
+  public void checkPermissionsOnDatabase(final SecurityDatabaseUser.DatabaseAccess access) {
     proxied.checkPermissionsOnDatabase(access);
   }
 
   @Override
-  public void checkPermissionsOnFile(final int fileId, final SecurityDatabaseUser.ACCESS access) {
+  public void checkPermissionsOnFile(final int fileId, final SecurityDatabaseUser.Access access) {
     proxied.checkPermissionsOnFile(fileId, access);
   }
 
@@ -243,17 +243,17 @@ public class ReplicatedDatabase implements DatabaseInternal {
   }
 
   @Override
-  public void registerCallback(final CALLBACK_EVENT event, final Callable<Void> callback) {
+  public void registerCallback(final CallbackEvent event, final Callable<Void> callback) {
     proxied.registerCallback(event, callback);
   }
 
   @Override
-  public void unregisterCallback(final CALLBACK_EVENT event, final Callable<Void> callback) {
+  public void unregisterCallback(final CallbackEvent event, final Callable<Void> callback) {
     proxied.unregisterCallback(event, callback);
   }
 
   @Override
-  public void executeCallbacks(final CALLBACK_EVENT event) throws IOException {
+  public void executeCallbacks(final CallbackEvent event) throws IOException {
     proxied.executeCallbacks(event);
   }
 
@@ -333,7 +333,7 @@ public class ReplicatedDatabase implements DatabaseInternal {
   }
 
   @Override
-  public ComponentFile.MODE getMode() {
+  public ComponentFile.Mode getMode() {
     return proxied.getMode();
   }
 
@@ -418,7 +418,7 @@ public class ReplicatedDatabase implements DatabaseInternal {
   }
 
   @Override
-  public void begin(final TRANSACTION_ISOLATION_LEVEL isolationLevel) {
+  public void begin(final TransactionIsolationLevel isolationLevel) {
     proxied.begin(isolationLevel);
   }
 
@@ -688,12 +688,12 @@ public class ReplicatedDatabase implements DatabaseInternal {
   }
 
   @Override
-  public Database setTransactionIsolationLevel(final TRANSACTION_ISOLATION_LEVEL level) {
+  public Database setTransactionIsolationLevel(final TransactionIsolationLevel level) {
     return proxied.setTransactionIsolationLevel(level);
   }
 
   @Override
-  public TRANSACTION_ISOLATION_LEVEL getTransactionIsolationLevel() {
+  public TransactionIsolationLevel getTransactionIsolationLevel() {
     return proxied.getTransactionIsolationLevel();
   }
 

--- a/server/src/main/java/com/arcadedb/server/ha/message/DatabaseChangeStructureRequest.java
+++ b/server/src/main/java/com/arcadedb/server/ha/message/DatabaseChangeStructureRequest.java
@@ -109,7 +109,7 @@ public class DatabaseChangeStructureRequest extends HAAbstractCommand {
       updateFiles(db);
 
       // RELOAD SCHEMA
-      db.getSchema().getEmbedded().load(ComponentFile.MODE.READ_WRITE, true);
+      db.getSchema().getEmbedded().load(ComponentFile.Mode.READ_WRITE, true);
       return new DatabaseChangeStructureResponse();
 
     } catch (final Exception e) {

--- a/server/src/main/java/com/arcadedb/server/ha/message/TxForwardRequest.java
+++ b/server/src/main/java/com/arcadedb/server/ha/message/TxForwardRequest.java
@@ -51,7 +51,7 @@ public class TxForwardRequest extends TxRequestAbstract {
   public TxForwardRequest() {
   }
 
-  public TxForwardRequest(final DatabaseInternal database, Database.TRANSACTION_ISOLATION_LEVEL transactionIsolationLevel,
+  public TxForwardRequest(final DatabaseInternal database, Database.TransactionIsolationLevel transactionIsolationLevel,
       final Map<Integer, Integer> bucketRecordDelta, final Binary bufferChanges,
       final Map<String, TreeMap<TransactionIndexContext.ComparableKey, Map<TransactionIndexContext.IndexKey, TransactionIndexContext.IndexKey>>> keysTx) {
     super(database.getName(), bucketRecordDelta, bufferChanges);
@@ -90,7 +90,7 @@ public class TxForwardRequest extends TxRequestAbstract {
           db);
 
       // FORWARDED FROM A REPLICA
-      db.begin(Database.TRANSACTION_ISOLATION_LEVEL.values()[isolationLevelIndex]);
+      db.begin(Database.TransactionIsolationLevel.values()[isolationLevelIndex]);
       final TransactionContext tx = db.getTransaction();
 
       tx.commitFromReplica(walTx, keysTx, bucketRecordDelta);

--- a/server/src/main/java/com/arcadedb/server/ha/message/TxRequest.java
+++ b/server/src/main/java/com/arcadedb/server/ha/message/TxRequest.java
@@ -84,7 +84,7 @@ public class TxRequest extends TxRequestAbstract {
         changeStructure.updateFiles(db);
 
         // RELOAD THE SCHEMA BUT NOT INITIALIZE THE COMPONENTS (SOME NEW PAGES COULD BE IN THE TX ITSELF)
-        db.getSchema().getEmbedded().load(ComponentFile.MODE.READ_WRITE, false);
+        db.getSchema().getEmbedded().load(ComponentFile.Mode.READ_WRITE, false);
       } catch (final Exception e) {
         LogManager.instance().log(this, Level.SEVERE, "Error on changing database structure request from the leader node", e);
         throw new ReplicationException("Error on changing database structure request from the leader node", e);

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractQueryHandler.java
@@ -161,13 +161,13 @@ public abstract class AbstractQueryHandler extends DatabaseAbstractHandler {
         try {
           final Vertex vertex = entry.asVertex(true);
 
-          final Iterable<Edge> vEdgesOut = vertex.getEdges(Vertex.DIRECTION.OUT);
+          final Iterable<Edge> vEdgesOut = vertex.getEdges(Vertex.Direction.OUT);
           for (final Edge e : vEdgesOut) {
             if (includedVertices.contains(e.getIn()) && !includedEdges.contains(e.getIdentity()))
               edges.put(serializerImpl.serializeGraphElement(e));
           }
 
-          final Iterable<Edge> vEdgesIn = vertex.getEdges(Vertex.DIRECTION.IN);
+          final Iterable<Edge> vEdgesIn = vertex.getEdges(Vertex.Direction.IN);
           for (final Edge e : vEdgesIn) {
             if (includedVertices.contains(e.getOut()) && !includedEdges.contains(e.getIdentity()))
               edges.put(serializerImpl.serializeGraphElement(e));

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetReadyHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetReadyHandler.java
@@ -34,7 +34,7 @@ public class GetReadyHandler extends AbstractServerHttpHandler {
   public ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user, final JSONObject payload) {
     Metrics.counter("http.ready").increment();
 
-    if (httpServer.getServer().getStatus() == ArcadeDBServer.STATUS.ONLINE)
+    if (httpServer.getServer().getStatus() == ArcadeDBServer.Status.ONLINE)
       return new ExecutionResponse(204, "");
     return new ExecutionResponse(503, "Server not started yet");
   }

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetServerHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetServerHandler.java
@@ -184,7 +184,7 @@ public class GetServerHandler extends AbstractServerHttpHandler {
 
     final List<Map<String, Object>> settings = new ArrayList<>();
     for (GlobalConfiguration cfg : GlobalConfiguration.values()) {
-      if (cfg.getScope() != GlobalConfiguration.SCOPE.DATABASE) {
+      if (cfg.getScope() != GlobalConfiguration.Scope.DATABASE) {
         final Map<String, Object> map = new LinkedHashMap<>();
         map.put("key", cfg.getKey());
         map.put("value", convertValue(cfg.getKey(), cfg.getValue()));

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostBeginHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostBeginHandler.java
@@ -59,7 +59,7 @@ public class PostBeginHandler extends DatabaseAbstractHandler {
       if (isolationLevel == null)
         return new ExecutionResponse(400, "Missing parameter 'isolationLevel'");
 
-      database.begin(Database.TRANSACTION_ISOLATION_LEVEL.valueOf(isolationLevel));
+      database.begin(Database.TransactionIsolationLevel.valueOf(isolationLevel));
     } else
       database.begin();
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -179,7 +179,7 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     final ArcadeDBServer server = httpServer.getServer();
     Metrics.counter("http.create-database").increment();
 
-    final ServerDatabase db = server.createDatabase(databaseName, ComponentFile.MODE.READ_WRITE);
+    final ServerDatabase db = server.createDatabase(databaseName, ComponentFile.Mode.READ_WRITE);
 
     if (server.getConfiguration().getValueAsBoolean(GlobalConfiguration.HA_ENABLED)) {
       final ReplicatedDatabase replicatedDatabase = (ReplicatedDatabase) db.getWrappedDatabaseInstance();

--- a/server/src/main/java/com/arcadedb/server/http/ws/ChangeEvent.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/ChangeEvent.java
@@ -21,15 +21,15 @@ package com.arcadedb.server.http.ws;
 import com.arcadedb.database.Record;
 import com.arcadedb.serializer.json.JSONObject;
 
-import java.util.*;
+import java.util.Locale;
 
 public class ChangeEvent {
-  private final TYPE   type;
+  private final Type   type;
   private final Record record;
 
-  public enum TYPE {CREATE, UPDATE, DELETE}
+  public enum Type {CREATE, UPDATE, DELETE}
 
-  public ChangeEvent(final TYPE type, final Record record) {
+  public ChangeEvent(final Type type, final Record record) {
     this.type = type;
     this.record = record;
   }
@@ -38,7 +38,7 @@ public class ChangeEvent {
     return record;
   }
 
-  public TYPE getType() {
+  public Type getType() {
     return type;
   }
 

--- a/server/src/main/java/com/arcadedb/server/http/ws/EventWatcherSubscription.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/EventWatcherSubscription.java
@@ -28,9 +28,9 @@ import java.util.stream.*;
 public class EventWatcherSubscription {
   private final String                             database;
   private final WebSocketChannel                   channel;
-  private final Map<String, Set<ChangeEvent.TYPE>> typeSubscriptions = new ConcurrentHashMap<>();
+  private final Map<String, Set<ChangeEvent.Type>> typeSubscriptions = new ConcurrentHashMap<>();
 
-  private final static Set<ChangeEvent.TYPE> allTypes = Arrays.stream(ChangeEvent.TYPE.values()).collect(Collectors.toSet());
+  private final static Set<ChangeEvent.Type> allTypes = Arrays.stream(ChangeEvent.Type.values()).collect(Collectors.toSet());
 
   public EventWatcherSubscription(final String database, final WebSocketChannel channel) {
     this.database = database;
@@ -48,7 +48,7 @@ public class EventWatcherSubscription {
     typeSubscriptions.clear();
   }
 
-  public void add(final String type, final Set<ChangeEvent.TYPE> changeTypes) {
+  public void add(final String type, final Set<ChangeEvent.Type> changeTypes) {
     final var key = type == null ? "*" : type; // ConcurrentHashMap can't have null keys, so use * for "all types."
     typeSubscriptions.computeIfAbsent(key, k -> new HashSet<>()).addAll(changeTypes == null ? allTypes : changeTypes);
   }

--- a/server/src/main/java/com/arcadedb/server/http/ws/WebSocketEventBus.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/WebSocketEventBus.java
@@ -47,7 +47,7 @@ public class WebSocketEventBus {
     databaseWatchers.clear();
   }
 
-  public void subscribe(final String databaseName, final String type, final Set<ChangeEvent.TYPE> changeTypes, final WebSocketChannel channel) {
+  public void subscribe(final String databaseName, final String type, final Set<ChangeEvent.Type> changeTypes, final WebSocketChannel channel) {
     final var channelId = (UUID) channel.getAttribute(CHANNEL_ID);
     final var databaseSubscribers = this.subscribers.computeIfAbsent(databaseName, k -> new ConcurrentHashMap<>());
 

--- a/server/src/main/java/com/arcadedb/server/http/ws/WebSocketEventListener.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/WebSocketEventListener.java
@@ -36,16 +36,16 @@ public class WebSocketEventListener implements AfterRecordCreateListener, AfterR
 
   @Override
   public void onAfterCreate(final Record record) {
-    this.watcherThread.push(new ChangeEvent(ChangeEvent.TYPE.CREATE, record));
+    this.watcherThread.push(new ChangeEvent(ChangeEvent.Type.CREATE, record));
   }
 
   @Override
   public void onAfterUpdate(final Record record) {
-    this.watcherThread.push(new ChangeEvent(ChangeEvent.TYPE.UPDATE, record));
+    this.watcherThread.push(new ChangeEvent(ChangeEvent.Type.UPDATE, record));
   }
 
   @Override
   public void onAfterDelete(final Record record) {
-    this.watcherThread.push(new ChangeEvent(ChangeEvent.TYPE.DELETE, record));
+    this.watcherThread.push(new ChangeEvent(ChangeEvent.Type.DELETE, record));
   }
 }

--- a/server/src/main/java/com/arcadedb/server/http/ws/WebSocketReceiveListener.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/WebSocketReceiveListener.java
@@ -39,7 +39,7 @@ public class WebSocketReceiveListener extends AbstractReceiveListener {
   private final HttpServer        httpServer;
   private final WebSocketEventBus webSocketEventBus;
 
-  public enum ACTION {UNKNOWN, SUBSCRIBE, UNSUBSCRIBE}
+  public enum Action {UNKNOWN, SUBSCRIBE, UNSUBSCRIBE}
 
   public WebSocketReceiveListener(final HttpServer httpServer, final WebSocketEventBus webSocketEventBus) {
     this.httpServer = httpServer;
@@ -51,9 +51,9 @@ public class WebSocketReceiveListener extends AbstractReceiveListener {
     try {
       final var message = new JSONObject(textMessage.getData());
       final var rawAction = message.optString("action", "");
-      var action = ACTION.UNKNOWN;
+      var action = Action.UNKNOWN;
       try {
-        action = ACTION.valueOf(rawAction.toUpperCase(Locale.ENGLISH));
+        action = Action.valueOf(rawAction.toUpperCase(Locale.ENGLISH));
       } catch (final IllegalArgumentException ignored) {
       }
 
@@ -62,7 +62,7 @@ public class WebSocketReceiveListener extends AbstractReceiveListener {
         final var jsonChangeTypes = !message.isNull("changeTypes") ? message.getJSONArray("changeTypes") : null;
         final var changeTypes = jsonChangeTypes == null ?
             null :
-            jsonChangeTypes.toList().stream().map(t -> ChangeEvent.TYPE.valueOf(t.toString().toUpperCase(Locale.ENGLISH))).collect(Collectors.toSet());
+            jsonChangeTypes.toList().stream().map(t -> ChangeEvent.Type.valueOf(t.toString().toUpperCase(Locale.ENGLISH))).collect(Collectors.toSet());
         this.webSocketEventBus.subscribe(message.getString("database"), message.optString("type", null), changeTypes, channel);
         this.sendAck(channel, action);
         break;
@@ -94,7 +94,7 @@ public class WebSocketReceiveListener extends AbstractReceiveListener {
     this.webSocketEventBus.unsubscribeAll(channelId);
   }
 
-  private void sendAck(final WebSocketChannel channel, final ACTION action) {
+  private void sendAck(final WebSocketChannel channel, final Action action) {
     final var json = new JSONObject("{\"result\": \"ok\"}");
     json.put("action", action.toString().toLowerCase(Locale.ENGLISH));
     WebSockets.sendText(json.toString(), channel, null);

--- a/server/src/main/java/com/arcadedb/server/monitor/ServerMonitor.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/ServerMonitor.java
@@ -80,7 +80,8 @@ public class ServerMonitor {
     final float freeSpacePerc = freeSpace * 100F / totalSpace;
     if (freeSpacePerc < 20) {
       // REPORT THE SPIKE
-      server.getEventLog().reportEvent(ServerEventLog.EVENT_TYPE.WARNING, "JVM", null, "Available space on disk is only " + ((int) freeSpacePerc) + "%");
+      server.getEventLog().reportEvent(
+          ServerEventLog.EventType.WARNING, "JVM", null, "Available space on disk is only " + ((int) freeSpacePerc) + "%");
       lastDiskSpaceWarningReported = System.currentTimeMillis();
     }
   }
@@ -98,7 +99,7 @@ public class ServerMonitor {
     if (heapAvailablePerc < 20) {
       // REPORT THE SPIKE
       server.getEventLog()
-          .reportEvent(ServerEventLog.EVENT_TYPE.WARNING, "JVM", null, "Server overloaded: available heap RAM is only " + ((int) heapAvailablePerc) + "%");
+          .reportEvent(ServerEventLog.EventType.WARNING, "JVM", null, "Server overloaded: available heap RAM is only " + ((int) heapAvailablePerc) + "%");
       lastHeapWarningReported = System.currentTimeMillis();
     }
   }
@@ -116,7 +117,7 @@ public class ServerMonitor {
 
       if (deltaPerc > 20) {
         // REPORT THE SPIKE
-        server.getEventLog().reportEvent(ServerEventLog.EVENT_TYPE.WARNING, "JVM", null,
+        server.getEventLog().reportEvent(ServerEventLog.EventType.WARNING, "JVM", null,
             "Server overloaded: JVM Safepoint spiked up " + ((int) deltaPerc) + "% from the last sampling");
       }
     }

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurityDatabaseUser.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurityDatabaseUser.java
@@ -39,7 +39,7 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
   private volatile     boolean[][] fileAccessMap     = null;
   private              long        resultSetLimit    = -1;
   private              long        readTimeout       = -1;
-  private final        boolean[]   databaseAccessMap = new boolean[DATABASE_ACCESS.values().length];
+  private final        boolean[]   databaseAccessMap = new boolean[DatabaseAccess.values().length];
 
   public ServerSecurityDatabaseUser(final String databaseName, final String userName, final String[] groups) {
     this.databaseName = databaseName;
@@ -76,12 +76,12 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
   }
 
   @Override
-  public boolean requestAccessOnDatabase(final DATABASE_ACCESS access) {
+  public boolean requestAccessOnDatabase(final DatabaseAccess access) {
     return databaseAccessMap[access.ordinal()];
   }
 
   @Override
-  public boolean requestAccessOnFile(final int fileId, final ACCESS access) {
+  public boolean requestAccessOnFile(final int fileId, final Access access) {
     if (fileId >= fileAccessMap.length) {
       LogManager.instance().log(this, Level.SEVERE,
           "Error on requesting access to fileId %d because not found in security configuration (registeredFiles=%d)", fileId,
@@ -101,7 +101,7 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
 
   public void updateDatabaseConfiguration(final JSONObject configuredGroups) {
     // RESET THE ARRAY
-    for (int i = 0; i < DATABASE_ACCESS.values().length; i++)
+    for (int i = 0; i < DatabaseAccess.values().length; i++)
       databaseAccessMap[i] = false;
 
     if (configuredGroups == null)
@@ -156,7 +156,7 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
     if (access != null) {
       // UPDATE THE ARRAY WITH LATEST CONFIGURATION
       for (int i = 0; i < access.length(); i++)
-        databaseAccessMap[DATABASE_ACCESS.getByName(access.getString(i)).ordinal()] = true;
+        databaseAccessMap[DatabaseAccess.getByName(access.getString(i)).ordinal()] = true;
     }
   }
 

--- a/server/src/test/java/com/arcadedb/remote/RemoteDatabaseIT.java
+++ b/server/src/test/java/com/arcadedb/remote/RemoteDatabaseIT.java
@@ -32,7 +32,6 @@ import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.MutableEdge;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
-import com.arcadedb.graph.Vertex.DIRECTION;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Schema;
@@ -45,7 +44,7 @@ import org.junit.jupiter.api.Test;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
-import static com.arcadedb.graph.Vertex.DIRECTION.*;
+import static com.arcadedb.graph.Vertex.Direction.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -496,7 +495,7 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
 
       t1.command("sql", "create vertex type SimpleVertex");
 
-      t1.begin(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
+      t1.begin(Database.TransactionIsolationLevel.REPEATABLE_READ);
       MutableVertex svt1 = t1.newVertex("SimpleVertex");
       svt1.set("s", "concurrent t1");
       svt1.save();
@@ -504,11 +503,11 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
       RID rid = svt1.getIdentity();
 
       t1.commit();
-      t1.begin(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
+      t1.begin(Database.TransactionIsolationLevel.REPEATABLE_READ);
       svt1 = t1.lookupByRID(rid).asVertex().modify();
 
       // recover the same vertex over t2
-      t2.begin(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
+      t2.begin(Database.TransactionIsolationLevel.REPEATABLE_READ);
       MutableVertex svt2 = t2.lookupByRID(rid).asVertex().modify();
 
       svt2.set("s", "concurrent t2");
@@ -550,9 +549,9 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
       try (RemoteDatabase tx = new RemoteDatabase("127.0.0.1", 2480 + serverIndex, DATABASE_NAME, "root",
           BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);) {
         tx.getSchema().createVertexType("SimpleVertexEx").createProperty("svuuid", String.class)
-            .createIndex(Schema.INDEX_TYPE.LSM_TREE, true);
+            .createIndex(Schema.IndexType.LSM_TREE, true);
 
-        tx.begin(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
+        tx.begin(Database.TransactionIsolationLevel.REPEATABLE_READ);
 
         MutableVertex svt1 = tx.newVertex("SimpleVertexEx");
         String uuid1 = UUID.randomUUID().toString();
@@ -561,7 +560,7 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
         svt1.save();
         tx.commit();
 
-        tx.begin(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
+        tx.begin(Database.TransactionIsolationLevel.REPEATABLE_READ);
         MutableVertex svt2 = tx.newVertex("SimpleVertexEx");
         String uuid2 = UUID.randomUUID().toString();
         svt2.set("svex", uuid2);
@@ -569,7 +568,7 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
         svt2.save();
         tx.commit();
 
-        tx.begin(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
+        tx.begin(Database.TransactionIsolationLevel.REPEATABLE_READ);
         svt2.set("svuuid", uuid1);
         svt2.save();
         tx.commit();
@@ -587,10 +586,10 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
         try (RemoteDatabase t2 = new RemoteDatabase("127.0.0.1", 2480 + serverIndex, DATABASE_NAME, "root",
             BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS)) {
 
-          t1.setTransactionIsolationLevel(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
-          t2.setTransactionIsolationLevel(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
+          t1.setTransactionIsolationLevel(Database.TransactionIsolationLevel.REPEATABLE_READ);
+          t2.setTransactionIsolationLevel(Database.TransactionIsolationLevel.REPEATABLE_READ);
 
-          t1.begin(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
+          t1.begin(Database.TransactionIsolationLevel.REPEATABLE_READ);
           MutableVertex mvSVt1 = t1.newVertex("SimpleVertex");
           mvSVt1.set("s", "init concurrent test");
           mvSVt1.save();
@@ -601,10 +600,10 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
 //        t1.begin(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
           Vertex vSVt1 = t1.lookupByRID(rid).asVertex();
 
-          t2.begin(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
+          t2.begin(Database.TransactionIsolationLevel.REPEATABLE_READ);
           Vertex vSVt2 = t2.lookupByRID(rid).asVertex();
 
-          t1.begin(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
+          t1.begin(Database.TransactionIsolationLevel.REPEATABLE_READ);
           mvSVt1 = vSVt1.modify();
           System.out.println("mvSVt1: " + vSVt1);
           mvSVt1.set("s", "concurrent t1");

--- a/server/src/test/java/com/arcadedb/remote/RemoteDatabaseJavaApiIT.java
+++ b/server/src/test/java/com/arcadedb/remote/RemoteDatabaseJavaApiIT.java
@@ -4,13 +4,9 @@ import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.RID;
 import com.arcadedb.engine.Bucket;
-import com.arcadedb.engine.LocalBucket;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.MutableEdge;
 import com.arcadedb.graph.MutableVertex;
-import com.arcadedb.graph.Vertex;
-import com.arcadedb.schema.DocumentType;
-import com.arcadedb.schema.EdgeType;
 import com.arcadedb.server.BaseGraphServerTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,8 +14,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.*;
 
-import static com.arcadedb.graph.Vertex.DIRECTION.IN;
-import static com.arcadedb.graph.Vertex.DIRECTION.OUT;
+import static com.arcadedb.graph.Vertex.Direction.IN;
+import static com.arcadedb.graph.Vertex.Direction.OUT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class RemoteDatabaseJavaApiIT extends BaseGraphServerTest {

--- a/server/src/test/java/com/arcadedb/server/AsyncInsertTest.java
+++ b/server/src/test/java/com/arcadedb/server/AsyncInsertTest.java
@@ -66,7 +66,7 @@ public class AsyncInsertTest {
     database.transaction(() -> {
       DocumentType dtProducts = database.getSchema().buildDocumentType().withName("Product").withTotalBuckets(8).create();
       dtProducts.createProperty("name", Type.STRING);
-      dtProducts.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "name");
+      dtProducts.createTypeIndex(Schema.IndexType.LSM_TREE, true, "name");
       dtProducts.setBucketSelectionStrategy(new ThreadBucketSelectionStrategy());
     });
 
@@ -123,7 +123,7 @@ public class AsyncInsertTest {
     database.transaction(() -> {
       DocumentType dtProducts = database.getSchema().buildDocumentType().withName("Product").withTotalBuckets(4).create();
       dtProducts.createProperty("name", Type.STRING);
-      dtProducts.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "name");
+      dtProducts.createTypeIndex(Schema.IndexType.LSM_TREE, true, "name");
       dtProducts.setBucketSelectionStrategy(new ThreadBucketSelectionStrategy());
     });
 

--- a/server/src/test/java/com/arcadedb/server/BaseGraphServerTest.java
+++ b/server/src/test/java/com/arcadedb/server/BaseGraphServerTest.java
@@ -140,7 +140,7 @@ public abstract class BaseGraphServerTest extends StaticBaseServerTest {
       final VertexType v = schema.buildVertexType().withName(VERTEX1_TYPE_NAME).withTotalBuckets(3).create();
       v.createProperty("id", Long.class);
 
-      schema.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, VERTEX1_TYPE_NAME, "id");
+      schema.createTypeIndex(Schema.IndexType.LSM_TREE, true, VERTEX1_TYPE_NAME, "id");
 
       assertThat(schema.existsType(VERTEX2_TYPE_NAME)).isFalse();
       schema.buildVertexType().withName(VERTEX2_TYPE_NAME).withTotalBuckets(3).create();
@@ -261,7 +261,7 @@ public abstract class BaseGraphServerTest extends StaticBaseServerTest {
       for (final ArcadeDBServer server : servers) {
         if (server != null) {
           assertThat(server.isStarted()).isFalse();
-          assertThat(server.getStatus()).isEqualTo(ArcadeDBServer.STATUS.OFFLINE);
+          assertThat(server.getStatus()).isEqualTo(ArcadeDBServer.Status.OFFLINE);
           assertThat(server.getHttpServer().getSessionManager().getActiveSessions()).isEqualTo(0);
         }
       }
@@ -314,8 +314,8 @@ public abstract class BaseGraphServerTest extends StaticBaseServerTest {
     waitAllReplicasAreConnected();
   }
 
-  protected HAServer.SERVER_ROLE getServerRole(final int serverIndex) {
-    return serverIndex == 0 ? HAServer.SERVER_ROLE.ANY : HAServer.SERVER_ROLE.REPLICA;
+  protected HAServer.ServerRole getServerRole(final int serverIndex) {
+    return serverIndex == 0 ? HAServer.ServerRole.ANY : HAServer.ServerRole.REPLICA;
   }
 
   protected void waitAllReplicasAreConnected() {
@@ -328,7 +328,7 @@ public abstract class BaseGraphServerTest extends StaticBaseServerTest {
     while (System.currentTimeMillis() - beginTime < 10_000) {
       try {
         for (int i = 0; i < serverCount; ++i) {
-          if (getServerRole(i) == HAServer.SERVER_ROLE.ANY) {
+          if (getServerRole(i) == HAServer.ServerRole.ANY) {
             // ONLY FOR CANDIDATE LEADERS
             if (servers[i].getHA() != null) {
               if (servers[i].getHA().isLeader()) {
@@ -362,7 +362,7 @@ public abstract class BaseGraphServerTest extends StaticBaseServerTest {
     int lastTotalConnectedReplica;
 
     for (int i = 0; i < serverCount; ++i) {
-      if (getServerRole(i) == HAServer.SERVER_ROLE.ANY) {
+      if (getServerRole(i) == HAServer.ServerRole.ANY) {
         // ONLY FOR CANDIDATE LEADERS
         if (servers[i].getHA() != null) {
           if (servers[i].getHA().isLeader()) {

--- a/server/src/test/java/com/arcadedb/server/BatchInsertUpdateTest.java
+++ b/server/src/test/java/com/arcadedb/server/BatchInsertUpdateTest.java
@@ -98,7 +98,7 @@ public class BatchInsertUpdateTest {
         type.createProperty("processor", Type.STRING);
         type.createProperty("vstart", Type.STRING);
         type.createProperty("vstop", Type.STRING);
-        type.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "processor", "vstart", "vstop");
+        type.createTypeIndex(Schema.IndexType.LSM_TREE, true, "processor", "vstart", "vstop");
       }
 
       ArcadeDBServer arcadeDBServer = new ArcadeDBServer(serverConfiguration);

--- a/server/src/test/java/com/arcadedb/server/CompositeIndexTest.java
+++ b/server/src/test/java/com/arcadedb/server/CompositeIndexTest.java
@@ -65,9 +65,9 @@ public class CompositeIndexTest {
           dtOrders.createProperty("vstop", Type.DATETIME_MICROS);
           dtOrders.createProperty("status", Type.STRING);
           dtOrders.createProperty("node", Type.STRING);
-          dtOrders.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "id");
-          dtOrders.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "status", "id");
-          dtOrders.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "processor", "vstart", "vstop");
+          dtOrders.createTypeIndex(Schema.IndexType.LSM_TREE, true, "id");
+          dtOrders.createTypeIndex(Schema.IndexType.LSM_TREE, true, "status", "id");
+          dtOrders.createTypeIndex(Schema.IndexType.LSM_TREE, true, "processor", "vstart", "vstop");
           dtOrders.setBucketSelectionStrategy(new ThreadBucketSelectionStrategy());
         });
       }

--- a/server/src/test/java/com/arcadedb/server/HTTPDocumentIT.java
+++ b/server/src/test/java/com/arcadedb/server/HTTPDocumentIT.java
@@ -25,7 +25,6 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.serializer.json.JSONObject;
 
-import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
@@ -375,7 +374,7 @@ public class  HTTPDocumentIT extends BaseGraphServerTest {
       assertThat(schema.existsType("Person")).isFalse();
       final DocumentType v = schema.buildDocumentType().withName("Person").withTotalBuckets(3).create();
       v.createProperty("id", Long.class);
-      schema.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Person", "id");
+      schema.createTypeIndex(Schema.IndexType.LSM_TREE, true, "Person", "id");
 
       for (int i = 0; i < 100; i++)
         database.newDocument("Person").set("id", i).set("name", "John" + i).save();

--- a/server/src/test/java/com/arcadedb/server/RemoteQueriesIT.java
+++ b/server/src/test/java/com/arcadedb/server/RemoteQueriesIT.java
@@ -86,10 +86,10 @@ public class RemoteQueriesIT {
     Vertex toVtx = database.command("sql", "CREATE VERTEX ToVtx").next().getVertex().get();
     Edge conEdg = fromVtx.newEdge("ConEdge", toVtx);
 
-    assertThat(fromVtx.countEdges(Vertex.DIRECTION.OUT, "ConEdge")).isEqualTo(1);
-    assertThat(fromVtx.countEdges(Vertex.DIRECTION.IN, "ConEdge")).isEqualTo(0);
-    assertThat(fromVtx.getEdges(Vertex.DIRECTION.OUT, "ConEdge").iterator().hasNext()).isTrue();
-    assertThat(fromVtx.getEdges(Vertex.DIRECTION.IN, "ConEdge").iterator().hasNext()).isFalse();
+    assertThat(fromVtx.countEdges(Vertex.Direction.OUT, "ConEdge")).isEqualTo(1);
+    assertThat(fromVtx.countEdges(Vertex.Direction.IN, "ConEdge")).isEqualTo(0);
+    assertThat(fromVtx.getEdges(Vertex.Direction.OUT, "ConEdge").iterator().hasNext()).isTrue();
+    assertThat(fromVtx.getEdges(Vertex.Direction.IN, "ConEdge").iterator().hasNext()).isFalse();
   }
 
   @Test
@@ -111,7 +111,7 @@ public class RemoteQueriesIT {
         dtOrders.createProperty("id", Type.STRING);
         dtOrders.createProperty("processor", Type.STRING);
         dtOrders.createProperty("status", Type.STRING);
-        typeIndex[0] = dtOrders.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "status", "id");
+        typeIndex[0] = dtOrders.createTypeIndex(Schema.IndexType.LSM_TREE, true, "status", "id");
       });
     }
 
@@ -178,8 +178,8 @@ public class RemoteQueriesIT {
           dtProduct.createProperty("type", Type.STRING);
           dtProduct.createProperty("start", Type.DATETIME_MICROS);
           dtProduct.createProperty("stop", Type.DATETIME_MICROS);
-          dtProduct.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "name");
-          dtProduct.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "type", "start", "stop");
+          dtProduct.createTypeIndex(Schema.IndexType.LSM_TREE, true, "name");
+          dtProduct.createTypeIndex(Schema.IndexType.LSM_TREE, true, "type", "start", "stop");
         });
       }
     }

--- a/server/src/test/java/com/arcadedb/server/SelectOrderTest.java
+++ b/server/src/test/java/com/arcadedb/server/SelectOrderTest.java
@@ -69,8 +69,8 @@ public class SelectOrderTest {
           dtOrders.createProperty("pstop", Type.STRING);
           dtOrders.createProperty("status", Type.STRING);
           dtOrders.createProperty("node", Type.STRING);
-          dtOrders.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "status");
-          dtOrders.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "processor", "vstart", "vstop");
+          dtOrders.createTypeIndex(Schema.IndexType.LSM_TREE, false, "status");
+          dtOrders.createTypeIndex(Schema.IndexType.LSM_TREE, true, "processor", "vstart", "vstop");
         });
       }
 
@@ -188,8 +188,8 @@ public class SelectOrderTest {
           dtProduct.createProperty("type", Type.STRING);
           dtProduct.createProperty("start", Type.DATETIME_MICROS);
           dtProduct.createProperty("stop", Type.DATETIME_MICROS);
-          dtProduct.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "name");
-          dtProduct.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "type", "start", "stop");
+          dtProduct.createTypeIndex(Schema.IndexType.LSM_TREE, true, "name");
+          dtProduct.createTypeIndex(Schema.IndexType.LSM_TREE, true, "type", "start", "stop");
         });
       }
 

--- a/server/src/test/java/com/arcadedb/server/ServerDefaultDatabasesIT.java
+++ b/server/src/test/java/com/arcadedb/server/ServerDefaultDatabasesIT.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.*;
 
-import static com.arcadedb.engine.ComponentFile.MODE.READ_WRITE;
+import static com.arcadedb.engine.ComponentFile.Mode.READ_WRITE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 

--- a/server/src/test/java/com/arcadedb/server/ServerReadOnlyDatabasesIT.java
+++ b/server/src/test/java/com/arcadedb/server/ServerReadOnlyDatabasesIT.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.*;
 
-import static com.arcadedb.engine.ComponentFile.MODE.READ_ONLY;
+import static com.arcadedb.engine.ComponentFile.Mode.READ_ONLY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ServerReadOnlyDatabasesIT extends BaseGraphServerTest {

--- a/server/src/test/java/com/arcadedb/server/TestLinkedPropertiesSchemaReloadIT.java
+++ b/server/src/test/java/com/arcadedb/server/TestLinkedPropertiesSchemaReloadIT.java
@@ -3,7 +3,7 @@ package com.arcadedb.server;
 import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.DatabaseContext;
-import com.arcadedb.engine.ComponentFile.MODE;
+import com.arcadedb.engine.ComponentFile.Mode;
 import com.arcadedb.schema.DocumentType;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
@@ -136,7 +136,7 @@ public class TestLinkedPropertiesSchemaReloadIT {
     }
     try {
       if (!server.existsDatabase(url)) {
-        sdb = server.createDatabase(url, MODE.READ_WRITE);
+        sdb = server.createDatabase(url, Mode.READ_WRITE);
       } else {
         sdb = server.getDatabase(url);
       }

--- a/server/src/test/java/com/arcadedb/server/ha/HARandomCrashIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/HARandomCrashIT.java
@@ -32,7 +32,6 @@ import com.arcadedb.remote.RemoteException;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.BaseGraphServerTest;
 import com.arcadedb.utility.CodeUtils;
-import org.graalvm.nativebridge.In;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
@@ -50,8 +49,8 @@ public class HARandomCrashIT extends ReplicationServerIT {
   }
 
   @Override
-  protected HAServer.SERVER_ROLE getServerRole(int serverIndex) {
-    return HAServer.SERVER_ROLE.ANY;
+  protected HAServer.ServerRole getServerRole(int serverIndex) {
+    return HAServer.ServerRole.ANY;
   }
 
   @Test
@@ -98,7 +97,7 @@ public class HARandomCrashIT extends ReplicationServerIT {
 
             getServer(serverId).stop();
 
-            while (getServer(serverId).getStatus() == ArcadeDBServer.STATUS.SHUTTING_DOWN)
+            while (getServer(serverId).getStatus() == ArcadeDBServer.Status.SHUTTING_DOWN)
               CodeUtils.sleep(300);
 
             LogManager.instance().log(this, getLogLevel(), "TEST: Restarting the Server %s (delay=%d)...", null, serverId, delay);

--- a/server/src/test/java/com/arcadedb/server/ha/HASplitBrainIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/HASplitBrainIT.java
@@ -61,19 +61,19 @@ public class HASplitBrainIT extends ReplicationServerIT {
   }
 
   @Override
-  protected HAServer.SERVER_ROLE getServerRole(int serverIndex) {
-    return HAServer.SERVER_ROLE.ANY;
+  protected HAServer.ServerRole getServerRole(int serverIndex) {
+    return HAServer.ServerRole.ANY;
   }
 
   @Override
   protected void onBeforeStarting(final ArcadeDBServer server) {
     server.registerTestEventListener(new ReplicationCallback() {
       @Override
-      public void onEvent(final TYPE type, final Object object, final ArcadeDBServer server) throws IOException {
-        if (type == TYPE.LEADER_ELECTED) {
+      public void onEvent(final Type type, final Object object, final ArcadeDBServer server) throws IOException {
+        if (type == Type.LEADER_ELECTED) {
           if (firstLeader == null)
             firstLeader = (String) object;
-        } else if (type == TYPE.NETWORK_CONNECTION && split) {
+        } else if (type == Type.NETWORK_CONNECTION && split) {
           final String connectTo = (String) object;
 
           final String[] parts = HostUtil.parseHostAddress(connectTo, HostUtil.HA_DEFAULT_PORT);
@@ -111,7 +111,7 @@ public class HASplitBrainIT extends ReplicationServerIT {
     if (server.getServerName().equals("ArcadeDB_4"))
       server.registerTestEventListener((type, object, server1) -> {
         if (!split) {
-          if (type == ReplicationCallback.TYPE.REPLICA_MSG_RECEIVED) {
+          if (type == ReplicationCallback.Type.REPLICA_MSG_RECEIVED) {
             messages.incrementAndGet();
             if (messages.get() > 10) {
 

--- a/server/src/test/java/com/arcadedb/server/ha/IndexOperations3ServersIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/IndexOperations3ServersIT.java
@@ -54,9 +54,9 @@ public class IndexOperations3ServersIT extends BaseGraphServerTest {
     final Database database = getServerDatabase(0, getDatabaseName());
     final VertexType v = database.getSchema().buildVertexType().withName("Person").withTotalBuckets(3).create();
     v.createProperty("id", Long.class);
-    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Person", "id");
+    database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, "Person", "id");
     v.createProperty("uuid", String.class);
-    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Person", "uuid");
+    database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, "Person", "uuid");
 
     LogManager.instance().log(this, Level.FINE, "Inserting 1M records with 2 indexes...");
     // CREATE 1M RECORD IN 10 TX CHUNKS OF 100K EACH
@@ -93,9 +93,9 @@ public class IndexOperations3ServersIT extends BaseGraphServerTest {
     database.transaction(() -> insertRecords(database));
 
     v.createProperty("id", Long.class);
-    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Person", "id");
+    database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, "Person", "id");
     v.createProperty("uuid", String.class);
-    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Person", "uuid");
+    database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, "Person", "uuid");
 
     testEachServer((serverIndex) -> {
       LogManager.instance()
@@ -129,9 +129,9 @@ public class IndexOperations3ServersIT extends BaseGraphServerTest {
       database.transaction(() -> insertRecords(database));
 
       v.createProperty("id", Long.class);
-      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Person", "id");
+      database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, "Person", "id");
       v.createProperty("uuid", String.class);
-      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Person", "uuid");
+      database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, "Person", "uuid");
 
       // TRY CREATING A DUPLICATE
       TestServerHelper.expectException(() -> database.newVertex("Person").set("id", 0, "uuid", UUID.randomUUID().toString()).save(),
@@ -169,14 +169,14 @@ public class IndexOperations3ServersIT extends BaseGraphServerTest {
       v.createProperty("id", Long.class);
 
       // TRY CREATING INDEX WITH DUPLICATES
-      TestServerHelper.expectException(() -> database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Person", "id"),
+      TestServerHelper.expectException(() -> database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, "Person", "id"),
           IndexException.class);
 
       TestServerHelper.expectException(() -> database.getSchema().getIndexByName("Person[id]"), SchemaException.class);
 
       // TRY CREATING INDEX WITH DUPLICATES
       v.createProperty("uuid", String.class);
-      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Person", "uuid");
+      database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, "Person", "uuid");
 
       database.getSchema().getType("Person").dropProperty("id");
       database.getSchema().dropIndex("Person[uuid]");

--- a/server/src/test/java/com/arcadedb/server/ha/ReplicationChangeSchemaIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/ReplicationChangeSchemaIT.java
@@ -106,7 +106,7 @@ public class ReplicationChangeSchemaIT extends ReplicationServerIT {
     final Property indexedProperty = indexedType.createProperty("propertyIndexed", Type.INTEGER);
     testOnAllServers((database) -> isInSchemaFile(database, "propertyIndexed"));
 
-    final Index idx = indexedProperty.createIndex(Schema.INDEX_TYPE.LSM_TREE, true);
+    final Index idx = indexedProperty.createIndex(Schema.IndexType.LSM_TREE, true);
     testOnAllServers((database) -> isInSchemaFile(database, "\"IndexedVertex0\""));
 
     testOnAllServers((database) -> isInSchemaFile(database, "\"indexes\":{\"IndexedVertex0_"));

--- a/server/src/test/java/com/arcadedb/server/ha/ReplicationServerFixedClientConnectionIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/ReplicationServerFixedClientConnectionIT.java
@@ -58,8 +58,8 @@ public class ReplicationServerFixedClientConnectionIT extends ReplicationServerI
   }
 
   @Override
-  protected HAServer.SERVER_ROLE getServerRole(int serverIndex) {
-    return HAServer.SERVER_ROLE.ANY;
+  protected HAServer.ServerRole getServerRole(int serverIndex) {
+    return HAServer.ServerRole.ANY;
   }
 
   @Test
@@ -72,7 +72,7 @@ public class ReplicationServerFixedClientConnectionIT extends ReplicationServerI
     final RemoteDatabase db = new RemoteDatabase("http://" + server1AddressParts[0], Integer.parseInt(server1AddressParts[1]),
         getDatabaseName(), "root", BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
 
-    db.setConnectionStrategy(RemoteHttpComponent.CONNECTION_STRATEGY.FIXED);
+    db.setConnectionStrategy(RemoteHttpComponent.ConnectionStrategy.FIXED);
 
     LogManager.instance()
         .log(this, Level.FINE, "Executing %s transactions with %d vertices each...", null, getTxs(), getVerticesPerTx());
@@ -131,7 +131,7 @@ public class ReplicationServerFixedClientConnectionIT extends ReplicationServerI
   protected void onBeforeStarting(final ArcadeDBServer server) {
     if (server.getServerName().equals("ArcadeDB_1"))
       server.registerTestEventListener((type, object, server1) -> {
-        if (type == ReplicationCallback.TYPE.REPLICA_MSG_RECEIVED) {
+        if (type == ReplicationCallback.Type.REPLICA_MSG_RECEIVED) {
           if (messages.incrementAndGet() > 1000 && getServer(0).isStarted()) {
             testLog("TEST: Stopping the Leader...");
 

--- a/server/src/test/java/com/arcadedb/server/ha/ReplicationServerLeaderChanges3TimesIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/ReplicationServerLeaderChanges3TimesIT.java
@@ -56,8 +56,8 @@ public class ReplicationServerLeaderChanges3TimesIT extends ReplicationServerIT 
   }
 
   @Override
-  protected HAServer.SERVER_ROLE getServerRole(int serverIndex) {
-    return HAServer.SERVER_ROLE.ANY;
+  protected HAServer.ServerRole getServerRole(int serverIndex) {
+    return HAServer.ServerRole.ANY;
   }
 
   @Test
@@ -144,11 +144,11 @@ public class ReplicationServerLeaderChanges3TimesIT extends ReplicationServerIT 
   protected void onBeforeStarting(final ArcadeDBServer server) {
     server.registerTestEventListener(new ReplicationCallback() {
       @Override
-      public void onEvent(final TYPE type, final Object object, final ArcadeDBServer server) {
+      public void onEvent(final Type type, final Object object, final ArcadeDBServer server) {
         if (!serversSynchronized)
           return;
 
-        if (type == TYPE.REPLICA_MSG_RECEIVED) {
+        if (type == Type.REPLICA_MSG_RECEIVED) {
           if (!(((Pair) object).getSecond() instanceof TxRequest))
             return;
 

--- a/server/src/test/java/com/arcadedb/server/ha/ReplicationServerLeaderDownIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/ReplicationServerLeaderDownIT.java
@@ -50,8 +50,8 @@ public class ReplicationServerLeaderDownIT extends ReplicationServerIT {
   }
 
   @Override
-  protected HAServer.SERVER_ROLE getServerRole(int serverIndex) {
-    return HAServer.SERVER_ROLE.ANY;
+  protected HAServer.ServerRole getServerRole(int serverIndex) {
+    return HAServer.ServerRole.ANY;
   }
 
   @Test
@@ -118,7 +118,7 @@ public class ReplicationServerLeaderDownIT extends ReplicationServerIT {
   protected void onBeforeStarting(final ArcadeDBServer server) {
     if (server.getServerName().equals("ArcadeDB_2"))
       server.registerTestEventListener((type, object, server1) -> {
-        if (type == ReplicationCallback.TYPE.REPLICA_MSG_RECEIVED) {
+        if (type == ReplicationCallback.Type.REPLICA_MSG_RECEIVED) {
           if (messages.incrementAndGet() > 10 && getServer(0).isStarted()) {
             testLog("TEST: Stopping the Leader...");
 

--- a/server/src/test/java/com/arcadedb/server/ha/ReplicationServerLeaderDownNoTransactionsToForwardIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/ReplicationServerLeaderDownNoTransactionsToForwardIT.java
@@ -47,8 +47,8 @@ public class ReplicationServerLeaderDownNoTransactionsToForwardIT extends Replic
   }
 
   @Override
-  protected HAServer.SERVER_ROLE getServerRole(int serverIndex) {
-    return HAServer.SERVER_ROLE.ANY;
+  protected HAServer.ServerRole getServerRole(int serverIndex) {
+    return HAServer.ServerRole.ANY;
   }
 
   @Test
@@ -117,7 +117,7 @@ public class ReplicationServerLeaderDownNoTransactionsToForwardIT extends Replic
   protected void onBeforeStarting(final ArcadeDBServer server) {
     if (server.getServerName().equals("ArcadeDB_2"))
       server.registerTestEventListener((type, object, server1) -> {
-        if (type == ReplicationCallback.TYPE.REPLICA_MSG_RECEIVED) {
+        if (type == ReplicationCallback.Type.REPLICA_MSG_RECEIVED) {
           if (messages.incrementAndGet() > 10 && getServer(0).isStarted()) {
             testLog("TEST: Stopping the Leader...");
 

--- a/server/src/test/java/com/arcadedb/server/ha/ReplicationServerQuorumMajority1ServerOutIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/ReplicationServerQuorumMajority1ServerOutIT.java
@@ -33,11 +33,11 @@ public class ReplicationServerQuorumMajority1ServerOutIT extends ReplicationServ
     if (server.getServerName().equals("ArcadeDB_2"))
       server.registerTestEventListener(new ReplicationCallback() {
         @Override
-        public void onEvent(final TYPE type, final Object object, final ArcadeDBServer server) {
+        public void onEvent(final Type type, final Object object, final ArcadeDBServer server) {
           if (!serversSynchronized)
             return;
 
-          if (type == TYPE.REPLICA_MSG_RECEIVED) {
+          if (type == Type.REPLICA_MSG_RECEIVED) {
             if (messages.incrementAndGet() > 100) {
               LogManager.instance().log(this, Level.FINE, "TEST: Stopping Replica 2...");
               getServer(2).stop();

--- a/server/src/test/java/com/arcadedb/server/ha/ReplicationServerQuorumMajority2ServersOutIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/ReplicationServerQuorumMajority2ServersOutIT.java
@@ -44,8 +44,8 @@ public class ReplicationServerQuorumMajority2ServersOutIT extends ReplicationSer
     if (server.getServerName().equals("ArcadeDB_1"))
       server.registerTestEventListener(new ReplicationCallback() {
         @Override
-        public void onEvent(final TYPE type, final Object object, final ArcadeDBServer server) {
-          if (type == TYPE.REPLICA_MSG_RECEIVED) {
+        public void onEvent(final Type type, final Object object, final ArcadeDBServer server) {
+          if (type == Type.REPLICA_MSG_RECEIVED) {
             if (messages.incrementAndGet() > 100) {
               LogManager.instance().log(this, Level.FINE, "TEST: Stopping Replica 1...");
               getServer(1).stop();
@@ -57,8 +57,8 @@ public class ReplicationServerQuorumMajority2ServersOutIT extends ReplicationSer
     if (server.getServerName().equals("ArcadeDB_2"))
       server.registerTestEventListener(new ReplicationCallback() {
         @Override
-        public void onEvent(final TYPE type, final Object object, final ArcadeDBServer server) {
-          if (type == TYPE.REPLICA_MSG_RECEIVED) {
+        public void onEvent(final Type type, final Object object, final ArcadeDBServer server) {
+          if (type == Type.REPLICA_MSG_RECEIVED) {
             if (messages.incrementAndGet() > 200) {
               LogManager.instance().log(this, Level.FINE, "TEST: Stopping Replica 2...");
               getServer(2).stop();

--- a/server/src/test/java/com/arcadedb/server/ha/ReplicationServerReplicaHotResyncIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/ReplicationServerReplicaHotResyncIT.java
@@ -64,7 +64,7 @@ public class ReplicationServerReplicaHotResyncIT extends ReplicationServerIT {
     if (server.getServerName().equals("ArcadeDB_2")) {
       server.registerTestEventListener(new ReplicationCallback() {
         @Override
-        public void onEvent(final TYPE type, final Object object, final ArcadeDBServer server) {
+        public void onEvent(final Type type, final Object object, final ArcadeDBServer server) {
           if (!serversSynchronized)
             return;
 
@@ -80,10 +80,10 @@ public class ReplicationServerReplicaHotResyncIT extends ReplicationServerIT {
               }
             }
           } else {
-            if (type == TYPE.REPLICA_HOT_RESYNC) {
+            if (type == Type.REPLICA_HOT_RESYNC) {
               LogManager.instance().log(this, Level.INFO, "TEST: Received hot resync request");
               hotResyncLatch.countDown();
-            } else if (type == TYPE.REPLICA_FULL_RESYNC) {
+            } else if (type == Type.REPLICA_FULL_RESYNC) {
               LogManager.instance().log(this, Level.INFO, "TEST: Received full resync request");
               fullResyncLatch.countDown();
             }
@@ -95,11 +95,11 @@ public class ReplicationServerReplicaHotResyncIT extends ReplicationServerIT {
     if (server.getServerName().equals("ArcadeDB_0")) {
       server.registerTestEventListener(new ReplicationCallback() {
         @Override
-        public void onEvent(final TYPE type, final Object object, final ArcadeDBServer server) {
+        public void onEvent(final Type type, final Object object, final ArcadeDBServer server) {
           if (!serversSynchronized)
             return;
 
-          if ("ArcadeDB_2".equals(object) && type == TYPE.REPLICA_OFFLINE) {
+          if ("ArcadeDB_2".equals(object) && type == Type.REPLICA_OFFLINE) {
             LogManager.instance().log(this, Level.INFO, "TEST: Replica 2 is offline removing latency...");
             slowDown = false;
           }

--- a/server/src/test/java/com/arcadedb/server/ha/ReplicationServerReplicaRestartForceDbInstallIT.java
+++ b/server/src/test/java/com/arcadedb/server/ha/ReplicationServerReplicaRestartForceDbInstallIT.java
@@ -52,7 +52,7 @@ public class ReplicationServerReplicaRestartForceDbInstallIT extends Replication
     if (server.getServerName().equals("ArcadeDB_2"))
       server.registerTestEventListener(new ReplicationCallback() {
         @Override
-        public void onEvent(final TYPE type, final Object object, final ArcadeDBServer server) {
+        public void onEvent(final Type type, final Object object, final ArcadeDBServer server) {
           if (!serversSynchronized)
             return;
 
@@ -70,10 +70,10 @@ public class ReplicationServerReplicaRestartForceDbInstallIT extends Replication
             }
           } else {
 
-            if (type == TYPE.REPLICA_HOT_RESYNC) {
+            if (type == Type.REPLICA_HOT_RESYNC) {
               LogManager.instance().log(this, getErrorLevel(), "TEST: Received hot resync request");
               hotResync = true;
-            } else if (type == TYPE.REPLICA_FULL_RESYNC) {
+            } else if (type == Type.REPLICA_FULL_RESYNC) {
               LogManager.instance().log(this, getErrorLevel(), "TEST: Received full resync request");
               fullResync = true;
             }
@@ -84,12 +84,12 @@ public class ReplicationServerReplicaRestartForceDbInstallIT extends Replication
     if (server.getServerName().equals("ArcadeDB_0"))
       server.registerTestEventListener(new ReplicationCallback() {
         @Override
-        public void onEvent(final TYPE type, final Object object, final ArcadeDBServer server) {
+        public void onEvent(final Type type, final Object object, final ArcadeDBServer server) {
           if (!serversSynchronized)
             return;
 
           // AS SOON AS SERVER 2 IS OFFLINE, A CLEAN OF REPLICATION LOG AND RESTART IS EXECUTED
-          if ("ArcadeDB_2".equals(object) && type == TYPE.REPLICA_OFFLINE && firstTimeServerShutdown) {
+          if ("ArcadeDB_2".equals(object) && type == Type.REPLICA_OFFLINE && firstTimeServerShutdown) {
             LogManager.instance().log(this, Level.SEVERE,
                 "TEST: Stopping Replica 2, removing latency, delete the replication log file and restart the server...");
             slowDown = false;

--- a/server/src/test/java/com/arcadedb/server/security/ServerProfilingIT.java
+++ b/server/src/test/java/com/arcadedb/server/security/ServerProfilingIT.java
@@ -582,10 +582,10 @@ public class ServerProfilingIT {
 
     expectedSecurityException(
         () -> database.getSchema().buildBucketIndex("Document1", "Bucket1", new String[] { "id" }).withUnique(true)
-            .withType(Schema.INDEX_TYPE.LSM_TREE).withPageSize(10_000).withNullStrategy(LSMTreeIndexAbstract.NULL_STRATEGY.ERROR)
+            .withType(Schema.IndexType.LSM_TREE).withPageSize(10_000).withNullStrategy(LSMTreeIndexAbstract.NullStrategy.ERROR)
             .create());
 
-    expectedSecurityException(() -> database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "Document1", "id"));
+    expectedSecurityException(() -> database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, true, "Document1", "id"));
 
     expectedSecurityException(() -> database.getSchema().dropType("Document1"));
     expectedSecurityException(() -> database.getSchema().dropIndex("Idx1"));

--- a/server/src/test/java/performance/ReplicationSpeedQuorumMajorityIT.java
+++ b/server/src/test/java/performance/ReplicationSpeedQuorumMajorityIT.java
@@ -84,9 +84,6 @@ public class ReplicationSpeedQuorumMajorityIT extends BasePerformanceTest {
 
     final Database db = getServerDatabase(0, getDatabaseName());
 
-//    db.begin();
-//    db.setWALFlush(WALFile.FLUSH_TYPE.YES_NO_METADATA);
-
     LogManager.instance().log(this, Level.INFO, "TEST: Executing %s transactions with %d vertices each...", null, getTxs(), getVerticesPerTx());
 
     final int totalToInsert = getTxs() * getVerticesPerTx();
@@ -180,9 +177,9 @@ public class ReplicationSpeedQuorumMajorityIT extends BasePerformanceTest {
     v.createProperty("operationalStatus", String.class);
     v.createProperty("supplierName", String.class);
 
-    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "Device", new String[] { "id" }, 2 * 1024 * 1024);
-    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "Device", new String[] { "number" }, 2 * 1024 * 1024);
-    database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "Device", new String[] { "relativeName" }, 2 * 1024 * 1024);
+    database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, false, "Device", new String[] { "id" }, 2 * 1024 * 1024);
+    database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, false, "Device", new String[] { "number" }, 2 * 1024 * 1024);
+    database.getSchema().createTypeIndex(Schema.IndexType.LSM_TREE, false, "Device", new String[] { "relativeName" }, 2 * 1024 * 1024);
   }
 
 }


### PR DESCRIPTION
#2376 

This pull request focuses on improving code consistency and readability by replacing uppercase enum constants with proper camel-case enum references and removing unused imports. The changes span across multiple files, affecting both the main codebase and test cases.

### Code consistency improvements:
* Updated enum references from uppercase (e.g., `ComponentFile.MODE`) to camel-case (e.g., `ComponentFile.Mode`) in `Console.java` for better readability and adherence to naming conventions. [[1]](diffhunk://#diff-a1bb54898c0fb689c4f019cdf0af238dd35cdfad2ba6ec318e5281624745c4cbL445-R447) [[2]](diffhunk://#diff-a1bb54898c0fb689c4f019cdf0af238dd35cdfad2ba6ec318e5281624745c4cbL1032-R1032)
* Replaced uppercase enum constants (e.g., `Schema.INDEX_TYPE`) with camel-case equivalents (e.g., `Schema.IndexType`) in test cases such as `CompositeIndexUpdateTest` and `ConsoleAsyncInsertTest`. [[1]](diffhunk://#diff-8dfe9c16f37292d7593335ee9f37d991c781b9b6af9544190bfe44370e4d7321L134-R134) [[2]](diffhunk://#diff-8dfe9c16f37292d7593335ee9f37d991c781b9b6af9544190bfe44370e4d7321L225-R224) [[3]](diffhunk://#diff-fade594b8fd4666f441bfe7f0e3b4063b458d65717521e2761ec909cc63630aeL168-R169) [[4]](diffhunk://#diff-fade594b8fd4666f441bfe7f0e3b4063b458d65717521e2761ec909cc63630aeL244-R245) [[5]](diffhunk://#diff-fade594b8fd4666f441bfe7f0e3b4063b458d65717521e2761ec909cc63630aeL323-R333) [[6]](diffhunk://#diff-fade594b8fd4666f441bfe7f0e3b4063b458d65717521e2761ec909cc63630aeL492-R492)
* Updated `Vertex.DIRECTION` to `Vertex.Direction` in test cases for consistency with naming conventions. [[1]](diffhunk://#diff-c1ca7d83f123c920662ffa1bc2de7bfa652a9b4decce9224aa70072693b275dbL291-R291) [[2]](diffhunk://#diff-c1ca7d83f123c920662ffa1bc2de7bfa652a9b4decce9224aa70072693b275dbL335-R335) [[3]](diffhunk://#diff-339c59821bf373a8c5a264ebefd6ca6df73cfe29668728fbd585407a740427efL97-R97)
* Changed `GlobalConfiguration.SCOPE` to `GlobalConfiguration.Scope` in both main code (`GlobalConfiguration.java`) and test cases (`DumpCfgApp.java`). [[1]](diffhunk://#diff-9021a2fb7b6615ac1930a8b07485fea45ee1ed34ac8805b52943e15a7e2e5a10L28-R28) [[2]](diffhunk://#diff-9021a2fb7b6615ac1930a8b07485fea45ee1ed34ac8805b52943e15a7e2e5a10L38-R38) [[3]](diffhunk://#diff-170362872e4ccee90c31cafbcea962276cf29fc7899106fc8f0f265089d9a506L30-R47) [[4]](diffhunk://#diff-170362872e4ccee90c31cafbcea962276cf29fc7899106fc8f0f265089d9a506L59-R67) [[5]](diffhunk://#diff-170362872e4ccee90c31cafbcea962276cf29fc7899106fc8f0f265089d9a506L78-R86) [[6]](diffhunk://#diff-170362872e4ccee90c31cafbcea962276cf29fc7899106fc8f0f265089d9a506L122-R133) [[7]](diffhunk://#diff-170362872e4ccee90c31cafbcea962276cf29fc7899106fc8f0f265089d9a506L150-R161) [[8]](diffhunk://#diff-170362872e4ccee90c31cafbcea962276cf29fc7899106fc8f0f265089d9a506L166-R177)
* Updated `LSMTreeIndexAbstract.NULL_STRATEGY` to `LSMTreeIndexAbstract.NullStrategy` in `SQLGrammar.jjt`.

### Removal of unused imports:
* Removed unused imports such as `PrintStream` in `CompositeIndexUpdateTest` and other files to clean up the codebase. [[1]](diffhunk://#diff-8dfe9c16f37292d7593335ee9f37d991c781b9b6af9544190bfe44370e4d7321L46) [[2]](diffhunk://#diff-170362872e4ccee90c31cafbcea962276cf29fc7899106fc8f0f265089d9a506L30-R47)

These changes collectively enhance code readability, maintainability, and adherence to standard naming conventions.