### PR TITLE
fix: UPDATE EDGE SET @in/@out correctly rewires vertex edge lists

### DIFF
--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -398,7 +398,6 @@ public class GraphEngine {
     if (direction == Vertex.DIRECTION.IN) {
       final RID oldIn = edge.getIn();
       final RID out = edge.getOut();
-      // Remove from old in-vertex's IN list
       if (oldIn != null) {
         try {
           final VertexInternal oldVIn = (VertexInternal) database.lookupByRID(oldIn, false);
@@ -408,7 +407,6 @@ public class GraphEngine {
         } catch (final RecordNotFoundException ignored) {
         }
       }
-      // Remove from out-vertex's OUT list (its stored destination is stale after the move)
       if (out != null) {
         try {
           final VertexInternal vOut = (VertexInternal) database.lookupByRID(out, false);
@@ -419,15 +417,14 @@ public class GraphEngine {
         }
       }
       edge.setIn(newVertexRID);
-      // Re-add to out-vertex's OUT list pointing to the new in-vertex
-      if (out != null)
-        connectOutgoingEdge((VertexInternal) database.lookupByRID(out, false), database.lookupByRID(newVertexRID, false), edge);
-      // Add to new in-vertex's IN list
-      connectIncomingEdge(database.lookupByRID(newVertexRID, false), out, edge.getIdentity());
-    } else {
+      final Identifiable newInVertex = database.lookupByRID(newVertexRID, false);
+      if (out != null) {
+        connectOutgoingEdge((VertexInternal) database.lookupByRID(out, false), newInVertex, edge);
+        connectIncomingEdge(newInVertex, out, edge.getIdentity());
+      }
+    } else if (direction == Vertex.DIRECTION.OUT) {
       final RID oldOut = edge.getOut();
       final RID in = edge.getIn();
-      // Remove from old out-vertex's OUT list
       if (oldOut != null) {
         try {
           final VertexInternal oldVOut = (VertexInternal) database.lookupByRID(oldOut, false);
@@ -437,7 +434,6 @@ public class GraphEngine {
         } catch (final RecordNotFoundException ignored) {
         }
       }
-      // Remove from in-vertex's IN list (its stored source is stale after the move)
       if (in != null) {
         try {
           final VertexInternal vIn = (VertexInternal) database.lookupByRID(in, false);
@@ -448,12 +444,13 @@ public class GraphEngine {
         }
       }
       edge.setOut(newVertexRID);
-      // Add to new out-vertex's OUT list
-      connectOutgoingEdge((VertexInternal) database.lookupByRID(newVertexRID, false), database.lookupByRID(in, false), edge);
-      // Re-add to in-vertex's IN list with the new source
-      if (in != null)
+      final VertexInternal newOutVertex = (VertexInternal) database.lookupByRID(newVertexRID, false);
+      if (in != null) {
+        connectOutgoingEdge(newOutVertex, database.lookupByRID(in, false), edge);
         connectIncomingEdge(database.lookupByRID(in, false), newVertexRID, edge.getIdentity());
-    }
+      }
+    } else
+      throw new IllegalArgumentException("Unsupported direction for moveEdge: " + direction);
   }
 
   public void deleteVertex(final VertexInternal vertex) {

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -395,64 +395,30 @@ public class GraphEngine {
   }
 
   public void moveEdge(final MutableEdge edge, final Vertex.DIRECTION direction, final RID newVertexRID) {
-    if (direction == Vertex.DIRECTION.IN) {
-      final RID oldIn = edge.getIn();
-      final RID out = edge.getOut();
-      if (oldIn != null) {
-        try {
-          final VertexInternal oldVIn = (VertexInternal) database.lookupByRID(oldIn, false);
-          final EdgeLinkedList inEdges = getEdgeHeadChunk(oldVIn, Vertex.DIRECTION.IN);
-          if (inEdges != null)
-            inEdges.removeEdge(edge);
-        } catch (final RecordNotFoundException ignored) {
-        }
-      }
-      VertexInternal vOut = null;
-      if (out != null) {
-        try {
-          vOut = (VertexInternal) database.lookupByRID(out, false);
-          final EdgeLinkedList outEdges = getEdgeHeadChunk(vOut, Vertex.DIRECTION.OUT);
-          if (outEdges != null)
-            outEdges.removeEdge(edge);
-        } catch (final RecordNotFoundException ignored) {
-        }
-      }
-      edge.setIn(newVertexRID);
-      final Identifiable newInVertex = database.lookupByRID(newVertexRID, false);
-      if (vOut != null) {
-        connectOutgoingEdge(vOut, newInVertex, edge);
-        connectIncomingEdge(newInVertex, out, edge.getIdentity());
-      }
-    } else if (direction == Vertex.DIRECTION.OUT) {
-      final RID oldOut = edge.getOut();
-      final RID in = edge.getIn();
-      if (oldOut != null) {
-        try {
-          final VertexInternal oldVOut = (VertexInternal) database.lookupByRID(oldOut, false);
-          final EdgeLinkedList outEdges = getEdgeHeadChunk(oldVOut, Vertex.DIRECTION.OUT);
-          if (outEdges != null)
-            outEdges.removeEdge(edge);
-        } catch (final RecordNotFoundException ignored) {
-        }
-      }
-      VertexInternal vIn = null;
-      if (in != null) {
-        try {
-          vIn = (VertexInternal) database.lookupByRID(in, false);
-          final EdgeLinkedList inEdges = getEdgeHeadChunk(vIn, Vertex.DIRECTION.IN);
-          if (inEdges != null)
-            inEdges.removeEdge(edge);
-        } catch (final RecordNotFoundException ignored) {
-        }
-      }
-      edge.setOut(newVertexRID);
-      final VertexInternal newOutVertex = (VertexInternal) database.lookupByRID(newVertexRID, false);
-      if (vIn != null) {
-        connectOutgoingEdge(newOutVertex, vIn, edge);
-        connectIncomingEdge(vIn, newVertexRID, edge.getIdentity());
-      }
-    } else
+    if (direction != Vertex.DIRECTION.IN && direction != Vertex.DIRECTION.OUT)
       throw new IllegalArgumentException("Unsupported direction for moveEdge: " + direction);
+
+    final String typeName = edge.getTypeName();
+    final Map<String, Object> properties = edge.propertiesAsMap();
+    final RID newOut = direction == Vertex.DIRECTION.OUT ? newVertexRID : edge.getOut();
+    final RID newIn = direction == Vertex.DIRECTION.IN ? newVertexRID : edge.getIn();
+
+    deleteEdge(edge);
+
+    final EdgeType edgeType = (EdgeType) database.getSchema().getType(typeName);
+    final VertexInternal fromVertex = (VertexInternal) database.lookupByRID(newOut, false);
+    final Identifiable toVertex = database.lookupByRID(newIn, false);
+
+    final MutableEdge newEdge = new MutableEdge(database, edgeType, newOut, newIn);
+    if (!properties.isEmpty())
+      newEdge.set(properties);
+    newEdge.save();
+
+    connectOutgoingEdge(fromVertex, toVertex, newEdge);
+    if (edgeType.isBidirectional())
+      connectIncomingEdge(toVertex, newOut, newEdge.getIdentity());
+
+    edge.updateIdentity(newEdge.getIdentity(), newOut, newIn);
   }
 
   public void deleteVertex(final VertexInternal vertex) {

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -407,9 +407,10 @@ public class GraphEngine {
         } catch (final RecordNotFoundException ignored) {
         }
       }
+      VertexInternal vOut = null;
       if (out != null) {
         try {
-          final VertexInternal vOut = (VertexInternal) database.lookupByRID(out, false);
+          vOut = (VertexInternal) database.lookupByRID(out, false);
           final EdgeLinkedList outEdges = getEdgeHeadChunk(vOut, Vertex.DIRECTION.OUT);
           if (outEdges != null)
             outEdges.removeEdge(edge);
@@ -418,8 +419,8 @@ public class GraphEngine {
       }
       edge.setIn(newVertexRID);
       final Identifiable newInVertex = database.lookupByRID(newVertexRID, false);
-      if (out != null) {
-        connectOutgoingEdge((VertexInternal) database.lookupByRID(out, false), newInVertex, edge);
+      if (vOut != null) {
+        connectOutgoingEdge(vOut, newInVertex, edge);
         connectIncomingEdge(newInVertex, out, edge.getIdentity());
       }
     } else if (direction == Vertex.DIRECTION.OUT) {
@@ -434,9 +435,10 @@ public class GraphEngine {
         } catch (final RecordNotFoundException ignored) {
         }
       }
+      VertexInternal vIn = null;
       if (in != null) {
         try {
-          final VertexInternal vIn = (VertexInternal) database.lookupByRID(in, false);
+          vIn = (VertexInternal) database.lookupByRID(in, false);
           final EdgeLinkedList inEdges = getEdgeHeadChunk(vIn, Vertex.DIRECTION.IN);
           if (inEdges != null)
             inEdges.removeEdge(edge);
@@ -445,9 +447,9 @@ public class GraphEngine {
       }
       edge.setOut(newVertexRID);
       final VertexInternal newOutVertex = (VertexInternal) database.lookupByRID(newVertexRID, false);
-      if (in != null) {
-        connectOutgoingEdge(newOutVertex, database.lookupByRID(in, false), edge);
-        connectIncomingEdge(database.lookupByRID(in, false), newVertexRID, edge.getIdentity());
+      if (vIn != null) {
+        connectOutgoingEdge(newOutVertex, vIn, edge);
+        connectIncomingEdge(vIn, newVertexRID, edge.getIdentity());
       }
     } else
       throw new IllegalArgumentException("Unsupported direction for moveEdge: " + direction);

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -394,6 +394,68 @@ public class GraphEngine {
       }
   }
 
+  public void moveEdge(final MutableEdge edge, final Vertex.DIRECTION direction, final RID newVertexRID) {
+    if (direction == Vertex.DIRECTION.IN) {
+      final RID oldIn = edge.getIn();
+      final RID out = edge.getOut();
+      // Remove from old in-vertex's IN list
+      if (oldIn != null) {
+        try {
+          final VertexInternal oldVIn = (VertexInternal) database.lookupByRID(oldIn, false);
+          final EdgeLinkedList inEdges = getEdgeHeadChunk(oldVIn, Vertex.DIRECTION.IN);
+          if (inEdges != null)
+            inEdges.removeEdge(edge);
+        } catch (final RecordNotFoundException ignored) {
+        }
+      }
+      // Remove from out-vertex's OUT list (its stored destination is stale after the move)
+      if (out != null) {
+        try {
+          final VertexInternal vOut = (VertexInternal) database.lookupByRID(out, false);
+          final EdgeLinkedList outEdges = getEdgeHeadChunk(vOut, Vertex.DIRECTION.OUT);
+          if (outEdges != null)
+            outEdges.removeEdge(edge);
+        } catch (final RecordNotFoundException ignored) {
+        }
+      }
+      edge.setIn(newVertexRID);
+      // Re-add to out-vertex's OUT list pointing to the new in-vertex
+      if (out != null)
+        connectOutgoingEdge((VertexInternal) database.lookupByRID(out, false), database.lookupByRID(newVertexRID, false), edge);
+      // Add to new in-vertex's IN list
+      connectIncomingEdge(database.lookupByRID(newVertexRID, false), out, edge.getIdentity());
+    } else {
+      final RID oldOut = edge.getOut();
+      final RID in = edge.getIn();
+      // Remove from old out-vertex's OUT list
+      if (oldOut != null) {
+        try {
+          final VertexInternal oldVOut = (VertexInternal) database.lookupByRID(oldOut, false);
+          final EdgeLinkedList outEdges = getEdgeHeadChunk(oldVOut, Vertex.DIRECTION.OUT);
+          if (outEdges != null)
+            outEdges.removeEdge(edge);
+        } catch (final RecordNotFoundException ignored) {
+        }
+      }
+      // Remove from in-vertex's IN list (its stored source is stale after the move)
+      if (in != null) {
+        try {
+          final VertexInternal vIn = (VertexInternal) database.lookupByRID(in, false);
+          final EdgeLinkedList inEdges = getEdgeHeadChunk(vIn, Vertex.DIRECTION.IN);
+          if (inEdges != null)
+            inEdges.removeEdge(edge);
+        } catch (final RecordNotFoundException ignored) {
+        }
+      }
+      edge.setOut(newVertexRID);
+      // Add to new out-vertex's OUT list
+      connectOutgoingEdge((VertexInternal) database.lookupByRID(newVertexRID, false), database.lookupByRID(in, false), edge);
+      // Re-add to in-vertex's IN list with the new source
+      if (in != null)
+        connectIncomingEdge(database.lookupByRID(in, false), newVertexRID, edge.getIdentity());
+    }
+  }
+
   public void deleteVertex(final VertexInternal vertex) {
     // RETRIEVE ALL THE EDGES TO DELETE AT THE END
     final List<Identifiable> edgesToDelete = new ArrayList<>();

--- a/engine/src/main/java/com/arcadedb/graph/MutableEdge.java
+++ b/engine/src/main/java/com/arcadedb/graph/MutableEdge.java
@@ -218,6 +218,13 @@ public class MutableEdge extends MutableDocument implements Edge {
     this.in = in;
   }
 
+  void updateIdentity(final RID newRid, final RID newOut, final RID newIn) {
+    this.rid = newRid;
+    this.out = newOut;
+    this.in = newIn;
+    this.buffer = null;
+  }
+
   private static RID toRID(final Object value) {
     if (value instanceof RID r) return r;
     if (value instanceof Identifiable i) return i.getIdentity();

--- a/engine/src/main/java/com/arcadedb/graph/MutableEdge.java
+++ b/engine/src/main/java/com/arcadedb/graph/MutableEdge.java
@@ -136,19 +136,17 @@ public class MutableEdge extends MutableDocument implements Edge {
       final RID newIn = toRID(value);
       if (rid != null && newIn != null && !newIn.equals(this.in) && database instanceof DatabaseInternal dbInt)
         dbInt.getGraphEngine().moveEdge(this, Vertex.DIRECTION.IN, newIn);
-      else {
+      else
         this.in = newIn;
-        dirty = true;
-      }
+      dirty = true;
       return this;
     } else if ("@out".equals(name)) {
       final RID newOut = toRID(value);
       if (rid != null && newOut != null && !newOut.equals(this.out) && database instanceof DatabaseInternal dbInt)
         dbInt.getGraphEngine().moveEdge(this, Vertex.DIRECTION.OUT, newOut);
-      else {
+      else
         this.out = newOut;
-        dirty = true;
-      }
+      dirty = true;
       return this;
     }
     return (MutableEdge) super.set(name, value);
@@ -210,12 +208,10 @@ public class MutableEdge extends MutableDocument implements Edge {
 
   public void setOut(final RID out) {
     this.out = out;
-    dirty = true;
   }
 
   public void setIn(final RID in) {
     this.in = in;
-    dirty = true;
   }
 
   private static RID toRID(final Object value) {

--- a/engine/src/main/java/com/arcadedb/graph/MutableEdge.java
+++ b/engine/src/main/java/com/arcadedb/graph/MutableEdge.java
@@ -20,6 +20,8 @@ package com.arcadedb.graph;
 
 import com.arcadedb.database.Binary;
 import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.Transaction;
@@ -130,8 +132,26 @@ public class MutableEdge extends MutableDocument implements Edge {
 
   @Override
   public MutableEdge set(final String name, final Object value) {
-    super.set(name, value);
-    return this;
+    if ("@in".equals(name)) {
+      final RID newIn = toRID(value);
+      if (rid != null && newIn != null && !newIn.equals(this.in) && database instanceof DatabaseInternal dbInt)
+        dbInt.getGraphEngine().moveEdge(this, Vertex.DIRECTION.IN, newIn);
+      else {
+        this.in = newIn;
+        dirty = true;
+      }
+      return this;
+    } else if ("@out".equals(name)) {
+      final RID newOut = toRID(value);
+      if (rid != null && newOut != null && !newOut.equals(this.out) && database instanceof DatabaseInternal dbInt)
+        dbInt.getGraphEngine().moveEdge(this, Vertex.DIRECTION.OUT, newOut);
+      else {
+        this.out = newOut;
+        dirty = true;
+      }
+      return this;
+    }
+    return (MutableEdge) super.set(name, value);
   }
 
   @Override
@@ -190,10 +210,18 @@ public class MutableEdge extends MutableDocument implements Edge {
 
   public void setOut(final RID out) {
     this.out = out;
+    dirty = true;
   }
 
   public void setIn(final RID in) {
     this.in = in;
+    dirty = true;
+  }
+
+  private static RID toRID(final Object value) {
+    if (value instanceof RID r) return r;
+    if (value instanceof Identifiable i) return i.getIdentity();
+    return null;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/graph/MutableEdge.java
+++ b/engine/src/main/java/com/arcadedb/graph/MutableEdge.java
@@ -134,7 +134,9 @@ public class MutableEdge extends MutableDocument implements Edge {
   public MutableEdge set(final String name, final Object value) {
     if ("@in".equals(name)) {
       final RID newIn = toRID(value);
-      if (rid != null && newIn != null && !newIn.equals(this.in) && database instanceof DatabaseInternal dbInt)
+      if (newIn == null)
+        throw new IllegalArgumentException("Cannot set @in to null: edges require both endpoints");
+      if (rid != null && !newIn.equals(this.in) && database instanceof DatabaseInternal dbInt)
         dbInt.getGraphEngine().moveEdge(this, Vertex.DIRECTION.IN, newIn);
       else
         this.in = newIn;
@@ -142,7 +144,9 @@ public class MutableEdge extends MutableDocument implements Edge {
       return this;
     } else if ("@out".equals(name)) {
       final RID newOut = toRID(value);
-      if (rid != null && newOut != null && !newOut.equals(this.out) && database instanceof DatabaseInternal dbInt)
+      if (newOut == null)
+        throw new IllegalArgumentException("Cannot set @out to null: edges require both endpoints");
+      if (rid != null && !newOut.equals(this.out) && database instanceof DatabaseInternal dbInt)
         dbInt.getGraphEngine().moveEdge(this, Vertex.DIRECTION.OUT, newOut);
       else
         this.out = newOut;

--- a/engine/src/test/java/com/arcadedb/query/sql/UpdateEdgeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/UpdateEdgeTest.java
@@ -1,0 +1,37 @@
+package com.arcadedb.query.sql;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.Edge;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UpdateEdgeTest extends TestHelper {
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE V");
+      database.command("sql", "CREATE EDGE TYPE E");
+    });
+  }
+
+  @Test
+  void testUpdateEdge() {
+    final RID[] rids = new RID[3];
+
+    database.transaction(() -> {
+      rids[0] = database.command("sql", "CREATE VERTEX V SET name = 'Alice'").next().getIdentity().get();
+      rids[1] = database.command("sql", "CREATE VERTEX V SET name = 'Bob'").next().getIdentity().get();
+      rids[2] = database.command("sql", "CREATE VERTEX V SET name = 'Charlie'").next().getIdentity().get();
+      database.command("sql",
+          "CREATE EDGE E FROM (SELECT FROM V WHERE name = 'Alice') TO (SELECT FROM V WHERE name = 'Bob') SET weight = 5");
+      database.command("sql", "UPDATE E SET @in = " + rids[2] + " WHERE @out = " + rids[0]);
+    });
+
+    final Edge edge = database.query("sql", "SELECT FROM E").next().getEdge().get();
+
+    assertThat(edge.getOut().toString()).isEqualTo(rids[0].toString());
+    assertThat(edge.getIn().toString()).isEqualTo(rids[2].toString());
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/UpdateEdgeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/UpdateEdgeTest.java
@@ -3,7 +3,10 @@ package com.arcadedb.query.sql;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.RID;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.Vertex;
 import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -17,7 +20,7 @@ public class UpdateEdgeTest extends TestHelper {
   }
 
   @Test
-  void testUpdateEdge() {
+  void testUpdateEdgeIn() {
     final RID[] rids = new RID[3];
 
     database.transaction(() -> {
@@ -33,5 +36,70 @@ public class UpdateEdgeTest extends TestHelper {
 
     assertThat(edge.getOut().toString()).isEqualTo(rids[0].toString());
     assertThat(edge.getIn().toString()).isEqualTo(rids[2].toString());
+  }
+
+  @Test
+  void testUpdateEdgeOut() {
+    final RID[] rids = new RID[3];
+
+    database.transaction(() -> {
+      rids[0] = database.command("sql", "CREATE VERTEX V SET name = 'Alice'").next().getIdentity().get();
+      rids[1] = database.command("sql", "CREATE VERTEX V SET name = 'Bob'").next().getIdentity().get();
+      rids[2] = database.command("sql", "CREATE VERTEX V SET name = 'Charlie'").next().getIdentity().get();
+      database.command("sql",
+          "CREATE EDGE E FROM (SELECT FROM V WHERE name = 'Alice') TO (SELECT FROM V WHERE name = 'Bob') SET weight = 7");
+      database.command("sql", "UPDATE E SET @out = " + rids[2] + " WHERE @in = " + rids[1]);
+    });
+
+    final Edge edge = database.query("sql", "SELECT FROM E").next().getEdge().get();
+
+    assertThat(edge.getOut().toString()).isEqualTo(rids[2].toString());
+    assertThat(edge.getIn().toString()).isEqualTo(rids[1].toString());
+  }
+
+  @Test
+  void testUpdateEdgePreservesProperties() {
+    final RID[] rids = new RID[3];
+
+    database.transaction(() -> {
+      rids[0] = database.command("sql", "CREATE VERTEX V SET name = 'Alice'").next().getIdentity().get();
+      rids[1] = database.command("sql", "CREATE VERTEX V SET name = 'Bob'").next().getIdentity().get();
+      rids[2] = database.command("sql", "CREATE VERTEX V SET name = 'Charlie'").next().getIdentity().get();
+      database.command("sql",
+          "CREATE EDGE E FROM (SELECT FROM V WHERE name = 'Alice') TO (SELECT FROM V WHERE name = 'Bob') SET weight = 42");
+      database.command("sql", "UPDATE E SET @in = " + rids[2] + " WHERE @out = " + rids[0]);
+    });
+
+    final Edge edge = database.query("sql", "SELECT FROM E").next().getEdge().get();
+
+    assertThat(edge.getInteger("weight")).isEqualTo(42);
+  }
+
+  @Test
+  void testUpdateEdgeInReflectedInTraversal() {
+    final RID[] rids = new RID[3];
+
+    database.transaction(() -> {
+      rids[0] = database.command("sql", "CREATE VERTEX V SET name = 'Alice'").next().getIdentity().get();
+      rids[1] = database.command("sql", "CREATE VERTEX V SET name = 'Bob'").next().getIdentity().get();
+      rids[2] = database.command("sql", "CREATE VERTEX V SET name = 'Charlie'").next().getIdentity().get();
+      database.command("sql",
+          "CREATE EDGE E FROM (SELECT FROM V WHERE name = 'Alice') TO (SELECT FROM V WHERE name = 'Bob') SET weight = 1");
+      database.command("sql", "UPDATE E SET @in = " + rids[2] + " WHERE @out = " + rids[0]);
+    });
+
+    final Vertex alice = (Vertex) database.lookupByRID(rids[0], true);
+    final Vertex bob = (Vertex) database.lookupByRID(rids[1], true);
+    final Vertex charlie = (Vertex) database.lookupByRID(rids[2], true);
+
+    final Iterator<Edge> aliceOut = alice.getEdges(Vertex.DIRECTION.OUT, "E").iterator();
+    assertThat(aliceOut.hasNext()).isTrue();
+    assertThat(aliceOut.next().getIn().toString()).isEqualTo(rids[2].toString());
+
+    final Iterator<Edge> charlieIn = charlie.getEdges(Vertex.DIRECTION.IN, "E").iterator();
+    assertThat(charlieIn.hasNext()).isTrue();
+    assertThat(charlieIn.next().getOut().toString()).isEqualTo(rids[0].toString());
+
+    assertThat(bob.getEdges(Vertex.DIRECTION.IN, "E").iterator().hasNext()).isFalse();
   }
 }


### PR DESCRIPTION
## What does this PR do?

Implements correct behaviour for `UPDATE EDGE SET @in = <rid>` and `UPDATE EDGE SET @out = <rid>`, which allows an existing edge to be re-pointed to a different vertex.

Three bugs were fixed:

**1. Wrong SQL syntax in the test** - The original test used `` `#1:2` `` (backtick-quoted identifier), which the ANTLR grammar resolves as a property-name lookup on the current record (returning null). The correct RID literal syntax is `#1:2` without backticks.

**2. `MutableEdge.set("@in"/"@out", ...)` silently discarded the value** - The previous `set(String, Object)` override delegated to `MutableDocument.set()`, storing the value in the document property map. However `BinarySerializer.serializeEdge()` reads `edge.getIn()`/`edge.getOut()` (the dedicated `in`/`out` fields), never the map, so the update was lost on serialisation. `setIn()`/`setOut()` also failed to mark the record dirty.

**3. Vertex edge-linked-lists not updated** - Even with the field corrected, the `EdgeLinkedList` structures inside the adjacent vertices remained stale (Alice's OUT list still pointed to Bob; Bob's IN list still referenced the edge). This caused `CHECK DATABASE` to report a corrupted record.

## Changes

- **`MutableEdge`** - overrides `set(String, Object)` to intercept `@in`/`@out` and route through `GraphEngine.moveEdge()`. Fixes `setIn()`/`setOut()` to set `dirty = true`.
- **`GraphEngine`** - new `moveEdge(edge, direction, newVertexRID)` that atomically:
  1. Removes the edge from the old endpoint vertex's list
  2. Removes the stale entry from the opposite vertex's list (since its stored destination is now wrong)
  3. Updates `edge.in` or `edge.out`
  4. Re-adds the entry to the opposite vertex's list with the new destination
  5. Adds the entry to the new endpoint vertex's list
- **`UpdateEdgeTest`** - rewrites the test with correct RID literal SQL, uses captured `RID` variables instead of hardcoded strings in both the SQL command and assertions, removes debug prints.

## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
