### PR TITLE
#4231 fix: [cypher] DATETIME property comparison with datetime() returned 0 rows (#4231)

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/temporal/CypherDateTime.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/temporal/CypherDateTime.java
@@ -280,8 +280,9 @@ public class CypherDateTime implements CypherTemporalValue {
   public int compareTo(final CypherTemporalValue other) {
     if (other instanceof CypherDateTime cdt)
       return value.toInstant().compareTo(cdt.value.toInstant());
+    // Cross-type with naive LocalDateTime: treat it as UTC, mirroring datetime(localDatetimeValue).
     if (other instanceof CypherLocalDateTime cld)
-      return value.toInstant().compareTo(cld.getValue().atOffset(ZoneOffset.UTC).toInstant());
+      return value.toInstant().compareTo(cld.getValue().toInstant(ZoneOffset.UTC));
     throw new IllegalArgumentException("Cannot compare DateTime with " + other.getClass().getSimpleName());
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/temporal/CypherDateTime.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/temporal/CypherDateTime.java
@@ -278,8 +278,10 @@ public class CypherDateTime implements CypherTemporalValue {
 
   @Override
   public int compareTo(final CypherTemporalValue other) {
-    if (other instanceof CypherDateTime)
-      return value.toInstant().compareTo(((CypherDateTime) other).value.toInstant());
+    if (other instanceof CypherDateTime cdt)
+      return value.toInstant().compareTo(cdt.value.toInstant());
+    if (other instanceof CypherLocalDateTime cld)
+      return value.toInstant().compareTo(cld.getValue().atOffset(ZoneOffset.UTC).toInstant());
     throw new IllegalArgumentException("Cannot compare DateTime with " + other.getClass().getSimpleName());
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/temporal/CypherLocalDateTime.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/temporal/CypherLocalDateTime.java
@@ -166,8 +166,9 @@ public class CypherLocalDateTime implements CypherTemporalValue {
   public int compareTo(final CypherTemporalValue other) {
     if (other instanceof CypherLocalDateTime cld)
       return value.compareTo(cld.value);
+    // Cross-type with zoned DateTime: treat LocalDateTime as UTC, mirroring datetime(localDatetimeValue).
     if (other instanceof CypherDateTime cdt)
-      return value.atOffset(ZoneOffset.UTC).toInstant().compareTo(cdt.getValue().toInstant());
+      return value.toInstant(ZoneOffset.UTC).compareTo(cdt.getValue().toInstant());
     throw new IllegalArgumentException("Cannot compare LocalDateTime with " + other.getClass().getSimpleName());
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/temporal/CypherLocalDateTime.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/temporal/CypherLocalDateTime.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher.temporal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.time.temporal.IsoFields;
 import java.time.temporal.WeekFields;
 import java.util.Map;
@@ -163,8 +164,10 @@ public class CypherLocalDateTime implements CypherTemporalValue {
 
   @Override
   public int compareTo(final CypherTemporalValue other) {
-    if (other instanceof CypherLocalDateTime)
-      return value.compareTo(((CypherLocalDateTime) other).value);
+    if (other instanceof CypherLocalDateTime cld)
+      return value.compareTo(cld.value);
+    if (other instanceof CypherDateTime cdt)
+      return value.atOffset(ZoneOffset.UTC).toInstant().compareTo(cdt.getValue().toInstant());
     throw new IllegalArgumentException("Cannot compare LocalDateTime with " + other.getClass().getSimpleName());
   }
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue4231CypherDatetimeComparisonTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue4231CypherDatetimeComparisonTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+import com.arcadedb.schema.VertexType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for comparing DATETIME-typed properties directly with datetime() in Cypher
+ * without an explicit datetime() conversion wrapper.
+ * <p>
+ * MATCH (c:Channel) WHERE c.updatedAt &lt; datetime() must work when updatedAt is DATETIME-typed,
+ * without requiring the user to write WHERE datetime(c.updatedAt) &lt; datetime().
+ */
+class Issue4231CypherDatetimeComparisonTest {
+
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    database = new DatabaseFactory("./target/databases/issue-4231-datetime-comparison").create();
+    database.transaction(() -> {
+      final VertexType type = database.getSchema().createVertexType("Channel");
+      type.createProperty("name", Type.STRING);
+      type.createProperty("updatedAt", Type.DATETIME);
+    });
+    database.transaction(() -> {
+      // past: 2020-01-01T00:00:00
+      database.command("cypher", "CREATE (c:Channel {name: 'past', updatedAt: localdatetime('2020-01-01T00:00:00')})");
+      // future: year 2099
+      database.command("cypher", "CREATE (c:Channel {name: 'future', updatedAt: localdatetime('2099-06-01T00:00:00')})");
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void datetimePropertyLessThanDatetimeFunction() {
+    // Both 2020 nodes and the future node are present; only the past node satisfies updatedAt < now
+    final ResultSet rs = database.query("cypher", "MATCH (c:Channel) WHERE c.updatedAt < datetime() RETURN c.name");
+    final List<String> names = rs.stream().map(r -> (String) r.getProperty("c.name")).collect(Collectors.toList());
+    assertThat(names).containsExactlyInAnyOrder("past");
+  }
+
+  @Test
+  void datetimePropertyGreaterThanDatetimeFunction() {
+    final ResultSet rs = database.query("cypher", "MATCH (c:Channel) WHERE c.updatedAt > datetime() RETURN c.name");
+    final List<String> names = rs.stream().map(r -> (String) r.getProperty("c.name")).collect(Collectors.toList());
+    assertThat(names).containsExactlyInAnyOrder("future");
+  }
+
+  @Test
+  void datetimeFunctionLessThanDatetimeProperty() {
+    // datetime() < future node → only future satisfies this
+    final ResultSet rs = database.query("cypher", "MATCH (c:Channel) WHERE datetime() < c.updatedAt RETURN c.name");
+    final List<String> names = rs.stream().map(r -> (String) r.getProperty("c.name")).collect(Collectors.toList());
+    assertThat(names).containsExactlyInAnyOrder("future");
+  }
+
+  @Test
+  void datetimePropertyLessThanEqualDatetimeFunction() {
+    final ResultSet rs = database.query("cypher",
+        "MATCH (c:Channel) WHERE c.updatedAt <= datetime('2020-01-01T00:00:00Z') RETURN c.name");
+    final List<String> names = rs.stream().map(r -> (String) r.getProperty("c.name")).collect(Collectors.toList());
+    assertThat(names).containsExactlyInAnyOrder("past");
+  }
+
+  @Test
+  void datetimePropertyGreaterThanEqualDatetimeFunction() {
+    final ResultSet rs = database.query("cypher",
+        "MATCH (c:Channel) WHERE c.updatedAt >= datetime('2099-06-01T00:00:00Z') RETURN c.name");
+    final List<String> names = rs.stream().map(r -> (String) r.getProperty("c.name")).collect(Collectors.toList());
+    assertThat(names).containsExactlyInAnyOrder("future");
+  }
+
+  @Test
+  void datetimePropertyEqualsDatetime() {
+    // Equality: stored 2020-01-01T00:00:00 (treated as UTC) == datetime('2020-01-01T00:00:00Z')
+    final ResultSet rs = database.query("cypher",
+        "MATCH (c:Channel) WHERE c.updatedAt = datetime('2020-01-01T00:00:00Z') RETURN c.name");
+    final List<String> names = rs.stream().map(r -> (String) r.getProperty("c.name")).collect(Collectors.toList());
+    assertThat(names).containsExactlyInAnyOrder("past");
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #4231. Direct comparison of a DATETIME-typed property with `datetime()` (e.g. `WHERE c.updatedAt < datetime()`) returned 0 rows, forcing users to wrap the property in `datetime(c.updatedAt)` for the query to work.

**Root cause:** ArcadeDB's DATETIME schema type stores `LocalDateTime` (timezone-naive). `PropertyAccessExpression.convertFromStorage` wraps it as `CypherLocalDateTime`, while `datetime()` returns `CypherDateTime` (timezone-aware). The `compareTo` methods on both classes only accepted their own type and threw `IllegalArgumentException` for cross-type comparisons. `ComparisonExpression.compareValuesTernary` caught the exception and returned `null` for ordering operators - which evaluates to false in WHERE.

**Fix:** Added cross-type comparison in both `CypherLocalDateTime.compareTo` and `CypherDateTime.compareTo`. When comparing across the two types, the `LocalDateTime` value is treated as UTC, consistent with the existing `datetime(localDatetimeValue)` constructor which already uses `atZone(ZoneOffset.UTC)`.

## Test plan

- [x] Added `Issue4231CypherDatetimeComparisonTest` covering `<`, `>`, `<=`, `>=`, `=` and the symmetric `datetime() < c.updatedAt` direction (6 tests)
- [x] All 132 `OpenCypherTemporalFunctionsComprehensiveTest` tests pass
- [x] All 3897 `OpenCypherTCKSuite` tests pass (85 skipped, no regressions)
- [x] `ComparisonNormalizerTest` and `SimpleComparisonTest` pass