### PR TITLE
Show version number same as in server log

### DIFF
--- a/console/src/main/java/com/arcadedb/console/Console.java
+++ b/console/src/main/java/com/arcadedb/console/Console.java
@@ -116,7 +116,7 @@ public class Console {
 
     terminal = TerminalBuilder.builder().system(system).streams(System.in, System.out).jni(true).build();
 
-    output(3, "%s Console v.%s - %s (%s)", Constants.PRODUCT, Constants.getRawVersion(), Constants.COPYRIGHT, Constants.URL);
+    output(3, "%s Console v%s - %s (%s)", Constants.PRODUCT, Constants.getRawVersion(), Constants.COPYRIGHT, Constants.URL);
   }
 
   public void interactiveMode() throws IOException {


### PR DESCRIPTION
## What does this PR do?

This change make the console display the version number the same way the server log does. Before the console showed `v.25.XX.1`, now it shows `v25.XX.1`.

## Motivation

Server log

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
