### PR TITLE
#4202 fix: [postgres] advertise scalar columns with native OIDs

### DIFF
--- a/e2e-python/tests/test_arcadedb.py
+++ b/e2e-python/tests/test_arcadedb.py
@@ -117,7 +117,8 @@ def test_psycopg2_basic_queries():
             product = products[0]
             print(f"Product: {product}")
             assert 'TestItem' in product
-            assert '29' in product
+            # price is INTEGER on the wire, so psycopg returns it as a native int
+            assert 29 in product
     finally:
         conn.close()
 

--- a/e2e-python/tests/test_arcadedb.py
+++ b/e2e-python/tests/test_arcadedb.py
@@ -118,7 +118,7 @@ def test_psycopg2_basic_queries():
             print(f"Product: {product}")
             assert 'TestItem' in product
             # price is INTEGER on the wire, so psycopg returns it as a native int
-            assert 29 in product
+            assert 29 in product  # nosec B101
     finally:
         conn.close()
 

--- a/e2e-python/tests/test_asyncpg.py
+++ b/e2e-python/tests/test_asyncpg.py
@@ -302,4 +302,4 @@ async def test_transaction(connection, test_type_setup):
     assert row['name'] == 'TxTest'
     # Without a schema-typed property, ArcadeDB stores the integer literal as Long; it is now
     # advertised as INT8 on the wire (#4201) so asyncpg returns it as a native int.
-    assert row['value'] == 999
+    assert row['value'] == 999  # nosec B101

--- a/e2e-python/tests/test_asyncpg.py
+++ b/e2e-python/tests/test_asyncpg.py
@@ -300,4 +300,6 @@ async def test_transaction(connection, test_type_setup):
     assert len(rows) == 1
     row = rows[0]
     assert row['name'] == 'TxTest'
-    assert row['value'] == '999'
+    # Without a schema-typed property, ArcadeDB stores the integer literal as Long; it is now
+    # advertised as INT8 on the wire (#4201) so asyncpg returns it as a native int.
+    assert row['value'] == 999

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -918,8 +918,9 @@ public class PostgresNetworkExecutor extends Thread {
       // The type modifier (see pg_attribute.atttypmod). The meaning of the modifier is type-specific.
       bufferDescription.putInt(-1);
       // The format code being used for the field (0=text, 1=binary). Comes from the Bind message's
-      // result-column formats when present; defaults to 0 (text) otherwise.
-      bufferDescription.putShort(resolveResultFormat(resultFormats, colIndex++));
+      // result-column formats when present; defaults to 0 (text) otherwise. Types that lack a
+      // binary encoder (arrays) are forced to text so the announced format and DataRow agree.
+      bufferDescription.putShort(effectiveResultFormat(resultFormats, colIndex++, columnType));
     }
 
     bufferDescription.flip();
@@ -942,6 +943,18 @@ public class PostgresNetworkExecutor extends Thread {
     if (colIndex < resultFormats.size())
       return resultFormats.get(colIndex).shortValue();
     return 0;
+  }
+
+  /**
+   * Same as {@link #resolveResultFormat} but forces text (0) for columns whose type lacks a
+   * binary encoder. Used by both RowDescription and DataRow so the announced format code and the
+   * written bytes always agree, even when the client requested binary.
+   */
+  private static short effectiveResultFormat(final List<Integer> resultFormats, final int colIndex,
+      final PostgresType columnType) {
+    if (!columnType.hasBinaryEncoding())
+      return 0;
+    return resolveResultFormat(resultFormats, colIndex);
   }
 
   private void writeDataRows(final List<Result> resultSet, final Map<String, PostgresType> columns) throws IOException {
@@ -1009,7 +1022,7 @@ public class PostgresNetworkExecutor extends Thread {
         };
 
         final PostgresType columnType = postgresTypeEntry.getValue();
-        if (resolveResultFormat(resultFormats, colIndex++) == 1)
+        if (effectiveResultFormat(resultFormats, colIndex++, columnType) == 1)
           columnType.serializeAsBinary(columnType, bufferValues, value);
         else
           columnType.serializeAsText(columnType, bufferValues, value);

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -760,14 +760,13 @@ public class PostgresNetworkExecutor extends Thread {
       for (final String p : propertyNames) {
         if (!columns.containsKey(p)) {
           // Determine the PostgreSQL type based on the actual value.
-          // Arrays/collections use proper array type codes so clients can parse them. Scalars
-          // default to VARCHAR for consistent text serialization, with one exception: Long values
-          // are advertised as INT8 so Postgres clients (psycopg, JDBC, ...) deserialize them as
-          // native integers. Without this, numeric scalars round-trip through clients as strings
-          // and a {@code WHERE id(n) IN $array} parameter loop silently mismatches Long vs. String.
+          // Arrays/collections use proper array type codes; native scalar types (numeric, boolean,
+          // temporal) are advertised with their native OID so Postgres clients (psycopg, JDBC, ...)
+          // deserialize them as native values instead of strings. Without this, typed scalars
+          // round-trip through clients as strings and parameter comparisons fail silently.
           final Object value = row.getProperty(p);
           final PostgresType pgType = PostgresType.getTypeForValue(value);
-          if (pgType.isArrayType() || pgType == PostgresType.LONG)
+          if (pgType.isArrayType() || pgType.isNativeScalarType())
             columns.put(p, pgType);
           else
             columns.put(p, PostgresType.VARCHAR);

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -296,13 +296,13 @@ public class PostgresNetworkExecutor extends Thread {
             if (schemaColumns != null)
               portal.columns = schemaColumns;
           }
-          writeRowDescription(portal.columns);
+          writeRowDescription(portal.columns, portal.resultFormats);
           portal.rowDescriptionSent = true;
         } else
           writeNoData();
       } else {
         if (portal.columns != null) {
-          writeRowDescription(portal.columns);
+          writeRowDescription(portal.columns, portal.resultFormats);
           portal.rowDescriptionSent = true;
         }
       }
@@ -380,7 +380,7 @@ public class PostgresNetworkExecutor extends Thread {
                 if (schemaColumns != null)
                   portal.columns = schemaColumns;
               }
-              writeRowDescription(portal.columns);
+              writeRowDescription(portal.columns, portal.resultFormats);
               portal.rowDescriptionSent = true;
               profile.addSerializationNanos(System.nanoTime() - serStart);
             }
@@ -406,7 +406,7 @@ public class PostgresNetworkExecutor extends Thread {
           // we need to send it now before the data rows
           if (!portal.rowDescriptionSent) {
             portal.columns = dataRowColumns;
-            writeRowDescription(portal.columns);
+            writeRowDescription(portal.columns, portal.resultFormats);
             portal.rowDescriptionSent = true;
           }
 
@@ -422,7 +422,7 @@ public class PostgresNetworkExecutor extends Thread {
 
           // Use the columns that were sent in RowDescription for consistency
           final Map<String, PostgresType> columnsToUse = portal.columns != null ? portal.columns : dataRowColumns;
-          writeDataRows(portal.cachedResultSet, columnsToUse);
+          writeDataRows(portal.cachedResultSet, columnsToUse, portal.resultFormats);
           writeCommandComplete(portal.query, portal.cachedResultSet.size());
           profile.addSerializationNanos(System.nanoTime() - serStart);
         } else {
@@ -885,6 +885,10 @@ public class PostgresNetworkExecutor extends Thread {
   }
 
   private void writeRowDescription(final Map<String, PostgresType> columns) {
+    writeRowDescription(columns, null);
+  }
+
+  private void writeRowDescription(final Map<String, PostgresType> columns, final List<Integer> resultFormats) {
     if (columns == null)
       return;
 
@@ -895,6 +899,7 @@ public class PostgresNetworkExecutor extends Thread {
 //    final ByteBuffer bufferDescription = ByteBuffer.allocate(64 * 1024).order(ByteOrder.BIG_ENDIAN);
     final Binary bufferDescription = new Binary();
 
+    int colIndex = 0;
     for (final Map.Entry<String, PostgresType> col : columns.entrySet()) {
       final String columnName = col.getKey();
       final PostgresType columnType = col.getValue();
@@ -912,8 +917,9 @@ public class PostgresNetworkExecutor extends Thread {
       bufferDescription.putShort((short) columnType.size);
       // The type modifier (see pg_attribute.atttypmod). The meaning of the modifier is type-specific.
       bufferDescription.putInt(-1);
-      // The format code being used for the field. Currently will be zero (text) or one (binary). In a RowDescription returned from the statement variant of Describe, the format code is not yet known and will always be zero.
-      bufferDescription.putShort((short) 0);
+      // The format code being used for the field (0=text, 1=binary). Comes from the Bind message's
+      // result-column formats when present; defaults to 0 (text) otherwise.
+      bufferDescription.putShort(resolveResultFormat(resultFormats, colIndex++));
     }
 
     bufferDescription.flip();
@@ -923,7 +929,27 @@ public class PostgresNetworkExecutor extends Thread {
     }, 'T', 4 + 2 + bufferDescription.limit());
   }
 
+  /**
+   * Returns the wire format code (0=text, 1=binary) requested for the column at {@code colIndex}.
+   * Mirrors the Postgres protocol rules for the {@code formats} list in a Bind message:
+   * empty list -> text, single entry -> applies to all columns, otherwise per-column.
+   */
+  private static short resolveResultFormat(final List<Integer> resultFormats, final int colIndex) {
+    if (resultFormats == null || resultFormats.isEmpty())
+      return 0;
+    if (resultFormats.size() == 1)
+      return resultFormats.get(0).shortValue();
+    if (colIndex < resultFormats.size())
+      return resultFormats.get(colIndex).shortValue();
+    return 0;
+  }
+
   private void writeDataRows(final List<Result> resultSet, final Map<String, PostgresType> columns) throws IOException {
+    writeDataRows(resultSet, columns, null);
+  }
+
+  private void writeDataRows(final List<Result> resultSet, final Map<String, PostgresType> columns,
+      final List<Integer> resultFormats) throws IOException {
     if (resultSet.isEmpty())
       return;
 
@@ -933,6 +959,7 @@ public class PostgresNetworkExecutor extends Thread {
     for (final Result row : resultSet) {
       bufferValues.putShort((short) columns.size()); // Int16 The number of column values that follow (possibly zero).
 
+      int colIndex = 0;
       for (final Map.Entry<String, PostgresType> postgresTypeEntry : columns.entrySet()) {
         final String propertyName = postgresTypeEntry.getKey();
 
@@ -981,7 +1008,11 @@ public class PostgresNetworkExecutor extends Thread {
           }
         };
 
-        postgresTypeEntry.getValue().serializeAsText(postgresTypeEntry.getValue(), bufferValues, value);
+        final PostgresType columnType = postgresTypeEntry.getValue();
+        if (resolveResultFormat(resultFormats, colIndex++) == 1)
+          columnType.serializeAsBinary(columnType, bufferValues, value);
+        else
+          columnType.serializeAsText(columnType, bufferValues, value);
       }
 
       bufferValues.flip();

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -30,6 +30,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -44,8 +45,6 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-
-import static java.time.OffsetDateTime.parse;
 
 /**
  * Represents PostgreSQL data types and provides serialization/deserialization functionality.
@@ -109,7 +108,7 @@ public enum PostgresType {
     try {
       return LocalDateTime.parse(iso);
     } catch (DateTimeParseException e) {
-      return parse(iso).toLocalDateTime();
+      return OffsetDateTime.parse(iso).toLocalDateTime();
     }
   }
 
@@ -139,7 +138,7 @@ public enum PostgresType {
     if (value instanceof Date d)
       return d.toInstant().atZone(ZoneOffset.UTC).toLocalDate();
     if (value instanceof String s)
-      return parseDateText(s).toInstant().atZone(ZoneOffset.UTC).toLocalDate();
+      return LocalDate.parse(s);
     throw new PostgresProtocolException("Unsupported DATE binary value type: " + value.getClass());
   }
 
@@ -748,9 +747,15 @@ public enum PostgresType {
    * strings and breaks typed parameter comparisons.
    */
   public boolean isNativeScalarType() {
-    return this == SMALLINT || this == INTEGER || this == LONG ||
-        this == REAL || this == DOUBLE || this == CHAR ||
-        this == BOOLEAN || this == DATE || this == TIMESTAMP;
+    return this == SMALLINT ||
+        this == INTEGER ||
+        this == LONG ||
+        this == REAL ||
+        this == DOUBLE ||
+        this == CHAR ||
+        this == BOOLEAN ||
+        this == DATE ||
+        this == TIMESTAMP;
   }
 
   /**

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -56,7 +56,7 @@ public enum PostgresType {
   CHAR(18, Character.class, 1, value -> value.charAt(0)),
   BOOLEAN(16, Boolean.class, 1, value -> parseBooleanText(value)),
   DATE(1082, Date.class, 4, value -> parseDateText(value)),
-  TIMESTAMP(1114, LocalDateTime.class, 8, value -> LocalDateTime.parse(value.replace(' ', 'T'))),
+  TIMESTAMP(1114, LocalDateTime.class, 8, value -> parseTimestampText(value)),
   VARCHAR(1043, String.class, -1, value -> value),
   TEXT(25, String.class, -1, value -> value),
   BPCHAR(1042, String.class, -1, value -> value),
@@ -85,23 +85,71 @@ public enum PostgresType {
 
   private static Boolean parseBooleanText(final String value) {
     if (value == null)
-      return Boolean.FALSE;
+      throw new PostgresProtocolException("Cannot parse null BOOLEAN text value");
     return switch (value.toLowerCase()) {
-      case "t", "true", "1", "y", "yes", "on" -> Boolean.TRUE;
-      default -> Boolean.FALSE;
+      case "t", "true", "1", "y", "yes", "on"   -> Boolean.TRUE;
+      case "f", "false", "0", "n", "no", "off"  -> Boolean.FALSE;
+      default -> throw new PostgresProtocolException("Cannot parse BOOLEAN text value: " + value);
     };
   }
 
   private static Date parseDateText(final String value) {
     if (value == null)
       throw new PostgresProtocolException("Cannot parse null DATE text value");
+    return Date.from(LocalDate.parse(value).atStartOfDay(ZoneOffset.UTC).toInstant());
+  }
+
+  private static LocalDateTime parseTimestampText(final String value) {
+    if (value == null)
+      throw new PostgresProtocolException("Cannot parse null TIMESTAMP text value");
+    final String iso = value.replace(' ', 'T');
     try {
-      // Accept ISO "YYYY-MM-DD" as Postgres sends in text format
-      return Date.from(LocalDate.parse(value).atStartOfDay(ZoneOffset.UTC).toInstant());
+      return LocalDateTime.parse(iso);
     } catch (DateTimeParseException e) {
-      // Fallback: numeric epoch millis (legacy callers)
-      return new Date(Long.parseLong(value));
+      return java.time.OffsetDateTime.parse(iso).toLocalDateTime();
     }
+  }
+
+  private static Number toNumber(final Object value) {
+    if (value instanceof Number n)
+      return n;
+    if (value instanceof Boolean b)
+      return b ? 1 : 0;
+    if (value instanceof Character c)
+      return (int) c;
+    return new java.math.BigDecimal(value.toString());
+  }
+
+  private static boolean toBooleanValue(final Object value) {
+    if (value instanceof Boolean b)
+      return b;
+    if (value instanceof Number n)
+      return n.intValue() != 0;
+    return parseBooleanText(value.toString());
+  }
+
+  private static LocalDate toLocalDateValue(final Object value) {
+    if (value instanceof LocalDate ld)
+      return ld;
+    if (value instanceof LocalDateTime ldt)
+      return ldt.toLocalDate();
+    if (value instanceof Date d)
+      return d.toInstant().atZone(ZoneOffset.UTC).toLocalDate();
+    if (value instanceof String s)
+      return parseDateText(s).toInstant().atZone(ZoneOffset.UTC).toLocalDate();
+    throw new PostgresProtocolException("Unsupported DATE binary value type: " + value.getClass());
+  }
+
+  private static LocalDateTime toLocalDateTimeValue(final Object value) {
+    if (value instanceof LocalDateTime l)
+      return l;
+    if (value instanceof Date d)
+      return LocalDateTime.ofInstant(d.toInstant(), ZoneOffset.UTC);
+    if (value instanceof LocalDate ld)
+      return ld.atStartOfDay();
+    if (value instanceof String s)
+      return parseTimestampText(s);
+    throw new PostgresProtocolException("Unsupported TIMESTAMP binary value type: " + value.getClass());
   }
 
   public final  int                      code;
@@ -297,7 +345,7 @@ public enum PostgresType {
       // DATE (OID 1082) expects "YYYY-MM-DD" in text format
       serializedValue = date.toInstant().atZone(ZoneOffset.UTC).format(DateTimeFormatter.ISO_LOCAL_DATE);
     } else if (value instanceof LocalDateTime ldt) {
-      // TIMESTAMP (OID 1114) expects "YYYY-MM-DD HH:MM:SS.ffffff" in text format
+      // TIMESTAMP (OID 1114) expects "yyyy-MM-dd HH:mm:ss.SSSSSS" in text format
       serializedValue = ldt.format(POSTGRES_DATETIME_FORMATTER);
     } else if (value instanceof JSONObject json) {
       serializedValue = json.toString();
@@ -328,56 +376,41 @@ public enum PostgresType {
     switch (pgType) {
       case SMALLINT -> {
         typeBuffer.putInt(2);
-        typeBuffer.putShort(((Number) value).shortValue());
+        typeBuffer.putShort(toNumber(value).shortValue());
       }
       case INTEGER -> {
         typeBuffer.putInt(4);
-        typeBuffer.putInt(((Number) value).intValue());
+        typeBuffer.putInt(toNumber(value).intValue());
       }
       case LONG -> {
         typeBuffer.putInt(8);
-        typeBuffer.putLong(((Number) value).longValue());
+        typeBuffer.putLong(toNumber(value).longValue());
       }
       case REAL -> {
         typeBuffer.putInt(4);
-        typeBuffer.putInt(Float.floatToRawIntBits(((Number) value).floatValue()));
+        typeBuffer.putInt(Float.floatToRawIntBits(toNumber(value).floatValue()));
       }
       case DOUBLE -> {
         typeBuffer.putInt(8);
-        typeBuffer.putLong(Double.doubleToRawLongBits(((Number) value).doubleValue()));
+        typeBuffer.putLong(Double.doubleToRawLongBits(toNumber(value).doubleValue()));
       }
       case BOOLEAN -> {
         typeBuffer.putInt(1);
-        typeBuffer.putByte((byte) (Boolean.TRUE.equals(value) ? 1 : 0));
+        typeBuffer.putByte((byte) (toBooleanValue(value) ? 1 : 0));
       }
       case CHAR -> {
-        // Postgres "char" (1 byte) - take first char as single byte
+        // Postgres "char" (OID 18) is a single byte on the wire.
         typeBuffer.putInt(1);
         final char c = (value instanceof Character ch) ? ch : value.toString().charAt(0);
         typeBuffer.putByte((byte) c);
       }
       case DATE -> {
         typeBuffer.putInt(4);
-        final long epochDay;
-        if (value instanceof Date d)
-          epochDay = d.toInstant().atZone(ZoneOffset.UTC).toLocalDate().toEpochDay();
-        else if (value instanceof LocalDateTime ldt)
-          epochDay = ldt.toLocalDate().toEpochDay();
-        else if (value instanceof LocalDate ld)
-          epochDay = ld.toEpochDay();
-        else
-          throw new PostgresProtocolException("Unsupported DATE binary value type: " + value.getClass());
-        typeBuffer.putInt((int) (epochDay - POSTGRES_EPOCH_DAYS));
+        typeBuffer.putInt((int) (toLocalDateValue(value).toEpochDay() - POSTGRES_EPOCH_DAYS));
       }
       case TIMESTAMP -> {
         typeBuffer.putInt(8);
-        final LocalDateTime ldt;
-        if (value instanceof LocalDateTime l)
-          ldt = l;
-        else if (value instanceof Date d)
-          ldt = LocalDateTime.ofInstant(d.toInstant(), ZoneOffset.UTC);
-        else
-          throw new PostgresProtocolException("Unsupported TIMESTAMP binary value type: " + value.getClass());
+        final LocalDateTime ldt = toLocalDateTimeValue(value);
         final long secsFromPgEpoch = ldt.toEpochSecond(ZoneOffset.UTC) - POSTGRES_EPOCH_SECONDS;
         typeBuffer.putLong(secsFromPgEpoch * 1_000_000L + ldt.getNano() / 1000L);
       }
@@ -620,7 +653,7 @@ public enum PostgresType {
         }
         yield LocalDateTime.ofEpochSecond(secs, nanos, ZoneOffset.UTC);
       }
-      case CHAR -> buffer.getChar();
+      case CHAR -> (char) buffer.get();
       case BOOLEAN -> buffer.get() == 1;
       case JSON -> {
         int length = buffer.getInt();

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -53,7 +53,8 @@ public enum PostgresType {
   DOUBLE(701, Double.class, 8, value -> Double.parseDouble(value)),
   CHAR(18, Character.class, 1, value -> value.charAt(0)),
   BOOLEAN(16, Boolean.class, 1, value -> value.equalsIgnoreCase("true")),
-  DATE(1082, Date.class, 8, value -> new Date(Long.parseLong(value))),
+  DATE(1082, Date.class, 4, value -> new Date(Long.parseLong(value))),
+  TIMESTAMP(1114, LocalDateTime.class, 8, value -> LocalDateTime.parse(value.replace(' ', 'T'))),
   VARCHAR(1043, String.class, -1, value -> value),
   TEXT(25, String.class, -1, value -> value),
   BPCHAR(1042, String.class, -1, value -> value),
@@ -206,7 +207,7 @@ public enum PostgresType {
     } else if (val instanceof Date) {
       return PostgresType.DATE;
     } else if (val instanceof LocalDateTime) {
-      return PostgresType.DATE;
+      return PostgresType.TIMESTAMP;
     }
 
     return PostgresType.VARCHAR;
@@ -233,7 +234,8 @@ public enum PostgresType {
       case DOUBLE -> PostgresType.DOUBLE;
       case BYTE -> PostgresType.SMALLINT;
       case STRING -> PostgresType.VARCHAR;
-      case DATETIME, DATE -> PostgresType.DATE;
+      case DATETIME -> PostgresType.TIMESTAMP;
+      case DATE -> PostgresType.DATE;
       case BINARY -> PostgresType.VARCHAR; // No direct binary type, use VARCHAR
       case LIST -> PostgresType.ARRAY_TEXT;
       case MAP, EMBEDDED -> PostgresType.JSON;
@@ -262,12 +264,14 @@ public enum PostgresType {
       // Handle primitive arrays by converting them to Collections
       Collection<?> collection = convertPrimitiveArrayToCollection(value);
       serializedValue = serializeArrayToString(collection, pgType);
+    } else if (value instanceof Boolean b) {
+      // PostgreSQL BOOL text format is "t"/"f"
+      serializedValue = b ? "t" : "f";
     } else if (value instanceof Date date) {
-      // Format Date as PostgreSQL-compatible timestamp
-      LocalDateTime ldt = LocalDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC);
-      serializedValue = ldt.format(POSTGRES_DATETIME_FORMATTER);
+      // DATE (OID 1082) expects "YYYY-MM-DD" in text format
+      serializedValue = date.toInstant().atZone(ZoneOffset.UTC).format(DateTimeFormatter.ISO_LOCAL_DATE);
     } else if (value instanceof LocalDateTime ldt) {
-      // Format LocalDateTime as PostgreSQL-compatible timestamp
+      // TIMESTAMP (OID 1114) expects "YYYY-MM-DD HH:MM:SS.ffffff" in text format
       serializedValue = ldt.format(POSTGRES_DATETIME_FORMATTER);
     } else if (value instanceof JSONObject json) {
       serializedValue = json.toString();
@@ -503,6 +507,18 @@ public enum PostgresType {
       case REAL -> buffer.getFloat();
       case DOUBLE -> buffer.getDouble();
       case DATE -> new Date(buffer.getLong());
+      case TIMESTAMP -> {
+        // PostgreSQL binary timestamp: int64 microseconds since 2000-01-01T00:00:00Z
+        final long microseconds = buffer.getLong();
+        final long POSTGRES_EPOCH_SECONDS = 946684800L;
+        long secs = POSTGRES_EPOCH_SECONDS + microseconds / 1_000_000L;
+        int nanos = (int) (microseconds % 1_000_000L) * 1000;
+        if (nanos < 0) {
+          secs -= 1;
+          nanos += 1_000_000_000;
+        }
+        yield LocalDateTime.ofEpochSecond(secs, nanos, ZoneOffset.UTC);
+      }
       case CHAR -> buffer.getChar();
       case BOOLEAN -> buffer.get() == 1;
       case JSON -> {
@@ -590,5 +606,17 @@ public enum PostgresType {
         this == ARRAY_TEXT ||
         this == ARRAY_JSON ||
         this == ARRAY_BOOLEAN;
+  }
+
+  /**
+   * Returns true for scalar types that should be advertised with their native Postgres OID rather
+   * than collapsing to VARCHAR. Clients use the announced OID to choose a deserializer, so
+   * advertising VARCHAR for numeric/boolean/temporal columns causes values to round-trip as
+   * strings and breaks typed parameter comparisons.
+   */
+  public boolean isNativeScalarType() {
+    return this == SMALLINT || this == INTEGER || this == LONG ||
+        this == REAL || this == DOUBLE || this == CHAR ||
+        this == BOOLEAN || this == DATE || this == TIMESTAMP;
   }
 }

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -267,11 +267,17 @@ public enum PostgresType {
       // Handle Java arrays
       return switch (val) {
         case int[] ints -> PostgresType.ARRAY_INT;
+        case Integer[] ints -> PostgresType.ARRAY_INT;
         case long[] longs -> PostgresType.ARRAY_LONG;
+        case Long[] longs -> PostgresType.ARRAY_LONG;
         case double[] doubles -> PostgresType.ARRAY_DOUBLE;
+        case Double[] doubles -> PostgresType.ARRAY_DOUBLE;
         case float[] floats -> PostgresType.ARRAY_REAL;
+        case Float[] floats -> PostgresType.ARRAY_REAL;
         case boolean[] booleans -> PostgresType.ARRAY_BOOLEAN;
+        case Boolean[] booleans -> PostgresType.ARRAY_BOOLEAN;
         case char[] chars -> PostgresType.ARRAY_CHAR;
+        case Character[] chars -> PostgresType.ARRAY_CHAR;
         case String[] strings -> PostgresType.ARRAY_TEXT;
         default -> throw new IllegalStateException("Unexpected value: " + val);
       };

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -81,7 +81,7 @@ public enum PostgresType {
   private static final int MAX_ARRAY_DIMENSIONS = 6;
   // PostgreSQL's epoch for DATE/TIMESTAMP binary formats is 2000-01-01T00:00:00 UTC.
   private static final long POSTGRES_EPOCH_SECONDS = 946684800L;
-  private static final long POSTGRES_EPOCH_DAYS    = 10957L; // LocalDate.of(2000, 1, 1).toEpochDay()
+  private static final long POSTGRES_EPOCH_DAYS = 10957L; // LocalDate.of(2000, 1, 1).toEpochDay()
 
   private static Boolean parseBooleanText(final String value) {
     if (value == null)
@@ -752,5 +752,16 @@ public enum PostgresType {
     return this == SMALLINT || this == INTEGER || this == LONG ||
         this == REAL || this == DOUBLE || this == CHAR ||
         this == BOOLEAN || this == DATE || this == TIMESTAMP;
+  }
+
+  /**
+   * Returns true when {@link #serializeAsBinary} produces a wire payload that matches the type's
+   * binary protocol specification. Array types currently lack a binary encoder, so they MUST be
+   * advertised as text (0) in RowDescription regardless of what the client requested in Bind -
+   * otherwise the RowDescription format code and the DataRow bytes disagree and clients misparse.
+   * String/JSON types are safe because their text and binary wire formats are identical raw bytes.
+   */
+  public boolean hasBinaryEncoding() {
+    return !isArrayType();
   }
 }

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -26,6 +26,7 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.json.JSONObject;
 
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -43,6 +44,8 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+
+import static java.time.OffsetDateTime.parse;
 
 /**
  * Represents PostgreSQL data types and provides serialization/deserialization functionality.
@@ -75,20 +78,20 @@ public enum PostgresType {
       .collect(Collectors.toMap(type -> type.code, type -> type));
 
   // PostgreSQL-compatible datetime format (ISO 8601 without 'T' separator)
-  private static final String POSTGRES_TIMESTAMP_FORMAT = "yyyy-MM-dd HH:mm:ss.SSSSSS";
+  private static final String            POSTGRES_TIMESTAMP_FORMAT   = "yyyy-MM-dd HH:mm:ss.SSSSSS";
   private static final DateTimeFormatter POSTGRES_DATETIME_FORMATTER = DateTimeFormatter.ofPattern(POSTGRES_TIMESTAMP_FORMAT);
   // PostgreSQL caps array dimensions at 6 (MAXDIM in pg_config_manual.h).
-  private static final int MAX_ARRAY_DIMENSIONS = 6;
+  private static final int               MAX_ARRAY_DIMENSIONS        = 6;
   // PostgreSQL's epoch for DATE/TIMESTAMP binary formats is 2000-01-01T00:00:00 UTC.
-  private static final long POSTGRES_EPOCH_SECONDS = 946684800L;
-  private static final long POSTGRES_EPOCH_DAYS = 10957L; // LocalDate.of(2000, 1, 1).toEpochDay()
+  private static final long              POSTGRES_EPOCH_SECONDS      = 946684800L;
+  private static final long              POSTGRES_EPOCH_DAYS         = 10957L; // LocalDate.of(2000, 1, 1).toEpochDay()
 
   private static Boolean parseBooleanText(final String value) {
     if (value == null)
       throw new PostgresProtocolException("Cannot parse null BOOLEAN text value");
     return switch (value.toLowerCase()) {
-      case "t", "true", "1", "y", "yes", "on"   -> Boolean.TRUE;
-      case "f", "false", "0", "n", "no", "off"  -> Boolean.FALSE;
+      case "t", "true", "1", "y", "yes", "on" -> Boolean.TRUE;
+      case "f", "false", "0", "n", "no", "off" -> Boolean.FALSE;
       default -> throw new PostgresProtocolException("Cannot parse BOOLEAN text value: " + value);
     };
   }
@@ -106,7 +109,7 @@ public enum PostgresType {
     try {
       return LocalDateTime.parse(iso);
     } catch (DateTimeParseException e) {
-      return java.time.OffsetDateTime.parse(iso).toLocalDateTime();
+      return parse(iso).toLocalDateTime();
     }
   }
 
@@ -117,7 +120,7 @@ public enum PostgresType {
       return b ? 1 : 0;
     if (value instanceof Character c)
       return (int) c;
-    return new java.math.BigDecimal(value.toString());
+    return new BigDecimal(value.toString());
   }
 
   private static boolean toBooleanValue(final Object value) {
@@ -263,21 +266,16 @@ public enum PostgresType {
       return PostgresType.ARRAY_CHAR;
     } else if (val.getClass().isArray()) {
       // Handle Java arrays
-      if (val instanceof int[]) {
-        return PostgresType.ARRAY_INT;
-      } else if (val instanceof long[]) {
-        return PostgresType.ARRAY_LONG;
-      } else if (val instanceof double[]) {
-        return PostgresType.ARRAY_DOUBLE;
-      } else if (val instanceof float[]) {
-        return PostgresType.ARRAY_REAL;
-      } else if (val instanceof boolean[]) {
-        return PostgresType.ARRAY_BOOLEAN;
-      } else if (val instanceof char[]) {
-        return PostgresType.ARRAY_CHAR;
-      } else if (val instanceof String[]) {
-        return PostgresType.ARRAY_TEXT;
-      }
+      return switch (val) {
+        case int[] ints -> PostgresType.ARRAY_INT;
+        case long[] longs -> PostgresType.ARRAY_LONG;
+        case double[] doubles -> PostgresType.ARRAY_DOUBLE;
+        case float[] floats -> PostgresType.ARRAY_REAL;
+        case boolean[] booleans -> PostgresType.ARRAY_BOOLEAN;
+        case char[] chars -> PostgresType.ARRAY_CHAR;
+        case String[] strings -> PostgresType.ARRAY_TEXT;
+        default -> throw new IllegalStateException("Unexpected value: " + val);
+      };
     } else if (val instanceof Date) {
       return PostgresType.DATE;
     } else if (val instanceof LocalDateTime) {
@@ -292,6 +290,7 @@ public enum PostgresType {
    * Maps an ArcadeDB schema Type to a PostgreSQL type.
    *
    * @param arcadeType The ArcadeDB schema type
+   *
    * @return The corresponding PostgreSQL type
    */
   public static PostgresType getTypeFromArcade(Type arcadeType) {
@@ -374,49 +373,49 @@ public enum PostgresType {
       return;
     }
     switch (pgType) {
-      case SMALLINT -> {
-        typeBuffer.putInt(2);
-        typeBuffer.putShort(toNumber(value).shortValue());
-      }
-      case INTEGER -> {
-        typeBuffer.putInt(4);
-        typeBuffer.putInt(toNumber(value).intValue());
-      }
-      case LONG -> {
-        typeBuffer.putInt(8);
-        typeBuffer.putLong(toNumber(value).longValue());
-      }
-      case REAL -> {
-        typeBuffer.putInt(4);
-        typeBuffer.putInt(Float.floatToRawIntBits(toNumber(value).floatValue()));
-      }
-      case DOUBLE -> {
-        typeBuffer.putInt(8);
-        typeBuffer.putLong(Double.doubleToRawLongBits(toNumber(value).doubleValue()));
-      }
-      case BOOLEAN -> {
-        typeBuffer.putInt(1);
-        typeBuffer.putByte((byte) (toBooleanValue(value) ? 1 : 0));
-      }
-      case CHAR -> {
-        // Postgres "char" (OID 18) is a single byte on the wire.
-        typeBuffer.putInt(1);
-        final char c = (value instanceof Character ch) ? ch : value.toString().charAt(0);
-        typeBuffer.putByte((byte) c);
-      }
-      case DATE -> {
-        typeBuffer.putInt(4);
-        typeBuffer.putInt((int) (toLocalDateValue(value).toEpochDay() - POSTGRES_EPOCH_DAYS));
-      }
-      case TIMESTAMP -> {
-        typeBuffer.putInt(8);
-        final LocalDateTime ldt = toLocalDateTimeValue(value);
-        final long secsFromPgEpoch = ldt.toEpochSecond(ZoneOffset.UTC) - POSTGRES_EPOCH_SECONDS;
-        typeBuffer.putLong(secsFromPgEpoch * 1_000_000L + ldt.getNano() / 1000L);
-      }
-      // Strings, JSON, and arrays do not have a separate binary representation: their wire format
-      // is identical to text for our purposes (length-prefixed UTF-8 bytes / array literal text).
-      default -> serializeAsText(pgType, typeBuffer, value);
+    case SMALLINT -> {
+      typeBuffer.putInt(2);
+      typeBuffer.putShort(toNumber(value).shortValue());
+    }
+    case INTEGER -> {
+      typeBuffer.putInt(4);
+      typeBuffer.putInt(toNumber(value).intValue());
+    }
+    case LONG -> {
+      typeBuffer.putInt(8);
+      typeBuffer.putLong(toNumber(value).longValue());
+    }
+    case REAL -> {
+      typeBuffer.putInt(4);
+      typeBuffer.putInt(Float.floatToRawIntBits(toNumber(value).floatValue()));
+    }
+    case DOUBLE -> {
+      typeBuffer.putInt(8);
+      typeBuffer.putLong(Double.doubleToRawLongBits(toNumber(value).doubleValue()));
+    }
+    case BOOLEAN -> {
+      typeBuffer.putInt(1);
+      typeBuffer.putByte((byte) (toBooleanValue(value) ? 1 : 0));
+    }
+    case CHAR -> {
+      // Postgres "char" (OID 18) is a single byte on the wire.
+      typeBuffer.putInt(1);
+      final char c = (value instanceof Character ch) ? ch : value.toString().charAt(0);
+      typeBuffer.putByte((byte) c);
+    }
+    case DATE -> {
+      typeBuffer.putInt(4);
+      typeBuffer.putInt((int) (toLocalDateValue(value).toEpochDay() - POSTGRES_EPOCH_DAYS));
+    }
+    case TIMESTAMP -> {
+      typeBuffer.putInt(8);
+      final LocalDateTime ldt = toLocalDateTimeValue(value);
+      final long secsFromPgEpoch = ldt.toEpochSecond(ZoneOffset.UTC) - POSTGRES_EPOCH_SECONDS;
+      typeBuffer.putLong(secsFromPgEpoch * 1_000_000L + ldt.getNano() / 1000L);
+    }
+    // Strings, JSON, and arrays do not have a separate binary representation: their wire format
+    // is identical to text for our purposes (length-prefixed UTF-8 bytes / array literal text).
+    default -> serializeAsText(pgType, typeBuffer, value);
     }
   }
 

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java
@@ -27,9 +27,11 @@ import com.arcadedb.schema.Type;
 import com.arcadedb.serializer.json.JSONObject;
 
 import java.nio.ByteBuffer;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -52,8 +54,8 @@ public enum PostgresType {
   REAL(700, Float.class, 4, value -> Float.parseFloat(value)),
   DOUBLE(701, Double.class, 8, value -> Double.parseDouble(value)),
   CHAR(18, Character.class, 1, value -> value.charAt(0)),
-  BOOLEAN(16, Boolean.class, 1, value -> value.equalsIgnoreCase("true")),
-  DATE(1082, Date.class, 4, value -> new Date(Long.parseLong(value))),
+  BOOLEAN(16, Boolean.class, 1, value -> parseBooleanText(value)),
+  DATE(1082, Date.class, 4, value -> parseDateText(value)),
   TIMESTAMP(1114, LocalDateTime.class, 8, value -> LocalDateTime.parse(value.replace(' ', 'T'))),
   VARCHAR(1043, String.class, -1, value -> value),
   TEXT(25, String.class, -1, value -> value),
@@ -77,6 +79,30 @@ public enum PostgresType {
   private static final DateTimeFormatter POSTGRES_DATETIME_FORMATTER = DateTimeFormatter.ofPattern(POSTGRES_TIMESTAMP_FORMAT);
   // PostgreSQL caps array dimensions at 6 (MAXDIM in pg_config_manual.h).
   private static final int MAX_ARRAY_DIMENSIONS = 6;
+  // PostgreSQL's epoch for DATE/TIMESTAMP binary formats is 2000-01-01T00:00:00 UTC.
+  private static final long POSTGRES_EPOCH_SECONDS = 946684800L;
+  private static final long POSTGRES_EPOCH_DAYS    = 10957L; // LocalDate.of(2000, 1, 1).toEpochDay()
+
+  private static Boolean parseBooleanText(final String value) {
+    if (value == null)
+      return Boolean.FALSE;
+    return switch (value.toLowerCase()) {
+      case "t", "true", "1", "y", "yes", "on" -> Boolean.TRUE;
+      default -> Boolean.FALSE;
+    };
+  }
+
+  private static Date parseDateText(final String value) {
+    if (value == null)
+      throw new PostgresProtocolException("Cannot parse null DATE text value");
+    try {
+      // Accept ISO "YYYY-MM-DD" as Postgres sends in text format
+      return Date.from(LocalDate.parse(value).atStartOfDay(ZoneOffset.UTC).toInstant());
+    } catch (DateTimeParseException e) {
+      // Fallback: numeric epoch millis (legacy callers)
+      return new Date(Long.parseLong(value));
+    }
+  }
 
   public final  int                      code;
   public final  Class<?>                 cls;
@@ -287,6 +313,78 @@ public enum PostgresType {
       serializedValue = value.toString();
     }
     writeString(typeBuffer, serializedValue);
+  }
+
+  /**
+   * Serializes a value as PostgreSQL binary format into the provided Binary buffer.
+   * Used when a client requests binary results via Bind message format codes. Types without a
+   * binary mapping fall back to {@link #serializeAsText}.
+   */
+  public void serializeAsBinary(final PostgresType pgType, final Binary typeBuffer, final Object value) {
+    if (value == null) {
+      typeBuffer.putInt(-1);
+      return;
+    }
+    switch (pgType) {
+      case SMALLINT -> {
+        typeBuffer.putInt(2);
+        typeBuffer.putShort(((Number) value).shortValue());
+      }
+      case INTEGER -> {
+        typeBuffer.putInt(4);
+        typeBuffer.putInt(((Number) value).intValue());
+      }
+      case LONG -> {
+        typeBuffer.putInt(8);
+        typeBuffer.putLong(((Number) value).longValue());
+      }
+      case REAL -> {
+        typeBuffer.putInt(4);
+        typeBuffer.putInt(Float.floatToRawIntBits(((Number) value).floatValue()));
+      }
+      case DOUBLE -> {
+        typeBuffer.putInt(8);
+        typeBuffer.putLong(Double.doubleToRawLongBits(((Number) value).doubleValue()));
+      }
+      case BOOLEAN -> {
+        typeBuffer.putInt(1);
+        typeBuffer.putByte((byte) (Boolean.TRUE.equals(value) ? 1 : 0));
+      }
+      case CHAR -> {
+        // Postgres "char" (1 byte) - take first char as single byte
+        typeBuffer.putInt(1);
+        final char c = (value instanceof Character ch) ? ch : value.toString().charAt(0);
+        typeBuffer.putByte((byte) c);
+      }
+      case DATE -> {
+        typeBuffer.putInt(4);
+        final long epochDay;
+        if (value instanceof Date d)
+          epochDay = d.toInstant().atZone(ZoneOffset.UTC).toLocalDate().toEpochDay();
+        else if (value instanceof LocalDateTime ldt)
+          epochDay = ldt.toLocalDate().toEpochDay();
+        else if (value instanceof LocalDate ld)
+          epochDay = ld.toEpochDay();
+        else
+          throw new PostgresProtocolException("Unsupported DATE binary value type: " + value.getClass());
+        typeBuffer.putInt((int) (epochDay - POSTGRES_EPOCH_DAYS));
+      }
+      case TIMESTAMP -> {
+        typeBuffer.putInt(8);
+        final LocalDateTime ldt;
+        if (value instanceof LocalDateTime l)
+          ldt = l;
+        else if (value instanceof Date d)
+          ldt = LocalDateTime.ofInstant(d.toInstant(), ZoneOffset.UTC);
+        else
+          throw new PostgresProtocolException("Unsupported TIMESTAMP binary value type: " + value.getClass());
+        final long secsFromPgEpoch = ldt.toEpochSecond(ZoneOffset.UTC) - POSTGRES_EPOCH_SECONDS;
+        typeBuffer.putLong(secsFromPgEpoch * 1_000_000L + ldt.getNano() / 1000L);
+      }
+      // Strings, JSON, and arrays do not have a separate binary representation: their wire format
+      // is identical to text for our purposes (length-prefixed UTF-8 bytes / array literal text).
+      default -> serializeAsText(pgType, typeBuffer, value);
+    }
   }
 
   private void writeString(final Binary typeBuffer, final String value) {
@@ -506,11 +604,14 @@ public enum PostgresType {
       case LONG -> buffer.getLong();
       case REAL -> buffer.getFloat();
       case DOUBLE -> buffer.getDouble();
-      case DATE -> new Date(buffer.getLong());
+      case DATE -> {
+        // PostgreSQL binary DATE: int32 days since 2000-01-01
+        final int days = buffer.getInt();
+        yield Date.from(LocalDate.ofEpochDay(POSTGRES_EPOCH_DAYS + days).atStartOfDay(ZoneOffset.UTC).toInstant());
+      }
       case TIMESTAMP -> {
-        // PostgreSQL binary timestamp: int64 microseconds since 2000-01-01T00:00:00Z
+        // PostgreSQL binary TIMESTAMP: int64 microseconds since 2000-01-01T00:00:00Z
         final long microseconds = buffer.getLong();
-        final long POSTGRES_EPOCH_SECONDS = 946684800L;
         long secs = POSTGRES_EPOCH_SECONDS + microseconds / 1_000_000L;
         int nanos = (int) (microseconds % 1_000_000L) * 1000;
         if (nanos < 0) {

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
@@ -448,9 +448,38 @@ class PostgresTypeTest {
 
   @Test
   void deserializeTextBoolean() {
+    // Canonical Postgres text format
+    assertThat(PostgresType.deserialize(PostgresType.BOOLEAN.code, 0, "t".getBytes())).isEqualTo(true);
+    assertThat(PostgresType.deserialize(PostgresType.BOOLEAN.code, 0, "f".getBytes())).isEqualTo(false);
+    // Legacy / verbose forms also accepted
     assertThat(PostgresType.deserialize(PostgresType.BOOLEAN.code, 0, "true".getBytes())).isEqualTo(true);
     assertThat(PostgresType.deserialize(PostgresType.BOOLEAN.code, 0, "TRUE".getBytes())).isEqualTo(true);
     assertThat(PostgresType.deserialize(PostgresType.BOOLEAN.code, 0, "false".getBytes())).isEqualTo(false);
+    assertThat(PostgresType.deserialize(PostgresType.BOOLEAN.code, 0, "1".getBytes())).isEqualTo(true);
+    assertThat(PostgresType.deserialize(PostgresType.BOOLEAN.code, 0, "0".getBytes())).isEqualTo(false);
+    assertThat(PostgresType.deserialize(PostgresType.BOOLEAN.code, 0, "yes".getBytes())).isEqualTo(true);
+    assertThat(PostgresType.deserialize(PostgresType.BOOLEAN.code, 0, "no".getBytes())).isEqualTo(false);
+  }
+
+  @Test
+  void deserializeTextDateIsoFormat() {
+    // After advertising DATE columns natively, clients send dates as "YYYY-MM-DD" text
+    Object result = PostgresType.deserialize(PostgresType.DATE.code, 0, "2024-08-22".getBytes());
+    assertThat(result).isInstanceOf(Date.class);
+    final long expectedMillis = java.time.LocalDate.of(2024, 8, 22)
+        .atStartOfDay(java.time.ZoneOffset.UTC).toInstant().toEpochMilli();
+    assertThat(((Date) result).getTime()).isEqualTo(expectedMillis);
+  }
+
+  @Test
+  void deserializeBinaryTimestamp() {
+    // PostgreSQL binary TIMESTAMP: int64 microseconds since 2000-01-01T00:00:00Z
+    final long microsSince2000 = 777600000000L; // 2000-01-01 + 9 days
+    ByteBuffer buffer = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN);
+    buffer.putLong(microsSince2000);
+    Object result = PostgresType.deserialize(PostgresType.TIMESTAMP.code, 1, buffer.array());
+    assertThat(result).isInstanceOf(java.time.LocalDateTime.class);
+    assertThat((java.time.LocalDateTime) result).isEqualTo(java.time.LocalDateTime.of(2000, 1, 10, 0, 0, 0));
   }
 
   @Test
@@ -679,12 +708,15 @@ class PostgresTypeTest {
 
   @Test
   void deserializeBinaryDate() {
-    long timestamp = System.currentTimeMillis();
-    ByteBuffer buffer = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN);
-    buffer.putLong(timestamp);
+    // PostgreSQL binary DATE: int32 days since 2000-01-01 UTC
+    final int daysSince2000 = 9000; // 2000-01-01 + 9000 days = 2024-08-22
+    ByteBuffer buffer = ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN);
+    buffer.putInt(daysSince2000);
     Object result = PostgresType.deserialize(PostgresType.DATE.code, 1, buffer.array());
     assertThat(result).isInstanceOf(Date.class);
-    assertThat(((Date) result).getTime()).isEqualTo(timestamp);
+    final long expectedMillis = java.time.LocalDate.of(2000, 1, 1).plusDays(daysSince2000)
+        .atStartOfDay(java.time.ZoneOffset.UTC).toInstant().toEpochMilli();
+    assertThat(((Date) result).getTime()).isEqualTo(expectedMillis);
   }
 
   @Test
@@ -1076,6 +1108,88 @@ class PostgresTypeTest {
     // DATE (OID 1082) must be serialized as "YYYY-MM-DD" only
     assertThat(result).matches("\\d{4}-\\d{2}-\\d{2}");
     assertThat(result).isEqualTo("2024-05-19");
+  }
+
+  @Test
+  void serializeAsTextBoolean() {
+    final Binary t = new Binary();
+    PostgresType.BOOLEAN.serializeAsText(PostgresType.BOOLEAN, t, Boolean.TRUE);
+    t.flip();
+    final byte[] tData = new byte[t.getInt()];
+    t.getByteBuffer().get(tData);
+    assertThat(new String(tData)).isEqualTo("t");
+
+    final Binary f = new Binary();
+    PostgresType.BOOLEAN.serializeAsText(PostgresType.BOOLEAN, f, Boolean.FALSE);
+    f.flip();
+    final byte[] fData = new byte[f.getInt()];
+    f.getByteBuffer().get(fData);
+    assertThat(new String(fData)).isEqualTo("f");
+  }
+
+  @Test
+  void serializeAsBinaryInteger() {
+    Binary buffer = new Binary();
+    PostgresType.INTEGER.serializeAsBinary(PostgresType.INTEGER, buffer, 12345);
+    buffer.flip();
+    assertThat(buffer.getInt()).isEqualTo(4);
+    assertThat(buffer.getInt()).isEqualTo(12345);
+  }
+
+  @Test
+  void serializeAsBinaryDouble() {
+    Binary buffer = new Binary();
+    PostgresType.DOUBLE.serializeAsBinary(PostgresType.DOUBLE, buffer, 3.14159d);
+    buffer.flip();
+    assertThat(buffer.getInt()).isEqualTo(8);
+    assertThat(Double.longBitsToDouble(buffer.getLong())).isEqualTo(3.14159d);
+  }
+
+  @Test
+  void serializeAsBinaryBoolean() {
+    final Binary t = new Binary();
+    PostgresType.BOOLEAN.serializeAsBinary(PostgresType.BOOLEAN, t, Boolean.TRUE);
+    t.flip();
+    assertThat(t.getInt()).isEqualTo(1);
+    assertThat(t.getByte()).isEqualTo((byte) 1);
+
+    final Binary f = new Binary();
+    PostgresType.BOOLEAN.serializeAsBinary(PostgresType.BOOLEAN, f, Boolean.FALSE);
+    f.flip();
+    assertThat(f.getInt()).isEqualTo(1);
+    assertThat(f.getByte()).isEqualTo((byte) 0);
+  }
+
+  @Test
+  void serializeAsBinaryDateRoundTrip() {
+    // Round-trip: binary serialize -> binary deserialize must preserve the date portion
+    final java.time.LocalDate ld = java.time.LocalDate.of(2024, 8, 22);
+    final Date input = Date.from(ld.atStartOfDay(java.time.ZoneOffset.UTC).toInstant());
+
+    final Binary buffer = new Binary();
+    PostgresType.DATE.serializeAsBinary(PostgresType.DATE, buffer, input);
+    buffer.flip();
+    assertThat(buffer.getInt()).isEqualTo(4);
+
+    final byte[] bytes = new byte[4];
+    buffer.getByteBuffer().get(bytes);
+    final Object decoded = PostgresType.deserialize(PostgresType.DATE.code, 1, bytes);
+    assertThat(decoded).isInstanceOf(Date.class);
+    assertThat(((Date) decoded).toInstant().atZone(java.time.ZoneOffset.UTC).toLocalDate()).isEqualTo(ld);
+  }
+
+  @Test
+  void serializeAsBinaryTimestampRoundTrip() {
+    final java.time.LocalDateTime ldt = java.time.LocalDateTime.of(2024, 8, 22, 14, 30, 45, 123_456_000);
+    final Binary buffer = new Binary();
+    PostgresType.TIMESTAMP.serializeAsBinary(PostgresType.TIMESTAMP, buffer, ldt);
+    buffer.flip();
+    assertThat(buffer.getInt()).isEqualTo(8);
+
+    final byte[] bytes = new byte[8];
+    buffer.getByteBuffer().get(bytes);
+    final Object decoded = PostgresType.deserialize(PostgresType.TIMESTAMP.code, 1, bytes);
+    assertThat(decoded).isEqualTo(ldt);
   }
 
   @Test

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -678,10 +679,20 @@ class PostgresTypeTest {
 
   @Test
   void deserializeBinaryChar() {
-    ByteBuffer buffer = ByteBuffer.allocate(2).order(ByteOrder.BIG_ENDIAN);
-    buffer.putChar('X');
-    Object result = PostgresType.deserialize(PostgresType.CHAR.code, 1, buffer.array());
+    // PostgreSQL "char" (OID 18) is a single byte on the wire.
+    Object result = PostgresType.deserialize(PostgresType.CHAR.code, 1, new byte[]{(byte) 'X'});
     assertThat(result).isEqualTo('X');
+  }
+
+  @Test
+  void serializeAsBinaryCharRoundTrip() {
+    final Binary buffer = new Binary();
+    PostgresType.CHAR.serializeAsBinary(PostgresType.CHAR, buffer, 'Z');
+    buffer.flip();
+    assertThat(buffer.getInt()).isEqualTo(1);
+    final byte b = buffer.getByte();
+    final Object decoded = PostgresType.deserialize(PostgresType.CHAR.code, 1, new byte[]{b});
+    assertThat(decoded).isEqualTo('Z');
   }
 
   @Test
@@ -1643,5 +1654,160 @@ class PostgresTypeTest {
     // Arrays are variable length
     assertThat(PostgresType.ARRAY_INT.size).isEqualTo(-1);
     assertThat(PostgresType.ARRAY_TEXT.size).isEqualTo(-1);
+  }
+
+  // ==================== Defensive serializeAsBinary coercion ====================
+  // Schemaless documents can hold values whose runtime Java type does not match the column type
+  // advertised in RowDescription (the announcement is derived from the first row). The Postgres
+  // wire protocol fixes one format code per column for the whole result, so the binary serializer
+  // must coerce mismatched values rather than throwing.
+
+  @Test
+  void serializeAsBinaryIntegerCoercesNumericString() {
+    final Binary buffer = new Binary();
+    PostgresType.INTEGER.serializeAsBinary(PostgresType.INTEGER, buffer, "12345");
+    buffer.flip();
+    assertThat(buffer.getInt()).isEqualTo(4);
+    assertThat(buffer.getInt()).isEqualTo(12345);
+  }
+
+  @Test
+  void serializeAsBinaryLongCoercesNumericString() {
+    final Binary buffer = new Binary();
+    PostgresType.LONG.serializeAsBinary(PostgresType.LONG, buffer, "9876543210");
+    buffer.flip();
+    assertThat(buffer.getInt()).isEqualTo(8);
+    assertThat(buffer.getLong()).isEqualTo(9876543210L);
+  }
+
+  @Test
+  void serializeAsBinaryDoubleCoercesNumericString() {
+    final Binary buffer = new Binary();
+    PostgresType.DOUBLE.serializeAsBinary(PostgresType.DOUBLE, buffer, "3.14159");
+    buffer.flip();
+    assertThat(buffer.getInt()).isEqualTo(8);
+    assertThat(Double.longBitsToDouble(buffer.getLong())).isEqualTo(3.14159d);
+  }
+
+  @Test
+  void serializeAsBinaryBooleanCoercesString() {
+    final Binary t = new Binary();
+    PostgresType.BOOLEAN.serializeAsBinary(PostgresType.BOOLEAN, t, "t");
+    t.flip();
+    assertThat(t.getInt()).isEqualTo(1);
+    assertThat(t.getByte()).isEqualTo((byte) 1);
+
+    final Binary f = new Binary();
+    PostgresType.BOOLEAN.serializeAsBinary(PostgresType.BOOLEAN, f, "false");
+    f.flip();
+    assertThat(f.getInt()).isEqualTo(1);
+    assertThat(f.getByte()).isEqualTo((byte) 0);
+  }
+
+  @Test
+  void serializeAsBinaryBooleanCoercesNumber() {
+    final Binary t = new Binary();
+    PostgresType.BOOLEAN.serializeAsBinary(PostgresType.BOOLEAN, t, 1);
+    t.flip();
+    assertThat(t.getInt()).isEqualTo(1);
+    assertThat(t.getByte()).isEqualTo((byte) 1);
+
+    final Binary f = new Binary();
+    PostgresType.BOOLEAN.serializeAsBinary(PostgresType.BOOLEAN, f, 0);
+    f.flip();
+    assertThat(f.getInt()).isEqualTo(1);
+    assertThat(f.getByte()).isEqualTo((byte) 0);
+  }
+
+  @Test
+  void serializeAsBinaryDateCoercesIsoString() {
+    final Binary buffer = new Binary();
+    PostgresType.DATE.serializeAsBinary(PostgresType.DATE, buffer, "2024-08-22");
+    buffer.flip();
+    assertThat(buffer.getInt()).isEqualTo(4);
+    final byte[] bytes = new byte[4];
+    buffer.getByteBuffer().get(bytes);
+    final Object decoded = PostgresType.deserialize(PostgresType.DATE.code, 1, bytes);
+    assertThat(decoded).isInstanceOf(Date.class);
+    assertThat(((Date) decoded).toInstant().atZone(java.time.ZoneOffset.UTC).toLocalDate())
+        .isEqualTo(java.time.LocalDate.of(2024, 8, 22));
+  }
+
+  @Test
+  void serializeAsBinaryTimestampCoercesString() {
+    final Binary buffer = new Binary();
+    PostgresType.TIMESTAMP.serializeAsBinary(PostgresType.TIMESTAMP, buffer, "2024-08-22 14:30:45.123456");
+    buffer.flip();
+    assertThat(buffer.getInt()).isEqualTo(8);
+    final byte[] bytes = new byte[8];
+    buffer.getByteBuffer().get(bytes);
+    final Object decoded = PostgresType.deserialize(PostgresType.TIMESTAMP.code, 1, bytes);
+    assertThat(decoded).isEqualTo(LocalDateTime.of(2024, 8, 22, 14, 30, 45, 123_456_000));
+  }
+
+  @Test
+  void serializeAsBinaryTimestampPre2000RoundTrip() {
+    // 1999-12-31T23:59:59.999999 - exercises the nanos < 0 borrow branch in deserializeBinary.
+    final LocalDateTime ldt = LocalDateTime.of(1999, 12, 31, 23, 59, 59, 999_999_000);
+
+    final Binary buffer = new Binary();
+    PostgresType.TIMESTAMP.serializeAsBinary(PostgresType.TIMESTAMP, buffer, ldt);
+    buffer.flip();
+    assertThat(buffer.getInt()).isEqualTo(8);
+
+    final byte[] bytes = new byte[8];
+    buffer.getByteBuffer().get(bytes);
+    final Object decoded = PostgresType.deserialize(PostgresType.TIMESTAMP.code, 1, bytes);
+    assertThat(decoded).isEqualTo(ldt);
+  }
+
+  // ==================== Text parser edge cases ====================
+
+  @Test
+  void parseBooleanTextNullThrows() {
+    assertThatThrownBy(() -> PostgresType.deserialize(PostgresType.BOOLEAN.code, 0,
+        new byte[0])) // empty string after charset decode goes to switch and falls through
+        .isInstanceOf(PostgresProtocolException.class);
+  }
+
+  @Test
+  void parseBooleanTextAcceptsCanonicalForms() {
+    assertThat(PostgresType.deserialize(PostgresType.BOOLEAN.code, 0, "t".getBytes())).isEqualTo(Boolean.TRUE);
+    assertThat(PostgresType.deserialize(PostgresType.BOOLEAN.code, 0, "true".getBytes())).isEqualTo(Boolean.TRUE);
+    assertThat(PostgresType.deserialize(PostgresType.BOOLEAN.code, 0, "yes".getBytes())).isEqualTo(Boolean.TRUE);
+    assertThat(PostgresType.deserialize(PostgresType.BOOLEAN.code, 0, "1".getBytes())).isEqualTo(Boolean.TRUE);
+    assertThat(PostgresType.deserialize(PostgresType.BOOLEAN.code, 0, "f".getBytes())).isEqualTo(Boolean.FALSE);
+    assertThat(PostgresType.deserialize(PostgresType.BOOLEAN.code, 0, "false".getBytes())).isEqualTo(Boolean.FALSE);
+    assertThat(PostgresType.deserialize(PostgresType.BOOLEAN.code, 0, "0".getBytes())).isEqualTo(Boolean.FALSE);
+  }
+
+  @Test
+  void parseBooleanTextRejectsUnknown() {
+    assertThatThrownBy(() -> PostgresType.deserialize(PostgresType.BOOLEAN.code, 0, "maybe".getBytes()))
+        .isInstanceOf(PostgresProtocolException.class);
+  }
+
+  @Test
+  void parseTimestampTextAcceptsIso() {
+    final Object decoded = PostgresType.deserialize(PostgresType.TIMESTAMP.code, 0,
+        "2024-06-15 12:30:45".getBytes());
+    assertThat(decoded).isEqualTo(LocalDateTime.of(2024, 6, 15, 12, 30, 45));
+  }
+
+  @Test
+  void parseTimestampTextAcceptsOffset() {
+    // Postgres servers/clients can send timestamps with offset suffix - the parser must accept
+    // ISO_OFFSET_DATE_TIME and reduce to LocalDateTime for the schema-less binding path.
+    final Object decoded = PostgresType.deserialize(PostgresType.TIMESTAMP.code, 0,
+        "2024-06-15 12:30:45+00:00".getBytes());
+    assertThat(decoded).isEqualTo(LocalDateTime.of(2024, 6, 15, 12, 30, 45));
+  }
+
+  @Test
+  void parseDateTextRejectsNonIso() {
+    // Removed legacy Long.parseLong fallback - epoch-millis strings are no longer accepted.
+    assertThatThrownBy(() -> PostgresType.deserialize(PostgresType.DATE.code, 0,
+        "1716138311000".getBytes()))
+        .isInstanceOf(DateTimeParseException.class);
   }
 }

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
@@ -128,7 +128,7 @@ class PostgresTypeTest {
 
   @Test
   void getTypeForValueLocalDateTime() {
-    assertThat(PostgresType.getTypeForValue(LocalDateTime.now())).isEqualTo(PostgresType.DATE);
+    assertThat(PostgresType.getTypeForValue(LocalDateTime.now())).isEqualTo(PostgresType.TIMESTAMP);
   }
 
   // ==================== Collection Type Detection Tests ====================
@@ -354,7 +354,7 @@ class PostgresTypeTest {
 
   @Test
   void getTypeFromArcadeDatetime() {
-    assertThat(PostgresType.getTypeFromArcade(Type.DATETIME)).isEqualTo(PostgresType.DATE);
+    assertThat(PostgresType.getTypeFromArcade(Type.DATETIME)).isEqualTo(PostgresType.TIMESTAMP);
   }
 
   @Test
@@ -1073,7 +1073,9 @@ class PostgresTypeTest {
     byte[] data = new byte[length];
     buffer.getByteBuffer().get(data);
     String result = new String(data);
-    assertThat(result).matches("\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d+");
+    // DATE (OID 1082) must be serialized as "YYYY-MM-DD" only
+    assertThat(result).matches("\\d{4}-\\d{2}-\\d{2}");
+    assertThat(result).isEqualTo("2024-05-19");
   }
 
   @Test
@@ -1519,7 +1521,8 @@ class PostgresTypeTest {
     assertThat(PostgresType.DOUBLE.size).isEqualTo(8);
     assertThat(PostgresType.CHAR.size).isEqualTo(1);
     assertThat(PostgresType.BOOLEAN.size).isEqualTo(1);
-    assertThat(PostgresType.DATE.size).isEqualTo(8);
+    assertThat(PostgresType.DATE.size).isEqualTo(4);
+    assertThat(PostgresType.TIMESTAMP.size).isEqualTo(8);
     assertThat(PostgresType.VARCHAR.size).isEqualTo(-1); // variable
     assertThat(PostgresType.TEXT.size).isEqualTo(-1); // variable
     assertThat(PostgresType.JSON.size).isEqualTo(-1); // variable

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresTypeTest.java
@@ -1746,6 +1746,47 @@ class PostgresTypeTest {
   }
 
   @Test
+  void serializeAsBinaryTimestampTruncatesSubMicrosecondNanos() {
+    // PostgreSQL timestamp has microsecond resolution. Sub-microsecond nanos are intentionally
+    // dropped on the wire, so a value with 123_456_789 nanos round-trips as 123_456_000.
+    final LocalDateTime input = LocalDateTime.of(2024, 8, 22, 14, 30, 45, 123_456_789);
+
+    final Binary buffer = new Binary();
+    PostgresType.TIMESTAMP.serializeAsBinary(PostgresType.TIMESTAMP, buffer, input);
+    buffer.flip();
+    assertThat(buffer.getInt()).isEqualTo(8);
+
+    final byte[] bytes = new byte[8];
+    buffer.getByteBuffer().get(bytes);
+    final Object decoded = PostgresType.deserialize(PostgresType.TIMESTAMP.code, 1, bytes);
+    assertThat(decoded).isEqualTo(LocalDateTime.of(2024, 8, 22, 14, 30, 45, 123_456_000));
+  }
+
+  @Test
+  void hasBinaryEncodingScalarTypesTrue() {
+    assertThat(PostgresType.INTEGER.hasBinaryEncoding()).isTrue();
+    assertThat(PostgresType.LONG.hasBinaryEncoding()).isTrue();
+    assertThat(PostgresType.BOOLEAN.hasBinaryEncoding()).isTrue();
+    assertThat(PostgresType.DATE.hasBinaryEncoding()).isTrue();
+    assertThat(PostgresType.TIMESTAMP.hasBinaryEncoding()).isTrue();
+    // Strings/JSON have identical text and binary wire bytes - safe to honor binary requests.
+    assertThat(PostgresType.VARCHAR.hasBinaryEncoding()).isTrue();
+    assertThat(PostgresType.JSON.hasBinaryEncoding()).isTrue();
+  }
+
+  @Test
+  void hasBinaryEncodingArrayTypesFalse() {
+    // Array binary wire format is not yet implemented in serializeAsBinary, so callers must
+    // advertise text format in RowDescription for arrays regardless of what the client requested.
+    assertThat(PostgresType.ARRAY_INT.hasBinaryEncoding()).isFalse();
+    assertThat(PostgresType.ARRAY_LONG.hasBinaryEncoding()).isFalse();
+    assertThat(PostgresType.ARRAY_TEXT.hasBinaryEncoding()).isFalse();
+    assertThat(PostgresType.ARRAY_DOUBLE.hasBinaryEncoding()).isFalse();
+    assertThat(PostgresType.ARRAY_BOOLEAN.hasBinaryEncoding()).isFalse();
+    assertThat(PostgresType.ARRAY_JSON.hasBinaryEncoding()).isFalse();
+  }
+
+  @Test
   void serializeAsBinaryTimestampPre2000RoundTrip() {
     // 1999-12-31T23:59:59.999999 - exercises the nanos < 0 borrow branch in deserializeBinary.
     final LocalDateTime ldt = LocalDateTime.of(1999, 12, 31, 23, 59, 59, 999_999_000);

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcIT.java
@@ -23,7 +23,6 @@ import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.BaseGraphServerTest;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -478,12 +477,6 @@ public class PostgresWJdbcIT extends BaseGraphServerTest {
         rs.close();
       }
     }
-  }
-
-  @Test
-  @Disabled
-  void waitForConnectionFromExternal() throws Exception {
-    Thread.sleep(1000000);
   }
 
   private Connection getConnection() throws ClassNotFoundException, SQLException {

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcIT.java
@@ -39,6 +39,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -830,7 +831,7 @@ public class PostgresWJdbcIT extends BaseGraphServerTest {
   void scalarColumnTypeFidelity() throws Exception {
     try (var conn = getConnection()) {
       try (var st = conn.createStatement()) {
-        st.execute("CREATE VERTEX TYPE SCALAR_COL_TYPES");
+        st.execute("CREATE VERTEX TYPE SCALAR_COL_TYPES IF NOT EXISTS");
         st.execute("CREATE PROPERTY SCALAR_COL_TYPES.iVal IF NOT EXISTS INTEGER");
         st.execute("CREATE PROPERTY SCALAR_COL_TYPES.dVal IF NOT EXISTS DOUBLE");
         st.execute("CREATE PROPERTY SCALAR_COL_TYPES.fVal IF NOT EXISTS FLOAT");
@@ -866,7 +867,7 @@ public class PostgresWJdbcIT extends BaseGraphServerTest {
   void temporalColumnTypeFidelity() throws Exception {
     try (var conn = getConnection()) {
       try (var st = conn.createStatement()) {
-        st.execute("CREATE VERTEX TYPE TEMPORAL_COL_TYPES");
+        st.execute("CREATE VERTEX TYPE TEMPORAL_COL_TYPES IF NOT EXISTS");
         st.execute("CREATE PROPERTY TEMPORAL_COL_TYPES.dtVal IF NOT EXISTS DATETIME");
         st.execute("CREATE VERTEX TEMPORAL_COL_TYPES SET dtVal = '2024-06-15 12:30:45'");
       }
@@ -879,7 +880,10 @@ public class PostgresWJdbcIT extends BaseGraphServerTest {
         assertThat(rs.next()).isTrue();
         final Timestamp ts = rs.getTimestamp("dtVal");
         assertThat(ts).isNotNull();
-        assertThat(ts.toString()).startsWith("2024-06-15 12:30:45");
+        // Compare via toLocalDateTime() rather than toString() - Timestamp.toString() formats in
+        // the JVM default timezone, so a non-UTC test host would fail the assertion even though
+        // the wire round-trip is correct.
+        assertThat(ts.toLocalDateTime()).isEqualTo(LocalDateTime.of(2024, 6, 15, 12, 30, 45));
         assertThat(rs.next()).isFalse();
       }
     }

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresWJdbcIT.java
@@ -819,6 +819,72 @@ public class PostgresWJdbcIT extends BaseGraphServerTest {
     }
   }
 
+  /**
+   * Postgres wire must advertise scalar columns of all native non-string types with their proper
+   * Postgres OIDs instead of VARCHAR, so Postgres clients (pgjdbc, psycopg) deserialize them as
+   * native values. Covers INTEGER (int4), DOUBLE (float8), FLOAT (float4), BOOLEAN (bool).
+   * Queries via Cypher so value-based column type detection in {@code getColumns()} is exercised,
+   * not the schema-based path.
+   */
+  @Test
+  void scalarColumnTypeFidelity() throws Exception {
+    try (var conn = getConnection()) {
+      try (var st = conn.createStatement()) {
+        st.execute("CREATE VERTEX TYPE SCALAR_COL_TYPES");
+        st.execute("CREATE PROPERTY SCALAR_COL_TYPES.iVal IF NOT EXISTS INTEGER");
+        st.execute("CREATE PROPERTY SCALAR_COL_TYPES.dVal IF NOT EXISTS DOUBLE");
+        st.execute("CREATE PROPERTY SCALAR_COL_TYPES.fVal IF NOT EXISTS FLOAT");
+        st.execute("CREATE PROPERTY SCALAR_COL_TYPES.bVal IF NOT EXISTS BOOLEAN");
+        st.execute("INSERT INTO SCALAR_COL_TYPES SET iVal = 42, dVal = 3.14, fVal = 1.5, bVal = true");
+      }
+
+      try (var st = conn.createStatement();
+          var rs = st.executeQuery(
+              "{opencypher} MATCH (n:SCALAR_COL_TYPES) RETURN n.iVal AS iVal, n.dVal AS dVal, n.fVal AS fVal, n.bVal AS bVal")) {
+        final var meta = rs.getMetaData();
+        assertThat(meta.getColumnTypeName(1)).isEqualToIgnoringCase("int4");
+        assertThat(meta.getColumnTypeName(2)).isEqualToIgnoringCase("float8");
+        assertThat(meta.getColumnTypeName(3)).isEqualToIgnoringCase("float4");
+        assertThat(meta.getColumnTypeName(4)).isEqualToIgnoringCase("bool");
+
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getInt("iVal")).isEqualTo(42);
+        assertThat(rs.getDouble("dVal")).isCloseTo(3.14, offset(0.001));
+        assertThat(rs.getFloat("fVal")).isCloseTo(1.5f, offset(0.001f));
+        assertThat(rs.getBoolean("bVal")).isTrue();
+        assertThat(rs.next()).isFalse();
+      }
+    }
+  }
+
+  /**
+   * Postgres wire must advertise DATETIME properties as timestamp (OID 1114) so Postgres clients
+   * parse them as native timestamp values instead of dates. This exercises the schema-based
+   * column type path ({@code getColumnsFromQuerySchema} via {@code getTypeFromArcade}).
+   */
+  @Test
+  void temporalColumnTypeFidelity() throws Exception {
+    try (var conn = getConnection()) {
+      try (var st = conn.createStatement()) {
+        st.execute("CREATE VERTEX TYPE TEMPORAL_COL_TYPES");
+        st.execute("CREATE PROPERTY TEMPORAL_COL_TYPES.dtVal IF NOT EXISTS DATETIME");
+        st.execute("CREATE VERTEX TEMPORAL_COL_TYPES SET dtVal = '2024-06-15 12:30:45'");
+      }
+
+      try (var st = conn.createStatement();
+          var rs = st.executeQuery("SELECT dtVal FROM TEMPORAL_COL_TYPES")) {
+        final var meta = rs.getMetaData();
+        assertThat(meta.getColumnTypeName(1)).isEqualToIgnoringCase("timestamp");
+
+        assertThat(rs.next()).isTrue();
+        final Timestamp ts = rs.getTimestamp("dtVal");
+        assertThat(ts).isNotNull();
+        assertThat(ts.toString()).startsWith("2024-06-15 12:30:45");
+        assertThat(rs.next()).isFalse();
+      }
+    }
+  }
+
   @Test
   void floatArrayPropertyRoundTrip() throws Exception {
     try (var conn = getConnection()) {


### PR DESCRIPTION
## Summary

- Extends PR #4201 which limited the wire-level type fidelity fix to `LONG`/`INT8`. `PostgresNetworkExecutor.getColumns()` now passes through all native scalar types with their proper Postgres OIDs instead of collapsing to `VARCHAR`.
- Adds a new `TIMESTAMP` (OID 1114) `PostgresType` entry so `LocalDateTime` values (and `DATETIME` schema columns) round-trip as native timestamps, not date strings.
- Fixes related serialization bugs surfaced by the audit: `BOOL` now uses canonical `t`/`f`, `DATE` is emitted as `YYYY-MM-DD` (was timestamp format), and the `DATE` size field is corrected to 4 bytes.

## Why

Postgres clients (pgjdbc, psycopg) choose a deserializer based on the announced OID. Advertising `VARCHAR` for typed scalar columns causes values to round-trip as strings - the exact class of bug fixed for `Long`/`id()` in #4201 - which silently breaks numeric, boolean, and temporal parameter comparisons against client-side types.

## Changes

`postgresw/src/main/java/com/arcadedb/postgres/PostgresType.java`
- Added `TIMESTAMP(1114, LocalDateTime.class, 8, ...)` enum entry with text parser and binary (microseconds since 2000-01-01T00:00:00Z) deserialization
- `getTypeForValue(LocalDateTime)` -> `TIMESTAMP` (was `DATE`)
- `getTypeFromArcade(DATETIME)` -> `TIMESTAMP` (was `DATE`)
- `serializeAsText` for `Boolean` emits canonical `t`/`f`
- `serializeAsText` for `Date` emits `YYYY-MM-DD` (was timestamp format, wrong for DATE OID 1082)
- `DATE.size` corrected from 8 to 4 (matches pg_type binary size)
- New `isNativeScalarType()` helper

`postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java`
- `getColumns()` condition changed from `pgType.isArrayType() || pgType == LONG` to `pgType.isArrayType() || pgType.isNativeScalarType()` - covers SMALLINT, INTEGER, LONG, REAL, DOUBLE, CHAR, BOOLEAN, DATE, TIMESTAMP

## Test plan

- [x] `PostgresWJdbcIT.scalarColumnTypeFidelity` (new) - Cypher RETURN path asserts `int4`/`float8`/`float4`/`bool` column-type announcement and round-trip values
- [x] `PostgresWJdbcIT.temporalColumnTypeFidelity` (new) - schema-based SELECT asserts `timestamp` column type and `Timestamp` round-trip
- [x] `PostgresTypeTest` (160 unit tests, 4 updated to reflect new behavior)
- [x] `PostgresWJdbcIT` (31 tests pass, 1 pre-existing skip)
- [x] `PostgresProtocolIT` + `TomcatConnectionPoolPostgresWJdbcIT` (73 tests pass)
- [x] No regressions in existing date/timestamp round-trip tests (`dateTimeSerializationFormat`, `queryVertices`)

Closes #4202

🤖 Generated with [Claude Code](https://claude.com/claude-code)