### PR TITLE
#3585 fix: SQL aggregating projection with count(*) returns nothing on empty type

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/GuaranteeEmptyCountStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/GuaranteeEmptyCountStep.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.query.sql.parser.Projection;
 import com.arcadedb.query.sql.parser.ProjectionItem;
 
 import java.util.*;
@@ -26,11 +27,14 @@ import java.util.*;
 public class GuaranteeEmptyCountStep extends AbstractExecutionStep {
 
   private final ProjectionItem item;
+  private final Projection     preAggregateProjection;
   private       boolean        executed = false;
 
-  public GuaranteeEmptyCountStep(final ProjectionItem oProjectionItem, final CommandContext context) {
+  public GuaranteeEmptyCountStep(final ProjectionItem countItem, final Projection preAggregateProjection,
+      final CommandContext context) {
     super(context);
-    this.item = oProjectionItem;
+    this.item = countItem;
+    this.preAggregateProjection = preAggregateProjection;
   }
 
   @Override
@@ -57,6 +61,11 @@ public class GuaranteeEmptyCountStep extends AbstractExecutionStep {
 
           final ResultInternal result = new ResultInternal(context.getDatabase());
           result.setProperty(item.getProjectionAliasAsString(), 0L);
+          if (preAggregateProjection != null) {
+            for (final ProjectionItem preAggItem : preAggregateProjection.getItems()) {
+              result.setProperty(preAggItem.getProjectionAliasAsString(), preAggItem.execute((Result) null, context));
+            }
+          }
           return result;
         } finally {
           executed = true;
@@ -72,7 +81,7 @@ public class GuaranteeEmptyCountStep extends AbstractExecutionStep {
 
   @Override
   public ExecutionStep copy(final CommandContext context) {
-    return new GuaranteeEmptyCountStep(item.copy(), context);
+    return new GuaranteeEmptyCountStep(item.copy(), preAggregateProjection != null ? preAggregateProjection.copy() : null, context);
   }
 
   public boolean canBeCached() {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -472,27 +472,12 @@ public class SelectExecutionPlanner {
       if (countItem != null)
         return null; // more than one aggregate function
       final Expression exp = item.getExpression();
-      if (exp.getMathExpression() != null && exp.getMathExpression() instanceof final BaseExpression base
-          && base.isCount() && base.getModifier() == null)
+      if (exp.getMathExpression() instanceof final BaseExpression base && base.isCount() && base.getModifier() == null)
         countItem = item;
       else
         return null; // aggregate but not count(*)
     }
     return countItem;
-  }
-
-  private static boolean isCountOnly(final QueryPlanningInfo info) {
-    if (info.aggregateProjection == null || info.projection == null || info.aggregateProjection.getItems().size() != 1 ||
-        info.projection.getItems().stream().filter(x -> !x.getProjectionAliasAsString().startsWith("_$$$ORDER_BY_ALIAS$$$_"))
-            .count() != 1) {
-      return false;
-    }
-    final ProjectionItem item = info.aggregateProjection.getItems().getFirst();
-    final Expression exp = item.getExpression();
-    if (exp.getMathExpression() != null && exp.getMathExpression() instanceof final BaseExpression base) {
-      return base.isCount() && base.getModifier() == null;
-    }
-    return false;
   }
 
   private boolean isCount(final Projection aggregateProjection, final Projection projection) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -457,6 +457,30 @@ public class SelectExecutionPlanner {
     return item.getExpression().toString().equalsIgnoreCase("count(*)");
   }
 
+  /**
+   * Returns the count(*) ProjectionItem if the aggregateProjection contains exactly one true aggregate and it is count(*),
+   * otherwise returns null. Non-aggregate pass-through alias items (added for non-aggregate projections) are ignored.
+   */
+  private static ProjectionItem findCountStarItem(final QueryPlanningInfo info, final CommandContext context) {
+    if (info.aggregateProjection == null)
+      return null;
+
+    ProjectionItem countItem = null;
+    for (final ProjectionItem item : info.aggregateProjection.getItems()) {
+      if (!item.isAggregate(context))
+        continue;
+      if (countItem != null)
+        return null; // more than one aggregate function
+      final Expression exp = item.getExpression();
+      if (exp.getMathExpression() != null && exp.getMathExpression() instanceof final BaseExpression base
+          && base.isCount() && base.getModifier() == null)
+        countItem = item;
+      else
+        return null; // aggregate but not count(*)
+    }
+    return countItem;
+  }
+
   private static boolean isCountOnly(final QueryPlanningInfo info) {
     if (info.aggregateProjection == null || info.projection == null || info.aggregateProjection.getItems().size() != 1 ||
         info.projection.getItems().stream().filter(x -> !x.getProjectionAliasAsString().startsWith("_$$$ORDER_BY_ALIAS$$$_"))
@@ -663,8 +687,9 @@ public class SelectExecutionPlanner {
 
         result.chain(new AggregateProjectionCalculationStep(info.aggregateProjection, info.groupBy, aggregationLimit, context,
             info.timeout != null ? info.timeout.getVal().longValue() : -1));
-        if (isCountOnly(info) && info.groupBy == null) {
-          result.chain(new GuaranteeEmptyCountStep(info.aggregateProjection.getItems().getFirst(), context));
+        final ProjectionItem countStarItem = findCountStarItem(info, context);
+        if (countStarItem != null && info.groupBy == null) {
+          result.chain(new GuaranteeEmptyCountStep(countStarItem, info.preAggregateProjection, context));
         }
       }
       result.chain(new ProjectionCalculationStep(info.projection, context));

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/SelectStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/SelectStatementExecutionTest.java
@@ -616,6 +616,38 @@ public class SelectStatementExecutionTest extends TestHelper {
   }
 
   @Test
+  void countStarWithLiteralProjectionOnEmptyType() {
+    // Regression test for https://github.com/ArcadeData/arcadedb/issues/3585
+    // SELECT count(*), <non-aggregate> FROM empty_type should return 1 row with count=0
+    final String className = "testCountStarWithLiteralProjectionOnEmptyType";
+    database.getSchema().createDocumentType(className);
+
+    final ResultSet result = database.query("sql", "select count(*), 2 from " + className);
+    assertThat(result.hasNext()).isTrue();
+    final Result next = result.next();
+    assertThat((Object) next.getProperty("count(*)")).isEqualTo(0L);
+    assertThat((Object) next.getProperty("2")).isEqualTo(2);
+    assertThat(result.hasNext()).isFalse();
+    result.close();
+  }
+
+  @Test
+  void countStarWithLetVariableProjectionOnEmptyType() {
+    // Regression test for https://github.com/ArcadeData/arcadedb/issues/3585
+    // SELECT count(*), $x FROM empty_type LET $x = 2 should return 1 row with count=0
+    final String className = "testCountStarWithLetVariableProjectionOnEmptyType";
+    database.getSchema().createDocumentType(className);
+
+    final ResultSet result = database.query("sql", "select count(*), $x from " + className + " let $x = 2");
+    assertThat(result.hasNext()).isTrue();
+    final Result next = result.next();
+    assertThat((Object) next.getProperty("count(*)")).isEqualTo(0L);
+    assertThat((Object) next.getProperty("$x")).isEqualTo(2);
+    assertThat(result.hasNext()).isFalse();
+    result.close();
+  }
+
+  @Test
   void aggregateMixedWithNonAggregate() {
     final String className = "testAggregateMixedWithNonAggregate";
     database.getSchema().createDocumentType(className);

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/SelectStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/SelectStatementExecutionTest.java
@@ -648,6 +648,26 @@ public class SelectStatementExecutionTest extends TestHelper {
   }
 
   @Test
+  void countStarWithLiteralProjectionOnNonEmptyType() {
+    // Verify count(*) + literal works correctly when the type has records
+    final String className = "testCountStarWithLiteralProjectionOnNonEmptyType";
+    database.getSchema().createDocumentType(className);
+
+    database.begin();
+    for (int i = 0; i < 5; i++)
+      database.newDocument(className).save();
+    database.commit();
+
+    final ResultSet result = database.query("sql", "select count(*), 2 from " + className);
+    assertThat(result.hasNext()).isTrue();
+    final Result next = result.next();
+    assertThat((Object) next.getProperty("count(*)")).isEqualTo(5L);
+    assertThat((Object) next.getProperty("2")).isEqualTo(2);
+    assertThat(result.hasNext()).isFalse();
+    result.close();
+  }
+
+  @Test
   void aggregateMixedWithNonAggregate() {
     final String className = "testAggregateMixedWithNonAggregate";
     database.getSchema().createDocumentType(className);


### PR DESCRIPTION
## Summary

Fixes #3585

- `SELECT count(*), 2 FROM empty_type` and `SELECT count(*), $x FROM empty_type LET $x = 2` now correctly return 1 row with `count(*) = 0` and the non-aggregate values
- Added `findCountStarItem()` to properly identify count(*) as the sole aggregate even when `aggregateProjection` contains pass-through alias refs for non-aggregate items
- Extended `GuaranteeEmptyCountStep` to evaluate `preAggregateProjection` items (literals, LET variables) in the zero-count synthetic result

## Test plan

- [x] Added `countStarWithLiteralProjectionOnEmptyType` — covers `SELECT count(*), 2 FROM empty`
- [x] Added `countStarWithLetVariableProjectionOnEmptyType` — covers `SELECT count(*), $x FROM empty LET $x = 2`
- [x] All 150 tests in `SelectStatementExecutionTest` pass
- [x] All related test classes pass (SelectStatementExecutionTestIT, SelectExecutionTest, SelectStatementTest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)