### PR TITLE
Fix async vector index rebuild to preserve concurrent mutations

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -1012,6 +1012,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
   private void buildGraphFromScratchWithRetry(final GraphBuildCallback graphCallback) {
     // Snapshot the next vector ID so we know which delta entries were included in this build
     final int deltaSnapshotId = nextId.get();
+    // Snapshot mutation counter so we only subtract mutations present at build start (not concurrent ones)
+    final int mutationsAtBuildStart = mutationsSinceSerialize.get();
 
     // Always have a progress reporter: if caller didn't provide one, log throttled progress every ~5s
     final GraphBuildCallback effectiveGraphCallback;
@@ -1259,7 +1261,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
       if (filteredVectorIds.length == 0) {
         this.graphIndex = null;
-        this.graphState = GraphState.IMMUTABLE;
+        mutationsSinceSerialize.addAndGet(-mutationsAtBuildStart);
+        this.graphState = deltaVectors.isEmpty() ? GraphState.IMMUTABLE : GraphState.MUTABLE;
         LogManager.instance().log(this, Level.INFO, "No vectors to index, graph is null for index: " + indexName);
         return;
       }
@@ -1369,7 +1372,6 @@ public class LSMVectorIndex implements Index, IndexInternal {
       lock.writeLock().lock();
       try {
         this.graphIndex = builtGraph;
-        this.graphState = GraphState.IMMUTABLE;
         // Track graph rebuild metric
         metrics.incrementGraphRebuildCount();
         // Reset page tracking since we rebuilt from persisted pages
@@ -1381,6 +1383,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
           if (e.vectorId >= deltaSnapshotId)
             remaining.add(e);
         this.deltaVectors = remaining;
+
+        // Subtract only mutations present at build start, preserving concurrent ones
+        mutationsSinceSerialize.addAndGet(-mutationsAtBuildStart);
+
+        // Only transition to IMMUTABLE if no new mutations arrived during rebuild
+        this.graphState = remaining.isEmpty() ? GraphState.IMMUTABLE : GraphState.MUTABLE;
       } finally {
         lock.writeLock().unlock();
       }
@@ -1450,7 +1458,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
                 lock.writeLock().lock();
                 try {
                   this.graphIndex = diskGraph;
-                  this.graphState = GraphState.IMMUTABLE;
+                  if (deltaVectors.isEmpty())
+                    this.graphState = GraphState.IMMUTABLE;
                 } finally {
                   lock.writeLock().unlock();
                 }
@@ -1493,7 +1502,6 @@ public class LSMVectorIndex implements Index, IndexInternal {
       } else {
         LogManager.instance().log(this, Level.SEVERE, "PERSIST: graphFile is NULL, cannot persist graph for index: %s", indexName);
       }
-      this.mutationsSinceSerialize.set(0);
 
       LogManager.instance().log(this, Level.INFO, "Built graph for index: " + indexName);
 

--- a/engine/src/test/java/com/arcadedb/index/vector/Issue3683AsyncRebuildRetriggerTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/Issue3683AsyncRebuildRetriggerTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.schema.Type;
+import com.arcadedb.utility.Pair;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that async graph rebuild is re-triggered when embeddings are added during an ongoing build.
+ * <p>
+ * Issue: https://github.com/ArcadeData/arcadedb/issues/3683
+ * <p>
+ * Before the fix, adding vectors during an async rebuild would cause the mutation counter to be
+ * unconditionally reset to 0 and the graph state set to IMMUTABLE, preventing the next search
+ * from triggering a new rebuild for the vectors added during the build.
+ */
+class Issue3683AsyncRebuildRetriggerTest extends TestHelper {
+
+  private static final int EMBEDDING_DIM = 32;
+  private static final int LARGE_INDEX_VECTORS = 1100;
+
+  @Test
+  void asyncRebuildShouldBeRetriggeredForMutationsDuringBuild() throws InterruptedException {
+    final int threshold = 5;
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD, threshold);
+
+    // Create schema with vector index
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Embedding");
+      database.getSchema().getType("Embedding").createProperty("vector", Type.ARRAY_OF_FLOATS);
+
+      database.command("sql", """
+          CREATE INDEX ON Embedding (vector) LSM_VECTOR
+          METADATA {
+              "dimensions": %d,
+              "similarity": "EUCLIDEAN"
+          }""".formatted(EMBEDDING_DIM));
+    });
+
+    final Random random = new Random(42);
+
+    // Insert enough vectors for a "large" graph (>= 1000 to use async path)
+    database.transaction(() -> {
+      for (int i = 0; i < LARGE_INDEX_VECTORS; i++)
+        database.command("sql", "INSERT INTO Embedding SET vector = ?", (Object) generateRandomVector(random));
+    });
+
+    // First search to trigger initial synchronous graph build
+    final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("Embedding[vector]");
+    final LSMVectorIndex lsmIndex = (LSMVectorIndex) typeIndex.getIndexesOnBuckets()[0];
+    final float[] queryVector = generateRandomVector(random);
+    List<Pair<RID, Float>> results = lsmIndex.findNeighborsFromVector(queryVector, 10);
+    assertThat(results).isNotEmpty();
+
+    // After initial build, mutation counter should be 0
+    Map<String, Long> stats = lsmIndex.getStats();
+    assertThat(stats.get("mutationsSinceRebuild")).isEqualTo(0L);
+
+    // Add enough vectors to exceed the threshold and trigger async rebuild
+    database.transaction(() -> {
+      for (int i = 0; i < threshold; i++)
+        database.command("sql", "INSERT INTO Embedding SET vector = ?", (Object) generateRandomVector(random));
+    });
+
+    // Trigger async rebuild via search
+    results = lsmIndex.findNeighborsFromVector(queryVector, 10);
+    assertThat(results).isNotEmpty();
+
+    // Give async rebuild a moment to start
+    Thread.sleep(200);
+
+    // Add more vectors DURING the async rebuild (above threshold count)
+    final int vectorsDuringBuild = threshold + 5;
+    database.transaction(() -> {
+      for (int i = 0; i < vectorsDuringBuild; i++)
+        database.command("sql", "INSERT INTO Embedding SET vector = ?", (Object) generateRandomVector(random));
+    });
+
+    // Wait for async rebuild to complete
+    Thread.sleep(10000);
+
+    // After async rebuild completes, the mutations added DURING the build should be preserved
+    stats = lsmIndex.getStats();
+    final long mutationsAfterRebuild = stats.get("mutationsSinceRebuild");
+    assertThat(mutationsAfterRebuild)
+        .as("Mutations added during async rebuild should be preserved in the counter")
+        .isGreaterThan(0L);
+
+    // Graph state should be MUTABLE since there are remaining delta vectors
+    assertThat(stats.get("graphState"))
+        .as("Graph state should be MUTABLE (2) when mutations exist after rebuild")
+        .isEqualTo(2L); // GraphState.MUTABLE ordinal
+
+    // Trigger another search - should start a new async rebuild since mutations >= threshold
+    if (mutationsAfterRebuild >= threshold) {
+      results = lsmIndex.findNeighborsFromVector(queryVector, 10);
+      assertThat(results).isNotEmpty();
+
+      // Wait for second async rebuild to complete
+      Thread.sleep(10000);
+
+      // After second rebuild (with no concurrent inserts), counter should be 0
+      stats = lsmIndex.getStats();
+      assertThat(stats.get("mutationsSinceRebuild"))
+          .as("After second rebuild with no concurrent inserts, counter should be 0")
+          .isEqualTo(0L);
+      assertThat(stats.get("graphState"))
+          .as("Graph state should be IMMUTABLE (1) after clean rebuild")
+          .isEqualTo(1L); // GraphState.IMMUTABLE ordinal
+    }
+  }
+
+  private float[] generateRandomVector(final Random random) {
+    final float[] vector = new float[EMBEDDING_DIM];
+    float norm = 0;
+    for (int i = 0; i < EMBEDDING_DIM; i++) {
+      vector[i] = random.nextFloat() * 2 - 1;
+      norm += vector[i] * vector[i];
+    }
+    norm = (float) Math.sqrt(norm);
+    if (norm > 0)
+      for (int i = 0; i < EMBEDDING_DIM; i++)
+        vector[i] /= norm;
+    return vector;
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes issue #3683 where async vector index rebuilds would unconditionally reset the mutation counter to 0 and set the graph state to IMMUTABLE, even when new vectors were added during the rebuild. This prevented subsequent searches from triggering a new rebuild for those concurrent mutations.

The fix:
1. Snapshots the mutation counter at the start of each rebuild to track only mutations present at build initiation
2. Subtracts only the snapshotted mutations from the counter after rebuild completes, preserving any mutations that arrived concurrently
3. Sets graph state to MUTABLE (instead of always IMMUTABLE) when delta vectors remain after rebuild
4. Removes the unconditional `mutationsSinceSerialize.set(0)` call that was losing concurrent mutation tracking

## Motivation

When vectors are inserted during an async rebuild, the rebuild process was losing track of these concurrent mutations. After the rebuild completed, the mutation counter would be reset to 0 and the graph marked as IMMUTABLE, causing the index to ignore the newly added vectors until enough additional mutations accumulated to trigger another rebuild. This could lead to stale search results.

## Related issues

- Fixes #3683: Async graph rebuild should be re-triggered when embeddings are added during an ongoing build

## Additional Notes

The fix ensures that:
- Mutations present at rebuild start are properly accounted for and subtracted from the counter
- Mutations arriving during rebuild are preserved in the counter
- Graph state correctly reflects whether delta vectors exist (MUTABLE) or not (IMMUTABLE)
- The next search will trigger a new rebuild if the preserved mutations exceed the threshold

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
  - Added `Issue3683AsyncRebuildRetriggerTest` which verifies:
    - Initial synchronous build works correctly
    - Async rebuild is triggered when mutations exceed threshold
    - Mutations added during async rebuild are preserved
    - Graph state is MUTABLE when delta vectors exist
    - Subsequent search triggers another rebuild for preserved mutations
    - Final rebuild completes with counter at 0 and IMMUTABLE state

https://claude.ai/code/session_01Ue8363XvhDLpWGmF6rJGbk