### PR TITLE
#3941 fix: REFRESH MATERIALIZED VIEW now commits immediately in async HTTP commands

### DIFF
--- a/engine/src/main/java/com/arcadedb/schema/MaterializedViewRefresher.java
+++ b/engine/src/main/java/com/arcadedb/schema/MaterializedViewRefresher.java
@@ -39,6 +39,11 @@ public class MaterializedViewRefresher {
     try {
       final String backingTypeName = view.getBackingTypeName();
 
+      // Use joinCurrentTx=false to always create a dedicated transaction for the refresh.
+      // This ensures changes are committed immediately even when called from an async context
+      // (e.g. HTTP API with awaitResponse=false), where a long-running batched transaction
+      // would otherwise defer the commit indefinitely.
+      // See: https://github.com/ArcadeData/arcadedb/issues/3941
       database.transaction(() -> {
         // Truncate existing data — faster than DELETE FROM (no per-record WAL entries)
         database.command("sql", "TRUNCATE TYPE `" + backingTypeName + "` UNSAFE");
@@ -55,7 +60,7 @@ public class MaterializedViewRefresher {
             doc.save();
           }
         }
-      });
+      }, false);
 
       final long durationMs = (System.nanoTime() - startNs) / 1_000_000;
       view.recordRefreshSuccess(durationMs);

--- a/server/src/test/java/com/arcadedb/server/Issue3941AsyncRefreshMaterializedViewIT.java
+++ b/server/src/test/java/com/arcadedb/server/Issue3941AsyncRefreshMaterializedViewIT.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.serializer.json.JSONObject;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.*;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Regression test for GitHub Issue #3941: REFRESH MATERIALIZED VIEW not working in async HTTP commands.
+ * https://github.com/ArcadeData/arcadedb/issues/3941
+ *
+ * When sending REFRESH MATERIALIZED VIEW via HTTP with awaitResponse=false, the view was not updated
+ * because the refresh joined the async thread's long-running batched transaction instead of
+ * committing its own transaction immediately.
+ */
+class Issue3941AsyncRefreshMaterializedViewIT extends BaseGraphServerTest {
+
+  private static final String DATABASE_NAME = "Issue3941AsyncRefreshMaterializedView";
+  private static final String DOC_TYPE_NAME = "Doc";
+  private static final String VIEW_NAME     = "DocView";
+
+  @Override
+  protected String getDatabaseName() {
+    return DATABASE_NAME;
+  }
+
+  @Override
+  protected void populateDatabase() {
+    // No default population
+  }
+
+  @Test
+  void refreshMaterializedViewAsyncUpdatesView() throws Exception {
+    testEachServer((serverIndex) -> {
+      final Database database = getServer(serverIndex).getDatabase(getDatabaseName());
+
+      // Setup: create document type, insert initial record, then create view
+      // The INSERT must be committed before CREATE MATERIALIZED VIEW so the initial
+      // population query can see the committed data.
+      database.transaction(() -> {
+        database.command("sql", "CREATE DOCUMENT TYPE " + DOC_TYPE_NAME);
+        database.command("sql", "INSERT INTO " + DOC_TYPE_NAME);
+      });
+      database.transaction(() ->
+          database.command("sql", "CREATE MATERIALIZED VIEW " + VIEW_NAME + " AS SELECT FROM " + DOC_TYPE_NAME));
+
+      // Verify initial state: view has 1 record
+      final long initialCount = countViewRecords(database);
+      assertThat(initialCount).as("View should have 1 record after creation").isEqualTo(1L);
+
+      // Insert a second document (not yet reflected in view)
+      database.transaction(() -> database.command("sql", "INSERT INTO " + DOC_TYPE_NAME));
+
+      final long sourceCountBeforeRefresh = countSourceRecords(database);
+      assertThat(sourceCountBeforeRefresh).as("Source type should have 2 records").isEqualTo(2L);
+
+      // Send REFRESH MATERIALIZED VIEW asynchronously (awaitResponse=false) — the bug scenario
+      final HttpURLConnection connection = (HttpURLConnection) new URL(
+          "http://localhost:248" + serverIndex + "/api/v1/command/" + DATABASE_NAME).openConnection();
+      connection.setRequestMethod("POST");
+      connection.setRequestProperty("Authorization",
+          "Basic " + Base64.getEncoder().encodeToString(("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+
+      formatPayload(connection, new JSONObject()
+          .put("language", "sql")
+          .put("command", "REFRESH MATERIALIZED VIEW " + VIEW_NAME)
+          .put("awaitResponse", false));
+      connection.connect();
+
+      try {
+        assertThat(connection.getResponseCode()).as("Async command should return 202 Accepted").isEqualTo(202);
+      } finally {
+        connection.disconnect();
+      }
+
+      // Wait for the async command to complete and commit
+      database.async().waitCompletion(10000);
+
+      // The view should now reflect the 2 source records
+      final long refreshedCount = countViewRecords(database);
+      assertThat(refreshedCount)
+          .as("View should have 2 records after async REFRESH MATERIALIZED VIEW (was %d before refresh)", initialCount)
+          .isEqualTo(2L);
+    });
+  }
+
+  @Test
+  void refreshMaterializedViewSyncUpdatesView() throws Exception {
+    testEachServer((serverIndex) -> {
+      final Database database = getServer(serverIndex).getDatabase(getDatabaseName());
+
+      final String syncDocType = DOC_TYPE_NAME + "Sync";
+      final String syncViewName = VIEW_NAME + "Sync";
+
+      database.transaction(() -> {
+        database.command("sql", "CREATE DOCUMENT TYPE " + syncDocType);
+        database.command("sql", "INSERT INTO " + syncDocType);
+      });
+      database.transaction(() ->
+          database.command("sql", "CREATE MATERIALIZED VIEW " + syncViewName + " AS SELECT FROM " + syncDocType));
+
+      assertThat(countRecords(database, syncViewName)).isEqualTo(1L);
+
+      database.transaction(() -> database.command("sql", "INSERT INTO " + syncDocType));
+
+      // Send REFRESH synchronously (the working baseline)
+      final HttpURLConnection connection = (HttpURLConnection) new URL(
+          "http://localhost:248" + serverIndex + "/api/v1/command/" + DATABASE_NAME).openConnection();
+      connection.setRequestMethod("POST");
+      connection.setRequestProperty("Authorization",
+          "Basic " + Base64.getEncoder().encodeToString(("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+
+      formatPayload(connection, new JSONObject()
+          .put("language", "sql")
+          .put("command", "REFRESH MATERIALIZED VIEW " + syncViewName));
+      connection.connect();
+
+      try {
+        assertThat(connection.getResponseCode()).as("Sync command should return 200 OK").isEqualTo(200);
+      } finally {
+        connection.disconnect();
+      }
+
+      assertThat(countRecords(database, syncViewName)).as("View should have 2 records after sync refresh").isEqualTo(2L);
+    });
+  }
+
+  private long countViewRecords(final Database database) {
+    return countRecords(database, VIEW_NAME);
+  }
+
+  private long countSourceRecords(final Database database) {
+    return countRecords(database, DOC_TYPE_NAME);
+  }
+
+  private long countRecords(final Database database, final String typeName) {
+    try (final var rs = database.query("sql", "SELECT count(*) as cnt FROM " + typeName)) {
+      if (rs.hasNext())
+        return ((Number) rs.next().getProperty("cnt")).longValue();
+      return 0;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #3941

`REFRESH MATERIALIZED VIEW` sent via HTTP with `awaitResponse: false` had no visible effect on the view data.

**Root cause**: `MaterializedViewRefresher.fullRefresh()` called `database.transaction(lambda)` with the default `joinCurrentTx=true`. In async mode the async thread already holds a long-running batched transaction (`commitEvery=10240` by default). The refresh joined that transaction and its changes were never committed promptly — effectively the view was not updated from the caller's perspective.

**Fix**: Changed to `database.transaction(lambda, false)`. With `joinCurrentTx=false` the refresh always creates a dedicated transaction (nested on the outer one if present) that is committed to disk immediately on success. This works correctly in all call contexts:
- **Async mode** (active batch TX): creates a nested TX, commits it immediately, batch TX continues empty
- **Sync mode** (active HTTP TX): creates a nested TX, commits it immediately, HTTP TX continues
- **Direct call** (no active TX): creates and commits a standalone TX as before

## Test plan

- [x] New regression test `Issue3941AsyncRefreshMaterializedViewIT` covering both async (`awaitResponse=false`) and sync paths
- [x] All 52 existing materialized view tests pass
- [x] `Issue2097AsyncRebuildIndexIT` (related async scenario) still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)