### PR TITLE
fix: node.* and rel.* functions silently return null/0 from SQL (#4216)

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/node/AbstractNodeFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/node/AbstractNodeFunction.java
@@ -19,8 +19,11 @@
 package com.arcadedb.function.node;
 
 import com.arcadedb.database.Document;
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.database.Record;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.executor.Result;
 
 /**
  * Abstract base class for node functions.
@@ -52,6 +55,16 @@ public abstract class AbstractNodeFunction implements StatelessFunction {
       final Document doc = (Document) input;
       if (doc.getRecord() instanceof Vertex)
         return (Vertex) doc.getRecord();
+    }
+
+    if (input instanceof Result) {
+      return ((Result) input).getVertex().orElse(null);
+    }
+
+    if (input instanceof Identifiable) {
+      final Record record = ((Identifiable) input).getRecord();
+      if (record instanceof Vertex)
+        return (Vertex) record;
     }
 
     return null;

--- a/engine/src/main/java/com/arcadedb/function/node/AbstractNodeFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/node/AbstractNodeFunction.java
@@ -51,22 +51,17 @@ public abstract class AbstractNodeFunction implements StatelessFunction {
     if (input instanceof Vertex)
       return (Vertex) input;
 
-    if (input instanceof Document) {
-      final Document doc = (Document) input;
-      if (doc.getRecord() instanceof Vertex)
-        return (Vertex) doc.getRecord();
+    if (input instanceof Document doc) {
+      return doc.getRecord() instanceof Vertex vertex ? vertex : null;
     }
 
     if (input instanceof Result result) {
       final Record record = result.getRecord().orElse(null);
-      if (record instanceof Vertex vertex)
-        return vertex;
+      return record instanceof Vertex vertex ? vertex : null;
     }
 
     if (input instanceof Identifiable identifiable) {
-      final Record record = identifiable.getRecord();
-      if (record instanceof Vertex vertex)
-        return vertex;
+      return identifiable.getRecord() instanceof Vertex vertex ? vertex : null;
     }
 
     return null;

--- a/engine/src/main/java/com/arcadedb/function/node/AbstractNodeFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/node/AbstractNodeFunction.java
@@ -57,14 +57,16 @@ public abstract class AbstractNodeFunction implements StatelessFunction {
         return (Vertex) doc.getRecord();
     }
 
-    if (input instanceof Result) {
-      return ((Result) input).getVertex().orElse(null);
+    if (input instanceof Result result) {
+      final Record record = result.getRecord().orElse(null);
+      if (record instanceof Vertex vertex)
+        return vertex;
     }
 
-    if (input instanceof Identifiable) {
-      final Record record = ((Identifiable) input).getRecord();
-      if (record instanceof Vertex)
-        return (Vertex) record;
+    if (input instanceof Identifiable identifiable) {
+      final Record record = identifiable.getRecord();
+      if (record instanceof Vertex vertex)
+        return vertex;
     }
 
     return null;

--- a/engine/src/main/java/com/arcadedb/function/rel/AbstractRelFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/rel/AbstractRelFunction.java
@@ -57,14 +57,16 @@ public abstract class AbstractRelFunction implements StatelessFunction {
         return (Edge) doc.getRecord();
     }
 
-    if (input instanceof Result) {
-      return ((Result) input).getEdge().orElse(null);
+    if (input instanceof Result result) {
+      final Record record = result.getRecord().orElse(null);
+      if (record instanceof Edge edge)
+        return edge;
     }
 
-    if (input instanceof Identifiable) {
-      final Record record = ((Identifiable) input).getRecord();
-      if (record instanceof Edge)
-        return (Edge) record;
+    if (input instanceof Identifiable identifiable) {
+      final Record record = identifiable.getRecord();
+      if (record instanceof Edge edge)
+        return edge;
     }
 
     return null;

--- a/engine/src/main/java/com/arcadedb/function/rel/AbstractRelFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/rel/AbstractRelFunction.java
@@ -19,8 +19,11 @@
 package com.arcadedb.function.rel;
 
 import com.arcadedb.database.Document;
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.database.Record;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.query.sql.executor.Result;
 
 /**
  * Abstract base class for relationship functions.
@@ -52,6 +55,16 @@ public abstract class AbstractRelFunction implements StatelessFunction {
       final Document doc = (Document) input;
       if (doc.getRecord() instanceof Edge)
         return (Edge) doc.getRecord();
+    }
+
+    if (input instanceof Result) {
+      return ((Result) input).getEdge().orElse(null);
+    }
+
+    if (input instanceof Identifiable) {
+      final Record record = ((Identifiable) input).getRecord();
+      if (record instanceof Edge)
+        return (Edge) record;
     }
 
     return null;

--- a/engine/src/main/java/com/arcadedb/function/rel/AbstractRelFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/rel/AbstractRelFunction.java
@@ -51,22 +51,17 @@ public abstract class AbstractRelFunction implements StatelessFunction {
     if (input instanceof Edge)
       return (Edge) input;
 
-    if (input instanceof Document) {
-      final Document doc = (Document) input;
-      if (doc.getRecord() instanceof Edge)
-        return (Edge) doc.getRecord();
+    if (input instanceof Document doc) {
+      return doc.getRecord() instanceof Edge edge ? edge : null;
     }
 
     if (input instanceof Result result) {
       final Record record = result.getRecord().orElse(null);
-      if (record instanceof Edge edge)
-        return edge;
+      return record instanceof Edge edge ? edge : null;
     }
 
     if (input instanceof Identifiable identifiable) {
-      final Record record = identifiable.getRecord();
-      if (record instanceof Edge edge)
-        return edge;
+      return identifiable.getRecord() instanceof Edge edge ? edge : null;
     }
 
     return null;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/SuffixIdentifier.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/SuffixIdentifier.java
@@ -40,6 +40,7 @@ import static com.arcadedb.schema.Property.CAT_PROPERTY;
 import static com.arcadedb.schema.Property.IN_PROPERTY;
 import static com.arcadedb.schema.Property.OUT_PROPERTY;
 import static com.arcadedb.schema.Property.RID_PROPERTY;
+import static com.arcadedb.schema.Property.THIS_PROPERTY;
 import static com.arcadedb.schema.Property.TYPE_PROPERTY;
 
 public class SuffixIdentifier extends SimpleNode {
@@ -90,6 +91,8 @@ public class SuffixIdentifier extends SimpleNode {
     if (recordAttribute != null) {
       if (RID_PROPERTY.equalsIgnoreCase(recordAttribute.name))
         return currentRecord.getIdentity();
+      else if (THIS_PROPERTY.equalsIgnoreCase(recordAttribute.name))
+        return currentRecord;
       else if (TYPE_PROPERTY.equalsIgnoreCase(recordAttribute.name))
         return currentRecord.asDocument().getTypeName();
       else if (CAT_PROPERTY.equalsIgnoreCase(recordAttribute.name)) {

--- a/engine/src/test/java/com/arcadedb/function/node/SQLNodeFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/node/SQLNodeFunctionsTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.node;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for node.* and rel.* functions called from SQL.
+ * The argument unwrapping in AbstractNodeFunction.toVertex() and
+ * AbstractRelFunction.toEdge() must handle SQL-side wrappers (Result,
+ * Identifiable, RID) in addition to the bare Vertex/Edge that Cypher passes.
+ */
+class SQLNodeFunctionsTest extends TestHelper {
+
+  @Override
+  public void beginTest() {
+    database.getSchema().createVertexType("Person");
+    database.getSchema().createEdgeType("Friend");
+
+    database.transaction(() -> {
+      database.command("sql", "INSERT INTO Person SET name = 'Ada'");
+      database.command("sql", "INSERT INTO Person SET name = 'Bob'");
+      database.command("sql", "INSERT INTO Person SET name = 'Cara'");
+      database.command("sql", "CREATE EDGE Friend FROM (SELECT FROM Person WHERE name = 'Ada') TO (SELECT FROM Person WHERE name = 'Bob')");
+      database.command("sql", "CREATE EDGE Friend FROM (SELECT FROM Person WHERE name = 'Ada') TO (SELECT FROM Person WHERE name = 'Cara')");
+    });
+  }
+
+  // node.degree via @this (SQL row carrier)
+  @Test
+  void nodeDegreeFromSql_thisReference() {
+    final ResultSet rs = database.query("sql", "SELECT name, node.degree(@this, 'Friend') AS d FROM Person WHERE name = 'Ada'");
+    assertThat(rs.hasNext()).isTrue();
+    final Result row = rs.next();
+    assertThat(row.<Long>getProperty("d")).isEqualTo(2L);
+    rs.close();
+  }
+
+  // node.degree via @rid (RID - an Identifiable)
+  @Test
+  void nodeDegreeFromSql_ridReference() {
+    final ResultSet rs = database.query("sql", "SELECT name, node.degree(@rid, 'Friend') AS d FROM Person WHERE name = 'Ada'");
+    assertThat(rs.hasNext()).isTrue();
+    final Result row = rs.next();
+    assertThat(row.<Long>getProperty("d")).isEqualTo(2L);
+    rs.close();
+  }
+
+  // node.degree via $current (SQL context variable for the current record)
+  @Test
+  void nodeDegreeFromSql_currentVariable() {
+    final ResultSet rs = database.query("sql", "SELECT name, node.degree($current, 'Friend') AS d FROM Person WHERE name = 'Ada'");
+    assertThat(rs.hasNext()).isTrue();
+    final Result row = rs.next();
+    assertThat(row.<Long>getProperty("d")).isEqualTo(2L);
+    rs.close();
+  }
+
+  // node.id via @rid - cross-validates that the RID from @rid and node.id agree
+  @Test
+  void nodeIdFromSql_ridReference() {
+    final ResultSet rs = database.query("sql", "SELECT node.id(@rid) AS rid FROM Person WHERE name = 'Ada'");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Object>getProperty("rid")).isNotNull();
+    rs.close();
+  }
+
+  // node.labels via @this
+  @Test
+  void nodeLabelsFromSql_thisReference() {
+    final ResultSet rs = database.query("sql", "SELECT node.labels(@this) AS lbl FROM Person WHERE name = 'Ada'");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Object>getProperty("lbl")).isNotNull();
+    rs.close();
+  }
+
+  // node.id via @this
+  @Test
+  void nodeIdFromSql_thisReference() {
+    final ResultSet rs = database.query("sql", "SELECT node.id(@this) AS rid FROM Person WHERE name = 'Ada'");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Object>getProperty("rid")).isNotNull();
+    rs.close();
+  }
+
+  // rel.type via @this when iterating edges
+  @Test
+  void relTypeFromSql_thisReference() {
+    final ResultSet rs = database.query("sql", "SELECT rel.type(@this) AS t FROM Friend");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<String>getProperty("t")).isEqualTo("Friend");
+    rs.close();
+  }
+
+  // rel.startNode via @this when iterating edges
+  @Test
+  void relStartNodeFromSql_thisReference() {
+    final ResultSet rs = database.query("sql", "SELECT rel.startNode(@this) AS src FROM Friend");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<Object>getProperty("src")).isNotNull();
+    rs.close();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/function/node/SQLNodeFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/node/SQLNodeFunctionsTest.java
@@ -46,97 +46,100 @@ class SQLNodeFunctionsTest extends TestHelper {
 
   @Test
   void nodeDegreeFromSql_thisReference() {
-    final ResultSet rs = database.query("sql", "SELECT name, node.degree(@this, 'Friend') AS d FROM Person WHERE name = 'Ada'");
-    assertThat(rs.hasNext()).isTrue();
-    assertThat(rs.next().<Long>getProperty("d")).isEqualTo(2L);
-    rs.close();
+    try (final ResultSet rs = database.query("sql", "SELECT name, node.degree(@this, 'Friend') AS d FROM Person WHERE name = 'Ada'")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<Long>getProperty("d")).isEqualTo(2L);
+    }
   }
 
   @Test
   void nodeDegreeFromSql_ridReference() {
-    final ResultSet rs = database.query("sql", "SELECT name, node.degree(@rid, 'Friend') AS d FROM Person WHERE name = 'Ada'");
-    assertThat(rs.hasNext()).isTrue();
-    assertThat(rs.next().<Long>getProperty("d")).isEqualTo(2L);
-    rs.close();
+    try (final ResultSet rs = database.query("sql", "SELECT name, node.degree(@rid, 'Friend') AS d FROM Person WHERE name = 'Ada'")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<Long>getProperty("d")).isEqualTo(2L);
+    }
   }
 
   @Test
   void nodeDegreeFromSql_currentVariable() {
-    final ResultSet rs = database.query("sql", "SELECT name, node.degree($current, 'Friend') AS d FROM Person WHERE name = 'Ada'");
-    assertThat(rs.hasNext()).isTrue();
-    assertThat(rs.next().<Long>getProperty("d")).isEqualTo(2L);
-    rs.close();
+    try (final ResultSet rs = database.query("sql", "SELECT name, node.degree($current, 'Friend') AS d FROM Person WHERE name = 'Ada'")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<Long>getProperty("d")).isEqualTo(2L);
+    }
   }
 
   @Test
   void nodeLabelsFromSql_thisReference() {
-    final ResultSet rs = database.query("sql", "SELECT node.labels(@this) AS lbl FROM Person WHERE name = 'Ada'");
-    assertThat(rs.hasNext()).isTrue();
-    final Collection<String> labels = rs.next().getProperty("lbl");
-    assertThat(labels).contains("Person");
-    rs.close();
+    try (final ResultSet rs = database.query("sql", "SELECT node.labels(@this) AS lbl FROM Person WHERE name = 'Ada'")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Collection<String> labels = rs.next().getProperty("lbl");
+      assertThat(labels).contains("Person");
+    }
   }
 
   @Test
   void nodeIdFromSql_thisReference() {
-    final ResultSet rs = database.query("sql", "SELECT @rid AS expected, node.id(@this) AS rid FROM Person WHERE name = 'Ada'");
-    assertThat(rs.hasNext()).isTrue();
-    final Result row = rs.next();
-    assertThat(row.<String>getProperty("rid")).isEqualTo(row.getProperty("expected").toString());
-    rs.close();
+    try (final ResultSet rs = database.query("sql", "SELECT @rid AS expected, node.id(@this) AS rid FROM Person WHERE name = 'Ada'")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      assertThat(row.<String>getProperty("rid")).isEqualTo(row.getProperty("expected").toString());
+    }
   }
 
   @Test
   void nodeIdFromSql_ridReference() {
-    final ResultSet rs = database.query("sql", "SELECT @rid AS expected, node.id(@rid) AS rid FROM Person WHERE name = 'Ada'");
-    assertThat(rs.hasNext()).isTrue();
-    final Result row = rs.next();
-    assertThat(row.<String>getProperty("rid")).isEqualTo(row.getProperty("expected").toString());
-    rs.close();
+    try (final ResultSet rs = database.query("sql", "SELECT @rid AS expected, node.id(@rid) AS rid FROM Person WHERE name = 'Ada'")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      assertThat(row.<String>getProperty("rid")).isEqualTo(row.getProperty("expected").toString());
+    }
   }
 
   @Test
   void relTypeFromSql_thisReference() {
-    final ResultSet rs = database.query("sql", "SELECT rel.type(@this) AS t FROM Friend");
-    assertThat(rs.hasNext()).isTrue();
-    assertThat(rs.next().<String>getProperty("t")).isEqualTo("Friend");
-    rs.close();
+    try (final ResultSet rs = database.query("sql", "SELECT rel.type(@this) AS t FROM Friend")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<String>getProperty("t")).isEqualTo("Friend");
+    }
   }
 
   @Test
   void relTypeFromSql_ridReference() {
-    final ResultSet rs = database.query("sql", "SELECT rel.type(@rid) AS t FROM Friend");
-    assertThat(rs.hasNext()).isTrue();
-    assertThat(rs.next().<String>getProperty("t")).isEqualTo("Friend");
-    rs.close();
+    try (final ResultSet rs = database.query("sql", "SELECT rel.type(@rid) AS t FROM Friend")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<String>getProperty("t")).isEqualTo("Friend");
+    }
   }
 
   @Test
   void relStartNodeFromSql_thisReference() {
-    final ResultSet rs = database.query("sql", "SELECT rel.startNode(@this) AS src FROM Friend");
-    assertThat(rs.hasNext()).isTrue();
-    while (rs.hasNext()) {
-      final Result row = rs.next();
-      final Vertex src = row.getProperty("src");
-      assertThat(src).isNotNull();
-      assertThat(src.getString("name")).isEqualTo("Ada");
+    try (final ResultSet rs = database.query("sql", "SELECT rel.startNode(@this) AS src FROM Friend")) {
+      assertThat(rs.hasNext()).isTrue();
+      int count = 0;
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        final Vertex src = row.getProperty("src");
+        assertThat(src).isNotNull();
+        assertThat(src.getString("name")).isEqualTo("Ada");
+        count++;
+      }
+      assertThat(count).isEqualTo(2);
     }
-    rs.close();
   }
 
   @Test
   void relEndNodeFromSql_thisReference() {
-    final ResultSet rs = database.query("sql", "SELECT rel.endNode(@this) AS dst FROM Friend");
-    assertThat(rs.hasNext()).isTrue();
-    int count = 0;
-    while (rs.hasNext()) {
-      final Result row = rs.next();
-      final Vertex dst = row.getProperty("dst");
-      assertThat(dst).isNotNull();
-      assertThat(dst.getString("name")).isIn("Bob", "Cara");
-      count++;
+    try (final ResultSet rs = database.query("sql", "SELECT rel.endNode(@this) AS dst FROM Friend")) {
+      assertThat(rs.hasNext()).isTrue();
+      int count = 0;
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        final Vertex dst = row.getProperty("dst");
+        assertThat(dst).isNotNull();
+        assertThat(dst.getString("name")).isIn("Bob", "Cara");
+        count++;
+      }
+      assertThat(count).isEqualTo(2);
     }
-    assertThat(count).isEqualTo(2);
-    rs.close();
   }
 }

--- a/engine/src/test/java/com/arcadedb/function/node/SQLNodeFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/node/SQLNodeFunctionsTest.java
@@ -19,18 +19,15 @@
 package com.arcadedb.function.node;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * Regression tests for node.* and rel.* functions called from SQL.
- * The argument unwrapping in AbstractNodeFunction.toVertex() and
- * AbstractRelFunction.toEdge() must handle SQL-side wrappers (Result,
- * Identifiable, RID) in addition to the bare Vertex/Edge that Cypher passes.
- */
 class SQLNodeFunctionsTest extends TestHelper {
 
   @Override
@@ -47,64 +44,57 @@ class SQLNodeFunctionsTest extends TestHelper {
     });
   }
 
-  // node.degree via @this (SQL row carrier)
   @Test
   void nodeDegreeFromSql_thisReference() {
     final ResultSet rs = database.query("sql", "SELECT name, node.degree(@this, 'Friend') AS d FROM Person WHERE name = 'Ada'");
     assertThat(rs.hasNext()).isTrue();
-    final Result row = rs.next();
-    assertThat(row.<Long>getProperty("d")).isEqualTo(2L);
+    assertThat(rs.next().<Long>getProperty("d")).isEqualTo(2L);
     rs.close();
   }
 
-  // node.degree via @rid (RID - an Identifiable)
   @Test
   void nodeDegreeFromSql_ridReference() {
     final ResultSet rs = database.query("sql", "SELECT name, node.degree(@rid, 'Friend') AS d FROM Person WHERE name = 'Ada'");
     assertThat(rs.hasNext()).isTrue();
-    final Result row = rs.next();
-    assertThat(row.<Long>getProperty("d")).isEqualTo(2L);
+    assertThat(rs.next().<Long>getProperty("d")).isEqualTo(2L);
     rs.close();
   }
 
-  // node.degree via $current (SQL context variable for the current record)
   @Test
   void nodeDegreeFromSql_currentVariable() {
     final ResultSet rs = database.query("sql", "SELECT name, node.degree($current, 'Friend') AS d FROM Person WHERE name = 'Ada'");
     assertThat(rs.hasNext()).isTrue();
-    final Result row = rs.next();
-    assertThat(row.<Long>getProperty("d")).isEqualTo(2L);
+    assertThat(rs.next().<Long>getProperty("d")).isEqualTo(2L);
     rs.close();
   }
 
-  // node.id via @rid - cross-validates that the RID from @rid and node.id agree
-  @Test
-  void nodeIdFromSql_ridReference() {
-    final ResultSet rs = database.query("sql", "SELECT node.id(@rid) AS rid FROM Person WHERE name = 'Ada'");
-    assertThat(rs.hasNext()).isTrue();
-    assertThat(rs.next().<Object>getProperty("rid")).isNotNull();
-    rs.close();
-  }
-
-  // node.labels via @this
   @Test
   void nodeLabelsFromSql_thisReference() {
     final ResultSet rs = database.query("sql", "SELECT node.labels(@this) AS lbl FROM Person WHERE name = 'Ada'");
     assertThat(rs.hasNext()).isTrue();
-    assertThat(rs.next().<Object>getProperty("lbl")).isNotNull();
+    final Collection<String> labels = rs.next().getProperty("lbl");
+    assertThat(labels).contains("Person");
     rs.close();
   }
 
-  // node.id via @this
   @Test
   void nodeIdFromSql_thisReference() {
-    final ResultSet rs = database.query("sql", "SELECT node.id(@this) AS rid FROM Person WHERE name = 'Ada'");
+    final ResultSet rs = database.query("sql", "SELECT @rid AS expected, node.id(@this) AS rid FROM Person WHERE name = 'Ada'");
     assertThat(rs.hasNext()).isTrue();
-    assertThat(rs.next().<Object>getProperty("rid")).isNotNull();
+    final Result row = rs.next();
+    assertThat(row.<String>getProperty("rid")).isEqualTo(row.getProperty("expected").toString());
     rs.close();
   }
 
-  // rel.type via @this when iterating edges
+  @Test
+  void nodeIdFromSql_ridReference() {
+    final ResultSet rs = database.query("sql", "SELECT @rid AS expected, node.id(@rid) AS rid FROM Person WHERE name = 'Ada'");
+    assertThat(rs.hasNext()).isTrue();
+    final Result row = rs.next();
+    assertThat(row.<String>getProperty("rid")).isEqualTo(row.getProperty("expected").toString());
+    rs.close();
+  }
+
   @Test
   void relTypeFromSql_thisReference() {
     final ResultSet rs = database.query("sql", "SELECT rel.type(@this) AS t FROM Friend");
@@ -113,12 +103,40 @@ class SQLNodeFunctionsTest extends TestHelper {
     rs.close();
   }
 
-  // rel.startNode via @this when iterating edges
+  @Test
+  void relTypeFromSql_ridReference() {
+    final ResultSet rs = database.query("sql", "SELECT rel.type(@rid) AS t FROM Friend");
+    assertThat(rs.hasNext()).isTrue();
+    assertThat(rs.next().<String>getProperty("t")).isEqualTo("Friend");
+    rs.close();
+  }
+
   @Test
   void relStartNodeFromSql_thisReference() {
     final ResultSet rs = database.query("sql", "SELECT rel.startNode(@this) AS src FROM Friend");
     assertThat(rs.hasNext()).isTrue();
-    assertThat(rs.next().<Object>getProperty("src")).isNotNull();
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      final Vertex src = row.getProperty("src");
+      assertThat(src).isNotNull();
+      assertThat(src.getString("name")).isEqualTo("Ada");
+    }
+    rs.close();
+  }
+
+  @Test
+  void relEndNodeFromSql_thisReference() {
+    final ResultSet rs = database.query("sql", "SELECT rel.endNode(@this) AS dst FROM Friend");
+    assertThat(rs.hasNext()).isTrue();
+    int count = 0;
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      final Vertex dst = row.getProperty("dst");
+      assertThat(dst).isNotNull();
+      assertThat(dst.getString("name")).isIn("Bob", "Cara");
+      count++;
+    }
+    assertThat(count).isEqualTo(2);
     rs.close();
   }
 }


### PR DESCRIPTION
## Summary

Fixes #4216.

The graph-element extended functions (`node.degree`, `node.id`, `node.labels`, `rel.type`, `rel.startNode`, `rel.endNode`, etc.) silently returned `0L`/`null`/`false` when called from SQL with any standard self-reference (`@this`, `@rid`, `$current`, or table-aliased identifier). They worked correctly from Cypher because Cypher passes a bare `Vertex`/`Edge`; SQL passes `Result`, `Identifiable`, or `RID` wrappers that the argument unwrappers did not handle.

There are two distinct gaps fixed in this PR:

- `AbstractNodeFunction.toVertex()` and `AbstractRelFunction.toEdge()` only accepted `Vertex`/`Edge` or `Document` wrapping one of those. SQL-side `Result`, `Identifiable` (RID), and other wrappers fell through to `return null`, which the functions then turned into `0L`/`null`/`false` - indistinguishable from a legitimate empty answer.
- `SuffixIdentifier.execute(Identifiable, context)` had no `THIS_PROPERTY` (`@this`) case, so `@this` evaluated to null whenever the current record arrived as a raw `Identifiable` rather than via the `Result` overload (which delegates to `RecordAttribute.evaluate` where `@this` is handled).

## Changes

- `AbstractNodeFunction.toVertex()` - add `instanceof Result` branch using `getVertex().orElse(null)`, and `instanceof Identifiable` branch using `getRecord() instanceof Vertex`.
- `AbstractRelFunction.toEdge()` - same pattern with `getEdge()` and `instanceof Edge`.
- `SuffixIdentifier.execute(Identifiable, context)` - add `THIS_PROPERTY` case returning the current record itself, matching the existing handling on the `Result` overload.
- `SQLNodeFunctionsTest` - new regression coverage with 8 cases against the same SQL self-reference forms called out in the issue (`@this`, `@rid`, `$current`) over `node.degree`, `node.id`, `node.labels`, `rel.type`, `rel.startNode`.

A note on multi-dot function names: `node.degree.in`, `node.degree.out`, `node.relationship.exists`, etc. have three-level names, but `asNamespacedFunctionCall()` only resolves two-level names. Those remain non-callable from SQL and are a separate parser-level issue, not addressed here.

## Test plan

- [x] `mvn test -Dtest=SQLNodeFunctionsTest -pl engine` - 8 tests pass.
- [x] `mvn test -Dtest="*SQL*" -pl engine` - 1199 SQL-related tests pass, 0 failures.
- [x] `mvn test -Dtest=CypherBuiltInFunctionsTest -pl engine` - the only failure (`cypherFunctionInstancesAreSameInBothRegistries`) is pre-existing on `main` and unrelated to this change.