### PR TITLE
Fix Opencypher tck tests

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ArithmeticExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ArithmeticExpression.java
@@ -21,6 +21,9 @@ package com.arcadedb.query.opencypher.ast;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Expression representing an arithmetic operation.
  * Supports: +, -, *, /, %, ^ (power)
@@ -91,6 +94,26 @@ public class ArithmeticExpression implements Expression {
     // String concatenation for + operator
     if (operator == Operator.ADD && (leftValue instanceof String || rightValue instanceof String))
       return leftValue.toString() + rightValue.toString();
+
+    // List concatenation/append for + operator
+    if (operator == Operator.ADD) {
+      if (leftValue instanceof List && rightValue instanceof List) {
+        final List<Object> combined = new ArrayList<>((List<?>) leftValue);
+        combined.addAll((List<?>) rightValue);
+        return combined;
+      }
+      if (leftValue instanceof List) {
+        final List<Object> appended = new ArrayList<>((List<?>) leftValue);
+        appended.add(rightValue);
+        return appended;
+      }
+      if (rightValue instanceof List) {
+        final List<Object> prepended = new ArrayList<>();
+        prepended.add(leftValue);
+        prepended.addAll((List<?>) rightValue);
+        return prepended;
+      }
+    }
 
     // Numeric operations
     if (!(leftValue instanceof Number) || !(rightValue instanceof Number))

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ListSliceExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ListSliceExpression.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.ast;
+
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Expression representing list slicing: list[from..to]
+ * Both from and to are optional. Supports negative indices (Python-style).
+ * Examples: list[0..3], list[1..], list[..5], list[-3..]
+ */
+public class ListSliceExpression implements Expression {
+  private final Expression listExpression;
+  private final Expression fromExpression; // null means start from beginning
+  private final Expression toExpression;   // null means go to end
+
+  public ListSliceExpression(final Expression listExpression, final Expression fromExpression, final Expression toExpression) {
+    this.listExpression = listExpression;
+    this.fromExpression = fromExpression;
+    this.toExpression = toExpression;
+  }
+
+  @Override
+  public Object evaluate(final Result result, final CommandContext context) {
+    final Object listValue = listExpression.evaluate(result, context);
+    if (listValue == null)
+      return null;
+
+    final int size;
+    if (listValue instanceof List)
+      size = ((List<?>) listValue).size();
+    else if (listValue instanceof String)
+      size = ((String) listValue).length();
+    else
+      throw new IllegalArgumentException("Cannot slice type: " + listValue.getClass().getSimpleName());
+
+    // Resolve from index (default: 0)
+    int from = 0;
+    if (fromExpression != null) {
+      final Object fromValue = fromExpression.evaluate(result, context);
+      if (fromValue == null)
+        return null;
+      if (fromValue instanceof Number)
+        from = ((Number) fromValue).intValue();
+      else
+        throw new IllegalArgumentException("Slice index must be a number, got: " + fromValue.getClass().getSimpleName());
+    }
+
+    // Resolve to index (default: size)
+    int to = size;
+    if (toExpression != null) {
+      final Object toValue = toExpression.evaluate(result, context);
+      if (toValue == null)
+        return null;
+      if (toValue instanceof Number)
+        to = ((Number) toValue).intValue();
+      else
+        throw new IllegalArgumentException("Slice index must be a number, got: " + toValue.getClass().getSimpleName());
+    }
+
+    // Handle negative indices
+    if (from < 0)
+      from = Math.max(0, size + from);
+    if (to < 0)
+      to = Math.max(0, size + to);
+
+    // Clamp to valid range
+    from = Math.min(from, size);
+    to = Math.min(to, size);
+
+    // If from >= to, return empty
+    if (from >= to) {
+      if (listValue instanceof String)
+        return "";
+      return new ArrayList<>();
+    }
+
+    if (listValue instanceof List)
+      return new ArrayList<>(((List<?>) listValue).subList(from, to));
+    else
+      return ((String) listValue).substring(from, to);
+  }
+
+  @Override
+  public boolean isAggregation() {
+    return listExpression.isAggregation()
+        || (fromExpression != null && fromExpression.isAggregation())
+        || (toExpression != null && toExpression.isAggregation());
+  }
+
+  @Override
+  public boolean containsAggregation() {
+    return listExpression.containsAggregation()
+        || (fromExpression != null && fromExpression.containsAggregation())
+        || (toExpression != null && toExpression.containsAggregation());
+  }
+
+  @Override
+  public String getText() {
+    final String fromText = fromExpression != null ? fromExpression.getText() : "";
+    final String toText = toExpression != null ? toExpression.getText() : "";
+    return listExpression.getText() + "[" + fromText + ".." + toText + "]";
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/traversal/GraphTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/traversal/GraphTraverser.java
@@ -58,9 +58,8 @@ public abstract class GraphTraverser {
     this.trackPaths = trackPaths;
     this.detectCycles = detectCycles;
 
-    if (this.minHops > this.maxHops) {
-      throw new IllegalArgumentException("minHops (" + minHops + ") cannot be greater than maxHops (" + maxHops + ")");
-    }
+    // When minHops > maxHops, traversal naturally returns empty results
+    // (no path can satisfy depth >= minHops AND depth <= maxHops)
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherResultFormatTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherResultFormatTest.java
@@ -63,8 +63,8 @@ class CypherResultFormatTest {
   }
 
   @Test
-  void returnSingleNodeIsElement() {
-    // MATCH (n) RETURN n should return elements directly, not wrapped in {"n": element}
+  void returnSingleNodeHasVariableColumn() {
+    // MATCH (n) RETURN n should return result with column "n" containing the vertex
     final ResultSet result = database.query("opencypher", "MATCH (n:Person) RETURN n");
     final List<Result> results = new ArrayList<>();
     while (result.hasNext()) {
@@ -73,14 +73,14 @@ class CypherResultFormatTest {
 
     assertThat(results).hasSize(2);
     for (final Result r : results) {
-      assertThat(r.isElement()).as("Result should be an element, not a projection wrapping the element").isTrue();
-      assertThat(r.toElement()).isInstanceOf(Vertex.class);
+      assertThat(r.getPropertyNames()).contains("n");
+      assertThat((Object) r.getProperty("n")).isInstanceOf(Vertex.class);
     }
   }
 
   @Test
-  void returnSingleEdgeIsElement() {
-    // MATCH ()-[r]->() RETURN r should return elements directly
+  void returnSingleEdgeHasVariableColumn() {
+    // MATCH ()-[r]->() RETURN r should return result with column "r"
     final ResultSet result = database.query("opencypher", "MATCH ()-[r:KNOWS]->() RETURN r");
     final List<Result> results = new ArrayList<>();
     while (result.hasNext()) {
@@ -88,8 +88,7 @@ class CypherResultFormatTest {
     }
 
     assertThat(results).hasSize(1);
-    assertThat(results.getFirst().isElement())
-        .as("Edge result should be an element, not a projection").isTrue();
+    assertThat(results.getFirst().getPropertyNames()).contains("r");
   }
 
   @Test
@@ -126,7 +125,7 @@ class CypherResultFormatTest {
 
   @Test
   void returnNodeWithAlias() {
-    // MATCH (n) RETURN n AS person - single element with alias should still unwrap
+    // MATCH (n) RETURN n AS person — result should have column "person" with the vertex
     final ResultSet result = database.query("opencypher", "MATCH (n:Person) RETURN n AS person");
     final List<Result> results = new ArrayList<>();
     while (result.hasNext()) {
@@ -135,7 +134,8 @@ class CypherResultFormatTest {
 
     assertThat(results).hasSize(2);
     for (final Result r : results) {
-      assertThat(r.isElement()).as("Single aliased element should be unwrapped").isTrue();
+      assertThat(r.getPropertyNames()).contains("person");
+      assertThat((Object) r.getProperty("person")).isInstanceOf(Vertex.class);
     }
   }
 
@@ -155,6 +155,7 @@ class CypherResultFormatTest {
   @Test
   void singleNodeHasProjectionNameMetadata() {
     // RETURN n should have _projectionName metadata for wire protocols
+    // The result should have column "n" with the vertex as value
     final ResultSet result = database.query("opencypher", "MATCH (n:Person) RETURN n");
     final List<Result> results = new ArrayList<>();
     while (result.hasNext()) {
@@ -163,7 +164,7 @@ class CypherResultFormatTest {
 
     assertThat(results).hasSize(2);
     for (final Result r : results) {
-      assertThat(r.isElement()).isTrue();
+      assertThat(r.getPropertyNames()).contains("n");
       assertThat(r.getMetadata(PROJECTION_NAME_METADATA)).isEqualTo("n");
     }
   }


### PR DESCRIPTION
2nd pass, much better.

```
=======================================================
         OpenCypher TCK Compliance Report
=======================================================
Total scenarios:  3897
Passed:           1908 (48%)
Failed:           1939 (49%)
Skipped:          50 (1%)
-------------------------------------------------------
By category:
  clauses/call                               2/ 52 passed (3%)
  clauses/create                            64/ 78 passed (82%)
  clauses/delete                            24/ 41 passed (58%)
  clauses/match                            292/381 passed (76%)
  clauses/match-where                       25/ 34 passed (73%)
  clauses/merge                             47/ 75 passed (62%)
  clauses/remove                            29/ 33 passed (87%)
  clauses/return                            35/ 63 passed (55%)
  clauses/return-orderby                    23/ 35 passed (65%)
  clauses/return-skip-limit                 26/ 31 passed (83%)
  clauses/set                               30/ 53 passed (56%)
  clauses/union                              8/ 12 passed (66%)
  clauses/unwind                            10/ 14 passed (71%)
  clauses/with                              14/ 29 passed (48%)
  clauses/with-orderBy                     124/292 passed (42%)
  clauses/with-skip-limit                    7/  9 passed (77%)
  clauses/with-where                        10/ 19 passed (52%)
  expressions/aggregation                   23/ 35 passed (65%)
  expressions/boolean                      150/150 passed (100%)
  expressions/comparison                    36/ 72 passed (50%)
  expressions/conditional                   13/ 13 passed (100%)
  expressions/existentialSubqueries          4/ 10 passed (40%)
  expressions/graph                         32/ 61 passed (52%)
  expressions/list                         120/185 passed (64%)
  expressions/literals                     120/131 passed (91%)
  expressions/map                           28/ 44 passed (63%)
  expressions/mathematical                   3/  6 passed (50%)
  expressions/null                          44/ 44 passed (100%)
  expressions/path                           0/  7 passed (0%)
  expressions/pattern                       19/ 50 passed (38%)
  expressions/precedence                    20/121 passed (16%)
  expressions/quantifier                   478/604 passed (79%)
  expressions/string                        22/ 32 passed (68%)
  expressions/temporal                       0/1004 passed (0%)
  expressions/typeConversion                19/ 47 passed (40%)
  useCases/countingSubgraphMatches           6/ 11 passed (54%)
  useCases/triadicSelection                  1/ 19 passed (5%)
=======================================================
```