### PR TITLE
docs: update README.md for 26.3.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ ArcadeDB supports the following models:
   SQL)
 - [Key/Value](https://docs.arcadedb.com#keyvalue-model) (compatible with the Redis driver)
 - [Search Engine](https://docs.arcadedb.com/#searchengine-model)
-- [Time Series](https://docs.arcadedb.com#timeseries-model) (with InfluxDB Line Protocol, Prometheus remote_write/read, and PromQL support)
+- [Time Series](https://docs.arcadedb.com/#timeseries-model) (with InfluxDB Line Protocol, Prometheus remote_write/read, and PromQL support)
 - [Vector Embedding](https://docs.arcadedb.com/#vector-model)
 - [Geospatial](https://docs.arcadedb.com/#geospatial-model)
 
@@ -95,10 +95,10 @@ ArcadeDB understands multiple languages:
 
 ArcadeDB key capabilities:
 
-- **73 Built-in Graph Algorithms** — Pathfinding, centrality, community detection, link prediction, graph embeddings, and more — all available out of the box
+- **70+ Built-in Graph Algorithms** — Pathfinding, centrality, community detection, link prediction, graph embeddings, and more — all available out of the box
 - **Parallel Query Execution** — SQL queries leverage multiple CPU cores for faster execution on large datasets
 - **Materialized Views** — Pre-computed query results stored and automatically maintained
-- **MCP Server** — Built-in [Model Context Protocol](https://docs.arcadedb.com#mcp) server for AI assistant and LLM integration
+- **MCP Server** — Built-in [Model Context Protocol](https://docs.arcadedb.com/#mcp) server for AI assistant and LLM integration
 - **AI Assistant** — Integrated AI assistant in Studio (Beta) for query help and database management
 - **Geospatial Indexing** — Native spatial queries and proximity searches with `geo.*` SQL functions
 - **TimeSeries** — Columnar storage with Gorilla/Delta-of-Delta compression, InfluxDB/Prometheus ingestion, PromQL queries, Grafana integration
@@ -112,7 +112,7 @@ ArcadeDB can be used as:
 - Remotely by using a [Postgres driver](https://docs.arcadedb.com#postgres-driver) (ArcadeDB implements Postgres Wire protocol)
 - Remotely by using a [Redis driver](https://docs.arcadedb.com#redis-query-language) (only a subset of the operations are implemented)
 - Remotely by using a [MongoDB driver](https://docs.arcadedb.com#mongodb-query-language) (only a subset of the operations are implemented)
-- By AI assistants via the built-in [MCP Server](https://docs.arcadedb.com#mcp) (Model Context Protocol)
+- By AI assistants via the built-in [MCP Server](https://docs.arcadedb.com/#mcp) (Model Context Protocol)
 
 For more information, see the [documentation](https://docs.arcadedb.com).
 
@@ -137,12 +137,12 @@ You can also [download the latest release](https://github.com/ArcadeData/arcaded
 
 ### Releases
 
-There are three variants of (about monthly) releases:
+There are four variants of (about monthly) releases:
 
 - `full` - this is the complete package including all modules
 - `minimal` - this package excludes the `gremlin`, `redisw`, `mongodbw`, `graphql` modules
 - `headless` - this package excludes the `gremlin`, `redisw`, `mongodbw`, `graphql`, `studio` modules
-- `base` - core engine only, minimal footprint
+- `base` - core engine, server, and network only — excludes all optional modules (`console`, `gremlin`, `studio`, `redisw`, `mongodbw`, `postgresw`, `grpcw`, `graphql`, `metrics`)
 
 The nightly builds of the repository head can be found [here](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/arcadedb/arcadedb-package/).
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ ArcadeDB supports the following models:
   SQL)
 - [Key/Value](https://docs.arcadedb.com#keyvalue-model) (compatible with the Redis driver)
 - [Search Engine](https://docs.arcadedb.com/#searchengine-model)
-- [Time Series](https://docs.arcadedb.com#timeseries-model)
+- [Time Series](https://docs.arcadedb.com#timeseries-model) (with InfluxDB Line Protocol, Prometheus remote_write/read, and PromQL support)
 - [Vector Embedding](https://docs.arcadedb.com/#vector-model)
+- [Geospatial](https://docs.arcadedb.com/#geospatial-model)
 
 ArcadeDB understands multiple languages:
 
@@ -92,6 +93,17 @@ ArcadeDB understands multiple languages:
 - [GraphQL Language](https://docs.arcadedb.com#graphql)
 - [MongoDB Query Language](https://docs.arcadedb.com#mongodb-query-language)
 
+ArcadeDB key capabilities:
+
+- **73 Built-in Graph Algorithms** — Pathfinding, centrality, community detection, link prediction, graph embeddings, and more — all available out of the box
+- **Parallel Query Execution** — SQL queries leverage multiple CPU cores for faster execution on large datasets
+- **Materialized Views** — Pre-computed query results stored and automatically maintained
+- **MCP Server** — Built-in [Model Context Protocol](https://docs.arcadedb.com#mcp) server for AI assistant and LLM integration
+- **AI Assistant** — Integrated AI assistant in Studio (Beta) for query help and database management
+- **Geospatial Indexing** — Native spatial queries and proximity searches with `geo.*` SQL functions
+- **TimeSeries** — Columnar storage with Gorilla/Delta-of-Delta compression, InfluxDB/Prometheus ingestion, PromQL queries, Grafana integration
+- **Hash Indexes** — Extendible hashing for faster exact-match lookups alongside LSM-Tree indexes
+
 ArcadeDB can be used as:
 
 - Embedded from any language on top of the Java Virtual Machine
@@ -100,6 +112,7 @@ ArcadeDB can be used as:
 - Remotely by using a [Postgres driver](https://docs.arcadedb.com#postgres-driver) (ArcadeDB implements Postgres Wire protocol)
 - Remotely by using a [Redis driver](https://docs.arcadedb.com#redis-query-language) (only a subset of the operations are implemented)
 - Remotely by using a [MongoDB driver](https://docs.arcadedb.com#mongodb-query-language) (only a subset of the operations are implemented)
+- By AI assistants via the built-in [MCP Server](https://docs.arcadedb.com#mcp) (Model Context Protocol)
 
 For more information, see the [documentation](https://docs.arcadedb.com).
 
@@ -126,9 +139,10 @@ You can also [download the latest release](https://github.com/ArcadeData/arcaded
 
 There are three variants of (about monthly) releases:
 
-- `full` - this is the complete package of including all modules
+- `full` - this is the complete package including all modules
 - `minimal` - this package excludes the `gremlin`, `redisw`, `mongodbw`, `graphql` modules
 - `headless` - this package excludes the `gremlin`, `redisw`, `mongodbw`, `graphql`, `studio` modules
+- `base` - core engine only, minimal footprint
 
 The nightly builds of the repository head can be found [here](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/arcadedb/arcadedb-package/).
 
@@ -154,7 +168,7 @@ To use Java 17 inside your project, add the repository to your `pom.xml` and ref
       <dependency>
           <groupId>com.arcadedb</groupId>
           <artifactId>arcadedb-engine</artifactId>
-          <version>25.5.1-java17</version>
+          <version>26.3.1-java17</version>
       </dependency>
     </dependencies>
 ```
@@ -162,7 +176,7 @@ To use Java 17 inside your project, add the repository to your `pom.xml` and ref
 Docker images are available on ghcr.io too:
 
 ```shell
-docker pull ghcr.io/arcadedata/arcadedb:25.5.1-java17
+docker pull ghcr.io/arcadedata/arcadedb:26.3.1-java17
 ```
 
 ### Community

--- a/README.md
+++ b/README.md
@@ -146,6 +146,15 @@ There are three variants of (about monthly) releases:
 
 The nightly builds of the repository head can be found [here](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/arcadedb/arcadedb-package/).
 
+You can also build a **custom distribution** with only the modules you need using the [Custom Package Builder](https://docs.arcadedb.com/#custom-package-builder):
+
+```bash
+curl -fsSL https://github.com/ArcadeData/arcadedb/releases/download/26.3.1/arcadedb-builder.sh | \
+  bash -s -- --version=26.3.1 --modules=gremlin,studio
+```
+
+Available optional modules: `console`, `gremlin`, `studio`, `redisw`, `mongodbw`, `postgresw`, `grpcw`, `graphql`, `metrics`. The builder supports interactive mode, Docker image generation, and offline builds from local Maven repositories.
+
 ### Java Versions
 
 Starting from ArcadeDB 24.4.1 code is compatible with Java 21.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,18 @@ ArcadeDB can be used as:
 
 For more information, see the [documentation](https://docs.arcadedb.com).
 
+### Use Cases
+
+Explore real-world examples in the [arcadedb-usecases](https://github.com/ArcadeData/arcadedb-usecases) repository — self-contained projects with Docker Compose, SQL schemas, and runnable demos covering:
+
+- **Recommendation Engine** — graph traversal + vector similarity + time-series
+- **Knowledge Graphs** — co-authorship and citation networks with full-text search
+- **Graph RAG** — retrieval-augmented generation with LangChain4j and Neo4j Bolt
+- **Fraud Detection** — graph, vector, and time-series signals with Cypher
+- **Real-time Analytics** — IoT and service monitoring with time-series
+- **Social Network Analytics** — materialized view dashboards with polyglot queries
+- **Supply Chain** — multi-tier visibility with PostgreSQL protocol and JavaScript
+
 ### Getting started in 5 minutes
 
 Start ArcadeDB Server with Docker:


### PR DESCRIPTION
## Summary

- Add **Geospatial** model to the supported models list
- Add **key capabilities** section highlighting major 26.3.1 features: 73 graph algorithms, parallel query execution, materialized views, MCP server, AI assistant, geospatial indexing, TimeSeries enhancements, hash indexes
- Add **MCP Server** as a usage mode under "can be used as"
- Add **base** release variant to the releases section
- Update Java 17 version references from `25.5.1` to `26.3.1`
- Fix typo in `full` variant description ("of including" → "including")
- Enhance Time Series model description with InfluxDB/Prometheus/PromQL details

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all documentation links are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)