### PR TITLE
Potential fix for code scanning alert no. 1654: Incomplete string escaping or encoding

### DIFF
--- a/studio/src/main/resources/static/js/studio-record-editor.js
+++ b/studio/src/main/resources/static/js/studio-record-editor.js
@@ -23,6 +23,12 @@ function openRecordEditor(rid, type, properties, source) {
     showGraphRecordEditor();
 }
 
+function escapeSqlStringLiteral(value) {
+  return String(value)
+    .replace(/\\/g, "\\\\")
+    .replace(/'/g, "\\'");
+}
+
 function getRecordEditorTarget() {
   if (globalRecordEditorState.source === "table")
     return "#tableRecordEditorContent";
@@ -344,10 +350,10 @@ function saveRecordEditor() {
         JSON.parse(current);
         sqlValue = current;
       } catch (e) {
-        sqlValue = "'" + current.replace(/'/g, "\\'") + "'";
+        sqlValue = "'" + escapeSqlStringLiteral(current) + "'";
       }
     } else
-      sqlValue = "'" + current.replace(/'/g, "\\'") + "'";
+      sqlValue = "'" + escapeSqlStringLiteral(current) + "'";
 
     setParts.push("`" + prop + "` = " + sqlValue);
   });


### PR DESCRIPTION
Potential fix for [https://github.com/ArcadeData/arcadedb/security/code-scanning/1654](https://github.com/ArcadeData/arcadedb/security/code-scanning/1654)

Use a robust escaping helper that escapes backslashes first, then single quotes, and reuse it in both places where string SQL literals are formed (the `catch` branch and the final `else` branch).  
This preserves existing behavior while addressing the incomplete escaping finding.

Best targeted fix in `studio/src/main/resources/static/js/studio-record-editor.js`:

- Add a small helper function near the top-level functions (e.g., after `openRecordEditor`) such as:
  - `escapeSqlStringLiteral(value)` that converts input to string and does:
    - `.replace(/\\/g, "\\\\")` (escape backslashes globally)
    - `.replace(/'/g, "\\'")` (escape single quotes globally)
- Replace:
  - `current.replace(/'/g, "\\'")`
  with:
  - `escapeSqlStringLiteral(current)`
  in both line-347 and line-350 logic.

No new imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
