### PR TITLE
fix(pom.xml): explicitly import commons-lang3 to address CVE-2025-48924

### DIFF
--- a/gremlin/pom.xml
+++ b/gremlin/pom.xml
@@ -39,8 +39,9 @@
         <snakeyaml.version>2.4</snakeyaml.version>
         <netty.version>4.2.5.Final</netty.version>
         <commons-configuration2.version>2.12.0</commons-configuration2.version>
-        <groovy.version>4.0.28</groovy.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
+        <commons-lang3.version>3.18.0</commons-lang3.version>
+        <groovy.version>4.0.28</groovy.version>
     </properties>
 
     <dependencies>
@@ -62,6 +63,12 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
             <version>${netty.version}</version>
+        </dependency>
+        <!-- explicit import to solve CVE-2025-48924-->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
This pull request updates the `gremlin/pom.xml` file to address a security vulnerability and improve dependency management. The most important changes include explicitly adding the `commons-lang3` dependency to resolve a CVE and introducing a version property for better control.

**Security and Dependency Management:**

* Added an explicit import of the `commons-lang3` library to solve CVE-2025-48924. (`gremlin/pom.xml`)
* Introduced a new property for `commons-lang3.version` to manage its version in the project. (`gremlin/pom.xml`)