### PR TITLE
fix: transaction commit fails when indexes are dropped mid-transaction

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/TransactionIndexContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionIndexContext.java
@@ -164,6 +164,9 @@ public class TransactionIndexContext {
   }
 
   public void commit() {
+    // REMOVE ENTRIES FOR INDEXES DROPPED DURING THE TRANSACTION (e.g. TYPE DROP)
+    indexEntries.keySet().removeIf(indexName -> !database.getSchema().existsIndex(indexName));
+
     checkUniqueIndexKeys();
 
     for (final Map.Entry<String, TreeMap<ComparableKey, Map<IndexKey, IndexKey>>> entry : indexEntries.entrySet()) {
@@ -224,6 +227,10 @@ public class TransactionIndexContext {
     final Set<Index> lockedIndexes = new HashSet<>(indexEntries.size());
 
     for (final String indexName : indexEntries.keySet()) {
+      if (!schema.existsIndex(indexName))
+        // INDEX WAS DROPPED DURING THE TRANSACTION (e.g. TYPE DROP), SKIP IT
+        continue;
+
       final IndexInternal index = (IndexInternal) schema.getIndexByName(indexName);
 
       if (!lockedIndexes.add(index))

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPConfiguration.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPConfiguration.java
@@ -171,6 +171,8 @@ public class MCPConfiguration {
    * also matches the bare token name against the allowed list.
    */
   public boolean isUserAllowed(final String username) {
+    if (username == null)
+      return false;
     if (allowedUsers.contains("*") || allowedUsers.contains(username))
       return true;
     // API token users have synthetic names like "apitoken:<tokenName>".


### PR DESCRIPTION
## Summary
- **TransactionIndexContext**: `commit()` and `addFilesToLock()` threw `SchemaException` when iterating index entries that referenced indexes dropped during the same transaction (e.g., via `dropType()`). Now pruned before processing.
- **MCPConfiguration**: `isUserAllowed()` threw NPE when called with a null username. Added null guard.

## Test plan
- [x] `DropIndexTest.dropAndRecreateTypeWithIndex` — passes (was failing)
- [x] `TruncateClassStatementExecutionTest.truncateClass` — passes (was failing)
- [x] `MCPPermissionsTest.mcpNullUserNotAllowed` — passes (was failing)
- [x] All other tests in those classes still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)