### PR TITLE
#4000 fix(cypher): SET propagates to all aliases bound to the same node

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
@@ -20,12 +20,12 @@ package com.arcadedb.query.opencypher.executor.steps;
 
 import com.arcadedb.database.Document;
 import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.Labels;
-import com.arcadedb.query.opencypher.ast.Expression;
 import com.arcadedb.query.opencypher.ast.SetClause;
 import com.arcadedb.query.opencypher.executor.CypherFunctionFactory;
 import com.arcadedb.query.opencypher.executor.ExpressionEvaluator;
@@ -178,8 +178,9 @@ public class SetStep extends AbstractExecutionStep {
       mutableDoc.set(item.getProperty(), value);
     }
     mutableDoc.save();
-
-    if (variableToUpdate != null)
+    propagateUpdateToSameNodeAliases(result, doc, mutableDoc);
+    // Fallback: ensure the named variable is updated even when doc has no identity yet
+    if (variableToUpdate != null && doc.getIdentity() == null)
       ((ResultInternal) result).setProperty(variableToUpdate, mutableDoc);
   }
 
@@ -210,7 +211,9 @@ public class SetStep extends AbstractExecutionStep {
     }
 
     mutableDoc.save();
-    ((ResultInternal) result).setProperty(item.getVariable(), mutableDoc);
+    propagateUpdateToSameNodeAliases(result, doc, mutableDoc);
+    if (doc.getIdentity() == null)
+      ((ResultInternal) result).setProperty(item.getVariable(), mutableDoc);
   }
 
   @SuppressWarnings("unchecked")
@@ -235,7 +238,24 @@ public class SetStep extends AbstractExecutionStep {
     }
 
     mutableDoc.save();
-    ((ResultInternal) result).setProperty(item.getVariable(), mutableDoc);
+    propagateUpdateToSameNodeAliases(result, doc, mutableDoc);
+    if (doc.getIdentity() == null)
+      ((ResultInternal) result).setProperty(item.getVariable(), mutableDoc);
+  }
+
+  /**
+   * After mutating a document, update every alias in the result row that points to the same node
+   * (identified by RID) so all aliases observe the new state within the same query.
+   */
+  private void propagateUpdateToSameNodeAliases(final Result result, final Document originalDoc, final Document updatedDoc) {
+    final RID originalRid = originalDoc.getIdentity();
+    if (originalRid == null)
+      return;
+    for (final String propName : result.getPropertyNames()) {
+      final Object prop = result.getProperty(propName);
+      if (prop instanceof Document other && originalRid.equals(other.getIdentity()))
+        ((ResultInternal) result).setProperty(propName, updatedDoc);
+    }
   }
 
   private void applyLabels(final SetClause.SetItem item, final Result result) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
@@ -253,7 +253,7 @@ public class SetStep extends AbstractExecutionStep {
       return;
     for (final String propName : result.getPropertyNames()) {
       final Object prop = result.getProperty(propName);
-      if (prop instanceof Document other && originalRid.equals(other.getIdentity()))
+      if (prop instanceof Document other && other != updatedDoc && originalRid.equals(other.getIdentity()))
         ((ResultInternal) result).setProperty(propName, updatedDoc);
     }
   }
@@ -293,7 +293,7 @@ public class SetStep extends AbstractExecutionStep {
     // Delete old vertex
     vertex.delete();
 
-    ((ResultInternal) result).setProperty(item.getVariable(), newVertex);
+    propagateUpdateToSameNodeAliases(result, vertex, newVertex);
   }
 
   private void validatePropertyValue(final Object value) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherSetTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherSetTest.java
@@ -411,6 +411,21 @@ public class OpenCypherSetTest {
   }
 
   @Test
+  void setLabelThroughOneAliasPropagatestoOtherAliasOnSameNode() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Person {name: 'Alice', age: 30})");
+    });
+
+    final ResultSet result = database.command("opencypher",
+        "MATCH (n:Person {name: 'Alice'}), (m:Person {name: 'Alice'}) SET n:Employee RETURN n.name AS n_name, m.name AS m_name");
+
+    assertThat(result.hasNext()).isTrue();
+    final Result row = result.next();
+    assertThat((String) row.getProperty("n_name")).isEqualTo("Alice");
+    assertThat((String) row.getProperty("m_name")).isEqualTo("Alice");
+  }
+
+  @Test
   void setAfterCreate() {
     // CREATE and SET in same query
     database.transaction(() -> {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherSetTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherSetTest.java
@@ -374,6 +374,42 @@ public class OpenCypherSetTest {
     assertThat(vb.get("propB")).isNull();
   }
 
+  /**
+   * Issue #4000: SET through one alias must be visible through other aliases bound to the same node in the same row.
+   */
+  @Test
+  void setThroughOneAliasPropagatestoOtherAliasOnSameNode() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Person {name: 'Alice', age: 30}), (:Person {name: 'Bob', age: 25})");
+    });
+
+    final ResultSet result = database.command("opencypher",
+        "MATCH (n:Person {name: 'Alice'}), (m:Person {name: 'Alice'}) SET n.age = 35 RETURN n.age AS n_age, m.age AS m_age");
+
+    assertThat(result.hasNext()).isTrue();
+    final Result row = result.next();
+    assertThat(((Number) row.getProperty("n_age")).intValue()).isEqualTo(35);
+    assertThat(((Number) row.getProperty("m_age")).intValue()).isEqualTo(35);
+  }
+
+  /**
+   * Issue #4000: stronger reproducer — full node aliases bound via WITH+MATCH to the same node must reflect a SET on the other alias.
+   */
+  @Test
+  void setThroughOneAliasPropagatestoOtherAliasOnSameNodeFullNode() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Person {name: 'Alice', age: 30})");
+    });
+
+    final ResultSet result = database.command("opencypher",
+        "MATCH (n:Person {name: 'Alice'}) WITH n MATCH (m:Person {name: 'Alice'}) SET n.age = 35 RETURN n.age AS n_age, m.age AS m_age");
+
+    assertThat(result.hasNext()).isTrue();
+    final Result row = result.next();
+    assertThat(((Number) row.getProperty("n_age")).intValue()).isEqualTo(35);
+    assertThat(((Number) row.getProperty("m_age")).intValue()).isEqualTo(35);
+  }
+
   @Test
   void setAfterCreate() {
     // CREATE and SET in same query


### PR DESCRIPTION
## Summary

Fixes #4000.

When two Cypher variables are bound to the same node, a `SET` through one alias left the other alias stale in the same result row:

```cypher
MATCH (n:Person {name:'Alice'}), (m:Person {name:'Alice'})
SET n.age = 35
RETURN n.age AS n_age, m.age AS m_age
-- Was returning: 35, 30  (m stale)
-- Now returns:   35, 35  (both consistent)
```

**Root cause:** `SetStep.java` called `doc.modify()` to get a `MutableDocument`, saved it, then updated only the single variable named in the SET item. Any other result-row entries pointing to the same underlying node (by RID) kept their old immutable snapshot.

**Fix:** Added `propagateUpdateToSameNodeAliases()` - after saving the mutated document, it scans every property in the result row and replaces any `Document` whose `getIdentity()` matches the original RID with the updated document. Applied in `applyPropertySet`, `applyReplaceMap`, and `applyMergeMap`.

## Test plan

- [x] `setThroughOneAliasPropagatestoOtherAliasOnSameNode` - reproduces the main issue (two aliases in same MATCH)
- [x] `setThroughOneAliasPropagatestoOtherAliasOnSameNodeFullNode` - reproduces the stronger WITH+MATCH reproducer from the issue
- [x] All 15 tests in `OpenCypherSetTest` pass
- [x] Full OpenCypher suite: 5390 tests, 0 new failures

🤖 Generated with [Claude Code](https://claude.ai/claude-code)