### PR TITLE
#4006 fix(cypher): VLP segments must not re-traverse a relationship bound in a prior MATCH

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -1664,7 +1664,7 @@ public class CypherExecutionPlan {
           AbstractExecutionStep nextStep;
           if (relPattern.isVariableLength()) {
             nextStep = new ExpandPathStep(effectiveSourceVar, pathVariable, relVar, effectiveTargetVar, relPattern,
-                true, effectiveTargetNode, pathPattern.getEffectivePathMode(), new HashSet<>(boundVariables), context);
+                true, effectiveTargetNode, pathPattern.getEffectivePathMode(), computePrevVarsForVlp(pathPattern, i, boundVariables), context);
           } else {
             // Check if this hop requires IN traversal on a unidirectional edge.
             // Unidirectional edges don't store incoming links, so we must restructure:
@@ -2028,7 +2028,7 @@ public class CypherExecutionPlan {
                   // Variable-length path - pass path variable, relationship variable, and target node for label
                   // filtering. Snapshot previously bound variables for relationship-uniqueness scoping.
                   nextStep = new ExpandPathStep(currentSourceVar, pathVariable, relVar, targetVar, relPattern, true,
-                      targetNode, pathPattern.getEffectivePathMode(), new HashSet<>(legacyBoundVariables), context);
+                      targetNode, pathPattern.getEffectivePathMode(), computePrevVarsForVlp(pathPattern, i, legacyBoundVariables), context);
                 } else {
                   // Fixed-length relationship - pass path variable, target node pattern, and bound variables
                   nextStep = new MatchRelationshipStep(currentSourceVar, relVar, targetVar, relPattern, pathVariable,
@@ -3509,6 +3509,29 @@ public class CypherExecutionPlan {
       }
     }
     return needs;
+  }
+
+  /**
+   * Computes the set of "previously bound" variables to pass to {@link ExpandPathStep} for a
+   * variable-length hop at {@code vlpHopIndex} within {@code pathPattern}.
+   * <p>
+   * OpenCypher path isomorphism applies within a single <em>path</em>, not within a MATCH clause.
+   * A relationship variable bound by a prior MATCH that is also explicitly named in the current
+   * path pattern is a same-path co-participant and must be checked for edge conflicts even though
+   * it was introduced before this MATCH. We therefore remove those co-participants from the
+   * exclusion set before handing it to ExpandPathStep.
+   */
+  private static Set<String> computePrevVarsForVlp(final PathPattern pathPattern, final int vlpHopIndex,
+      final Set<String> boundVariables) {
+    final Set<String> prevVars = new HashSet<>(boundVariables);
+    for (int j = 0; j < pathPattern.getRelationshipCount(); j++) {
+      if (j == vlpHopIndex)
+        continue;
+      final RelationshipPattern rel = pathPattern.getRelationship(j);
+      if (rel.getVariable() != null && !rel.getVariable().isEmpty())
+        prevVars.remove(rel.getVariable());
+    }
+    return prevVars;
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue4006BoundRelVarPathIsomorphismTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue4006BoundRelVarPathIsomorphismTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for GitHub issue #4006.
+ * <p>
+ * When a relationship variable {@code r} is bound in one MATCH clause and then referenced
+ * explicitly inside a path pattern containing variable-length segments in a subsequent MATCH,
+ * the variable-length segments must not re-traverse {@code r}. OpenCypher path isomorphism
+ * applies within a single path, not within a single MATCH clause.
+ * <p>
+ * This corresponds to TCK scenario {@code Match4 [7]}:
+ * "Matching variable length patterns including a bound relationship".
+ */
+class Issue4006BoundRelVarPathIsomorphismTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/testopencypher-4006").create();
+    database.getSchema().createVertexType("Node4006");
+    database.getSchema().createEdgeType("EDGE4006");
+    database.transaction(() -> database.command("opencypher",
+        "CREATE (n0:Node4006)-[:EDGE4006]->(n1:Node4006)-[:EDGE4006]->(n2:Node4006)-[:EDGE4006]->(n3:Node4006)"));
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  /**
+   * TCK Match4 [7]: variable-length segments flanking a bound relationship must obey path
+   * isomorphism - they must not re-traverse the explicitly named {@code r}.
+   */
+  @Test
+  void vlpSegmentsDoNotReuseExplicitlyNamedBoundRelationship() {
+    final ResultSet result = database.query("opencypher",
+        "MATCH ()-[r:EDGE4006]-()"
+            + " MATCH p = (n)-[*0..1]-()-[r]-()-[*0..1]-(m)"
+            + " RETURN count(p) AS c");
+
+    final List<Result> rows = collect(result);
+    assertThat(rows).hasSize(1);
+    assertThat(((Number) rows.get(0).getProperty("c")).longValue()).isEqualTo(32L);
+  }
+
+  /**
+   * Regression guard for issue #3999: a previously bound relationship that is NOT part
+   * of the current path pattern must not block the variable-length traversal.
+   */
+  @Test
+  void unboundedVlpIsNotBlockedByUnrelatedPreviouslyBoundRel() {
+    final ResultSet result = database.query("opencypher",
+        "MATCH (a:Node4006)-[r:EDGE4006]->(b:Node4006)"
+            + " WITH a, b, r"
+            + " MATCH path = (a)-[:EDGE4006*1..2]->(b)"
+            + " RETURN count(r) AS rc");
+
+    final List<Result> rows = collect(result);
+    assertThat(rows).hasSize(1);
+    assertThat(((Number) rows.get(0).getProperty("rc")).longValue()).isGreaterThan(0L);
+  }
+
+  private static List<Result> collect(final ResultSet rs) {
+    final List<Result> list = new ArrayList<>();
+    while (rs.hasNext())
+      list.add(rs.next());
+    return list;
+  }
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes #4006.

OpenCypher path isomorphism applies within a single **path**, not a single MATCH clause. When a relationship variable `r` is bound in one MATCH and explicitly co-participates in a path pattern with variable-length segments in a subsequent MATCH, those segments must not re-traverse `r`.

**Before:** `MATCH ()-[r:EDGE]-() MATCH p = (n)-[*0..1]-()-[r]-()-[*0..1]-(m) RETURN count(p)` returned `52`
**After:** returns `32` (correct per TCK Match4 [7])

## Root Cause

`ExpandPathStep.hasEdgeConflict()` skipped conflict checking for all variables listed in `previousStepVariables` (a snapshot of variables bound by prior MATCH clauses). This was too broad: a named relationship that is also an explicit node in the current path is a same-path co-participant and must still be excluded from variable-length traversal.

## Fix

Added `computePrevVarsForVlp(pathPattern, vlpHopIndex, boundVariables)` in `CypherExecutionPlan`. It copies `boundVariables` then removes any named relationship variables appearing in other hops of the same path pattern. The resulting set is passed as `previousStepVariables` to `ExpandPathStep`, so co-participants remain subject to edge conflict checking.

Applied at both VLP step creation sites (primary optimizer path and legacy path).

## Test Plan

- [x] New regression test `Issue4006BoundRelVarPathIsomorphismTest` - 2 methods
  - `vlpSegmentsDoNotReuseExplicitlyNamedBoundRelationship` - verifies count = 32
  - `unboundedVlpIsNotBlockedByUnrelatedPreviouslyBoundRel` - regression guard for #3999
- [x] All related traversal tests pass (45 tests)
- [x] Full Cypher suite passes (5891 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF