### PR TITLE
fix: preserve field names for single-element Cypher RETURN over Bolt …

### DIFF
--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -20,12 +20,22 @@ package com.arcadedb.bolt;
 
 import com.arcadedb.Constants;
 import com.arcadedb.GlobalConfiguration;
-import com.arcadedb.bolt.message.*;
+import com.arcadedb.bolt.message.BeginMessage;
+import com.arcadedb.bolt.message.BoltMessage;
+import com.arcadedb.bolt.message.DiscardMessage;
+import com.arcadedb.bolt.message.FailureMessage;
+import com.arcadedb.bolt.message.HelloMessage;
+import com.arcadedb.bolt.message.IgnoredMessage;
+import com.arcadedb.bolt.message.LogonMessage;
+import com.arcadedb.bolt.message.PullMessage;
+import com.arcadedb.bolt.message.RecordMessage;
+import com.arcadedb.bolt.message.RouteMessage;
+import com.arcadedb.bolt.message.RunMessage;
+import com.arcadedb.bolt.message.SuccessMessage;
 import com.arcadedb.bolt.packstream.PackStreamReader;
 import com.arcadedb.bolt.packstream.PackStreamWriter;
 import com.arcadedb.bolt.structure.BoltStructureMapper;
 import com.arcadedb.database.Database;
-import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.query.sql.executor.Result;
@@ -38,8 +48,16 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.net.Socket;
 import java.net.SocketException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
+
+import static com.arcadedb.query.opencypher.executor.steps.FinalProjectionStep.PROJECTION_NAME_METADATA;
 
 /**
  * Handles a single BOLT protocol connection.
@@ -72,11 +90,11 @@ public class BoltNetworkExecutor extends Thread {
   private final boolean             debug;
   private final BoltNetworkListener listener; // For notifying when connection closes
 
-  private State             state = State.DISCONNECTED;
-  private int               protocolVersion;
+  private State              state = State.DISCONNECTED;
+  private int                protocolVersion;
   private ServerSecurityUser user;
-  private Database          database;
-  private String            databaseName;
+  private Database           database;
+  private String             databaseName;
 
   // Transaction state
   private boolean explicitTransaction = false;
@@ -86,15 +104,16 @@ public class BoltNetworkExecutor extends Thread {
    * Thread-safety: This class is designed to handle a single connection in a dedicated thread.
    * All state variables are accessed only by the executor thread and do not require synchronization.
    */
-  private ResultSet      currentResultSet;
-  private List<String>   currentFields;
-  private Result         firstResult; // Buffered first result for field name extraction
-  private int            recordsStreamed;
-  private long           queryStartTime; // Nanosecond timestamp when query execution started
-  private long           firstRecordTime; // Nanosecond timestamp when first record was retrieved
-  private boolean        isWriteOperation; // Whether the current query performs writes
+  private ResultSet    currentResultSet;
+  private List<String> currentFields;
+  private Result       firstResult; // Buffered first result for field name extraction
+  private int          recordsStreamed;
+  private long         queryStartTime; // Nanosecond timestamp when query execution started
+  private long         firstRecordTime; // Nanosecond timestamp when first record was retrieved
+  private boolean      isWriteOperation; // Whether the current query performs writes
 
-  public BoltNetworkExecutor(final ArcadeDBServer server, final Socket socket, final BoltNetworkListener listener) throws IOException {
+  public BoltNetworkExecutor(final ArcadeDBServer server, final Socket socket, final BoltNetworkListener listener)
+      throws IOException {
     super("BOLT-" + socket.getRemoteSocketAddress());
     this.server = server;
     this.socket = socket;
@@ -128,7 +147,8 @@ public class BoltNetworkExecutor extends Thread {
           final Object value = reader.readValue();
 
           if (!(value instanceof PackStreamReader.StructureValue structure)) {
-            sendFailure(BoltException.PROTOCOL_ERROR, "Expected structure, got: " + (value != null ? value.getClass().getSimpleName() : "null"));
+            sendFailure(BoltException.PROTOCOL_ERROR,
+                "Expected structure, got: " + (value != null ? value.getClass().getSimpleName() : "null"));
             continue;
           }
 
@@ -195,7 +215,8 @@ public class BoltNetworkExecutor extends Thread {
           break;
         }
       }
-      if (protocolVersion != 0) break;
+      if (protocolVersion != 0)
+        break;
     }
 
     // Send selected version
@@ -785,7 +806,7 @@ public class BoltNetworkExecutor extends Thread {
   /**
    * Extract field names from result set by peeking at the first result.
    * The first result is buffered and will be returned first during PULL.
-   *
+   * <p>
    * For single-element results (e.g., RETURN n), the projection name is stored
    * in metadata by FinalProjectionStep and used here to preserve field names.
    */
@@ -803,7 +824,7 @@ public class BoltNetworkExecutor extends Thread {
       // This happens for queries like "MATCH (n) RETURN n" where the vertex is
       // returned directly but we need to preserve the field name "n" for Bolt protocol
       if (firstResult.isElement()) {
-        final Object projectionName = firstResult.getMetadata("_projectionName");
+        final Object projectionName = firstResult.getMetadata(PROJECTION_NAME_METADATA);
         if (projectionName instanceof String name) {
           return List.of(name);
         }
@@ -819,7 +840,7 @@ public class BoltNetworkExecutor extends Thread {
   /**
    * Extract values from a result for sending as a BOLT RECORD.
    * Handles both projection results and element results.
-   *
+   * <p>
    * For element results (e.g., RETURN n where n is a vertex), the whole element
    * is returned as a single value, converted to BoltNode/BoltRelationship.
    */
@@ -828,7 +849,7 @@ public class BoltNetworkExecutor extends Thread {
 
     // Check if this is an unwrapped element result
     // (single vertex/edge returned directly from RETURN clause)
-    if (result.isElement() && result.getMetadata("_projectionName") != null) {
+    if (result.isElement() && result.getMetadata(PROJECTION_NAME_METADATA) != null) {
       // Return the element as a single value
       values.add(BoltStructureMapper.toPackStreamValue(result.getElement().orElse(null)));
     } else {
@@ -858,7 +879,7 @@ public class BoltNetworkExecutor extends Thread {
       // Log at FINE level to avoid spam for complex but valid queries
       LogManager.instance().log(this, Level.FINE,
           "Query analysis failed for: " + (query.length() > 100 ? query.substring(0, 100) + "..." : query) +
-          " - assuming write operation", e);
+              " - assuming write operation", e);
       return true;
     }
   }
@@ -873,9 +894,11 @@ public class BoltNetworkExecutor extends Thread {
   /**
    * Authenticate user with provided credentials.
    *
-   * @param principal the username
+   * @param principal   the username
    * @param credentials the password
+   *
    * @return true if authentication succeeded, false otherwise (failure already sent)
+   *
    * @throws IOException if sending failure message fails
    */
   private boolean authenticateUser(final String principal, final String credentials) throws IOException {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherResultFormatTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherResultFormatTest.java
@@ -150,4 +150,20 @@ class CypherResultFormatTest {
     assertThat(results).hasSize(1);
     assertThat(results.getFirst().isProjection()).as("Count result should be a projection").isTrue();
   }
+
+  @Test
+  void singleNodeHasProjectionNameMetadata() {
+    // RETURN n should have _projectionName metadata for wire protocols
+    final ResultSet result = database.query("opencypher", "MATCH (n:Person) RETURN n");
+    final List<Result> results = new ArrayList<>();
+    while (result.hasNext()) {
+      results.add(result.next());
+    }
+
+    assertThat(results).hasSize(2);
+    for (final Result r : results) {
+      assertThat(r.isElement()).isTrue();
+      assertThat(r.getMetadata("_projectionName")).isEqualTo("n");
+    }
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherResultFormatTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherResultFormatTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.arcadedb.query.opencypher.executor.steps.FinalProjectionStep.PROJECTION_NAME_METADATA;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -163,7 +164,7 @@ class CypherResultFormatTest {
     assertThat(results).hasSize(2);
     for (final Result r : results) {
       assertThat(r.isElement()).isTrue();
-      assertThat(r.getMetadata("_projectionName")).isEqualTo("n");
+      assertThat(r.getMetadata(PROJECTION_NAME_METADATA)).isEqualTo("n");
     }
   }
 }

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcIT.java
@@ -321,19 +321,21 @@ public class PostgresWJdbcIT extends BaseGraphServerTest {
 
         for (int i = 0; i < 100; i++) {
           st.execute("{opencypher} MATCH (n) DETACH DELETE n;");
-          st.execute("{opencypher} CREATE (james:PersonVertex {name: \"James\", height: 1.9});");
-          st.execute("{opencypher} CREATE (henry:PersonVertex {name: \"Henry\"});");
+          st.execute("""
+              {opencypher} CREATE (james:PersonVertex {name: "James", height: 1.9});""");
+          st.execute("""
+              {opencypher} CREATE (henry:PersonVertex {name: "Henry"});""");
 
-          var rs = st.executeQuery("{opencypher} MATCH (person:PersonVertex) RETURN person.name, person.height;");
+          var rs = st.executeQuery("{opencypher} MATCH (person:PersonVertex) RETURN person.name AS name, person.height AS height;");
 
           int numberOfPeople = 0;
           while (rs.next()) {
-            assertThat(rs.getString(1)).isNotNull();
+            assertThat(rs.getString("name")).isNotNull();
 
-            if (rs.getString(1).equals("James"))
-              assertThat(rs.getFloat(2)).isEqualTo(1.9F);
-            else if (rs.getString(1).equals("Henry"))
-              assertThat(rs.getString(2)).isNull();
+            if (rs.getString("name").equals("James"))
+              assertThat(rs.getFloat("height")).isEqualTo(1.9F);
+            else if (rs.getString("name").equals("Henry"))
+              assertThat(rs.getString("height")).isNull();
             else
               fail("");
 


### PR DESCRIPTION
…protocol

When FinalProjectionStep unwraps single-element results (e.g., RETURN n), it stores the vertex directly as an element but loses the field name "n". This caused Bolt protocol to send vertex properties as field names instead of the RETURN clause field name.

Changes:
- FinalProjectionStep: Store projection name in metadata when unwrapping
- BoltNetworkExecutor: Use metadata to get correct field names for elements
- BoltNetworkExecutor: Extract element values correctly for Bolt RECORD

This fixes 10+ failing Bolt integration tests where nodes/edges were returned as NULL because field names didn't match.

