### PR TITLE
fix: remove flaky spinner visibility check in E2E tests for improved …

### DIFF
--- a/e2e-studio/tests/create-database.spec.ts
+++ b/e2e-studio/tests/create-database.spec.ts
@@ -32,10 +32,8 @@ test.describe('ArcadeDB Studio Database Creation', () => {
     // Click sign in button using actual onclick handler
     await page.click('button[onclick="login()"]');
 
-    // Wait for login spinner to appear (indicates login started)
-    await expect(page.locator('#loginSpinner')).toBeVisible();
-
     // Wait for login to complete - check multiple conditions
+    // Note: Removed flaky spinner visibility check that fails when login is fast
     await Promise.all([
       expect(page.locator('#loginSpinner')).toBeHidden({ timeout: 30000 }),
       expect(page.locator('#studioPanel')).toBeVisible({ timeout: 30000 }),

--- a/e2e-studio/tests/query-beer-database.spec.ts
+++ b/e2e-studio/tests/query-beer-database.spec.ts
@@ -70,9 +70,6 @@ test.describe('ArcadeDB Studio Beer Database Query', () => {
     // Check specifically for "Displayed 10 vertices and 0 edges"
     const graphStats = page.locator('text=Displayed').locator('..'); // Get parent element
     await expect(graphStats).toContainText('Displayed 10 vertices and 0 edges');
-
-    // Alternative verification: check for the exact count in the graph stats
-    await expect(page.getByText('10').nth(1)).toBeVisible(); // Second occurrence should be in graph stats
   });
 
   test.skip('should navigate graph by expanding edges from Beer to Brewery', async ({ page }) => {


### PR DESCRIPTION
This pull request makes small improvements to the end-to-end tests for ArcadeDB Studio, focusing on removing flaky or redundant test verifications.

Testing reliability improvements:

* In `e2e-studio/tests/create-database.spec.ts`, removed the check for the login spinner's visibility, which was prone to flakiness when login completed quickly. The test now only waits for the spinner to be hidden and the studio panel to be visible.
* In `e2e-studio/tests/query-beer-database.spec.ts`, removed a redundant verification for the graph stats count, relying instead on a more robust check for the displayed text.