### PR TITLE
#4125 fix(cypher): persist datetime() value on DATETIME-typed properties

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CreateStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CreateStep.java
@@ -489,19 +489,9 @@ public class CreateStep extends AbstractExecutionStep {
     if (value == null || value instanceof Number || value instanceof String || value instanceof Boolean)
       return value;
 
-    // Handle single temporal values
-    if (value instanceof CypherDate)
-      return ((CypherDate) value).getValue();
-    if (value instanceof CypherLocalDateTime)
-      return ((CypherLocalDateTime) value).getValue();
-    if (value instanceof CypherDateTime)
-      return value.toString(); // Store as String to preserve timezone info
-    if (value instanceof CypherLocalTime)
-      return ((CypherLocalTime) value).getValue().toString();
-    if (value instanceof CypherTime)
-      return ((CypherTime) value).getValue().toString();
-    if (value instanceof CypherDuration)
-      return value.toString();
+    // Handle single temporal values via shared converter
+    if (value instanceof CypherTemporalValue)
+      return TemporalUtil.toCoreJavaType(value);
 
     // Handle collections - only iterate if the collection could contain temporal values
     if (value instanceof Collection<?> collection) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CreateStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CreateStep.java
@@ -41,7 +41,6 @@ import com.arcadedb.query.opencypher.traversal.TraversalPath;
 import com.arcadedb.query.sql.executor.*;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -481,45 +480,11 @@ public class CreateStep extends AbstractExecutionStep {
   }
 
   /**
-   * Convert CypherTemporalValue objects to java.time types for ArcadeDB storage.
-   * Handles both single values and collections/arrays of temporal values.
+   * Convert CypherTemporalValue objects (and collections of them) to types ArcadeDB can serialize.
+   * Delegates to the shared TemporalUtil so all Cypher write paths apply identical conversion.
    */
   private static Object convertTemporalForStorage(final Object value) {
-    // Fast path: skip non-temporal primitives, numbers, strings, and boolean (common case for vector embeddings)
-    if (value == null || value instanceof Number || value instanceof String || value instanceof Boolean)
-      return value;
-
-    // Handle single temporal values via shared converter
-    if (value instanceof CypherTemporalValue)
-      return TemporalUtil.toCoreJavaType(value);
-
-    // Handle collections - only iterate if the collection could contain temporal values
-    if (value instanceof Collection<?> collection) {
-      if (collection.isEmpty())
-        return value;
-      // Check the first element: if it's a simple type (Number, String, Boolean),
-      // the entire collection is unlikely to contain temporal values
-      final Object first = collection.iterator().next();
-      if (first instanceof Number || first instanceof String || first instanceof Boolean)
-        return value;
-      // Collection may contain temporal values, convert each element
-      final List<Object> converted = new ArrayList<>(collection.size());
-      for (final Object item : collection)
-        converted.add(convertTemporalForStorage(item));
-      return converted;
-    }
-    if (value instanceof Object[] array) {
-      if (array.length == 0)
-        return value;
-      if (array[0] instanceof Number || array[0] instanceof String || array[0] instanceof Boolean)
-        return value;
-      final Object[] converted = new Object[array.length];
-      for (int i = 0; i < array.length; i++)
-        converted[i] = convertTemporalForStorage(array[i]);
-      return converted;
-    }
-
-    return value;
+    return TemporalUtil.toCoreJavaType(value);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -806,7 +806,7 @@ public class MergeStep extends AbstractExecutionStep {
         }
       }
 
-      document.set(key, value);
+      document.set(key, TemporalUtil.toCoreJavaType(value));
     }
   }
 
@@ -834,7 +834,7 @@ public class MergeStep extends AbstractExecutionStep {
       else if (value instanceof CypherASTBuilder.ParameterReference) {
         final String paramName = ((CypherASTBuilder.ParameterReference) value).getName();
         if (context.getInputParameters() != null)
-          value = context.getInputParameters().get(paramName);
+          value = TemporalUtil.toCoreJavaType(context.getInputParameters().get(paramName));
       }
       // Legacy support: If the value looks like a property access (e.g., "BatchEntry.subtype"),
       // try to evaluate it against the current result context
@@ -922,7 +922,7 @@ public class MergeStep extends AbstractExecutionStep {
               mutableDoc.remove(prop);
           for (final Map.Entry<String, Object> entry : map.entrySet())
             if (entry.getValue() != null)
-              mutableDoc.set(entry.getKey(), entry.getValue());
+              mutableDoc.set(entry.getKey(), TemporalUtil.toCoreJavaType(entry.getValue()));
           mutableDoc.save();
           ((ResultInternal) result).setProperty(variable, mutableDoc);
           break;
@@ -943,7 +943,7 @@ public class MergeStep extends AbstractExecutionStep {
             if (entry.getValue() == null)
               mutableDoc.remove(entry.getKey());
             else
-              mutableDoc.set(entry.getKey(), entry.getValue());
+              mutableDoc.set(entry.getKey(), TemporalUtil.toCoreJavaType(entry.getValue()));
           mutableDoc.save();
           ((ResultInternal) result).setProperty(variable, mutableDoc);
           break;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -37,6 +37,7 @@ import com.arcadedb.query.opencypher.ast.SetClause;
 import com.arcadedb.query.opencypher.executor.CypherFunctionFactory;
 import com.arcadedb.query.opencypher.executor.ExpressionEvaluator;
 import com.arcadedb.query.opencypher.parser.CypherASTBuilder;
+import com.arcadedb.query.opencypher.temporal.TemporalUtil;
 import com.arcadedb.query.sql.executor.AbstractExecutionStep;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -827,7 +828,7 @@ public class MergeStep extends AbstractExecutionStep {
 
       // If the value is an Expression object, evaluate it in the current result context
       if (value instanceof Expression) {
-        value = evaluator.evaluate((Expression) value, result, context);
+        value = TemporalUtil.toCoreJavaType(evaluator.evaluate((Expression) value, result, context));
       }
       // Resolve parameter references (e.g., $username -> actual value from context)
       else if (value instanceof CypherASTBuilder.ParameterReference) {
@@ -895,11 +896,11 @@ public class MergeStep extends AbstractExecutionStep {
           if (!(obj instanceof Document doc))
             break;
           final MutableDocument mutableDoc = doc.modify();
-          final Object value = evaluator.evaluate(item.getValueExpression(), result, context);
+          Object value = evaluator.evaluate(item.getValueExpression(), result, context);
           if (value == null)
             mutableDoc.remove(item.getProperty());
           else
-            mutableDoc.set(item.getProperty(), value);
+            mutableDoc.set(item.getProperty(), TemporalUtil.toCoreJavaType(value));
           mutableDoc.save();
           ((ResultInternal) result).setProperty(variable, mutableDoc);
           break;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
@@ -27,6 +27,7 @@ import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.Labels;
 import com.arcadedb.query.opencypher.ast.SetClause;
+import com.arcadedb.query.opencypher.temporal.TemporalUtil;
 import com.arcadedb.query.opencypher.executor.CypherFunctionFactory;
 import com.arcadedb.query.opencypher.executor.ExpressionEvaluator;
 import com.arcadedb.query.sql.executor.AbstractExecutionStep;
@@ -211,10 +212,11 @@ public class SetStep extends AbstractExecutionStep {
     if (mutableDoc != doc && variableToUpdate != null)
       ((ResultInternal) result).setProperty(variableToUpdate, mutableDoc);
 
-    final Object value = evaluator.evaluate(item.getValueExpression(), result, context);
+    Object value = evaluator.evaluate(item.getValueExpression(), result, context);
     if (value == null)
       mutableDoc.remove(item.getProperty());
     else {
+      value = TemporalUtil.toCoreJavaType(value);
       validatePropertyValue(value);
       mutableDoc.set(item.getProperty(), value);
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
@@ -259,7 +259,7 @@ public class SetStep extends AbstractExecutionStep {
     // Set new properties from map (skip null values - they mean "remove")
     for (final Map.Entry<String, Object> entry : map.entrySet()) {
       if (entry.getValue() != null)
-        mutableDoc.set(entry.getKey(), entry.getValue());
+        mutableDoc.set(entry.getKey(), TemporalUtil.toCoreJavaType(entry.getValue()));
     }
 
     mutableDoc.save();
@@ -292,7 +292,7 @@ public class SetStep extends AbstractExecutionStep {
       if (entry.getValue() == null)
         mutableDoc.remove(entry.getKey());
       else
-        mutableDoc.set(entry.getKey(), entry.getValue());
+        mutableDoc.set(entry.getKey(), TemporalUtil.toCoreJavaType(entry.getValue()));
     }
 
     mutableDoc.save();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/temporal/TemporalUtil.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/temporal/TemporalUtil.java
@@ -373,6 +373,32 @@ public final class TemporalUtil {
     return nanos;
   }
 
+  /**
+   * Convert a Cypher temporal value to a form that ArcadeDB can serialize.
+   *
+   * CypherDateTime is kept as its ISO-8601 string representation (not unwrapped to ZonedDateTime)
+   * so that: (a) untyped properties store it as TYPE_STRING, preserving timezone info for
+   * later component access via PropertyAccessExpression.convertFromStorage(); and (b) for
+   * schema-typed DATETIME properties, Type.convert() can parse the string to the target Java type.
+   *
+   * Non-temporal values are returned unchanged.
+   */
+  public static Object toCoreJavaType(final Object value) {
+    if (value instanceof CypherDateTime dt)
+      return dt.toString();
+    if (value instanceof CypherDate d)
+      return d.getValue();
+    if (value instanceof CypherLocalDateTime ldt)
+      return ldt.getValue();
+    if (value instanceof CypherLocalTime lt)
+      return lt.getValue().toString();
+    if (value instanceof CypherTime t)
+      return t.getValue().toString();
+    if (value instanceof CypherDuration dur)
+      return dur.toString();
+    return value;
+  }
+
   private static boolean isTimeOnly(final CypherTemporalValue val) {
     return val instanceof CypherLocalTime || val instanceof CypherTime;
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/temporal/TemporalUtil.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/temporal/TemporalUtil.java
@@ -25,6 +25,9 @@ import java.time.temporal.IsoFields;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAdjusters;
 import java.time.temporal.WeekFields;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -374,16 +377,21 @@ public final class TemporalUtil {
   }
 
   /**
-   * Convert a Cypher temporal value to a form that ArcadeDB can serialize.
+   * Convert a Cypher temporal value (or a collection/array containing temporal values) to a form
+   * that ArcadeDB can serialize.
    *
    * CypherDateTime is kept as its ISO-8601 string representation (not unwrapped to ZonedDateTime)
    * so that: (a) untyped properties store it as TYPE_STRING, preserving timezone info for
    * later component access via PropertyAccessExpression.convertFromStorage(); and (b) for
-   * schema-typed DATETIME properties, Type.convert() can parse the string to the target Java type.
+   * schema-typed DATETIME properties, Type.convert() parses the string into the target Java type
+   * (timezone is dropped on a LocalDateTime target, matching the SQL sysdate() semantics).
    *
-   * Non-temporal values are returned unchanged.
+   * Non-temporal scalars and collections of non-temporal scalars are returned unchanged.
    */
   public static Object toCoreJavaType(final Object value) {
+    if (value == null || value instanceof Number || value instanceof String || value instanceof Boolean)
+      return value;
+
     if (value instanceof CypherDateTime dt)
       return dt.toString();
     if (value instanceof CypherDate d)
@@ -396,6 +404,30 @@ public final class TemporalUtil {
       return t.getValue().toString();
     if (value instanceof CypherDuration dur)
       return dur.toString();
+
+    // Recurse into collections - skip when first element is a non-temporal scalar (vector embeddings, etc.)
+    if (value instanceof Collection<?> collection) {
+      if (collection.isEmpty())
+        return value;
+      final Object first = collection.iterator().next();
+      if (first instanceof Number || first instanceof String || first instanceof Boolean)
+        return value;
+      final List<Object> converted = new ArrayList<>(collection.size());
+      for (final Object item : collection)
+        converted.add(toCoreJavaType(item));
+      return converted;
+    }
+    if (value instanceof Object[] array) {
+      if (array.length == 0)
+        return value;
+      if (array[0] instanceof Number || array[0] instanceof String || array[0] instanceof Boolean)
+        return value;
+      final Object[] converted = new Object[array.length];
+      for (int i = 0; i < array.length; i++)
+        converted[i] = toCoreJavaType(array[i]);
+      return converted;
+    }
+
     return value;
   }
 

--- a/engine/src/main/java/com/arcadedb/schema/Type.java
+++ b/engine/src/main/java/com/arcadedb/schema/Type.java
@@ -586,11 +586,11 @@ public enum Type {
             if (database != null)
               try {
                 return LocalDateTime.parse(valueAsString);
-              } catch (Exception e) {
+              } catch (DateTimeParseException e) {
                 try {
                   // Handle timezone-aware strings (e.g. from Cypher datetime()): strip timezone
                   return ZonedDateTime.parse(valueAsString).toLocalDateTime();
-                } catch (Exception e2) {
+                } catch (DateTimeParseException e2) {
                   try {
                     return LocalDateTime.parse(valueAsString,
                         DateTimeFormatter.ofPattern((database.getSchema().getDateTimeFormat())));

--- a/engine/src/main/java/com/arcadedb/schema/Type.java
+++ b/engine/src/main/java/com/arcadedb/schema/Type.java
@@ -588,10 +588,15 @@ public enum Type {
                 return LocalDateTime.parse(valueAsString);
               } catch (Exception e) {
                 try {
-                  return LocalDateTime.parse(valueAsString,
-                      DateTimeFormatter.ofPattern((database.getSchema().getDateTimeFormat())));
-                } catch (final DateTimeParseException ignore) {
-                  return LocalDateTime.parse(valueAsString, DateTimeFormatter.ofPattern((database.getSchema().getDateFormat())));
+                  // Handle timezone-aware strings (e.g. from Cypher datetime()): strip timezone
+                  return ZonedDateTime.parse(valueAsString).toLocalDateTime();
+                } catch (Exception e2) {
+                  try {
+                    return LocalDateTime.parse(valueAsString,
+                        DateTimeFormatter.ofPattern((database.getSchema().getDateTimeFormat())));
+                  } catch (final DateTimeParseException ignore) {
+                    return LocalDateTime.parse(valueAsString, DateTimeFormatter.ofPattern((database.getSchema().getDateFormat())));
+                  }
                 }
               }
             else {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue4125CypherDatetimePersistenceTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue4125CypherDatetimePersistenceTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import com.arcadedb.schema.VertexType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for datetime() value persistence on DATETIME-typed properties via Cypher.
+ * <p>
+ * CREATE or SET with datetime() on a DATETIME-typed column must persist the value so that
+ * a subsequent MATCH returns a non-null result.
+ */
+class Issue4125CypherDatetimePersistenceTest {
+
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    database = new DatabaseFactory("./target/databases/issue-4125-datetime-persistence").create();
+    database.transaction(() -> {
+      final VertexType type = database.getSchema().createVertexType("Foo");
+      type.createProperty("id", Type.STRING);
+      type.createProperty("t", Type.DATETIME);
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void createWithDatetimePersists() {
+    database.command("opencypher", "CREATE (n:Foo {id: 'a', t: datetime()})");
+
+    try (final ResultSet rs = database.query("opencypher", "MATCH (n:Foo {id: 'a'}) RETURN n.t AS t")) {
+      final Object t = rs.next().getProperty("t");
+      assertThat(t).as("datetime() set via CREATE must persist on DATETIME property").isNotNull();
+    }
+  }
+
+  @Test
+  void setDatetimeNowPersists() {
+    database.command("opencypher", "CREATE (n:Foo {id: 'b'})");
+    database.command("opencypher", "MATCH (n:Foo {id: 'b'}) SET n.t = datetime()");
+
+    try (final ResultSet rs = database.query("opencypher", "MATCH (n:Foo {id: 'b'}) RETURN n.t AS t")) {
+      final Object t = rs.next().getProperty("t");
+      assertThat(t).as("datetime() set via SET must persist on DATETIME property").isNotNull();
+    }
+  }
+
+  @Test
+  void setExplicitDatetimeStringPersists() {
+    database.command("opencypher", "CREATE (n:Foo {id: 'c'})");
+    database.command("opencypher", "MATCH (n:Foo {id: 'c'}) SET n.t = datetime('2026-01-01T00:00:00')");
+
+    try (final ResultSet rs = database.query("opencypher", "MATCH (n:Foo {id: 'c'}) RETURN n.t AS t")) {
+      final Object t = rs.next().getProperty("t");
+      assertThat(t).as("datetime(string) set via SET must persist on DATETIME property").isNotNull();
+    }
+  }
+
+  @Test
+  void mergeOnCreateSetDatetimePersists() {
+    database.command("opencypher", "MERGE (n:Foo {id: 'merge-a'}) ON CREATE SET n.t = datetime()");
+
+    try (final ResultSet rs = database.query("opencypher", "MATCH (n:Foo {id: 'merge-a'}) RETURN n.t AS t")) {
+      final Object t = rs.next().getProperty("t");
+      assertThat(t).as("datetime() set via MERGE ON CREATE SET must persist").isNotNull();
+    }
+  }
+
+  @Test
+  void mergeOnMatchSetDatetimePersists() {
+    database.command("opencypher", "CREATE (n:Foo {id: 'merge-b'})");
+    database.command("opencypher", "MERGE (n:Foo {id: 'merge-b'}) ON MATCH SET n.t = datetime()");
+
+    try (final ResultSet rs = database.query("opencypher", "MATCH (n:Foo {id: 'merge-b'}) RETURN n.t AS t")) {
+      final Object t = rs.next().getProperty("t");
+      assertThat(t).as("datetime() set via MERGE ON MATCH SET must persist").isNotNull();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue4125CypherDatetimePersistenceTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue4125CypherDatetimePersistenceTest.java
@@ -20,12 +20,15 @@ package com.arcadedb.query.opencypher;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.opencypher.temporal.CypherLocalDateTime;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Type;
 import com.arcadedb.schema.VertexType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -59,22 +62,30 @@ class Issue4125CypherDatetimePersistenceTest {
 
   @Test
   void createWithDatetimePersists() {
+    final LocalDateTime before = LocalDateTime.now().minusMinutes(1);
     database.command("opencypher", "CREATE (n:Foo {id: 'a', t: datetime()})");
+    final LocalDateTime after = LocalDateTime.now().plusMinutes(1);
 
     try (final ResultSet rs = database.query("opencypher", "MATCH (n:Foo {id: 'a'}) RETURN n.t AS t")) {
       final Object t = rs.next().getProperty("t");
-      assertThat(t).as("datetime() set via CREATE must persist on DATETIME property").isNotNull();
+      assertThat(t).as("datetime() set via CREATE must persist on DATETIME property")
+          .isNotNull().isInstanceOf(CypherLocalDateTime.class);
+      assertThat(((CypherLocalDateTime) t).getValue()).isBetween(before, after);
     }
   }
 
   @Test
   void setDatetimeNowPersists() {
     database.command("opencypher", "CREATE (n:Foo {id: 'b'})");
+    final LocalDateTime before = LocalDateTime.now().minusMinutes(1);
     database.command("opencypher", "MATCH (n:Foo {id: 'b'}) SET n.t = datetime()");
+    final LocalDateTime after = LocalDateTime.now().plusMinutes(1);
 
     try (final ResultSet rs = database.query("opencypher", "MATCH (n:Foo {id: 'b'}) RETURN n.t AS t")) {
       final Object t = rs.next().getProperty("t");
-      assertThat(t).as("datetime() set via SET must persist on DATETIME property").isNotNull();
+      assertThat(t).as("datetime() set via SET must persist on DATETIME property")
+          .isNotNull().isInstanceOf(CypherLocalDateTime.class);
+      assertThat(((CypherLocalDateTime) t).getValue()).isBetween(before, after);
     }
   }
 
@@ -85,28 +96,38 @@ class Issue4125CypherDatetimePersistenceTest {
 
     try (final ResultSet rs = database.query("opencypher", "MATCH (n:Foo {id: 'c'}) RETURN n.t AS t")) {
       final Object t = rs.next().getProperty("t");
-      assertThat(t).as("datetime(string) set via SET must persist on DATETIME property").isNotNull();
+      assertThat(t).as("datetime(string) set via SET must persist on DATETIME property")
+          .isNotNull().isInstanceOf(CypherLocalDateTime.class);
+      assertThat(((CypherLocalDateTime) t).getValue()).isEqualTo(LocalDateTime.of(2026, 1, 1, 0, 0, 0));
     }
   }
 
   @Test
   void mergeOnCreateSetDatetimePersists() {
+    final LocalDateTime before = LocalDateTime.now().minusMinutes(1);
     database.command("opencypher", "MERGE (n:Foo {id: 'merge-a'}) ON CREATE SET n.t = datetime()");
+    final LocalDateTime after = LocalDateTime.now().plusMinutes(1);
 
     try (final ResultSet rs = database.query("opencypher", "MATCH (n:Foo {id: 'merge-a'}) RETURN n.t AS t")) {
       final Object t = rs.next().getProperty("t");
-      assertThat(t).as("datetime() set via MERGE ON CREATE SET must persist").isNotNull();
+      assertThat(t).as("datetime() set via MERGE ON CREATE SET must persist")
+          .isNotNull().isInstanceOf(CypherLocalDateTime.class);
+      assertThat(((CypherLocalDateTime) t).getValue()).isBetween(before, after);
     }
   }
 
   @Test
   void mergeOnMatchSetDatetimePersists() {
     database.command("opencypher", "CREATE (n:Foo {id: 'merge-b'})");
+    final LocalDateTime before = LocalDateTime.now().minusMinutes(1);
     database.command("opencypher", "MERGE (n:Foo {id: 'merge-b'}) ON MATCH SET n.t = datetime()");
+    final LocalDateTime after = LocalDateTime.now().plusMinutes(1);
 
     try (final ResultSet rs = database.query("opencypher", "MATCH (n:Foo {id: 'merge-b'}) RETURN n.t AS t")) {
       final Object t = rs.next().getProperty("t");
-      assertThat(t).as("datetime() set via MERGE ON MATCH SET must persist").isNotNull();
+      assertThat(t).as("datetime() set via MERGE ON MATCH SET must persist")
+          .isNotNull().isInstanceOf(CypherLocalDateTime.class);
+      assertThat(((CypherLocalDateTime) t).getValue()).isBetween(before, after);
     }
   }
 }


### PR DESCRIPTION
## Summary

- `SetStep`/`MergeStep` passed `CypherDateTime` directly to `MutableDocument.set()`; the binary serializer did not recognize the type, returned `-1` (unknown), and silently dropped the property.
- `CreateStep` already converted to `toString()`, but `Type.convert(LocalDateTime, "2026-05-07T12:37:33Z")` failed because `LocalDateTime.parse()` rejects timezone-bearing strings; the exception was swallowed and `null` stored.
- Routes Cypher temporal writes through a new `TemporalUtil.toCoreJavaType()` (string form for `CypherDateTime`, preserving timezone for untyped-property round-trips via `PropertyAccessExpression.convertFromStorage()`) and teaches `Type.convert()` to fall back to `ZonedDateTime.parse().toLocalDateTime()` for timezone-bearing strings.

Fixes #4125.

## Test plan

- [x] New regression test `Issue4125CypherDatetimePersistenceTest` (5 tests: CREATE inline, SET datetime(), SET datetime(string), MERGE ON CREATE SET, MERGE ON MATCH SET)
- [x] Full OpenCypher TCK suite: 3897 tests, 0 failures (untyped `datetime()` round-trips still preserve timezone via string storage)
- [x] Full Cypher test suite passes (3 pre-existing failures unrelated to this change, verified by checkout main)
- [x] Type/DateTime tests: 362 tests, 0 failures