### PR TITLE
[Helm] Adding support for plugins configuration

### DIFF
--- a/k8s/helm/Chart.yaml
+++ b/k8s/helm/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 25.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/k8s/helm/Chart.yaml
+++ b/k8s/helm/Chart.yaml
@@ -22,4 +22,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "25.2.1"
+appVersion: "25.7.1"

--- a/k8s/helm/templates/_helpers.tpl
+++ b/k8s/helm/templates/_helpers.tpl
@@ -95,11 +95,11 @@ Preparing a list of plugin ports to build plugin configurations.
       {{- if eq $plugin "gremlin" }}
         {{- $port = default 8082 $config.port }}
       {{- else if eq $plugin "postgres" }}
-        {{- $port = default 5432 $config.port}}
+        {{- $port = default 5432 $config.port }}
       {{- else if eq $plugin "mongo" }}
         {{- $port = default 27017 $config.port }}
       {{- else if eq $plugin "redis" }}
-        {{- $port = default 6379 }}
+        {{- $port = default 6379 $config.port }}
       {{- else if eq $plugin "prometheus" }}
         {{/*
         Prometheus does not use a port in the plugin configuration. It is accessible from /prometheus endpoint.
@@ -122,27 +122,32 @@ Create a comma separated list of plugins to be enabled in arcadedb
 */}}
 {{- define "arcadedb.plugin.parameters" -}}
 {{- $plugins := list -}}
-  {{- range $plugin, $config := (include "_arcadedb.plugin.ports" . | fromYaml) }}
-    {{- if eq $plugin "gremlin" }}
-      {{- $plugins = append $plugins "GremlinServer:com.arcadedb.server.gremlin.GremlinServerPlugin" }}
-    {{- else if eq $plugin "postgres" }}
-      {{- $plugins = append $plugins "Postgres:com.arcadedb.postgres.PostgresProtocolPlugin" }}
-- {{- printf " -Darcadedb.postgres.port=%d" (int $config.port) -}}
-    {{- else if eq $plugin "mongo" }}
-      {{- $plugins = append $plugins "MongoDB:com.arcadedb.mongo.MongoDBProtocolPlugin" }}
-- {{- printf " -Darcadedb.mongo.port=%d" (int $config.port) -}}
-    {{- else if eq $plugin "redis" }}
-      {{- $plugins = append $plugins "Redis:com.arcadedb.redis.RedisProtocolPlugin" }}
-- {{- printf " -Darcadedb.redis.port=%d" (int $config.port) -}}
-    {{- else if eq $plugin "prometheus" }}
-      {{- $plugins = append $plugins "Prometheus:com.arcadedb.metrics.prometheus.PrometheusMetricsPlugin" }}
-    {{- else }}
-      {{- $plugins = append $plugins (printf "%s:%s" $plugin $config.class) }}
-    {{- end }}
-{{- end }}
-{{- if gt (len $plugins) 0 }}
-- {{- printf " -Darcadedb.server.plugins=%s" (join "," $plugins) -}}
+{{- $params := list -}}
+  {{- range $plugin, $config := (include "_arcadedb.plugin.ports" . | fromYaml) -}}
+    {{- if eq $plugin "gremlin" -}}
+      {{- $plugins = append $plugins "GremlinServer:com.arcadedb.server.gremlin.GremlinServerPlugin" -}}
+      {{- $params = append $params (printf "-Darcadedb.gremlin.port=%d" (int $config.port)) -}}
+    {{- else if eq $plugin "postgres" -}}
+      {{- $plugins = append $plugins "Postgres:com.arcadedb.postgres.PostgresProtocolPlugin" -}}
+      {{- $params = append $params (printf "-Darcadedb.postgres.port=%d" (int $config.port)) -}}
+    {{- else if eq $plugin "mongo" -}}
+      {{- $plugins = append $plugins "MongoDB:com.arcadedb.mongo.MongoDBProtocolPlugin" -}}
+      {{- $params = append $params (printf "-Darcadedb.mongo.port=%d" (int $config.port)) -}}
+    {{- else if eq $plugin "redis" -}}
+      {{- $plugins = append $plugins "Redis:com.arcadedb.redis.RedisProtocolPlugin" -}}
+      {{- $params = append $params (printf "-Darcadedb.redis.port=%d" (int $config.port)) -}}
+    {{- else if eq $plugin "prometheus" -}}
+      {{- $plugins = append $plugins "Prometheus:com.arcadedb.metrics.prometheus.PrometheusMetricsPlugin" -}}
+    {{- else -}}
+      {{- $plugins = append $plugins (printf "%s:%s" $plugin $config.class) -}}
+    {{- end -}}
+  {{- end -}}
+{{- if gt (len $plugins) 0 -}}
+- -Darcadedb.server.plugins={{ join "," $plugins }}
 {{- end -}}
+{{ range $param := $params }}
+- {{ $param }}
+{{ end }}
 {{- end -}}
 
 {{/*

--- a/k8s/helm/templates/_helpers.tpl
+++ b/k8s/helm/templates/_helpers.tpl
@@ -93,7 +93,7 @@ Preparing a list of plugin ports to build plugin configurations.
     {{- if $config.enabled }}
       {{- $port := int 0}}
       {{- if eq $plugin "gremlin" }}
-        {{- $port = default 8082 $config.port }}
+        {{- $port = default 8182 $config.port }}
       {{- else if eq $plugin "postgres" }}
         {{- $port = default 5432 $config.port }}
       {{- else if eq $plugin "mongo" }}

--- a/k8s/helm/templates/_helpers.tpl
+++ b/k8s/helm/templates/_helpers.tpl
@@ -147,7 +147,7 @@ Create a comma separated list of plugins to be enabled in arcadedb
 {{- end -}}
 {{ range $param := $params }}
 - {{ $param }}
-{{ end }}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/k8s/helm/templates/_helpers.tpl
+++ b/k8s/helm/templates/_helpers.tpl
@@ -84,3 +84,78 @@ Create a list of pod names based the number of replica.
 {{- end }}
 {{- join "," $names -}}
 {{- end }}
+
+{{/*
+Preparing a list of plugin ports to build plugin configurations.
+*/}}
+{{- define "_arcadedb.plugin.ports" -}}
+  {{- range $plugin, $config := .Values.arcadedb.plugins -}}
+    {{- if $config.enabled }}
+      {{- $port := int 0}}
+      {{- if eq $plugin "gremlin" }}
+        {{- $port = default 8082 $config.port }}
+      {{- else if eq $plugin "postgres" }}
+        {{- $port = default 5432 $config.port}}
+      {{- else if eq $plugin "mongo" }}
+        {{- $port = default 27017 $config.port }}
+      {{- else if eq $plugin "redis" }}
+        {{- $port = default 6379 }}
+      {{- else if eq $plugin "prometheus" }}
+        {{/*
+        Prometheus does not use a port in the plugin configuration. It is accessible from /prometheus endpoint.
+        */}}
+        {{- $port = -1 }}
+      {{- else }}
+        {{- if not $config.port }}
+          {{- fail (printf "Custom plugin '%s' has no port specified." $plugin) -}}
+        {{- end }}
+      {{- end }}
+{{ $plugin }}:
+  port: {{ $port }}
+  class: {{ default "" $config.class }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{/*
+Create a comma separated list of plugins to be enabled in arcadedb
+*/}}
+{{- define "arcadedb.plugin.parameters" -}}
+{{- $plugins := list -}}
+  {{- range $plugin, $config := (include "_arcadedb.plugin.ports" . | fromYaml) }}
+    {{- if eq $plugin "gremlin" }}
+      {{- $plugins = append $plugins "GremlinServer:com.arcadedb.server.gremlin.GremlinServerPlugin" }}
+    {{- else if eq $plugin "postgres" }}
+      {{- $plugins = append $plugins "Postgres:com.arcadedb.postgres.PostgresProtocolPlugin" }}
+- {{- printf " -Darcadedb.postgres.port=%d" (int $config.port) -}}
+    {{- else if eq $plugin "mongo" }}
+      {{- $plugins = append $plugins "MongoDB:com.arcadedb.mongo.MongoDBProtocolPlugin" }}
+- {{- printf " -Darcadedb.mongo.port=%d" (int $config.port) -}}
+    {{- else if eq $plugin "redis" }}
+      {{- $plugins = append $plugins "Redis:com.arcadedb.redis.RedisProtocolPlugin" }}
+- {{- printf " -Darcadedb.redis.port=%d" (int $config.port) -}}
+    {{- else if eq $plugin "prometheus" }}
+      {{- $plugins = append $plugins "Prometheus:com.arcadedb.metrics.prometheus.PrometheusMetricsPlugin" }}
+    {{- else }}
+      {{- $plugins = append $plugins (printf "%s:%s" $plugin $config.class) }}
+    {{- end }}
+{{- end }}
+{{- if gt (len $plugins) 0 }}
+- {{- printf " -Darcadedb.server.plugins=%s" (join "," $plugins) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create service configuration for the enabled plugins
+*/}}
+{{- define "arcadedb.plugin.service" -}}
+  {{- $plugins := (include "_arcadedb.plugin.ports" . | fromYaml) }}
+  {{- range $plugin, $config := $plugins }}
+    {{- if (gt (int $config.port) 0) }}
+- port: {{ $config.port }}
+  targetPort: {{ $config.port }}
+  protocol: TCP
+  name: {{ $plugin }}-port
+    {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/k8s/helm/templates/service.yaml
+++ b/k8s/helm/templates/service.yaml
@@ -39,5 +39,6 @@ spec:
       targetPort: rpc
       protocol: TCP
       name: rpc
+    {{- include "arcadedb.plugin.service" . | nindent 4 }}
   selector:
     {{- include "arcadedb.selectorLabels" . | nindent 4 }}

--- a/k8s/helm/templates/statefulset.yaml
+++ b/k8s/helm/templates/statefulset.yaml
@@ -60,6 +60,7 @@ spec:
             {{- with .Values.arcadedb.extraCommands }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- include "arcadedb.plugin.parameters" . | nindent 12 }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -31,36 +31,36 @@ arcadedb:
   ## @section arcadedb.plugins in this section you can enable and configure the plugins available in ArcadeDB.
   plugins: {}
     # gremlin:
-    ## @param arcadedb.plugins.gremlin.enabled Enable Gremlin plugin
-    # enabled: true
-    ## @param arcadedb.plugins.gremlin.port Port for Gremlin HTTP service
-    # port: 8082
+      ## @param arcadedb.plugins.gremlin.enabled Enable Gremlin plugin
+      # enabled: true
+      ## @param arcadedb.plugins.gremlin.port Port for Gremlin HTTP service
+      # port: 8082
     # postgres:
-    ## @param arcadedb.plugins.postgres.enabled Enable Postgres plugin
-    # enabled: true
-    ## @param arcadedb.plugins.postgres.port Port for Postgres service
-    # port: 5432
+      ## @param arcadedb.plugins.postgres.enabled Enable Postgres plugin
+      # enabled: true
+      ## @param arcadedb.plugins.postgres.port Port for Postgres service
+      # port: 5432
     # mongo:
-    ## @param arcadedb.plugins.mongo.enabled Enable Mongo plugin
-    # enabled: false
-    ## @param arcadedb.plugins.mongo.port Port for Mongo service
-    # port: 27017
+      ## @param arcadedb.plugins.mongo.enabled Enable Mongo plugin
+      # enabled: false
+      ## @param arcadedb.plugins.mongo.port Port for Mongo service
+      # port: 27017
     # redis:
-    ## @param arcadedb.plugins.redis.enabled Enable Redis plugin
-    # enabled: false
-    ## @param arcadedb.plugins.redis.port Port for Redis service
-    # port: 6379
+      ## @param arcadedb.plugins.redis.enabled Enable Redis plugin
+      # enabled: false
+      ## @param arcadedb.plugins.redis.port Port for Redis service
+      # port: 6379
     # prometheus:
-    ## @param arcadedb.plugins.prometheus.enabled Enable Prometheus plugin
-    # enabled: false
-    ## The following plugin is commented out as they are an example how configure a custom plugin.
+      ## @param arcadedb.plugins.prometheus.enabled Enable Prometheus plugin
+      # enabled: false
+      ## The following plugin is commented out as they are an example how configure a custom plugin.
     ## custom:
-    ## @param arcadedb.plugins.custom.enabled Enable custom plugin
-    ## enabled: false
-    ## @param arcadedb.plugins.custom.port Port for custom service
-    ## port: 1234
-    ## @param arcadedb.plugins.custom.class Class name for custom plugin
-    ## class: com.example.CustomPlugin
+      ## @param arcadedb.plugins.custom.enabled Enable custom plugin
+      ## enabled: false
+      ## @param arcadedb.plugins.custom.port Port for custom service
+      ## port: 1234
+      ## @param arcadedb.plugins.custom.class Class name for custom plugin
+      ## class: com.example.CustomPlugin
 
 ## @section image
 ## This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -34,7 +34,7 @@ arcadedb:
       ## @param arcadedb.plugins.gremlin.enabled Enable Gremlin plugin
       # enabled: true
       ## @param arcadedb.plugins.gremlin.port Port for Gremlin HTTP service
-      # port: 8082
+      # port: 8182
     # postgres:
       ## @param arcadedb.plugins.postgres.enabled Enable Postgres plugin
       # enabled: true

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -28,6 +28,40 @@ arcadedb:
         ## @param arcadedb.credentials.rootPassword.secret.key Key to use in existing secret
         key: null
 
+  ## @section arcadedb.plugins in this section you can enable and configure the plugins available in ArcadeDB.
+  plugins: {}
+    # gremlin:
+    ## @param arcadedb.plugins.gremlin.enabled Enable Gremlin plugin
+    # enabled: true
+    ## @param arcadedb.plugins.gremlin.port Port for Gremlin HTTP service
+    # port: 8082
+    # postgres:
+    ## @param arcadedb.plugins.postgres.enabled Enable Postgres plugin
+    # enabled: true
+    ## @param arcadedb.plugins.postgres.port Port for Postgres service
+    # port: 5432
+    # mongo:
+    ## @param arcadedb.plugins.mongo.enabled Enable Mongo plugin
+    # enabled: false
+    ## @param arcadedb.plugins.mongo.port Port for Mongo service
+    # port: 27017
+    # redis:
+    ## @param arcadedb.plugins.redis.enabled Enable Redis plugin
+    # enabled: false
+    ## @param arcadedb.plugins.redis.port Port for Redis service
+    # port: 6379
+    # prometheus:
+    ## @param arcadedb.plugins.prometheus.enabled Enable Prometheus plugin
+    # enabled: false
+    ## The following plugin is commented out as they are an example how configure a custom plugin.
+    ## custom:
+    ## @param arcadedb.plugins.custom.enabled Enable custom plugin
+    ## enabled: false
+    ## @param arcadedb.plugins.custom.port Port for custom service
+    ## port: 1234
+    ## @param arcadedb.plugins.custom.class Class name for custom plugin
+    ## class: com.example.CustomPlugin
+
 ## @section image
 ## This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:


### PR DESCRIPTION
## What does this PR do?

Added configuration for built-in plugins through well defined properties.
Added support for configuring custom plugins.

## Motivation

Contribute for the community.

## Related issues

https://github.com/ArcadeData/arcadedb/issues/2436

## Additional Notes

For testing propose:

- Create `values_test.yaml` with content:
```yaml
arcadedb:
  plugins:
    gremlin:
      enabled: true
    prometheus:
      enabled: true
```
- Execute the command the following command inside k8s/helm directory:
```
helm template . --namespace foo -f values.yaml -f values_test.yml 
```
- Validate the output:
  - service manifest:
```yaml
apiVersion: v1
kind: Service
metadata:
  name: release-name-arcadedb
  labels:
    app: arcadedb
    helm.sh/chart: arcadedb-0.1.0
    app.kubernetes.io/name: arcadedb
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "25.2.1"
    app.kubernetes.io/managed-by: Helm
spec:
  clusterIP: None
  ports:
    - port: 2480
      targetPort: http
      protocol: TCP
      name: http
    - port: 2424
      targetPort: rpc
      protocol: TCP
      name: rpc

    - port: 8082
      targetPort: 8082
      protocol: TCP
      name: gremlin-port
  selector:
    app.kubernetes.io/name: arcadedb
    app.kubernetes.io/instance: release-name
---
```
  - statefulset manifest:
```yaml
...
            - -Darcadedb.server.plugins=GremlinServer:com.arcadedb.server.gremlin.GremlinServerPlugin,Prometheus:com.arcadedb.metrics.prometheus.PrometheusMetricsPlugin
          livenessProbe:
            httpGet:
...

```

## Checklist

- [x] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
