### PR TITLE
fix: repair links on studio resource page

### DIFF
--- a/studio/src/main/resources/static/resources.html
+++ b/studio/src/main/resources/static/resources.html
@@ -23,7 +23,7 @@
                 <p><a class="link" href="https://docs.arcadedb.com#gremlin-api">Apache Gremlin (Apache Tinkerpop v3.7.x)</a></p>
               </li>
               <li>
-                <p><a class="link" href="https://docs.arcadedb.com#mongodb-api">MongoDB Query Language</a></p>
+                <p><a class="link" href="https://docs.arcadedb.com#mongodb-query-language">MongoDB Query Language</a></p>
               </li>
             </ul>
           </div>
@@ -44,10 +44,10 @@
           <div class="ulist">
             <ul>
               <li>
-                <p><a class="link" href="https://docs.arcadedb.com#java-api">Embedded</a> from any language on top of the Java Virtual Machine</p>
+                <p><a class="link" href="https://docs.arcadedb.com#java-api-local">Embedded</a> from any language on top of the Java Virtual Machine</p>
               </li>
               <li>
-                <p>Remotely by using <a class="link" href="https://docs.arcadedb.com#http-api">HTTP/JSON</a></p>
+                <p>Remotely by using <a class="link" href="https://docs.arcadedb.com#http-json-api">HTTP/JSON</a></p>
               </li>
               <li>
                 <p>
@@ -57,13 +57,13 @@
               </li>
               <li>
                 <p>
-                  Remotely by using a <a class="link" href="https://docs.arcadedb.com#mongodb-api">MongoDB driver</a> (only a subset of the operations are
+                  Remotely by using a <a class="link" href="https://docs.arcadedb.com#mongodb-protocol">MongoDB driver</a> (only a subset of the operations are
                   implemented)
                 </p>
               </li>
               <li>
                 <p>
-                  Remotely by using a <a class="link" href="https://docs.arcadedb.com#redis-api">Redis driver</a> (only a subset of the operations are
+                  Remotely by using a <a class="link" href="https://docs.arcadedb.com#redis-query-language">Redis driver</a> (only a subset of the operations are
                   implemented)
                 </p>
               </li>


### PR DESCRIPTION
## What does this PR do?

This change repairs the links on the studio resources page pointing to the docs.

## Motivation

Finding broken links

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
