### PR TITLE
chore: update testontainer to 2.0.2

### DIFF
--- a/e2e-perf/pom.xml
+++ b/e2e-perf/pom.xml
@@ -92,13 +92,13 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>toxiproxy</artifactId>
+            <artifactId>testcontainers-toxiproxy</artifactId>
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>

--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -30,7 +30,6 @@
     </parent>
 
     <properties>
-        <testcontainers.version>1.21.3</testcontainers.version>
         <postgresql.version>42.7.8</postgresql.version>
         <logback-classic.version>1.5.21</logback-classic.version>
         <allowIncompleteProjects>true</allowIncompleteProjects>
@@ -79,7 +78,7 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <license-maven-plugin.version>5.0.0</license-maven-plugin.version>
         <maven-central-publishing-plugin.version>0.9.0</maven-central-publishing-plugin.version>
 
-        <testcontainers.version>1.21.3</testcontainers.version>
+        <testcontainers.version>2.0.2</testcontainers.version>
         <logback-classic.version>1.5.21</logback-classic.version>
         <micrometer.version>1.16.0</micrometer.version>
         <postgres.version>42.7.8</postgres.version>


### PR DESCRIPTION
This pull request updates the Testcontainers dependencies to use the latest naming conventions and versions across multiple Maven configuration files. The changes ensure consistency and compatibility with newer versions of Testcontainers modules.

Dependency version updates:

* Updated the `testcontainers.version` property in `pom.xml` to `2.0.2` to use the latest Testcontainers release.

Dependency artifact renaming:

* Changed the artifact name from `toxiproxy` to `testcontainers-toxiproxy` in `e2e-perf/pom.xml`, aligning with the new Testcontainers module naming.
* Changed the artifact name from `junit-jupiter` to `testcontainers-junit-jupiter` in both `e2e-perf/pom.xml` and `e2e/pom.xml`, updating to the correct Testcontainers JUnit integration module. [[1]](diffhunk://#diff-a62ae2b366288f8379a9ae389cc1460b63827cdb74a980861929aca52d5449e9L95-R101) [[2]](diffhunk://#diff-4d1281c05b0edf851f40c26c20432b43471299520e055e1e21b1350f086da074L82-R81)

Cleanup of unused properties:

* Removed the redundant `testcontainers.version` property from `e2e/pom.xml` since it is now managed in the parent `pom.xml`.## What does this PR do?

