### PR TITLE
Add missing maven variable to grpc pom

### DIFF
--- a/grpc/pom.xml
+++ b/grpc/pom.xml
@@ -170,6 +170,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-clean-plugin</artifactId>
+				<version>${maven-clean-plugin.version}</version>
 				<configuration>
 					<filesets>
 						<fileset>


### PR DESCRIPTION
## What does this PR do?

Adds a missing version variable to the grpc module pom.xml

## Motivation

Warning in logs

## Related issues

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
