### PR TITLE
test: clean target/config between test runs to prevent stale credentials

### DIFF
--- a/test-utils/src/main/java/com/arcadedb/test/TestServerHelper.java
+++ b/test-utils/src/main/java/com/arcadedb/test/TestServerHelper.java
@@ -150,6 +150,7 @@ public final class TestServerHelper {
 
   public static void deleteDatabaseFolders(final int totalServers) {
     FileUtils.deleteRecursively(new File("./target/databases/"));
+    FileUtils.deleteRecursively(new File("./target/config/"));
     FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + File.separator));
     for (int i = 0; i < totalServers; ++i)
       FileUtils.deleteRecursively(new File(GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString() + i + File.separator));


### PR DESCRIPTION
## Summary

- `TestServerHelper.deleteDatabaseFolders()` was cleaning database directories but not `./target/config/`
- `server-users.jsonl` could persist across test runs with a password hash from a different password
- This caused `FollowerSessionTokenQueryIT` to fail intermittently with HTTP 403 when Basic auth hit a stale hash that did not match `DefaultPasswordForTests`

## Root cause

The auth flow in `AbstractServerHttpHandler` maps any `ServerSecurityException` to HTTP 403. `ServerSecurity.authenticate()` uses PBKDF2 to re-encode the supplied password with the stored salt and compares to the stored hash. If `server-users.jsonl` contained a hash produced from a different password (e.g. from a manual server run or a different test context), `passwordMatch()` returned false and login returned 403.

## Fix

One line added to `TestServerHelper.deleteDatabaseFolders()` to also delete `./target/config/`, matching the existing hardcoded cleanup of `./target/databases/`. This ensures each test run starts with no stale security configuration.

## Test plan

- [x] `FollowerSessionTokenQueryIT` passes on first run (clean slate, fresh credentials created)
- [x] `FollowerSessionTokenQueryIT` passes on repeated runs (config cleaned between each run)
- [x] `ServerSecurityIT` and `SecurityGroupMigrationIT` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)