### PR TITLE
#2114 add test for named parameterized Cypher query handling

### DIFF
--- a/e2e-python/tests/test_arcadedb.py
+++ b/e2e-python/tests/test_arcadedb.py
@@ -214,6 +214,21 @@ def test_psycopg2_with_named_parameterized_query():
     finally:
         conn.close()
 
+def test_psycopg2_with_named_parameterized_cypher_query():
+    """Check if the driver correctly handles parameterized named queries"""
+    params = get_connection_params(arcadedb)
+    conn = psycopg.connect(**params)
+    conn.autocommit = True
+
+    try:
+        with conn.cursor() as cursor:
+            query_params = {'name': 'Stout'}
+            cursor.execute('{cypher} MATCH (b:Beer) WHERE b.name =%(name)s RETURN b', query_params)
+            beer = cursor.fetchall()[0]
+            assert 'Stout' in beer
+    finally:
+        conn.close()
+
 
 def test_psycopg2_with_positional_parameterized_query():
     """Check if the driver correctly handles parameterized positional queries"""


### PR DESCRIPTION
#2114 
 This pull request adds a new test to ensure that the driver correctly handles named parameterized Cypher queries using the psycopg2 interface. This helps verify that named parameters are properly substituted in Cypher statements.

Testing improvements:

* Added `test_psycopg2_with_named_parameterized_cypher_query` to validate support for named parameters in Cypher queries executed via the psycopg2 driver (`test_arcadedb.py`).