### PR TITLE
feat: upgrade Apache Tinkerpop Gremlin from 3.7.5 to 3.8.0

### DIFF
--- a/gremlin/pom.xml
+++ b/gremlin/pom.xml
@@ -34,7 +34,7 @@
     <name>ArcadeDB Gremlin</name>
 
     <properties>
-        <gremlin.version>3.7.5</gremlin.version>
+        <gremlin.version>3.8.0</gremlin.version>
         <translation.version>1.0.4</translation.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <netty.version>4.2.10.Final</netty.version>

--- a/gremlin/src/main/java/org/apache/tinkerpop/gremlin/util/GremlinValueComparator.java
+++ b/gremlin/src/main/java/org/apache/tinkerpop/gremlin/util/GremlinValueComparator.java
@@ -18,7 +18,6 @@
  */
 package org.apache.tinkerpop.gremlin.util;
 
-import org.apache.tinkerpop.gremlin.process.traversal.GremlinTypeErrorException;
 import org.apache.tinkerpop.gremlin.process.traversal.Path;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Element;
@@ -131,7 +130,7 @@ public abstract class GremlinValueComparator implements Comparator<Object> {
         // comparable(f, s) assures that type(f) == type(s)
         final Type type = Type.type(f);
         return comparator(type).compare(f, s) == 0;
-      } catch (GremlinTypeErrorException ex) {
+      } catch (IllegalStateException ex) {
         /**
          * By routing through the compare(f, s) path we expose ourselves to type errors, which should be
          * reduced to false for equality:
@@ -159,7 +158,7 @@ public abstract class GremlinValueComparator implements Comparator<Object> {
   };
 
   private static <T> T throwTypeError() {
-    throw new GremlinTypeErrorException();
+    throw new IllegalStateException();
   }
 
   /**
@@ -301,7 +300,7 @@ public abstract class GremlinValueComparator implements Comparator<Object> {
   /**
    * Return true if the two objects are of the same comparison type (although they may not be the exact same Class)
    */
-  private static boolean comparable(final Object f, final Object s) {
+  public static boolean comparable(final Object f, final Object s) {
     if (f == null || s == null)
       return f == s; // true iff both in the null space
 

--- a/gremlin/src/test/java/com/arcadedb/gremlin/GremlinTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/GremlinTest.java
@@ -435,8 +435,9 @@ class GremlinTest {
       Result value = graph.gremlin("g.inject(Long.MAX_VALUE, 0).sum()").execute().nextIfAvailable();
       assertThat((long) value.getProperty("result")).isEqualTo(Long.MAX_VALUE);
 
-      value = graph.gremlin("g.inject(Long.MAX_VALUE, 1).sum()").execute().nextIfAvailable();
-      assertThat((long) value.getProperty("result")).isEqualTo(Long.MAX_VALUE + 1);
+      // Since Gremlin 3.8.0, sum() throws ArithmeticException on long overflow instead of silently wrapping
+      assertThatThrownBy(() -> graph.gremlin("g.inject(Long.MAX_VALUE, 1).sum()").execute().nextIfAvailable())
+          .isInstanceOf(ArithmeticException.class);
 
       value = graph.gremlin("g.inject(BigInteger.valueOf(Long.MAX_VALUE), 1).sum()").execute().nextIfAvailable();
       assertThat((BigInteger) value.getProperty("result")).isEqualTo(


### PR DESCRIPTION
## Summary
- Upgrades `gremlin.version` from 3.7.5 to 3.8.0 in `gremlin/pom.xml`
- Adapts `GremlinValueComparator` to 3.8.0 API changes: `GremlinTypeErrorException` removed (replaced with `IllegalStateException`), `comparable()` visibility changed from `private` to `public`
- Updates `longOverflow` test to expect `ArithmeticException` (Gremlin 3.8.0 no longer silently wraps on long overflow in `sum()`)

## Test plan
- [x] Gremlin module compiles cleanly
- [x] All 236 gremlin tests pass (0 failures, 0 errors)
- [x] Full project builds successfully (22/22 modules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)