### PR TITLE
fix: update e2e graph-styling test for no-label default

### DIFF
--- a/e2e-studio/tests/graph-styling.spec.ts
+++ b/e2e-studio/tests/graph-styling.spec.ts
@@ -80,25 +80,29 @@ test.describe('ArcadeDB Studio Graph Styling and HTML Labels', () => {
 
     console.log('HTML labels supported:', htmlLabelsSupported);
 
-    // Verify node labels are displayed
+    // Verify nodes exist and have the label data property (may be empty by default)
     const nodeLabels = await page.evaluate(() => {
       if (!globalCy) return [];
 
       const nodes = globalCy.nodes();
       return nodes.map(node => ({
         id: node.id(),
-        label: node.data('label') || node.data('name') || 'No label'
+        label: node.data('label'),
+        type: node.data('type'),
+        hasLabelProp: 'label' in node.data()
       }));
     });
 
     expect(nodeLabels.length).toBeGreaterThan(0);
     console.log('Node labels:', nodeLabels.slice(0, 3)); // Log first 3 for verification
 
-    // Verify labels are not empty
-    const hasNonEmptyLabels = nodeLabels.some(node =>
-      node.label && node.label !== 'No label' && node.label.trim() !== ''
-    );
-    expect(hasNonEmptyLabels).toBe(true);
+    // Verify all nodes have the label property defined (even if empty, since default is no label)
+    const allHaveLabelProp = nodeLabels.every(node => node.hasLabelProp);
+    expect(allHaveLabelProp).toBe(true);
+
+    // Verify all nodes have a type assigned
+    const allHaveType = nodeLabels.every(node => node.type && node.type.trim() !== '');
+    expect(allHaveType).toBe(true);
   });
 
   test('should apply different styles for different vertex types', async ({ authenticatedHelper }) => {


### PR DESCRIPTION
## Summary
- Fix failing `should display HTML labels correctly` e2e test in `graph-styling.spec.ts`
- The studio refactor (b1a00939) changed the default to no labels on graph nodes, but the test still asserted non-empty labels
- Updated test to verify label property existence and type assignment instead of asserting non-empty label text

## Test plan
- [x] Run `npx playwright test tests/graph-styling.spec.ts` in `e2e-studio/` to verify the test passes
- [x] Confirm other graph-styling tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)