### PR TITLE
feat: implemented sparse vector partitioning

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorAbstract.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorAbstract.java
@@ -25,6 +25,7 @@ import com.arcadedb.database.RID;
 import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.function.sql.SQLFunctionAbstract;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.utility.IntHashSet;
 
 import java.util.HashSet;
 import java.util.List;
@@ -203,6 +204,40 @@ public abstract class SQLFunctionVectorAbstract extends SQLFunctionAbstract {
     public boolean isFull() {
       return filledGroups >= limit;
     }
+  }
+
+  /**
+   * Narrows {@code allowedBucketIds} (the per-type bucket allow-list assembled from
+   * {@code DocumentType.getBuckets(false)}) to the partition-pruned subset stashed on the
+   * {@link CommandContext} by {@code SelectExecutionPlanner.derivePartitionPrunedClusters}.
+   * <p>
+   * Returns the input unchanged when the planner did not stash a hint, when the hint was
+   * derived from a different FROM type than the function's target, or when the hint is empty.
+   * The intersection is computed via {@link IntHashSet#forEach}; building a fresh set keeps the
+   * input immutable so two parallel function calls in the same projection cannot stomp on each
+   * other's narrowed view.
+   * <p>
+   * Net effect: a query like {@code SELECT vector.neighbors('Doc[embedding]', ..., k) FROM Doc
+   * WHERE tenant_id = 'X'} on a {@code partitioned('tenant_id')} type only enumerates the
+   * vector sub-index for {@code X}'s bucket instead of the full N-bucket fan-out. Issue #4087
+   * follow-up.
+   */
+  protected static IntHashSet narrowAllowedBucketIdsByPartitionHint(final IntHashSet allowedBucketIds,
+      final String typeName, final CommandContext context) {
+    if (allowedBucketIds == null || allowedBucketIds.isEmpty() || typeName == null || context == null)
+      return allowedBucketIds;
+    final Object hintTypeName = context.getVariable(CommandContext.PARTITION_PRUNED_TYPE_NAME_VAR);
+    if (!(hintTypeName instanceof String hintType) || !hintType.equals(typeName))
+      return allowedBucketIds;
+    final Object hintIds = context.getVariable(CommandContext.PARTITION_PRUNED_BUCKET_FILE_IDS_VAR);
+    if (!(hintIds instanceof IntHashSet hintSet) || hintSet.isEmpty())
+      return allowedBucketIds;
+    final IntHashSet narrowed = new IntHashSet(Math.min(allowedBucketIds.size(), hintSet.size()));
+    allowedBucketIds.forEach(id -> {
+      if (hintSet.contains(id))
+        narrowed.add(id);
+    });
+    return narrowed;
   }
 
   protected static Set<RID> parseRidFilter(final List<?> items, final String functionName, final CommandContext context) {

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorAbstract.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorAbstract.java
@@ -213,9 +213,8 @@ public abstract class SQLFunctionVectorAbstract extends SQLFunctionAbstract {
    * <p>
    * Returns the input unchanged when the planner did not stash a hint, when the hint was
    * derived from a different FROM type than the function's target, or when the hint is empty.
-   * The intersection is computed via {@link IntHashSet#forEach}; building a fresh set keeps the
-   * input immutable so two parallel function calls in the same projection cannot stomp on each
-   * other's narrowed view.
+   * Builds a fresh {@link IntHashSet} (rather than mutating the input) so concurrent function
+   * calls in the same projection do not stomp on each other's narrowed view.
    * <p>
    * Net effect: a query like {@code SELECT vector.neighbors('Doc[embedding]', ..., k) FROM Doc
    * WHERE tenant_id = 'X'} on a {@code partitioned('tenant_id')} type only enumerates the

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighbors.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorNeighbors.java
@@ -135,10 +135,17 @@ public class SQLFunctionVectorNeighbors extends SQLFunctionVectorAbstract {
     // Get the bucket IDs that belong to the specified type (not polymorphic - just this type's own buckets).
     // IntHashSet is zero-boxing - the contains() in executeWithTypeIndex runs once per bucket index per
     // vector query, and avoiding Integer boxing on every probe matters under sustained ANN workloads.
-    final IntHashSet allowedBucketIds = new IntHashSet();
+    IntHashSet allowedBucketIds = new IntHashSet();
     for (final Bucket bucket : specifiedType.getBuckets(false)) {
       allowedBucketIds.add(bucket.getFileId());
     }
+
+    // Narrow the per-type bucket allow-list to the partition-pruned subset when the outer SELECT
+    // already restricted to specific buckets via a WHERE on the partition key (issue #4087
+    // follow-up). The function would otherwise enumerate every bucket sub-index even though the
+    // outer query is logically constrained to one bucket; the intersection skips work AND keeps
+    // results consistent with the WHERE.
+    allowedBucketIds = narrowAllowedBucketIdsByPartitionHint(allowedBucketIds, specifiedTypeName, context);
 
     return executeWithTypeIndex(typeIndex, allowedBucketIds, key, limit, efSearch, allowedRIDs, groupBy, groupSize, context);
   }

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorSparseNeighbors.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorSparseNeighbors.java
@@ -145,14 +145,21 @@ public class SQLFunctionVectorSparseNeighbors extends SQLFunctionVectorAbstract 
 
   private List<LSMSparseVectorIndex> collectSparseIndexes(final String indexSpec, final TypeIndex typeIndex,
       final CommandContext context) {
-    final IntHashSet allowedBucketIds = new IntHashSet();
+    IntHashSet allowedBucketIds = new IntHashSet();
+    String specifiedTypeName = null;
     final int bracketStart = indexSpec.indexOf('[');
     if (bracketStart > 0 && indexSpec.endsWith("]")) {
-      final String specifiedTypeName = indexSpec.substring(0, bracketStart);
+      specifiedTypeName = indexSpec.substring(0, bracketStart);
       final DocumentType specifiedType = context.getDatabase().getSchema().getType(specifiedTypeName);
       for (final Bucket bucket : specifiedType.getBuckets(false))
         allowedBucketIds.add(bucket.getFileId());
     }
+
+    // Narrow to the partition-pruned subset when the outer SELECT bound every partition property
+    // (issue #4087 follow-up). Same rationale as {@link SQLFunctionVectorNeighbors}: skips per
+    // bucket sparse indexes outside the partition AND keeps results consistent with the WHERE.
+    if (specifiedTypeName != null)
+      allowedBucketIds = narrowAllowedBucketIdsByPartitionHint(allowedBucketIds, specifiedTypeName, context);
 
     final var bucketIndexes = typeIndex.getIndexesOnBuckets();
     final List<LSMSparseVectorIndex> result = new ArrayList<>();

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CommandContext.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CommandContext.java
@@ -82,4 +82,25 @@ public interface CommandContext {
   /** Context variable set by algorithm procedures to the total number of results they will yield.
    *  Used by CallStep to optimize count-only queries by skipping per-row Result object creation. */
   String RESULT_COUNT_HINT_VAR = "_resultCountHint";
+
+  /**
+   * Context variable holding the partition-pruned bucket file ids derived by
+   * {@code SelectExecutionPlanner.derivePartitionPrunedClusters}. Set when a SELECT's WHERE
+   * clause binds every partition property of the FROM type to a literal, so any downstream
+   * consumer (e.g. {@code vector.neighbors} / {@code vector.sparseNeighbors}) that does its
+   * own per-bucket fan-out can intersect this set with its full per-type bucket allow-list and
+   * skip indexes outside the partition.
+   * <p>
+   * Value type: {@link com.arcadedb.utility.IntHashSet} of bucket file ids.
+   * Companion variable: {@link #PARTITION_PRUNED_TYPE_NAME_VAR}.
+   */
+  String PARTITION_PRUNED_BUCKET_FILE_IDS_VAR = "_partitionPrunedBucketFileIds";
+
+  /**
+   * Companion to {@link #PARTITION_PRUNED_BUCKET_FILE_IDS_VAR}: the FROM type name the prune was
+   * derived from. Consumers must verify their target type matches before applying the prune so
+   * a vector-function call against an unrelated type in the same query (rare but possible) is
+   * not accidentally narrowed.
+   */
+  String PARTITION_PRUNED_TYPE_NAME_VAR = "_partitionPrunedTypeName";
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CommandContext.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CommandContext.java
@@ -83,32 +83,9 @@ public interface CommandContext {
    *  Used by CallStep to optimize count-only queries by skipping per-row Result object creation. */
   String RESULT_COUNT_HINT_VAR = "_resultCountHint";
 
-  /**
-   * Context variable holding the partition-pruned bucket file ids derived by
-   * {@code SelectExecutionPlanner.derivePartitionPrunedClusters}. Set when a SELECT's WHERE
-   * clause binds every partition property of the FROM type to a literal, so any downstream
-   * consumer (e.g. {@code vector.neighbors} / {@code vector.sparseNeighbors}) that does its
-   * own per-bucket fan-out can intersect this set with its full per-type bucket allow-list and
-   * skip indexes outside the partition.
-   * <p>
-   * Value type: {@link com.arcadedb.utility.IntHashSet} of bucket file ids.
-   * Companion variable: {@link #PARTITION_PRUNED_TYPE_NAME_VAR}.
-   * <p>
-   * <b>NOTE (multi-type queries).</b> The slot is single-valued: a query that triggers pruning
-   * on more than one partitioned type (e.g. a future projection that calls
-   * {@code vector.neighbors} on type A while the FROM clause prunes type B) will have its first
-   * type's hint silently overwritten by the second derivation. The companion type-name variable
-   * blocks cross-type misapplication on the read side, but the first type's hint is lost. Today
-   * the planner only calls this from a single FROM-type context so this is not reachable; if
-   * multi-type pruning is ever added, swap the two scalars for a {@code Map<String, IntHashSet>}.
-   */
+  /** Partition-pruned bucket file ids ({@link com.arcadedb.utility.IntHashSet}) for the FROM type named in {@link #PARTITION_PRUNED_TYPE_NAME_VAR}. Single-valued: only one partitioned FROM type per query (issue #4087). */
   String PARTITION_PRUNED_BUCKET_FILE_IDS_VAR = "_partitionPrunedBucketFileIds";
 
-  /**
-   * Companion to {@link #PARTITION_PRUNED_BUCKET_FILE_IDS_VAR}: the FROM type name the prune was
-   * derived from. Consumers must verify their target type matches before applying the prune so
-   * a vector-function call against an unrelated type in the same query (rare but possible) is
-   * not accidentally narrowed.
-   */
+  /** Companion to {@link #PARTITION_PRUNED_BUCKET_FILE_IDS_VAR}: the FROM type name the prune was derived from. Consumers must match before applying. */
   String PARTITION_PRUNED_TYPE_NAME_VAR = "_partitionPrunedTypeName";
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CommandContext.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CommandContext.java
@@ -93,6 +93,14 @@ public interface CommandContext {
    * <p>
    * Value type: {@link com.arcadedb.utility.IntHashSet} of bucket file ids.
    * Companion variable: {@link #PARTITION_PRUNED_TYPE_NAME_VAR}.
+   * <p>
+   * <b>NOTE (multi-type queries).</b> The slot is single-valued: a query that triggers pruning
+   * on more than one partitioned type (e.g. a future projection that calls
+   * {@code vector.neighbors} on type A while the FROM clause prunes type B) will have its first
+   * type's hint silently overwritten by the second derivation. The companion type-name variable
+   * blocks cross-type misapplication on the read side, but the first type's hint is lost. Today
+   * the planner only calls this from a single FROM-type context so this is not reachable; if
+   * multi-type pruning is ever added, swap the two scalars for a {@code Map<String, IntHashSet>}.
    */
   String PARTITION_PRUNED_BUCKET_FILE_IDS_VAR = "_partitionPrunedBucketFileIds";
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -90,6 +90,7 @@ import com.arcadedb.schema.LocalTimeSeriesType;
 import com.arcadedb.schema.Property;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
+import com.arcadedb.utility.IntHashSet;
 import com.arcadedb.utility.Pair;
 
 import java.time.Instant;
@@ -2053,22 +2054,47 @@ public class SelectExecutionPlanner {
     if (derivedBuckets.isEmpty())
       return filterClusters;
 
-    if (filterClusters == null || filterClusters.contains("*"))
-      return derivedBuckets;
+    final Set<String> result;
+    if (filterClusters == null || filterClusters.contains("*")) {
+      result = derivedBuckets;
+    } else {
+      final Set<String> intersected = new HashSet<>(derivedBuckets);
+      intersected.retainAll(filterClusters);
+      // If the intersection is empty the user's explicit cluster filter is incompatible with the
+      // partition-derived set - the query should return nothing. The downstream fetch step's
+      // filtering already handles this (no buckets pass), so returning the empty set is correct.
+      // Log at FINE so an operator chasing a "query mysteriously returns zero rows" report can grep
+      // for the type name and see that pruning + an explicit cluster filter intersected to empty.
+      if (intersected.isEmpty())
+        LogManager.instance().log(SelectExecutionPlanner.class, Level.FINE,
+            "Partition pruning on type '%s' intersected to an empty set: derived buckets %s do not "
+                + "overlap the explicit cluster filter %s. Query will return zero rows.",
+            null, docType.getName(), derivedBuckets, filterClusters);
+      result = intersected;
+    }
 
-    final Set<String> intersected = new HashSet<>(derivedBuckets);
-    intersected.retainAll(filterClusters);
-    // If the intersection is empty the user's explicit cluster filter is incompatible with the
-    // partition-derived set - the query should return nothing. The downstream fetch step's
-    // filtering already handles this (no buckets pass), so returning the empty set is correct.
-    // Log at FINE so an operator chasing a "query mysteriously returns zero rows" report can grep
-    // for the type name and see that pruning + an explicit cluster filter intersected to empty.
-    if (intersected.isEmpty())
-      LogManager.instance().log(SelectExecutionPlanner.class, Level.FINE,
-          "Partition pruning on type '%s' intersected to an empty set: derived buckets %s do not "
-              + "overlap the explicit cluster filter %s. Query will return zero rows.",
-          null, docType.getName(), derivedBuckets, filterClusters);
-    return intersected;
+    // Stash the pruned bucket *file ids* on the context so consumers that do their own per-bucket
+    // fan-out can apply the same narrowing as the SQL fetch path. Today this benefits
+    // {@code vector.neighbors} / {@code vector.sparseNeighbors}: those functions enumerate per
+    // bucket vector sub-indexes and would otherwise scan every bucket of the type even when the
+    // outer query already pruned to a single bucket. Skipping unrelated bucket sub-indexes is a
+    // direct cost win and also narrows results to records that match the partition predicate.
+    // Skipped when the result set is empty - nothing to hint - and skipped when only a single
+    // bucket maps to "the whole type", in which case the function's per-type allow list already
+    // covers exactly the same set.
+    if (!result.isEmpty()) {
+      final IntHashSet bucketFileIds = new IntHashSet(result.size());
+      for (final String bucketName : result) {
+        final com.arcadedb.engine.Bucket bucket = context.getDatabase().getSchema().getBucketByName(bucketName);
+        if (bucket != null)
+          bucketFileIds.add(bucket.getFileId());
+      }
+      if (!bucketFileIds.isEmpty()) {
+        context.setVariable(CommandContext.PARTITION_PRUNED_BUCKET_FILE_IDS_VAR, bucketFileIds);
+        context.setVariable(CommandContext.PARTITION_PRUNED_TYPE_NAME_VAR, docType.getName());
+      }
+    }
+    return result;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -1762,6 +1762,11 @@ public class SelectExecutionPlanner {
     // partitioning. Skipped when the type's {@code needsRepartition} flag is true (the mapping
     // is stale until {@code REBUILD TYPE Doc WITH repartition = true} runs); a throttled
     // WARNING is emitted in that case so operators see the lost optimisation.
+    // <p>
+    // <b>Side effect.</b> When pruning fires, {@link #derivePartitionPrunedClusters} also stashes
+    // the pruned bucket file ids on {@code context} (see
+    // {@link CommandContext#PARTITION_PRUNED_BUCKET_FILE_IDS_VAR}) for downstream consumers like
+    // {@code vector.neighbors} that do their own per-bucket fan-out and need the same narrowing.
     final Set<String> effectiveClusters = docType != null
         ? derivePartitionPrunedClusters(docType, filterClusters, info, context)
         : filterClusters;
@@ -2051,6 +2056,10 @@ public class SelectExecutionPlanner {
       derivedBuckets.add(typeBuckets.get(bucketIndex).getName());
     }
 
+    // No partition prune was derivable (no AndBlock fully bound the partition properties); fall
+    // back to the caller's filterClusters. The hint-stashing block below is skipped intentionally:
+    // with no pruning, downstream consumers (vector.neighbors etc.) must keep their full per-type
+    // bucket allow-list, which the absence of the context variables already gives them.
     if (derivedBuckets.isEmpty())
       return filterClusters;
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -2088,9 +2088,10 @@ public class SelectExecutionPlanner {
     // bucket vector sub-indexes and would otherwise scan every bucket of the type even when the
     // outer query already pruned to a single bucket. Skipping unrelated bucket sub-indexes is a
     // direct cost win and also narrows results to records that match the partition predicate.
-    // Skipped when the result set is empty - nothing to hint - and skipped when only a single
-    // bucket maps to "the whole type", in which case the function's per-type allow list already
-    // covers exactly the same set.
+    // Skipped when the result set is empty (nothing to hint). When the pruned set happens to
+    // equal the type's full bucket set (e.g. an OR across every tenant value), the hint is still
+    // stashed and the function-side intersection is a no-op; not worth the extra type-bucket
+    // lookup to detect.
     if (!result.isEmpty()) {
       final IntHashSet bucketFileIds = new IntHashSet(result.size());
       for (final String bucketName : result) {

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/PartitionPruningVectorNeighborsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/PartitionPruningVectorNeighborsTest.java
@@ -152,11 +152,13 @@ class PartitionPruningVectorNeighborsTest extends TestHelper {
       assertThat(neighbors).isNotNull();
       assertThat(neighbors).hasSizeGreaterThanOrEqualTo(1);
 
-      // At least one of the three close-cluster tenants must surface in the global top-3.
+      // At least one of the close-cluster tenants must surface in the global top-3. The fixture
+      // only inserts {@code globex} and {@code umbrella} as close-cluster members; {@code initech}
+      // is intentionally excluded because it would collide with {@code acme}'s bucket.
       boolean foundCloseCluster = false;
       for (final Map<String, Object> neighbour : neighbors) {
         final String tenant = ((Document) neighbour.get("record")).getString("tenant_id");
-        if ("globex".equals(tenant) || "initech".equals(tenant) || "umbrella".equals(tenant)) {
+        if ("globex".equals(tenant) || "umbrella".equals(tenant)) {
           foundCloseCluster = true;
           break;
         }

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/PartitionPruningVectorNeighborsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/PartitionPruningVectorNeighborsTest.java
@@ -20,11 +20,13 @@ package com.arcadedb.function.sql.vector;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.Document;
+import com.arcadedb.database.RID;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -90,11 +92,11 @@ class PartitionPruningVectorNeighborsTest extends TestHelper {
     // and one of our chosen tenants now collides with acme, the {@code vectorNeighbors...} tests
     // below would silently degrade (the prune would still narrow but the bucket would contain
     // both tenants). This sanity check makes that failure mode loud.
-    final Map<String, Integer> tenantBucket = new java.util.HashMap<>();
+    final Map<String, Integer> tenantBucket = new HashMap<>();
     try (final ResultSet rs = database.query("sql", "SELECT tenant_id, @rid AS rid FROM " + TYPE_NAME)) {
       while (rs.hasNext()) {
         final Result r = rs.next();
-        final com.arcadedb.database.RID rid = (com.arcadedb.database.RID) r.getProperty("rid");
+        final RID rid = (RID) r.getProperty("rid");
         tenantBucket.put(r.getProperty("tenant_id"), rid.getBucketId());
       }
     }

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/PartitionPruningVectorNeighborsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/PartitionPruningVectorNeighborsTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.sql.vector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Document;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the contract that {@code vector.neighbors} on a partitioned type narrows its candidate
+ * bucket set to the partition-pruned subset when the query's WHERE clause binds every partition
+ * property to a literal (issue #4087, follow-up).
+ * <p>
+ * Without the planner-to-function plumbing the function would scan every bucket of the type and
+ * return the globally-closest vectors regardless of the row's tenant. This test fails on that
+ * baseline and passes once the planner stashes the partition-derived bucket file ids on the
+ * {@link com.arcadedb.query.sql.executor.CommandContext} and the function intersects them with
+ * its own per-type bucket allow-list.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class PartitionPruningVectorNeighborsTest extends TestHelper {
+
+  private static final String TYPE_NAME = "PartVecDoc";
+  private static final int    BUCKETS   = 32;
+
+  @Override
+  public void beginTest() {
+    database.transaction(() -> {
+      database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(BUCKETS).create();
+      database.command("sql", "CREATE PROPERTY " + TYPE_NAME + ".tenant_id STRING");
+      database.command("sql", "CREATE PROPERTY " + TYPE_NAME + ".embedding ARRAY_OF_FLOATS");
+      // Unique on tenant_id is required by PartitionedBucketSelectionStrategy and also serves as
+      // the vector index's idPropertyName (so vector.neighbors can resolve a tenant_id to a RID).
+      database.command("sql", "CREATE INDEX ON " + TYPE_NAME + "(tenant_id) UNIQUE");
+      database.command("sql", "ALTER TYPE " + TYPE_NAME + " BucketSelectionStrategy `partitioned('tenant_id')`");
+      database.command("sql", """
+          CREATE INDEX ON %s (embedding) LSM_VECTOR
+          METADATA {
+            dimensions: 3,
+            similarity: 'COSINE',
+            idPropertyName: 'tenant_id'
+          }""".formatted(TYPE_NAME));
+    });
+
+    // The partition strategy enforces UNIQUE on the partition property, so each tenant gets one
+    // record. We deliberately pick three tenant names whose {@code hash(name) % 32} land in
+    // distinct buckets ({@code acme} -> b27, {@code globex} -> b12, {@code umbrella} -> b5 in
+    // the current strategy implementation). {@code initech} would collide with {@code acme} on
+    // bucket 27 and is left out so the prune cleanly isolates acme.
+    database.transaction(() -> {
+      // tenant=acme is FAR from query [1,0,0]: Y-axis vector. Must be the lone resident of its
+      // bucket - if it shared a bucket with a close-cluster tenant, the prune would still let
+      // that tenant's record slip through and the test would silently mis-pin its contract.
+      insertDoc("acme", new float[] { 0.0f, 1.0f, 0.0f });
+
+      // Two close-cluster tenants in OTHER buckets:
+      insertDoc("globex", new float[] { 1.0f, 0.0f, 0.0f });
+      insertDoc("umbrella", new float[] { 0.98f, 0.02f, 0.0f });
+    });
+  }
+
+  @Test
+  void fixtureSanityTenantBucketsAreDistinct() {
+    // Defensive: if a future change to the partition-strategy hash function shifts assignments
+    // and one of our chosen tenants now collides with acme, the {@code vectorNeighbors...} tests
+    // below would silently degrade (the prune would still narrow but the bucket would contain
+    // both tenants). This sanity check makes that failure mode loud.
+    final Map<String, Integer> tenantBucket = new java.util.HashMap<>();
+    try (final ResultSet rs = database.query("sql", "SELECT tenant_id, @rid AS rid FROM " + TYPE_NAME)) {
+      while (rs.hasNext()) {
+        final Result r = rs.next();
+        final com.arcadedb.database.RID rid = (com.arcadedb.database.RID) r.getProperty("rid");
+        tenantBucket.put(r.getProperty("tenant_id"), rid.getBucketId());
+      }
+    }
+    assertThat(tenantBucket).hasSize(3);
+    assertThat(tenantBucket.get("acme"))
+        .as("acme must own its bucket exclusively for the prune-isolation tests below to be meaningful")
+        .isNotEqualTo(tenantBucket.get("globex"))
+        .isNotEqualTo(tenantBucket.get("umbrella"));
+  }
+
+  @Test
+  void vectorNeighborsHonorsPartitionPrune() {
+    // WHERE tenant_id='acme' must restrict vector.neighbors to acme's bucket only. With the
+    // prune the function sees acme's single Y-axis vector and returns it alone (k=3 caps the
+    // result, but only one record lives in that bucket). Without the prune the global top-3
+    // are globex/initech/umbrella - so this assertion catches the un-pruned regression.
+    // The predicate is a literal (not a parameter) because the planner-side prune intentionally
+    // refuses to fire on parameter-bound values - the cached plan would freeze the bucket id at
+    // the first execution's binding (see PartitionPruningPlannerTest.parameterizedQuery...).
+    try (final ResultSet rs = database.query("sql",
+        "SELECT `vector.neighbors`('" + TYPE_NAME + "[embedding]', [1.0, 0.0, 0.0], 3) AS neighbors "
+            + "FROM " + TYPE_NAME + " WHERE tenant_id = 'acme' LIMIT 1")) {
+
+      assertThat(rs.hasNext()).as("Query must return a row for the acme tenant").isTrue();
+      final Result row = rs.next();
+      @SuppressWarnings("unchecked")
+      final List<Map<String, Object>> neighbors = row.getProperty("neighbors");
+      assertThat(neighbors).as("neighbors projection must not be null").isNotNull();
+      assertThat(neighbors).as("expected at least one partition-restricted neighbour").isNotEmpty();
+
+      // Every returned record must belong to tenant='acme'. Without the prune the closest three
+      // globally are globex, initech, umbrella (all NOT acme) and this assertion fails.
+      for (final Map<String, Object> neighbour : neighbors) {
+        final String tenant = ((Document) neighbour.get("record")).getString("tenant_id");
+        assertThat(tenant)
+            .as("partition-pruned vector.neighbors must only return acme records, got tenant_id='%s'", tenant)
+            .isEqualTo("acme");
+      }
+    }
+  }
+
+  @Test
+  void vectorNeighborsWithoutPartitionPredicateScansAllBuckets() {
+    // Counter-test: a query without a WHERE on the partition key must NOT trigger pruning, so
+    // the function returns the globally-closest neighbours (globex, initech, umbrella). Pins
+    // the "no-pruning regression" half of the contract so a future overzealous implementation
+    // that always narrows would break this assertion.
+    try (final ResultSet rs = database.query("sql",
+        "SELECT `vector.neighbors`('" + TYPE_NAME + "[embedding]', [1.0, 0.0, 0.0], 3) AS neighbors")) {
+
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      @SuppressWarnings("unchecked")
+      final List<Map<String, Object>> neighbors = row.getProperty("neighbors");
+      assertThat(neighbors).isNotNull();
+      assertThat(neighbors).hasSizeGreaterThanOrEqualTo(1);
+
+      // At least one of the three close-cluster tenants must surface in the global top-3.
+      boolean foundCloseCluster = false;
+      for (final Map<String, Object> neighbour : neighbors) {
+        final String tenant = ((Document) neighbour.get("record")).getString("tenant_id");
+        if ("globex".equals(tenant) || "initech".equals(tenant) || "umbrella".equals(tenant)) {
+          foundCloseCluster = true;
+          break;
+        }
+      }
+      assertThat(foundCloseCluster)
+          .as("baseline (no partition prune) must surface at least one of the close-cluster tenants")
+          .isTrue();
+    }
+  }
+
+  private void insertDoc(final String tenant, final float[] embedding) {
+    database.newDocument(TYPE_NAME).set("tenant_id", tenant).set("embedding", embedding).save();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/PartitionPruningVectorSparseNeighborsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/PartitionPruningVectorSparseNeighborsTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.function.sql.vector;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.Document;
+import com.arcadedb.database.RID;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 
@@ -89,7 +90,7 @@ class PartitionPruningVectorSparseNeighborsTest extends TestHelper {
     try (final ResultSet rs = database.query("sql", "SELECT tenant_id, @rid AS rid FROM " + TYPE_NAME)) {
       while (rs.hasNext()) {
         final Result r = rs.next();
-        final com.arcadedb.database.RID rid = (com.arcadedb.database.RID) r.getProperty("rid");
+        final RID rid = (RID) r.getProperty("rid");
         tenantBucket.put(r.getProperty("tenant_id"), rid.getBucketId());
       }
     }

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/PartitionPruningVectorSparseNeighborsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/PartitionPruningVectorSparseNeighborsTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.sql.vector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Document;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Sparse-vector counterpart of {@link PartitionPruningVectorNeighborsTest}: pins the contract
+ * that {@code vector.sparseNeighbors} on a partitioned type narrows its candidate bucket set to
+ * the partition-pruned subset when the query's WHERE clause binds every partition property to a
+ * literal (issue #4087, follow-up).
+ * <p>
+ * The dense and sparse neighbour functions take separate code paths to assemble the per-bucket
+ * index list ({@code SQLFunctionVectorNeighbors.execute} vs
+ * {@code SQLFunctionVectorSparseNeighbors.collectSparseIndexes}). The narrowing helper is shared
+ * but each call site invokes it independently, so a regression in the sparse path would not
+ * surface in the dense test - hence the dedicated coverage.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class PartitionPruningVectorSparseNeighborsTest extends TestHelper {
+
+  private static final String TYPE_NAME = "PartSparseDoc";
+  private static final int    BUCKETS   = 32;
+
+  @Override
+  public void beginTest() {
+    database.transaction(() -> {
+      database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(BUCKETS).create();
+      database.command("sql", "CREATE PROPERTY " + TYPE_NAME + ".tenant_id STRING");
+      database.command("sql", "CREATE PROPERTY " + TYPE_NAME + ".tokens ARRAY_OF_INTEGERS");
+      database.command("sql", "CREATE PROPERTY " + TYPE_NAME + ".weights ARRAY_OF_FLOATS");
+      database.command("sql", "CREATE INDEX ON " + TYPE_NAME + "(tenant_id) UNIQUE");
+      database.command("sql", "ALTER TYPE " + TYPE_NAME + " BucketSelectionStrategy `partitioned('tenant_id')`");
+      database.getSchema()
+          .buildTypeIndex(TYPE_NAME, new String[] { "tokens", "weights" })
+          .withSparseVectorType()
+          .withDimensions(50)
+          .create();
+    });
+
+    // Three tenants in distinct buckets (acme -> b27, globex -> b12, umbrella -> b5 under the
+    // current partition strategy hash; verified by {@link #fixtureSanityTenantBucketsAreDistinct}).
+    // Sparse vectors all touch dimension 1 so the dot-product query can score every record - what
+    // distinguishes acme is its tiny weight, which keeps it out of the global top-3 ranking but
+    // makes it the lone resident of its bucket once the partition prune isolates the search.
+    database.transaction(() -> {
+      // acme: small weight on shared dim 1 -> low global rank.
+      insertDoc("acme", new int[] { 1 }, new float[] { 0.05f });
+
+      // Close-cluster tenants: high weights on shared dim 1.
+      insertDoc("globex", new int[] { 1 }, new float[] { 1.0f });
+      insertDoc("umbrella", new int[] { 1 }, new float[] { 0.9f });
+    });
+  }
+
+  @Test
+  void fixtureSanityTenantBucketsAreDistinct() {
+    // Same defensive sanity check as the dense test: a future hash-function shift that puts two of
+    // our tenants in the same bucket would silently weaken the prune-isolation tests below.
+    final Map<String, Integer> tenantBucket = new HashMap<>();
+    try (final ResultSet rs = database.query("sql", "SELECT tenant_id, @rid AS rid FROM " + TYPE_NAME)) {
+      while (rs.hasNext()) {
+        final Result r = rs.next();
+        final com.arcadedb.database.RID rid = (com.arcadedb.database.RID) r.getProperty("rid");
+        tenantBucket.put(r.getProperty("tenant_id"), rid.getBucketId());
+      }
+    }
+    assertThat(tenantBucket).hasSize(3);
+    assertThat(tenantBucket.get("acme"))
+        .as("acme must own its bucket exclusively for the prune-isolation tests below to be meaningful")
+        .isNotEqualTo(tenantBucket.get("globex"))
+        .isNotEqualTo(tenantBucket.get("umbrella"));
+  }
+
+  @Test
+  void sparseNeighborsHonorsPartitionPrune() {
+    // WHERE tenant_id='acme' must restrict vector.sparseNeighbors to acme's bucket only. With
+    // the prune the function sees acme's lone low-score record and returns it; without the prune
+    // the global top-3 are globex/umbrella/acme (all three tenants share dim 1) but globex and
+    // umbrella outrank acme by weight - the assertion below catches the un-pruned regression by
+    // requiring every returned record to be acme's.
+    try (final ResultSet rs = database.query("sql",
+        "SELECT `vector.sparseNeighbors`('" + TYPE_NAME + "[tokens,weights]', [1], [1.0], 3) AS neighbors "
+            + "FROM " + TYPE_NAME + " WHERE tenant_id = 'acme' LIMIT 1")) {
+
+      assertThat(rs.hasNext()).as("Query must return a row for the acme tenant").isTrue();
+      final Result row = rs.next();
+      @SuppressWarnings("unchecked")
+      final List<Map<String, Object>> neighbors = row.getProperty("neighbors");
+      assertThat(neighbors).as("neighbors projection must not be null").isNotNull();
+      assertThat(neighbors).as("expected at least one partition-restricted neighbour").isNotEmpty();
+
+      for (final Map<String, Object> neighbour : neighbors) {
+        final String tenant = ((Document) neighbour.get("record")).getString("tenant_id");
+        assertThat(tenant)
+            .as("partition-pruned vector.sparseNeighbors must only return acme records, got tenant_id='%s'", tenant)
+            .isEqualTo("acme");
+      }
+    }
+  }
+
+  @Test
+  void sparseNeighborsWithoutPartitionPredicateScansAllBuckets() {
+    // Counter-test: a query without a WHERE on the partition key must NOT trigger pruning. The
+    // global top-3 should include at least one of the close-cluster tenants whose weight on the
+    // shared dim outranks acme's.
+    try (final ResultSet rs = database.query("sql",
+        "SELECT `vector.sparseNeighbors`('" + TYPE_NAME + "[tokens,weights]', [1], [1.0], 3) AS neighbors")) {
+
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      @SuppressWarnings("unchecked")
+      final List<Map<String, Object>> neighbors = row.getProperty("neighbors");
+      assertThat(neighbors).isNotNull();
+      assertThat(neighbors).hasSizeGreaterThanOrEqualTo(1);
+
+      boolean foundCloseCluster = false;
+      for (final Map<String, Object> neighbour : neighbors) {
+        final String tenant = ((Document) neighbour.get("record")).getString("tenant_id");
+        if ("globex".equals(tenant) || "umbrella".equals(tenant)) {
+          foundCloseCluster = true;
+          break;
+        }
+      }
+      assertThat(foundCloseCluster)
+          .as("baseline (no partition prune) must surface at least one of the close-cluster tenants")
+          .isTrue();
+    }
+  }
+
+  private void insertDoc(final String tenant, final int[] tokens, final float[] weights) {
+    database.newDocument(TYPE_NAME).set("tenant_id", tenant).set("tokens", tokens).set("weights", weights).save();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/schema/PartitioningRepartitionFlagTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/PartitioningRepartitionFlagTest.java
@@ -310,12 +310,16 @@ class PartitioningRepartitionFlagTest extends TestHelper {
 
     // Simulate the window expiring by rewinding the throttle past the 60-second boundary. The
     // next call must advance the timestamp again, proving the throttle releases on schedule
-    // without blocking the test on a real 60-second sleep.
-    type.setLastRepartitionWarnMsForTesting(System.currentTimeMillis() - 120_000L);
+    // without blocking the test on a real 60-second sleep. Compare against the rewound value
+    // (not against {@code firstStamp}) so the assertion stays robust on sub-millisecond fast
+    // paths where {@code System.currentTimeMillis()} has not advanced since {@code firstStamp}
+    // was sampled.
+    final long rewoundStamp = System.currentTimeMillis() - 120_000L;
+    type.setLastRepartitionWarnMsForTesting(rewoundStamp);
     type.warnIfNeedsRepartition();
     assertThat(type.lastRepartitionWarnMsForTesting())
-        .as("warn after the throttle window has elapsed must advance the timestamp")
-        .isGreaterThan(firstStamp);
+        .as("warn after the throttle window has elapsed must advance the timestamp from the rewound value")
+        .isGreaterThan(rewoundStamp);
   }
 
   // ---- shared scaffolding -------------------------------------------------

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -1546,7 +1546,7 @@ function createType(category) {
     html += "<small class='text-muted' style='display:block;margin-top:-10px;margin-bottom:10px;'>No existing " + escapeHtml(catLabel.toLowerCase()) + " types to extend from.</small>";
 
   // Buckets + Page Size
-  html += "<div class='row mb-3'>";
+  html += "<div class='row mb-2'>";
   html += "<div class='col-6'>";
   html += "<label for='inputCreateTypeBuckets'>Buckets (optional)</label>";
   html += "<input class='form-control mt-1' id='inputCreateTypeBuckets' type='number' min='1' max='32' placeholder='default'>";
@@ -1555,6 +1555,21 @@ function createType(category) {
   html += "<label for='inputCreateTypePageSize'>Page Size (optional)</label>";
   html += "<input class='form-control mt-1' id='inputCreateTypePageSize' type='number' min='1' placeholder='default'>";
   html += "</div>";
+  html += "</div>";
+
+  // Partition-strategy hint (issue #4087 follow-up). Surfaced near the bucket count because that
+  // is the field most directly tied to the partition-strategy decision: > 1 bucket is what makes
+  // partitioning useful, and the strategy itself defaults to round-robin and is set post-create
+  // via ALTER TYPE (Studio surfaces a stale-mapping banner + Run Repartition button on the type
+  // detail panel when a later schema mutation invalidates an existing partition mapping). The
+  // hint nudges the operator toward a partitioned strategy at schema-design time so the
+  // optimisation is in place before data lands, instead of being noticed retroactively.
+  html += "<div class='alert alert-info py-2 px-3 mb-3' style='font-size:0.82rem;'>";
+  html += "<i class='fa fa-circle-info me-1'></i> ";
+  html += "<strong>Tip:</strong> If your data is scoped by tenant, customer, region, or another high-cardinality identifier, ";
+  html += "partition by that property (after creating the type and its properties) for query-time bucket pruning. ";
+  html += "<a href='https://docs.arcadedb.com/#schema-design-101-bucket-strategy' target='_blank' rel='noopener noreferrer'>";
+  html += "Schema design 101 <i class='fa fa-external-link-alt' style='font-size:0.75rem;'></i></a>";
   html += "</div>";
 
   // Options row

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -1568,7 +1568,7 @@ function createType(category) {
   html += "<i class='fa fa-circle-info me-1'></i> ";
   html += "<strong>Tip:</strong> If your data is scoped by tenant, customer, region, or another high-cardinality identifier, ";
   html += "partition by that property (after creating the type and its properties) for query-time bucket pruning. ";
-  html += "<a href='https://docs.arcadedb.com/#schema-design-101-bucket-strategy' target='_blank' rel='noopener noreferrer'>";
+  html += "<a href='https://docs.arcadedb.com/arcadedb/concepts/basics#schema-design-101-bucket-strategy' target='_blank' rel='noopener noreferrer'>";
   html += "Schema design 101 <i class='fa fa-external-link-alt' style='font-size:0.75rem;'></i></a>";
   html += "</div>";
 


### PR DESCRIPTION
Fixed issue #4087

A query like `SELECT vector.neighbors('Doc[embedding]', :query, k) FROM Doc WHERE tenant_id = 'X'` on a partitioned('tenant_id') type now narrows the function's per-bucket vector-index fan-out to the partition-derived bucket(s) instead of scanning every bucket. Same for vector.sparseNeighbors. Without a partition-key WHERE the function continues to scan every bucket - no regression.

## What does this PR do?

A brief description of the change being made with this pull request.

## Motivation

What inspired you to submit this pull request?

## Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

## Additional Notes

Anything else we should know when reviewing?

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
