### PR TITLE
[POC] Virtual Threads 

### DIFF
--- a/e2e-perf/src/test/java/com/arcadedb/test/performance/SingleServerLoadTestIT.java
+++ b/e2e-perf/src/test/java/com/arcadedb/test/performance/SingleServerLoadTestIT.java
@@ -48,10 +48,10 @@ class SingleServerLoadTestIT extends ContainersTestTemplate {
 
     // Parameters for the test
     final int numOfThreads = 5; //number of threads to use to insert users and photos
-    final int numOfUsers = 10000; // Each thread will create 200000 users
-    final int numOfPhotos = 10; // Each user will have 5 photos
-    final int numOfFriendship = 1000; // Each thread will create 100000 friendships
-    final int numOfLike = 1000; // Each thread will create 100000 likes
+    final int numOfUsers = 10000; // number of users per thread
+    final int numOfPhotos = 10; // number of phots per user
+    final int numOfFriendship = 1000; // total number of friendships edges to create
+    final int numOfLike = 1000; // total number of likes to photo edges to create
 
     int expectedUsersCount = numOfUsers * numOfThreads;
     int expectedPhotoCount = expectedUsersCount * numOfPhotos;

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -443,6 +443,10 @@ public enum GlobalConfiguration {
   HA_REPLICATION_INCOMING_PORTS("arcadedb.ha.replicationIncomingPorts", SCOPE.SERVER,
       "TCP/IP port number used for incoming replication connections", String.class, "2424-2433"),
 
+  HA_USE_VIRTUAL_THREADS("arcadedb.ha.useVirtualThreads", SCOPE.SERVER,
+      "Use virtual threads for HA replication network executors. Virtual threads provide better scalability for replica connections (requires Java 21+).",
+      Boolean.class, true),
+
   // KUBERNETES
   HA_K8S("arcadedb.ha.k8s", SCOPE.SERVER, "The server is running inside Kubernetes", Boolean.class, false),
 

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -460,12 +460,20 @@ public enum GlobalConfiguration {
   POSTGRES_DEBUG("arcadedb.postgres.debug", SCOPE.SERVER,
       "Enables the printing of Postgres protocol to the console. Default is false", Boolean.class, false),
 
+  POSTGRES_USE_VIRTUAL_THREADS("arcadedb.postgres.useVirtualThreads", SCOPE.SERVER,
+      "Use virtual threads for PostgreSQL wire protocol connections. Virtual threads provide better scalability for concurrent connections (requires Java 21+).",
+      Boolean.class, true),
+
   // REDIS
   REDIS_PORT("arcadedb.redis.port", SCOPE.SERVER,
       "TCP/IP port number used for incoming connections for Redis plugin. Default is 6379", Integer.class, 6379),
 
   REDIS_HOST("arcadedb.redis.host", SCOPE.SERVER,
       "TCP/IP host name used for incoming connections for Redis plugin. Default is '0.0.0.0'", String.class, "0.0.0.0"),
+
+  REDIS_USE_VIRTUAL_THREADS("arcadedb.redis.useVirtualThreads", SCOPE.SERVER,
+      "Use virtual threads for Redis wire protocol connections. Virtual threads provide better scalability for concurrent connections (requires Java 21+).",
+      Boolean.class, true),
 
   // MONGO
   MONGO_PORT("arcadedb.mongo.port", SCOPE.SERVER,

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -272,6 +272,10 @@ public enum GlobalConfiguration {
   POLYGLOT_COMMAND_TIMEOUT("arcadedb.polyglotCommand.timeout", SCOPE.DATABASE, "Default timeout for polyglot commands (in ms)",
       Long.class, 10_000),
 
+  QUERY_ENGINES_USE_VIRTUAL_THREADS("arcadedb.queryEngines.useVirtualThreads", SCOPE.DATABASE,
+      "Use virtual threads for executing Java and Polyglot queries. Virtual threads provide better scalability for concurrent query execution.",
+      Boolean.class, true),
+
   QUERY_MAX_HEAP_ELEMENTS_ALLOWED_PER_OP("arcadedb.queryMaxHeapElementsAllowedPerOp", SCOPE.DATABASE, """
       Maximum number of elements (records) allowed in a single query for memory-intensive operations (eg. ORDER BY in heap). \
       If exceeded, the query fails with an OCommandExecutionException. Negative number means no limit.\

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -379,6 +379,10 @@ public enum GlobalConfiguration {
       "Timeout in seconds for a HTTP session (managing a transaction) to expire. This timeout is computed from the latest command against the session",
       Long.class, 5), // 5 SECONDS DEFAULT
 
+  SERVER_HTTP_USE_VIRTUAL_THREADS("arcadedb.server.httpUseVirtualThreads", SCOPE.SERVER,
+      "Use virtual threads for HTTP request handling. Virtual threads provide better scalability for concurrent HTTP connections (requires Java 21+).",
+      Boolean.class, true),
+
   // SERVER WS
   SERVER_WS_EVENT_BUS_QUEUE_SIZE("arcadedb.server.eventBusQueueSize", SCOPE.SERVER,
       "Size of the queue used as a buffer for unserviced database change events.", Integer.class, 1000),

--- a/engine/src/test/java/com/arcadedb/query/java/JavaQueryEngineVirtualThreadTest.java
+++ b/engine/src/test/java/com/arcadedb/query/java/JavaQueryEngineVirtualThreadTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.java;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Test for Java Query Engine with Virtual Threads support.
+ * Tests both virtual thread and traditional platform thread execution.
+ */
+public class JavaQueryEngineVirtualThreadTest extends TestHelper {
+
+  @Test
+  public void testVirtualThreadsEnabled() {
+    database.getConfiguration().setValue(GlobalConfiguration.QUERY_ENGINES_USE_VIRTUAL_THREADS, true);
+
+    database.getQueryEngine("java").registerFunctions(JavaMethods.class.getName() + "::sum");
+
+    final ResultSet result = database.command("java", "com.arcadedb.query.java.JavaMethods::sum", 5, 3);
+    assertThat(result.hasNext()).isTrue();
+    assertThat((Integer) result.next().getProperty("value")).isEqualTo(8);
+  }
+
+  @Test
+  public void testPlatformThreadsEnabled() {
+    database.getConfiguration().setValue(GlobalConfiguration.QUERY_ENGINES_USE_VIRTUAL_THREADS, false);
+
+    database.getQueryEngine("java").registerFunctions(JavaMethods.class.getName() + "::sum");
+
+    final ResultSet result = database.command("java", "com.arcadedb.query.java.JavaMethods::sum", 5, 3);
+    assertThat(result.hasNext()).isTrue();
+    assertThat((Integer) result.next().getProperty("value")).isEqualTo(8);
+  }
+
+  @Test
+  public void testConcurrentExecutionWithVirtualThreads() throws InterruptedException {
+    database.getConfiguration().setValue(GlobalConfiguration.QUERY_ENGINES_USE_VIRTUAL_THREADS, true);
+
+    database.getQueryEngine("java").registerFunctions(JavaMethods.class.getName() + "::sum");
+
+    // Execute multiple concurrent queries
+    final CountDownLatch latch = new CountDownLatch(10);
+    final ExecutorService executor = Executors.newFixedThreadPool(5);
+
+    for (int i = 0; i < 10; i++) {
+      final int index = i;
+      executor.submit(() -> {
+        try {
+          final ResultSet result = database.command("java", "com.arcadedb.query.java.JavaMethods::sum", index, index * 2);
+          assertThat(result.hasNext()).isTrue();
+          assertThat((Integer) result.next().getProperty("value")).isEqualTo(index + index * 2);
+        } finally {
+          latch.countDown();
+        }
+      });
+    }
+
+    try {
+      assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+    } finally {
+      executor.shutdown();
+    }
+  }
+
+  @Test
+  public void testConcurrentExecutionWithPlatformThreads() throws InterruptedException {
+    database.getConfiguration().setValue(GlobalConfiguration.QUERY_ENGINES_USE_VIRTUAL_THREADS, false);
+
+    database.getQueryEngine("java").registerFunctions(JavaMethods.class.getName() + "::sum");
+
+    // Execute multiple concurrent queries
+    final CountDownLatch latch = new CountDownLatch(10);
+    final ExecutorService executor = Executors.newFixedThreadPool(5);
+
+    for (int i = 0; i < 10; i++) {
+      final int index = i;
+      executor.submit(() -> {
+        try {
+          final ResultSet result = database.command("java", "com.arcadedb.query.java.JavaMethods::sum", index, index * 2);
+          assertThat(result.hasNext()).isTrue();
+          assertThat((Integer) result.next().getProperty("value")).isEqualTo(index + index * 2);
+        } finally {
+          latch.countDown();
+        }
+      });
+    }
+
+    try {
+      assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+    } finally {
+      executor.shutdown();
+    }
+  }
+}

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcServerPlugin.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcServerPlugin.java
@@ -39,6 +39,8 @@ import io.grpc.xds.XdsServerBuilder;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
@@ -141,7 +143,9 @@ public class GrpcServerPlugin implements ServerPlugin {
     grpcServer = serverBuilder
         .maxInboundMessageSize(256 * 1024 * 1024)
         .maxInboundMetadataSize(32 * 1024 * 1024)
-        .build().start();
+        .executor(Executors.newVirtualThreadPerTaskExecutor())
+        .build()
+        .start();
 
     // Build status message
     StringBuilder status = new StringBuilder();
@@ -180,7 +184,9 @@ public class GrpcServerPlugin implements ServerPlugin {
     xdsServer = xdsBuilder
         .maxInboundMessageSize(256 * 1024 * 1024)
         .maxInboundMetadataSize(32 * 1024 * 1024)
-        .build().start();
+        .executor(Executors.newVirtualThreadPerTaskExecutor())
+        .build()
+        .start();
 
     LogManager.instance().log(this, Level.INFO, "gRPC XDS server started on port %s (xDS management enabled)", port);
   }

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkListener.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkListener.java
@@ -69,7 +69,13 @@ public class PostgresNetworkListener extends Thread {
           // CREATE A NEW PROTOCOL INSTANCE
           // TODO: OPEN A DATABASE
           final PostgresNetworkExecutor connection = new PostgresNetworkExecutor(server, socket, null);
-          connection.start();
+
+          // Use virtual threads if configured, otherwise use platform threads
+          if (server.getConfiguration().getValueAsBoolean(com.arcadedb.GlobalConfiguration.POSTGRES_USE_VIRTUAL_THREADS)) {
+            Thread.startVirtualThread(connection);
+          } else {
+            connection.start();
+          }
 
         } catch (final Exception e) {
           if (active)

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresVirtualThreadTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresVirtualThreadTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.ArcadeDBServer;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for PostgreSQL wire protocol with virtual threads support.
+ */
+public class PostgresVirtualThreadTest {
+
+  @Test
+  public void testVirtualThreadsConfigurationExists() {
+    // Verify that the configuration flag exists
+    assertThat(GlobalConfiguration.POSTGRES_USE_VIRTUAL_THREADS).isNotNull();
+    assertThat(GlobalConfiguration.POSTGRES_USE_VIRTUAL_THREADS.getKey())
+        .isEqualTo("arcadedb.postgres.useVirtualThreads");
+  }
+
+  @Test
+  public void testVirtualThreadsCanBeDisabled() {
+    // Verify the type is Boolean
+    assertThat(GlobalConfiguration.POSTGRES_USE_VIRTUAL_THREADS.getType())
+        .isEqualTo(Boolean.class);
+  }
+
+  @Test
+  public void testConfigurationScope() {
+    // Verify that configuration is server-scoped
+    assertThat(GlobalConfiguration.POSTGRES_USE_VIRTUAL_THREADS.getScope())
+        .isEqualTo(GlobalConfiguration.SCOPE.SERVER);
+  }
+}

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkListener.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkListener.java
@@ -62,7 +62,13 @@ public class RedisNetworkListener extends Thread {
 
           // CREATE A NEW PROTOCOL INSTANCE
           final RedisNetworkExecutor connection = new RedisNetworkExecutor(server, socket);
-          connection.start();
+
+          // Use virtual threads if configured, otherwise use platform threads
+          if (server.getConfiguration().getValueAsBoolean(com.arcadedb.GlobalConfiguration.REDIS_USE_VIRTUAL_THREADS)) {
+            Thread.startVirtualThread(connection);
+          } else {
+            connection.start();
+          }
 
           if (callback != null)
             callback.connected();

--- a/redisw/src/test/java/com/arcadedb/redis/RedisVirtualThreadTest.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisVirtualThreadTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.redis;
+
+import com.arcadedb.GlobalConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for Redis wire protocol with virtual threads support.
+ */
+public class RedisVirtualThreadTest {
+
+  @Test
+  public void testVirtualThreadsConfigurationExists() {
+    // Verify that the configuration flag exists
+    assertThat(GlobalConfiguration.REDIS_USE_VIRTUAL_THREADS).isNotNull();
+    assertThat(GlobalConfiguration.REDIS_USE_VIRTUAL_THREADS.getKey())
+        .isEqualTo("arcadedb.redis.useVirtualThreads");
+  }
+
+  @Test
+  public void testVirtualThreadsCanBeDisabled() {
+    // Verify the type is Boolean
+    assertThat(GlobalConfiguration.REDIS_USE_VIRTUAL_THREADS.getType())
+        .isEqualTo(Boolean.class);
+  }
+
+  @Test
+  public void testConfigurationScope() {
+    // Verify that configuration is server-scoped
+    assertThat(GlobalConfiguration.REDIS_USE_VIRTUAL_THREADS.getScope())
+        .isEqualTo(GlobalConfiguration.SCOPE.SERVER);
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/ha/HAServer.java
+++ b/server/src/main/java/com/arcadedb/server/ha/HAServer.java
@@ -1004,7 +1004,12 @@ public class HAServer implements ServerPlugin {
     leaderConnection.get().startup();
 
     // START SEPARATE THREAD TO EXECUTE LEADER'S REQUESTS
-    leaderConnection.get().start();
+    final Replica2LeaderNetworkExecutor replicaExecutor = leaderConnection.get();
+    if (configuration.getValueAsBoolean(GlobalConfiguration.HA_USE_VIRTUAL_THREADS)) {
+      Thread.startVirtualThread(replicaExecutor);
+    } else {
+      replicaExecutor.start();
+    }
   }
 
   protected ChannelBinaryClient createNetworkConnection(final String host, final int port, final short commandId)

--- a/server/src/main/java/com/arcadedb/server/ha/LeaderNetworkListener.java
+++ b/server/src/main/java/com/arcadedb/server/ha/LeaderNetworkListener.java
@@ -278,7 +278,12 @@ public class LeaderNetworkListener extends Thread {
 
     ha.registerIncomingConnection(connection.getRemoteServerName(), connection);
 
-    connection.start();
+    // Use virtual threads if configured, otherwise use platform threads
+    if (ha.getServer().getConfiguration().getValueAsBoolean(com.arcadedb.GlobalConfiguration.HA_USE_VIRTUAL_THREADS)) {
+      Thread.startVirtualThread(connection);
+    } else {
+      connection.start();
+    }
   }
 
   private void readClusterName(final Socket socket, final ChannelBinaryServer channel) throws IOException {

--- a/server/src/test/java/com/arcadedb/server/DeleteTest.java
+++ b/server/src/test/java/com/arcadedb/server/DeleteTest.java
@@ -1,0 +1,307 @@
+package com.arcadedb.server;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.engine.ComponentFile.MODE;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.remote.RemoteDatabase;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class DeleteTest {
+  private static final String DB_NAME = "testDB";
+  private static final String ROOT_PASSWORD = "playwithdata";
+  private static final String ROOT_DIR = "arcade_db_delete_test";
+  private static final List<String> TMP_DIRS = List.of("backups", "log", "databases", "config");
+  private static ArcadeDBServer SERVER = null;
+  private static RemoteDatabase DATABASE = null;
+  private static Path ROOT_PATH = null;
+
+  // Schema
+  private static final String VERTEX_DUCT = "duct";
+  private static final String EDGE_HIERARCHY_DUCT_DUCT = "hierarchy_duct_duct";
+  private static final String PROPERTY_INTERNAL_ID = "internal_id";
+  private static final String PROPERTY_INTERNAL_FROM = "internal_from";
+  private static final String PROPERTY_INTERNAL_TO = "internal_to";
+  private static final String PROPERTY_SWAP = "swap";
+  private static final String PROPERTY_ORDER_NUMBER = "order_number";
+  private static final String PROPERTY_RID = "@rid";
+
+  // Use case params
+  private static final String DUCT_ELID = "duct_elid";
+  private static final String SUB_DUCT_ELID_1 = "sub_duct_elid_1";
+  private static final String SUB_DUCT_ELID_2 = "sub_duct_elid_2";
+  private static final String SUB_DUCT_ELID_3 = "sub_duct_elid_3";
+  private static final String SUB_DUCT_ELID_4 = "sub_duct_elid_4";
+  private static final String SUB_DUCT_ELID_5 = "sub_duct_elid_5";
+  private static final String SUB_DUCT_ELID_6 = "sub_duct_elid_6";
+  private static final String OBJECT_OWNER = "owner";
+  private static final String SWAP = "N";
+  private static final String ORDER_NUMBER = "1";
+  private static final List<String> ALL_DUCT_ELIDS = List.of(DUCT_ELID, SUB_DUCT_ELID_1, SUB_DUCT_ELID_2, SUB_DUCT_ELID_3, SUB_DUCT_ELID_4, SUB_DUCT_ELID_5, SUB_DUCT_ELID_6);
+  private static final List<String> SUB_DUCT_ELIDS = List.of(SUB_DUCT_ELID_1, SUB_DUCT_ELID_2, SUB_DUCT_ELID_3, SUB_DUCT_ELID_4, SUB_DUCT_ELID_5, SUB_DUCT_ELID_6);
+
+  public static void main(String[] args) {
+    try {
+      new Thread(() -> {
+        prepareTestDirectory();
+        startArcadeDBServer();
+        initRemoteDatabase();
+        setupDatabaseSchema();
+        insertInitialData();
+        executeTestCase();
+      }).start();
+      Thread.currentThread().join();
+    } catch (Exception e) {
+      System.err.print("\nERROR: " + e.getMessage());
+    } finally {
+      closeDatabase();
+      stopServer();
+    }
+  }
+
+  private static void setupDatabaseSchema() {
+    System.out.print("\nSetting up database schema.");
+    createVertexType(VERTEX_DUCT);
+    createHierarchyEdgeType(EDGE_HIERARCHY_DUCT_DUCT);
+  }
+
+  private static void insertInitialData() {
+    System.out.print("\nInserting initial data.");
+    /**
+     *             duct
+     * 		      ||..|
+     * 		  sub_duct_1..6
+     */
+    insertTestCaseVertices();
+    insertTestCaseEdges();
+  }
+
+  private static void executeTestCase() {
+    System.out.print("\nExecuting test case.");
+    final String where = "((internal_from = ?) AND (internal_to = ?) AND (swap = ?) AND (order_number = ?)) OR "
+        + "((internal_from = ?) AND (internal_to = ?) AND (swap = ?) AND (order_number = ?)) OR "
+        + "((internal_from = ?) AND (internal_to = ?) AND (swap = ?) AND (order_number = ?)) OR "
+        + "((internal_from = ?) AND (internal_to = ?) AND (swap = ?) AND (order_number = ?)) OR "
+        + "((internal_from = ?) AND (internal_to = ?) AND (swap = ?) AND (order_number = ?)) OR "
+        + "((internal_from = ?) AND (internal_to = ?) AND (swap = ?) AND (order_number = ?))";
+    deleteEdge(EDGE_HIERARCHY_DUCT_DUCT, where,
+        List.of(DUCT_ELID, SUB_DUCT_ELID_1, SWAP, ORDER_NUMBER,
+            DUCT_ELID, SUB_DUCT_ELID_2, SWAP, ORDER_NUMBER,
+            DUCT_ELID, SUB_DUCT_ELID_3, SWAP, ORDER_NUMBER,
+            DUCT_ELID, SUB_DUCT_ELID_4, SWAP, ORDER_NUMBER,
+            DUCT_ELID, SUB_DUCT_ELID_5, SWAP, ORDER_NUMBER,
+            DUCT_ELID, SUB_DUCT_ELID_6, SWAP, ORDER_NUMBER));
+    final Map<String, String> allDuctIdMap = queryIdMap(VERTEX_DUCT, ALL_DUCT_ELIDS);
+    createHierarchyEdge(SUB_DUCT_ELIDS.stream().map(subDuctElid -> new CreateHierarchyEdgeRecord(EDGE_HIERARCHY_DUCT_DUCT, allDuctIdMap.get(DUCT_ELID),  allDuctIdMap.get(subDuctElid), DUCT_ELID, subDuctElid, ORDER_NUMBER)).toList());
+  }
+
+  private static void insertTestCaseVertices() {
+    createVertex(ALL_DUCT_ELIDS.stream().map(elid -> new CreateVertexRecord(VERTEX_DUCT, elid)).toList());
+  }
+
+  private static void insertTestCaseEdges() {
+    // query vertex's rid(s)
+    final Map<String, String> ductIdMap = queryIdMap(VERTEX_DUCT, ALL_DUCT_ELIDS);
+    // duct <-..> sub_duct(s)
+    final String ductRid = ductIdMap.get(DUCT_ELID);
+    final List<CreateHierarchyEdgeRecord> records = new ArrayList<>();
+    SUB_DUCT_ELIDS.forEach(subDuctElid -> records.add(new CreateHierarchyEdgeRecord(EDGE_HIERARCHY_DUCT_DUCT, ductRid, ductIdMap.get(subDuctElid), DUCT_ELID, subDuctElid, ORDER_NUMBER)));
+    createHierarchyEdge(records);
+  }
+
+  private static Map<String, String> queryIdMap(final String label, final Collection<String> internalIds) {
+    final List<String> properties = List.of(PROPERTY_RID, PROPERTY_INTERNAL_ID);
+    final List<String> arguments = new ArrayList<>();
+    final String placeholders = internalIds.stream() //
+        .map(attr -> {
+          arguments.add(attr);
+          return "?";
+        }).collect(Collectors.joining(", "));
+    final String where = "%s in [%s]".formatted(PROPERTY_INTERNAL_ID, placeholders);
+    return command("sql", "select %s from %s where %s".formatted(String.join(", ", properties), label, where), arguments)
+        .stream() //
+        .map(result -> Map.entry((String) result.getProperty(PROPERTY_INTERNAL_ID), (String) result.getProperty(PROPERTY_RID)))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  private static void createVertex(final List<CreateVertexRecord> records) {
+    final List<InsertVertexRecord> insertRecords = records.stream().map(record -> new InsertVertexRecord(record.vertex,
+        Map.of(PROPERTY_INTERNAL_ID, record.internal_id))).toList();
+    insertVertex(insertRecords);
+  }
+
+  private record CreateVertexRecord(String vertex, String internal_id) {}
+
+  private static void createHierarchyEdge(final List<CreateHierarchyEdgeRecord> records) {
+    final List<CreateEdgeRecord> createEdgeRecords = records.stream().map(record -> new CreateEdgeRecord(record.edge, record.fromRid, record.toRid,
+        Map.of(PROPERTY_INTERNAL_FROM, record.internal_from, PROPERTY_INTERNAL_TO, record.internal_to, PROPERTY_SWAP, SWAP, PROPERTY_ORDER_NUMBER, record.orderNumber))).toList();
+    createEdge(createEdgeRecords);
+  }
+
+  private record CreateHierarchyEdgeRecord(String edge, String fromRid, String toRid, String internal_from, String internal_to, String orderNumber) {}
+
+  private static void insertVertex(final List<InsertVertexRecord> records) {
+    final List<String> arguments = new ArrayList<>();
+    final List<String> commands = records.stream().map(record -> {
+      arguments.addAll(record.properties.values());
+      final String valuesPlaceholder = record.properties.values().stream().map(attr -> "?").collect(Collectors.joining(", "));
+      return "insert into %s (%s) values (%s)".formatted(record.into, String.join(", ", record.properties.keySet()), valuesPlaceholder);
+    }).toList();
+    command("sqlscript", String.join("; ", commands), arguments);
+  }
+
+  private record InsertVertexRecord(String into, Map<String, String> properties) {}
+
+  private static void createEdge(final List<CreateEdgeRecord> records) {
+    final List<String> arguments = new ArrayList<>();
+    final List<String> commands = records.stream().map(record -> {
+      arguments.add(record.fromRid);
+      arguments.add(record.toRid);
+      final List<String> placeholders = record.properties.entrySet() //
+          .stream() //
+          .map(entry -> {
+            arguments.add(entry.getValue());
+            return "%s = ?".formatted(entry.getKey());
+          }).toList();
+      return "create edge %s from ? to ? set %s".formatted(record.edge, String.join(", ", placeholders));
+    }).toList();
+    command("sqlscript", String.join("; ", commands), arguments);
+  }
+
+  private record CreateEdgeRecord(String edge, String fromRid, String toRid, Map<String, String> properties) {}
+
+  private static ResultSet deleteEdge(final String edge, final String where, final List<String> params) {
+    return command("sql", "delete from %s where %s".formatted(edge, where), params);
+  }
+
+  private static void createVertexType(final String label) {
+    command("sql", "create vertex type %s if not exists".formatted(label));
+    command("sql", "alter type %s BucketSelectionStrategy `thread`".formatted(label));
+    createIndexedStringProperty(label, PROPERTY_INTERNAL_ID, true);
+  }
+
+  private static void createHierarchyEdgeType(final String label) {
+    createEdgeType(label);
+    createStringProperty(label, PROPERTY_SWAP);
+    createStringProperty(label, PROPERTY_ORDER_NUMBER);
+    createIndexedStringProperty(label, PROPERTY_INTERNAL_FROM, false);
+    createIndexedStringProperty(label, PROPERTY_INTERNAL_TO, false);
+    createIndex(label, List.of(PROPERTY_INTERNAL_FROM, PROPERTY_INTERNAL_TO, PROPERTY_SWAP, PROPERTY_ORDER_NUMBER), true);
+  }
+
+  private static void createEdgeType(final String label) {
+    command("sql", "create edge type %s if not exists".formatted(label));
+    command("sql", "alter type %s BucketSelectionStrategy `thread`".formatted(label));
+  }
+
+  private static void createStringProperty(final String label, final String property) {
+    createProperty(label, property, "STRING");
+  }
+
+  private static void createIndexedStringProperty(final String label, final String property, final boolean unique) {
+    createStringProperty(label, property);
+    createIndex(label, Collections.singletonList(property), unique);
+  }
+
+  private static void createProperty(final String label, final String property, final String type) {
+    command("sql", "create property " + label + "." + property + " " + type);
+  }
+
+  private static void createIndex(final String label, final List<String> properties, final boolean unique) {
+    command("sql", "create index on %s (%s) %s".formatted(label, String.join(",", properties), unique ? "UNIQUE" : "NOTUNIQUE"));
+  }
+
+  private static ResultSet command(final String language, final String command) {
+    		System.out.print("\nCommand: " + command);
+    return DATABASE.command(language, command);
+  }
+
+  private static ResultSet command(final String language, final String command, Collection<String> parameters) {
+    		System.out.print("\nCommand: " + command + "; Parameters: " + parameters);
+    return DATABASE.command(language, command, parameters.toArray());
+  }
+
+  private static void closeDatabase() {
+    if (DATABASE != null && DATABASE.isOpen()) {
+      DATABASE.close();
+    }
+    DATABASE = null;
+  }
+
+  private static void stopServer() {
+    if (SERVER != null && SERVER.isStarted()) {
+      SERVER.stop();
+    }
+    SERVER = null;
+  }
+
+  private static void prepareTestDirectory() {
+    System.out.print("\nPreparing test directory.");
+    ROOT_PATH = Paths.get(ROOT_DIR);
+    clearTestDirectory(ROOT_PATH);
+    createDirectoryIfNotExists(ROOT_PATH);
+    createTmpDirectories(ROOT_PATH);
+  }
+
+  private static void createTmpDirectories(final Path rootPath) {
+    TMP_DIRS.stream().map(rootPath::resolve).forEach(DeleteTest::createDirectoryIfNotExists);
+  }
+
+  private static void createDirectoryIfNotExists(final Path dir) {
+    if (Files.exists(dir)) {
+      return;
+    }
+    try {
+      Files.createDirectory(dir);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static void startArcadeDBServer() {
+    System.out.print("\nStarting ArcadeDB server.");
+    final ContextConfiguration config = new ContextConfiguration(
+        Map.of(GlobalConfiguration.SERVER_ROOT_PASSWORD.getKey(), ROOT_PASSWORD, GlobalConfiguration.SERVER_ROOT_PATH.getKey(), ROOT_PATH.toAbsolutePath().toString()));
+    SERVER = new ArcadeDBServer(config);
+    SERVER.start();
+    SERVER.createDatabase(DB_NAME, MODE.READ_WRITE);
+  }
+
+  private static void initRemoteDatabase() {
+    System.out.print("\nInitializing remote database.");
+    DATABASE = new RemoteDatabase("localhost", 2480, DB_NAME, "root", ROOT_PASSWORD);
+  }
+
+  private static void clearTestDirectory(final Path rootPath) {
+    TMP_DIRS.stream() //
+        .map(rootPath::resolve) //
+        .flatMap(path -> {
+          try {
+            return Files.walk(path).sorted(Comparator.reverseOrder());
+          } catch (IOException e) {
+            System.err.println("Failed to enter: " + e.getMessage());
+            return null;
+          }
+        }) //
+        .filter(Objects::nonNull) //
+        .forEach(path -> {
+          try {
+            Files.delete(path);
+          } catch (IOException e) {
+            System.err.println("Failed to delete: " + e.getMessage());
+          }
+        });
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/ha/HAVirtualThreadTest.java
+++ b/server/src/test/java/com/arcadedb/server/ha/HAVirtualThreadTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha;
+
+import com.arcadedb.GlobalConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for HA replication with virtual threads support.
+ */
+public class HAVirtualThreadTest {
+
+  @Test
+  public void testVirtualThreadsConfigurationExists() {
+    // Verify that the configuration flag exists
+    assertThat(GlobalConfiguration.HA_USE_VIRTUAL_THREADS).isNotNull();
+    assertThat(GlobalConfiguration.HA_USE_VIRTUAL_THREADS.getKey())
+        .isEqualTo("arcadedb.ha.useVirtualThreads");
+  }
+
+  @Test
+  public void testVirtualThreadsCanBeDisabled() {
+    // Verify the type is Boolean
+    assertThat(GlobalConfiguration.HA_USE_VIRTUAL_THREADS.getType())
+        .isEqualTo(Boolean.class);
+  }
+
+  @Test
+  public void testConfigurationScope() {
+    // Verify that configuration is server-scoped
+    assertThat(GlobalConfiguration.HA_USE_VIRTUAL_THREADS.getScope())
+        .isEqualTo(GlobalConfiguration.SCOPE.SERVER);
+  }
+
+  @Test
+  public void testConfigurationDefault() {
+    // Verify that virtual threads are enabled by default
+    assertThat(GlobalConfiguration.HA_USE_VIRTUAL_THREADS.getDefValue())
+        .isEqualTo(true);
+  }
+}


### PR DESCRIPTION
This pull request introduces support for using Java virtual threads (Project Loom) across several components of ArcadeDB to improve scalability and concurrency, especially for query execution and network protocols. It adds new configuration options to enable or disable virtual threads for different subsystems, refactors executors to support this feature, and adds tests to verify correct behavior with both virtual and platform threads.

Key changes include:

**Virtual Thread Support and Configuration:**

* Added new configuration options in `GlobalConfiguration.java` to enable virtual threads for query engines, HTTP server, HA replication, PostgreSQL, and Redis protocols. These are enabled by default and allow users to toggle between virtual and platform threads as needed. [[1]](diffhunk://#diff-170362872e4ccee90c31cafbcea962276cf29fc7899106fc8f0f265089d9a506R275-R278) [[2]](diffhunk://#diff-170362872e4ccee90c31cafbcea962276cf29fc7899106fc8f0f265089d9a506R382-R385) [[3]](diffhunk://#diff-170362872e4ccee90c31cafbcea962276cf29fc7899106fc8f0f265089d9a506R446-R449) [[4]](diffhunk://#diff-170362872e4ccee90c31cafbcea962276cf29fc7899106fc8f0f265089d9a506R467-R481)

**Query Engine Refactoring:**

* Refactored `JavaQueryEngine` and `PolyglotQueryEngine` to use an `ExecutorService` that can be either a virtual thread executor or a fixed thread pool, based on the new configuration. This improves scalability for concurrent query execution. [[1]](diffhunk://#diff-ae3c0f409a3bc92bd315990bdff96e3bcf4b03103d637f63715d6701b628b20aL40-R40) [[2]](diffhunk://#diff-ae3c0f409a3bc92bd315990bdff96e3bcf4b03103d637f63715d6701b628b20aL97-L105) [[3]](diffhunk://#diff-69e2d8cafb2dee6b6b1b25641895840a0891dafa20b0d0040cc16834a113c0c8L45) [[4]](diffhunk://#diff-69e2d8cafb2dee6b6b1b25641895840a0891dafa20b0d0040cc16834a113c0c8L93-R105) [[5]](diffhunk://#diff-69e2d8cafb2dee6b6b1b25641895840a0891dafa20b0d0040cc16834a113c0c8L218)

**Network Protocols and Server Integration:**

* Updated the gRPC server (`GrpcServerPlugin.java`) to use a virtual thread executor for handling requests, enhancing its ability to manage many concurrent connections. [[1]](diffhunk://#diff-f71ad3479f5c5ddc09bf8ef484f566f499d9a133647e59808e32b5db112d8ee0R42-R43) [[2]](diffhunk://#diff-f71ad3479f5c5ddc09bf8ef484f566f499d9a133647e59808e32b5db112d8ee0L144-R148) [[3]](diffhunk://#diff-f71ad3479f5c5ddc09bf8ef484f566f499d9a133647e59808e32b5db112d8ee0L183-R189)
* Modified the PostgreSQL protocol listener (`PostgresNetworkListener.java`) to conditionally use virtual threads for each connection, controlled by the new configuration.

**Testing:**

* Added comprehensive tests for virtual thread support in both the Java query engine and PostgreSQL protocol, ensuring correct configuration, concurrent execution, and compatibility with both thread types. [[1]](diffhunk://#diff-34256f4ada79d9fa6d6d48411cfe8cbab255df55276ffbd3744ec06361174347R1-R117) [[2]](diffhunk://#diff-21223b9f6b9258e73056b863ac573a6bf1ae22009e9665bff19d15d044910ae4R1-R53)

**Minor and Related Improvements:**

* Improved logging and metrics reporting in performance test classes, and clarified comments and parameter names for better maintainability. [[1]](diffhunk://#diff-c7a022fc8884a652447afe83ff2c66b65af1e42b80bcf9e1b0ddbad04511ea47R24-R32) [[2]](diffhunk://#diff-c7a022fc8884a652447afe83ff2c66b65af1e42b80bcf9e1b0ddbad04511ea47L40-R44) [[3]](diffhunk://#diff-c7a022fc8884a652447afe83ff2c66b65af1e42b80bcf9e1b0ddbad04511ea47L57-R63) [[4]](diffhunk://#diff-c7a022fc8884a652447afe83ff2c66b65af1e42b80bcf9e1b0ddbad04511ea47R88-R95) [[5]](diffhunk://#diff-eba3c81d56ffb7789ec81f4aa902f479c51aa5b0f90cf5e51a65d23728e0dea4L52-R55)

These changes collectively make ArcadeDB more scalable and ready for high-concurrency workloads by leveraging modern Java threading capabilities.