### PR TITLE
fix: edge indexes become invalid when deleting and recreating same edge (#3097)

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/TransactionIndexContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionIndexContext.java
@@ -294,9 +294,14 @@ public class TransactionIndexContext {
 
             // REPLACE EXISTENT WITH THIS
             v.operation = IndexKey.IndexKeyOperation.REPLACE;
-            if (entry != null && entry.operation == IndexKey.IndexKeyOperation.REMOVE)
-              // SAVE THE OLD RID SO IT CAN BE PROPERLY REMOVED FROM THE PERSISTED INDEX AT COMMIT TIME
-              v.oldRid = entry.rid;
+            if (entry != null) {
+              if (entry.operation == IndexKey.IndexKeyOperation.REMOVE)
+                // SAVE THE OLD RID SO IT CAN BE PROPERLY REMOVED FROM THE PERSISTED INDEX AT COMMIT TIME
+                v.oldRid = entry.rid;
+              else if (entry.operation == IndexKey.IndexKeyOperation.REPLACE)
+                // PROPAGATE THE OLD RID FROM THE PREVIOUS REPLACE OPERATION (e.g. REMOVE → ADD → ADD)
+                v.oldRid = entry.oldRid;
+            }
           }
         }
       }

--- a/engine/src/test/java/com/arcadedb/graph/EdgeIndexDuplicateKeyTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/EdgeIndexDuplicateKeyTest.java
@@ -33,52 +33,59 @@ class EdgeIndexDuplicateKeyTest extends TestHelper {
   void edgeDeleteAndRecreateMultipleTimes() {
     // Transaction #1: Create schema
     database.transaction(() -> {
-      database.command("sql", "CREATE VERTEX TYPE duct");
-      database.command("sql", "CREATE VERTEX TYPE trs");
-      database.command("sql", "CREATE PROPERTY duct.id STRING");
-      database.command("sql", "CREATE INDEX ON duct (id) UNIQUE");
-      database.command("sql", "CREATE PROPERTY trs.id STRING");
-      database.command("sql", "CREATE INDEX ON trs (id) UNIQUE");
-      database.command("sql", "CREATE EDGE TYPE trs_duct");
-      database.command("sql", "CREATE PROPERTY trs_duct.from_id STRING");
-      database.command("sql", "CREATE INDEX ON trs_duct (from_id) NOTUNIQUE");
-      database.command("sql", "CREATE PROPERTY trs_duct.to_id STRING");
-      database.command("sql", "CREATE INDEX ON trs_duct (to_id) NOTUNIQUE");
-      database.command("sql", "CREATE PROPERTY trs_duct.swap STRING");
-      database.command("sql", "CREATE PROPERTY trs_duct.order_number INTEGER");
-      database.command("sql", "CREATE INDEX ON trs_duct (from_id,to_id,swap,order_number) UNIQUE");
+      database.command("sqlscript", """
+          CREATE VERTEX TYPE duct;
+          CREATE VERTEX TYPE trs;
+          CREATE PROPERTY duct.id STRING;
+          CREATE INDEX ON duct (id) UNIQUE;
+          CREATE PROPERTY trs.id STRING;
+          CREATE INDEX ON trs (id) UNIQUE;
+          CREATE EDGE TYPE trs_duct;
+          CREATE PROPERTY trs_duct.from_id STRING;
+          CREATE INDEX ON trs_duct (from_id) NOTUNIQUE;
+          CREATE PROPERTY trs_duct.to_id STRING;
+          CREATE INDEX ON trs_duct (to_id) NOTUNIQUE;
+          CREATE PROPERTY trs_duct.swap STRING;
+          CREATE PROPERTY trs_duct.order_number INTEGER;
+          CREATE INDEX ON trs_duct (from_id,to_id,swap,order_number) UNIQUE;
+          """);
     });
 
     // Transaction #2: Insert vertices and create edge
     database.transaction(() -> {
-      database.command("sql", "INSERT INTO duct (id) VALUES ('duct_1')");
-      database.command("sql", "INSERT INTO trs (id) VALUES ('trs_1')");
-      database.command("sql",
-          """
-          CREATE EDGE trs_duct from (SELECT FROM trs WHERE id='trs_1') to (SELECT FROM duct WHERE id='duct_1') \
+      database.command("sqlscript", """
+          INSERT INTO duct (id) VALUES ('duct_1');
+          INSERT INTO trs (id) VALUES ('trs_1');
+
+          CREATE EDGE trs_duct
+          from (SELECT FROM trs WHERE id='trs_1')
+          to (SELECT FROM duct WHERE id='duct_1')
           SET from_id='trs_1', to_id='duct_1', swap='N', order_number=1""");
     });
 
     // Transaction #3: Delete and recreate edge (first time - should work)
     database.transaction(() -> {
-      database.command("sql",
-          "DELETE FROM trs_duct WHERE (from_id='trs_1') AND (to_id='duct_1') AND (swap='N') AND (order_number=1)");
-      database.command("sql",
-          """
-          CREATE EDGE trs_duct from (SELECT FROM trs WHERE id='trs_1') to (SELECT FROM duct WHERE id='duct_1') \
+      database.command("sqlscript", """
+          DELETE FROM trs_duct WHERE (from_id='trs_1') AND (to_id='duct_1') AND (swap='N') AND (order_number=1);
+
+          CREATE EDGE trs_duct
+          from (SELECT FROM trs WHERE id='trs_1')
+          to (SELECT FROM duct WHERE id='duct_1')
           SET from_id='trs_1', to_id='duct_1', swap='N', order_number=1""");
     });
 
     // Transaction #4: Delete and recreate edge (second time - this should NOT throw DuplicatedKeyException)
-    database.transaction(() -> {
-      database.command("sql",
-          "DELETE FROM trs_duct WHERE (from_id='trs_1') AND (to_id='duct_1') AND (swap='N') AND (order_number=1)");
-      database.command("sql",
-          """
-          CREATE EDGE trs_duct from (SELECT FROM trs WHERE id='trs_1') to (SELECT FROM duct WHERE id='duct_1') \
-          SET from_id='trs_1', to_id='duct_1', swap='N', order_number=1""");
-    });
+    for (int i = 0; i < 10; i++) {
+      database.transaction(() -> {
+        database.command("sqlscript", """
+            DELETE FROM trs_duct WHERE (from_id='trs_1') AND (to_id='duct_1') AND (swap='N') AND (order_number=1);
 
+            CREATE EDGE trs_duct
+            from (SELECT FROM trs WHERE id='trs_1')
+            to (SELECT FROM duct WHERE id='duct_1')
+            SET from_id='trs_1', to_id='duct_1', swap='N', order_number=1""");
+      });
+    }
     // If we got here without exception, the test passes
   }
 }

--- a/engine/src/test/java/com/arcadedb/graph/EdgeIndexDuplicateKeyTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/EdgeIndexDuplicateKeyTest.java
@@ -19,7 +19,10 @@
 package com.arcadedb.graph;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test for issue #3097: Edge indexes become invalid in certain scenario #2
@@ -86,6 +89,10 @@ class EdgeIndexDuplicateKeyTest extends TestHelper {
             SET from_id='trs_1', to_id='duct_1', swap='N', order_number=1""");
       });
     }
-    // If we got here without exception, the test passes
+
+    Result result = database.query("sql",
+            "SELECT COUNT(*) AS edgeCount FROM trs_duct WHERE from_id='trs_1' AND to_id='duct_1' AND swap='N' AND order_number=1")
+        .next();
+    assertThat(result.<Long>getProperty("edgeCount")).isEqualTo(1);
   }
 }


### PR DESCRIPTION


In TransactionIndexContext.addIndexKeyLock(), when a unique index entry is deleted (REMOVE) and recreated (ADD) with the same key within the same transaction on the same bucket-level index, the REMOVE entry was silently replaced by a REPLACE entry — losing the old RID. At commit time the old persisted index entry was never removed, causing stale entries to accumulate. After 2+ iterations, checkUniqueIndexKeys detected >2 entries for the same unique key and threw DuplicatedKeyException.

Fix: store the old RID in the REPLACE entry (IndexKey.oldRid). At commit time, call index.remove(key, oldRid) for REPLACE entries with a non-null oldRid to properly clean up the old persisted entry. Also fix getTxDeletedEntries() to use oldRid as the deleted RID for correctness in checkUniqueIndexKeys. Update TxForwardRequest serialization to include oldRid for HA replication.

