### PR TITLE
#4210 fix: [cypher] MERGE+UNWIND crash on single-quote property value

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -906,16 +906,7 @@ public class MergeStep extends AbstractExecutionStep {
   private boolean matchesProperties(final Document doc, final Map<String, Object> properties) {
     for (final Map.Entry<String, Object> entry : properties.entrySet()) {
       final String key = entry.getKey();
-      Object expectedValue = entry.getValue();
-
-      // Handle string literals: remove quotes
-      if (expectedValue instanceof String) {
-        final String strValue = (String) expectedValue;
-        if (strValue.startsWith("'") && strValue.endsWith("'"))
-          expectedValue = strValue.substring(1, strValue.length() - 1);
-        else if (strValue.startsWith("\"") && strValue.endsWith("\""))
-          expectedValue = strValue.substring(1, strValue.length() - 1);
-      }
+      final Object expectedValue = entry.getValue();
 
       final Object actualValue = doc.get(key);
       if (actualValue == null)
@@ -997,22 +988,8 @@ public class MergeStep extends AbstractExecutionStep {
    * Sets properties on a document from a property map.
    */
   private void setProperties(final MutableDocument document, final Map<String, Object> properties) {
-    for (final Map.Entry<String, Object> entry : properties.entrySet()) {
-      final String key = entry.getKey();
-      Object value = entry.getValue();
-
-      // Handle string literals: remove quotes
-      if (value instanceof String) {
-        final String strValue = (String) value;
-        if (strValue.startsWith("'") && strValue.endsWith("'")) {
-          value = strValue.substring(1, strValue.length() - 1);
-        } else if (strValue.startsWith("\"") && strValue.endsWith("\"")) {
-          value = strValue.substring(1, strValue.length() - 1);
-        }
-      }
-
-      document.set(key, TemporalUtil.toCoreJavaType(value));
-    }
+    for (final Map.Entry<String, Object> entry : properties.entrySet())
+      document.set(entry.getKey(), TemporalUtil.toCoreJavaType(entry.getValue()));
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue4210MergeUnwindSingleQuoteTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue4210MergeUnwindSingleQuoteTest.java
@@ -96,25 +96,27 @@ class Issue4210MergeUnwindSingleQuoteTest {
     params.put("batch", batch);
 
     database.transaction(() -> {
-      final ResultSet rs = database.command("opencypher", query, params);
-      int count = 0;
-      while (rs.hasNext()) {
-        rs.next();
-        count++;
+      try (final ResultSet rs = database.command("opencypher", query, params)) {
+        int count = 0;
+        while (rs.hasNext()) {
+          rs.next();
+          count++;
+        }
+        assertThat(count).isEqualTo(4);
       }
-      assertThat(count).isEqualTo(4);
     });
 
     // Second run - all must match (ON MATCH path)
     database.transaction(() -> {
-      final ResultSet rs = database.command("opencypher", query, params);
-      int count = 0;
-      while (rs.hasNext()) {
-        final var row = rs.next();
-        assertThat(row.<Boolean>getProperty("created")).isFalse();
-        count++;
+      try (final ResultSet rs = database.command("opencypher", query, params)) {
+        int count = 0;
+        while (rs.hasNext()) {
+          final var row = rs.next();
+          assertThat(row.<Boolean>getProperty("created")).isFalse();
+          count++;
+        }
+        assertThat(count).isEqualTo(4);
       }
-      assertThat(count).isEqualTo(4);
     });
   }
 
@@ -135,8 +137,9 @@ class Issue4210MergeUnwindSingleQuoteTest {
 
     database.transaction(() -> database.command("opencypher", query, params).close());
 
-    final ResultSet rs = database.query("opencypher", "MATCH (n:Token) RETURN n.value AS val");
-    assertThat(rs.hasNext()).isTrue();
-    assertThat(rs.next().<String>getProperty("val")).isEqualTo("'");
+    try (final ResultSet rs = database.query("opencypher", "MATCH (n:Token) RETURN n.value AS val")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<String>getProperty("val")).isEqualTo("'");
+    }
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue4210MergeUnwindSingleQuoteTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue4210MergeUnwindSingleQuoteTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for GitHub issue #4210.
+ * <p>
+ * UNWIND $batch MERGE with a property value that is a single {@code '} character
+ * (or any string that starts AND ends with a quote) must not throw a
+ * {@code StringIndexOutOfBoundsException} ({@code Range [1, 0) out of bounds for length 1}).
+ */
+class Issue4210MergeUnwindSingleQuoteTest {
+  private Database database;
+
+  @BeforeEach
+  void setup() {
+    database = new DatabaseFactory("./target/databases/issue-4210-merge-unwind-single-quote").create();
+  }
+
+  @AfterEach
+  void cleanup() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  @Test
+  void mergeWithSingleQuotePropertyValueDoesNotCrash() {
+    final String query = """
+        UNWIND $batch AS BatchEntry
+        MERGE (n:NER {identity: BatchEntry.identity, name: BatchEntry.name})
+        ON CREATE SET n._temp_created = true
+        ON MATCH SET n._temp_created = false
+        WITH n, n._temp_created AS created
+        REMOVE n._temp_created
+        RETURN ID(n) AS id, created
+        """;
+
+    final List<Map<String, Object>> batch = new ArrayList<>();
+
+    final Map<String, Object> entry1 = new HashMap<>();
+    entry1.put("identity", "normal");
+    entry1.put("name", "normal");
+    batch.add(entry1);
+
+    // Single quote character: the original crash case
+    final Map<String, Object> entryQuote = new HashMap<>();
+    entryQuote.put("identity", "'");
+    entryQuote.put("name", "'");
+    batch.add(entryQuote);
+
+    // Starts and ends with quote but length > 1
+    final Map<String, Object> entryQuotedString = new HashMap<>();
+    entryQuotedString.put("identity", "'wrapped'");
+    entryQuotedString.put("name", "'wrapped'");
+    batch.add(entryQuotedString);
+
+    // Contains a quote but not both start+end
+    final Map<String, Object> entryPartialQuote = new HashMap<>();
+    entryPartialQuote.put("identity", "it's");
+    entryPartialQuote.put("name", "it's");
+    batch.add(entryPartialQuote);
+
+    final Map<String, Object> params = new HashMap<>();
+    params.put("batch", batch);
+
+    database.transaction(() -> {
+      final ResultSet rs = database.command("opencypher", query, params);
+      int count = 0;
+      while (rs.hasNext()) {
+        rs.next();
+        count++;
+      }
+      assertThat(count).isEqualTo(4);
+    });
+
+    // Second run - all must match (ON MATCH path)
+    database.transaction(() -> {
+      final ResultSet rs = database.command("opencypher", query, params);
+      int count = 0;
+      while (rs.hasNext()) {
+        final var row = rs.next();
+        assertThat(row.<Boolean>getProperty("created")).isFalse();
+        count++;
+      }
+      assertThat(count).isEqualTo(4);
+    });
+  }
+
+  @Test
+  void mergeWithQuotePropertyPreservesExactValue() {
+    final String query = """
+        UNWIND $batch AS entry
+        MERGE (n:Token {value: entry.value})
+        RETURN n.value AS val
+        """;
+
+    final Map<String, Object> entry = new HashMap<>();
+    entry.put("value", "'");
+    final List<Object> batch = List.of(entry);
+
+    final Map<String, Object> params = new HashMap<>();
+    params.put("batch", batch);
+
+    database.transaction(() -> database.command("opencypher", query, params).close());
+
+    final ResultSet rs = database.query("opencypher", "MATCH (n:Token) RETURN n.value AS val");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<String>getProperty("val")).isEqualTo("'");
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes #4210. `MergeStep.matchesProperties` and `setProperties` stripped surrounding quotes from string property values with `substring(1, len-1)` and no length guard, so a value equal to a single `'` (or `"`) crashed with `StringIndexOutOfBoundsException: Range [1, 0) out of bounds for length 1`.
- The stripping is also dead: literals are already unquoted by `LiteralExpression.getValue()` (parsed via `CypherExpressionBuilder.tryParseLiteral`, which has its own `length >= 2` guard), and `evaluateProperties` resolves expressions/parameters to plain Java values before either method runs. The block additionally would silently corrupt genuine values that happen to start and end with a quote (e.g. `'wrapped'` stored as `wrapped`).
- Removed the stripping blocks from both methods.

## Test plan
- [x] New `Issue4210MergeUnwindSingleQuoteTest` reproduces the original `UNWIND $batch ... MERGE (n:NER {...})` crash with a single-quote property value, plus value-fidelity for quote-wrapped strings; both pass.
- [x] All 54 MERGE-related Cypher tests pass.
- [x] Full Cypher/Issue test suite (6112 tests) passes with no new failures.