### PR TITLE
chore: update Java version in CI configurations to JDK 25

### DIFF
--- a/.github/workflows/mvn-deploy.yml
+++ b/.github/workflows/mvn-deploy.yml
@@ -29,11 +29,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
           distribution: "temurin"
-          java-version: 21
+          java-version: 25
           cache: "maven"
           server-id: central
           server-username: MAVEN_USERNAME

--- a/.github/workflows/mvn-release.yml
+++ b/.github/workflows/mvn-release.yml
@@ -34,11 +34,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
           distribution: "temurin"
-          java-version: 21
+          java-version: 25
           cache: "maven"
           server-id: central
           server-username: MAVEN_USERNAME

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -29,11 +29,11 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
           distribution: "temurin"
-          java-version: 21
+          java-version: 25
           cache: "maven"
 
       - name: Set up QEMU
@@ -72,11 +72,11 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
           distribution: "temurin"
-          java-version: 21
+          java-version: 25
           cache: "maven"
 
       - name: Restore Maven artifacts
@@ -159,11 +159,11 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
           distribution: "temurin"
-          java-version: 21
+          java-version: 25
           cache: "maven"
 
       - name: Restore Maven artifacts
@@ -202,11 +202,11 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
           distribution: "temurin"
-          java-version: 21
+          java-version: 25
           cache: "maven"
 
       - name: Restore Maven artifacts
@@ -246,11 +246,11 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
           distribution: "temurin"
-          java-version: 21
+          java-version: 25
           cache: "maven"
 
       - name: Restore Maven artifacts

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-XX:+UseCompactObjectHeaders

--- a/package/src/main/docker/Dockerfile
+++ b/package/src/main/docker/Dockerfile
@@ -14,11 +14,11 @@
 # limitations under the License.
 #
 
-FROM eclipse-temurin:21-alpine@sha256:df8ce8302ed2ed1690ef490c633981b07e752b373b5fdf796960fb2eb0d640ea
-
+#FROM eclipse-temurin:21-alpine@sha256:df8ce8302ed2ed1690ef490c633981b07e752b373b5fdf796960fb2eb0d640ea
+FROM amazoncorretto:25-alpine3.22@sha256:807ea3c4000a052986cd1e7097a883f9cd7a6e527f73841f462e3d04851b8835
 LABEL maintainer="Arcade Data LTD (info@arcadedb.com)"
 
-ENV JAVA_OPTS="-XX:+UseZGC -XX:+ZGenerational"
+ENV JAVA_OPTS="-XX:+UseZGC -XX:+ZGenerational -XX:+UseCompactObjectHeaders"
 
 ENV ARCADEDB_OPTS_MEMORY="-Xms2G -Xmx2G"
 


### PR DESCRIPTION
# **THIS IS A POC**


This pull request updates the Java Development Kit (JDK) version used in all GitHub Actions workflows from JDK 21 to JDK 25. This ensures that all CI/CD pipelines (testing, deployment, and release) are aligned with the latest Java version.

**CI/CD Workflow Updates:**

* Updated the JDK version from 21 to 25 in the `mvn-deploy.yml` workflow to ensure deployments use the latest Java version.
* Updated the JDK version from 21 to 25 in the `mvn-release.yml` workflow for release builds.
* Updated the JDK version from 21 to 25 in all relevant steps of the `mvn-test.yml` workflow to run tests with the latest Java version. [[1]](diffhunk://#diff-de8e1c99a0afd1ff3311ccc77eb1d3495d898aea420ba3450bf6edb8794aa660L32-R36) [[2]](diffhunk://#diff-de8e1c99a0afd1ff3311ccc77eb1d3495d898aea420ba3450bf6edb8794aa660L75-R79) [[3]](diffhunk://#diff-de8e1c99a0afd1ff3311ccc77eb1d3495d898aea420ba3450bf6edb8794aa660L119-R123) [[4]](diffhunk://#diff-de8e1c99a0afd1ff3311ccc77eb1d3495d898aea420ba3450bf6edb8794aa660L162-R166) [[5]](diffhunk://#diff-de8e1c99a0afd1ff3311ccc77eb1d3495d898aea420ba3450bf6edb8794aa660L206-R210)