### PR TITLE
#4095 fix(cypher): anonymous directed rel patterns must not reuse the same edge

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/ExpandAll.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/ExpandAll.java
@@ -57,6 +57,9 @@ public class ExpandAll extends AbstractPhysicalOperator {
   // Cypher relationship uniqueness applies only within a single MATCH clause, so this
   // scoping prevents blocking valid cross-clause edge reuse.
   private Set<String> sameClausePrecedingRelVars;
+  // Synthetic row property name under which to stash this hop's edge when edgeVariable
+  // is null but the edge is still needed by later same-clause hops for the uniqueness check.
+  private String edgeTrackingVar;
 
   public ExpandAll(final PhysicalOperator child, final String sourceVariable,
                   final String edgeVariable, final String targetVariable,
@@ -78,6 +81,10 @@ public class ExpandAll extends AbstractPhysicalOperator {
    */
   public void setSameClausePrecedingRelVars(final Set<String> sameClausePrecedingRelVars) {
     this.sameClausePrecedingRelVars = sameClausePrecedingRelVars;
+  }
+
+  public void setEdgeTrackingVar(final String edgeTrackingVar) {
+    this.edgeTrackingVar = edgeTrackingVar;
   }
 
   public void setTargetLabel(final String targetLabel) {
@@ -172,6 +179,8 @@ public class ExpandAll extends AbstractPhysicalOperator {
 
             if (edgeVariable != null) {
               result.setProperty(edgeVariable, edge);
+            } else if (edgeTrackingVar != null) {
+              result.setProperty(edgeTrackingVar, edge);
             }
             if (targetVariable != null) {
               result.setProperty(targetVariable, targetVertex);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
@@ -250,23 +250,19 @@ public class CypherOptimizer {
           break;
         }
       if (hasUntyped) {
+        // Untyped hops match any edge type, so every hop in the clause may collide.
         needs.addAll(clauseRels);
         continue;
       }
 
-      outer:
-      for (int i = 0; i < clauseRels.size(); i++) {
-        for (int j = 0; j < clauseRels.size(); j++) {
-          if (i == j)
-            continue;
-          for (final String type : clauseRels.get(i).getTypes()) {
-            if (clauseRels.get(j).getTypes().contains(type)) {
-              needs.add(clauseRels.get(i));
-              continue outer;
-            }
-          }
-        }
-      }
+      final Map<String, List<LogicalRelationship>> byType = new HashMap<>();
+      for (final LogicalRelationship rel : clauseRels)
+        for (final String type : rel.getTypes())
+          byType.computeIfAbsent(type, k -> new ArrayList<>()).add(rel);
+
+      for (final List<LogicalRelationship> sharingType : byType.values())
+        if (sharingType.size() > 1)
+          needs.addAll(sharingType);
     }
     return needs;
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/CypherOptimizer.java
@@ -226,6 +226,52 @@ public class CypherOptimizer {
   }
 
   /**
+   * Returns the relationships that must store their edge in the row so subsequent
+   * same-clause hops can enforce Cypher relationship uniqueness. A hop is included
+   * when another hop in the same MATCH clause shares an edge type or either is untyped.
+   */
+  private Set<LogicalRelationship> computeNeedsEdgeTracking(final List<LogicalRelationship> orderedRels) {
+    if (orderedRels.size() <= 1)
+      return Collections.emptySet();
+
+    final Map<Integer, List<LogicalRelationship>> byClause = new HashMap<>();
+    for (final LogicalRelationship rel : orderedRels)
+      byClause.computeIfAbsent(rel.getClauseIndex(), k -> new ArrayList<>()).add(rel);
+
+    final Set<LogicalRelationship> needs = new HashSet<>();
+    for (final List<LogicalRelationship> clauseRels : byClause.values()) {
+      if (clauseRels.size() <= 1)
+        continue;
+
+      boolean hasUntyped = false;
+      for (final LogicalRelationship rel : clauseRels)
+        if (rel.getTypes().isEmpty()) {
+          hasUntyped = true;
+          break;
+        }
+      if (hasUntyped) {
+        needs.addAll(clauseRels);
+        continue;
+      }
+
+      outer:
+      for (int i = 0; i < clauseRels.size(); i++) {
+        for (int j = 0; j < clauseRels.size(); j++) {
+          if (i == j)
+            continue;
+          for (final String type : clauseRels.get(i).getTypes()) {
+            if (clauseRels.get(j).getTypes().contains(type)) {
+              needs.add(clauseRels.get(i));
+              continue outer;
+            }
+          }
+        }
+      }
+    }
+    return needs;
+  }
+
+  /**
    * Builds a logical plan from the Cypher AST.
    *
    * @return logical plan
@@ -345,6 +391,9 @@ public class CypherOptimizer {
     PhysicalOperator currentOp = anchorOperator;
     final Map<Integer, Set<String>> relVarsPerClause = new HashMap<>();
 
+    final Set<LogicalRelationship> needsEdgeTracking = computeNeedsEdgeTracking(orderedRels);
+    int syntheticEdgeVarCounter = 0;
+
     for (final LogicalRelationship rel : orderedRels) {
       final Set<String> sameClausePreceding = relVarsPerClause.getOrDefault(
           rel.getClauseIndex(), Collections.emptySet());
@@ -357,6 +406,17 @@ public class CypherOptimizer {
         // Use ExpandAll for unbounded patterns
         currentOp = createExpandAllOperator(rel, currentOp, boundVariables, sameClausePreceding);
 
+        // Must run before addTargetLabelFilter wraps currentOp.
+        if ((rel.getVariable() == null || rel.getVariable().isEmpty())
+            && needsEdgeTracking.contains(rel)
+            && currentOp instanceof ExpandAll expand) {
+          final String synVar = "  anon_e_" + (syntheticEdgeVarCounter++);
+          expand.setEdgeTrackingVar(synVar);
+          relVarsPerClause
+              .computeIfAbsent(rel.getClauseIndex(), k -> new HashSet<>())
+              .add(synVar);
+        }
+
         // Add label filter for target vertex if required
         currentOp = addTargetLabelFilter(logicalPlan, rel, currentOp);
       }
@@ -365,7 +425,7 @@ public class CypherOptimizer {
       boundVariables.add(rel.getSourceVariable());
       boundVariables.add(rel.getTargetVariable());
 
-      // Track this relationship variable for subsequent hops in the same clause
+      // Track named relationship variables for subsequent hops in the same clause
       if (rel.getVariable() != null && !rel.getVariable().isEmpty()) {
         relVarsPerClause
             .computeIfAbsent(rel.getClauseIndex(), k -> new HashSet<>())

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue4095DirectedRelReuseIsomorphismTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue4095DirectedRelReuseIsomorphismTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for GitHub issue #4095.
+ * <p>
+ * Consecutive directed relationship patterns with anonymous (unnamed) relationship variables
+ * must not reuse the same relationship for two different positions in the same MATCH pattern.
+ * <p>
+ * For {@code (s)<-[:KNOWS]-(f)-[:KNOWS]->(d)}, the two KNOWS slots must always bind
+ * to distinct edges — returning (Alice,Bob,Alice) or (Charlie,Bob,Charlie) is invalid.
+ */
+class Issue4095DirectedRelReuseIsomorphismTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/testopencypher-4095").create();
+    database.getSchema().createVertexType("Person4095");
+    database.getSchema().createEdgeType("KNOWS4095");
+    database.transaction(() -> {
+      // Diverging graph: Bob has two outgoing KNOWS edges (to Alice and Charlie)
+      database.command("opencypher",
+          "CREATE (:Person4095 {name:'Alice'})<-[:KNOWS4095]-(:Person4095 {name:'Bob'})-[:KNOWS4095]->(:Person4095 {name:'Charlie'})");
+      // Converging graph: Dave and Frank both have outgoing KNOWS edges to Eve
+      database.command("opencypher",
+          "CREATE (:Person4095 {name:'Dave'})-[:KNOWS4095]->(:Person4095 {name:'Eve'})<-[:KNOWS4095]-(:Person4095 {name:'Frank'})");
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  /**
+   * Diverging anonymous directed pattern: same edge must not fill both outgoing slots.
+   * Bob has edges to Alice and Charlie; Alice,Bob,Alice and Charlie,Bob,Charlie are invalid.
+   */
+  @Test
+  void divergingAnonymousDirectedDoesNotReuseRelationship() {
+    final ResultSet result = database.query("opencypher",
+        """
+            MATCH (s:Person4095)<-[:KNOWS4095]-(f:Person4095)-[:KNOWS4095]->(d:Person4095)
+            WHERE f.name = 'Bob'
+            RETURN s.name AS s, f.name AS f, d.name AS d
+            ORDER BY s, d""");
+
+    final List<Result> rows = collect(result);
+    assertThat(rows).hasSize(2);
+
+    assertThat((String) rows.get(0).getProperty("s")).isEqualTo("Alice");
+    assertThat((String) rows.get(0).getProperty("f")).isEqualTo("Bob");
+    assertThat((String) rows.get(0).getProperty("d")).isEqualTo("Charlie");
+
+    assertThat((String) rows.get(1).getProperty("s")).isEqualTo("Charlie");
+    assertThat((String) rows.get(1).getProperty("f")).isEqualTo("Bob");
+    assertThat((String) rows.get(1).getProperty("d")).isEqualTo("Alice");
+  }
+
+  /**
+   * Converging anonymous directed pattern: same edge must not fill both incoming slots.
+   * Both Dave and Frank point to Eve; (Dave,Eve,Dave) and (Frank,Eve,Frank) are invalid.
+   */
+  @Test
+  void convergingAnonymousDirectedDoesNotReuseRelationship() {
+    final ResultSet result = database.query("opencypher",
+        """
+            MATCH (p1:Person4095)-[:KNOWS4095]->(p2:Person4095)<-[:KNOWS4095]-(p3:Person4095)
+            WHERE p2.name = 'Eve'
+            RETURN p1.name AS p1, p2.name AS p2, p3.name AS p3
+            ORDER BY p1, p3""");
+
+    final List<Result> rows = collect(result);
+    assertThat(rows).hasSize(2);
+
+    assertThat((String) rows.get(0).getProperty("p1")).isEqualTo("Dave");
+    assertThat((String) rows.get(0).getProperty("p2")).isEqualTo("Eve");
+    assertThat((String) rows.get(0).getProperty("p3")).isEqualTo("Frank");
+
+    assertThat((String) rows.get(1).getProperty("p1")).isEqualTo("Frank");
+    assertThat((String) rows.get(1).getProperty("p2")).isEqualTo("Eve");
+    assertThat((String) rows.get(1).getProperty("p3")).isEqualTo("Dave");
+  }
+
+  /**
+   * Aggregate on diverging pattern must not be doubled by spurious self-reuse rows.
+   * count(d) must equal 2, not 4.
+   */
+  @Test
+  void divergingAnonymousDirectedCountIsCorrect() {
+    final ResultSet result = database.query("opencypher",
+        """
+            MATCH (s:Person4095)<-[:KNOWS4095]-(f:Person4095)-[:KNOWS4095]->(d:Person4095)
+            WHERE f.name = 'Bob'
+            RETURN count(d) AS c""");
+
+    final List<Result> rows = collect(result);
+    assertThat(rows).hasSize(1);
+    assertThat(((Number) rows.get(0).getProperty("c")).longValue()).isEqualTo(2L);
+  }
+
+  /**
+   * Aggregate on converging pattern must not be doubled by spurious self-reuse rows.
+   * count(p1) must equal 2, not 4.
+   */
+  @Test
+  void convergingAnonymousDirectedCountIsCorrect() {
+    final ResultSet result = database.query("opencypher",
+        """
+            MATCH (p1:Person4095)-[:KNOWS4095]->(p2:Person4095)<-[:KNOWS4095]-(p3:Person4095)
+            WHERE p2.name = 'Eve'
+            RETURN count(p1) AS c""");
+
+    final List<Result> rows = collect(result);
+    assertThat(rows).hasSize(1);
+    assertThat(((Number) rows.get(0).getProperty("c")).longValue()).isEqualTo(2L);
+  }
+
+  private static List<Result> collect(final ResultSet rs) {
+    final List<Result> list = new ArrayList<>();
+    while (rs.hasNext())
+      list.add(rs.next());
+    return list;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue4095DirectedRelReuseIsomorphismTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue4095DirectedRelReuseIsomorphismTest.java
@@ -150,6 +150,74 @@ class Issue4095DirectedRelReuseIsomorphismTest {
     assertThat(((Number) rows.get(0).getProperty("c")).longValue()).isEqualTo(2L);
   }
 
+  /**
+   * Three-hop anonymous chain of the same type. Exercises multiple synthetic counters
+   * and verifies all three slots bind to distinct edges.
+   */
+  @Test
+  void threeHopAnonymousSameTypeChainHasDistinctEdges() {
+    database.transaction(() -> database.command("opencypher",
+        """
+            CREATE (:Person4095 {name:'C1'})-[:KNOWS4095]->(:Person4095 {name:'C2'})
+                  -[:KNOWS4095]->(:Person4095 {name:'C3'})
+                  -[:KNOWS4095]->(:Person4095 {name:'C4'})"""));
+
+    final ResultSet result = database.query("opencypher",
+        """
+            MATCH (a:Person4095)-[:KNOWS4095]->(b:Person4095)-[:KNOWS4095]->(c:Person4095)-[:KNOWS4095]->(d:Person4095)
+            WHERE a.name STARTS WITH 'C'
+            RETURN a.name AS a, b.name AS b, c.name AS c, d.name AS d""");
+
+    final List<Result> rows = collect(result);
+    assertThat(rows).hasSize(1);
+    assertThat((String) rows.get(0).getProperty("a")).isEqualTo("C1");
+    assertThat((String) rows.get(0).getProperty("b")).isEqualTo("C2");
+    assertThat((String) rows.get(0).getProperty("c")).isEqualTo("C3");
+    assertThat((String) rows.get(0).getProperty("d")).isEqualTo("C4");
+  }
+
+  /**
+   * Mixed named + anonymous relationship variables in the same MATCH clause: both
+   * tracking paths must coexist and exclude each other's edges.
+   */
+  @Test
+  void mixedNamedAndAnonymousSameClauseBindsDistinctEdges() {
+    final ResultSet result = database.query("opencypher",
+        """
+            MATCH (s:Person4095)<-[r:KNOWS4095]-(f:Person4095)-[:KNOWS4095]->(d:Person4095)
+            WHERE f.name = 'Bob'
+            RETURN s.name AS s, type(r) AS rt, d.name AS d
+            ORDER BY s, d""");
+
+    final List<Result> rows = collect(result);
+    assertThat(rows).hasSize(2);
+    assertThat((String) rows.get(0).getProperty("s")).isEqualTo("Alice");
+    assertThat((String) rows.get(0).getProperty("d")).isEqualTo("Charlie");
+    assertThat((String) rows.get(1).getProperty("s")).isEqualTo("Charlie");
+    assertThat((String) rows.get(1).getProperty("d")).isEqualTo("Alice");
+  }
+
+  /**
+   * Cross-clause edge reuse must remain valid: relationship uniqueness is per-clause,
+   * not per-row, so the same physical edge in two separate MATCH clauses is allowed.
+   */
+  @Test
+  void crossClauseAnonymousEdgeReuseIsAllowed() {
+    final ResultSet result = database.query("opencypher",
+        """
+            MATCH (a:Person4095)-[:KNOWS4095]->(b:Person4095)
+            MATCH (b:Person4095)<-[:KNOWS4095]-(c:Person4095)
+            WHERE b.name = 'Eve'
+            RETURN count(*) AS cnt""");
+
+    final List<Result> rows = collect(result);
+    assertThat(rows).hasSize(1);
+    // Eve has 2 IN edges (Dave→Eve, Frank→Eve). First MATCH binds (a,b)=(Dave,Eve) or
+    // (Frank,Eve). Second MATCH binds c independently from b's IN edges. Same edge can
+    // legitimately fill the first MATCH's slot AND the second MATCH's slot, giving 4 rows.
+    assertThat(((Number) rows.get(0).getProperty("cnt")).longValue()).isEqualTo(4L);
+  }
+
   private static List<Result> collect(final ResultSet rs) {
     final List<Result> list = new ArrayList<>();
     while (rs.hasNext())


### PR DESCRIPTION
## Summary

- Fixes #4095 (companion to #4096): consecutive anonymous relationship patterns in the same MATCH clause could reuse the same physical edge, producing spurious rows like `(Alice, Bob, Alice)` for `(s)<-[:KNOWS]-(f)-[:KNOWS]->(d)`.
- The #4096 fix tracked named relationship variables in `relVarsPerClause`. Anonymous rels (`rel.getVariable() == null`) were never added, so `sameClausePrecedingRelVars` stayed empty and the per-row isomorphism check in `ExpandAll.collectUsedEdgeRids` had nothing to compare against. Same root pattern as the legacy `MatchRelationshipStep` handles via `computeHopEdgeTrackingNeeds` + synthetic `"  relN"` names.
- `ExpandAll` now has an `edgeTrackingVar` field that stashes the edge in the row under a synthetic property name even when `edgeVariable` is null. `CypherOptimizer.computeNeedsEdgeTracking` flags anonymous hops whose edge types overlap with a sibling hop in the same MATCH clause, and `buildExpansionChain` assigns each one a synthetic `"  anon_e_N"` name, sets it on the operator before `addTargetLabelFilter` wraps it, and registers it in `relVarsPerClause` for subsequent hops.

## Test plan

- [x] New `Issue4095DirectedRelReuseIsomorphismTest` (4 tests): diverging + converging row count + aggregate count
- [x] `Issue4096UndirectedRelReuseIsomorphismTest` still passes (named-variable path unchanged)
- [x] `Issue4006BoundRelVarPathIsomorphismTest` still passes
- [x] All 6572 Cypher tests pass with no regressions