### PR TITLE
fix: add support for LSM sparse vector type in BoltNetworkExecutor

### DIFF
--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -1266,6 +1266,7 @@ public class BoltNetworkExecutor extends Thread {
       case HASH -> "HASH";
       case FULL_TEXT -> "FULLTEXT";
       case LSM_VECTOR -> "VECTOR";
+      case LSM_SPARSE_VECTOR -> "SPARSE_VECTOR";
       case GEOSPATIAL -> "POINT";
     };
   }
@@ -1278,6 +1279,7 @@ public class BoltNetworkExecutor extends Thread {
       case HASH -> "hash-1.0";
       case FULL_TEXT -> "fulltext-1.0";
       case LSM_VECTOR -> "vector-2.0";
+      case LSM_SPARSE_VECTOR -> "sparse-vector-2.0";
       case GEOSPATIAL -> "point-1.0";
     };
   }
@@ -1295,6 +1297,8 @@ public class BoltNetworkExecutor extends Thread {
       return "FULLTEXT".equals(neoType);
     if (filter.startsWith("show vector index"))
       return "VECTOR".equals(neoType);
+    if (filter.startsWith("show sparse_vector index"))
+      return "SPARSE_VECTOR".equals(neoType);
     return true;
   }
 

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -41,13 +41,13 @@ import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.EdgeType;
 import com.arcadedb.schema.Property;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.VertexType;
-import com.arcadedb.query.sql.executor.Result;
-import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.security.ServerSecurityException;
 import com.arcadedb.server.security.ServerSecurityUser;
@@ -252,9 +252,9 @@ public class BoltNetworkExecutor extends Thread {
       if (magic[0] == 0x16 && magic[1] == 0x03)
         LogManager.instance().log(this, Level.WARNING,
             """
-            TLS/SSL connection attempted on BOLT port but TLS is disabled. \
-            Configure arcadedb.bolt.ssl=OPTIONAL or REQUIRED to enable TLS, \
-            or use bolt:// (unencrypted) on the client""");
+                TLS/SSL connection attempted on BOLT port but TLS is disabled. \
+                Configure arcadedb.bolt.ssl=OPTIONAL or REQUIRED to enable TLS, \
+                or use bolt:// (unencrypted) on the client""");
       else
         LogManager.instance().log(this, Level.WARNING,
             "Invalid BOLT magic bytes: [%d, %d, %d, %d]", magic[0], magic[1], magic[2], magic[3]);
@@ -1083,7 +1083,8 @@ public class BoltNetworkExecutor extends Thread {
         || normalized.startsWith("show point index")
         || normalized.startsWith("show lookup index")
         || normalized.startsWith("show fulltext index")
-        || normalized.startsWith("show vector index")) {
+        || normalized.startsWith("show vector index")
+        || normalized.startsWith("show sparse_vector index")) {
       // SHOW INDEXES / SHOW ... INDEXES - list indexes from ArcadeDB schema
       currentFields = List.of("id", "name", "state", "populationPercent", "type", "entityType",
           "labelsOrTypes", "properties", "indexProvider", "owningConstraint", "lastRead", "readCount");

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltProtocolIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltProtocolIT.java
@@ -23,14 +23,21 @@ import com.arcadedb.database.Database;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
 import com.arcadedb.test.BaseGraphServerTest;
-
 import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.neo4j.driver.*;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Config;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
+import org.neo4j.driver.Transaction;
+import org.neo4j.driver.Values;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.summary.ResultSummary;
-import org.neo4j.driver.Values;
 
 import java.io.BufferedReader;
 import java.io.DataInputStream;
@@ -44,19 +51,17 @@ import java.net.http.WebSocket;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
-import java.util.Base64;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import org.neo4j.driver.Record;
 
 /**
  * Integration tests for BOLT protocol using Neo4j Java driver.
@@ -161,7 +166,8 @@ public class BoltProtocolIT extends BaseGraphServerTest {
         session.run("CREATE (a:EdgePerson {name: 'EdgeAlice'}), (b:EdgePerson {name: 'EdgeBob'})");
 
         // Create edge
-        session.run("MATCH (a:EdgePerson {name: 'EdgeAlice'}), (b:EdgePerson {name: 'EdgeBob'}) CREATE (a)-[:KNOWS {since: 2020}]->(b)");
+        session.run(
+            "MATCH (a:EdgePerson {name: 'EdgeAlice'}), (b:EdgePerson {name: 'EdgeBob'}) CREATE (a)-[:KNOWS {since: 2020}]->(b)");
 
         // Query edge
         final Result result = session.run(
@@ -877,7 +883,8 @@ public class BoltProtocolIT extends BaseGraphServerTest {
 
     // Check for errors
     if (!errors.isEmpty()) {
-      throw new AssertionError("Concurrent test failed with " + errors.size() + " errors: " + errors.get(0).getMessage(), errors.get(0));
+      throw new AssertionError("Concurrent test failed with " + errors.size() + " errors: " + errors.get(0).getMessage(),
+          errors.get(0));
     }
   }
 
@@ -957,7 +964,8 @@ public class BoltProtocolIT extends BaseGraphServerTest {
         // Build a query that uses all parameters
         StringBuilder query = new StringBuilder("RETURN ");
         for (int i = 0; i < 50; i++) {
-          if (i > 0) query.append(" + ");
+          if (i > 0)
+            query.append(" + ");
           query.append("$param").append(i);
         }
         query.append(" AS sum");
@@ -1103,7 +1111,8 @@ public class BoltProtocolIT extends BaseGraphServerTest {
   @Test
   void systemDatabaseDbmsComponents() {
     // Neo4j Desktop queries the "system" database for version info
-    try (final Driver driver = GraphDatabase.driver("bolt://localhost:7687", AuthTokens.basic("root", DEFAULT_PASSWORD_FOR_TESTS))) {
+    try (final Driver driver = GraphDatabase.driver("bolt://localhost:7687",
+        AuthTokens.basic("root", DEFAULT_PASSWORD_FOR_TESTS))) {
       try (final Session session = driver.session(SessionConfig.forDatabase("system"))) {
         final var result = session.run("CALL dbms.components()");
         assertThat(result.hasNext()).isTrue();
@@ -1612,6 +1621,20 @@ public class BoltProtocolIT extends BaseGraphServerTest {
         final List<Record> rows = result.list();
         for (final Record r : rows)
           assertThat(r.get("type").asString()).isEqualTo("VECTOR");
+      }
+    }
+  }
+
+  @Test
+  void showSparseVectorIndexesReturnsEmptyWithoutSparseVectorIndexes() {
+    try (Driver driver = getDriver()) {
+      try (Session session = driver.session(SessionConfig.forDatabase(getDatabaseName()))) {
+        final Result result = session.run("SHOW SPARSE_VECTOR INDEXES");
+        assertThat(result.keys()).containsExactly("id", "name", "state", "populationPercent", "type",
+            "entityType", "labelsOrTypes", "properties", "indexProvider", "owningConstraint", "lastRead", "readCount");
+        final List<Record> rows = result.list();
+        for (final Record r : rows)
+          assertThat(r.get("type").asString()).isEqualTo("SPARSE_VECTOR");
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?

fix bolt executor adding map for sparse vector


## Checklist

- [x] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
