### PR TITLE
chore: refactor assertions to use assertThatThrownBy 

### DIFF
--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ScriptExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ScriptExecutionTest.java
@@ -29,12 +29,12 @@ import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.query.sql.SQLQueryEngine;
 import com.arcadedb.query.sql.function.SQLFunctionAbstract;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.Test;
+  import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Luigi Dell'Aquila (l.dellaquila-(at)-orientdatabase.com)
@@ -352,7 +352,7 @@ public class ScriptExecutionTest extends TestHelper {
           SELECT throwCME(#-1:-1, 1, 1, 1);
           COMMIT RETRY 10;
           """.formatted(typeName);
-      ;
+
       try {
         database.command("sqlscript", script);
       } catch (ConcurrentModificationException x) {
@@ -440,11 +440,8 @@ public class ScriptExecutionTest extends TestHelper {
               } AND FAIL;
           """.formatted(typeName, typeName);
 
-      try {
-        database.command("sqlscript", script);
-        Assertions.fail();
-      } catch (ConcurrentModificationException e) {
-      }
+      assertThatThrownBy(() -> database.command("sqlscript", script))
+          .isInstanceOf(ConcurrentModificationException.class);
     });
 
     ResultSet result = database.query("sql", "select from " + typeName);
@@ -472,12 +469,8 @@ public class ScriptExecutionTest extends TestHelper {
               }
           """.formatted(typeName, typeName);
 
-      try {
-        database.command("sqlscript", script);
-        Assertions.fail();
-      } catch (ConcurrentModificationException e) {
-
-      }
+      assertThatThrownBy(() -> database.command("sqlscript", script))
+          .isInstanceOf(ConcurrentModificationException.class);
 
       ResultSet result = database.query("sql", "select from " + typeName);
       Result item = result.next();
@@ -489,14 +482,10 @@ public class ScriptExecutionTest extends TestHelper {
   @Test
   public void testFunctionAsStatement() {
     database.transaction(() -> {
-      String script = "";
-      script += "sqrt(64);";
+      String script = "sqrt(64);";
 
-      try {
-        database.command("sql", script);
-        Assertions.fail();
-      } catch (CommandSQLParsingException e) {
-      }
+      assertThatThrownBy(() -> database.command("sql", script))
+          .isInstanceOf(CommandSQLParsingException.class);
 
       ResultSet rs = database.command("sqlscript", script);
       Result item = rs.next();

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/SQLGrammarErrorsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/SQLGrammarErrorsTest.java
@@ -1,41 +1,37 @@
 package com.arcadedb.query.sql.parser;
 
 import com.arcadedb.exception.CommandSQLParsingException;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Simple test to verify improved SQL grammar error messages
  */
-public class SQLGrammarErrorsTest {
-  public static void main(String[] args) {
+class SQLGrammarErrorsTest {
+
+  @Test
+  void testSQLGrammarErrors() {
     StatementCache cache = new StatementCache(null, 100);
 
     // Test case 1: Duplicate AND operators
-    try {
-      cache.get("select from Chat where #22:1 IN $brain AND  and contextVariables['local:insuranceGrid'] = true");
-      Assertions.fail();
-    } catch (CommandSQLParsingException e) {
-      Assertions.assertTrue(e.getMessage().contains("AND operator") && e.getMessage().contains("must be followed by a condition"),
-          "Expected improved error message about AND operator, got: " + e.getMessage());
-    }
+    assertThatThrownBy(
+        () -> cache.get("select from Chat where #22:1 IN $brain AND  and contextVariables['local:insuranceGrid'] = true"))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("AND operator")
+        .hasMessageContaining("must be followed by a condition");
 
     // Test case 2: OR followed by AND
-    try {
-      cache.get("select from Chat where col = 1 OR AND col2 = 2");
-      Assertions.fail();
-    } catch (CommandSQLParsingException e) {
-      Assertions.assertTrue(e.getMessage().contains("OR operator") && e.getMessage().contains("must be followed by a condition"),
-          "Expected improved error message about OR operator, got: " + e.getMessage());
-    }
+    assertThatThrownBy(() -> cache.get("select from Chat where col = 1 OR AND col2 = 2"))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("OR operator")
+        .hasMessageContaining("must be followed by a condition");
 
     // Test case 3: Missing condition after AND
-    try {
-      cache.get("select from Chat where col = 1 AND");
-      Assertions.fail();
-    } catch (CommandSQLParsingException e) {
-      Assertions.assertTrue(e.getMessage().contains("AND operator") && e.getMessage().contains("must be followed by a condition"),
-          "Expected improved error message about AND operator, got: " + e.getMessage());
-    }
+    assertThatThrownBy(() -> cache.get("select from Chat where col = 1 AND"))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("AND operator")
+        .hasMessageContaining("must be followed by a condition");
 
     // Test case 4: Valid query should work
     cache.get("select from Chat where col = 1 AND col2 = 2");

--- a/engine/src/test/java/com/arcadedb/schema/DictionaryTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/DictionaryTest.java
@@ -25,14 +25,12 @@ import com.arcadedb.database.Record;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.ResultSet;
-
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class DictionaryTest extends TestHelper {
   @Test
@@ -99,14 +97,10 @@ public class DictionaryTest extends TestHelper {
       assertThat(i).isEqualTo(11);
     });
 
-    try {
-      database.transaction(() -> {
-        assertThat(database.getSchema().existsType("V")).isTrue();
-        database.getSchema().getDictionary().updateName("V", "V2");
-      });
-      fail("");
-    } catch (final Exception e) {
-    }
+    assertThatThrownBy(() -> database.transaction(() -> {
+      assertThat(database.getSchema().existsType("V")).isTrue();
+      database.getSchema().getDictionary().updateName("V", "V2");
+    })).isInstanceOf(Exception.class);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/schema/DropTypeTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/DropTypeTest.java
@@ -23,7 +23,6 @@ import com.arcadedb.database.MutableDocument;
 import com.arcadedb.engine.Bucket;
 import com.arcadedb.exception.SchemaException;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
@@ -72,23 +71,14 @@ public class DropTypeTest extends TestHelper {
 
       // CHECK ALL THE BUCKETS ARE REMOVED
       for (final Bucket b : buckets) {
-        try {
-          database.getSchema().getBucketById(b.getFileId());
-          fail();
-        } catch (final SchemaException e) {
-        }
+        assertThatThrownBy(() -> database.getSchema().getBucketById(b.getFileId()))
+            .isInstanceOf(SchemaException.class);
 
-        try {
-          database.getSchema().getBucketByName(b.getName());
-          fail();
-        } catch (final SchemaException e) {
-        }
+        assertThatThrownBy(() -> database.getSchema().getBucketByName(b.getName()))
+            .isInstanceOf(SchemaException.class);
 
-        try {
-          database.getSchema().getFileById(b.getFileId());
-          fail();
-        } catch (final SchemaException e) {
-        }
+        assertThatThrownBy(() -> database.getSchema().getFileById(b.getFileId()))
+            .isInstanceOf(SchemaException.class);
       }
 
       // CHECK TYPE HAS BEEN REMOVED FROM INHERITANCE

--- a/graphql/src/test/java/com/arcadedb/graphql/AbstractGraphQLTest.java
+++ b/graphql/src/test/java/com/arcadedb/graphql/AbstractGraphQLTest.java
@@ -30,7 +30,7 @@ import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-import java.io.*;
+import java.io.File;
 
 public abstract class AbstractGraphQLTest {
   protected static final String DB_PATH = "./target/testgraphql";
@@ -92,31 +92,26 @@ public abstract class AbstractGraphQLTest {
     }
   }
 
-  protected int countIterable(final Iterable<?> iter) {
-    int count = 0;
-    for (final Object o : iter)
-      ++count;
-
-    return count;
-  }
-
   protected void defineTypes(final Database database) {
-    final String types = "type Query {\n" +//
-        "  bookById(id: String): Book\n" +//
-        "  bookByName(name: String): Book\n" +//
-        "}\n\n" +//
-        "type Book {\n" +//
-        "  id: String\n" +//
-        "  name: String\n" +//
-        "  pageCount: Int\n" +//
-        "  authors: [Author] @relationship(type: \"IS_AUTHOR_OF\", direction: IN)\n" +//
-        "}\n\n" +//
-        "type Author {\n" +//
-        "  id: String\n" +//
-        "  firstName: String\n" +//
-        "  lastName: String\n" +//
-        "  wrote: [Book] @relationship(type: \"IS_AUTHOR_OF\", direction: OUT)\n" +//
-        "}";
+    final String types = """
+        type Query {
+          bookById(id: String): Book
+          bookByName(name: String): Book
+        }
+
+        type Book {
+          id: String
+          name: String
+          pageCount: Int
+          authors: [Author] @relationship(type: "IS_AUTHOR_OF", direction: IN)
+        }
+
+        type Author {
+          id: String
+          firstName: String
+          lastName: String
+          wrote: [Book] @relationship(type: "IS_AUTHOR_OF", direction: OUT)
+        }""";
     database.command("graphql", types);
   }
 }

--- a/graphql/src/test/java/com/arcadedb/graphql/GraphQLCypherDirectivesTest.java
+++ b/graphql/src/test/java/com/arcadedb/graphql/GraphQLCypherDirectivesTest.java
@@ -29,9 +29,10 @@ public class GraphQLCypherDirectivesTest extends AbstractGraphQLNativeLanguageDi
   @Override
   protected void defineTypes(final Database database) {
     super.defineTypes(database);
-    database.command("graphql", "type Query {\n" +//
-        "  bookById(id: String): Book\n" +//
-        "  bookByName(bookNameParameter: String): Book @cypher(statement: \"MATCH (b:Book {name: $bookNameParameter}) RETURN b\")\n" +//
-        "}");
+    database.command("graphql", """
+        type Query {
+          bookById(id: String): Book
+          bookByName(bookNameParameter: String): Book @cypher(statement: "MATCH (b:Book {name: $bookNameParameter}) RETURN b")
+        }""");
   }
 }

--- a/graphql/src/test/java/com/arcadedb/graphql/GraphQLGremlinDirectivesTest.java
+++ b/graphql/src/test/java/com/arcadedb/graphql/GraphQLGremlinDirectivesTest.java
@@ -25,9 +25,10 @@ public class GraphQLGremlinDirectivesTest extends AbstractGraphQLNativeLanguageD
   @Override
   protected void defineTypes(final Database database) {
     super.defineTypes(database);
-    final ResultSet command = database.command("graphql", "type Query {\n" +//
-            "  bookById(id: String): Book\n" +//
-            "  bookByName(bookNameParameter: String): Book @gremlin(statement: \"g.V().has('name', bookNameParameter)\")\n" +//
-            "}");
+    final ResultSet command = database.command("graphql", """
+        type Query {
+          bookById(id: String): Book
+          bookByName(bookNameParameter: String): Book @gremlin(statement: "g.V().has('name', bookNameParameter)")
+        }""");
   }
 }

--- a/graphql/src/test/java/com/arcadedb/graphql/GraphQLSQLMatchDirectivesTest.java
+++ b/graphql/src/test/java/com/arcadedb/graphql/GraphQLSQLMatchDirectivesTest.java
@@ -24,9 +24,10 @@ public class GraphQLSQLMatchDirectivesTest extends AbstractGraphQLNativeLanguage
   @Override
   protected void defineTypes(final Database database) {
     super.defineTypes(database);
-    database.command("graphql", "type Query {\n" +//
-        "  bookById(id: String): Book\n" +//
-        "  bookByName(bookNameParameter: String): Book @sql(statement: \"match {type:Book, as:b, where:(name = :bookNameParameter)} return expand(b)\")\n" +//
-        "}");
+    database.command("graphql", """
+        type Query {
+          bookById(id: String): Book
+          bookByName(bookNameParameter: String): Book @sql(statement: "match {type:Book, as:b, where:(name = :bookNameParameter)} return expand(b)")
+        }""");
   }
 }

--- a/graphql/src/test/java/com/arcadedb/graphql/GraphQLSQLSelectDirectivesTest.java
+++ b/graphql/src/test/java/com/arcadedb/graphql/GraphQLSQLSelectDirectivesTest.java
@@ -24,9 +24,10 @@ public class GraphQLSQLSelectDirectivesTest extends AbstractGraphQLNativeLanguag
   @Override
   protected void defineTypes(final Database database) {
     super.defineTypes(database);
-    database.command("graphql", "type Query {\n" +//
-        "  bookById(id: String): Book\n" +//
-        "  bookByName(bookNameParameter: String): Book @sql(statement: \"select from Book where name = :bookNameParameter\")\n" +//
-        "}");
+    database.command("graphql", """
+        type Query {
+          bookById(id: String): Book
+          bookByName(bookNameParameter: String): Book @sql(statement: "select from Book where name = :bookNameParameter")
+        }""");
   }
 }

--- a/graphql/src/test/java/com/arcadedb/graphql/parser/GraphQLParserSchemaTest.java
+++ b/graphql/src/test/java/com/arcadedb/graphql/parser/GraphQLParserSchemaTest.java
@@ -26,21 +26,24 @@ import static org.assertj.core.api.Assertions.fail;
 public class GraphQLParserSchemaTest {
   @Test
   public void testTypes() throws ParseException {
-    final Document ast = GraphQLParser.parse("type Query {\n" +//
-        "  bookById(id: ID): Book\n" +//
-        "}\n" +//
-        "\n" +//
-        "type Book {\n" +//
-        "  id: ID\n" +//
-        "  name: String\n" +//
-        "  pageCount: Int\n" + "  author: Author\n" +//
-        "}\n" +//
-        "\n" +//
-        "type Author {\n" +//
-        "  id: ID\n" +//
-        "  firstName: String\n" +//
-        "  lastName: String\n" +//
-        "}");
+
+    final Document ast = GraphQLParser.parse("""
+        type Query {
+          bookById(id: ID): Book
+        }
+
+        type Book {
+          id: ID
+          name: String
+          pageCount: Int
+          author: Author
+        }
+
+        type Author {
+          id: ID
+          firstName: String
+          lastName: String
+        }""");
 
     assertThat(ast.children.length > 0).isTrue();
   }
@@ -48,22 +51,25 @@ public class GraphQLParserSchemaTest {
   @Test
   public void errorInvalidCharacters() {
     try {
-      final Document ast = GraphQLParser.parse("type Query {\n" +//
-          "  bookById(id: String): Book\n" +//
-          "  bookByName(name: String): Book { id name pageCount authors }\n" +//
-          "}\n\n" +//
-          "type Book {\n" +//
-          "  id: String\n" +//
-          "  name: String\n" +//
-          "  pageCount: Int\n" +//
-          "  authors: [Author] @relationship(type: \"IS_AUTHOR_OF\", direction: IN)\n" +//
-          "}\n\n" +//
-          "type Author {\n" +//
-          "  id: String\n" +//
-          "  firstName: String\n" +//
-          "  lastName: String\n" +//
-          "  wrote: [Book] @relationship(type: \"IS_AUTHOR_OF\", direction: OUT)\n" +//
-          "} dsfjsd fjsdkjf sdk");
+      final Document ast = GraphQLParser.parse("""
+          type Query {
+            bookById(id: String): Book
+            bookByName(name: String): Book { id name pageCount authors }
+          }
+
+          type Book {
+            id: String
+            name: String
+            pageCount: Int
+            authors: [Author] @relationship(type: "IS_AUTHOR_OF", direction: IN)
+          }
+
+          type Author {
+            id: String
+            firstName: String
+            lastName: String
+            wrote: [Book] @relationship(type: "IS_AUTHOR_OF", direction: OUT)
+          } dsfjsd fjsdkjf sdk""");
       fail(ast.treeToString(""));
     } catch (final ParseException e) {
       // EXPECTED
@@ -73,22 +79,25 @@ public class GraphQLParserSchemaTest {
   @Test
   public void errorInvalidCharactersWithDirective() {
     try {
-      final Document ast = GraphQLParser.parse("type Query {\n" +//
-          "  bookById(id: String): Book\n" +//
-          "  bookByName(name: String): Book @sql(statement: \"select from Book where name = :name\", a = 3 ) { id name pageCount authors }\n" +//
-          "}\n\n" +//
-          "type Book {\n" +//
-          "  id: String\n" +//
-          "  name: String\n" +//
-          "  pageCount: Int\n" +//
-          "  authors: [Author] @relationship(type: \"IS_AUTHOR_OF\", direction: IN)\n" +//
-          "}\n\n" +//
-          "type Author {\n" +//
-          "  id: String\n" +//
-          "  firstName: String\n" +//
-          "  lastName: String\n" +//
-          "  wrote: [Book] @relationship(type: \"IS_AUTHOR_OF\", direction: OUT)\n" +//
-          "} dsfjsd fjsdkjf sdk");
+      final Document ast = GraphQLParser.parse("""
+          type Query {
+            bookById(id: String): Book
+            bookByName(name: String): Book @sql(statement: "select from Book where name = :name", a = 3 ) { id name pageCount authors }
+          }
+
+          type Book {
+            id: String
+            name: String
+            pageCount: Int
+            authors: [Author] @relationship(type: "IS_AUTHOR_OF", direction: IN)
+          }
+
+          type Author {
+            id: String
+            firstName: String
+            lastName: String
+            wrote: [Book] @relationship(type: "IS_AUTHOR_OF", direction: OUT)
+          } dsfjsd fjsdkjf sdk""");
       fail(ast.treeToString(""));
     } catch (final ParseException e) {
       // EXPECTED

--- a/graphql/src/test/java/com/arcadedb/graphql/parser/GraphQLParserTest.java
+++ b/graphql/src/test/java/com/arcadedb/graphql/parser/GraphQLParserTest.java
@@ -30,16 +30,17 @@ public class GraphQLParserTest {
 
   @Test
   public void testLookup() throws ParseException {
-    final Document ast = GraphQLParser.parse("{ bookById(id: \"book-1\"){" +//
-        "  id" +//
-        "      name" +//
-        "  pageCount" +//
-        "  author {" +//
-        "    firstName" +//
-        "        lastName" +//
-        "  }" +//
-        "}" +//
-        "}");
+    final Document ast = GraphQLParser.parse("""
+        { bookById(id: "book-1"){\
+          id\
+              name\
+          pageCount\
+          author {\
+            firstName\
+                lastName\
+          }\
+        }\
+        }""");
 
     assertThat(ast.children.length > 0).isTrue();
 

--- a/server/src/test/java/com/arcadedb/remote/RemoteDatabaseIT.java
+++ b/server/src/test/java/com/arcadedb/remote/RemoteDatabaseIT.java
@@ -35,7 +35,6 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.server.BaseGraphServerTest;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,7 +44,7 @@ import java.util.concurrent.atomic.*;
 
 import static com.arcadedb.graph.Vertex.DIRECTION.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class RemoteDatabaseIT extends BaseGraphServerTest {
   private static final String DATABASE_NAME = "remote-database";
@@ -77,12 +76,8 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
 
         // TEST DELETION AND LOOKUP
         jay.delete();
-        try {
-          jay.reload();
-          fail();
-        } catch (RecordNotFoundException e) {
-          // EXPECTED
-        }
+        assertThatThrownBy(() -> jay.reload())
+            .isInstanceOf(RecordNotFoundException.class);
 
         // CREATE DOCUMENT VIA SQL
         ResultSet result = database.command("SQL", "insert into Person set name = 'John'");
@@ -172,12 +167,8 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
 
         // TEST DELETION AND LOOKUP
         jay.delete();
-        try {
-          jay.reload();
-          fail();
-        } catch (RecordNotFoundException e) {
-          // EXPECTED
-        }
+        assertThatThrownBy(() -> jay.reload())
+            .isInstanceOf(RecordNotFoundException.class);
 
         // CREATE VERTEX 1
         result = database.command("SQL", "insert into Character set name = 'John'");
@@ -311,12 +302,8 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
 
       // DELETE ONE VERTEX
       albert.delete();
-      try {
-        database.lookupByRID(albert.getIdentity());
-        fail();
-      } catch (final RecordNotFoundException e) {
-        // EXPECTED
-      }
+      assertThatThrownBy(() -> database.lookupByRID(albert.getIdentity()))
+          .isInstanceOf(RecordNotFoundException.class);
     });
   }
 
@@ -467,12 +454,8 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
       final String sessionId = database1.getSessionId();
       database1.setSessionId(sessionId + "1");
 
-      try {
-        final MutableDocument albert = database1.newDocument("Person").set("name", "John").save();
-        fail();
-      } catch (TransactionException e) {
-        // EXPECTED
-      }
+      assertThatThrownBy(() -> database1.newDocument("Person").set("name", "John").save())
+          .isInstanceOf(TransactionException.class);
 
       database1.setSessionId(sessionId);
 
@@ -516,12 +499,8 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
 
       svt1.set("s", "concurrent t1 - 2");
       svt1.save();
-      try {
-        t1.commit();
-        fail("Expected ConcurrentModificationException due to concurrent update, but commit succeeded");
-      } catch (ConcurrentModificationException e) {
-        // EXPECTED
-      }
+      assertThatThrownBy(() -> t1.commit())
+          .isInstanceOf(ConcurrentModificationException.class);
     });
   }
 
@@ -533,12 +512,8 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
       assertThat(database.isOpen()).isTrue();
       database.close();
       assertThat(database.isOpen()).isFalse();
-      try {
-        database.countType("aaa", true);
-        fail();
-      } catch (DatabaseIsClosedException e) {
-        //EXPECTED
-      }
+      assertThatThrownBy(() -> database.countType("aaa", true))
+          .isInstanceOf(DatabaseIsClosedException.class);
     });
   }
 
@@ -619,12 +594,8 @@ public class RemoteDatabaseIT extends BaseGraphServerTest {
           mvSVt2.set("s", "concurrent t2");
           mvSVt2.save();
 
-          try {
-            t2.commit();
-            Assertions.fail();
-          } catch (ConcurrentModificationException e) {
-            // EXPECTED
-          }
+          assertThatThrownBy(() -> t2.commit())
+              .isInstanceOf(ConcurrentModificationException.class);
         }
       }
     });

--- a/server/src/test/java/com/arcadedb/server/HTTPTransactionIT.java
+++ b/server/src/test/java/com/arcadedb/server/HTTPTransactionIT.java
@@ -21,7 +21,6 @@ package com.arcadedb.server;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONObject;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
@@ -33,6 +32,7 @@ import static com.arcadedb.schema.Property.RID_PROPERTY;
 import static com.arcadedb.server.http.HttpSessionManager.ARCADEDB_SESSION_ID;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class HTTPTransactionIT extends BaseGraphServerTest {
 
@@ -91,12 +91,8 @@ public class HTTPTransactionIT extends BaseGraphServerTest {
       }
 
       // CANNOT RETRIEVE DOCUMENT OUTSIDE A TX
-      try {
-        checkDocumentWasCreated(DATABASE_NAME, serverIndex, payload, rid, null);
-        fail();
-      } catch (final Exception e) {
-        // EXPECTED
-      }
+      assertThatThrownBy(() -> checkDocumentWasCreated(DATABASE_NAME, serverIndex, payload, rid, null))
+          .isInstanceOf(Exception.class);
 
       // RETRIEVE DOCUMENT
       checkDocumentWasCreated(DATABASE_NAME, serverIndex, payload, rid, sessionId);
@@ -216,16 +212,13 @@ public class HTTPTransactionIT extends BaseGraphServerTest {
       pw.write(payload.toString());
       pw.close();
 
-      String response = null;
-      try {
-        response = readResponse(connection);
-        fail();
-      } catch (final IOException e) {
-        response = readError(connection);
-        assertThat(connection.getResponseCode()).isEqualTo(503);
-        connection.disconnect();
-        assertThat(response.contains("DuplicatedKeyException")).isTrue();
-      }
+      assertThatThrownBy(() -> readResponse(connection))
+          .isInstanceOf(IOException.class);
+
+      String response = readError(connection);
+      assertThat(connection.getResponseCode()).isEqualTo(503);
+      connection.disconnect();
+      assertThat(response.contains("DuplicatedKeyException")).isTrue();
     });
   }
 
@@ -274,12 +267,9 @@ public class HTTPTransactionIT extends BaseGraphServerTest {
       connection.connect();
 
       try {
-        readResponse(connection);
-
-        fail();
-
-      } catch (Exception e) {
-        assertThat(e.getMessage().contains("400")).isTrue();
+        assertThatThrownBy(() -> readResponse(connection))
+            .isInstanceOf(Exception.class)
+            .hasMessageContaining("400");
       } finally {
         connection.disconnect();
       }


### PR DESCRIPTION
This pull request refactors test code across multiple modules to improve readability and consistency by replacing manual exception handling with AssertJ's `assertThatThrownBy`. The changes streamline how exceptions are asserted in tests, making them more idiomatic and easier to maintain. Additionally, some minor code cleanups and formatting improvements are included.

**Test exception assertion improvements:**

* Replaced manual try/catch blocks and calls to `Assertions.fail()` with `assertThatThrownBy` for exception assertions in various test files, including `ScriptExecutionTest.java`, `SQLGrammarErrorsTest.java`, `DictionaryTest.java`, `DocumentValidationTest.java`, and `DropTypeTest.java`. This change improves clarity and reduces boilerplate in test code. [[1]](diffhunk://#diff-3e0ea0f3d57aae5b7c22b6ce8eaae2b17c7dbc6f13359828100ef15a5c69f8f6L443-R444) [[2]](diffhunk://#diff-f9eb54e8a59711e4dd56ded3cbc60e3853a77720a2a72b70fae13b3028b53b19L282-R287) [[3]](diffhunk://#diff-f9eb54e8a59711e4dd56ded3cbc60e3853a77720a2a72b70fae13b3028b53b19L306-R313) [[4]](diffhunk://#diff-f9eb54e8a59711e4dd56ded3cbc60e3853a77720a2a72b70fae13b3028b53b19L351-R341) [[5]](diffhunk://#diff-f9eb54e8a59711e4dd56ded3cbc60e3853a77720a2a72b70fae13b3028b53b19L384-R371) [[6]](diffhunk://#diff-f9eb54e8a59711e4dd56ded3cbc60e3853a77720a2a72b70fae13b3028b53b19L418-R402) [[7]](diffhunk://#diff-f9eb54e8a59711e4dd56ded3cbc60e3853a77720a2a72b70fae13b3028b53b19L739-R722) [[8]](diffhunk://#diff-f9eb54e8a59711e4dd56ded3cbc60e3853a77720a2a72b70fae13b3028b53b19L765-R755) [[9]](diffhunk://#diff-fe0eeb4b02ba781cbfb3ffe529cfced7e1ff83c4b12300e04d89e772bf604786L75-R81) [[10]](diffhunk://#diff-b34382610a2602ce2f9d1e72f3db69c91f7d516635028e5fbdc96871be7b67c3L102-R103) [[11]](diffhunk://#diff-2280f223b430b5d838a648d5bbb0fc585ffb0c8932c407c456262e3daa9ea99aL4-R34)

**Test code formatting and imports:**

* Cleaned up imports in several test files by removing unused imports and organizing them, such as in `ScriptExecutionTest.java`, `DictionaryTest.java`, `DocumentValidationTest.java`, `DropTypeTest.java`, and `GraphQLBasicTest.java`. [[1]](diffhunk://#diff-3e0ea0f3d57aae5b7c22b6ce8eaae2b17c7dbc6f13359828100ef15a5c69f8f6L32-R37) [[2]](diffhunk://#diff-b34382610a2602ce2f9d1e72f3db69c91f7d516635028e5fbdc96871be7b67c3L28-R33) [[3]](diffhunk://#diff-f9eb54e8a59711e4dd56ded3cbc60e3853a77720a2a72b70fae13b3028b53b19L32-R43) [[4]](diffhunk://#diff-fe0eeb4b02ba781cbfb3ffe529cfced7e1ff83c4b12300e04d89e772bf604786L26) [[5]](diffhunk://#diff-6866a7b4c1c09abfd878e3903c87088774751dda6e8bec2791c0fb521a161a0dL28-R28)
* Improved formatting of multi-line strings for GraphQL schema definitions in `AbstractGraphQLTest.java` and `GraphQLBasicTest.java`, replacing string concatenation with Java text blocks for better readability. [[1]](diffhunk://#diff-2451dc815deba4ea90e334c915075c2ac912b21fd6a3bede2df2910913acc43cL95-R114) [[2]](diffhunk://#diff-6866a7b4c1c09abfd878e3903c87088774751dda6e8bec2791c0fb521a161a0dL38-R71)

**General code cleanup:**

* Removed redundant code and simplified test setup, such as eliminating unnecessary methods and variables in test files. [[1]](diffhunk://#diff-2451dc815deba4ea90e334c915075c2ac912b21fd6a3bede2df2910913acc43cL95-R114) [[2]](diffhunk://#diff-6866a7b4c1c09abfd878e3903c87088774751dda6e8bec2791c0fb521a161a0dL38-R71)

These changes make the test codebase more maintainable and modern, leveraging best practices for exception assertions and code formatting.