### PR TITLE
#3858 fix: OpenCypher aggregation with CASE returns multiple rows

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
@@ -242,10 +242,11 @@ class CypherExpressionBuilder {
    * This is a helper for parsing lower-level expression contexts.
    */
   Expression parseExpressionFromText(final ParseTree node) {
-    // Check for CASE expressions in the parse tree.
-    // Guard: only match when the CASE context covers (almost) the full node text so that
-    // sum(CASE WHEN ... END) is not mis-parsed as just the inner CaseExpression.
+    // All recursive searches below use a length guard: only match when the found
+    // context covers (almost) the full node text, preventing mis-parsing of
+    // func(CASE ...) as just the inner CASE.  The - 2 allows for whitespace.
     final String nodeText = node.getText();
+
     final Cypher25Parser.CaseExpressionContext caseCtx = findCaseExpressionRecursive(node);
     if (caseCtx != null && caseCtx.getText().length() >= nodeText.length() - 2)
       return parseCaseExpression(caseCtx);
@@ -256,7 +257,7 @@ class CypherExpressionBuilder {
 
     // Check for EXISTS expressions
     final Cypher25Parser.ExistsExpressionContext existsCtx = findExistsExpressionRecursive(node);
-    if (existsCtx != null)
+    if (existsCtx != null && existsCtx.getText().length() >= nodeText.length() - 2)
       return parseExistsExpression(existsCtx);
 
     // Check for logical expressions (AND, OR, XOR, NOT) in the parse tree

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherExpressionBuilder.java
@@ -242,13 +242,16 @@ class CypherExpressionBuilder {
    * This is a helper for parsing lower-level expression contexts.
    */
   Expression parseExpressionFromText(final ParseTree node) {
-    // Check for CASE expressions in the parse tree
+    // Check for CASE expressions in the parse tree.
+    // Guard: only match when the CASE context covers (almost) the full node text so that
+    // sum(CASE WHEN ... END) is not mis-parsed as just the inner CaseExpression.
+    final String nodeText = node.getText();
     final Cypher25Parser.CaseExpressionContext caseCtx = findCaseExpressionRecursive(node);
-    if (caseCtx != null)
+    if (caseCtx != null && caseCtx.getText().length() >= nodeText.length() - 2)
       return parseCaseExpression(caseCtx);
 
     final Cypher25Parser.ExtendedCaseExpressionContext extCaseCtx = findExtendedCaseExpressionRecursive(node);
-    if (extCaseCtx != null)
+    if (extCaseCtx != null && extCaseCtx.getText().length() >= nodeText.length() - 2)
       return parseExtendedCaseExpression(extCaseCtx);
 
     // Check for EXISTS expressions

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/ExpressionTypeDetector.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/ExpressionTypeDetector.java
@@ -58,13 +58,17 @@ class ExpressionTypeDetector {
     if (existsCtx != null)
       return builder.parseExistsExpression(existsCtx);
 
-    // CASE expressions (both forms)
+    // CASE expressions (both forms).
+    // Guard: only match if the CASE context covers (almost) the full expression text.
+    // Without this guard, sum(CASE WHEN ... END) would be mis-parsed as just the
+    // inner CaseExpression, losing the outer sum() aggregation wrapper.
+    final String exprText = ctx.getText();
     final Cypher25Parser.CaseExpressionContext caseCtx = builder.findCaseExpressionRecursive(ctx);
-    if (caseCtx != null)
+    if (caseCtx != null && caseCtx.getText().length() >= exprText.length() - 2)
       return builder.parseCaseExpression(caseCtx);
 
     final Cypher25Parser.ExtendedCaseExpressionContext extCaseCtx = builder.findExtendedCaseExpressionRecursive(ctx);
-    if (extCaseCtx != null)
+    if (extCaseCtx != null && extCaseCtx.getText().length() >= exprText.length() - 2)
       return builder.parseExtendedCaseExpression(extCaseCtx);
 
     // shortestPath expressions

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/ExpressionTypeDetector.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/ExpressionTypeDetector.java
@@ -53,16 +53,19 @@ class ExpressionTypeDetector {
       return new FunctionCallExpression("count", args, false);
     }
 
+    // All recursive searches below use a length guard: only match when the found
+    // context covers (almost) the full expression text.  Without this, expressions
+    // like sum(CASE WHEN ... END) would be mis-parsed as just the inner special
+    // expression, losing the outer function wrapper.  The - 2 tolerance allows for
+    // whitespace that ANTLR's getText() strips from tokens.
+    final String exprText = ctx.getText();
+
     // EXISTS expression
     final Cypher25Parser.ExistsExpressionContext existsCtx = builder.findExistsExpressionRecursive(ctx);
-    if (existsCtx != null)
+    if (existsCtx != null && existsCtx.getText().length() >= exprText.length() - 2)
       return builder.parseExistsExpression(existsCtx);
 
-    // CASE expressions (both forms).
-    // Guard: only match if the CASE context covers (almost) the full expression text.
-    // Without this guard, sum(CASE WHEN ... END) would be mis-parsed as just the
-    // inner CaseExpression, losing the outer sum() aggregation wrapper.
-    final String exprText = ctx.getText();
+    // CASE expressions (both forms)
     final Cypher25Parser.CaseExpressionContext caseCtx = builder.findCaseExpressionRecursive(ctx);
     if (caseCtx != null && caseCtx.getText().length() >= exprText.length() - 2)
       return builder.parseCaseExpression(caseCtx);
@@ -73,7 +76,7 @@ class ExpressionTypeDetector {
 
     // shortestPath expressions
     final Cypher25Parser.ShortestPathExpressionContext shortestPathCtx = builder.findShortestPathExpressionRecursive(ctx);
-    if (shortestPathCtx != null)
+    if (shortestPathCtx != null && shortestPathCtx.getText().length() >= exprText.length() - 2)
       return builder.parseShortestPathExpression(shortestPathCtx);
 
     return null;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/ExpressionTypeDetector.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/ExpressionTypeDetector.java
@@ -45,20 +45,20 @@ class ExpressionTypeDetector {
    * Returns null if not a special function.
    */
   Expression tryParseSpecialFunctions(final Cypher25Parser.ExpressionContext ctx) {
-    // count(*) - special grammar rule
-    final Cypher25Parser.CountStarContext countStarCtx = builder.findCountStarRecursive(ctx);
-    if (countStarCtx != null) {
-      final List<Expression> args = new ArrayList<>();
-      args.add(new StarExpression());
-      return new FunctionCallExpression("count", args, false);
-    }
-
     // All recursive searches below use a length guard: only match when the found
     // context covers (almost) the full expression text.  Without this, expressions
     // like sum(CASE WHEN ... END) would be mis-parsed as just the inner special
     // expression, losing the outer function wrapper.  The - 2 tolerance allows for
     // whitespace that ANTLR's getText() strips from tokens.
     final String exprText = ctx.getText();
+
+    // count(*) - special grammar rule
+    final Cypher25Parser.CountStarContext countStarCtx = builder.findCountStarRecursive(ctx);
+    if (countStarCtx != null && countStarCtx.getText().length() >= exprText.length() - 2) {
+      final List<Expression> args = new ArrayList<>();
+      args.add(new StarExpression());
+      return new FunctionCallExpression("count", args, false);
+    }
 
     // EXISTS expression
     final Cypher25Parser.ExistsExpressionContext existsCtx = builder.findExistsExpressionRecursive(ctx);

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherCaseTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherCaseTest.java
@@ -186,6 +186,52 @@ class CypherCaseTest {
     assertThat((Object) result.getProperty("category")).isEqualTo("unknown");
   }
 
+  /**
+   * Regression test for issue #3858:
+   * Aggregation with CASE statement should not create implicit GROUP BY on variables inside the CASE.
+   * When all RETURN items are aggregations, a single row must be returned.
+   */
+  @Test
+  void aggregationWithCaseNoImplicitGroupBy() {
+    // Both count(loc) and sum(CASE...) are aggregations — no grouping keys exist.
+    // Expected: single row {total: 3, pa: 2}
+    final ResultSet results = database.query("opencypher",
+        "UNWIND [{state: 'NY'}, {state: 'PA'}, {state: 'PA'}] AS loc " +
+        "RETURN count(loc) AS total, sum(CASE WHEN loc.state = 'PA' THEN 1 ELSE 0 END) AS pa");
+
+    assertThat((boolean) results.hasNext()).isTrue();
+    final Result result = results.next();
+    assertThat(((Number) result.getProperty("total")).longValue()).isEqualTo(3L);
+    assertThat(((Number) result.getProperty("pa")).longValue()).isEqualTo(2L);
+    assertThat((boolean) results.hasNext()).isFalse();
+  }
+
+  /**
+   * Regression test for issue #3858 (variant):
+   * When RETURN has both aggregations and a non-aggregated grouping key,
+   * the CASE arguments must not act as additional grouping keys.
+   */
+  @Test
+  void aggregationWithCaseAndGroupByKey() {
+    // category is the real grouping key; sum(CASE...) must aggregate per category, not per loc.state
+    final ResultSet results = database.query("opencypher",
+        "UNWIND [{state: 'NY', cat: 'A'}, {state: 'PA', cat: 'A'}, {state: 'PA', cat: 'B'}] AS loc " +
+        "RETURN loc.cat AS category, sum(CASE WHEN loc.state = 'PA' THEN 1 ELSE 0 END) AS pa " +
+        "ORDER BY category");
+
+    assertThat((boolean) results.hasNext()).isTrue();
+    final Result rowA = results.next();
+    assertThat((Object) rowA.getProperty("category")).isEqualTo("A");
+    assertThat(((Number) rowA.getProperty("pa")).longValue()).isEqualTo(1L);
+
+    assertThat((boolean) results.hasNext()).isTrue();
+    final Result rowB = results.next();
+    assertThat((Object) rowB.getProperty("category")).isEqualTo("B");
+    assertThat(((Number) rowB.getProperty("pa")).longValue()).isEqualTo(1L);
+
+    assertThat((boolean) results.hasNext()).isFalse();
+  }
+
   @Test
   void nestedCaseExpressions() {
     // Nested CASE expressions


### PR DESCRIPTION
## Summary

- Fix expression parser mis-parsing `sum(CASE WHEN ... END)` as a bare `CaseExpression` instead of `FunctionCallExpression("sum", [CaseExpression])`, which caused the planner to treat it as a non-aggregation grouping key and split results into multiple rows
- Add text-length guards to `tryParseSpecialFunctions` and `parseExpressionFromText` so recursive CASE detection only matches when the CASE covers the full expression (same pattern already used for reduce/pattern comprehension)
- Add two regression tests: pure aggregation with CASE (single-row result) and mixed aggregation+grouping with CASE

Closes #3858

## Test plan

- [x] New test `aggregationWithCaseNoImplicitGroupBy` - exact reproduction of the reported query
- [x] New test `aggregationWithCaseAndGroupByKey` - CASE inside aggregation alongside a real grouping key
- [x] All 8 CypherCaseTest tests pass
- [x] All 5147 Cypher/OpenCypher engine tests pass (0 failures)
- [x] All 62 aggregation-related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)