### PR TITLE
#4210 fix: [cypher] remove dead quote-stripping in remaining executor steps

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ExpandPathStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ExpandPathStep.java
@@ -344,13 +344,7 @@ public class ExpandPathStep extends AbstractExecutionStep {
   private boolean matchesTargetProperties(final Vertex vertex) {
     for (final Map.Entry<String, Object> entry : targetNodePattern.getProperties().entrySet()) {
       final Object actual = vertex.get(entry.getKey());
-      Object expected = entry.getValue();
-      // Handle string literals: remove quotes
-      if (expected instanceof String) {
-        final String s = (String) expected;
-        if ((s.startsWith("'") && s.endsWith("'")) || (s.startsWith("\"") && s.endsWith("\"")))
-          expected = s.substring(1, s.length() - 1);
-      }
+      final Object expected = entry.getValue();
       if (actual == null || !actual.equals(expected))
         return false;
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/FilterPropertiesStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/FilterPropertiesStep.java
@@ -151,12 +151,11 @@ public class FilterPropertiesStep extends AbstractExecutionStep {
       final String operator = matcher.group(3);
       String value = matcher.group(4);
 
-      // Remove quotes from string values
-      if (value.startsWith("'") && value.endsWith("'")) {
+      // Remove quotes from string-literal source text (regex match is on raw WHERE text)
+      if (value.length() >= 2
+          && ((value.charAt(0) == '\'' && value.charAt(value.length() - 1) == '\'')
+          || (value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"')))
         value = value.substring(1, value.length() - 1);
-      } else if (value.startsWith("\"") && value.endsWith("\"")) {
-        value = value.substring(1, value.length() - 1);
-      }
 
       // Get the object from result
       final Object obj = result.getProperty(variable);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/FilterPropertiesStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/FilterPropertiesStep.java
@@ -154,7 +154,7 @@ public class FilterPropertiesStep extends AbstractExecutionStep {
       // Remove quotes from string-literal source text (regex match is on raw WHERE text)
       if (value.length() >= 2
           && ((value.charAt(0) == '\'' && value.charAt(value.length() - 1) == '\'')
-          || (value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"')))
+              || (value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"')))
         value = value.substring(1, value.length() - 1);
 
       // Get the object from result

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchNodeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchNodeStep.java
@@ -931,20 +931,14 @@ public class MatchNodeStep extends AbstractExecutionStep {
       } else if (expectedValue instanceof String) {
         final String strValue = (String) expectedValue;
 
-        // Check if it's a parameter reference
-        if (strValue.startsWith("$")) {
+        // Legacy parameter reference encoded as "$name"
+        if (strValue.startsWith("$") && strValue.length() > 1) {
           final String paramName = strValue.substring(1);
           if (context.getInputParameters() != null) {
             final Object paramValue = context.getInputParameters().get(paramName);
             if (paramValue != null)
               expectedValue = paramValue;
           }
-        }
-        // Handle string literals: remove quotes
-        else if (strValue.startsWith("'") && strValue.endsWith("'")) {
-          expectedValue = strValue.substring(1, strValue.length() - 1);
-        } else if (strValue.startsWith("\"") && strValue.endsWith("\"")) {
-          expectedValue = strValue.substring(1, strValue.length() - 1);
         }
       }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchRelationshipStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchRelationshipStep.java
@@ -903,7 +903,8 @@ public class MatchRelationshipStep extends AbstractExecutionStep {
           expected = context.getInputParameters().get(paramName);
       } else if (expected instanceof String) {
         final String s = (String) expected;
-        if (s.startsWith("$")) {
+        // Legacy parameter reference encoded as "$name"
+        if (s.startsWith("$") && s.length() > 1) {
           final String paramName = s.substring(1);
           if (context.getInputParameters() != null) {
             final Object paramValue = context.getInputParameters().get(paramName);
@@ -911,9 +912,6 @@ public class MatchRelationshipStep extends AbstractExecutionStep {
               expected = paramValue;
           }
         }
-        // Handle string literals: remove quotes
-        else if ((s.startsWith("'") && s.endsWith("'")) || (s.startsWith("\"") && s.endsWith("\"")))
-          expected = s.substring(1, s.length() - 1);
       }
 
       if (actual == null || !actual.equals(expected)) {
@@ -999,7 +997,8 @@ public class MatchRelationshipStep extends AbstractExecutionStep {
           expected = context.getInputParameters().get(paramName);
       } else if (expected instanceof String) {
         final String s = (String) expected;
-        if (s.startsWith("$")) {
+        // Legacy parameter reference encoded as "$name"
+        if (s.startsWith("$") && s.length() > 1) {
           final String paramName = s.substring(1);
           if (context.getInputParameters() != null) {
             final Object paramValue = context.getInputParameters().get(paramName);
@@ -1007,9 +1006,6 @@ public class MatchRelationshipStep extends AbstractExecutionStep {
               expected = paramValue;
           }
         }
-        // Handle string literals: remove quotes
-        else if ((s.startsWith("'") && s.endsWith("'")) || (s.startsWith("\"") && s.endsWith("\"")))
-          expected = s.substring(1, s.length() - 1);
       }
 
       if (actual == null || !actual.equals(expected)) {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue4210MergeUnwindSingleQuoteTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue4210MergeUnwindSingleQuoteTest.java
@@ -175,6 +175,50 @@ class Issue4210MergeUnwindSingleQuoteTest {
   }
 
   @Test
+  void variableLengthPathEndpointWithSingleQuotePropertyDoesNotCrash() {
+    // ExpandPathStep.matchesTargetProperties: VLP endpoint with a quote-containing literal.
+    // Pre-fix, quote-stripping would have transformed the literal "'" into the empty string,
+    // causing zero matches; post-fix, the literal is compared as-is.
+    database.getSchema().createVertexType("Node");
+    database.getSchema().createEdgeType("LINK");
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Node {tag: 'start'})");
+      database.command("opencypher", "CREATE (:Node {tag: \"'\"})");
+      database.command("opencypher",
+          "MATCH (a:Node {tag: 'start'}), (b:Node {tag: \"'\"}) CREATE (a)-[:LINK]->(b)");
+    });
+
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (:Node {tag: 'start'})-[:LINK*1..3]->(m:Node {tag: \"'\"}) RETURN m.tag AS tag")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<String>getProperty("tag")).isEqualTo("'");
+    }
+  }
+
+  @Test
+  void matchRelationshipWithQuoteLiteralEdgePropertyDoesNotCrash() {
+    // MatchRelationshipStep.matchesEdgeProperties: inline edge property filter with a literal
+    // value that starts and ends with a quote character. Pre-fix this would have been stripped
+    // to the empty string; post-fix it round-trips correctly.
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("KNOWS");
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Person {name: 'Alice'})");
+      database.command("opencypher", "CREATE (:Person {name: 'Bob'})");
+      database.command("opencypher",
+          "MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'}) CREATE (a)-[:KNOWS {note: \"'\"}]->(b)");
+    });
+
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH ()-[r:KNOWS {note: \"'\"}]->() RETURN r.note AS note")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<String>getProperty("note")).isEqualTo("'");
+    }
+  }
+
+  @Test
   void matchRelationshipEndpointWithSingleQuotePropertyViaUnwindDoesNotCrash() {
     // Creates edges and MATCHes them using UNWIND-supplied endpoint node property filters.
     // MatchRelationshipStep.matchesTargetProperties evaluates expression values and must not

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue4210MergeUnwindSingleQuoteTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue4210MergeUnwindSingleQuoteTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -140,6 +141,73 @@ class Issue4210MergeUnwindSingleQuoteTest {
     try (final ResultSet rs = database.query("opencypher", "MATCH (n:Token) RETURN n.value AS val")) {
       assertThat(rs.hasNext()).isTrue();
       assertThat(rs.next().<String>getProperty("val")).isEqualTo("'");
+    }
+  }
+
+  @Test
+  void matchNodeWithSingleQuotePropertyViaUnwindDoesNotCrash() {
+    // Creates nodes and then MATCHes them using UNWIND-supplied property values.
+    // MatchNodeStep.matchesProperties must not strip quotes from evaluated values.
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Tag {name: \"'\"})");
+      database.command("opencypher", "CREATE (:Tag {name: \"'wrapped'\"})");
+      database.command("opencypher", "CREATE (:Tag {name: 'plain'})");
+    });
+
+    final List<Map<String, Object>> batch = List.of(
+        Map.of("name", "'"),
+        Map.of("name", "'wrapped'"),
+        Map.of("name", "plain")
+    );
+    final Map<String, Object> params = new HashMap<>();
+    params.put("batch", batch);
+
+    try (final ResultSet rs = database.query("opencypher",
+        "UNWIND $batch AS item MATCH (n:Tag {name: item.name}) RETURN n.name AS name", params)) {
+      int count = 0;
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        assertThat(row.<String>getProperty("name")).isNotNull();
+        count++;
+      }
+      assertThat(count).isEqualTo(3);
+    }
+  }
+
+  @Test
+  void matchRelationshipEndpointWithSingleQuotePropertyViaUnwindDoesNotCrash() {
+    // Creates edges and MATCHes them using UNWIND-supplied endpoint node property filters.
+    // MatchRelationshipStep.matchesTargetProperties evaluates expression values and must not
+    // strip quotes when the evaluated value starts and ends with a quote character.
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("KNOWS");
+
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Person {name: 'Alice'})");
+      database.command("opencypher", "CREATE (:Person {name: \"'\"})");
+      database.command("opencypher", "CREATE (:Person {name: 'plain'})");
+      database.command("opencypher",
+          "MATCH (a:Person {name: 'Alice'}), (b:Person {name: \"'\"}) CREATE (a)-[:KNOWS]->(b)");
+      database.command("opencypher",
+          "MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'plain'}) CREATE (a)-[:KNOWS]->(b)");
+    });
+
+    final List<Map<String, Object>> batch = List.of(
+        Map.of("name", "'"),
+        Map.of("name", "plain")
+    );
+    final Map<String, Object> params = new HashMap<>();
+    params.put("batch", batch);
+
+    try (final ResultSet rs = database.query("opencypher",
+        "UNWIND $batch AS item MATCH (:Person)-[:KNOWS]->(m:Person {name: item.name}) RETURN m.name AS name", params)) {
+      int count = 0;
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        assertThat(row.<String>getProperty("name")).isNotNull();
+        count++;
+      }
+      assertThat(count).isEqualTo(2);
     }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #4237 (the original fix for issue #4210). The contributor's [diff in the issue](https://github.com/ArcadeData/arcadedb/issues/4210#issuecomment-4429313574) pointed out the same dead quote-stripping pattern in four other executor steps. This PR removes them so they cannot crash with `Range [1, 0) out of bounds for length 1` when a property value is a single-quote character (`'`) or any string that starts and ends with a quote.

## Changes

- `ExpandPathStep.matchesTargetProperties`: drop quote-stripping; values from the parsed AST are already clean.
- `MatchNodeStep.matchesProperties`: drop quote-stripping; add `length > 1` guard on the legacy `$name` parameter reference.
- `MatchRelationshipStep.matchesTargetProperties` and `matchesEdgeProperties`: same as above.
- `FilterPropertiesStep`: keeps the unquoting (its regex matches raw WHERE source text where quotes really are present) but adds a `length >= 2` guard so a one-character `'` literal no longer crashes.

## Tests

Extended `Issue4210MergeUnwindSingleQuoteTest`:
- `matchNodeWithSingleQuotePropertyViaUnwindDoesNotCrash` exercises `MatchNodeStep.matchesProperties` via `UNWIND $batch AS item MATCH (n:Tag {name: item.name})` with `'`, `'wrapped'`, and `plain` values.
- `matchRelationshipEndpointWithSingleQuotePropertyViaUnwindDoesNotCrash` exercises `MatchRelationshipStep.matchesTargetProperties` via an UNWIND-driven endpoint match.

## Test plan

- [x] `mvn test -pl engine -Dtest=Issue4210MergeUnwindSingleQuoteTest` (4/4 pass)
- [x] `mvn test -pl engine -Dtest="*Cypher*"` (5939 pass, 0 failures, 91 skipped)
- [x] `mvn compile -pl engine` (build success)

Closes #4210.