### PR TITLE
fix: Cypher -> WITH-carried node variable becomes null after anonymous CREATE or MERGE

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CreateStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CreateStep.java
@@ -288,8 +288,8 @@ public class CreateStep extends AbstractExecutionStep {
       // Simple node creation: CREATE (n:Person {name: 'Alice'})
       final NodePattern nodePattern = pathPattern.getFirstNode();
       final Vertex vertex = createVertex(nodePattern, result);
-      final String variable = nodePattern.getVariable() != null ? nodePattern.getVariable() : "n";
-      result.setProperty(variable, vertex);
+      if (nodePattern.getVariable() != null)
+        result.setProperty(nodePattern.getVariable(), vertex);
     } else {
       // Path with relationships: CREATE (a)-[r:KNOWS]->(b)
       final List<Vertex> vertices = new ArrayList<>();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -237,12 +237,10 @@ public class MergeStep extends AbstractExecutionStep {
    * MERGE returns one row per matching node, or creates if none match.
    */
   private List<Result> mergeSingleNodeAll(final NodePattern nodePattern, final ResultInternal baseResult) {
-    final String variable = nodePattern.getVariable() != null ? nodePattern.getVariable() : "n";
-
     // Only check for already-bound variable when explicitly named by the user.
     // Anonymous MERGE nodes (no variable) should always search for matches.
     if (nodePattern.getVariable() != null) {
-      final Object existing = baseResult.getProperty(variable);
+      final Object existing = baseResult.getProperty(nodePattern.getVariable());
       if (existing instanceof Vertex) {
         baseResult.setProperty("  wasCreated", false);
         return List.of(baseResult);
@@ -256,7 +254,8 @@ public class MergeStep extends AbstractExecutionStep {
       final List<Result> results = new ArrayList<>();
       for (final Vertex v : matches) {
         final ResultInternal r = copyResult(baseResult);
-        r.setProperty(variable, v);
+        if (nodePattern.getVariable() != null)
+          r.setProperty(nodePattern.getVariable(), v);
         r.setProperty("  wasCreated", false);
         results.add(r);
       }
@@ -265,7 +264,8 @@ public class MergeStep extends AbstractExecutionStep {
 
     // No match - create one
     final Vertex vertex = createVertex(nodePattern, baseResult);
-    baseResult.setProperty(variable, vertex);
+    if (nodePattern.getVariable() != null)
+      baseResult.setProperty(nodePattern.getVariable(), vertex);
     baseResult.setProperty("  wasCreated", true);
     return List.of(baseResult);
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -237,10 +237,12 @@ public class MergeStep extends AbstractExecutionStep {
    * MERGE returns one row per matching node, or creates if none match.
    */
   private List<Result> mergeSingleNodeAll(final NodePattern nodePattern, final ResultInternal baseResult) {
+    final String variable = nodePattern.getVariable();
+
     // Only check for already-bound variable when explicitly named by the user.
     // Anonymous MERGE nodes (no variable) should always search for matches.
-    if (nodePattern.getVariable() != null) {
-      final Object existing = baseResult.getProperty(nodePattern.getVariable());
+    if (variable != null) {
+      final Object existing = baseResult.getProperty(variable);
       if (existing instanceof Vertex) {
         baseResult.setProperty("  wasCreated", false);
         return List.of(baseResult);
@@ -254,8 +256,8 @@ public class MergeStep extends AbstractExecutionStep {
       final List<Result> results = new ArrayList<>();
       for (final Vertex v : matches) {
         final ResultInternal r = copyResult(baseResult);
-        if (nodePattern.getVariable() != null)
-          r.setProperty(nodePattern.getVariable(), v);
+        if (variable != null)
+          r.setProperty(variable, v);
         r.setProperty("  wasCreated", false);
         results.add(r);
       }
@@ -264,8 +266,8 @@ public class MergeStep extends AbstractExecutionStep {
 
     // No match - create one
     final Vertex vertex = createVertex(nodePattern, baseResult);
-    if (nodePattern.getVariable() != null)
-      baseResult.setProperty(nodePattern.getVariable(), vertex);
+    if (variable != null)
+      baseResult.setProperty(variable, vertex);
     baseResult.setProperty("  wasCreated", true);
     return List.of(baseResult);
   }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue4019WithNodeVarNullAfterCreateMergeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue4019WithNodeVarNullAfterCreateMergeTest.java
@@ -45,6 +45,7 @@ class Issue4019WithNodeVarNullAfterCreateMergeTest {
   void setUp() {
     database = new DatabaseFactory("./target/databases/testopencypher-4019").create();
     database.getSchema().createVertexType("Person4019");
+    database.getSchema().createVertexType("Temp4019");
     database.transaction(() -> database.command("opencypher",
         "CREATE (:Person4019 {name:'Alice'}), (:Person4019 {name:'Bob'})"));
   }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue4019WithNodeVarNullAfterCreateMergeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue4019WithNodeVarNullAfterCreateMergeTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for GitHub issue #4019.
+ * <p>
+ * A node variable carried through WITH must remain bound after a later anonymous
+ * CREATE or MERGE writes an unrelated node. The anonymous write node has no
+ * variable, so it must not overwrite any variable already present in the row.
+ */
+class Issue4019WithNodeVarNullAfterCreateMergeTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/testopencypher-4019").create();
+    database.getSchema().createVertexType("Person4019");
+    database.transaction(() -> database.command("opencypher",
+        "CREATE (:Person4019 {name:'Alice'}), (:Person4019 {name:'Bob'})"));
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void nodeVarCarriedThroughWithMustSurviveAnonymousCreate() {
+    final ResultSet[] ref = new ResultSet[1];
+    database.transaction(() -> ref[0] = database.command("opencypher",
+        "MATCH (n:Person4019) WITH n CREATE (:Temp4019 {x:1}) RETURN n.name AS name ORDER BY name"));
+
+    final List<Result> rows = collect(ref[0]);
+    assertThat(rows).hasSize(2);
+    assertThat((String) rows.get(0).getProperty("name")).isEqualTo("Alice");
+    assertThat((String) rows.get(1).getProperty("name")).isEqualTo("Bob");
+  }
+
+  @Test
+  void nodeVarCarriedThroughWithMustSurviveAnonymousMerge() {
+    final ResultSet[] ref = new ResultSet[1];
+    database.transaction(() -> ref[0] = database.command("opencypher",
+        "MATCH (n:Person4019) WITH n MERGE (:Temp4019 {x:10}) RETURN n.name AS name ORDER BY name"));
+
+    final List<Result> rows = collect(ref[0]);
+    assertThat(rows).hasSize(2);
+    assertThat((String) rows.get(0).getProperty("name")).isEqualTo("Alice");
+    assertThat((String) rows.get(1).getProperty("name")).isEqualTo("Bob");
+  }
+
+  @Test
+  void nodeVarAndScalarBothSurviveAnonymousCreate() {
+    final ResultSet[] ref = new ResultSet[1];
+    database.transaction(() -> ref[0] = database.command("opencypher",
+        "MATCH (n:Person4019) WITH n, 1 AS x CREATE (:Temp4019 {x:3}) RETURN n.name AS name, x ORDER BY name"));
+
+    final List<Result> rows = collect(ref[0]);
+    assertThat(rows).hasSize(2);
+    assertThat((String) rows.get(0).getProperty("name")).isEqualTo("Alice");
+    assertThat(((Number) rows.get(0).getProperty("x")).intValue()).isEqualTo(1);
+    assertThat((String) rows.get(1).getProperty("name")).isEqualTo("Bob");
+    assertThat(((Number) rows.get(1).getProperty("x")).intValue()).isEqualTo(1);
+  }
+
+  @Test
+  void scalarAliasAloneStillWorksWithCreate() {
+    final ResultSet[] ref = new ResultSet[1];
+    database.transaction(() -> ref[0] = database.command("opencypher",
+        "MATCH (n:Person4019) WITH n.name AS name CREATE (:Temp4019 {x:2}) RETURN name ORDER BY name"));
+
+    final List<Result> rows = collect(ref[0]);
+    assertThat(rows).hasSize(2);
+    assertThat((String) rows.get(0).getProperty("name")).isEqualTo("Alice");
+    assertThat((String) rows.get(1).getProperty("name")).isEqualTo("Bob");
+  }
+
+  @Test
+  void withoutCreateNodeVarIsCorrect() {
+    final List<Result> rows = collect(database.query("opencypher",
+        "MATCH (n:Person4019) WITH n RETURN n.name AS name ORDER BY name"));
+
+    assertThat(rows).hasSize(2);
+    assertThat((String) rows.get(0).getProperty("name")).isEqualTo("Alice");
+    assertThat((String) rows.get(1).getProperty("name")).isEqualTo("Bob");
+  }
+
+  private static List<Result> collect(final ResultSet rs) {
+    final List<Result> list = new ArrayList<>();
+    while (rs.hasNext())
+      list.add(rs.next());
+    return list;
+  }
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes #4019.

Anonymous node patterns (no variable) in `CREATE` and `MERGE` used `"n"` as a hardcoded fallback variable name and stored the newly created vertex at that result-row key, silently overwriting any `n` already bound by an upstream `MATCH`/`WITH`.

- **`CreateStep.java`** (`createPath`, single-node branch): removed the `"n"` default; the created vertex is only bound to the row when the pattern has an explicit variable.
- **`MergeStep.java`** (`mergeSingleNodeAll`): same fix for both the match path and the create path.

## Test plan

- [ ] `Issue4019WithNodeVarNullAfterCreateMergeTest` - 5 regression tests covering all cases from the issue report:
  - `MATCH (n) WITH n CREATE (:Temp)` - node var survives anonymous CREATE
  - `MATCH (n) WITH n MERGE (:Temp)` - node var survives anonymous MERGE
  - `MATCH (n) WITH n, 1 AS x CREATE (:Temp)` - both node var and scalar survive
  - scalar alias + CREATE (was already correct - control)
  - `WITH n` without any write (was already correct - control)
- [ ] `OpenCypherCreateTest`, `OpenCypherMergeTest`, `OpenCypherMergeActionsTest`, `OpenCypherSetTest` - no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)