### PR TITLE
#3971 fix(postgres): return RowDescription with schema columns for empty SELECT results

### DIFF
--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -292,8 +292,8 @@ public class PostgresNetworkExecutor extends Thread {
           portal.cachedResultSet = browseAndCacheResultSet(resultSet, 0);
           portal.columns = getColumns(portal.cachedResultSet);
           if (portal.columns.isEmpty() && portal.cachedResultSet.isEmpty()) {
-            final Map<String, PostgresType> schemaColumns = getColumnsFromQuerySchema(portal.query);
-            if (schemaColumns != null && !schemaColumns.isEmpty())
+            final Map<String, PostgresType> schemaColumns = resolveEmptyResultSchemaColumns(portal.query);
+            if (schemaColumns != null)
               portal.columns = schemaColumns;
           }
           writeRowDescription(portal.columns);
@@ -375,9 +375,9 @@ public class PostgresNetworkExecutor extends Thread {
             if (!portal.rowDescriptionSent) {
               final long serStart = System.nanoTime();
               portal.columns = getColumns(portal.cachedResultSet);
-              if (portal.columns.isEmpty() && portal.cachedResultSet.isEmpty() && portal.isExpectingResult) {
-                final Map<String, PostgresType> schemaColumns = getColumnsFromQuerySchema(portal.query);
-                if (schemaColumns != null && !schemaColumns.isEmpty())
+              if (portal.columns.isEmpty() && portal.cachedResultSet.isEmpty()) {
+                final Map<String, PostgresType> schemaColumns = resolveEmptyResultSchemaColumns(portal.query);
+                if (schemaColumns != null)
                   portal.columns = schemaColumns;
               }
               writeRowDescription(portal.columns);
@@ -522,9 +522,9 @@ public class PostgresNetworkExecutor extends Thread {
 
       final long serStart = System.nanoTime();
       Map<String, PostgresType> columns = getColumns(cachedResultSet);
-      if (columns.isEmpty() && cachedResultSet.isEmpty() && upperCaseText.startsWith("SELECT")) {
-        final Map<String, PostgresType> schemaColumns = getColumnsFromQuerySchema(query.query);
-        if (schemaColumns != null && !schemaColumns.isEmpty())
+      if (columns.isEmpty() && cachedResultSet.isEmpty()) {
+        final Map<String, PostgresType> schemaColumns = resolveEmptyResultSchemaColumns(query.query);
+        if (schemaColumns != null)
           columns = schemaColumns;
       }
       writeRowDescription(columns);
@@ -859,6 +859,19 @@ public class PostgresNetworkExecutor extends Thread {
             query, e.getMessage());
       return null;
     }
+  }
+
+  /**
+   * Schema-discovery fallback for SELECT queries that returned 0 rows. RowDescription must still
+   * carry column metadata so JDBC clients (Spark/PySpark probe schema with WHERE 1=0) can build
+   * a typed result set. Returns null when the query is not a SELECT or no schema match is found,
+   * letting the caller fall through to the empty-RowDescription default.
+   */
+  private Map<String, PostgresType> resolveEmptyResultSchemaColumns(final String query) {
+    if (query == null || !query.toUpperCase(Locale.ENGLISH).trim().startsWith("SELECT"))
+      return null;
+    final Map<String, PostgresType> schemaColumns = getColumnsFromQuerySchema(query);
+    return (schemaColumns != null && !schemaColumns.isEmpty()) ? schemaColumns : null;
   }
 
   private void writeRowDescription(final Map<String, PostgresType> columns) {

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -291,6 +291,11 @@ public class PostgresNetworkExecutor extends Thread {
         if (portal.isExpectingResult) {
           portal.cachedResultSet = browseAndCacheResultSet(resultSet, 0);
           portal.columns = getColumns(portal.cachedResultSet);
+          if (portal.columns.isEmpty() && portal.cachedResultSet.isEmpty()) {
+            final Map<String, PostgresType> schemaColumns = getColumnsFromQuerySchema(portal.query);
+            if (schemaColumns != null && !schemaColumns.isEmpty())
+              portal.columns = schemaColumns;
+          }
           writeRowDescription(portal.columns);
           portal.rowDescriptionSent = true;
         } else
@@ -370,6 +375,11 @@ public class PostgresNetworkExecutor extends Thread {
             if (!portal.rowDescriptionSent) {
               final long serStart = System.nanoTime();
               portal.columns = getColumns(portal.cachedResultSet);
+              if (portal.columns.isEmpty() && portal.cachedResultSet.isEmpty() && portal.isExpectingResult) {
+                final Map<String, PostgresType> schemaColumns = getColumnsFromQuerySchema(portal.query);
+                if (schemaColumns != null && !schemaColumns.isEmpty())
+                  portal.columns = schemaColumns;
+              }
               writeRowDescription(portal.columns);
               portal.rowDescriptionSent = true;
               profile.addSerializationNanos(System.nanoTime() - serStart);
@@ -511,7 +521,12 @@ public class PostgresNetworkExecutor extends Thread {
       profile.addEngineNanos(System.nanoTime() - engineStart);
 
       final long serStart = System.nanoTime();
-      final Map<String, PostgresType> columns = getColumns(cachedResultSet);
+      Map<String, PostgresType> columns = getColumns(cachedResultSet);
+      if (columns.isEmpty() && cachedResultSet.isEmpty() && upperCaseText.startsWith("SELECT")) {
+        final Map<String, PostgresType> schemaColumns = getColumnsFromQuerySchema(query.query);
+        if (schemaColumns != null && !schemaColumns.isEmpty())
+          columns = schemaColumns;
+      }
       writeRowDescription(columns);
       writeDataRows(cachedResultSet, columns);
       writeCommandComplete(queryText, cachedResultSet.size());

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresProtocolIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresProtocolIT.java
@@ -992,10 +992,15 @@ class PostgresProtocolIT extends BaseGraphServerTest {
 
   // ==================== Empty Result Schema Tests (issue #3971) ====================
 
-  /**
-   * WHERE 1=0 must return RowDescription with declared columns even when 0 rows are returned.
-   * Spark/PySpark sends this to discover schema before loading data; 0 columns means empty rows.
-   */
+  private static java.util.Set<String> columnNames(ResultSetMetaData meta) throws SQLException {
+    final java.util.Set<String> names = new java.util.HashSet<>();
+    for (int i = 1; i <= meta.getColumnCount(); i++)
+      names.add(meta.getColumnName(i).toLowerCase(java.util.Locale.ENGLISH));
+    return names;
+  }
+
+  // WHERE 1=0 must return RowDescription with type columns even when 0 rows are returned.
+  // Spark/PySpark sends this to discover schema before loading data.
   @Test
   void selectWhere1Eq0ReturnsSchemaColumns() throws Exception {
     try (var conn = getConnection(); var st = conn.createStatement()) {
@@ -1004,26 +1009,11 @@ class PostgresProtocolIT extends BaseGraphServerTest {
 
       ResultSet rs = st.executeQuery("SELECT name, age FROM SparkSchemaTest WHERE 1=0");
       assertThat(rs.next()).isFalse();
-      ResultSetMetaData meta = rs.getMetaData();
-      assertThat(meta.getColumnCount()).isGreaterThan(0);
-      // Column names must include the projected fields
-      boolean foundName = false;
-      boolean foundAge = false;
-      for (int i = 1; i <= meta.getColumnCount(); i++) {
-        if ("name".equalsIgnoreCase(meta.getColumnName(i)))
-          foundName = true;
-        if ("age".equalsIgnoreCase(meta.getColumnName(i)))
-          foundAge = true;
-      }
-      assertThat(foundName).isTrue();
-      assertThat(foundAge).isTrue();
+      assertThat(columnNames(rs.getMetaData())).contains("name", "age");
     }
   }
 
-  /**
-   * SELECT * FROM type WHERE 1=0 must return RowDescription with schema columns.
-   * This is the exact probe pattern used by Apache Spark JDBC connector.
-   */
+  // SELECT * FROM type WHERE 1=0 - the exact probe pattern used by Apache Spark JDBC.
   @Test
   void selectStarWhere1Eq0ReturnsSchemaColumns() throws Exception {
     try (var conn = getConnection(); var st = conn.createStatement()) {
@@ -1032,21 +1022,11 @@ class PostgresProtocolIT extends BaseGraphServerTest {
 
       ResultSet rs = st.executeQuery("SELECT * FROM SparkStarSchemaTest WHERE 1=0");
       assertThat(rs.next()).isFalse();
-      ResultSetMetaData meta = rs.getMetaData();
-      assertThat(meta.getColumnCount()).isGreaterThan(0);
-      boolean foundCity = false;
-      for (int i = 1; i <= meta.getColumnCount(); i++) {
-        if ("city".equalsIgnoreCase(meta.getColumnName(i)))
-          foundCity = true;
-      }
-      assertThat(foundCity).isTrue();
+      assertThat(columnNames(rs.getMetaData())).contains("city", "population");
     }
   }
 
-  /**
-   * Prepared statement with WHERE 1=0 must also return RowDescription with schema columns.
-   * JDBC drivers use the extended query protocol (Parse/Describe/Bind/Execute).
-   */
+  // Prepared statement uses the extended query protocol (Parse/Describe/Bind/Execute).
   @Test
   void preparedSelectWhere1Eq0ReturnsSchemaColumns() throws Exception {
     try (var conn = getConnection(); var st = conn.createStatement()) {
@@ -1057,14 +1037,23 @@ class PostgresProtocolIT extends BaseGraphServerTest {
         var pst = conn.prepareStatement("SELECT label, value FROM SparkPreparedSchemaTest WHERE 1=0")) {
       ResultSet rs = pst.executeQuery();
       assertThat(rs.next()).isFalse();
-      ResultSetMetaData meta = rs.getMetaData();
-      assertThat(meta.getColumnCount()).isGreaterThan(0);
-      boolean foundLabel = false;
-      for (int i = 1; i <= meta.getColumnCount(); i++) {
-        if ("label".equalsIgnoreCase(meta.getColumnName(i)))
-          foundLabel = true;
-      }
-      assertThat(foundLabel).isTrue();
+      assertThat(columnNames(rs.getMetaData())).contains("label", "value");
     }
   }
+
+  // Truly empty type with schema-defined properties must still return RowDescription with schema
+  // columns. Exercises the schema-property fallback in getColumnsFromQuerySchema (no sample row).
+  @Test
+  void selectWhere1Eq0OnEmptyTypeReturnsSchemaColumns() throws Exception {
+    try (var conn = getConnection(); var st = conn.createStatement()) {
+      st.execute("CREATE DOCUMENT TYPE EmptySparkTest IF NOT EXISTS");
+      st.execute("CREATE PROPERTY EmptySparkTest.title STRING");
+      st.execute("CREATE PROPERTY EmptySparkTest.score INTEGER");
+
+      ResultSet rs = st.executeQuery("SELECT title, score FROM EmptySparkTest WHERE 1=0");
+      assertThat(rs.next()).isFalse();
+      assertThat(columnNames(rs.getMetaData())).contains("title", "score");
+    }
+  }
+
 }

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresProtocolIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresProtocolIT.java
@@ -989,4 +989,82 @@ class PostgresProtocolIT extends BaseGraphServerTest {
       assertThat(rs.next()).isTrue();
     }
   }
+
+  // ==================== Empty Result Schema Tests (issue #3971) ====================
+
+  /**
+   * WHERE 1=0 must return RowDescription with declared columns even when 0 rows are returned.
+   * Spark/PySpark sends this to discover schema before loading data; 0 columns means empty rows.
+   */
+  @Test
+  void selectWhere1Eq0ReturnsSchemaColumns() throws Exception {
+    try (var conn = getConnection(); var st = conn.createStatement()) {
+      st.execute("CREATE DOCUMENT TYPE SparkSchemaTest IF NOT EXISTS");
+      st.execute("INSERT INTO SparkSchemaTest SET name = 'alice', age = 30");
+
+      ResultSet rs = st.executeQuery("SELECT name, age FROM SparkSchemaTest WHERE 1=0");
+      assertThat(rs.next()).isFalse();
+      ResultSetMetaData meta = rs.getMetaData();
+      assertThat(meta.getColumnCount()).isGreaterThan(0);
+      // Column names must include the projected fields
+      boolean foundName = false;
+      boolean foundAge = false;
+      for (int i = 1; i <= meta.getColumnCount(); i++) {
+        if ("name".equalsIgnoreCase(meta.getColumnName(i)))
+          foundName = true;
+        if ("age".equalsIgnoreCase(meta.getColumnName(i)))
+          foundAge = true;
+      }
+      assertThat(foundName).isTrue();
+      assertThat(foundAge).isTrue();
+    }
+  }
+
+  /**
+   * SELECT * FROM type WHERE 1=0 must return RowDescription with schema columns.
+   * This is the exact probe pattern used by Apache Spark JDBC connector.
+   */
+  @Test
+  void selectStarWhere1Eq0ReturnsSchemaColumns() throws Exception {
+    try (var conn = getConnection(); var st = conn.createStatement()) {
+      st.execute("CREATE DOCUMENT TYPE SparkStarSchemaTest IF NOT EXISTS");
+      st.execute("INSERT INTO SparkStarSchemaTest SET city = 'Rome', population = 2800000");
+
+      ResultSet rs = st.executeQuery("SELECT * FROM SparkStarSchemaTest WHERE 1=0");
+      assertThat(rs.next()).isFalse();
+      ResultSetMetaData meta = rs.getMetaData();
+      assertThat(meta.getColumnCount()).isGreaterThan(0);
+      boolean foundCity = false;
+      for (int i = 1; i <= meta.getColumnCount(); i++) {
+        if ("city".equalsIgnoreCase(meta.getColumnName(i)))
+          foundCity = true;
+      }
+      assertThat(foundCity).isTrue();
+    }
+  }
+
+  /**
+   * Prepared statement with WHERE 1=0 must also return RowDescription with schema columns.
+   * JDBC drivers use the extended query protocol (Parse/Describe/Bind/Execute).
+   */
+  @Test
+  void preparedSelectWhere1Eq0ReturnsSchemaColumns() throws Exception {
+    try (var conn = getConnection(); var st = conn.createStatement()) {
+      st.execute("CREATE DOCUMENT TYPE SparkPreparedSchemaTest IF NOT EXISTS");
+      st.execute("INSERT INTO SparkPreparedSchemaTest SET label = 'x', value = 42");
+    }
+    try (var conn = getConnection();
+        var pst = conn.prepareStatement("SELECT label, value FROM SparkPreparedSchemaTest WHERE 1=0")) {
+      ResultSet rs = pst.executeQuery();
+      assertThat(rs.next()).isFalse();
+      ResultSetMetaData meta = rs.getMetaData();
+      assertThat(meta.getColumnCount()).isGreaterThan(0);
+      boolean foundLabel = false;
+      for (int i = 1; i <= meta.getColumnCount(); i++) {
+        if ("label".equalsIgnoreCase(meta.getColumnName(i)))
+          foundLabel = true;
+      }
+      assertThat(foundLabel).isTrue();
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Fix #3971: PostgreSQL wire protocol returned RowDescription with 0 columns when a SELECT query returned 0 rows (e.g. Spark/PySpark's `WHERE 1=0` schema probe)
- Adds schema-discovery fallback via `getColumnsFromQuerySchema()` in three protocol paths: `describeCommand` (type='P'), `executeCommand` (when RowDescription not yet sent), and `queryCommand` (simple query)
- Restores compatibility with Apache Spark / PySpark JDBC schema probing

## Root cause

When `getColumns()` is called on an empty result set it correctly returns an empty map (no rows = no property names to inspect), but no fallback to type schema was attempted. PySpark caches the 0-column schema and later renders N empty rows even though data exists.

The primary path triggered by PgJDBC's default extended protocol is `describeCommand` type='P' (Describe Portal): it executes the query, gets 0 rows, then `getColumns(emptyList)` returns empty and a 0-column RowDescription is sent.

## Test plan

- [x] New tests in `PostgresProtocolIT`:
  - `selectWhere1Eq0ReturnsSchemaColumns` (simple `Statement.executeQuery`)
  - `selectStarWhere1Eq0ReturnsSchemaColumns` (Spark's exact `SELECT *` probe)
  - `preparedSelectWhere1Eq0ReturnsSchemaColumns` (`PreparedStatement` path)
- [x] Each test verifies `ResultSetMetaData.getColumnCount() > 0` and that projected columns appear in metadata even with 0 rows returned
- [x] Full `PostgresProtocolIT` suite (69 tests) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)