### PR TITLE
Temporary fix for Mongo commands

### DIFF
--- a/mongodbw/src/main/java/com/arcadedb/mongo/query/MongoQueryEngine.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/query/MongoQueryEngine.java
@@ -71,13 +71,20 @@ public class MongoQueryEngine implements QueryEngine {
     return query(query, null, (Map) null);
   }
 
+  // TODO: This command method can only handle queries, a command method needs to be provided in mongoDBWrapper
   @Override
   public ResultSet command(final String query, ContextConfiguration configuration, final Map<String, Object> parameters) {
-    return null;
+    try {
+      return mongoDBWrapper.query(query);
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.SEVERE, "Error on initializing Mongo query engine", e);
+      throw new CommandParsingException("Error on initializing Mongo query engine", e);
+    }
   }
 
+  // TODO: This command method can only handle queries, a command method needs to be provided in mongoDBWrapper
   @Override
   public ResultSet command(final String query, ContextConfiguration configuration, final Object... parameters) {
-    return null;
+    return query(query, null, (Map) null);
   }
 }


### PR DESCRIPTION
## What does this PR do?

This change temporary makes mongoDB commands be handled as queries, so instead of returning just `null` at least queries can be handled this way. This is important to make mongo queries work in studio.

## Motivation

Mongo queries are not working in studio

## Related issues

https://github.com/ArcadeData/arcadedb/issues/2168

## Additional Notes

To execute actual commands, the mongoDBWrapper needs to add a `command` method similar to its `query` method.

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
