### PR TITLE
fix: support List<Float> in vector index

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/vector/ArcadePageVectorValues.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/ArcadePageVectorValues.java
@@ -232,9 +232,16 @@ public class ArcadePageVectorValues implements RandomAccessVectorValues {
         return null; // Property not found
       }
 
-      if (!(vectorObj instanceof float[] vector)) {
+      float[] vector = null;
+      if (vectorObj instanceof float[] f) {
+        vector = f;
+      } else if (vectorObj instanceof java.util.List<?> list) {
+        vector = new float[list.size()];
+        for (int i = 0; i < list.size(); i++)
+          vector[i] = ((Number) list.get(i)).floatValue();
+      } else {
         com.arcadedb.log.LogManager.instance().log(this, java.util.logging.Level.WARNING,
-            "Vector property '%s' is not float[] (type=%s, RID=%s)",
+            "Vector property '%s' is not float[] or List (type=%s, RID=%s)",
             vectorPropertyName, vectorObj.getClass().getName(), loc.rid);
         return null;
       }

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -878,7 +878,15 @@ public class LSMVectorIndex implements Index, IndexInternal {
             if (record != null) {
               final com.arcadedb.database.Document doc = (com.arcadedb.database.Document) record;
               final Object vectorObj = doc.get(vectorProp);
-              if (vectorObj instanceof float[] vector && vector.length == metadata.dimensions) {
+              float[] vector = null;
+              if (vectorObj instanceof float[] f) {
+                vector = f;
+              } else if (vectorObj instanceof java.util.List<?> list) {
+                vector = new float[list.size()];
+                for (int i = 0; i < list.size(); i++)
+                  vector[i] = ((Number) list.get(i)).floatValue();
+              }
+              if (vector != null && vector.length == metadata.dimensions) {
                 // Validate vector is not all zeros (would cause NaN in cosine similarity)
                 boolean hasNonZero = false;
                 for (float v : vector) {


### PR DESCRIPTION
When vectors are inserted via SQL using [0.1, 0.2, ...] syntax, they are stored as ArrayList in documents. The graph building code only accepted float[] type, causing vectorNeighbors() to return empty results.

This fix adds List<?> handling in:
- LSMVectorIndex.buildGraphFromScratchWithRetry()
- ArcadePageVectorValues.getVector()

Fixes the issue where vectorNeighbors() returns empty array for SQL-inserted vectors while vectorDistance() works correctly.