### PR TITLE
fix: resolve gRPC parallel scan context, channel leaks, and null-db EID issues

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromTypeExecutionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromTypeExecutionStep.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.DatabaseContext;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.async.DatabaseAsyncExecutorImpl;
 import com.arcadedb.engine.PaginatedComponentFile;
@@ -248,7 +249,11 @@ public class FetchFromTypeExecutionStep extends AbstractExecutionStep {
       for (final ExecutionStep step : getSubSteps()) {
         final Future<?> future = scanExecutor.submit(() -> {
           try {
-            // Each thread gets its own database context for thread safety
+            // Initialize DatabaseContext for this worker thread so that
+            // BucketIterator and other components find the correct database
+            // in the thread-local context (gRPC/executor threads may have
+            // a stale or missing context).
+            DatabaseContext.INSTANCE.init(db);
             db.executeInReadLock(() -> {
               final AbstractExecutionStep execStep = (AbstractExecutionStep) step;
               ResultSet rs = execStep.syncPull(context, nRecords);

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromTypeExecutionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromTypeExecutionStep.java
@@ -248,12 +248,12 @@ public class FetchFromTypeExecutionStep extends AbstractExecutionStep {
 
       for (final ExecutionStep step : getSubSteps()) {
         final Future<?> future = scanExecutor.submit(() -> {
+          // Initialize DatabaseContext for this worker thread so that
+          // BucketIterator and other components find the correct database
+          // in the thread-local context (gRPC/executor threads may have
+          // a stale or missing context).
+          DatabaseContext.INSTANCE.init(db);
           try {
-            // Initialize DatabaseContext for this worker thread so that
-            // BucketIterator and other components find the correct database
-            // in the thread-local context (gRPC/executor threads may have
-            // a stale or missing context).
-            DatabaseContext.INSTANCE.init(db);
             db.executeInReadLock(() -> {
               final AbstractExecutionStep execStep = (AbstractExecutionStep) step;
               ResultSet rs = execStep.syncPull(context, nRecords);
@@ -272,6 +272,8 @@ public class FetchFromTypeExecutionStep extends AbstractExecutionStep {
             });
           } catch (final Exception e) {
             LogManager.instance().log(this, Level.WARNING, "Error during parallel bucket scan", e);
+          } finally {
+            DatabaseContext.INSTANCE.removeContext(db.getDatabasePath());
           }
         });
         scanFutures.add(future);

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcServer.java
@@ -71,6 +71,7 @@ public class RemoteGrpcServer implements AutoCloseable {
   private final boolean                 plaintext;
 
   private ManagedChannel channel;
+  private EventLoopGroup eventLoopGroup;
 
   private ArcadeDbAdminServiceGrpc.ArcadeDbAdminServiceBlockingV2Stub adminServiceBlockingV2Stub;
 
@@ -109,10 +110,10 @@ public class RemoteGrpcServer implements AutoCloseable {
 //				.decompressorRegistry(DecompressorRegistry.getDefaultInstance())
 //				.compressorRegistry(CompressorRegistry.getDefaultInstance());
 
-    EventLoopGroup elg = new NioEventLoopGroup();
+    eventLoopGroup = new NioEventLoopGroup();
 
     NettyChannelBuilder chBuilder = NettyChannelBuilder.forAddress(host, port)
-        .eventLoopGroup(elg)                           // share across clients
+        .eventLoopGroup(eventLoopGroup)                // share across clients
         .channelType(NioSocketChannel.class)
         .maxInboundMessageSize(150 * 1024 * 1024)
         .maxInboundMetadataSize(32 * 1024 * 1024)
@@ -172,7 +173,7 @@ public class RemoteGrpcServer implements AutoCloseable {
 
   @PreDestroy
   @Override
-  public void close() {
+  public synchronized void close() {
     if (channel == null)
       return;
     try {
@@ -181,11 +182,16 @@ public class RemoteGrpcServer implements AutoCloseable {
         channel.shutdownNow();
         channel.awaitTermination(2, TimeUnit.SECONDS);
       }
-    } catch (InterruptedException ie) {
+    } catch (final InterruptedException ie) {
       Thread.currentThread().interrupt();
       channel.shutdownNow();
     } finally {
-      // log.info("gRPC channel to {}:{} closed.", host, port);
+      channel = null;
+      adminServiceBlockingV2Stub = null;
+      if (eventLoopGroup != null) {
+        eventLoopGroup.shutdownGracefully(0, 2, TimeUnit.SECONDS);
+        eventLoopGroup = null;
+      }
     }
   }
 

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/RemoteGrpcDatabaseCoverageIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/RemoteGrpcDatabaseCoverageIT.java
@@ -107,6 +107,9 @@ class RemoteGrpcDatabaseCoverageIT extends BaseGraphServerTest {
       }
       grpc.close();
     }
+    if (grpcServer != null) {
+      grpcServer.close();
+    }
   }
 
   // Helper: insert a doc via SQL and return its RID string
@@ -384,7 +387,8 @@ class RemoteGrpcDatabaseCoverageIT extends BaseGraphServerTest {
     // Close should auto-rollback the active transaction
     grpc.close();
 
-    // Re-open to verify the insert was rolled back (recreate server ref since close invalidates)
+    // Re-open to verify the insert was rolled back
+    grpcServer.close();
     grpcServer = new RemoteGrpcServer("localhost", 50051, "root", DEFAULT_PASSWORD_FOR_TESTS, true, List.of());
     grpc = new RemoteGrpcDatabase(grpcServer, "localhost", 50051, 2480, getDatabaseName(), "root", DEFAULT_PASSWORD_FOR_TESTS);
     try (ResultSet rs = grpc.query("sql", "SELECT FROM `" + DOC_TYPE + "` WHERE name = 'autoRollback'", Map.of())) {

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/RemoteGrpcDatabaseRegressionTest.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/RemoteGrpcDatabaseRegressionTest.java
@@ -27,6 +27,7 @@ import com.arcadedb.server.grpc.InsertOptions;
 import com.arcadedb.server.grpc.InsertOptions.ConflictMode;
 import com.arcadedb.server.grpc.InsertOptions.TransactionMode;
 import com.arcadedb.server.grpc.InsertSummary;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -84,9 +85,14 @@ class RemoteGrpcDatabaseRegressionTest extends BaseGraphServerTest {
 
   @BeforeAll
   void ensureDatabaseExists() {
-
     grpcServer = new RemoteGrpcServer("localhost", 50051, "root", DEFAULT_PASSWORD_FOR_TESTS, true, List.of());
+  }
 
+  @AfterAll
+  void teardownServer() {
+    if (grpcServer != null) {
+      grpcServer.close();
+    }
   }
 
   @BeforeEach

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -506,8 +506,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         if (outStr == null || inStr == null)
           throw new IllegalArgumentException("Edge requires 'out' and 'in' RIDs");
 
-        final var outEl = db.lookupByRID(new RID(outStr), false);
-        final var inEl = db.lookupByRID(new RID(inStr), false);
+        final var outEl = db.lookupByRID(new RID(db, outStr), false);
+        final var inEl = db.lookupByRID(new RID(db, inStr), false);
         final Vertex outV = outEl.asVertex(false);
 
         final MutableEdge e = outV.newEdge(cls, inEl);
@@ -549,7 +549,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       if (ridStr == null || ridStr.isBlank())
         throw new IllegalArgumentException("rid is required");
 
-      var el = db.lookupByRID(new RID(ridStr), true);
+      var el = db.lookupByRID(new RID(db, ridStr), true);
 
       resp.onNext(LookupByRidResponse.newBuilder().setFound(true).setRecord(convertToGrpcRecord(el.getRecord(), db)).build());
       resp.onCompleted();
@@ -621,8 +621,9 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         beganHere = true;
       }
 
-      // Lookup the record by RID
-      var el = db.lookupByRID(new RID(ridStr), true);
+      // Lookup the record by RID (use database-aware constructor so the returned
+      // record's RID carries the database reference needed by modify()/getPageId())
+      var el = db.lookupByRID(new RID(db, ridStr), true);
 
       final var dbRef = db;
 
@@ -766,7 +767,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     }
 
     try {
-      final var el = db.lookupByRID(new RID(ridStr), false);
+      final var el = db.lookupByRID(new RID(db, ridStr), false);
       el.delete();
 
       if (beganHere) {
@@ -1928,10 +1929,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
             c.errors.add(InsertError.newBuilder().setRowIndex(ctx.received - 1).setCode("MISSING_ENDPOINTS")
                 .setMessage("Edge requires 'out' and 'in'").build());
           } else {
-            var outV = ctx.db.lookupByRID(new RID(outRid), false).asVertex(false);
+            var outV = ctx.db.lookupByRID(new RID(ctx.db, outRid), false).asVertex(false);
 
             // Create edge from the OUT vertex
-            MutableEdge e = outV.newEdge(ctx.opts.getTargetClass(), new RID(inRid));
+            MutableEdge e = outV.newEdge(ctx.opts.getTargetClass(), new RID(ctx.db, inRid));
             applyGrpcRecord(e, r); // sets edge properties
             e.save();
             c.inserted++;


### PR DESCRIPTION


- Initialize DatabaseContext in FetchFromTypeExecutionStep worker threads to fix "Invalid transactional context (different db)" during parallel bucket scans triggered via gRPC queries
- Fix RemoteGrpcServer channel and EventLoopGroup leak by storing the EventLoopGroup as a field and properly shutting it down in close()
- Fix null-database RID in ArcadeDbGrpcService by using RID(db, string) constructor so records returned by lookupByRID carry the database reference needed by modify()/getPageId()
- Add missing grpcServer.close() calls in test teardown methods

