### PR TITLE
fix: prevent DATE record corruption when gRPC binds Timestamp param (#4181)

### DIFF
--- a/engine/src/main/java/com/arcadedb/schema/Type.java
+++ b/engine/src/main/java/com/arcadedb/schema/Type.java
@@ -548,6 +548,8 @@ public enum Type {
       } else if (targetClass.equals(LocalDate.class)) {
         if (value instanceof LocalDateTime time)
           return time.toLocalDate();
+        else if (value instanceof Instant instant)
+          return instant.atOffset(ZoneOffset.UTC).toLocalDate();
         else if (value instanceof Number number)
           return DateUtils.date(database, number.longValue(), LocalDate.class);
         else if (value instanceof Date date)

--- a/engine/src/main/java/com/arcadedb/serializer/BinarySerializer.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinarySerializer.java
@@ -448,6 +448,9 @@ public class BinarySerializer {
         content.putUnsignedNumber(date.getTime() / DateUtils.MS_IN_A_DAY);
       else if (value instanceof LocalDate date)
         content.putUnsignedNumber(date.toEpochDay());
+      else
+        throw new IllegalArgumentException(
+            "Cannot serialize " + value.getClass() + " as DATE; expected java.util.Date or java.time.LocalDate");
       break;
     case BinaryTypes.TYPE_DATETIME_SECOND:
     case BinaryTypes.TYPE_DATETIME:

--- a/engine/src/test/java/com/arcadedb/schema/TypeTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/TypeTest.java
@@ -1119,7 +1119,7 @@ class TypeTest extends TestHelper {
   void convertInstantToLocalDate() {
     // midnight UTC on a known date
     final LocalDate expected = LocalDate.of(2026, 5, 11);
-    final Instant instant = expected.atStartOfDay(java.time.ZoneOffset.UTC).toInstant();
+    final Instant instant = expected.atStartOfDay(ZoneOffset.UTC).toInstant();
     final Object result = Type.convert(null, instant, LocalDate.class);
     assertThat(result).isInstanceOf(LocalDate.class);
     assertThat((LocalDate) result).isEqualTo(expected);
@@ -1129,7 +1129,7 @@ class TypeTest extends TestHelper {
   void convertInstantWithTimeComponentToLocalDateTruncates() {
     // 15:30 UTC on a known date - time part must be discarded
     final LocalDate expected = LocalDate.of(2026, 5, 11);
-    final Instant instant = expected.atStartOfDay(java.time.ZoneOffset.UTC).toInstant().plusSeconds(55800L); // +15h30m
+    final Instant instant = expected.atStartOfDay(ZoneOffset.UTC).toInstant().plusSeconds(55800L); // +15h30m
     final Object result = Type.convert(null, instant, LocalDate.class);
     assertThat(result).isInstanceOf(LocalDate.class);
     assertThat((LocalDate) result).isEqualTo(expected);

--- a/engine/src/test/java/com/arcadedb/schema/TypeTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/TypeTest.java
@@ -1112,4 +1112,26 @@ class TypeTest extends TestHelper {
     final Date now = new Date();
     assertThat(Type.convert(database, now, Long.class)).isEqualTo(now.getTime());
   }
+
+  // ───── convert: Instant -> LocalDate (regression #4181) ─────
+
+  @Test
+  void convertInstantToLocalDate() {
+    // midnight UTC on a known date
+    final LocalDate expected = LocalDate.of(2026, 5, 11);
+    final Instant instant = expected.atStartOfDay(java.time.ZoneOffset.UTC).toInstant();
+    final Object result = Type.convert(null, instant, LocalDate.class);
+    assertThat(result).isInstanceOf(LocalDate.class);
+    assertThat((LocalDate) result).isEqualTo(expected);
+  }
+
+  @Test
+  void convertInstantWithTimeComponentToLocalDateTruncates() {
+    // 15:30 UTC on a known date - time part must be discarded
+    final LocalDate expected = LocalDate.of(2026, 5, 11);
+    final Instant instant = expected.atStartOfDay(java.time.ZoneOffset.UTC).toInstant().plusSeconds(55800L); // +15h30m
+    final Object result = Type.convert(null, instant, LocalDate.class);
+    assertThat(result).isInstanceOf(LocalDate.class);
+    assertThat((LocalDate) result).isEqualTo(expected);
+  }
 }

--- a/engine/src/test/java/com/arcadedb/serializer/BinarySerializerTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/BinarySerializerTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 
 import java.math.*;
 import java.nio.*;
+import java.time.*;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -575,6 +576,21 @@ class BinarySerializerTest extends TestHelper {
     assertThatThrownBy(() -> serializer.deserializeValue(database, empty, (byte) 101, null))
         .isInstanceOf(SerializationException.class)
         .hasMessageContaining("101");
+  }
+
+  /**
+   * Pins the defensive contract added with #4181: TYPE_DATE must reject value classes it
+   * cannot encode rather than silently writing the type marker with no content bytes (which
+   * mis-aligns the varint reader on every subsequent property in the record).
+   */
+  @Test
+  void serializeDateWithUnsupportedTypeThrows() throws Exception {
+    final BinarySerializer serializer = new BinarySerializer(database.getConfiguration());
+    final Binary buffer = new Binary();
+    assertThatThrownBy(() -> serializer.serializeValue(database, buffer, BinaryTypes.TYPE_DATE, Instant.now()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("DATE")
+        .hasMessageContaining("Instant");
   }
 
   /**

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4181GrpcDateCorruptionIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4181GrpcDateCorruptionIT.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.test.BaseGraphServerTest;
+import com.google.protobuf.Timestamp;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4181: DATE column written via gRPC Timestamp parameter binding
+ * produced a corrupt binary record (BufferUnderflowException on every subsequent read).
+ *
+ * Root causes:
+ * 1. Type.convert(Instant, LocalDate.class) had no Instant branch and returned the Instant
+ *    unchanged, bypassing the LocalDate conversion.
+ * 2. BinarySerializer.serializeValue TYPE_DATE had no else branch for unrecognised types,
+ *    so it wrote the type marker byte but no content bytes, corrupting the record layout.
+ */
+public class Issue4181GrpcDateCorruptionIT extends BaseGraphServerTest {
+
+  private static final int GRPC_PORT = 50051;
+
+  private static final Metadata.Key<String> USER_HEADER =
+      Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER =
+      Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER =
+      Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  private ManagedChannel channel;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub authenticatedStub;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+    GlobalConfiguration.QUERY_PARALLEL_SCAN.setValue(false);
+  }
+
+  @BeforeEach
+  void setupGrpcClient() {
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    final Channel authenticatedChannel = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+    authenticatedStub = ArcadeDbServiceGrpc.newBlockingStub(authenticatedChannel);
+  }
+
+  @AfterEach
+  void shutdownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private class AuthClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        final MethodDescriptor<ReqT, RespT> method, final CallOptions callOptions, final Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata headers) {
+          headers.put(USER_HEADER, "root");
+          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
+          headers.put(DATABASE_HEADER, getDatabaseName());
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+
+  private DatabaseCredentials credentials() {
+    return DatabaseCredentials.newBuilder()
+        .setUsername("root")
+        .setPassword(DEFAULT_PASSWORD_FOR_TESTS)
+        .build();
+  }
+
+  private void executeCommand(final String command) {
+    authenticatedStub.executeCommand(
+        ExecuteCommandRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setCommand(command)
+            .build());
+  }
+
+  @Test
+  void dateInsertViaGrpcTimestampRoundTrips() {
+    // Create schema
+    executeCommand("CREATE DOCUMENT TYPE DateTest4181 IF NOT EXISTS");
+    executeCommand("CREATE PROPERTY DateTest4181.d IF NOT EXISTS DATE");
+
+    // 2026-05-09T00:00:00Z - midnight UTC, so date part is unambiguous
+    final Timestamp ts = Timestamp.newBuilder().setSeconds(1778457600L).setNanos(0).build();
+
+    // Insert via gRPC parameter binding (the path that was producing corrupt records)
+    authenticatedStub.executeCommand(
+        ExecuteCommandRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setCommand("INSERT INTO DateTest4181 SET d = :v")
+            .putParameters("v", GrpcValue.newBuilder().setTimestampValue(ts).build())
+            .build());
+
+    // Read back - before the fix this threw BufferUnderflowException and returned an empty record
+    final ExecuteQueryResponse response = authenticatedStub.executeQuery(
+        ExecuteQueryRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setQuery("SELECT d FROM DateTest4181")
+            .build());
+
+    assertThat(response.getResultsList()).as("query must return at least one result group").isNotEmpty();
+    assertThat(response.getResultsList().get(0).getRecordsList()).as("result group must contain records").isNotEmpty();
+
+    final GrpcRecord record = response.getResultsList().get(0).getRecordsList().get(0);
+    assertThat(record.getPropertiesMap()).as("'d' property must be present (not missing due to corruption)").containsKey("d");
+    final GrpcValue dValue = record.getPropertiesMap().get("d");
+    assertThat(dValue.hasTimestampValue()).as("DATE property must come back as a Timestamp").isTrue();
+    // seconds for 2026-05-09 must match the input date (allow +/- 1 day tolerance for timezone edge cases)
+    assertThat(dValue.getTimestampValue().getSeconds()).isBetween(1778457600L - 86400L, 1778457600L + 86400L);
+  }
+
+  @Test
+  void dateInsertViaGrpcTimestampDoesNotCorruptSiblingProperties() {
+    // Verify that subsequent reads do not throw (i.e. no record corruption occurred).
+    // The corruption caused the varint reader to mis-align, making sibling properties unreadable.
+    executeCommand("CREATE DOCUMENT TYPE DateCorrupt4181 IF NOT EXISTS");
+    executeCommand("CREATE PROPERTY DateCorrupt4181.d IF NOT EXISTS DATE");
+    executeCommand("CREATE PROPERTY DateCorrupt4181.name IF NOT EXISTS STRING");
+
+    final Timestamp ts = Timestamp.newBuilder().setSeconds(1778457600L).setNanos(0).build();
+    authenticatedStub.executeCommand(
+        ExecuteCommandRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setCommand("INSERT INTO DateCorrupt4181 SET d = :v, name = :n")
+            .putParameters("v", GrpcValue.newBuilder().setTimestampValue(ts).build())
+            .putParameters("n", GrpcValue.newBuilder().setStringValue("test").build())
+            .build());
+
+    final ExecuteQueryResponse response = authenticatedStub.executeQuery(
+        ExecuteQueryRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setQuery("SELECT d, name FROM DateCorrupt4181")
+            .build());
+
+    assertThat(response.getResultsList()).isNotEmpty();
+    assertThat(response.getResultsList().get(0).getRecordsList()).isNotEmpty();
+    final GrpcRecord record = response.getResultsList().get(0).getRecordsList().get(0);
+
+    // The sibling 'name' property must be readable (corruption broke this too)
+    assertThat(record.getPropertiesMap()).containsKey("name");
+    assertThat(record.getPropertiesMap().get("name").getStringValue()).isEqualTo("test");
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4181GrpcDateCorruptionIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4181GrpcDateCorruptionIT.java
@@ -35,6 +35,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,6 +61,9 @@ public class Issue4181GrpcDateCorruptionIT extends BaseGraphServerTest {
       Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
   private static final Metadata.Key<String> DATABASE_HEADER =
       Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  private static final LocalDate TEST_DATE          = LocalDate.of(2026, 5, 9);
+  private static final long      TEST_DATE_EPOCH_S  = TEST_DATE.atStartOfDay(ZoneOffset.UTC).toEpochSecond();
 
   private ManagedChannel channel;
   private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub authenticatedStub;
@@ -123,8 +128,8 @@ public class Issue4181GrpcDateCorruptionIT extends BaseGraphServerTest {
     executeCommand("CREATE DOCUMENT TYPE DateTest4181 IF NOT EXISTS");
     executeCommand("CREATE PROPERTY DateTest4181.d IF NOT EXISTS DATE");
 
-    // 2026-05-09T00:00:00Z - midnight UTC, so date part is unambiguous
-    final Timestamp ts = Timestamp.newBuilder().setSeconds(1778457600L).setNanos(0).build();
+    // Midnight UTC on a known date - unambiguous, no zone-edge case
+    final Timestamp ts = Timestamp.newBuilder().setSeconds(TEST_DATE_EPOCH_S).setNanos(0).build();
 
     // Insert via gRPC parameter binding (the path that was producing corrupt records)
     authenticatedStub.executeCommand(
@@ -150,8 +155,7 @@ public class Issue4181GrpcDateCorruptionIT extends BaseGraphServerTest {
     assertThat(record.getPropertiesMap()).as("'d' property must be present (not missing due to corruption)").containsKey("d");
     final GrpcValue dValue = record.getPropertiesMap().get("d");
     assertThat(dValue.hasTimestampValue()).as("DATE property must come back as a Timestamp").isTrue();
-    // seconds for 2026-05-09 must match the input date (allow +/- 1 day tolerance for timezone edge cases)
-    assertThat(dValue.getTimestampValue().getSeconds()).isBetween(1778457600L - 86400L, 1778457600L + 86400L);
+    assertThat(dValue.getTimestampValue().getSeconds()).isEqualTo(TEST_DATE_EPOCH_S);
   }
 
   @Test
@@ -162,7 +166,7 @@ public class Issue4181GrpcDateCorruptionIT extends BaseGraphServerTest {
     executeCommand("CREATE PROPERTY DateCorrupt4181.d IF NOT EXISTS DATE");
     executeCommand("CREATE PROPERTY DateCorrupt4181.name IF NOT EXISTS STRING");
 
-    final Timestamp ts = Timestamp.newBuilder().setSeconds(1778457600L).setNanos(0).build();
+    final Timestamp ts = Timestamp.newBuilder().setSeconds(TEST_DATE_EPOCH_S).setNanos(0).build();
     authenticatedStub.executeCommand(
         ExecuteCommandRequest.newBuilder()
             .setDatabase(getDatabaseName())


### PR DESCRIPTION
Fixes #4181 - regression from #4149.

## Summary

A `DATE`-typed column receiving a `Timestamp` via gRPC parameter binding wrote a corrupt binary record, causing `BufferUnderflowException` on every subsequent read of the row (both gRPC and HTTP, since the corruption is in storage).

## Root cause

Two cooperating defects, both reachable only via the `Instant` inbound path introduced by the #4149 fix:

1. **`Type.convert(Instant, LocalDate.class)`** had no `Instant` branch. Control fell through the entire LocalDate target block and hit the catch-all `return value`, leaving the original `Instant` unconverted.
2. **`BinarySerializer.serializeValue` TYPE_DATE** wrote the type-marker byte, then called the inline serializer which matched neither `Date` nor `LocalDate` (it received the unconverted `Instant`) and `break`'d without writing any content bytes. The next read found `TYPE_DATE | (no varint) | next-property-bytes`, mis-aligning every subsequent property in the record.

`DATETIME*` columns avoided the same fate because their serializer routes through `DateUtils.dateTimeToTimestamp`, which has an explicit `Instant` branch.

## Fix

- **`Type.java`** - add `Instant` -> `LocalDate` branch using UTC, matching the implicit zone of the existing `Date` branch.
- **`BinarySerializer.java`** - throw `IllegalArgumentException` for unrecognised value types in `TYPE_DATE` so future regressions fail loudly at write time instead of silently corrupting records.

## Tests

- `TypeTest#convertInstantToLocalDate` and `convertInstantWithTimeComponentToLocalDateTruncates` - unit tests for the converter
- `Issue4181GrpcDateCorruptionIT` - integration tests covering the gRPC `Timestamp` -> DATE round-trip and verifying that sibling properties remain readable

## Test plan

- [x] New unit tests pass (`TypeTest`)
- [x] New IT covers the full gRPC round-trip
- [x] All existing tests pass: `TypeTest` (108), `BinarySerializerTest` (13), `DateUtilsTest` (5), `DateQueryConsistencyTest` (10), `Issue4149GrpcTypeConverterTest` (5), `GrpcTypeConverterTest` (38)