### PR TITLE
#3678 feat(grpc): add GraphBatchLoad RPC for bulk graph loading

### DIFF
--- a/grpc/src/main/proto/arcadedb-server.proto
+++ b/grpc/src/main/proto/arcadedb-server.proto
@@ -504,10 +504,10 @@ message GraphBatchOptions {
   int32  batch_size               = 1;  // default 100000
   bool   light_edges              = 2;  // default false
   bool   wal                      = 3;  // default false
-  bool   parallel_flush           = 4;  // default true
-  bool   pre_allocate_edge_chunks = 5;  // default true
+  optional bool   parallel_flush           = 4;  // default true (unset = true)
+  optional bool   pre_allocate_edge_chunks = 5;  // default true (unset = true)
   int32  edge_list_initial_size   = 6;  // default 2048
-  bool   bidirectional            = 7;  // default true
+  optional bool   bidirectional            = 7;  // default true (unset = true)
   int32  commit_every             = 8;  // default 50000
   int32  expected_edge_count      = 9;  // default 0
 }
@@ -522,6 +522,8 @@ message GraphBatchRecord {
   map<string, GrpcValue> properties = 6;
 }
 
+// IMPORTANT: all VERTEX records must appear before any EDGE records across all chunks.
+// Interleaving is not supported and will result in an error.
 message GraphBatchChunk {
   string database                    = 1;  // required on first chunk
   DatabaseCredentials credentials    = 2;  // required on first chunk

--- a/grpc/src/main/proto/arcadedb-server.proto
+++ b/grpc/src/main/proto/arcadedb-server.proto
@@ -526,7 +526,7 @@ message GraphBatchRecord {
 // Interleaving is not supported and will result in an error.
 message GraphBatchChunk {
   string database                    = 1;  // required on first chunk
-  DatabaseCredentials credentials    = 2;  // required on first chunk
+  DatabaseCredentials credentials    = 2;  // optional if channel-level auth is used
   GraphBatchOptions options          = 3;  // required on first chunk, ignored after
   repeated GraphBatchRecord records  = 4;
 }
@@ -536,6 +536,9 @@ message GraphBatchResult {
   int64 edges_created            = 2;
   int64 elapsed_ms               = 3;
   map<string, string> id_mapping = 4;  // temp_id → RID string
+  // Note: for very large batches with many temp IDs, the id_mapping may exceed the default
+  // gRPC message size limit (4 MB). Callers importing millions of vertices with temp IDs should
+  // increase maxInboundMessageSize or avoid temp IDs when RID mapping is not needed.
 }
 
 // -----------------------------------------------------------------------------

--- a/grpc/src/main/proto/arcadedb-server.proto
+++ b/grpc/src/main/proto/arcadedb-server.proto
@@ -174,6 +174,9 @@ service ArcadeDbService {
   rpc BeginTransaction(BeginTransactionRequest) returns (BeginTransactionResponse);
   rpc CommitTransaction(CommitTransactionRequest) returns (CommitTransactionResponse);
   rpc RollbackTransaction(RollbackTransactionRequest) returns (RollbackTransactionResponse);
+
+  // Graph batch load (client-streaming)
+  rpc GraphBatchLoad (stream GraphBatchChunk) returns (GraphBatchResult);
 }
 
 // -----------------------------------------------------------------------------
@@ -491,6 +494,46 @@ message BatchAck {
 
 message Committed {
   InsertSummary summary = 1; // full-stream totals
+}
+
+// ---------------------------------------------------------------------------
+// Graph Batch Load API
+// ---------------------------------------------------------------------------
+
+message GraphBatchOptions {
+  int32  batch_size               = 1;  // default 100000
+  bool   light_edges              = 2;  // default false
+  bool   wal                      = 3;  // default false
+  bool   parallel_flush           = 4;  // default true
+  bool   pre_allocate_edge_chunks = 5;  // default true
+  int32  edge_list_initial_size   = 6;  // default 2048
+  bool   bidirectional            = 7;  // default true
+  int32  commit_every             = 8;  // default 50000
+  int32  expected_edge_count      = 9;  // default 0
+}
+
+message GraphBatchRecord {
+  enum Kind { VERTEX = 0; EDGE = 1; }
+  Kind   kind      = 1;
+  string type_name = 2;  // vertex or edge type name
+  string temp_id   = 3;  // vertex temp ID (for later edge references)
+  string from_ref  = 4;  // edge source: temp ID or "#bucket:pos"
+  string to_ref    = 5;  // edge target: temp ID or "#bucket:pos"
+  map<string, GrpcValue> properties = 6;
+}
+
+message GraphBatchChunk {
+  string database                    = 1;  // required on first chunk
+  DatabaseCredentials credentials    = 2;  // required on first chunk
+  GraphBatchOptions options          = 3;  // required on first chunk, ignored after
+  repeated GraphBatchRecord records  = 4;
+}
+
+message GraphBatchResult {
+  int64 vertices_created         = 1;
+  int64 edges_created            = 2;
+  int64 elapsed_ms               = 3;
+  map<string, string> id_mapping = 4;  // temp_id → RID string
 }
 
 // -----------------------------------------------------------------------------

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -33,6 +33,7 @@ import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.SchemaException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GraphBatch;
 import com.arcadedb.graph.MutableEdge;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
@@ -98,6 +99,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   private static final JsonSerializer SAFE = JsonSerializer.createJsonSerializer().setIncludeVertexEdges(false)
       .setUseVertexEdgeSize(true)
       .setUseCollectionSizeForEdges(false).setUseCollectionSize(false);
+
+  private static final int GRAPH_BATCH_VERTEX_BUFFER = 10_000;
 
   // Transaction management - now stores TransactionContext with executor for thread affinity
   private final Map<String, TransactionContext> activeTransactions = new ConcurrentHashMap<>();
@@ -1577,6 +1580,205 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         }
       }
     };
+  }
+
+  // --- 3) Client-streaming graph batch load ---
+  @Override
+  public StreamObserver<GraphBatchChunk> graphBatchLoad(final StreamObserver<GraphBatchResult> resp) {
+    final ServerCallStreamObserver<GraphBatchResult> call = (ServerCallStreamObserver<GraphBatchResult>) resp;
+    call.disableAutoInboundFlowControl();
+
+    final long startedAt = System.currentTimeMillis();
+    final AtomicBoolean cancelled = new AtomicBoolean(false);
+    final AtomicReference<GraphBatch> batchRef = new AtomicReference<>();
+    final AtomicReference<Database> dbRef = new AtomicReference<>();
+    final Map<String, RID> tempIdMap = new HashMap<>();
+
+    // Vertex accumulation state
+    final List<Object[]> vertexPropsBatch = new ArrayList<>(GRAPH_BATCH_VERTEX_BUFFER);
+    final List<String> vertexTempIds = new ArrayList<>(GRAPH_BATCH_VERTEX_BUFFER);
+    final AtomicReference<String> currentTypeRef = new AtomicReference<>();
+    final long[] counts = new long[2]; // [0]=vertices, [1]=edges
+    final AtomicBoolean inEdgePhase = new AtomicBoolean(false);
+
+    call.setOnCancelHandler(() -> cancelled.set(true));
+    call.request(1);
+
+    return new StreamObserver<>() {
+
+      @Override
+      public void onNext(final GraphBatchChunk chunk) {
+        if (cancelled.get())
+          return;
+        try {
+          GraphBatch batch = batchRef.get();
+          if (batch == null) {
+            // First chunk: initialize
+            final Database db = getDatabase(chunk.getDatabase(), chunk.getCredentials());
+            dbRef.set(db);
+            final GraphBatch.Builder builder = db.batch();
+            configureGraphBatchOptions(builder, chunk.hasOptions() ? chunk.getOptions() : null);
+            batch = builder.build();
+            batchRef.set(batch);
+          }
+
+          // Process records in this chunk
+          for (final GraphBatchRecord rec : chunk.getRecordsList()) {
+            if (rec.getKind() == GraphBatchRecord.Kind.EDGE) {
+              // Flush remaining vertices on transition to edge phase
+              if (!inEdgePhase.get()) {
+                if (!vertexPropsBatch.isEmpty())
+                  counts[0] += flushVertexBatch(batch, currentTypeRef.get(), vertexPropsBatch, vertexTempIds, tempIdMap);
+                inEdgePhase.set(true);
+              }
+              processEdge(batch, rec, tempIdMap);
+              counts[1]++;
+            } else {
+              if (inEdgePhase.get())
+                throw new IllegalArgumentException("Vertex record received after edges. All vertices must appear before edges");
+
+              // Type change -> flush
+              final String currentType = currentTypeRef.get();
+              if (currentType != null && !currentType.equals(rec.getTypeName()))
+                counts[0] += flushVertexBatch(batch, currentType, vertexPropsBatch, vertexTempIds, tempIdMap);
+              currentTypeRef.set(rec.getTypeName());
+
+              final Object[] props = rec.getPropertiesMap().isEmpty() ? new Object[0] : toPropertyArray(rec.getPropertiesMap());
+              vertexPropsBatch.add(props);
+              vertexTempIds.add(rec.getTempId().isEmpty() ? null : rec.getTempId());
+
+              if (vertexPropsBatch.size() >= GRAPH_BATCH_VERTEX_BUFFER)
+                counts[0] += flushVertexBatch(batch, currentTypeRef.get(), vertexPropsBatch, vertexTempIds, tempIdMap);
+            }
+          }
+        } catch (final Exception e) {
+          resp.onError(Status.INTERNAL.withDescription("graphBatchLoad: " + e.getMessage()).asException());
+          closeQuietly(batchRef.get());
+          return;
+        } finally {
+          if (!cancelled.get())
+            call.request(1);
+        }
+      }
+
+      @Override
+      public void onError(final Throwable t) {
+        closeQuietly(batchRef.get());
+      }
+
+      @Override
+      public void onCompleted() {
+        try {
+          final GraphBatch batch = batchRef.get();
+          if (batch == null) {
+            resp.onNext(GraphBatchResult.newBuilder().build());
+            resp.onCompleted();
+            return;
+          }
+
+          // Flush remaining vertices
+          if (!vertexPropsBatch.isEmpty())
+            counts[0] += flushVertexBatch(batch, currentTypeRef.get(), vertexPropsBatch, vertexTempIds, tempIdMap);
+
+          // Close batch -> flushes edges, connects incoming edges
+          batch.close();
+
+          final GraphBatchResult.Builder result = GraphBatchResult.newBuilder()
+              .setVerticesCreated(counts[0])
+              .setEdgesCreated(counts[1])
+              .setElapsedMs(System.currentTimeMillis() - startedAt);
+
+          for (final Map.Entry<String, RID> entry : tempIdMap.entrySet())
+            result.putIdMapping(entry.getKey(), entry.getValue().toString());
+
+          if (!cancelled.get()) {
+            resp.onNext(result.build());
+            resp.onCompleted();
+          }
+        } catch (final Exception e) {
+          resp.onError(Status.INTERNAL.withDescription("graphBatchLoad: " + e.getMessage()).asException());
+          closeQuietly(batchRef.get());
+        }
+      }
+    };
+  }
+
+  private Object[] toPropertyArray(final Map<String, GrpcValue> properties) {
+    final Object[] result = new Object[properties.size() * 2];
+    int i = 0;
+    for (final Map.Entry<String, GrpcValue> entry : properties.entrySet()) {
+      result[i++] = entry.getKey();
+      result[i++] = GrpcTypeConverter.fromGrpcValue(entry.getValue());
+    }
+    return result;
+  }
+
+  private RID resolveRef(final String ref, final Map<String, RID> tempIdMap) {
+    if (ref.charAt(0) == '#') {
+      final int colonIdx = ref.indexOf(':');
+      if (colonIdx < 0)
+        throw new IllegalArgumentException("Malformed RID '" + ref + "'");
+      final int bucketId = Integer.parseInt(ref.substring(1, colonIdx));
+      final long position = Long.parseLong(ref.substring(colonIdx + 1));
+      return new RID(null, bucketId, position);
+    }
+    final RID rid = tempIdMap.get(ref);
+    if (rid == null)
+      throw new IllegalArgumentException("Unknown temporary ID '" + ref + "'. Vertices must appear before edges that reference them");
+    return rid;
+  }
+
+  private int flushVertexBatch(final GraphBatch batch, final String typeName,
+      final List<Object[]> propsBatch, final List<String> tempIds, final Map<String, RID> tempIdMap) {
+    final int count = propsBatch.size();
+    final Object[][] propsArray = propsBatch.toArray(new Object[count][]);
+    final RID[] rids = batch.createVertices(typeName, propsArray);
+    for (int i = 0; i < count; i++) {
+      final String tempId = tempIds.get(i);
+      if (tempId != null)
+        tempIdMap.put(tempId, rids[i]);
+    }
+    propsBatch.clear();
+    tempIds.clear();
+    return count;
+  }
+
+  private void processEdge(final GraphBatch batch, final GraphBatchRecord rec, final Map<String, RID> tempIdMap) {
+    final RID srcRID = resolveRef(rec.getFromRef(), tempIdMap);
+    final RID dstRID = resolveRef(rec.getToRef(), tempIdMap);
+    if (rec.getPropertiesMap().isEmpty())
+      batch.newEdge(srcRID, rec.getTypeName(), dstRID);
+    else
+      batch.newEdge(srcRID, rec.getTypeName(), dstRID, toPropertyArray(rec.getPropertiesMap()));
+  }
+
+  private void configureGraphBatchOptions(final GraphBatch.Builder builder, final GraphBatchOptions opts) {
+    if (opts == null)
+      return;
+    if (opts.getBatchSize() > 0)
+      builder.withBatchSize(opts.getBatchSize());
+    if (opts.getLightEdges())
+      builder.withLightEdges(true);
+    if (opts.getWal())
+      builder.withWAL(true);
+    if (!opts.getParallelFlush())
+      builder.withParallelFlush(false);
+    if (!opts.getPreAllocateEdgeChunks())
+      builder.withPreAllocateEdgeChunks(false);
+    if (opts.getEdgeListInitialSize() > 0)
+      builder.withEdgeListInitialSize(opts.getEdgeListInitialSize());
+    if (!opts.getBidirectional())
+      builder.withBidirectional(false);
+    if (opts.getCommitEvery() > 0)
+      builder.withCommitEvery(opts.getCommitEvery());
+    if (opts.getExpectedEdgeCount() > 0)
+      builder.withExpectedEdgeCount(opts.getExpectedEdgeCount());
+  }
+
+  private void closeQuietly(final GraphBatch batch) {
+    if (batch != null) {
+      try { batch.close(); } catch (final Exception ignored) { }
+    }
   }
 
   /**

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -1590,6 +1590,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
     final long startedAt = System.currentTimeMillis();
     final AtomicBoolean cancelled = new AtomicBoolean(false);
+    final boolean[] errorSent = { false };
     final AtomicReference<GraphBatch> batchRef = new AtomicReference<>();
     final AtomicReference<Database> dbRef = new AtomicReference<>();
     final Map<String, RID> tempIdMap = new HashMap<>();
@@ -1633,7 +1634,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
                   counts[0] += flushVertexBatch(batch, currentType[0], vertexPropsBatch, vertexTempIds, tempIdMap);
                 inEdgePhase[0] = true;
               }
-              processEdge(batch, rec, tempIdMap);
+              processEdge(batch, rec, dbRef.get(), tempIdMap);
               counts[1]++;
             } else {
               if (inEdgePhase[0])
@@ -1654,11 +1655,14 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
             }
           }
         } catch (final Exception e) {
+          errorSent[0] = true;
           resp.onError(Status.INTERNAL.withDescription("graphBatchLoad: " + e.getMessage()).asException());
+          // Note: closeQuietly may flush/commit partial data. GraphBatch has no rollback path by design
+          // (same as the HTTP batch endpoint). Callers should treat batch loading as non-atomic.
           closeQuietly(batchRef.get());
           return;
         } finally {
-          if (!cancelled.get())
+          if (!cancelled.get() && !errorSent[0])
             call.request(1);
         }
       }
@@ -1715,7 +1719,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     return result;
   }
 
-  private RID resolveRef(final String ref, final Map<String, RID> tempIdMap) {
+  private RID resolveRef(final String ref, final Database db, final Map<String, RID> tempIdMap) {
     if (ref == null || ref.isEmpty())
       throw new IllegalArgumentException("Edge record is missing from_ref or to_ref");
     if (ref.charAt(0) == '#') {
@@ -1724,7 +1728,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         throw new IllegalArgumentException("Malformed RID '" + ref + "'");
       final int bucketId = Integer.parseInt(ref.substring(1, colonIdx));
       final long position = Long.parseLong(ref.substring(colonIdx + 1));
-      return new RID(null, bucketId, position);
+      return new RID(db, bucketId, position);
     }
     final RID rid = tempIdMap.get(ref);
     if (rid == null)
@@ -1747,9 +1751,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     return count;
   }
 
-  private void processEdge(final GraphBatch batch, final GraphBatchRecord rec, final Map<String, RID> tempIdMap) {
-    final RID srcRID = resolveRef(rec.getFromRef(), tempIdMap);
-    final RID dstRID = resolveRef(rec.getToRef(), tempIdMap);
+  private void processEdge(final GraphBatch batch, final GraphBatchRecord rec, final Database db,
+      final Map<String, RID> tempIdMap) {
+    final RID srcRID = resolveRef(rec.getFromRef(), db, tempIdMap);
+    final RID dstRID = resolveRef(rec.getToRef(), db, tempIdMap);
     if (rec.getPropertiesMap().isEmpty())
       batch.newEdge(srcRID, rec.getTypeName(), dstRID);
     else
@@ -1765,6 +1770,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       builder.withLightEdges(true);
     if (opts.getWal())
       builder.withWAL(true);
+    // Only need to disable: builder defaults to true; setting true explicitly is a no-op
     if (opts.hasParallelFlush() && !opts.getParallelFlush())
       builder.withParallelFlush(false);
     if (opts.hasPreAllocateEdgeChunks() && !opts.getPreAllocateEdgeChunks())

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -1597,9 +1597,9 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     // Vertex accumulation state
     final List<Object[]> vertexPropsBatch = new ArrayList<>(GRAPH_BATCH_VERTEX_BUFFER);
     final List<String> vertexTempIds = new ArrayList<>(GRAPH_BATCH_VERTEX_BUFFER);
-    final AtomicReference<String> currentTypeRef = new AtomicReference<>();
+    final String[] currentType = { null };
     final long[] counts = new long[2]; // [0]=vertices, [1]=edges
-    final AtomicBoolean inEdgePhase = new AtomicBoolean(false);
+    final boolean[] inEdgePhase = { false };
 
     call.setOnCancelHandler(() -> cancelled.set(true));
     call.request(1);
@@ -1614,6 +1614,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           GraphBatch batch = batchRef.get();
           if (batch == null) {
             // First chunk: initialize
+            if (chunk.getDatabase().isEmpty())
+              throw new IllegalArgumentException("First chunk must contain the database name");
             final Database db = getDatabase(chunk.getDatabase(), chunk.getCredentials());
             dbRef.set(db);
             final GraphBatch.Builder builder = db.batch();
@@ -1626,29 +1628,29 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           for (final GraphBatchRecord rec : chunk.getRecordsList()) {
             if (rec.getKind() == GraphBatchRecord.Kind.EDGE) {
               // Flush remaining vertices on transition to edge phase
-              if (!inEdgePhase.get()) {
+              if (!inEdgePhase[0]) {
                 if (!vertexPropsBatch.isEmpty())
-                  counts[0] += flushVertexBatch(batch, currentTypeRef.get(), vertexPropsBatch, vertexTempIds, tempIdMap);
-                inEdgePhase.set(true);
+                  counts[0] += flushVertexBatch(batch, currentType[0], vertexPropsBatch, vertexTempIds, tempIdMap);
+                inEdgePhase[0] = true;
               }
               processEdge(batch, rec, tempIdMap);
               counts[1]++;
             } else {
-              if (inEdgePhase.get())
+              if (inEdgePhase[0])
                 throw new IllegalArgumentException("Vertex record received after edges. All vertices must appear before edges");
 
               // Type change -> flush
-              final String currentType = currentTypeRef.get();
-              if (currentType != null && !currentType.equals(rec.getTypeName()))
-                counts[0] += flushVertexBatch(batch, currentType, vertexPropsBatch, vertexTempIds, tempIdMap);
-              currentTypeRef.set(rec.getTypeName());
+              final String prevType = currentType[0];
+              if (prevType != null && !prevType.equals(rec.getTypeName()))
+                counts[0] += flushVertexBatch(batch, prevType, vertexPropsBatch, vertexTempIds, tempIdMap);
+              currentType[0] = rec.getTypeName();
 
               final Object[] props = rec.getPropertiesMap().isEmpty() ? new Object[0] : toPropertyArray(rec.getPropertiesMap());
               vertexPropsBatch.add(props);
               vertexTempIds.add(rec.getTempId().isEmpty() ? null : rec.getTempId());
 
               if (vertexPropsBatch.size() >= GRAPH_BATCH_VERTEX_BUFFER)
-                counts[0] += flushVertexBatch(batch, currentTypeRef.get(), vertexPropsBatch, vertexTempIds, tempIdMap);
+                counts[0] += flushVertexBatch(batch, currentType[0], vertexPropsBatch, vertexTempIds, tempIdMap);
             }
           }
         } catch (final Exception e) {
@@ -1678,7 +1680,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
           // Flush remaining vertices
           if (!vertexPropsBatch.isEmpty())
-            counts[0] += flushVertexBatch(batch, currentTypeRef.get(), vertexPropsBatch, vertexTempIds, tempIdMap);
+            counts[0] += flushVertexBatch(batch, currentType[0], vertexPropsBatch, vertexTempIds, tempIdMap);
 
           // Close batch -> flushes edges, connects incoming edges
           batch.close();
@@ -1714,6 +1716,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   }
 
   private RID resolveRef(final String ref, final Map<String, RID> tempIdMap) {
+    if (ref == null || ref.isEmpty())
+      throw new IllegalArgumentException("Edge record is missing from_ref or to_ref");
     if (ref.charAt(0) == '#') {
       final int colonIdx = ref.indexOf(':');
       if (colonIdx < 0)
@@ -1761,13 +1765,13 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       builder.withLightEdges(true);
     if (opts.getWal())
       builder.withWAL(true);
-    if (!opts.getParallelFlush())
+    if (opts.hasParallelFlush() && !opts.getParallelFlush())
       builder.withParallelFlush(false);
-    if (!opts.getPreAllocateEdgeChunks())
+    if (opts.hasPreAllocateEdgeChunks() && !opts.getPreAllocateEdgeChunks())
       builder.withPreAllocateEdgeChunks(false);
     if (opts.getEdgeListInitialSize() > 0)
       builder.withEdgeListInitialSize(opts.getEdgeListInitialSize());
-    if (!opts.getBidirectional())
+    if (opts.hasBidirectional() && !opts.getBidirectional())
       builder.withBidirectional(false);
     if (opts.getCommitEvery() > 0)
       builder.withCommitEvery(opts.getCommitEvery());

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcServerIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcServerIT.java
@@ -191,9 +191,6 @@ public class GrpcServerIT extends BaseGraphServerTest {
     return GrpcValue.newBuilder().setInt64Value(l).build();
   }
 
-  private GrpcValue sv(final String s) {
-    return stringValue(s);
-  }
 
   @Test
   void executeQuerySelectsExistingData() {
@@ -1007,7 +1004,7 @@ public class GrpcServerIT extends BaseGraphServerTest {
             .setKind(GraphBatchRecord.Kind.VERTEX)
             .setTypeName("BatchNode")
             .setTempId("n1")
-            .putProperties("name", sv("Node1")))
+            .putProperties("name", stringValue("Node1")))
         .addRecords(GraphBatchRecord.newBuilder()
             .setKind(GraphBatchRecord.Kind.EDGE)
             .setTypeName("BatchLink")
@@ -1049,12 +1046,12 @@ public class GrpcServerIT extends BaseGraphServerTest {
             .setKind(GraphBatchRecord.Kind.VERTEX)
             .setTypeName("BatchItem")
             .setTempId("i1")
-            .putProperties("name", sv("Item1")))
+            .putProperties("name", stringValue("Item1")))
         .addRecords(GraphBatchRecord.newBuilder()
             .setKind(GraphBatchRecord.Kind.VERTEX)
             .setTypeName("BatchItem")
             .setTempId("i2")
-            .putProperties("name", sv("Item2")))
+            .putProperties("name", stringValue("Item2")))
         .build());
 
     // Second chunk: edge then vertex (violates ordering constraint)
@@ -1069,7 +1066,7 @@ public class GrpcServerIT extends BaseGraphServerTest {
             .setKind(GraphBatchRecord.Kind.VERTEX)
             .setTypeName("BatchItem")
             .setTempId("i3")
-            .putProperties("name", sv("Item3")))
+            .putProperties("name", stringValue("Item3")))
         .build());
 
     requestObserver.onCompleted();
@@ -1078,6 +1075,8 @@ public class GrpcServerIT extends BaseGraphServerTest {
     assertThat(errorRef.get().getMessage()).contains("Vertex record received after edges");
   }
 
+  // This test sends only edges in the first chunk (no vertices in the batch).
+  // The batch is initialized with inEdgePhase=false; edge records immediately trigger the transition.
   @Test
   void graphBatchLoadWithDirectRidReferences() throws Exception {
     authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcServerIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcServerIT.java
@@ -191,6 +191,10 @@ public class GrpcServerIT extends BaseGraphServerTest {
     return GrpcValue.newBuilder().setInt64Value(l).build();
   }
 
+  private GrpcValue sv(final String s) {
+    return stringValue(s);
+  }
+
   @Test
   void executeQuerySelectsExistingData() {
     ExecuteQueryRequest request = ExecuteQueryRequest.newBuilder()
@@ -900,7 +904,7 @@ public class GrpcServerIT extends BaseGraphServerTest {
     assertThat(result).isNotNull();
     assertThat(result.getVerticesCreated()).isEqualTo(2);
     assertThat(result.getEdgesCreated()).isEqualTo(1);
-    assertThat(result.getElapsedMs()).isGreaterThan(0);
+    assertThat(result.getElapsedMs()).isGreaterThanOrEqualTo(0);
     assertThat(result.getIdMappingMap()).hasSize(2);
     assertThat(result.getIdMappingMap()).containsKeys("p1", "p2");
 
@@ -973,5 +977,162 @@ public class GrpcServerIT extends BaseGraphServerTest {
     assertThat(result).isNotNull();
     assertThat(result.getVerticesCreated()).isEqualTo(0);
     assertThat(result.getEdgesCreated()).isEqualTo(0);
+  }
+
+  @Test
+  void graphBatchLoadUnknownTempIdReturnsError() throws Exception {
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCommand("CREATE VERTEX TYPE BatchNode IF NOT EXISTS")
+        .build());
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCommand("CREATE EDGE TYPE BatchLink IF NOT EXISTS")
+        .build());
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+    final StreamObserver<GraphBatchChunk> requestObserver = asyncAuthenticatedStub.graphBatchLoad(
+        new StreamObserver<>() {
+          @Override public void onNext(final GraphBatchResult result) { }
+          @Override public void onError(final Throwable t) { errorRef.set(t); latch.countDown(); }
+          @Override public void onCompleted() { latch.countDown(); }
+        });
+
+    // Send a vertex, then an edge referencing a non-existent temp ID
+    requestObserver.onNext(GraphBatchChunk.newBuilder()
+        .setDatabase(getDatabaseName())
+        .addRecords(GraphBatchRecord.newBuilder()
+            .setKind(GraphBatchRecord.Kind.VERTEX)
+            .setTypeName("BatchNode")
+            .setTempId("n1")
+            .putProperties("name", sv("Node1")))
+        .addRecords(GraphBatchRecord.newBuilder()
+            .setKind(GraphBatchRecord.Kind.EDGE)
+            .setTypeName("BatchLink")
+            .setFromRef("n1")
+            .setToRef("n999"))  // non-existent temp ID
+        .build());
+
+    requestObserver.onCompleted();
+    assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
+    assertThat(errorRef.get()).isNotNull();
+    assertThat(errorRef.get().getMessage()).contains("Unknown temporary ID");
+  }
+
+  @Test
+  void graphBatchLoadVertexAfterEdgeReturnsError() throws Exception {
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCommand("CREATE VERTEX TYPE BatchItem IF NOT EXISTS")
+        .build());
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCommand("CREATE EDGE TYPE BatchRel IF NOT EXISTS")
+        .build());
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+    final StreamObserver<GraphBatchChunk> requestObserver = asyncAuthenticatedStub.graphBatchLoad(
+        new StreamObserver<>() {
+          @Override public void onNext(final GraphBatchResult result) { }
+          @Override public void onError(final Throwable t) { errorRef.set(t); latch.countDown(); }
+          @Override public void onCompleted() { latch.countDown(); }
+        });
+
+    // Send vertices, then edge, then another vertex (invalid)
+    requestObserver.onNext(GraphBatchChunk.newBuilder()
+        .setDatabase(getDatabaseName())
+        .addRecords(GraphBatchRecord.newBuilder()
+            .setKind(GraphBatchRecord.Kind.VERTEX)
+            .setTypeName("BatchItem")
+            .setTempId("i1")
+            .putProperties("name", sv("Item1")))
+        .addRecords(GraphBatchRecord.newBuilder()
+            .setKind(GraphBatchRecord.Kind.VERTEX)
+            .setTypeName("BatchItem")
+            .setTempId("i2")
+            .putProperties("name", sv("Item2")))
+        .build());
+
+    // Second chunk: edge then vertex (violates ordering constraint)
+    requestObserver.onNext(GraphBatchChunk.newBuilder()
+        .setDatabase(getDatabaseName())
+        .addRecords(GraphBatchRecord.newBuilder()
+            .setKind(GraphBatchRecord.Kind.EDGE)
+            .setTypeName("BatchRel")
+            .setFromRef("i1")
+            .setToRef("i2"))
+        .addRecords(GraphBatchRecord.newBuilder()
+            .setKind(GraphBatchRecord.Kind.VERTEX)
+            .setTypeName("BatchItem")
+            .setTempId("i3")
+            .putProperties("name", sv("Item3")))
+        .build());
+
+    requestObserver.onCompleted();
+    assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
+    assertThat(errorRef.get()).isNotNull();
+    assertThat(errorRef.get().getMessage()).contains("Vertex record received after edges");
+  }
+
+  @Test
+  void graphBatchLoadWithDirectRidReferences() throws Exception {
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCommand("CREATE VERTEX TYPE BatchDirect IF NOT EXISTS")
+        .build());
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCommand("CREATE EDGE TYPE BatchDirectEdge IF NOT EXISTS")
+        .build());
+
+    // Create two vertices via regular API to get real RIDs
+    final ExecuteCommandResponse v1Resp = authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCommand("CREATE VERTEX BatchDirect SET name = 'Existing1'")
+        .setReturnRows(true)
+        .build());
+    final ExecuteCommandResponse v2Resp = authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCommand("CREATE VERTEX BatchDirect SET name = 'Existing2'")
+        .setReturnRows(true)
+        .build());
+
+    final String rid1 = v1Resp.getRecords(0).getRid();
+    final String rid2 = v2Resp.getRecords(0).getRid();
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicReference<GraphBatchResult> resultRef = new AtomicReference<>();
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+    final StreamObserver<GraphBatchChunk> requestObserver = asyncAuthenticatedStub.graphBatchLoad(
+        new StreamObserver<>() {
+          @Override public void onNext(final GraphBatchResult result) { resultRef.set(result); }
+          @Override public void onError(final Throwable t) { errorRef.set(t); latch.countDown(); }
+          @Override public void onCompleted() { latch.countDown(); }
+        });
+
+    // Send only edges referencing existing RIDs (no vertices in batch)
+    requestObserver.onNext(GraphBatchChunk.newBuilder()
+        .setDatabase(getDatabaseName())
+        .addRecords(GraphBatchRecord.newBuilder()
+            .setKind(GraphBatchRecord.Kind.EDGE)
+            .setTypeName("BatchDirectEdge")
+            .setFromRef(rid1)
+            .setToRef(rid2))
+        .build());
+
+    requestObserver.onCompleted();
+    assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
+    assertThat(errorRef.get()).isNull();
+
+    final GraphBatchResult result = resultRef.get();
+    assertThat(result).isNotNull();
+    assertThat(result.getVerticesCreated()).isEqualTo(0);
+    assertThat(result.getEdgesCreated()).isEqualTo(1);
+    assertThat(result.getIdMappingMap()).isEmpty();
   }
 }

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcServerIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcServerIT.java
@@ -36,6 +36,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import io.grpc.stub.StreamObserver;
+
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -43,7 +45,9 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -64,6 +68,7 @@ public class GrpcServerIT extends BaseGraphServerTest {
   private ManagedChannel channel;
   private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub blockingStub;
   private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub authenticatedStub;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceStub asyncAuthenticatedStub;
 
   @Override
   public void setTestConfiguration() {
@@ -82,6 +87,7 @@ public class GrpcServerIT extends BaseGraphServerTest {
     // Create an authenticated channel using a client interceptor
     Channel authenticatedChannel = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
     authenticatedStub = ArcadeDbServiceGrpc.newBlockingStub(authenticatedChannel);
+    asyncAuthenticatedStub = ArcadeDbServiceGrpc.newStub(authenticatedChannel);
   }
 
   /**
@@ -831,5 +837,141 @@ public class GrpcServerIT extends BaseGraphServerTest {
     assertThatThrownBy(() -> tokenStub.executeQuery(request))
         .isInstanceOf(StatusRuntimeException.class)
         .hasMessageContaining("UNAUTHENTICATED");
+  }
+
+  // Graph batch load tests
+
+  @Test
+  void graphBatchLoadVerticesAndEdges() throws Exception {
+    // Create vertex and edge types
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCommand("CREATE VERTEX TYPE BatchPerson IF NOT EXISTS")
+        .build());
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCommand("CREATE EDGE TYPE BatchKnows IF NOT EXISTS")
+        .build());
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicReference<GraphBatchResult> resultRef = new AtomicReference<>();
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+    final StreamObserver<GraphBatchChunk> requestObserver = asyncAuthenticatedStub.graphBatchLoad(
+        new StreamObserver<>() {
+          @Override public void onNext(final GraphBatchResult result) { resultRef.set(result); }
+          @Override public void onError(final Throwable t) { errorRef.set(t); latch.countDown(); }
+          @Override public void onCompleted() { latch.countDown(); }
+        });
+
+    // Send vertices in first chunk
+    requestObserver.onNext(GraphBatchChunk.newBuilder()
+        .setDatabase(getDatabaseName())
+        .addRecords(GraphBatchRecord.newBuilder()
+            .setKind(GraphBatchRecord.Kind.VERTEX)
+            .setTypeName("BatchPerson")
+            .setTempId("p1")
+            .putProperties("name", stringValue("Alice"))
+            .putProperties("age", intValue(30)))
+        .addRecords(GraphBatchRecord.newBuilder()
+            .setKind(GraphBatchRecord.Kind.VERTEX)
+            .setTypeName("BatchPerson")
+            .setTempId("p2")
+            .putProperties("name", stringValue("Bob"))
+            .putProperties("age", intValue(25)))
+        .build());
+
+    // Send edges in second chunk
+    requestObserver.onNext(GraphBatchChunk.newBuilder()
+        .setDatabase(getDatabaseName())
+        .addRecords(GraphBatchRecord.newBuilder()
+            .setKind(GraphBatchRecord.Kind.EDGE)
+            .setTypeName("BatchKnows")
+            .setFromRef("p1")
+            .setToRef("p2")
+            .putProperties("since", intValue(2020)))
+        .build());
+
+    requestObserver.onCompleted();
+    assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
+    assertThat(errorRef.get()).isNull();
+
+    final GraphBatchResult result = resultRef.get();
+    assertThat(result).isNotNull();
+    assertThat(result.getVerticesCreated()).isEqualTo(2);
+    assertThat(result.getEdgesCreated()).isEqualTo(1);
+    assertThat(result.getElapsedMs()).isGreaterThan(0);
+    assertThat(result.getIdMappingMap()).hasSize(2);
+    assertThat(result.getIdMappingMap()).containsKeys("p1", "p2");
+
+    // Verify graph structure via query
+    final ExecuteQueryResponse queryResp = authenticatedStub.executeQuery(ExecuteQueryRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setQuery("SELECT FROM BatchPerson")
+        .build());
+    assertThat(queryResp.getResultsList().get(0).getRecordsList()).hasSize(2);
+  }
+
+  @Test
+  void graphBatchLoadVerticesOnly() throws Exception {
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCommand("CREATE VERTEX TYPE BatchCity IF NOT EXISTS")
+        .build());
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicReference<GraphBatchResult> resultRef = new AtomicReference<>();
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+    final StreamObserver<GraphBatchChunk> requestObserver = asyncAuthenticatedStub.graphBatchLoad(
+        new StreamObserver<>() {
+          @Override public void onNext(final GraphBatchResult result) { resultRef.set(result); }
+          @Override public void onError(final Throwable t) { errorRef.set(t); latch.countDown(); }
+          @Override public void onCompleted() { latch.countDown(); }
+        });
+
+    requestObserver.onNext(GraphBatchChunk.newBuilder()
+        .setDatabase(getDatabaseName())
+        .addRecords(GraphBatchRecord.newBuilder()
+            .setKind(GraphBatchRecord.Kind.VERTEX)
+            .setTypeName("BatchCity")
+            .setTempId("c1")
+            .putProperties("name", stringValue("Rome")))
+        .addRecords(GraphBatchRecord.newBuilder()
+            .setKind(GraphBatchRecord.Kind.VERTEX)
+            .setTypeName("BatchCity")
+            .setTempId("c2")
+            .putProperties("name", stringValue("Milan")))
+        .build());
+
+    requestObserver.onCompleted();
+    assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
+    assertThat(errorRef.get()).isNull();
+
+    final GraphBatchResult result = resultRef.get();
+    assertThat(result.getVerticesCreated()).isEqualTo(2);
+    assertThat(result.getEdgesCreated()).isEqualTo(0);
+    assertThat(result.getIdMappingMap()).hasSize(2);
+  }
+
+  @Test
+  void graphBatchLoadEmptyStream() throws Exception {
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicReference<GraphBatchResult> resultRef = new AtomicReference<>();
+
+    final StreamObserver<GraphBatchChunk> requestObserver = asyncAuthenticatedStub.graphBatchLoad(
+        new StreamObserver<>() {
+          @Override public void onNext(final GraphBatchResult result) { resultRef.set(result); }
+          @Override public void onError(final Throwable t) { latch.countDown(); }
+          @Override public void onCompleted() { latch.countDown(); }
+        });
+
+    requestObserver.onCompleted();
+    assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+
+    final GraphBatchResult result = resultRef.get();
+    assertThat(result).isNotNull();
+    assertThat(result.getVerticesCreated()).isEqualTo(0);
+    assertThat(result.getEdgesCreated()).isEqualTo(0);
   }
 }


### PR DESCRIPTION
## Summary

- Adds a new `GraphBatchLoad` client-streaming gRPC RPC that mirrors the HTTP `POST /api/v1/batch/{database}` endpoint (issue #3675)
- Introduces dedicated proto messages: `GraphBatchOptions`, `GraphBatchRecord`, `GraphBatchChunk`, `GraphBatchResult`
- Supports streaming vertices and edges with temporary ID mapping and all `GraphBatch` tuning parameters
- Includes 3 integration tests (vertex+edge, vertex-only, empty stream) — all 99 grpcw tests pass

## Test plan

- [x] Proto compiles and generates Java sources (`mvn generate-sources` in grpc module)
- [x] grpcw module compiles cleanly (`mvn clean compile`)
- [x] `graphBatchLoadVerticesAndEdges` — streams 2 vertices + 1 edge, verifies counts and ID mapping
- [x] `graphBatchLoadVerticesOnly` — streams 2 vertices only, verifies 0 edges
- [x] `graphBatchLoadEmptyStream` — immediately completes, verifies empty result
- [x] Full grpcw test suite passes (99 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)