### PR TITLE
IF NOT EXISTS doesn't work for EDGE [@out,@in] index

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
@@ -111,6 +111,7 @@ public class CreateIndexStatement extends DDLStatement {
 
     database.getSchema().buildTypeIndex(typeName.getStringValue(), fields)
         .withType(indexType)
+        .withIgnoreIfExists(ifNotExists)
         .withUnique(unique)
         .withPageSize(LSMTreeIndexAbstract.DEF_PAGE_SIZE)
         .withNullStrategy(nullStrategy)


### PR DESCRIPTION
## What does this PR do?

This PR aims to fix an error when creating an index a second time when using the clause IF NOT EXISTS

## Motivation

Improving Arcadedb

## Related issues

https://github.com/ArcadeData/arcadedb/issues/1601
https://github.com/ArcadeData/arcadedb/issues/1819

## Additional Notes

It is necessary to refactor code under `com.arcadedb.query.sql.parser`. Found unused code and code that could be simplified.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
