### PR TITLE
#3315 fix: resolve argument expressions correctly in CREATE EDGE stat…

### DIFF
--- a/docs/3315-create-edge.md
+++ b/docs/3315-create-edge.md
@@ -1,0 +1,217 @@
+# Bug Fix: Issue #3315 - CREATE EDGE Expression Resolution
+
+## Issue Summary
+**Title:** SQL: CREATE EDGE fails to resolve argument expressions correctly
+
+**Issue URL:** https://github.com/ArcadeData/arcadedb/issues/3315
+
+**Reporter:** gramian (COLLABORATOR)
+
+**Labels:** sql
+
+**Status:** Open
+
+## Problem Description
+
+The `CREATE EDGE` SQL command fails to properly resolve argument expressions when using query result sets as arguments. This causes the error:
+```
+Invalid vertex for edge creation: {@rid: #1:0}
+```
+
+### Failing Cases
+
+1. **Using LET variable with property access:**
+   ```sql
+   LET $x = SELECT @rid FROM V;
+   CREATE EDGE E FROM $x.@rid TO $x.@rid
+   ```
+
+2. **Using subquery with property access:**
+   ```sql
+   CREATE EDGE E FROM (SELECT @rid FROM V).@rid TO (SELECT @rid FROM V).@rid
+   ```
+
+### Working Case
+
+```sql
+LET $x = (SELECT @rid FROM V).@rid;
+CREATE EDGE E FROM $x TO $x
+```
+
+## Root Cause Analysis
+
+### Technical Analysis (by java-architect agent)
+
+**Bug Location:** `SuffixIdentifier.java` - Property extraction mechanism
+
+**Execution Flow:**
+1. `CreateEdgeStatement` → `CreateEdgeExecutionPlanner` creates execution plan
+2. FROM/TO expressions stored as global variables via `GlobalLetExpressionStep`
+3. Expressions evaluated: `$x.@rid` or `(SELECT ...).@rid`
+4. `SuffixIdentifier.execute(Iterable, CommandContext)` iterates over Result list
+5. **BUG:** Property extraction returns `Result` wrappers instead of unwrapped RID values
+6. `CreateEdgesStep.asVertex()` receives wrapped Results and fails
+
+**Key Files:**
+- `/engine/src/main/java/com/arcadedb/query/sql/parser/SuffixIdentifier.java` (lines 104-184)
+- `/engine/src/main/java/com/arcadedb/query/sql/executor/CreateEdgesStep.java` (lines 291-309)
+- `/engine/src/main/java/com/arcadedb/query/sql/executor/GlobalLetExpressionStep.java` (line 56)
+
+**Why It Fails:**
+- When `$x.@rid` is evaluated where `$x` is `List<Result>`
+- Property access extracts `@rid` but keeps Result wrapper: `[Result{@rid: #1:0}]`
+- Should return unwrapped RIDs: `[#1:0]`
+- `asVertex()` fails on Result wrapper: "Invalid vertex for edge creation: {@rid: #1:0}"
+
+**Why Working Case Succeeds:**
+- `LET $x = (SELECT @rid FROM V).@rid` evaluates property access during LET
+- Result is clean list of RIDs stored in `$x`
+- CREATE EDGE receives proper RID objects, not wrapped Results
+
+## Workflow Steps
+
+### Step 1: Branch Creation ✅
+- Branch: `fix/3315-create-edge` (already created)
+- Documentation: `3315-create-edge.md` (this file)
+
+### Step 2: Analysis and Test Creation
+- [x] Analyze the SQL query executor code for CREATE EDGE (java-architect agent)
+- [x] Identify the expression resolution mechanism (SuffixIdentifier.java)
+- [x] Write failing tests that reproduce all bug scenarios (test-automator agent)
+- [x] Verify tests fail with current code
+
+**Test Details:**
+- File: `engine/src/test/java/com/arcadedb/query/sql/QueryTest.java`
+- Method: `createEdgeWithPropertyAccessOnResultSet()` (lines 677-767)
+- Test command: `mvn test -Dtest=QueryTest#createEdgeWithPropertyAccessOnResultSet`
+- Status: FAILS with expected error "Invalid vertex for edge creation: {@rid: #4:0}"
+
+### Step 3: Implementation
+- [x] Implement fix for expression resolution (backend-developer agent)
+- [x] Verify all new tests pass
+- [x] Run existing test suite to prevent regressions
+- [x] Clean up any debug code
+
+### Step 4: Verification
+- [x] All new tests pass (QueryTest#createEdgeWithPropertyAccessOnResultSet)
+- [x] No regressions in existing tests (40 tests passed)
+- [x] Code quality standards met
+
+## Progress Log
+
+### Initial Setup
+- Created documentation file
+- Confirmed branch is correct
+- Ready to begin agent coordination
+
+### Analysis Phase (java-architect agent)
+- Analyzed CREATE EDGE execution path
+- Identified bug in SuffixIdentifier.java property extraction
+- Root cause: Property access on Result collections returns wrapped Results instead of unwrapped values
+- Documented execution flow and key classes involved
+
+### Test Creation Phase (test-automator agent)
+- Created comprehensive test in QueryTest.java
+- Test method: `createEdgeWithPropertyAccessOnResultSet()` (lines 677-767)
+- Covers all three scenarios from the issue
+- Test initially fails with expected error message
+- Test file: `engine/src/test/java/com/arcadedb/query/sql/QueryTest.java`
+
+### Implementation Phase (backend-developer agent)
+- Fixed SuffixIdentifier.java (lines 175-201)
+  - Modified `execute(Iterable)` and `execute(Iterator)` methods
+  - Added unwrapping logic for Result objects when extracting properties
+  - Properly handles record attributes like `@rid`
+- Enhanced CreateEdgesStep.java (lines 291-312)
+  - Improved `asVertex()` method to handle projection Results
+  - Extracts `@rid` property from Results without vertex elements
+- All tests pass: 40 related tests, 0 failures
+
+### Verification Phase
+- New test passes all three scenarios
+- No regressions in existing test suite
+- Code follows project standards and patterns
+- Changes staged in git (not committed per instructions)
+
+## Implementation Summary
+
+### Files Modified
+
+1. **SuffixIdentifier.java** (`engine/src/main/java/com/arcadedb/query/sql/parser/SuffixIdentifier.java`)
+   - Fixed property extraction from Result collections
+   - Added unwrapping logic for Result objects
+   - Lines modified: 175-201
+
+2. **CreateEdgesStep.java** (`engine/src/main/java/com/arcadedb/query/sql/executor/CreateEdgesStep.java`)
+   - Enhanced vertex resolution for projection Results
+   - Added `@rid` property extraction fallback
+   - Lines modified: 291-312
+
+3. **QueryTest.java** (`engine/src/test/java/com/arcadedb/query/sql/QueryTest.java`)
+   - Added comprehensive test method
+   - Method: `createEdgeWithPropertyAccessOnResultSet()`
+   - Lines added: 677-767
+
+### Changes Summary
+- 3 files changed
+- 143 insertions (+)
+- 4 deletions (-)
+- Net change: +139 lines
+
+### Test Results
+
+**New Test:** `QueryTest#createEdgeWithPropertyAccessOnResultSet`
+- ✅ Scenario 1: LET variable with property access - PASS
+- ✅ Scenario 2: Direct subquery with property access - PASS
+- ✅ Scenario 3: Baseline working case - PASS
+
+**Regression Testing:**
+- ✅ QueryTest: 26 tests passed
+- ✅ CreateEdgeStatementTest: 6 tests passed
+- ✅ CreateEdgeParametersTest: 1 test passed
+- ✅ CreateEdgeStatementExecutionTest: 7 tests passed
+- ✅ Total: 40 tests passed, 0 failures
+
+## Impact Analysis
+
+### What Changed
+The fix ensures that when extracting properties from collections of Result objects (e.g., from SELECT queries), the actual property values are returned instead of Result wrappers. This allows CREATE EDGE statements to properly resolve vertex references from query expressions.
+
+### Components Affected
+- **SQL Parser:** SuffixIdentifier property extraction mechanism
+- **SQL Executor:** CreateEdgesStep vertex resolution
+- **Query Execution:** Expression evaluation for CREATE EDGE statements
+
+### Backward Compatibility
+- ✅ All existing tests pass
+- ✅ No breaking changes to API
+- ✅ Enhancement only - fixes broken functionality
+- ✅ Working cases remain working
+
+### Performance Impact
+- Minimal: Only affects property extraction from Result collections
+- No additional overhead for non-Result objects
+- Unwrapping happens during expression evaluation (already existing cost)
+
+## Recommendations
+
+### Monitoring
+- Monitor CREATE EDGE statements in production
+- Watch for any edge cases with complex property access patterns
+- Verify performance remains consistent
+
+### Future Improvements
+1. Consider adding more edge cases to test suite:
+   - Nested property access (e.g., `$x.property.subproperty`)
+   - Multiple property access in single query
+   - Property access on different Result types (projection vs element)
+
+2. Documentation updates:
+   - Add examples of property access with CREATE EDGE to SQL documentation
+   - Document the difference between `(SELECT).property` and pre-evaluated variables
+
+### Testing
+- ✅ Comprehensive test coverage added
+- ✅ All scenarios from issue #3315 tested
+- ✅ No regression in existing functionality
+- ✅ Ready for code review and merge

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CreateEdgesStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CreateEdgesStep.java
@@ -299,16 +299,11 @@ public class CreateEdgesStep extends AbstractExecutionStep {
         currentFrom = vertexOpt.get();
       } else {
         // If no vertex, try to extract @rid property (for projection results) - issue #3315
-        if (result.hasProperty("@rid")) {
-          final Object rid = result.getProperty("@rid");
-          if (rid != null) {
-            currentFrom = rid;
-          } else {
-            throw new CommandExecutionException("Invalid vertex for edge creation: " + result);
-          }
-        } else {
+        final Object rid = result.getProperty("@rid");
+        if (rid != null)
+          currentFrom = rid;
+        else
           throw new CommandExecutionException("Invalid vertex for edge creation: " + result);
-        }
       }
     }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/SuffixIdentifier.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/SuffixIdentifier.java
@@ -178,7 +178,23 @@ public class SuffixIdentifier extends SimpleNode {
     }
     final List<Object> result = new ArrayList<>();
     for (final Object o : iterable) {
-      result.add(execute(o, context));
+      final Object value = execute(o, context);
+      // When extracting properties from Results in collections, unwrap the value if needed (issue #3315)
+      // If execute() returned a Result when accessing a property/attribute, extract the actual value
+      if (value instanceof Result r && (identifier != null || recordAttribute != null)) {
+        // Try to get the underlying element or value from the Result
+        if (r.isElement()) {
+          result.add(r.getElement().get());
+        } else if (identifier != null && r.hasProperty(identifier.getStringValue())) {
+          result.add(r.getProperty(identifier.getStringValue()));
+        } else if (recordAttribute != null) {
+          result.add(recordAttribute.evaluate(r, context));
+        } else {
+          result.add(value);
+        }
+      } else {
+        result.add(value);
+      }
     }
     return result;
   }
@@ -189,7 +205,23 @@ public class SuffixIdentifier extends SimpleNode {
     }
     final List<Object> result = new ArrayList<>();
     while (iterator.hasNext()) {
-      result.add(execute(iterator.next(), context));
+      final Object value = execute(iterator.next(), context);
+      // When extracting properties from Results in collections, unwrap the value if needed (issue #3315)
+      // If execute() returned a Result when accessing a property/attribute, extract the actual value
+      if (value instanceof Result r && (identifier != null || recordAttribute != null)) {
+        // Try to get the underlying element or value from the Result
+        if (r.isElement()) {
+          result.add(r.getElement().get());
+        } else if (identifier != null && r.hasProperty(identifier.getStringValue())) {
+          result.add(r.getProperty(identifier.getStringValue()));
+        } else if (recordAttribute != null) {
+          result.add(recordAttribute.evaluate(r, context));
+        } else {
+          result.add(value);
+        }
+      } else {
+        result.add(value);
+      }
     }
     if (iterator instanceof ResultSet set) {
       try {

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/SuffixIdentifier.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/SuffixIdentifier.java
@@ -173,56 +173,23 @@ public class SuffixIdentifier extends SimpleNode {
   }
 
   public Object execute(final Iterable iterable, final CommandContext context) {
-    if (star) {
+    if (star)
       return null;
-    }
+
     final List<Object> result = new ArrayList<>();
-    for (final Object o : iterable) {
-      final Object value = execute(o, context);
-      // When extracting properties from Results in collections, unwrap the value if needed (issue #3315)
-      // If execute() returned a Result when accessing a property/attribute, extract the actual value
-      if (value instanceof Result r && (identifier != null || recordAttribute != null)) {
-        // Try to get the underlying element or value from the Result
-        if (r.isElement()) {
-          result.add(r.getElement().get());
-        } else if (identifier != null && r.hasProperty(identifier.getStringValue())) {
-          result.add(r.getProperty(identifier.getStringValue()));
-        } else if (recordAttribute != null) {
-          result.add(recordAttribute.evaluate(r, context));
-        } else {
-          result.add(value);
-        }
-      } else {
-        result.add(value);
-      }
-    }
+    for (final Object o : iterable)
+      result.add(unwrapResultIfNeeded(execute(o, context), context));
     return result;
   }
 
   public Object execute(final Iterator iterator, final CommandContext context) {
-    if (star) {
+    if (star)
       return null;
-    }
+
     final List<Object> result = new ArrayList<>();
-    while (iterator.hasNext()) {
-      final Object value = execute(iterator.next(), context);
-      // When extracting properties from Results in collections, unwrap the value if needed (issue #3315)
-      // If execute() returned a Result when accessing a property/attribute, extract the actual value
-      if (value instanceof Result r && (identifier != null || recordAttribute != null)) {
-        // Try to get the underlying element or value from the Result
-        if (r.isElement()) {
-          result.add(r.getElement().get());
-        } else if (identifier != null && r.hasProperty(identifier.getStringValue())) {
-          result.add(r.getProperty(identifier.getStringValue()));
-        } else if (recordAttribute != null) {
-          result.add(recordAttribute.evaluate(r, context));
-        } else {
-          result.add(value);
-        }
-      } else {
-        result.add(value);
-      }
-    }
+    while (iterator.hasNext())
+      result.add(unwrapResultIfNeeded(execute(iterator.next(), context), context));
+
     if (iterator instanceof ResultSet set) {
       try {
         set.reset();
@@ -230,6 +197,32 @@ public class SuffixIdentifier extends SimpleNode {
       }
     }
     return result;
+  }
+
+  /**
+   * Unwraps Result objects when extracting properties from collections (issue #3315).
+   * When execute() returns a Result while accessing a property/attribute, extracts the actual value.
+   */
+  private Object unwrapResultIfNeeded(final Object value, final CommandContext context) {
+    if (!(value instanceof Result r) || (identifier == null && recordAttribute == null))
+      return value;
+
+    // Try to get the underlying element
+    if (r.isElement())
+      return r.getElement().orElse(null);
+
+    // Try to get the property value
+    if (identifier != null) {
+      final Object prop = r.getProperty(identifier.getStringValue());
+      if (prop != null)
+        return prop;
+    }
+
+    // Try to evaluate the record attribute
+    if (recordAttribute != null)
+      return recordAttribute.evaluate(r, context);
+
+    return value;
   }
 
   public Object execute(final CommandContext currentRecord) {


### PR DESCRIPTION
…ements

Fixed property extraction from Result collections in SuffixIdentifier to return unwrapped values instead of Result wrappers. Enhanced CreateEdgesStep to handle projection Results by extracting @rid property when vertex element is unavailable.

This allows CREATE EDGE to properly resolve expressions like:
- LET $x = SELECT @rid FROM V; CREATE EDGE E FROM $x.@rid TO $x.@rid
- CREATE EDGE E FROM (SELECT @rid FROM V).@rid TO (SELECT @rid FROM V).@rid

