### PR TITLE
fix #3514

### DIFF
--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurityDatabaseUser.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurityDatabaseUser.java
@@ -222,9 +222,10 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
         newFileAccessMap[i] = new boolean[] { false, false, false, false };
 
         final JSONObject t;
-        if (defaultGroup.has(typeName)) {
+        final JSONObject defaultGroupTypes = defaultGroup.getJSONObject("types");
+        if (defaultGroupTypes.has(typeName)) {
           // APPLY THE FOUND TYPE FROM DEFAULT GROUP
-          t = defaultGroup.getJSONObject(typeName);
+          t = defaultGroupTypes.getJSONObject(typeName);
         } else
           // APPLY DEFAULT TYPE FROM DEFAULT GROUP
           t = defaultType;


### PR DESCRIPTION
Qwen 3.5 27B wrote the fix, while running in claude code binary
fixes #3514

  ## Error
  java.lang.IllegalStateException: Not a JSON Object: []
      at com.arcadedb.serializer.json.JSONObject.getJSONObject(JSONObject.java:326)
      at com.arcadedb.server.security.ServerSecurityDatabaseUser.updateFileAccess(ServerSecurityDatabaseUser.java:227)

  ## Trigger Query
  ```cypher
  UNWIND $batch as row
  MATCH (a) WHERE ID(a) = row.source_id
  MATCH (b) WHERE ID(b) = row.target_id
  MERGE (a)-[r:`causal_action`{chunk: row.features.chunk}]->(b)
  RETURN a, b, r
```

  Root Cause

  In ServerSecurityDatabaseUser.java at line 225-227, there's a bug where the code looks for a type name at the wrong level of the JSON hierarchy:
```java
  // BUGGY CODE (line 225-227)
  if (defaultGroup.has(typeName)) {
    t = defaultGroup.getJSONObject(typeName);  // <-- Wrong level!
  }
```
  The Problem

  The variable defaultGroup is a group configuration object with this structure:
```json
  {
    "*": {                    // <-- defaultGroup is THIS object
      "types": {             // <-- typeName should be looked up HERE
        "causal_action": {
          "access": [...]
        }
      }
    }
  }
```
  The code incorrectly checks `defaultGroup.has(typeName)` directly, but the type name is nested inside `defaultGroup.getJSONObject("types").`


**Qwen claims this but i'm not sure at all : **

  When a new edge type is created via Cypher MERGE, the security system is updated. If the security configuration has any key at the group level that matches the type name (even accidentally), the code finds
   it and tries to call getJSONObject() on it. If that value happens to be an array [], the error occurs.

