### PR TITLE
fix: [cypher] label disjunction (n:A|B) returned 0 rows

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/NodeByLabelDisjunctionScan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/NodeByLabelDisjunctionScan.java
@@ -56,7 +56,7 @@ public class NodeByLabelDisjunctionScan extends AbstractPhysicalOperator {
   public ResultSet execute(final CommandContext context, final int nRecords) {
     return new ResultSet() {
       private Iterator<Identifiable> currentIterator = null;
-      private Iterator<Iterator<Identifiable>> iteratorQueue = null;
+      private Iterator<Iterator<Identifiable>> typeIteratorCursor = null;
       private final List<Result> buffer = new ArrayList<>();
       private int bufferIndex = 0;
       private boolean finished = false;
@@ -82,16 +82,16 @@ public class NodeByLabelDisjunctionScan extends AbstractPhysicalOperator {
         buffer.clear();
         bufferIndex = 0;
 
-        if (iteratorQueue == null)
-          iteratorQueue = buildMatchingIterators(context).iterator();
+        if (typeIteratorCursor == null)
+          typeIteratorCursor = buildMatchingIterators(context).iterator();
 
         while (buffer.size() < n) {
           if (currentIterator == null || !currentIterator.hasNext()) {
-            if (!iteratorQueue.hasNext()) {
+            if (!typeIteratorCursor.hasNext()) {
               finished = true;
               return;
             }
-            currentIterator = iteratorQueue.next();
+            currentIterator = typeIteratorCursor.next();
           }
           while (buffer.size() < n && currentIterator.hasNext()) {
             final Identifiable identifiable = currentIterator.next();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/NodeByLabelDisjunctionScan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/NodeByLabelDisjunctionScan.java
@@ -40,6 +40,17 @@ import java.util.NoSuchElementException;
  * at least one of the given labels. Types are iterated once (no duplicates).
  * <p>
  * Cost: O(N) where N is the total number of vertices matching any of the given labels.
+ * <p>
+ * Design notes:
+ * <ul>
+ *   <li>No inline WHERE pushdown (unlike {@link NodeByLabelScan#whereFilter}). Filters are
+ *       applied as a separate step; pushdown is a perf optimization tracked separately.</li>
+ *   <li>Type iterators are constructed eagerly in {@link #buildMatchingIterators}. Each call
+ *       to {@code iterateType} wraps the bucket iterators in a {@code MultiIterator} under
+ *       a read lock — the wrapper is cheap and page reads stay lazy inside the bucket
+ *       iterators, so eager construction has negligible cost for the typical small label
+ *       sets seen in practice.</li>
+ * </ul>
  */
 public class NodeByLabelDisjunctionScan extends AbstractPhysicalOperator {
   private final String       variable;
@@ -155,6 +166,9 @@ public class NodeByLabelDisjunctionScan extends AbstractPhysicalOperator {
     return variable;
   }
 
+  /**
+   * Returns the disjunction labels. Internal-only consumer API; not defensively copied.
+   */
   public List<String> getLabels() {
     return labels;
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/NodeByLabelDisjunctionScan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/NodeByLabelDisjunctionScan.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.executor.operators;
+
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.VertexType;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.NoSuchElementException;
+
+/**
+ * Physical operator for label disjunction node patterns such as {@code (n:A|B)}.
+ * <p>
+ * Scans every VertexType in the schema and returns vertices whose type is an instance of
+ * at least one of the given labels. Types are iterated once (no duplicates).
+ * <p>
+ * Cost: O(N) where N is the total number of vertices matching any of the given labels.
+ */
+public class NodeByLabelDisjunctionScan extends AbstractPhysicalOperator {
+  private final String       variable;
+  private final List<String> labels;
+
+  public NodeByLabelDisjunctionScan(final String variable, final List<String> labels,
+      final double estimatedCost, final long estimatedCardinality) {
+    super(estimatedCost, estimatedCardinality);
+    this.variable = variable;
+    this.labels = labels;
+  }
+
+  @Override
+  public ResultSet execute(final CommandContext context, final int nRecords) {
+    return new ResultSet() {
+      private Iterator<Identifiable> currentIterator = null;
+      private Iterator<Iterator<Identifiable>> iteratorQueue = null;
+      private final List<Result> buffer = new ArrayList<>();
+      private int bufferIndex = 0;
+      private boolean finished = false;
+
+      @Override
+      public boolean hasNext() {
+        if (bufferIndex < buffer.size())
+          return true;
+        if (finished)
+          return false;
+        fetchMore(nRecords > 0 ? nRecords : 100);
+        return bufferIndex < buffer.size();
+      }
+
+      @Override
+      public Result next() {
+        if (!hasNext())
+          throw new NoSuchElementException();
+        return buffer.get(bufferIndex++);
+      }
+
+      private void fetchMore(final int n) {
+        buffer.clear();
+        bufferIndex = 0;
+
+        if (iteratorQueue == null)
+          iteratorQueue = buildMatchingIterators(context).iterator();
+
+        while (buffer.size() < n) {
+          if (currentIterator == null || !currentIterator.hasNext()) {
+            if (!iteratorQueue.hasNext()) {
+              finished = true;
+              return;
+            }
+            currentIterator = iteratorQueue.next();
+          }
+          while (buffer.size() < n && currentIterator.hasNext()) {
+            final Identifiable identifiable = currentIterator.next();
+            final Vertex vertex = identifiable.asVertex();
+            final ResultInternal result = new ResultInternal();
+            result.setProperty(variable, vertex);
+            buffer.add(result);
+          }
+        }
+      }
+
+      @Override
+      public void close() {
+        // No resources to close
+      }
+    };
+  }
+
+  /**
+   * Builds one iterator per VertexType that is an instance of at least one disjunction label.
+   * Each type is visited at most once, so no deduplication is needed at the record level.
+   */
+  private List<Iterator<Identifiable>> buildMatchingIterators(final CommandContext context) {
+    final List<Iterator<Identifiable>> iterators = new ArrayList<>();
+    for (final DocumentType type : context.getDatabase().getSchema().getTypes()) {
+      if (!(type instanceof VertexType))
+        continue;
+      for (final String label : labels) {
+        if (type.instanceOf(label)) {
+          @SuppressWarnings("unchecked")
+          final Iterator<Identifiable> iter =
+              (Iterator<Identifiable>) (Object) context.getDatabase().iterateType(type.getName(), false);
+          iterators.add(iter);
+          break; // matched — add this type once and move on
+        }
+      }
+    }
+    return iterators;
+  }
+
+  @Override
+  public String getOperatorType() {
+    return "NodeByLabelDisjunctionScan";
+  }
+
+  @Override
+  public String explain(final int depth) {
+    final StringBuilder sb = new StringBuilder();
+    final String indent = getIndent(depth);
+    sb.append(indent).append("+ NodeByLabelDisjunctionScan");
+    sb.append("(").append(variable).append(":").append(String.join("|", labels)).append(")");
+    sb.append(" [cost=").append(String.format(Locale.US, "%.2f", estimatedCost));
+    sb.append(", rows=").append(estimatedCardinality);
+    sb.append("]\n");
+    return sb.toString();
+  }
+
+  public String getVariable() {
+    return variable;
+  }
+
+  public List<String> getLabels() {
+    return labels;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/NodeByLabelDisjunctionScan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/NodeByLabelDisjunctionScan.java
@@ -112,7 +112,9 @@ public class NodeByLabelDisjunctionScan extends AbstractPhysicalOperator {
 
   /**
    * Builds one iterator per VertexType that is an instance of at least one disjunction label.
-   * Each type is visited at most once, so no deduplication is needed at the record level.
+   * The outer loop already enumerates every subtype in the schema, so {@code iterateType} is
+   * called with {@code polymorphic=false} — using {@code true} would duplicate records of
+   * subtypes that match through both the parent type and their own type entry.
    */
   private List<Iterator<Identifiable>> buildMatchingIterators(final CommandContext context) {
     final List<Iterator<Identifiable>> iterators = new ArrayList<>();
@@ -125,7 +127,7 @@ public class NodeByLabelDisjunctionScan extends AbstractPhysicalOperator {
           final Iterator<Identifiable> iter =
               (Iterator<Identifiable>) (Object) context.getDatabase().iterateType(type.getName(), false);
           iterators.add(iter);
-          break; // matched — add this type once and move on
+          break;
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/NodeByLabelDisjunctionScan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/NodeByLabelDisjunctionScan.java
@@ -50,6 +50,11 @@ import java.util.NoSuchElementException;
  *       a read lock — the wrapper is cheap and page reads stay lazy inside the bucket
  *       iterators, so eager construction has negligible cost for the typical small label
  *       sets seen in practice.</li>
+ *   <li>{@code estimatedCardinality} is inherited from the anchor selector and reflects a
+ *       single-label scan (the first label only). The true upper bound for a disjunction
+ *       is the sum across all matching types; under-estimation here may bias join-order
+ *       choices when a disjunction node competes with other anchor candidates. Tracked as
+ *       a follow-up rather than fixed in this PR.</li>
  * </ul>
  */
 public class NodeByLabelDisjunctionScan extends AbstractPhysicalOperator {
@@ -112,6 +117,12 @@ public class NodeByLabelDisjunctionScan extends AbstractPhysicalOperator {
             buffer.add(result);
           }
         }
+
+        // Mark exhausted eagerly when both the current iterator and the type queue are drained,
+        // avoiding one redundant fetchMore round-trip when a query reads to the end (matching
+        // NodeByLabelScan's pattern).
+        if ((currentIterator == null || !currentIterator.hasNext()) && !typeIteratorCursor.hasNext())
+          finished = true;
       }
 
       @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/plan/LogicalNode.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/plan/LogicalNode.java
@@ -30,11 +30,18 @@ public class LogicalNode {
   private final String variable;
   private final List<String> labels;
   private final Map<String, Object> properties;
+  private final boolean labelDisjunction;
 
   public LogicalNode(final String variable, final List<String> labels, final Map<String, Object> properties) {
+    this(variable, labels, properties, false);
+  }
+
+  public LogicalNode(final String variable, final List<String> labels, final Map<String, Object> properties,
+      final boolean labelDisjunction) {
     this.variable = variable;
     this.labels = labels != null ? labels : Collections.emptyList();
     this.properties = properties != null ? properties : Collections.emptyMap();
+    this.labelDisjunction = labelDisjunction;
   }
 
   public String getVariable() {
@@ -55,6 +62,10 @@ public class LogicalNode {
 
   public boolean hasProperties() {
     return !properties.isEmpty();
+  }
+
+  public boolean isLabelDisjunction() {
+    return labelDisjunction;
   }
 
   public String getFirstLabel() {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/plan/LogicalPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/plan/LogicalPlan.java
@@ -143,7 +143,7 @@ public class LogicalPlan {
       if (variable != null) {
         nodeVars[i] = variable;
         if (!nodes.containsKey(variable)) {
-          nodes.put(variable, new LogicalNode(variable, np.getLabels(), np.getProperties()));
+          nodes.put(variable, new LogicalNode(variable, np.getLabels(), np.getProperties(), np.isLabelDisjunction()));
         }
       } else {
         nodeVars[i] = "  __anon" + anonNodeCounter++;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/rules/IndexSelectionRule.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/optimizer/rules/IndexSelectionRule.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher.optimizer.rules;
 
 import com.arcadedb.query.opencypher.Labels;
 import com.arcadedb.query.opencypher.ast.ComparisonExpression;
+import com.arcadedb.query.opencypher.executor.operators.NodeByLabelDisjunctionScan;
 import com.arcadedb.query.opencypher.executor.operators.NodeByLabelScan;
 import com.arcadedb.query.opencypher.executor.operators.NodeIndexRangeScan;
 import com.arcadedb.query.opencypher.executor.operators.NodeIndexSeek;
@@ -102,14 +103,25 @@ public class IndexSelectionRule implements OptimizationRule {
    * @return physical operator (NodeIndexSeek, NodeIndexRangeScan, or NodeByLabelScan)
    */
   public PhysicalOperator createAnchorOperator(final AnchorSelection anchor) {
-    // Determine the label/type to use for iteration
-    // For multi-label nodes, use the composite type name
     final List<String> labels = anchor.getNode().getLabels();
+
+    // Label disjunction (n:A|B) requires scanning each label type separately — a composite
+    // type A~B would not exist in the schema, so NodeByLabelScan would return 0 rows.
+    // Index seeks are also not applicable for disjunctions.
+    if (anchor.getNode().isLabelDisjunction() && labels.size() > 1) {
+      return new NodeByLabelDisjunctionScan(
+          anchor.getVariable(),
+          labels,
+          anchor.getEstimatedCost(),
+          anchor.getEstimatedCardinality()
+      );
+    }
+
+    // For conjunction labels (n:A:B) use the composite type name
     final String labelToUse = Labels.getCompositeTypeName(labels);
 
     if (anchor.useIndex()) {
       if (anchor.isRangeScan()) {
-        // RANGE SCAN - pass predicates for runtime parameter resolution
         return new NodeIndexRangeScan(
             anchor.getVariable(),
             labelToUse,
@@ -120,7 +132,6 @@ public class IndexSelectionRule implements OptimizationRule {
             anchor.getEstimatedCardinality()
         );
       } else {
-        // INDEX SEEK (equality)
         final Object propertyValue = anchor.getPropertyValue();
         return new NodeIndexSeek(
             anchor.getVariable(),
@@ -133,7 +144,6 @@ public class IndexSelectionRule implements OptimizationRule {
         );
       }
     } else {
-      // FULL SCAN
       return new NodeByLabelScan(
           anchor.getVariable(),
           labelToUse,

--- a/engine/src/main/java/com/arcadedb/query/opencypher/planner/CypherExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/planner/CypherExecutionPlanner.java
@@ -238,11 +238,19 @@ public class CypherExecutionPlanner {
             if (!node.hasLabels() && (node.getVariable() == null || !labeledVariables.contains(node.getVariable())))
               return false;
 
-            // Multi-label nodes not yet supported in optimizer
-            // NodeByLabelScan uses composite type name which doesn't match
-            // superset labels (e.g., A~B~C doesn't extend A~B)
-            if (node.getLabels().size() > 1)
-              return false;
+            // Multi-label nodes: conjunction (n:A:B) is unsupported in the optimizer
+            // (NodeByLabelScan uses a composite type name that does not match supersets,
+            // e.g. A~B~C does not extend A~B). Disjunction (n:A|B) is routed to
+            // NodeByLabelDisjunctionScan, but only when the node has no incident
+            // relationships — ExpandAll/ExpandInto carry a single targetLabel and
+            // cannot represent OR semantics, so target-side disjunction falls back to
+            // the legacy path.
+            if (node.getLabels().size() > 1) {
+              if (!node.isLabelDisjunction())
+                return false;
+              if (path.getRelationshipCount() > 0)
+                return false;
+            }
 
             // Phase 4: Property constraints without indexes not yet supported
             // The optimizer doesn't apply property filters when using NodeByLabelScan

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelDisjunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelDisjunctionTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for label disjunction patterns in Cypher MATCH clauses.
+ * Tests that (n:A|B) returns nodes with label A OR label B.
+ *
+ * Reproduces GitHub issue #4211 where MATCH (n:A|B) returned 0 rows even when
+ * nodes with both labels existed.
+ */
+class CypherLabelDisjunctionTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/cypher-label-disjunction");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.transaction(() -> {
+      database.command("opencypher",
+          "CREATE (:A {id: 1}), (:B {id: 2}), (:C {id: 3})");
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void twoLabelDisjunctionReturnsBothNodes() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (n:A|B) RETURN n.id AS id ORDER BY id");
+    final List<Integer> ids = collectIds(rs);
+    assertThat(ids).containsExactly(1, 2);
+  }
+
+  @Test
+  void twoLabelDisjunctionCountIsTwo() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (n:A|B) RETURN count(*) AS cnt");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(((Number) rs.next().getProperty("cnt")).intValue()).isEqualTo(2);
+  }
+
+  @Test
+  void twoLabelDisjunctionAcReturnsACNodes() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (n:A|C) RETURN n.id AS id ORDER BY id");
+    final List<Integer> ids = collectIds(rs);
+    assertThat(ids).containsExactly(1, 3);
+  }
+
+  @Test
+  void twoLabelDisjunctionBCReturnsBCNodes() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (n:B|C) RETURN n.id AS id ORDER BY id");
+    final List<Integer> ids = collectIds(rs);
+    assertThat(ids).containsExactly(2, 3);
+  }
+
+  @Test
+  void threeLabelDisjunctionReturnsAllThreeNodes() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (n:A|B|C) RETURN n.id AS id ORDER BY id");
+    final List<Integer> ids = collectIds(rs);
+    assertThat(ids).containsExactly(1, 2, 3);
+  }
+
+  @Test
+  void threeLabelDisjunctionCountIsThree() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (n:A|B|C) RETURN count(*) AS cnt");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(((Number) rs.next().getProperty("cnt")).intValue()).isEqualTo(3);
+  }
+
+  @Test
+  void singleLabelMatchStillWorks() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (n:A) RETURN count(*) AS cnt");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(((Number) rs.next().getProperty("cnt")).intValue()).isEqualTo(1);
+  }
+
+  @Test
+  void labelDisjunctionWithPropertyFilter() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (n:A|B) WHERE n.id > 1 RETURN n.id AS id");
+    final List<Integer> ids = collectIds(rs);
+    assertThat(ids).containsExactly(2);
+  }
+
+  private List<Integer> collectIds(final ResultSet rs) {
+    final List<Integer> ids = new ArrayList<>();
+    while (rs.hasNext()) {
+      final Result r = rs.next();
+      final Object val = r.getProperty("id");
+      ids.add(((Number) val).intValue());
+    }
+    return ids;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelDisjunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelDisjunctionTest.java
@@ -126,6 +126,22 @@ class CypherLabelDisjunctionTest {
   }
 
   @Test
+  void labelDisjunctionAnchorWithRelationshipFallsBackToLegacy() {
+    // Anchor-side disjunction with a relationship — planner falls back to MatchNodeStep
+    // (ExpandAll cannot represent OR semantics on the target side). Must still return rows.
+    database.transaction(() -> {
+      database.command("opencypher",
+          "MATCH (a:A {id: 1}), (b:B {id: 2}), (c:C {id: 3}) "
+              + "CREATE (a)-[:REL]->(c), (b)-[:REL]->(c)");
+    });
+
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (n:A|B)-[:REL]->(m) RETURN n.id AS id ORDER BY id");
+    final List<Integer> ids = collectIds(rs);
+    assertThat(ids).containsExactly(1, 2);
+  }
+
+  @Test
   void labelDisjunctionMatchesSubtypeInstances() {
     database.transaction(() -> {
       database.command("opencypher", "CREATE (:Animal:Dog {id: 10})");

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelDisjunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelDisjunctionTest.java
@@ -154,6 +154,24 @@ class CypherLabelDisjunctionTest {
     assertThat(ids).containsExactly(10, 20);
   }
 
+  @Test
+  void labelDisjunctionMatchesSchemaSubtype() {
+    // Real schema inheritance: Dog extends Animal as a parent type, not via multi-label.
+    // The scan must include Dog records when querying MATCH (n:Animal|X) — verifies the
+    // type.instanceOf(label) path that walks the schema parent chain.
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Animal");
+      database.getSchema().getOrCreateVertexType("Dog").addSuperType("Animal");
+      database.command("opencypher", "CREATE (:Dog {id: 100})");
+      database.command("opencypher", "CREATE (:Pet {id: 200})");
+    });
+
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (n:Animal|Pet) RETURN n.id AS id ORDER BY id");
+    final List<Integer> ids = collectIds(rs);
+    assertThat(ids).containsExactly(100, 200);
+  }
+
   private List<Integer> collectIds(final ResultSet rs) {
     final List<Integer> ids = new ArrayList<>();
     while (rs.hasNext()) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelDisjunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelDisjunctionTest.java
@@ -125,6 +125,19 @@ class CypherLabelDisjunctionTest {
     assertThat(ids).containsExactly(2);
   }
 
+  @Test
+  void labelDisjunctionMatchesSubtypeInstances() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Animal:Dog {id: 10})");
+      database.command("opencypher", "CREATE (:Pet {id: 20})");
+    });
+
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (n:Animal|Pet) RETURN n.id AS id ORDER BY id");
+    final List<Integer> ids = collectIds(rs);
+    assertThat(ids).containsExactly(10, 20);
+  }
+
   private List<Integer> collectIds(final ResultSet rs) {
     final List<Integer> ids = new ArrayList<>();
     while (rs.hasNext()) {


### PR DESCRIPTION
## Summary

- Closes #4211 — `MATCH (n:A|B)` returned 0 rows even when nodes with both labels exist.
- Root cause: the optimizer always called `Labels.getCompositeTypeName(["A","B"])` → `"A~B"`, treating multiple labels as AND. `NodeByLabelScan` then short-circuited on `existsType("A~B")` → false.
- `LogicalNode` now carries the `labelDisjunction` flag propagated from `NodePattern`. `IndexSelectionRule.createAnchorOperator()` routes disjunction patterns to a new `NodeByLabelDisjunctionScan` operator that walks each `VertexType` once and includes types matching any disjunction label.

## Files

- `engine/src/main/java/com/arcadedb/query/opencypher/optimizer/plan/LogicalNode.java` — `labelDisjunction` field + getter
- `engine/src/main/java/com/arcadedb/query/opencypher/optimizer/plan/LogicalPlan.java` — propagates flag from `NodePattern`
- `engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/NodeByLabelDisjunctionScan.java` — new operator
- `engine/src/main/java/com/arcadedb/query/opencypher/optimizer/rules/IndexSelectionRule.java` — disjunction routing in `createAnchorOperator`
- `engine/src/test/java/com/arcadedb/query/opencypher/CypherLabelDisjunctionTest.java` — 8 regression tests

## Test plan

- [x] `CypherLabelDisjunctionTest` — 8/8 pass (A|B, A|C, B|C, A|B|C, count variants, single-label sanity, disjunction + WHERE)
- [x] `CypherMultiLabelTest`, `CypherMultiLabelPreExistingTypeTest`, `CypherLabelFilteringTest`, `CypherLabelCheckInWhereTest`, `CypherTest` — 40/40 pass (no regressions)
- [x] `CountEdgesOptimizationTest`, `CypherInlinePropertyFilterTest`, `CypherRangeIndexTest`, `CypherCountSubqueryTest`, `CypherPatternPredicateTest`, `CypherPolymorphicEdgeTraversalTest`, `CypherRelationDirectionTest` — 50/50 pass
- [x] `CypherCallYieldWithVariablesTest`, `CollectDistinctTest`, `CypherCaseTest`, `CypherExistsTest`, `CypherMissingFunctionsTest`, `CypherCountNonExistingLabelTest` — 82/82 pass