### PR TITLE
fix: revert Groovy 5.0.4 to 4.0.28 — GremlinServerPlugin fails to start

### DIFF
--- a/gremlin/pom.xml
+++ b/gremlin/pom.xml
@@ -41,7 +41,7 @@
         <commons-configuration2.version>2.13.0</commons-configuration2.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
-        <groovy.version>5.0.4</groovy.version>
+        <groovy.version>4.0.28</groovy.version>
         <antlr4.version>4.9.1</antlr4.version>
     </properties>
 

--- a/gremlin/src/test/java/com/arcadedb/gremlin/GremlinGroovyEngineTest.java
+++ b/gremlin/src/test/java/com/arcadedb/gremlin/GremlinGroovyEngineTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.gremlin;
+
+import org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinGroovyScriptEngine;
+import org.apache.tinkerpop.gremlin.jsr223.CoreGremlinPlugin;
+import org.apache.tinkerpop.gremlin.jsr223.Customizer;
+import org.junit.jupiter.api.Test;
+
+import javax.script.ScriptException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the Gremlin Groovy script engine initialises correctly with the TinkerPop
+ * core imports.  With Groovy 5 (incompatible with TinkerPop 3.8.x) this fails with
+ * "The name valueOf is already declared" because {@code ImportGroovyCustomizer} adds a
+ * wildcard static import ({@code import static Enum.*}) for every enum in
+ * {@link org.apache.tinkerpop.gremlin.jsr223.CoreImports}, and Groovy 5 rejects duplicate
+ * {@code valueOf} symbols introduced by multiple such imports.
+ *
+ * <p>Regression test for <a href="https://github.com/ArcadeData/arcadedb/issues/3724">#3724</a>.
+ */
+class GremlinGroovyEngineTest {
+
+  @Test
+  void groovyEngineInitializesWithCoreImports() throws ScriptException {
+    final Customizer[] customizers = CoreGremlinPlugin.instance()
+        .getCustomizers("gremlin-groovy")
+        .orElse(new Customizer[0]);
+
+    final GremlinGroovyScriptEngine engine = new GremlinGroovyScriptEngine(customizers);
+
+    // A successful eval proves the engine started without "valueOf is already declared"
+    assertThat(engine.eval("1 + 1")).isEqualTo(2);
+  }
+}


### PR DESCRIPTION
## Summary

- Reverts `groovy.version` in `gremlin/pom.xml` from `5.0.4` back to `4.0.28`
- Dependabot's major-version bump (commit `63b536a41`) is incompatible with TinkerPop 3.8.0, which targets Groovy 4.x (`<groovy.version>4.0.25</groovy.version>` in its parent POM)
- Groovy 5 rejects the multiple wildcard static enum imports (`import static SomeEnum.*`) added by TinkerPop's `ImportGroovyCustomizer`, because all enums share a `valueOf(String)` method — causing `"The name valueOf is already declared"`
- Adds regression test `GremlinGroovyEngineTest` that exercises the exact initialization path

Closes #3724

## Test plan

- [x] New `GremlinGroovyEngineTest.groovyEngineInitializesWithCoreImports` passes
- [x] `GremlinGAVTest` (8 tests) passes
- [x] `SQLFromGremlinTest` passes
- [x] Pre-existing failures in `CypherQueryEngineTest`, `CypherTest`, `GremlinTest.gremlinFromDatabase` confirmed unrelated (fail on `main` before this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)