### PR TITLE
#2560 fix: ensure consistent exception propagation in ImmutableDocument duing lazy loading 

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/ImmutableDocument.java
+++ b/engine/src/main/java/com/arcadedb/database/ImmutableDocument.java
@@ -61,8 +61,8 @@ public class ImmutableDocument extends BaseDocument {
     if (propertyName == null)
       return null;
 
+    checkForLazyLoading();
     try {
-      checkForLazyLoading();
       return database.getSerializer()
           .deserializeProperty(database, buffer, new EmbeddedModifierProperty(this, propertyName), propertyName, rid);
     } catch (Exception e) {

--- a/engine/src/test/java/com/arcadedb/database/ImmutableDocumentLazyLoadingInconsistencyTest.java
+++ b/engine/src/test/java/com/arcadedb/database/ImmutableDocumentLazyLoadingInconsistencyTest.java
@@ -23,239 +23,222 @@ import com.arcadedb.event.AfterRecordReadListener;
 import com.arcadedb.schema.DocumentType;
 import org.junit.jupiter.api.Test;
 
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Test to verify the fix for issue #2560 - ImmutableDocument.checkForLazyLoading() consistency.
- *
+ * <p>
  * This test verifies that after the fix, the get() method now behaves consistently with other methods
  * (has(), modify(), toJSON(), toMap(), getPropertyNames()) by properly propagating exceptions thrown
  * during lazy loading instead of catching them and returning null.
- *
+ * <p>
  * The fix ensures that permission checking workflows that depend on exceptions being thrown during
  * lazy loading now work correctly with the get() method.
  */
 public class ImmutableDocumentLazyLoadingInconsistencyTest extends TestHelper {
 
-    /**
-     * Custom RuntimeException to simulate permission denied scenarios.
-     */
-    public static class PermissionDeniedException extends RuntimeException {
-        public PermissionDeniedException(String message) {
-            super(message);
-        }
+  /**
+   * Custom RuntimeException to simulate permission denied scenarios.
+   */
+  public static class PermissionDeniedException extends RuntimeException {
+    public PermissionDeniedException(String message) {
+      super(message);
     }
+  }
 
-    /**
-     * Test listener that simulates a security check that denies access.
-     */
-    public static class SecurityCheckListener implements AfterRecordReadListener {
-        private final boolean shouldDenyAccess;
-        private final String propertyName;
+  /**
+   * Test listener that simulates a security check that denies access.
+   */
+  public static class SecurityCheckListener implements AfterRecordReadListener {
+    private final boolean shouldDenyAccess;
+    private final String  propertyName;
 
-        public SecurityCheckListener(boolean shouldDenyAccess, String propertyName) {
-            this.shouldDenyAccess = shouldDenyAccess;
-            this.propertyName = propertyName;
-        }
-
-        @Override
-        public Record onAfterRead(Record record) {
-            if (shouldDenyAccess) {
-                throw new PermissionDeniedException("Access denied to property: " + propertyName);
-            }
-            return record;
-        }
+    public SecurityCheckListener(boolean shouldDenyAccess, String propertyName) {
+      this.shouldDenyAccess = shouldDenyAccess;
+      this.propertyName = propertyName;
     }
 
     @Override
-    public void beginTest() {
-        database.transaction(() -> {
-            final DocumentType type = database.getSchema().createDocumentType("SecurityTest");
-            type.createProperty("publicProperty", com.arcadedb.schema.Type.STRING);
-            type.createProperty("secretProperty", com.arcadedb.schema.Type.STRING);
-        });
+    public Record onAfterRead(Record record) {
+      if (shouldDenyAccess) {
+        throw new PermissionDeniedException("Access denied to property: " + propertyName);
+      }
+      return record;
     }
+  }
 
-    @Test
-    public void testLazyLoadingConsistencyWithSecurityException() {
-        database.transaction(() -> {
-            // Create a document with both public and secret properties
-            final MutableDocument doc = database.newDocument("SecurityTest");
-            doc.set("publicProperty", "public_value");
-            doc.set("secretProperty", "secret_value");
-            doc.save();
+  @Override
+  public void beginTest() {
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().createDocumentType("SecurityTest");
+      type.createProperty("publicProperty", com.arcadedb.schema.Type.STRING);
+      type.createProperty("secretProperty", com.arcadedb.schema.Type.STRING);
+    });
+  }
 
-            final RID documentRid = doc.getIdentity();
+  @Test
+  public void testLazyLoadingConsistencyWithSecurityException() {
+    database.transaction(() -> {
+      // Create a document with both public and secret properties
+      final MutableDocument doc = database.newDocument("SecurityTest");
+      doc.set("publicProperty", "public_value");
+      doc.set("secretProperty", "secret_value");
+      doc.save();
 
-            // Register a security listener that denies access when reading records
-            final SecurityCheckListener securityListener = new SecurityCheckListener(true, "secretProperty");
-            database.getEvents().registerListener(securityListener);
+      final RID documentRid = doc.getIdentity();
 
-            try {
-                // Test with an ImmutableDocument created by reading from DB (lazy loading will occur on first access)
-                database.commit();
-                database.begin();
+      // Register a security listener that denies access when reading records
+      final SecurityCheckListener securityListener = new SecurityCheckListener(true, "secretProperty");
+      database.getEvents().registerListener(securityListener);
 
-                // Get the document as ImmutableDocument (it will have buffer=null initially)
-                final ImmutableDocument immutableDoc = (ImmutableDocument) database.lookupByRID(documentRid, false);
+      try {
+        // Test with an ImmutableDocument created by reading from DB (lazy loading will occur on first access)
+        database.commit();
+        database.begin();
 
-                // Test 1: has() method should throw exception (current behavior - correct)
-                assertThatThrownBy(() -> immutableDoc.has("secretProperty"))
-                    .isInstanceOf(PermissionDeniedException.class)
-                    .hasMessage("Access denied to property: secretProperty");
+        // Get the document as ImmutableDocument (it will have buffer=null initially)
+        final ImmutableDocument immutableDoc = (ImmutableDocument) database.lookupByRID(documentRid, false);
 
-                // Test 2: Get another instance for modify() test
-                final ImmutableDocument immutableDoc2 = (ImmutableDocument) database.lookupByRID(documentRid, false);
-                assertThatThrownBy(() -> immutableDoc2.modify())
-                    .isInstanceOf(PermissionDeniedException.class)
-                    .hasMessage("Access denied to property: secretProperty");
-
-                // Test 3: Get another instance for toJSON() test
-                final ImmutableDocument immutableDoc3 = (ImmutableDocument) database.lookupByRID(documentRid, false);
-                assertThatThrownBy(() -> immutableDoc3.toJSON())
-                    .isInstanceOf(PermissionDeniedException.class)
-                    .hasMessage("Access denied to property: secretProperty");
-
-                // Test 4: Get another instance for toMap() test
-                final ImmutableDocument immutableDoc4 = (ImmutableDocument) database.lookupByRID(documentRid, false);
-                assertThatThrownBy(() -> immutableDoc4.toMap())
-                    .isInstanceOf(PermissionDeniedException.class)
-                    .hasMessage("Access denied to property: secretProperty");
-
-                // Test 5: Get another instance for getPropertyNames() test
-                final ImmutableDocument immutableDoc5 = (ImmutableDocument) database.lookupByRID(documentRid, false);
-                assertThatThrownBy(() -> immutableDoc5.getPropertyNames())
-                    .isInstanceOf(PermissionDeniedException.class)
-                    .hasMessage("Access denied to property: secretProperty");
-
-                // Test 6: get() method now correctly throws exception (FIXED - consistent behavior)
-                // After the fix, get() now properly propagates exceptions like other methods
-                final ImmutableDocument immutableDoc6 = (ImmutableDocument) database.lookupByRID(documentRid, false);
-                assertThatThrownBy(() -> immutableDoc6.get("secretProperty"))
-                    .isInstanceOf(PermissionDeniedException.class)
-                    .hasMessage("Access denied to property: secretProperty");
-
-            } finally {
-                // Clean up the security listener
-                database.getEvents().unregisterListener(securityListener);
-            }
+        // Test all methods that should trigger lazy loading and p ropagate the exception
+        Stream.<Consumer<ImmutableDocument>>of(
+            d -> d.has("secretProperty"),
+            ImmutableDocument::modify,
+            ImmutableDocument::toJSON,
+            ImmutableDocument::toMap,
+            ImmutableDocument::getPropertyNames,
+            d -> d.get("secretProperty")
+        ).forEach(action -> {
+          // Get a new instance for each test to ensure lazy loading is triggered
+          final ImmutableDocument freshDoc = (ImmutableDocument) database.lookupByRID(documentRid, false);
+          assertThatThrownBy(() -> action.accept(freshDoc))
+              .isInstanceOf(PermissionDeniedException.class)
+              .hasMessage("Access denied to property: secretProperty");
         });
-    }
 
-    @Test
-    public void testLazyLoadingConsistencyWithoutSecurityException() {
-        database.transaction(() -> {
-            // Create a document
-            final MutableDocument doc = database.newDocument("SecurityTest");
-            doc.set("publicProperty", "public_value");
-            doc.set("secretProperty", "secret_value");
-            doc.save();
+      } finally {
+        // Clean up the security listener
+        database.getEvents().unregisterListener(securityListener);
+      }
+    });
+  }
 
-            final RID documentRid = doc.getIdentity();
+  @Test
+  public void testLazyLoadingConsistencyWithoutSecurityException() {
+    database.transaction(() -> {
+      // Create a document
+      final MutableDocument doc = database.newDocument("SecurityTest");
+      doc.set("publicProperty", "public_value");
+      doc.set("secretProperty", "secret_value");
+      doc.save();
 
-            // Register a security listener that allows access
-            final SecurityCheckListener securityListener = new SecurityCheckListener(false, "secretProperty");
-            database.getEvents().registerListener(securityListener);
+      final RID documentRid = doc.getIdentity();
 
-            try {
-                database.commit();
-                database.begin();
+      // Register a security listener that allows access
+      final SecurityCheckListener securityListener = new SecurityCheckListener(false, "secretProperty");
+      database.getEvents().registerListener(securityListener);
 
-                // All methods should work normally when security check passes
-                final ImmutableDocument immutableDoc1 = (ImmutableDocument) database.lookupByRID(documentRid, false);
-                assertThat(immutableDoc1.has("secretProperty")).isTrue();
+      try {
+        database.commit();
+        database.begin();
 
-                final ImmutableDocument immutableDoc2 = (ImmutableDocument) database.lookupByRID(documentRid, false);
-                assertThat(immutableDoc2.get("secretProperty")).isEqualTo("secret_value");
+        // All methods should work normally when security check passes
+        final ImmutableDocument immutableDoc1 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+        assertThat(immutableDoc1.has("secretProperty")).isTrue();
 
-                final ImmutableDocument immutableDoc3 = (ImmutableDocument) database.lookupByRID(documentRid, false);
-                assertThat(immutableDoc3.modify()).isNotNull();
+        final ImmutableDocument immutableDoc2 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+        assertThat(immutableDoc2.get("secretProperty")).isEqualTo("secret_value");
 
-                final ImmutableDocument immutableDoc4 = (ImmutableDocument) database.lookupByRID(documentRid, false);
-                assertThat(immutableDoc4.toJSON().has("secretProperty")).isTrue();
+        final ImmutableDocument immutableDoc3 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+        assertThat(immutableDoc3.modify()).isNotNull();
 
-                final ImmutableDocument immutableDoc5 = (ImmutableDocument) database.lookupByRID(documentRid, false);
-                assertThat(immutableDoc5.toMap()).containsKey("secretProperty");
+        final ImmutableDocument immutableDoc4 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+        assertThat(immutableDoc4.toJSON().has("secretProperty")).isTrue();
 
-                final ImmutableDocument immutableDoc6 = (ImmutableDocument) database.lookupByRID(documentRid, false);
-                assertThat(immutableDoc6.getPropertyNames()).contains("secretProperty");
+        final ImmutableDocument immutableDoc5 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+        assertThat(immutableDoc5.toMap()).containsKey("secretProperty");
 
-            } finally {
-                // Clean up the security listener
-                database.getEvents().unregisterListener(securityListener);
-            }
-        });
-    }
+        final ImmutableDocument immutableDoc6 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+        assertThat(immutableDoc6.getPropertyNames()).contains("secretProperty");
 
-    @Test
-    public void testConsistentExceptionTypesInLazyLoading() {
-        database.transaction(() -> {
-            // Create a document
-            final MutableDocument doc = database.newDocument("SecurityTest");
-            doc.set("publicProperty", "public_value");
-            doc.save();
+      } finally {
+        // Clean up the security listener
+        database.getEvents().unregisterListener(securityListener);
+      }
+    });
+  }
 
-            final RID documentRid = doc.getIdentity();
+  @Test
+  public void testConsistentExceptionTypesInLazyLoading() {
+    database.transaction(() -> {
+      // Create a document
+      final MutableDocument doc = database.newDocument("SecurityTest");
+      doc.set("publicProperty", "public_value");
+      doc.save();
 
-            // Test with different exception types
-            final AfterRecordReadListener runtimeExceptionListener = new AfterRecordReadListener() {
-                @Override
-                public Record onAfterRead(Record record) {
-                    throw new RuntimeException("General runtime error");
-                }
-            };
+      final RID documentRid = doc.getIdentity();
 
-            final AfterRecordReadListener illegalStateListener = new AfterRecordReadListener() {
-                @Override
-                public Record onAfterRead(Record record) {
-                    throw new IllegalStateException("Invalid state for access");
-                }
-            };
+      // Test with different exception types
+      final AfterRecordReadListener runtimeExceptionListener = new AfterRecordReadListener() {
+        @Override
+        public Record onAfterRead(Record record) {
+          throw new RuntimeException("General runtime error");
+        }
+      };
 
-            // Test with RuntimeException
-            database.getEvents().registerListener(runtimeExceptionListener);
-            try {
-                database.commit();
-                database.begin();
+      final AfterRecordReadListener illegalStateListener = new AfterRecordReadListener() {
+        @Override
+        public Record onAfterRead(Record record) {
+          throw new IllegalStateException("Invalid state for access");
+        }
+      };
 
-                final ImmutableDocument immutableDoc1 = (ImmutableDocument) database.lookupByRID(documentRid, false);
-                // has() should propagate RuntimeException
-                assertThatThrownBy(() -> immutableDoc1.has("publicProperty"))
-                    .isInstanceOf(RuntimeException.class)
-                    .hasMessage("General runtime error");
+      // Test with RuntimeException
+      database.getEvents().registerListener(runtimeExceptionListener);
+      try {
+        database.commit();
+        database.begin();
 
-                // get() now correctly propagates RuntimeException (FIXED)
-                final ImmutableDocument immutableDoc2 = (ImmutableDocument) database.lookupByRID(documentRid, false);
-                assertThatThrownBy(() -> immutableDoc2.get("publicProperty"))
-                    .isInstanceOf(RuntimeException.class)
-                    .hasMessage("General runtime error");
+        final ImmutableDocument immutableDoc1 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+        // has() should propagate RuntimeException
+        assertThatThrownBy(() -> immutableDoc1.has("publicProperty"))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("General runtime error");
 
-            } finally {
-                database.getEvents().unregisterListener(runtimeExceptionListener);
-            }
+        // get() now correctly propagates RuntimeException (FIXED)
+        final ImmutableDocument immutableDoc2 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+        assertThatThrownBy(() -> immutableDoc2.get("publicProperty"))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("General runtime error");
 
-            // Test with IllegalStateException
-            database.getEvents().registerListener(illegalStateListener);
-            try {
-                database.commit();
-                database.begin();
+      } finally {
+        database.getEvents().unregisterListener(runtimeExceptionListener);
+      }
 
-                final ImmutableDocument immutableDoc3 = (ImmutableDocument) database.lookupByRID(documentRid, false);
-                // has() should propagate IllegalStateException
-                assertThatThrownBy(() -> immutableDoc3.has("publicProperty"))
-                    .isInstanceOf(IllegalStateException.class)
-                    .hasMessage("Invalid state for access");
+      // Test with IllegalStateException
+      database.getEvents().registerListener(illegalStateListener);
+      try {
+        database.commit();
+        database.begin();
 
-                // get() now correctly propagates IllegalStateException (FIXED)
-                final ImmutableDocument immutableDoc4 = (ImmutableDocument) database.lookupByRID(documentRid, false);
-                assertThatThrownBy(() -> immutableDoc4.get("publicProperty"))
-                    .isInstanceOf(IllegalStateException.class)
-                    .hasMessage("Invalid state for access");
+        final ImmutableDocument immutableDoc3 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+        // has() should propagate IllegalStateException
+        assertThatThrownBy(() -> immutableDoc3.has("publicProperty"))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Invalid state for access");
 
-            } finally {
-                database.getEvents().unregisterListener(illegalStateListener);
-            }
-        });
-    }
+        // get() now correctly propagates IllegalStateException (FIXED)
+        final ImmutableDocument immutableDoc4 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+        assertThatThrownBy(() -> immutableDoc4.get("publicProperty"))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Invalid state for access");
+
+      } finally {
+        database.getEvents().unregisterListener(illegalStateListener);
+      }
+    });
+  }
 }

--- a/engine/src/test/java/com/arcadedb/database/ImmutableDocumentLazyLoadingInconsistencyTest.java
+++ b/engine/src/test/java/com/arcadedb/database/ImmutableDocumentLazyLoadingInconsistencyTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.event.AfterRecordReadListener;
+import com.arcadedb.schema.DocumentType;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Test to verify the fix for issue #2560 - ImmutableDocument.checkForLazyLoading() consistency.
+ *
+ * This test verifies that after the fix, the get() method now behaves consistently with other methods
+ * (has(), modify(), toJSON(), toMap(), getPropertyNames()) by properly propagating exceptions thrown
+ * during lazy loading instead of catching them and returning null.
+ *
+ * The fix ensures that permission checking workflows that depend on exceptions being thrown during
+ * lazy loading now work correctly with the get() method.
+ */
+public class ImmutableDocumentLazyLoadingInconsistencyTest extends TestHelper {
+
+    /**
+     * Custom RuntimeException to simulate permission denied scenarios.
+     */
+    public static class PermissionDeniedException extends RuntimeException {
+        public PermissionDeniedException(String message) {
+            super(message);
+        }
+    }
+
+    /**
+     * Test listener that simulates a security check that denies access.
+     */
+    public static class SecurityCheckListener implements AfterRecordReadListener {
+        private final boolean shouldDenyAccess;
+        private final String propertyName;
+
+        public SecurityCheckListener(boolean shouldDenyAccess, String propertyName) {
+            this.shouldDenyAccess = shouldDenyAccess;
+            this.propertyName = propertyName;
+        }
+
+        @Override
+        public Record onAfterRead(Record record) {
+            if (shouldDenyAccess) {
+                throw new PermissionDeniedException("Access denied to property: " + propertyName);
+            }
+            return record;
+        }
+    }
+
+    @Override
+    public void beginTest() {
+        database.transaction(() -> {
+            final DocumentType type = database.getSchema().createDocumentType("SecurityTest");
+            type.createProperty("publicProperty", com.arcadedb.schema.Type.STRING);
+            type.createProperty("secretProperty", com.arcadedb.schema.Type.STRING);
+        });
+    }
+
+    @Test
+    public void testLazyLoadingConsistencyWithSecurityException() {
+        database.transaction(() -> {
+            // Create a document with both public and secret properties
+            final MutableDocument doc = database.newDocument("SecurityTest");
+            doc.set("publicProperty", "public_value");
+            doc.set("secretProperty", "secret_value");
+            doc.save();
+
+            final RID documentRid = doc.getIdentity();
+
+            // Register a security listener that denies access when reading records
+            final SecurityCheckListener securityListener = new SecurityCheckListener(true, "secretProperty");
+            database.getEvents().registerListener(securityListener);
+
+            try {
+                // Test with an ImmutableDocument created by reading from DB (lazy loading will occur on first access)
+                database.commit();
+                database.begin();
+
+                // Get the document as ImmutableDocument (it will have buffer=null initially)
+                final ImmutableDocument immutableDoc = (ImmutableDocument) database.lookupByRID(documentRid, false);
+
+                // Test 1: has() method should throw exception (current behavior - correct)
+                assertThatThrownBy(() -> immutableDoc.has("secretProperty"))
+                    .isInstanceOf(PermissionDeniedException.class)
+                    .hasMessage("Access denied to property: secretProperty");
+
+                // Test 2: Get another instance for modify() test
+                final ImmutableDocument immutableDoc2 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+                assertThatThrownBy(() -> immutableDoc2.modify())
+                    .isInstanceOf(PermissionDeniedException.class)
+                    .hasMessage("Access denied to property: secretProperty");
+
+                // Test 3: Get another instance for toJSON() test
+                final ImmutableDocument immutableDoc3 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+                assertThatThrownBy(() -> immutableDoc3.toJSON())
+                    .isInstanceOf(PermissionDeniedException.class)
+                    .hasMessage("Access denied to property: secretProperty");
+
+                // Test 4: Get another instance for toMap() test
+                final ImmutableDocument immutableDoc4 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+                assertThatThrownBy(() -> immutableDoc4.toMap())
+                    .isInstanceOf(PermissionDeniedException.class)
+                    .hasMessage("Access denied to property: secretProperty");
+
+                // Test 5: Get another instance for getPropertyNames() test
+                final ImmutableDocument immutableDoc5 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+                assertThatThrownBy(() -> immutableDoc5.getPropertyNames())
+                    .isInstanceOf(PermissionDeniedException.class)
+                    .hasMessage("Access denied to property: secretProperty");
+
+                // Test 6: get() method now correctly throws exception (FIXED - consistent behavior)
+                // After the fix, get() now properly propagates exceptions like other methods
+                final ImmutableDocument immutableDoc6 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+                assertThatThrownBy(() -> immutableDoc6.get("secretProperty"))
+                    .isInstanceOf(PermissionDeniedException.class)
+                    .hasMessage("Access denied to property: secretProperty");
+
+            } finally {
+                // Clean up the security listener
+                database.getEvents().unregisterListener(securityListener);
+            }
+        });
+    }
+
+    @Test
+    public void testLazyLoadingConsistencyWithoutSecurityException() {
+        database.transaction(() -> {
+            // Create a document
+            final MutableDocument doc = database.newDocument("SecurityTest");
+            doc.set("publicProperty", "public_value");
+            doc.set("secretProperty", "secret_value");
+            doc.save();
+
+            final RID documentRid = doc.getIdentity();
+
+            // Register a security listener that allows access
+            final SecurityCheckListener securityListener = new SecurityCheckListener(false, "secretProperty");
+            database.getEvents().registerListener(securityListener);
+
+            try {
+                database.commit();
+                database.begin();
+
+                // All methods should work normally when security check passes
+                final ImmutableDocument immutableDoc1 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+                assertThat(immutableDoc1.has("secretProperty")).isTrue();
+
+                final ImmutableDocument immutableDoc2 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+                assertThat(immutableDoc2.get("secretProperty")).isEqualTo("secret_value");
+
+                final ImmutableDocument immutableDoc3 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+                assertThat(immutableDoc3.modify()).isNotNull();
+
+                final ImmutableDocument immutableDoc4 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+                assertThat(immutableDoc4.toJSON().has("secretProperty")).isTrue();
+
+                final ImmutableDocument immutableDoc5 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+                assertThat(immutableDoc5.toMap()).containsKey("secretProperty");
+
+                final ImmutableDocument immutableDoc6 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+                assertThat(immutableDoc6.getPropertyNames()).contains("secretProperty");
+
+            } finally {
+                // Clean up the security listener
+                database.getEvents().unregisterListener(securityListener);
+            }
+        });
+    }
+
+    @Test
+    public void testConsistentExceptionTypesInLazyLoading() {
+        database.transaction(() -> {
+            // Create a document
+            final MutableDocument doc = database.newDocument("SecurityTest");
+            doc.set("publicProperty", "public_value");
+            doc.save();
+
+            final RID documentRid = doc.getIdentity();
+
+            // Test with different exception types
+            final AfterRecordReadListener runtimeExceptionListener = new AfterRecordReadListener() {
+                @Override
+                public Record onAfterRead(Record record) {
+                    throw new RuntimeException("General runtime error");
+                }
+            };
+
+            final AfterRecordReadListener illegalStateListener = new AfterRecordReadListener() {
+                @Override
+                public Record onAfterRead(Record record) {
+                    throw new IllegalStateException("Invalid state for access");
+                }
+            };
+
+            // Test with RuntimeException
+            database.getEvents().registerListener(runtimeExceptionListener);
+            try {
+                database.commit();
+                database.begin();
+
+                final ImmutableDocument immutableDoc1 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+                // has() should propagate RuntimeException
+                assertThatThrownBy(() -> immutableDoc1.has("publicProperty"))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("General runtime error");
+
+                // get() now correctly propagates RuntimeException (FIXED)
+                final ImmutableDocument immutableDoc2 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+                assertThatThrownBy(() -> immutableDoc2.get("publicProperty"))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("General runtime error");
+
+            } finally {
+                database.getEvents().unregisterListener(runtimeExceptionListener);
+            }
+
+            // Test with IllegalStateException
+            database.getEvents().registerListener(illegalStateListener);
+            try {
+                database.commit();
+                database.begin();
+
+                final ImmutableDocument immutableDoc3 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+                // has() should propagate IllegalStateException
+                assertThatThrownBy(() -> immutableDoc3.has("publicProperty"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Invalid state for access");
+
+                // get() now correctly propagates IllegalStateException (FIXED)
+                final ImmutableDocument immutableDoc4 = (ImmutableDocument) database.lookupByRID(documentRid, false);
+                assertThatThrownBy(() -> immutableDoc4.get("publicProperty"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Invalid state for access");
+
+            } finally {
+                database.getEvents().unregisterListener(illegalStateListener);
+            }
+        });
+    }
+}


### PR DESCRIPTION
This pull request addresses an inconsistency in the lazy loading behavior of the `ImmutableDocument` class, specifically ensuring that the `get()` method now properly propagates exceptions thrown during lazy loading, just like other related methods. This fix improves the reliability of permission checks and exception handling in workflows that depend on consistent error propagation. Additionally, comprehensive tests have been added to verify the fix and ensure consistent behavior across various scenarios.

### Lazy loading consistency and exception propagation

* The `get()` method in `ImmutableDocument` was updated to propagate exceptions thrown during lazy loading, aligning its behavior with other methods such as `has()`, `modify()`, `toJSON()`, `toMap()`, and `getPropertyNames()`. This ensures that permission checks and security workflows relying on exceptions now work correctly with `get()`.

### Test coverage for lazy loading and exception handling

* Added a new test class `ImmutableDocumentLazyLoadingInconsistencyTest` to verify consistent exception propagation for the `get()` method and other related methods. The tests cover scenarios with and without security exceptions, and check propagation of different exception types.