### PR TITLE
#3532 fix: add --add-modules jdk.incubator.vector to javadoc plugin in deploy profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -532,6 +532,10 @@
                         <version>${maven-javadoc-plugin.version}</version>
                         <configuration>
                             <doclint>none</doclint>  <!-- Turnoff all checks -->
+                            <additionalOptions>
+                                <!-- TimeSeries SIMD: requires jdk.incubator.vector module (JEP 448) -->
+                                <additionalOption>--add-modules jdk.incubator.vector</additionalOption>
+                            </additionalOptions>
                         </configuration>
                         <executions>
                             <execution>


### PR DESCRIPTION
…

The deploy workflow failed because the maven-javadoc-plugin was missing the incubator vector module from its module graph, while the compiler and surefire plugins already had it configured.

