### PR TITLE
#3992 fix(cypher): point() WGS-84-3D now exposes .height as alias for .z

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/geo/CypherPointFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/geo/CypherPointFunction.java
@@ -88,6 +88,8 @@ public class CypherPointFunction implements StatelessFunction {
       result.put("x", x);
       result.put("y", y);
       addOptionalZ(result, map);
+      if (result.containsKey("z"))
+        result.put("height", result.get("z"));
       result.put("crs", result.containsKey("z") ? "WGS-84-3D" : "WGS-84");
       result.put("srid", result.containsKey("z") ? 4979 : 4326);
     } else if (map.containsKey("x") || map.containsKey("y")) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherSpatialFunctionsComprehensiveTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherSpatialFunctionsComprehensiveTest.java
@@ -376,4 +376,56 @@ class OpenCypherSpatialFunctionsComprehensiveTest {
     final Double distance = (Double) result.next().getProperty("distance");
     assertThat(distance).isCloseTo(5.0, within(0.001));
   }
+
+  // ==================== point() Property Accessor Tests (Issue #3992) ====================
+
+  @Test
+  void pointWGS84_3D_HeightAccessorWithHeightInput() {
+    // Regression test for Issue #3992: p.height should return the height value, not null
+    final ResultSet result = database.command("opencypher",
+        "WITH point({longitude: 56.7, latitude: 12.78, height: 8}) AS p " +
+            "RETURN p.longitude AS lon, p.latitude AS lat, p.z AS z, p.height AS height, p.crs AS crs");
+    Assertions.assertThat(result.hasNext() != false).isTrue();
+    final Result row = result.next();
+    final Number lon = row.getProperty("lon");
+    final Number lat = row.getProperty("lat");
+    final Number z = row.getProperty("z");
+    final Number height = row.getProperty("height");
+    final String crs = row.getProperty("crs");
+    assertThat(lon.doubleValue()).isCloseTo(56.7, within(0.001));
+    assertThat(lat.doubleValue()).isCloseTo(12.78, within(0.001));
+    assertThat(z.doubleValue()).isCloseTo(8.0, within(0.001));
+    assertThat(height).isNotNull();
+    assertThat(height.doubleValue()).isCloseTo(8.0, within(0.001));
+    assertThat(crs).isEqualTo("WGS-84-3D");
+  }
+
+  @Test
+  void pointWGS84_3D_HeightAccessorWithZInput() {
+    // When using z= for WGS-84-3D, p.height should also be accessible as an alias
+    final ResultSet result = database.command("opencypher",
+        "WITH point({longitude: 56.7, latitude: 12.78, z: 8}) AS p " +
+            "RETURN p.z AS z, p.height AS height");
+    Assertions.assertThat(result.hasNext() != false).isTrue();
+    final Result row = result.next();
+    final Number z = row.getProperty("z");
+    final Number height = row.getProperty("height");
+    assertThat(z.doubleValue()).isCloseTo(8.0, within(0.001));
+    assertThat(height).isNotNull();
+    assertThat(height.doubleValue()).isCloseTo(8.0, within(0.001));
+  }
+
+  @Test
+  void pointCartesian3D_NoHeightAccessor() {
+    // Cartesian 3D points should NOT expose .height - only .z
+    final ResultSet result = database.command("opencypher",
+        "WITH point({x: 1.0, y: 2.0, z: 3.0}) AS p " +
+            "RETURN p.z AS z, p.height AS height");
+    Assertions.assertThat(result.hasNext() != false).isTrue();
+    final Result row = result.next();
+    final Number z = row.getProperty("z");
+    final Object height = row.getProperty("height");
+    assertThat(z.doubleValue()).isCloseTo(3.0, within(0.001));
+    Assertions.assertThat(height == null).isTrue();
+  }
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes #3992

Accessing `p.height` on a WGS-84 3D point returned `null` even though the point was constructed with `height:`. Per the Neo4j Cypher spec, `.height` and `.z` are aliases for each other on geographic 3D points.

**Root cause:** `CypherPointFunction.addOptionalZ()` always stored the third coordinate under the `z` key in the result map but never wrote `height`. So `p.height` was always resolved as a missing key (`null`).

**Fix:** After `addOptionalZ` writes `z` into the WGS-84 result map, also write `height` as an alias (2 lines in `CypherPointFunction.java`). Cartesian 3D points are unaffected - they correctly expose only `.z`.

## Changes

- `engine/src/main/java/com/arcadedb/function/geo/CypherPointFunction.java` - add `height` alias for WGS-84-3D points
- `engine/src/test/java/com/arcadedb/query/opencypher/functions/OpenCypherSpatialFunctionsComprehensiveTest.java` - 3 new regression tests

## Test plan

- [x] `pointWGS84_3D_HeightAccessorWithHeightInput` - `p.height` returns correct value when `height=` is used as input
- [x] `pointWGS84_3D_HeightAccessorWithZInput` - `p.height` also works when `z=` is used (WGS-84-3D alias symmetry)
- [x] `pointCartesian3D_NoHeightAccessor` - Cartesian 3D points do NOT expose `.height` (only `.z`)
- [x] All 31 existing `OpenCypherSpatialFunctionsComprehensiveTest` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)