### PR TITLE
feat: enhance CI by adding slow unit tests and coverage reporting

### DIFF
--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -87,7 +87,50 @@ jobs:
 
       - name: Run Unit Tests with Coverage
         # verify because it runs the tests and generates the coverage report, ITs are skipped
-        run: ./mvnw verify -Pcoverage --batch-mode --errors --fail-never --show-version -pl !e2e,!e2e-perf
+        run: ./mvnw verify -Pcoverage --batch-mode --errors --fail-never --show-version -pl !e2e,!e2e-perf -DexcludedGroups=slow
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Unit Tests Reporter
+        uses: dorny/test-reporter@dc3a92680fcc15842eef52e8c4606ea7ce6bd3f3 # v2.1.1
+        if: success() || failure()
+        with:
+          name: Unit Tests Report
+          path: "**/surefire-reports/TEST*.xml"
+          list-suites: "failed"
+          list-tests: "failed"
+          reporter: java-junit
+
+      - name: Upload unit test coverage reports
+        if: success() || failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: unit-coverage-reports
+          path: |
+            **/jacoco*.xml
+          retention-days: 1
+
+  slow-unit-tests:
+    runs-on: ubuntu-latest
+    needs: build-and-package
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+        with:
+          distribution: "temurin"
+          java-version: 21
+          cache: "maven"
+
+      - name: Restore Maven artifacts
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.m2/repository
+          key: maven-repo-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Run Slow Unit Tests with Coverage
+        run: ./mvnw verify -Pcoverage --batch-mode --errors --fail-never --show-version -pl engine  -Dgroups=slow
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/engine/src/test/java/com/arcadedb/ACIDTransactionTest.java
+++ b/engine/src/test/java/com/arcadedb/ACIDTransactionTest.java
@@ -36,6 +36,8 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.schema.VertexType;
+import jdk.jfr.Category;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
@@ -256,6 +258,7 @@ public class ACIDTransactionTest extends TestHelper {
   }
 
   @Test
+  @Tag("slow")
   public void testAsyncIOExceptionAfterWALIsWrittenManyRecords() {
     final Database db = database;
 
@@ -397,6 +400,7 @@ public class ACIDTransactionTest extends TestHelper {
   }
 
   @Test
+  @Tag("slow")
   public void testAsyncEdges() {
     final Database db = database;
 

--- a/engine/src/test/java/com/arcadedb/CRUDTest.java
+++ b/engine/src/test/java/com/arcadedb/CRUDTest.java
@@ -28,6 +28,7 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.*;
@@ -77,6 +78,7 @@ public class CRUDTest extends TestHelper {
   }
 
   @Test
+  @Tag("slow")
   public void testMultiUpdatesOverlap() {
     final Database db = database;
 
@@ -177,6 +179,7 @@ public class CRUDTest extends TestHelper {
   }
 
   @Test
+  @Tag("slow")
   public void testMultiUpdatesAndDeleteOverlap() {
     final Database db = database;
     try {

--- a/engine/src/test/java/com/arcadedb/RandomTestMultiThreadsTest.java
+++ b/engine/src/test/java/com/arcadedb/RandomTestMultiThreadsTest.java
@@ -32,6 +32,7 @@ import com.arcadedb.schema.EdgeType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.VertexType;
 import com.arcadedb.utility.Pair;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.math.*;
@@ -58,6 +59,7 @@ public class RandomTestMultiThreadsTest extends TestHelper {
   private final boolean                              debug                   = false;
 
   @Test
+  @Tag("slow")
   public void testRandom() {
     GlobalConfiguration.COMMIT_LOCK_TIMEOUT.setValue(10_000);
 

--- a/engine/src/test/java/com/arcadedb/engine/RandomDeleteTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/RandomDeleteTest.java
@@ -24,6 +24,7 @@ import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
 import com.arcadedb.graph.MutableVertex;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
@@ -34,6 +35,7 @@ public class RandomDeleteTest {
   private static final int    CYCLES      = 3;
 
   @Test
+  @Tag("slow")
   public void testSmallRecords() {
     try (DatabaseFactory databaseFactory = new DatabaseFactory("databases/randomDeleteTest")) {
       if (databaseFactory.exists())

--- a/engine/src/test/java/com/arcadedb/engine/RecordRecyclingTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/RecordRecyclingTest.java
@@ -22,15 +22,15 @@ import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.RID;
-import com.arcadedb.graph.MutableEdge;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.select.SelectIterator;
 import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.util.Collection;
 
 import static com.arcadedb.schema.LocalSchema.STATISTICS_FILE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,6 +43,7 @@ public class RecordRecyclingTest {
   private final static int    TOT_VERTICES = 1000;
 
   @Test
+  @Tag("slow")
   public void testCreateAndDeleteGraph() {
     GlobalConfiguration.BUCKET_REUSE_SPACE_MODE.setValue("high");
 

--- a/engine/src/test/java/com/arcadedb/index/LSMTreeIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/LSMTreeIndexTest.java
@@ -31,6 +31,7 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -1011,6 +1012,7 @@ public class LSMTreeIndexTest extends TestHelper {
   }
 
   @Test
+  @Tag("slow")
   public void testUniqueConcurrentWithIndexesCompaction() throws InterruptedException {
     database.begin();
     final long startingWith = database.countType(TYPE_NAME, true);

--- a/engine/src/test/java/com/arcadedb/index/TypeLSMTreeIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/TypeLSMTreeIndexTest.java
@@ -32,6 +32,7 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.schema.VertexType;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -560,6 +561,7 @@ public class TypeLSMTreeIndexTest extends TestHelper {
   }
 
   @Test
+  @Tag("slow")
   public void testUniqueConcurrentWithIndexesCompaction() {
     GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE.setValue(0);
 


### PR DESCRIPTION
This pull request improves the test workflow by splitting slow-running unit tests from standard ones and updating the GitHub Actions configuration to report and upload test results. Additionally, several tests are now explicitly marked as "slow" using JUnit tags, allowing for more granular test execution and reporting.

**CI Workflow Improvements:**

- The `.github/workflows/mvn-test.yml` file is updated to:
  - Exclude "slow" tests from the regular unit test job by using `-DexcludedGroups=slow` and introduce a separate `slow-unit-tests` job to run only tests tagged as "slow".
  - Add steps for reporting unit test results using `dorny/test-reporter` and uploading coverage reports as artifacts for easier access and review.

**Test Suite Organization:**

- Multiple test classes (`ACIDTransactionTest`, `CRUDTest`, `RandomTestMultiThreadsTest`, `RandomDeleteTest`, `RecordRecyclingTest`, `LSMTreeIndexTest`, `TypeLSMTreeIndexTest`) now import and use `@Tag("slow")` from JUnit to mark specific long-running tests. This enables selective execution and improves CI performance. [[1]](diffhunk://#diff-cb37b3c403271a9d79b3936f9195b1f7ffa0b21f14399bb71caf5377cc659e36R39-R40) [[2]](diffhunk://#diff-cb37b3c403271a9d79b3936f9195b1f7ffa0b21f14399bb71caf5377cc659e36R261) [[3]](diffhunk://#diff-cb37b3c403271a9d79b3936f9195b1f7ffa0b21f14399bb71caf5377cc659e36R403) [[4]](diffhunk://#diff-308623daf3f9d17f4e4d8dba493915c1c5addc2a91c181785ae6ec5e536e8b0aR31) [[5]](diffhunk://#diff-308623daf3f9d17f4e4d8dba493915c1c5addc2a91c181785ae6ec5e536e8b0aR81) [[6]](diffhunk://#diff-308623daf3f9d17f4e4d8dba493915c1c5addc2a91c181785ae6ec5e536e8b0aR182) [[7]](diffhunk://#diff-345366d453b42e5edd71b5c3367fdf20004bd16c81b97b4428209dfb77c66962R35) [[8]](diffhunk://#diff-345366d453b42e5edd71b5c3367fdf20004bd16c81b97b4428209dfb77c66962R62) [[9]](diffhunk://#diff-63dc90ea38f8131722e954e8b49f04884f67e0347bb9e56d7a5fbd0117a532cfR27) [[10]](diffhunk://#diff-63dc90ea38f8131722e954e8b49f04884f67e0347bb9e56d7a5fbd0117a532cfR38) [[11]](diffhunk://#diff-21ee2909897ea2e0d1f173b84b16f3adaef4544a10323fbb1d22e5d2f2e016b1L25-R33) [[12]](diffhunk://#diff-21ee2909897ea2e0d1f173b84b16f3adaef4544a10323fbb1d22e5d2f2e016b1R46) [[13]](diffhunk://#diff-dd38a7695e24ce74ee7bf004b1d096677bcc4886af765fccbb360c92d918c629R34) [[14]](diffhunk://#diff-dd38a7695e24ce74ee7bf004b1d096677bcc4886af765fccbb360c92d918c629R1015) [[15]](diffhunk://#diff-4acdd28ddea8687d89cca02557321344b05c247f868c5824de79aff6220e6e66R35) [[16]](diffhunk://#diff-4acdd28ddea8687d89cca02557321344b05c247f868c5824de79aff6220e6e66R564)