### PR TITLE
Improve Python bindings code quality (Codacy/Bandit cleanup)

### DIFF
--- a/.github/workflows/test-python-bindings.yml
+++ b/.github/workflows/test-python-bindings.yml
@@ -33,6 +33,25 @@ permissions:
   contents: read
 
 jobs:
+  bandit:
+    name: Bandit security scan (bindings/python)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Bandit
+        run: python -m pip install "bandit>=1.9.0"
+
+      - name: Run Bandit on src (must be clean)
+        working-directory: bindings/python
+        run: python -m bandit -c pyproject.toml -r src --severity-level low --confidence-level low
+
   # First job: Download ArcadeDB JARs (platform-agnostic)
   download-jars:
     name: Download ArcadeDB JARs

--- a/.github/workflows/test-python-bindings.yml
+++ b/.github/workflows/test-python-bindings.yml
@@ -48,9 +48,9 @@ jobs:
       - name: Install Bandit
         run: python -m pip install "bandit>=1.9.0"
 
-      - name: Run Bandit on src (must be clean)
+      - name: Run Bandit on src and tests (must be clean)
         working-directory: bindings/python
-        run: python -m bandit -c pyproject.toml -r src --severity-level low --confidence-level low
+        run: python -m bandit -c pyproject.toml -r src tests --severity-level low --confidence-level low
 
   # First job: Download ArcadeDB JARs (platform-agnostic)
   download-jars:

--- a/.github/workflows/test-python-bindings.yml
+++ b/.github/workflows/test-python-bindings.yml
@@ -41,12 +41,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
       - name: Install Bandit
-        run: python -m pip install "bandit>=1.9.0"
+        run: python -m pip install "bandit==1.9.4"
 
       - name: Run Bandit on src and tests (must be clean)
         working-directory: bindings/python

--- a/.github/workflows/test-python-bindings.yml
+++ b/.github/workflows/test-python-bindings.yml
@@ -52,6 +52,10 @@ jobs:
         working-directory: bindings/python
         run: python -m bandit -c pyproject.toml -r src tests --severity-level low --confidence-level low
 
+      - name: Run Bandit on examples (must be clean at medium+/high-confidence)
+        working-directory: bindings/python
+        run: python -m bandit -c pyproject.toml -r examples --severity-level medium --confidence-level high
+
   # First job: Download ArcadeDB JARs (platform-agnostic)
   download-jars:
     name: Download ArcadeDB JARs

--- a/bindings/python/examples/11_vector_index_build.py
+++ b/bindings/python/examples/11_vector_index_build.py
@@ -95,8 +95,10 @@ def get_docker_version() -> str | None:
 
 
 def fetch_json(url: str) -> dict:
+    if not url.startswith("https://"):
+        raise ValueError(f"Refusing to open non-HTTPS URL: {url!r}")
     req = Request(url, headers={"User-Agent": "arcadedb-bench"})
-    with urlopen(req, timeout=30) as response:
+    with urlopen(req, timeout=30) as response:  # nosec B310 - https-only
         payload = json.load(response)
     if not isinstance(payload, dict):
         raise RuntimeError(f"Expected JSON object from {url}")
@@ -962,7 +964,9 @@ def wait_for_qdrant_ready(host: str, port: int, timeout_sec: int = 120) -> None:
     while True:
         for url in urls:
             try:
-                with urlopen(url, timeout=3) as response:
+                with urlopen(
+                    url, timeout=3
+                ) as response:  # nosec B310 - localhost health-check URL
                     if 200 <= int(response.status) < 500:
                         return
             except Exception:
@@ -1012,7 +1016,9 @@ def ensure_milvus_compose_file(compose_file: Path, release_tag: str) -> None:
             "https://github.com/milvus-io/milvus/releases/download/"
             f"{release_tag}/milvus-standalone-docker-compose.yml"
         )
-        urlretrieve(url, str(compose_file))
+        urlretrieve(
+            url, str(compose_file)
+        )  # nosec B310 - url is a hardcoded https://github.com URL
         raw = compose_file.read_text(encoding="utf-8")
 
     sanitized = re.sub(r"(?m)^\s*container_name:\s*.*\n", "", raw)

--- a/bindings/python/examples/11_vector_index_build.py
+++ b/bindings/python/examples/11_vector_index_build.py
@@ -870,7 +870,9 @@ def get_qdrant_version(client) -> str | None:
 
 
 def qdrant_project_name(db_path: Path) -> str:
-    digest = hashlib.sha1(str(db_path).encode("utf-8")).hexdigest()[:10]
+    digest = hashlib.sha1(
+        str(db_path).encode("utf-8"), usedforsecurity=False
+    ).hexdigest()[:10]
     return f"arcadb-qdrant-{digest}"
 
 
@@ -1024,7 +1026,9 @@ def ensure_milvus_compose_file(compose_file: Path, release_tag: str) -> None:
 
 
 def milvus_project_name(db_path: Path) -> str:
-    digest = hashlib.sha1(str(db_path).encode("utf-8")).hexdigest()[:10]
+    digest = hashlib.sha1(
+        str(db_path).encode("utf-8"), usedforsecurity=False
+    ).hexdigest()[:10]
     return f"arcadb-milvus-{digest}"
 
 

--- a/bindings/python/examples/12_vector_search.py
+++ b/bindings/python/examples/12_vector_search.py
@@ -100,8 +100,10 @@ def get_docker_version() -> str | None:
 
 
 def fetch_json(url: str) -> dict:
+    if not url.startswith("https://"):
+        raise ValueError(f"Refusing to open non-HTTPS URL: {url!r}")
     req = Request(url, headers={"User-Agent": "arcadedb-bench"})
-    with urlopen(req, timeout=30) as response:
+    with urlopen(req, timeout=30) as response:  # nosec B310 - https-only
         payload = json.load(response)
     if not isinstance(payload, dict):
         raise RuntimeError(f"Expected JSON object from {url}")
@@ -1006,7 +1008,9 @@ def wait_for_qdrant_ready(host: str, port: int, timeout_sec: int = 120) -> None:
     while True:
         for url in urls:
             try:
-                with urlopen(url, timeout=3) as response:
+                with urlopen(
+                    url, timeout=3
+                ) as response:  # nosec B310 - localhost health-check URL
                     if 200 <= int(response.status) < 500:
                         return
             except Exception:
@@ -1243,7 +1247,9 @@ def ensure_milvus_compose_file(compose_file: Path, release_tag: str) -> None:
             "https://github.com/milvus-io/milvus/releases/download/"
             f"{release_tag}/milvus-standalone-docker-compose.yml"
         )
-        urlretrieve(url, str(compose_file))
+        urlretrieve(
+            url, str(compose_file)
+        )  # nosec B310 - url is a hardcoded https://github.com URL
         raw = compose_file.read_text(encoding="utf-8")
 
     sanitized = re.sub(r"(?m)^\s*version\s*:\s*.*\n", "", raw)

--- a/bindings/python/examples/12_vector_search.py
+++ b/bindings/python/examples/12_vector_search.py
@@ -914,7 +914,9 @@ def get_qdrant_version(client) -> str | None:
 
 
 def qdrant_project_name(db_path: Path) -> str:
-    digest = hashlib.sha1(str(db_path).encode("utf-8")).hexdigest()[:10]
+    digest = hashlib.sha1(
+        str(db_path).encode("utf-8"), usedforsecurity=False
+    ).hexdigest()[:10]
     return f"arcadb-qdrant-{digest}"
 
 
@@ -1120,7 +1122,8 @@ def run_repeated_search(
             **run_stats,
             "run": run_idx + 1,
             "query_order_hash": hashlib.sha1(
-                ",".join(str(v) for v in run_qids).encode("utf-8")
+                ",".join(str(v) for v in run_qids).encode("utf-8"),
+                usedforsecurity=False,
             ).hexdigest(),
         }
         per_run_stats.append(run_stats)
@@ -1255,7 +1258,9 @@ def ensure_milvus_compose_file(compose_file: Path, release_tag: str) -> None:
 
 
 def milvus_project_name(db_path: Path) -> str:
-    digest = hashlib.sha1(str(db_path).encode("utf-8")).hexdigest()[:10]
+    digest = hashlib.sha1(
+        str(db_path).encode("utf-8"), usedforsecurity=False
+    ).hexdigest()[:10]
     return f"arcadb-milvus-{digest}"
 
 

--- a/bindings/python/examples/16_import_database_vs_transactional_graph_ingest.py
+++ b/bindings/python/examples/16_import_database_vs_transactional_graph_ingest.py
@@ -131,7 +131,10 @@ def edge_endpoints(edge_id: int, vertex_count: int) -> Tuple[int, int]:
 
 
 def build_rid_lookup_for_vertex_type(db, vertex_type: str) -> Dict[int, str]:
-    rows = db.query("sql", f"SELECT Id, @rid as rid FROM {vertex_type}").to_list()
+    rows = db.query(
+        "sql",
+        f"SELECT Id, @rid as rid FROM {vertex_type}",  # nosec B608 - vertex_type is a script constant
+    ).to_list()
     rid_lookup: Dict[int, str] = {}
     for row in rows:
         row_id = row.get("Id")
@@ -165,7 +168,12 @@ def collect_vertex_sample(
     db, vertex_type: str, vertex_id: int, props: List[ColumnDef]
 ) -> dict:
     row = query_one_or_none(
-        db.query("sql", f"SELECT FROM {vertex_type} WHERE Id = {vertex_id}")
+        db.query(
+            "sql",
+            # vertex_type is a constant from this script; vertex_id is bound as parameter.
+            f"SELECT FROM {vertex_type} WHERE Id = ?",  # nosec B608
+            vertex_id,
+        )
     )
     if row is None:
         return {"Id": vertex_id, "missing": True}
@@ -246,7 +254,8 @@ def collect_graph_signature(
         vertex_aggregate = query_one_or_none(
             db.query(
                 "sql",
-                f"SELECT {', '.join(vertex_aggregate_fields)} FROM {vertex_type}",
+                # vertex_aggregate_fields and vertex_type are script-local constants.
+                f"SELECT {', '.join(vertex_aggregate_fields)} FROM {vertex_type}",  # nosec B608
             )
         )
         edge_aggregate = query_one_or_none(

--- a/bindings/python/examples/17_timeseries_end_to_end.py
+++ b/bindings/python/examples/17_timeseries_end_to_end.py
@@ -338,10 +338,13 @@ def main() -> int:
             for row in db.query(
                 "sql",
                 "SELECT FROM SensorReading "
-                f"WHERE ts BETWEEN {raw_window_start} AND {raw_window_end} "
-                f"AND sensor_id = '{focus_sensor.sensor_id}' "
-                f"AND building = '{focus_sensor.building}' "
+                "WHERE ts BETWEEN ? AND ? "
+                "AND sensor_id = ? AND building = ? "
                 "ORDER BY ts",
+                raw_window_start,
+                raw_window_end,
+                focus_sensor.sensor_id,
+                focus_sensor.building,
             )
         ]
         print_rows(

--- a/bindings/python/examples/20_graph_algorithms_route_planning.py
+++ b/bindings/python/examples/20_graph_algorithms_route_planning.py
@@ -284,7 +284,8 @@ def insert_seed_data(db) -> None:
         for route in ROUTES:
             db.command(
                 "sql",
-                f"CREATE EDGE {route['edge_type']} "
+                # route['edge_type'] is a constant from the demo schema.
+                f"CREATE EDGE {route['edge_type']} "  # nosec B608
                 "FROM (SELECT FROM City WHERE code = ? LIMIT 1) "
                 "TO (SELECT FROM City WHERE code = ? LIMIT 1) "
                 "SET distance = ?, duration = ?, risk = ?, lane = ?",
@@ -755,7 +756,10 @@ def run_reopen_phase(db_path: Path) -> None:
             .get("count")
         )
         route_count = sum(
-            reopened_db.query("sql", f"SELECT count(*) AS count FROM {edge_type}")
+            reopened_db.query(
+                "sql",
+                f"SELECT count(*) AS count FROM {edge_type}",  # nosec B608 - edge_type is a script constant
+            )
             .first()
             .get("count")
             for edge_type in ("Road", "Rail", "Ferry")

--- a/bindings/python/examples/21_server_mode_http_access.py
+++ b/bindings/python/examples/21_server_mode_http_access.py
@@ -164,8 +164,14 @@ def http_json_request(
         request_headers["Content-Type"] = "application/json"
 
     request = Request(url, data=data, headers=request_headers, method=method)
+    if not request.full_url.startswith(
+        ("http://localhost", "http://127.0.0.1", "https://")
+    ):
+        raise ValueError(f"Refusing to call unexpected URL: {request.full_url!r}")
     try:
-        with urlopen(request, timeout=timeout) as response:
+        with urlopen(
+            request, timeout=timeout
+        ) as response:  # nosec B310 - localhost or https
             body = response.read().decode("utf-8")
     except HTTPError as exc:
         detail = exc.read().decode("utf-8", errors="replace")

--- a/bindings/python/examples/22_graph_analytical_view_sql.py
+++ b/bindings/python/examples/22_graph_analytical_view_sql.py
@@ -539,6 +539,7 @@ def query_direct_neighbor_sample(
 
 
 def query_two_hop_summary(db, origin_code: str) -> dict:
+    # origin_code is a script-local constant from the demo dataset.
     result = db.query(
         "sql",
         f"""
@@ -550,7 +551,7 @@ def query_two_hop_summary(db, origin_code: str) -> dict:
                   {{type: City, as: dst}}
             RETURN DISTINCT dst.code AS code
         )
-        """,
+        """,  # nosec B608 - demo-data constants only
     )
     row = result.first()
     require(row is not None, "Expected a two-hop summary row")
@@ -567,7 +568,7 @@ def query_hub_inbound_count(db, hub_code: str) -> int:
                   {{type: City, as: hub, where: (code = '{hub_code}')}}
             RETURN src.code AS code
         )
-        """,
+        """,  # nosec B608 - demo-data constants only
     )
     row = result.first()
     require(row is not None, "Expected an inbound count row")
@@ -583,7 +584,7 @@ def query_region_sample(db, sample_limit: int) -> list[dict]:
         GROUP BY region
         ORDER BY region
         LIMIT {sample_limit}
-        """,
+        """,  # nosec B608 - sample_limit is a script integer constant
     )
     return rows_to_dicts(result, ["region", "city_count", "avg_demand"])
 

--- a/bindings/python/examples/download_data.py
+++ b/bindings/python/examples/download_data.py
@@ -113,6 +113,18 @@ except ImportError:
     tqdm = None
 
 
+def _require_https(url: str) -> str:
+    """Reject non-HTTPS URLs before opening them.
+
+    Bandit B310 flags urlopen() because it permits file:// and custom schemes.
+    Examples download from a fixed list of HTTPS dataset URLs, so we enforce
+    that contract explicitly here.
+    """
+    if not url.startswith("https://"):
+        raise ValueError(f"Refusing to open non-HTTPS URL: {url!r}")
+    return url
+
+
 def ensure_clean_dir(path: Path, label: str) -> None:
     if path.exists():
         print(f"[CLEAN] Removing existing {label} directory: {path}")
@@ -188,8 +200,10 @@ def _download_with_python(
             f"[DOWNLOAD] Resuming {destination.name} from {_format_bytes(resume_from)}"
         )
 
-    request = urllib.request.Request(url, headers=headers)
-    with urllib.request.urlopen(request, timeout=60) as response:
+    request = urllib.request.Request(_require_https(url), headers=headers)
+    with urllib.request.urlopen(
+        request, timeout=60
+    ) as response:  # nosec B310 - https-only
         status = getattr(response, "status", response.getcode())
 
         if resume_from > 0 and status != 206:
@@ -649,7 +663,9 @@ def download_movielens(size="large", inject_nulls=True):
                 end="",
             )
 
-        urllib.request.urlretrieve(url, zip_path, reporthook=report_progress)
+        urllib.request.urlretrieve(
+            _require_https(url), zip_path, reporthook=report_progress
+        )  # nosec B310 - https-only
         print()  # New line after progress
         download_elapsed = time.time() - download_start
         print(f"[OK] Downloaded to: {zip_path} " f"({download_elapsed:.2f}s)")
@@ -1085,9 +1101,11 @@ def create_stackoverflow_large(
 
 
 def _iter_stackoverflow_rows(xml_path: Path, fields: list[str]):
-    import xml.etree.ElementTree as ET
+    import xml.etree.ElementTree as ET  # nosec B405 - parsing files we just downloaded over HTTPS and verified
 
-    context = ET.iterparse(xml_path, events=("start", "end"))
+    context = ET.iterparse(
+        xml_path, events=("start", "end")
+    )  # nosec B314 - input is a downloaded, checksum-verified file
     _, root = next(context)
     for event, elem in context:
         if event == "end" and elem.tag == "row":
@@ -1618,7 +1636,9 @@ def download_tpch(scale_factor: int = 10) -> Path:
                 end="",
             )
 
-        urllib.request.urlretrieve(url, dbgen_zip, reporthook=report_progress)
+        urllib.request.urlretrieve(
+            _require_https(url), dbgen_zip, reporthook=report_progress
+        )  # nosec B310 - https-only
         print()
 
         extract_dir = data_dir / "tpch-dbgen-extract"
@@ -1701,7 +1721,13 @@ def download_ldbc_snb(scale_factor: int = 1) -> Path:
             "main/params-csv-merge-foreign.ini"
         )
         print("[DOWNLOAD] LDBC SNB params template")
-        template = urllib.request.urlopen(template_url).read().decode("utf-8")
+        template = (
+            urllib.request.urlopen(  # nosec B310 - https-only
+                _require_https(template_url)
+            )
+            .read()
+            .decode("utf-8")
+        )
         lines = []
         inserted = False
         for line in template.splitlines():
@@ -2139,7 +2165,7 @@ def verify_xml_nulls(extract_dir, sample_size=None):
     Returns:
         dict: Verification results
     """
-    import xml.etree.ElementTree as ET
+    import xml.etree.ElementTree as ET  # nosec B405 - parsing files we just downloaded over HTTPS and verified
 
     verification_start = time.time()
     results = {}
@@ -2163,7 +2189,9 @@ def verify_xml_nulls(extract_dir, sample_size=None):
         file_start = time.time()
 
         # Parse XML iteratively for large files
-        context = ET.iterparse(xml_path, events=("start", "end"))
+        context = ET.iterparse(
+            xml_path, events=("start", "end")
+        )  # nosec B314 - input is a downloaded, checksum-verified file
         _, root = next(context)  # Get root element
 
         all_attrs = set()

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -87,7 +87,9 @@ markers = [
 
 [tool.bandit]
 # Skip recursion into test data and build artifacts.
-exclude_dirs = ["tests/.cache", "build", "dist"]
+# Patterns are matched as substrings, so anchor with leading "/" to avoid
+# accidentally excluding files like examples/11_vector_index_build.py.
+exclude_dirs = ["/tests/.cache/", "/build/", "/dist/"]
 
 [tool.bandit.assert_used]
 # Asserts are the standard idiom in pytest; do not flag them in tests/conftest.

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -90,7 +90,7 @@ markers = [
 # Patterns are matched as substrings, so anchor with leading "/" to avoid
 # accidentally excluding files like examples/11_vector_index_build.py.
 exclude_dirs = ["/tests/.cache/", "/build/", "/dist/"]
-
-[tool.bandit.assert_used]
-# Asserts are the standard idiom in pytest; do not flag them in tests/conftest.
-skips = ["**/tests/test_*.py", "**/tests/conftest.py"]
+# B101 (assert_used) is the standard pytest idiom and the production source
+# (src/) intentionally contains no assert statements - so we skip it globally
+# rather than maintaining a per-file glob list.
+skips = ["B101"]

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     "pytest>=7.0.0",
     "pytest-cov",
     "numpy>=1.20.0",
+    "bandit>=1.9.0",
 ]
 vector = [
     "numpy>=1.20.0",
@@ -83,3 +84,11 @@ markers = [
     "server: tests that require server/studio support",
     "integration: tests that require external components",
 ]
+
+[tool.bandit]
+# Skip recursion into test data and build artifacts.
+exclude_dirs = ["tests/.cache", "build", "dist"]
+
+[tool.bandit.assert_used]
+# Asserts are the standard idiom in pytest; do not flag them in tests/conftest.
+skips = ["**/tests/test_*.py", "**/tests/conftest.py"]

--- a/bindings/python/src/arcadedb_embedded/_logging.py
+++ b/bindings/python/src/arcadedb_embedded/_logging.py
@@ -1,0 +1,23 @@
+"""Internal logging helpers for arcadedb_embedded.
+
+Centralises the pattern for swallowing exceptions in finalizers and
+best-effort cleanup paths so the suppression is observable at DEBUG level
+instead of being silently dropped.
+"""
+
+import logging
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a namespaced logger for an arcadedb_embedded submodule."""
+    return logging.getLogger(name)
+
+
+def log_swallowed_exception(logger: logging.Logger, context: str) -> None:
+    """Log the currently-handled exception at DEBUG with full traceback.
+
+    Use only inside an `except` block where the caller has decided the
+    error is non-fatal (e.g. JVM finalizer paths, optional best-effort
+    rollback) and continuing is the right behaviour.
+    """
+    logger.debug("Swallowed exception %s", context, exc_info=True)

--- a/bindings/python/src/arcadedb_embedded/async_executor.py
+++ b/bindings/python/src/arcadedb_embedded/async_executor.py
@@ -27,10 +27,13 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence, Union
 
 import jpype
 
+from ._logging import get_logger, log_swallowed_exception
 from .type_conversion import convert_python_to_java
 
 if TYPE_CHECKING:
     from .core import Database
+
+_LOGGER = get_logger(__name__)
 
 
 class AsyncExecutor:
@@ -209,7 +212,7 @@ class AsyncExecutor:
             if bool(self._java_async.isProcessing()):
                 return True
         except Exception:
-            pass
+            log_swallowed_exception(_LOGGER, "while polling isProcessing()")
 
         try:
             return not bool(self._java_async.waitCompletion(0))

--- a/bindings/python/src/arcadedb_embedded/core.py
+++ b/bindings/python/src/arcadedb_embedded/core.py
@@ -901,14 +901,21 @@ class Database:
         return first_error
 
     def __del__(self):
-        """Finalizer - ensure database is closed when object is garbage collected."""
+        """Finalizer - ensure database is closed when object is garbage collected.
+
+        Errors during garbage collection are intentionally suppressed: the
+        interpreter is shutting down and logging may already be unavailable,
+        so we narrow the catch to AttributeError/RuntimeError that JPype can
+        raise when the JVM has been torn down before this finalizer runs.
+        """
         try:
             if not self._closed and self._java_db is not None:
                 self._close_async_executors()
                 self._java_db.close()
                 self._closed = True
-        except Exception:
-            pass  # Ignore errors during garbage collection
+        except (AttributeError, RuntimeError):
+            # JVM or referenced attributes already gone; nothing to do.
+            return
 
 
 class DatabaseFactory:

--- a/bindings/python/src/arcadedb_embedded/graph_batch.py
+++ b/bindings/python/src/arcadedb_embedded/graph_batch.py
@@ -8,9 +8,12 @@ from typing import Any, Iterable, Optional
 
 import jpype
 
+from ._logging import get_logger, log_swallowed_exception
 from .exceptions import ArcadeDBError
 from .graph import Document, Vertex
 from .type_conversion import convert_python_to_java
+
+_LOGGER = get_logger(__name__)
 
 
 class GraphBatch:
@@ -119,7 +122,7 @@ class GraphBatch:
                 try:
                     self._java_db.rollback()
                 except Exception:
-                    pass
+                    log_swallowed_exception(_LOGGER, "during batch vertex rollback")
             raise ArcadeDBError(
                 f"Failed to create batch vertex of type '{type_name}': {e}"
             ) from e

--- a/bindings/python/src/arcadedb_embedded/jvm.py
+++ b/bindings/python/src/arcadedb_embedded/jvm.py
@@ -388,9 +388,14 @@ def _build_jvm_args(
 
 
 def shutdown_jvm():
-    """Shutdown JVM if it was started by this module."""
+    """Shutdown JVM if it was started by this module.
+
+    JPype can raise RuntimeError when the JVM is already mid-shutdown or
+    has been detached from the calling thread; in that case there is
+    nothing left for us to do.
+    """
     if jpype.isJVMStarted():
         try:
             jpype.shutdownJVM()
-        except Exception:
-            pass  # Ignore errors during shutdown
+        except RuntimeError:
+            return

--- a/bindings/python/src/arcadedb_embedded/schema.py
+++ b/bindings/python/src/arcadedb_embedded/schema.py
@@ -15,7 +15,10 @@ from typing import Any, List, Optional, Union
 
 import jpype
 
+from ._logging import get_logger, log_swallowed_exception
 from .exceptions import ArcadeDBError
+
+_LOGGER = get_logger(__name__)
 
 
 class IndexType(Enum):
@@ -692,7 +695,9 @@ class Schema:
                                     if len(props) == 1 and props[0] == vector_property:
                                         return VectorIndex(java_index, self._db)
                         except Exception:
-                            pass
+                            log_swallowed_exception(
+                                _LOGGER, "while inspecting TypeIndex sub-indexes"
+                            )
 
                     # Check if it's directly an LSM vector index (JVector)
                     elif "LSMVectorIndex" in index_class_name:
@@ -701,7 +706,7 @@ class Schema:
                         if len(props) == 1 and props[0] == vector_property:
                             return VectorIndex(java_index, self._db)
             except Exception:
-                pass
+                log_swallowed_exception(_LOGGER, "while iterating schema indexes")
 
             return None
 
@@ -734,7 +739,7 @@ class Schema:
                             if "LSMVectorIndex" in first_sub.getClass().getName():
                                 indexes.append(java_index.getName())
                     except Exception:
-                        pass
+                        log_swallowed_exception(_LOGGER, "while listing vector indexes")
 
             return indexes
         except Exception:

--- a/bindings/python/src/arcadedb_embedded/server.py
+++ b/bindings/python/src/arcadedb_embedded/server.py
@@ -7,9 +7,12 @@ ArcadeDB server for HTTP API and Studio web interface.
 import os
 from typing import Any, Dict, Optional
 
+from ._logging import get_logger, log_swallowed_exception
 from .core import Database
 from .exceptions import ArcadeDBError
 from .jvm import start_jvm
+
+_LOGGER = get_logger(__name__)
 
 
 class ArcadeDBServer:
@@ -61,7 +64,9 @@ class ArcadeDBServer:
         mode = self._config.get("mode", "development")
         context_config.setValue("arcadedb.server.mode", mode)
 
-        host = self._config.get("host", "0.0.0.0")
+        # Default to loopback; callers must opt in to "0.0.0.0" explicitly to
+        # expose the server on all interfaces.
+        host = self._config.get("host", "localhost")
         context_config.setValue("arcadedb.server.httpIncomingHost", host)
 
         http_port = self._config.get("http_port", 2480)
@@ -100,13 +105,16 @@ class ArcadeDBServer:
             raise ArcadeDBError(f"Failed to stop server: {e}") from e
 
     def __del__(self):
-        """Finalizer - ensure server is stopped."""
+        """Finalizer - ensure server is stopped.
+
+        See Database.__del__ for rationale on the narrowed except clause.
+        """
         try:
             if self._started and self._java_server is not None:
                 self._java_server.stop()
                 self._started = False
-        except Exception:
-            pass  # Ignore errors during garbage collection
+        except (AttributeError, RuntimeError):
+            return
 
     def get_database(self, name: str) -> Database:
         """
@@ -162,7 +170,7 @@ class ArcadeDBServer:
     def get_studio_url(self) -> str:
         """Get the URL for the Studio web interface."""
         host = self._config.get("host", "localhost")
-        if host == "0.0.0.0":
+        if host == "0.0.0.0":  # nosec B104 - equality comparison, not a bind
             host = "localhost"
         port = self.get_http_port()
         return f"http://{host}:{port}/"

--- a/bindings/python/src/arcadedb_embedded/server.py
+++ b/bindings/python/src/arcadedb_embedded/server.py
@@ -7,12 +7,9 @@ ArcadeDB server for HTTP API and Studio web interface.
 import os
 from typing import Any, Dict, Optional
 
-from ._logging import get_logger, log_swallowed_exception
 from .core import Database
 from .exceptions import ArcadeDBError
 from .jvm import start_jvm
-
-_LOGGER = get_logger(__name__)
 
 
 class ArcadeDBServer:
@@ -35,7 +32,11 @@ class ArcadeDBServer:
             config: Optional configuration dictionary with keys like:
                 - http_port: HTTP API port (default: 2480)
                 - binary_port: Binary protocol port (default: 2424)
-                - host: Host to bind to (default: 0.0.0.0)
+                - host: Host to bind to (default: "localhost"). Pass "0.0.0.0"
+                    explicitly to expose the server on all IPv4 interfaces, or
+                    "::" for all IPv6 interfaces. Earlier versions defaulted to
+                    "0.0.0.0"; the default was tightened to loopback in the
+                    Python bindings v0.x security cleanup.
                 - mode: Server mode (default: development)
             jvm_kwargs: Optional JVM args passed to start_jvm()
                 Example: {"heap_size": "8g"}
@@ -170,7 +171,7 @@ class ArcadeDBServer:
     def get_studio_url(self) -> str:
         """Get the URL for the Studio web interface."""
         host = self._config.get("host", "localhost")
-        if host == "0.0.0.0":  # nosec B104 - equality comparison, not a bind
+        if host in ("0.0.0.0", "::"):  # nosec B104 - equality comparison, not a bind
             host = "localhost"
         port = self.get_http_port()
         return f"http://{host}:{port}/"

--- a/bindings/python/src/arcadedb_embedded/vector.py
+++ b/bindings/python/src/arcadedb_embedded/vector.py
@@ -234,10 +234,12 @@ class VectorIndex:
             result = None
 
         if result is None:
+            # Identifiers are quoted via _quote_identifier(); the user-supplied
+            # `key` is passed as a `?` parameter, so this is not SQL injection.
             result = self._database.query(
                 "sql",
                 (
-                    f"SELECT {quoted_vector_property} AS `query_vector` FROM {quoted_type_name} "
+                    f"SELECT {quoted_vector_property} AS `query_vector` FROM {quoted_type_name} "  # nosec B608
                     f"WHERE {quoted_id_property} = ? LIMIT 1"
                 ),
                 key,

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -8,6 +8,10 @@ import tempfile
 
 import pytest
 
+# Shared test password used by server-mode tests. ArcadeDB requires >= 8 chars.
+# Hardcoded test fixture, not a real credential.
+TEST_PASSWORD = "test12345"  # nosec B105 - test fixture
+
 
 @pytest.fixture
 def temp_db_path():

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -57,7 +57,7 @@ def temp_db():
         if not db.is_closed():
             db.close()
     except Exception:
-        pass
+        pass  # nosec B110 - best-effort teardown after JVM may be down
 
     # Force garbage collection to release file handles (Windows fix)
     import gc

--- a/bindings/python/tests/test_async_executor.py
+++ b/bindings/python/tests/test_async_executor.py
@@ -105,7 +105,7 @@ def test_async_executor_pending_and_processing_flags(temp_db):
             if async_exec._java_async.waitCompletion(0):
                 break
         except Exception:
-            pass
+            pass  # nosec B110 - best-effort teardown after JVM may be down
 
         time.sleep(0.01)
 

--- a/bindings/python/tests/test_concurrency.py
+++ b/bindings/python/tests/test_concurrency.py
@@ -88,7 +88,7 @@ def test_thread_safety(cleanup_db):
     def query_thread(thread_id):
         start = time.time()
         query = (
-            f"SELECT FROM Person WHERE id >= {thread_id * 5} "
+            f"SELECT FROM Person WHERE id >= {thread_id * 5} "  # nosec B608
             f"AND id < {(thread_id + 1) * 5}"
         )
         result = db.query("sql", query)
@@ -197,9 +197,9 @@ def test_oltp_mixed_workload_threads(cleanup_db):
     )
 
     def worker(worker_id):
-        import random
+        import random  # nosec B311 - synthetic benchmark data, not security
 
-        rng = random.Random(42 + worker_id)
+        rng = random.Random(42 + worker_id)  # nosec B311
         latencies_ms = []
         reads = 0
         writes = 0
@@ -212,7 +212,7 @@ def test_oltp_mixed_workload_threads(cleanup_db):
             if op == "read":
                 result = db.query(
                     "sql",
-                    f"SELECT balance FROM Account WHERE account_id = {account_id}",
+                    f"SELECT balance FROM Account WHERE account_id = {account_id}",  # nosec B608
                 )
                 _ = list(result)
                 reads += 1

--- a/bindings/python/tests/test_core.py
+++ b/bindings/python/tests/test_core.py
@@ -421,7 +421,7 @@ def test_transactions(temp_db_path):
                 db.command("sql", "INSERT INTO TransactionTest SET id = 3")
                 raise Exception("Intentional error")
         except Exception:
-            pass  # Expected
+            pass  # nosec B110 - intentional rollback test, exception is expected
 
         # Verify rollback worked
         result = db.query("sql", "SELECT count(*) as count FROM TransactionTest")

--- a/bindings/python/tests/test_docs_examples.py
+++ b/bindings/python/tests/test_docs_examples.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-import subprocess
+import subprocess  # nosec B404 - launching Python interpreter to run example scripts
 import sys
 import textwrap
 from pathlib import Path
@@ -64,7 +64,7 @@ def _run_snippet_subprocess(
     if snippet.strip():
         parts.extend(["", textwrap.dedent(snippet).strip()])
     code = "\n".join(parts) + "\n"
-    result = subprocess.run(
+    result = subprocess.run(  # nosec B603 - argv built from script paths and constants, not user input
         [sys.executable, "-c", code],
         cwd=workdir,
         check=False,

--- a/bindings/python/tests/test_exporter.py
+++ b/bindings/python/tests/test_exporter.py
@@ -142,7 +142,7 @@ def sample_db(temp_db_path):
                     TO (SELECT FROM Movie WHERE movieId = {movie_id})
                     SET rating = {rating_val},
                         timestamp = {timestamp + i * 3600},
-                        review = '{review}'""",
+                        review = '{review}'""",  # nosec B608
             )
 
         # Create 30 ActedIn edges (actors in movies)
@@ -157,7 +157,7 @@ def sample_db(temp_db_path):
                 f"""CREATE EDGE ActedIn
                     FROM (SELECT FROM Actor WHERE actorId = {actor_id})
                     TO (SELECT FROM Movie WHERE movieId = {movie_id})
-                    SET role = '{role}', year = {year}""",
+                    SET role = '{role}', year = {year}""",  # nosec B608
             )
 
         # Create 15 Follows edges (users following each other)
@@ -169,7 +169,7 @@ def sample_db(temp_db_path):
                     "sql",
                     f"""CREATE EDGE Follows
                         FROM (SELECT FROM User WHERE userId = {from_user})
-                        TO (SELECT FROM User WHERE userId = {to_user})""",
+                        TO (SELECT FROM User WHERE userId = {to_user})""",  # nosec B608
                 )
 
         # Create 10 log entries with different levels
@@ -882,7 +882,7 @@ class TestAllDataTypes:
                 if db:
                     db.close()
             except Exception:
-                pass  # Database already closed or error during close
+                pass  # nosec B110 - best-effort teardown after JVM may be down
 
 
 if __name__ == "__main__":

--- a/bindings/python/tests/test_graph_algorithms_sql.py
+++ b/bindings/python/tests/test_graph_algorithms_sql.py
@@ -39,7 +39,7 @@ def _path_query_or_skip(db, select_statement):
     LET $src = (SELECT FROM Node WHERE name = 'A' LIMIT 1);
     LET $dst = (SELECT FROM Node WHERE name = 'D' LIMIT 1);
     {select_statement}
-    """
+    """  # nosec B608
 
     try:
         result = db.command("sqlscript", script)

--- a/bindings/python/tests/test_graph_api.py
+++ b/bindings/python/tests/test_graph_api.py
@@ -301,7 +301,9 @@ def test_wrapper_delete_method(temp_db_path):
         # Delete using wrapper
         with db.transaction():
             # Use SQL DELETE for reliable deletion of query results
-            db.command("sql", f"DELETE FROM TempNode WHERE @rid = {node_id}")
+            db.command(
+                "sql", f"DELETE FROM TempNode WHERE @rid = {node_id}"  # nosec B608
+            )
 
         # Verify it's gone
         results_after = list(db.query("sql", "SELECT FROM TempNode"))
@@ -479,7 +481,8 @@ def test_edge_delete_leaves_vertices(temp_db_path):
         # Verify specific vertices still exist
         nodes = list(
             db.query(
-                "sql", f"SELECT FROM Node WHERE @rid = {node1_id} OR @rid = {node2_id}"
+                "sql",
+                f"SELECT FROM Node WHERE @rid = {node1_id} OR @rid = {node2_id}",  # nosec B608
             )
         )
         assert len(nodes) == 2
@@ -503,7 +506,9 @@ def test_document_delete_sql(temp_db_path):
 
         # Delete using SQL
         with db.transaction():
-            db.command("sql", f"DELETE FROM `Record` WHERE @rid = {doc_id}")
+            db.command(
+                "sql", f"DELETE FROM `Record` WHERE @rid = {doc_id}"  # nosec B608
+            )
 
         # Verify deleted
         docs_after = list(db.query("sql", "SELECT FROM `Record`"))

--- a/bindings/python/tests/test_jvm_args.py
+++ b/bindings/python/tests/test_jvm_args.py
@@ -109,7 +109,11 @@ def test_custom_jvm_args_no_duplicates():
 def test_error_file_env():
     """Test ARCADEDB_JVM_ERROR_FILE injection."""
     with patch.dict(
-        os.environ, {"ARCADEDB_JVM_ERROR_FILE": "/tmp/crash.log"}, clear=True
+        os.environ,
+        {
+            "ARCADEDB_JVM_ERROR_FILE": "/tmp/crash.log"
+        },  # nosec B108 - test-only path for JVM error file argument
+        clear=True,
     ):
         args = _build_jvm_args(
             heap_size="4g",

--- a/bindings/python/tests/test_logging_helper.py
+++ b/bindings/python/tests/test_logging_helper.py
@@ -1,0 +1,26 @@
+"""Tests for the internal _logging helper."""
+
+import logging
+
+from arcadedb_embedded._logging import get_logger, log_swallowed_exception
+
+
+def test_get_logger_returns_namespaced_logger():
+    logger = get_logger("arcadedb_embedded.foo")
+    assert isinstance(logger, logging.Logger)
+    assert logger.name == "arcadedb_embedded.foo"
+
+
+def test_log_swallowed_exception_emits_debug(caplog):
+    logger = get_logger("arcadedb_embedded.test")
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        try:
+            raise RuntimeError("boom")
+        except RuntimeError:
+            log_swallowed_exception(logger, "during shutdown")
+
+    records = [r for r in caplog.records if r.name == logger.name]
+    assert len(records) == 1
+    assert records[0].levelno == logging.DEBUG
+    assert "during shutdown" in records[0].getMessage()
+    assert records[0].exc_info is not None

--- a/bindings/python/tests/test_server.py
+++ b/bindings/python/tests/test_server.py
@@ -116,3 +116,15 @@ def test_server_context_manager(temp_server_root):
 
     # Note: We can't easily test if stopped after context exit
     # because the server object is out of scope
+
+
+def test_default_host_is_localhost(temp_server_root):
+    """Default host should be localhost; binding to all interfaces must be opt-in."""
+    from arcadedb_embedded.server import ArcadeDBServer
+
+    server = ArcadeDBServer(
+        root_path=temp_server_root,
+        root_password="test_password",
+    )
+    assert server._config.get("host", "localhost") == "localhost"
+    assert server.get_studio_url().startswith("http://localhost:")

--- a/bindings/python/tests/test_server.py
+++ b/bindings/python/tests/test_server.py
@@ -119,12 +119,17 @@ def test_server_context_manager(temp_server_root):
 
 
 def test_default_host_is_localhost(temp_server_root):
-    """Default host should be localhost; binding to all interfaces must be opt-in."""
+    """Default host should be localhost; binding to all interfaces must be opt-in.
+
+    Asserts on the publicly-observable Studio URL composition; we do not
+    start the server here because that requires a real JVM. The same default
+    host feeds both ``get_studio_url()`` and the underlying ContextConfiguration,
+    so the URL is a faithful proxy for the configured host.
+    """
     from arcadedb_embedded.server import ArcadeDBServer
 
     server = ArcadeDBServer(
         root_path=temp_server_root,
         root_password=TEST_PASSWORD,
     )
-    assert server._config.get("host", "localhost") == "localhost"
     assert server.get_studio_url().startswith("http://localhost:")

--- a/bindings/python/tests/test_server.py
+++ b/bindings/python/tests/test_server.py
@@ -16,7 +16,7 @@ import time
 
 import pytest
 from arcadedb_embedded import ArcadeDBServer
-from tests.conftest import has_server_support
+from tests.conftest import TEST_PASSWORD, has_server_support
 
 
 @pytest.mark.server
@@ -25,7 +25,7 @@ def test_server_creation(temp_server_root):
     """Test creating and starting a server."""
     server = ArcadeDBServer(
         root_path=temp_server_root,
-        root_password="test_password",
+        root_password=TEST_PASSWORD,
         config={"http_port": 2480},
     )
 
@@ -57,7 +57,7 @@ def test_server_database_operations(temp_server_root):
     - Operations within same Python process (embedded access)
     """
     with ArcadeDBServer(
-        root_path=temp_server_root, root_password="test_password"
+        root_path=temp_server_root, root_password=TEST_PASSWORD
     ) as server:
         # Server auto-starts in context manager
         time.sleep(1)
@@ -90,7 +90,7 @@ def test_server_custom_config(temp_server_root):
     config = {"http_port": 8080, "host": "127.0.0.1", "mode": "production"}
 
     server = ArcadeDBServer(
-        root_path=temp_server_root, root_password="test_password", config=config
+        root_path=temp_server_root, root_password=TEST_PASSWORD, config=config
     )
     server.start()
     time.sleep(1)
@@ -105,7 +105,7 @@ def test_server_custom_config(temp_server_root):
 def test_server_context_manager(temp_server_root):
     """Test server context manager."""
     with ArcadeDBServer(
-        root_path=temp_server_root, root_password="test_password"
+        root_path=temp_server_root, root_password=TEST_PASSWORD
     ) as server:
         # Server auto-starts in context manager
         time.sleep(1)
@@ -124,7 +124,7 @@ def test_default_host_is_localhost(temp_server_root):
 
     server = ArcadeDBServer(
         root_path=temp_server_root,
-        root_password="test_password",
+        root_password=TEST_PASSWORD,
     )
     assert server._config.get("host", "localhost") == "localhost"
     assert server.get_studio_url().startswith("http://localhost:")

--- a/bindings/python/tests/test_server_patterns.py
+++ b/bindings/python/tests/test_server_patterns.py
@@ -45,7 +45,7 @@ def cleanup_test_dirs():
             if server.is_started():
                 server.stop()
         except Exception:
-            pass
+            pass  # nosec B110 - best-effort teardown after JVM may be down
 
     # Give servers time to release locks
     time.sleep(0.5)
@@ -55,7 +55,7 @@ def cleanup_test_dirs():
             try:
                 shutil.rmtree(path, ignore_errors=True)
             except Exception:
-                pass
+                pass  # nosec B110 - best-effort temp cleanup
 
 
 def test_server_pattern_recommended(cleanup_test_dirs):
@@ -685,7 +685,7 @@ def test_http_api_access_pattern(cleanup_test_dirs):
     try:
         db.command("sql", "CREATE DOCUMENT TYPE BenchItem")
     except Exception:
-        pass  # Already exists
+        pass  # nosec B110 - type may already exist
 
     # Same mixed operations
     for i in range(num_operations):

--- a/bindings/python/tests/test_server_patterns.py
+++ b/bindings/python/tests/test_server_patterns.py
@@ -17,6 +17,7 @@ import time
 
 import arcadedb_embedded as arcadedb
 import pytest
+from tests.conftest import TEST_PASSWORD
 
 
 @pytest.fixture
@@ -76,9 +77,7 @@ def test_server_pattern_recommended(cleanup_test_dirs):
 
     # Step 1: Start server first
     print("\n1. Starting ArcadeDB server...")
-    server = arcadedb.create_server(
-        root_path=root_path, root_password="test12345"  # Min 8 chars required
-    )
+    server = arcadedb.create_server(root_path=root_path, root_password=TEST_PASSWORD)
     register_server(server)
     server.start()
     print(f"   ✅ Server started on port {server.get_http_port()}")
@@ -132,7 +131,7 @@ def test_server_thread_safety(cleanup_test_dirs):
 
     # Start server and create database
     print("\n1. Setting up server and database...")
-    server = arcadedb.create_server(root_path=root_path, root_password="test12345")
+    server = arcadedb.create_server(root_path=root_path, root_password=TEST_PASSWORD)
     register_server(server)
     server.start()
 
@@ -203,7 +202,7 @@ def test_server_context_manager(cleanup_test_dirs):
 
     # Server automatically starts and stops
     with arcadedb.create_server(
-        root_path=root_path, root_password="test12345"
+        root_path=root_path, root_password=TEST_PASSWORD
     ) as server:
         print("   ✅ Server started (automatic)")
 
@@ -277,7 +276,7 @@ def test_pattern1_embedded_first_requires_close(cleanup_test_dirs):
 
     # Step 4: Start server
     print("\n4. Starting ArcadeDB server...")
-    server = arcadedb.create_server(root_path=root_path, root_password="test12345")
+    server = arcadedb.create_server(root_path=root_path, root_password=TEST_PASSWORD)
     register_server(server)
     server.start()
     print(f"   ✅ Server started on port {server.get_http_port()}")
@@ -405,7 +404,7 @@ def test_embedded_performance_comparison(cleanup_test_dirs):
     print("\n2. Server-Managed Embedded Mode (same process)...")
     server_path = create_temp_dir("server_perf_")
 
-    server = arcadedb.create_server(root_path=server_path, root_password="test12345")
+    server = arcadedb.create_server(root_path=server_path, root_password=TEST_PASSWORD)
     register_server(server)
     server.start()
 
@@ -500,7 +499,7 @@ def test_http_api_access_pattern(cleanup_test_dirs):
 
     # Step 1: Start server (required for HTTP API)
     print("\n1. Starting ArcadeDB server...")
-    server = arcadedb.create_server(root_path=root_path, root_password="test12345")
+    server = arcadedb.create_server(root_path=root_path, root_password=TEST_PASSWORD)
     register_server(server)
     server.start()
     time.sleep(1)  # Give server time to fully start

--- a/bindings/python/tests/test_server_patterns.py
+++ b/bindings/python/tests/test_server_patterns.py
@@ -157,7 +157,8 @@ def test_server_thread_safety(cleanup_test_dirs):
             start = thread_id * 4
             end = start + 4
             result = db.query(
-                "sql", f"SELECT FROM `Item` WHERE id >= {start} AND id < {end}"
+                "sql",
+                f"SELECT FROM `Item` WHERE id >= {start} AND id < {end}",  # nosec B608
             )
             count = len(list(result))
             results.append(f"   Thread {thread_id}: Found {count} items")
@@ -346,18 +347,22 @@ def test_embedded_performance_comparison(cleanup_test_dirs):
 
     # Insert complex data with various data types
     categories = ["Electronics", "Books", "Clothing", "Home", "Sports"]
-    import random
+    import random  # nosec B311 - benchmark uses random for synthetic test data, not security
     from datetime import datetime, timedelta
 
     with db_standalone.transaction():
 
         for i in range(num_records):
             category = categories[i % len(categories)]
-            price = round(random.uniform(10.0, 999.99), 2)
-            created_date = datetime.now() - timedelta(days=random.randint(0, 365))
-            is_active = random.choice([True, False])
+            price = round(random.uniform(10.0, 999.99), 2)  # nosec B311
+            created_date = datetime.now() - timedelta(
+                days=random.randint(0, 365)  # nosec B311
+            )
+            is_active = random.choice([True, False])  # nosec B311
             tags = ",".join(
-                random.choices(["new", "sale", "popular", "limited", "premium"], k=2)
+                random.choices(
+                    ["new", "sale", "popular", "limited", "premium"], k=2
+                )  # nosec B311
             )
 
             db_standalone.command(
@@ -416,11 +421,15 @@ def test_embedded_performance_comparison(cleanup_test_dirs):
     with db_server.transaction():
         for i in range(num_records):
             category = categories[i % len(categories)]
-            price = round(random.uniform(10.0, 999.99), 2)
-            created_date = datetime.now() - timedelta(days=random.randint(0, 365))
-            is_active = random.choice([True, False])
+            price = round(random.uniform(10.0, 999.99), 2)  # nosec B311
+            created_date = datetime.now() - timedelta(
+                days=random.randint(0, 365)  # nosec B311
+            )
+            is_active = random.choice([True, False])  # nosec B311
             tags = ",".join(
-                random.choices(["new", "sale", "popular", "limited", "premium"], k=2)
+                random.choices(
+                    ["new", "sale", "popular", "limited", "premium"], k=2
+                )  # nosec B311
             )
 
             db_server.command(
@@ -578,7 +587,7 @@ def test_http_api_access_pattern(cleanup_test_dirs):
 
     # Benchmark parameters
     num_operations = 100  # Reduced from 1000 for more realistic mixed operations
-    import random
+    import random  # nosec B311 - benchmark uses random for synthetic test data, not security
 
     # --- HTTP API Full CRUD Benchmark ---
     print("\n   6a. HTTP API - Full CRUD operations...")
@@ -603,7 +612,7 @@ def test_http_api_access_pattern(cleanup_test_dirs):
                     "language": "sql",
                     "command": (
                         f"INSERT INTO BenchItem SET id = {i}, "
-                        f"value = {random.randint(1, 1000)}, name = 'Item {i}'"
+                        f"value = {random.randint(1, 1000)}, name = 'Item {i}'"  # nosec B311 B608
                     ),
                 },
                 timeout=30,
@@ -614,8 +623,8 @@ def test_http_api_access_pattern(cleanup_test_dirs):
                 json={
                     "language": "sql",
                     "command": (
-                        f"SELECT FROM BenchItem WHERE "
-                        f"value > {random.randint(1, 500)} LIMIT 10"
+                        f"SELECT FROM BenchItem WHERE "  # nosec B608
+                        f"value > {random.randint(1, 500)} LIMIT 10"  # nosec B311
                     ),
                 },
                 timeout=30,
@@ -626,8 +635,8 @@ def test_http_api_access_pattern(cleanup_test_dirs):
                 json={
                     "language": "sql",
                     "command": (
-                        f"UPDATE BenchItem SET value = {random.randint(1, 1000)} "
-                        f"WHERE id = {random.randint(0, max(1, i-1))}"
+                        f"UPDATE BenchItem SET value = {random.randint(1, 1000)} "  # nosec B608 B311
+                        f"WHERE id = {random.randint(0, max(1, i-1))}"  # nosec B311
                     ),
                 },
                 timeout=30,
@@ -650,8 +659,8 @@ def test_http_api_access_pattern(cleanup_test_dirs):
                 json={
                     "language": "sql",
                     "command": (
-                        f"SELECT FROM BenchItem WHERE name LIKE "
-                        f"'%{random.randint(0, 9)}%' ORDER BY value DESC LIMIT 5"
+                        f"SELECT FROM BenchItem WHERE name LIKE "  # nosec B608
+                        f"'%{random.randint(0, 9)}%' ORDER BY value DESC LIMIT 5"  # nosec B311
                     ),
                 },
                 timeout=30,
@@ -687,21 +696,21 @@ def test_http_api_access_pattern(cleanup_test_dirs):
                 db.command(
                     "sql",
                     f"INSERT INTO BenchItem SET id = {i}, "
-                    f"value = {random.randint(1, 1000)}, name = 'Item {i}'",
+                    f"value = {random.randint(1, 1000)}, name = 'Item {i}'",  # nosec B311 B608
                 )
         elif op_type == 1:  # Query with filter
             result = db.query(
                 "sql",
-                f"SELECT FROM BenchItem WHERE "
-                f"value > {random.randint(1, 500)} LIMIT 10",
+                f"SELECT FROM BenchItem WHERE "  # nosec B608
+                f"value > {random.randint(1, 500)} LIMIT 10",  # nosec B311
             )
             list(result)  # Consume results
         elif op_type == 2:  # Update
             with db.transaction():
                 db.command(
                     "sql",
-                    f"UPDATE BenchItem SET value = {random.randint(1, 1000)} "
-                    f"WHERE id = {random.randint(0, max(1, i-1))}",
+                    f"UPDATE BenchItem SET value = {random.randint(1, 1000)} "  # nosec B608 B311
+                    f"WHERE id = {random.randint(0, max(1, i-1))}",  # nosec B311
                 )
         elif op_type == 3:  # Aggregation query
             result = db.query(
@@ -712,8 +721,8 @@ def test_http_api_access_pattern(cleanup_test_dirs):
         else:  # Complex query
             result = db.query(
                 "sql",
-                f"SELECT FROM BenchItem WHERE name LIKE "
-                f"'%{random.randint(0, 9)}%' ORDER BY value DESC LIMIT 5",
+                f"SELECT FROM BenchItem WHERE name LIKE "  # nosec B608
+                f"'%{random.randint(0, 9)}%' ORDER BY value DESC LIMIT 5",  # nosec B311
             )
             list(result)
 

--- a/bindings/python/tests/test_vector.py
+++ b/bindings/python/tests/test_vector.py
@@ -685,7 +685,7 @@ class TestLSMVectorIndex:
     )
     def test_lsm_vector_delete_and_search_others(self, test_db):
         """Test deleting vertices in a larger dataset and ensuring others are still found."""
-        import random
+        import random  # nosec B311 - synthetic vector data, not security
 
         # Create schema
         test_db.command("sql", "CREATE VERTEX TYPE Doc")
@@ -710,7 +710,7 @@ class TestLSMVectorIndex:
         with test_db.transaction():
             for i in range(num_vectors):
                 # Create random vector
-                vec = [random.random() for _ in range(dims)]
+                vec = [random.random() for _ in range(dims)]  # nosec B311
                 vectors.append(vec)
 
                 test_db.command(

--- a/bindings/python/tests/test_vector_params_verification.py
+++ b/bindings/python/tests/test_vector_params_verification.py
@@ -79,7 +79,7 @@ class TestVectorParams:
                 # Try getter
                 val = metadata.isStoreVectorsInGraph()
             except Exception:
-                pass
+                pass  # nosec B110 - best-effort introspection of Java metadata object
 
         if val is None:
             # Try inspecting the string representation as a fallback for verification

--- a/bindings/python/tests/test_vector_sql.py
+++ b/bindings/python/tests/test_vector_sql.py
@@ -581,11 +581,13 @@ class TestVectorSQL:
             for i in range(num_vectors):
                 vec = [random.random() for _ in range(dims)]  # nosec B311
                 vectors.append(vec)
+                # Embedded literals: the wrapper's _convert_args path supports
+                # only one positional ? per call (numpy/list rebinding); a
+                # multi-? signature would dispatch to JPype as
+                # command(str, str, int, list) which has no Java overload.
                 test_db.command(
                     "sql",
-                    "INSERT INTO DocSql SET id = ?, embedding = ?",
-                    i,
-                    vec,
+                    f"INSERT INTO DocSql SET id = {i}, embedding = {vec}",  # nosec B608
                 )
 
         # Delete every 10th vector

--- a/bindings/python/tests/test_vector_sql.py
+++ b/bindings/python/tests/test_vector_sql.py
@@ -517,8 +517,7 @@ class TestVectorSQL:
             # Should return list of RIDs or similar
             assert len(res) > 0
         except Exception:
-            # Maybe it expects type name?
-            pass
+            pass  # nosec B110 - best-effort probe; index API may expect type name instead
 
     def test_vector_neighbors_accepts_parameterized_index_and_vector(self, test_db):
         """SQL vectorNeighbors should accept bound index and vector parameters."""

--- a/bindings/python/tests/test_vector_sql.py
+++ b/bindings/python/tests/test_vector_sql.py
@@ -548,7 +548,7 @@ class TestVectorSQL:
 
     def test_vector_delete_and_search_others_sql(self, test_db):
         """Test deleting vertices in a larger dataset using SQL."""
-        import random
+        import random  # nosec B311 - synthetic vector data
 
         # Create schema
         test_db.command("sql", "CREATE VERTEX TYPE DocSql")
@@ -580,11 +580,13 @@ class TestVectorSQL:
 
         with test_db.transaction():
             for i in range(num_vectors):
-                vec = [random.random() for _ in range(dims)]
+                vec = [random.random() for _ in range(dims)]  # nosec B311
                 vectors.append(vec)
-                # Insert via SQL using string formatting
                 test_db.command(
-                    "sql", f"INSERT INTO DocSql SET id = {i}, embedding = {vec}"
+                    "sql",
+                    "INSERT INTO DocSql SET id = ?, embedding = ?",
+                    i,
+                    vec,
                 )
 
         # Delete every 10th vector
@@ -592,7 +594,7 @@ class TestVectorSQL:
 
         with test_db.transaction():
             for i in deleted_indices:
-                test_db.command("sql", f"DELETE FROM DocSql WHERE id = {i}")
+                test_db.command("sql", "DELETE FROM DocSql WHERE id = ?", i)
 
         # Verify
         for i in range(num_vectors):
@@ -601,7 +603,8 @@ class TestVectorSQL:
             # Search using projection and ORDER BY alias
             rs = test_db.query(
                 "sql",
-                f"SELECT id, vectorL2Distance(embedding, {vec}) as dist FROM DocSql ORDER BY dist ASC LIMIT 1",
+                # Vector literal is required by vectorL2Distance(); not user input.
+                f"SELECT id, vectorL2Distance(embedding, {vec}) as dist FROM DocSql ORDER BY dist ASC LIMIT 1",  # nosec B608
             )
 
             row = next(rs, None)
@@ -677,7 +680,8 @@ class TestVectorSQL:
         # Using vectorL2Distance for distance calculation
         rs = test_db.query(
             "sql",
-            f"SELECT name, vectorL2Distance(vector, {query_vector}) as dist FROM {doc_type} ORDER BY dist ASC LIMIT 2",
+            # Vector literal is required by vectorL2Distance(); not user input.
+            f"SELECT name, vectorL2Distance(vector, {query_vector}) as dist FROM {doc_type} ORDER BY dist ASC LIMIT 2",  # nosec B608
         )
 
         results = list(rs)

--- a/docs/superpowers/plans/2026-05-05-python-bindings-codacy-fixes.md
+++ b/docs/superpowers/plans/2026-05-05-python-bindings-codacy-fixes.md
@@ -1,0 +1,1457 @@
+# Python Bindings Codacy/Bandit Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the Bandit findings Codacy reports against `bindings/python/` (1192 issues across src/tests/examples) by fixing real defects in production code, parameterizing where practical in tests/examples, configuring Bandit to suppress test/example noise that is not actually unsafe, and wiring Bandit into the existing Python CI workflow as a quality gate.
+
+**Architecture:** Three-PR rollout. PR1 hardens the production library (`src/`) with no `# nosec` allowed except for documented false positives; adds a project-level Bandit config to `pyproject.toml`; and adds a `bandit` job to `.github/workflows/test-python-bindings.yml`. PR2 sweeps the test suite (move shared test password to `conftest.py`, parameterize SQL where reasonable, suppress idiomatic `assert`/`random` noise via configuration). PR3 sweeps `examples/` (one-character SHA1 fix using `usedforsecurity=False`, narrow targeted suppressions for educational SQL/subprocess usage).
+
+**Tech Stack:** Python 3.10+, Bandit 1.9+, pytest, JPype, existing GitHub Actions workflow `test-python-bindings.yml`.
+
+**Verification baseline:**
+- Before any change: `python3 -m bandit -r bindings/python/src` reports `Low: 8, Medium: 3, High: 0`.
+- After PR1 (src + config + CI): `python3 -m bandit -c bindings/python/pyproject.toml -r bindings/python/src` reports `No issues identified`.
+- After PR2 (tests): same command on `bindings/python/tests` reports `No issues identified` at Medium+ confidence and severity.
+- After PR3 (examples): same command on `bindings/python/examples` reports `High: 0` (Low/Medium kept at advisory level only).
+
+---
+
+## File Structure
+
+**Created:**
+- `docs/superpowers/plans/2026-05-05-python-bindings-codacy-fixes.md` (this file)
+
+**Modified - PR1 (src + config + CI):**
+- `bindings/python/pyproject.toml` - add `[tool.bandit]` config, `bandit` to `dev` extras
+- `bindings/python/src/arcadedb_embedded/_logging.py` - new helper module (single responsibility: provide module loggers + a `log_swallowed_exception` helper)
+- `bindings/python/src/arcadedb_embedded/async_executor.py:207-217` - replace try/except/pass with debug log
+- `bindings/python/src/arcadedb_embedded/core.py:903-911` - replace finalizer try/except/pass with narrowed except
+- `bindings/python/src/arcadedb_embedded/graph_batch.py:117-125` - replace nested rollback try/except/pass with debug log
+- `bindings/python/src/arcadedb_embedded/jvm.py:390-396` - replace shutdown try/except/pass with narrowed except
+- `bindings/python/src/arcadedb_embedded/schema.py:684-709, 730-738` - replace probing try/except/pass with debug log
+- `bindings/python/src/arcadedb_embedded/server.py:64, 102-109, 162-167` - safer default host + finalizer logging + nosec on equality check
+- `bindings/python/src/arcadedb_embedded/vector.py:230-244` - annotate documented-false-positive SQL builder with `# nosec`
+- `.github/workflows/test-python-bindings.yml` - new `bandit` job runs on `bindings/python/src` and `bindings/python/tests`
+
+**Modified - PR2 (tests):**
+- `bindings/python/tests/conftest.py` - export `TEST_PASSWORD` constant
+- `bindings/python/tests/test_server.py` - import `TEST_PASSWORD`
+- `bindings/python/tests/test_server_patterns.py` - import `TEST_PASSWORD`; parameterize the bench-loop SQL into `?` placeholders
+- `bindings/python/tests/test_vector_sql.py` - parameterize INSERT/DELETE; annotate the `vectorL2Distance({vec})` literal queries (vector literal is not a value parameter in ArcadeDB SQL)
+- `bindings/python/tests/test_vector.py` - replace `random.random()` with `random.Random(seed).random()` plus nosec where seeded determinism is desired
+
+**Modified - PR3 (examples):**
+- `bindings/python/examples/11_vector_index_build.py:873, 1027` - `hashlib.sha1(..., usedforsecurity=False)`
+- `bindings/python/examples/12_vector_search.py:917, 1122, 1258` - same
+- `bindings/python/examples/download_data.py:192, 652, 1090, 1621, 1704, 2166` - whitelist `https://` schemes before `urlopen`/`iterparse`, then nosec
+- `bindings/python/examples/16_..._graph_ingest.py`, `17_timeseries_end_to_end.py`, `20_graph_algorithms_route_planning.py`, `22_graph_analytical_view_sql.py` - parameterize SQL where ArcadeDB accepts `?`; nosec the rest with a one-line justification
+- `bindings/python/examples/21_server_mode_http_access.py:168` - https whitelist + nosec
+
+---
+
+# PR1 - Production source hardening
+
+## Task 1: Add Bandit config and dev dependency
+
+**Files:**
+- Modify: `bindings/python/pyproject.toml`
+
+- [ ] **Step 1: Verify current Bandit baseline**
+
+Run: `cd bindings/python && python3 -m bandit -r src 2>&1 | tail -8`
+
+Expected:
+```
+Run metrics:
+        Total issues (by severity):
+                Undefined: 0
+                Low: 8
+                Medium: 3
+                High: 0
+```
+
+- [ ] **Step 2: Add bandit to dev extras**
+
+Edit `bindings/python/pyproject.toml`. Locate the `[project.optional-dependencies]` block. Inside the `dev = [` list, add a `"bandit>=1.9.0",` entry just before the closing `]`. The block should read:
+
+```toml
+dev = [
+    "black",
+    "isort",
+    "mypy",
+    "pytest>=7.0.0",
+    "pytest-cov",
+    "numpy>=1.20.0",
+    "bandit>=1.9.0",
+]
+```
+
+- [ ] **Step 3: Add Bandit config section**
+
+Append the following block to the end of `bindings/python/pyproject.toml`:
+
+```toml
+[tool.bandit]
+# Skip recursion into test data and build artifacts.
+exclude_dirs = ["tests/.cache", "build", "dist"]
+
+[tool.bandit.assert_used]
+# Asserts are the standard idiom in pytest; do not flag them in tests/conftest.
+skips = ["**/tests/test_*.py", "**/tests/conftest.py"]
+```
+
+- [ ] **Step 4: Re-run Bandit with the config to confirm it loads**
+
+Run: `cd bindings/python && python3 -m bandit -c pyproject.toml -r src 2>&1 | tail -8`
+
+Expected: same 8 Low / 3 Medium baseline (config does not affect src yet, just confirms the file parses).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bindings/python/pyproject.toml
+git commit -m "build(python): add bandit dev dependency and project config"
+```
+
+---
+
+## Task 2: Add `_logging` helper module
+
+**Files:**
+- Create: `bindings/python/src/arcadedb_embedded/_logging.py`
+- Test: `bindings/python/tests/test_logging_helper.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `bindings/python/tests/test_logging_helper.py`:
+
+```python
+"""Tests for the internal _logging helper."""
+import logging
+
+from arcadedb_embedded._logging import get_logger, log_swallowed_exception
+
+
+def test_get_logger_returns_namespaced_logger():
+    logger = get_logger("arcadedb_embedded.foo")
+    assert isinstance(logger, logging.Logger)
+    assert logger.name == "arcadedb_embedded.foo"
+
+
+def test_log_swallowed_exception_emits_debug(caplog):
+    logger = get_logger("arcadedb_embedded.test")
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        try:
+            raise RuntimeError("boom")
+        except RuntimeError:
+            log_swallowed_exception(logger, "during shutdown")
+
+    records = [r for r in caplog.records if r.name == logger.name]
+    assert len(records) == 1
+    assert records[0].levelno == logging.DEBUG
+    assert "during shutdown" in records[0].getMessage()
+    assert records[0].exc_info is not None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd bindings/python && python3 -m pytest tests/test_logging_helper.py -v`
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'arcadedb_embedded._logging'`
+
+- [ ] **Step 3: Implement the helper**
+
+Create `bindings/python/src/arcadedb_embedded/_logging.py`:
+
+```python
+"""Internal logging helpers for arcadedb_embedded.
+
+Centralises the pattern for swallowing exceptions in finalizers and
+best-effort cleanup paths so the suppression is observable at DEBUG level
+instead of being silently dropped.
+"""
+
+import logging
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a namespaced logger for an arcadedb_embedded submodule."""
+    return logging.getLogger(name)
+
+
+def log_swallowed_exception(logger: logging.Logger, context: str) -> None:
+    """Log the currently-handled exception at DEBUG with full traceback.
+
+    Use only inside an `except` block where the caller has decided the
+    error is non-fatal (e.g. JVM finalizer paths, optional best-effort
+    rollback) and continuing is the right behaviour.
+    """
+    logger.debug("Swallowed exception %s", context, exc_info=True)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd bindings/python && python3 -m pytest tests/test_logging_helper.py -v`
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bindings/python/src/arcadedb_embedded/_logging.py bindings/python/tests/test_logging_helper.py
+git commit -m "feat(python): add internal _logging helper for swallowed exceptions"
+```
+
+---
+
+## Task 3: Replace `try/except/pass` in `async_executor.py`
+
+**Files:**
+- Modify: `bindings/python/src/arcadedb_embedded/async_executor.py:207-217`
+
+- [ ] **Step 1: Verify Bandit currently flags this site**
+
+Run: `cd bindings/python && python3 -m bandit src/arcadedb_embedded/async_executor.py 2>&1 | grep -A1 "B110"`
+
+Expected: shows the issue at line 211.
+
+- [ ] **Step 2: Apply the fix**
+
+In `bindings/python/src/arcadedb_embedded/async_executor.py`, add the import near the top with other relative imports:
+
+```python
+from ._logging import get_logger, log_swallowed_exception
+```
+
+Add a module-level logger immediately after the imports, before the first class definition:
+
+```python
+_LOGGER = get_logger(__name__)
+```
+
+Replace the `is_processing` method body (currently lines 207-217) with:
+
+```python
+    def is_processing(self) -> bool:
+        try:
+            if bool(self._java_async.isProcessing()):
+                return True
+        except Exception:
+            log_swallowed_exception(_LOGGER, "while polling isProcessing()")
+
+        try:
+            return not bool(self._java_async.waitCompletion(0))
+        except Exception:
+            return False
+```
+
+- [ ] **Step 3: Run tests for the affected module**
+
+Run: `cd bindings/python && python3 -m pytest tests/test_async_executor.py -v`
+
+Expected: all tests pass (behaviour unchanged).
+
+- [ ] **Step 4: Verify Bandit no longer flags this file**
+
+Run: `cd bindings/python && python3 -m bandit src/arcadedb_embedded/async_executor.py`
+
+Expected: `No issues identified.`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bindings/python/src/arcadedb_embedded/async_executor.py
+git commit -m "fix(python): log swallowed exception in AsyncExecutor.is_processing"
+```
+
+---
+
+## Task 4: Replace `try/except/pass` in `graph_batch.py`
+
+**Files:**
+- Modify: `bindings/python/src/arcadedb_embedded/graph_batch.py:117-125`
+
+- [ ] **Step 1: Apply the fix**
+
+In `bindings/python/src/arcadedb_embedded/graph_batch.py`, add at the top with other relative imports:
+
+```python
+from ._logging import get_logger, log_swallowed_exception
+```
+
+Add module-level logger after imports:
+
+```python
+_LOGGER = get_logger(__name__)
+```
+
+Locate the inner rollback `try`/`except` (around line 117-122). Replace:
+
+```python
+        except Exception as e:
+            if started_transaction:
+                try:
+                    self._java_db.rollback()
+                except Exception:
+                    pass
+            raise ArcadeDBError(
+                f"Failed to create batch vertex of type '{type_name}': {e}"
+            ) from e
+```
+
+with:
+
+```python
+        except Exception as e:
+            if started_transaction:
+                try:
+                    self._java_db.rollback()
+                except Exception:
+                    log_swallowed_exception(_LOGGER, "during batch vertex rollback")
+            raise ArcadeDBError(
+                f"Failed to create batch vertex of type '{type_name}': {e}"
+            ) from e
+```
+
+- [ ] **Step 2: Run the affected tests**
+
+Run: `cd bindings/python && python3 -m pytest tests/test_graph_batch.py -v`
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Verify Bandit no longer flags this file**
+
+Run: `cd bindings/python && python3 -m bandit src/arcadedb_embedded/graph_batch.py`
+
+Expected: `No issues identified.`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bindings/python/src/arcadedb_embedded/graph_batch.py
+git commit -m "fix(python): log swallowed exception in GraphBatch rollback path"
+```
+
+---
+
+## Task 5: Narrow `try/except` in `core.py` finalizer
+
+**Files:**
+- Modify: `bindings/python/src/arcadedb_embedded/core.py:903-911`
+
+- [ ] **Step 1: Apply the fix**
+
+In `bindings/python/src/arcadedb_embedded/core.py`, replace:
+
+```python
+    def __del__(self):
+        """Finalizer - ensure database is closed when object is garbage collected."""
+        try:
+            if not self._closed and self._java_db is not None:
+                self._close_async_executors()
+                self._java_db.close()
+                self._closed = True
+        except Exception:
+            pass  # Ignore errors during garbage collection
+```
+
+with:
+
+```python
+    def __del__(self):
+        """Finalizer - ensure database is closed when object is garbage collected.
+
+        Errors during garbage collection are intentionally suppressed: the
+        interpreter is shutting down and logging may already be unavailable,
+        so we narrow the catch to AttributeError/RuntimeError that JPype can
+        raise when the JVM has been torn down before this finalizer runs.
+        """
+        try:
+            if not self._closed and self._java_db is not None:
+                self._close_async_executors()
+                self._java_db.close()
+                self._closed = True
+        except (AttributeError, RuntimeError):
+            # JVM or referenced attributes already gone; nothing to do.
+            return
+```
+
+- [ ] **Step 2: Run the affected tests**
+
+Run: `cd bindings/python && python3 -m pytest tests/test_core.py tests/test_concurrency.py -v`
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Verify Bandit no longer flags this file**
+
+Run: `cd bindings/python && python3 -m bandit src/arcadedb_embedded/core.py`
+
+Expected: `No issues identified.`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bindings/python/src/arcadedb_embedded/core.py
+git commit -m "fix(python): narrow Database.__del__ finalizer exception handling"
+```
+
+---
+
+## Task 6: Narrow `try/except` in `jvm.py` shutdown
+
+**Files:**
+- Modify: `bindings/python/src/arcadedb_embedded/jvm.py:390-396`
+
+- [ ] **Step 1: Apply the fix**
+
+In `bindings/python/src/arcadedb_embedded/jvm.py`, replace:
+
+```python
+def shutdown_jvm():
+    """Shutdown JVM if it was started by this module."""
+    if jpype.isJVMStarted():
+        try:
+            jpype.shutdownJVM()
+        except Exception:
+            pass  # Ignore errors during shutdown
+```
+
+with:
+
+```python
+def shutdown_jvm():
+    """Shutdown JVM if it was started by this module.
+
+    JPype can raise RuntimeError when the JVM is already mid-shutdown or
+    has been detached from the calling thread; in that case there is
+    nothing left for us to do.
+    """
+    if jpype.isJVMStarted():
+        try:
+            jpype.shutdownJVM()
+        except RuntimeError:
+            return
+```
+
+- [ ] **Step 2: Run the affected tests**
+
+Run: `cd bindings/python && python3 -m pytest tests/test_jvm_args.py -v`
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Verify Bandit no longer flags this file**
+
+Run: `cd bindings/python && python3 -m bandit src/arcadedb_embedded/jvm.py`
+
+Expected: `No issues identified.`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bindings/python/src/arcadedb_embedded/jvm.py
+git commit -m "fix(python): narrow shutdown_jvm exception handling to RuntimeError"
+```
+
+---
+
+## Task 7: Replace `try/except/pass` in `schema.py` (3 sites)
+
+**Files:**
+- Modify: `bindings/python/src/arcadedb_embedded/schema.py:684-709, 730-738`
+
+- [ ] **Step 1: Apply the fix**
+
+In `bindings/python/src/arcadedb_embedded/schema.py`, add the relative import alongside existing imports:
+
+```python
+from ._logging import get_logger, log_swallowed_exception
+```
+
+Add module-level logger after imports:
+
+```python
+_LOGGER = get_logger(__name__)
+```
+
+Replace the three `except Exception: pass` blocks. For lines 684-695 (inner sub-index probe inside `_find_vector_index`):
+
+```python
+                        try:
+                            sub_indexes = java_index.getSubIndexes()
+                            if sub_indexes and not sub_indexes.isEmpty():
+                                first_sub = sub_indexes.get(0)
+                                if "LSMVectorIndex" in first_sub.getClass().getName():
+                                    props = java_index.getPropertyNames()
+                                    if len(props) == 1 and props[0] == vector_property:
+                                        return VectorIndex(java_index, self._db)
+                        except Exception:
+                            log_swallowed_exception(_LOGGER, "while inspecting TypeIndex sub-indexes")
+```
+
+For lines 700-704 (outer iteration in same method):
+
+```python
+            except Exception:
+                log_swallowed_exception(_LOGGER, "while iterating schema indexes")
+```
+
+For lines 730-738 (`list_vector_indexes` inner sub-index probe):
+
+```python
+                    try:
+                        sub_indexes = java_index.getSubIndexes()
+                        if sub_indexes and not sub_indexes.isEmpty():
+                            first_sub = sub_indexes.get(0)
+                            if "LSMVectorIndex" in first_sub.getClass().getName():
+                                indexes.append(java_index.getName())
+                    except Exception:
+                        log_swallowed_exception(_LOGGER, "while listing vector indexes")
+```
+
+- [ ] **Step 2: Run the affected tests**
+
+Run: `cd bindings/python && python3 -m pytest tests/test_schema.py tests/test_vector.py tests/test_vector_sql.py -v`
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Verify Bandit no longer flags this file**
+
+Run: `cd bindings/python && python3 -m bandit src/arcadedb_embedded/schema.py`
+
+Expected: `No issues identified.`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bindings/python/src/arcadedb_embedded/schema.py
+git commit -m "fix(python): log swallowed exceptions in vector-index discovery"
+```
+
+---
+
+## Task 8: Fix `server.py` bind default and finalizer
+
+**Files:**
+- Modify: `bindings/python/src/arcadedb_embedded/server.py:64, 102-109, 162-167`
+
+- [ ] **Step 1: Write the failing test for the safer default**
+
+Append to `bindings/python/tests/test_server.py`:
+
+```python
+def test_default_host_is_localhost(temp_server_root):
+    """Default host should be localhost; binding to all interfaces must be opt-in."""
+    from arcadedb_embedded.server import ArcadeDBServer
+
+    server = ArcadeDBServer(
+        root_path=temp_server_root,
+        root_password="test_password",
+    )
+    assert server._config.get("host", "localhost") == "localhost"
+    assert server.get_studio_url().startswith("http://localhost:")
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd bindings/python && python3 -m pytest tests/test_server.py::test_default_host_is_localhost -v`
+
+Expected: FAIL because the current default is `"0.0.0.0"`.
+
+- [ ] **Step 3: Apply the fix**
+
+In `bindings/python/src/arcadedb_embedded/server.py`:
+
+Add the relative import alongside other imports:
+
+```python
+from ._logging import get_logger, log_swallowed_exception
+```
+
+Add module-level logger after imports:
+
+```python
+_LOGGER = get_logger(__name__)
+```
+
+Replace line 64:
+
+```python
+        host = self._config.get("host", "0.0.0.0")
+```
+
+with:
+
+```python
+        # Default to loopback; callers must opt in to "0.0.0.0" explicitly to
+        # expose the server on all interfaces.
+        host = self._config.get("host", "localhost")
+```
+
+Replace the `__del__` finalizer (lines 102-109):
+
+```python
+    def __del__(self):
+        """Finalizer - ensure server is stopped."""
+        try:
+            if self._started and self._java_server is not None:
+                self._java_server.stop()
+                self._started = False
+        except Exception:
+            pass  # Ignore errors during garbage collection
+```
+
+with:
+
+```python
+    def __del__(self):
+        """Finalizer - ensure server is stopped.
+
+        See Database.__del__ for rationale on the narrowed except clause.
+        """
+        try:
+            if self._started and self._java_server is not None:
+                self._java_server.stop()
+                self._started = False
+        except (AttributeError, RuntimeError):
+            return
+```
+
+For the equality check at line 165 (false positive: it is comparing, not binding), annotate it:
+
+```python
+        host = self._config.get("host", "localhost")
+        if host == "0.0.0.0":  # nosec B104 - equality comparison, not a bind
+            host = "localhost"
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd bindings/python && python3 -m pytest tests/test_server.py -v`
+
+Expected: all tests pass, including the new `test_default_host_is_localhost`.
+
+- [ ] **Step 5: Verify Bandit no longer flags this file**
+
+Run: `cd bindings/python && python3 -m bandit src/arcadedb_embedded/server.py`
+
+Expected: `No issues identified.`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add bindings/python/src/arcadedb_embedded/server.py bindings/python/tests/test_server.py
+git commit -m "fix(python): default server host to localhost and harden finalizer"
+```
+
+---
+
+## Task 9: Annotate `vector.py` SQL builder false positive
+
+**Files:**
+- Modify: `bindings/python/src/arcadedb_embedded/vector.py:230-244`
+
+- [ ] **Step 1: Verify the query is in fact parameterized**
+
+Run: `cd bindings/python && grep -n "SELECT.*query_vector" src/arcadedb_embedded/vector.py`
+
+Expected: shows the `key` is bound via `?` and `quoted_vector_property`/`quoted_type_name`/`quoted_id_property` come from `_quote_identifier`.
+
+- [ ] **Step 2: Apply the annotation**
+
+In `bindings/python/src/arcadedb_embedded/vector.py`, replace the `result = self._database.query(...)` block (around lines 237-244):
+
+```python
+        if result is None:
+            result = self._database.query(
+                "sql",
+                (
+                    f"SELECT {quoted_vector_property} AS `query_vector` FROM {quoted_type_name} "
+                    f"WHERE {quoted_id_property} = ? LIMIT 1"
+                ),
+                key,
+            ).first()
+```
+
+with:
+
+```python
+        if result is None:
+            # Identifiers are quoted via _quote_identifier(); the user-supplied
+            # `key` is passed as a `?` parameter, so this is not SQL injection.
+            result = self._database.query(
+                "sql",
+                (  # nosec B608
+                    f"SELECT {quoted_vector_property} AS `query_vector` FROM {quoted_type_name} "
+                    f"WHERE {quoted_id_property} = ? LIMIT 1"
+                ),
+                key,
+            ).first()
+```
+
+- [ ] **Step 3: Run the affected tests**
+
+Run: `cd bindings/python && python3 -m pytest tests/test_vector.py -v -k "lookup_by_key or query_vector"`
+
+Expected: all matching tests pass.
+
+- [ ] **Step 4: Verify Bandit no longer flags the file**
+
+Run: `cd bindings/python && python3 -m bandit src/arcadedb_embedded/vector.py`
+
+Expected: `No issues identified.`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bindings/python/src/arcadedb_embedded/vector.py
+git commit -m "fix(python): annotate vector lookup query as parameterized"
+```
+
+---
+
+## Task 10: Verify whole-of-`src/` is clean
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run Bandit against the whole src tree**
+
+Run: `cd bindings/python && python3 -m bandit -c pyproject.toml -r src 2>&1 | tail -10`
+
+Expected:
+```
+Run metrics:
+        Total issues (by severity):
+                Undefined: 0
+                Low: 0
+                Medium: 0
+                High: 0
+```
+
+- [ ] **Step 2: Run the full Python test suite**
+
+Run: `cd bindings/python && python3 -m pytest -x`
+
+Expected: all tests pass.
+
+---
+
+## Task 11: Wire Bandit into CI
+
+**Files:**
+- Modify: `.github/workflows/test-python-bindings.yml`
+
+- [ ] **Step 1: Add a `bandit` job**
+
+In `.github/workflows/test-python-bindings.yml`, locate the `jobs:` section and add a new top-level job *before* the existing `download-jars:` job (so it runs in parallel and acts as a fast gate):
+
+```yaml
+  bandit:
+    name: Bandit security scan (bindings/python)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Bandit
+        run: python -m pip install "bandit>=1.9.0"
+
+      - name: Run Bandit on src and tests (must be clean)
+        working-directory: bindings/python
+        run: python -m bandit -c pyproject.toml -r src tests --severity-level low --confidence-level low
+
+      - name: Run Bandit on examples (informational, must have no High findings)
+        working-directory: bindings/python
+        run: python -m bandit -c pyproject.toml -r examples --severity-level high --confidence-level high
+```
+
+- [ ] **Step 2: Validate workflow syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test-python-bindings.yml'))"`
+
+Expected: no output (valid YAML).
+
+- [ ] **Step 3: Dry-run the same Bandit invocations locally**
+
+Run: `cd bindings/python && python3 -m bandit -c pyproject.toml -r src tests --severity-level low --confidence-level low`
+
+Expected: at this point in PR1 the `src` portion is clean but `tests` still reports the test-side findings. **This is expected to fail this command in PR1.** Document this in the commit message and do not fail the PR locally; the workflow gate becomes effective once PR2 lands. Adjust the workflow temporarily to scan only `src` for now:
+
+Replace the "Run Bandit on src and tests" step with:
+
+```yaml
+      - name: Run Bandit on src (must be clean)
+        working-directory: bindings/python
+        run: python -m bandit -c pyproject.toml -r src --severity-level low --confidence-level low
+```
+
+Note: PR2 will broaden this to include `tests`, and PR3 will drop the `--severity-level high` to medium for examples once they are cleaned up.
+
+- [ ] **Step 4: Re-run the local check matching the workflow**
+
+Run: `cd bindings/python && python3 -m bandit -c pyproject.toml -r src --severity-level low --confidence-level low`
+
+Expected: `No issues identified.`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/test-python-bindings.yml
+git commit -m "ci(python): add Bandit security scan job for bindings/python/src"
+```
+
+---
+
+# PR2 - Test suite cleanup
+
+## Task 12: Centralise `TEST_PASSWORD` in `conftest.py`
+
+**Files:**
+- Modify: `bindings/python/tests/conftest.py`
+- Modify: `bindings/python/tests/test_server.py`
+- Modify: `bindings/python/tests/test_server_patterns.py`
+
+- [ ] **Step 1: Add the constant**
+
+Append the following near the top of `bindings/python/tests/conftest.py`, after the existing imports:
+
+```python
+# Shared test password used by server-mode tests. ArcadeDB requires >= 8 chars.
+# Hardcoded test fixture, not a real credential.
+TEST_PASSWORD = "test12345"  # nosec B105 - test fixture
+```
+
+- [ ] **Step 2: Update `test_server.py` to use the constant**
+
+In `bindings/python/tests/test_server.py`, add the import (top of file, after existing imports):
+
+```python
+from .conftest import TEST_PASSWORD
+```
+
+Then replace every occurrence of `root_password="test_password"` with `root_password=TEST_PASSWORD`. (There are 4 occurrences at approximately lines 28, 60, 93, 108.)
+
+- [ ] **Step 3: Update `test_server_patterns.py` to use the constant**
+
+In `bindings/python/tests/test_server_patterns.py`, add the import:
+
+```python
+from .conftest import TEST_PASSWORD
+```
+
+Then replace every occurrence of `root_password="test12345"` with `root_password=TEST_PASSWORD`. (There are 6 occurrences at approximately lines 80, 135, 206, 280, 408, 503; remove the trailing `# Min 8 chars required` comment from line 80 since the constant doc-string covers it.)
+
+- [ ] **Step 4: Run the affected tests**
+
+Run: `cd bindings/python && python3 -m pytest tests/test_server.py tests/test_server_patterns.py -v -k "not benchmark"`
+
+Expected: all tests pass (or are skipped on platforms without server support, as before).
+
+- [ ] **Step 5: Verify Bandit no longer flags B106 in tests**
+
+Run: `cd bindings/python && python3 -m bandit -c pyproject.toml -r tests 2>&1 | grep -c B106`
+
+Expected: `0`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add bindings/python/tests/conftest.py bindings/python/tests/test_server.py bindings/python/tests/test_server_patterns.py
+git commit -m "test(python): centralise TEST_PASSWORD constant in conftest"
+```
+
+---
+
+## Task 13: Parameterize bench-loop SQL in `test_server_patterns.py`
+
+**Files:**
+- Modify: `bindings/python/tests/test_server_patterns.py:625-720`
+
+- [ ] **Step 1: Replace string-formatted SQL with `?` placeholders**
+
+In `bindings/python/tests/test_server_patterns.py`, locate the bench loop (approximately lines 625-720). Replace each SQL `f"..."` with parameter binding. Concretely, change the four formatted commands:
+
+From:
+```python
+                    "command": (
+                        f"UPDATE BenchItem SET value = {random.randint(1, 1000)} "
+                        f"WHERE id = {random.randint(0, max(1, i-1))}"
+                    ),
+```
+
+to:
+```python
+                    "command": "UPDATE BenchItem SET value = ? WHERE id = ?",
+                    "params": [random.randint(1, 1000), random.randint(0, max(1, i - 1))],
+```
+
+(Adjust the dict construction wherever the test infra reads `command`/`params`. Do the same for the SELECT-LIKE, INSERT, second UPDATE, second SELECT-LIKE, and SELECT-WHERE-value occurrences in the file.)
+
+The `random.randint` calls remain - they are seeded test data generation, not security-relevant. Add a top-of-file marker once:
+
+```python
+# random is used to generate synthetic benchmark data; not for security.
+import random  # nosec B311
+```
+
+- [ ] **Step 2: Run the affected tests**
+
+Run: `cd bindings/python && python3 -m pytest tests/test_server_patterns.py -v`
+
+Expected: all tests pass; bench loop produces equivalent output.
+
+- [ ] **Step 3: Verify Bandit issues drop**
+
+Run: `cd bindings/python && python3 -m bandit -c pyproject.toml tests/test_server_patterns.py 2>&1 | tail -8`
+
+Expected: no B608 entries; B311 is now masked by the `# nosec` on the import line.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bindings/python/tests/test_server_patterns.py
+git commit -m "test(python): parameterize bench SQL and annotate seeded random"
+```
+
+---
+
+## Task 14: Parameterize INSERT/DELETE in `test_vector_sql.py`
+
+**Files:**
+- Modify: `bindings/python/tests/test_vector_sql.py:580-610, 670-690`
+
+- [ ] **Step 1: Apply the parameterization**
+
+In `bindings/python/tests/test_vector_sql.py`, replace the INSERT and DELETE in the `with test_db.transaction():` block (approximately lines 588-595):
+
+From:
+```python
+                test_db.command(
+                    "sql", f"INSERT INTO DocSql SET id = {i}, embedding = {vec}"
+                )
+        ...
+                test_db.command("sql", f"DELETE FROM DocSql WHERE id = {i}")
+```
+
+to:
+```python
+                test_db.command(
+                    "sql",
+                    "INSERT INTO DocSql SET id = ?, embedding = ?",
+                    i,
+                    vec,
+                )
+        ...
+                test_db.command("sql", "DELETE FROM DocSql WHERE id = ?", i)
+```
+
+For the two `vectorL2Distance(embedding, {vec})` SELECTs (approximately lines 602-604 and 678-680): ArcadeDB SQL does not bind list literals as `?` parameters in distance functions, so leave the literal but annotate:
+
+```python
+            rs = test_db.query(
+                "sql",
+                # Vector literal is required by vectorL2Distance(); not user input.
+                f"SELECT id, vectorL2Distance(embedding, {vec}) as dist FROM DocSql ORDER BY dist ASC LIMIT 1",  # nosec B608
+            )
+```
+
+Add a single top-of-file annotation for `random` if not already present:
+
+```python
+import random  # nosec B311 - synthetic vector data
+```
+
+- [ ] **Step 2: Run the affected tests**
+
+Run: `cd bindings/python && python3 -m pytest tests/test_vector_sql.py -v`
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Verify Bandit results**
+
+Run: `cd bindings/python && python3 -m bandit -c pyproject.toml tests/test_vector_sql.py 2>&1 | grep -E "B608|B311" | wc -l`
+
+Expected: `0` (the remaining occurrences are masked by `# nosec`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bindings/python/tests/test_vector_sql.py
+git commit -m "test(python): parameterize vector INSERT/DELETE; annotate distance literals"
+```
+
+---
+
+## Task 15: Annotate `random` usage in `test_vector.py`
+
+**Files:**
+- Modify: `bindings/python/tests/test_vector.py:710-715`
+
+- [ ] **Step 1: Apply the annotation**
+
+In `bindings/python/tests/test_vector.py`, find the `import random` statement at the top of the file. Append `# nosec B311 - synthetic vector data, not security` to that line. If `random` is imported as part of a multi-import, split it onto its own line first.
+
+- [ ] **Step 2: Run the affected tests**
+
+Run: `cd bindings/python && python3 -m pytest tests/test_vector.py -v -k "not benchmark"`
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add bindings/python/tests/test_vector.py
+git commit -m "test(python): annotate seeded random data generation as nosec B311"
+```
+
+---
+
+## Task 15a: Annotate remaining `try/except/pass` and subprocess findings in tests
+
+**Files:**
+- Modify: `bindings/python/tests/conftest.py:55`
+- Modify: `bindings/python/tests/test_async_executor.py:107`
+- Modify: `bindings/python/tests/test_core.py:423`
+- Modify: `bindings/python/tests/test_docs_examples.py:4, 67`
+- Modify: `bindings/python/tests/test_exporter.py:884`
+- Modify: `bindings/python/tests/test_jvm_args.py:112`
+- Modify: `bindings/python/tests/test_server_patterns.py:46, 56, 679`
+- Modify: `bindings/python/tests/test_vector_params_verification.py:81`
+- Modify: `bindings/python/tests/test_vector_sql.py:519`
+
+- [ ] **Step 1: Generate the current location list**
+
+Run: `cd bindings/python && python3 -m bandit -c pyproject.toml -r tests -t B110,B603,B404,B108 2>&1 | grep "Location:"`
+
+Expected: the 12 locations listed in this task's Files section.
+
+- [ ] **Step 2: Annotate or narrow each `try/except/pass`**
+
+For each `B110` site (the lines other than `test_docs_examples.py:4` and `test_jvm_args.py:112`):
+
+- If the swallowed cleanup is intentional (most are best-effort cleanup in fixtures/teardown), narrow the exception class to the specific JPype/OS error expected (e.g. `RuntimeError`, `OSError`, `PermissionError`) and remove the bare `except Exception`.
+- If narrowing is impractical (Java exception types may be unavailable when the JVM is down), keep the bare `except Exception` but replace `pass` with a short `# nosec B110` comment explaining the cleanup intent: e.g. `pass  # nosec B110 - best-effort teardown after JVM may be down`.
+
+Concrete example for `tests/conftest.py:55` (cleanup retry loop):
+
+```python
+        try:
+            shutil.rmtree(temp_dir)
+        except PermissionError:
+            # On Windows, files might still be locked by Java process
+            time.sleep(1)
+            try:
+                shutil.rmtree(temp_dir)
+            except OSError:
+                pass  # nosec B110 - best-effort temp cleanup; pytest tmp will be reaped
+```
+
+- [ ] **Step 3: Annotate `subprocess` import (B404) in `test_docs_examples.py`**
+
+Edit line 4:
+
+```python
+import subprocess  # nosec B404 - launching Python interpreter to run example scripts
+```
+
+- [ ] **Step 4: Annotate `subprocess.run` call (B603) in `test_docs_examples.py:67`**
+
+Append `# nosec B603 - argv built from script paths and constants, not user input` to the `subprocess.run(...)` call.
+
+- [ ] **Step 5: Annotate `tempfile.gettempdir()` usage (B108) in `test_jvm_args.py:112`**
+
+Append a short comment justifying the hardcoded temp directory:
+
+```python
+        ...,  # nosec B108 - using a stable temp path is required by JPype's argv contract
+```
+
+- [ ] **Step 6: Run the affected tests**
+
+Run: `cd bindings/python && python3 -m pytest tests/conftest.py tests/test_async_executor.py tests/test_core.py tests/test_docs_examples.py tests/test_exporter.py tests/test_jvm_args.py tests/test_server_patterns.py tests/test_vector_params_verification.py tests/test_vector_sql.py -v -k "not benchmark"`
+
+Expected: all tests pass (or are appropriately skipped).
+
+- [ ] **Step 7: Verify Bandit on tests/ is clean**
+
+Run: `cd bindings/python && python3 -m bandit -c pyproject.toml -r tests 2>&1 | tail -8`
+
+Expected: `Total issues: 0` across all severities.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add bindings/python/tests/
+git commit -m "test(python): annotate teardown try/except and subprocess usage"
+```
+
+---
+
+## Task 16: Verify whole-of-`tests/` is clean and broaden CI gate
+
+**Files:**
+- Modify: `.github/workflows/test-python-bindings.yml`
+
+- [ ] **Step 1: Confirm tests are clean at medium+ level**
+
+Run: `cd bindings/python && python3 -m bandit -c pyproject.toml -r tests --severity-level medium --confidence-level medium 2>&1 | tail -8`
+
+Expected: `Total issues (by severity): Low: 0, Medium: 0, High: 0`. (Some Low-confidence Low items may remain - acceptable.)
+
+- [ ] **Step 2: Confirm tests are clean at low level too**
+
+Run: `cd bindings/python && python3 -m bandit -c pyproject.toml -r tests 2>&1 | tail -8`
+
+Expected: `Total issues: 0` across all severities (B101 is masked via `assert_used.skips`, B106 via constant, B608 parameterised or annotated, B311 annotated).
+
+- [ ] **Step 3: Broaden the CI step to include tests**
+
+In `.github/workflows/test-python-bindings.yml`, replace the step added in Task 11:
+
+```yaml
+      - name: Run Bandit on src (must be clean)
+        working-directory: bindings/python
+        run: python -m bandit -c pyproject.toml -r src --severity-level low --confidence-level low
+```
+
+with:
+
+```yaml
+      - name: Run Bandit on src and tests (must be clean)
+        working-directory: bindings/python
+        run: python -m bandit -c pyproject.toml -r src tests --severity-level low --confidence-level low
+```
+
+- [ ] **Step 4: Validate workflow syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test-python-bindings.yml'))"`
+
+Expected: no output.
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `cd bindings/python && python3 -m pytest -x`
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/test-python-bindings.yml
+git commit -m "ci(python): require Bandit-clean tests in addition to src"
+```
+
+---
+
+# PR3 - Examples cleanup
+
+## Task 17: Fix SHA1 high-severity findings
+
+**Files:**
+- Modify: `bindings/python/examples/11_vector_index_build.py:873, 1027`
+- Modify: `bindings/python/examples/12_vector_search.py:917, 1122, 1258`
+
+- [ ] **Step 1: Apply the `usedforsecurity=False` flag**
+
+For each of the five locations, replace the `hashlib.sha1(<bytes>).hexdigest()` call with `hashlib.sha1(<bytes>, usedforsecurity=False).hexdigest()`.
+
+Concretely, in `bindings/python/examples/11_vector_index_build.py`:
+
+Replace line 873:
+```python
+    digest = hashlib.sha1(str(db_path).encode("utf-8")).hexdigest()[:10]
+```
+with:
+```python
+    digest = hashlib.sha1(str(db_path).encode("utf-8"), usedforsecurity=False).hexdigest()[:10]
+```
+
+Apply the same transformation at line 1027 in the same file, and at lines 917, 1122, 1258 in `12_vector_search.py`.
+
+- [ ] **Step 2: Verify no behaviour change**
+
+Run: `cd bindings/python && python3 -c "import hashlib; assert hashlib.sha1(b'x').hexdigest() == hashlib.sha1(b'x', usedforsecurity=False).hexdigest()"`
+
+Expected: no output (assertion passes - the digest is byte-identical, only the security-intent annotation changes).
+
+- [ ] **Step 3: Verify Bandit no longer reports High severity**
+
+Run: `cd bindings/python && python3 -m bandit -c pyproject.toml -r examples --severity-level high 2>&1 | tail -8`
+
+Expected: `Total issues (by severity): Low: 0, Medium: 0, High: 0`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bindings/python/examples/11_vector_index_build.py bindings/python/examples/12_vector_search.py
+git commit -m "examples(python): mark SHA1 short-digest as usedforsecurity=False"
+```
+
+---
+
+## Task 18: Whitelist HTTPS schemes in `download_data.py` and `21_server_mode_http_access.py`
+
+**Files:**
+- Modify: `bindings/python/examples/download_data.py:192, 652, 1090, 1621, 1704, 2166`
+- Modify: `bindings/python/examples/21_server_mode_http_access.py:168`
+
+- [ ] **Step 1: Add a scheme guard helper near the top of `download_data.py`**
+
+After the imports at the top of `bindings/python/examples/download_data.py`, add:
+
+```python
+def _require_https(url: str) -> str:
+    """Reject non-HTTPS URLs before opening them.
+
+    Bandit B310 flags urlopen() because it permits file:// and custom schemes.
+    Examples download from a fixed list of HTTPS dataset URLs, so we enforce
+    that contract explicitly here.
+    """
+    if not url.startswith("https://"):
+        raise ValueError(f"Refusing to open non-HTTPS URL: {url!r}")
+    return url
+```
+
+For each `urlopen`/`urlretrieve` call site (lines 192, 652, 1090, 1621, 1704, 2166), wrap the URL argument in `_require_https(...)` and append `# nosec B310` to the call:
+
+```python
+    request = urllib.request.Request(_require_https(url), headers=headers)
+    with urllib.request.urlopen(request, timeout=60) as response:  # nosec B310 - https-only
+```
+
+The two `ET.iterparse(xml_path, ...)` lines (1090, 2166) need a different remediation: the file came from a checksum-verified ZIP earlier in the script. Switch the import:
+
+```python
+import xml.etree.ElementTree as ET  # nosec B405 - parsing files we just downloaded over HTTPS and verified
+```
+
+and annotate each `iterparse` call:
+
+```python
+    context = ET.iterparse(xml_path, events=("start", "end"))  # nosec B314 - input is a downloaded, checksum-verified file
+```
+
+- [ ] **Step 2: Repeat the HTTPS guard in `21_server_mode_http_access.py`**
+
+In `bindings/python/examples/21_server_mode_http_access.py`, line 168, add an inline check just before the `urlopen` call:
+
+```python
+    if not request.full_url.startswith(("http://localhost", "http://127.0.0.1", "https://")):
+        raise ValueError(f"Refusing to call unexpected URL: {request.full_url!r}")
+    try:
+        with urlopen(request, timeout=timeout) as response:  # nosec B310 - localhost or https
+```
+
+- [ ] **Step 3: Smoke-test the example imports**
+
+Run: `cd bindings/python && python3 -c "import importlib.util, pathlib; [importlib.util.spec_from_file_location('m', p).loader.exec_module(importlib.util.module_from_spec(importlib.util.spec_from_file_location('m', p))) for p in [pathlib.Path('examples/download_data.py'), pathlib.Path('examples/21_server_mode_http_access.py')]]" 2>&1 | head`
+
+Expected: no syntax errors. (Examples are not part of the unit test suite, so this only checks the file parses and imports.)
+
+- [ ] **Step 4: Verify Bandit no longer flags B310/B314**
+
+Run: `cd bindings/python && python3 -m bandit -c pyproject.toml examples/download_data.py examples/21_server_mode_http_access.py 2>&1 | grep -E "B310|B314" | wc -l`
+
+Expected: `0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bindings/python/examples/download_data.py bindings/python/examples/21_server_mode_http_access.py
+git commit -m "examples(python): enforce https-only URL fetches and annotate XML parse"
+```
+
+---
+
+## Task 19: Parameterize/annotate SQL f-strings in numbered examples
+
+**Files:**
+- Modify: `bindings/python/examples/16_import_database_vs_transactional_graph_ingest.py:168, 249`
+- Modify: `bindings/python/examples/17_timeseries_end_to_end.py:340`
+- Modify: `bindings/python/examples/20_graph_algorithms_route_planning.py:287, 758`
+- Modify: `bindings/python/examples/22_graph_analytical_view_sql.py:544, 563, 580`
+
+- [ ] **Step 1: Parameterize where ArcadeDB accepts `?`**
+
+For `16_..._graph_ingest.py:168`, change:
+
+```python
+    row = query_one_or_none(
+        db.query("sql", f"SELECT FROM {vertex_type} WHERE Id = {vertex_id}")
+    )
+```
+
+to:
+
+```python
+    row = query_one_or_none(
+        db.query(
+            "sql",
+            # Type name is a constant from this script; Id is bound as parameter.
+            f"SELECT FROM {vertex_type} WHERE Id = ?",  # nosec B608 - identifier from literal
+            vertex_id,
+        )
+    )
+```
+
+For `17_timeseries_end_to_end.py:339-345`, parameterize the value bindings:
+
+```python
+                "sql",
+                "SELECT FROM SensorReading "
+                "WHERE ts BETWEEN ? AND ? "
+                "AND sensor_id = ? AND building = ? "
+                "ORDER BY ts",
+                raw_window_start,
+                raw_window_end,
+                focus_sensor.sensor_id,
+                focus_sensor.building,
+            )
+```
+
+- [ ] **Step 2: Annotate the rest with one-line justifications**
+
+For each remaining f-string SQL where the interpolated values are constants/types from the script and not user input - `16_..._graph_ingest.py:249`, `20_graph_algorithms_route_planning.py:287, 758`, `22_graph_analytical_view_sql.py:544, 563, 580` - append `# nosec B608` to the offending line and add a one-line comment above it stating the interpolated values are static (e.g. `# vertex_type and aggregate fields are script constants, not user input.`).
+
+Concrete example for `22_graph_analytical_view_sql.py:544`:
+
+```python
+    # origin_code is a script-local constant from the demo dataset.
+    rs = db.query(
+        "sql",
+        f"""
+        SELECT count(*) AS destination_count FROM (
+            MATCH {{type: City, as: src, where: (code = '{origin_code}')}}
+                  -ROAD->
+                  {{type: City, as: mid}}
+                  -ROAD->
+                  {{type: City, as: dst}}
+            RETURN DISTINCT dst.code AS code
+        )
+        """,  # nosec B608 - demo-data constants only
+    )
+```
+
+- [ ] **Step 3: Verify the examples still parse and import**
+
+Run: `cd bindings/python && python3 -m py_compile examples/16_import_database_vs_transactional_graph_ingest.py examples/17_timeseries_end_to_end.py examples/20_graph_algorithms_route_planning.py examples/22_graph_analytical_view_sql.py`
+
+Expected: no output (all four compile).
+
+- [ ] **Step 4: Verify Bandit Medium count drops**
+
+Run: `cd bindings/python && python3 -m bandit -c pyproject.toml -r examples --severity-level medium --confidence-level medium 2>&1 | tail -8`
+
+Expected: `Medium: 0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bindings/python/examples/16_import_database_vs_transactional_graph_ingest.py bindings/python/examples/17_timeseries_end_to_end.py bindings/python/examples/20_graph_algorithms_route_planning.py bindings/python/examples/22_graph_analytical_view_sql.py
+git commit -m "examples(python): parameterize timeseries SQL; annotate demo-data SQL"
+```
+
+---
+
+## Task 20: Annotate remaining example findings
+
+**Files:**
+- Modify: any `bindings/python/examples/*.py` that still has B603/B607/B311/B110/B112/B105/B404/B403 findings
+
+- [ ] **Step 1: Generate a fresh report scoped to remaining items**
+
+Run: `cd bindings/python && python3 -m bandit -c pyproject.toml -r examples 2>&1 | grep "Location:" | sort -u`
+
+Expected: a list of remaining file:line locations.
+
+- [ ] **Step 2: Annotate each remaining site**
+
+For each line in the report:
+
+- B603/B607 (subprocess): add `# nosec B603 B607 - launching <tool name> with literal argv` to the `subprocess.run(...)` call.
+- B311 (random): on the `import random` line, append `# nosec B311 - synthetic data`.
+- B110/B112 (try/except/pass or continue): replace with a top-of-file `from arcadedb_embedded._logging import get_logger` (examples already depend on the package) plus a `_LOGGER.debug(...)` call - or, if logging is overkill for the example, narrow the exception to a specific class.
+- B105 (hardcoded password string): if the constant is named `*PASSWORD*` and is a sample value, append `# nosec B105 - sample password`.
+- B404/B403 (subprocess/pickle import): add `# nosec` next to the import with a brief justification.
+
+- [ ] **Step 3: Verify Bandit Low count is now informational only**
+
+Run: `cd bindings/python && python3 -m bandit -c pyproject.toml -r examples --severity-level low --confidence-level high 2>&1 | tail -8`
+
+Expected: `Total issues: 0` at high confidence; some low-confidence Low items may remain.
+
+- [ ] **Step 4: Tighten the CI gate for examples**
+
+In `.github/workflows/test-python-bindings.yml`, the `bandit` job currently has:
+
+```yaml
+      - name: Run Bandit on examples (informational, must have no High findings)
+        working-directory: bindings/python
+        run: python -m bandit -c pyproject.toml -r examples --severity-level high --confidence-level high
+```
+
+Change to:
+
+```yaml
+      - name: Run Bandit on examples (must be clean at medium+/high-confidence)
+        working-directory: bindings/python
+        run: python -m bandit -c pyproject.toml -r examples --severity-level medium --confidence-level high
+```
+
+- [ ] **Step 5: Validate workflow syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test-python-bindings.yml'))"`
+
+Expected: no output.
+
+- [ ] **Step 6: Run the local CI equivalent**
+
+Run: `cd bindings/python && python3 -m bandit -c pyproject.toml -r src tests --severity-level low --confidence-level low && python3 -m bandit -c pyproject.toml -r examples --severity-level medium --confidence-level high`
+
+Expected: both commands exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add bindings/python/examples .github/workflows/test-python-bindings.yml
+git commit -m "examples(python): annotate remaining bandit findings; tighten CI gate"
+```
+
+---
+
+## Task 21: Final whole-tree verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full Python test suite**
+
+Run: `cd bindings/python && python3 -m pytest -x`
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run the full CI Bandit equivalent**
+
+Run: `cd bindings/python && python3 -m bandit -c pyproject.toml -r src tests --severity-level low --confidence-level low && python3 -m bandit -c pyproject.toml -r examples --severity-level medium --confidence-level high`
+
+Expected: both invocations exit 0; final report shows `No issues identified.` on the strict run and only Low/low-confidence items on examples.
+
+- [ ] **Step 3: Compare against initial baseline**
+
+Run: `cd bindings/python && python3 -m bandit -r src tests examples 2>&1 | tail -10`
+
+Expected: substantial drop from the original `Low: 1067, Medium: 120, High: 5` to single-digit Low items in examples (informational), with `Medium: 0, High: 0`.
+
+---
+
+## Plan complete
+
+**Saved to:** `docs/superpowers/plans/2026-05-05-python-bindings-codacy-fixes.md`
+
+**Suggested PR boundaries:**
+- PR1: Tasks 1-11 (production code + CI gate for src)
+- PR2: Tasks 12-16 (test suite cleanup + broaden CI gate)
+- PR3: Tasks 17-21 (examples cleanup + final CI gate)


### PR DESCRIPTION
## Summary

Eliminates the Codacy/Bandit findings in `bindings/python/` and adds a CI gate to prevent regression. Plan documented at `docs/superpowers/plans/2026-05-05-python-bindings-codacy-fixes.md`.

**Bandit posture before vs. after:**

| Scope | Before | After |
|---|---|---|
| `src/` | 8 Low, 3 Medium, 0 High | 0 / 0 / 0 |
| `tests/` | 929 Low, 20 Medium, 0 High | 0 / 0 / 0 |
| `examples/` | 130 Low, 97 Medium, 5 High | 0 medium-severity high-confidence (informational Low items remain by design) |

## What changed

- **Production source (`src/`)**: New `_logging` helper module replaces silent `try/except/pass` swallowing with debug-level traceback logging across `async_executor`, `graph_batch`, `core` (`__del__`), `jvm` (`shutdown_jvm`), `schema`, and `server`. Finalizers narrowed from bare `except Exception` to `(AttributeError, RuntimeError)`. `ArcadeDBServer` default host changed from `0.0.0.0` to `localhost` (callers must opt in to bind on all interfaces). One annotated false-positive in `vector.py` where the SQL identifiers are quoted via `_quote_identifier()` and the user key is passed as a `?` parameter.
- **Tests (`tests/`)**: `TEST_PASSWORD` constant centralised in `conftest.py`. Vector INSERT/DELETE in `test_vector_sql.py` now parameterized with `?`. Bench-loop SQL in `test_server_patterns.py` annotated (parameterizing would change the workload being measured). Idiomatic `assert` statements skipped via `[tool.bandit] skips = ["B101"]`.
- **Examples (`examples/`)**: SHA1 short-digests now use `usedforsecurity=False`. URL fetches in `download_data.py` and `21_server_mode_http_access.py` are HTTPS-validated via a `_require_https()` guard. SQL string-builds in numbered demos either parameterized (`17_timeseries_end_to_end.py`) or annotated where interpolated values are script constants.
- **CI**: New `bandit` job in `.github/workflows/test-python-bindings.yml` runs in parallel with the existing test matrix. Two gates:
  - `src` + `tests`: must be clean at low-severity / low-confidence.
  - `examples`: must be clean at medium-severity / high-confidence.

## In-flight discoveries

- `exclude_dirs = ["build", ...]` in bandit's pyproject config was substring-matching `examples/11_vector_index_build.py`. Fixed by anchoring patterns with `/`.
- Bandit 1.9 does not honour `[tool.bandit.assert_used] skips` from pyproject.toml; switched to global `skips = ["B101"]`. Safe because `src/` has no `assert` statements.

## Test plan

- [ ] CI `bandit` job passes on Linux runner
- [ ] CI `test` matrix continues to pass on linux/amd64, linux/arm64, darwin/arm64, windows/amd64 across Python 3.10-3.14
- [ ] `Server.__del__` still tears down cleanly when JVM is already detached (covered by existing teardown tests)
- [ ] `ArcadeDBServer(root_password=...)` defaults to localhost; explicit `host="0.0.0.0"` still works for opt-in (covered by new `test_default_host_is_localhost`)
- [ ] Local verification: `python3 -m bandit -c bindings/python/pyproject.toml -r bindings/python/src bindings/python/tests --severity-level low --confidence-level low` exits 0
- [ ] Local verification: `python3 -m bandit -c bindings/python/pyproject.toml -r bindings/python/examples --severity-level medium --confidence-level high` exits 0

## Reviewing

The 21 commits map 1:1 to plan tasks and group naturally into 3 logical phases at boundaries `27da10759` (end of src+CI), `c8121a024` (end of tests), and `fdfda61cd` (end of examples). Reviewers can read the commits in order and stop at any boundary.