### PR TITLE
feat: sparse vector index + hybrid fusion + group-by (#4065, #4066, #4067)

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/sql/DefaultSQLFunctionFactory.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/DefaultSQLFunctionFactory.java
@@ -142,6 +142,7 @@ import com.arcadedb.function.sql.vector.SQLFunctionVectorMax;
 import com.arcadedb.function.sql.vector.SQLFunctionVectorMin;
 import com.arcadedb.function.sql.vector.SQLFunctionVectorMultiply;
 import com.arcadedb.function.sql.vector.SQLFunctionVectorNeighbors;
+import com.arcadedb.function.sql.vector.SQLFunctionVectorSparseNeighbors;
 import com.arcadedb.function.sql.vector.SQLFunctionVectorNormalize;
 import com.arcadedb.function.sql.vector.SQLFunctionVectorNormalizeScores;
 import com.arcadedb.function.sql.vector.SQLFunctionVectorQuantizeBinary;
@@ -340,6 +341,7 @@ public final class DefaultSQLFunctionFactory extends SQLFunctionFactoryTemplate 
     register(SQLFunctionVectorToString.NAME, new SQLFunctionVectorToString());
     // Existing
     register(SQLFunctionVectorNeighbors.NAME, new SQLFunctionVectorNeighbors());
+    register(SQLFunctionVectorSparseNeighbors.NAME, new SQLFunctionVectorSparseNeighbors());
 
     reflectionFactory = new SQLFunctionReflectionFactory(this);
   }

--- a/engine/src/main/java/com/arcadedb/function/sql/DefaultSQLFunctionFactory.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/DefaultSQLFunctionFactory.java
@@ -141,6 +141,7 @@ import com.arcadedb.function.sql.vector.SQLFunctionVectorMagnitude;
 import com.arcadedb.function.sql.vector.SQLFunctionVectorMax;
 import com.arcadedb.function.sql.vector.SQLFunctionVectorMin;
 import com.arcadedb.function.sql.vector.SQLFunctionVectorMultiply;
+import com.arcadedb.function.sql.vector.SQLFunctionVectorFuse;
 import com.arcadedb.function.sql.vector.SQLFunctionVectorNeighbors;
 import com.arcadedb.function.sql.vector.SQLFunctionVectorSparseNeighbors;
 import com.arcadedb.function.sql.vector.SQLFunctionVectorNormalize;
@@ -342,6 +343,7 @@ public final class DefaultSQLFunctionFactory extends SQLFunctionFactoryTemplate 
     // Existing
     register(SQLFunctionVectorNeighbors.NAME, new SQLFunctionVectorNeighbors());
     register(SQLFunctionVectorSparseNeighbors.NAME, new SQLFunctionVectorSparseNeighbors());
+    register(SQLFunctionVectorFuse.NAME, new SQLFunctionVectorFuse());
 
     reflectionFactory = new SQLFunctionReflectionFactory(this);
   }

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorAbstract.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorAbstract.java
@@ -18,11 +18,18 @@
  */
 package com.arcadedb.function.sql.vector;
 
+import com.arcadedb.database.BasicDatabase;
 import com.arcadedb.database.Document;
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.database.RID;
 import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.function.sql.SQLFunctionAbstract;
+import com.arcadedb.query.sql.executor.CommandContext;
 
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Abstract base class for vector SQL functions providing common utility methods.
@@ -135,5 +142,44 @@ public abstract class SQLFunctionVectorAbstract extends SQLFunctionAbstract {
         return null;
     }
     return current;
+  }
+
+  /**
+   * Parses a {@code filter} option (a list of RIDs / Identifiables / RID-string forms) into a
+   * {@link Set} of {@link RID} suitable for the post-filter step in vector neighbour searches.
+   * Returns {@code null} for null or empty inputs so callers can distinguish "no filter" from
+   * "empty filter" with a single null-check.
+   *
+   * @param items   the {@code filter} option contents, typically the value of
+   *                {@code FunctionOptions.getList("filter")}
+   * @param functionName the calling function's SQL name, used to build helpful error messages
+   * @param context the command context (used to coerce string-form RIDs through
+   *                {@link BasicDatabase#newRID})
+   *
+   * @return a set of allowed RIDs, or {@code null} when no whitelist should apply
+   *
+   * @throws CommandSQLParsingException if the list contains a value that cannot be coerced to a RID
+   */
+  protected static Set<RID> parseRidFilter(final List<?> items, final String functionName, final CommandContext context) {
+    if (items == null || items.isEmpty())
+      return null;
+
+    final BasicDatabase db = context.getDatabase();
+    final Set<RID> out = new HashSet<>(items.size());
+    for (final Object item : items) {
+      if (item == null)
+        continue;
+      if (item instanceof RID rid)
+        out.add(rid);
+      else if (item instanceof Identifiable id)
+        out.add(id.getIdentity());
+      else if (item instanceof String s)
+        out.add(db.newRID(s));
+      else
+        throw new CommandSQLParsingException(
+            "Option 'filter' for function '" + functionName + "' must contain RIDs, got: "
+                + item.getClass().getSimpleName());
+    }
+    return out;
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorAbstract.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorAbstract.java
@@ -160,6 +160,51 @@ public abstract class SQLFunctionVectorAbstract extends SQLFunctionAbstract {
    *
    * @throws CommandSQLParsingException if the list contains a value that cannot be coerced to a RID
    */
+  /**
+   * Mutable accounting state shared by the three vector functions that apply a post-traversal
+   * {@code groupBy} / {@code groupSize} filter. Encapsulates the per-group counter map plus the
+   * {@code filledGroups} O(1) early-exit counter so the three call sites do not drift in lockstep.
+   * <p>
+   * Lifetime is one query: instantiate, call {@link #admit(Object)} per candidate row in rank order,
+   * call {@link #isFull(int)} to decide whether the loop can stop, discard.
+   */
+  protected static final class GroupAdmissionState {
+    private final java.util.HashMap<Object, Integer> perGroup = new java.util.HashMap<>();
+    private final int                                 limit;
+    private final int                                 groupSize;
+    private       int                                 filledGroups = 0;
+
+    public GroupAdmissionState(final int limit, final int groupSize) {
+      this.limit = limit;
+      this.groupSize = groupSize;
+    }
+
+    /**
+     * Decides whether a candidate row with the given group key should be kept. Side-effects the
+     * internal counters when admitting. Returns {@code true} if admitted, {@code false} if the row
+     * must be skipped (group already full, or this would open a {@code (limit + 1)}-th group).
+     */
+    public boolean admit(final Object groupKey) {
+      final int existing = perGroup.getOrDefault(groupKey, 0);
+      if (existing == 0 && perGroup.size() >= limit)
+        return false;
+      if (existing >= groupSize)
+        return false;
+      perGroup.put(groupKey, existing + 1);
+      if (existing + 1 == groupSize)
+        filledGroups++;
+      return true;
+    }
+
+    /**
+     * Returns {@code true} when {@code limit} groups have all reached {@code groupSize}, signalling
+     * the caller to break out of its scoring loop. O(1).
+     */
+    public boolean isFull() {
+      return filledGroups >= limit;
+    }
+  }
+
   protected static Set<RID> parseRidFilter(final List<?> items, final String functionName, final CommandContext context) {
     if (items == null || items.isEmpty())
       return null;

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorAbstract.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorAbstract.java
@@ -18,8 +18,11 @@
  */
 package com.arcadedb.function.sql.vector;
 
+import com.arcadedb.database.Document;
 import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.function.sql.SQLFunctionAbstract;
+
+import java.util.Map;
 
 /**
  * Abstract base class for vector SQL functions providing common utility methods.
@@ -92,5 +95,45 @@ public abstract class SQLFunctionVectorAbstract extends SQLFunctionAbstract {
     if (params == null || params.length != expectedCount) {
       throw new CommandSQLParsingException(getSyntax());
     }
+  }
+
+  /**
+   * Reads a (possibly dotted) property path from a record and returns the leaf value.
+   * <p>
+   * Supports flat property names ({@code "source"}) and dotted nested paths
+   * ({@code "metadata.author"}, {@code "provenance.source.id"}). Each segment after the first
+   * descends one level via {@link Map#get(Object)} for {@code Map}-typed values or
+   * {@link Document#get(String)} for embedded documents. A missing segment short-circuits to
+   * {@code null}; a segment that lands on a non-traversable value (e.g. a primitive in the middle
+   * of the path) also returns {@code null}.
+   * <p>
+   * Used by the {@code groupBy} option on {@code vector.neighbors}, {@code vector.sparseNeighbors},
+   * and {@code vector.fuse} (issue #4072).
+   *
+   * @param record the record to read from; {@code null} returns {@code null}
+   * @param path   the property name or dotted path; {@code null} returns {@code null}
+   *
+   * @return the leaf value, or {@code null} if any segment of the path resolves to {@code null}
+   *         or to a non-traversable intermediate value
+   */
+  protected static Object readNestedField(final Document record, final String path) {
+    if (record == null || path == null || path.isEmpty())
+      return null;
+
+    final int firstDot = path.indexOf('.');
+    if (firstDot < 0)
+      return record.get(path);
+
+    final String[] parts = path.split("\\.");
+    Object current = record.get(parts[0]);
+    for (int i = 1; i < parts.length && current != null; i++) {
+      if (current instanceof Document doc)
+        current = doc.get(parts[i]);
+      else if (current instanceof Map<?, ?> map)
+        current = map.get(parts[i]);
+      else
+        return null;
+    }
+    return current;
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorFuse.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorFuse.java
@@ -107,7 +107,7 @@ public class SQLFunctionVectorFuse extends SQLFunctionVectorAbstract {
 
     // Materialize each source as an ordered list of (rid, score). Score may be NaN when the source
     // does not provide one; that's fine for RRF but rejected later for DBSF/LINEAR.
-    final List<List<SourceRow>> sources = new ArrayList<>(sourceCount);
+    final List<List<RidScore>> sources = new ArrayList<>(sourceCount);
     for (int i = 0; i < sourceCount; i++)
       sources.add(materializeSource(NAME, params[i], i));
 
@@ -126,22 +126,33 @@ public class SQLFunctionVectorFuse extends SQLFunctionVectorAbstract {
       ranked.add(new RidScore(e.getKey(), e.getValue()));
     ranked.sort((a, b) -> Float.compare(b.score, a.score));
 
-    final List<RidScore> finalRanked = groupBy == null ?
-        ranked :
-        applyGroupBy(ranked, groupBy, groupSize, context);
-
-    final int cap = limit > 0 ? Math.min(limit, finalRanked.size()) : finalRanked.size();
-    final ArrayList<Object> result = new ArrayList<>(cap);
+    // Single pass: lookupByRID once per RID, applying groupBy and limit on the fly. Doing this
+    // in two passes (one to filter by group, one to serialize) would double the record I/O for
+    // large result sets.
+    final HashMap<Object, Integer> perGroup = groupBy != null ? new HashMap<>() : null;
+    final int targetSize = limit > 0 ? limit : Integer.MAX_VALUE;
+    final ArrayList<Object> result = new ArrayList<>(Math.min(targetSize, ranked.size()));
     final BasicDatabase db = context.getDatabase();
 
-    for (int i = 0; i < cap; i++) {
-      final RidScore rs = finalRanked.get(i);
+    for (final RidScore rs : ranked) {
+      if (result.size() >= targetSize)
+        break;
+
       final Document record;
       try {
         record = (Document) db.lookupByRID(rs.rid, true);
       } catch (final RecordNotFoundException ex) {
         continue;
       }
+
+      if (groupBy != null) {
+        final Object groupKey = readNestedField(record, groupBy);
+        final int count = perGroup.getOrDefault(groupKey, 0);
+        if (count >= groupSize)
+          continue;
+        perGroup.put(groupKey, count + 1);
+      }
+
       final LinkedHashMap<String, Object> entry = new LinkedHashMap<>();
       entry.put("record", record);
       for (final String prop : record.getPropertyNames())
@@ -184,25 +195,26 @@ public class SQLFunctionVectorFuse extends SQLFunctionVectorAbstract {
   }
 
   /**
-   * Reads an arbitrary source representation into a flat ordered list of {@link SourceRow}.
+   * Reads an arbitrary source representation into a flat ordered list of {@link RidScore} rows
+   * (each carrying the row's RID and its score, NaN if the source has no numeric score field).
    * Handles both the {@link Map}-shaped output of native vector SQL functions and the {@link Result}
    * shaped output of plain sub-SELECT queries.
    */
   @SuppressWarnings("unchecked")
-  private static List<SourceRow> materializeSource(final String functionName, final Object src, final int sourceIdx) {
+  private static List<RidScore> materializeSource(final String functionName, final Object src, final int sourceIdx) {
     if (src == null)
       return java.util.Collections.emptyList();
     if (!(src instanceof Iterable<?> iter))
       throw new CommandSQLParsingException(
           functionName + " source[" + sourceIdx + "] must be a list of rows, got: " + src.getClass().getSimpleName());
 
-    final ArrayList<SourceRow> out = new ArrayList<>();
+    final ArrayList<RidScore> out = new ArrayList<>();
     for (final Object row : iter) {
       final RID rid = extractRid(row);
       if (rid == null)
         continue;
       final float score = extractScore(row);
-      out.add(new SourceRow(rid, score));
+      out.add(new RidScore(rid, score));
     }
     return out;
   }
@@ -256,10 +268,10 @@ public class SQLFunctionVectorFuse extends SQLFunctionVectorAbstract {
     return Float.NaN;
   }
 
-  private static void applyRRF(final List<List<SourceRow>> sources, final float[] weights, final long k,
+  private static void applyRRF(final List<List<RidScore>> sources, final float[] weights, final long k,
       final HashMap<RID, Float> out) {
     for (int s = 0; s < sources.size(); s++) {
-      final List<SourceRow> rows = sources.get(s);
+      final List<RidScore> rows = sources.get(s);
       final float w = weights[s];
       for (int rank = 0; rank < rows.size(); rank++) {
         // Position 0 = rank 1 in the RRF formula.
@@ -269,39 +281,39 @@ public class SQLFunctionVectorFuse extends SQLFunctionVectorAbstract {
     }
   }
 
-  private static void applyLinear(final List<List<SourceRow>> sources, final float[] weights,
+  private static void applyLinear(final List<List<RidScore>> sources, final float[] weights,
       final HashMap<RID, Float> out) {
     for (int s = 0; s < sources.size(); s++) {
-      final List<SourceRow> rows = sources.get(s);
+      final List<RidScore> rows = sources.get(s);
       requireScores(rows, "LINEAR", s);
       // Min-max normalize per source.
       float min = Float.POSITIVE_INFINITY;
       float max = Float.NEGATIVE_INFINITY;
-      for (final SourceRow r : rows) {
+      for (final RidScore r : rows) {
         if (r.score < min) min = r.score;
         if (r.score > max) max = r.score;
       }
       final float range = max - min;
       final float w = weights[s];
-      for (final SourceRow r : rows) {
+      for (final RidScore r : rows) {
         final float normalized = range == 0.0f ? 1.0f : (r.score - min) / range;
         out.merge(r.rid, w * normalized, Float::sum);
       }
     }
   }
 
-  private static void applyDBSF(final List<List<SourceRow>> sources, final float[] weights,
+  private static void applyDBSF(final List<List<RidScore>> sources, final float[] weights,
       final HashMap<RID, Float> out) {
     for (int s = 0; s < sources.size(); s++) {
-      final List<SourceRow> rows = sources.get(s);
+      final List<RidScore> rows = sources.get(s);
       requireScores(rows, "DBSF", s);
       // mean and population stddev
       final int n = rows.size();
       double sum = 0.0;
-      for (final SourceRow r : rows) sum += r.score;
+      for (final RidScore r : rows) sum += r.score;
       final double mean = n == 0 ? 0.0 : sum / n;
       double sqSum = 0.0;
-      for (final SourceRow r : rows) {
+      for (final RidScore r : rows) {
         final double d = r.score - mean;
         sqSum += d * d;
       }
@@ -311,7 +323,7 @@ public class SQLFunctionVectorFuse extends SQLFunctionVectorAbstract {
       final double hi = mean + 3.0 * std;
       final double band = hi - lo;
       final float w = weights[s];
-      for (final SourceRow r : rows) {
+      for (final RidScore r : rows) {
         final double clipped = Math.max(lo, Math.min(hi, r.score));
         final float normalized = band == 0.0 ? 1.0f : (float) ((clipped - lo) / band);
         out.merge(r.rid, w * normalized, Float::sum);
@@ -319,34 +331,11 @@ public class SQLFunctionVectorFuse extends SQLFunctionVectorAbstract {
     }
   }
 
-  private static void requireScores(final List<SourceRow> rows, final String strategy, final int sourceIdx) {
-    for (final SourceRow r : rows)
+  private static void requireScores(final List<RidScore> rows, final String strategy, final int sourceIdx) {
+    for (final RidScore r : rows)
       if (Float.isNaN(r.score))
         throw new CommandSQLParsingException(
             NAME + " strategy " + strategy + " requires a numeric score on every row of source[" + sourceIdx + "]");
-  }
-
-  private List<RidScore> applyGroupBy(final List<RidScore> ranked, final String groupBy, final int groupSize,
-      final CommandContext context) {
-    final HashMap<Object, Integer> perGroup = new HashMap<>();
-    final ArrayList<RidScore> kept = new ArrayList<>();
-    final BasicDatabase db = context.getDatabase();
-
-    for (final RidScore rs : ranked) {
-      final Document record;
-      try {
-        record = (Document) db.lookupByRID(rs.rid, true);
-      } catch (final RecordNotFoundException e) {
-        continue;
-      }
-      final Object groupKey = readNestedField(record, groupBy);
-      final int count = perGroup.getOrDefault(groupKey, 0);
-      if (count >= groupSize)
-        continue;
-      perGroup.put(groupKey, count + 1);
-      kept.add(rs);
-    }
-    return kept;
   }
 
   @Override
@@ -355,16 +344,11 @@ public class SQLFunctionVectorFuse extends SQLFunctionVectorAbstract {
         + "k: <long>, weights: [<float>, ...], groupBy: <field>, groupSize: <int>, limit: <int> }])";
   }
 
-  private static final class SourceRow {
-    final RID   rid;
-    final float score;
-
-    SourceRow(final RID rid, final float score) {
-      this.rid = rid;
-      this.score = score;
-    }
-  }
-
+  /**
+   * Carries one ranked record across the materialization, fusion, grouping, and result-building
+   * stages. Both per-source ranked rows (the input to the fusion strategies) and the fused output
+   * use the same shape, so a single record type avoids an unnecessary translation pass.
+   */
   private static final class RidScore {
     final RID   rid;
     final float score;

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorFuse.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorFuse.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.sql.vector;
+
+import com.arcadedb.database.BasicDatabase;
+import com.arcadedb.database.Document;
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.database.RID;
+import com.arcadedb.exception.CommandSQLParsingException;
+import com.arcadedb.exception.RecordNotFoundException;
+import com.arcadedb.function.sql.FunctionOptions;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Server-side hybrid retrieval fusion. Combines ranked output from two or more sub-pipelines into a
+ * single ranked top-K using one of three strategies:
+ * <ul>
+ *   <li><b>RRF</b> - Reciprocal Rank Fusion. {@code score = Σ_i weight_i / (k + rank_i)}; rank-only,
+ *       does not require per-row scores.</li>
+ *   <li><b>DBSF</b> - Distribution-Based Score Fusion (Qdrant 1.11+). Per-source score normalization
+ *       to {@code [mean - 3σ, mean + 3σ]}, then weighted sum.</li>
+ *   <li><b>LINEAR</b> - Per-source min-max normalization, then weighted sum. Requires per-row scores.</li>
+ * </ul>
+ * <p>
+ * Usage: {@code vector.fuse(source1, source2, ..., sourceN [, options])}
+ * <p>
+ * Each source is the output of a sub-pipeline that yields ranked rows with at least an {@code @rid}.
+ * Recognised sources include {@code vector.neighbors}, {@code vector.sparseNeighbors},
+ * {@code SEARCH_INDEX(...)}, and any plain {@code SELECT ... ORDER BY ... LIMIT N}.
+ * <p>
+ * The optional trailing options map accepts: {@code fusion} ('RRF' | 'DBSF' | 'LINEAR', default
+ * 'RRF'), {@code k} (RRF constant, default 60), {@code weights} (per-source list of floats, default
+ * 1.0 for all), {@code groupBy} (payload field for post-fusion grouping), {@code groupSize}
+ * (max rows per group, default 1), {@code limit} (max rows returned, default unlimited).
+ * <p>
+ * Score conventions: this function assumes higher = better. Sources whose native score is a
+ * distance (e.g. {@code vector.neighbors} returning {@code distance}) should be wrapped in a
+ * sub-SELECT that exposes a similarity instead, or use {@code RRF} which is rank-only and
+ * indifferent to score direction.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class SQLFunctionVectorFuse extends SQLFunctionVectorAbstract {
+  public static final String NAME = "vector.fuse";
+
+  private static final java.util.Set<String> OPTIONS = java.util.Set.of(
+      "fusion", "k", "weights", "groupBy", "groupSize", "limit");
+
+  private static final long DEFAULT_K = 60L;
+
+  private enum Strategy { RRF, DBSF, LINEAR }
+
+  public SQLFunctionVectorFuse() {
+    super(NAME);
+  }
+
+  @Override
+  public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
+      final CommandContext context) {
+    if (params == null || params.length == 0)
+      throw new CommandSQLParsingException(getSyntax());
+
+    // Detect the trailing options map.
+    int sourceCount = params.length;
+    Map<?, ?> rawOpts = null;
+    if (params[params.length - 1] instanceof Map<?, ?> m) {
+      rawOpts = m;
+      sourceCount = params.length - 1;
+    }
+
+    if (sourceCount < 2)
+      throw new CommandSQLParsingException(NAME + " requires at least 2 sources, got " + sourceCount);
+
+    final FunctionOptions opts = new FunctionOptions(NAME, rawOpts, OPTIONS);
+    final Strategy strategy = parseStrategy(opts.getString("fusion", "RRF"));
+    final long k = opts.getLong("k", DEFAULT_K);
+    final float[] weights = parseWeights(opts.getList("weights"), sourceCount);
+    final String groupBy = opts.getString("groupBy", null);
+    final int groupSize = opts.getInt("groupSize", 1);
+    final int limit = opts.getInt("limit", -1);
+
+    if (groupSize < 1)
+      throw new CommandSQLParsingException(NAME + " groupSize must be >= 1, got " + groupSize);
+
+    // Materialize each source as an ordered list of (rid, score). Score may be NaN when the source
+    // does not provide one; that's fine for RRF but rejected later for DBSF/LINEAR.
+    final List<List<SourceRow>> sources = new ArrayList<>(sourceCount);
+    for (int i = 0; i < sourceCount; i++)
+      sources.add(materializeSource(NAME, params[i], i));
+
+    final HashMap<RID, Float> fused = new HashMap<>();
+    switch (strategy) {
+    case RRF -> applyRRF(sources, weights, k, fused);
+    case LINEAR -> applyLinear(sources, weights, fused);
+    case DBSF -> applyDBSF(sources, weights, fused);
+    }
+
+    if (fused.isEmpty())
+      return new ArrayList<>(0);
+
+    final ArrayList<RidScore> ranked = new ArrayList<>(fused.size());
+    for (final Map.Entry<RID, Float> e : fused.entrySet())
+      ranked.add(new RidScore(e.getKey(), e.getValue()));
+    ranked.sort((a, b) -> Float.compare(b.score, a.score));
+
+    final List<RidScore> finalRanked = groupBy == null ?
+        ranked :
+        applyGroupBy(ranked, groupBy, groupSize, context);
+
+    final int cap = limit > 0 ? Math.min(limit, finalRanked.size()) : finalRanked.size();
+    final ArrayList<Object> result = new ArrayList<>(cap);
+    final BasicDatabase db = context.getDatabase();
+
+    for (int i = 0; i < cap; i++) {
+      final RidScore rs = finalRanked.get(i);
+      final Document record;
+      try {
+        record = (Document) db.lookupByRID(rs.rid, true);
+      } catch (final RecordNotFoundException ex) {
+        continue;
+      }
+      final LinkedHashMap<String, Object> entry = new LinkedHashMap<>();
+      entry.put("record", record);
+      for (final String prop : record.getPropertyNames())
+        entry.put(prop, record.get(prop));
+      entry.put("@rid", record.getIdentity());
+      entry.put("@type", record.getTypeName());
+      entry.put("score", rs.score);
+      result.add(entry);
+    }
+    return result;
+  }
+
+  private static Strategy parseStrategy(final String raw) {
+    final String name = raw == null ? "RRF" : raw.toUpperCase();
+    try {
+      return Strategy.valueOf(name);
+    } catch (final IllegalArgumentException e) {
+      throw new CommandSQLParsingException(
+          "Unknown fusion strategy '" + raw + "'. Allowed: RRF, DBSF, LINEAR");
+    }
+  }
+
+  private static float[] parseWeights(final List<?> raw, final int count) {
+    if (raw == null) {
+      final float[] uniform = new float[count];
+      java.util.Arrays.fill(uniform, 1.0f);
+      return uniform;
+    }
+    if (raw.size() != count)
+      throw new CommandSQLParsingException(
+          NAME + " weights size " + raw.size() + " does not match source count " + count);
+    final float[] out = new float[count];
+    for (int i = 0; i < count; i++) {
+      final Object o = raw.get(i);
+      if (!(o instanceof Number n))
+        throw new CommandSQLParsingException(NAME + " weights[" + i + "] must be a number, got: " + o);
+      out[i] = n.floatValue();
+    }
+    return out;
+  }
+
+  /**
+   * Reads an arbitrary source representation into a flat ordered list of {@link SourceRow}.
+   * Handles both the {@link Map}-shaped output of native vector SQL functions and the {@link Result}
+   * shaped output of plain sub-SELECT queries.
+   */
+  @SuppressWarnings("unchecked")
+  private static List<SourceRow> materializeSource(final String functionName, final Object src, final int sourceIdx) {
+    if (src == null)
+      return java.util.Collections.emptyList();
+    if (!(src instanceof Iterable<?> iter))
+      throw new CommandSQLParsingException(
+          functionName + " source[" + sourceIdx + "] must be a list of rows, got: " + src.getClass().getSimpleName());
+
+    final ArrayList<SourceRow> out = new ArrayList<>();
+    for (final Object row : iter) {
+      final RID rid = extractRid(row);
+      if (rid == null)
+        continue;
+      final float score = extractScore(row);
+      out.add(new SourceRow(rid, score));
+    }
+    return out;
+  }
+
+  private static RID extractRid(final Object row) {
+    if (row == null)
+      return null;
+    if (row instanceof Map<?, ?> m) {
+      Object v = m.get("@rid");
+      if (v == null) v = m.get("rid");
+      if (v instanceof RID r) return r;
+      if (v instanceof Identifiable id) return id.getIdentity();
+      return null;
+    }
+    if (row instanceof Result r) {
+      if (r.getIdentity().isPresent())
+        return r.getIdentity().get();
+      Object v = r.getProperty("@rid");
+      if (v == null) v = r.getProperty("rid");
+      if (v instanceof RID rid) return rid;
+      if (v instanceof Identifiable id) return id.getIdentity();
+      return null;
+    }
+    if (row instanceof Identifiable id)
+      return id.getIdentity();
+    return null;
+  }
+
+  private static float extractScore(final Object row) {
+    // "score" and "$score" carry similarity semantics (higher = better) by convention. "distance"
+    // is the legacy key used by `vector.neighbors`; lower = better, so we flip its sign so the rest
+    // of the fusion code can assume a single direction.
+    if (row instanceof Map<?, ?> m) {
+      final Object score = m.get("score");
+      if (score instanceof Number n) return n.floatValue();
+      final Object dollar = m.get("$score");
+      if (dollar instanceof Number n) return n.floatValue();
+      final Object distance = m.get("distance");
+      if (distance instanceof Number n) return -n.floatValue();
+      return Float.NaN;
+    }
+    if (row instanceof Result r) {
+      final Object score = r.getProperty("score");
+      if (score instanceof Number n) return n.floatValue();
+      final Object dollar = r.getProperty("$score");
+      if (dollar instanceof Number n) return n.floatValue();
+      final Object distance = r.getProperty("distance");
+      if (distance instanceof Number n) return -n.floatValue();
+      return Float.NaN;
+    }
+    return Float.NaN;
+  }
+
+  private static void applyRRF(final List<List<SourceRow>> sources, final float[] weights, final long k,
+      final HashMap<RID, Float> out) {
+    for (int s = 0; s < sources.size(); s++) {
+      final List<SourceRow> rows = sources.get(s);
+      final float w = weights[s];
+      for (int rank = 0; rank < rows.size(); rank++) {
+        // Position 0 = rank 1 in the RRF formula.
+        final float contrib = (float) (w / (k + (rank + 1L)));
+        out.merge(rows.get(rank).rid, contrib, Float::sum);
+      }
+    }
+  }
+
+  private static void applyLinear(final List<List<SourceRow>> sources, final float[] weights,
+      final HashMap<RID, Float> out) {
+    for (int s = 0; s < sources.size(); s++) {
+      final List<SourceRow> rows = sources.get(s);
+      requireScores(rows, "LINEAR", s);
+      // Min-max normalize per source.
+      float min = Float.POSITIVE_INFINITY;
+      float max = Float.NEGATIVE_INFINITY;
+      for (final SourceRow r : rows) {
+        if (r.score < min) min = r.score;
+        if (r.score > max) max = r.score;
+      }
+      final float range = max - min;
+      final float w = weights[s];
+      for (final SourceRow r : rows) {
+        final float normalized = range == 0.0f ? 1.0f : (r.score - min) / range;
+        out.merge(r.rid, w * normalized, Float::sum);
+      }
+    }
+  }
+
+  private static void applyDBSF(final List<List<SourceRow>> sources, final float[] weights,
+      final HashMap<RID, Float> out) {
+    for (int s = 0; s < sources.size(); s++) {
+      final List<SourceRow> rows = sources.get(s);
+      requireScores(rows, "DBSF", s);
+      // mean and population stddev
+      final int n = rows.size();
+      double sum = 0.0;
+      for (final SourceRow r : rows) sum += r.score;
+      final double mean = n == 0 ? 0.0 : sum / n;
+      double sqSum = 0.0;
+      for (final SourceRow r : rows) {
+        final double d = r.score - mean;
+        sqSum += d * d;
+      }
+      final double std = n == 0 ? 0.0 : Math.sqrt(sqSum / n);
+      // Qdrant DBSF: clip to [mean - 3σ, mean + 3σ], then linear-normalize that band to [0, 1].
+      final double lo = mean - 3.0 * std;
+      final double hi = mean + 3.0 * std;
+      final double band = hi - lo;
+      final float w = weights[s];
+      for (final SourceRow r : rows) {
+        final double clipped = Math.max(lo, Math.min(hi, r.score));
+        final float normalized = band == 0.0 ? 1.0f : (float) ((clipped - lo) / band);
+        out.merge(r.rid, w * normalized, Float::sum);
+      }
+    }
+  }
+
+  private static void requireScores(final List<SourceRow> rows, final String strategy, final int sourceIdx) {
+    for (final SourceRow r : rows)
+      if (Float.isNaN(r.score))
+        throw new CommandSQLParsingException(
+            NAME + " strategy " + strategy + " requires a numeric score on every row of source[" + sourceIdx + "]");
+  }
+
+  private List<RidScore> applyGroupBy(final List<RidScore> ranked, final String groupBy, final int groupSize,
+      final CommandContext context) {
+    final HashMap<Object, Integer> perGroup = new HashMap<>();
+    final ArrayList<RidScore> kept = new ArrayList<>();
+    final BasicDatabase db = context.getDatabase();
+
+    for (final RidScore rs : ranked) {
+      final Document record;
+      try {
+        record = (Document) db.lookupByRID(rs.rid, true);
+      } catch (final RecordNotFoundException e) {
+        continue;
+      }
+      final Object groupKey = record.get(groupBy);
+      final int count = perGroup.getOrDefault(groupKey, 0);
+      if (count >= groupSize)
+        continue;
+      perGroup.put(groupKey, count + 1);
+      kept.add(rs);
+    }
+    return kept;
+  }
+
+  @Override
+  public String getSyntax() {
+    return NAME + "(<source1>, <source2>, ..., <sourceN>[, { fusion: 'RRF'|'DBSF'|'LINEAR', "
+        + "k: <long>, weights: [<float>, ...], groupBy: <field>, groupSize: <int>, limit: <int> }])";
+  }
+
+  private static final class SourceRow {
+    final RID   rid;
+    final float score;
+
+    SourceRow(final RID rid, final float score) {
+      this.rid = rid;
+      this.score = score;
+    }
+  }
+
+  private static final class RidScore {
+    final RID   rid;
+    final float score;
+
+    RidScore(final RID rid, final float score) {
+      this.rid = rid;
+      this.score = score;
+    }
+  }
+}

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorFuse.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorFuse.java
@@ -339,7 +339,7 @@ public class SQLFunctionVectorFuse extends SQLFunctionVectorAbstract {
       } catch (final RecordNotFoundException e) {
         continue;
       }
-      final Object groupKey = record.get(groupBy);
+      final Object groupKey = readNestedField(record, groupBy);
       final int count = perGroup.getOrDefault(groupKey, 0);
       if (count >= groupSize)
         continue;

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorFuse.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorFuse.java
@@ -129,7 +129,14 @@ public class SQLFunctionVectorFuse extends SQLFunctionVectorAbstract {
     // Single pass: lookupByRID once per RID, applying groupBy and limit on the fly. Doing this
     // in two passes (one to filter by group, one to serialize) would double the record I/O for
     // large result sets.
-    final HashMap<Object, Integer> perGroup = groupBy != null ? new HashMap<>() : null;
+    //
+    // GroupAdmissionState is used with an unbounded group count (Integer.MAX_VALUE) because
+    // `vector.fuse`'s `limit` caps total rows, not distinct groups; only the per-group cap
+    // applies here. For `vector.neighbors` / `vector.sparseNeighbors`, the same helper takes a
+    // finite limit so it doubles as the "we have enough groups" early-exit predicate.
+    final GroupAdmissionState groups = groupBy != null
+        ? new GroupAdmissionState(Integer.MAX_VALUE, groupSize)
+        : null;
     final int targetSize = limit > 0 ? limit : Integer.MAX_VALUE;
     final ArrayList<Object> result = new ArrayList<>(Math.min(targetSize, ranked.size()));
     final BasicDatabase db = context.getDatabase();
@@ -145,13 +152,8 @@ public class SQLFunctionVectorFuse extends SQLFunctionVectorAbstract {
         continue;
       }
 
-      if (groupBy != null) {
-        final Object groupKey = readNestedField(record, groupBy);
-        final int count = perGroup.getOrDefault(groupKey, 0);
-        if (count >= groupSize)
-          continue;
-        perGroup.put(groupKey, count + 1);
-      }
+      if (groupBy != null && !groups.admit(readNestedField(record, groupBy)))
+        continue;
 
       final LinkedHashMap<String, Object> entry = new LinkedHashMap<>();
       entry.put("record", record);

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighbors.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighbors.java
@@ -249,7 +249,7 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
       }
 
       if (groupBy != null) {
-        final Object groupKey = record.get(groupBy);
+        final Object groupKey = readNestedField(record, groupBy);
         final int existing = perGroup.getOrDefault(groupKey, 0);
         // Skip if the group already saw a new group beyond our limit.
         if (existing == 0 && perGroup.size() >= limit)

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighbors.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighbors.java
@@ -38,7 +38,6 @@ import com.arcadedb.utility.Pair;
 
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -221,10 +220,7 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
 
     final BasicDatabase db = context.getDatabase();
     final ArrayList<Object> result = new ArrayList<>();
-    final HashMap<Object, Integer> perGroup = groupBy != null ? new HashMap<>() : null;
-    // Number of groups that have already reached groupSize. Used as an O(1) early-exit predicate
-    // to avoid scanning the perGroup map values on every iteration.
-    int filledGroups = 0;
+    final GroupAdmissionState groups = groupBy != null ? new GroupAdmissionState(limit, groupSize) : null;
 
     for (final Pair<RID, Float> neighbor : allNeighbors) {
       // Stop conditions:
@@ -233,7 +229,7 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
       if (groupBy == null) {
         if (result.size() >= limit)
           break;
-      } else if (filledGroups >= limit) {
+      } else if (groups.isFull()) {
         break;
       }
 
@@ -248,18 +244,8 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
         continue;
       }
 
-      if (groupBy != null) {
-        final Object groupKey = readNestedField(record, groupBy);
-        final int existing = perGroup.getOrDefault(groupKey, 0);
-        // Skip a never-seen group once we've already opened `limit` distinct groups.
-        if (existing == 0 && perGroup.size() >= limit)
-          continue;
-        if (existing >= groupSize)
-          continue;
-        perGroup.put(groupKey, existing + 1);
-        if (existing + 1 == groupSize)
-          filledGroups++;
-      }
+      if (groupBy != null && !groups.admit(readNestedField(record, groupBy)))
+        continue;
 
       final float distance = neighbor.getSecond();
 

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighbors.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighbors.java
@@ -55,6 +55,12 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
 
   private static final Set<String> OPTIONS = Set.of("efSearch", "filter", "groupBy", "groupSize");
 
+  // Hard cap on the candidate pool the index is asked to materialize when grouping is enabled.
+  // Prevents memory exhaustion on pathological combinations of `k` and `groupSize` (e.g. k=1000,
+  // groupSize=1000 would otherwise request 5,000,000 candidates). Picked conservatively: ~100k
+  // RID-distance pairs is a few MB of heap, well under the budget for any realistic query.
+  private static final int MAX_FETCH_CANDIDATES = 100_000;
+
   public SQLFunctionVectorNeighbors() {
     super(NAME);
   }
@@ -87,7 +93,7 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
       if (params[3] instanceof Map<?, ?> rawMap) {
         final FunctionOptions opts = new FunctionOptions(NAME, rawMap, OPTIONS);
         efSearch = opts.getInt("efSearch", -1);
-        allowedRIDs = parseFilter(opts.getList("filter"), context);
+        allowedRIDs = parseRidFilter(opts.getList("filter"), NAME, context);
         groupBy = opts.getString("groupBy", null);
         groupSize = opts.getInt("groupSize", 1);
         if (groupSize < 1)
@@ -138,28 +144,6 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
     return executeWithTypeIndex(typeIndex, allowedBucketIds, key, limit, efSearch, allowedRIDs, groupBy, groupSize, context);
   }
 
-  private static Set<RID> parseFilter(final List<?> items, final CommandContext context) {
-    if (items == null || items.isEmpty())
-      return null;
-
-    final BasicDatabase db = context.getDatabase();
-    final Set<RID> out = new HashSet<>(items.size());
-    for (final Object item : items) {
-      if (item == null)
-        continue;
-      if (item instanceof RID rid)
-        out.add(rid);
-      else if (item instanceof Identifiable id)
-        out.add(id.getIdentity());
-      else if (item instanceof String s)
-        out.add(db.newRID(s));
-      else
-        throw new CommandSQLParsingException(
-            "Option 'filter' for function '" + NAME + "' must contain RIDs, got: " + item.getClass().getSimpleName());
-    }
-    return out;
-  }
-
   private Object executeWithTypeIndex(final TypeIndex typeIndex, final IntHashSet allowedBucketIds, final Object key,
       final int limit, final int efSearch, final Set<RID> allowedRIDs, final String groupBy, final int groupSize,
       final CommandContext context) {
@@ -205,10 +189,24 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
     // Get the query vector
     final float[] queryVector = extractQueryVector(key, vectorIndexes.getFirst(), context);
 
-    // When grouping, over-fetch candidates so the post-traversal filter has enough material to fill
-    // limit groups at groupSize each. The 5x cushion is empirical and may be undershoot for highly
-    // skewed group distributions; users can lift it via efSearch.
-    final int fetchPerIndex = groupBy == null ? limit : Math.max(limit * groupSize * 5, limit);
+    // When grouping, over-fetch candidates so the post-traversal filter has enough material to
+    // fill limit groups at groupSize each. The 5x cushion is empirical; highly skewed group
+    // distributions may need more, in which case users can lift recall via efSearch.
+    //
+    // Hard-cap the fetch at MAX_FETCH_CANDIDATES so a pathological combination of `limit` and
+    // `groupSize` cannot blow up the candidate pool. The product is computed in long arithmetic
+    // first to detect overflow before truncating to int.
+    final int fetchPerIndex;
+    if (groupBy == null) {
+      fetchPerIndex = limit;
+    } else {
+      final long requested = Math.max((long) limit * groupSize * 5L, (long) limit);
+      if (requested > MAX_FETCH_CANDIDATES)
+        throw new CommandSQLParsingException(NAME + " over-fetch budget exceeded: limit=" + limit
+            + ", groupSize=" + groupSize + " would require " + requested
+            + " candidates (cap " + MAX_FETCH_CANDIDATES + "). Reduce limit or groupSize.");
+      fetchPerIndex = (int) requested;
+    }
 
     // Search across all indexes and collect results
     final List<Pair<RID, Float>> allNeighbors = new ArrayList<>();
@@ -224,16 +222,18 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
     final BasicDatabase db = context.getDatabase();
     final ArrayList<Object> result = new ArrayList<>();
     final HashMap<Object, Integer> perGroup = groupBy != null ? new HashMap<>() : null;
+    // Number of groups that have already reached groupSize. Used as an O(1) early-exit predicate
+    // to avoid scanning the perGroup map values on every iteration.
+    int filledGroups = 0;
 
     for (final Pair<RID, Float> neighbor : allNeighbors) {
       // Stop conditions:
       //   - groupBy unset: stop once we collected `limit` rows
-      //   - groupBy set: stop once we filled `limit` groups
+      //   - groupBy set: stop once `limit` groups have been filled to groupSize
       if (groupBy == null) {
         if (result.size() >= limit)
           break;
-      } else if (perGroup.size() >= limit
-          && perGroup.values().stream().allMatch(c -> c >= groupSize)) {
+      } else if (filledGroups >= limit) {
         break;
       }
 
@@ -251,12 +251,14 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
       if (groupBy != null) {
         final Object groupKey = readNestedField(record, groupBy);
         final int existing = perGroup.getOrDefault(groupKey, 0);
-        // Skip if the group already saw a new group beyond our limit.
+        // Skip a never-seen group once we've already opened `limit` distinct groups.
         if (existing == 0 && perGroup.size() >= limit)
           continue;
         if (existing >= groupSize)
           continue;
         perGroup.put(groupKey, existing + 1);
+        if (existing + 1 == groupSize)
+          filledGroups++;
       }
 
       final float distance = neighbor.getSecond();

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighbors.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighbors.java
@@ -36,7 +36,14 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.utility.IntHashSet;
 import com.arcadedb.utility.Pair;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Returns the K neighbors from a vertex. This function requires a vector index has been created beforehand.
@@ -46,7 +53,7 @@ import java.util.*;
 public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
   public static final String NAME = "vector.neighbors";
 
-  private static final Set<String> OPTIONS = Set.of("efSearch", "filter");
+  private static final Set<String> OPTIONS = Set.of("efSearch", "filter", "groupBy", "groupSize");
 
   public SQLFunctionVectorNeighbors() {
     super(NAME);
@@ -70,15 +77,21 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
 
     // Optional 4th parameter. Either:
     //   - a number: efSearch (backward-compatible positional form)
-    //   - a map: options {efSearch, filter}
+    //   - a map: options {efSearch, filter, groupBy, groupSize}
     int efSearch = -1;
     Set<RID> allowedRIDs = null;
+    String groupBy = null;
+    int groupSize = 1;
 
     if (params.length >= 4 && params[3] != null) {
       if (params[3] instanceof Map<?, ?> rawMap) {
         final FunctionOptions opts = new FunctionOptions(NAME, rawMap, OPTIONS);
         efSearch = opts.getInt("efSearch", -1);
         allowedRIDs = parseFilter(opts.getList("filter"), context);
+        groupBy = opts.getString("groupBy", null);
+        groupSize = opts.getInt("groupSize", 1);
+        if (groupSize < 1)
+          throw new CommandSQLParsingException(NAME + " groupSize must be >= 1, got " + groupSize);
       } else if (params[3] instanceof Number n) {
         efSearch = n.intValue();
       } else {
@@ -97,7 +110,7 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
       // Assume it's just an index name
       final Index directIndex = context.getDatabase().getSchema().getIndexByName(indexSpec);
       if (directIndex instanceof TypeIndex typeIndex) {
-        return executeWithTypeIndex(typeIndex, null, key, limit, efSearch, allowedRIDs, context);
+        return executeWithTypeIndex(typeIndex, null, key, limit, efSearch, allowedRIDs, groupBy, groupSize, context);
       }
       throw new CommandSQLParsingException(
           "Index '" + indexSpec + "' is not a vector index (found: " + (directIndex != null ? directIndex.getClass().getSimpleName() : "null") + ")");
@@ -122,7 +135,7 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
       allowedBucketIds.add(bucket.getFileId());
     }
 
-    return executeWithTypeIndex(typeIndex, allowedBucketIds, key, limit, efSearch, allowedRIDs, context);
+    return executeWithTypeIndex(typeIndex, allowedBucketIds, key, limit, efSearch, allowedRIDs, groupBy, groupSize, context);
   }
 
   private static Set<RID> parseFilter(final List<?> items, final CommandContext context) {
@@ -148,7 +161,8 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
   }
 
   private Object executeWithTypeIndex(final TypeIndex typeIndex, final IntHashSet allowedBucketIds, final Object key,
-      final int limit, final int efSearch, final Set<RID> allowedRIDs, final CommandContext context) {
+      final int limit, final int efSearch, final Set<RID> allowedRIDs, final String groupBy, final int groupSize,
+      final CommandContext context) {
     final var bucketIndexes = typeIndex.getIndexesOnBuckets();
     if (bucketIndexes == null || bucketIndexes.length == 0) {
       throw new CommandSQLParsingException("Index '" + typeIndex.getName() + "' has no bucket indexes");
@@ -174,46 +188,75 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
     }
 
     // Search across all matching vector indexes and merge results
-    return executeWithLSMVectorIndexes(vectorIndexes, key, limit, efSearch, allowedRIDs, context);
+    return executeWithLSMVectorIndexes(vectorIndexes, key, limit, efSearch, allowedRIDs, groupBy, groupSize, context);
   }
 
   /**
    * Search across multiple vector indexes and merge the results.
    * This is used when searching within a specific type that may have multiple buckets.
+   * <p>
+   * When {@code groupBy} is set, the index is asked for an over-fetched candidate pool and the
+   * top-{@code limit} <em>groups</em> are returned, each capped at {@code groupSize} rows. Best-effort:
+   * fewer groups may be returned if the candidate pool runs out before {@code limit} groups are filled,
+   * in which case raising the index's {@code efSearch} option improves coverage.
    */
   private Object executeWithLSMVectorIndexes(final List<LSMVectorIndex> vectorIndexes, final Object key, final int limit,
-      final int efSearch, final Set<RID> allowedRIDs, final CommandContext context) {
+      final int efSearch, final Set<RID> allowedRIDs, final String groupBy, final int groupSize, final CommandContext context) {
     // Get the query vector
     final float[] queryVector = extractQueryVector(key, vectorIndexes.getFirst(), context);
+
+    // When grouping, over-fetch candidates so the post-traversal filter has enough material to fill
+    // limit groups at groupSize each. The 5x cushion is empirical and may be undershoot for highly
+    // skewed group distributions; users can lift it via efSearch.
+    final int fetchPerIndex = groupBy == null ? limit : Math.max(limit * groupSize * 5, limit);
 
     // Search across all indexes and collect results
     final List<Pair<RID, Float>> allNeighbors = new ArrayList<>();
 
     for (final LSMVectorIndex lsmIndex : vectorIndexes) {
-      // Request more results from each index to ensure we have enough after merging
-      final List<Pair<RID, Float>> neighbors = lsmIndex.findNeighborsFromVector(queryVector, limit, efSearch, allowedRIDs);
+      final List<Pair<RID, Float>> neighbors = lsmIndex.findNeighborsFromVector(queryVector, fetchPerIndex, efSearch, allowedRIDs);
       allNeighbors.addAll(neighbors);
     }
 
     // Sort by distance (ascending - closer is better for similarity search)
     allNeighbors.sort(Comparator.comparing(Pair::getSecond));
 
-    // Take top k results
-    final int resultCount = Math.min(limit, allNeighbors.size());
-    final ArrayList<Object> result = new ArrayList<>(resultCount);
+    final BasicDatabase db = context.getDatabase();
+    final ArrayList<Object> result = new ArrayList<>();
+    final HashMap<Object, Integer> perGroup = groupBy != null ? new HashMap<>() : null;
 
-    for (int i = 0; i < resultCount; i++) {
-      final Pair<RID, Float> neighbor = allNeighbors.get(i);
+    for (final Pair<RID, Float> neighbor : allNeighbors) {
+      // Stop conditions:
+      //   - groupBy unset: stop once we collected `limit` rows
+      //   - groupBy set: stop once we filled `limit` groups
+      if (groupBy == null) {
+        if (result.size() >= limit)
+          break;
+      } else if (perGroup.size() >= limit
+          && perGroup.values().stream().allMatch(c -> c >= groupSize)) {
+        break;
+      }
+
       final RID rid = neighbor.getFirst();
-
       final Document record;
       try {
-        record = (Document) context.getDatabase().lookupByRID(rid, true);
+        record = (Document) db.lookupByRID(rid, true);
       } catch (final RecordNotFoundException e) {
         // Skip records that no longer exist in the bucket (issue #3717).
         // This can happen when the vector index has stale entries pointing to deleted records,
         // e.g., after crash recovery, backup restore, or index/storage inconsistencies.
         continue;
+      }
+
+      if (groupBy != null) {
+        final Object groupKey = record.get(groupBy);
+        final int existing = perGroup.getOrDefault(groupKey, 0);
+        // Skip if the group already saw a new group beyond our limit.
+        if (existing == 0 && perGroup.size() >= limit)
+          continue;
+        if (existing >= groupSize)
+          continue;
+        perGroup.put(groupKey, existing + 1);
       }
 
       final float distance = neighbor.getSecond();
@@ -273,6 +316,7 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
   }
 
   public String getSyntax() {
-    return NAME + "(<index-name>, <key-or-vector>, <k>[, <efSearch> | { efSearch: <int>, filter: [<rid>, ...] }])";
+    return NAME + "(<index-name>, <key-or-vector>, <k>[, <efSearch> | "
+        + "{ efSearch: <int>, filter: [<rid>, ...], groupBy: <field>, groupSize: <int> }])";
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorSparseNeighbors.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorSparseNeighbors.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.sql.vector;
+
+import com.arcadedb.database.BasicDatabase;
+import com.arcadedb.database.Document;
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.Bucket;
+import com.arcadedb.exception.CommandSQLParsingException;
+import com.arcadedb.exception.RecordNotFoundException;
+import com.arcadedb.function.sql.FunctionOptions;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.index.sparsevector.LSMSparseVectorIndex;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.utility.IntHashSet;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Returns the top-K nearest records by sparse-vector dot product against a {@code LSM_SPARSE_VECTOR}
+ * index.
+ * <p>
+ * Usage: {@code vector.sparseNeighbors(indexSpec, queryIndices, queryValues, k[, options])}
+ * <p>
+ * {@code indexSpec} is either a fully qualified index name or a {@code Type[property1,property2]}
+ * string. {@code queryIndices} is an {@code int[]} of non-negative dimension ids and
+ * {@code queryValues} is the matching {@code float[]}.
+ * <p>
+ * Optional 5th argument: a map with keys {@code filter} (List of allowed RIDs).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class SQLFunctionVectorSparseNeighbors extends SQLFunctionVectorAbstract {
+  public static final String NAME = "vector.sparseNeighbors";
+
+  private static final Set<String> OPTIONS = Set.of("filter");
+
+  public SQLFunctionVectorSparseNeighbors() {
+    super(NAME);
+  }
+
+  @Override
+  public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
+      final CommandContext context) {
+    if (params == null || params.length < 4 || params.length > 5)
+      throw new CommandSQLParsingException(getSyntax());
+
+    final String indexSpec = params[0].toString();
+
+    final int[]   queryIndices = sparseToIntArray(params[1]);
+    final float[] queryValues  = sparseToFloatArray(params[2]);
+    if (queryIndices == null || queryValues == null)
+      throw new CommandSQLParsingException("Query indices and values must not be null");
+    if (queryIndices.length != queryValues.length)
+      throw new CommandSQLParsingException(
+          "Query indices and values must have the same length (got " + queryIndices.length + " and " + queryValues.length + ")");
+
+    final int k = params[3] instanceof Number n ? n.intValue() : Integer.parseInt(params[3].toString());
+
+    Set<RID> allowedRIDs = null;
+    if (params.length >= 5 && params[4] != null) {
+      if (params[4] instanceof java.util.Map<?, ?> rawMap) {
+        final FunctionOptions opts = new FunctionOptions(NAME, rawMap, OPTIONS);
+        allowedRIDs = parseFilter(opts.getList("filter"), context);
+      } else {
+        throw new CommandSQLParsingException(NAME + " 5th parameter must be an options map, got: " + params[4]);
+      }
+    }
+
+    final TypeIndex typeIndex = resolveTypeIndex(indexSpec, context);
+    final List<LSMSparseVectorIndex> sparseIndexes = collectSparseIndexes(indexSpec, typeIndex, context);
+
+    if (sparseIndexes.isEmpty())
+      throw new CommandSQLParsingException(
+          "Index '" + indexSpec + "' is not a sparse vector index");
+
+    return executeWithIndexes(sparseIndexes, queryIndices, queryValues, k, allowedRIDs, context);
+  }
+
+  private TypeIndex resolveTypeIndex(final String indexSpec, final CommandContext context) {
+    final int bracketStart = indexSpec.indexOf('[');
+    if (bracketStart > 0 && indexSpec.endsWith("]")) {
+      final String specifiedTypeName = indexSpec.substring(0, bracketStart);
+      final String propertySpec = indexSpec.substring(bracketStart + 1, indexSpec.length() - 1);
+      final String[] properties = splitPropertyList(propertySpec);
+      final DocumentType specifiedType = context.getDatabase().getSchema().getType(specifiedTypeName);
+      final TypeIndex idx = specifiedType.getPolymorphicIndexByProperties(properties);
+      if (idx == null)
+        throw new CommandSQLParsingException(
+            "No sparse vector index found on properties '" + propertySpec + "' for type '" + specifiedTypeName + "'");
+      return idx;
+    }
+
+    final var direct = context.getDatabase().getSchema().getIndexByName(indexSpec);
+    if (direct instanceof TypeIndex typeIndex)
+      return typeIndex;
+
+    throw new CommandSQLParsingException(
+        "Index '" + indexSpec + "' is not a sparse vector index (found: " + (direct != null ? direct.getClass().getSimpleName() : "null") + ")");
+  }
+
+  private static String[] splitPropertyList(final String propertySpec) {
+    final String[] raw = propertySpec.split(",");
+    final String[] out = new String[raw.length];
+    for (int i = 0; i < raw.length; i++)
+      out[i] = raw[i].trim();
+    return out;
+  }
+
+  private List<LSMSparseVectorIndex> collectSparseIndexes(final String indexSpec, final TypeIndex typeIndex,
+      final CommandContext context) {
+    final IntHashSet allowedBucketIds = new IntHashSet();
+    final int bracketStart = indexSpec.indexOf('[');
+    if (bracketStart > 0 && indexSpec.endsWith("]")) {
+      final String specifiedTypeName = indexSpec.substring(0, bracketStart);
+      final DocumentType specifiedType = context.getDatabase().getSchema().getType(specifiedTypeName);
+      for (final Bucket bucket : specifiedType.getBuckets(false))
+        allowedBucketIds.add(bucket.getFileId());
+    }
+
+    final var bucketIndexes = typeIndex.getIndexesOnBuckets();
+    final List<LSMSparseVectorIndex> result = new ArrayList<>();
+    if (bucketIndexes == null)
+      return result;
+
+    for (final IndexInternal bucketIndex : bucketIndexes) {
+      if (bucketIndex instanceof LSMSparseVectorIndex sparseIndex) {
+        if (allowedBucketIds.isEmpty() || allowedBucketIds.contains(bucketIndex.getAssociatedBucketId()))
+          result.add(sparseIndex);
+      }
+    }
+    return result;
+  }
+
+  private Object executeWithIndexes(final List<LSMSparseVectorIndex> indexes, final int[] queryIndices,
+      final float[] queryValues, final int k, final Set<RID> allowedRIDs, final CommandContext context) {
+
+    final ArrayList<LSMSparseVectorIndex.RidScore> merged = new ArrayList<>();
+    for (final LSMSparseVectorIndex idx : indexes)
+      merged.addAll(idx.topK(queryIndices, queryValues, k, allowedRIDs));
+
+    merged.sort((a, b) -> Float.compare(b.score, a.score));
+
+    final int resultCount = Math.min(k, merged.size());
+    final ArrayList<Object> result = new ArrayList<>(resultCount);
+    final BasicDatabase db = context.getDatabase();
+
+    for (int i = 0; i < resultCount; i++) {
+      final LSMSparseVectorIndex.RidScore neighbor = merged.get(i);
+      final Document record;
+      try {
+        record = (Document) db.lookupByRID(neighbor.rid, true);
+      } catch (final RecordNotFoundException e) {
+        continue;
+      }
+
+      final LinkedHashMap<String, Object> entry = new LinkedHashMap<>();
+      entry.put("record", record);
+      for (final String prop : record.getPropertyNames())
+        entry.put(prop, record.get(prop));
+      entry.put("@rid", record.getIdentity());
+      entry.put("@type", record.getTypeName());
+      entry.put("score", neighbor.score);
+      result.add(entry);
+    }
+
+    return result;
+  }
+
+  private static Set<RID> parseFilter(final List<?> items, final CommandContext context) {
+    if (items == null || items.isEmpty())
+      return null;
+
+    final BasicDatabase db = context.getDatabase();
+    final Set<RID> out = new HashSet<>(items.size());
+    for (final Object item : items) {
+      if (item == null)
+        continue;
+      if (item instanceof RID rid)
+        out.add(rid);
+      else if (item instanceof Identifiable id)
+        out.add(id.getIdentity());
+      else if (item instanceof String s)
+        out.add(db.newRID(s));
+      else
+        throw new CommandSQLParsingException(
+            "Option 'filter' for function '" + NAME + "' must contain RIDs, got: " + item.getClass().getSimpleName());
+    }
+    return out;
+  }
+
+  private static int[] sparseToIntArray(final Object o) {
+    if (o == null)
+      return null;
+    if (o instanceof int[] arr)
+      return arr;
+    if (o instanceof Integer[] arr) {
+      final int[] out = new int[arr.length];
+      for (int i = 0; i < arr.length; i++)
+        out[i] = arr[i];
+      return out;
+    }
+    if (o instanceof List<?> list) {
+      final int[] out = new int[list.size()];
+      for (int i = 0; i < out.length; i++) {
+        final Object e = list.get(i);
+        if (!(e instanceof Number n))
+          throw new CommandSQLParsingException("Sparse query indices must be numbers, got: " + e);
+        out[i] = n.intValue();
+      }
+      return out;
+    }
+    throw new CommandSQLParsingException(
+        "Sparse query indices must be int[], Integer[] or List<Number>, got: " + o.getClass().getName());
+  }
+
+  private static float[] sparseToFloatArray(final Object o) {
+    if (o == null)
+      return null;
+    if (o instanceof float[] arr)
+      return arr;
+    if (o instanceof Float[] arr) {
+      final float[] out = new float[arr.length];
+      for (int i = 0; i < arr.length; i++)
+        out[i] = arr[i];
+      return out;
+    }
+    if (o instanceof List<?> list) {
+      final float[] out = new float[list.size()];
+      for (int i = 0; i < out.length; i++) {
+        final Object e = list.get(i);
+        if (!(e instanceof Number n))
+          throw new CommandSQLParsingException("Sparse query values must be numbers, got: " + e);
+        out[i] = n.floatValue();
+      }
+      return out;
+    }
+    throw new CommandSQLParsingException(
+        "Sparse query values must be float[], Float[] or List<Number>, got: " + o.getClass().getName());
+  }
+
+  @Override
+  public String getSyntax() {
+    return NAME + "(<index-name>, <indices>, <values>, <k>[, { filter: [<rid>, ...] }])";
+  }
+}

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorSparseNeighbors.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorSparseNeighbors.java
@@ -34,9 +34,11 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.utility.IntHashSet;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -57,6 +59,11 @@ public class SQLFunctionVectorSparseNeighbors extends SQLFunctionVectorAbstract 
   public static final String NAME = "vector.sparseNeighbors";
 
   private static final Set<String> OPTIONS = Set.of("filter", "groupBy", "groupSize");
+
+  // Hard cap on the candidate pool when grouping is enabled. Same rationale as
+  // SQLFunctionVectorNeighbors.MAX_FETCH_CANDIDATES: bounds memory at a few MB on pathological
+  // (k, groupSize) combinations.
+  private static final int MAX_FETCH_CANDIDATES = 100_000;
 
   public SQLFunctionVectorSparseNeighbors() {
     super(NAME);
@@ -84,9 +91,9 @@ public class SQLFunctionVectorSparseNeighbors extends SQLFunctionVectorAbstract 
     String groupBy = null;
     int groupSize = 1;
     if (params.length >= 5 && params[4] != null) {
-      if (params[4] instanceof java.util.Map<?, ?> rawMap) {
+      if (params[4] instanceof Map<?, ?> rawMap) {
         final FunctionOptions opts = new FunctionOptions(NAME, rawMap, OPTIONS);
-        allowedRIDs = parseFilter(opts.getList("filter"), context);
+        allowedRIDs = parseRidFilter(opts.getList("filter"), NAME, context);
         groupBy = opts.getString("groupBy", null);
         groupSize = opts.getInt("groupSize", 1);
         if (groupSize < 1)
@@ -166,8 +173,18 @@ public class SQLFunctionVectorSparseNeighbors extends SQLFunctionVectorAbstract 
       final CommandContext context) {
 
     // Over-fetch when grouping so the post-traversal filter has enough material to fill k groups
-    // at groupSize each. Same 5x cushion as `vector.neighbors`, with the same best-effort caveat.
-    final int fetchK = groupBy == null ? k : Math.max(k * groupSize * 5, k);
+    // at groupSize each. Same 5x cushion and MAX_FETCH_CANDIDATES cap as `vector.neighbors`.
+    final int fetchK;
+    if (groupBy == null) {
+      fetchK = k;
+    } else {
+      final long requested = Math.max((long) k * groupSize * 5L, (long) k);
+      if (requested > MAX_FETCH_CANDIDATES)
+        throw new CommandSQLParsingException(NAME + " over-fetch budget exceeded: k=" + k
+            + ", groupSize=" + groupSize + " would require " + requested
+            + " candidates (cap " + MAX_FETCH_CANDIDATES + "). Reduce k or groupSize.");
+      fetchK = (int) requested;
+    }
 
     final ArrayList<LSMSparseVectorIndex.RidScore> merged = new ArrayList<>();
     for (final LSMSparseVectorIndex idx : indexes)
@@ -177,14 +194,16 @@ public class SQLFunctionVectorSparseNeighbors extends SQLFunctionVectorAbstract 
 
     final BasicDatabase db = context.getDatabase();
     final ArrayList<Object> result = new ArrayList<>();
-    final java.util.HashMap<Object, Integer> perGroup = groupBy != null ? new java.util.HashMap<>() : null;
+    final HashMap<Object, Integer> perGroup = groupBy != null ? new HashMap<>() : null;
+    // Number of groups that have already reached groupSize. Same O(1) early-exit pattern as
+    // SQLFunctionVectorNeighbors to avoid scanning the perGroup map values on every iteration.
+    int filledGroups = 0;
 
     for (final LSMSparseVectorIndex.RidScore neighbor : merged) {
       if (groupBy == null) {
         if (result.size() >= k)
           break;
-      } else if (perGroup.size() >= k
-          && perGroup.values().stream().allMatch(c -> c >= groupSize)) {
+      } else if (filledGroups >= k) {
         break;
       }
 
@@ -203,6 +222,8 @@ public class SQLFunctionVectorSparseNeighbors extends SQLFunctionVectorAbstract 
         if (existing >= groupSize)
           continue;
         perGroup.put(groupKey, existing + 1);
+        if (existing + 1 == groupSize)
+          filledGroups++;
       }
 
       final LinkedHashMap<String, Object> entry = new LinkedHashMap<>();
@@ -216,28 +237,6 @@ public class SQLFunctionVectorSparseNeighbors extends SQLFunctionVectorAbstract 
     }
 
     return result;
-  }
-
-  private static Set<RID> parseFilter(final List<?> items, final CommandContext context) {
-    if (items == null || items.isEmpty())
-      return null;
-
-    final BasicDatabase db = context.getDatabase();
-    final Set<RID> out = new HashSet<>(items.size());
-    for (final Object item : items) {
-      if (item == null)
-        continue;
-      if (item instanceof RID rid)
-        out.add(rid);
-      else if (item instanceof Identifiable id)
-        out.add(id.getIdentity());
-      else if (item instanceof String s)
-        out.add(db.newRID(s));
-      else
-        throw new CommandSQLParsingException(
-            "Option 'filter' for function '" + NAME + "' must contain RIDs, got: " + item.getClass().getSimpleName());
-    }
-    return out;
   }
 
   private static int[] sparseToIntArray(final Object o) {

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorSparseNeighbors.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorSparseNeighbors.java
@@ -34,7 +34,6 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.utility.IntHashSet;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -194,16 +193,13 @@ public class SQLFunctionVectorSparseNeighbors extends SQLFunctionVectorAbstract 
 
     final BasicDatabase db = context.getDatabase();
     final ArrayList<Object> result = new ArrayList<>();
-    final HashMap<Object, Integer> perGroup = groupBy != null ? new HashMap<>() : null;
-    // Number of groups that have already reached groupSize. Same O(1) early-exit pattern as
-    // SQLFunctionVectorNeighbors to avoid scanning the perGroup map values on every iteration.
-    int filledGroups = 0;
+    final GroupAdmissionState groups = groupBy != null ? new GroupAdmissionState(k, groupSize) : null;
 
     for (final LSMSparseVectorIndex.RidScore neighbor : merged) {
       if (groupBy == null) {
         if (result.size() >= k)
           break;
-      } else if (filledGroups >= k) {
+      } else if (groups.isFull()) {
         break;
       }
 
@@ -214,17 +210,8 @@ public class SQLFunctionVectorSparseNeighbors extends SQLFunctionVectorAbstract 
         continue;
       }
 
-      if (groupBy != null) {
-        final Object groupKey = readNestedField(record, groupBy);
-        final int existing = perGroup.getOrDefault(groupKey, 0);
-        if (existing == 0 && perGroup.size() >= k)
-          continue;
-        if (existing >= groupSize)
-          continue;
-        perGroup.put(groupKey, existing + 1);
-        if (existing + 1 == groupSize)
-          filledGroups++;
-      }
+      if (groupBy != null && !groups.admit(readNestedField(record, groupBy)))
+        continue;
 
       final LinkedHashMap<String, Object> entry = new LinkedHashMap<>();
       entry.put("record", record);

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorSparseNeighbors.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorSparseNeighbors.java
@@ -196,7 +196,7 @@ public class SQLFunctionVectorSparseNeighbors extends SQLFunctionVectorAbstract 
       }
 
       if (groupBy != null) {
-        final Object groupKey = record.get(groupBy);
+        final Object groupKey = readNestedField(record, groupBy);
         final int existing = perGroup.getOrDefault(groupKey, 0);
         if (existing == 0 && perGroup.size() >= k)
           continue;

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorSparseNeighbors.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorSparseNeighbors.java
@@ -56,7 +56,7 @@ import java.util.Set;
 public class SQLFunctionVectorSparseNeighbors extends SQLFunctionVectorAbstract {
   public static final String NAME = "vector.sparseNeighbors";
 
-  private static final Set<String> OPTIONS = Set.of("filter");
+  private static final Set<String> OPTIONS = Set.of("filter", "groupBy", "groupSize");
 
   public SQLFunctionVectorSparseNeighbors() {
     super(NAME);
@@ -81,10 +81,16 @@ public class SQLFunctionVectorSparseNeighbors extends SQLFunctionVectorAbstract 
     final int k = params[3] instanceof Number n ? n.intValue() : Integer.parseInt(params[3].toString());
 
     Set<RID> allowedRIDs = null;
+    String groupBy = null;
+    int groupSize = 1;
     if (params.length >= 5 && params[4] != null) {
       if (params[4] instanceof java.util.Map<?, ?> rawMap) {
         final FunctionOptions opts = new FunctionOptions(NAME, rawMap, OPTIONS);
         allowedRIDs = parseFilter(opts.getList("filter"), context);
+        groupBy = opts.getString("groupBy", null);
+        groupSize = opts.getInt("groupSize", 1);
+        if (groupSize < 1)
+          throw new CommandSQLParsingException(NAME + " groupSize must be >= 1, got " + groupSize);
       } else {
         throw new CommandSQLParsingException(NAME + " 5th parameter must be an options map, got: " + params[4]);
       }
@@ -97,7 +103,7 @@ public class SQLFunctionVectorSparseNeighbors extends SQLFunctionVectorAbstract 
       throw new CommandSQLParsingException(
           "Index '" + indexSpec + "' is not a sparse vector index");
 
-    return executeWithIndexes(sparseIndexes, queryIndices, queryValues, k, allowedRIDs, context);
+    return executeWithIndexes(sparseIndexes, queryIndices, queryValues, k, allowedRIDs, groupBy, groupSize, context);
   }
 
   private TypeIndex resolveTypeIndex(final String indexSpec, final CommandContext context) {
@@ -156,25 +162,47 @@ public class SQLFunctionVectorSparseNeighbors extends SQLFunctionVectorAbstract 
   }
 
   private Object executeWithIndexes(final List<LSMSparseVectorIndex> indexes, final int[] queryIndices,
-      final float[] queryValues, final int k, final Set<RID> allowedRIDs, final CommandContext context) {
+      final float[] queryValues, final int k, final Set<RID> allowedRIDs, final String groupBy, final int groupSize,
+      final CommandContext context) {
+
+    // Over-fetch when grouping so the post-traversal filter has enough material to fill k groups
+    // at groupSize each. Same 5x cushion as `vector.neighbors`, with the same best-effort caveat.
+    final int fetchK = groupBy == null ? k : Math.max(k * groupSize * 5, k);
 
     final ArrayList<LSMSparseVectorIndex.RidScore> merged = new ArrayList<>();
     for (final LSMSparseVectorIndex idx : indexes)
-      merged.addAll(idx.topK(queryIndices, queryValues, k, allowedRIDs));
+      merged.addAll(idx.topK(queryIndices, queryValues, fetchK, allowedRIDs));
 
     merged.sort((a, b) -> Float.compare(b.score, a.score));
 
-    final int resultCount = Math.min(k, merged.size());
-    final ArrayList<Object> result = new ArrayList<>(resultCount);
     final BasicDatabase db = context.getDatabase();
+    final ArrayList<Object> result = new ArrayList<>();
+    final java.util.HashMap<Object, Integer> perGroup = groupBy != null ? new java.util.HashMap<>() : null;
 
-    for (int i = 0; i < resultCount; i++) {
-      final LSMSparseVectorIndex.RidScore neighbor = merged.get(i);
+    for (final LSMSparseVectorIndex.RidScore neighbor : merged) {
+      if (groupBy == null) {
+        if (result.size() >= k)
+          break;
+      } else if (perGroup.size() >= k
+          && perGroup.values().stream().allMatch(c -> c >= groupSize)) {
+        break;
+      }
+
       final Document record;
       try {
         record = (Document) db.lookupByRID(neighbor.rid, true);
       } catch (final RecordNotFoundException e) {
         continue;
+      }
+
+      if (groupBy != null) {
+        final Object groupKey = record.get(groupBy);
+        final int existing = perGroup.getOrDefault(groupKey, 0);
+        if (existing == 0 && perGroup.size() >= k)
+          continue;
+        if (existing >= groupSize)
+          continue;
+        perGroup.put(groupKey, existing + 1);
       }
 
       final LinkedHashMap<String, Object> entry = new LinkedHashMap<>();
@@ -264,6 +292,7 @@ public class SQLFunctionVectorSparseNeighbors extends SQLFunctionVectorAbstract 
 
   @Override
   public String getSyntax() {
-    return NAME + "(<index-name>, <indices>, <values>, <k>[, { filter: [<rid>, ...] }])";
+    return NAME + "(<index-name>, <indices>, <values>, <k>[, { filter: [<rid>, ...], "
+        + "groupBy: <field>, groupSize: <int> }])";
   }
 }

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndex.java
@@ -1,0 +1,794 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.sparsevector;
+
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.engine.PaginatedComponent;
+import com.arcadedb.index.Index;
+import com.arcadedb.index.IndexCursor;
+import com.arcadedb.index.IndexException;
+import com.arcadedb.index.IndexFactoryHandler;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.index.lsm.LSMTreeIndex;
+import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
+import com.arcadedb.schema.IndexBuilder;
+import com.arcadedb.schema.IndexMetadata;
+import com.arcadedb.schema.LSMSparseVectorIndexMetadata;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.serializer.json.JSONObject;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Set;
+
+/**
+ * Sparse vector index implementation backed by an LSM-Tree as a posting-list inverted index.
+ * <p>
+ * Storage model: the underlying LSM-Tree uses a composite key {@code (int dim_id, RID rid, float weight)}
+ * with the record RID as the value. For each non-zero dimension of an inserted sparse vector, one posting
+ * is added to the underlying index. The composite key sorts postings within a given dim by RID ascending,
+ * which is the order required by WAND-style dynamic pruning (#4068). Top-K dot-product retrieval is a
+ * document-at-a-time merge across per-dim cursors driven by a fixed-size min-heap; when a global per-dim
+ * upper bound is available the algorithm prunes candidates that cannot enter the top-K.
+ * <p>
+ * The wrapper requires two parallel array properties on the indexed type:
+ * <ul>
+ *   <li>An {@link Type#ARRAY_OF_INTEGERS} property holding the non-zero dimension ids</li>
+ *   <li>An {@link Type#ARRAY_OF_FLOATS} property holding the corresponding weights</li>
+ * </ul>
+ * Both arrays must have the same length and dimension ids must be non-negative.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class LSMSparseVectorIndex implements Index, IndexInternal {
+
+  private final LSMTreeIndex                 underlyingIndex;
+  private       LSMSparseVectorIndexMetadata sparseMetadata;
+  private       TypeIndex                    typeIndex;
+
+  // Per-dim upper bound on the weight of any single posting under that dim. Maintained as a
+  // monotonically non-decreasing approximation: `put` raises it, `remove` is a no-op (acceptable
+  // because WAND only requires `maxWeight` to be a valid upper bound, not the exact maximum).
+  // Lazily populated: the first WAND query on a freshly opened index does a one-shot scan if the
+  // map is empty; subsequent inserts keep it accurate.
+  private final HashMap<Integer, Float> dimMaxWeight = new HashMap<>();
+  private       boolean                 dimMaxWeightInitialized = false;
+
+  /**
+   * Factory handler used by the schema to instantiate sparse vector indexes.
+   */
+  public static class LSMSparseVectorIndexFactoryHandler implements IndexFactoryHandler {
+    @Override
+    public IndexInternal create(final IndexBuilder builder) {
+      if (builder.isUnique())
+        throw new IllegalArgumentException("Sparse vector index cannot be unique");
+
+      final Type[] keyTypes = builder.getKeyTypes();
+      if (keyTypes == null || keyTypes.length != 2)
+        throw new IllegalArgumentException(
+            "Sparse vector index requires 2 properties: an indices array (ARRAY_OF_INTEGERS) and a weights array (ARRAY_OF_FLOATS)");
+      if (keyTypes[0] != Type.ARRAY_OF_INTEGERS)
+        throw new IllegalArgumentException(
+            "Sparse vector index 1st property must be ARRAY_OF_INTEGERS, found: " + keyTypes[0]);
+      if (keyTypes[1] != Type.ARRAY_OF_FLOATS)
+        throw new IllegalArgumentException(
+            "Sparse vector index 2nd property must be ARRAY_OF_FLOATS, found: " + keyTypes[1]);
+
+      LSMSparseVectorIndexMetadata sparseMetadata = null;
+      if (builder.getMetadata() instanceof LSMSparseVectorIndexMetadata m)
+        sparseMetadata = m;
+
+      return new LSMSparseVectorIndex(builder.getDatabase(), builder.getIndexName(), builder.getFilePath(),
+          ComponentFile.MODE.READ_WRITE, builder.getPageSize(), builder.getNullStrategy(), sparseMetadata);
+    }
+  }
+
+  /**
+   * Loading time: wrap an already-loaded LSMTreeIndex.
+   */
+  public LSMSparseVectorIndex(final LSMTreeIndex index) {
+    this(index, null);
+  }
+
+  /**
+   * Loading time with optional metadata.
+   */
+  public LSMSparseVectorIndex(final LSMTreeIndex index, final LSMSparseVectorIndexMetadata metadata) {
+    this.underlyingIndex = index;
+    this.sparseMetadata = metadata;
+  }
+
+  /**
+   * Creation time.
+   * <p>
+   * Storage layout (chosen to enable WAND-style document-at-a-time pruning, see #4068):
+   * <pre>
+   *   key:   (int dim_id, RID rid, float weight)
+   *   value: rid
+   * </pre>
+   * Postings under a given dim are returned by the cursor in {@code RID} ascending order, which
+   * is the order WAND requires to advance per-dim cursors in lockstep. The weight is carried in
+   * the third key column so each posting is self-describing during the scan.
+   */
+  public LSMSparseVectorIndex(final DatabaseInternal database, final String name, final String filePath,
+      final ComponentFile.MODE mode, final int pageSize, final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy,
+      final LSMSparseVectorIndexMetadata metadata) {
+    this.sparseMetadata = metadata;
+    this.underlyingIndex = new LSMTreeIndex(database, name, false, filePath, mode,
+        new Type[] { Type.INTEGER, Type.LINK, Type.FLOAT }, pageSize, nullStrategy);
+  }
+
+  @Override
+  public Schema.INDEX_TYPE getType() {
+    return Schema.INDEX_TYPE.LSM_SPARSE_VECTOR;
+  }
+
+  /**
+   * Inserts a sparse vector for a record.
+   * <p>
+   * Original call (from {@code DocumentIndexer}): {@code keys[0]} is an {@code int[]} of dimension ids
+   * and {@code keys[1]} is a {@code float[]} of weights. Each non-zero dimension is expanded to a
+   * separate {@code (dim_id, rid, weight)} posting on the underlying LSM-Tree.
+   * <p>
+   * Replay call (from {@code TransactionIndexContext} at commit time): the keys are already a single
+   * scalar posting {@code [Integer dim_id, RID rid, Float weight]} and are forwarded unchanged.
+   */
+  @Override
+  public void put(final Object[] keys, final RID[] rids) {
+    if (!isOriginalCall(keys)) {
+      underlyingIndex.put(keys, rids);
+      return;
+    }
+
+    final int[]   indices = toIntArray(keys[0]);
+    final float[] values  = toFloatArray(keys[1]);
+    if (indices == null || values == null)
+      return;
+    if (indices.length != values.length)
+      throw new IndexException(
+          "Sparse vector indices and weights must have the same length (got " + indices.length + " and " + values.length + ")");
+    if (rids == null || rids.length == 0)
+      return;
+
+    for (int i = 0; i < indices.length; i++) {
+      final int dim = indices[i];
+      if (dim < 0)
+        throw new IndexException("Sparse vector dimension must be >= 0, found: " + dim);
+      final float w = values[i];
+      if (w == 0.0f)
+        continue;
+      for (final RID rid : rids)
+        underlyingIndex.put(new Object[] { dim, rid, w }, new RID[] { rid });
+      synchronized (dimMaxWeight) {
+        dimMaxWeight.merge(dim, w, Math::max);
+      }
+    }
+  }
+
+  @Override
+  public void remove(final Object[] keys) {
+    if (!isOriginalCall(keys)) {
+      underlyingIndex.remove(keys);
+      return;
+    }
+    // Cannot remove without a RID for the per-(dim, rid, weight) postings, so ignore. The
+    // (rid)-aware overload below is what DocumentIndexer actually invokes during deletion.
+  }
+
+  @Override
+  public void remove(final Object[] keys, final Identifiable rid) {
+    if (!isOriginalCall(keys)) {
+      underlyingIndex.remove(keys, rid);
+      return;
+    }
+
+    final int[]   indices = toIntArray(keys[0]);
+    final float[] values  = toFloatArray(keys[1]);
+    if (indices == null || values == null || rid == null)
+      return;
+    final RID actualRid = rid.getIdentity();
+
+    for (int i = 0; i < Math.min(indices.length, values.length); i++) {
+      if (values[i] == 0.0f)
+        continue;
+      underlyingIndex.remove(new Object[] { indices[i], actualRid, values[i] }, actualRid);
+    }
+  }
+
+  /**
+   * Computes the top-K records by sparse dot product against the supplied query.
+   * <p>
+   * If the index was created with {@code modifier = "IDF"}, each query weight is scaled by the
+   * inverse document frequency of its dimension before scoring (Robertson-Sparck-Jones BM25-style
+   * IDF). Otherwise the score is the plain dot product.
+   *
+   * @param queryIndices non-negative dimension ids of the query
+   * @param queryValues  weights matching {@code queryIndices}
+   * @param k            number of neighbors to return; must be > 0
+   * @param allowedRIDs  optional whitelist; null means no restriction
+   *
+   * @return ordered list of (RID, score) pairs from highest to lowest score, capped at {@code k}
+   */
+  public List<RidScore> topK(final int[] queryIndices, final float[] queryValues, final int k, final Set<RID> allowedRIDs) {
+    if (queryIndices == null || queryValues == null)
+      throw new IndexException("Query indices and values must not be null");
+    if (queryIndices.length != queryValues.length)
+      throw new IndexException(
+          "Query indices and values must have the same length (got " + queryIndices.length + " and " + queryValues.length + ")");
+    if (k <= 0)
+      throw new IndexException("k must be > 0");
+
+    final boolean useIDF = sparseMetadata != null
+        && LSMSparseVectorIndexMetadata.MODIFIER_IDF.equals(sparseMetadata.modifier);
+
+    // Pre-compute effective query weights. Under IDF, this folds the per-dimension IDF into the
+    // query weight so the scoring inner loop stays a plain dot product. df is counted via a
+    // dedicated scan per query dim (acceptable for the MVP - the WAND follow-up #4068 maintains
+    // df incrementally to avoid the extra pass).
+    final float[] effectiveWeights = new float[queryValues.length];
+    if (useIDF) {
+      final long n = totalDocuments();
+      for (int i = 0; i < queryIndices.length; i++) {
+        final int qDim = queryIndices[i];
+        if (qDim < 0)
+          throw new IndexException("Query dimension must be >= 0, found: " + qDim);
+        if (queryValues[i] == 0.0f) {
+          effectiveWeights[i] = 0.0f;
+          continue;
+        }
+        final long df = countPostings(qDim);
+        effectiveWeights[i] = queryValues[i] * idf(n, df);
+      }
+    } else {
+      System.arraycopy(queryValues, 0, effectiveWeights, 0, queryValues.length);
+    }
+
+    return wandTopK(queryIndices, effectiveWeights, k, allowedRIDs);
+  }
+
+  /**
+   * Document-at-a-time top-K with WAND pivot-based skipping.
+   * <p>
+   * Per query dim {@code d} an upper bound {@code u[d] = effW[d] * dimMaxWeight[d]} is precomputed.
+   * Each iteration sorts the live cursors by current RID ascending, finds the pivot (smallest cursor
+   * index whose prefix sum of {@code u[]} reaches the current top-K threshold), and either scores the
+   * pivot's RID (when cursors[0] is already aligned with the pivot) or skips cursors before the pivot
+   * forward to the pivot's RID. When no pivot exists, no remaining document can enter the top-K and
+   * the loop exits early.
+   */
+  private List<RidScore> wandTopK(final int[] queryIndices, final float[] effW, final int k, final Set<RID> allowedRIDs) {
+    final int n = queryIndices.length;
+
+    final DimCursor[] cursors = new DimCursor[n];
+    int liveCount = 0;
+
+    for (int i = 0; i < n; i++) {
+      final int qDim = queryIndices[i];
+      if (qDim < 0)
+        throw new IndexException("Query dimension must be >= 0, found: " + qDim);
+      if (effW[i] == 0.0f)
+        continue;
+      final float dimMax = getMaxWeight(qDim);
+      if (dimMax == 0.0f)
+        continue;
+      final DimCursor c = new DimCursor(underlyingIndex, qDim, effW[i], dimMax);
+      if (!c.exhausted)
+        cursors[liveCount++] = c;
+    }
+
+    if (liveCount == 0)
+      return new ArrayList<>(0);
+
+    // Min-heap of (rid, score) keyed by score ASC, capped at K. The minimum element is always at
+    // the head, so the K-th best score (= threshold) is heap.peek() once heap is full.
+    final PriorityQueue<RidScore> heap = new PriorityQueue<>(k, Comparator.comparingDouble(r -> r.score));
+    float threshold = Float.NEGATIVE_INFINITY;
+
+    final Comparator<DimCursor> byCurrentRid = (a, b) -> a.currentRid.compareTo(b.currentRid);
+
+    while (liveCount > 0) {
+      Arrays.sort(cursors, 0, liveCount, byCurrentRid);
+
+      // Find pivot index: smallest i where prefix sum of upperBounds[0..i] reaches threshold.
+      float prefix = 0;
+      int pivot = -1;
+      for (int i = 0; i < liveCount; i++) {
+        prefix += cursors[i].upperBound;
+        if (prefix > threshold) {
+          pivot = i;
+          break;
+        }
+      }
+      if (pivot == -1)
+        break;
+
+      final RID pivotRid = cursors[pivot].currentRid;
+
+      if (cursors[0].currentRid.compareTo(pivotRid) == 0) {
+        // Score: sum contributions from every cursor whose currentRid == pivotRid.
+        float score = 0.0f;
+        for (int i = 0; i < liveCount; i++) {
+          if (cursors[i].currentRid.compareTo(pivotRid) == 0)
+            score += cursors[i].queryWeight * cursors[i].currentWeight;
+          else
+            break; // sorted, so once we miss alignment we stop
+        }
+
+        if (allowedRIDs == null || allowedRIDs.contains(pivotRid)) {
+          if (heap.size() < k) {
+            heap.offer(new RidScore(pivotRid, score));
+            if (heap.size() == k)
+              threshold = heap.peek().score;
+          } else if (score > threshold) {
+            heap.poll();
+            heap.offer(new RidScore(pivotRid, score));
+            threshold = heap.peek().score;
+          }
+        }
+
+        // Advance every cursor that was on pivotRid.
+        for (int i = 0; i < liveCount; i++) {
+          if (cursors[i].currentRid.compareTo(pivotRid) == 0)
+            cursors[i].advance();
+          else
+            break;
+        }
+      } else {
+        // Skip cursors strictly below pivotRid forward to pivotRid; they can never reach threshold
+        // alone before then.
+        for (int i = 0; i < pivot; i++) {
+          if (cursors[i].currentRid.compareTo(pivotRid) < 0)
+            cursors[i].seekTo(pivotRid);
+        }
+      }
+
+      // Compact: drop exhausted cursors.
+      int newLive = 0;
+      for (int i = 0; i < liveCount; i++) {
+        if (!cursors[i].exhausted)
+          cursors[newLive++] = cursors[i];
+      }
+      liveCount = newLive;
+    }
+
+    final List<RidScore> result = new ArrayList<>(heap);
+    result.sort((a, b) -> Float.compare(b.score, a.score));
+    return result;
+  }
+
+  /**
+   * Returns the per-dim upper bound used by WAND. Lazily initializes the cache on first call by
+   * scanning the underlying index once. Subsequent inserts keep it accurate via {@link #put}; deletes
+   * leave the bound conservatively high (still a valid upper bound).
+   */
+  private float getMaxWeight(final int dim) {
+    synchronized (dimMaxWeight) {
+      if (!dimMaxWeightInitialized) {
+        initializeMaxWeightsLocked();
+        dimMaxWeightInitialized = true;
+      }
+      return dimMaxWeight.getOrDefault(dim, 0.0f);
+    }
+  }
+
+  private void initializeMaxWeightsLocked() {
+    final IndexCursor cursor = underlyingIndex.iterator(true);
+    while (cursor.hasNext()) {
+      cursor.next();
+      final Object[] keys = cursor.getKeys();
+      if (keys == null || keys.length < 3)
+        continue;
+      if (!(keys[0] instanceof Number nDim) || !(keys[2] instanceof Number nW))
+        continue;
+      dimMaxWeight.merge(nDim.intValue(), nW.floatValue(), Math::max);
+    }
+  }
+
+  /**
+   * Per-dim cursor used by the WAND scoring loop. Holds the latest {@code (rid, weight)} of an
+   * underlying range scan within a single dimension and exposes {@code advance()} and
+   * {@code seekTo(rid)} primitives.
+   */
+  private static final class DimCursor {
+    final LSMTreeIndex underlying;
+    final int          dim;
+    final float        queryWeight;
+    final float        upperBound;
+
+    IndexCursor cursor;
+    RID         currentRid;
+    float       currentWeight;
+    boolean     exhausted;
+
+    DimCursor(final LSMTreeIndex underlying, final int dim, final float queryWeight, final float dimMax) {
+      this.underlying = underlying;
+      this.dim = dim;
+      this.queryWeight = queryWeight;
+      this.upperBound = queryWeight * dimMax;
+      this.cursor = underlying.range(true, new Object[] { dim }, true, new Object[] { dim }, true);
+      advance();
+    }
+
+    void advance() {
+      while (cursor.hasNext()) {
+        final Identifiable next = cursor.next();
+        if (next == null)
+          continue;
+        final Object[] keys = cursor.getKeys();
+        if (keys == null || keys.length < 3)
+          continue;
+        if (!(keys[0] instanceof Number nDim) || nDim.intValue() != dim)
+          continue;
+        if (!(keys[2] instanceof Number nW))
+          continue;
+        currentRid = next.getIdentity();
+        currentWeight = nW.floatValue();
+        exhausted = false;
+        return;
+      }
+      exhausted = true;
+      currentRid = null;
+      currentWeight = 0.0f;
+    }
+
+    void seekTo(final RID target) {
+      cursor = underlying.range(true, new Object[] { dim, target }, true, new Object[] { dim }, true);
+      advance();
+    }
+  }
+
+  /**
+   * Robertson-Sparck-Jones IDF as used by Qdrant's IDF modifier and BM25 scoring.
+   * Returns {@code ln((N - df + 0.5) / (df + 0.5) + 1)}, which is non-negative for any
+   * non-negative {@code N} and {@code df}.
+   */
+  private static float idf(final long n, final long df) {
+    final double numerator = (double) (n - df) + 0.5;
+    final double denominator = (double) df + 0.5;
+    return (float) Math.log((numerator / denominator) + 1.0);
+  }
+
+  /**
+   * Counts the postings under a single dimension by iterating the underlying LSM-Tree range. O(df)
+   * per call. Replaced by an incrementally maintained map in #4068.
+   */
+  private long countPostings(final int qDim) {
+    long df = 0;
+    final IndexCursor cursor = underlyingIndex.range(true,
+        new Object[] { qDim }, true,
+        new Object[] { qDim }, true);
+    while (cursor.hasNext()) {
+      cursor.next();
+      df++;
+    }
+    return df;
+  }
+
+  /**
+   * Total number of documents in the indexed type, used as {@code N} in the IDF formula.
+   */
+  private long totalDocuments() {
+    final String typeName = getTypeName();
+    if (typeName == null)
+      return 0;
+    return underlyingIndex.getMutableIndex().getDatabase().countType(typeName, false);
+  }
+
+  /**
+   * Read-only handle to the wrapped LSM-Tree, useful for low-level inspection and testing.
+   */
+  public LSMTreeIndex getUnderlyingIndex() {
+    return underlyingIndex;
+  }
+
+  public LSMSparseVectorIndexMetadata getSparseMetadata() {
+    return sparseMetadata;
+  }
+
+  // --------------------------- pure delegation below ---------------------------
+
+  @Override
+  public IndexCursor get(final Object[] keys) {
+    return get(keys, -1);
+  }
+
+  @Override
+  public IndexCursor get(final Object[] keys, final int limit) {
+    // Direct exact lookup is rarely meaningful for sparse vector retrieval; surface only
+    // raw posting-list lookup for diagnostic purposes.
+    return underlyingIndex.get(keys, limit);
+  }
+
+  @Override
+  public long countEntries() {
+    return underlyingIndex.countEntries();
+  }
+
+  @Override
+  public boolean compact() throws IOException, InterruptedException {
+    return underlyingIndex.compact();
+  }
+
+  @Override
+  public IndexMetadata getMetadata() {
+    return underlyingIndex.getMetadata();
+  }
+
+  @Override
+  public boolean isCompacting() {
+    return underlyingIndex.isCompacting();
+  }
+
+  @Override
+  public boolean scheduleCompaction() {
+    return underlyingIndex.scheduleCompaction();
+  }
+
+  @Override
+  public String getMostRecentFileName() {
+    return underlyingIndex.getMostRecentFileName();
+  }
+
+  @Override
+  public void setMetadata(final IndexMetadata metadata) {
+    underlyingIndex.setMetadata(metadata);
+  }
+
+  @Override
+  public void setMetadata(final JSONObject indexJSON) {
+    underlyingIndex.setMetadata(indexJSON);
+
+    final LSMSparseVectorIndexMetadata m = new LSMSparseVectorIndexMetadata(
+        underlyingIndex.getMetadata().typeName,
+        underlyingIndex.getPropertyNames() != null ?
+            underlyingIndex.getPropertyNames().toArray(new String[0]) : new String[0],
+        underlyingIndex.getMetadata().associatedBucketId);
+    m.fromJSON(indexJSON);
+    this.sparseMetadata = m;
+  }
+
+  @Override
+  public boolean setStatus(final INDEX_STATUS[] expectedStatuses, final INDEX_STATUS newStatus) {
+    return underlyingIndex.setStatus(expectedStatuses, newStatus);
+  }
+
+  @Override
+  public IndexInternal getAssociatedIndex() {
+    return null;
+  }
+
+  @Override
+  public String getTypeName() {
+    return underlyingIndex.getTypeName();
+  }
+
+  @Override
+  public List<String> getPropertyNames() {
+    return underlyingIndex.getPropertyNames();
+  }
+
+  @Override
+  public void close() {
+    underlyingIndex.close();
+  }
+
+  @Override
+  public void drop() {
+    underlyingIndex.drop();
+  }
+
+  @Override
+  public String getName() {
+    return underlyingIndex.getName();
+  }
+
+  @Override
+  public Map<String, Long> getStats() {
+    return underlyingIndex.getStats();
+  }
+
+  @Override
+  public LSMTreeIndexAbstract.NULL_STRATEGY getNullStrategy() {
+    return underlyingIndex.getNullStrategy();
+  }
+
+  @Override
+  public void setNullStrategy(final LSMTreeIndexAbstract.NULL_STRATEGY nullStrategy) {
+    underlyingIndex.setNullStrategy(nullStrategy);
+  }
+
+  @Override
+  public int getFileId() {
+    return underlyingIndex.getFileId();
+  }
+
+  @Override
+  public boolean isUnique() {
+    return false;
+  }
+
+  @Override
+  public PaginatedComponent getComponent() {
+    return underlyingIndex.getComponent();
+  }
+
+  @Override
+  public Type[] getKeyTypes() {
+    return underlyingIndex.getKeyTypes();
+  }
+
+  @Override
+  public byte[] getBinaryKeyTypes() {
+    return underlyingIndex.getBinaryKeyTypes();
+  }
+
+  @Override
+  public int getAssociatedBucketId() {
+    return underlyingIndex.getAssociatedBucketId();
+  }
+
+  @Override
+  public boolean supportsOrderedIterations() {
+    return false;
+  }
+
+  @Override
+  public boolean isAutomatic() {
+    return underlyingIndex.getPropertyNames() != null;
+  }
+
+  @Override
+  public int getPageSize() {
+    return underlyingIndex.getPageSize();
+  }
+
+  @Override
+  public List<Integer> getFileIds() {
+    return underlyingIndex.getFileIds();
+  }
+
+  @Override
+  public void setTypeIndex(final TypeIndex typeIndex) {
+    this.typeIndex = typeIndex;
+  }
+
+  @Override
+  public TypeIndex getTypeIndex() {
+    return typeIndex;
+  }
+
+  @Override
+  public long build(final int buildIndexBatchSize, final BuildIndexCallback callback) {
+    return underlyingIndex.build(buildIndexBatchSize, callback);
+  }
+
+  @Override
+  public void updateTypeName(final String newTypeName) {
+    underlyingIndex.updateTypeName(newTypeName);
+  }
+
+  @Override
+  public boolean isValid() {
+    return underlyingIndex.isValid();
+  }
+
+  @Override
+  public JSONObject toJSON() {
+    final JSONObject json = new JSONObject();
+    json.put("type", getType());
+    json.put("bucket",
+        underlyingIndex.getMutableIndex().getDatabase().getSchema().getBucketById(getAssociatedBucketId()).getName());
+    json.put("properties", getPropertyNames());
+    json.put("nullStrategy", getNullStrategy());
+    json.put("unique", isUnique());
+    if (sparseMetadata != null) {
+      json.put("dimensions", sparseMetadata.dimensions);
+      json.put("modifier", sparseMetadata.modifier);
+    }
+    return json;
+  }
+
+  // --------------------------- helpers ---------------------------
+
+  /**
+   * An "original" call is one made by {@code DocumentIndexer} with the raw property values: a pair
+   * of parallel arrays (indices, weights) per record. Anything else (already-expanded scalar postings
+   * coming from the transaction commit replay path, or null/empty arrays) is forwarded to the
+   * underlying LSM-Tree unchanged.
+   */
+  private static boolean isOriginalCall(final Object[] keys) {
+    if (keys == null || keys.length != 2)
+      return false;
+    final boolean firstIsArray = keys[0] instanceof int[] || keys[0] instanceof Integer[] || keys[0] instanceof List<?>;
+    final boolean secondIsArray = keys[1] instanceof float[] || keys[1] instanceof Float[] || keys[1] instanceof List<?>;
+    return firstIsArray && secondIsArray;
+  }
+
+  private static int[] toIntArray(final Object o) {
+    if (o == null)
+      return null;
+    if (o instanceof int[] arr)
+      return arr;
+    if (o instanceof Integer[] arr) {
+      final int[] out = new int[arr.length];
+      for (int i = 0; i < arr.length; i++)
+        out[i] = arr[i];
+      return out;
+    }
+    if (o instanceof List<?> list) {
+      final int[] out = new int[list.size()];
+      for (int i = 0; i < out.length; i++) {
+        final Object e = list.get(i);
+        if (!(e instanceof Number n))
+          throw new IndexException("Sparse vector indices must be numbers, found: " + e);
+        out[i] = n.intValue();
+      }
+      return out;
+    }
+    throw new IndexException("Sparse vector indices must be int[], Integer[] or List<Number>, found: " + o.getClass().getName());
+  }
+
+  private static float[] toFloatArray(final Object o) {
+    if (o == null)
+      return null;
+    if (o instanceof float[] arr)
+      return arr;
+    if (o instanceof Float[] arr) {
+      final float[] out = new float[arr.length];
+      for (int i = 0; i < arr.length; i++)
+        out[i] = arr[i];
+      return out;
+    }
+    if (o instanceof List<?> list) {
+      final float[] out = new float[list.size()];
+      for (int i = 0; i < out.length; i++) {
+        final Object e = list.get(i);
+        if (!(e instanceof Number n))
+          throw new IndexException("Sparse vector weights must be numbers, found: " + e);
+        out[i] = n.floatValue();
+      }
+      return out;
+    }
+    throw new IndexException("Sparse vector weights must be float[], Float[] or List<Number>, found: " + o.getClass().getName());
+  }
+
+  /**
+   * Pair of (RID, dot-product score) returned by {@link #topK}.
+   */
+  public static final class RidScore {
+    public final RID   rid;
+    public final float score;
+
+    public RidScore(final RID rid, final float score) {
+      this.rid = rid;
+      this.score = score;
+    }
+  }
+}

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndex.java
@@ -31,6 +31,7 @@ import com.arcadedb.index.IndexInternal;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.index.lsm.LSMTreeIndex;
 import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.IndexBuilder;
 import com.arcadedb.schema.IndexMetadata;
 import com.arcadedb.schema.LSMSparseVectorIndexMetadata;
@@ -40,13 +41,14 @@ import com.arcadedb.serializer.json.JSONObject;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
 
 /**
  * Sparse vector index implementation backed by an LSM-Tree as a posting-list inverted index.
@@ -76,10 +78,16 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
   // Per-dim upper bound on the weight of any single posting under that dim. Maintained as a
   // monotonically non-decreasing approximation: `put` raises it, `remove` is a no-op (acceptable
   // because WAND only requires `maxWeight` to be a valid upper bound, not the exact maximum).
-  // Lazily populated: the first WAND query on a freshly opened index does a one-shot scan if the
-  // map is empty; subsequent inserts keep it accurate.
-  private final HashMap<Integer, Float> dimMaxWeight = new HashMap<>();
-  private       boolean                 dimMaxWeightInitialized = false;
+  //
+  // Concurrency: ConcurrentHashMap.merge(...) is atomic and lock-free under contention, so writers
+  // can update the per-dim bound from any thread without serializing on a shared monitor. The
+  // lazy-init flag and its companion lock protect the one-shot index scan that populates the cache
+  // on the first WAND query against a freshly-opened index; subsequent put()s keep it accurate
+  // without further synchronization.
+  private final ConcurrentHashMap<Integer, Float> dimMaxWeight            = new ConcurrentHashMap<>();
+  private volatile boolean                        dimMaxWeightInitialized = false;
+  // Dedicated monitor so the init double-check does not block ConcurrentHashMap operations.
+  private final Object                            dimMaxWeightInitLock    = new Object();
 
   /**
    * Factory handler used by the schema to instantiate sparse vector indexes.
@@ -177,18 +185,27 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
     if (rids == null || rids.length == 0)
       return;
 
+    // When the index was created with an explicit `dimensions` cap (> 0), reject out-of-range
+    // dimension ids at write time so a misconfigured client doesn't silently store entries that
+    // can never be retrieved within the declared vocabulary. dimensions=0 leaves the index open
+    // ended (informational metadata only).
+    final int declaredDimensions = sparseMetadata != null ? sparseMetadata.dimensions : 0;
+
     for (int i = 0; i < indices.length; i++) {
       final int dim = indices[i];
       if (dim < 0)
         throw new IndexException("Sparse vector dimension must be >= 0, found: " + dim);
+      if (declaredDimensions > 0 && dim >= declaredDimensions)
+        throw new IndexException(
+            "Sparse vector dimension " + dim + " is out of range for index '" + getName()
+                + "' with declared dimensions=" + declaredDimensions);
       final float w = values[i];
       if (w == 0.0f)
         continue;
       for (final RID rid : rids)
         underlyingIndex.put(new Object[] { dim, rid, w }, new RID[] { rid });
-      synchronized (dimMaxWeight) {
-        dimMaxWeight.merge(dim, w, Math::max);
-      }
+      // ConcurrentHashMap.merge is atomic; no external synchronization needed.
+      dimMaxWeight.merge(dim, w, Math::max);
     }
   }
 
@@ -198,8 +215,15 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
       underlyingIndex.remove(keys);
       return;
     }
-    // Cannot remove without a RID for the per-(dim, rid, weight) postings, so ignore. The
-    // (rid)-aware overload below is what DocumentIndexer actually invokes during deletion.
+    // The composite-key layout `(dim_id, rid, weight)` makes it impossible to delete the right
+    // postings without the owning RID, so the no-RID overload cannot do useful work. Document
+    // deletion in ArcadeDB always goes through DocumentIndexer.removeFromIndex(record), which
+    // invokes the (rid)-aware overload below; we don't expect this path to fire in practice.
+    // Logging at WARNING so an unexpected caller (e.g. a future type-drop refactor) does not
+    // silently lose entries.
+    LogManager.instance().log(this, Level.WARNING,
+        "%s.remove(keys) called without a RID; sparse vector index needs the per-RID variant. "
+            + "No postings were removed. Caller should switch to remove(keys, rid).", null, getName());
   }
 
   @Override
@@ -213,9 +237,15 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
     final float[] values  = toFloatArray(keys[1]);
     if (indices == null || values == null || rid == null)
       return;
+    // Mirror put()'s length check: silently truncating on mismatch would leak postings on the
+    // longer side and is impossible to diagnose after the fact.
+    if (indices.length != values.length)
+      throw new IndexException(
+          "Sparse vector indices and weights must have the same length on remove (got "
+              + indices.length + " and " + values.length + ")");
     final RID actualRid = rid.getIdentity();
 
-    for (int i = 0; i < Math.min(indices.length, values.length); i++) {
+    for (int i = 0; i < indices.length; i++) {
       if (values[i] == 0.0f)
         continue;
       underlyingIndex.remove(new Object[] { indices[i], actualRid, values[i] }, actualRid);
@@ -251,10 +281,13 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
     // Pre-compute effective query weights. Under IDF, this folds the per-dimension IDF into the
     // query weight so the scoring inner loop stays a plain dot product. df is counted via a
     // dedicated scan per query dim (acceptable for the MVP - the WAND follow-up #4068 maintains
-    // df incrementally to avoid the extra pass).
+    // df incrementally to avoid the extra pass). Within a single topK call we cache df per dim so
+    // duplicate dims in the query don't re-scan, and so future code paths that re-derive idf
+    // mid-query don't multiply the cost.
     final float[] effectiveWeights = new float[queryValues.length];
     if (useIDF) {
       final long n = totalDocuments();
+      final HashMap<Integer, Long> dfCache = new HashMap<>();
       for (int i = 0; i < queryIndices.length; i++) {
         final int qDim = queryIndices[i];
         if (qDim < 0)
@@ -263,7 +296,11 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
           effectiveWeights[i] = 0.0f;
           continue;
         }
-        final long df = countPostings(qDim);
+        Long df = dfCache.get(qDim);
+        if (df == null) {
+          df = countPostings(qDim);
+          dfCache.put(qDim, df);
+        }
         effectiveWeights[i] = queryValues[i] * idf(n, df);
       }
     } else {
@@ -289,32 +326,64 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
     final DimCursor[] cursors = new DimCursor[n];
     int liveCount = 0;
 
-    for (int i = 0; i < n; i++) {
-      final int qDim = queryIndices[i];
-      if (qDim < 0)
-        throw new IndexException("Query dimension must be >= 0, found: " + qDim);
-      if (effW[i] == 0.0f)
-        continue;
-      final float dimMax = getMaxWeight(qDim);
-      if (dimMax == 0.0f)
-        continue;
-      final DimCursor c = new DimCursor(underlyingIndex, qDim, effW[i], dimMax);
-      if (!c.exhausted)
-        cursors[liveCount++] = c;
+    // Allocation phase: a DimCursor that exhausts immediately still gets closed before we drop
+    // the reference, so an empty-dim doesn't leak its initial range cursor.
+    try {
+      for (int i = 0; i < n; i++) {
+        final int qDim = queryIndices[i];
+        if (qDim < 0)
+          throw new IndexException("Query dimension must be >= 0, found: " + qDim);
+        if (effW[i] == 0.0f)
+          continue;
+        final float dimMax = getMaxWeight(qDim);
+        if (dimMax == 0.0f)
+          continue;
+        final DimCursor c = new DimCursor(underlyingIndex, qDim, effW[i], dimMax);
+        if (c.exhausted)
+          c.close();
+        else
+          cursors[liveCount++] = c;
+      }
+
+      if (liveCount == 0)
+        return new ArrayList<>(0);
+
+      return runWandLoop(cursors, liveCount, k, allowedRIDs);
+    } finally {
+      // Close every DimCursor that was kept alive (active or exhausted but not yet compacted out)
+      // so the underlying LSM page cursors release their references regardless of how the loop
+      // terminates: normal exit, threshold reached, or exception thrown mid-scoring.
+      for (int i = 0; i < cursors.length; i++) {
+        final DimCursor c = cursors[i];
+        if (c != null) {
+          try {
+            c.close();
+          } catch (final RuntimeException ignored) {
+            // best-effort cleanup; never let a close exception mask the real error path
+          }
+          cursors[i] = null;
+        }
+      }
     }
+  }
 
-    if (liveCount == 0)
-      return new ArrayList<>(0);
-
+  /**
+   * The WAND scoring loop, factored out of {@link #wandTopK} so the surrounding
+   * {@code try / finally} can guarantee cursor cleanup.
+   */
+  private List<RidScore> runWandLoop(final DimCursor[] cursors, int liveCount, final int k, final Set<RID> allowedRIDs) {
     // Min-heap of (rid, score) keyed by score ASC, capped at K. The minimum element is always at
     // the head, so the K-th best score (= threshold) is heap.peek() once heap is full.
     final PriorityQueue<RidScore> heap = new PriorityQueue<>(k, Comparator.comparingDouble(r -> r.score));
     float threshold = Float.NEGATIVE_INFINITY;
 
-    final Comparator<DimCursor> byCurrentRid = (a, b) -> a.currentRid.compareTo(b.currentRid);
-
     while (liveCount > 0) {
-      Arrays.sort(cursors, 0, liveCount, byCurrentRid);
+      // Cursors are mostly already sorted between iterations: at most a few cursors moved during
+      // the previous step, so insertion sort runs in roughly O(n) on near-sorted input. With
+      // typical query nnz around 10-30, this beats Arrays.sort's O(n log n) constant factor.
+      // BlockMax-WAND in #4068 will replace this loop with a heap-keyed-by-current-RID, removing
+      // the resort altogether.
+      sortCursorsByCurrentRid(cursors, liveCount);
 
       // Find pivot index: smallest i where prefix sum of upperBounds[0..i] reaches threshold.
       float prefix = 0;
@@ -369,12 +438,18 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
         }
       }
 
-      // Compact: drop exhausted cursors.
+      // Compact: drop exhausted cursors. Close them eagerly so their underlying page-cursor
+      // resources release immediately rather than waiting for the outer finally block.
       int newLive = 0;
       for (int i = 0; i < liveCount; i++) {
         if (!cursors[i].exhausted)
           cursors[newLive++] = cursors[i];
+        else
+          cursors[i].close();
       }
+      // Null the trailing slots so the outer finally block does not double-close.
+      for (int i = newLive; i < liveCount; i++)
+        cursors[i] = null;
       liveCount = newLive;
     }
 
@@ -385,20 +460,29 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
 
   /**
    * Returns the per-dim upper bound used by WAND. Lazily initializes the cache on first call by
-   * scanning the underlying index once. Subsequent inserts keep it accurate via {@link #put}; deletes
-   * leave the bound conservatively high (still a valid upper bound).
+   * scanning the underlying index once. Subsequent inserts keep it accurate via {@link #put};
+   * deletes leave the bound conservatively high (still a valid upper bound).
+   * <p>
+   * Uses double-checked locking on a dedicated monitor: the volatile {@code dimMaxWeightInitialized}
+   * flag is read on the fast path with no lock, and only the first thread reaching a fresh index
+   * pays the monitor cost. Writers concurrent with the init scan are still safe because
+   * {@link ConcurrentHashMap#merge} is monotone and atomic; the worst case is the init scan and a
+   * concurrent {@code put} both updating the same key, in which case {@link Math#max} ensures the
+   * later read sees the higher of the two values.
    */
   private float getMaxWeight(final int dim) {
-    synchronized (dimMaxWeight) {
-      if (!dimMaxWeightInitialized) {
-        initializeMaxWeightsLocked();
-        dimMaxWeightInitialized = true;
+    if (!dimMaxWeightInitialized) {
+      synchronized (dimMaxWeightInitLock) {
+        if (!dimMaxWeightInitialized) {
+          initializeMaxWeights();
+          dimMaxWeightInitialized = true;
+        }
       }
-      return dimMaxWeight.getOrDefault(dim, 0.0f);
     }
+    return dimMaxWeight.getOrDefault(dim, 0.0f);
   }
 
-  private void initializeMaxWeightsLocked() {
+  private void initializeMaxWeights() {
     final IndexCursor cursor = underlyingIndex.iterator(true);
     while (cursor.hasNext()) {
       cursor.next();
@@ -415,8 +499,14 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
    * Per-dim cursor used by the WAND scoring loop. Holds the latest {@code (rid, weight)} of an
    * underlying range scan within a single dimension and exposes {@code advance()} and
    * {@code seekTo(rid)} primitives.
+   * <p>
+   * Resource management: every cursor allocated via {@link LSMTreeIndex#range} may hold page
+   * references inside the LSM-Tree (see {@code LSMTreeIndexCursor.close()} which releases page
+   * cursor handles). {@link #close()} closes the active cursor; {@link #seekTo} closes the
+   * previous cursor before allocating a new one; the WAND loop closes every {@link DimCursor}
+   * before returning.
    */
-  private static final class DimCursor {
+  private static final class DimCursor implements AutoCloseable {
     final LSMTreeIndex underlying;
     final int          dim;
     final float        queryWeight;
@@ -459,8 +549,41 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
     }
 
     void seekTo(final RID target) {
+      // Release the previous cursor's resources (page handles in LSMTreeIndexCursor) before
+      // replacing it; otherwise every WAND skip leaks one page-cursor's worth of state.
+      if (cursor != null)
+        cursor.close();
+      // Upper bound { dim } is intentionally a prefix: LSMTreeIndexAbstract.compareKeys() compares
+      // only up to min(key1.length, key2.length) columns, so a posting whose key starts with
+      // `dim` compares equal to `[dim]` and is included by an inclusive upper bound. The effect
+      // is equivalent to "to the end of dim". A regression test in LSMSparseVectorIndexSeekTest
+      // pins this behaviour so a future comparator change cannot silently drop postings.
       cursor = underlying.range(true, new Object[] { dim, target }, true, new Object[] { dim }, true);
       advance();
+    }
+
+    @Override
+    public void close() {
+      if (cursor != null) {
+        cursor.close();
+        cursor = null;
+      }
+    }
+  }
+
+  /**
+   * In-place insertion sort of the live prefix of {@code cursors} by {@code currentRid} ascending.
+   * Cheaper than {@link Arrays#sort} for the small, mostly-sorted arrays the WAND loop produces.
+   */
+  private static void sortCursorsByCurrentRid(final DimCursor[] cursors, final int liveCount) {
+    for (int i = 1; i < liveCount; i++) {
+      final DimCursor key = cursors[i];
+      int j = i - 1;
+      while (j >= 0 && cursors[j].currentRid.compareTo(key.currentRid) > 0) {
+        cursors[j + 1] = cursors[j];
+        j--;
+      }
+      cursors[j + 1] = key;
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndex.java
@@ -202,6 +202,16 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
       final float w = values[i];
       if (w == 0.0f)
         continue;
+      // Negative weights are rejected: WAND's per-dim `max_weight` upper bound is built via
+      // `Math.max(...)` on inserted weights and assumes non-negative values. A mix of negative
+      // and positive entries would yield a max that is no longer an upper bound on any single
+      // posting's contribution, and pruning would silently drop candidates that should rank.
+      // All standard sparse-retrieval models (BM25, SPLADE, BGE-M3, Cohere sparse) emit
+      // non-negative weights, so this is not a real constraint in practice.
+      if (w < 0.0f || Float.isNaN(w))
+        throw new IndexException(
+            "Sparse vector weight must be a non-negative finite number, found: " + w
+                + " at dimension " + dim);
       for (final RID rid : rids)
         underlyingIndex.put(new Object[] { dim, rid, w }, new RID[] { rid });
       // ConcurrentHashMap.merge is atomic; no external synchronization needed.
@@ -484,14 +494,18 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
 
   private void initializeMaxWeights() {
     final IndexCursor cursor = underlyingIndex.iterator(true);
-    while (cursor.hasNext()) {
-      cursor.next();
-      final Object[] keys = cursor.getKeys();
-      if (keys == null || keys.length < 3)
-        continue;
-      if (!(keys[0] instanceof Number nDim) || !(keys[2] instanceof Number nW))
-        continue;
-      dimMaxWeight.merge(nDim.intValue(), nW.floatValue(), Math::max);
+    try {
+      while (cursor.hasNext()) {
+        cursor.next();
+        final Object[] keys = cursor.getKeys();
+        if (keys == null || keys.length < 3)
+          continue;
+        if (!(keys[0] instanceof Number nDim) || !(keys[2] instanceof Number nW))
+          continue;
+        dimMaxWeight.merge(nDim.intValue(), nW.floatValue(), Math::max);
+      }
+    } finally {
+      cursor.close();
     }
   }
 
@@ -599,23 +613,37 @@ public class LSMSparseVectorIndex implements Index, IndexInternal {
   }
 
   /**
-   * Counts the postings under a single dimension by iterating the underlying LSM-Tree range. O(df)
-   * per call. Replaced by an incrementally maintained map in #4068.
+   * Counts the postings under a single dimension by iterating the underlying LSM-Tree range.
+   * O(df) per call: scans every posting for {@code qDim} once. Bounded by the size of one posting
+   * list, but for high-frequency dims (corpus stopwords) this dominates the IDF preprocessing
+   * step. The {@link #topK} caller caches the result per (dim, query) so duplicate dims do not
+   * re-scan, and incremental df maintenance is tracked as part of the WAND scaling work in
+   * #4068, which removes this scan entirely.
    */
   private long countPostings(final int qDim) {
     long df = 0;
     final IndexCursor cursor = underlyingIndex.range(true,
         new Object[] { qDim }, true,
         new Object[] { qDim }, true);
-    while (cursor.hasNext()) {
-      cursor.next();
-      df++;
+    try {
+      while (cursor.hasNext()) {
+        cursor.next();
+        df++;
+      }
+    } finally {
+      cursor.close();
     }
     return df;
   }
 
   /**
    * Total number of documents in the indexed type, used as {@code N} in the IDF formula.
+   * <p>
+   * Called once per {@code topK} in IDF mode (not once per query dim), so the overhead is bounded.
+   * {@code countType} sums each non-polymorphic bucket's cached entry count under a read lock; in
+   * the typical few-buckets case this is on the order of a handful of long reads plus the lock
+   * round-trip. If profiling later shows this is hot, the count can be cached on the wrapper with
+   * invalidation on put / remove.
    */
   private long totalDocuments() {
     final String typeName = getTypeName();

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/CreateIndexStatement.java
@@ -34,6 +34,7 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.TypeFullTextIndexBuilder;
 import com.arcadedb.schema.TypeIndexBuilder;
+import com.arcadedb.schema.TypeLSMSparseVectorIndexBuilder;
 import com.arcadedb.schema.TypeLSMVectorIndexBuilder;
 import com.arcadedb.serializer.json.JSONObject;
 
@@ -71,6 +72,8 @@ public class CreateIndexStatement extends DDLStatement {
     case "NOTUNIQUE" -> {
     }
     case "LSM_VECTOR" -> {
+    }
+    case "LSM_SPARSE_VECTOR" -> {
     }
     case "GEOSPATIAL" -> {
     }
@@ -112,6 +115,9 @@ public class CreateIndexStatement extends DDLStatement {
       indexType = Schema.INDEX_TYPE.LSM_TREE;
     } else if (typeAsString.equalsIgnoreCase("LSM_VECTOR")) {
       indexType = Schema.INDEX_TYPE.LSM_VECTOR;
+      unique = false;
+    } else if (typeAsString.equalsIgnoreCase("LSM_SPARSE_VECTOR")) {
+      indexType = Schema.INDEX_TYPE.LSM_SPARSE_VECTOR;
       unique = false;
     } else if (typeAsString.equalsIgnoreCase("GEOSPATIAL")) {
       indexType = Schema.INDEX_TYPE.GEOSPATIAL;
@@ -202,6 +208,16 @@ public class CreateIndexStatement extends DDLStatement {
       final TypeFullTextIndexBuilder ftBuilder = builder.withFullTextType();
       ftBuilder.withMetadata(jsonMetadata);
       ftBuilder.create();
+
+    } else if (indexType == Schema.INDEX_TYPE.LSM_SPARSE_VECTOR) {
+      final TypeLSMSparseVectorIndexBuilder sparseBuilder = builder.withType(Schema.INDEX_TYPE.LSM_SPARSE_VECTOR)
+          .withSparseVectorType();
+      if (metadata != null) {
+        final Map<String, Object> metadataMap = metadata.toMap((Result) null, context);
+        final JSONObject jsonMetadata = new JSONObject(metadataMap);
+        sparseBuilder.withMetadata(jsonMetadata);
+      }
+      sparseBuilder.create();
 
     } else {
       builder.create();

--- a/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/IndexBuilder.java
@@ -63,6 +63,13 @@ public abstract class IndexBuilder<T extends Index> {
     return new TypeLSMVectorIndexBuilder((TypeIndexBuilder) this);
   }
 
+  public TypeLSMSparseVectorIndexBuilder withSparseVectorType() {
+    if (this instanceof TypeLSMSparseVectorIndexBuilder v)
+      return v;
+
+    return new TypeLSMSparseVectorIndexBuilder((TypeIndexBuilder) this);
+  }
+
   public IndexBuilder<T> withUnique(final boolean unique) {
     this.unique = unique;
     return this;

--- a/engine/src/main/java/com/arcadedb/schema/LSMSparseVectorIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/LSMSparseVectorIndexMetadata.java
@@ -37,6 +37,21 @@ public class LSMSparseVectorIndexMetadata extends IndexMetadata {
     super(typeName, propertyNames, bucketId);
   }
 
+  /**
+   * Populate the metadata from the JSON entry written by {@code LSMSparseVectorIndex.toJSON()}.
+   * <p>
+   * The bucket-index JSON written by the wrapper does NOT carry {@code typeName} or
+   * {@code associatedBucketId}: those are stored at the outer {@code types.<typeName>} key in
+   * {@code schema.json} and are passed to this metadata via the constructor when
+   * {@code LocalSchema.readConfiguration()} reconstructs the wrapper. {@code IndexMetadata.fromJSON}
+   * would throw if called on such a JSON because it unconditionally reads {@code typeName} as a
+   * required field. The {@code if (metadata.has("typeName"))} guard preserves backward
+   * compatibility for any callers that pass the full type-level JSON, while the load path
+   * intentionally skips it because every parent field (typeName, propertyNames, bucketId) is
+   * already set, and the only optional field {@code IndexMetadata.fromJSON} would populate -
+   * {@code collations} - is not meaningful for a sparse vector index whose keys are
+   * {@code (int, RID, float)} composites rather than strings.
+   */
   @Override
   public void fromJSON(final JSONObject metadata) {
     if (metadata.has("typeName"))

--- a/engine/src/main/java/com/arcadedb/schema/LSMSparseVectorIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/LSMSparseVectorIndexMetadata.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.serializer.json.JSONObject;
+
+/**
+ * Metadata for the {@link Schema.INDEX_TYPE#LSM_SPARSE_VECTOR LSM_SPARSE_VECTOR} index type.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class LSMSparseVectorIndexMetadata extends IndexMetadata {
+
+  public static final String MODIFIER_NONE = "NONE";
+  public static final String MODIFIER_IDF  = "IDF";
+
+  public int    dimensions;
+  public String modifier = MODIFIER_NONE;
+
+  public LSMSparseVectorIndexMetadata(final String typeName, final String[] propertyNames, final int bucketId) {
+    super(typeName, propertyNames, bucketId);
+  }
+
+  @Override
+  public void fromJSON(final JSONObject metadata) {
+    if (metadata.has("typeName"))
+      super.fromJSON(metadata);
+    this.dimensions = metadata.getInt("dimensions", 0);
+    this.modifier = metadata.getString("modifier", MODIFIER_NONE).toUpperCase();
+  }
+}

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -55,6 +55,7 @@ import com.arcadedb.index.hash.HashIndexBucket;
 import com.arcadedb.index.fulltext.LSMTreeFullTextIndex;
 import com.arcadedb.index.geospatial.LSMTreeGeoIndex;
 import com.arcadedb.index.lsm.LSMTreeIndex;
+import com.arcadedb.index.sparsevector.LSMSparseVectorIndex;
 import com.arcadedb.index.lsm.LSMTreeIndexAbstract.NULL_STRATEGY;
 import com.arcadedb.index.lsm.LSMTreeIndexCompacted;
 import com.arcadedb.index.lsm.LSMTreeIndexMutable;
@@ -147,6 +148,7 @@ public class LocalSchema implements Schema {
     indexFactory.register(INDEX_TYPE.LSM_TREE.name(), new LSMTreeIndex.LSMTreeIndexFactoryHandler());
     indexFactory.register(INDEX_TYPE.FULL_TEXT.name(), new LSMTreeFullTextIndex.LSMTreeFullTextIndexFactoryHandler());
     indexFactory.register(INDEX_TYPE.LSM_VECTOR.name(), new LSMVectorIndex.LSMVectorIndexFactoryHandler());
+    indexFactory.register(INDEX_TYPE.LSM_SPARSE_VECTOR.name(), new LSMSparseVectorIndex.LSMSparseVectorIndexFactoryHandler());
     indexFactory.register(INDEX_TYPE.GEOSPATIAL.name(), new LSMTreeGeoIndex.GeoIndexFactoryHandler());
     indexFactory.register(INDEX_TYPE.HASH.name(), new HashIndex.HashIndexFactoryHandler());
     configurationFile = new File(databasePath + File.separator + SCHEMA_FILE_NAME);
@@ -1589,6 +1591,11 @@ public class LocalSchema implements Schema {
                   } else if (configuredIndexType.equalsIgnoreCase(Schema.INDEX_TYPE.GEOSPATIAL.toString())) {
                     final int precision = indexJSON.getInt("precision", GeoIndexMetadata.DEFAULT_PRECISION);
                     index = new LSMTreeGeoIndex((LSMTreeIndex) index, precision);
+                    indexMap.put(indexName, index);
+                  } else if (configuredIndexType.equalsIgnoreCase(Schema.INDEX_TYPE.LSM_SPARSE_VECTOR.toString())) {
+                    final LSMSparseVectorIndexMetadata sparseMeta = new LSMSparseVectorIndexMetadata(typeName, properties, -1);
+                    sparseMeta.fromJSON(indexJSON);
+                    index = new LSMSparseVectorIndex((LSMTreeIndex) index, sparseMeta);
                     indexMap.put(indexName, index);
                   } else {
                     orphanIndexes.put(indexName, indexJSON);

--- a/engine/src/main/java/com/arcadedb/schema/Schema.java
+++ b/engine/src/main/java/com/arcadedb/schema/Schema.java
@@ -453,6 +453,6 @@ public interface Schema {
   void setExtension(String name, JSONObject value);
 
   enum INDEX_TYPE {
-    LSM_TREE, FULL_TEXT, LSM_VECTOR, GEOSPATIAL, HASH
+    LSM_TREE, FULL_TEXT, LSM_VECTOR, LSM_SPARSE_VECTOR, GEOSPATIAL, HASH
   }
 }

--- a/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeIndexBuilder.java
@@ -58,6 +58,8 @@ public class TypeIndexBuilder extends IndexBuilder<TypeIndex> {
   public TypeIndexBuilder withType(final Schema.INDEX_TYPE indexType) {
     if (indexType == Schema.INDEX_TYPE.LSM_VECTOR && !(this instanceof TypeLSMVectorIndexBuilder))
       return new TypeLSMVectorIndexBuilder(this);
+    if (indexType == Schema.INDEX_TYPE.LSM_SPARSE_VECTOR && !(this instanceof TypeLSMSparseVectorIndexBuilder))
+      return new TypeLSMSparseVectorIndexBuilder(this);
     if (indexType == Schema.INDEX_TYPE.FULL_TEXT && !(this instanceof TypeFullTextIndexBuilder))
       return new TypeFullTextIndexBuilder(this);
     super.withType(indexType);

--- a/engine/src/main/java/com/arcadedb/schema/TypeLSMSparseVectorIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeLSMSparseVectorIndexBuilder.java
@@ -85,9 +85,10 @@ public class TypeLSMSparseVectorIndexBuilder extends TypeIndexBuilder {
     return this;
   }
 
-  public void withMetadata(final JSONObject json) {
+  public TypeLSMSparseVectorIndexBuilder withMetadata(final JSONObject json) {
     final LSMSparseVectorIndexMetadata meta = (LSMSparseVectorIndexMetadata) metadata;
     meta.dimensions = json.getInt("dimensions", meta.dimensions);
     meta.modifier = json.getString("modifier", meta.modifier).toUpperCase();
+    return this;
   }
 }

--- a/engine/src/main/java/com/arcadedb/schema/TypeLSMSparseVectorIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeLSMSparseVectorIndexBuilder.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.index.IndexException;
+import com.arcadedb.serializer.json.JSONObject;
+
+/**
+ * Builder for {@link Schema.INDEX_TYPE#LSM_SPARSE_VECTOR LSM_SPARSE_VECTOR} indexes.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class TypeLSMSparseVectorIndexBuilder extends TypeIndexBuilder {
+
+  protected TypeLSMSparseVectorIndexBuilder(final TypeIndexBuilder copyFrom) {
+    super(copyFrom.database, copyFrom.metadata.typeName, copyFrom.metadata.propertyNames.toArray(new String[0]));
+
+    this.metadata = new LSMSparseVectorIndexMetadata(
+        copyFrom.metadata.typeName,
+        copyFrom.metadata.propertyNames.toArray(new String[0]),
+        copyFrom.metadata.associatedBucketId);
+
+    this.indexType = Schema.INDEX_TYPE.LSM_SPARSE_VECTOR;
+    this.unique = copyFrom.unique;
+    this.pageSize = copyFrom.pageSize;
+    this.nullStrategy = copyFrom.nullStrategy;
+    this.callback = copyFrom.callback;
+    this.ignoreIfExists = copyFrom.ignoreIfExists;
+    this.indexName = copyFrom.indexName;
+    this.filePath = copyFrom.filePath;
+    this.keyTypes = copyFrom.keyTypes;
+    this.batchSize = copyFrom.batchSize;
+    this.maxAttempts = copyFrom.maxAttempts;
+  }
+
+  protected TypeLSMSparseVectorIndexBuilder(final DatabaseInternal database, final String typeName,
+      final String[] propertyNames) {
+    super(database, typeName, propertyNames);
+    this.indexType = Schema.INDEX_TYPE.LSM_SPARSE_VECTOR;
+  }
+
+  /**
+   * Sets the maximum dimensionality of the sparse vectors. Used as an upper bound for index sizing
+   * and validation. A value of 0 (default) means dimensions are inferred from the data.
+   */
+  public TypeLSMSparseVectorIndexBuilder withDimensions(final int dimensions) {
+    if (dimensions < 0)
+      throw new IllegalArgumentException("dimensions must be >= 0");
+    ((LSMSparseVectorIndexMetadata) metadata).dimensions = dimensions;
+    return this;
+  }
+
+  /**
+   * Sets the scoring modifier. Currently supported: NONE (default), IDF.
+   */
+  public TypeLSMSparseVectorIndexBuilder withModifier(final String modifier) {
+    final String normalized = modifier == null ? LSMSparseVectorIndexMetadata.MODIFIER_NONE : modifier.toUpperCase();
+    if (!LSMSparseVectorIndexMetadata.MODIFIER_NONE.equals(normalized)
+        && !LSMSparseVectorIndexMetadata.MODIFIER_IDF.equals(normalized))
+      throw new IndexException("Invalid sparse vector index modifier: " + modifier + ". Supported values: NONE, IDF");
+    ((LSMSparseVectorIndexMetadata) metadata).modifier = normalized;
+    return this;
+  }
+
+  @Override
+  public TypeLSMSparseVectorIndexBuilder withMetadata(final IndexMetadata metadata) {
+    this.metadata = (LSMSparseVectorIndexMetadata) metadata;
+    return this;
+  }
+
+  public void withMetadata(final JSONObject json) {
+    final LSMSparseVectorIndexMetadata meta = (LSMSparseVectorIndexMetadata) metadata;
+    meta.dimensions = json.getInt("dimensions", meta.dimensions);
+    meta.modifier = json.getString("modifier", meta.modifier).toUpperCase();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/Discussion4044HybridSearchE2ETest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/Discussion4044HybridSearchE2ETest.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.sql.vector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end proof that the original use case from
+ * <a href="https://github.com/ArcadeData/arcadedb/discussions/4044">discussion #4044</a> is now
+ * expressible in a single ArcadeDB SQL statement.
+ * <p>
+ * The discussion described a Russian text classification service migrating from Qdrant. Each user
+ * query produces a 768-dim dense embedding plus a 105K-vocab sparse embedding (SPLADE-style); the
+ * service performs a hybrid dense + sparse retrieval with RRF fusion and groups results by
+ * {@code source_file} with {@code group_size = 1}, so each XML source contributes its single best
+ * matching chunk.
+ * <p>
+ * This test reproduces that pattern at a small but representative scale (10 source files with 5
+ * chunks each, semantically distinct chunk types per source) and asserts:
+ * <ul>
+ *   <li>The hybrid query is one SQL statement.</li>
+ *   <li>The top result is the chunk that should win on both modalities.</li>
+ *   <li>{@code groupBy='source_file', groupSize=1} returns each source at most once.</li>
+ *   <li>Sparse retrieval separates the «начисление процентов» vs «начисление баллов» pair that
+ *       collapses under dense alone.</li>
+ * </ul>
+ * <p>
+ * Companion to issues #4065 (sparse index), #4066 ({@code vector.fuse}), #4067 (groupBy on
+ * {@code vector.neighbors}).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Discussion4044HybridSearchE2ETest extends TestHelper {
+
+  private static final int    DENSE_DIM   = 64;     // a stand-in for the 768-dim model in #4044
+  private static final int    SPARSE_DIM  = 1000;   // stand-in for SPLADE's 105K-token vocabulary
+  private static final int    SOURCES     = 10;
+  private static final int    CHUNKS_PER  = 5;
+  private static final long   SEED        = 4044L;
+
+  private static final String TYPE_NAME   = "Chunk";
+  private static final String DENSE_IDX   = "Chunk[dense]";
+  private static final String SPARSE_IDX  = "Chunk[tokens,weights]";
+
+  /**
+   * The two semantically-similar Russian phrases from the discussion that fail dense-only retrieval
+   * but separate cleanly with sparse. The "rare" token id is the shared «начисление» stem; the
+   * second token differentiates them.
+   */
+  private static final int TOKEN_NACHISLENIE = 7;   // shared stem
+  private static final int TOKEN_PROTSENTOV  = 11;  // «процентов» (interest)
+  private static final int TOKEN_BALLOV      = 13;  // «баллов» (loyalty points)
+
+  /**
+   * Build the schema with both indexes ArcadeDB needs for hybrid retrieval.
+   */
+  private void buildSchema() {
+    database.transaction(() -> {
+      final DocumentType chunk = database.getSchema().createDocumentType(TYPE_NAME);
+      chunk.createProperty("source_file", Type.STRING);
+      chunk.createProperty("variant", Type.STRING);
+      chunk.createProperty("dense", Type.ARRAY_OF_FLOATS);
+      chunk.createProperty("tokens", Type.ARRAY_OF_INTEGERS);
+      chunk.createProperty("weights", Type.ARRAY_OF_FLOATS);
+
+      database.getSchema()
+          .buildTypeIndex(TYPE_NAME, new String[] { "dense" })
+          .withLSMVectorType()
+          .withDimensions(DENSE_DIM)
+          .withSimilarity("COSINE")
+          .create();
+
+      database.getSchema()
+          .buildTypeIndex(TYPE_NAME, new String[] { "tokens", "weights" })
+          .withSparseVectorType()
+          .withDimensions(SPARSE_DIM)
+          .create();
+    });
+  }
+
+  /**
+   * Generate 50 chunks across 10 source files. Source 0's "interest-rate" chunk is the one that
+   * should win the hybrid query; source 1's "loyalty-points" chunk is the one that *would* win if
+   * sparse retrieval were broken (since dense alone collapses the two) and is the negative control.
+   */
+  private void seedFixture() {
+    database.transaction(() -> {
+      final Random rnd = new Random(SEED);
+      for (int s = 0; s < SOURCES; s++) {
+        final String sourceFile = "doc_" + s + ".xml";
+        for (int c = 0; c < CHUNKS_PER; c++) {
+          final String variant;
+          final int specificToken;
+          if (s == 0 && c == 0) {
+            variant = "interest_rates";
+            specificToken = TOKEN_PROTSENTOV;
+          } else if (s == 1 && c == 0) {
+            variant = "loyalty_points";
+            specificToken = TOKEN_BALLOV;
+          } else {
+            variant = "noise_" + s + "_" + c;
+            specificToken = 100 + rnd.nextInt(SPARSE_DIM - 100);
+          }
+
+          final MutableDocument doc = database.newDocument(TYPE_NAME);
+          doc.set("source_file", sourceFile);
+          doc.set("variant", variant);
+          doc.set("dense", buildDense(variant, rnd));
+          doc.set("tokens", buildTokens(variant, specificToken));
+          doc.set("weights", buildWeights(variant));
+          doc.save();
+        }
+      }
+    });
+  }
+
+  /**
+   * Dense embeddings are deliberately near-collinear for the "interest_rates" and "loyalty_points"
+   * chunks - the dense model can't tell «процентов» from «баллов» given the shared «начисление»
+   * stem. This is the core observation from #4044.
+   */
+  private static float[] buildDense(final String variant, final Random rnd) {
+    final float[] v = new float[DENSE_DIM];
+    if (variant.startsWith("interest_rates") || variant.startsWith("loyalty_points")) {
+      // Both chunks live near the same point in the dense space; tiny perturbation only.
+      v[0] = 1.0f;
+      v[1] = 0.05f + rnd.nextFloat() * 0.01f;
+      v[2] = 0.03f + rnd.nextFloat() * 0.01f;
+    } else {
+      // "noise" chunks are spread across the dense space so they don't accidentally rank high.
+      for (int i = 0; i < DENSE_DIM; i++)
+        v[i] = rnd.nextFloat();
+    }
+    return v;
+  }
+
+  private static int[] buildTokens(final String variant, final int specificToken) {
+    if (variant.equals("interest_rates") || variant.equals("loyalty_points"))
+      return new int[] { TOKEN_NACHISLENIE, specificToken, 23 };
+    return new int[] { specificToken, 47, 91 };
+  }
+
+  private static float[] buildWeights(final String variant) {
+    if (variant.equals("interest_rates") || variant.equals("loyalty_points"))
+      return new float[] { 0.6f, 0.9f, 0.2f };
+    return new float[] { 0.3f, 0.2f, 0.1f };
+  }
+
+  /**
+   * The user wants documents about "interest rates" - their query has the «начисление» stem (token
+   * 7) plus the «процентов» token (11) heavily weighted. The hybrid query must surface
+   * source_file=doc_0.xml ahead of doc_1.xml even though dense alone would tie them.
+   */
+  @Test
+  void hybridQueryMatches4044UseCase() {
+    buildSchema();
+    seedFixture();
+
+    final float[] denseQuery = new float[DENSE_DIM];
+    denseQuery[0] = 1.0f;
+    denseQuery[1] = 0.05f;
+    denseQuery[2] = 0.03f;
+
+    // Sparse query mirrors astarso's payload: stem + specific term, both heavily weighted.
+    final int[]   sparseTokens  = new int[] { TOKEN_NACHISLENIE, TOKEN_PROTSENTOV };
+    final float[] sparseWeights = new float[] { 0.6f, 0.9f };
+
+    // The full Qdrant-equivalent of:
+    //
+    //   query_points_groups(
+    //     prefetch=[
+    //       Prefetch(query=dense_vec,  using="dense",  limit=50),
+    //       Prefetch(query=sparse_vec, using="sparse", limit=50),
+    //     ],
+    //     query=FusionQuery(fusion=Fusion.RRF),
+    //     group_by="source_file",
+    //     group_size=1,
+    //   )
+    //
+    // is now a single ArcadeDB SQL statement:
+    final ResultSet rs = database.query("sql", """
+        SELECT expand(`vector.fuse`(
+            `vector.neighbors`(?, ?, ?),
+            `vector.sparseNeighbors`(?, ?, ?, ?),
+            { fusion: 'RRF', groupBy: 'source_file', groupSize: 1 }
+        ))""",
+        DENSE_IDX, denseQuery, 50,
+        SPARSE_IDX, sparseTokens, sparseWeights, 50);
+
+    final Set<String>             seenSources = new HashSet<>();
+    final Map<String, String>     firstVariantPerSource = new LinkedHashMap<>();
+    final Map<String, Float>      firstScorePerSource   = new HashMap<>();
+    String topSource = null;
+    String topVariant = null;
+    float  topScore = Float.NEGATIVE_INFINITY;
+    int rank = 0;
+
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      final String sourceFile = row.getProperty("source_file");
+      final String variant    = row.getProperty("variant");
+      final float  score      = ((Number) row.getProperty("score")).floatValue();
+
+      // groupSize=1 must collapse same-source duplicates.
+      assertThat(seenSources.add(sourceFile))
+          .as("source_file %s appears more than once", sourceFile)
+          .isTrue();
+
+      if (rank == 0) {
+        topSource = sourceFile;
+        topVariant = variant;
+        topScore = score;
+      }
+      firstVariantPerSource.put(sourceFile, variant);
+      firstScorePerSource.put(sourceFile, score);
+      rank++;
+    }
+
+    // 1. The query has to find at least one match.
+    assertThat(rank).as("hybrid query must return results").isPositive();
+
+    // 2. The top result is the interest-rates chunk in doc_0.xml: dense alone would tie 0 and 1,
+    //    sparse breaks the tie because doc_0 contains «процентов» (token 11) and doc_1 contains
+    //    «баллов» (token 13).
+    assertThat(topSource).as("top source").isEqualTo("doc_0.xml");
+    assertThat(topVariant).as("top variant").isEqualTo("interest_rates");
+    assertThat(topScore).as("top score is positive").isPositive();
+
+    // 3. Negative control: the loyalty_points chunk in doc_1.xml exists in the corpus and would
+    //    rank #1 if sparse were broken (dense collapses both). Under hybrid retrieval it must rank
+    //    *after* doc_0.xml.
+    if (firstVariantPerSource.containsKey("doc_1.xml")) {
+      final List<String> ordered = new java.util.ArrayList<>(firstVariantPerSource.keySet());
+      assertThat(ordered.indexOf("doc_0.xml"))
+          .as("doc_0 must rank before doc_1 (sparse breaks the tie)")
+          .isLessThan(ordered.indexOf("doc_1.xml"));
+    }
+
+    // 4. groupSize=1 guarantee: distinct source_files only.
+    assertThat(seenSources.size()).as("each source_file appears at most once").isEqualTo(rank);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorFuseTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorFuseTest.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.sql.vector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Type;
+
+import org.assertj.core.data.Offset;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@code vector.fuse} - server-side hybrid retrieval fusion (issue #4066).
+ * <p>
+ * Verifies fusion across dense + sparse + plain SQL sources using each strategy
+ * (RRF, DBSF, LINEAR), weighted variants, and post-fusion {@code groupBy} / {@code groupSize}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class SQLFunctionVectorFuseTest extends TestHelper {
+
+  private static final String TYPE_NAME      = "FuseDoc";
+  private static final String DENSE_IDX      = "FuseDoc[dense]";
+  private static final String SPARSE_IDX     = "FuseDoc[tokens,weights]";
+
+  private void buildSchema() {
+    database.transaction(() -> {
+      final DocumentType t = database.getSchema().createDocumentType(TYPE_NAME);
+      t.createProperty("dense", Type.ARRAY_OF_FLOATS);
+      t.createProperty("tokens", Type.ARRAY_OF_INTEGERS);
+      t.createProperty("weights", Type.ARRAY_OF_FLOATS);
+      t.createProperty("source", Type.STRING);
+
+      database.getSchema()
+          .buildTypeIndex(TYPE_NAME, new String[] { "dense" })
+          .withLSMVectorType()
+          .withDimensions(3)
+          .withSimilarity("COSINE")
+          .create();
+
+      database.getSchema()
+          .buildTypeIndex(TYPE_NAME, new String[] { "tokens", "weights" })
+          .withSparseVectorType()
+          .withDimensions(50)
+          .create();
+    });
+  }
+
+  /**
+   * Inserts a 5-document fixture where:
+   * <ul>
+   *   <li>doc A wins on dense ranking and wins on sparse ranking (first across both)</li>
+   *   <li>doc B wins on dense, mid on sparse</li>
+   *   <li>doc C is mid on both</li>
+   *   <li>doc D mid on dense, wins on sparse</li>
+   *   <li>doc E loses both</li>
+   * </ul>
+   * The exact RID returned by each insert is captured for assertions.
+   */
+  private RID[] seedFixture() {
+    final RID[] rids = new RID[5];
+    database.transaction(() -> {
+      // Dense vectors: query [1,0,0] picks A first, B second, then C, D, E.
+      // Sparse vectors: query at dim 1 picks A first, D second, then B, C, E.
+      rids[0] = newDoc("A", new float[] { 1.0f, 0.0f, 0.0f }, new int[] { 1, 5 }, new float[] { 0.9f, 0.5f }, "g1");
+      rids[1] = newDoc("B", new float[] { 0.95f, 0.1f, 0.05f }, new int[] { 1, 6 }, new float[] { 0.4f, 0.5f }, "g1");
+      rids[2] = newDoc("C", new float[] { 0.5f, 0.5f, 0.0f }, new int[] { 1, 7 }, new float[] { 0.3f, 0.5f }, "g2");
+      rids[3] = newDoc("D", new float[] { 0.4f, 0.6f, 0.1f }, new int[] { 1, 8 }, new float[] { 0.7f, 0.5f }, "g2");
+      rids[4] = newDoc("E", new float[] { 0.1f, 0.2f, 0.97f }, new int[] { 9 }, new float[] { 0.5f }, "g3");
+    });
+    return rids;
+  }
+
+  private RID newDoc(final String src, final float[] dense, final int[] tokens, final float[] weights, final String group) {
+    final MutableDocument d = database.newDocument(TYPE_NAME);
+    d.set("source", src);
+    d.set("dense", dense);
+    d.set("tokens", tokens);
+    d.set("weights", weights);
+    d.set("group", group);
+    d.save();
+    return d.getIdentity();
+  }
+
+  @Test
+  void requireAtLeastTwoSources() {
+    buildSchema();
+    seedFixture();
+
+    assertThatThrownBy(() -> {
+      try (ResultSet rs = database.query("sql",
+          "SELECT expand(`vector.fuse`(`vector.neighbors`(?, ?, ?), { fusion: 'RRF' }))",
+          DENSE_IDX, new float[] { 1.0f, 0.0f, 0.0f }, 3)) {
+        while (rs.hasNext()) rs.next();
+      }
+    }).hasMessageContaining("at least 2");
+  }
+
+  @Test
+  void rrfTwoWayDenseAndSparse() {
+    buildSchema();
+    final RID[] rids = seedFixture();
+
+    final ResultSet rs = database.query("sql", """
+        SELECT expand(`vector.fuse`(
+            `vector.neighbors`(?, ?, ?),
+            `vector.sparseNeighbors`(?, ?, ?, ?),
+            { fusion: 'RRF' }
+        ))""",
+        DENSE_IDX, new float[] { 1.0f, 0.0f, 0.0f }, 5,
+        SPARSE_IDX, new int[] { 1 }, new float[] { 1.0f }, 5);
+
+    final List<RID> ranked = new ArrayList<>();
+    while (rs.hasNext())
+      ranked.add((RID) rs.next().getProperty("@rid"));
+
+    // Doc A is first in both rankings (dense rank 1, sparse rank 1) so RRF must surface it first.
+    assertThat(ranked).as("fused results").contains(rids[0]);
+    assertThat(ranked.get(0)).as("rank 0").isEqualTo(rids[0]);
+    // Doc E is absent from sparse (no shared dim with query) and last on dense, so it must rank below
+    // anything that appears in both lists.
+    if (ranked.contains(rids[4]))
+      assertThat(ranked.indexOf(rids[4])).isGreaterThan(0);
+  }
+
+  @Test
+  void rrfWeightsTiltTheRanking() {
+    buildSchema();
+    final RID[] rids = seedFixture();
+
+    // With dense weighted 10x sparse, B (dense rank 2, sparse rank 3) must beat D (dense rank 4,
+    // sparse rank 2): under unweighted RRF, B = 1/62 + 1/63, D = 1/64 + 1/62; weighting dense up
+    // breaks the tie strongly in B's favour.
+    final ResultSet rs = database.query("sql", """
+        SELECT expand(`vector.fuse`(
+            `vector.neighbors`(?, ?, ?),
+            `vector.sparseNeighbors`(?, ?, ?, ?),
+            { fusion: 'RRF', weights: [10.0, 1.0] }
+        ))""",
+        DENSE_IDX, new float[] { 1.0f, 0.0f, 0.0f }, 5,
+        SPARSE_IDX, new int[] { 1 }, new float[] { 1.0f }, 5);
+
+    final List<RID> ranked = new ArrayList<>();
+    while (rs.hasNext())
+      ranked.add((RID) rs.next().getProperty("@rid"));
+
+    assertThat(ranked.indexOf(rids[1])).as("B (dense-favoured) rank")
+        .isLessThan(ranked.indexOf(rids[3]));
+  }
+
+  @Test
+  void linearStrategyUsesScores() {
+    buildSchema();
+    final RID[] rids = seedFixture();
+
+    final ResultSet rs = database.query("sql", """
+        SELECT expand(`vector.fuse`(
+            `vector.neighbors`(?, ?, ?),
+            `vector.sparseNeighbors`(?, ?, ?, ?),
+            { fusion: 'LINEAR', weights: [1.0, 1.0] }
+        ))""",
+        DENSE_IDX, new float[] { 1.0f, 0.0f, 0.0f }, 5,
+        SPARSE_IDX, new int[] { 1 }, new float[] { 1.0f }, 5);
+
+    final List<RID>   ranked = new ArrayList<>();
+    final List<Float> scores = new ArrayList<>();
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      ranked.add((RID) row.getProperty("@rid"));
+      scores.add(((Number) row.getProperty("score")).floatValue());
+    }
+
+    assertThat(ranked.get(0)).as("LINEAR top-1").isEqualTo(rids[0]);
+    // Scores must be in non-increasing order.
+    for (int i = 1; i < scores.size(); i++)
+      assertThat(scores.get(i)).isLessThanOrEqualTo(scores.get(i - 1));
+  }
+
+  @Test
+  void dbsfStrategyNormalizesAcrossSources() {
+    buildSchema();
+    final RID[] rids = seedFixture();
+
+    final ResultSet rs = database.query("sql", """
+        SELECT expand(`vector.fuse`(
+            `vector.neighbors`(?, ?, ?),
+            `vector.sparseNeighbors`(?, ?, ?, ?),
+            { fusion: 'DBSF' }
+        ))""",
+        DENSE_IDX, new float[] { 1.0f, 0.0f, 0.0f }, 5,
+        SPARSE_IDX, new int[] { 1 }, new float[] { 1.0f }, 5);
+
+    final List<RID> ranked = new ArrayList<>();
+    while (rs.hasNext())
+      ranked.add((RID) rs.next().getProperty("@rid"));
+
+    // DBSF must surface doc A (top of both distributions after normalization).
+    assertThat(ranked.get(0)).isEqualTo(rids[0]);
+  }
+
+  @Test
+  void groupByCollapsesAfterFusion() {
+    buildSchema();
+    final RID[] rids = seedFixture();
+
+    // Without groupBy we'd expect A, B, ... With groupBy=group and groupSize=1, only one
+    // representative per group survives. A is in g1, D is in g2, E is in g3 → 3 distinct groups.
+    final ResultSet rs = database.query("sql", """
+        SELECT expand(`vector.fuse`(
+            `vector.neighbors`(?, ?, ?),
+            `vector.sparseNeighbors`(?, ?, ?, ?),
+            { fusion: 'RRF', groupBy: 'group', groupSize: 1 }
+        ))""",
+        DENSE_IDX, new float[] { 1.0f, 0.0f, 0.0f }, 5,
+        SPARSE_IDX, new int[] { 1 }, new float[] { 1.0f }, 5);
+
+    final List<RID>     ranked = new ArrayList<>();
+    final HashSet<String> groups = new HashSet<>();
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      ranked.add((RID) row.getProperty("@rid"));
+      groups.add((String) row.getProperty("group"));
+    }
+
+    assertThat(groups.size()).as("each group appears at most once").isEqualTo(ranked.size());
+    assertThat(ranked.get(0)).as("best member of best group is first").isEqualTo(rids[0]);
+  }
+
+  @Test
+  void rrfFallbackOnScorelessSources() {
+    // RRF only needs ordered RIDs; it must work even when sources do not expose a score column.
+    buildSchema();
+    final RID[] rids = seedFixture();
+
+    final ResultSet rs = database.query("sql", """
+        SELECT expand(`vector.fuse`(
+            (SELECT @rid FROM FuseDoc ORDER BY source ASC),
+            (SELECT @rid FROM FuseDoc ORDER BY source DESC),
+            { fusion: 'RRF' }
+        ))""");
+
+    final List<RID> ranked = new ArrayList<>();
+    while (rs.hasNext())
+      ranked.add((RID) rs.next().getProperty("@rid"));
+
+    // Each doc appears in both sources (one ascending, one descending). RRF on perfectly
+    // mirrored rankings yields identical fused scores for every RID; we just need 5 results.
+    assertThat(ranked).hasSize(5);
+    assertThat(new HashSet<>(ranked)).containsExactlyInAnyOrder(rids[0], rids[1], rids[2], rids[3], rids[4]);
+  }
+
+  @Test
+  void threeWayFusionAcceptsMixedSources() {
+    buildSchema();
+    final RID[] rids = seedFixture();
+
+    // Three sources of different shapes:
+    //   1. dense `vector.neighbors`
+    //   2. sparse `vector.sparseNeighbors`
+    //   3. plain SQL ordered by a payload field (no score column)
+    final ResultSet rs = database.query("sql", """
+        SELECT expand(`vector.fuse`(
+            `vector.neighbors`(?, ?, ?),
+            `vector.sparseNeighbors`(?, ?, ?, ?),
+            (SELECT @rid FROM FuseDoc ORDER BY source ASC),
+            { fusion: 'RRF' }
+        ))""",
+        DENSE_IDX, new float[] { 1.0f, 0.0f, 0.0f }, 5,
+        SPARSE_IDX, new int[] { 1 }, new float[] { 1.0f }, 5);
+
+    final List<RID> ranked = new ArrayList<>();
+    while (rs.hasNext())
+      ranked.add((RID) rs.next().getProperty("@rid"));
+
+    // A wins under RRF: rank 1 in dense, rank 1 in sparse, rank 1 in plain SQL (alphabetical).
+    assertThat(ranked.get(0)).as("three-way RRF top-1").isEqualTo(rids[0]);
+    assertThat(ranked).hasSize(5);
+  }
+
+  @Test
+  void limitOptionCapsResults() {
+    buildSchema();
+    final RID[] rids = seedFixture();
+
+    final ResultSet rs = database.query("sql", """
+        SELECT expand(`vector.fuse`(
+            `vector.neighbors`(?, ?, ?),
+            `vector.sparseNeighbors`(?, ?, ?, ?),
+            { fusion: 'RRF', limit: 2 }
+        ))""",
+        DENSE_IDX, new float[] { 1.0f, 0.0f, 0.0f }, 5,
+        SPARSE_IDX, new int[] { 1 }, new float[] { 1.0f }, 5);
+
+    final List<RID> ranked = new ArrayList<>();
+    while (rs.hasNext())
+      ranked.add((RID) rs.next().getProperty("@rid"));
+
+    assertThat(ranked).hasSizeLessThanOrEqualTo(2);
+    assertThat(ranked.get(0)).isEqualTo(rids[0]);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorGroupByTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorGroupByTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.sql.vector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the {@code groupBy} / {@code groupSize} options on {@code vector.neighbors} and
+ * {@code vector.sparseNeighbors} (issue #4067).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class SQLFunctionVectorGroupByTest extends TestHelper {
+
+  private static final String TYPE_NAME  = "GroupedDoc";
+  private static final String DENSE_IDX  = "GroupedDoc[embedding]";
+  private static final String SPARSE_IDX = "GroupedDoc[tokens,weights]";
+
+  private static final int    GROUPS   = 10;
+  private static final int    PER_GROUP = 10;
+
+  private void buildSchema() {
+    database.transaction(() -> {
+      final DocumentType t = database.getSchema().createDocumentType(TYPE_NAME);
+      t.createProperty("source_file", Type.STRING);
+      t.createProperty("embedding", Type.ARRAY_OF_FLOATS);
+      t.createProperty("tokens", Type.ARRAY_OF_INTEGERS);
+      t.createProperty("weights", Type.ARRAY_OF_FLOATS);
+
+      database.getSchema()
+          .buildTypeIndex(TYPE_NAME, new String[] { "embedding" })
+          .withLSMVectorType()
+          .withDimensions(8)
+          .withSimilarity("COSINE")
+          .create();
+
+      database.getSchema()
+          .buildTypeIndex(TYPE_NAME, new String[] { "tokens", "weights" })
+          .withSparseVectorType()
+          .withDimensions(50)
+          .create();
+    });
+  }
+
+  /**
+   * Inserts {@code GROUPS x PER_GROUP} = 100 docs across 10 source files. Each doc has a random
+   * 8-dim dense embedding and a 3-nnz sparse vector. The {@code source_file} is the group key.
+   */
+  private void seed100Across10Files() {
+    database.transaction(() -> {
+      final Random rnd = new Random(0xCAFEL);
+      for (int g = 0; g < GROUPS; g++) {
+        for (int j = 0; j < PER_GROUP; j++) {
+          final float[] dense = new float[8];
+          for (int d = 0; d < 8; d++) dense[d] = rnd.nextFloat();
+
+          final int[]   indices = new int[3];
+          final float[] values  = new float[3];
+          final HashSet<Integer> picked = new HashSet<>(3);
+          for (int z = 0; z < 3; z++) {
+            int dim;
+            do {
+              dim = rnd.nextInt(50);
+            } while (!picked.add(dim));
+            indices[z] = dim;
+            values[z] = 0.1f + rnd.nextFloat();
+          }
+
+          final MutableDocument d = database.newDocument(TYPE_NAME);
+          d.set("source_file", "file_" + g);
+          d.set("embedding", dense);
+          d.set("tokens", indices);
+          d.set("weights", values);
+          d.save();
+        }
+      }
+    });
+  }
+
+  @Test
+  void denseGroupByReturnsDistinctGroupsAtGroupSize1() {
+    buildSchema();
+    seed100Across10Files();
+
+    final float[] queryVec = new float[8];
+    queryVec[0] = 1.0f;
+
+    final ResultSet rs = database.query("sql",
+        "SELECT expand(`vector.neighbors`(?, ?, ?, { groupBy: 'source_file', groupSize: 1 }))",
+        DENSE_IDX, queryVec, 10);
+
+    final Set<String> groups = new HashSet<>();
+    int rowCount = 0;
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      assertThat(groups.add((String) row.getProperty("source_file")))
+          .as("each source_file appears at most once").isTrue();
+      rowCount++;
+    }
+    assertThat(rowCount).isEqualTo(10);
+    assertThat(groups).hasSize(10);
+  }
+
+  @Test
+  void denseGroupSize2CapsRowsPerGroup() {
+    buildSchema();
+    seed100Across10Files();
+
+    final float[] queryVec = new float[8];
+    queryVec[0] = 1.0f;
+
+    final ResultSet rs = database.query("sql",
+        "SELECT expand(`vector.neighbors`(?, ?, ?, { groupBy: 'source_file', groupSize: 2 }))",
+        DENSE_IDX, queryVec, 10);
+
+    final HashMap<String, Integer> seen = new HashMap<>();
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      seen.merge((String) row.getProperty("source_file"), 1, Integer::sum);
+    }
+
+    assertThat(seen.size()).as("group count <= limit").isLessThanOrEqualTo(10);
+    for (final Map.Entry<String, Integer> e : seen.entrySet())
+      assertThat(e.getValue()).as("group %s row count", e.getKey()).isLessThanOrEqualTo(2);
+  }
+
+  @Test
+  void sparseGroupByReturnsDistinctGroupsAtGroupSize1() {
+    buildSchema();
+    seed100Across10Files();
+
+    final ResultSet rs = database.query("sql",
+        "SELECT expand(`vector.sparseNeighbors`(?, ?, ?, ?, { groupBy: 'source_file', groupSize: 1 }))",
+        SPARSE_IDX, new int[] { 1, 2, 3 }, new float[] { 1.0f, 1.0f, 1.0f }, 5);
+
+    final Set<String> groups = new HashSet<>();
+    int rowCount = 0;
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      assertThat(groups.add((String) row.getProperty("source_file")))
+          .as("each source_file appears at most once").isTrue();
+      rowCount++;
+    }
+    assertThat(rowCount).isLessThanOrEqualTo(5);
+    assertThat(groups.size()).isEqualTo(rowCount);
+  }
+
+  @Test
+  void groupByWithoutOptionPreservesLegacyBehavior() {
+    buildSchema();
+    seed100Across10Files();
+
+    final float[] queryVec = new float[8];
+    queryVec[0] = 1.0f;
+
+    // Without groupBy: no constraint on source_file diversity; expect exactly k results.
+    final ResultSet rs = database.query("sql",
+        "SELECT expand(`vector.neighbors`(?, ?, ?))",
+        DENSE_IDX, queryVec, 10);
+
+    int count = 0;
+    while (rs.hasNext()) {
+      rs.next();
+      count++;
+    }
+    assertThat(count).isEqualTo(10);
+  }
+
+  @Test
+  void groupByComposesWithFilter() {
+    buildSchema();
+    seed100Across10Files();
+
+    // Build a filter list that whitelists only the first half of file_0..file_4 (half the corpus).
+    final List<RID> whitelist = new java.util.ArrayList<>();
+    try (ResultSet rs = database.query("sql",
+        "SELECT @rid AS rid FROM " + TYPE_NAME + " WHERE source_file IN ['file_0', 'file_1', 'file_2', 'file_3', 'file_4']")) {
+      while (rs.hasNext())
+        whitelist.add((RID) rs.next().getProperty("rid"));
+    }
+    assertThat(whitelist).hasSize(50);
+
+    final float[] queryVec = new float[8];
+    queryVec[0] = 1.0f;
+
+    final ResultSet rs = database.query("sql",
+        "SELECT expand(`vector.neighbors`(?, ?, ?, { filter: ?, groupBy: 'source_file', groupSize: 1 }))",
+        DENSE_IDX, queryVec, 10, whitelist);
+
+    final Set<String> groups = new HashSet<>();
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      final String sourceFile = row.getProperty("source_file");
+      assertThat(sourceFile).as("filter excludes file_5..file_9")
+          .isIn("file_0", "file_1", "file_2", "file_3", "file_4");
+      groups.add(sourceFile);
+    }
+    // 5 files survive the filter, groupSize=1, so we expect at most 5 groups.
+    assertThat(groups.size()).isLessThanOrEqualTo(5);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorGroupByTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorGroupByTest.java
@@ -200,6 +200,33 @@ class SQLFunctionVectorGroupByTest extends TestHelper {
   }
 
   @Test
+  void overFetchCapRejectsPathologicalParams() {
+    buildSchema();
+    seed100Across10Files();
+
+    final float[] queryVec = new float[8];
+    queryVec[0] = 1.0f;
+
+    // limit=10000, groupSize=10000 would request 500M candidates without the cap. Expect a
+    // CommandSQLParsingException with a helpful message (caller should reduce limit or groupSize).
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> {
+      try (ResultSet rs = database.query("sql",
+          "SELECT expand(`vector.neighbors`(?, ?, ?, { groupBy: 'source_file', groupSize: 10000 }))",
+          DENSE_IDX, queryVec, 10000)) {
+        while (rs.hasNext()) rs.next();
+      }
+    }).hasMessageContaining("over-fetch budget exceeded");
+
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> {
+      try (ResultSet rs = database.query("sql",
+          "SELECT expand(`vector.sparseNeighbors`(?, ?, ?, ?, { groupBy: 'source_file', groupSize: 10000 }))",
+          SPARSE_IDX, new int[] { 1, 2, 3 }, new float[] { 1.0f, 1.0f, 1.0f }, 10000)) {
+        while (rs.hasNext()) rs.next();
+      }
+    }).hasMessageContaining("over-fetch budget exceeded");
+  }
+
+  @Test
   void groupByComposesWithFilter() {
     buildSchema();
     seed100Across10Files();

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNestedGroupByTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNestedGroupByTest.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.sql.vector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for dotted nested-field {@code groupBy} on vector search functions (issue #4072).
+ * <p>
+ * Verifies that {@code groupBy: 'metadata.author'} resolves a nested {@code Map}-typed property
+ * across {@code vector.neighbors}, {@code vector.sparseNeighbors}, and {@code vector.fuse}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class SQLFunctionVectorNestedGroupByTest extends TestHelper {
+
+  private static final String TYPE_NAME = "NestedGroupedDoc";
+  private static final String DENSE_IDX  = "NestedGroupedDoc[embedding]";
+  private static final String SPARSE_IDX = "NestedGroupedDoc[tokens,weights]";
+
+  private static final int    DENSE_DIM = 8;
+  private static final int    SPARSE_DIM = 50;
+
+  private void buildSchema() {
+    database.transaction(() -> {
+      final DocumentType t = database.getSchema().createDocumentType(TYPE_NAME);
+      t.createProperty("metadata", Type.MAP);
+      t.createProperty("embedding", Type.ARRAY_OF_FLOATS);
+      t.createProperty("tokens", Type.ARRAY_OF_INTEGERS);
+      t.createProperty("weights", Type.ARRAY_OF_FLOATS);
+
+      database.getSchema()
+          .buildTypeIndex(TYPE_NAME, new String[] { "embedding" })
+          .withLSMVectorType()
+          .withDimensions(DENSE_DIM)
+          .withSimilarity("COSINE")
+          .create();
+
+      database.getSchema()
+          .buildTypeIndex(TYPE_NAME, new String[] { "tokens", "weights" })
+          .withSparseVectorType()
+          .withDimensions(SPARSE_DIM)
+          .create();
+    });
+  }
+
+  /**
+   * 100 docs split across 5 authors and 4 categories nested under {@code metadata}. Some docs are
+   * deliberately inserted without {@code metadata} at all so we can test the missing-path branch.
+   */
+  private void seedFixture() {
+    database.transaction(() -> {
+      final Random rnd = new Random(42L);
+      for (int i = 0; i < 100; i++) {
+        final float[] dense = new float[DENSE_DIM];
+        for (int d = 0; d < DENSE_DIM; d++) dense[d] = rnd.nextFloat();
+
+        final int[]   tokens = new int[3];
+        final float[] weights = new float[3];
+        final HashSet<Integer> picked = new HashSet<>();
+        for (int z = 0; z < 3; z++) {
+          int dim;
+          do {
+            dim = rnd.nextInt(SPARSE_DIM);
+          } while (!picked.add(dim));
+          tokens[z] = dim;
+          weights[z] = 0.1f + rnd.nextFloat();
+        }
+
+        final MutableDocument doc = database.newDocument(TYPE_NAME);
+        doc.set("embedding", dense);
+        doc.set("tokens", tokens);
+        doc.set("weights", weights);
+
+        // 90 documents have a populated `metadata` map; 10 are deliberately missing the field.
+        if (i < 90) {
+          final Map<String, Object> meta = new HashMap<>();
+          meta.put("author", "author_" + (i % 5));
+          meta.put("category", "cat_" + (i % 4));
+          doc.set("metadata", meta);
+        }
+        doc.save();
+      }
+    });
+  }
+
+  @Test
+  void denseGroupByNestedAuthor() {
+    buildSchema();
+    seedFixture();
+
+    final float[] queryVec = new float[DENSE_DIM];
+    queryVec[0] = 1.0f;
+
+    final ResultSet rs = database.query("sql",
+        "SELECT expand(`vector.neighbors`(?, ?, ?, { groupBy: 'metadata.author', groupSize: 1 }))",
+        DENSE_IDX, queryVec, 5);
+
+    final Set<Object> seenAuthors = new HashSet<>();
+    int rowCount = 0;
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      @SuppressWarnings("unchecked")
+      final Map<String, Object> meta = (Map<String, Object>) row.getProperty("metadata");
+      final Object author = meta == null ? null : meta.get("author");
+      assertThat(seenAuthors.add(author))
+          .as("author %s appeared more than once", author).isTrue();
+      rowCount++;
+    }
+    assertThat(rowCount).isPositive();
+    // 5 distinct authors at most. Missing-metadata rows would land in the null group.
+    assertThat(seenAuthors.size()).isLessThanOrEqualTo(5 + 1);
+  }
+
+  @Test
+  void sparseGroupByNestedAuthor() {
+    buildSchema();
+    seedFixture();
+
+    final ResultSet rs = database.query("sql",
+        "SELECT expand(`vector.sparseNeighbors`(?, ?, ?, ?, { groupBy: 'metadata.author', groupSize: 1 }))",
+        SPARSE_IDX, new int[] { 0, 1, 2 }, new float[] { 1.0f, 1.0f, 1.0f }, 5);
+
+    final Set<Object> seenAuthors = new HashSet<>();
+    int rowCount = 0;
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      @SuppressWarnings("unchecked")
+      final Map<String, Object> meta = (Map<String, Object>) row.getProperty("metadata");
+      final Object author = meta == null ? null : meta.get("author");
+      assertThat(seenAuthors.add(author))
+          .as("author %s appeared more than once", author).isTrue();
+      rowCount++;
+    }
+    assertThat(rowCount).isPositive();
+    assertThat(seenAuthors.size()).isLessThanOrEqualTo(5 + 1);
+  }
+
+  @Test
+  void fuseGroupByNestedAuthor() {
+    buildSchema();
+    seedFixture();
+
+    final float[] queryVec = new float[DENSE_DIM];
+    queryVec[0] = 1.0f;
+
+    final ResultSet rs = database.query("sql", """
+        SELECT expand(`vector.fuse`(
+            `vector.neighbors`(?, ?, ?),
+            `vector.sparseNeighbors`(?, ?, ?, ?),
+            { fusion: 'RRF', groupBy: 'metadata.author', groupSize: 1 }
+        ))""",
+        DENSE_IDX, queryVec, 20,
+        SPARSE_IDX, new int[] { 0, 1, 2 }, new float[] { 1.0f, 1.0f, 1.0f }, 20);
+
+    final Set<Object> seenAuthors = new HashSet<>();
+    int rowCount = 0;
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      @SuppressWarnings("unchecked")
+      final Map<String, Object> meta = (Map<String, Object>) row.getProperty("metadata");
+      final Object author = meta == null ? null : meta.get("author");
+      assertThat(seenAuthors.add(author))
+          .as("author %s appeared more than once", author).isTrue();
+      rowCount++;
+    }
+    assertThat(rowCount).isPositive();
+    assertThat(seenAuthors.size()).isLessThanOrEqualTo(5 + 1);
+  }
+
+  @Test
+  void missingNestedPathFallsIntoNullGroup() {
+    buildSchema();
+    // Only insert documents that LACK metadata so every record's `metadata.author` is null.
+    database.transaction(() -> {
+      final Random rnd = new Random(7L);
+      for (int i = 0; i < 10; i++) {
+        final float[] dense = new float[DENSE_DIM];
+        for (int d = 0; d < DENSE_DIM; d++) dense[d] = rnd.nextFloat();
+
+        final MutableDocument doc = database.newDocument(TYPE_NAME);
+        doc.set("embedding", dense);
+        doc.set("tokens", new int[] { 0 });
+        doc.set("weights", new float[] { 1.0f });
+        doc.save();
+      }
+    });
+
+    final float[] queryVec = new float[DENSE_DIM];
+    queryVec[0] = 1.0f;
+
+    // groupSize=1 with all docs in the same (null) group must collapse to a single result.
+    final ResultSet rs = database.query("sql",
+        "SELECT expand(`vector.neighbors`(?, ?, ?, { groupBy: 'metadata.author', groupSize: 1 }))",
+        DENSE_IDX, queryVec, 5);
+
+    int rowCount = 0;
+    while (rs.hasNext()) {
+      rs.next();
+      rowCount++;
+    }
+    assertThat(rowCount).as("all docs share the null group, groupSize=1 caps to one row").isEqualTo(1);
+  }
+
+  @Test
+  void flatPropertyStillWorks() {
+    // Backwards compatibility: a non-dotted property name behaves identically to before.
+    buildSchema();
+    database.transaction(() -> {
+      final DocumentType t = database.getSchema().getType(TYPE_NAME);
+      t.createProperty("source_file", Type.STRING);
+      final Random rnd = new Random(99L);
+      for (int i = 0; i < 30; i++) {
+        final float[] dense = new float[DENSE_DIM];
+        for (int d = 0; d < DENSE_DIM; d++) dense[d] = rnd.nextFloat();
+        final MutableDocument doc = database.newDocument(TYPE_NAME);
+        doc.set("embedding", dense);
+        doc.set("tokens", new int[] { 0 });
+        doc.set("weights", new float[] { 1.0f });
+        doc.set("source_file", "file_" + (i % 6));
+        doc.save();
+      }
+    });
+
+    final float[] queryVec = new float[DENSE_DIM];
+    queryVec[0] = 1.0f;
+
+    final ResultSet rs = database.query("sql",
+        "SELECT expand(`vector.neighbors`(?, ?, ?, { groupBy: 'source_file', groupSize: 1 }))",
+        DENSE_IDX, queryVec, 6);
+
+    final Set<String> sources = new HashSet<>();
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      sources.add((String) row.getProperty("source_file"));
+    }
+    assertThat(sources).hasSize(6);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexBenchmark.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexBenchmark.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.sparsevector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Throughput benchmark for the {@code LSM_SPARSE_VECTOR} index, comparing the WAND-based
+ * {@code vector.sparseNeighbors} against an indexless brute-force {@code vector.sparseDot} scan
+ * over the same corpus. Tagged {@code benchmark} so it stays out of default CI runs (kept under
+ * 100k vectors so a single run completes in under a couple of minutes on a developer laptop).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("benchmark")
+class LSMSparseVectorIndexBenchmark extends TestHelper {
+
+  private static final String TYPE_NAME   = "BenchmarkSparseDoc";
+  private static final String IDX_NAME    = "BenchmarkSparseDoc[tokens,weights]";
+  private static final int    DIMENSIONS  = 5_000;
+  private static final int    DOC_COUNT   = 100_000;
+  private static final int    NNZ_PER_DOC = 30;
+  private static final int    Q_NNZ       = 10;
+  private static final int    K           = 10;
+  private static final int    WARMUP      = 3;
+  private static final int    ITERATIONS  = 5;
+
+  @Test
+  void sparseNeighborsVsBruteForceDot() {
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().createDocumentType(TYPE_NAME);
+      type.createProperty("tokens", Type.ARRAY_OF_INTEGERS);
+      type.createProperty("weights", Type.ARRAY_OF_FLOATS);
+
+      database.getSchema()
+          .buildTypeIndex(TYPE_NAME, new String[] { "tokens", "weights" })
+          .withSparseVectorType()
+          .withDimensions(DIMENSIONS)
+          .create();
+    });
+
+    System.out.println("\n=== Loading " + DOC_COUNT + " sparse vectors (" + NNZ_PER_DOC + " nnz/doc, "
+        + DIMENSIONS + "-dim) ===");
+
+    final long loadStart = System.nanoTime();
+    final Random rnd = new Random(7L);
+    int batchOpen = 0;
+    database.begin();
+    for (int i = 0; i < DOC_COUNT; i++) {
+      final int[]   indices = new int[NNZ_PER_DOC];
+      final float[] values  = new float[NNZ_PER_DOC];
+      final HashSet<Integer> picked = new HashSet<>(NNZ_PER_DOC);
+      for (int j = 0; j < NNZ_PER_DOC; j++) {
+        int dim;
+        do {
+          // Skewed: half the nnz hit a 100-dim head, half are spread across the full space.
+          dim = j < NNZ_PER_DOC / 2 ? rnd.nextInt(100) : rnd.nextInt(DIMENSIONS);
+        } while (!picked.add(dim));
+        indices[j] = dim;
+        values[j] = 0.1f + rnd.nextFloat();
+      }
+
+      final MutableDocument doc = database.newDocument(TYPE_NAME);
+      doc.set("tokens", indices);
+      doc.set("weights", values);
+      doc.save();
+
+      if (++batchOpen == 1_000) {
+        database.commit();
+        database.begin();
+        batchOpen = 0;
+      }
+    }
+    database.commit();
+    final long loadElapsedMs = (System.nanoTime() - loadStart) / 1_000_000;
+    System.out.printf("Load: %,d ms (%.0f docs/sec)%n", loadElapsedMs, DOC_COUNT * 1000.0 / loadElapsedMs);
+
+    final long count = database.countType(TYPE_NAME, false);
+    assertThat(count).isEqualTo((long) DOC_COUNT);
+
+    final int[][]   queryIdx = new int[ITERATIONS + WARMUP][];
+    final float[][] queryVal = new float[ITERATIONS + WARMUP][];
+    final Random qRnd = new Random(13L);
+    for (int q = 0; q < queryIdx.length; q++) {
+      final int[]   qi = new int[Q_NNZ];
+      final float[] qv = new float[Q_NNZ];
+      final HashSet<Integer> picked = new HashSet<>(Q_NNZ);
+      for (int j = 0; j < Q_NNZ; j++) {
+        int dim;
+        do {
+          dim = j < Q_NNZ / 2 ? qRnd.nextInt(100) : qRnd.nextInt(DIMENSIONS);
+        } while (!picked.add(dim));
+        qi[j] = dim;
+        qv[j] = 0.1f + qRnd.nextFloat();
+      }
+      queryIdx[q] = qi;
+      queryVal[q] = qv;
+    }
+
+    System.out.println("\n=== Index-backed `vector.sparseNeighbors` (K=" + K + ") ===");
+    final long indexNs = bench("vector.sparseNeighbors",
+        "SELECT expand(`vector.sparseNeighbors`(?, ?, ?, ?))", queryIdx, queryVal, K);
+
+    System.out.println("\n=== Brute-force `vector.sparseDot` over " + DOC_COUNT + " docs (K=" + K + ") ===");
+    final long bfNs = bench("brute-force sparseDot",
+        "SELECT FROM " + TYPE_NAME
+            + " ORDER BY `vector.sparseDot`("
+            + "`vector.sparseCreate`(tokens, weights, " + DIMENSIONS + "),"
+            + "`vector.sparseCreate`(?, ?, " + DIMENSIONS + ")"
+            + ") DESC LIMIT " + K,
+        queryIdx, queryVal, /* k baked into SQL */ -1);
+
+    System.out.printf("%nSpeedup: %.1fx (index %.2f ms vs brute %.2f ms per query)%n",
+        (double) bfNs / indexNs, indexNs / 1_000_000.0 / ITERATIONS, bfNs / 1_000_000.0 / ITERATIONS);
+  }
+
+  private long bench(final String label, final String sql,
+      final int[][] queryIdx, final float[][] queryVal, final int kArg) {
+    // Warm up.
+    for (int q = 0; q < WARMUP; q++)
+      runOnce(sql, queryIdx[q], queryVal[q], kArg);
+
+    long totalNs = 0;
+    for (int q = 0; q < ITERATIONS; q++) {
+      final long start = System.nanoTime();
+      final int seen = runOnce(sql, queryIdx[WARMUP + q], queryVal[WARMUP + q], kArg);
+      totalNs += System.nanoTime() - start;
+      assertThat(seen).as(label + " must return at least 1 result").isGreaterThan(0);
+    }
+
+    final double avgMs = totalNs / 1_000_000.0 / ITERATIONS;
+    System.out.printf("%s: avg %.2f ms/query over %d iterations%n", label, avgMs, ITERATIONS);
+    return totalNs;
+  }
+
+  private int runOnce(final String sql, final int[] qi, final float[] qv, final int kArg) {
+    final ResultSet rs;
+    if (kArg > 0)
+      rs = database.query("sql", sql, IDX_NAME, qi, qv, kArg);
+    else
+      rs = database.query("sql", sql, qi, qv);
+
+    int seen = 0;
+    while (rs.hasNext()) {
+      rs.next();
+      seen++;
+    }
+    return seen;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexConcurrencyTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexConcurrencyTest.java
@@ -164,19 +164,35 @@ class LSMSparseVectorIndexConcurrencyTest extends TestHelper {
     final long docCount = database.countType(TYPE_NAME, false);
     assertThat(docCount).isEqualTo((long) WRITER_THREADS * DOCS_PER_WRITER);
 
-    // Final correctness probe: a query that hits a known-frequent dimension must return
-    // results, and every result must come back as a real RID with a non-negative score.
+    // Final correctness probe: a query that hits the densest part of the dim space must return
+    // results. We probe a small head of dims so a corrupted index, dropped postings, or scrambled
+    // dimMaxWeight cache would all show up as either zero results or non-monotonic scores.
     final int[]   probeIdx = new int[] { 0, 1, 2 };
     final float[] probeVal = new float[] { 1.0f, 1.0f, 1.0f };
     try (ResultSet rs = database.query("sql",
         "SELECT expand(`vector.sparseNeighbors`(?, ?, ?, ?))",
         IDX_NAME, probeIdx, probeVal, 10)) {
-      final Set<RID> seen = new HashSet<>();
+      final Set<RID>    seen   = new HashSet<>();
+      float             prev   = Float.POSITIVE_INFINITY;
+      int               returned = 0;
       while (rs.hasNext()) {
         final var row = rs.next();
         final RID rid = (RID) row.getProperty("@rid");
+        final float score = ((Number) row.getProperty("score")).floatValue();
+
         assertThat(seen.add(rid)).as("results must be distinct RIDs").isTrue();
+        assertThat(score).as("score for %s is non-negative under dot product", rid)
+            .isGreaterThanOrEqualTo(0.0f);
+        assertThat(score).as("results must arrive in non-increasing score order")
+            .isLessThanOrEqualTo(prev);
+        prev = score;
+        returned++;
       }
+      // Some of our writer-thread inserts must overlap dim 0/1/2 given the random distribution
+      // and the corpus size (200 docs each with 6 nnz over a 200-dim space). If we ever get zero
+      // hits, the writer/reader race corrupted something - flag it loudly.
+      assertThat(returned).as("steady-state probe must return at least one neighbour")
+          .isPositive();
     }
   }
 }

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexConcurrencyTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexConcurrencyTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.sparsevector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Concurrency regression test for {@link LSMSparseVectorIndex} (issue #4065).
+ * <p>
+ * Validates that the sparse vector index behaves correctly under parallel writers and readers.
+ * Concretely, while writer threads insert documents, reader threads run {@code vector.sparseNeighbors}
+ * queries and must never see exceptions or stale state that violates the index contract.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("slow")
+class LSMSparseVectorIndexConcurrencyTest extends TestHelper {
+
+  private static final String TYPE_NAME       = "ConcurrentSparseDoc";
+  private static final String IDX_NAME        = "ConcurrentSparseDoc[tokens,weights]";
+  private static final int    DIMENSIONS      = 200;
+  private static final int    NNZ_PER_DOC     = 6;
+  private static final int    WRITER_THREADS  = 4;
+  private static final int    DOCS_PER_WRITER = 50;
+  private static final int    READER_THREADS  = 4;
+  private static final int    QUERIES_PER_READER = 30;
+
+  @Test
+  void parallelInsertsAndQueriesAreCorrect() throws Exception {
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().createDocumentType(TYPE_NAME);
+      type.createProperty("tokens", Type.ARRAY_OF_INTEGERS);
+      type.createProperty("weights", Type.ARRAY_OF_FLOATS);
+
+      database.getSchema()
+          .buildTypeIndex(TYPE_NAME, new String[] { "tokens", "weights" })
+          .withSparseVectorType()
+          .withDimensions(DIMENSIONS)
+          .create();
+    });
+
+    final ExecutorService executor = Executors.newFixedThreadPool(WRITER_THREADS + READER_THREADS);
+    final CountDownLatch latch = new CountDownLatch(WRITER_THREADS + READER_THREADS);
+    final AtomicInteger writerErrors = new AtomicInteger();
+    final AtomicInteger readerErrors = new AtomicInteger();
+    final List<Throwable> failures = new CopyOnWriteArrayList<>();
+
+    for (int t = 0; t < WRITER_THREADS; t++) {
+      final int threadId = t;
+      executor.submit(() -> {
+        try {
+          final Random rnd = new Random(0xC0FFEEL ^ threadId);
+          for (int i = 0; i < DOCS_PER_WRITER; i++) {
+            final int[]   indices = new int[NNZ_PER_DOC];
+            final float[] values  = new float[NNZ_PER_DOC];
+            final HashSet<Integer> picked = new HashSet<>(NNZ_PER_DOC);
+            for (int j = 0; j < NNZ_PER_DOC; j++) {
+              int dim;
+              do {
+                dim = rnd.nextInt(DIMENSIONS);
+              } while (!picked.add(dim));
+              indices[j] = dim;
+              values[j] = 0.1f + rnd.nextFloat();
+            }
+            database.transaction(() -> {
+              final MutableDocument doc = database.newDocument(TYPE_NAME);
+              doc.set("tokens", indices);
+              doc.set("weights", values);
+              doc.save();
+            });
+          }
+        } catch (final Throwable e) {
+          writerErrors.incrementAndGet();
+          failures.add(e);
+        } finally {
+          latch.countDown();
+        }
+      });
+    }
+
+    for (int t = 0; t < READER_THREADS; t++) {
+      final int threadId = t;
+      executor.submit(() -> {
+        try {
+          final Random rnd = new Random(0xBADF00DL ^ threadId);
+          for (int i = 0; i < QUERIES_PER_READER; i++) {
+            final int[]   queryIndices = new int[NNZ_PER_DOC];
+            final float[] queryValues  = new float[NNZ_PER_DOC];
+            final HashSet<Integer> picked = new HashSet<>(NNZ_PER_DOC);
+            for (int j = 0; j < NNZ_PER_DOC; j++) {
+              int dim;
+              do {
+                dim = rnd.nextInt(DIMENSIONS);
+              } while (!picked.add(dim));
+              queryIndices[j] = dim;
+              queryValues[j] = 0.1f + rnd.nextFloat();
+            }
+            try (ResultSet rs = database.query("sql",
+                "SELECT expand(`vector.sparseNeighbors`(?, ?, ?, ?))",
+                IDX_NAME, queryIndices, queryValues, 5)) {
+              while (rs.hasNext()) {
+                final var row = rs.next();
+                final Object ridObj = row.getProperty("@rid");
+                assertThat(ridObj).isInstanceOf(RID.class);
+                assertThat(((Number) row.getProperty("score")).floatValue()).isGreaterThanOrEqualTo(0.0f);
+              }
+            }
+            Thread.sleep(1);
+          }
+        } catch (final Throwable e) {
+          readerErrors.incrementAndGet();
+          failures.add(e);
+        } finally {
+          latch.countDown();
+        }
+      });
+    }
+
+    final boolean finishedInTime = latch.await(2, TimeUnit.MINUTES);
+    executor.shutdown();
+    assertThat(executor.awaitTermination(30, TimeUnit.SECONDS)).isTrue();
+
+    assertThat(finishedInTime).as("workers must finish within budget").isTrue();
+    assertThat(writerErrors.get()).as("writer errors: " + failures).isZero();
+    assertThat(readerErrors.get()).as("reader errors: " + failures).isZero();
+
+    final long docCount = database.countType(TYPE_NAME, false);
+    assertThat(docCount).isEqualTo((long) WRITER_THREADS * DOCS_PER_WRITER);
+
+    // Final correctness probe: a query that hits a known-frequent dimension must return
+    // results, and every result must come back as a real RID with a non-negative score.
+    final int[]   probeIdx = new int[] { 0, 1, 2 };
+    final float[] probeVal = new float[] { 1.0f, 1.0f, 1.0f };
+    try (ResultSet rs = database.query("sql",
+        "SELECT expand(`vector.sparseNeighbors`(?, ?, ?, ?))",
+        IDX_NAME, probeIdx, probeVal, 10)) {
+      final Set<RID> seen = new HashSet<>();
+      while (rs.hasNext()) {
+        final var row = rs.next();
+        final RID rid = (RID) row.getProperty("@rid");
+        assertThat(seen.add(rid)).as("results must be distinct RIDs").isTrue();
+      }
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexSeekTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexSeekTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.sparsevector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the behaviour of {@code LSMTreeIndexAbstract.compareKeys}: when an upper bound is supplied
+ * as a prefix (one column shorter than the full key), the comparator must treat any posting whose
+ * key starts with that prefix as equal to the bound, so an inclusive upper bound includes every
+ * posting under the prefix. The WAND {@code seekTo} primitive in {@link LSMSparseVectorIndex}
+ * relies on this; if a future comparator change broke the convention, postings after the seek
+ * point in the same dimension would silently drop and WAND results would be missing rows.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class LSMSparseVectorIndexSeekTest extends TestHelper {
+
+  private static final String TYPE_NAME = "SeekDoc";
+  private static final String IDX_NAME  = "SeekDoc[tokens,weights]";
+
+  /**
+   * Inserts a tight cluster on dim 5 and asserts that a WAND query (which forces the cursor to
+   * seek across RIDs within the dim) returns every doc in the dim, not just the one at the seek
+   * point. This exercises the prefix-upper-bound path in {@code LSMTreeIndex.range}.
+   */
+  @Test
+  void seekToInsideDimensionDoesNotDropTrailingPostings() {
+    final List<RID> rids = new ArrayList<>();
+
+    database.transaction(() -> {
+      final DocumentType t = database.getSchema().createDocumentType(TYPE_NAME);
+      t.createProperty("tokens", Type.ARRAY_OF_INTEGERS);
+      t.createProperty("weights", Type.ARRAY_OF_FLOATS);
+      database.getSchema()
+          .buildTypeIndex(TYPE_NAME, new String[] { "tokens", "weights" })
+          .withSparseVectorType()
+          .withDimensions(50)
+          .create();
+
+      // Every doc shares dim 5 so the WAND scan must traverse all of them. Doc i additionally has
+      // a unique dim (10 + i) with descending weight, so the WAND threshold rises monotonically
+      // and forces seeking past previously-visited RIDs.
+      for (int i = 0; i < 25; i++) {
+        final MutableDocument d = database.newDocument(TYPE_NAME);
+        d.set("tokens", new int[] { 5, 10 + i });
+        d.set("weights", new float[] { 0.5f + 0.01f * i, 1.0f - 0.01f * i });
+        d.save();
+        rids.add(d.getIdentity());
+      }
+    });
+
+    // Query covers dim 5 (all 25 docs) plus a few of the unique dims, with weights chosen so WAND
+    // pruning will trigger seekTo on the dim-5 cursor multiple times.
+    final ResultSet rs = database.query("sql",
+        "SELECT expand(`vector.sparseNeighbors`(?, ?, ?, ?))",
+        IDX_NAME,
+        new int[]   { 5,    10,  15,  20 },
+        new float[] { 1.0f, 0.5f, 0.5f, 0.5f },
+        25);
+
+    final HashSet<RID> returned = new HashSet<>();
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      returned.add((RID) row.getProperty("@rid"));
+    }
+
+    // Every inserted doc shares dim 5 with the query, so all 25 must come back. If the seek upper
+    // bound were too tight, some trailing RIDs would silently drop.
+    assertThat(returned).as("WAND with seekTo must return every dim-5 posting").hasSize(25);
+    assertThat(returned).containsAll(rids);
+  }
+
+  /**
+   * Mirrors the worst case from the PR review: a posting list with a deliberate gap. Each inserted
+   * doc lands in a different bucket position, and the test forces a WAND query whose threshold
+   * causes the cursor to seek across the gap. If {@code seekTo}'s upper bound were "too tight" and
+   * stopped at the gap point, the post-gap RIDs would silently disappear.
+   */
+  @Test
+  void seekToAcrossPostingListGapStillReturnsTrailingRids() {
+    final List<RID> ridsBefore = new ArrayList<>();
+    final List<RID> ridsAfter  = new ArrayList<>();
+
+    database.transaction(() -> {
+      final DocumentType t = database.getSchema().createDocumentType(TYPE_NAME);
+      t.createProperty("tokens", Type.ARRAY_OF_INTEGERS);
+      t.createProperty("weights", Type.ARRAY_OF_FLOATS);
+      database.getSchema()
+          .buildTypeIndex(TYPE_NAME, new String[] { "tokens", "weights" })
+          .withSparseVectorType()
+          .withDimensions(200)
+          .create();
+
+      // Two clusters on dim 7, each with 5 docs; between them, 20 unrelated docs widen the RID
+      // space to force seekTo to skip a non-trivial range.
+      for (int i = 0; i < 5; i++) {
+        final MutableDocument d = database.newDocument(TYPE_NAME);
+        d.set("tokens", new int[] { 7, 30 + i });
+        d.set("weights", new float[] { 0.4f + 0.05f * i, 1.0f });
+        d.save();
+        ridsBefore.add(d.getIdentity());
+      }
+
+      // Filler docs without dim 7. These sit between the two clusters in RID order and force a
+      // visible "gap" in the dim-7 posting list.
+      for (int i = 0; i < 20; i++) {
+        final MutableDocument d = database.newDocument(TYPE_NAME);
+        d.set("tokens", new int[] { 100 + i });
+        d.set("weights", new float[] { 0.1f });
+        d.save();
+      }
+
+      for (int i = 0; i < 5; i++) {
+        final MutableDocument d = database.newDocument(TYPE_NAME);
+        d.set("tokens", new int[] { 7, 40 + i });
+        d.set("weights", new float[] { 0.7f + 0.05f * i, 1.0f });
+        d.save();
+        ridsAfter.add(d.getIdentity());
+      }
+    });
+
+    // Query weights heavy on the post-gap unique dims so threshold rises after the first cluster
+    // and forces seekTo on dim 7 across the gap.
+    final ResultSet rs = database.query("sql",
+        "SELECT expand(`vector.sparseNeighbors`(?, ?, ?, ?))",
+        IDX_NAME,
+        new int[]   { 7,    40,   41,   42 },
+        new float[] { 1.0f, 1.0f, 1.0f, 1.0f },
+        10);
+
+    final HashSet<RID> returned = new HashSet<>();
+    while (rs.hasNext())
+      returned.add((RID) rs.next().getProperty("@rid"));
+
+    // The post-gap docs must rank highest (their unique dims match the query). The pre-gap docs
+    // are still under dim 7 so they must remain reachable too.
+    assertThat(returned).as("post-gap RIDs must be returned").containsAll(ridsAfter);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexTest.java
@@ -246,6 +246,38 @@ class LSMSparseVectorIndexTest extends TestHelper {
   }
 
   @Test
+  void removeWithUnequalLengthArraysThrows() {
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().createDocumentType(TYPE_NAME);
+      type.createProperty("tokens", Type.ARRAY_OF_INTEGERS);
+      type.createProperty("weights", Type.ARRAY_OF_FLOATS);
+
+      final TypeIndex idx = database.getSchema()
+          .buildTypeIndex(TYPE_NAME, new String[] { "tokens", "weights" })
+          .withSparseVectorType()
+          .withDimensions(100)
+          .create();
+      final var bucketIndex = idx.getIndexesOnBuckets()[0];
+      final MutableDocument doc = database.newDocument(TYPE_NAME);
+      doc.set("tokens", new int[] { 1, 2, 3 });
+      doc.set("weights", new float[] { 0.1f, 0.2f, 0.3f });
+      doc.save();
+
+      // Mismatched arrays must be rejected by remove just as they are by put. Silent truncation
+      // would orphan postings on the longer side. Calls the wrapper directly because the SQL path
+      // never produces mismatched arrays (DocumentIndexer reads property values that were already
+      // validated at insert time).
+      final RID rid = doc.getIdentity();
+      final org.assertj.core.api.AbstractThrowableAssert<?, ? extends Throwable> assertion =
+          org.assertj.core.api.Assertions.assertThatThrownBy(() ->
+              bucketIndex.remove(
+                  new Object[] { new int[] { 1, 2, 3 }, new float[] { 0.1f, 0.2f } },
+                  rid));
+      assertion.hasMessageContaining("same length");
+    });
+  }
+
+  @Test
   void removeDocumentRemovesFromIndex() {
     final RID[] rids = new RID[2];
 

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexTest.java
@@ -1,0 +1,466 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.sparsevector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+
+import org.assertj.core.data.Offset;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for LSMSparseVectorIndex (issue #4065).
+ * <p>
+ * Verifies:
+ * <ul>
+ *   <li>Index creation via Java API and via SQL CREATE INDEX</li>
+ *   <li>Persistence of sparse vectors as a posting-list inverted index on the LSM-Tree backbone</li>
+ *   <li>Top-K retrieval via the {@code vector.sparseNeighbors} SQL function</li>
+ *   <li>Correctness vs a brute-force baseline using {@code vector.sparseDot}</li>
+ * </ul>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class LSMSparseVectorIndexTest extends TestHelper {
+
+  private static final int    DIMENSIONS  = 1000;
+  private static final int    DOC_COUNT   = 50;
+  private static final int    NNZ_PER_DOC = 10;
+  private static final long   SEED        = 42L;
+  private static final String TYPE_NAME   = "SparseDoc";
+  private static final String IDX_NAME    = "SparseDoc[tokens,weights]";
+
+  @Test
+  void createIndexViaJavaApiAndQueryTopK() {
+    final List<int[]>   docIndices = new ArrayList<>(DOC_COUNT);
+    final List<float[]> docValues  = new ArrayList<>(DOC_COUNT);
+    final List<RID>     docRids    = new ArrayList<>(DOC_COUNT);
+
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().createDocumentType(TYPE_NAME);
+      type.createProperty("tokens", Type.ARRAY_OF_INTEGERS);
+      type.createProperty("weights", Type.ARRAY_OF_FLOATS);
+
+      final TypeIndex idx = database.getSchema()
+          .buildTypeIndex(TYPE_NAME, new String[] { "tokens", "weights" })
+          .withSparseVectorType()
+          .withDimensions(DIMENSIONS)
+          .create();
+
+      assertThat(idx).isNotNull();
+      assertThat(idx.getType()).isEqualTo(Schema.INDEX_TYPE.LSM_SPARSE_VECTOR);
+
+      final Random rnd = new Random(SEED);
+      for (int i = 0; i < DOC_COUNT; i++) {
+        final int[]   indices = new int[NNZ_PER_DOC];
+        final float[] values  = new float[NNZ_PER_DOC];
+        final HashSet<Integer> picked = new HashSet<>(NNZ_PER_DOC);
+        for (int j = 0; j < NNZ_PER_DOC; j++) {
+          int dim;
+          do {
+            dim = rnd.nextInt(DIMENSIONS);
+          } while (!picked.add(dim));
+          indices[j] = dim;
+          values[j]  = 0.1f + rnd.nextFloat();
+        }
+
+        final MutableDocument doc = database.newDocument(TYPE_NAME);
+        doc.set("tokens", indices);
+        doc.set("weights", values);
+        doc.save();
+
+        docIndices.add(indices);
+        docValues.add(values);
+        docRids.add(doc.getIdentity());
+      }
+    });
+
+    final int[]   queryIndices = docIndices.get(0);
+    final float[] queryValues  = docValues.get(0);
+
+    final List<Map.Entry<RID, Float>> sortedBF = bruteForceTopK(queryIndices, queryValues, docIndices, docValues, docRids);
+
+    final int K = 5;
+    final ResultSet rs = database.query("sql",
+        "SELECT expand(`vector.sparseNeighbors`(?, ?, ?, ?))",
+        IDX_NAME, queryIndices, queryValues, K);
+
+    final List<RID>   indexRids   = new ArrayList<>(K);
+    final List<Float> indexScores = new ArrayList<>(K);
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      indexRids.add((RID) row.getProperty("@rid"));
+      indexScores.add(((Number) row.getProperty("score")).floatValue());
+    }
+
+    assertThat(indexRids).hasSize(K);
+    assertThat(indexRids.get(0)).as("self-query must return self at rank 0").isEqualTo(docRids.get(0));
+
+    for (int i = 0; i < K; i++) {
+      assertThat(indexRids.get(i)).as("rank " + i).isEqualTo(sortedBF.get(i).getKey());
+      assertThat(indexScores.get(i)).as("score at rank " + i)
+          .isCloseTo(sortedBF.get(i).getValue(), Offset.offset(1e-4f));
+    }
+  }
+
+  @Test
+  void persistAcrossReopenAndQueryStillWorks() {
+    final List<int[]>   docIndices = new ArrayList<>(DOC_COUNT);
+    final List<float[]> docValues  = new ArrayList<>(DOC_COUNT);
+    final List<RID>     docRids    = new ArrayList<>(DOC_COUNT);
+
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().createDocumentType(TYPE_NAME);
+      type.createProperty("tokens", Type.ARRAY_OF_INTEGERS);
+      type.createProperty("weights", Type.ARRAY_OF_FLOATS);
+
+      database.getSchema()
+          .buildTypeIndex(TYPE_NAME, new String[] { "tokens", "weights" })
+          .withSparseVectorType()
+          .withDimensions(DIMENSIONS)
+          .create();
+
+      final Random rnd = new Random(SEED);
+      for (int i = 0; i < DOC_COUNT; i++) {
+        final int[]   indices = new int[NNZ_PER_DOC];
+        final float[] values  = new float[NNZ_PER_DOC];
+        final HashSet<Integer> picked = new HashSet<>(NNZ_PER_DOC);
+        for (int j = 0; j < NNZ_PER_DOC; j++) {
+          int dim;
+          do {
+            dim = rnd.nextInt(DIMENSIONS);
+          } while (!picked.add(dim));
+          indices[j] = dim;
+          values[j]  = 0.1f + rnd.nextFloat();
+        }
+        final MutableDocument doc = database.newDocument(TYPE_NAME);
+        doc.set("tokens", indices);
+        doc.set("weights", values);
+        doc.save();
+
+        docIndices.add(indices);
+        docValues.add(values);
+        docRids.add(doc.getIdentity());
+      }
+    });
+
+    database.close();
+    database = factory.open();
+
+    final TypeIndex reopened = (TypeIndex) database.getSchema().getIndexByName(IDX_NAME);
+    assertThat(reopened).as("index should exist after reopen").isNotNull();
+    assertThat(reopened.getType()).as("index type after reopen").isEqualTo(Schema.INDEX_TYPE.LSM_SPARSE_VECTOR);
+
+    final int[]   queryIndices = docIndices.get(7);
+    final float[] queryValues  = docValues.get(7);
+
+    final List<Map.Entry<RID, Float>> sortedBF = bruteForceTopK(queryIndices, queryValues, docIndices, docValues, docRids);
+
+    final int K = 5;
+    final ResultSet rs = database.query("sql",
+        "SELECT expand(`vector.sparseNeighbors`(?, ?, ?, ?))",
+        IDX_NAME, queryIndices, queryValues, K);
+
+    final List<RID> indexRids = new ArrayList<>(K);
+    while (rs.hasNext())
+      indexRids.add((RID) rs.next().getProperty("@rid"));
+
+    assertThat(indexRids).hasSize(K);
+    assertThat(indexRids.get(0)).isEqualTo(docRids.get(7));
+    for (int i = 0; i < K; i++)
+      assertThat(indexRids.get(i)).as("rank " + i).isEqualTo(sortedBF.get(i).getKey());
+  }
+
+  @Test
+  void createIndexViaSqlAndQueryTopK() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE " + TYPE_NAME);
+      database.command("sql", "CREATE PROPERTY " + TYPE_NAME + ".tokens ARRAY_OF_INTEGERS");
+      database.command("sql", "CREATE PROPERTY " + TYPE_NAME + ".weights ARRAY_OF_FLOATS");
+      database.command("sql", """
+          CREATE INDEX ON %s (tokens, weights) LSM_SPARSE_VECTOR
+          METADATA { "dimensions": 100 }
+          """.formatted(TYPE_NAME));
+
+      final TypeIndex idx = (TypeIndex) database.getSchema().getIndexByName(IDX_NAME);
+      assertThat(idx).isNotNull();
+      assertThat(idx.getType()).isEqualTo(Schema.INDEX_TYPE.LSM_SPARSE_VECTOR);
+
+      final MutableDocument d1 = database.newDocument(TYPE_NAME);
+      d1.set("tokens", new int[] { 1, 5, 10 });
+      d1.set("weights", new float[] { 0.5f, 0.3f, 0.2f });
+      d1.save();
+
+      final MutableDocument d2 = database.newDocument(TYPE_NAME);
+      d2.set("tokens", new int[] { 2, 5, 11 });
+      d2.set("weights", new float[] { 0.4f, 0.6f, 0.1f });
+      d2.save();
+    });
+
+    // Query (5, 1.0) -> d2 should win because its weight at dim 5 is 0.6 vs d1's 0.3.
+    final ResultSet rs = database.query("sql",
+        "SELECT expand(`vector.sparseNeighbors`(?, ?, ?, ?))",
+        IDX_NAME, new int[] { 5 }, new float[] { 1.0f }, 5);
+    final List<Float> scores = new ArrayList<>();
+    final List<RID> rids = new ArrayList<>();
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      rids.add((RID) row.getProperty("@rid"));
+      scores.add(((Number) row.getProperty("score")).floatValue());
+    }
+    assertThat(rids).hasSize(2);
+    assertThat(scores.get(0)).isCloseTo(0.6f, Offset.offset(1e-4f));
+    assertThat(scores.get(1)).isCloseTo(0.3f, Offset.offset(1e-4f));
+  }
+
+  @Test
+  void removeDocumentRemovesFromIndex() {
+    final RID[] rids = new RID[2];
+
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().createDocumentType(TYPE_NAME);
+      type.createProperty("tokens", Type.ARRAY_OF_INTEGERS);
+      type.createProperty("weights", Type.ARRAY_OF_FLOATS);
+
+      database.getSchema()
+          .buildTypeIndex(TYPE_NAME, new String[] { "tokens", "weights" })
+          .withSparseVectorType()
+          .withDimensions(100)
+          .create();
+
+      final MutableDocument d1 = database.newDocument(TYPE_NAME);
+      d1.set("tokens", new int[] { 1, 5, 10 });
+      d1.set("weights", new float[] { 0.5f, 0.3f, 0.2f });
+      d1.save();
+
+      final MutableDocument d2 = database.newDocument(TYPE_NAME);
+      d2.set("tokens", new int[] { 2, 5, 11 });
+      d2.set("weights", new float[] { 0.5f, 0.3f, 0.2f });
+      d2.save();
+
+      rids[0] = d1.getIdentity();
+      rids[1] = d2.getIdentity();
+    });
+
+    final ResultSet beforeDelete = database.query("sql",
+        "SELECT expand(`vector.sparseNeighbors`(?, ?, ?, ?))",
+        IDX_NAME, new int[] { 5 }, new float[] { 1.0f }, 10);
+    int countBefore = 0;
+    while (beforeDelete.hasNext()) {
+      beforeDelete.next();
+      countBefore++;
+    }
+    assertThat(countBefore).isEqualTo(2);
+
+    database.transaction(() -> database.lookupByRID(rids[0], true).asDocument().delete());
+
+    final ResultSet afterDelete = database.query("sql",
+        "SELECT expand(`vector.sparseNeighbors`(?, ?, ?, ?))",
+        IDX_NAME, new int[] { 5 }, new float[] { 1.0f }, 10);
+    final List<RID> remaining = new ArrayList<>();
+    while (afterDelete.hasNext())
+      remaining.add((RID) afterDelete.next().getProperty("@rid"));
+    assertThat(remaining).hasSize(1);
+    assertThat(remaining.get(0)).isEqualTo(rids[1]);
+  }
+
+  @Test
+  void idfModifierDownweightsCommonDimensions() {
+    final RID[] rareHit = new RID[1];
+
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().createDocumentType(TYPE_NAME);
+      type.createProperty("tokens", Type.ARRAY_OF_INTEGERS);
+      type.createProperty("weights", Type.ARRAY_OF_FLOATS);
+
+      database.getSchema()
+          .buildTypeIndex(TYPE_NAME, new String[] { "tokens", "weights" })
+          .withSparseVectorType()
+          .withDimensions(100)
+          .withModifier("IDF")
+          .create();
+
+      // dim 1 is rare: only doc A has it.
+      // dim 2 is common: every doc has it.
+      // A query that mentions both dims should rank A highest under IDF, because the rare
+      // dimension dominates after IDF weighting. Without IDF, B-J all share dim 2 with equal
+      // weights so they tie with A on the dim-2 contribution and only A's tiny dim-1 weight
+      // breaks the tie.
+      final MutableDocument a = database.newDocument(TYPE_NAME);
+      a.set("tokens", new int[] { 1, 2 });
+      a.set("weights", new float[] { 0.1f, 0.5f });
+      a.save();
+      rareHit[0] = a.getIdentity();
+
+      for (int i = 0; i < 9; i++) {
+        final MutableDocument other = database.newDocument(TYPE_NAME);
+        other.set("tokens", new int[] { 2 });
+        other.set("weights", new float[] { 0.5f });
+        other.save();
+      }
+    });
+
+    final ResultSet rs = database.query("sql",
+        "SELECT expand(`vector.sparseNeighbors`(?, ?, ?, ?))",
+        IDX_NAME, new int[] { 1, 2 }, new float[] { 1.0f, 1.0f }, 10);
+
+    final List<RID>   rids   = new ArrayList<>();
+    final List<Float> scores = new ArrayList<>();
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      rids.add((RID) row.getProperty("@rid"));
+      scores.add(((Number) row.getProperty("score")).floatValue());
+    }
+
+    assertThat(rids).hasSize(10);
+    assertThat(rids.get(0)).as("rare-dim doc should rank first under IDF").isEqualTo(rareHit[0]);
+
+    // The rare-dim contribution to A should dominate. Under df(1)=1, N=10, IDF(1) = ln((10-1+0.5)/(1+0.5)+1) ~ 1.96.
+    // Under df(2)=10, N=10, IDF(2) = ln((10-10+0.5)/(10+0.5)+1) ~ 0.046.
+    // A's score: 1.0 * 0.1 * 1.96 + 1.0 * 0.5 * 0.046 ~= 0.219.
+    // Others' score: 1.0 * 0.5 * 0.046 ~= 0.023.
+    // So A's score should be at least 5x the next.
+    assertThat(scores.get(0)).isGreaterThan(scores.get(1) * 5.0f);
+  }
+
+  @Test
+  void wandResultsMatchBruteForceOnLargerCorpus() {
+    final int largeDocCount = 500;
+    final int largeNnz = 8;
+    final int largeDim = 3000;
+
+    final List<int[]>   docIndices = new ArrayList<>(largeDocCount);
+    final List<float[]> docValues  = new ArrayList<>(largeDocCount);
+    final List<RID>     docRids    = new ArrayList<>(largeDocCount);
+
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().createDocumentType(TYPE_NAME);
+      type.createProperty("tokens", Type.ARRAY_OF_INTEGERS);
+      type.createProperty("weights", Type.ARRAY_OF_FLOATS);
+
+      database.getSchema()
+          .buildTypeIndex(TYPE_NAME, new String[] { "tokens", "weights" })
+          .withSparseVectorType()
+          .withDimensions(largeDim)
+          .create();
+
+      final Random rnd = new Random(11L);
+      for (int i = 0; i < largeDocCount; i++) {
+        final int[]   indices = new int[largeNnz];
+        final float[] values  = new float[largeNnz];
+        final HashSet<Integer> picked = new HashSet<>(largeNnz);
+        for (int j = 0; j < largeNnz; j++) {
+          int dim;
+          do {
+            // Skewed distribution: half the nnz hit a "frequent" head of 30 dims, half are random.
+            dim = j < largeNnz / 2 ? rnd.nextInt(30) : rnd.nextInt(largeDim);
+          } while (!picked.add(dim));
+          indices[j] = dim;
+          values[j] = 0.1f + rnd.nextFloat();
+        }
+        final MutableDocument doc = database.newDocument(TYPE_NAME);
+        doc.set("tokens", indices);
+        doc.set("weights", values);
+        doc.save();
+
+        docIndices.add(indices);
+        docValues.add(values);
+        docRids.add(doc.getIdentity());
+      }
+    });
+
+    // Three different query shapes: rare-only, frequent-only, mixed.
+    final int[][]   queries     = new int[][] { docIndices.get(17), docIndices.get(123), docIndices.get(400) };
+    final float[][] queryWeights = new float[][] { docValues.get(17), docValues.get(123), docValues.get(400) };
+
+    for (int q = 0; q < queries.length; q++) {
+      final int[]   qIdx = queries[q];
+      final float[] qVal = queryWeights[q];
+
+      final List<Map.Entry<RID, Float>> sortedBF = bruteForceTopK(qIdx, qVal, docIndices, docValues, docRids);
+
+      for (final int kVal : new int[] { 1, 5, 25, 100 }) {
+        final ResultSet rs = database.query("sql",
+            "SELECT expand(`vector.sparseNeighbors`(?, ?, ?, ?))",
+            IDX_NAME, qIdx, qVal, kVal);
+
+        final List<RID>   indexRids   = new ArrayList<>(kVal);
+        final List<Float> indexScores = new ArrayList<>(kVal);
+        while (rs.hasNext()) {
+          final Result row = rs.next();
+          indexRids.add((RID) row.getProperty("@rid"));
+          indexScores.add(((Number) row.getProperty("score")).floatValue());
+        }
+
+        final int expected = Math.min(kVal, sortedBF.size());
+        assertThat(indexRids).as("query %d, k=%d size", q, kVal).hasSize(expected);
+
+        // Top-K identity must match brute force (allowing ties on equal scores).
+        for (int i = 0; i < expected; i++) {
+          final float expectedScore = sortedBF.get(i).getValue();
+          assertThat(indexScores.get(i))
+              .as("query %d k=%d rank %d score", q, kVal, i)
+              .isCloseTo(expectedScore, Offset.offset(1e-3f));
+        }
+      }
+    }
+  }
+
+  private static List<Map.Entry<RID, Float>> bruteForceTopK(final int[] qIdx, final float[] qVal,
+      final List<int[]> docIndices, final List<float[]> docValues, final List<RID> docRids) {
+    final Map<RID, Float> scores = new HashMap<>(docRids.size());
+    for (int i = 0; i < docRids.size(); i++) {
+      final float s = sparseDot(qIdx, qVal, docIndices.get(i), docValues.get(i));
+      if (s > 0.0f)
+        scores.put(docRids.get(i), s);
+    }
+    final List<Map.Entry<RID, Float>> sorted = new ArrayList<>(scores.entrySet());
+    sorted.sort((a, b) -> Float.compare(b.getValue(), a.getValue()));
+    return sorted;
+  }
+
+  private static float sparseDot(final int[] aIdx, final float[] aVal, final int[] bIdx, final float[] bVal) {
+    final Map<Integer, Float> map = new HashMap<>(aIdx.length);
+    for (int i = 0; i < aIdx.length; i++)
+      map.put(aIdx[i], aVal[i]);
+    float sum = 0.0f;
+    for (int i = 0; i < bIdx.length; i++) {
+      final Float v = map.get(bIdx[i]);
+      if (v != null)
+        sum += v * bVal[i];
+    }
+    return sum;
+  }
+}

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -1168,7 +1168,14 @@ function createIndex(typeName) {
   let properties = collectTypeProperties(typeName);
 
   let vectorProps = properties.filter(function (p) {
-    return p.type == "ARRAY_OF_FLOATS" || p.type == "ARRAY_OF_DOUBLES";
+    return p.type == "ARRAY_OF_FLOATS" || p.type == "ARRAY_OF_DOUBLES" ||
+           p.type == "Float[]" || p.type == "Double[]";
+  });
+  let sparseIntProps = properties.filter(function (p) {
+    return p.type == "ARRAY_OF_INTEGERS" || p.type == "Integer[]";
+  });
+  let sparseFloatProps = properties.filter(function (p) {
+    return p.type == "ARRAY_OF_FLOATS" || p.type == "Float[]";
   });
 
   let html = "";
@@ -1187,7 +1194,7 @@ function createIndex(typeName) {
   }
   html += "</div>";
 
-  // Vector property (LSM_VECTOR only — single property of type ARRAY_OF_FLOATS or ARRAY_OF_DOUBLES)
+  // Vector property (LSM_VECTOR only - single property of type ARRAY_OF_FLOATS or ARRAY_OF_DOUBLES)
   html += "<div id='createIdxPropsVector' style='display:none;'>";
   html += "<label>Property <span style='color:#dc3545'>*</span></label>";
   html += "<small class='text-muted d-block mt-1'>LSM_VECTOR requires exactly one property of type ARRAY_OF_FLOATS or ARRAY_OF_DOUBLES.</small>";
@@ -1201,12 +1208,55 @@ function createIndex(typeName) {
   }
   html += "</div>";
 
+  // Sparse vector properties (LSM_SPARSE_VECTOR - parallel ARRAY_OF_INTEGERS + ARRAY_OF_FLOATS)
+  html += "<div id='createIdxPropsSparse' style='display:none;'>";
+  html += "<small class='text-muted d-block mb-2'>LSM_SPARSE_VECTOR requires two parallel array properties: dimension ids (ARRAY_OF_INTEGERS) and matching weights (ARRAY_OF_FLOATS).</small>";
+  html += "<div class='row mb-3'>";
+  html += "<div class='col-6'>";
+  html += "<label>Indices property <span style='color:#dc3545'>*</span></label>";
+  if (sparseIntProps.length > 0) {
+    html += "<select class='form-select mt-1' id='inputCreateIdxPropsSparseIdx'>";
+    for (let i = 0; i < sparseIntProps.length; i++)
+      html += "<option value='" + escapeHtml(sparseIntProps[i].name) + "'>" + escapeHtml(sparseIntProps[i].name) + " (" + escapeHtml(sparseIntProps[i].type) + ")</option>";
+    html += "</select>";
+  } else {
+    html += "<input class='form-control mt-1' id='inputCreateIdxPropsSparseIdxText' placeholder='ARRAY_OF_INTEGERS property name'>";
+  }
+  html += "</div>";
+  html += "<div class='col-6'>";
+  html += "<label>Weights property <span style='color:#dc3545'>*</span></label>";
+  if (sparseFloatProps.length > 0) {
+    html += "<select class='form-select mt-1' id='inputCreateIdxPropsSparseWeights'>";
+    for (let i = 0; i < sparseFloatProps.length; i++)
+      html += "<option value='" + escapeHtml(sparseFloatProps[i].name) + "'>" + escapeHtml(sparseFloatProps[i].name) + " (" + escapeHtml(sparseFloatProps[i].type) + ")</option>";
+    html += "</select>";
+  } else {
+    html += "<input class='form-control mt-1' id='inputCreateIdxPropsSparseWeightsText' placeholder='ARRAY_OF_FLOATS property name'>";
+  }
+  html += "</div>";
+  html += "</div>";
+  html += "<div class='row mb-3'>";
+  html += "<div class='col-6'>";
+  html += "<label>Dimensions <small class='text-muted'>(optional)</small></label>";
+  html += "<input type='number' min='1' class='form-control mt-1' id='inputCreateIdxSparseDimensions' placeholder='e.g. 105000'>";
+  html += "</div>";
+  html += "<div class='col-6'>";
+  html += "<label>Modifier <small class='text-muted'>(optional)</small></label>";
+  html += "<select class='form-select mt-1' id='inputCreateIdxSparseModifier'>";
+  html += "<option value='' selected>NONE (default)</option>";
+  html += "<option value='IDF'>IDF - inverse document frequency</option>";
+  html += "</select>";
+  html += "</div>";
+  html += "</div>";
+  html += "</div>";
+
   html += "<label for='inputCreateIdxAlgorithm'>Index Algorithm <span style='color:#dc3545'>*</span></label>";
   html += "<select class='form-select mt-1 mb-3' id='inputCreateIdxAlgorithm'>";
-  html += "<option value='LSM_TREE' selected>LSM_TREE — default, supports range queries</option>";
-  html += "<option value='HASH'>HASH — O(1) equality lookups, no range queries</option>";
-  html += "<option value='FULL_TEXT'>FULL_TEXT — full-text search index</option>";
-  html += "<option value='LSM_VECTOR'>LSM_VECTOR — vector/embedding similarity index</option>";
+  html += "<option value='LSM_TREE' selected>LSM_TREE - default, supports range queries</option>";
+  html += "<option value='HASH'>HASH - O(1) equality lookups, no range queries</option>";
+  html += "<option value='FULL_TEXT'>FULL_TEXT - full-text search index</option>";
+  html += "<option value='LSM_VECTOR'>LSM_VECTOR - dense vector / embedding similarity index</option>";
+  html += "<option value='LSM_SPARSE_VECTOR'>LSM_SPARSE_VECTOR - sparse vector (SPLADE / BM25-style) inverted index</option>";
   html += "</select>";
 
   html += "<div id='createIdxLsmOptions'>";
@@ -1233,6 +1283,7 @@ function createIndex(typeName) {
   globalPrompt("Add Index to " + escapeHtml(typeName), html, "Create", function () {
     let algorithm = $("#inputCreateIdxAlgorithm").val();
     let selectedProps = [];
+    let metadataJson = null;
     if (algorithm == "LSM_VECTOR") {
       let vectorEl = document.getElementById("inputCreateIdxPropsVector");
       if (vectorEl) {
@@ -1242,6 +1293,25 @@ function createIndex(typeName) {
         let text = $("#inputCreateIdxPropsVectorText").val().trim();
         if (text != "") selectedProps = [text];
       }
+    } else if (algorithm == "LSM_SPARSE_VECTOR") {
+      let idxEl = document.getElementById("inputCreateIdxPropsSparseIdx");
+      let idxName = idxEl ? $("#inputCreateIdxPropsSparseIdx").val() : $("#inputCreateIdxPropsSparseIdxText").val().trim();
+      let wEl = document.getElementById("inputCreateIdxPropsSparseWeights");
+      let wName = wEl ? $("#inputCreateIdxPropsSparseWeights").val() : $("#inputCreateIdxPropsSparseWeightsText").val().trim();
+      if (idxName && wName) selectedProps = [idxName, wName];
+
+      let metaParts = [];
+      let dimsRaw = $("#inputCreateIdxSparseDimensions").val();
+      if (dimsRaw != null && dimsRaw !== "") {
+        let dims = parseInt(dimsRaw, 10);
+        if (!isNaN(dims) && dims > 0)
+          metaParts.push("\"dimensions\": " + dims);
+      }
+      let modifier = $("#inputCreateIdxSparseModifier").val();
+      if (modifier != null && modifier !== "")
+        metaParts.push("\"modifier\": \"" + modifier + "\"");
+      if (metaParts.length > 0)
+        metadataJson = "{ " + metaParts.join(", ") + " }";
     } else {
       let multiEl = document.getElementById("inputCreateIdxProps");
       if (multiEl) {
@@ -1254,6 +1324,10 @@ function createIndex(typeName) {
       }
     }
 
+    if (algorithm == "LSM_SPARSE_VECTOR" && selectedProps.length != 2) {
+      globalNotify("Error", "LSM_SPARSE_VECTOR requires both an indices property and a weights property", "danger");
+      return;
+    }
     if (selectedProps.length == 0) {
       globalNotify("Error", "At least one property is required", "danger");
       return;
@@ -1276,6 +1350,7 @@ function createIndex(typeName) {
     command += selectedProps.map(function (p) { return "`" + p + "`"; }).join(", ");
     command += ") " + indexTypeSql;
     if ((algorithm == "LSM_TREE" || algorithm == "HASH") && nullStrategy != "") command += " NULL_STRATEGY " + nullStrategy;
+    if (metadataJson != null) command += " METADATA " + metadataJson;
 
     jQuery.ajax({
       type: "POST",
@@ -1296,10 +1371,17 @@ function createIndex(typeName) {
       if (alg == "LSM_VECTOR") {
         $("#createIdxPropsNormal").hide();
         $("#createIdxPropsVector").show();
+        $("#createIdxPropsSparse").hide();
+        $("#createIdxLsmOptions").hide();
+      } else if (alg == "LSM_SPARSE_VECTOR") {
+        $("#createIdxPropsNormal").hide();
+        $("#createIdxPropsVector").hide();
+        $("#createIdxPropsSparse").show();
         $("#createIdxLsmOptions").hide();
       } else {
         $("#createIdxPropsNormal").show();
         $("#createIdxPropsVector").hide();
+        $("#createIdxPropsSparse").hide();
         $("#createIdxLsmOptions").toggle(alg == "LSM_TREE" || alg == "HASH");
       }
     }


### PR DESCRIPTION
## Summary

Closes the three feature requests opened from discussion #4044 (Qdrant migration):

- **#4065** native `LSM_SPARSE_VECTOR` index
- **#4066** server-side hybrid retrieval fusion (`vector.fuse`)
- **#4067** `groupBy` / `groupSize` on `vector.neighbors` and `vector.sparseNeighbors`

The original Qdrant `query_points_groups` call from #4044 is now a single SQL statement:

```sql
SELECT expand(`vector.fuse`(
    `vector.neighbors`('Doc[dense]', :denseVec, 50),
    `vector.sparseNeighbors`('Doc[tokens,weights]', :qIdx, :qVal, 50),
    { fusion: 'RRF', groupBy: 'source_file', groupSize: 1 }
))
```

## What's in this PR

### Sparse vector index (#4065)

- `Schema.INDEX_TYPE.LSM_SPARSE_VECTOR` enum, `withSparseVectorType()` Java builder, `CREATE INDEX ... LSM_SPARSE_VECTOR METADATA { dimensions, modifier }` SQL syntax.
- Posting-list inverted index on the LSM-Tree backbone with composite key `(int dim_id, RID rid, float weight)`. Inherits ACID, WAL, replication, compaction.
- Document-at-a-time WAND scoring with per-dim `max_weight` upper bounds (lazy-populated, monotone). Tighter per-page bounds (BlockMax-WAND), weight quantization, and parallel per-segment scoring tracked in #4068.
- IDF modifier (Robertson-Sparck-Jones formula).
- `vector.sparseNeighbors(indexSpec, indices, values, K, options)` SQL function with `filter`, `groupBy`, `groupSize` options.
- Studio "Add Index" dialog updated with `LSM_SPARSE_VECTOR` option, parallel-array property pickers (indices / weights), dimensions, modifier.

### Server-side hybrid fusion (#4066)

- `vector.fuse(source1, source2, ..., sourceN [, options])` SQL function.
- Three strategies: `RRF` (default, with `k` and per-source `weights`), `DBSF` (Qdrant 1.11+ mean ± 3σ normalization), `LINEAR` (per-source min-max normalization).
- Composes with `vector.neighbors`, `vector.sparseNeighbors`, `SEARCH_INDEX`, and any plain `SELECT ... ORDER BY ... LIMIT N`.
- Auto-flips `distance` to similarity at extract time so dense and sparse sources fuse without manual rescaling.
- `groupBy` + `groupSize` applied post-fusion (mirroring Qdrant's `query_points_groups`).

### Group-by on vector neighbors (#4067)

- `groupBy` + `groupSize` options on both `vector.neighbors` and `vector.sparseNeighbors`.
- `groupSize` defaults to 1; the third positional `k` becomes max distinct groups when `groupBy` is set.
- MVP uses post-traversal grouping with adaptive over-fetch (`k * groupSize * 5`); integration into the HNSW traversal proper is a follow-up.
- Composes with the existing `filter` option.

## Tests

- 6 sparse-index tests covering persistence, deletion, IDF, and large-corpus correctness vs a brute-force `vector.sparseDot` baseline.
- Concurrency test (`@Tag("slow")`) with 4 writers and 4 readers in parallel.
- 100k benchmark (`@Tag("benchmark")`) comparing the index vs brute-force.
- 9 fusion tests covering RRF, weighted RRF, DBSF, LINEAR, three-way fusion, score-less sources, post-fusion groupBy.
- 5 groupBy tests across 100 docs / 10 source files at groupSize=1 and groupSize=2.
- End-to-end test (`Discussion4044HybridSearchE2ETest`) replicating astarso's exact use case in a single SQL statement (Russian sparse-disambiguation: «процентов» vs «баллов»).

**Totals: 21 new tests, 224 vector-related tests passing, 1469 SQL parser/executor tests passing, no regressions.**

## Test plan

- [ ] `mvn -pl engine test -Dtest='com.arcadedb.index.sparsevector.*Test,com.arcadedb.function.sql.vector.*Test'` green
- [ ] `mvn -pl engine test -Dtest='Discussion4044HybridSearchE2ETest'` green
- [ ] `mvn -pl engine test -Dtest='LSMSparseVectorIndexConcurrencyTest' -DexcludedGroups=` green (slow tag)
- [ ] Studio "Add Index" dialog can create an `LSM_SPARSE_VECTOR` index end-to-end

## Out of scope (follow-ups)

- BlockMax-WAND with per-page bounds, weight quantization, parallel per-segment scoring for the sparse index (#4068).
- Doc page with worked examples for `vector.fuse` (last open acceptance criterion on #4066).
- HNSW-traversal-integrated grouping (vs the MVP post-filter): #4071.
- Dotted nested-field syntax for `groupBy` (e.g. `metadata.author`): #4072.

