### PR TITLE
fix: remove support for hidden properties

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/BaseDocument.java
+++ b/engine/src/main/java/com/arcadedb/database/BaseDocument.java
@@ -23,10 +23,20 @@ import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.JavaBinarySerializer;
 import com.arcadedb.serializer.json.JSONObject;
 
-import java.io.*;
-import java.math.*;
-import java.time.*;
-import java.util.*;
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
 
 public abstract class BaseDocument extends BaseRecord implements Document, Serializable, Externalizable {
   protected final DocumentType type;
@@ -50,11 +60,6 @@ public abstract class BaseDocument extends BaseRecord implements Document, Seria
   @Override
   public DetachedDocument detach() {
     return new DetachedDocument(this);
-  }
-
-  @Override
-  public DetachedDocument detach(boolean filterHiddenProperties) {
-    return new DetachedDocument(this, filterHiddenProperties);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/database/DetachedDocument.java
+++ b/engine/src/main/java/com/arcadedb/database/DetachedDocument.java
@@ -21,7 +21,11 @@ package com.arcadedb.database;
 import com.arcadedb.schema.Property;
 import com.arcadedb.serializer.json.JSONObject;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static com.arcadedb.schema.Property.RID_PROPERTY;
 
@@ -30,18 +34,11 @@ import static com.arcadedb.schema.Property.RID_PROPERTY;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-public class DetachedDocument extends ImmutableDocument {
-  private Map<String, Object> map;
-  private boolean             filterHiddenProperties = false;
+public class DetachedDocument extends BaseDocument {
+  protected Map<String, Object> map;
 
-  protected DetachedDocument(final BaseDocument source) {
-    super(null, source.type, source.rid, null);
-    init(source);
-  }
-
-  protected DetachedDocument(final BaseDocument source, boolean filterHiddenProperties) {
-    super(null, source.type, source.rid, null);
-    this.filterHiddenProperties = filterHiddenProperties;
+  protected DetachedDocument(final Document source) {
+    super(null, source.getType(), source.getIdentity(), null);
     init(source);
   }
 
@@ -50,11 +47,6 @@ public class DetachedDocument extends ImmutableDocument {
     final Map<String, Object> sourceMap = sourceDocument.propertiesAsMap();
     for (final Map.Entry<String, Object> entry : sourceMap.entrySet()) {
 
-      if (filterHiddenProperties) {
-        Property property = sourceDocument.getType().getPropertyIfExists(entry.getKey());
-        if (property != null && property.isHidden())
-          continue;
-      }
       Object value = entry.getValue();
 
       if (value instanceof List list) {
@@ -95,6 +87,14 @@ public class DetachedDocument extends ImmutableDocument {
         result.put(RID_PROPERTY, getIdentity().toString());
     }
     return result;
+  }
+
+  /**
+   * @return
+   */
+  @Override
+  public Map<String, Object> propertiesAsMap() {
+    return Map.of();
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/database/Document.java
+++ b/engine/src/main/java/com/arcadedb/database/Document.java
@@ -18,14 +18,20 @@
  */
 package com.arcadedb.database;
 
-import com.arcadedb.database.Record;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.ExcludeFromJacocoGeneratedReport;
 
-import java.math.*;
-import java.time.*;
-import java.util.*;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Document interface. Vertex and Edge both extend the Document interface.
@@ -39,8 +45,6 @@ public interface Document extends Record {
   MutableDocument modify();
 
   DetachedDocument detach();
-
-  DetachedDocument detach(boolean filterHiddenProperties);
 
   boolean has(String propertyName);
 

--- a/engine/src/main/java/com/arcadedb/graph/ImmutableVertex.java
+++ b/engine/src/main/java/com/arcadedb/graph/ImmutableVertex.java
@@ -32,8 +32,8 @@ import com.arcadedb.schema.Property;
 import com.arcadedb.schema.VertexType;
 import com.arcadedb.serializer.json.JSONObject;
 
-import java.io.*;
-import java.util.*;
+import java.io.IOException;
+import java.util.Map;
 
 /**
  * Immutable read-only vertex. It is returned from database on read operations such as queries or lookups. To modify a vertex use {@link #modify()} to have the

--- a/engine/src/main/java/com/arcadedb/graph/SynchronizedVertex.java
+++ b/engine/src/main/java/com/arcadedb/graph/SynchronizedVertex.java
@@ -28,9 +28,16 @@ import com.arcadedb.database.Record;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.serializer.json.JSONObject;
 
-import java.math.*;
-import java.time.*;
-import java.util.*;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Vertex wrapper to share a vertex among threads. This is useful when you want to cache the vertex in RAM to
@@ -197,11 +204,6 @@ public class SynchronizedVertex implements Vertex {
   @Override
   public synchronized DetachedDocument detach() {
     return delegate.detach();
-  }
-
-  @Override
-  public synchronized DetachedDocument detach(boolean filterHiddenProperties) {
-    return delegate.detach(filterHiddenProperties);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Projection.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Projection.java
@@ -27,8 +27,14 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.schema.Property;
 
-import java.util.*;
-import java.util.stream.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.arcadedb.schema.Property.RID_PROPERTY;
 
@@ -108,6 +114,8 @@ public class Projection extends SimpleNode {
         continue;
 
       if (item.isAll()) {
+        result.setElement(record.toElement());
+
         for (final String alias : record.getPropertyNames()) {
           if (excludes.contains(alias)) {
             continue;
@@ -134,8 +142,6 @@ public class Projection extends SimpleNode {
             result.setProperty(Property.TYPE_PROPERTY, doc.getType().getName());
           }
 
-          Document detached = doc.detach(true);
-          result.setElement(detached);
         });
       } else {
         result.setProperty(item.getProjectionAliasAsString(), item.execute(record, context));

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/CreatePropertyStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/CreatePropertyStatementExecutionTest.java
@@ -216,7 +216,9 @@ public class CreatePropertyStatementExecutionTest extends TestHelper {
 
   @Test
   void testCreateHiddenProperty() {
-    database.command("sql", "create document type testHiddenProperty").close();
+    // due to https://github.com/ArcadeData/arcadedb/issues/2378 hidden properties are supported in thhe schema, but not in the
+    // database
+    database.command("sql", "create vertex type testHiddenProperty").close();
     database.command("sql", "CREATE property testHiddenProperty.name STRING (hidden)").close();
 
     DocumentType clazz = database.getSchema().getType("testHiddenProperty");
@@ -227,20 +229,19 @@ public class CreatePropertyStatementExecutionTest extends TestHelper {
     assertThat(nameProperty.isHidden()).isTrue();
 
     database.transaction(() -> {
-
       database.command("sql", "INSERT INTO testHiddenProperty SET name = 'hidden' , no_secret = 'seeme' ").close();
     });
 
-    // check that the property is hidden when select *
     ResultSet result = database.query("sql", "SELECT * FROM testHiddenProperty");
     assertThat(result.hasNext()).isTrue();
     Result doc = result.next();
-    assertThat(doc.getPropertyNames()).doesNotContain("name").contains("no_secret");
-    // check that the property is visibilw when selected directly
-    result = database.query("sql", "SELECT name FROM testHiddenProperty");
+    assertThat(doc.getPropertyNames()).contains("name").contains("no_secret");
+    assertThat(doc.isVertex()).isTrue();
+    result = database.query("sql", "SELECT  FROM testHiddenProperty");
     assertThat(result.hasNext()).isTrue();
     doc = result.next();
-    assertThat(doc.getPropertyNames()).contains("name");
+    assertThat(doc.getPropertyNames()).contains("name").contains("no_secret");
+    assertThat(doc.isVertex()).isTrue();
 
   }
 }


### PR DESCRIPTION
#2378 

This pull request refactors the handling of `DetachedDocument` and hidden properties in the codebase, simplifies the `detach` method, and updates related tests. Key changes include the removal of hidden property filtering, adjustments to the `DetachedDocument` class, and updates to test cases for hidden properties.

### Refactoring of `DetachedDocument`:

* [`engine/src/main/java/com/arcadedb/database/DetachedDocument.java`](diffhunk://#diff-9ae0c0cfa6896961942e945caf4ef31f523c57858935cc9e3c17b074f33e1e67L33-R41): Changed the parent class of `DetachedDocument` from `ImmutableDocument` to `BaseDocument`, removed the `filterHiddenProperties` mechanism, and simplified the `init` method by eliminating hidden property checks. [[1]](diffhunk://#diff-9ae0c0cfa6896961942e945caf4ef31f523c57858935cc9e3c17b074f33e1e67L33-R41) [[2]](diffhunk://#diff-9ae0c0cfa6896961942e945caf4ef31f523c57858935cc9e3c17b074f33e1e67L53-L57)

### Simplification of `detach` methods:

* [`engine/src/main/java/com/arcadedb/database/BaseDocument.java`](diffhunk://#diff-ecc83bc47e505bb18eba78108cd168d989c20f88cea6d88d761bf3189b3b582fL55-L59): Removed the `detach(boolean filterHiddenProperties)` method, retaining only the simpler `detach()` method.
* [`engine/src/main/java/com/arcadedb/graph/SynchronizedVertex.java`](diffhunk://#diff-3662be6036f6d777b3220159549975083e9134f2403555435ad81aa8af457c39L202-L206): Removed the overridden `detach(boolean filterHiddenProperties)` method for consistency with the `BaseDocument` changes.

### Updates to hidden property handling in tests:

* [`engine/src/test/java/com/arcadedb/query/sql/executor/CreatePropertyStatementExecutionTest.java`](diffhunk://#diff-1c689fa3b939d9230d4975e41b40646153796750084d4d34470d654e51c50d55L219-R221): Updated the test `testCreateHiddenProperty` to reflect the removal of hidden property filtering, ensuring hidden properties are now visible during queries. [[1]](diffhunk://#diff-1c689fa3b939d9230d4975e41b40646153796750084d4d34470d654e51c50d55L219-R221) [[2]](diffhunk://#diff-1c689fa3b939d9230d4975e41b40646153796750084d4d34470d654e51c50d55L230-R244)

### Standardization of imports:

* Various files (`BaseDocument.java`, `DetachedDocument.java`, `Document.java`, `ImmutableVertex.java`, `SynchronizedVertex.java`, `Projection.java`) were updated to standardize imports, improving readability and consistency. [[1]](diffhunk://#diff-ecc83bc47e505bb18eba78108cd168d989c20f88cea6d88d761bf3189b3b582fL26-R39) [[2]](diffhunk://#diff-9ae0c0cfa6896961942e945caf4ef31f523c57858935cc9e3c17b074f33e1e67L24-R28) [[3]](diffhunk://#diff-00d3a27aef58667ad976c29ffcf3c9e7a6e2a29e42d25ab5b14326d3676d9d7aL21-R34) [[4]](diffhunk://#diff-5e84898972371fa476406babd6976e64e8e4fc0fac7c1142cb7ae9351664ed7aL35-R36) [[5]](diffhunk://#diff-3662be6036f6d777b3220159549975083e9134f2403555435ad81aa8af457c39L31-R40) [[6]](diffhunk://#diff-1ebfff8995bc54eab127a05a7f09d799b215972c6aa872635f37d86e824fb0b3L30-R37)

### Other minor adjustments:

* [`engine/src/main/java/com/arcadedb/query/sql/parser/Projection.java`](diffhunk://#diff-1ebfff8995bc54eab127a05a7f09d799b215972c6aa872635f37d86e824fb0b3L137-L138): Removed the call to `detach(true)` in the `calculateSingle` method, aligning with the removal of hidden property filtering.