### PR TITLE
fix: sanitize license filenames before upload-artifact

### DIFF
--- a/.github/workflows/license-compliance.yml
+++ b/.github/workflows/license-compliance.yml
@@ -82,6 +82,20 @@ jobs:
           mvn org.codehaus.mojo:license-maven-plugin:2.4.0:aggregate-download-licenses -DskipTests
         continue-on-error: true
 
+      - name: Sanitize license filenames for upload-artifact compatibility
+        if: always()
+        run: |
+          # upload-artifact forbids: " : < > | * ? \r \n in filenames
+          find target/generated-resources/licenses/ -type f 2>/dev/null | while IFS= read -r f; do
+            dir="$(dirname "$f")"
+            base="$(basename "$f")"
+            sanitized="$(printf '%s' "$base" | sed 's/[":<>|*?]/_/g')"
+            if [ "$base" != "$sanitized" ]; then
+              echo "Renaming: $base -> $sanitized"
+              mv "$f" "$dir/$sanitized"
+            fi
+          done
+
       - name: Upload license report
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()


### PR DESCRIPTION
## Summary
- The `license-maven-plugin` downloads license files with names containing double quotes (e.g., `bsd 3-clause "new" or "revised" license`), which causes `upload-artifact` to fail since it forbids `"`, `:`, `<`, `>`, `|`, `*`, `?` in file paths
- Adds a sanitization step that replaces forbidden characters with underscores before uploading

## Test plan
- [ ] Trigger the License Compliance Check workflow manually and verify the artifact uploads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)