### PR TITLE
fix: #3722 - Optimize LSM Vector Index fallback scan to target specific bucket instead of entire type 

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -1136,21 +1136,21 @@ public class LSMVectorIndex implements Index, IndexInternal {
     // If pages have corrupted entries (e.g., old-format tombstones), the parser may miss many vectors.
     // In that case, fall back to scanning documents directly to rebuild the vector list.
     boolean documentScanPerformed = false;
-    final String typeName = getTypeName();
-    if (typeName != null && !ridToLatestVector.isEmpty()) {
+    if (metadata.associatedBucketId != -1 && !ridToLatestVector.isEmpty()) {
       try {
-        final long docCount = database.countType(typeName, false);
+        final com.arcadedb.engine.Bucket bucket = database.getSchema().getBucketById(metadata.associatedBucketId);
+        final long docCount = database.countBucket(bucket.getName());
         if (ridToLatestVector.size() < docCount * 8 / 10) {
           LogManager.instance().log(this, Level.WARNING,
               "Page-parsed vectors (%d) significantly less than document count (%d) for index %s. "
                   + "Falling back to document scan to recover missing vectors.",
               ridToLatestVector.size(), docCount, indexName);
 
-          // Scan all documents to find vectors missing from the page-parsed set
+          // Scan all documents in the bucket to find vectors missing from the page-parsed set
           final String vectorProp =
               metadata.propertyNames != null && !metadata.propertyNames.isEmpty() ? metadata.propertyNames.getFirst() :
                   "vector";
-          database.scanType(typeName, false, record -> {
+          database.scanBucket(bucket.getName(), record -> {
             final Document doc = (Document) record;
             final RID rid = doc.getIdentity();
             if (!ridToLatestVector.containsKey(rid)) {


### PR DESCRIPTION
 ## Fix: Scoped vector index fallback scan to specific bucket (#3722)

## Description

This PR fixes an issue in `LSMVectorIndex` where the fallback mechanism for recovering missing vectors would incorrectly scan all documents of a given type rather than restricting the scan to the specific bucket associated with the index.

Previously, when the number of page-parsed vectors fell significantly short of the document count, the fallback relied on `database.countType()` and `database.scanType()`. If a type contained multiple buckets, this resulted in inaccurate counts and unnecessary scanning of documents outside the index's scope.

The implementation now correctly leverages `metadata.associatedBucketId` to retrieve the target bucket, replacing type-wide operations with `database.countBucket()` and `database.scanBucket()`.

## Changes Made
   * Replaced `getTypeName()` usage with `metadata.associatedBucketId` to resolve the specific target bucket.
   * Updated document counting logic to use `database.countBucket(bucket.getName())` instead of `database.countType()`.
   * Updated the fallback document scan to use `database.scanBucket(bucket.getName(), ...)` to ensure only documents within the indexed bucket are scanned for missing vectors.

## Related Issues
   * Fixes #3722

by Gemini