### PR TITLE
fix: make values method behave like keys method

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodValues.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/collection/SQLMethodValues.java
@@ -24,6 +24,7 @@ import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.method.AbstractSQLMethod;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -50,6 +51,11 @@ public class SQLMethodValues extends AbstractSQLMethod {
       return List.of(document.toMap().values());
     else if (value instanceof Result result)
       return result.toMap().values();
+    else if (value instanceof Collection<?> collection) {
+      final List<Object> result = collection.stream()
+          .flatMap(o -> ((Collection<Object>) execute(o, currentRecord, context, params)).stream()).toList();
+      return result;
+    }
 
     return null;
   }

--- a/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodValuesTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/method/collection/SQLMethodValuesTest.java
@@ -45,4 +45,18 @@ class SQLMethodValuesTest {
     final Object result = function.execute(resultInternal, null, null, null);
     assertThat(new ArrayList<>((Collection<String>) result)).isEqualTo(Arrays.asList("Foo", "Bar"));
   }
+
+  @Test
+  void withCollection() {
+    List<Map<String, Object>> collection = List.of(Map.of("key1", "value1"), Map.of("key2", "value2"));
+
+    Object result = function.execute(collection, null, null, null);
+    assertThat(result).isEqualTo(List.of("value1", "value2"));
+  }
+
+  @Test
+  void withNull() {
+    Object result = function.execute(null, null, null, null);
+    assertThat(result).isNull();
+  }
 }


### PR DESCRIPTION
## What does this PR do?

This change adds handling of collection arguments to the `values` method, copied from the `keys` method which already handles these argument types. 

## Motivation

Comparing outputs of `keys` and `values` methods.

## Related issues

https://github.com/ArcadeData/arcadedb/issues/2964

## Checklist

- [X] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
