### PR TITLE
fix: adapt test so it does not fail randomly in MacOS

### DIFF
--- a/engine/src/test/java/com/arcadedb/query/sql/function/sql/SQLFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/function/sql/SQLFunctionsTest.java
@@ -437,8 +437,10 @@ public class SQLFunctionsTest {
 
     database.transaction(() -> {
       final ResultSet result2 = database.command("sql", "update Account set created = date()");
-      assertThat(result2.next().<Long>getProperty("count")).isEqualTo(tot);
     });
+    result = database.command("sql", "select count(*) as tot from Account where created is not null");
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.next().<Long>getProperty("tot")).isEqualTo(tot);
 
     final String pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
 //    final String pattern = GlobalConfiguration.DATE_TIME_FORMAT.getValueAsString();


### PR DESCRIPTION
## What does this PR do?

This change fixes the `queryDate` test from failing randomly under MacOS by moving the assertion out of the transaction.

## Motivation

Often failing test during dev

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
