### PR TITLE
chore: add Dependabot support for pre-commit hook updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -100,6 +100,21 @@ updates:
       - dependency-name: "bootstrap"
         update-types: ["version-update:semver-major"]
 
+  # Pre-commit hook versions
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: "sunday"
+    open-pull-requests-limit: 10
+    groups:
+      pre-commit-hooks:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
   # E2E JavaScript Testing Dependencies
   - package-ecosystem: "npm"
     directory: "/e2e-js"


### PR DESCRIPTION
## Summary
- Adds a `pre-commit` package ecosystem entry to Dependabot configuration
- Automatically keeps `.pre-commit-config.yaml` hook versions up to date (pre-commit-hooks, black, isort, prettier, shfmt, etc.)
- Groups minor/patch updates together, runs weekly on Sundays matching other ecosystems

## Test plan
- [ ] Verify Dependabot picks up the new ecosystem on the next scheduled run
- [ ] Confirm PRs are created with grouped minor/patch updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)