### PR TITLE
chore: add .venv and .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -548,3 +548,6 @@ dist
 /backups/
 /claude/
 /grpc/src/generated
+
+.venv/
+.vscode/


### PR DESCRIPTION
## What does this PR do?

Most Python and VS Code users have `.venv/` and `.vscode/` directories in the Github repo root. And lately many systems add them to `.gitignore` by default.

## Motivation

My VS Code thinks that changes are made but it's not. I just have my venv and vscode configured.