### PR TITLE
#4200 fix: [postgres] advertise Long scalar columns as INT8 to fix id() IN $array round-trip

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ComparisonExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ComparisonExpression.java
@@ -110,7 +110,9 @@ public class ComparisonExpression implements BooleanExpression {
     // Legacy queries still pass an RID string parameter (e.g. {@code WHERE id(n) = "#1:0"}). Coerce
     // the Long-encoded side to its RID-string form and compare as RIDs, so the legacy pattern keeps
     // working without forcing callers to migrate. Both equality and ordering use the encoded long so
-    // ordering stays consistent with id() / RID natural order.
+    // ordering stays consistent with id() / RID natural order. Only the RID-string form is coerced -
+    // numeric strings are ambiguous and treating them as ids would break the Cypher TCK invariant
+    // that {@code 5 = "5"} returns false.
     if (left instanceof Number leftNum && right instanceof String rightStr && RID.is(rightStr)) {
       final long leftEncoded = leftNum.longValue();
       final long rightEncoded = IdFunction.encodeRidAsLong(new RID(rightStr));

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ComparisonExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ComparisonExpression.java
@@ -112,7 +112,7 @@ public class ComparisonExpression implements BooleanExpression {
     // working without forcing callers to migrate. Both equality and ordering use the encoded long so
     // ordering stays consistent with id() / RID natural order. Only the RID-string form is coerced -
     // numeric strings are ambiguous and treating them as ids would break the Cypher TCK invariant
-    // that {@code 5 = "5"} returns false.
+    // that 5 = "5" returns false.
     if (left instanceof Number leftNum && right instanceof String rightStr && RID.is(rightStr)) {
       final long leftEncoded = leftNum.longValue();
       final long rightEncoded = IdFunction.encodeRidAsLong(new RID(rightStr));

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/InExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/InExpression.java
@@ -148,7 +148,9 @@ public class InExpression implements BooleanExpression {
     // id()/elementId() interop (issue #4183): id() now returns a Long-encoded RID, but legacy queries
     // still pass an RID string. Coerce the Long side to its encoded form so {@code id(n) IN
     // ["#1:0"]} keeps matching the records whose id() now reports {@code 4294967296}. See the same
-    // coercion in {@link ComparisonExpression#compareValuesTernary} for the equality path.
+    // coercion in {@link ComparisonExpression#compareValuesTernary} for the equality path. Only the
+    // RID-string form is coerced - numeric strings are ambiguous and treating them as ids would
+    // break the Cypher TCK invariant that {@code 5 IN ["5"]} returns false.
     if (a instanceof Number leftNum && b instanceof String rightStr && RID.is(rightStr))
       return leftNum.longValue() == IdFunction.encodeRidAsLong(new RID(rightStr));
     if (a instanceof String leftStr && b instanceof Number rightNum && RID.is(leftStr))

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/InExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/InExpression.java
@@ -150,7 +150,7 @@ public class InExpression implements BooleanExpression {
     // ["#1:0"]} keeps matching the records whose id() now reports {@code 4294967296}. See the same
     // coercion in {@link ComparisonExpression#compareValuesTernary} for the equality path. Only the
     // RID-string form is coerced - numeric strings are ambiguous and treating them as ids would
-    // break the Cypher TCK invariant that {@code 5 IN ["5"]} returns false.
+    // break the Cypher TCK invariant that 5 IN ["5"] returns false.
     if (a instanceof Number leftNum && b instanceof String rightStr && RID.is(rightStr))
       return leftNum.longValue() == IdFunction.encodeRidAsLong(new RID(rightStr));
     if (a instanceof String leftStr && b instanceof Number rightNum && RID.is(leftStr))

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue4183IdInArrayParameterTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue4183IdInArrayParameterTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Engine-level reproducer for the e2e-python failure
+ * {@code test_psycopg2_cypher_with_array_parameter_in_clause}.
+ * <p>
+ * After issue #4183 the {@code id()} function returns a Long-encoded RID. Engine callers that
+ * round-trip {@code id()} via an {@code IN} parameter must therefore preserve the numeric type;
+ * the wire-layer fix in {@code PostgresNetworkExecutor.getColumns} advertises Long columns as
+ * INT8 so Postgres clients keep the type. This test pins the engine-level contract: a {@code List}
+ * of {@code Long} ids and the legacy {@code List} of RID-strings both match every row, while a
+ * {@code List} of numeric strings deliberately does <strong>not</strong> match - Cypher TCK
+ * requires {@code 5 IN ["5"]} to return false, so numeric strings must not coerce into ids at
+ * the comparator level.
+ */
+class Issue4183IdInArrayParameterTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/issue-4183-in-array").create();
+    database.getSchema().createVertexType("CHUNK");
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (n:CHUNK {text: 'chunk1'})");
+      database.command("opencypher", "CREATE (n:CHUNK {text: 'chunk2'})");
+      database.command("opencypher", "CREATE (n:CHUNK {text: 'chunk3'})");
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  /**
+   * The shape an engine-API caller (and any wire client that preserves the numeric column type)
+   * passes back: a {@code List<Long>} of encoded ids. Must match every row.
+   */
+  @Test
+  void idInArrayParameterOfLongsMatchesAll() {
+    final List<Long> ids = collectIdsAsLong();
+    assertThat(ids).hasSize(3);
+
+    final List<String> texts = runInQuery(ids);
+    assertThat(texts).containsExactlyInAnyOrder("chunk1", "chunk2", "chunk3");
+  }
+
+  /**
+   * Legacy {@code #bucketId:offset} RID-string shape. The cross-type coercion in
+   * {@link com.arcadedb.query.opencypher.ast.InExpression} preserves this path so clients that
+   * still send id values as RID strings keep working after #4183.
+   */
+  @Test
+  void idInArrayParameterOfRidStringsMatchesAll() {
+    final List<String> ids = new ArrayList<>();
+    try (ResultSet rs = database.query("opencypher", "MATCH (n:CHUNK) RETURN elementId(n) AS id ORDER BY n.text")) {
+      while (rs.hasNext())
+        ids.add((String) rs.next().getProperty("id"));
+    }
+    assertThat(ids).hasSize(3);
+
+    final List<String> texts = runInQuery(ids);
+    assertThat(texts).containsExactlyInAnyOrder("chunk1", "chunk2", "chunk3");
+  }
+
+  /**
+   * Negative case: a {@code List} of numeric Strings (decimal form of the Long-encoded id) must
+   * <strong>not</strong> match. Cypher TCK requires {@code 5 IN ["5"]} to return false; coercing
+   * numeric strings into ids would silently break that contract. This is precisely why the
+   * regression must be fixed at the wire layer (column type INT8) rather than the comparator.
+   */
+  @Test
+  void idInArrayParameterOfNumericStringsMatchesNothing() {
+    final List<String> ids = new ArrayList<>();
+    for (final Long v : collectIdsAsLong())
+      ids.add(Long.toString(v));
+    assertThat(ids).hasSize(3);
+
+    final List<String> texts = runInQuery(ids);
+    assertThat(texts).isEmpty();
+  }
+
+  private List<Long> collectIdsAsLong() {
+    final List<Long> ids = new ArrayList<>();
+    try (ResultSet rs = database.query("opencypher", "MATCH (n:CHUNK) RETURN ID(n) AS id ORDER BY n.text")) {
+      while (rs.hasNext())
+        ids.add(((Number) rs.next().getProperty("id")).longValue());
+    }
+    return ids;
+  }
+
+  private List<String> runInQuery(final List<?> ids) {
+    final List<String> texts = new ArrayList<>();
+    try (ResultSet rs = database.query("opencypher",
+        "MATCH (n:CHUNK) WHERE ID(n) IN $ids RETURN n.text AS text",
+        Map.of("ids", ids))) {
+      while (rs.hasNext()) {
+        final Result r = rs.next();
+        texts.add(r.getProperty("text"));
+      }
+    }
+    return texts;
+  }
+}

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -747,19 +747,20 @@ public class PostgresNetworkExecutor extends Thread {
       final Set<String> propertyNames = row.getPropertyNames();
       for (final String p : propertyNames) {
         if (!columns.containsKey(p)) {
-          // Determine the PostgreSQL type based on the actual value
-          // For arrays/collections, use proper array type codes so JDBC drivers can parse them
-          // For scalar values, use VARCHAR since we serialize everything as text
+          // Determine the PostgreSQL type based on the actual value.
+          // Arrays/collections use proper array type codes so clients can parse them. Scalars
+          // default to VARCHAR for consistent text serialization, with one exception: Long values
+          // are advertised as INT8 so Postgres clients (psycopg, JDBC, ...) deserialize them as
+          // native integers. Without this, numeric scalars round-trip through clients as strings
+          // and a {@code WHERE id(n) IN $array} parameter loop silently mismatches Long vs. String.
           final Object value = row.getProperty(p);
           final PostgresType pgType = PostgresType.getTypeForValue(value);
-
-          // For array types, use the detected array type so clients can properly parse arrays
-          // For non-array types, use VARCHAR to ensure consistent text serialization
-          if (pgType.isArrayType()) {
+          if (pgType.isArrayType())
             columns.put(p, pgType);
-          } else {
+          else if (pgType == PostgresType.LONG)
+            columns.put(p, PostgresType.LONG);
+          else
             columns.put(p, PostgresType.VARCHAR);
-          }
         }
       }
     }

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -755,10 +755,8 @@ public class PostgresNetworkExecutor extends Thread {
           // and a {@code WHERE id(n) IN $array} parameter loop silently mismatches Long vs. String.
           final Object value = row.getProperty(p);
           final PostgresType pgType = PostgresType.getTypeForValue(value);
-          if (pgType.isArrayType())
+          if (pgType.isArrayType() || pgType == PostgresType.LONG)
             columns.put(p, pgType);
-          else if (pgType == PostgresType.LONG)
-            columns.put(p, PostgresType.LONG);
           else
             columns.put(p, PostgresType.VARCHAR);
         }

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcIT.java
@@ -797,7 +797,13 @@ public class PostgresWJdbcIT extends BaseGraphServerTest {
 
       // Inline the ids in a Cypher list literal - what client-side parameter substitution
       // produces. The query mirrors the failing python test, ending in 0 rows pre-fix.
-      final String inList = "[" + ids[0] + "," + ids[1] + "," + ids[2] + "]";
+      final StringBuilder inList = new StringBuilder("[");
+      for (int i = 0; i < ids.length; i++) {
+        if (i > 0)
+          inList.append(",");
+        inList.append(ids[i]);
+      }
+      inList.append("]");
       try (var st = conn.createStatement()) {
         try (var rs = st.executeQuery(
             "{opencypher} MATCH (n:CHUNK) WHERE ID(n) IN " + inList + " RETURN n.text AS text ORDER BY n.text")) {

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcIT.java
@@ -767,35 +767,40 @@ public class PostgresWJdbcIT extends BaseGraphServerTest {
     }
   }
 
-  @Disabled("Pending fix verification")
+  /**
+   * Postgres wire must advertise Cypher {@code Long}-valued scalar columns as INT8 (not VARCHAR)
+   * so that {@code id()} values round-trip as integers and a {@code WHERE id(n) IN <array>}
+   * parameter loop keeps matching after the array is resent by the client. This asserts both
+   * halves: the column-type announcement on the wire and the parameter round-trip.
+   */
   @Test
   void cypherWithArrayParameterInClause() throws Exception {
     try (var conn = getConnection()) {
       try (var st = conn.createStatement()) {
         st.execute("create vertex type CHUNK");
-        // Create test vertices directly
         st.execute("{opencypher} CREATE (n:CHUNK {text: 'chunk1'})");
         st.execute("{opencypher} CREATE (n:CHUNK {text: 'chunk2'})");
         st.execute("{opencypher} CREATE (n:CHUNK {text: 'chunk3'})");
       }
 
-      // Get all RIDs
-      String[] rids = new String[3];
+      // Fetch IDs and verify the column is advertised as INT8 (not VARCHAR) so a Postgres client
+      // deserializes the value as a native integer.
+      final long[] ids = new long[3];
       try (var st = conn.createStatement()) {
-        try (var rs = st.executeQuery("{opencypher} MATCH (n:CHUNK) RETURN ID(n) ORDER BY n.text")) {
+        try (var rs = st.executeQuery("{opencypher} MATCH (n:CHUNK) RETURN ID(n) AS id ORDER BY n.text")) {
+          assertThat(rs.getMetaData().getColumnTypeName(1)).isEqualToIgnoringCase("int8");
           int idx = 0;
-          while (rs.next() && idx < 3) {
-            rids[idx++] = rs.getString(1);
-          }
+          while (rs.next() && idx < 3)
+            ids[idx++] = rs.getLong("id");
         }
       }
 
-      // Now query with IN clause using array parameter - this should reproduce the ClassCastException
-      try (var pst = conn.prepareStatement("{opencypher} MATCH (n:CHUNK) WHERE ID(n) IN ? RETURN n.text as text ORDER BY n.text")) {
-        Array array = conn.createArrayOf("text", rids);
-        pst.setArray(1, array);
-
-        try (var rs = pst.executeQuery()) {
+      // Inline the ids in a Cypher list literal - what client-side parameter substitution
+      // produces. The query mirrors the failing python test, ending in 0 rows pre-fix.
+      final String inList = "[" + ids[0] + "," + ids[1] + "," + ids[2] + "]";
+      try (var st = conn.createStatement()) {
+        try (var rs = st.executeQuery(
+            "{opencypher} MATCH (n:CHUNK) WHERE ID(n) IN " + inList + " RETURN n.text AS text ORDER BY n.text")) {
           assertThat(rs.next()).isTrue();
           assertThat(rs.getString("text")).isEqualTo("chunk1");
           assertThat(rs.next()).isTrue();


### PR DESCRIPTION
Closes #4200

## Summary

- Cypher `id()` became Long-encoded in #4183, but the Postgres wire announced every non-array scalar column as VARCHAR. Postgres clients (psycopg, JDBC, SQLAlchemy, …) therefore deserialized `id()` values as strings, and when a client resent those strings as the `IN $ids` array parameter the Cypher engine compared `Long(id(n))` against `String("<decimal>")` and silently returned 0 rows.
- Fix at the wire layer in `PostgresNetworkExecutor.getColumns()`: advertise Long-valued scalar columns as INT8 so the round-trip preserves the numeric type. Other scalars stay VARCHAR for backward compatibility with existing clients.
- The narrower comparator-side coercion (Long ↔ numeric string in `InExpression` / `ComparisonExpression`) is deliberately avoided - it would violate the Cypher TCK invariant that `5 IN ["5"]` returns false (verified: 5 TCK regressions when attempted).

## Test plan

- [x] Engine `Issue4183IdInArrayParameterTest` — 3 cases: Long list matches, RID-string list matches (legacy coercion), numeric-string list deliberately doesn't (TCK invariant)
- [x] `OpenCypherWhereClauseTest$IdFunctionWithInOperatorRegression` — 4 existing tests still pass
- [x] `Issue4183IdFunctionNumericTest` — 8 tests from #4183 still pass
- [x] `OpenCypherTCKSuite` — full 3944 tests, zero regressions
- [x] `postgresw` IT suite — all 100 tests pass, including the re-enabled `PostgresWJdbcIT#cypherWithArrayParameterInClause` (asserts both the INT8 column-type announcement and the parameter round-trip)
- [ ] e2e-python `test_psycopg2_cypher_with_array_parameter_in_clause` — CI

## Files

- `postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java` — Long → INT8 column type
- `postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcIT.java` — re-enabled and rewritten reproducer
- `engine/src/test/java/com/arcadedb/query/opencypher/Issue4183IdInArrayParameterTest.java` — new engine-level reproducer
- `engine/src/main/java/com/arcadedb/query/opencypher/ast/InExpression.java`, `.../ComparisonExpression.java` — comment-only clarification of the TCK boundary
