### PR TITLE
#3761 fix: Cypher WITH *, extra AS alias dropped extra items

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/WithStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/WithStep.java
@@ -227,29 +227,21 @@ public class WithStep extends AbstractExecutionStep {
 
   /**
    * Projects a result according to the WITH clause items.
+   * Handles WITH *, WITH *, extra AS alias, and WITH expr AS alias.
    */
   private ResultInternal projectResult(final Result inputResult) {
     final ResultInternal result = new ResultInternal();
 
-    // WITH * - copy all properties
-    if (withClause.getItems().size() == 1) {
-      final ReturnClause.ReturnItem item = withClause.getItems().get(0);
-      if ("*".equals(item.getOutputName())) {
-        for (final String prop : inputResult.getPropertyNames()) {
-          result.setProperty(prop, inputResult.getProperty(prop));
-        }
-        return result;
-      }
-    }
-
-    // Project specified items
     for (final ReturnClause.ReturnItem item : withClause.getItems()) {
-      final Expression expr = item.getExpression();
-      final String outputName = item.getOutputName();
-
-      // Evaluate expression
-      final Object value = evaluator.evaluate(expr, inputResult, context);
-      result.setProperty(outputName, value);
+      if ("*".equals(item.getOutputName())) {
+        // WITH * — copy all properties from input
+        for (final String prop : inputResult.getPropertyNames())
+          result.setProperty(prop, inputResult.getProperty(prop));
+      } else {
+        // Evaluate and project the expression
+        final Object value = evaluator.evaluate(item.getExpression(), inputResult, context);
+        result.setProperty(item.getOutputName(), value);
+      }
     }
 
     return result;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherASTBuilder.java
@@ -604,21 +604,20 @@ public class CypherASTBuilder extends Cypher25ParserBaseVisitor<Object> {
 
     // Parse return items
     final List<ReturnClause.ReturnItem> items = new ArrayList<>();
-    if (body.returnItems().TIMES() != null) {
-      // WITH *
+    if (body.returnItems().TIMES() != null)
+      // WITH * — pass all variables through
       items.add(new ReturnClause.ReturnItem(new VariableExpression("*"), "*"));
-    } else {
-      for (final Cypher25Parser.ReturnItemContext itemCtx : body.returnItems().returnItem()) {
-        // Pattern expressions (e.g., (n)-[]->()) are not allowed in WITH projections
-        if (findPatternExpressionRecursive(itemCtx.expression()) != null)
-          throw new CommandParsingException("UnexpectedSyntax: Pattern expressions are not allowed in WITH projections");
-        final Expression expr = expressionBuilder.parseExpression(itemCtx.expression());
-        final String alias = itemCtx.variable() != null ? stripBackticks(itemCtx.variable().getText()) : null;
-        final ReturnClause.ReturnItem item = new ReturnClause.ReturnItem(expr, alias);
-        if (alias == null)
-          item.setOriginalText(getOriginalText(itemCtx.expression()));
-        items.add(item);
-      }
+    // Always process explicit return items (handles both "WITH expr" and "WITH *, expr AS alias")
+    for (final Cypher25Parser.ReturnItemContext itemCtx : body.returnItems().returnItem()) {
+      // Pattern expressions (e.g., (n)-[]->()) are not allowed in WITH projections
+      if (findPatternExpressionRecursive(itemCtx.expression()) != null)
+        throw new CommandParsingException("UnexpectedSyntax: Pattern expressions are not allowed in WITH projections");
+      final Expression expr = expressionBuilder.parseExpression(itemCtx.expression());
+      final String alias = itemCtx.variable() != null ? stripBackticks(itemCtx.variable().getText()) : null;
+      final ReturnClause.ReturnItem item = new ReturnClause.ReturnItem(expr, alias);
+      if (alias == null)
+        item.setOriginalText(getOriginalText(itemCtx.expression()));
+      items.add(item);
     }
 
     // Parse DISTINCT flag

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
@@ -383,7 +383,17 @@ public class CypherSemanticValidator {
             }
           }
           if (hasWildcard) {
-            // WITH * keeps all variables in scope — don't validate or reset
+            // WITH * keeps all variables in scope; also validate and register any extra aliases
+            for (final ReturnClause.ReturnItem item : withClause.getItems()) {
+              if (item.getExpression() instanceof StarExpression ||
+                  (item.getExpression() instanceof VariableExpression &&
+                      "*".equals(((VariableExpression) item.getExpression()).getVariableName())))
+                continue;
+              checkExpressionScope(item.getExpression(), scope);
+              final String alias = item.getAlias();
+              if (alias != null)
+                scope.add(alias);
+            }
             break;
           }
           // First validate that all referenced variables in WITH are in scope

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
@@ -383,13 +383,18 @@ public class CypherSemanticValidator {
             }
           }
           if (hasWildcard) {
-            // WITH * keeps all variables in scope; also validate and register any extra aliases
+            // WITH * keeps all variables in scope.
+            // First validate all extra item expressions against the incoming scope (no scope
+            // mutation during validation — aliases must not be visible to sibling expressions).
             for (final ReturnClause.ReturnItem item : withClause.getItems()) {
               if (item.getExpression() instanceof StarExpression ||
                   (item.getExpression() instanceof VariableExpression &&
                       "*".equals(((VariableExpression) item.getExpression()).getVariableName())))
                 continue;
               checkExpressionScope(item.getExpression(), scope);
+            }
+            // Then add extra aliases to scope for subsequent clauses
+            for (final ReturnClause.ReturnItem item : withClause.getItems()) {
               final String alias = item.getAlias();
               if (alias != null)
                 scope.add(alias);

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue3761Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue3761Test.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for https://github.com/ArcadeData/arcadedb/issues/3761
+ * Cypher: unable to parse query when using WITH *
+ * <p>
+ * Root cause: CypherASTBuilder.visitWithClause used an if/else pattern, so when
+ * TIMES (*) was present, additional return items (e.g. "t2 AS out2") were silently
+ * dropped. The RETURN clause then referenced an undefined alias, causing a parse error.
+ */
+class Issue3761Test {
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    database = new DatabaseFactory("./target/databases/testopencypher-issue3761").create();
+
+    database.getSchema().createVertexType("Thing1");
+    database.getSchema().createVertexType("Thing2");
+    database.getSchema().createEdgeType("basedOn");
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Thing1 {id: 'A'})");
+      database.command("opencypher", "CREATE (:Thing2 {name: 'B'})");
+      database.command("opencypher",
+          "MATCH (t1:Thing1 {id: 'A'}), (t2:Thing2 {name: 'B'}) CREATE (t1)-[:basedOn]->(t2)");
+    });
+  }
+
+  @AfterEach
+  void cleanup() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  /**
+   * Exact query from the issue: OPTIONAL MATCH followed by WITH *, alias.
+   * Previously threw "Error parsing OpenCypher query" due to undefined alias.
+   */
+  @Test
+  void withStarAndAliasAfterOptionalMatch() {
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("opencypher", """
+          MATCH (t1:Thing1 {id: 'A'})
+          OPTIONAL MATCH (t1)-[:basedOn]->(t2:Thing2)
+          WITH *, t2 AS out2
+          RETURN t1 AS out1, out2
+          """)) {
+        final List<Result> results = new ArrayList<>();
+        while (rs.hasNext())
+          results.add(rs.next());
+
+        assertThat(results).hasSize(1);
+        final Result row = results.get(0);
+        assertThat(row.getPropertyNames()).contains("out1", "out2");
+        assertThat((Object) row.getProperty("out1")).isNotNull();
+        assertThat((Object) row.getProperty("out2")).isNotNull();
+      }
+    });
+  }
+
+  /**
+   * WITH * alone (without extra items) should still pass all variables through.
+   */
+  @Test
+  void withStarAlonePassesAllVariables() {
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("opencypher", """
+          MATCH (t1:Thing1 {id: 'A'})
+          OPTIONAL MATCH (t1)-[:basedOn]->(t2:Thing2)
+          WITH *
+          RETURN t1, t2
+          """)) {
+        final List<Result> results = new ArrayList<>();
+        while (rs.hasNext())
+          results.add(rs.next());
+
+        assertThat(results).hasSize(1);
+        final Result row = results.get(0);
+        assertThat(row.getPropertyNames()).contains("t1", "t2");
+      }
+    });
+  }
+
+  /**
+   * WITH *, computed expression as alias — the expression should be evaluated.
+   */
+  @Test
+  void withStarAndComputedAlias() {
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("opencypher", """
+          MATCH (t1:Thing1 {id: 'A'})
+          WITH *, t1.id AS itemId
+          RETURN t1, itemId
+          """)) {
+        final List<Result> results = new ArrayList<>();
+        while (rs.hasNext())
+          results.add(rs.next());
+
+        assertThat(results).hasSize(1);
+        final Result row = results.get(0);
+        assertThat(row.getPropertyNames()).contains("t1", "itemId");
+        assertThat(row.<String>getProperty("itemId")).isEqualTo("A");
+      }
+    });
+  }
+
+  /**
+   * WITH *, expr1 AS a, expr2 AS b — multiple extra items after the wildcard.
+   */
+  @Test
+  void withStarAndMultipleExtraAliases() {
+    database.transaction(() -> {
+      try (final ResultSet rs = database.query("opencypher", """
+          MATCH (t1:Thing1 {id: 'A'})
+          OPTIONAL MATCH (t1)-[:basedOn]->(t2:Thing2)
+          WITH *, t1.id AS srcId, t2.name AS tgtName
+          RETURN srcId, tgtName
+          """)) {
+        final List<Result> results = new ArrayList<>();
+        while (rs.hasNext())
+          results.add(rs.next());
+
+        assertThat(results).hasSize(1);
+        final Result row = results.get(0);
+        assertThat(row.<String>getProperty("srcId")).isEqualTo("A");
+        assertThat(row.<String>getProperty("tgtName")).isEqualTo("B");
+      }
+    });
+  }
+
+  /**
+   * WITH *, alias used in WHERE clause filtering.
+   */
+  @Test
+  void withStarAndAliasInWhereClause() {
+    database.transaction(() -> {
+      // Add a second Thing1 node that should be filtered out
+      database.command("opencypher", "CREATE (:Thing1 {id: 'X'})");
+
+      try (final ResultSet rs = database.query("opencypher", """
+          MATCH (t1:Thing1)
+          WITH *, t1.id AS tid
+          WHERE tid = 'A'
+          RETURN t1, tid
+          """)) {
+        final List<Result> results = new ArrayList<>();
+        while (rs.hasNext())
+          results.add(rs.next());
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).<String>getProperty("tid")).isEqualTo("A");
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #3761 — `WITH *, expr AS alias` threw "Error parsing OpenCypher query" because the alias was silently dropped during AST construction.

**Root causes (three locations):**

- `CypherASTBuilder.visitWithClause`: used `if/else` — when `TIMES (*)` was present, the `returnItem()` loop was skipped, so `WITH *, t2 AS out2` produced items `[*]` only.
- `WithStep.projectResult`: checked `items.size() == 1 && name == "*"` and returned early, so a mixed list never evaluated the non-wildcard items.
- `CypherSemanticValidator`: when `hasWildcard` was true, broke out immediately without registering extra aliases in scope — causing the "undefined variable" error on the RETURN clause.

**Fixes:**

- `CypherASTBuilder`: changed `if/else` to `if` + unconditional loop so both the wildcard and any explicit items are always appended.
- `WithStep.projectResult`: unified loop — `*` copies all input properties, explicit items evaluate the expression.
- `CypherSemanticValidator`: when wildcard is present, still validate and register extra aliases in scope.

## Test plan

- [ ] New `Issue3761Test` (5 cases): exact issue query, `WITH *` alone, computed alias, multiple aliases, alias in WHERE
- [ ] `WithAndUnwindTest`, `OpenCypherOptionalMatchTest`, `OpenCypherExecutionTest`, `OpenCypherBasicTest`, `CypherTest`, `Issue3758Test` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)