### PR TITLE
#3997 test(cypher): regression tests for collect(r)+VLP row-drop bug

### DIFF
--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherVariableLengthPathTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherVariableLengthPathTest.java
@@ -29,6 +29,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 
@@ -179,5 +182,57 @@ public class OpenCypherVariableLengthPathTest {
     } finally {
       db2.drop();
     }
+  }
+
+  @Test
+  void collectRelThenVlpReturnsRows() {
+    // Issue #3997: collect(r) carried via WITH drops all rows when a later MATCH uses VLP
+    final List<Result> rows = new ArrayList<>();
+    database.query("opencypher",
+        """
+        MATCH (a:Person {name: 'Alice'})-[r:KNOWS]->(b:Person)
+        WITH a, collect(r) AS rels
+        MATCH path = (a)-[:KNOWS*1..2]->(c:Person)
+        RETURN length(path) AS len, size(rels) AS relationCount
+        ORDER BY len""").forEachRemaining(rows::add);
+
+    assertThat(rows).as("collect(r) + VLP should return 2 rows (len=1 and len=2)").hasSize(2);
+    assertThat(rows.get(0).<Long>getProperty("len")).isEqualTo(1L);
+    assertThat(rows.get(0).<Long>getProperty("relationCount")).isEqualTo(1L);
+    assertThat(rows.get(1).<Long>getProperty("len")).isEqualTo(2L);
+    assertThat(rows.get(1).<Long>getProperty("relationCount")).isEqualTo(1L);
+  }
+
+  @Test
+  void collectDistinctRelThenVlpReturnsRows() {
+    // Issue #3997: collect(DISTINCT r) carried via WITH also drops all rows
+    final List<Result> rows = new ArrayList<>();
+    database.query("opencypher",
+        """
+        MATCH (a:Person {name: 'Alice'})
+        OPTIONAL MATCH (a)-[r:KNOWS]->(b:Person)
+        WITH a, collect(DISTINCT r) AS rels
+        MATCH path = (a)-[:KNOWS*1..2]->(c:Person)
+        RETURN length(path) AS len, size(rels) AS relationCount
+        ORDER BY len""").forEachRemaining(rows::add);
+
+    assertThat(rows).as("collect(DISTINCT r) + VLP should return 2 rows").hasSize(2);
+    assertThat(rows.get(0).<Long>getProperty("len")).isEqualTo(1L);
+    assertThat(rows.get(1).<Long>getProperty("len")).isEqualTo(2L);
+  }
+
+  @Test
+  void collectScalarThenVlpReturnsRows() {
+    // Issue #3997 control case: collect(type(r)) should work (and does)
+    final List<Result> rows = new ArrayList<>();
+    database.query("opencypher",
+        """
+        MATCH (a:Person {name: 'Alice'})-[r:KNOWS]->(b:Person)
+        WITH a, collect(type(r)) AS relTypes
+        MATCH path = (a)-[:KNOWS*1..2]->(c:Person)
+        RETURN length(path) AS len, relTypes
+        ORDER BY len""").forEachRemaining(rows::add);
+
+    assertThat(rows).as("collect(type(r)) + VLP control case should also return 2 rows").hasSize(2);
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherVariableLengthPathTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherVariableLengthPathTest.java
@@ -188,13 +188,15 @@ public class OpenCypherVariableLengthPathTest {
   void collectRelThenVlpReturnsRows() {
     // Issue #3997: collect(r) carried via WITH drops all rows when a later MATCH uses VLP
     final List<Result> rows = new ArrayList<>();
-    database.query("opencypher",
+    try (final ResultSet rs = database.query("opencypher",
         """
         MATCH (a:Person {name: 'Alice'})-[r:KNOWS]->(b:Person)
         WITH a, collect(r) AS rels
         MATCH path = (a)-[:KNOWS*1..2]->(c:Person)
         RETURN length(path) AS len, size(rels) AS relationCount
-        ORDER BY len""").forEachRemaining(rows::add);
+        ORDER BY len""")) {
+      rs.forEachRemaining(rows::add);
+    }
 
     assertThat(rows).as("collect(r) + VLP should return 2 rows (len=1 and len=2)").hasSize(2);
     assertThat(rows.get(0).<Long>getProperty("len")).isEqualTo(1L);
@@ -207,14 +209,16 @@ public class OpenCypherVariableLengthPathTest {
   void collectDistinctRelThenVlpReturnsRows() {
     // Issue #3997: collect(DISTINCT r) carried via WITH also drops all rows
     final List<Result> rows = new ArrayList<>();
-    database.query("opencypher",
+    try (final ResultSet rs = database.query("opencypher",
         """
         MATCH (a:Person {name: 'Alice'})
         OPTIONAL MATCH (a)-[r:KNOWS]->(b:Person)
         WITH a, collect(DISTINCT r) AS rels
         MATCH path = (a)-[:KNOWS*1..2]->(c:Person)
         RETURN length(path) AS len, size(rels) AS relationCount
-        ORDER BY len""").forEachRemaining(rows::add);
+        ORDER BY len""")) {
+      rs.forEachRemaining(rows::add);
+    }
 
     assertThat(rows).as("collect(DISTINCT r) + VLP should return 2 rows").hasSize(2);
     assertThat(rows.get(0).<Long>getProperty("len")).isEqualTo(1L);
@@ -225,13 +229,15 @@ public class OpenCypherVariableLengthPathTest {
   void collectScalarThenVlpReturnsRows() {
     // Issue #3997 control case: collect(type(r)) should work (and does)
     final List<Result> rows = new ArrayList<>();
-    database.query("opencypher",
+    try (final ResultSet rs = database.query("opencypher",
         """
         MATCH (a:Person {name: 'Alice'})-[r:KNOWS]->(b:Person)
         WITH a, collect(type(r)) AS relTypes
         MATCH path = (a)-[:KNOWS*1..2]->(c:Person)
         RETURN length(path) AS len, relTypes
-        ORDER BY len""").forEachRemaining(rows::add);
+        ORDER BY len""")) {
+      rs.forEachRemaining(rows::add);
+    }
 
     assertThat(rows).as("collect(type(r)) + VLP control case should also return 2 rows").hasSize(2);
   }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Closes #3997.

Adds regression tests for the scenario where `collect(r)` is carried via `WITH` and a later `MATCH` uses a variable-length path (VLP) - previously causing all rows to be dropped.

- `collectRelThenVlpReturnsRows` - basic `collect(r) AS rels` + VLP returns 2 rows (len=1 and len=2)
- `collectDistinctRelThenVlpReturnsRows` - OPTIONAL MATCH + `collect(DISTINCT r)` + VLP (the "stronger variant" from the issue) returns 2 rows
- `collectScalarThenVlpReturnsRows` - control case: `collect(type(r))` continues to work

## Root cause and fix

The bug was caused by `ExpandPathStep.hasEdgeConflict()` treating `List<Edge>` values (from `collect(r)`) as same-MATCH bound relationships, blocking all VLP paths when those edges appeared in the traversal.

The fix was already merged in commit `d58bf7b1c` (issue #3999), which introduced the `previousStepVariables` mechanism in `ExpandPathStep`. After `WITH a, collect(r) AS rels`, `boundVariables = {a, rels}`. When the second MATCH VLP runs, `previousStepVariables = {a, rels}`, so `rels` is correctly skipped in the conflict check.

## Test plan

- [x] `collectRelThenVlpReturnsRows` passes - primary bug scenario
- [x] `collectDistinctRelThenVlpReturnsRows` passes - OPTIONAL MATCH + collect(DISTINCT r) variant
- [x] `collectScalarThenVlpReturnsRows` passes - control case (scalar collect)
- [x] All existing `OpenCypherVariableLengthPathTest` tests pass (3 pre-existing + 3 new = 6 total)
- [x] All existing `Issue3999RelVarLostAfterVarLengthMatchTest` tests pass (6 total)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
EOF
)