### PR TITLE
feat(logging): replace SLF4J logger with LogManager for consistent lo…

### DIFF
--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
@@ -71,8 +71,8 @@ import io.grpc.stub.BlockingClientCall;
 import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.ClientResponseObserver;
 import io.grpc.stub.StreamObserver;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.arcadedb.log.LogManager;
+import java.util.logging.Level;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -102,7 +102,6 @@ import java.util.function.Supplier;
  */
 public class RemoteGrpcDatabase extends RemoteDatabase {
 
-  private static final Logger logger = LoggerFactory.getLogger(RemoteGrpcDatabase.class);
 
   private final    ArcadeDbServiceGrpc.ArcadeDbServiceBlockingV2Stub blockingStub;
   private final    ArcadeDbServiceGrpc.ArcadeDbServiceStub           asyncStub;
@@ -254,7 +253,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
           CommitTransactionResponse response = blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
               .commitTransaction(request);
 
-          logger.debug("[After commit] Success: {} Committed: {}", response.getSuccess(), response.getCommitted());
+          LogManager.instance().log(this, Level.FINE, "[After commit] Success: %s Committed: %s", response.getSuccess(), response.getCommitted());
 
           if (!response.getSuccess()) {
             throw new TransactionException("Failed to commit transaction: " + response.getMessage());
@@ -304,7 +303,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
           RollbackTransactionResponse response = blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS)
               .rollbackTransaction(request);
 
-          logger.debug("[After rollback] Success: {} Committed: {}", response.getSuccess(), response.getRolledBack());
+          LogManager.instance().log(this, Level.FINE, "[After rollback] Success: %s Committed: %s", response.getSuccess(), response.getRolledBack());
 
           if (!response.getSuccess()) {
             throw new TransactionException("Failed to rollback transaction: " + response.getMessage());
@@ -340,8 +339,8 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
         .setCredentials(buildCredentials()).build();
 
     try {
-      if (logger.isDebugEnabled()) {
-        logger.debug("CLIENT deleteRecord: db={}, tx={}, rid={}", getName(), (transactionId != null), record.getIdentity());
+      if (LogManager.instance().isDebugEnabled()) {
+        LogManager.instance().log(this, Level.FINE, "CLIENT deleteRecord: db=%s, tx=%s, rid=%s", getName(), (transactionId != null), record.getIdentity());
       }
 
       final DeleteRecordResponse resp = callUnary("DeleteRecord",
@@ -368,8 +367,8 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
         .build();
 
     try {
-      if (logger.isDebugEnabled()) {
-        logger.debug("CLIENT deleteRecord: db={}, tx={}, rid={}, timeoutMs={}", getName(), (transactionId != null), rid, timeoutMs);
+      if (LogManager.instance().isDebugEnabled()) {
+        LogManager.instance().log(this, Level.FINE, "CLIENT deleteRecord: db=%s, tx=%s, rid=%s, timeoutMs=%s", getName(), (transactionId != null), rid, timeoutMs);
       }
 
       final DeleteRecordResponse res = callUnary("DeleteRecord",
@@ -441,15 +440,15 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
     try {
 
-      if (logger.isDebugEnabled())
-        logger.debug("CLIENT executeCommand: db={}, tx={}, cmdLen={}, params={}", getName(), (transactionId != null),
+      if (LogManager.instance().isDebugEnabled())
+        LogManager.instance().log(this, Level.FINE, "CLIENT executeCommand: db=%s, tx=%s, cmdLen=%s, params=%s", getName(), (transactionId != null),
             requestBuilder.getCommand().length(), requestBuilder.getParametersCount());
 
       final ExecuteCommandResponse response = callUnary("ExecuteCommand",
           () -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS).executeCommand(requestBuilder.build()));
 
-      if (logger.isDebugEnabled())
-        logger.debug("CLIENT executeCommand: success = {}", response.getSuccess());
+      if (LogManager.instance().isDebugEnabled())
+        LogManager.instance().log(this, Level.FINE, "CLIENT executeCommand: success = %s", response.getSuccess());
 
       if (!response.getSuccess()) {
         throw new DatabaseOperationException("Failed to execute command: " + response.getMessage());
@@ -533,8 +532,8 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
     try {
 
-      if (logger.isDebugEnabled()) {
-        logger.debug("CLIENT executeQuery: db={}, tx={}, queryLen={}, params={}", getName(), (transactionId != null),
+      if (LogManager.instance().isDebugEnabled()) {
+        LogManager.instance().log(this, Level.FINE, "CLIENT executeQuery: db=%s, tx=%s, queryLen=%s, params=%s", getName(), (transactionId != null),
             requestBuilder.getQuery().length(), requestBuilder.getParametersCount());
       }
 
@@ -544,11 +543,11 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
           () -> blockingStub.withDeadlineAfter(getTimeout(), TimeUnit.MILLISECONDS) // or getTimeout(MODE_QUERY)
               .executeQuery(req));
 
-      if (logger.isDebugEnabled()) {
+      if (LogManager.instance().isDebugEnabled()) {
         int _r = 0;
         for (var qr : response.getResultsList())
           _r += qr.getRecordsCount();
-        logger.debug("CLIENT executeQuery: results={}", _r);
+        LogManager.instance().log(this, Level.FINE, "CLIENT executeQuery: results=%s", _r);
       }
       return createGrpcResultSet(response);
     } catch (io.grpc.StatusException | io.grpc.StatusRuntimeException e) {
@@ -969,8 +968,8 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
         .setCredentials(buildCredentials()).build();
 
     try {
-      if (logger.isDebugEnabled()) {
-        logger.debug("CLIENT createRecord: db={}, txOpen={}, type={}, propCount={}, timeoutMs={}", getName(),
+      if (LogManager.instance().isDebugEnabled()) {
+        LogManager.instance().log(this, Level.FINE, "CLIENT createRecord: db=%s, txOpen=%s, type=%s, propCount=%s, timeoutMs=%s", getName(),
             (transactionId != null),
             cls, props.size(), timeoutMs);
       }
@@ -1029,8 +1028,8 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
         .setTransaction(TransactionContext.newBuilder().setBegin(true).setCommit(true)).setCredentials(buildCredentials()).build();
 
     try {
-      if (logger.isDebugEnabled()) {
-        logger.debug("CLIENT updateRecord(partial): db={}, txOpen={}, rid={}, timeoutMs={}", getName(), (transactionId != null),
+      if (LogManager.instance().isDebugEnabled()) {
+        LogManager.instance().log(this, Level.FINE, "CLIENT updateRecord(partial): db=%s, txOpen=%s, rid=%s, timeoutMs=%s", getName(), (transactionId != null),
             rid,
             timeoutMs);
       }
@@ -1060,8 +1059,8 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
         .setTransaction(TransactionContext.newBuilder().setBegin(true).setCommit(true)).setCredentials(buildCredentials()).build();
 
     try {
-      if (logger.isDebugEnabled()) {
-        logger.debug("CLIENT updateRecord(full): db={}, txOpen={}, rid={}, timeoutMs={}", getName(), (transactionId != null), rid,
+      if (LogManager.instance().isDebugEnabled()) {
+        LogManager.instance().log(this, Level.FINE, "CLIENT updateRecord(full): db=%s, txOpen=%s, rid=%s, timeoutMs=%s", getName(), (transactionId != null), rid,
             timeoutMs);
       }
 
@@ -1127,8 +1126,8 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
         .setCredentials(buildCredentials()).build();
 
     try {
-      if (logger.isDebugEnabled()) {
-        logger.debug("CLIENT lookupByRID: db={}, txOpen={}, rid={}, loadContent={}, timeoutMs={}", getName(),
+      if (LogManager.instance().isDebugEnabled()) {
+        LogManager.instance().log(this, Level.FINE, "CLIENT lookupByRID: db=%s, txOpen=%s, rid=%s, loadContent=%s, timeoutMs=%s", getName(),
             (transactionId != null),
             rid, loadContent, getTimeout());
       }
@@ -1191,8 +1190,8 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     final BulkInsertRequest req = BulkInsertRequest.newBuilder().setOptions(newOptions).addAllRows(protoRows).build();
 
     try {
-      if (logger.isDebugEnabled()) {
-        logger.debug("CLIENT insertBulk: rows={}, timeoutMs={}, tx={}", req.getRowsCount(), timeoutMs, (transactionId != null));
+      if (LogManager.instance().isDebugEnabled()) {
+        LogManager.instance().log(this, Level.FINE, "CLIENT insertBulk: rows=%s, timeoutMs=%s, tx=%s", req.getRowsCount(), timeoutMs, (transactionId != null));
       }
 
       // use callUnary so tx cross-thread checks + rpcSeq happen in one place
@@ -1256,8 +1255,8 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       }
     };
 
-    if (logger.isDebugEnabled()) {
-      logger.debug("CLIENT ingestStream: db={}, rows={}, chunkSize={}, timeoutMs={}", getName(), protoRows.size(), chunkSize,
+    if (LogManager.instance().isDebugEnabled()) {
+      LogManager.instance().log(this, Level.FINE, "CLIENT ingestStream: db=%s, rows=%s, chunkSize=%s, timeoutMs=%s", getName(), protoRows.size(), chunkSize,
           timeoutMs);
     }
 
@@ -1308,8 +1307,8 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       s = InsertSummary.newBuilder().setReceived(sent).build();
     }
 
-    if (logger.isDebugEnabled()) {
-      logger.debug("CLIENT ingestStream: completed; received={}", s.getReceived());
+    if (LogManager.instance().isDebugEnabled()) {
+      LogManager.instance().log(this, Level.FINE, "CLIENT ingestStream: completed; received=%s", s.getReceived());
     }
 
     return s;
@@ -1375,8 +1374,8 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     // Pre-map rows → proto
     final List<GrpcRecord> protoRows = rows.stream().map(mapper).collect(java.util.stream.Collectors.toList());
 
-    if (logger.isDebugEnabled()) {
-      logger.debug("CLIENT ingestBidi start: rows={}, chunkSize={}, maxInflight={}, timeoutMs={}", protoRows.size(), chunkSize,
+    if (LogManager.instance().isDebugEnabled()) {
+      LogManager.instance().log(this, Level.FINE, "CLIENT ingestBidi start: rows=%s, chunkSize=%s, maxInflight=%s, timeoutMs=%s", protoRows.size(), chunkSize,
           maxInflight, timeoutMs);
     }
 
@@ -1570,9 +1569,9 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
         throw new RemoteException("gRPC bidi stream failed: " + err.getMessage(), err);
       }
 
-      if (logger.isDebugEnabled()) {
+      if (LogManager.instance().isDebugEnabled()) {
         try {
-          logger.debug("CLIENT ingestBidi finished: sent={}, acked={}", sent.get(), acked.get());
+          LogManager.instance().log(this, Level.FINE, "CLIENT ingestBidi finished: sent=%s, acked=%s", sent.get(), acked.get());
         } catch (Throwable ignore) {
         }
       }
@@ -1599,8 +1598,8 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     GrpcRecord.Builder b = GrpcRecord.newBuilder();
     row.forEach((k, v) -> b.putProperties(k, objectToGrpcValue(v)));
     GrpcRecord rec = b.build();
-    if (logger.isDebugEnabled())
-      logger.debug("CLIENT toProtoRecordFromMap: {}", summarize(rec));
+    if (LogManager.instance().isDebugEnabled())
+      LogManager.instance().log(this, Level.FINE, "CLIENT toProtoRecordFromMap: %s", summarize(rec));
     return rec;
   }
 
@@ -1608,8 +1607,8 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
   private GrpcRecord toProtoRecordFromDbRecord(com.arcadedb.database.Record rec) {
     // Use ProtoUtils for proper conversion
     GrpcRecord out = ProtoUtils.toProtoRecord(rec);
-    if (logger.isDebugEnabled())
-      logger.debug("CLIENT toProtoRecordFromDbRecord: {}", summarize(out));
+    if (LogManager.instance().isDebugEnabled())
+      LogManager.instance().log(this, Level.FINE, "CLIENT toProtoRecordFromDbRecord: %s", summarize(out));
     return out;
   }
 
@@ -1808,8 +1807,8 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
 
   private Object grpcValueToObject(GrpcValue grpcValue) {
     Object out = ProtoUtils.fromGrpcValue(grpcValue);
-    if (logger.isDebugEnabled())
-      logger.debug("CLIENT decode grpcValueToObject: {} -> {}", summarize(grpcValue), summarize(out));
+    if (LogManager.instance().isDebugEnabled())
+      LogManager.instance().log(this, Level.FINE, "CLIENT decode grpcValueToObject: %s -> %s", summarize(grpcValue), summarize(out));
     return out;
   }
 
@@ -1930,10 +1929,10 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
   }
 
   private void logTx(String phase, String rpcOp) {
-    if (debugTx == null || !logger.isDebugEnabled())
+    if (debugTx == null || !LogManager.instance().isDebugEnabled())
       return;
     TxDebug d = debugTx;
-    logger.debug("TXDBG {} db={} tx#{} label={} owner={} now={} rpcOp={} rpcSeq={} beginSent={} committed={} rolledBack={}", phase,
+    LogManager.instance().log(this, Level.FINE, "TXDBG %s db=%s tx#%s label=%s owner=%s now=%s rpcOp=%s rpcSeq=%s beginSent=%s committed=%s rolledBack=%s", phase,
         d.dbName,
         d.id, d.txLabel, tidName(d.ownerThread), tidName(Thread.currentThread()), rpcOp, d.rpcSeq.get(), d.beginRpcSent,
         d.committed,
@@ -1946,7 +1945,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
       return;
     Thread now = Thread.currentThread();
     if (now != d.ownerThread) {
-      logger.warn("TXDBG CROSS-THREAD {} db={} tx#{} owner={} now={} label={} (begin site follows)", where, d.dbName, d.id,
+      LogManager.instance().log(this, Level.WARNING, "TXDBG CROSS-THREAD %s db=%s tx#%s owner=%s now=%s label=%s (begin site follows)", where, d.dbName, d.id,
           tidName(d.ownerThread), tidName(now), d.txLabel, d.beginSite);
     }
   }

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/StreamingResultSet.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/StreamingResultSet.java
@@ -5,8 +5,8 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.server.grpc.GrpcRecord;
 import com.arcadedb.server.grpc.QueryResult;
 import io.grpc.stub.BlockingClientCall;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.arcadedb.log.LogManager;
+import java.util.logging.Level;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -20,7 +20,6 @@ import java.util.concurrent.atomic.AtomicLong;
  * Supports both Record results and projection/aggregation results.
  */
 class StreamingResultSet implements ResultSet {
-  private static final Logger logger = LoggerFactory.getLogger(StreamingResultSet.class);
 
   private final BlockingClientCall<?, QueryResult> stream;
   private final RemoteGrpcDatabase                 db;
@@ -57,8 +56,8 @@ class StreamingResultSet implements ResultSet {
       while (stream.hasNext()) {
         final QueryResult queryResult = stream.read();
 
-        if (logger.isDebugEnabled()) {
-          logger.debug("Received batch with {} records, isLastBatch={}", queryResult.getRecordsCount(),
+        if (LogManager.instance().isDebugEnabled()) {
+          LogManager.instance().log(this, Level.FINE, "Received batch with %d records, isLastBatch=%s", queryResult.getRecordsCount(),
               queryResult.getIsLastBatch());
         }
 
@@ -133,7 +132,7 @@ class StreamingResultSet implements ResultSet {
         stream.read();
       }
     } catch (Exception e) {
-      logger.debug("Exception while draining stream during close", e);
+      LogManager.instance().log(this, Level.FINE, "Exception while draining stream during close: %s", e.getMessage());
     }
 
     // BlockingClientCall doesn't implement AutoCloseable

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/utils/ProtoUtils.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/utils/ProtoUtils.java
@@ -10,15 +10,14 @@ import com.arcadedb.server.grpc.GrpcValue;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.ToNumberPolicy;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.arcadedb.log.LogManager;
+import java.util.logging.Level;
 
 import java.util.Collection;
 import java.util.Map;
 
 public class ProtoUtils {
 
-  private static final Logger logger = LoggerFactory.getLogger(ProtoUtils.class);
 
   private static final Gson GSON = new GsonBuilder().disableHtmlEscaping().serializeNulls().
       setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE).create();
@@ -46,7 +45,7 @@ public class ProtoUtils {
       return "null";
     try {
       if (o instanceof CharSequence s) {
-        if (logger.isTraceEnabled() || LOG_SHOW_STR_AT_DEBUG) {
+        if (LogManager.instance().isDebugEnabled() || LOG_SHOW_STR_AT_DEBUG) {
           String txt = s.toString();
           return "String(" + s.length() + ")=\"" + (txt.length() > LOG_STR_PREVIEW ? txt.substring(0, LOG_STR_PREVIEW) + "…" : txt)
               + "\"";
@@ -81,7 +80,7 @@ public class ProtoUtils {
       return "DOUBLE(" + v.getDoubleValue() + ")";
     case STRING_VALUE: {
       String s = v.getStringValue();
-      if (logger.isTraceEnabled() || LOG_SHOW_STR_AT_DEBUG) {
+      if (LogManager.instance().isDebugEnabled() || LOG_SHOW_STR_AT_DEBUG) {
         String txt = s;
         return "STRING(" + s.length() + ")=\"" + (txt.length() > LOG_STR_PREVIEW ? txt.substring(0, LOG_STR_PREVIEW) + "…" : txt)
             + "\"";
@@ -109,14 +108,14 @@ public class ProtoUtils {
   }
 
   private static GrpcValue dbgEnc(String where, Object in, GrpcValue out) {
-    if (logger.isDebugEnabled())
-      logger.debug("CLIENT GRPC-ENC [{}]{} in={} -> out={}", where, ctx(), summarizeJava(in), summarizeGrpc(out));
+    if (LogManager.instance().isDebugEnabled())
+      LogManager.instance().log(ProtoUtils.class, Level.FINE, "CLIENT GRPC-ENC [%s]%s in=%s -> out=%s", where, ctx(), summarizeJava(in), summarizeGrpc(out));
     return out;
   }
 
   private static Object dbgDec(String where, GrpcValue in, Object out) {
-    if (logger.isDebugEnabled())
-      logger.debug("CLIENT GRPC-DEC [{}]{} in={} -> out={}", where, ctx(), summarizeGrpc(in), summarizeJava(out));
+    if (LogManager.instance().isDebugEnabled())
+      LogManager.instance().log(ProtoUtils.class, Level.FINE, "CLIENT GRPC-DEC [%s]%s in=%s -> out=%s", where, ctx(), summarizeGrpc(in), summarizeJava(out));
     return out;
   }
 

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/CompressionAwareService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/CompressionAwareService.java
@@ -2,14 +2,13 @@ package com.arcadedb.server.grpc;
 
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.arcadedb.log.LogManager;
+import java.util.logging.Level;
 
 /**
  * Enhanced compression-aware service wrapper
  */
 class CompressionAwareService {
-  private static final Logger logger = LoggerFactory.getLogger(CompressionAwareService.class);
 
   /**
    * Force compression for a specific response
@@ -18,7 +17,7 @@ class CompressionAwareService {
     if (responseObserver instanceof ServerCallStreamObserver) {
       ServerCallStreamObserver<T> serverObserver = (ServerCallStreamObserver<T>) responseObserver;
       serverObserver.setCompression(compression);
-      logger.debug("Set response compression to: {}", compression);
+      LogManager.instance().log(CompressionAwareService.class, Level.FINE, "Set response compression to: %s", compression);
     }
   }
 

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcCompressionInterceptor.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcCompressionInterceptor.java
@@ -1,5 +1,6 @@
 package com.arcadedb.server.grpc;
 
+import com.arcadedb.log.LogManager;
 import io.grpc.Context;
 import io.grpc.Contexts;
 import io.grpc.ForwardingServerCall;
@@ -7,27 +8,23 @@ import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import java.util.logging.Level;
 
 /**
  * Compression interceptor that can force compression based on configuration
  */
 class GrpcCompressionInterceptor implements ServerInterceptor {
-  private static final Logger logger = LoggerFactory.getLogger(GrpcCompressionInterceptor.class);
 
   // Context key to store compression info
-  public static final Context.Key<CompressionInfo> COMPRESSION_KEY = Context.key("compression-info");
-
-  private static final Metadata.Key<String> GRPC_ACCEPT_ENCODING = Metadata.Key.of("grpc-accept-encoding",
+  public static final  Context.Key<CompressionInfo> COMPRESSION_KEY      = Context.key("compression-info");
+  private static final Metadata.Key<String>         GRPC_ACCEPT_ENCODING = Metadata.Key.of("grpc-accept-encoding",
       Metadata.ASCII_STRING_MARSHALLER);
-  private static final Metadata.Key<String> GRPC_ENCODING        = Metadata.Key.of("grpc-encoding",
+  private static final Metadata.Key<String>         GRPC_ENCODING        = Metadata.Key.of("grpc-encoding",
       Metadata.ASCII_STRING_MARSHALLER);
-
-  private final boolean forceCompression;
-  private final String  compressionType;
-
-  private final int minMessageSizeForCompression;
+  private final        boolean                      forceCompression;
+  private final        String                       compressionType;
+  private final        int                          minMessageSizeForCompression;
 
   public GrpcCompressionInterceptor(boolean forceCompression, String compressionType, int minMessageSizeBytes) {
     this.forceCompression = forceCompression;
@@ -65,7 +62,9 @@ class GrpcCompressionInterceptor implements ServerInterceptor {
           super.setCompression("gzip");
           setMessageCompression(true);
 
-          logger.debug("Forced {} compression for method: {}", compressionType, methodName);
+          LogManager.instance()
+              .log(GrpcCompressionInterceptor.this, Level.FINE, "Forced %s compression for method: %s", compressionType,
+                  methodName);
 
           compressionSet = true;
         }
@@ -85,7 +84,9 @@ class GrpcCompressionInterceptor implements ServerInterceptor {
             setMessageCompression(true);
             compressionSet = true;
 
-            logger.debug("Forced {} compression for method: {}", compressionType, methodName);
+            LogManager.instance()
+                .log(GrpcCompressionInterceptor.this, Level.FINE, "Forced %s compression for method: %s", compressionType,
+                    methodName);
           }
         }
 

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcMetricsInterceptor.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcMetricsInterceptor.java
@@ -11,15 +11,11 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Metrics interceptor for gRPC requests using Micrometer
  */
 class GrpcMetricsInterceptor implements ServerInterceptor {
-
-  private static final Logger logger = LoggerFactory.getLogger(GrpcMetricsInterceptor.class);
 
   private final MeterRegistry meterRegistry;
   private final Counter       requestCounter;

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcServerPlugin.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcServerPlugin.java
@@ -1,6 +1,7 @@
 package com.arcadedb.server.grpc;
 
 import com.arcadedb.ContextConfiguration;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.ServerPlugin;
 import com.arcadedb.server.security.ServerSecurity;
@@ -17,12 +18,11 @@ import io.grpc.health.v1.HealthCheckResponse;
 import io.grpc.protobuf.services.HealthStatusManager;
 import io.grpc.protobuf.services.ProtoReflectionService;
 import io.grpc.xds.XdsServerBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 
 /**
  * ArcadeDB gRPC Server Plugin
@@ -41,8 +41,6 @@ import java.util.concurrent.TimeUnit;
  * - grpc.health.enabled: Enable health checking (default: true)
  */
 public class GrpcServerPlugin implements ServerPlugin {
-
-  private static final Logger logger = LoggerFactory.getLogger(GrpcServerPlugin.class);
 
   private ArcadeDBServer      arcadeServer;
   private Server              grpcServer;
@@ -80,7 +78,7 @@ public class GrpcServerPlugin implements ServerPlugin {
     // Get configuration values with defaults
     boolean enabled = getConfigBoolean(config, CONFIG_ENABLED, true);
     if (!enabled) {
-      logger.info("gRPC server is disabled");
+      LogManager.instance().log(this, Level.INFO, "gRPC server is disabled");
       return;
     }
 
@@ -88,24 +86,19 @@ public class GrpcServerPlugin implements ServerPlugin {
 
     try {
       switch (mode) {
-      case "standard":
-        startStandardServer(config);
-        break;
-      case "xds":
-        startXdsServer(config);
-        break;
-      case "both":
+      case "standard" -> startStandardServer(config);
+      case "xds" -> startXdsServer(config);
+      case "both" -> {
         startStandardServer(config);
         startXdsServer(config);
-        break;
-      default:
-        logger.error("Invalid gRPC mode: {}. Use 'standard', 'xds', or 'both'", mode);
+      }
+      default -> LogManager.instance().log(this, Level.SEVERE, "Invalid gRPC mode: %s. Use 'standard', 'xds', or 'both'", mode);
       }
 
       registerShutdownHook();
 
     } catch (IOException e) {
-      logger.error("Failed to start gRPC server", e);
+      LogManager.instance().log(this, Level.SEVERE, "Failed to start gRPC server", e);
       throw new RuntimeException("Failed to start gRPC server", e);
     }
   }
@@ -153,7 +146,7 @@ public class GrpcServerPlugin implements ServerPlugin {
     }
 
     status.append(")");
-    logger.info(status.toString());
+    LogManager.instance().log(this, Level.INFO, status.toString());
   }
 
   private void startXdsServer(ContextConfiguration config) throws IOException {
@@ -171,7 +164,7 @@ public class GrpcServerPlugin implements ServerPlugin {
         .maxInboundMetadataSize(32 * 1024 * 1024)
         .build().start();
 
-    logger.info("gRPC XDS server started on port {} (xDS management enabled)", port);
+    LogManager.instance().log(this, Level.INFO, "gRPC XDS server started on port %s (xDS management enabled)", port);
   }
 
   private void configureServer(ServerBuilder<?> serverBuilder, ContextConfiguration config) {
@@ -238,7 +231,8 @@ public class GrpcServerPlugin implements ServerPlugin {
     String keyPath = getConfigString(config, CONFIG_TLS_KEY, null);
 
     if (certPath == null || keyPath == null) {
-      logger.warn("TLS enabled but certificate or key path not provided. Falling back to insecure.");
+      LogManager.instance()
+          .log(this, Level.WARNING, "TLS enabled but certificate or key path not provided. Falling back to insecure.");
       return ServerBuilder.forPort(port);
     }
 
@@ -246,7 +240,7 @@ public class GrpcServerPlugin implements ServerPlugin {
     File keyFile = new File(keyPath);
 
     if (!certFile.exists() || !keyFile.exists()) {
-      logger.warn("TLS certificate or key file not found. Falling back to insecure.");
+      LogManager.instance().log(this, Level.WARNING, "TLS certificate or key file not found. Falling back to insecure.");
       return ServerBuilder.forPort(port);
     }
 
@@ -255,7 +249,7 @@ public class GrpcServerPlugin implements ServerPlugin {
       // Use Grpc.newServerBuilderForPort for TLS
       return Grpc.newServerBuilderForPort(port, credentials);
     } catch (Exception e) {
-      logger.error("Failed to configure TLS", e);
+      LogManager.instance().log(this, Level.SEVERE, "Failed to configure TLS", e);
       return ServerBuilder.forPort(port);
     }
   }
@@ -265,7 +259,8 @@ public class GrpcServerPlugin implements ServerPlugin {
     String keyPath = getConfigString(config, CONFIG_TLS_KEY, null);
 
     if (certPath == null || keyPath == null) {
-      logger.warn("TLS enabled but certificate or key path not provided. Using insecure credentials.");
+      LogManager.instance()
+          .log(this, Level.WARNING, "TLS enabled but certificate or key path not provided. Using insecure credentials.");
       return InsecureServerCredentials.create();
     }
 
@@ -273,21 +268,21 @@ public class GrpcServerPlugin implements ServerPlugin {
     File keyFile = new File(keyPath);
 
     if (!certFile.exists() || !keyFile.exists()) {
-      logger.warn("TLS certificate or key file not found. Using insecure credentials.");
+      LogManager.instance().log(this, Level.WARNING, "TLS certificate or key file not found. Using insecure credentials.");
       return InsecureServerCredentials.create();
     }
 
     try {
       return TlsServerCredentials.create(certFile, keyFile);
     } catch (Exception e) {
-      logger.error("Failed to configure TLS credentials", e);
+      LogManager.instance().log(this, Level.SEVERE, "Failed to configure TLS credentials", e);
       return InsecureServerCredentials.create();
     }
   }
 
   private void registerShutdownHook() {
     shutdownHook = new Thread(() -> {
-      logger.info("Shutting down gRPC server...");
+      LogManager.instance().log(GrpcServerPlugin.this, Level.INFO, "Shutting down gRPC server...");
       stopService();
     });
     Runtime.getRuntime().addShutdownHook(shutdownHook);
@@ -308,9 +303,9 @@ public class GrpcServerPlugin implements ServerPlugin {
       if (grpcService != null) {
         try {
           grpcService.close();
-          logger.info("gRPC service closed and database connections released");
+          LogManager.instance().log(this, Level.INFO, "gRPC service closed and database connections released");
         } catch (Exception e) {
-          logger.error("Error closing gRPC service", e);
+          LogManager.instance().log(this, Level.SEVERE, "Error closing gRPC service", e);
         }
       }
 
@@ -321,7 +316,7 @@ public class GrpcServerPlugin implements ServerPlugin {
           grpcServer.shutdownNow();
           grpcServer.awaitTermination(5, TimeUnit.SECONDS);
         }
-        logger.info("Standard gRPC server stopped");
+        LogManager.instance().log(this, Level.INFO, "Standard gRPC server stopped");
       }
 
       if (xdsServer != null) {
@@ -330,7 +325,7 @@ public class GrpcServerPlugin implements ServerPlugin {
           xdsServer.shutdownNow();
           xdsServer.awaitTermination(5, TimeUnit.SECONDS);
         }
-        logger.info("XDS gRPC server stopped");
+        LogManager.instance().log(this, Level.INFO, "XDS gRPC server stopped");
       }
 
       // Remove shutdown hook if it exists
@@ -344,7 +339,7 @@ public class GrpcServerPlugin implements ServerPlugin {
 
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      logger.error("Interrupted while shutting down gRPC server", e);
+      LogManager.instance().log(this, Level.SEVERE, "Interrupted while shutting down gRPC server", e);
     }
   }
 
@@ -373,7 +368,7 @@ public class GrpcServerPlugin implements ServerPlugin {
       try {
         return Integer.parseInt(value);
       } catch (NumberFormatException e) {
-        logger.warn("Invalid integer value for {}: {}", key, value);
+        LogManager.instance().log(this, Level.WARNING, "Invalid integer value for %s: %s", key, value);
       }
     }
     return defaultValue;


### PR DESCRIPTION
This pull request refactors logging throughout the `ArcadeDbGrpcService` class to replace usage of SLF4J's `Logger` with ArcadeDB's own `LogManager`. All log statements have been updated to use `LogManager.instance().log(...)` with appropriate log levels, and message formatting has been adapted to use `%s` placeholders. Additionally, some conditional logging checks (`logger.isDebugEnabled()`) have been replaced with unconditional logging.

### Logging Refactor

* Replaced all SLF4J `Logger` imports and usage with ArcadeDB's `LogManager` for logging across the service, including error, debug, and info messages. [[1]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddR14) [[2]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL33-L47)
* Updated all log statements in methods such as `close`, `executeCommand`, `updateRecord`, `executeQuery`, `beginTransaction`, and `commitTransaction` to use `LogManager.instance().log(...)` with Java `Level` constants (e.g., `Level.FINE`, `Level.SEVERE`) and `%s` formatting. [[1]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL87-R85) [[2]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL100-R98) [[3]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL128-R126) [[4]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL144-R152) [[5]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL195-R193) [[6]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL214-R230) [[7]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL243-R244) [[8]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL431-R436) [[9]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL453-R454) [[10]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL463-R464) [[11]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL480-R481) [[12]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL507-R508) [[13]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL609-R611) [[14]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL620-R622) [[15]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL631-R664) [[16]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL673-R676) [[17]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL688-R691) [[18]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL698-R707)
* Removed all conditional checks for debug logging (`logger.isDebugEnabled()`), replacing them with unconditional calls to `LogManager` for debug-level logs. [[1]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL714-R731) [[2]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL737-R743) [[3]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL748-R758) [[4]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL760-R773)

### Error Handling

* Updated error logging in `catch` blocks to use `LogManager` instead of `logger.error`, ensuring consistent error reporting throughout the service. [[1]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL87-R85) [[2]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL100-R98) [[3]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL243-R244) [[4]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL507-R508) [[5]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL698-R707) [[6]](diffhunk://#diff-ad754f93ad1e3b82341252a607a76ed59e0164eaeb6ef7241662a0945da371ddL748-R758)

These changes standardize logging within the gRPC service to use ArcadeDB's preferred logging mechanism, improving consistency and maintainability.