### PR TITLE
fix: CONTAINSANY with method call on left-hand side (#3581)

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ScanWithFilterStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ScanWithFilterStep.java
@@ -93,6 +93,10 @@ public class ScanWithFilterStep extends AbstractExecutionStep {
             // Phase 1: Evaluate WHERE on the full document (uses lazy per-field deserialization)
             final ResultInternal candidate = new ResultInternal(record);
 
+            // Set $current before evaluating WHERE clause so expressions like method calls
+            // (e.g., field.split(' ') CONTAINSANY 'value') can resolve the current record context
+            context.setVariable("current", candidate);
+
             final long filterBegin = context.isProfiling() ? System.nanoTime() : 0;
             try {
               if (whereClause.matchesFilters(candidate, context)) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ScanWithFilterStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ScanWithFilterStep.java
@@ -93,8 +93,7 @@ public class ScanWithFilterStep extends AbstractExecutionStep {
             // Phase 1: Evaluate WHERE on the full document (uses lazy per-field deserialization)
             final ResultInternal candidate = new ResultInternal(record);
 
-            // Set $current before evaluating WHERE clause so expressions like method calls
-            // (e.g., field.split(' ') CONTAINSANY 'value') can resolve the current record context
+            // Set $current before WHERE evaluation so method calls (e.g. split()) resolve correctly
             context.setVariable("current", candidate);
 
             final long filterBegin = context.isProfiling() ? System.nanoTime() : 0;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsAllCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsAllCondition.java
@@ -58,6 +58,8 @@ public class ContainsAllCondition extends BooleanExpression {
     }
     if (left instanceof Iterable<?> iterable)
       left = iterable.iterator();
+    else if (left != null && left.getClass().isArray())
+      left = MultiValue.getMultiValueIterator(left);
 
     if (left instanceof Iterator<?> leftIterator) {
       if (!(right instanceof Iterable))

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsAnyCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ContainsAnyCondition.java
@@ -55,6 +55,8 @@ public class ContainsAnyCondition extends BooleanExpression {
 
     if (left instanceof Iterable<?> iterable)
       left = iterable.iterator();
+    else if (left != null && left.getClass().isArray())
+      left = MultiValue.getMultiValueIterator(left);
 
     if (left instanceof Iterator<?> leftIterator) {
       if (!(right instanceof Iterable))

--- a/engine/src/test/java/com/arcadedb/query/sql/Issue3581ContainsAnyMethodLhsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/Issue3581ContainsAnyMethodLhsTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for GitHub issue #3581: SQL: Left-hand side of CONTAINSANY being method return value errors (Regression).
+ * <p>
+ * Using CONTAINSANY with a method call (e.g., split()) on the left-hand side was throwing
+ * "Invalid value for $current: null" because the $current context variable was not set
+ * before evaluating the WHERE clause filter in ScanWithFilterStep.
+ * </p>
+ */
+class Issue3581ContainsAnyMethodLhsTest extends TestHelper {
+
+  @Test
+  void testContainsAnyWithSplitOnLhs() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE doc3581 IF NOT EXISTS");
+      database.command("sql", "INSERT INTO doc3581 SET txt = 'te st'");
+      database.command("sql", "INSERT INTO doc3581 SET txt = 'hello world'");
+      database.command("sql", "INSERT INTO doc3581 SET txt = 'no match here'");
+
+      final ResultSet rs = database.query("sql", "SELECT FROM doc3581 WHERE txt.split(' ') CONTAINSANY 'te'");
+      assertThat(rs.hasNext()).isTrue();
+      final var result = rs.next();
+      assertThat(result.<String>getProperty("txt")).isEqualTo("te st");
+      assertThat(rs.hasNext()).isFalse();
+    });
+  }
+
+  @Test
+  void testContainsAnyWithSplitOnLhsMultipleMatches() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE doc3581b IF NOT EXISTS");
+      database.command("sql", "INSERT INTO doc3581b SET txt = 'te st'");
+      database.command("sql", "INSERT INTO doc3581b SET txt = 'te other'");
+      database.command("sql", "INSERT INTO doc3581b SET txt = 'no match'");
+
+      final ResultSet rs = database.query("sql", "SELECT FROM doc3581b WHERE txt.split(' ') CONTAINSANY 'te'");
+      int count = 0;
+      while (rs.hasNext()) {
+        rs.next();
+        count++;
+      }
+      assertThat(count).isEqualTo(2);
+    });
+  }
+
+  @Test
+  void testContainsAnyWithSplitOnLhsNoMatch() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE doc3581c IF NOT EXISTS");
+      database.command("sql", "INSERT INTO doc3581c SET txt = 'hello world'");
+
+      final ResultSet rs = database.query("sql", "SELECT FROM doc3581c WHERE txt.split(' ') CONTAINSANY 'te'");
+      assertThat(rs.hasNext()).isFalse();
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/Issue3581ContainsAnyMethodLhsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/Issue3581ContainsAnyMethodLhsTest.java
@@ -78,4 +78,36 @@ class Issue3581ContainsAnyMethodLhsTest extends TestHelper {
       assertThat(rs.hasNext()).isFalse();
     });
   }
+
+  @Test
+  void testContainsAnyWithSplitOnLhsNullField() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE doc3581d IF NOT EXISTS");
+      database.command("sql", "INSERT INTO doc3581d SET txt = 'te st'");
+      database.command("sql", "INSERT INTO doc3581d SET other = 'no txt field'");
+
+      final ResultSet rs = database.query("sql", "SELECT FROM doc3581d WHERE txt.split(' ') CONTAINSANY 'te'");
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<String>getProperty("txt")).isEqualTo("te st");
+      assertThat(rs.hasNext()).isFalse();
+    });
+  }
+
+  @Test
+  void testContainsAllWithSplitOnLhs() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE doc3581e IF NOT EXISTS");
+      database.command("sql", "INSERT INTO doc3581e SET txt = 'te st'");
+      database.command("sql", "INSERT INTO doc3581e SET txt = 'te other'");
+
+      final ResultSet rs = database.query("sql", "SELECT FROM doc3581e WHERE txt.split(' ') CONTAINSALL 'te'");
+      // CONTAINSALL with single value: both records have 'te' as a split token
+      int count = 0;
+      while (rs.hasNext()) {
+        rs.next();
+        count++;
+      }
+      assertThat(count).isEqualTo(2);
+    });
+  }
 }


### PR DESCRIPTION
## Summary

- Fix `ScanWithFilterStep` to set `$current` context variable **before** evaluating the WHERE clause filter, so method calls like `split()` can resolve their parameters
- Fix `ContainsAnyCondition.execute()` to handle Java arrays (e.g., `String[]` returned by `split()`) using `MultiValue.getMultiValueIterator()`
- Add regression test with 3 test cases covering single match, multiple matches, and no match scenarios

Closes #3581

## Test plan

- [x] New regression test `Issue3581ContainsAnyMethodLhsTest` passes (3 tests)
- [x] Existing `ContainsAnyConditionTest` passes
- [x] Existing `FilterStepTest` passes
- [x] Broad SQL test suite passes (1378 tests, 0 failures)

