### PR TITLE
Fix restore log entry

### DIFF
--- a/integration/src/main/java/com/arcadedb/integration/restore/format/FullRestoreFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/restore/format/FullRestoreFormat.java
@@ -105,7 +105,7 @@ public class FullRestoreFormat extends AbstractRestoreFormat {
         throw new RestoreException("Unable to perform restore");
 
       logger.logLine(0, "Full restore completed in %d seconds %s -> %s (%,d%% compression)", elapsedInSecs,
-          FileUtils.getSizeAsString(databaseOrigSize), FileUtils.getSizeAsString((inputSource.fileSize)),
+          FileUtils.getSizeAsString((inputSource.fileSize)), FileUtils.getSizeAsString(databaseOrigSize),
           databaseOrigSize > 0 ? (databaseOrigSize - inputSource.fileSize) * 100 / databaseOrigSize : 0);
     });
   }


### PR DESCRIPTION
## What does this PR do?

This change swaps two arguments in the format method of the log entry when a restore is complete. Before the change the log entry is equal to the back-up log entry which writes the uncompressed database compressed to disk. For restore the compressed database is loaded uncompressed to memory, so the entry should state: "from small to large".

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
