### PR TITLE
#2230 enhance variable behaviour  in SQL script

### DIFF
--- a/e2e/src/test/java/com/arcadedb/e2e/RemoteDatabaseJavaApiTest.java
+++ b/e2e/src/test/java/com/arcadedb/e2e/RemoteDatabaseJavaApiTest.java
@@ -136,9 +136,11 @@ public class RemoteDatabaseJavaApiTest extends ArcadeContainerTemplate {
 
     database.command("sqlscript",
         """
-            BEGIN;LET photo = CREATE VERTEX Photos SET id = "p5555", name = "download3.jpg";
+            BEGIN;
+            LET photo = CREATE VERTEX Photos SET id = "p5555", name = "download3.jpg";
             LET user = SELECT FROM Users WHERE id = "u1111";
-            LET userEdge = CREATE EDGE HasUploaded FROM $user TO $photo SET kind = "User_Photos";
+            LET edgeType = 'HasUploaded';
+            LET userEdge = CREATE EDGE $edgeType FROM $user TO $photo SET kind = "User_Photos";
             COMMIT RETRY 30;
             RETURN $photo;""");
 

--- a/e2e/src/test/java/com/arcadedb/e2e/RemoteDatabaseJavaApiTest.java
+++ b/e2e/src/test/java/com/arcadedb/e2e/RemoteDatabaseJavaApiTest.java
@@ -24,6 +24,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.remote.RemoteDatabase;
+import com.arcadedb.schema.Schema;
 import com.arcadedb.utility.CollectionUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -164,6 +165,47 @@ public class RemoteDatabaseJavaApiTest extends ArcadeContainerTemplate {
     result = database.query("sql", "select * from Birra limit 10");
     assertThat(result.stream().count()).isEqualTo(10);
 
+  }
+
+  @Test
+  void createSchemaWithDynamicSqlScript() {
+    database.command("sqlscript", """
+        BEGIN;
+
+        LET vTypes = ['V1', 'V2', 'V3'];
+        FOREACH ($vType IN $vTypes) {
+          CREATE VERTEX TYPE $vType;
+        }
+
+        LET eTypes = ['E1', 'E2', 'E3'];
+        FOREACH ($eType IN $eTypes) {
+          CREATE EDGE TYPE  $eType;
+        }
+
+        LET dTypes = ['D1', 'D2', 'D3'];
+        FOREACH ($dType IN $dTypes) {
+          CREATE DOCUMENT TYPE $dType ;
+        }
+
+        LET types = ['V1', 'V2', 'V3','E1', 'E2', 'E3','D1', 'D2', 'D3'];
+        FOREACH ($type IN $types) {
+          CREATE PROPERTY $type.id  STRING;
+          CREATE INDEX ON $type (id) UNIQUE NULL_STRATEGY SKIP;
+        }
+        COMMIT;
+        """);
+
+    Schema schema = database.getSchema();
+    System.out.println("schema.toString() = " + schema.toString());
+    assertThat(schema.existsType("V1")).isTrue();
+    assertThat(schema.existsType("V2")).isTrue();
+    assertThat(schema.existsType("V3")).isTrue();
+    assertThat(schema.existsType("D1")).isTrue();
+    assertThat(schema.existsType("D2")).isTrue();
+    assertThat(schema.existsType("D3")).isTrue();
+    assertThat(schema.existsType("E1")).isTrue();
+    assertThat(schema.existsType("E2")).isTrue();
+    assertThat(schema.existsType("E3")).isTrue();
   }
 
   @Test

--- a/engine/src/main/java/com/arcadedb/query/sql/SQLScriptQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/SQLScriptQueryEngine.java
@@ -213,8 +213,9 @@ public class SQLScriptQueryEngine extends SQLQueryEngine {
           throw new CommandSQLParsingException("Found COMMIT statement without a BEGIN");
       }
 
-      if (stm instanceof LetStatement letStatement)
+      if (stm instanceof LetStatement letStatement) {
         scriptContext.declareScriptVariable(letStatement.getVariableName().getStringValue());
+      }
     }
 
     return new LocalResultSet(plan);

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/BasicCommandContext.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/BasicCommandContext.java
@@ -123,9 +123,15 @@ public class BasicCommandContext implements CommandContext {
 
     String fieldName = null;
     if (name.contains(".")) {
-      String[] parts = name.split("\\.");
+      final String[] parts = name.split("\\.");
+      if (parts.length > 2) {
+        throw new com.arcadedb.exception.CommandSQLParsingException(
+            "Nested property access is not supported in this context: " + name);
+      }
       name = parts[0];
-      fieldName = parts[1];
+      if (parts.length > 1) {
+        fieldName = parts[1];
+      }
     }
 
     if (name.equalsIgnoreCase("CONTEXT"))

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CommandContext.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CommandContext.java
@@ -35,11 +35,11 @@ public interface CommandContext {
 
   Object getVariablePath(String name, Object iDefault);
 
-  Object getVariable(String iName);
+  Object getVariable(String name);
 
-  Object getVariable(String iName, Object iDefaultValue);
+  Object getVariable(String name, Object iDefaultValue);
 
-  CommandContext setVariable(String iName, Object iValue);
+  CommandContext setVariable(String name, Object iValue);
 
   CommandContext incrementVariable(String getNeighbors);
 
@@ -47,7 +47,7 @@ public interface CommandContext {
 
   CommandContext getParent();
 
-  CommandContext setParent(CommandContext iParentContext);
+  CommandContext setParent(CommandContext parentContext);
 
   CommandContext setChild(CommandContext context);
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CreateVertexExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CreateVertexExecutionPlanner.java
@@ -20,13 +20,16 @@ package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.query.sql.parser.CreateVertexStatement;
+import com.arcadedb.query.sql.parser.Identifier;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Luigi Dell'Aquila (luigi.dellaquila-(at)-gmail.com)
  */
 public class CreateVertexExecutionPlanner extends InsertExecutionPlanner {
+
   public CreateVertexExecutionPlanner(final CreateVertexStatement statement) {
     this.targetType = statement.getTargetType() == null ? null : statement.getTargetType().copy();
     this.targetBucketName = statement.getTargetBucketName() == null ? null : statement.getTargetBucketName().copy();
@@ -40,6 +43,11 @@ public class CreateVertexExecutionPlanner extends InsertExecutionPlanner {
 
   @Override
   public InsertExecutionPlan createExecutionPlan(final CommandContext context) {
+    if (targetType.getStringValue().startsWith("$")) {
+      String variable = (String) context.getVariable(targetType.getStringValue());
+      targetType = new Identifier(variable);
+    }
+
     final InsertExecutionPlan prev = super.createExecutionPlan(context);
     final List<ExecutionStep> steps = new ArrayList<>(prev.getSteps());
     final InsertExecutionPlan result = new InsertExecutionPlan(context);

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CreateVertexExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CreateVertexExecutionPlanner.java
@@ -43,10 +43,6 @@ public class CreateVertexExecutionPlanner extends InsertExecutionPlanner {
 
   @Override
   public InsertExecutionPlan createExecutionPlan(final CommandContext context) {
-    if (targetType.getStringValue().startsWith("$")) {
-      String variable = (String) context.getVariable(targetType.getStringValue());
-      targetType = new Identifier(variable);
-    }
 
     final InsertExecutionPlan prev = super.createExecutionPlan(context);
     final List<ExecutionStep> steps = new ArrayList<>(prev.getSteps());

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/DeleteExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/DeleteExecutionPlanner.java
@@ -168,10 +168,12 @@ public class DeleteExecutionPlanner {
       plan.chain(new LimitExecutionStep(limit, context));
   }
 
-  private void handleTarget(final UpdateExecutionPlan result, final CommandContext context, final FromClause target,
+  private void handleTarget(final UpdateExecutionPlan result,
+      final CommandContext context,
+      final FromClause fromClause,
       final WhereClause whereClause) {
     final SelectStatement sourceStatement = new SelectStatement(-1);
-    sourceStatement.setTarget(target);
+    sourceStatement.setTarget(fromClause);
     sourceStatement.setWhereClause(whereClause);
     final SelectExecutionPlanner planner = new SelectExecutionPlanner(sourceStatement);
     result.chain(

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/InsertExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/InsertExecutionPlanner.java
@@ -55,6 +55,12 @@ public class InsertExecutionPlanner {
   }
 
   public InsertExecutionPlan createExecutionPlan(final CommandContext context) {
+
+    if (targetType.getStringValue().startsWith("$")) {
+      String variable = (String) context.getVariable(targetType.getStringValue());
+      targetType = new Identifier(variable);
+    }
+
     final InsertExecutionPlan result = new InsertExecutionPlan(context);
 
     if (selectStatement != null) {
@@ -62,7 +68,7 @@ public class InsertExecutionPlanner {
     } else {
       handleCreateRecord(result, this.insertBody, context);
     }
-    handleTargetClass(result, targetType, context);
+    handleTargetType(result, targetType, context);
     handleSetFields(result, insertBody, context);
     if (targetBucket != null) {
       String name = targetBucket.getBucketName();
@@ -113,9 +119,9 @@ public class InsertExecutionPlanner {
     }
   }
 
-  private void handleTargetClass(final InsertExecutionPlan result, final Identifier targetClass, final CommandContext context) {
-    if (targetClass != null)
-      result.chain(new SetDocumentStepStep(targetClass, context));
+  private void handleTargetType(final InsertExecutionPlan result, final Identifier targetType, final CommandContext context) {
+    if (targetType != null)
+      result.chain(new SetDocumentStepStep(targetType, context));
   }
 
   private void handleCreateRecord(final InsertExecutionPlan result, final InsertBody body, final CommandContext context) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/InsertExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/InsertExecutionPlanner.java
@@ -28,7 +28,8 @@ import com.arcadedb.query.sql.parser.Projection;
 import com.arcadedb.query.sql.parser.SelectStatement;
 import com.arcadedb.query.sql.parser.UpdateItem;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by luigidellaquila on 08/08/16.
@@ -56,7 +57,7 @@ public class InsertExecutionPlanner {
 
   public InsertExecutionPlan createExecutionPlan(final CommandContext context) {
 
-    if (targetType.getStringValue().startsWith("$")) {
+    if (targetType != null && targetType.getStringValue().startsWith("$")) {
       String variable = (String) context.getVariable(targetType.getStringValue());
       targetType = new Identifier(variable);
     }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -72,8 +72,18 @@ import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.utility.Pair;
 
-import java.util.*;
-import java.util.stream.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.arcadedb.schema.Property.RID_PROPERTY;
 import static com.arcadedb.schema.Schema.INDEX_TYPE.FULL_TEXT;
@@ -432,13 +442,24 @@ public class SelectExecutionPlanner {
   }
 
   private static void rewriteIndexChainsAsSubqueries(QueryPlanningInfo info, CommandContext context) {
-    if (context == null || context.getDatabase() == null) {
+    if (context == null ||
+        context.getDatabase() == null) {
       return;
     }
-    if (info.whereClause != null && info.target != null && info.target.getItem().getIdentifier() != null) {
+
+    if (info.whereClause != null &&
+        info.target != null &&
+        info.target.getItem().getIdentifier() != null) {
+
       String className = info.target.getItem().getIdentifier().getStringValue();
+      if (className.startsWith("$")) {
+        className = (String) context.getVariable(className);
+        info.target.getItem().setIdentifier(new Identifier(className));
+      }
+
       Schema schema = context.getDatabase().getSchema();
       DocumentType type = schema.getType(className);
+
       info.whereClause.getBaseExpression().rewriteIndexChainsAsSubqueries(context, type);
     }
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -451,14 +451,14 @@ public class SelectExecutionPlanner {
         info.target != null &&
         info.target.getItem().getIdentifier() != null) {
 
-      String className = info.target.getItem().getIdentifier().getStringValue();
-      if (className.startsWith("$")) {
-        className = (String) context.getVariable(className);
-        info.target.getItem().setIdentifier(new Identifier(className));
+      String typeName = info.target.getItem().getIdentifier().getStringValue();
+      if (typeName.startsWith("$")) {
+        typeName = (String) context.getVariable(typeName);
+        info.target.getItem().setIdentifier(new Identifier(typeName));
       }
 
       Schema schema = context.getDatabase().getSchema();
-      DocumentType type = schema.getType(className);
+      DocumentType type = schema.getType(typeName);
 
       info.whereClause.getBaseExpression().rewriteIndexChainsAsSubqueries(context, type);
     }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
@@ -52,20 +52,31 @@ public class CreateIndexStatement extends DDLStatement {
 
   @Override
   public void validate() throws CommandSQLParsingException {
-    final String typeAsString = type.getStringValue();
-    if (typeAsString.equalsIgnoreCase("FULL_TEXT"))
+    final String typeAsString = type.getStringValue().toUpperCase();
+    switch (typeAsString) {
+    case "FULL_TEXT" -> {
       ;
-    else if (typeAsString.equalsIgnoreCase("UNIQUE"))
+    }
+    case "UNIQUE" -> {
       ;
-    else if (typeAsString.equalsIgnoreCase("NOTUNIQUE"))
+    }
+    case "NOTUNIQUE" -> {
       ;
-    else
-      throw new CommandSQLParsingException("Index type '" + typeAsString + "' is not supported");
+    }
+    default -> throw new CommandSQLParsingException("Index type '" + typeAsString + "' is not supported");
+    }
   }
 
   @Override
   public ResultSet executeDDL(final CommandContext context) {
     final Database database = context.getDatabase();
+
+    Identifier prevName= typeName;
+    if (typeName.getStringValue().startsWith("$")) {
+      String variable = (String) context.getVariable(typeName.getStringValue());
+      typeName = new Identifier(variable);
+      name = null;
+    }
 
     if (name == null)
       // GENERATE THE NAME AUTOMATICALLY
@@ -113,6 +124,8 @@ public class CreateIndexStatement extends DDLStatement {
             System.out.flush();
           }
         }).create();
+
+    typeName = prevName;
 
     final InternalResultSet rs = new InternalResultSet();
     final ResultInternal result = new ResultInternal(context.getDatabase());

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreatePropertyStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreatePropertyStatement.java
@@ -61,6 +61,12 @@ public class CreatePropertyStatement extends DDLStatement {
 
   private void executeInternal(final CommandContext context, final ResultInternal result) {
     final Database db = context.getDatabase();
+    Identifier prevType= typeName;
+    if (typeName.getStringValue().startsWith("$")) {
+      String variable = (String) context.getVariable(typeName.getStringValue());
+      typeName = new Identifier(variable);
+    }
+
     final DocumentType typez = db.getSchema().getType(typeName.getStringValue());
     if (typez == null)
       throw new CommandExecutionException("Type '" + typeName.getStringValue() + "' not found");
@@ -81,6 +87,7 @@ public class CreatePropertyStatement extends DDLStatement {
       final Object val = attr.setOnProperty(internalProp, context);
       result.setProperty(attr.settingName.getStringValue(), val);
     }
+    typeName = prevType;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateTypeAbstractStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateTypeAbstractStatement.java
@@ -67,6 +67,12 @@ public abstract class CreateTypeAbstractStatement extends DDLStatement {
   @Override
   public ResultSet executeDDL(final CommandContext context) {
 
+    Identifier prevName= name;
+    if (name.getStringValue().startsWith("$")) {
+      String variable = (String) context.getVariable(name.getStringValue());
+      name = new Identifier(variable);
+    }
+
     final Schema schema = context.getDatabase().getSchema();
     if (schema.existsType(name.getStringValue())) {
       if (ifNotExists) {
@@ -88,6 +94,7 @@ public abstract class CreateTypeAbstractStatement extends DDLStatement {
     for (final DocumentType c : superclasses)
       type.addSuperType(c);
 
+    name = prevName;
     return new InternalResultSet(result);
   }
 

--- a/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
@@ -30,6 +30,7 @@ import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexException;
 import com.arcadedb.index.IndexInternal;
 import com.arcadedb.index.TypeIndex;
+import com.arcadedb.query.sql.parser.Identifier;
 import com.arcadedb.security.SecurityDatabaseUser;
 
 import java.util.*;

--- a/engine/src/test/java/com/arcadedb/query/sql/BatchTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/BatchTest.java
@@ -274,23 +274,43 @@ public class BatchTest extends TestHelper {
   }
 
   @Test
-  public void testReadTypeFromVariable() {
-    database.command("sql", "CREATE VERTEX TYPE V1");
-    database.command("sql", "CREATE VERTEX TYPE V2");
-    database.command("sql", "CREATE EDGE TYPE HasSource");
+  public void testDynamicDocumentTypeName() {
+    database.command("sql", "CREATE DOCUMENT TYPE TheDoc");
+
     database.transaction(() -> {
-      for (int i = 0; i < 10; i++) {
-        database.command("sql", "INSERT INTO V1 set id = ? , vType = ? ", i, "V2");
-        database.command("sql", "INSERT INTO V2 set id = ? ", i);
-      }
+      database.command("sqlscript", """
+          LET docType = 'TheDoc';
+          LET d =INSERT INTO $docType SET id = 1;
+          """);
     });
+
+    assertThat(database.query("sql", "SELECT count() AS value FROM TheDoc").next().<Long>getProperty("value")).isEqualTo(1);
+  }
+  @Test
+  public void testDynamicGraphTypesNames() {
+    database.command("sql", "CREATE DOCUMENT TYPE TheDoc");
+
+    database.transaction(() -> {
+      database.command("sqlscript", """
+          LET numbers = [1, 2, 3];
+          LET vTypes = ['V1', 'V2'];
+          FOREACH ($i IN $numbers) {
+            FOREACH ($vType IN $vTypes) {
+                 CREATE VERTEX $vType SET id = $i, vType = 'V2';
+            }
+          }
+          """);
+    });
+
+    assertThat(database.query("sql", "SELECT count() AS value FROM V1").next().<Long>getProperty("value")).isEqualTo(3);
+    assertThat(database.query("sql", "SELECT count() AS value FROM V2").next().<Long>getProperty("value")).isEqualTo(3);
 
     final ResultSet resultSet = database.command("sqlscript", """
         BEGIN;
         LET sources = SELECT FROM V1 WHERE id = '1';
         LET source = $sources[0];
         LET type = $source.vType;
-        LET target = SELECT FROM $type WHERE id = '9';
+        LET target = SELECT FROM $type WHERE id = '3';
         LET edgeType = 'HasSource';
         LET e = CREATE EDGE $edgeType FROM $target TO $source IF NOT EXISTS ;
         COMMIT;
@@ -300,7 +320,7 @@ public class BatchTest extends TestHelper {
     assertThat(resultSet.hasNext()).isTrue();
     Edge edge = resultSet.next().getEdge().get();
     assertThat(edge.getInVertex().getInteger("id")).isEqualTo(1);
-    assertThat(edge.getOutVertex().getInteger("id")).isEqualTo(9);
+    assertThat(edge.getOutVertex().getInteger("id")).isEqualTo(3);
 
   }
 

--- a/engine/src/test/java/com/arcadedb/query/sql/BatchTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/BatchTest.java
@@ -288,7 +288,9 @@ public class BatchTest extends TestHelper {
   }
   @Test
   public void testDynamicGraphTypesNames() {
-    database.command("sql", "CREATE DOCUMENT TYPE TheDoc");
+    database.command("sql", "CREATE VERTEX TYPE V1");
+    database.command("sql", "CREATE VERTEX TYPE V2");
+    database.command("sql", "CREATE EDGE TYPE HasSource");
 
     database.transaction(() -> {
       database.command("sqlscript", """

--- a/engine/src/test/java/com/arcadedb/query/sql/BatchTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/BatchTest.java
@@ -257,6 +257,22 @@ public class BatchTest extends TestHelper {
   }
 
   @Test
+  public void testForeachResultSetReadFieldName() {
+    database.command("sql", "CREATE DOCUMENT TYPE DocumentType");
+    database.transaction(() -> {
+      database.command("sql", "INSERT INTO DocumentType set a = 'aaaa' ");
+    });
+
+    final ResultSet result = database.command("sqlscript", """
+        LET row = select from DocumentType;
+        LET counter = $row.a;
+        RETURN $counter;
+        """);
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next().<String>getProperty("value")).isEqualTo("aaaa");
+  }
+
+  @Test
   public void testUsingReservedVariableNames() {
     try {
       database.command("sqlscript", """

--- a/engine/src/test/java/com/arcadedb/query/sql/BatchTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/BatchTest.java
@@ -291,7 +291,8 @@ public class BatchTest extends TestHelper {
         LET source = $sources[0];
         LET type = $source.vType;
         LET target = SELECT FROM $type WHERE id = '9';
-        LET e = CREATE EDGE HasSource FROM $target TO $source IF NOT EXISTS ;
+        LET edgeType = 'HasSource';
+        LET e = CREATE EDGE $edgeType FROM $target TO $source IF NOT EXISTS ;
         COMMIT;
         RETURN $e;
         """);

--- a/engine/src/test/java/com/arcadedb/query/sql/DDLTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/DDLTest.java
@@ -19,6 +19,8 @@
 package com.arcadedb.query.sql;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
 import org.junit.jupiter.api.Test;
 
 import java.util.stream.IntStream;
@@ -33,6 +35,38 @@ public class DDLTest extends TestHelper {
       database.command("sql", "CREATE VERTEX TYPE V");
       database.command("sql", "CREATE EDGE TYPE E");
     });
+
+  }
+
+  @Test
+  void testDynamicSchemaCreation() {
+    database.command("sqlscript", """
+        BEGIN;
+        LET vTypes = ['V1', 'V2', 'V3'];
+        FOREACH ($vType IN $vTypes) {
+          CREATE VERTEX TYPE $vType EXTENDS V;
+        }
+        LET eTypes = ['E1', 'E2', 'E3'];
+        FOREACH ($eType IN $eTypes) {
+          CREATE EDGE TYPE  $eType ;
+        }
+        LET dTypes = ['D1', 'D2', 'D3'];
+        FOREACH ($dType IN $dTypes) {
+          CREATE DOCUMENT TYPE  $dType ;
+        }
+        COMMIT;
+        """);
+
+    Schema schema = database.getSchema();
+    assertThat(schema.existsType("V1")).isTrue();
+    assertThat(schema.existsType("V2")).isTrue();
+    assertThat(schema.existsType("V3")).isTrue();
+    assertThat(schema.existsType("D1")).isTrue();
+    assertThat(schema.existsType("D2")).isTrue();
+    assertThat(schema.existsType("D3")).isTrue();
+    assertThat(schema.existsType("E1")).isTrue();
+    assertThat(schema.existsType("E2")).isTrue();
+    assertThat(schema.existsType("E3")).isTrue();
 
   }
 

--- a/engine/src/test/java/com/arcadedb/query/sql/DDLTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/DDLTest.java
@@ -19,7 +19,6 @@
 package com.arcadedb.query.sql;
 
 import com.arcadedb.TestHelper;
-import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Schema;
 import org.junit.jupiter.api.Test;
 
@@ -42,31 +41,49 @@ public class DDLTest extends TestHelper {
   void testDynamicSchemaCreation() {
     database.command("sqlscript", """
         BEGIN;
+
         LET vTypes = ['V1', 'V2', 'V3'];
         FOREACH ($vType IN $vTypes) {
           CREATE VERTEX TYPE $vType EXTENDS V;
         }
+
         LET eTypes = ['E1', 'E2', 'E3'];
         FOREACH ($eType IN $eTypes) {
           CREATE EDGE TYPE  $eType ;
         }
+
         LET dTypes = ['D1', 'D2', 'D3'];
         FOREACH ($dType IN $dTypes) {
           CREATE DOCUMENT TYPE  $dType ;
+        }
+
+        LET types = ['V1', 'V2', 'V3','E1', 'E2', 'E3','D1', 'D2', 'D3'];
+        FOREACH ($type IN $types) {
+          CREATE PROPERTY $type.id  STRING;
+          CREATE INDEX ON $type (id) UNIQUE NULL_STRATEGY SKIP;
         }
         COMMIT;
         """);
 
     Schema schema = database.getSchema();
     assertThat(schema.existsType("V1")).isTrue();
+    assertThat(schema.existsIndex("V1[id]")).isTrue();
     assertThat(schema.existsType("V2")).isTrue();
+    assertThat(schema.existsIndex("V2[id]")).isTrue();
     assertThat(schema.existsType("V3")).isTrue();
+    assertThat(schema.existsIndex("V3[id]")).isTrue();
     assertThat(schema.existsType("D1")).isTrue();
+    assertThat(schema.existsIndex("D1[id]")).isTrue();
     assertThat(schema.existsType("D2")).isTrue();
+    assertThat(schema.existsIndex("D2[id]")).isTrue();
     assertThat(schema.existsType("D3")).isTrue();
+    assertThat(schema.existsIndex("D3[id]")).isTrue();
     assertThat(schema.existsType("E1")).isTrue();
+    assertThat(schema.existsIndex("E1[id]")).isTrue();
     assertThat(schema.existsType("E2")).isTrue();
+    assertThat(schema.existsIndex("E2[id]")).isTrue();
     assertThat(schema.existsType("E3")).isTrue();
+    assertThat(schema.existsIndex("E3[id]")).isTrue();
 
   }
 

--- a/engine/src/test/java/com/arcadedb/query/sql/DDLTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/DDLTest.java
@@ -49,12 +49,12 @@ public class DDLTest extends TestHelper {
 
         LET eTypes = ['E1', 'E2', 'E3'];
         FOREACH ($eType IN $eTypes) {
-          CREATE EDGE TYPE  $eType ;
+          CREATE EDGE TYPE  $eType EXTENDS E;
         }
 
         LET dTypes = ['D1', 'D2', 'D3'];
         FOREACH ($dType IN $dTypes) {
-          CREATE DOCUMENT TYPE  $dType ;
+          CREATE DOCUMENT TYPE $dType ;
         }
 
         LET types = ['V1', 'V2', 'V3','E1', 'E2', 'E3','D1', 'D2', 'D3'];

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/BatchScriptTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/BatchScriptTest.java
@@ -35,49 +35,52 @@ public class BatchScriptTest {
     checkRightSyntax("begin;\nselect from foo;/*foo bar*/ return bar;");
     checkRightSyntax("/*foo bar*/ begin;\nselect from foo;return bar;/*foo bar*/ ");
 
-    String s = ""//
-        + "begin;"//
-        + "let $a = select from foo let a = 13 where bar = 'baz';"//
-        + "let $b = insert into foo set name = 'baz';"//
-        + "let $c = update v set name = 'lkajsd';"//
-        + "if($c < $a){"//
-        + "   update v set surname = baz;"//
-        + "   if($c < $b){"//
-        + "       return 0;"//
-        + "   }"//
-        + "}"//
-        + "return 1;";
+    String s = """
+        begin;
+        let $a = select from foo let a = 13 where bar = 'baz';
+        let $b = insert into foo set name = 'baz';
+        let $c = update v set name = 'lkajsd';
+        if($c < $a){
+           update v set surname = baz;
+           if($c < $b){
+               return 0;
+           }
+        }
+        return 1;""";
 
     checkRightSyntax(s);
 
-    s = ""//
-        + "begin;\n"//
-        + "let $a = select from foo let a = 13 where bar = 'baz';\n"//
-        + "let $b = insert into foo set name = 'baz';\n"//
-        + "let $c = update v set name = 'lkajsd';\n"//
-        + "if($c < $a){\n"//
-        + "   update v set surname = baz;\n"//
-        + "   if($c < $b){\n"//
-        + "       return 0;\n"//
-        + "   }\n"//
-        + "}\n"//
-        + "return 1;\n";
+    s = """
+
+        begin;
+        let $a = select from foo let a = 13 where bar = 'baz';
+        let $b = insert into foo set name = 'baz';
+        let $c = update v set name = 'lkajsd';
+        if($c < $a){
+           update v set surname = baz;
+           if($c < $b){
+               return 0;
+           }
+        }
+        return 1;
+        """;
     checkRightSyntax(s);
 
-    s = ""//
-        + "begin;\n"//
-        + "let $a = select from foo let a = 13 where bar = 'baz';\n"//
-        + "let $b = insert into foo set name = 'baz';\n"//
-        + "let $c = update v set \n"//
-        + "/** foo bar */\n"//
-        + "name = 'lkajsd';\n"//
-        + "if($c < $a){\n"//
-        + "   update v set surname = baz;\n"//
-        + "   if($c < $b){\n"//
-        + "       return 0;\n"//
-        + "   }\n"//
-        + "}\n"//
-        + "return 1;\n";
+    s = """
+        begin;
+        let $a = select from foo let a = 13 where bar = 'baz';
+        let $b = insert into foo set name = 'baz';
+        let $c = update v set
+        /** foo bar */
+        name = 'lkajsd';
+        if($c < $a){
+           update v set surname = baz;
+           if($c < $b){
+               return 0;
+           }
+        }
+        return 1;
+        """;
     checkRightSyntax(s);
 
     s = "let a = select 1 as result;let b = select 2 as result;return [$a,$b];";


### PR DESCRIPTION
#2230 

This pull request introduces improvements to variable handling in the SQL execution context and enhances test coverage for batch scripts and variable access. The most significant changes are the addition of support for accessing fields of result set variables using dot notation, refactoring for clarity and consistency, and new tests to validate these features.

### Variable access and handling improvements

* Enhanced the `getVariable` method in `BasicCommandContext` to support dot notation (e.g., `$row.a`), allowing direct access to fields within result set variables. This improves usability in SQL scripts and batch operations.
* Updated method signatures in the `CommandContext` interface for improved clarity and consistency (e.g., renaming parameters for better readability).

### Test coverage and validation

* Added a new test `testForeachResultSetReadFieldName` in `BatchTest.java` to verify that field access via dot notation works correctly in SQL scripts.
* Refactored multi-line script strings in `BatchScriptTest.java` to use Java's text block syntax for better readability and maintainability.

### Code quality

* Cleaned up imports in `BasicCommandContext.java` for clarity and reduced unnecessary wildcard usage.