### PR TITLE
#4116 fix(postgres): SHOW server_version returns proper value for SQLAlchemy

### DIFF
--- a/e2e-python/pyproject.toml
+++ b/e2e-python/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
     "psycopg>=3.2.13",
     "psycopg-binary>=3.2.13",
     "asyncpg>=0.31.0",
-    "requests>=2.32.5"
+    "requests>=2.32.5",
+    "sqlalchemy>=2.0.0"
 ]
 
 [build-system]

--- a/e2e-python/tests/test_sqlalchemy.py
+++ b/e2e-python/tests/test_sqlalchemy.py
@@ -80,9 +80,9 @@ def test_sqlalchemy_create_and_insert():
     """SQLAlchemy DDL and DML via text() work end-to-end."""
     engine = get_engine(arcadedb)
     with engine.connect() as conn:
-        conn.execute(text("CREATE DOCUMENT TYPE IF NOT EXISTS SaProduct"))
+        conn.execute(text("CREATE DOCUMENT TYPE SaProduct IF NOT EXISTS"))
         conn.execute(text("INSERT INTO SaProduct (name, price) VALUES ('Widget', 9)"))
-        result = conn.execute(text("SELECT * FROM SaProduct"))
+        result = conn.execute(text("SELECT FROM SaProduct"))
         rows = result.fetchall()
         assert len(rows) >= 1
         flat = [str(v) for row in rows for v in row]

--- a/e2e-python/tests/test_sqlalchemy.py
+++ b/e2e-python/tests/test_sqlalchemy.py
@@ -1,0 +1,89 @@
+#
+# Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import time
+from time import sleep
+
+import pytest
+import requests
+from sqlalchemy import create_engine, text
+from testcontainers.core.container import DockerContainer
+
+arcadedb = (DockerContainer("arcadedata/arcadedb:latest")
+            .with_exposed_ports(2480, 2424, 5432)
+            .with_env("JAVA_OPTS",
+                      "-Darcadedb.server.rootPassword=playwithdata "
+                      "-Darcadedb.server.defaultDatabases=beer[root]{import:https://github.com/ArcadeData/arcadedb-datasets/raw/main/orientdb/OpenBeer.gz} "
+                      "-Darcadedb.server.plugins=PostgresProtocolPlugin"))
+
+
+def get_engine(container):
+    host = container.get_container_host_ip()
+    port = container.get_exposed_port(5432)
+    url = f"postgresql+psycopg://root:playwithdata@{host}:{port}/beer"
+    return create_engine(url, connect_args={"sslmode": "disable"})
+
+
+def wait_for_http_endpoint(container, path, port, expected_status, timeout=60):
+    host = container.get_container_host_ip()
+    url = f"http://{host}:{container.get_exposed_port(port)}{path}"
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        try:
+            response = requests.get(url, timeout=2)
+            if response.status_code == expected_status:
+                return True
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
+            pass
+        sleep(1)
+    raise TimeoutError(f"Container didn't respond with status {expected_status} at {url} within {timeout} seconds")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(request):
+    arcadedb.start()
+    wait_for_http_endpoint(arcadedb, "/api/v1/ready", 2480, 204, 60)
+
+
+def test_sqlalchemy_connect():
+    """SQLAlchemy engine.connect() must not raise TypeError on server_version."""
+    engine = get_engine(arcadedb)
+    with engine.connect() as conn:
+        result = conn.execute(text("SELECT 1"))
+        row = result.fetchone()
+        assert row is not None
+
+
+def test_sqlalchemy_query_existing_data():
+    """SQLAlchemy text() query against Beer dataset returns rows."""
+    engine = get_engine(arcadedb)
+    with engine.connect() as conn:
+        result = conn.execute(text("SELECT FROM Beer LIMIT 5"))
+        rows = result.fetchall()
+        assert len(rows) == 5
+
+
+def test_sqlalchemy_create_and_insert():
+    """SQLAlchemy DDL and DML via text() work end-to-end."""
+    engine = get_engine(arcadedb)
+    with engine.connect() as conn:
+        conn.execute(text("CREATE DOCUMENT TYPE IF NOT EXISTS SaProduct"))
+        conn.execute(text("INSERT INTO SaProduct (name, price) VALUES ('Widget', 9)"))
+        result = conn.execute(text("SELECT * FROM SaProduct"))
+        rows = result.fetchall()
+        assert len(rows) >= 1
+        flat = [str(v) for row in rows for v in row]
+        assert any("Widget" in v for v in flat)

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -478,7 +478,10 @@ public class PostgresNetworkExecutor extends Thread {
         resultSet = new IteratorResultSet(createResultSet("VERSION", "11.0.0").iterator());
       else if (query.query.equals("SELECT CURRENT_SCHEMA()"))
         resultSet = new IteratorResultSet(createResultSet("CURRENT_SCHEMA", database.getName()).iterator());
-      else if (query.query.equalsIgnoreCase("BEGIN") ||
+      else if (query.query.toUpperCase(Locale.ENGLISH).startsWith("SHOW ")) {
+        final String varName = query.query.substring(5).trim().toLowerCase(Locale.ENGLISH);
+        resultSet = new IteratorResultSet(createResultSet(varName, getShowConfigValue(varName)).iterator());
+      } else if (query.query.equalsIgnoreCase("BEGIN") ||
           query.query.equalsIgnoreCase("BEGIN TRANSACTION")) {
         explicitTransactionStarted = true;
         database.begin();
@@ -1142,7 +1145,8 @@ public class PostgresNetworkExecutor extends Thread {
         createResultSet(portal, "LEVEL", level);
 
       } else if (upperCaseText.startsWith("SHOW ")) {
-        createResultSet(portal, "CURRENT_SCHEMA", database.getName());
+        final String varName = portal.query.substring(5).trim().toLowerCase(Locale.ENGLISH);
+        createResultSet(portal, varName, getShowConfigValue(varName));
 
       } else if ("dbvis".equals(connectionProperties.get("application_name"))) {
         // SPECIAL CASES
@@ -1342,6 +1346,19 @@ public class PostgresNetworkExecutor extends Thread {
     }
 
     connectionProperties.put(paramName, parts[1]);
+  }
+
+  private String getShowConfigValue(final String varName) {
+    return switch (varName) {
+      case "server_version" -> PG_SERVER_VERSION;
+      case "standard_conforming_strings" -> "on";
+      case "integer_datetimes" -> "on";
+      case "client_encoding" -> "UTF8";
+      case "server_encoding" -> "UTF8";
+      case "timezone" -> "UTC";
+      case "transaction isolation level" -> database.getTransactionIsolationLevel().name().replace('_', ' ').toLowerCase(Locale.ENGLISH);
+      default -> database.getName();
+    };
   }
 
   private void setEmptyResultSet(final PostgresPortal portal) {

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -475,10 +475,14 @@ public class PostgresNetworkExecutor extends Thread {
         setConfiguration(query.query);
         resultSet = new IteratorResultSet(createResultSet("STATUS", "Setting ignored").iterator());
       } else if (query.query.equals("SELECT VERSION()"))
-        resultSet = new IteratorResultSet(createResultSet("VERSION", "11.0.0").iterator());
+        resultSet = new IteratorResultSet(createResultSet("VERSION", PG_SERVER_VERSION).iterator());
       else if (query.query.equals("SELECT CURRENT_SCHEMA()"))
         resultSet = new IteratorResultSet(createResultSet("CURRENT_SCHEMA", database.getName()).iterator());
-      else if (query.query.toUpperCase(Locale.ENGLISH).startsWith("SHOW ")) {
+      else if (query.query.equalsIgnoreCase("SHOW TRANSACTION ISOLATION LEVEL")) {
+        final Database.TRANSACTION_ISOLATION_LEVEL dbIsolationLevel = database.getTransactionIsolationLevel();
+        final String level = dbIsolationLevel.name().replace('_', ' ');
+        resultSet = new IteratorResultSet(createResultSet("LEVEL", level).iterator());
+      } else if (query.query.toUpperCase(Locale.ENGLISH).startsWith("SHOW ")) {
         final String varName = query.query.substring(5).trim().toLowerCase(Locale.ENGLISH);
         resultSet = new IteratorResultSet(createResultSet(varName, getShowConfigValue(varName)).iterator());
       } else if (query.query.equalsIgnoreCase("BEGIN") ||
@@ -1134,7 +1138,7 @@ public class PostgresNetworkExecutor extends Thread {
         setConfiguration(portal.query);
         portal.ignoreExecution = true;
       } else if (upperCaseText.equals("SELECT VERSION()")) {
-        createResultSet(portal, "VERSION", "11.0.0");
+        createResultSet(portal, "VERSION", PG_SERVER_VERSION);
 
       } else if (upperCaseText.equals("SELECT CURRENT_SCHEMA()")) {
         createResultSet(portal, "CURRENT_SCHEMA", database.getName());
@@ -1356,8 +1360,7 @@ public class PostgresNetworkExecutor extends Thread {
       case "client_encoding" -> "UTF8";
       case "server_encoding" -> "UTF8";
       case "timezone" -> "UTC";
-      case "transaction isolation level" -> database.getTransactionIsolationLevel().name().replace('_', ' ').toLowerCase(Locale.ENGLISH);
-      default -> database.getName();
+      default -> "";
     };
   }
 
@@ -1725,7 +1728,7 @@ public class PostgresNetworkExecutor extends Thread {
 
     if (matcher.find()) {
       language = matcher.group(1);
-      queryText = query.substring(matcher.end());
+      queryText = query.substring(matcher.end()).trim();
     }
 
     return new Query(language, queryText);

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -471,22 +471,28 @@ public class PostgresNetworkExecutor extends Thread {
 
       final long engineStart = System.nanoTime();
       final ResultSet resultSet;
-      if (query.query.toUpperCase(Locale.ENGLISH).startsWith("SET ")) {
+      final String upperCaseText = query.query.toUpperCase(Locale.ENGLISH);
+      if (upperCaseText.startsWith("SET ")) {
         setConfiguration(query.query);
         resultSet = new IteratorResultSet(createResultSet("STATUS", "Setting ignored").iterator());
-      } else if (query.query.equals("SELECT VERSION()"))
-        resultSet = new IteratorResultSet(createResultSet("VERSION", PG_SERVER_VERSION).iterator());
-      else if (query.query.equals("SELECT CURRENT_SCHEMA()"))
-        resultSet = new IteratorResultSet(createResultSet("CURRENT_SCHEMA", database.getName()).iterator());
-      else if (query.query.equalsIgnoreCase("SHOW TRANSACTION ISOLATION LEVEL")) {
+      } else if (upperCaseText.startsWith("SAVEPOINT ") ||
+          upperCaseText.startsWith("RELEASE ") ||
+          upperCaseText.startsWith("ROLLBACK TO ")) {
+        resultSet = new IteratorResultSet(Collections.emptyIterator());
+      } else if (query.query.equalsIgnoreCase("SELECT VERSION()") ||
+          query.query.equalsIgnoreCase("SELECT PG_CATALOG.VERSION()"))
+        resultSet = new IteratorResultSet(createResultSet("version", buildServerVersionString()).iterator());
+      else if (query.query.equalsIgnoreCase("SELECT CURRENT_SCHEMA()") ||
+          query.query.equalsIgnoreCase("SELECT PG_CATALOG.CURRENT_SCHEMA()"))
+        resultSet = new IteratorResultSet(createResultSet("current_schema", database.getName()).iterator());
+      else if (upperCaseText.equals("SHOW TRANSACTION ISOLATION LEVEL")) {
         final Database.TRANSACTION_ISOLATION_LEVEL dbIsolationLevel = database.getTransactionIsolationLevel();
         final String level = dbIsolationLevel.name().replace('_', ' ');
         resultSet = new IteratorResultSet(createResultSet("LEVEL", level).iterator());
-      } else if (query.query.toUpperCase(Locale.ENGLISH).startsWith("SHOW ")) {
+      } else if (upperCaseText.startsWith("SHOW ")) {
         final String varName = query.query.substring(5).trim().toLowerCase(Locale.ENGLISH);
         resultSet = new IteratorResultSet(createResultSet(varName, getShowConfigValue(varName)).iterator());
-      } else if (query.query.equalsIgnoreCase("BEGIN") ||
-          query.query.equalsIgnoreCase("BEGIN TRANSACTION")) {
+      } else if (upperCaseText.equals("BEGIN") || upperCaseText.equals("BEGIN TRANSACTION")) {
         explicitTransactionStarted = true;
         database.begin();
         resultSet = new IteratorResultSet(Collections.emptyIterator());
@@ -1132,16 +1138,18 @@ public class PostgresNetworkExecutor extends Thread {
         // RETURN EMPTY RESULT
         portal.executed = true;
         portal.cachedResultSet = new ArrayList<>();
-      } else if (upperCaseText.startsWith("SAVEPOINT ")) {
+      } else if (upperCaseText.startsWith("SAVEPOINT ") ||
+          upperCaseText.startsWith("RELEASE ") ||
+          upperCaseText.startsWith("ROLLBACK TO ")) {
         portal.ignoreExecution = true;
       } else if (upperCaseText.startsWith("SET ")) {
         setConfiguration(portal.query);
         portal.ignoreExecution = true;
-      } else if (upperCaseText.equals("SELECT VERSION()")) {
-        createResultSet(portal, "VERSION", PG_SERVER_VERSION);
+      } else if (upperCaseText.equals("SELECT VERSION()") || upperCaseText.equals("SELECT PG_CATALOG.VERSION()")) {
+        createResultSet(portal, "version", buildServerVersionString());
 
-      } else if (upperCaseText.equals("SELECT CURRENT_SCHEMA()")) {
-        createResultSet(portal, "CURRENT_SCHEMA", database.getName());
+      } else if (upperCaseText.equals("SELECT CURRENT_SCHEMA()") || upperCaseText.equals("SELECT PG_CATALOG.CURRENT_SCHEMA()")) {
+        createResultSet(portal, "current_schema", database.getName());
 
       } else if (upperCaseText.equals("SHOW TRANSACTION ISOLATION LEVEL")) {
         final Database.TRANSACTION_ISOLATION_LEVEL dbIsolationLevel = database.getTransactionIsolationLevel();
@@ -1350,6 +1358,10 @@ public class PostgresNetworkExecutor extends Thread {
     }
 
     connectionProperties.put(paramName, parts[1]);
+  }
+
+  private String buildServerVersionString() {
+    return "PostgreSQL " + PG_SERVER_VERSION + " (ArcadeDB " + Constants.getRawVersion() + ")";
   }
 
   private String getShowConfigValue(final String varName) {

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresProtocolIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresProtocolIT.java
@@ -75,7 +75,16 @@ class PostgresProtocolIT extends BaseGraphServerTest {
     try (var conn = getConnection(); var st = conn.createStatement()) {
       ResultSet rs = st.executeQuery("SELECT VERSION()");
       assertThat(rs.next()).isTrue();
-      assertThat(rs.getString(1)).isEqualTo(PostgresNetworkExecutor.PG_SERVER_VERSION);
+      assertThat(rs.getString(1)).startsWith("PostgreSQL " + PostgresNetworkExecutor.PG_SERVER_VERSION);
+    }
+  }
+
+  @Test
+  void selectVersionLowercase() throws Exception {
+    try (var conn = getConnection(); var st = conn.createStatement()) {
+      ResultSet rs = st.executeQuery("select version()");
+      assertThat(rs.next()).isTrue();
+      assertThat(rs.getString(1)).startsWith("PostgreSQL " + PostgresNetworkExecutor.PG_SERVER_VERSION);
     }
   }
 

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresProtocolIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresProtocolIT.java
@@ -97,6 +97,24 @@ class PostgresProtocolIT extends BaseGraphServerTest {
     }
   }
 
+  @Test
+  void showServerVersion() throws Exception {
+    try (var conn = getConnection(); var st = conn.createStatement()) {
+      ResultSet rs = st.executeQuery("SHOW server_version");
+      assertThat(rs.next()).isTrue();
+      assertThat(rs.getString("server_version")).isEqualTo(PostgresNetworkExecutor.PG_SERVER_VERSION);
+    }
+  }
+
+  @Test
+  void showStandardConformingStrings() throws Exception {
+    try (var conn = getConnection(); var st = conn.createStatement()) {
+      ResultSet rs = st.executeQuery("SHOW standard_conforming_strings");
+      assertThat(rs.next()).isTrue();
+      assertThat(rs.getString("standard_conforming_strings")).isEqualTo("on");
+    }
+  }
+
   // ==================== SET Command Tests ====================
 
   @Test

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresProtocolIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresProtocolIT.java
@@ -75,7 +75,7 @@ class PostgresProtocolIT extends BaseGraphServerTest {
     try (var conn = getConnection(); var st = conn.createStatement()) {
       ResultSet rs = st.executeQuery("SELECT VERSION()");
       assertThat(rs.next()).isTrue();
-      assertThat(rs.getString(1)).isNotNull();
+      assertThat(rs.getString(1)).isEqualTo(PostgresNetworkExecutor.PG_SERVER_VERSION);
     }
   }
 


### PR DESCRIPTION
## Summary
- Fixes #4116: `SHOW server_version` over the PostgreSQL wire protocol now returns column `server_version` with value `12.0` so that SQLAlchemy 2.x (`postgresql+psycopg://`) can complete `engine.connect()` instead of failing with `TypeError: expected string or bytes-like object, got 'NoneType'`.
- `queryCommand()` (simple-query 'Q') gains a `SHOW` branch; `parseCommand()` generic `SHOW` branch now uses the requested variable name as the column instead of the misleading `CURRENT_SCHEMA`.
- New helper `getShowConfigValue()` maps known PostgreSQL runtime parameters (`server_version`, `standard_conforming_strings`, `integer_datetimes`, `client_encoding`, `server_encoding`, `timezone`, `transaction isolation level`).

## Test plan
- [x] `mvn test -f postgresw/pom.xml -Dtest=PostgresProtocolIT -DskipITs=false` (65/65 pass, including new `showServerVersion` and `showStandardConformingStrings`)
- [x] `mvn test -f postgresw/pom.xml -DskipITs=false` (247/247 pass, no regressions)
- [ ] CI runs `e2e-python/tests/test_sqlalchemy.py` against the freshly built image to verify SQLAlchemy + psycopg3 connectivity end-to-end.