### PR TITLE
#3571 fix: accessing internal properties 

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
@@ -3102,22 +3102,12 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
         }
       }
 
-      // Check if the first identifier is a record attribute (@rid, @type, @in, @out, @this)
-      if (firstIdCtx.RID_ATTR() != null || firstIdCtx.TYPE_ATTR() != null ||
-          firstIdCtx.IN_ATTR() != null || firstIdCtx.OUT_ATTR() != null ||
-          firstIdCtx.THIS() != null) {
-        // Handle record attributes specially
-        final RecordAttribute attr = new RecordAttribute(-1);
-        attr.setName(firstIdCtx.getText());
-        final BaseIdentifier baseId = new BaseIdentifier(attr);
-        baseExpr.identifier = baseId;
-      } else {
-        // Regular identifier
-        final Identifier firstId = (Identifier) visit(firstIdCtx);
-        // Use BaseIdentifier constructor that automatically creates SuffixIdentifier
-        final BaseIdentifier baseId = new BaseIdentifier(firstId);
-        baseExpr.identifier = baseId;
-      }
+      // Check if the first identifier is a record attribute (@rid, @type, @in, @out, @this),
+      // including backtick-quoted variants like `@rid`
+      final SuffixIdentifier firstSuffix = buildSuffixForIdentifier(firstIdCtx);
+      final BaseIdentifier baseId = new BaseIdentifier(-1);
+      baseId.suffix = firstSuffix;
+      baseExpr.identifier = baseId;
 
       // Check for namespaced function call pattern: namespace.method(args)
       // e.g., ts.first(value, ts) → builds FunctionCall with name "ts.first"

--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
@@ -27,6 +27,7 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.grammar.SQLParser;
 import com.arcadedb.query.sql.grammar.SQLParserBaseVisitor;
 import com.arcadedb.query.sql.parser.*;
+import com.arcadedb.schema.Property;
 import com.arcadedb.utility.CollectionUtils;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
@@ -3162,16 +3163,7 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
             final SuffixIdentifier suffix;
 
             // Check if this identifier is a record attribute (@rid, @type, @in, @out, @this)
-            if (idCtx.RID_ATTR() != null || idCtx.TYPE_ATTR() != null ||
-                idCtx.IN_ATTR() != null || idCtx.OUT_ATTR() != null ||
-                idCtx.THIS() != null) {
-              final RecordAttribute attr = new RecordAttribute(-1);
-              attr.setName(idCtx.getText());
-              suffix = new SuffixIdentifier(attr);
-            } else {
-              final Identifier id = (Identifier) visit(idCtx);
-              suffix = new SuffixIdentifier(id);
-            }
+            suffix = buildSuffixForIdentifier(idCtx);
 
             modifier.suffix = suffix;
 
@@ -3397,6 +3389,47 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
   }
 
   /**
+   * Builds a SuffixIdentifier for the given identifier context, recognising record attributes
+   * ({@code @rid}, {@code @type}, {@code @in}, {@code @out}, {@code @cat}, {@code @this}, etc.)
+   * whether they appear as unquoted tokens (e.g. {@code .@rid}) or as backtick-quoted identifiers
+   * (e.g. {@code .`@rid`}).
+   */
+  private SuffixIdentifier buildSuffixForIdentifier(final SQLParser.IdentifierContext idCtx) {
+    // Unquoted record attribute tokens (@rid, @type, @in, @out, @this)
+    if (idCtx.RID_ATTR() != null || idCtx.TYPE_ATTR() != null ||
+        idCtx.IN_ATTR() != null || idCtx.OUT_ATTR() != null ||
+        idCtx.THIS() != null) {
+      final RecordAttribute attr = new RecordAttribute(-1);
+      attr.setName(idCtx.getText());
+      return new SuffixIdentifier(attr);
+    }
+    // Quoted identifiers (e.g. `@rid`) or plain identifiers whose value matches a record attribute
+    final Identifier id = (Identifier) visit(idCtx);
+    if (isRecordAttributeName(id.getStringValue())) {
+      final RecordAttribute attr = new RecordAttribute(-1);
+      attr.setName(id.getStringValue());
+      return new SuffixIdentifier(attr);
+    }
+    return new SuffixIdentifier(id);
+  }
+
+  /**
+   * Returns true if the given name matches a known internal record attribute
+   * ({@code @rid}, {@code @type}, {@code @in}, {@code @out}, {@code @cat}, {@code @props}, {@code @this}).
+   */
+  private static boolean isRecordAttributeName(final String name) {
+    if (name == null)
+      return false;
+    return name.equalsIgnoreCase(Property.RID_PROPERTY) ||
+        name.equalsIgnoreCase(Property.TYPE_PROPERTY) ||
+        name.equalsIgnoreCase(Property.IN_PROPERTY) ||
+        name.equalsIgnoreCase(Property.OUT_PROPERTY) ||
+        name.equalsIgnoreCase(Property.CAT_PROPERTY) ||
+        name.equalsIgnoreCase(Property.PROPERTY_TYPES_PROPERTY) ||
+        name.equalsIgnoreCase(Property.THIS_PROPERTY);
+  }
+
+  /**
    * Visit modifier (DOT identifier with optional parentheses or array selector).
    * Grammar: modifier: DOT identifier (LPAREN (expression (COMMA expression)*)? RPAREN)? | arraySelector
    * <p>
@@ -3423,10 +3456,8 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
 
           modifier.methodCall = methodCall;
         } else {
-          // Property access: .identifier
-          final Identifier id = (Identifier) visit(ctx.identifier());
-          final SuffixIdentifier suffix = new SuffixIdentifier(id);
-          modifier.suffix = suffix;
+          // Property access: .identifier — may be a record attribute like @rid
+          modifier.suffix = buildSuffixForIdentifier(ctx.identifier());
         }
       } else if (ctx.arraySelector() != null) {
         // Array selector modifier

--- a/engine/src/test/java/com/arcadedb/query/sql/Issue3571InternalPropertyOnFunctionResultTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/Issue3571InternalPropertyOnFunctionResultTest.java
@@ -42,10 +42,10 @@ class Issue3571InternalPropertyOnFunctionResultTest extends TestHelper {
     database.transaction(() -> {
       database.command("sql", "CREATE VERTEX TYPE V3571a IF NOT EXISTS");
       database.command("sql", "CREATE EDGE TYPE E3571a IF NOT EXISTS");
+      database.command("sql", "DELETE FROM V3571a");
       database.command("sql", "INSERT INTO V3571a");
       database.command("sql", "CREATE EDGE E3571a FROM (SELECT FROM V3571a) TO (SELECT FROM V3571a)");
 
-      // SELECT inE().@rid FROM V — should return an array of RIDs
       final ResultSet rs = database.query("sql", "SELECT inE().@rid FROM V3571a");
       assertThat(rs.hasNext()).isTrue();
       final Result row = rs.next();
@@ -53,7 +53,7 @@ class Issue3571InternalPropertyOnFunctionResultTest extends TestHelper {
       assertThat(ridList).isNotNull();
       assertThat(ridList).isInstanceOf(List.class);
       final List<?> rids = (List<?>) ridList;
-      assertThat(rids).isNotEmpty();
+      assertThat(rids).hasSize(1);
       assertThat(rids.getFirst()).isInstanceOf(RID.class);
       rs.close();
     });
@@ -64,11 +64,11 @@ class Issue3571InternalPropertyOnFunctionResultTest extends TestHelper {
     database.transaction(() -> {
       database.command("sql", "CREATE VERTEX TYPE V3571b IF NOT EXISTS");
       database.command("sql", "CREATE EDGE TYPE E3571b IF NOT EXISTS");
+      database.command("sql", "DELETE FROM V3571b");
       database.command("sql", "INSERT INTO V3571b");
       database.command("sql", "CREATE EDGE E3571b FROM (SELECT FROM V3571b) TO (SELECT FROM V3571b)");
 
-      // SELECT inE().`@rid` FROM V — backtick-quoted variant, should also return an array of RIDs.
-      // The backtick-quoted `@rid` is treated as a record attribute, so the projection key is "inE().@rid".
+      // Backtick-quoted `@rid` is treated as a record attribute, so the projection key is "inE().@rid"
       final ResultSet rs = database.query("sql", "SELECT inE().`@rid` FROM V3571b");
       assertThat(rs.hasNext()).isTrue();
       final Result row = rs.next();
@@ -76,7 +76,7 @@ class Issue3571InternalPropertyOnFunctionResultTest extends TestHelper {
       assertThat(ridList).isNotNull();
       assertThat(ridList).isInstanceOf(List.class);
       final List<?> rids = (List<?>) ridList;
-      assertThat(rids).isNotEmpty();
+      assertThat(rids).hasSize(1);
       assertThat(rids.getFirst()).isInstanceOf(RID.class);
       rs.close();
     });
@@ -87,10 +87,10 @@ class Issue3571InternalPropertyOnFunctionResultTest extends TestHelper {
     database.transaction(() -> {
       database.command("sql", "CREATE VERTEX TYPE V3571c IF NOT EXISTS");
       database.command("sql", "CREATE EDGE TYPE E3571c IF NOT EXISTS");
+      database.command("sql", "DELETE FROM V3571c");
       database.command("sql", "INSERT INTO V3571c");
       database.command("sql", "CREATE EDGE E3571c FROM (SELECT FROM V3571c) TO (SELECT FROM V3571c)");
 
-      // SELECT inE()[0].@rid FROM V — should return an RID (not a list)
       final ResultSet rs = database.query("sql", "SELECT inE()[0].@rid FROM V3571c");
       assertThat(rs.hasNext()).isTrue();
       final Result row = rs.next();
@@ -106,17 +106,58 @@ class Issue3571InternalPropertyOnFunctionResultTest extends TestHelper {
     database.transaction(() -> {
       database.command("sql", "CREATE VERTEX TYPE V3571d IF NOT EXISTS");
       database.command("sql", "CREATE EDGE TYPE E3571d IF NOT EXISTS");
+      database.command("sql", "DELETE FROM V3571d");
       database.command("sql", "INSERT INTO V3571d");
       database.command("sql", "CREATE EDGE E3571d FROM (SELECT FROM V3571d) TO (SELECT FROM V3571d)");
 
-      // SELECT inE()[0].`@rid` FROM V — backtick-quoted, should return an RID.
-      // The backtick-quoted `@rid` is treated as a record attribute, so the projection key is "inE()[0].@rid".
+      // Backtick-quoted `@rid` is treated as a record attribute, so the projection key is "inE()[0].@rid"
       final ResultSet rs = database.query("sql", "SELECT inE()[0].`@rid` FROM V3571d");
       assertThat(rs.hasNext()).isTrue();
       final Result row = rs.next();
       final Object rid = row.getProperty("inE()[0].@rid");
       assertThat(rid).isNotNull();
       assertThat(rid).isInstanceOf(RID.class);
+      rs.close();
+    });
+  }
+
+  @Test
+  void testInEAtType() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE V3571e IF NOT EXISTS");
+      database.command("sql", "CREATE EDGE TYPE E3571e IF NOT EXISTS");
+      database.command("sql", "DELETE FROM V3571e");
+      database.command("sql", "INSERT INTO V3571e");
+      database.command("sql", "CREATE EDGE E3571e FROM (SELECT FROM V3571e) TO (SELECT FROM V3571e)");
+
+      // @type on function result should return the edge type name
+      final ResultSet rs = database.query("sql", "SELECT inE()[0].@type FROM V3571e");
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      final Object type = row.getProperty("inE()[0].@type");
+      assertThat(type).isNotNull();
+      assertThat(type).isEqualTo("E3571e");
+      rs.close();
+    });
+  }
+
+  @Test
+  void testInEAtCat() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE V3571f IF NOT EXISTS");
+      database.command("sql", "CREATE EDGE TYPE E3571f IF NOT EXISTS");
+      database.command("sql", "DELETE FROM V3571f");
+      database.command("sql", "INSERT INTO V3571f");
+      database.command("sql", "CREATE EDGE E3571f FROM (SELECT FROM V3571f) TO (SELECT FROM V3571f)");
+
+      // @cat on an edge should return "e" — uses isRecordAttributeName string-matching fallback
+      // since @cat has no dedicated grammar token
+      final ResultSet rs = database.query("sql", "SELECT inE()[0].`@cat` FROM V3571f");
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      final Object cat = row.getProperty("inE()[0].@cat");
+      assertThat(cat).isNotNull();
+      assertThat(cat).isEqualTo("e");
       rs.close();
     });
   }

--- a/engine/src/test/java/com/arcadedb/query/sql/Issue3571InternalPropertyOnFunctionResultTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/Issue3571InternalPropertyOnFunctionResultTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for GitHub issue #3571: SQL: accessing internal properties in a map.
+ * <p>
+ * Accessing properties with an {@code @} prefix (internal properties) via dot notation on the result
+ * of a function call (e.g. {@code inE().@rid}) was returning null instead of the expected values.
+ * </p>
+ */
+class Issue3571InternalPropertyOnFunctionResultTest extends TestHelper {
+
+  @Test
+  void testInEAtRidUnquoted() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE V3571a IF NOT EXISTS");
+      database.command("sql", "CREATE EDGE TYPE E3571a IF NOT EXISTS");
+      database.command("sql", "INSERT INTO V3571a");
+      database.command("sql", "CREATE EDGE E3571a FROM (SELECT FROM V3571a) TO (SELECT FROM V3571a)");
+
+      // SELECT inE().@rid FROM V — should return an array of RIDs
+      final ResultSet rs = database.query("sql", "SELECT inE().@rid FROM V3571a");
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      final Object ridList = row.getProperty("inE().@rid");
+      assertThat(ridList).isNotNull();
+      assertThat(ridList).isInstanceOf(List.class);
+      final List<?> rids = (List<?>) ridList;
+      assertThat(rids).isNotEmpty();
+      assertThat(rids.getFirst()).isInstanceOf(RID.class);
+      rs.close();
+    });
+  }
+
+  @Test
+  void testInEAtRidQuoted() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE V3571b IF NOT EXISTS");
+      database.command("sql", "CREATE EDGE TYPE E3571b IF NOT EXISTS");
+      database.command("sql", "INSERT INTO V3571b");
+      database.command("sql", "CREATE EDGE E3571b FROM (SELECT FROM V3571b) TO (SELECT FROM V3571b)");
+
+      // SELECT inE().`@rid` FROM V — backtick-quoted variant, should also return an array of RIDs.
+      // The backtick-quoted `@rid` is treated as a record attribute, so the projection key is "inE().@rid".
+      final ResultSet rs = database.query("sql", "SELECT inE().`@rid` FROM V3571b");
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      final Object ridList = row.getProperty("inE().@rid");
+      assertThat(ridList).isNotNull();
+      assertThat(ridList).isInstanceOf(List.class);
+      final List<?> rids = (List<?>) ridList;
+      assertThat(rids).isNotEmpty();
+      assertThat(rids.getFirst()).isInstanceOf(RID.class);
+      rs.close();
+    });
+  }
+
+  @Test
+  void testInEIndexedAtRidUnquoted() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE V3571c IF NOT EXISTS");
+      database.command("sql", "CREATE EDGE TYPE E3571c IF NOT EXISTS");
+      database.command("sql", "INSERT INTO V3571c");
+      database.command("sql", "CREATE EDGE E3571c FROM (SELECT FROM V3571c) TO (SELECT FROM V3571c)");
+
+      // SELECT inE()[0].@rid FROM V — should return an RID (not a list)
+      final ResultSet rs = database.query("sql", "SELECT inE()[0].@rid FROM V3571c");
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      final Object rid = row.getProperty("inE()[0].@rid");
+      assertThat(rid).isNotNull();
+      assertThat(rid).isInstanceOf(RID.class);
+      rs.close();
+    });
+  }
+
+  @Test
+  void testInEIndexedAtRidQuoted() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE V3571d IF NOT EXISTS");
+      database.command("sql", "CREATE EDGE TYPE E3571d IF NOT EXISTS");
+      database.command("sql", "INSERT INTO V3571d");
+      database.command("sql", "CREATE EDGE E3571d FROM (SELECT FROM V3571d) TO (SELECT FROM V3571d)");
+
+      // SELECT inE()[0].`@rid` FROM V — backtick-quoted, should return an RID.
+      // The backtick-quoted `@rid` is treated as a record attribute, so the projection key is "inE()[0].@rid".
+      final ResultSet rs = database.query("sql", "SELECT inE()[0].`@rid` FROM V3571d");
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      final Object rid = row.getProperty("inE()[0].@rid");
+      assertThat(rid).isNotNull();
+      assertThat(rid).isInstanceOf(RID.class);
+      rs.close();
+    });
+  }
+}


### PR DESCRIPTION
accessing internal properties  (@rid, @type, etc.) on functionon results

In SQLASTBuilder.visitModifier(), property-access modifiers always created a plain Identifier node, even for record attribute tokens like @rid. This caused expressions like inE().@rid to return null because the execution path used document.get("@rid") instead of the record attribute lookup.

Fixed by extracting a buildSuffixForIdentifier() helper that recognizes both unquoted record attribute tokens (RID_ATTR, TYPE_ATTR, etc.) and backtick-quoted identifiers whose value matches a known record attribute name. Both visitModifier and visitIdentifierChain now use this helper.
