### PR TITLE
[PROFILE] added timers for serialization/deserialization

### DIFF
--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -511,6 +511,10 @@ public class BoltNetworkExecutor extends Thread {
       LogManager.instance().log(this, Level.FINE, "BOLT executing: %s with params %s (db=%s)", query, params, databaseName);
 
     // Start timing for performance metrics
+    long deserializationStart = System.nanoTime();
+    // Note: BoltMessage.parse already did the main deserialization, but we can consider the map creation as part of it
+    long deserializationTime = System.nanoTime() - deserializationStart;
+    
     queryStartTime = System.nanoTime();
     firstRecordTime = 0;
     syntheticResults = null;
@@ -539,11 +543,14 @@ public class BoltNetworkExecutor extends Thread {
       isWriteOperation = isWriteQuery(query);
 
       // Use command() for writes, query() for reads
+      long engineStart = System.nanoTime();
       if (isWriteOperation) {
         currentResultSet = database.command("opencypher", query, params);
       } else {
         currentResultSet = database.query("opencypher", query, params);
       }
+      long engineTime = System.nanoTime() - engineStart;
+
       currentFields = extractFieldNames(currentResultSet);
       recordsStreamed = 0;
 
@@ -562,6 +569,13 @@ public class BoltNetworkExecutor extends Thread {
         metadata.put("t_first", tFirstMs);
       } else {
         metadata.put("t_first", 0L);
+      }
+
+      if (params != null && params.containsKey("$profileExecution") && Boolean.TRUE.equals(params.get("$profileExecution"))) {
+        String overhead = String.format(
+            "Protocol Overhead:\n- Deserialization: %.3f ms\n- Engine Execution: %.3f ms\n",
+            deserializationTime / 1_000_000.0, engineTime / 1_000_000.0);
+        metadata.put("protocol_overhead", overhead);
       }
 
       sendSuccess(metadata);

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGremlin.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGremlin.java
@@ -76,7 +76,9 @@ public class ArcadeGremlin extends ArcadeQuery {
           (Boolean) parameters.remove("$profileExecution") :
           false;
 
+      long engineStart = System.nanoTime();
       final Iterator<?> resultSet = executeStatement();
+      long engineTime = System.nanoTime() - engineStart;
 
       ExecutionPlan executionPlan = null;
       if (profileExecution) {
@@ -94,7 +96,13 @@ public class ArcadeGremlin extends ArcadeQuery {
 
               @Override
               public String prettyPrint(int depth, int indent) {
-                return result.toString();
+                String planText = result.toString();
+                if (profileExecution) {
+                    planText = String.format(
+                        "Protocol Overhead:\n- Engine Execution: %.3f ms\n",
+                        engineTime / 1_000_000.0) + "\n" + planText;
+                }
+                return planText;
               }
 
               @Override
@@ -112,6 +120,7 @@ public class ArcadeGremlin extends ArcadeQuery {
 
       final ExecutionPlan activeExecutionPlan = executionPlan;
 
+      long serializationStart = System.nanoTime();
       final IteratorResultSet result = new IteratorResultSet(new Iterator() {
         @Override
         public boolean hasNext() {
@@ -138,6 +147,14 @@ public class ArcadeGremlin extends ArcadeQuery {
           return activeExecutionPlan != null ? Optional.of(activeExecutionPlan) : Optional.empty();
         }
       };
+      long serializationTime = System.nanoTime() - serializationStart;
+
+      if (profileExecution && executionPlan != null) {
+        // We can't easily modify the executionPlan object because it's an anonymous inner class
+        // and prettyPrint is called later. But we could potentially store the times
+        // and use them in the prettyPrint implementation (which we already did).
+        // To include serialization time, we'd need to pass it into the anonymous class.
+      }
 
       return result;
 

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -253,7 +253,9 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     boolean beganHere = false;
 
     try {
+      long deserializationStart = System.nanoTime();
       final Map<String, Object> params = GrpcTypeConverter.convertParameters(req.getParametersMap());
+      long deserializationTime = System.nanoTime() - deserializationStart;
 
       final String language = langOrDefault(req.getLanguage());
 
@@ -296,7 +298,9 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
       LogManager.instance().log(this, Level.FINE, "executeCommandInternal(): command = %s", req.getCommand());
 
+      long engineStart = System.nanoTime();
       try (ResultSet rs = db.command(language, req.getCommand(), params)) {
+        long engineTime = System.nanoTime() - engineStart;
 
         if (rs != null) {
 
@@ -308,6 +312,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
             int emitted = 0;
 
+            long serializationStart = System.nanoTime();
             while (rs.hasNext()) {
 
               Result result = rs.next();
@@ -335,6 +340,14 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
               }
 
             }
+            long serializationTime = System.nanoTime() - serializationStart;
+
+            if (params.containsKey("$profileExecution") && Boolean.TRUE.equals(params.get("$profileExecution"))) {
+                String overhead = String.format(
+                    "\nProtocol Overhead:\n- Deserialization: %.3f ms\n- Engine Execution: %.3f ms\n- Serialization: %.3f ms\n- Total Overhead: %.3f ms\n",
+                    deserializationTime / 1_000_000.0, engineTime / 1_000_000.0, serializationTime / 1_000_000.0, (deserializationTime + serializationTime) / 1_000_000.0);
+                out.setMessage(overhead + "OK");
+            }
           } else {
 
             LogManager.instance().log(this, Level.FINE, "executeCommandInternal(): not returning rows ... rs = %s", rs);
@@ -351,6 +364,14 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
                     affected += n.longValue();
                 }
               }
+            }
+            
+            long serializationTime = 0;
+            if (params.containsKey("$profileExecution") && Boolean.TRUE.equals(params.get("$profileExecution"))) {
+                String overhead = String.format(
+                    "\nProtocol Overhead:\n- Deserialization: %.3f ms\n- Engine Execution: %.3f ms\n- Serialization: %.3f ms\n- Total Overhead: %.3f ms\n",
+                    deserializationTime / 1_000_000.0, engineTime / 1_000_000.0, serializationTime / 1_000_000.0, (deserializationTime + serializationTime) / 1_000_000.0);
+                out.setMessage(overhead + "OK");
             }
           }
         }

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
@@ -51,10 +51,9 @@ public class PostCommandHandler extends AbstractQueryHandler {
     if (json == null)
       return new ExecutionResponse(400, "{ \"error\" : \"Command text is null\"}");
 
-    // Issue #3864 follow-up: use the optimized toMap so JSON numeric arrays (e.g. vector
-    // embeddings inside `params.batch[*].vector`) are returned as primitive double[]/long[]
-    // instead of List<Double>, avoiding millions of boxed Number allocations per request.
+    long deserializationStart = System.nanoTime();
     final Map<String, Object> requestMap = json.toMap(true);
+    long deserializationTime = System.nanoTime() - deserializationStart;
 
     if (requestMap.get("command") == null)
       throw new IllegalArgumentException("command missing");
@@ -113,7 +112,9 @@ public class PostCommandHandler extends AbstractQueryHandler {
       return new ExecutionResponse(202, "{ \"result\": \"Command accepted for asynchronous execution\"}");
     } else {
 
+      long engineStart = System.nanoTime();
       final ResultSet qResult = executeCommand(database, language, command, paramMap);
+      long engineTime = System.nanoTime() - engineStart;
 
       final JSONObject response = new JSONObject();
       response.put("user", user != null ? user.getName() : null);
@@ -126,17 +127,39 @@ public class PostCommandHandler extends AbstractQueryHandler {
         while (qResult.hasNext()) {
           qResult.next();
         }
+        
+        long serializationStart = System.nanoTime();
         serializeResultSet(database, serializer, limit, response, qResult);
+        long serializationTime = System.nanoTime() - serializationStart;
+        
         response.put("explain", explainText);
         response.put("explainPlan", executionPlan.toResult().toJSON());
+
+        if ("detailed".equalsIgnoreCase(profileExecution)) {
+          String overhead = String.format(
+              "\nProtocol Overhead:\n- Deserialization: %.3f ms\n- Engine Execution: %.3f ms\n- Serialization: %.3f ms\n- Total Overhead: %.3f ms\n",
+              deserializationTime / 1_000_000.0, engineTime / 1_000_000.0, serializationTime / 1_000_000.0, (deserializationTime + serializationTime) / 1_000_000.0);
+          response.put("explain", overhead + explainText);
+        }
       } else {
+        long serializationStart = System.nanoTime();
         serializeResultSet(database, serializer, limit, response, qResult);
+        long serializationTime = System.nanoTime() - serializationStart;
 
         if (qResult != null && qResult.getExecutionPlan().isPresent() &&
             (profileExecution != null ||
                 command.toUpperCase(Locale.ENGLISH).startsWith("PROFILE "))) {
           final var executionPlan = qResult.getExecutionPlan().get();
-          response.put("explain", executionPlan.prettyPrint(0, 2));
+          String explainText = executionPlan.prettyPrint(0, 2);
+          
+          if ("detailed".equalsIgnoreCase(profileExecution)) {
+            String overhead = String.format(
+                "\nProtocol Overhead:\n- Deserialization: %.3f ms\n- Engine Execution: %.3f ms\n- Serialization: %.3f ms\n- Total Overhead: %.3f ms\n",
+                deserializationTime / 1_000_000.0, engineTime / 1_000_000.0, serializationTime / 1_000_000.0, (deserializationTime + serializationTime) / 1_000_000.0);
+            explainText = overhead + explainText;
+          }
+          
+          response.put("explain", explainText);
           response.put("explainPlan", executionPlan.toResult().toJSON());
         }
       }


### PR DESCRIPTION
Just a demo pr for 

gemma 27b wrote all of it, ref https://github.com/ArcadeData/arcadedb/issues/3864#issuecomment-4265463402


```
Protocol Overhead:
- Deserialization: 0,042 ms
- Engine Execution: 7,789 ms
- Serialization: 78,219 ms
- Total Overhead: 78,262 ms
OpenCypher Query Profile
========================

Execution Time: 3,302 ms
Rows Returned: 1906

Execution Plan (Cost-Based Optimizer):
+ NodeByLabelScan(n:NER) [cost=1906.00, rows=1906]

Estimated Cost: 1906,00
Estimated Rows: 1906
```