### PR TITLE
Fix Python workflow triggers

### DIFF
--- a/.github/workflows/test-python-bindings.yml
+++ b/.github/workflows/test-python-bindings.yml
@@ -5,14 +5,12 @@ on:
   push:
     paths:
       - 'bindings/python/**'
-      - '**/*.java'
       - '.github/workflows/test-python-bindings.yml'
 
   # Run on pull request affecting bindings/python/
   pull_request:
     paths:
       - 'bindings/python/**'
-      - '**/*.java'
       - '.github/workflows/test-python-bindings.yml'
 
   # Run after release workflow completes

--- a/.github/workflows/test-python-examples.yml
+++ b/.github/workflows/test-python-examples.yml
@@ -5,14 +5,12 @@ on:
   push:
     paths:
       - 'bindings/python/**'
-      - '**/*.java'
       - '.github/workflows/test-python-examples.yml'
 
   # Run on pull request affecting bindings/python/
   pull_request:
     paths:
       - 'bindings/python/**'
-      - '**/*.java'
       - '.github/workflows/test-python-examples.yml'
 
   # Run after release workflow completes


### PR DESCRIPTION
## What does this PR do?

Removes unnecessary Java file path filters from the Python GitHub Actions workflows so changes relevant to the Python bindings and examples trigger the expected CI jobs.

## Motivation

This cherry-picks `c30803c468d53f7183e0056e717428e4cd5314a0` onto an upstream-based branch so the workflow fix can be proposed directly to `ArcadeData/arcadedb:main`.

## Related issues

Cherry-picks `c30803c468d53f7183e0056e717428e4cd5314a0` from `main`.

## Additional Notes

This change updates:
- `.github/workflows/test-python-bindings.yml`
- `.github/workflows/test-python-examples.yml`

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios