### PR TITLE
refactor(tests): rename test classes and simplify resource management

### DIFF
--- a/engine/src/test/java/com/arcadedb/MultipleDatabasesTest.java
+++ b/engine/src/test/java/com/arcadedb/MultipleDatabasesTest.java
@@ -24,9 +24,7 @@ import com.arcadedb.database.EmbeddedDocument;
 import com.arcadedb.exception.DatabaseOperationException;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.utility.FileUtils;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -37,7 +35,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class MultipleDatabasesTest extends TestHelper {
   @Test
@@ -56,12 +54,8 @@ public class MultipleDatabasesTest extends TestHelper {
     // CREATE VERTEX AND DOCUMENT AS EMBEDDED
     database.transaction(() -> {
       final MutableVertex v = database.newVertex("V1").set("db", 1).save();
-      try {
-        v.newEmbeddedDocument("V1", "embedded").set("db", 1).set("embedded", true).save();
-        fail();
-      } catch (final IllegalArgumentException e) {
-        // EXPECTED
-      }
+      assertThatThrownBy(() -> v.newEmbeddedDocument("V1", "embedded").set("db", 1).set("embedded", true).save())
+          .isInstanceOf(IllegalArgumentException.class);
       v.newEmbeddedDocument("Embedded", "embedded").set("db", 1).set("embedded", true).save();
     });
 
@@ -99,8 +93,11 @@ public class MultipleDatabasesTest extends TestHelper {
 
     // CHECK COPIED RECORDS TOO
     assertThat(database3.iterateType("V1", true).next().asVertex().getEmbedded("embedded1").get("db")).isEqualTo(1);
-    assertThat(((List<EmbeddedDocument>) database3.iterateType("V1", true).next().asVertex().get("list2")).getFirst().get("db")).isEqualTo(2);
-    assertThat(((Map<String, EmbeddedDocument>) database3.iterateType("V1", true).next().asVertex().get("map2")).get("copied2").get("db")).isEqualTo(2);
+    assertThat(
+        ((List<EmbeddedDocument>) database3.iterateType("V1", true).next().asVertex().get("list2")).getFirst().get("db")).isEqualTo(
+        2);
+    assertThat(((Map<String, EmbeddedDocument>) database3.iterateType("V1", true).next().asVertex().get("map2")).get("copied2")
+        .get("db")).isEqualTo(2);
 
     database.close();
     database2.close();
@@ -111,12 +108,8 @@ public class MultipleDatabasesTest extends TestHelper {
 
   @Test
   public void testErrorMultipleDatabaseInstancesSamePath() {
-    try {
-      new DatabaseFactory(getDatabasePath()).open();
-      fail("");
-    } catch (final DatabaseOperationException e) {
-      // EXPECTED
-    }
+    assertThatThrownBy(() -> new DatabaseFactory(getDatabasePath()).open())
+        .isInstanceOf(DatabaseOperationException.class);
   }
 
   @AfterEach

--- a/engine/src/test/java/com/arcadedb/index/DropIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/DropIndexTest.java
@@ -102,7 +102,7 @@ public class DropIndexTest extends TestHelper {
         ).isInstanceOf(SchemaException.class);
       }
 
-      final TypeIndex typeIndex3 = (TypeIndex) database.getSchema()
+      final TypeIndex typeIndex3 = database.getSchema()
           .buildTypeIndex(TYPE_NAME, new String[] { "id" })
           .withType(Schema.INDEX_TYPE.LSM_TREE)
           .withPageSize(PAGE_SIZE)
@@ -144,7 +144,7 @@ public class DropIndexTest extends TestHelper {
     type.createProperty("id", Integer.class);
     type.createProperty("name", String.class);
 
-    final TypeIndex typeIndex = (TypeIndex) database.getSchema()
+    final TypeIndex typeIndex = database.getSchema()
         .buildTypeIndex(TYPE_NAME, new String[] { "id" })
         .withType(Schema.INDEX_TYPE.LSM_TREE)
         .withPageSize(PAGE_SIZE)

--- a/engine/src/test/java/com/arcadedb/index/LSMTreeFullTextIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/LSMTreeFullTextIndexTest.java
@@ -27,14 +27,12 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
-
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class LSMTreeFullTextIndexTest extends TestHelper {
   private static final int    TOT       = 10000;
@@ -48,31 +46,35 @@ public class LSMTreeFullTextIndexTest extends TestHelper {
     final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(1).create();
     type.createProperty("text", String.class);
     final Index typeIndex = database.getSchema()
-        .createTypeIndex(Schema.INDEX_TYPE.FULL_TEXT, false, TYPE_NAME, new String[] { "text" }, PAGE_SIZE);
+        .buildTypeIndex(TYPE_NAME, new String[] { "text" })
+        .withType(Schema.INDEX_TYPE.FULL_TEXT)
+        .withPageSize(PAGE_SIZE)
+        .withUnique(false)
+        .create();
 
     assertThat(database.getSchema().existsType(TYPE_NAME)).isTrue();
 
     final String text =
         """
-        Jay Glenn Miner (May 31, 1932 – June 20, 1994) was an American integrated circuit designer, known primarily for developing multimedia chips for the Atari 2600 and Atari 8-bit family and as the "father of the Amiga". He received a BS in EECS from UC Berkeley in 1959.[2]
+            Jay Glenn Miner (May 31, 1932 – June 20, 1994) was an American integrated circuit designer, known primarily for developing multimedia chips for the Atari 2600 and Atari 8-bit family and as the "father of the Amiga". He received a BS in EECS from UC Berkeley in 1959.[2]
 
-        Miner started in the electronics industry with a number of designs in the medical world, including a remote-control pacemaker.
+            Miner started in the electronics industry with a number of designs in the medical world, including a remote-control pacemaker.
 
-        He moved to Atari, Inc. in the late 1970s. One of his first successes was to combine an entire breadboard of components into a single chip, known as the TIA. The TIA was the display hardware for the Atari 2600, which would go on to sell millions. After working on the TIA he headed up the design of the follow-on chip set known as ANTIC and CTIA for which he held a patent.[3] These chips would be used for the Atari 8-bit family of home computers and the Atari 5200 video game system.
+            He moved to Atari, Inc. in the late 1970s. One of his first successes was to combine an entire breadboard of components into a single chip, known as the TIA. The TIA was the display hardware for the Atari 2600, which would go on to sell millions. After working on the TIA he headed up the design of the follow-on chip set known as ANTIC and CTIA for which he held a patent.[3] These chips would be used for the Atari 8-bit family of home computers and the Atari 5200 video game system.
 
-        In the early 1980s, Jay, along with other Atari staffers, had become fed up with management and decamped. They set up another chipset project under a new company in Santa Clara, called Hi-Toro (later renamed to Amiga Corporation), where they could have creative freedom. There, they started to create a new Motorola 68000-based games console, codenamed Lorraine that could be upgraded to a computer. To raise money for the Lorraine project, Amiga Corp. designed and sold joysticks and game cartridges for popular game consoles such as the Atari 2600 and ColecoVision, as well as an odd input device called the Joyboard, essentially a joystick the player stood on. Atari continued to be interested in the team's efforts throughout this period, and funded them with $500,000 in capital in return for first use of their resulting chipset.
+            In the early 1980s, Jay, along with other Atari staffers, had become fed up with management and decamped. They set up another chipset project under a new company in Santa Clara, called Hi-Toro (later renamed to Amiga Corporation), where they could have creative freedom. There, they started to create a new Motorola 68000-based games console, codenamed Lorraine that could be upgraded to a computer. To raise money for the Lorraine project, Amiga Corp. designed and sold joysticks and game cartridges for popular game consoles such as the Atari 2600 and ColecoVision, as well as an odd input device called the Joyboard, essentially a joystick the player stood on. Atari continued to be interested in the team's efforts throughout this period, and funded them with $500,000 in capital in return for first use of their resulting chipset.
 
-        Also in the early 1980s, Jay worked on a project with Intermedics, Inc. to create their first microprocessor-based cardiac pacemaker. The microprocessor was called Lazarus and the pacemaker was eventually called Cosmos. Jay was listed co-inventor on two patents. US patent 4390022, Richard V. Calfee & Jay Miner, "Implantable device with microprocessor control", issued 1983-06-28, assigned to Intermedics, Inc. US patent 4404972, Pat L. Gordon; Richard V. Calfee & Jay Miner, "Implantable device with microprocessor control", issued 1983-06-28, assigned to Intermedics, Inc.
+            Also in the early 1980s, Jay worked on a project with Intermedics, Inc. to create their first microprocessor-based cardiac pacemaker. The microprocessor was called Lazarus and the pacemaker was eventually called Cosmos. Jay was listed co-inventor on two patents. US patent 4390022, Richard V. Calfee & Jay Miner, "Implantable device with microprocessor control", issued 1983-06-28, assigned to Intermedics, Inc. US patent 4404972, Pat L. Gordon; Richard V. Calfee & Jay Miner, "Implantable device with microprocessor control", issued 1983-06-28, assigned to Intermedics, Inc.
 
-        The Amiga crew, having continuing serious financial problems, had sought more monetary support from investors that entire Spring. Amiga entered into discussions with Commodore. The discussions ultimately led to Commodore wanting to purchase Amiga outright, which would (from Commodore's viewpoint) cancel any outstanding contracts - including Atari Inc.'s. So instead of Amiga delivering the chipset, Commodore delivered a check of $500,000 to Atari on Amiga's behalf, in effect returning the funds invested into Amiga for completion of the Lorraine chipset.
+            The Amiga crew, having continuing serious financial problems, had sought more monetary support from investors that entire Spring. Amiga entered into discussions with Commodore. The discussions ultimately led to Commodore wanting to purchase Amiga outright, which would (from Commodore's viewpoint) cancel any outstanding contracts - including Atari Inc.'s. So instead of Amiga delivering the chipset, Commodore delivered a check of $500,000 to Atari on Amiga's behalf, in effect returning the funds invested into Amiga for completion of the Lorraine chipset.
 
 
-        The original Amiga (1985)
-        Jay worked at Commodore-Amiga for several years, in Los Gatos, California. They made good progress at the beginning, but as Commodore management changed, they became marginalised and the original Amiga staff was fired or left out on a one-by-one basis, until the entire Los Gatos office was closed. Miner later worked as a consultant for Commodore until it went bankrupt. He was known as the 'Padre' (father) of the Amiga among Amiga users.
+            The original Amiga (1985)
+            Jay worked at Commodore-Amiga for several years, in Los Gatos, California. They made good progress at the beginning, but as Commodore management changed, they became marginalised and the original Amiga staff was fired or left out on a one-by-one basis, until the entire Los Gatos office was closed. Miner later worked as a consultant for Commodore until it went bankrupt. He was known as the 'Padre' (father) of the Amiga among Amiga users.
 
-        Jay always took his dog "Mitchy" (a cockapoo) with him wherever he went. While he worked at Atari, Mitchy even had her own ID-badge, and an embossing of Mitchy's paw print is visible on the inside of the Amiga 1000 top cover, alongside the signatures of the engineers who worked on it.
+            Jay always took his dog "Mitchy" (a cockapoo) with him wherever he went. While he worked at Atari, Mitchy even had her own ID-badge, and an embossing of Mitchy's paw print is visible on the inside of the Amiga 1000 top cover, alongside the signatures of the engineers who worked on it.
 
-        Jay endured kidney problems for most of his life, according to his wife, and relied on dialysis. His sister donated one of her own. Miner died due to complications from kidney failure at the age of 62, just two months after Commodore declared bankruptcy.""";
+            Jay endured kidney problems for most of his life, according to his wife, and relied on dialysis. His sister donated one of her own. Miner died due to complications from kidney failure at the age of 62, just two months after Commodore declared bankruptcy.""";
 
     database.transaction(() -> {
       for (int i = 0; i < TOT; ++i) {
@@ -123,13 +125,13 @@ public class LSMTreeFullTextIndexTest extends TestHelper {
     final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(1).create();
     type.createProperty("text", String.class);
     type.createProperty("type", String.class);
-    try {
-      database.getSchema()
-          .createTypeIndex(Schema.INDEX_TYPE.FULL_TEXT, false, TYPE_NAME, new String[] { "text", "type" }, PAGE_SIZE);
-      fail("");
-    } catch (IndexException e) {
-      // EXPECTED
-    }
+    assertThatThrownBy(() -> database.getSchema()
+        .buildTypeIndex(TYPE_NAME, new String[] { "text", "type" })
+        .withType(Schema.INDEX_TYPE.FULL_TEXT)
+        .withPageSize(PAGE_SIZE)
+        .withUnique(false)
+        .create())
+        .isInstanceOf(IndexException.class);
   }
 
   @Test
@@ -140,31 +142,34 @@ public class LSMTreeFullTextIndexTest extends TestHelper {
       final DocumentType type = database.getSchema().createDocumentType("Docs");
       type.createProperty("text", String.class);
       final Index typeIndex = database.getSchema()
-          .createTypeIndex(Schema.INDEX_TYPE.FULL_TEXT, false, "Docs", new String[] { "text" });
+          .buildTypeIndex("Docs", new String[] { "text" })
+          .withType(Schema.INDEX_TYPE.FULL_TEXT)
+          .withUnique(false)
+          .create();
 
       assertThat(database.getSchema().existsType("Docs")).isTrue();
 
       final String text =
           """
-          Jay Glenn Miner (May 31, 1932 – June 20, 1994) was an American integrated circuit designer, known primarily for developing multimedia chips for the Atari 2600 and Atari 8-bit family and as the "father of the Amiga". He received a BS in EECS from UC Berkeley in 1959.[2]
+              Jay Glenn Miner (May 31, 1932 – June 20, 1994) was an American integrated circuit designer, known primarily for developing multimedia chips for the Atari 2600 and Atari 8-bit family and as the "father of the Amiga". He received a BS in EECS from UC Berkeley in 1959.[2]
 
-          Miner started in the electronics industry with a number of designs in the medical world, including a remote-control pacemaker.
+              Miner started in the electronics industry with a number of designs in the medical world, including a remote-control pacemaker.
 
-          He moved to Atari, Inc. in the late 1970s. One of his first successes was to combine an entire breadboard of components into a single chip, known as the TIA. The TIA was the display hardware for the Atari 2600, which would go on to sell millions. After working on the TIA he headed up the design of the follow-on chip set known as ANTIC and CTIA for which he held a patent.[3] These chips would be used for the Atari 8-bit family of home computers and the Atari 5200 video game system.
+              He moved to Atari, Inc. in the late 1970s. One of his first successes was to combine an entire breadboard of components into a single chip, known as the TIA. The TIA was the display hardware for the Atari 2600, which would go on to sell millions. After working on the TIA he headed up the design of the follow-on chip set known as ANTIC and CTIA for which he held a patent.[3] These chips would be used for the Atari 8-bit family of home computers and the Atari 5200 video game system.
 
-          In the early 1980s, Jay, along with other Atari staffers, had become fed up with management and decamped. They set up another chipset project under a new company in Santa Clara, called Hi-Toro (later renamed to Amiga Corporation), where they could have creative freedom. There, they started to create a new Motorola 68000-based games console, codenamed Lorraine that could be upgraded to a computer. To raise money for the Lorraine project, Amiga Corp. designed and sold joysticks and game cartridges for popular game consoles such as the Atari 2600 and ColecoVision, as well as an odd input device called the Joyboard, essentially a joystick the player stood on. Atari continued to be interested in the team's efforts throughout this period, and funded them with $500,000 in capital in return for first use of their resulting chipset.
+              In the early 1980s, Jay, along with other Atari staffers, had become fed up with management and decamped. They set up another chipset project under a new company in Santa Clara, called Hi-Toro (later renamed to Amiga Corporation), where they could have creative freedom. There, they started to create a new Motorola 68000-based games console, codenamed Lorraine that could be upgraded to a computer. To raise money for the Lorraine project, Amiga Corp. designed and sold joysticks and game cartridges for popular game consoles such as the Atari 2600 and ColecoVision, as well as an odd input device called the Joyboard, essentially a joystick the player stood on. Atari continued to be interested in the team's efforts throughout this period, and funded them with $500,000 in capital in return for first use of their resulting chipset.
 
-          Also in the early 1980s, Jay worked on a project with Intermedics, Inc. to create their first microprocessor-based cardiac pacemaker. The microprocessor was called Lazarus and the pacemaker was eventually called Cosmos. Jay was listed co-inventor on two patents. US patent 4390022, Richard V. Calfee & Jay Miner, "Implantable device with microprocessor control", issued 1983-06-28, assigned to Intermedics, Inc. US patent 4404972, Pat L. Gordon; Richard V. Calfee & Jay Miner, "Implantable device with microprocessor control", issued 1983-06-28, assigned to Intermedics, Inc.
+              Also in the early 1980s, Jay worked on a project with Intermedics, Inc. to create their first microprocessor-based cardiac pacemaker. The microprocessor was called Lazarus and the pacemaker was eventually called Cosmos. Jay was listed co-inventor on two patents. US patent 4390022, Richard V. Calfee & Jay Miner, "Implantable device with microprocessor control", issued 1983-06-28, assigned to Intermedics, Inc. US patent 4404972, Pat L. Gordon; Richard V. Calfee & Jay Miner, "Implantable device with microprocessor control", issued 1983-06-28, assigned to Intermedics, Inc.
 
-          The Amiga crew, having continuing serious financial problems, had sought more monetary support from investors that entire Spring. Amiga entered into discussions with Commodore. The discussions ultimately led to Commodore wanting to purchase Amiga outright, which would (from Commodore's viewpoint) cancel any outstanding contracts - including Atari Inc.'s. So instead of Amiga delivering the chipset, Commodore delivered a check of $500,000 to Atari on Amiga's behalf, in effect returning the funds invested into Amiga for completion of the Lorraine chipset.
+              The Amiga crew, having continuing serious financial problems, had sought more monetary support from investors that entire Spring. Amiga entered into discussions with Commodore. The discussions ultimately led to Commodore wanting to purchase Amiga outright, which would (from Commodore's viewpoint) cancel any outstanding contracts - including Atari Inc.'s. So instead of Amiga delivering the chipset, Commodore delivered a check of $500,000 to Atari on Amiga's behalf, in effect returning the funds invested into Amiga for completion of the Lorraine chipset.
 
 
-          The original Amiga (1985)
-          Jay worked at Commodore-Amiga for several years, in Los Gatos, California. They made good progress at the beginning, but as Commodore management changed, they became marginalised and the original Amiga staff was fired or left out on a one-by-one basis, until the entire Los Gatos office was closed. Miner later worked as a consultant for Commodore until it went bankrupt. He was known as the 'Padre' (father) of the Amiga among Amiga users.
+              The original Amiga (1985)
+              Jay worked at Commodore-Amiga for several years, in Los Gatos, California. They made good progress at the beginning, but as Commodore management changed, they became marginalised and the original Amiga staff was fired or left out on a one-by-one basis, until the entire Los Gatos office was closed. Miner later worked as a consultant for Commodore until it went bankrupt. He was known as the 'Padre' (father) of the Amiga among Amiga users.
 
-          Jay always took his dog "Mitchy" (a cockapoo) with him wherever he went. While he worked at Atari, Mitchy even had her own ID-badge, and an embossing of Mitchy's paw print is visible on the inside of the Amiga 1000 top cover, alongside the signatures of the engineers who worked on it.
+              Jay always took his dog "Mitchy" (a cockapoo) with him wherever he went. While he worked at Atari, Mitchy even had her own ID-badge, and an embossing of Mitchy's paw print is visible on the inside of the Amiga 1000 top cover, alongside the signatures of the engineers who worked on it.
 
-          Jay endured kidney problems for most of his life, according to his wife, and relied on dialysis. His sister donated one of her own. Miner died due to complications from kidney failure at the age of 62, just two months after Commodore declared bankruptcy.""";
+              Jay endured kidney problems for most of his life, according to his wife, and relied on dialysis. His sister donated one of her own. Miner died due to complications from kidney failure at the age of 62, just two months after Commodore declared bankruptcy.""";
 
       final String[] words = text.split(" ");
 
@@ -205,16 +210,12 @@ public class LSMTreeFullTextIndexTest extends TestHelper {
 
   @Test
   public void testNullValuesViaSQL() {
-    try {
-      database.transaction(() -> {
-        database.command("sql", "CREATE DOCUMENT TYPE doc");
-        database.command("sql", "CREATE PROPERTY doc.str STRING");
-        database.command("sql", "CREATE INDEX ON doc (str) FULL_TEXT null_strategy error");
-        database.command("sql", "INSERT INTO doc (str) VALUES ('a'), ('b'), (null)");
-      });
-      fail("");
-    } catch (TransactionException e) {
-    }
+    assertThatThrownBy(() -> database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE doc");
+      database.command("sql", "CREATE PROPERTY doc.str STRING");
+      database.command("sql", "CREATE INDEX ON doc (str) FULL_TEXT null_strategy error");
+      database.command("sql", "INSERT INTO doc (str) VALUES ('a'), ('b'), (null)");
+    })).isInstanceOf(TransactionException.class);
 
     database.transaction(() -> {
       database.command("sql", "CREATE DOCUMENT TYPE doc2");
@@ -222,6 +223,7 @@ public class LSMTreeFullTextIndexTest extends TestHelper {
       database.command("sql", "CREATE INDEX ON doc2 (str) FULL_TEXT null_strategy skip");
       database.command("sql", "INSERT INTO doc2 (str) VALUES ('a'), ('b'), (null)");
     });
+
   }
 
   private boolean skipIndexing(final String toIndex) {

--- a/engine/src/test/java/com/arcadedb/index/LSMTreeIndexCompositeTest.java
+++ b/engine/src/test/java/com/arcadedb/index/LSMTreeIndexCompositeTest.java
@@ -24,10 +24,9 @@ import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
-
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -69,7 +68,7 @@ public class LSMTreeIndexCompositeTest extends TestHelper {
       final TypeIndex index = database.getSchema().getType("File").getIndexesByProperties("directoryId", "fileId").getFirst();
       for (int i = 0; i < TOT; ++i) {
         final IndexCursor value = index.get(new Object[] { i, null });
-        assertThat(value.hasNext()).withFailMessage( "id[" + i + "]").isTrue();
+        assertThat(value.hasNext()).withFailMessage("id[" + i + "]").isTrue();
 
         final Vertex v = value.next().asVertex();
         assertThat(v.get("directoryId")).isEqualTo(i);
@@ -85,14 +84,17 @@ public class LSMTreeIndexCompositeTest extends TestHelper {
       file.createProperty("absoluteId", Integer.class);
       file.createProperty("directoryId", Integer.class);
       file.createProperty("fileId", Integer.class);
-      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "File", "absoluteId");
-      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "File", "directoryId", "fileId");
+      database.getSchema().buildTypeIndex("File", new String[] { "absoluteId" }).withType(Schema.INDEX_TYPE.LSM_TREE)
+          .withUnique(true).create();
+      database.getSchema().buildTypeIndex("File", new String[] { "directoryId", "fileId" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true).create();
 
       file.setBucketSelectionStrategy(new RoundRobinBucketSelectionStrategy());
 
       assertThat(database.getSchema().existsType("HasChildren")).isFalse();
       database.getSchema().createEdgeType("HasChildren");
-      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, "HasChildren", "@out", "@in");
+      database.getSchema().buildTypeIndex("HasChildren", new String[] { "@out", "@in" }).withType(Schema.INDEX_TYPE.LSM_TREE)
+          .withUnique(true).create();
 
       int fileId = 0;
       for (int i = 0; i < TOT; ++i) {

--- a/engine/src/test/java/com/arcadedb/index/LSMTreeIndexPolymorphicTest.java
+++ b/engine/src/test/java/com/arcadedb/index/LSMTreeIndexPolymorphicTest.java
@@ -26,15 +26,13 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
-
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 public class LSMTreeIndexPolymorphicTest extends TestHelper {
@@ -46,19 +44,14 @@ public class LSMTreeIndexPolymorphicTest extends TestHelper {
   public void testPolymorphic() {
     populate(Schema.INDEX_TYPE.LSM_TREE);
 
-    try {
+    assertThatThrownBy(() -> {
       final MutableDocument docChildDuplicated = database.newDocument("TestChild");
       database.transaction(() -> {
         docChildDuplicated.set("name", "Root");
         assertThat(docChildDuplicated.get("name")).isEqualTo("Root");
         docChildDuplicated.save();
       }, true, 0);
-
-      fail("Duplicated shouldn't be allowed by unique index on sub type");
-
-    } catch (final DuplicatedKeyException e) {
-      // EXPECTED
-    }
+    }).isInstanceOf(DuplicatedKeyException.class);
 
     checkQueries();
   }

--- a/engine/src/test/java/com/arcadedb/index/MultipleTypesIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/MultipleTypesIndexTest.java
@@ -25,13 +25,12 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.schema.VertexType;
-
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MultipleTypesIndexTest extends TestHelper {
   private static final int    TOT       = 100000;
@@ -84,7 +83,7 @@ public class MultipleTypesIndexTest extends TestHelper {
       final Index index = database.getSchema().getIndexByName(TYPE_NAME + "[keywords]");
 
       MutableVertex v = database.newVertex(TYPE_NAME);
-      v.set("id", TOT+1);
+      v.set("id", TOT + 1);
       v.set("firstName", "Jake");
       v.set("lastName", "White");
 
@@ -125,12 +124,15 @@ public class MultipleTypesIndexTest extends TestHelper {
 
       final DocumentType type = database.getSchema().buildVertexType().withName(TYPE_NAME).withTotalBuckets(3).create();
       type.createProperty("id", Integer.class);
-      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, TYPE_NAME, new String[] { "id" });
+      database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "id" }).withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true)
+          .create();
       type.createProperty("firstName", String.class);
       type.createProperty("lastName", String.class);
-      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, TYPE_NAME, new String[] { "firstName", "lastName" });
+      database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "firstName", "lastName" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(false).create();
       type.createProperty("keywords", List.class);
-      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, TYPE_NAME, new String[] { "keywords" });
+      database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "keywords" }).withType(Schema.INDEX_TYPE.LSM_TREE)
+          .withUnique(false).create();
 
       MutableVertex v = database.newVertex(TYPE_NAME);
       v.set("id", 0);

--- a/engine/src/test/java/com/arcadedb/index/TypeLSMTreeIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/TypeLSMTreeIndexTest.java
@@ -41,12 +41,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 public class TypeLSMTreeIndexTest extends TestHelper {
   private static final int    TOT       = 100000;
@@ -91,10 +89,10 @@ public class TypeLSMTreeIndexTest extends TestHelper {
       for (int i = 0; i < TOT - 1; ++i) {
         int total = 0;
 
-        for (final Index index : indexes) {
+        for (final RangeIndex index : indexes) {
           assertThat(index).isNotNull();
 
-          final IndexCursor iterator = ((RangeIndex) index).range(true, new Object[] { i }, true, new Object[] { i + 1 }, true);
+          final IndexCursor iterator = index.range(true, new Object[] { i }, true, new Object[] { i + 1 }, true);
           assertThat((Iterator<? extends Identifiable>) iterator).isNotNull();
 
           while (iterator.hasNext()) {
@@ -158,26 +156,19 @@ public class TypeLSMTreeIndexTest extends TestHelper {
       for (int i = 0; i < TOT - 1; ++i) {
         int total = 0;
 
-        try {
-          ResultSet iterator = database.command("sql",
-              "select from " + TYPE_NAME + " where id >= " + i + " and id <= " + (i + 1));
+        ResultSet iterator = database.command("sql", "select from " + TYPE_NAME + " where id >= " + i + " and id <= " + (i + 1));
 
-          assertThat((Iterator<? extends Result>) iterator).isNotNull();
+        assertThat((Iterator<? extends Result>) iterator).isNotNull();
 
-          while (iterator.hasNext()) {
-            Result value = iterator.next();
+        while (iterator.hasNext()) {
+          Result value = iterator.next();
 
-            assertThat(value).isNotNull();
+          assertThat(value).isNotNull();
 
-            int id = value.<Integer>getProperty("id");
+          int id = value.<Integer>getProperty("id");
 
-            assertThat(id)
-                .isGreaterThanOrEqualTo(i)
-                .isLessThanOrEqualTo(i + 1);
-            total++;
-          }
-        } catch (final Exception e) {
-          fail(e);
+          assertThat(id).isGreaterThanOrEqualTo(i).isLessThanOrEqualTo(i + 1);
+          total++;
         }
         assertThat(total).isEqualTo(2).withFailMessage("For ids >= " + i + " and <= " + (i + 1));
       }
@@ -192,7 +183,7 @@ public class TypeLSMTreeIndexTest extends TestHelper {
         // WAIT FOR THE INDEX TO BE COMPACTED
         Thread.sleep(1000);
       } catch (final InterruptedException e) {
-        e.printStackTrace();
+        //noop
       }
 
       int total = 0;
@@ -202,29 +193,19 @@ public class TypeLSMTreeIndexTest extends TestHelper {
         assertThat(index).isNotNull();
 
         final IndexCursor iterator;
-        try {
-          iterator = ((RangeIndex) index).iterator(true);
+        iterator = ((RangeIndex) index).iterator(true);
 
-//            LogManager.instance()
-//                .log(this, Level.INFO, "*****************************************************************************\nCURSOR BEGIN%s", iterator.dumpStats());
+        assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
 
-          assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
+        while (iterator.hasNext()) {
+          assertThat(iterator.next()).isNotNull();
 
-          while (iterator.hasNext()) {
-            assertThat(iterator.next()).isNotNull();
+          assertThat(iterator.getKeys()).isNotNull();
+          assertThat(iterator.getKeys().length).isEqualTo(1);
 
-            assertThat(iterator.getKeys()).isNotNull();
-            assertThat(iterator.getKeys().length).isEqualTo(1);
-
-            total++;
-          }
-
-//            LogManager.instance().log(this, Level.INFO, "*****************************************************************************\nCURSOR END total=%d %s", total,
-//                iterator.dumpStats());
-
-        } catch (final Exception e) {
-          fail(e);
+          total++;
         }
+
       }
 
       assertThat(total).isEqualTo(TOT);
@@ -245,26 +226,20 @@ public class TypeLSMTreeIndexTest extends TestHelper {
       int total = 0;
 
       final Collection<TypeIndex> indexes = database.getSchema().getType(TYPE_NAME).getAllIndexes(false);
-      for (final Index index : indexes) {
+      for (final RangeIndex index : indexes) {
         assertThat(index).isNotNull();
 
         final IndexCursor iterator;
-        try {
-          iterator = ((RangeIndex) index).iterator(false);
-          assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
+        iterator = index.iterator(false);
+        assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
 
-          while (iterator.hasNext()) {
-            assertThat(iterator.next()).isNotNull();
+        while (iterator.hasNext()) {
+          assertThat(iterator.next()).isNotNull();
 
-            assertThat(iterator.getKeys()).isNotNull();
-            assertThat(iterator.getKeys().length).isEqualTo(1);
+          assertThat(iterator.getKeys()).isNotNull();
+          assertThat(iterator.getKeys().length).isEqualTo(1);
 
-            //LogManager.instance().log(this, Level.INFO, "Index %s Key %s", null, index, Arrays.toString(iterator.getKeys()));
-
-            total++;
-          }
-        } catch (final Exception e) {
-          fail(e);
+          total++;
         }
       }
 
@@ -279,25 +254,21 @@ public class TypeLSMTreeIndexTest extends TestHelper {
       int total = 0;
 
       final Collection<TypeIndex> indexes = database.getSchema().getType(TYPE_NAME).getAllIndexes(false);
-      for (final Index index : indexes) {
+      for (final RangeIndex index : indexes) {
         assertThat(index).isNotNull();
 
         final IndexCursor iterator;
-        try {
-          iterator = ((RangeIndex) index).iterator(true, new Object[] { 10 }, true);
+        iterator = index.iterator(true, new Object[] { 10 }, true);
 
-          assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
+        assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
 
-          while (iterator.hasNext()) {
-            assertThat(iterator.next()).isNotNull();
+        while (iterator.hasNext()) {
+          assertThat(iterator.next()).isNotNull();
 
-            assertThat(iterator.getKeys()).isNotNull();
-            assertThat(iterator.getKeys().length).isEqualTo(1);
+          assertThat(iterator.getKeys()).isNotNull();
+          assertThat(iterator.getKeys().length).isEqualTo(1);
 
-            total++;
-          }
-        } catch (final Exception e) {
-          fail(e);
+          total++;
         }
       }
 
@@ -312,25 +283,21 @@ public class TypeLSMTreeIndexTest extends TestHelper {
       int total = 0;
 
       final Collection<TypeIndex> indexes = database.getSchema().getType(TYPE_NAME).getAllIndexes(false);
-      for (final Index index : indexes) {
+      for (final RangeIndex index : indexes) {
         assertThat(index).isNotNull();
 
         final IndexCursor iterator;
-        try {
-          iterator = ((RangeIndex) index).iterator(true, new Object[] { 10 }, false);
+        iterator = index.iterator(true, new Object[] { 10 }, false);
 
-          assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
+        assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
 
-          while (iterator.hasNext()) {
-            assertThat(iterator.next()).isNotNull();
+        while (iterator.hasNext()) {
+          assertThat(iterator.next()).isNotNull();
 
-            assertThat(iterator.getKeys()).isNotNull();
-            assertThat(iterator.getKeys().length).isEqualTo(1);
+          assertThat(iterator.getKeys()).isNotNull();
+          assertThat(iterator.getKeys().length).isEqualTo(1);
 
-            total++;
-          }
-        } catch (final Exception e) {
-          fail(e);
+          total++;
         }
       }
 
@@ -345,24 +312,20 @@ public class TypeLSMTreeIndexTest extends TestHelper {
       int total = 0;
 
       final Collection<TypeIndex> indexes = database.getSchema().getType(TYPE_NAME).getAllIndexes(false);
-      for (final Index index : indexes) {
+      for (final RangeIndex index : indexes) {
         assertThat(index).isNotNull();
 
         final IndexCursor iterator;
-        try {
-          iterator = ((RangeIndex) index).iterator(false, new Object[] { 9 }, true);
-          assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
+        iterator = index.iterator(false, new Object[] { 9 }, true);
+        assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
 
-          while (iterator.hasNext()) {
-            assertThat(iterator.next()).isNotNull();
+        while (iterator.hasNext()) {
+          assertThat(iterator.next()).isNotNull();
 
-            assertThat(iterator.getKeys()).isNotNull();
-            assertThat(iterator.getKeys().length).isEqualTo(1);
+          assertThat(iterator.getKeys()).isNotNull();
+          assertThat(iterator.getKeys().length).isEqualTo(1);
 
-            total++;
-          }
-        } catch (final Exception e) {
-          fail(e);
+          total++;
         }
       }
 
@@ -377,24 +340,20 @@ public class TypeLSMTreeIndexTest extends TestHelper {
       int total = 0;
 
       final Collection<TypeIndex> indexes = database.getSchema().getType(TYPE_NAME).getAllIndexes(false);
-      for (final Index index : indexes) {
+      for (final RangeIndex index : indexes) {
         assertThat(index).isNotNull();
 
         final IndexCursor iterator;
-        try {
-          iterator = ((RangeIndex) index).iterator(false, new Object[] { 9 }, false);
-          assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
+        iterator = index.iterator(false, new Object[] { 9 }, false);
+        assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
 
-          while (iterator.hasNext()) {
-            assertThat(iterator.next()).isNotNull();
+        while (iterator.hasNext()) {
+          assertThat(iterator.next()).isNotNull();
 
-            assertThat(iterator.getKeys()).isNotNull();
-            assertThat(iterator.getKeys().length).isEqualTo(1);
+          assertThat(iterator.getKeys()).isNotNull();
+          assertThat(iterator.getKeys().length).isEqualTo(1);
 
-            total++;
-          }
-        } catch (final Exception e) {
-          fail(e);
+          total++;
         }
       }
 
@@ -409,29 +368,25 @@ public class TypeLSMTreeIndexTest extends TestHelper {
       int total = 0;
 
       final Collection<TypeIndex> indexes = database.getSchema().getType(TYPE_NAME).getAllIndexes(false);
-      for (final Index index : indexes) {
+      for (final RangeIndex index : indexes) {
         assertThat(index).isNotNull();
 
         final IndexCursor iterator;
-        try {
-          iterator = ((RangeIndex) index).range(true, new Object[] { 10 }, true, new Object[] { 19 }, true);
-          assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
+        iterator = index.range(true, new Object[] { 10 }, true, new Object[] { 19 }, true);
+        assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
 
-          while (iterator.hasNext()) {
-            final Identifiable value = iterator.next();
+        while (iterator.hasNext()) {
+          final Identifiable value = iterator.next();
 
-            assertThat(value).isNotNull();
+          assertThat(value).isNotNull();
 
-            final int fieldValue = (int) value.asDocument().get("id");
-            assertThat(fieldValue >= 10 && fieldValue <= 19).isTrue();
+          final int fieldValue = (int) value.asDocument().get("id");
+          assertThat(fieldValue >= 10 && fieldValue <= 19).isTrue();
 
-            assertThat(iterator.getKeys()).isNotNull();
-            assertThat(iterator.getKeys().length).isEqualTo(1);
+          assertThat(iterator.getKeys()).isNotNull();
+          assertThat(iterator.getKeys().length).isEqualTo(1);
 
-            total++;
-          }
-        } catch (final Exception e) {
-          fail(e);
+          total++;
         }
       }
 
@@ -446,29 +401,25 @@ public class TypeLSMTreeIndexTest extends TestHelper {
       int total = 0;
 
       final Collection<TypeIndex> indexes = database.getSchema().getType(TYPE_NAME).getAllIndexes(false);
-      for (final Index index : indexes) {
+      for (final RangeIndex index : indexes) {
         assertThat(index).isNotNull();
 
         final IndexCursor iterator;
-        try {
-          iterator = ((RangeIndex) index).range(true, new Object[] { 10 }, true, new Object[] { 19 }, false);
-          assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
+        iterator = index.range(true, new Object[] { 10 }, true, new Object[] { 19 }, false);
+        assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
 
-          while (iterator.hasNext()) {
-            final Identifiable value = iterator.next();
+        while (iterator.hasNext()) {
+          final Identifiable value = iterator.next();
 
-            assertThat(value).isNotNull();
+          assertThat(value).isNotNull();
 
-            final int fieldValue = (int) value.asDocument().get("id");
-            assertThat(fieldValue >= 10 && fieldValue < 19).isTrue();
+          final int fieldValue = (int) value.asDocument().get("id");
+          assertThat(fieldValue >= 10 && fieldValue < 19).isTrue();
 
-            assertThat(iterator.getKeys()).isNotNull();
-            assertThat(iterator.getKeys().length).isEqualTo(1);
+          assertThat(iterator.getKeys()).isNotNull();
+          assertThat(iterator.getKeys().length).isEqualTo(1);
 
-            total++;
-          }
-        } catch (final Exception e) {
-          fail(e);
+          total++;
         }
       }
 
@@ -483,29 +434,25 @@ public class TypeLSMTreeIndexTest extends TestHelper {
       int total = 0;
 
       final Collection<TypeIndex> indexes = database.getSchema().getType(TYPE_NAME).getAllIndexes(false);
-      for (final Index index : indexes) {
+      for (final RangeIndex index : indexes) {
         assertThat(index).isNotNull();
 
         final IndexCursor iterator;
-        try {
-          iterator = ((RangeIndex) index).range(true, new Object[] { 10 }, false, new Object[] { 19 }, true);
-          assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
+        iterator = index.range(true, new Object[] { 10 }, false, new Object[] { 19 }, true);
+        assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
 
-          while (iterator.hasNext()) {
-            final Identifiable value = iterator.next();
+        while (iterator.hasNext()) {
+          final Identifiable value = iterator.next();
 
-            assertThat(value).isNotNull();
+          assertThat(value).isNotNull();
 
-            final int fieldValue = (int) value.asDocument().get("id");
-            assertThat(fieldValue > 10 && fieldValue <= 19).isTrue();
+          final int fieldValue = (int) value.asDocument().get("id");
+          assertThat(fieldValue > 10 && fieldValue <= 19).isTrue();
 
-            assertThat(iterator.getKeys()).isNotNull();
-            assertThat(iterator.getKeys().length).isEqualTo(1);
+          assertThat(iterator.getKeys()).isNotNull();
+          assertThat(iterator.getKeys().length).isEqualTo(1);
 
-            total++;
-          }
-        } catch (final Exception e) {
-          fail(e);
+          total++;
         }
       }
 
@@ -520,29 +467,25 @@ public class TypeLSMTreeIndexTest extends TestHelper {
       int total = 0;
 
       final Collection<TypeIndex> indexes = database.getSchema().getType(TYPE_NAME).getAllIndexes(false);
-      for (final Index index : indexes) {
+      for (final RangeIndex index : indexes) {
         assertThat(index).isNotNull();
 
         final IndexCursor iterator;
-        try {
-          iterator = ((RangeIndex) index).range(false, new Object[] { 19 }, false, new Object[] { 10 }, true);
-          assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
+        iterator = index.range(false, new Object[] { 19 }, false, new Object[] { 10 }, true);
+        assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
 
-          while (iterator.hasNext()) {
-            final Identifiable value = iterator.next();
+        while (iterator.hasNext()) {
+          final Identifiable value = iterator.next();
 
-            assertThat(value).isNotNull();
+          assertThat(value).isNotNull();
 
-            final int fieldValue = (int) value.asDocument().get("id");
-            assertThat(fieldValue >= 10 && fieldValue < 19).isTrue();
+          final int fieldValue = (int) value.asDocument().get("id");
+          assertThat(fieldValue >= 10 && fieldValue < 19).isTrue();
 
-            assertThat(iterator.getKeys()).isNotNull();
-            assertThat(iterator.getKeys().length).isEqualTo(1);
+          assertThat(iterator.getKeys()).isNotNull();
+          assertThat(iterator.getKeys().length).isEqualTo(1);
 
-            total++;
-          }
-        } catch (final Exception e) {
-          fail(e);
+          total++;
         }
       }
 
@@ -557,29 +500,25 @@ public class TypeLSMTreeIndexTest extends TestHelper {
       int total = 0;
 
       final Collection<TypeIndex> indexes = database.getSchema().getType(TYPE_NAME).getAllIndexes(false);
-      for (final Index index : indexes) {
+      for (final RangeIndex index : indexes) {
         assertThat(index).isNotNull();
 
         final IndexCursor iterator;
-        try {
-          iterator = ((RangeIndex) index).range(true, new Object[] { 10 }, false, new Object[] { 19 }, false);
-          assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
+        iterator = index.range(true, new Object[] { 10 }, false, new Object[] { 19 }, false);
+        assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
 
-          while (iterator.hasNext()) {
-            final Identifiable value = iterator.next();
+        while (iterator.hasNext()) {
+          final Identifiable value = iterator.next();
 
-            assertThat(value).isNotNull();
+          assertThat(value).isNotNull();
 
-            final int fieldValue = (int) value.asDocument().get("id");
-            assertThat(fieldValue > 10 && fieldValue < 19).isTrue();
+          final int fieldValue = (int) value.asDocument().get("id");
+          assertThat(fieldValue > 10 && fieldValue < 19).isTrue();
 
-            assertThat(iterator.getKeys()).isNotNull();
-            assertThat(iterator.getKeys().length).isEqualTo(1);
+          assertThat(iterator.getKeys()).isNotNull();
+          assertThat(iterator.getKeys().length).isEqualTo(1);
 
-            total++;
-          }
-        } catch (final Exception e) {
-          fail(e);
+          total++;
         }
       }
 
@@ -594,29 +533,25 @@ public class TypeLSMTreeIndexTest extends TestHelper {
       int total = 0;
 
       final Collection<TypeIndex> indexes = database.getSchema().getType(TYPE_NAME).getAllIndexes(false);
-      for (final Index index : indexes) {
+      for (final RangeIndex index : indexes) {
         assertThat(index).isNotNull();
 
         final IndexCursor iterator;
-        try {
-          iterator = ((RangeIndex) index).range(false, new Object[] { 19 }, false, new Object[] { 10 }, false);
-          assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
+        iterator = index.range(false, new Object[] { 19 }, false, new Object[] { 10 }, false);
+        assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
 
-          while (iterator.hasNext()) {
-            final Identifiable value = iterator.next();
+        while (iterator.hasNext()) {
+          final Identifiable value = iterator.next();
 
-            assertThat(value).isNotNull();
+          assertThat(value).isNotNull();
 
-            final int fieldValue = (int) value.asDocument().get("id");
-            assertThat(fieldValue > 10 && fieldValue < 19).isTrue();
+          final int fieldValue = (int) value.asDocument().get("id");
+          assertThat(fieldValue > 10 && fieldValue < 19).isTrue();
 
-            assertThat(iterator.getKeys()).isNotNull();
-            assertThat(iterator.getKeys().length).isEqualTo(1);
+          assertThat(iterator.getKeys()).isNotNull();
+          assertThat(iterator.getKeys().length).isEqualTo(1);
 
-            total++;
-          }
-        } catch (final Exception e) {
-          fail(e);
+          total++;
         }
       }
 
@@ -643,86 +578,81 @@ public class TypeLSMTreeIndexTest extends TestHelper {
     LogManager.instance().log(this, Level.FINE, "%s Started with %d threads", null, getClass(), threads.length);
 
     for (int i = 0; i < threads.length; ++i) {
-      threads[i] = new Thread(new Runnable() {
-        @Override
-        public void run() {
-          try {
-            int threadInserted = 0;
-            for (int i = TOT; i < TOT + total; ++i) {
-              boolean keyPresent = false;
-              for (int retry = 0; retry < maxRetries && !keyPresent; ++retry) {
+      threads[i] = new Thread(() -> {
+        try {
+          int threadInserted = 0;
+          for (int i1 = TOT; i1 < TOT + total; ++i1) {
+            boolean keyPresent = false;
+            for (int retry = 0; retry < maxRetries && !keyPresent; ++retry) {
 
-                try {
-                  Thread.sleep(new Random().nextInt(10));
-                } catch (final InterruptedException e) {
-                  e.printStackTrace();
-                  Thread.currentThread().interrupt();
-                  return;
-                }
-
-                database.begin();
-                try {
-                  final MutableDocument v = database.newDocument(TYPE_NAME);
-                  v.set("id", i);
-                  v.set("name", "Jay");
-                  v.set("surname", "Miner");
-                  v.save();
-
-                  database.commit();
-
-                  threadInserted++;
-                  crossThreadsInserted.incrementAndGet();
-
-                  if (threadInserted % 1000 == 0)
-                    LogManager.instance()
-                        .log(this, Level.FINE, "%s Thread %d inserted %d records with key %d (total=%d)", null, getClass(),
-                            Thread.currentThread().threadId(), i, threadInserted, crossThreadsInserted.get());
-
-                  keyPresent = true;
-
-                } catch (final NeedRetryException e) {
-                  needRetryExceptions.incrementAndGet();
-                  assertThat(database.isTransactionActive()).isFalse();
-                  continue;
-                } catch (final DuplicatedKeyException e) {
-                  duplicatedExceptions.incrementAndGet();
-                  keyPresent = true;
-                  assertThat(database.isTransactionActive()).isFalse();
-                } catch (final Exception e) {
-                  LogManager.instance()
-                      .log(this, Level.SEVERE, "%s Thread %d Generic Exception", e, getClass(), Thread.currentThread().threadId());
-                  assertThat(database.isTransactionActive()).isFalse();
-                  return;
-                }
+              try {
+                Thread.sleep(new Random().nextInt(10));
+              } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
               }
 
-              if (!keyPresent)
-                LogManager.instance()
-                    .log(this, Level.WARNING, "%s Thread %d Cannot create key %d after %d retries! (total=%d)", null, getClass(),
-                        Thread.currentThread().threadId(), i, maxRetries, crossThreadsInserted.get());
+              database.begin();
+              try {
+                final MutableDocument v = database.newDocument(TYPE_NAME);
+                v.set("id", i1);
+                v.set("name", "Jay");
+                v.set("surname", "Miner");
+                v.save();
 
+                database.commit();
+
+                threadInserted++;
+                crossThreadsInserted.incrementAndGet();
+
+                if (threadInserted % 1000 == 0)
+                  LogManager.instance()
+                      .log(this, Level.FINE, "%s Thread %d inserted %d records with key %d (total=%d)", null, getClass(),
+                          Thread.currentThread().threadId(), i1, threadInserted, crossThreadsInserted.get());
+
+                keyPresent = true;
+
+              } catch (final NeedRetryException e) {
+                needRetryExceptions.incrementAndGet();
+                assertThat(database.isTransactionActive()).isFalse();
+
+              } catch (final DuplicatedKeyException e) {
+                duplicatedExceptions.incrementAndGet();
+                keyPresent = true;
+                assertThat(database.isTransactionActive()).isFalse();
+              } catch (final Exception e) {
+                LogManager.instance()
+                    .log(this, Level.SEVERE, "%s Thread %d Generic Exception", e, getClass(), Thread.currentThread().threadId());
+                assertThat(database.isTransactionActive()).isFalse();
+                return;
+              }
             }
 
-            LogManager.instance()
-                .log(this, Level.FINE, "%s Thread %d completed (inserted=%d)", null, getClass(), Thread.currentThread().threadId(),
-                    threadInserted);
+            if (!keyPresent)
+              LogManager.instance()
+                  .log(this, Level.WARNING, "%s Thread %d Cannot create key %d after %d retries! (total=%d)", null, getClass(),
+                      Thread.currentThread().threadId(), i1, maxRetries, crossThreadsInserted.get());
 
-          } catch (final Exception e) {
-            LogManager.instance().log(this, Level.SEVERE, "%s Thread %d Error", e, getClass(), Thread.currentThread().threadId());
           }
-        }
 
+          LogManager.instance()
+              .log(this, Level.FINE, "%s Thread %d completed (inserted=%d)", null, getClass(), Thread.currentThread().threadId(),
+                  threadInserted);
+
+        } catch (final Exception e) {
+          LogManager.instance().log(this, Level.SEVERE, "%s Thread %d Error", e, getClass(), Thread.currentThread().threadId());
+        }
       });
     }
 
-    for (int i = 0; i < threads.length; ++i)
-      threads[i].start();
+    for (Thread thread : threads)
+      thread.start();
 
-    for (int i = 0; i < threads.length; ++i) {
+    for (Thread thread : threads) {
       try {
-        threads[i].join();
+        thread.join();
       } catch (final InterruptedException e) {
-        e.printStackTrace();
+        //noop
       }
     }
 
@@ -741,26 +671,20 @@ public class TypeLSMTreeIndexTest extends TestHelper {
       final Map<Integer, Integer> result = new HashMap<>();
       database.scanType(TYPE_NAME, true, record -> {
         final int id = (int) record.get("id");
-        final Integer key = result.get(id);
-        if (key == null)
-          result.put(id, 1);
-        else
-          result.put(id, key + 1);
+        result.merge(id, 1, Integer::sum);
         return true;
       });
 
       LogManager.instance().log(this, Level.FINE, "FOUND %d ENTRIES", null, result.size());
 
-      final Iterator<Map.Entry<Integer, Integer>> it = result.entrySet().iterator();
-      while (it.hasNext()) {
-        final Map.Entry<Integer, Integer> next = it.next();
+      for (Map.Entry<Integer, Integer> next : result.entrySet()) {
         if (next.getValue() > 1)
           LogManager.instance().log(this, Level.FINE, "- %d = %d", null, next.getKey(), next.getValue());
       }
     }
 
     assertThat(crossThreadsInserted.get()).isEqualTo(total);
-//    Assertions.assertThat(needRetryExceptions.get() > 0).isTrue();
+    //    Assertions.assertThat(needRetryExceptions.get() > 0).isTrue();
     assertThat(duplicatedExceptions.get() > 0).isTrue();
 
     assertThat(database.countType(TYPE_NAME, true)).isEqualTo(startingWith + total);
@@ -841,8 +765,9 @@ public class TypeLSMTreeIndexTest extends TestHelper {
 
       final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(3).create();
       type.createProperty("id", Integer.class);
-      final Index typeIndex = database.getSchema()
-          .createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, TYPE_NAME, new String[] { "id" }, PAGE_SIZE);
+      final TypeIndex typeIndex = database.getSchema()
+          .buildTypeIndex(TYPE_NAME, new String[] { "id" }).withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(true)
+          .withPageSize(PAGE_SIZE).create();
 
       for (int i = 0; i < TOT; ++i) {
         final MutableDocument v = database.newDocument(TYPE_NAME);
@@ -856,7 +781,7 @@ public class TypeLSMTreeIndexTest extends TestHelper {
       database.commit();
       database.begin();
 
-      for (final IndexInternal index : ((TypeIndex) typeIndex).getIndexesOnBuckets()) {
+      for (final IndexInternal index : typeIndex.getIndexesOnBuckets()) {
 
         assertThat(index.getStats().get("pages")).isGreaterThan(1);
       }
@@ -869,29 +794,25 @@ public class TypeLSMTreeIndexTest extends TestHelper {
     for (int i = 0; i < TOT; ++i) {
       int total = 0;
 
-      for (final Index index : indexes) {
+      for (final RangeIndex index : indexes) {
         assertThat(index).isNotNull();
 
-        try {
-          final IndexCursor iterator;
-          iterator = ((RangeIndex) index).range(true, new Object[] { i }, true, new Object[] { i }, true);
-          assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
+        final IndexCursor iterator;
+        iterator = index.range(true, new Object[] { i }, true, new Object[] { i }, true);
+        assertThat((Iterable<? extends Identifiable>) iterator).isNotNull();
 
-          while (iterator.hasNext()) {
-            final Identifiable value = iterator.next();
+        while (iterator.hasNext()) {
+          final Identifiable value = iterator.next();
 
-            assertThat(value).isNotNull();
+          assertThat(value).isNotNull();
 
-            final int fieldValue = (int) value.asDocument().get("id");
-            assertThat(fieldValue).isEqualTo(i);
+          final int fieldValue = (int) value.asDocument().get("id");
+          assertThat(fieldValue).isEqualTo(i);
 
-            assertThat(iterator.getKeys()).isNotNull();
-            assertThat(iterator.getKeys().length).isEqualTo(1);
+          assertThat(iterator.getKeys()).isNotNull();
+          assertThat(iterator.getKeys().length).isEqualTo(1);
 
-            total++;
-          }
-        } catch (final Exception e) {
-          fail(e);
+          total++;
         }
       }
 


### PR DESCRIPTION
This pull request refactors several test classes to improve readability, maintainability, and consistency in error assertions. The main changes include replacing manual exception handling with AssertJ's fluent `assertThatThrownBy` assertions, updating index creation to use the new builder pattern, and cleaning up unused imports. These updates make the tests easier to understand and maintain, while also ensuring more robust error checking.

**Assertion and Error Handling Improvements:**
* Replaced manual try/catch and `fail()` error assertions with AssertJ's `assertThatThrownBy` for clearer and more concise exception testing in `MultipleDatabasesTest`, `DropIndexTest`, and `LSMTreeFullTextIndexTest`. [[1]](diffhunk://#diff-f6d6890bf9d7b99b0cf2d5cea8987927a129bfd1a8f2b2009e10aa0452531c82L59-R58) [[2]](diffhunk://#diff-f6d6890bf9d7b99b0cf2d5cea8987927a129bfd1a8f2b2009e10aa0452531c82L114-R112) [[3]](diffhunk://#diff-0a41fc4efe009dc0eb5a3c81c8089f28b23cf55cca86ae2357226f87f217b1ceL76-R114) [[4]](diffhunk://#diff-0a41fc4efe009dc0eb5a3c81c8089f28b23cf55cca86ae2357226f87f217b1ceL174-R190) [[5]](diffhunk://#diff-dae9a31d374330e656b9b100d0fa48de6215befe2592a678ffd8447b9e4678acL126-R134) [[6]](diffhunk://#diff-dae9a31d374330e656b9b100d0fa48de6215befe2592a678ffd8447b9e4678acL208-R226)

**Index Creation Refactor:**
* Updated index creation calls to use the builder pattern (`buildTypeIndex` and chained `.with*()` methods) instead of the older `createTypeIndex` method, improving clarity and flexibility in `DropIndexTest` and `LSMTreeFullTextIndexTest`. [[1]](diffhunk://#diff-0a41fc4efe009dc0eb5a3c81c8089f28b23cf55cca86ae2357226f87f217b1ceL55-R65) [[2]](diffhunk://#diff-0a41fc4efe009dc0eb5a3c81c8089f28b23cf55cca86ae2357226f87f217b1ceL136-R159) [[3]](diffhunk://#diff-0a41fc4efe009dc0eb5a3c81c8089f28b23cf55cca86ae2357226f87f217b1ceL202-R235) [[4]](diffhunk://#diff-dae9a31d374330e656b9b100d0fa48de6215befe2592a678ffd8447b9e4678acL51-R53) [[5]](diffhunk://#diff-dae9a31d374330e656b9b100d0fa48de6215befe2592a678ffd8447b9e4678acL143-R148)

**Import Cleanups:**
* Removed unused imports (such as `Assertions` and unused collections) and replaced wildcard imports with explicit ones for better code hygiene in all affected test files. [[1]](diffhunk://#diff-f6d6890bf9d7b99b0cf2d5cea8987927a129bfd1a8f2b2009e10aa0452531c82L27-L29) [[2]](diffhunk://#diff-0a41fc4efe009dc0eb5a3c81c8089f28b23cf55cca86ae2357226f87f217b1ceL29-L41) [[3]](diffhunk://#diff-dae9a31d374330e656b9b100d0fa48de6215befe2592a678ffd8447b9e4678acL30-R35) [[4]](diffhunk://#diff-c82482258722c83beee5f994d1f6bbddcf9e53cadc16d1e0a8cbb1ce0ce5b6e3L32-R39)

**Minor Test Improvements:**
* Improved formatting for assertion statements and updated method signatures for clarity, such as adding `throws InterruptedException` in `LSMTreeIndexCompactionTest`. [[1]](diffhunk://#diff-f6d6890bf9d7b99b0cf2d5cea8987927a129bfd1a8f2b2009e10aa0452531c82L102-R100) [[2]](diffhunk://#diff-0a41fc4efe009dc0eb5a3c81c8089f28b23cf55cca86ae2357226f87f217b1ceL120-R130) [[3]](diffhunk://#diff-0a41fc4efe009dc0eb5a3c81c8089f28b23cf55cca86ae2357226f87f217b1ceL248-R251) [[4]](diffhunk://#diff-c82482258722c83beee5f994d1f6bbddcf9e53cadc16d1e0a8cbb1ce0ce5b6e3L55-R57)

These changes collectively modernize the test codebase, reduce boilerplate, and make error handling more robust.