### PR TITLE
chore: update license headers to Apache-2.0

### DIFF
--- a/e2e-js/package-lock.json
+++ b/e2e-js/package-lock.json
@@ -1,6 +1,7 @@
 {
   "name": "js",
   "version": "1.0.0",
+  "license": "Apache-2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/e2e-js/package.json
+++ b/e2e-js/package.json
@@ -1,13 +1,13 @@
 {
   "name": "js",
   "version": "1.0.0",
+  "license": "Apache-2.0",
   "main": "index.js",
   "scripts": {
     "test": "jest --runInBand --ci --reporters=default --reporters=jest-junit --detectOpenHandles"
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
   "description": "",
   "dependencies": {
     "pg": "^8.16.0"

--- a/e2e-studio/fixtures/test-fixtures.ts
+++ b/e2e-studio/fixtures/test-fixtures.ts
@@ -1,18 +1,19 @@
-///
-/// Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
-///
-/// Licensed under the Apache License, Version 2.0 (the "License");
-/// you may not use this file except in compliance with the License.
-/// You may obtain a copy of the License at
-///
-///     http://www.apache.org/licenses/LICENSE-2.0
-///
-/// Unless required by applicable law or agreed to in writing, software
-/// distributed under the License is distributed on an "AS IS" BASIS,
-/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-/// See the License for the specific language governing permissions and
-/// limitations under the License.
-///
+/**
+* Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
 
 /**
  * Playwright Test Fixtures for ArcadeDB Studio E2E Tests

--- a/e2e-studio/global-setup.ts
+++ b/e2e-studio/global-setup.ts
@@ -1,18 +1,19 @@
-///
-/// Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
-///
-/// Licensed under the Apache License, Version 2.0 (the "License");
-/// you may not use this file except in compliance with the License.
-/// You may obtain a copy of the License at
-///
-///     http://www.apache.org/licenses/LICENSE-2.0
-///
-/// Unless required by applicable law or agreed to in writing, software
-/// distributed under the License is distributed on an "AS IS" BASIS,
-/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-/// See the License for the specific language governing permissions and
-/// limitations under the License.
-///
+/**
+* Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
 
 import { chromium, FullConfig } from '@playwright/test';
 import { GenericContainer, StartedTestContainer, Wait } from 'testcontainers';

--- a/e2e-studio/global-teardown.ts
+++ b/e2e-studio/global-teardown.ts
@@ -1,18 +1,19 @@
-///
-/// Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
-///
-/// Licensed under the Apache License, Version 2.0 (the "License");
-/// you may not use this file except in compliance with the License.
-/// You may obtain a copy of the License at
-///
-///     http://www.apache.org/licenses/LICENSE-2.0
-///
-/// Unless required by applicable law or agreed to in writing, software
-/// distributed under the License is distributed on an "AS IS" BASIS,
-/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-/// See the License for the specific language governing permissions and
-/// limitations under the License.
-///
+/**
+* Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
 
 import { FullConfig } from '@playwright/test';
 

--- a/e2e-studio/package-lock.json
+++ b/e2e-studio/package-lock.json
@@ -1,6 +1,7 @@
 {
   "name": "arcadedb-e2e-tests",
   "version": "1.0.0",
+  "license": "Apache-2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/e2e-studio/package.json
+++ b/e2e-studio/package.json
@@ -1,6 +1,7 @@
 {
   "name": "arcadedb-e2e-tests",
   "version": "1.0.0",
+  "license": "Apache-2.0",
   "description": "End-to-end tests for ArcadeDB Studio",
   "scripts": {
     "test": "playwright test",

--- a/e2e-studio/playwright.config.ts
+++ b/e2e-studio/playwright.config.ts
@@ -1,18 +1,19 @@
-///
-/// Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
-///
-/// Licensed under the Apache License, Version 2.0 (the "License");
-/// you may not use this file except in compliance with the License.
-/// You may obtain a copy of the License at
-///
-///     http://www.apache.org/licenses/LICENSE-2.0
-///
-/// Unless required by applicable law or agreed to in writing, software
-/// distributed under the License is distributed on an "AS IS" BASIS,
-/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-/// See the License for the specific language governing permissions and
-/// limitations under the License.
-///
+/**
+* Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
 
 import { defineConfig, devices } from '@playwright/test';
 

--- a/e2e-studio/tests/create-database.spec.ts
+++ b/e2e-studio/tests/create-database.spec.ts
@@ -1,18 +1,19 @@
-///
-/// Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
-///
-/// Licensed under the Apache License, Version 2.0 (the "License");
-/// you may not use this file except in compliance with the License.
-/// You may obtain a copy of the License at
-///
-///     http://www.apache.org/licenses/LICENSE-2.0
-///
-/// Unless required by applicable law or agreed to in writing, software
-/// distributed under the License is distributed on an "AS IS" BASIS,
-/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-/// See the License for the specific language governing permissions and
-/// limitations under the License.
-///
+/**
+* Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
 
 import { test, expect } from '@playwright/test';
 

--- a/e2e-studio/tests/cytoscape-validation.spec.ts
+++ b/e2e-studio/tests/cytoscape-validation.spec.ts
@@ -1,18 +1,19 @@
-///
-/// Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
-///
-/// Licensed under the Apache License, Version 2.0 (the "License");
-/// you may not use this file except in compliance with the License.
-/// You may obtain a copy of the License at
-///
-///     http://www.apache.org/licenses/LICENSE-2.0
-///
-/// Unless required by applicable law or agreed to in writing, software
-/// distributed under the License is distributed on an "AS IS" BASIS,
-/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-/// See the License for the specific language governing permissions and
-/// limitations under the License.
-///
+/**
+* Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
 
 import { test, expect } from '../fixtures/test-fixtures';
 import { ArcadeStudioTestHelper, TEST_CONFIG } from '../utils';

--- a/e2e-studio/tests/datatables-compatibility.spec.ts
+++ b/e2e-studio/tests/datatables-compatibility.spec.ts
@@ -1,18 +1,19 @@
-///
-/// Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
-///
-/// Licensed under the Apache License, Version 2.0 (the "License");
-/// you may not use this file except in compliance with the License.
-/// You may obtain a copy of the License at
-///
-///     http://www.apache.org/licenses/LICENSE-2.0
-///
-/// Unless required by applicable law or agreed to in writing, software
-/// distributed under the License is distributed on an "AS IS" BASIS,
-/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-/// See the License for the specific language governing permissions and
-/// limitations under the License.
-///
+/**
+* Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
 
 /**
  * DataTables v2.3.3 Compatibility Test Suite

--- a/e2e-studio/tests/datatables-critical-validation.spec.ts
+++ b/e2e-studio/tests/datatables-critical-validation.spec.ts
@@ -1,18 +1,19 @@
-///
-/// Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
-///
-/// Licensed under the Apache License, Version 2.0 (the "License");
-/// you may not use this file except in compliance with the License.
-/// You may obtain a copy of the License at
-///
-///     http://www.apache.org/licenses/LICENSE-2.0
-///
-/// Unless required by applicable law or agreed to in writing, software
-/// distributed under the License is distributed on an "AS IS" BASIS,
-/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-/// See the License for the specific language governing permissions and
-/// limitations under the License.
-///
+/**
+* Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
 
 /**
  * DataTables Critical Validation - Focused Test Suite

--- a/e2e-studio/tests/datatables-upgrade-validation.spec.ts
+++ b/e2e-studio/tests/datatables-upgrade-validation.spec.ts
@@ -1,18 +1,19 @@
-///
-/// Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
-///
-/// Licensed under the Apache License, Version 2.0 (the "License");
-/// you may not use this file except in compliance with the License.
-/// You may obtain a copy of the License at
-///
-///     http://www.apache.org/licenses/LICENSE-2.0
-///
-/// Unless required by applicable law or agreed to in writing, software
-/// distributed under the License is distributed on an "AS IS" BASIS,
-/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-/// See the License for the specific language governing permissions and
-/// limitations under the License.
-///
+/**
+* Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
 
 import { test, expect } from '../fixtures/test-fixtures';
 import { ArcadeStudioTestHelper, TEST_CONFIG } from '../utils';

--- a/e2e-studio/tests/debug-datatables-version.spec.ts
+++ b/e2e-studio/tests/debug-datatables-version.spec.ts
@@ -1,18 +1,19 @@
-///
-/// Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
-///
-/// Licensed under the Apache License, Version 2.0 (the "License");
-/// you may not use this file except in compliance with the License.
-/// You may obtain a copy of the License at
-///
-///     http://www.apache.org/licenses/LICENSE-2.0
-///
-/// Unless required by applicable law or agreed to in writing, software
-/// distributed under the License is distributed on an "AS IS" BASIS,
-/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-/// See the License for the specific language governing permissions and
-/// limitations under the License.
-///
+/**
+* Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
 
 import { test, expect } from '@playwright/test';
 import { ArcadeStudioTestHelper } from '../utils';

--- a/e2e-studio/tests/graph-context-menu.spec.ts
+++ b/e2e-studio/tests/graph-context-menu.spec.ts
@@ -1,18 +1,19 @@
-///
-/// Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
-///
-/// Licensed under the Apache License, Version 2.0 (the "License");
-/// you may not use this file except in compliance with the License.
-/// You may obtain a copy of the License at
-///
-///     http://www.apache.org/licenses/LICENSE-2.0
-///
-/// Unless required by applicable law or agreed to in writing, software
-/// distributed under the License is distributed on an "AS IS" BASIS,
-/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-/// See the License for the specific language governing permissions and
-/// limitations under the License.
-///
+/**
+* Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
 
 import { test, expect } from '../fixtures/test-fixtures';
 import { ArcadeStudioTestHelper, TEST_CONFIG } from '../utils';

--- a/e2e-studio/tests/graph-export.spec.ts
+++ b/e2e-studio/tests/graph-export.spec.ts
@@ -1,18 +1,19 @@
-///
-/// Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
-///
-/// Licensed under the Apache License, Version 2.0 (the "License");
-/// you may not use this file except in compliance with the License.
-/// You may obtain a copy of the License at
-///
-///     http://www.apache.org/licenses/LICENSE-2.0
-///
-/// Unless required by applicable law or agreed to in writing, software
-/// distributed under the License is distributed on an "AS IS" BASIS,
-/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-/// See the License for the specific language governing permissions and
-/// limitations under the License.
-///
+/**
+* Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
 
 import { test, expect } from '../fixtures/test-fixtures';
 import * as fs from 'fs';

--- a/e2e-studio/tests/graph-performance.spec.ts
+++ b/e2e-studio/tests/graph-performance.spec.ts
@@ -1,18 +1,19 @@
-///
-/// Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
-///
-/// Licensed under the Apache License, Version 2.0 (the "License");
-/// you may not use this file except in compliance with the License.
-/// You may obtain a copy of the License at
-///
-///     http://www.apache.org/licenses/LICENSE-2.0
-///
-/// Unless required by applicable law or agreed to in writing, software
-/// distributed under the License is distributed on an "AS IS" BASIS,
-/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-/// See the License for the specific language governing permissions and
-/// limitations under the License.
-///
+/**
+* Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
 
 import { test, expect } from '../fixtures/test-fixtures';
 import { ArcadeStudioTestHelper, TEST_CONFIG, getAdaptiveTimeout, getAdaptiveTestSizes, getPerformanceThresholds, getPerformanceBudget } from '../utils';

--- a/e2e-studio/tests/graph-styling.spec.ts
+++ b/e2e-studio/tests/graph-styling.spec.ts
@@ -1,18 +1,19 @@
-///
-/// Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
-///
-/// Licensed under the Apache License, Version 2.0 (the "License");
-/// you may not use this file except in compliance with the License.
-/// You may obtain a copy of the License at
-///
-///     http://www.apache.org/licenses/LICENSE-2.0
-///
-/// Unless required by applicable law or agreed to in writing, software
-/// distributed under the License is distributed on an "AS IS" BASIS,
-/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-/// See the License for the specific language governing permissions and
-/// limitations under the License.
-///
+/**
+* Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
 
 import { test, expect } from '../fixtures/test-fixtures';
 import { ArcadeStudioTestHelper, TEST_CONFIG } from '../utils';

--- a/e2e-studio/tests/notification-test.spec.ts
+++ b/e2e-studio/tests/notification-test.spec.ts
@@ -1,18 +1,19 @@
-///
-/// Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
-///
-/// Licensed under the Apache License, Version 2.0 (the "License");
-/// you may not use this file except in compliance with the License.
-/// You may obtain a copy of the License at
-///
-///     http://www.apache.org/licenses/LICENSE-2.0
-///
-/// Unless required by applicable law or agreed to in writing, software
-/// distributed under the License is distributed on an "AS IS" BASIS,
-/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-/// See the License for the specific language governing permissions and
-/// limitations under the License.
-///
+/**
+* Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
 
 import { test, expect } from '@playwright/test';
 

--- a/e2e-studio/tests/query-beer-database.spec.ts
+++ b/e2e-studio/tests/query-beer-database.spec.ts
@@ -1,18 +1,19 @@
-///
-/// Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
-///
-/// Licensed under the Apache License, Version 2.0 (the "License");
-/// you may not use this file except in compliance with the License.
-/// You may obtain a copy of the License at
-///
-///     http://www.apache.org/licenses/LICENSE-2.0
-///
-/// Unless required by applicable law or agreed to in writing, software
-/// distributed under the License is distributed on an "AS IS" BASIS,
-/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-/// See the License for the specific language governing permissions and
-/// limitations under the License.
-///
+/**
+* Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
 
 import { test, expect } from '@playwright/test';
 

--- a/e2e-studio/types/global.d.ts
+++ b/e2e-studio/types/global.d.ts
@@ -1,18 +1,19 @@
-///
-/// Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
-///
-/// Licensed under the Apache License, Version 2.0 (the "License");
-/// you may not use this file except in compliance with the License.
-/// You may obtain a copy of the License at
-///
-///     http://www.apache.org/licenses/LICENSE-2.0
-///
-/// Unless required by applicable law or agreed to in writing, software
-/// distributed under the License is distributed on an "AS IS" BASIS,
-/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-/// See the License for the specific language governing permissions and
-/// limitations under the License.
-///
+/**
+* Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
 
 import { StartedTestContainer } from 'testcontainers';
 

--- a/e2e-studio/utils/example-usage.ts
+++ b/e2e-studio/utils/example-usage.ts
@@ -1,18 +1,19 @@
-///
-/// Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
-///
-/// Licensed under the Apache License, Version 2.0 (the "License");
-/// you may not use this file except in compliance with the License.
-/// You may obtain a copy of the License at
-///
-///     http://www.apache.org/licenses/LICENSE-2.0
-///
-/// Unless required by applicable law or agreed to in writing, software
-/// distributed under the License is distributed on an "AS IS" BASIS,
-/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-/// See the License for the specific language governing permissions and
-/// limitations under the License.
-///
+/**
+* Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
 
 /**
  * Example Usage of Shared Test Utilities

--- a/e2e-studio/utils/index.ts
+++ b/e2e-studio/utils/index.ts
@@ -1,18 +1,19 @@
-///
-/// Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
-///
-/// Licensed under the Apache License, Version 2.0 (the "License");
-/// you may not use this file except in compliance with the License.
-/// You may obtain a copy of the License at
-///
-///     http://www.apache.org/licenses/LICENSE-2.0
-///
-/// Unless required by applicable law or agreed to in writing, software
-/// distributed under the License is distributed on an "AS IS" BASIS,
-/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-/// See the License for the specific language governing permissions and
-/// limitations under the License.
-///
+/**
+* Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
 
 /**
  * Test Utils Entry Point

--- a/e2e-studio/utils/test-config.ts
+++ b/e2e-studio/utils/test-config.ts
@@ -1,18 +1,19 @@
-///
-/// Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
-///
-/// Licensed under the Apache License, Version 2.0 (the "License");
-/// you may not use this file except in compliance with the License.
-/// You may obtain a copy of the License at
-///
-///     http://www.apache.org/licenses/LICENSE-2.0
-///
-/// Unless required by applicable law or agreed to in writing, software
-/// distributed under the License is distributed on an "AS IS" BASIS,
-/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-/// See the License for the specific language governing permissions and
-/// limitations under the License.
-///
+/**
+* Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
 
 /**
  * Test Configuration and Environment Variables

--- a/e2e-studio/utils/test-utils.ts
+++ b/e2e-studio/utils/test-utils.ts
@@ -1,18 +1,19 @@
-///
-/// Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
-///
-/// Licensed under the Apache License, Version 2.0 (the "License");
-/// you may not use this file except in compliance with the License.
-/// You may obtain a copy of the License at
-///
-///     http://www.apache.org/licenses/LICENSE-2.0
-///
-/// Unless required by applicable law or agreed to in writing, software
-/// distributed under the License is distributed on an "AS IS" BASIS,
-/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-/// See the License for the specific language governing permissions and
-/// limitations under the License.
-///
+/**
+* Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
 
 /**
  * Shared Test Utilities for ArcadeDB Studio E2E Tests


### PR DESCRIPTION
This pull request updates license declarations in the end-to-end testing packages and standardizes copyright headers in all source files. The most important changes are the addition of explicit `Apache-2.0` license fields to package manifests and the conversion of copyright headers from comment blocks using `///` to JSDoc-style `/** ... */` blocks for improved consistency and clarity.

License declaration updates:

* Added `"license": "Apache-2.0"` to `package.json` and `package-lock.json` files in both `e2e-js` and `e2e-studio` to ensure proper license specification for all test packages. [[1]](diffhunk://#diff-056e2db3081d3cc6ac467d2761311ca0086ca8fd7ca12baa0f8bfae2b3b2f728R4) [[2]](diffhunk://#diff-2ce55979994f6658e2453930a882ddf3b88a35a78650b50a7d85109a45d849a9R4-L10) [[3]](diffhunk://#diff-0a2923523aae915be303f89411f96dd3c46cebfa13d01c0984f51b5ddd00730fR4) [[4]](diffhunk://#diff-747fde6744911c753c08f8dd57b00b3bc58296dd6b4a401cf74ff111659483ceR4)

Copyright header standardization:

* Converted all copyright headers in `e2e-studio` source files from `///` style comments to JSDoc-style `/** ... */` blocks for consistency and better tooling support. This affects fixture files, configuration files, setup/teardown scripts, and all test specification files. [[1]](diffhunk://#diff-23acdc1f281c2d6d873d54b44fcaf06af193d92530e0894230d026d2ae215e5bL1-R16) [[2]](diffhunk://#diff-7feac1cceb6d617e47d209ffa4b4ecfb951da0fab83a6b67215cf6ea060bcf49L1-R16) [[3]](diffhunk://#diff-42cd5758278d804f1945499a1d329e16d0635f4d3e8cff2467bb55c23eb6c994L1-R16) [[4]](diffhunk://#diff-67b0326282b55e50eae74f301b8333b658ecf64260bc174c1da22aaa8d951779L1-R16) [[5]](diffhunk://#diff-b2d512a3356ab9fc5ed2d84ee99e56927291b6ba890740d6d0350538b31bc912L1-R16) [[6]](diffhunk://#diff-da1b4c6baee76e9eddb730dc51fddfd99f246c682787afba1d86247cd214d0c7L1-R16) [[7]](diffhunk://#diff-70730ee6a49517a92a4fab3ec4ea12bc10282637f5c42d503c6760989e316af2L1-R16) [[8]](diffhunk://#diff-c7272254dc0536e9ca47e73094692ed881f4bfe24718a93e533dcfefcb8bae72L1-R16) [[9]](diffhunk://#diff-3cfcf0f00860543055cd76f49d119087fb24f97e76b3707e4c21e6e37b6a8574L1-R16) [[10]](diffhunk://#diff-9cc37fbf25b95a8807e177fbd4abac356c1f051d73dd4dfc292f2aff1a027fe8L1-R16) [[11]](diffhunk://#diff-8c928175e3033716f88ca16715b03e4bf78e1ae9f1ebe69d99123e460c949e2eL1-R16) [[12]](diffhunk://#diff-7ac513d7c4249c88449f99f1da9f92f629aa9d7561dfe326846af126e89fc435L1-R16) [[13]](diffhunk://#diff-b0baff40a208ccaa0b67d734a7ac6d3945530be805b0da90cd8148f29dcf4523L1-R16) [[14]](diffhunk://#diff-4bf7206506a77891c682048075d35e5435bbfdd8e8cfed9a134f3f45fb69e5c0L1-R16)