### PR TITLE
#3359 fix: ConcurrentModificationException regression in schema getTypes()

### DIFF
--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -87,7 +87,7 @@ public class LocalSchema implements Schema {
   public static final String                                 STATISTICS_FILE_NAME          = "statistics.json";
   public static final int                                    BUILD_TX_BATCH_SIZE           = 100_000;
   final               IndexFactory                           indexFactory                  = new IndexFactory();
-  final               Map<String, LocalDocumentType>         types                         = new HashMap<>();
+  final               Map<String, LocalDocumentType>         types                         = new ConcurrentHashMap<>();
   private             String                                 encoding                      = DEFAULT_ENCODING;
   private final       DatabaseInternal                       database;
   private final       SecurityManager                        security;


### PR DESCRIPTION
## Summary

- Commit `9959c82` ("remove duplicates from types returned") introduced a regression where `LocalSchema.getTypes()` wraps `HashMap.values()` in a `LinkedHashSet`, iterating over a live view that throws `ConcurrentModificationException` when another thread modifies the schema concurrently
- Fix: change the `types` map from `HashMap` to `ConcurrentHashMap`, whose iterators are weakly consistent and safe for concurrent reads
- The deduplication logic from the previous fix is preserved

## Test plan

- [x] `Issue3359Test` passes (concurrent read queries with schema modification)
- [x] `SchemaTest` passes (7 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)