### PR TITLE
fix(tests): update Beer database selection to use specific query tab …

### DIFF
--- a/e2e-studio/tests/notification-test.spec.ts
+++ b/e2e-studio/tests/notification-test.spec.ts
@@ -49,11 +49,11 @@ test.describe('ArcadeDB Studio Notification System', () => {
     // Wait for the main interface to load
     await expect(page.getByText('Connected as').first()).toBeVisible();
 
-    // Select the Beer database from the dropdown
-    await page.getByLabel('root').selectOption('Beer');
+    // Select the Beer database from the dropdown - use specific query tab selector
+    await page.locator('#queryInputDatabase').selectOption('Beer');
 
     // Verify Beer database is selected
-    await expect(page.getByLabel('root')).toHaveValue('Beer');
+    await expect(page.locator('#queryInputDatabase')).toHaveValue('Beer');
 
     // Make sure we're on the Query tab
     await expect(page.getByText('Auto Limit')).toBeVisible();

--- a/e2e-studio/tests/query-beer-database.spec.ts
+++ b/e2e-studio/tests/query-beer-database.spec.ts
@@ -35,11 +35,11 @@ test.describe('ArcadeDB Studio Beer Database Query', () => {
     // Wait for the main interface to load
     await expect(page.getByText('Connected as').first()).toBeVisible();
 
-    // Select the Beer database from the dropdown
-    await page.getByLabel('root').selectOption('Beer');
+    // Select the Beer database from the dropdown - use specific query tab selector
+    await page.locator('#queryInputDatabase').selectOption('Beer');
 
     // Verify Beer database is selected
-    await expect(page.getByLabel('root')).toHaveValue('Beer');
+    await expect(page.locator('#queryInputDatabase')).toHaveValue('Beer');
 
     // Make sure we're on the Query tab (first tab should be selected by default)
     // Wait for the query interface to be visible
@@ -92,11 +92,11 @@ test.describe('ArcadeDB Studio Beer Database Query', () => {
     // Wait for the main interface to load with increased timeout
     await expect(page.getByText('Connected as').first()).toBeVisible({ timeout: 10000 });
 
-    // Select the Beer database from the dropdown
-    await page.getByLabel('root').selectOption('Beer');
+    // Select the Beer database from the dropdown - use specific query tab selector
+    await page.locator('#queryInputDatabase').selectOption('Beer');
 
     // Verify Beer database is selected
-    await expect(page.getByLabel('root')).toHaveValue('Beer');
+    await expect(page.locator('#queryInputDatabase')).toHaveValue('Beer');
 
     // Make sure we're on the Query tab
     await expect(page.getByText('Auto Limit')).toBeVisible();

--- a/e2e-studio/utils/test-utils.ts
+++ b/e2e-studio/utils/test-utils.ts
@@ -75,8 +75,10 @@ export class ArcadeStudioTestHelper {
     // Click sign in button using actual onclick handler
     await this.page.click('button[onclick="login()"]');
 
-    // Wait for login spinner to appear (indicates login started)
-    await expect(this.page.locator('#loginSpinner')).toBeVisible();
+    // Wait for login spinner to appear (indicates login started) - with short timeout for fast logins
+    await expect(this.page.locator('#loginSpinner')).toBeVisible({ timeout: 2000 }).catch(() => {
+      // If spinner doesn't appear, login might be very fast - continue
+    });
 
     // Wait for login to complete - check multiple conditions
     await Promise.all([


### PR DESCRIPTION
This pull request refines the end-to-end test suite for ArcadeDB Studio by improving selector specificity and enhancing test robustness. The changes primarily update how the Beer database is selected in tests and make the login flow more resilient to fast logins.

**Test selector improvements:**

* Updated database selection in `e2e-studio/tests/notification-test.spec.ts` and `e2e-studio/tests/query-beer-database.spec.ts` to use the more specific `#queryInputDatabase` selector instead of a generic label, ensuring tests interact with the correct UI element. [[1]](diffhunk://#diff-c5c318499e18c17bb10a2f53a973c05ef63e3e87219531c1a9cf0ef13c52fd31L52-R56) [[2]](diffhunk://#diff-fde75fe5f62ea65fb69726a832be0e2247a4f6b0d159e87056ef4eec8a604c1aL38-R42) [[3]](diffhunk://#diff-fde75fe5f62ea65fb69726a832be0e2247a4f6b0d159e87056ef4eec8a604c1aL95-R99)
* Adjusted assertions to verify the selected database using the new selector for greater reliability. [[1]](diffhunk://#diff-c5c318499e18c17bb10a2f53a973c05ef63e3e87219531c1a9cf0ef13c52fd31L52-R56) [[2]](diffhunk://#diff-fde75fe5f62ea65fb69726a832be0e2247a4f6b0d159e87056ef4eec8a604c1aL38-R42) [[3]](diffhunk://#diff-fde75fe5f62ea65fb69726a832be0e2247a4f6b0d159e87056ef4eec8a604c1aL95-R99)

**Login flow robustness:**

* Modified the login spinner wait in `e2e-studio/utils/test-utils.ts` to include a short timeout and handle cases where the spinner may not appear due to a fast login, preventing unnecessary test failures.