### PR TITLE
fix: backup concurrency race on Linux - flush thread ignored isSuspended

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -141,7 +141,7 @@ public class PageManager extends LockContext {
   public void suspendFlushAndExecute(final Database database, final CallableNoReturn callback)
       throws IOException, InterruptedException {
     if (flushThread.setSuspended(database, true)) {
-      flushThread.flushPagesFromQueueToDisk(database, 0L);
+      flushThread.waitForCurrentFlushToComplete(database);
       try {
         CodeUtils.executeIgnoringExceptions(callback, "Error during suspend flush", true);
       } finally {

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -199,7 +199,8 @@ public class PageManagerFlushThread extends Thread {
   }
 
   public void waitForCurrentFlushToComplete(final Database database) throws InterruptedException {
-    while (nextPagesToFlush.get() != null && database.equals(nextPagesToFlush.get().database))
+    PagesToFlush current;
+    while ((current = nextPagesToFlush.get()) != null && database.equals(current.database))
       Thread.sleep(1);
   }
 
@@ -219,6 +220,9 @@ public class PageManagerFlushThread extends Thread {
               break;
             try {
               pageManager.flushPage(page);
+            } catch (final DatabaseMetadataException e) {
+              // FILE DELETED, CONTINUE WITH THE NEXT PAGES
+              LogManager.instance().log(this, Level.WARNING, "Error on flushing deferred page '%s' to disk", e, page);
             } catch (final IOException e) {
               LogManager.instance().log(this, Level.WARNING, "Error on flushing deferred page '%s' to disk", e, page);
             } finally {
@@ -232,15 +236,24 @@ public class PageManagerFlushThread extends Thread {
     // Phase 2: mark the database as no longer suspended
     suspended.remove(database);
 
-    // Phase 3: drain any batches that were deferred during Phase 1 back into the main queue
+    // Phase 3: drain any batches that were deferred during Phase 1 back into the main queue.
+    // These batches were committed while Phase 1 was running; enqueue them so the background
+    // thread picks them up. Note: they are appended to the tail of the queue, so if any
+    // post-unsuspend commits have already been enqueued they will be flushed first. WAL-based
+    // recovery guarantees correctness even if the flush order differs from commit order.
     final ConcurrentLinkedQueue<PagesToFlush> newDeferred = deferredByDatabase.remove(database);
     if (newDeferred != null) {
       for (final PagesToFlush batch : newDeferred) {
-        try {
-          queue.offer(batch, 1, TimeUnit.SECONDS);
-        } catch (final InterruptedException e) {
-          Thread.currentThread().interrupt();
-          break;
+        while (running) {
+          try {
+            if (queue.offer(batch, 1, TimeUnit.SECONDS))
+              break;
+            LogManager.instance().log(this, Level.WARNING,
+                "Page flush queue is full while re-enqueueing deferred batch for database '%s'; retrying", database.getName());
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            break;
+          }
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -40,13 +40,14 @@ import java.util.logging.*;
  * a major bottleneck under high-throughput ingestion.
  */
 public class PageManagerFlushThread extends Thread {
-  private final        PageManager                          pageManager;
-  public final         ArrayBlockingQueue<PagesToFlush>     queue;
-  private final        String                               logContext;
-  private volatile     boolean                              running          = true;
-  private final        ConcurrentHashMap<Database, Boolean> suspended        = new ConcurrentHashMap<>(); // USED DURING BACKUP
-  private final static PagesToFlush                         SHUTDOWN_THREAD  = new PagesToFlush(null);
-  private final        AtomicReference<PagesToFlush>        nextPagesToFlush = new AtomicReference<>();
+  private final        PageManager                                              pageManager;
+  public final         ArrayBlockingQueue<PagesToFlush>                         queue;
+  private final        String                                                   logContext;
+  private volatile     boolean                                                  running             = true;
+  private final        ConcurrentHashMap<Database, Boolean>                     suspended           = new ConcurrentHashMap<>(); // USED DURING BACKUP
+  private final static PagesToFlush                                             SHUTDOWN_THREAD     = new PagesToFlush(null);
+  private final        AtomicReference<PagesToFlush>                            nextPagesToFlush    = new AtomicReference<>();
+  private final        ConcurrentHashMap<Database, ConcurrentLinkedQueue<PagesToFlush>> deferredByDatabase = new ConcurrentHashMap<>();
 
   /** O(1) index: pageId → most recent MutablePage in the flush queue or currently being flushed. */
   private final        ConcurrentHashMap<PageId, MutablePage> pageIndex = new ConcurrentHashMap<>();
@@ -155,6 +156,11 @@ public class PageManagerFlushThread extends Thread {
           running = false;
         else if (!pagesToFlush.pages.isEmpty()) {
           if (database == null || pagesToFlush.database.equals(database)) {
+            if (database == null && isSuspended((Database) pagesToFlush.database)) {
+              deferredByDatabase.computeIfAbsent((Database) pagesToFlush.database, k -> new ConcurrentLinkedQueue<>()).offer(pagesToFlush);
+              return;
+            }
+
             if (!pagesToFlush.database.isOpen())
               return;
 
@@ -192,10 +198,53 @@ public class PageManagerFlushThread extends Thread {
     }
   }
 
+  public void waitForCurrentFlushToComplete(final Database database) throws InterruptedException {
+    while (nextPagesToFlush.get() != null && database.equals(nextPagesToFlush.get().database))
+      Thread.sleep(1);
+  }
+
   public boolean setSuspended(final Database database, final boolean value) {
     if (value)
       return suspended.putIfAbsent(database, true) == null;
+
+    // Phase 1: synchronously flush all deferred batches accumulated while suspended
+    final ConcurrentLinkedQueue<PagesToFlush> deferred = deferredByDatabase.remove(database);
+    if (deferred != null) {
+      for (final PagesToFlush batch : deferred) {
+        if (!batch.database.isOpen())
+          continue;
+        synchronized (batch.pages) {
+          for (final MutablePage page : batch.pages) {
+            if (!batch.database.isOpen())
+              break;
+            try {
+              pageManager.flushPage(page);
+            } catch (final IOException e) {
+              LogManager.instance().log(this, Level.WARNING, "Error on flushing deferred page '%s' to disk", e, page);
+            } finally {
+              pageIndex.remove(page.getPageId(), page);
+            }
+          }
+        }
+      }
+    }
+
+    // Phase 2: mark the database as no longer suspended
     suspended.remove(database);
+
+    // Phase 3: drain any batches that were deferred during Phase 1 back into the main queue
+    final ConcurrentLinkedQueue<PagesToFlush> newDeferred = deferredByDatabase.remove(database);
+    if (newDeferred != null) {
+      for (final PagesToFlush batch : newDeferred) {
+        try {
+          queue.offer(batch, 1, TimeUnit.SECONDS);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+          break;
+        }
+      }
+    }
+
     return true;
   }
 

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcIT.java
@@ -577,7 +577,7 @@ public class PostgresWJdbcIT extends BaseGraphServerTest {
             """);
       }
       try (var st = conn.createStatement()) {
-        try (var rs = st.executeQuery("SELECT * FROM article")) {
+        try (var rs = st.executeQuery("SELECT * FROM article ORDER BY id")) {
           assertThat(rs.next()).isTrue();
           assertThat(rs.getString("title")).isEqualTo("My first article");
           //comments is an array of embedded docs on first row


### PR DESCRIPTION
## Summary

- `PageManagerFlushThread` never checked `isSuspended()` in its run loop, so the background thread kept writing pages to database files via `FileChannel.write()` while the backup's `FileInputStream.transferTo()` was reading those same files
- On Linux's CFS scheduler this race caused `FullBackupIT.fullBackupConcurrency` to fail with `count % 500 != 0` (partial transaction in backup)
- Added deferred-flush queue per database: when the background thread polls a batch for a suspended database it defers it instead of flushing
- `setSuspended(false)` now synchronously flushes deferred batches (preserving commit order), then re-enables normal async flushing
- Replaced the broken one-shot `flushPagesFromQueueToDisk(database, 0L)` pre-backup call with `waitForCurrentFlushToComplete(database)` to properly wait out any in-progress write

## Test plan

- [x] `FullBackupIT#fullBackupConcurrency` passes (was failing on Linux CI)
- [x] Full `FullBackupIT` suite (6 tests) passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)