### PR TITLE
fix: use static SecureRandom in RecordEncryptionTest to prevent flaky test on Linux

### DIFF
--- a/engine/src/test/java/com/arcadedb/event/RecordEncryptionTest.java
+++ b/engine/src/test/java/com/arcadedb/event/RecordEncryptionTest.java
@@ -58,6 +58,7 @@ public class RecordEncryptionTest extends TestHelper
   private final static String          ALGORITHM          = "AES/CBC/PKCS5Padding";
   private static final int             SALT_ITERATIONS    = 65536;
   private static final int             KEY_LENGTH         = 256;
+  private static final SecureRandom    SECURE_RANDOM      = new SecureRandom();
   private              SecretKey       key;
   private              IvParameterSpec ivParameterSpec;
   private final        AtomicInteger   creates            = new AtomicInteger();
@@ -75,7 +76,7 @@ public class RecordEncryptionTest extends TestHelper
       key = getKeyFromPassword(password, "salt");
       // Generate IV once during initialization
       byte[] iv = new byte[16];
-      new SecureRandom().nextBytes(iv);
+      SECURE_RANDOM.nextBytes(iv);
       ivParameterSpec = new IvParameterSpec(iv);
     } catch (Exception e) {
       throw new SecurityException(e);


### PR DESCRIPTION
… 

The test was creating a new SecureRandom() instance in beginTest(), which can block on Linux systems when /dev/random lacks sufficient entropy, causing intermittent test failures.

Changed to use a static SecureRandom instance (following the pattern used in DefaultDataEncryption.java) which is initialized once when the class loads, preventing blocking during test execution.

Fixes #3280

