### PR TITLE
Fix test failing because of locale

### DIFF
--- a/grpcw/src/test/java/com/arcadedb/server/grpc/CompressionAwareServiceTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/CompressionAwareServiceTest.java
@@ -96,7 +96,7 @@ class CompressionAwareServiceTest {
     String statsString = stats.getStats();
 
     // Should not throw with zero counts
-    assertThat(statsString).matches(".*0(\.|,)0%.*");
+    assertThat(statsString).matches(".*0(\\.|\\,)0%.*");
   }
 
   @Test
@@ -108,6 +108,6 @@ class CompressionAwareServiceTest {
     stats.recordRequest(false);
 
     String statsString = stats.getStats();
-    assertThat(statsString).matches(".*50(\.|,)0%.*");
+    assertThat(statsString).matches(".*50(\\.|\\,)0%.*");
   }
 }


### PR DESCRIPTION
## What does this PR do?

This change uses `matches` instead of `contains` in the `grpcw`'s module `CompressionAwareServiceTest` class to accept `.` and `,` when asserting test results.

## Motivation

Failing test

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
