### PR TITLE
fix: consistent http repsonses

### DIFF
--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -215,17 +215,6 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
       throw new ServerSecurityException("Only root user is authorized to execute server commands");
   }
 
-  protected JSONObject createResult(final SecurityUser user, final Database database) {
-    final JSONObject json = new JSONObject();
-    if (database != null)
-      json.setDateFormat(database.getSchema().getDateFormat())
-          .setDateTimeFormat(database.getSchema().getDateTimeFormat());
-
-    json.put("user", user.getName()).put("version", Constants.getVersion())
-        .put("serverName", httpServer.getServer().getServerName());
-    return json;
-  }
-
   protected String decode(final String command) {
     return command.replace("&amp;", " ").replace("&lt;", "<").replace("&gt;", ">").replace("&quot;", "\"").replace("&#039;", "'");
   }

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -18,7 +18,6 @@
  */
 package com.arcadedb.server.http.handler;
 
-import com.arcadedb.Constants;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetDatabasesHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetDatabasesHandler.java
@@ -42,7 +42,7 @@ public class GetDatabasesHandler extends AbstractServerHttpHandler {
     if (!allowedDatabases.contains("*"))
       installedDatabases.retainAll(allowedDatabases);
 
-    final JSONObject response = (new JSONObject()).put("result", new JSONArray(installedDatabases));
+    final JSONObject response = new JSONObject().put("result", new JSONArray(installedDatabases));
 
     Metrics.counter("http.list-databases").increment();
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetDatabasesHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetDatabasesHandler.java
@@ -42,10 +42,10 @@ public class GetDatabasesHandler extends AbstractServerHttpHandler {
     if (!allowedDatabases.contains("*"))
       installedDatabases.retainAll(allowedDatabases);
 
-    final JSONObject result = createResult(user, null).put("result", new JSONArray(installedDatabases));
+    final JSONObject response = (new JSONObject()).put("result", new JSONArray(installedDatabases));
 
     Metrics.counter("http.list-databases").increment();
 
-    return new ExecutionResponse(200, result.toString());
+    return new ExecutionResponse(200, response.toString());
   }
 }

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetServerHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetServerHandler.java
@@ -46,8 +46,8 @@ public class GetServerHandler extends AbstractServerHttpHandler {
 
   @Override
   public ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user, final JSONObject payload) {
-    final JSONObject response = (new JSONObject()).put("version", Constants.getVersion())
-                                                  .put("serverName", httpServer.getServer().getServerName());
+    final JSONObject response = new JSONObject().put("version", Constants.getVersion())
+                                                .put("serverName", httpServer.getServer().getServerName());
 
     final String mode = getQueryParameter(exchange, "mode", "default");
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetServerHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetServerHandler.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.http.handler;
 
+import com.arcadedb.Constants;
 import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.Profiler;
@@ -45,12 +46,13 @@ public class GetServerHandler extends AbstractServerHttpHandler {
 
   @Override
   public ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user, final JSONObject payload) {
-    final JSONObject response = createResult(user, null);
+    final JSONObject response = (new JSONObject()).put("version", Constants.getVersion())
+                                                  .put("serverName", httpServer.getServer().getServerName());
 
     final String mode = getQueryParameter(exchange, "mode", "default");
 
     if ("basic".equals(mode)) {
-      // JUST RETURN BASIC SERVER DATA
+      // JUST RETURN BASIC SERVER DATA (name and version)
     } else if ("default".equals(mode)) {
       exportMetrics(response);
       exportSettings(response);

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -141,7 +141,7 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     if (!allowedDatabases.contains("*"))
       installedDatabases.retainAll(allowedDatabases);
 
-    final JSONObject response = createResult(user, null).put("result", new JSONArray(installedDatabases));
+    final JSONObject response = (new JSONObject()).put("result", new JSONArray(installedDatabases));
 
     return new ExecutionResponse(200, response.toString());
   }

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -141,7 +141,7 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     if (!allowedDatabases.contains("*"))
       installedDatabases.retainAll(allowedDatabases);
 
-    final JSONObject response = (new JSONObject()).put("result", new JSONArray(installedDatabases));
+    final JSONObject response = new JSONObject().put("result", new JSONArray(installedDatabases));
 
     return new ExecutionResponse(200, response.toString());
   }


### PR DESCRIPTION
## What does this PR do?

This change:

* removes the `createResult` method in the `AbstractHttpServerHandler` class as it is now unneeded.
* adds server name and server version to the responses of the `/server` GET query (which was before done via `createResult`
* removes meta information from the `/server` POST commands
* removes meta information from the `/databases` GET query

## Motivation

I observed differing contents in HTTP responses in terms of non-result content.

## Related issues

https://github.com/ArcadeData/arcadedb/issues/2398

## Additional Notes

I will be updating the docs accordingly

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
