### PR TITLE
fix: stub newRID in remote mock tests

### DIFF
--- a/network/src/test/java/com/arcadedb/remote/RemoteImmutableDocumentTest.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteImmutableDocumentTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.remote;
 
+import com.arcadedb.database.RID;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Property;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,6 +49,7 @@ class RemoteImmutableDocumentTest {
     when(mockSchema.getType("TestDoc")).thenReturn(mockType);
     when(mockType.getName()).thenReturn("TestDoc");
     when(mockType.getPolymorphicPropertyIfExists(ArgumentMatchers.anyString())).thenReturn(null);
+    when(mockDatabase.newRID(ArgumentMatchers.anyString())).thenAnswer(inv -> new RID(inv.getArgument(0)));
 
     final Map<String, Object> attributes = new HashMap<>();
     attributes.put(Property.TYPE_PROPERTY, "TestDoc");

--- a/network/src/test/java/com/arcadedb/remote/RemoteImmutableEdgeTest.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteImmutableEdgeTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.remote;
 
+import com.arcadedb.database.RID;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.schema.Property;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,6 +48,7 @@ class RemoteImmutableEdgeTest {
     when(mockSchema.getType("TestEdge")).thenReturn(mockType);
     when(mockType.getName()).thenReturn("TestEdge");
     when(mockType.getPolymorphicPropertyIfExists(ArgumentMatchers.anyString())).thenReturn(null);
+    when(mockDatabase.newRID(ArgumentMatchers.anyString())).thenAnswer(inv -> new RID(inv.getArgument(0)));
 
     final Map<String, Object> attributes = new HashMap<>();
     attributes.put(Property.TYPE_PROPERTY, "TestEdge");

--- a/network/src/test/java/com/arcadedb/remote/RemoteImmutableVertexTest.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteImmutableVertexTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.remote;
 
+import com.arcadedb.database.RID;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.schema.Property;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,6 +48,7 @@ class RemoteImmutableVertexTest {
     when(mockSchema.getType("TestVertex")).thenReturn(mockType);
     when(mockType.getName()).thenReturn("TestVertex");
     when(mockType.getPolymorphicPropertyIfExists(ArgumentMatchers.anyString())).thenReturn(null);
+    when(mockDatabase.newRID(ArgumentMatchers.anyString())).thenAnswer(inv -> new RID(inv.getArgument(0)));
 
     final Map<String, Object> attributes = new HashMap<>();
     attributes.put(Property.TYPE_PROPERTY, "TestVertex");

--- a/network/src/test/java/com/arcadedb/remote/RemoteMutableEdgeTest.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteMutableEdgeTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.remote;
 
+import com.arcadedb.database.RID;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.Result;
@@ -50,6 +51,7 @@ class RemoteMutableEdgeTest {
     when(mockDatabase.getSchema()).thenReturn(mockSchema);
     when(mockSchema.getType("TestEdge")).thenReturn(mockEdgeType);
     when(mockEdgeType.getName()).thenReturn("TestEdge");
+    when(mockDatabase.newRID(ArgumentMatchers.anyString())).thenAnswer(inv -> new RID(inv.getArgument(0)));
 
     // Build an immutable edge to use as source for the mutable edge
     final Map<String, Object> attributes = new HashMap<>();


### PR DESCRIPTION
## Summary
- `RemoteImmutableDocumentTest`, `RemoteImmutableEdgeTest`, `RemoteImmutableVertexTest`, and `RemoteMutableEdgeTest` were failing because `mockDatabase.newRID(String)` was not stubbed
- Mockito returns null for unstubbed default interface methods, so `RemoteImmutableDocument` stored `null` RIDs and `RemoteImmutableEdge` stored `null` out/in RIDs
- Added `when(mockDatabase.newRID(anyString())).thenAnswer(inv -> new RID(inv.getArgument(0)))` to all four `setUp()` methods

## Test plan
- [x] `RemoteImmutableDocumentTest` - all 16 tests pass
- [x] `RemoteImmutableEdgeTest` - all 10 tests pass
- [x] `RemoteImmutableVertexTest` - all 10 tests pass
- [x] `RemoteMutableEdgeTest` - all 16 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)