### PR TITLE
remove leftover(?) slf4j references

### DIFF
--- a/gremlin/src/main/java/com/arcadedb/server/gremlin/ArcadeDBGremlinSettings.java
+++ b/gremlin/src/main/java/com/arcadedb/server/gremlin/ArcadeDBGremlinSettings.java
@@ -80,9 +80,6 @@ public class ArcadeDBGremlinSettings extends Settings {
     final TypeDescription jmxReporterDescription = new TypeDescription(JmxReporterMetrics.class);
     constructor.addTypeDescription(jmxReporterDescription);
 
-    final TypeDescription slf4jReporterDescription = new TypeDescription(Slf4jReporterMetrics.class);
-    constructor.addTypeDescription(slf4jReporterDescription);
-
     final TypeDescription gangliaReporterDescription = new TypeDescription(GangliaReporterMetrics.class);
     constructor.addTypeDescription(gangliaReporterDescription);
 

--- a/grpc-client/pom.xml
+++ b/grpc-client/pom.xml
@@ -35,7 +35,6 @@
 
     <properties>
         <mockito.version>5.15.2</mockito.version>
-        <slf4j-simple.version>2.0.17</slf4j-simple.version>
         <jackson-databind.version>2.20.0</jackson-databind.version>
     </properties>
 
@@ -122,13 +121,6 @@
             <artifactId>grpc-testing</artifactId>
             <version>${grpc.version}</version>
             <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>${slf4j-simple.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -192,9 +192,6 @@
                     <forkedProcessExitTimeoutInSeconds>60</forkedProcessExitTimeoutInSeconds>
                     <forkCount>1</forkCount>
                     <systemPropertyVariables>
-                        <org.slf4j.simpleLogger.defaultLogLevel>warn</org.slf4j.simpleLogger.defaultLogLevel>
-                        <org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener>warn
-                        </org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener>
                         <polyglot.engine.WarnInterpreterOnly>false</polyglot.engine.WarnInterpreterOnly>
                     </systemPropertyVariables>
                     <argLine>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -35,7 +35,6 @@
 
     <properties>
         <metrics.version>4.2.19</metrics.version>
-        <slf4j.version>2.0.17</slf4j.version>
         <undertow-core.version>2.3.19.Final</undertow-core.version>
         <micrometer.version>1.15.4</micrometer.version>
     </properties>
@@ -71,17 +70,6 @@
             <groupId>io.undertow</groupId>
             <artifactId>undertow-core</artifactId>
             <version>${undertow-core.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>


### PR DESCRIPTION
## What does this PR do?

This change removes SLF4J related code and infra that is not in `e2e-perf`.

## Related issues

https://github.com/ArcadeData/arcadedb/pull/2502

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
