### PR TITLE
#4213 fix: [cypher] MERGE with null endpoint from OPTIONAL MATCH emits rows and rebinds the variable

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -54,7 +54,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Set;
 
 /**
  * Execution step for MERGE clause.
@@ -178,11 +177,11 @@ public class MergeStep extends AbstractExecutionStep {
   private List<Result> executeMerge(final Result inputResult) {
     final PathPattern pathPattern = mergeClause.getPathPattern();
 
-    // Cypher null-propagation: a named node variable that was explicitly bound to
-    // null by a prior step (e.g. an unmatched OPTIONAL MATCH) is not an unbound
-    // free variable - it is a concrete null.  Merging a relationship to a null
-    // endpoint is undefined, so drop the row entirely.
-    if (inputResult != null && hasNullNodeEndpoint(pathPattern, inputResult))
+    // Cypher null-propagation: a named path variable that was explicitly bound
+    // to null by a prior step (e.g. an unmatched OPTIONAL MATCH) is not an
+    // unbound free variable - it is a concrete null.  Merging a pattern that
+    // references a null endpoint or relationship is undefined, so drop the row.
+    if (inputResult != null && hasNullBoundPathVariable(pathPattern, inputResult))
       return List.of();
 
     // Check if we're already in a transaction
@@ -339,17 +338,20 @@ public class MergeStep extends AbstractExecutionStep {
   }
 
   /**
-   * Returns true if any named node variable in {@code pathPattern} is present
-   * in the input row with a null value.  A variable that is absent from the
-   * result entirely is "unbound" and does not trigger this guard; only a value
-   * that was explicitly set to null (e.g. by an unmatched OPTIONAL MATCH)
-   * causes the method to return true.
+   * A variable explicitly bound to null by an upstream step (typically an
+   * unmatched OPTIONAL MATCH) differs from one that is absent: the former
+   * triggers Cypher null-propagation, the latter is an unbound free variable.
+   * {@link Result#hasProperty(String)} disambiguates the two cases.
    */
-  private boolean hasNullNodeEndpoint(final PathPattern pathPattern, final Result inputResult) {
-    final Set<String> propNames = inputResult.getPropertyNames();
+  private boolean hasNullBoundPathVariable(final PathPattern pathPattern, final Result inputResult) {
     for (int i = 0; i <= pathPattern.getRelationshipCount(); i++) {
-      final String var = pathPattern.getNode(i).getVariable();
-      if (var != null && propNames.contains(var) && inputResult.getProperty(var) == null)
+      final String nodeVar = pathPattern.getNode(i).getVariable();
+      if (nodeVar != null && inputResult.hasProperty(nodeVar) && inputResult.getProperty(nodeVar) == null)
+        return true;
+    }
+    for (int i = 0; i < pathPattern.getRelationshipCount(); i++) {
+      final String relVar = pathPattern.getRelationship(i).getVariable();
+      if (relVar != null && inputResult.hasProperty(relVar) && inputResult.getProperty(relVar) == null)
         return true;
     }
     return false;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -54,6 +54,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 
 /**
  * Execution step for MERGE clause.
@@ -176,6 +177,13 @@ public class MergeStep extends AbstractExecutionStep {
    */
   private List<Result> executeMerge(final Result inputResult) {
     final PathPattern pathPattern = mergeClause.getPathPattern();
+
+    // Cypher null-propagation: a named node variable that was explicitly bound to
+    // null by a prior step (e.g. an unmatched OPTIONAL MATCH) is not an unbound
+    // free variable - it is a concrete null.  Merging a relationship to a null
+    // endpoint is undefined, so drop the row entirely.
+    if (inputResult != null && hasNullNodeEndpoint(pathPattern, inputResult))
+      return List.of();
 
     // Check if we're already in a transaction
     final boolean wasInTransaction = context.getDatabase().isTransactionActive();
@@ -328,6 +336,23 @@ public class MergeStep extends AbstractExecutionStep {
         return i;
     }
     return -1;
+  }
+
+  /**
+   * Returns true if any named node variable in {@code pathPattern} is present
+   * in the input row with a null value.  A variable that is absent from the
+   * result entirely is "unbound" and does not trigger this guard; only a value
+   * that was explicitly set to null (e.g. by an unmatched OPTIONAL MATCH)
+   * causes the method to return true.
+   */
+  private boolean hasNullNodeEndpoint(final PathPattern pathPattern, final Result inputResult) {
+    final Set<String> propNames = inputResult.getPropertyNames();
+    for (int i = 0; i <= pathPattern.getRelationshipCount(); i++) {
+      final String var = pathPattern.getNode(i).getVariable();
+      if (var != null && propNames.contains(var) && inputResult.getProperty(var) == null)
+        return true;
+    }
+    return false;
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue4213OptionalMatchNullEndpointMergeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue4213OptionalMatchNullEndpointMergeTest.java
@@ -180,4 +180,30 @@ class Issue4213OptionalMatchNullEndpointMergeTest {
         .as("No KNOWS relationship must be created when endpoint is null")
         .isEqualTo(0L);
   }
+
+  /**
+   * Multi-hop MERGE pattern with a null intermediate node from OPTIONAL MATCH:
+   * the null at index 1 must drop the row even though the endpoints at index 0
+   * and index 2 are bound.
+   */
+  @Test
+  void mergeMultiHopPatternWithNullIntermediateProducesNoRows() {
+    final ResultSet rs = database.command("opencypher",
+        "MATCH (a:Node {id: 1}) "
+            + "OPTIONAL MATCH (a)-[:KNOWS]->(b:Node {id: 99}) "
+            + "WITH a, b "
+            + "MATCH (c:Node {id: 2}) "
+            + "MERGE (a)-[:KNOWS]->(b)-[:KNOWS]->(c) "
+            + "RETURN a.id AS aid, b.id AS bid, c.id AS cid");
+
+    assertThat(rs.hasNext())
+        .as("MERGE with null intermediate node must produce no rows")
+        .isFalse();
+
+    final ResultSet relCount = database.query("opencypher", "MATCH ()-[r:KNOWS]->() RETURN count(r) AS cnt");
+    assertThat(relCount.next().<Number>getProperty("cnt").longValue())
+        .as("No KNOWS relationship must be created when an intermediate node is null")
+        .isEqualTo(0L);
+  }
+
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue4213OptionalMatchNullEndpointMergeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue4213OptionalMatchNullEndpointMergeTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for GitHub issue #4213.
+ * <p>
+ * When OPTIONAL MATCH leaves a relationship endpoint variable as null, a
+ * subsequent relationship write (MERGE or CREATE) that references that null
+ * variable must drop the row rather than emitting a result or rebinding the
+ * variable to an unrelated node.
+ */
+class Issue4213OptionalMatchNullEndpointMergeTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/issue-4213-optional-match-null-endpoint").create();
+    database.getSchema().createVertexType("Node");
+    database.getSchema().createEdgeType("KNOWS");
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Node {id: 1})");
+      database.command("opencypher", "CREATE (:Node {id: 2})");
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  /**
+   * OPTIONAL MATCH that finds no match leaves the endpoint null; the subsequent
+   * MERGE must produce zero rows instead of rebinding the null endpoint and
+   * emitting a spurious result.
+   */
+  @Test
+  void mergeWithNullEndpointFromOptionalMatchProducesNoRows() {
+    final ResultSet rs = database.command("opencypher",
+        "MATCH (a:Node {id: 1}) "
+            + "OPTIONAL MATCH (a)-[:KNOWS]->(b:Node {id: 2}) "
+            + "WITH a, b "
+            + "MERGE (a)-[:KNOWS]->(b) "
+            + "RETURN a.id AS aid, b.id AS bid");
+
+    assertThat(rs.hasNext())
+        .as("MERGE with null endpoint from OPTIONAL MATCH must produce no rows")
+        .isFalse();
+  }
+
+  /**
+   * OPTIONAL MATCH itself must still expose a null value for unmatched
+   * variables - this verifies the control behaviour is unaffected.
+   */
+  @Test
+  void optionalMatchAloneReturnsNullEndpoint() {
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Node {id: 1}) "
+            + "OPTIONAL MATCH (a)-[:KNOWS]->(b:Node {id: 2}) "
+            + "WITH a, b "
+            + "RETURN a.id AS aid, b.id AS bid");
+
+    assertThat(rs.hasNext()).isTrue();
+    final var row = rs.next();
+    assertThat(row.<Number>getProperty("aid").longValue()).isEqualTo(1L);
+    assertThat(row.<Object>getProperty("bid")).isNull();
+    assertThat(rs.hasNext()).isFalse();
+  }
+
+  /**
+   * Once the endpoint is rebound via an explicit MATCH after the OPTIONAL MATCH,
+   * the subsequent MERGE must succeed normally and return one row.
+   */
+  @Test
+  void mergeAfterExplicitRebindSucceeds() {
+    final ResultSet rs = database.command("opencypher",
+        "MATCH (a:Node {id: 1}) "
+            + "OPTIONAL MATCH (a)-[:KNOWS]->(b:Node {id: 2}) "
+            + "WITH a, b "
+            + "MATCH (c:Node {id: 2}) "
+            + "MERGE (a)-[:KNOWS]->(c) "
+            + "RETURN a.id AS aid, c.id AS cid");
+
+    assertThat(rs.hasNext()).isTrue();
+    final var row = rs.next();
+    assertThat(row.<Number>getProperty("aid").longValue()).isEqualTo(1L);
+    assertThat(row.<Number>getProperty("cid").longValue()).isEqualTo(2L);
+    assertThat(rs.hasNext()).isFalse();
+  }
+
+  /**
+   * MERGE with both endpoints directly bound by a non-optional MATCH must
+   * create exactly one relationship and return one row.
+   */
+  @Test
+  void mergeWithBothEndpointsBoundCreatesRelationship() {
+    final ResultSet rs = database.command("opencypher",
+        "MATCH (a:Node {id: 1}), (b:Node {id: 2}) "
+            + "MERGE (a)-[:KNOWS]->(b) "
+            + "RETURN count(*) AS cnt");
+
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Number>getProperty("cnt").longValue()).isEqualTo(1L);
+  }
+
+  /**
+   * When OPTIONAL MATCH succeeds and binds the endpoint, the subsequent MERGE
+   * must create the relationship and return one row.
+   */
+  @Test
+  void mergeWithNonNullEndpointFromOptionalMatchCreatesRelationship() {
+    // Pre-create the KNOWS relationship so OPTIONAL MATCH will match.
+    database.transaction(() ->
+        database.command("opencypher",
+            "MATCH (a:Node {id: 1}), (b:Node {id: 2}) CREATE (a)-[:KNOWS]->(b)"));
+
+    final ResultSet rs = database.command("opencypher",
+        "MATCH (a:Node {id: 1}) "
+            + "OPTIONAL MATCH (a)-[:KNOWS]->(b:Node {id: 2}) "
+            + "WITH a, b "
+            + "MERGE (a)-[:KNOWS]->(b) "
+            + "RETURN a.id AS aid, b.id AS bid");
+
+    assertThat(rs.hasNext()).isTrue();
+    final var row = rs.next();
+    assertThat(row.<Number>getProperty("aid").longValue()).isEqualTo(1L);
+    assertThat(row.<Number>getProperty("bid").longValue()).isEqualTo(2L);
+    assertThat(rs.hasNext()).isFalse();
+  }
+
+  /**
+   * No spurious Node vertices must be created as a side effect of the skipped
+   * MERGE row; the graph should still contain only the two original nodes.
+   */
+  @Test
+  void mergeWithNullEndpointDoesNotCreateSpuriousVertex() {
+    // Execute the buggy query (which must now produce 0 rows and no side effects).
+    database.command("opencypher",
+        "MATCH (a:Node {id: 1}) "
+            + "OPTIONAL MATCH (a)-[:KNOWS]->(b:Node {id: 2}) "
+            + "WITH a, b "
+            + "MERGE (a)-[:KNOWS]->(b) "
+            + "RETURN a.id AS aid, b.id AS bid");
+
+    final ResultSet nodeCount = database.query("opencypher", "MATCH (n:Node) RETURN count(n) AS cnt");
+    assertThat(nodeCount.next().<Number>getProperty("cnt").longValue())
+        .as("No spurious Node vertex must be created by the skipped MERGE")
+        .isEqualTo(2L);
+
+    final ResultSet relCount = database.query("opencypher", "MATCH ()-[r:KNOWS]->() RETURN count(r) AS cnt");
+    assertThat(relCount.next().<Number>getProperty("cnt").longValue())
+        .as("No KNOWS relationship must be created when endpoint is null")
+        .isEqualTo(0L);
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes #4213: When `OPTIONAL MATCH` leaves a relationship endpoint variable as null, a subsequent `MERGE` using that null variable now drops the row (Cypher null-propagation) instead of emitting a result and rebinding the variable to the source node.
- Added null-endpoint guard in `MergeStep.executeMerge()` plus a `hasNullNodeEndpoint()` helper that distinguishes explicitly-null (set by an unmatched `OPTIONAL MATCH`) from absent/unbound via `Result.getPropertyNames().contains(var)`.
- 6 regression tests covering the main bug, OPTIONAL MATCH alone (null bid), explicit rebind via later MATCH, direct double-bound MERGE, OPTIONAL MATCH that does bind, and absence of spurious vertex/relationship side effects.

## Repro (from the issue)
```cypher
CREATE (a:Node {id: 1}), (b:Node {id: 2});

MATCH (a:Node {id: 1})
OPTIONAL MATCH (a)-[:KNOWS]->(b:Node {id: 2})
WITH a, b
MERGE (a)-[:KNOWS]->(b)
RETURN a.id AS aid, b.id AS bid;
```
- Before: returns `aid=1, bid=1` (b rebound to a, spurious self-loop created)
- After: returns 0 rows, no relationship created (matches Neo4j 2026.04.0 behaviour)

## Test plan
- [x] `mvn test -pl engine -Dtest=Issue4213OptionalMatchNullEndpointMergeTest` (6/6 pass)
- [x] All MERGE-related test classes pass (`OpenCypherMergeTest`, `OpenCypherMergeActionsTest`, `Issue4089MergeWithUniqueHashIndexTest`, `Issue4103MergeOnMatchStaleTest`, `Issue4104MergeReusedEndpointTest`, `Issue4226MergeBoundAnchorTest` - 42 tests total)
- [x] Recent Cypher issue tests pass (Issue 39xx/40xx/41xx/42xx - 237 tests total, no regressions)