### PR TITLE
#4092 fix(cypher): anonymous middle node in multi-hop chain matches rows

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/plan/LogicalPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/plan/LogicalPlan.java
@@ -138,10 +138,12 @@ public class LogicalPlan {
     final String[] nodeVars = new String[nodePatterns.size()];
     for (int i = 0; i < nodePatterns.size(); i++) {
       final NodePattern np = nodePatterns.get(i);
-      if (np.getVariable() != null) {
-        nodeVars[i] = np.getVariable();
-        if (!nodes.containsKey(np.getVariable()))
-          nodes.put(np.getVariable(), new LogicalNode(np.getVariable(), np.getLabels(), np.getProperties()));
+      final String variable = np.getVariable();
+      if (variable != null) {
+        nodeVars[i] = variable;
+        if (!nodes.containsKey(variable)) {
+          nodes.put(variable, new LogicalNode(variable, np.getLabels(), np.getProperties()));
+        }
       } else {
         nodeVars[i] = "  __anon" + anonNodeCounter++;
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/plan/LogicalPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/plan/LogicalPlan.java
@@ -50,6 +50,7 @@ public class LogicalPlan {
   private final List<LogicalRelationship> relationships;
   private final List<WhereClause> whereFilters;
   private final ReturnClause returnClause;
+  private int anonNodeCounter = 0;
 
   private LogicalPlan(final CypherStatement statement) {
     this.statement = statement;
@@ -119,34 +120,40 @@ public class LogicalPlan {
 
   /**
    * Extracts nodes and relationships from a single path pattern.
+   * Anonymous nodes (no variable) receive a synthetic internal name so that
+   * consecutive hops can refer to the same intermediate vertex, but they are
+   * NOT added to the nodes map. Only named nodes go into the map so that the
+   * AnchorSelector keeps its existing behavior (anonymous-only patterns fall
+   * back via an empty nodes map, which is relied on by count push-down).
+   * The synthetic prefix "  __anon" (two leading spaces) mirrors the convention
+   * in CypherExecutionPlan and cannot collide with user-defined variable names.
    */
   private void extractPathPattern(final PathPattern pathPattern) {
     final List<NodePattern> nodePatterns = pathPattern.getNodes();
     final List<RelationshipPattern> relPatterns = pathPattern.getRelationships();
 
-    // Extract nodes
-    for (final NodePattern nodePattern : nodePatterns) {
-      final String variable = nodePattern.getVariable();
-      if (variable != null && !nodes.containsKey(variable)) {
-        final LogicalNode logicalNode = new LogicalNode(
-            variable,
-            nodePattern.getLabels(),
-            nodePattern.getProperties()
-        );
-        nodes.put(variable, logicalNode);
+    // Assign a variable name to every node.
+    // Named nodes are registered in the nodes map for AnchorSelector.
+    // Anonymous nodes receive a synthetic name for relationship tracking only.
+    final String[] nodeVars = new String[nodePatterns.size()];
+    for (int i = 0; i < nodePatterns.size(); i++) {
+      final NodePattern np = nodePatterns.get(i);
+      if (np.getVariable() != null) {
+        nodeVars[i] = np.getVariable();
+        if (!nodes.containsKey(np.getVariable()))
+          nodes.put(np.getVariable(), new LogicalNode(np.getVariable(), np.getLabels(), np.getProperties()));
+      } else {
+        nodeVars[i] = "  __anon" + anonNodeCounter++;
       }
     }
 
-    // Extract relationships (linking nodes)
+    // Extract relationships using the resolved (never-null) variable names.
     for (int i = 0; i < relPatterns.size(); i++) {
       final RelationshipPattern relPattern = relPatterns.get(i);
-      final NodePattern sourceNode = nodePatterns.get(i);
-      final NodePattern targetNode = nodePatterns.get(i + 1);
-
       final LogicalRelationship logicalRel = new LogicalRelationship(
           relPattern.getVariable(),
-          sourceNode.getVariable(),
-          targetNode.getVariable(),
+          nodeVars[i],
+          nodeVars[i + 1],
           relPattern.getTypes(),
           relPattern.getDirection(),
           relPattern.getProperties(),

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue4092AnonMiddleNodeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue4092AnonMiddleNodeTest.java
@@ -46,15 +46,17 @@ class Issue4092AnonMiddleNodeTest {
     database.getSchema().createVertexType("Person");
     database.getSchema().createVertexType("City");
     database.getSchema().createVertexType("Country");
+    database.getSchema().createVertexType("Region");
     database.getSchema().createEdgeType("KNOWS");
     database.getSchema().createEdgeType("LOCATED_IN");
+    database.getSchema().createEdgeType("BELONGS_TO");
 
     database.transaction(() -> {
       database.command("opencypher",
-          "CREATE (:Person {name:'Alice'}), (:City {name:'New York'}), (:Country {name:'USA'})");
+          "CREATE (:Person {name:'Alice'}), (:City {name:'New York'}), (:Country {name:'USA'}), (:Region {name:'North America'})");
       database.command("opencypher",
-          "MATCH (a:Person {name:'Alice'}), (c:City {name:'New York'}), (u:Country {name:'USA'}) " +
-              "CREATE (a)-[:KNOWS]->(c), (c)-[:LOCATED_IN]->(u)");
+          "MATCH (a:Person {name:'Alice'}), (c:City {name:'New York'}), (u:Country {name:'USA'}), (r:Region {name:'North America'}) " +
+              "CREATE (a)-[:KNOWS]->(c), (c)-[:LOCATED_IN]->(u), (u)-[:BELONGS_TO]->(r)");
     });
   }
 
@@ -127,6 +129,61 @@ class Issue4092AnonMiddleNodeTest {
       rs.forEachRemaining(rows::add);
       assertThat(rows).hasSize(1);
       assertThat((String) rows.get(0).getProperty("person_name")).isEqualTo("Alice");
+    }
+  }
+
+  /**
+   * Three-hop chain with two consecutive anonymous middle nodes: synthetic
+   * names assigned to each anonymous position must be distinct, otherwise
+   * the second middle would overwrite the first in the row.
+   */
+  @Test
+  void threeHopChainWithTwoConsecutiveAnonMiddleNodes() {
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Person)-[:KNOWS]->(:City)-[:LOCATED_IN]->(:Country)-[:BELONGS_TO]->(r:Region) " +
+            "RETURN a.name AS person_name, r.name AS region_name")) {
+      final List<Result> rows = new ArrayList<>();
+      rs.forEachRemaining(rows::add);
+      assertThat(rows).hasSize(1);
+      assertThat((String) rows.get(0).getProperty("person_name")).isEqualTo("Alice");
+      assertThat((String) rows.get(0).getProperty("region_name")).isEqualTo("North America");
+    }
+  }
+
+  /**
+   * OPTIONAL MATCH with anonymous middle node must match the row when the data
+   * exists, exercising the OPTIONAL MATCH path through the optimizer.
+   */
+  @Test
+  void optionalMatchWithAnonMiddleNode() {
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Person) " +
+            "OPTIONAL MATCH (a)-[:KNOWS]->(:City)-[:LOCATED_IN]->(b:Country) " +
+            "RETURN a.name AS person_name, b.name AS country_name")) {
+      final List<Result> rows = new ArrayList<>();
+      rs.forEachRemaining(rows::add);
+      assertThat(rows).hasSize(1);
+      assertThat((String) rows.get(0).getProperty("person_name")).isEqualTo("Alice");
+      assertThat((String) rows.get(0).getProperty("country_name")).isEqualTo("USA");
+    }
+  }
+
+  /**
+   * Two separate MATCH clauses each with their own anonymous nodes: the
+   * synthetic counter must advance across clauses so distinct anonymous
+   * positions receive distinct internal names.
+   */
+  @Test
+  void multipleMatchClausesEachWithAnonNodes() {
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Person)-[:KNOWS]->(:City) " +
+            "MATCH (:City)-[:LOCATED_IN]->(b:Country) " +
+            "RETURN a.name AS person_name, b.name AS country_name")) {
+      final List<Result> rows = new ArrayList<>();
+      rs.forEachRemaining(rows::add);
+      assertThat(rows).hasSize(1);
+      assertThat((String) rows.get(0).getProperty("person_name")).isEqualTo("Alice");
+      assertThat((String) rows.get(0).getProperty("country_name")).isEqualTo("USA");
     }
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue4092AnonMiddleNodeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue4092AnonMiddleNodeTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test: anonymous middle node in a linear multi-hop chain must match rows.
+ * <p>
+ * (a:Person)-[:KNOWS]-&gt;(:City)-[:LOCATED_IN]-&gt;(b:Country) must return the same
+ * rows as the equivalent pattern with a named middle node.
+ */
+class Issue4092AnonMiddleNodeTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/issue4092-anon-middle-node").create();
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createVertexType("City");
+    database.getSchema().createVertexType("Country");
+    database.getSchema().createEdgeType("KNOWS");
+    database.getSchema().createEdgeType("LOCATED_IN");
+
+    database.transaction(() -> {
+      database.command("opencypher",
+          "CREATE (:Person {name:'Alice'}), (:City {name:'New York'}), (:Country {name:'USA'})");
+      database.command("opencypher",
+          "MATCH (a:Person {name:'Alice'}), (c:City {name:'New York'}), (u:Country {name:'USA'}) " +
+              "CREATE (a)-[:KNOWS]->(c), (c)-[:LOCATED_IN]->(u)");
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    database.drop();
+  }
+
+  /** Anonymous middle node: two-hop chain must match the one row. */
+  @Test
+  void twoHopChainWithAnonMiddleNode() {
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Person)-[:KNOWS]->(:City)-[:LOCATED_IN]->(b:Country) " +
+            "RETURN a.name AS person_name, b.name AS country_name")) {
+      final List<Result> rows = new ArrayList<>();
+      rs.forEachRemaining(rows::add);
+      assertThat(rows).hasSize(1);
+      assertThat((String) rows.get(0).getProperty("person_name")).isEqualTo("Alice");
+      assertThat((String) rows.get(0).getProperty("country_name")).isEqualTo("USA");
+    }
+  }
+
+  /** Named middle node must match the same row (control case). */
+  @Test
+  void twoHopChainWithNamedMiddleNode() {
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Person)-[:KNOWS]->(c:City)-[:LOCATED_IN]->(b:Country) " +
+            "RETURN a.name AS person_name, b.name AS country_name")) {
+      final List<Result> rows = new ArrayList<>();
+      rs.forEachRemaining(rows::add);
+      assertThat(rows).hasSize(1);
+      assertThat((String) rows.get(0).getProperty("person_name")).isEqualTo("Alice");
+      assertThat((String) rows.get(0).getProperty("country_name")).isEqualTo("USA");
+    }
+  }
+
+  /** Anonymous middle node with aggregation: collect(a.name) must work. */
+  @Test
+  void twoHopChainAnonMiddleNodeWithAggregation() {
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Person)-[:KNOWS]->(:City)-[:LOCATED_IN]->(b:Country) " +
+            "RETURN b.name AS country_name, collect(a.name) AS people")) {
+      final List<Result> rows = new ArrayList<>();
+      rs.forEachRemaining(rows::add);
+      assertThat(rows).hasSize(1);
+      assertThat((String) rows.get(0).getProperty("country_name")).isEqualTo("USA");
+      final List<?> people = (List<?>) rows.get(0).getProperty("people");
+      assertThat(people.stream().map(Object::toString).toList()).containsExactly("Alice");
+    }
+  }
+
+  /** Anonymous source node in a single hop must still match. */
+  @Test
+  void singleHopWithAnonSourceNode() {
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (:Person)-[:KNOWS]->(c:City) RETURN c.name AS city_name")) {
+      final List<Result> rows = new ArrayList<>();
+      rs.forEachRemaining(rows::add);
+      assertThat(rows).hasSize(1);
+      assertThat((String) rows.get(0).getProperty("city_name")).isEqualTo("New York");
+    }
+  }
+
+  /** Anonymous target node in a single hop must still match. */
+  @Test
+  void singleHopWithAnonTargetNode() {
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Person)-[:KNOWS]->(:City) RETURN a.name AS person_name")) {
+      final List<Result> rows = new ArrayList<>();
+      rs.forEachRemaining(rows::add);
+      assertThat(rows).hasSize(1);
+      assertThat((String) rows.get(0).getProperty("person_name")).isEqualTo("Alice");
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #4092. A linear Cypher chain with an anonymous middle node returned 0 rows on `26.4.x`, while the equivalent named-middle-node pattern matched correctly.

`LogicalPlan.extractPathPattern` stored anonymous nodes as `null` in the `LogicalRelationship` source/target variables. `ExpandAll.execute` skips storing the traversed vertex when `targetVariable` is `null`, so the next hop read `null` as its source and dropped every row.

## Fix

Anonymous nodes now receive a synthetic internal name (prefix `"  __anon"`) so consecutive hops can refer to the same intermediate vertex. Named nodes still go into the `nodes` map for `AnchorSelector`; anonymous nodes get the synthetic name in relationships only, preserving the count push-down optimization for fully-anonymous patterns.

## Test plan

- [x] New `Issue4092AnonMiddleNodeTest` covers anonymous middle node, named middle node (control), aggregation with `collect()`, anonymous source, anonymous target
- [x] `GAVEligibilityTest` (42 tests) - count push-down behavior preserved
- [x] `OpenCypherStackOverflowWorkloadTest` (23 tests) - including previously-known-failing `query9_topBadges` with anonymous source
- [x] Broader OpenCypher regression suite (369 tests) passes (1 unrelated pre-existing failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)