### PR TITLE
test: regression tests for issue #3650 (Bolt WHERE clause params)

### DIFF
--- a/bolt/src/test/java/com/arcadedb/bolt/BoltProtocolIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltProtocolIT.java
@@ -1338,4 +1338,63 @@ public class BoltProtocolIT extends BaseGraphServerTest {
       }
     }
   }
+
+  /**
+   * Regression test for https://github.com/ArcadeData/arcadedb/issues/3650
+   * Bolt: WHERE clause parameters not substituted — returns 0 results.
+   * Creates multiple vertices so that broken filtering (no filter = return all) is detectable.
+   */
+  @Test
+  void whereClauseParameterFiltering() {
+    try (Driver driver = getDriver()) {
+      try (Session session = driver.session(SessionConfig.forDatabase(getDatabaseName()))) {
+        // Create multiple vertices with different id values
+        session.run("CREATE (:WhereParamNode {id: 'A001', name: 'alpha'})");
+        session.run("CREATE (:WhereParamNode {id: 'B002', name: 'beta'})");
+        session.run("CREATE (:WhereParamNode {id: 'C003', name: 'gamma'})");
+
+        // Test 1: WHERE clause with string parameter returns exactly one matching vertex
+        final Result r1 = session.run(
+            "MATCH (t:WhereParamNode) WHERE t.id = $id RETURN t.name AS name",
+            Map.of("id", "A001"));
+        final List<Record> records1 = r1.list();
+        assertThat(records1).as("WHERE clause string parameter should return exactly 1 result").hasSize(1);
+        assertThat(records1.get(0).get("name").asString()).isEqualTo("alpha");
+
+        // Test 2: WHERE clause with different string parameter value
+        final Result r2 = session.run(
+            "MATCH (t:WhereParamNode) WHERE t.id = $id RETURN t.name AS name",
+            Map.of("id", "C003"));
+        final List<Record> records2 = r2.list();
+        assertThat(records2).as("WHERE clause string parameter should return exactly 1 result").hasSize(1);
+        assertThat(records2.get(0).get("name").asString()).isEqualTo("gamma");
+
+        // Test 3: WHERE clause with non-matching parameter returns 0 results
+        final Result r3 = session.run(
+            "MATCH (t:WhereParamNode) WHERE t.id = $id RETURN t.name AS name",
+            Map.of("id", "NONE"));
+        assertThat(r3.hasNext()).as("WHERE clause with non-matching parameter should return 0 results").isFalse();
+
+        // Test 4: WHERE clause with AND conditions and multiple parameters
+        final Result r4 = session.run(
+            "MATCH (t:WhereParamNode) WHERE t.id = $id AND t.name = $name RETURN t.id AS id",
+            Map.of("id", "B002", "name", "beta"));
+        final List<Record> records4 = r4.list();
+        assertThat(records4).as("WHERE clause with multiple parameters (AND) should return exactly 1 result").hasSize(1);
+        assertThat(records4.get(0).get("id").asString()).isEqualTo("B002");
+
+        // Test 5: WHERE clause with integer parameter
+        session.run("CREATE (:WhereParamNode {id: 'D004', seq: 42, name: 'delta'})");
+        final Result r5 = session.run(
+            "MATCH (t:WhereParamNode) WHERE t.seq = $seq RETURN t.name AS name",
+            Map.of("seq", 42));
+        final List<Record> records5 = r5.list();
+        assertThat(records5).as("WHERE clause integer parameter should return exactly 1 result").hasSize(1);
+        assertThat(records5.get(0).get("name").asString()).isEqualTo("delta");
+
+        // Clean up
+        session.run("MATCH (t:WhereParamNode) DELETE t");
+      }
+    }
+  }
 }

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltProtocolIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltProtocolIT.java
@@ -1348,52 +1348,53 @@ public class BoltProtocolIT extends BaseGraphServerTest {
   void whereClauseParameterFiltering() {
     try (Driver driver = getDriver()) {
       try (Session session = driver.session(SessionConfig.forDatabase(getDatabaseName()))) {
-        // Create multiple vertices with different id values
-        session.run("CREATE (:WhereParamNode {id: 'A001', name: 'alpha'})");
-        session.run("CREATE (:WhereParamNode {id: 'B002', name: 'beta'})");
-        session.run("CREATE (:WhereParamNode {id: 'C003', name: 'gamma'})");
+        try {
+          // Create multiple vertices with different id values
+          session.run("CREATE (:WhereParamNode {id: 'A001', name: 'alpha'})");
+          session.run("CREATE (:WhereParamNode {id: 'B002', name: 'beta'})");
+          session.run("CREATE (:WhereParamNode {id: 'C003', name: 'gamma'})");
 
-        // Test 1: WHERE clause with string parameter returns exactly one matching vertex
-        final Result r1 = session.run(
-            "MATCH (t:WhereParamNode) WHERE t.id = $id RETURN t.name AS name",
-            Map.of("id", "A001"));
-        final List<Record> records1 = r1.list();
-        assertThat(records1).as("WHERE clause string parameter should return exactly 1 result").hasSize(1);
-        assertThat(records1.get(0).get("name").asString()).isEqualTo("alpha");
+          // Test 1: WHERE clause with string parameter returns exactly one matching vertex
+          final Result r1 = session.run(
+              "MATCH (t:WhereParamNode) WHERE t.id = $id RETURN t.name AS name",
+              Map.of("id", "A001"));
+          final List<Record> records1 = r1.list();
+          assertThat(records1).as("WHERE clause string parameter should return exactly 1 result").hasSize(1);
+          assertThat(records1.get(0).get("name").asString()).isEqualTo("alpha");
 
-        // Test 2: WHERE clause with different string parameter value
-        final Result r2 = session.run(
-            "MATCH (t:WhereParamNode) WHERE t.id = $id RETURN t.name AS name",
-            Map.of("id", "C003"));
-        final List<Record> records2 = r2.list();
-        assertThat(records2).as("WHERE clause string parameter should return exactly 1 result").hasSize(1);
-        assertThat(records2.get(0).get("name").asString()).isEqualTo("gamma");
+          // Test 2: WHERE clause with different string parameter value
+          final Result r2 = session.run(
+              "MATCH (t:WhereParamNode) WHERE t.id = $id RETURN t.name AS name",
+              Map.of("id", "C003"));
+          final List<Record> records2 = r2.list();
+          assertThat(records2).as("WHERE clause string parameter should return exactly 1 result").hasSize(1);
+          assertThat(records2.get(0).get("name").asString()).isEqualTo("gamma");
 
-        // Test 3: WHERE clause with non-matching parameter returns 0 results
-        final Result r3 = session.run(
-            "MATCH (t:WhereParamNode) WHERE t.id = $id RETURN t.name AS name",
-            Map.of("id", "NONE"));
-        assertThat(r3.hasNext()).as("WHERE clause with non-matching parameter should return 0 results").isFalse();
+          // Test 3: WHERE clause with non-matching parameter returns 0 results
+          final Result r3 = session.run(
+              "MATCH (t:WhereParamNode) WHERE t.id = $id RETURN t.name AS name",
+              Map.of("id", "NONE"));
+          assertThat(r3.hasNext()).as("WHERE clause with non-matching parameter should return 0 results").isFalse();
 
-        // Test 4: WHERE clause with AND conditions and multiple parameters
-        final Result r4 = session.run(
-            "MATCH (t:WhereParamNode) WHERE t.id = $id AND t.name = $name RETURN t.id AS id",
-            Map.of("id", "B002", "name", "beta"));
-        final List<Record> records4 = r4.list();
-        assertThat(records4).as("WHERE clause with multiple parameters (AND) should return exactly 1 result").hasSize(1);
-        assertThat(records4.get(0).get("id").asString()).isEqualTo("B002");
+          // Test 4: WHERE clause with AND conditions and multiple parameters
+          final Result r4 = session.run(
+              "MATCH (t:WhereParamNode) WHERE t.id = $id AND t.name = $name RETURN t.id AS id",
+              Map.of("id", "B002", "name", "beta"));
+          final List<Record> records4 = r4.list();
+          assertThat(records4).as("WHERE clause with multiple parameters (AND) should return exactly 1 result").hasSize(1);
+          assertThat(records4.get(0).get("id").asString()).isEqualTo("B002");
 
-        // Test 5: WHERE clause with integer parameter
-        session.run("CREATE (:WhereParamNode {id: 'D004', seq: 42, name: 'delta'})");
-        final Result r5 = session.run(
-            "MATCH (t:WhereParamNode) WHERE t.seq = $seq RETURN t.name AS name",
-            Map.of("seq", 42));
-        final List<Record> records5 = r5.list();
-        assertThat(records5).as("WHERE clause integer parameter should return exactly 1 result").hasSize(1);
-        assertThat(records5.get(0).get("name").asString()).isEqualTo("delta");
-
-        // Clean up
-        session.run("MATCH (t:WhereParamNode) DELETE t");
+          // Test 5: WHERE clause with integer parameter
+          session.run("CREATE (:WhereParamNode {id: 'D004', seq: 42, name: 'delta'})");
+          final Result r5 = session.run(
+              "MATCH (t:WhereParamNode) WHERE t.seq = $seq RETURN t.name AS name",
+              Map.of("seq", 42));
+          final List<Record> records5 = r5.list();
+          assertThat(records5).as("WHERE clause integer parameter should return exactly 1 result").hasSize(1);
+          assertThat(records5.get(0).get("name").asString()).isEqualTo("delta");
+        } finally {
+          session.run("MATCH (t:WhereParamNode) DETACH DELETE t");
+        }
       }
     }
   }

--- a/docs/plans/2026-03-14-bolt-e2e-js-tests-design.md
+++ b/docs/plans/2026-03-14-bolt-e2e-js-tests-design.md
@@ -1,0 +1,56 @@
+# Bolt E2E JavaScript Tests for Issue #3650
+
+**Date**: 2026-03-14
+**Issue**: https://github.com/ArcadeData/arcadedb/issues/3650
+**Module**: e2e-js
+
+## Problem
+
+Issue #3650 reports that parameterized Cypher WHERE clause queries return 0 results over the Bolt protocol when using the Neo4j JavaScript driver. The bug is fixed and Java-level regression tests exist in `BoltProtocolIT` and `ParameterTest`. This design adds JavaScript e2e tests that reproduce the exact client-side scenario from the issue.
+
+## Design
+
+### File Structure
+
+New file: `e2e-js/src/js-bolt-e2e.test.js` (separate from existing `js-pg-e2e.test.js`).
+
+### Dependencies
+
+Add `neo4j-driver` (^5.27.0) to `e2e-js/package.json` dependencies. No other new dependencies needed.
+
+### Container Setup
+
+ArcadeDB testcontainer with:
+- **Plugins**: `BoltProtocolPlugin` (plus existing ones as needed)
+- **Exposed ports**: `2480` (HTTP, for health check and DB management), `7687` (Bolt)
+- **Wait strategy**: HTTP `/api/v1/ready` returning 204, same as existing tests
+- **Database**: Create `testbolt` database via HTTP API in `beforeAll`, drop in `afterAll`
+
+### Test Data
+
+Three `TestNode` vertices created in `beforeAll` via Cypher over Bolt:
+
+| id        | name      | value |
+|-----------|-----------|-------|
+| `node-1`  | `Alice`   | 100   |
+| `node-2`  | `Bob`     | 200   |
+| `node-3`  | `Charlie` | 300   |
+
+### Test Scenarios
+
+1. **WHERE clause with string parameter** — `WHERE t.id = $id` with `{id: 'node-1'}`, expect 1 result with correct name/value. Exact reproduction of the issue.
+
+2. **WHERE clause with different string value** — Same query with `{id: 'node-2'}`, expect 1 result with Bob's properties. Confirms filter varies with input.
+
+3. **Non-matching parameter returns 0** — Same query with `{id: 'nonexistent'}`, expect 0 results. Validates filter is applied.
+
+4. **WHERE with AND and multiple parameters** — `WHERE t.id = $id AND t.value = $val` with `{id: 'node-1', val: neo4j.int(100)}`, expect 1 result.
+
+5. **WHERE with integer parameter** — `WHERE t.value = $val` with `{val: neo4j.int(200)}`, expect 1 result.
+
+6. **Property map syntax baseline** — `MATCH (t:TestNode {id: $id})` with `{id: 'node-1'}`, expect 1 result. Sanity check (this syntax always worked).
+
+### Lifecycle
+
+- `beforeAll`: Start container, create database via HTTP, connect Neo4j driver, create test data
+- `afterAll`: DETACH DELETE test nodes, close session/driver, drop database via HTTP, stop container

--- a/e2e-js/package-lock.json
+++ b/e2e-js/package-lock.json
@@ -10,6 +10,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "neo4j-driver": "^5.27.0",
         "pg": "^8.16.0"
       },
       "devDependencies": {
@@ -2083,7 +2084,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2233,7 +2233,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3083,7 +3082,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4212,6 +4210,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/neo4j-driver": {
+      "version": "5.28.3",
+      "resolved": "https://registry.npmjs.org/neo4j-driver/-/neo4j-driver-5.28.3.tgz",
+      "integrity": "sha512-k7c0wEh3HoONv1v5AyLp9/BDAbYHJhz2TZvzWstSEU3g3suQcXmKEaYBfrK2UMzxcy3bCT0DrnfRbzsOW5G/Ag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "neo4j-driver-bolt-connection": "5.28.3",
+        "neo4j-driver-core": "5.28.3",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/neo4j-driver-bolt-connection": {
+      "version": "5.28.3",
+      "resolved": "https://registry.npmjs.org/neo4j-driver-bolt-connection/-/neo4j-driver-bolt-connection-5.28.3.tgz",
+      "integrity": "sha512-wqHBYcU0FVRDmdsoZ+Fk0S/InYmu9/4BT6fPYh45Jimg/J7vQBUcdkiHGU7nop7HRb1ZgJmL305mJb6g5Bv35Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "neo4j-driver-core": "5.28.3",
+        "string_decoder": "^1.3.0"
+      }
+    },
+    "node_modules/neo4j-driver-core": {
+      "version": "5.28.3",
+      "resolved": "https://registry.npmjs.org/neo4j-driver-core/-/neo4j-driver-core-5.28.3.tgz",
+      "integrity": "sha512-Jk+hAmjFmO5YzVH/U7FyKXigot9zmIfLz6SZQy0xfr4zfTE/S8fOYFOGqKQTHBE86HHOWH2RbTslbxIb+XtU2g==",
+      "license": "Apache-2.0"
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4814,11 +4840,19 @@
         "node": ">= 4"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5007,7 +5041,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -5290,9 +5323,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",

--- a/e2e-js/package.json
+++ b/e2e-js/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "description": "",
   "dependencies": {
+    "neo4j-driver": "^5.27.0",
     "pg": "^8.16.0"
   },
   "devDependencies": {

--- a/e2e-js/src/js-bolt-e2e.test.js
+++ b/e2e-js/src/js-bolt-e2e.test.js
@@ -1,0 +1,156 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+const neo4j = require("neo4j-driver");
+const { GenericContainer, Wait } = require("testcontainers");
+
+describe("E2E tests using Neo4j Bolt driver (issue #3650)", () => {
+  jest.setTimeout(120000);
+
+  let arcadedbContainer;
+  let driver;
+  let session;
+
+  const DB_NAME = "testbolt";
+  const PASSWORD = "playwithdata";
+
+  async function httpApi(host, port, payload) {
+    const response = await fetch(`http://${host}:${port}/api/v1/server`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Basic " + Buffer.from(`root:${PASSWORD}`).toString("base64"),
+      },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok)
+      throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+    return response.json();
+  }
+
+  beforeAll(async () => {
+    arcadedbContainer = await new GenericContainer("arcadedata/arcadedb:latest")
+      .withExposedPorts(2480, 7687)
+      .withEnvironment({
+        JAVA_OPTS:
+          `-Darcadedb.server.rootPassword=${PASSWORD}` +
+          " -Darcadedb.server.plugins=BoltProtocolPlugin",
+      })
+      .withStartupTimeout(60000)
+      .withWaitStrategy(Wait.forHttp("/api/v1/ready", 2480).forStatusCodeMatching((statusCode) => statusCode === 204))
+      .start();
+
+    const host = arcadedbContainer.getHost();
+    const httpPort = arcadedbContainer.getMappedPort(2480);
+    const boltPort = arcadedbContainer.getMappedPort(7687);
+
+    // Create test database via HTTP API
+    await httpApi(host, httpPort, { command: `create database ${DB_NAME}` });
+
+    driver = neo4j.driver(
+      `bolt://${host}:${boltPort}`,
+      neo4j.auth.basic("root", PASSWORD)
+    );
+    session = driver.session({ database: DB_NAME });
+
+    // Create test data
+    const nodes = [
+      { id: "node-1", name: "Alice", value: neo4j.int(100) },
+      { id: "node-2", name: "Bob", value: neo4j.int(200) },
+      { id: "node-3", name: "Charlie", value: neo4j.int(300) },
+    ];
+    for (const params of nodes) {
+      await session.run(
+        "CREATE (:TestNode {id: $id, name: $name, value: $value})",
+        params
+      );
+    }
+  });
+
+  afterAll(async () => {
+    try {
+      if (session) {
+        await session.run("MATCH (t:TestNode) DETACH DELETE t");
+        await session.close();
+      }
+      if (driver) await driver.close();
+      if (arcadedbContainer) {
+        const host = arcadedbContainer.getHost();
+        const httpPort = arcadedbContainer.getMappedPort(2480);
+        await httpApi(host, httpPort, { command: `drop database ${DB_NAME}` });
+        await arcadedbContainer.stop();
+      }
+    } catch (e) {
+      console.error("Cleanup error:", e.message);
+    }
+  });
+
+  it("should filter by WHERE clause with string parameter", async () => {
+    const result = await session.run(
+      "MATCH (t:TestNode) WHERE t.id = $id RETURN t.name AS name, t.value AS value",
+      { id: "node-1" }
+    );
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].get("name")).toBe("Alice");
+    expect(result.records[0].get("value").toNumber()).toBe(100);
+  });
+
+  it("should filter by WHERE clause with a different string value", async () => {
+    const result = await session.run(
+      "MATCH (t:TestNode) WHERE t.id = $id RETURN t.name AS name",
+      { id: "node-2" }
+    );
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].get("name")).toBe("Bob");
+  });
+
+  it("should return 0 results for non-matching parameter", async () => {
+    const result = await session.run(
+      "MATCH (t:TestNode) WHERE t.id = $id RETURN t.name AS name",
+      { id: "nonexistent" }
+    );
+    expect(result.records).toHaveLength(0);
+  });
+
+  it("should filter by WHERE clause with AND and multiple parameters", async () => {
+    const result = await session.run(
+      "MATCH (t:TestNode) WHERE t.id = $id AND t.value = $val RETURN t.name AS name",
+      { id: "node-1", val: neo4j.int(100) }
+    );
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].get("name")).toBe("Alice");
+  });
+
+  it("should filter by WHERE clause with integer parameter", async () => {
+    const result = await session.run(
+      "MATCH (t:TestNode) WHERE t.value = $val RETURN t.name AS name",
+      { val: neo4j.int(200) }
+    );
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].get("name")).toBe("Bob");
+  });
+
+  it("should filter by property map syntax as baseline", async () => {
+    const result = await session.run(
+      "MATCH (t:TestNode {id: $id}) RETURN t.name AS name",
+      { id: "node-1" }
+    );
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].get("name")).toBe("Alice");
+  });
+});

--- a/engine/src/test/java/com/arcadedb/query/opencypher/ParameterTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/ParameterTest.java
@@ -108,7 +108,6 @@ class ParameterTest {
 
     } finally {
       database.drop();
-      FileUtils.deleteRecursively(new File("./target/testparams_eq"));
     }
   }
 
@@ -245,5 +244,6 @@ class ParameterTest {
   @AfterEach
   void clean() {
     FileUtils.deleteRecursively(new File("./target/testparams"));
+    FileUtils.deleteRecursively(new File("./target/testparams_eq"));
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/ParameterTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/ParameterTest.java
@@ -74,6 +74,44 @@ class ParameterTest {
     }
   }
 
+  /**
+   * Regression test for issue #3650: WHERE clause equality with string parameter should filter correctly.
+   * Creates multiple nodes to verify that filtering is actually applied (not just that a result exists).
+   */
+  @Test
+  void whereClauseEqualityWithStringParameter() {
+    final Database database = new DatabaseFactory("./target/testparams_eq").create();
+    try {
+      database.getSchema().getOrCreateVertexType("EqTestNode");
+
+      database.transaction(() -> {
+        database.command("opencypher", "CREATE (n:EqTestNode {id: 'A001', name: 'alpha'})");
+        database.command("opencypher", "CREATE (n:EqTestNode {id: 'B002', name: 'beta'})");
+        database.command("opencypher", "CREATE (n:EqTestNode {id: 'C003', name: 'gamma'})");
+      });
+
+      // Test equality filter with string parameter - should return exactly 1 result
+      final ResultSet r1 = database.query("opencypher",
+          "MATCH (t:EqTestNode) WHERE t.id = $id RETURN t.name AS name",
+          Map.of("id", "A001"));
+      final List<String> names = new ArrayList<>();
+      while (r1.hasNext())
+        names.add(r1.next().getProperty("name").toString());
+      assertThat(names).as("WHERE clause string equality should return exactly 1 result").hasSize(1);
+      assertThat(names.get(0)).isEqualTo("alpha");
+
+      // Non-matching parameter should return 0 results
+      final ResultSet r2 = database.query("opencypher",
+          "MATCH (t:EqTestNode) WHERE t.id = $id RETURN t.name AS name",
+          Map.of("id", "NONE"));
+      assertThat(r2.hasNext()).as("Non-matching parameter should return 0 results").isFalse();
+
+    } finally {
+      database.drop();
+      FileUtils.deleteRecursively(new File("./target/testparams_eq"));
+    }
+  }
+
   @Test
   void positionalParameters() {
     final Database database = new DatabaseFactory("./target/testparams2").create();


### PR DESCRIPTION
## Summary
- Add comprehensive regression tests for [#3650](https://github.com/ArcadeData/arcadedb/issues/3650) verifying WHERE clause parameter substitution works correctly via both engine API and Bolt protocol
- Existing `parameterInMatchPropertyMap` step 3 tested WHERE clause params with only 1 node, which cannot detect "filter not applied" bugs — new tests use 3+ nodes and assert exact result counts
- Investigation confirmed no code bug exists: the full parameter flow (Bolt → OpenCypherQueryEngine → CypherExecutionPlan → FilterOperator → ParameterExpression) works correctly

## Test plan
- [x] `ParameterTest#whereClauseEqualityWithStringParameter` passes locally (engine-level, string equality with 3 nodes)
- [x] All existing `ParameterTest` tests pass (4 tests total)
- [x] `CypherTest` and `OpenCypherOptimizerVerificationTest` pass (no regressions)
- [x] Bolt module compiles cleanly
- [ ] `BoltProtocolIT#whereClauseParameterFiltering` needs CI to run (requires network/server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)