### PR TITLE
fix: add Multi-Release manifest attribute to shaded JARs for GraalVM/Truffle support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -396,6 +396,15 @@
                                     implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
                                 <addHeader>false</addHeader>
                             </transformer>
+                            <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                <manifestEntries>
+                                    <!-- Required for GraalVM/Truffle to initialize correctly when bundled in shaded JARs.
+                                         Without this, Truffle's CheckMultiReleaseSupport returns false (base class),
+                                         causing Engine$ImplHolder initialization failure. -->
+                                    <Multi-Release>true</Multi-Release>
+                                </manifestEntries>
+                            </transformer>
                         </transformers>
                         <filters>
                             <filter>


### PR DESCRIPTION


GraalVM/Truffle JARs are transitively included in protocol module shaded JARs (e.g. gremlin via arcadedb-integration -> arcadedb-engine -> GraalVM). The maven-shade-plugin strips the Multi-Release: true manifest attribute, causing Truffle's CheckMultiReleaseSupport check to use the base class (returns false) instead of the Java-9+ versioned class (returns true).

Since shaded JARs sort alphabetically before the individual truffle-api and polyglot JARs, the JVM always loaded the broken version first, resulting in Engine$ImplHolder initialization failure.

Fix: add ManifestResourceTransformer with Multi-Release: true to the parent pom shade plugin configuration, as recommended by the GraalVM documentation for Uber/shaded JAR setups.

