### PR TITLE
#2779 add shading to prometheus plugin

### DIFF
--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -58,4 +58,14 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -116,13 +116,20 @@
         </dependency>
         <dependency>
             <groupId>com.arcadedb</groupId>
-            <artifactId>arcadedb-metrics</artifactId>
+            <artifactId>arcadedb-studio</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>com.arcadedb</groupId>
-            <artifactId>arcadedb-studio</artifactId>
+            <artifactId>arcadedb-metrics</artifactId>
             <version>${project.parent.version}</version>
+            <classifier>shaded</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.arcadedb</groupId>

--- a/studio/package-lock.json
+++ b/studio/package-lock.json
@@ -469,7 +469,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -496,7 +495,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -645,7 +643,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -962,7 +959,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -1542,7 +1538,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2080,8 +2075,7 @@
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
       "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -2459,7 +2453,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2505,7 +2498,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3358,7 +3350,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3451,7 +3442,6 @@
       "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -3501,7 +3491,6 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",


### PR DESCRIPTION
This pull request includes updates to the Maven build configuration for the `metrics` and `package` modules, as well as dependency management improvements. Additionally, it cleans up the `studio/package-lock.json` by removing unnecessary `peer` fields from dependencies.

Dependency and build configuration improvements:

* Added the `maven-shade-plugin` to the `metrics/pom.xml` build configuration, enabling the creation of shaded (fat) JARs.
* In `package/pom.xml`, swapped the order of `arcadedb-metrics` and `arcadedb-studio` dependencies, added a `shaded` classifier to `arcadedb-metrics`, and excluded all its transitive dependencies to avoid potential conflicts.

Package lock file cleanup:

* Removed the `"peer": true` property from multiple dependencies in `studio/package-lock.json`, simplifying the dependency metadata and potentially reducing warnings or issues during npm/yarn installs. [[1]](diffhunk://#diff-eec431816d5b02cb26968dafe0b34355708e35e04de581d6fc43f4e130d33dccL472) [[2]](diffhunk://#diff-eec431816d5b02cb26968dafe0b34355708e35e04de581d6fc43f4e130d33dccL499) [[3]](diffhunk://#diff-eec431816d5b02cb26968dafe0b34355708e35e04de581d6fc43f4e130d33dccL648) [[4]](diffhunk://#diff-eec431816d5b02cb26968dafe0b34355708e35e04de581d6fc43f4e130d33dccL965) [[5]](diffhunk://#diff-eec431816d5b02cb26968dafe0b34355708e35e04de581d6fc43f4e130d33dccL1545) [[6]](diffhunk://#diff-eec431816d5b02cb26968dafe0b34355708e35e04de581d6fc43f4e130d33dccL2083-R2078) [[7]](diffhunk://#diff-eec431816d5b02cb26968dafe0b34355708e35e04de581d6fc43f4e130d33dccL2462) [[8]](diffhunk://#diff-eec431816d5b02cb26968dafe0b34355708e35e04de581d6fc43f4e130d33dccL2508) [[9]](diffhunk://#diff-eec431816d5b02cb26968dafe0b34355708e35e04de581d6fc43f4e130d33dccL3361) [[10]](diffhunk://#diff-eec431816d5b02cb26968dafe0b34355708e35e04de581d6fc43f4e130d33dccL3454) [[11]](diffhunk://#diff-eec431816d5b02cb26968dafe0b34355708e35e04de581d6fc43f4e130d33dccL3504)