### PR TITLE
fix: drop orphan TypeIndex wrapper when its last bucket child is removed

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/TypeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/TypeIndex.java
@@ -533,6 +533,10 @@ public class TypeIndex implements RangeIndex, IndexInternal {
     return indexesOnBuckets.toArray(new IndexInternal[indexesOnBuckets.size()]);
   }
 
+  public int countIndexesOnBuckets() {
+    return indexesOnBuckets.size();
+  }
+
   public List<? extends Index> getIndexesByKeys(final Object[] keys) {
     // For full-text indexes, always search all buckets regardless of bucket selection strategy.
     // Full-text queries contain search terms/phrases, not document property values, so bucket

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -578,7 +578,7 @@ public class LocalSchema implements Schema {
                 // A TypeIndex with no remaining bucket children must not stay in indexesByProperties:
                 // schema serialization (toJSON) calls TypeIndex.getPropertyNames(), which fails on an
                 // empty wrapper.
-                if (parentTypeIndex != null && parentTypeIndex.getIndexesOnBuckets().length == 0) {
+                if (parentTypeIndex != null && parentTypeIndex.countIndexesOnBuckets() == 0) {
                   type.removeTypeIndexInternal(parentTypeIndex);
                   indexMap.remove(parentTypeIndex.getName());
                 }

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -562,8 +562,9 @@ public class LocalSchema implements Schema {
 
         try {
           database.executeLockingFiles(index.getFileIds(), () -> {
-            if (index.getTypeIndex() != null)
-              index.getTypeIndex().removeIndexOnBucket(index);
+            final TypeIndex parentTypeIndex = index.getTypeIndex();
+            if (parentTypeIndex != null)
+              parentTypeIndex.removeIndexOnBucket(index);
 
             index.drop();
             indexMap.remove(indexName);
@@ -572,8 +573,16 @@ public class LocalSchema implements Schema {
               final LocalDocumentType type = getType(index.getTypeName());
               if (index instanceof TypeIndex typeIndex)
                 type.removeTypeIndexInternal(typeIndex);
-              else
+              else {
                 type.removeBucketIndexInternal(index);
+                // A TypeIndex with no remaining bucket children must not stay in indexesByProperties:
+                // schema serialization (toJSON) calls TypeIndex.getPropertyNames(), which fails on an
+                // empty wrapper.
+                if (parentTypeIndex != null && parentTypeIndex.getIndexesOnBuckets().length == 0) {
+                  type.removeTypeIndexInternal(parentTypeIndex);
+                  indexMap.remove(parentTypeIndex.getName());
+                }
+              }
             }
             return null;
           });

--- a/engine/src/test/java/com/arcadedb/ExplicitLockingTransactionTest.java
+++ b/engine/src/test/java/com/arcadedb/ExplicitLockingTransactionTest.java
@@ -37,6 +37,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
 
 class ExplicitLockingTransactionTest extends TestHelper {
+  // 16 threads serialize through a single type/bucket lock; per-thread wait scales with the
+  // tx commit time, so the default 5 s lock timeout is too tight on a slow host.
+  private static final long LOCK_TIMEOUT_MS = 60_000L;
+
+  @Override
+  protected void beginTest() {
+    database.getConfiguration().setValue(GlobalConfiguration.EXPLICIT_LOCK_TIMEOUT, LOCK_TIMEOUT_MS);
+    database.getConfiguration().setValue(GlobalConfiguration.COMMIT_LOCK_TIMEOUT, LOCK_TIMEOUT_MS);
+  }
+
   @Test
   void explicitLockType() {
     final Database db = database;

--- a/engine/src/test/java/com/arcadedb/index/DropIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/DropIndexTest.java
@@ -28,6 +28,7 @@ import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Schema;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -275,11 +276,20 @@ class DropIndexTest extends TestHelper {
 
     assertThat(typeIndex.countIndexesOnBuckets()).isEqualTo(3);
 
+    final List<String> bucketIndexNames = new ArrayList<>(3);
+    for (final Index sub : typeIndex.getIndexesOnBuckets())
+      bucketIndexNames.add(sub.getName());
+
     typeIndex.drop();
 
     assertThat(database.getSchema().existsIndex(typeIndex.getName())).isFalse();
     assertThatThrownBy(() -> database.getSchema().getIndexByName(typeIndex.getName()))
         .isInstanceOf(SchemaException.class);
     assertThat(type.getIndexesByProperties("id")).isEmpty();
+
+    final List<String> remainingNames = new ArrayList<>();
+    for (final Index idx : database.getSchema().getIndexes())
+      remainingNames.add(idx.getName());
+    assertThat(remainingNames).doesNotContainAnyElementsOf(bucketIndexNames);
   }
 }

--- a/engine/src/test/java/com/arcadedb/index/DropIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/DropIndexTest.java
@@ -256,4 +256,30 @@ class DropIndexTest extends TestHelper {
 
     }, false, 0);
   }
+
+  /**
+   * {@link TypeIndex#drop()} called directly outside an active transaction must succeed on a type
+   * that spans multiple buckets, leaving no orphan wrapper in the schema.
+   */
+  @Test
+  void dropTypeIndexOutsideTransactionMultiBucket() {
+    final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(3).create();
+    type.createProperty("id", Integer.class);
+
+    final TypeIndex typeIndex = database.getSchema()
+        .buildTypeIndex(TYPE_NAME, new String[] { "id" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withPageSize(PAGE_SIZE)
+        .withUnique(true)
+        .create();
+
+    assertThat(typeIndex.countIndexesOnBuckets()).isEqualTo(3);
+
+    typeIndex.drop();
+
+    assertThat(database.getSchema().existsIndex(typeIndex.getName())).isFalse();
+    assertThatThrownBy(() -> database.getSchema().getIndexByName(typeIndex.getName()))
+        .isInstanceOf(SchemaException.class);
+    assertThat(type.getIndexesByProperties("id")).isEmpty();
+  }
 }

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexConcurrencyTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexConcurrencyTest.java
@@ -58,8 +58,9 @@ class LSMSparseVectorIndexConcurrencyTest extends TestHelper {
   private static final int    DIMENSIONS      = 200;
   private static final int    NNZ_PER_DOC     = 6;
   // Scale to the host. The minimum of 2 keeps the writer/reader race exercised on every box.
-  private static final int    WRITER_THREADS  = Math.max(2, Runtime.getRuntime().availableProcessors() / 2);
-  private static final int    READER_THREADS  = Math.max(2, Runtime.getRuntime().availableProcessors() / 2);
+  private static final int    CONCURRENCY     = Math.max(2, Runtime.getRuntime().availableProcessors() / 2);
+  private static final int    WRITER_THREADS  = CONCURRENCY;
+  private static final int    READER_THREADS  = CONCURRENCY;
   private static final int    DOCS_PER_WRITER = 50;
   private static final int    QUERIES_PER_READER = 30;
 

--- a/engine/src/test/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexConcurrencyTest.java
+++ b/engine/src/test/java/com/arcadedb/index/sparsevector/LSMSparseVectorIndexConcurrencyTest.java
@@ -57,9 +57,10 @@ class LSMSparseVectorIndexConcurrencyTest extends TestHelper {
   private static final String IDX_NAME        = "ConcurrentSparseDoc[tokens,weights]";
   private static final int    DIMENSIONS      = 200;
   private static final int    NNZ_PER_DOC     = 6;
-  private static final int    WRITER_THREADS  = 4;
+  // Scale to the host. The minimum of 2 keeps the writer/reader race exercised on every box.
+  private static final int    WRITER_THREADS  = Math.max(2, Runtime.getRuntime().availableProcessors() / 2);
+  private static final int    READER_THREADS  = Math.max(2, Runtime.getRuntime().availableProcessors() / 2);
   private static final int    DOCS_PER_WRITER = 50;
-  private static final int    READER_THREADS  = 4;
   private static final int    QUERIES_PER_READER = 30;
 
   @Test

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexTest.java
@@ -141,9 +141,6 @@ class LSMVectorIndexTest extends TestHelper {
       TypeLSMVectorIndexBuilder builder = database.getSchema()
           .buildTypeIndex("VectorDoc", new String[] { "embedding" }).withLSMVectorType();
 
-      // Set common index properties
-      builder.withIndexName("VectorDoc_embedding_idx");
-
       // Cast to LSMVectorIndexBuilder to access vector-specific methods
       builder.withDimensions(3);
       builder.withSimilarity("EUCLIDEAN");


### PR DESCRIPTION
## Summary
Bundles four test-stability fixes touching one real schema bug and three test-only issues.

### 1. `IndexException` from `TypeIndex.drop()` outside a transaction (real bug)
`LocalSchema.dropIndex` now removes the parent `TypeIndex` from `LocalDocumentType.indexesByProperties` and `indexMap` once its last bucket child is gone, so the trailing `saveConfiguration()` no longer trips on an empty wrapper inside `LocalDocumentType.toJSON`.

**Root cause**: `TypeIndex.drop()` iterates its bucket children and calls `LocalSchema.dropIndex(bucketName)` for each. The bucket-drop branch only invoked `removeBucketIndexInternal`, leaving the empty `TypeIndex` wrapper referenced from `indexesByProperties` with `valid=true`. The trailing `saveConfiguration()` walked `LocalDocumentType.toJSON` (`engine/.../LocalDocumentType.java:1553`) and called `TypeIndex.getPropertyNames()` on the empty wrapper, which throws.

The bug was masked when the caller was inside a transaction (saves are postponed) or when `LocalSchema.dropIndex(typeIndexName)` was used directly (it goes through `removeTypeIndexInternal`). `LSMSparseVectorIndexLifecycleTest.dropReclaimsAllSegmentFiles` calls `typeIndex.drop()` outside a transaction with a single underlying bucket and surfaced it.

Also adds `TypeIndex.countIndexesOnBuckets()` to avoid allocating a throwaway array for the empty-children check (per Gemini review).

### 2. `LSMSparseVectorIndexConcurrencyTest` swamps small CI runners
4 writers + 4 readers on a 2-vCPU GitHub runner overcommit the host and trip the 2-minute latch. Scale both counts to `max(2, availableProcessors() / 2)` so a 2-vCPU runner sees 2 + 2 = 4 threads while an 8-core dev box still gets 4 + 4 = 8. The writer/reader race pattern is preserved at every host size.

### 3. `ExplicitLockingTransactionTest` lock acquisition times out on slow CI
16 threads × 100 transactions per test serialize through a single type/bucket lock. The default `EXPLICIT_LOCK_TIMEOUT` is 5 s; under CI I/O pressure, peers holding the lock through a WAL commit can take long enough that queued threads time out and throw `TransactionException`, breaking the `caughtExceptions == 0` assertion. Raise both `EXPLICIT_LOCK_TIMEOUT` and `COMMIT_LOCK_TIMEOUT` to 60 s per-database in `beginTest()`. Test intent (correctness under contention) preserved.

### 4. `LSMVectorIndexTest.createIndexProgrammatically` regressed by #4139
The test asserts the TypeIndex is registered under the auto-derived name `"VectorDoc[embedding]"` (per its inline comment). Since #4139 (`d4e752f6e`, May 8 2026) made `withIndexName` propagate to the TypeIndex wrapper itself, the previously-incidental `withIndexName("VectorDoc_embedding_idx")` now overrides the auto-name and breaks the lookup with `SchemaException: Index ... not found`. Remove the manual-name call so the test exercises the default-name path it documents. Manual-name semantics already have dedicated coverage in `Issue4139ManualIndexNameTest`.

## Test plan
- [x] `LSMSparseVectorIndexLifecycleTest.dropReclaimsAllSegmentFiles` passes (was failing, now green)
- [x] New regression: `DropIndexTest.dropTypeIndexOutsideTransactionMultiBucket` covers `typeIndex.drop()` outside a transaction on a 3-bucket type
- [x] All `com.arcadedb.index.*Test` and `com.arcadedb.schema.*Test` (455 tests) pass locally
- [x] `LSMSparseVectorIndexConcurrencyTest` passes locally
- [x] `ExplicitLockingTransactionTest` (5 tests) passes locally
- [x] `LSMVectorIndexTest.createIndexProgrammatically` passes locally