### PR TITLE
test: fix GitHubIssue3878Test - materialized view empty due to uncommitted setup data

### DIFF
--- a/engine/src/test/java/com/arcadedb/query/sql/executor/GitHubIssue3878Test.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/GitHubIssue3878Test.java
@@ -32,15 +32,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class GitHubIssue3878Test extends TestHelper {
 
-  public GitHubIssue3878Test() {
-    autoStartTx = true;
-  }
-
   @Override
   public void beginTest() {
     database.command("sql", "CREATE DOCUMENT TYPE TestDoc");
-    database.command("sql", "INSERT INTO TestDoc SET name = 'Alice', active = true");
-    database.command("sql", "INSERT INTO TestDoc SET name = 'Bob', active = false");
+    database.transaction(() -> {
+      database.command("sql", "INSERT INTO TestDoc SET name = 'Alice', active = true");
+      database.command("sql", "INSERT INTO TestDoc SET name = 'Bob', active = false");
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary

- `GitHubIssue3878Test` used `autoStartTx = true`, causing `beginTest()` to run inside an uncommitted transaction
- `MaterializedViewRefresher.fullRefresh()` creates a dedicated transaction with `joinCurrentTx=false` that cannot see uncommitted data under snapshot isolation — so both materialized views were created empty
- Fix: remove `autoStartTx`, wrap INSERTs in `database.transaction()` so test data is committed before the view's initial `fullRefresh` runs (matching the pattern in `MaterializedViewSQLTest`)

## Test plan

- [x] All 4 tests in `GitHubIssue3878Test` now pass (`Tests run: 4, Failures: 0, Errors: 0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)