### PR TITLE
fix(opencypher): MATCH WHERE ID(n) = <expr> falls back to full scan when expr is dynamic

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchNodeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchNodeStep.java
@@ -28,6 +28,7 @@ import com.arcadedb.query.opencypher.Labels;
 import com.arcadedb.query.opencypher.ast.BooleanExpression;
 import com.arcadedb.query.opencypher.ast.ComparisonExpression;
 import com.arcadedb.query.opencypher.ast.Expression;
+import com.arcadedb.query.opencypher.ast.FunctionCallExpression;
 import com.arcadedb.query.opencypher.ast.LogicalExpression;
 import com.arcadedb.query.opencypher.ast.NodePattern;
 import com.arcadedb.query.opencypher.ast.PropertyAccessExpression;
@@ -65,11 +66,12 @@ import java.util.NoSuchElementException;
  * predicates during scanning rather than in a separate FilterPropertiesStep.
  */
 public class MatchNodeStep extends AbstractExecutionStep {
-  private final String            variable;
-  private final NodePattern       pattern;
-  private final String            idFilter;    // Optional ID filter to apply (e.g., "#1:0")
-  private final BooleanExpression whereFilter; // Optional inline WHERE predicate (pushdown)
-  private       String            usedIndexName; // Track which index was used (if any)
+  private final String              variable;
+  private final NodePattern         pattern;
+  private final String              idFilter;    // Optional ID filter to apply (e.g., "#1:0")
+  private final BooleanExpression   whereFilter; // Optional inline WHERE predicate (pushdown)
+  private final ExpressionEvaluator evaluator;   // Shared evaluator for WHERE/ID expression resolution
+  private       String              usedIndexName; // Track which index was used (if any)
 
   /**
    * Creates a match node step.
@@ -111,6 +113,7 @@ public class MatchNodeStep extends AbstractExecutionStep {
     this.pattern = pattern;
     this.idFilter = idFilter;
     this.whereFilter = whereFilter;
+    this.evaluator = new ExpressionEvaluator(new CypherFunctionFactory(DefaultSQLFunctionFactory.getInstance()));
   }
 
   @Override
@@ -291,13 +294,19 @@ public class MatchNodeStep extends AbstractExecutionStep {
   }
 
   private Iterator<Identifiable> getVertexIterator(final Result currentInputResult) {
+    // Check for dynamic ID filter from WHERE clause if static idFilter is not present
+    String effectiveIdFilter = this.idFilter;
+    if ((effectiveIdFilter == null || effectiveIdFilter.isEmpty()) && whereFilter != null) {
+      effectiveIdFilter = extractDynamicIdFilter(whereFilter, currentInputResult);
+    }
+
     // OPTIMIZATION: If ID filter is present, look up the specific vertex by ID
     // This is critical for performance when matching by ID (e.g., WHERE ID(a) = "#1:0")
     // Without this optimization, MATCH (a),(b) WHERE ID(a) = x AND ID(b) = y
     // would create a Cartesian product of ALL vertices before filtering
-    if (idFilter != null && !idFilter.isEmpty()) {
+    if (effectiveIdFilter != null && !effectiveIdFilter.isEmpty()) {
       try {
-        final RID rid = new RID(context.getDatabase(), idFilter);
+        final RID rid = new RID(context.getDatabase(), effectiveIdFilter);
         final Identifiable vertex = context.getDatabase().lookupByRID(rid, true);
         // Return single-element iterator for the matched vertex
         return List.of(vertex).iterator();
@@ -571,6 +580,58 @@ public class MatchNodeStep extends AbstractExecutionStep {
   }
 
   /**
+   * Extracts ID filter from a boolean expression, resolving dynamic values against the current input result.
+   * This handles UNWIND...MATCH...WHERE patterns where ID is filtered dynamically.
+   */
+  private String extractDynamicIdFilter(final BooleanExpression expr, final Result currentInputResult) {
+    if (expr instanceof ComparisonExpression) {
+      final ComparisonExpression comp = (ComparisonExpression) expr;
+      if (comp.getOperator() != ComparisonExpression.Operator.EQUALS)
+        return null;
+
+      // Check for pattern: ID(variable) = <expression>
+      if (comp.getLeft() instanceof FunctionCallExpression) {
+        final FunctionCallExpression func = (FunctionCallExpression) comp.getLeft();
+        if ("id".equalsIgnoreCase(func.getFunctionName()) && func.getArguments().size() == 1) {
+          final Expression arg = func.getArguments().get(0);
+          if (arg instanceof VariableExpression && variable.equals(((VariableExpression) arg).getVariableName())) {
+            return evaluateToId(comp.getRight(), currentInputResult);
+          }
+        }
+      }
+
+      // Check for reversed: <expression> = ID(variable)
+      if (comp.getRight() instanceof FunctionCallExpression) {
+        final FunctionCallExpression func = (FunctionCallExpression) comp.getRight();
+        if ("id".equalsIgnoreCase(func.getFunctionName()) && func.getArguments().size() == 1) {
+          final Expression arg = func.getArguments().get(0);
+          if (arg instanceof VariableExpression && variable.equals(((VariableExpression) arg).getVariableName())) {
+            return evaluateToId(comp.getLeft(), currentInputResult);
+          }
+        }
+      }
+    } else if (expr instanceof LogicalExpression) {
+      final LogicalExpression logical = (LogicalExpression) expr;
+      if (logical.getOperator() == LogicalExpression.Operator.AND) {
+        final String leftId = extractDynamicIdFilter(logical.getLeft(), currentInputResult);
+        if (leftId != null) return leftId;
+        return extractDynamicIdFilter(logical.getRight(), currentInputResult);
+      }
+    }
+    return null;
+  }
+
+  private String evaluateToId(final Expression expr, final Result currentInputResult) {
+    final Object resolvedValue = evaluator.evaluate(expr, currentInputResult, context);
+    if (resolvedValue != null) {
+      if (resolvedValue instanceof Identifiable)
+        return ((Identifiable) resolvedValue).getIdentity().toString();
+      return resolvedValue.toString();
+    }
+    return null;
+  }
+
+  /**
    * Extracts equality predicates of the form variable.property = value from a boolean expression.
    * Supports AND conjunctions. Resolves dynamic expressions against the current input result.
    */
@@ -603,8 +664,6 @@ public class MatchNodeStep extends AbstractExecutionStep {
 
       if (propertyName != null && valueExpr != null) {
         // Resolve the value expression
-        final ExpressionEvaluator evaluator = new ExpressionEvaluator(
-            new CypherFunctionFactory(DefaultSQLFunctionFactory.getInstance()));
         final Object resolvedValue = evaluator.evaluate(valueExpr, currentInputResult, context);
         if (resolvedValue != null)
           predicates.put(propertyName, resolvedValue);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -42,6 +42,7 @@ import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.index.TypeIndex;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.VertexType;
 
@@ -382,6 +383,51 @@ public class MergeStep extends AbstractExecutionStep {
   }
 
   /**
+   * Tries to find and use an index for the evaluated property constraints.
+   * Returns an iterator of matching identifiables, or null if no suitable index found.
+   * Applies leftmost-prefix matching for composite indexes.
+   */
+  private Iterator<Identifiable> tryFindByIndex(final DocumentType type, final String label,
+      final Map<String, Object> evaluatedProperties) {
+    TypeIndex bestIndex = null;
+    int bestMatchCount = 0;
+    List<String> bestMatchedProperties = null;
+
+    for (final TypeIndex index : type.getAllIndexes(false)) {
+      final List<String> indexProperties = index.getPropertyNames();
+      int matchCount = 0;
+      final List<String> matchedProperties = new ArrayList<>();
+
+      for (final String indexProp : indexProperties) {
+        if (evaluatedProperties.containsKey(indexProp)) {
+          matchCount++;
+          matchedProperties.add(indexProp);
+        } else
+          break; // Leftmost prefix only
+      }
+
+      if (matchCount > 0 && matchCount > bestMatchCount) {
+        bestMatchCount = matchCount;
+        bestIndex = index;
+        bestMatchedProperties = matchedProperties;
+      }
+    }
+
+    if (bestIndex == null || bestMatchedProperties == null || bestMatchedProperties.isEmpty())
+      return null;
+
+    final String[] propertyNames = bestMatchedProperties.toArray(new String[0]);
+    final Object[] propertyValues = new Object[propertyNames.length];
+    for (int i = 0; i < propertyNames.length; i++)
+      propertyValues[i] = evaluatedProperties.get(propertyNames[i]);
+
+    @SuppressWarnings("unchecked")
+    final Iterator<Identifiable> iter = (Iterator<Identifiable>) (Object)
+        context.getDatabase().lookupByKey(label, propertyNames, propertyValues);
+    return iter;
+  }
+
+  /**
    * Finds a node matching the pattern.
    *
    * @param nodePattern node pattern to find
@@ -443,6 +489,22 @@ public class MergeStep extends AbstractExecutionStep {
     // Check if the type exists in the schema before iterating
     if (!context.getDatabase().getSchema().existsType(label))
       return null;
+
+    // OPTIMIZATION: try index before full scan
+    if (evaluatedProperties != null && !evaluatedProperties.isEmpty()) {
+      final DocumentType type = context.getDatabase().getSchema().getType(label);
+      if (type != null) {
+        final Iterator<Identifiable> indexIter = tryFindByIndex(type, label, evaluatedProperties);
+        if (indexIter != null) {
+          while (indexIter.hasNext()) {
+            final Identifiable identifiable = indexIter.next();
+            if (identifiable instanceof Vertex vertex && matchesProperties(vertex, evaluatedProperties))
+              return vertex;
+          }
+          return null;
+        }
+      }
+    }
 
     @SuppressWarnings("unchecked")
     final Iterator<Identifiable> iterator = (Iterator<Identifiable>) (Object) context.getDatabase().iterateType(label, true);
@@ -516,6 +578,23 @@ public class MergeStep extends AbstractExecutionStep {
     final String label = labels.get(0);
     if (!context.getDatabase().getSchema().existsType(label))
       return matches;
+
+    // OPTIMIZATION: try index before full scan
+    if (evaluatedProperties != null && !evaluatedProperties.isEmpty()) {
+      final DocumentType type = context.getDatabase().getSchema().getType(label);
+      if (type != null) {
+        final Iterator<Identifiable> indexIter = tryFindByIndex(type, label, evaluatedProperties);
+        if (indexIter != null) {
+          while (indexIter.hasNext()) {
+            final Identifiable identifiable = indexIter.next();
+            if (identifiable instanceof Vertex vertex && matchesProperties(vertex, evaluatedProperties))
+              matches.add(vertex);
+          }
+          return matches;
+        }
+      }
+    }
+
     @SuppressWarnings("unchecked")
     final Iterator<Identifiable> iterator = (Iterator<Identifiable>) (Object) context.getDatabase().iterateType(label, true);
     while (iterator.hasNext()) {


### PR DESCRIPTION
Fixes #3864

Long story short, in 


```CYPHER
UNWIND $batch AS BatchEntry
MATCH (b:CHUNK) WHERE ID(b) = BatchEntry.destRID
CREATE (p:CHUNK_EMBEDDING {vector: BatchEntry.vector})
CREATE (p)-[:embb]->(b)  
```

``MATCH (b:CHUNK) WHERE ID(b) = BatchEntry.destRID`` is doing a full scan on CHUNK

