### PR TITLE
Review and plan solution for GitHub issue

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -1686,9 +1686,6 @@ public class SelectExecutionPlanner {
     if (indexSearchDescriptors.contains(null))
       return null; // some blocks could not be managed with an index, fall back to full scan
 
-    if (indexSearchDescriptors.isEmpty())
-      return null;
-
     List<IndexSearchDescriptor> optimumIndexSearchDescriptors =
         commonFactor(indexSearchDescriptors);
 

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/DeleteStatementTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/DeleteStatementTest.java
@@ -25,8 +25,11 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.utility.CollectionUtils;
 import org.junit.jupiter.api.Test;
 
-import java.io.*;
-import java.util.*;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -107,13 +110,14 @@ public class DeleteStatementTest extends TestHelper {
     assertThat(CollectionUtils.countEntries(result)).isEqualTo(6);
 
     // Delete using multiple OR conditions (this should delete all 6 edges)
-    final String deleteQuery = "delete from HierarchyDuctDuct where " +
-        "((internal_from = 'A') AND (internal_to = 'B') AND (swap = false) AND (order_number = 1)) OR " +
-        "((internal_from = 'A') AND (internal_to = 'C') AND (swap = false) AND (order_number = 2)) OR " +
-        "((internal_from = 'A') AND (internal_to = 'D') AND (swap = false) AND (order_number = 3)) OR " +
-        "((internal_from = 'A') AND (internal_to = 'E') AND (swap = false) AND (order_number = 4)) OR " +
-        "((internal_from = 'A') AND (internal_to = 'F') AND (swap = false) AND (order_number = 5)) OR " +
-        "((internal_from = 'A') AND (internal_to = 'G') AND (swap = false) AND (order_number = 6))";
+    final String deleteQuery = """
+        delete from HierarchyDuctDuct where
+        ((internal_from = 'A') AND (internal_to = 'B') AND (swap = false) AND (order_number = 1)) OR
+        ((internal_from = 'A') AND (internal_to = 'C') AND (swap = false) AND (order_number = 2)) OR
+        ((internal_from = 'A') AND (internal_to = 'D') AND (swap = false) AND (order_number = 3)) OR
+        ((internal_from = 'A') AND (internal_to = 'E') AND (swap = false) AND (order_number = 4)) OR
+        ((internal_from = 'A') AND (internal_to = 'F') AND (swap = false) AND (order_number = 5)) OR
+        ((internal_from = 'A') AND (internal_to = 'G') AND (swap = false) AND (order_number = 6))""";
 
     final ResultSet deleteResult = database.command("sql", deleteQuery);
     final long deletedCount = deleteResult.next().getProperty("count");
@@ -150,13 +154,14 @@ public class DeleteStatementTest extends TestHelper {
     assertThat(CollectionUtils.countEntries(result)).isEqualTo(6);
 
     // Delete using OR with indexed field - all branches should be processed
-    final String deleteQuery = "delete from Product where " +
-        "(id = 1 AND category = 'cat1') OR " +
-        "(id = 2 AND category = 'cat2') OR " +
-        "(id = 3 AND category = 'cat3') OR " +
-        "(id = 4 AND category = 'cat4') OR " +
-        "(id = 5 AND category = 'cat5') OR " +
-        "(id = 6 AND category = 'cat6')";
+    final String deleteQuery = """
+        delete from Product where
+        (id = 1 AND category = 'cat1') OR
+        (id = 2 AND category = 'cat2') OR
+        (id = 3 AND category = 'cat3') OR
+        (id = 4 AND category = 'cat4') OR
+        (id = 5 AND category = 'cat5') OR
+        (id = 6 AND category = 'cat6')""";
 
     final ResultSet deleteResult = database.command("sql", deleteQuery);
     final long deletedCount = deleteResult.next().getProperty("count");


### PR DESCRIPTION
…st match

Problem:
When executing a DELETE statement with multiple OR conditions (e.g., (A AND B) OR (C AND D) OR (E AND F)), only records matching the FIRST OR branch were deleted. The remaining OR branches were silently ignored.

Root Cause:
In SelectExecutionPlanner.handleTypeAsTargetWithIndex(), when processing flattened WHERE clauses (one AndBlock per OR branch), the code attempted to optimize each branch using indexes via findBestIndexFor(). However, it used .filter(Objects::nonNull) to remove branches that couldn't be optimized, causing those branches to be silently dropped from execution.

This meant:
- If branch 1 could use an index → executed
- If branches 2-6 couldn't use indexes → silently dropped
- Result: only 1 record deleted instead of 6

Fix:
Changed the logic to check if ANY OR branch cannot be optimized with an index. If so, fall back to a full table scan with WHERE clause filtering instead of silently dropping branches. This ensures ALL OR conditions are evaluated.

The fix changes:
  .filter(Objects::nonNull)  // REMOVES null entries
  .collect(Collectors.toList());
to:
  .collect(Collectors.toList());
  if (indexSearchDescriptors.contains(null))  // CHECK for nulls
    return null;  // Fall back to full scan

Testing:
Added two comprehensive test cases:
1. testDeleteWithMultipleOrConditions - tests without indexes
2. testDeleteWithMultipleOrConditionsAndIndex - tests with indexes

Both verify that all 6 records matching different OR branches are deleted, not just the first one.

## What does this PR do?

A brief description of the change being made with this pull request.

## Motivation

What inspired you to submit this pull request?

## Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

## Additional Notes

Anything else we should know when reviewing?

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
