### PR TITLE
fix: /api/v1/server?mode=cluster returns no ha section after Raft migration (#4261)

### DIFF
--- a/engine/src/main/java/com/arcadedb/ContextConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/ContextConfiguration.java
@@ -163,6 +163,17 @@ public class ContextConfiguration implements Serializable {
     return v instanceof Boolean b ? b : Boolean.parseBoolean(v.toString());
   }
 
+  /**
+   * Returns {@code true} when HA is implicitly opted-in by a non-blank {@code HA_SERVER_LIST}.
+   * Combined with an explicit {@code HA_ENABLED=true}, this determines whether the Raft plugin
+   * is discovered and started. Kept here as the single source of truth so the {@code server}
+   * and {@code ha-raft} modules stay in sync.
+   */
+  public boolean isHAImplicitlyEnabled() {
+    final String serverList = getValueAsString(GlobalConfiguration.HA_SERVER_LIST);
+    return serverList != null && !serverList.isBlank();
+  }
+
   public String getValueAsString(final String iName, final String iDefaultValue) {
     return getValue(iName, iDefaultValue);
   }

--- a/engine/src/main/java/com/arcadedb/query/QueryEngineManager.java
+++ b/engine/src/main/java/com/arcadedb/query/QueryEngineManager.java
@@ -208,10 +208,6 @@ public class QueryEngineManager {
   }
 
   public List<String> getAvailableLanguages() {
-    final List<String> available = new ArrayList<>();
-    for (final QueryEngine.QueryEngineFactory impl : implementations.values()) {
-      available.add(impl.getLanguage());
-    }
-    return available;
+    return new ArrayList<>(implementations.keySet());
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/QueryEngineManager.java
+++ b/engine/src/main/java/com/arcadedb/query/QueryEngineManager.java
@@ -55,7 +55,7 @@ import java.util.logging.*;
  */
 public class QueryEngineManager {
   private static final QueryEngineManager                         INSTANCE        = new QueryEngineManager();
-  private final        Map<String, QueryEngine.QueryEngineFactory> implementations = new HashMap<>();
+  private final        Map<String, QueryEngine.QueryEngineFactory> implementations = new LinkedHashMap<>();
   private final        ThreadPoolExecutor                          executorService;
   // Per-pool counter the {@link RejectedExecutionHandler} below increments every time the queue
   // saturates and the task falls back to the caller. ThreadPoolExecutor itself doesn't expose

--- a/engine/src/test/java/com/arcadedb/ContextConfigurationTest.java
+++ b/engine/src/test/java/com/arcadedb/ContextConfigurationTest.java
@@ -271,4 +271,21 @@ class ContextConfigurationTest {
     config.setValue(GlobalConfiguration.TX_RETRY_DELAY, 100);
     assertThat(config.getValueAsInteger(GlobalConfiguration.TX_RETRY_DELAY)).isEqualTo(100);
   }
+
+  @Test
+  void haImplicitlyEnabledFalseWhenServerListUnset() {
+    assertThat(config.isHAImplicitlyEnabled()).isFalse();
+  }
+
+  @Test
+  void haImplicitlyEnabledFalseForBlankServerList() {
+    config.setValue(GlobalConfiguration.HA_SERVER_LIST, "   ");
+    assertThat(config.isHAImplicitlyEnabled()).isFalse();
+  }
+
+  @Test
+  void haImplicitlyEnabledTrueForConfiguredServerList() {
+    config.setValue(GlobalConfiguration.HA_SERVER_LIST, "localhost:2434:2480");
+    assertThat(config.isHAImplicitlyEnabled()).isTrue();
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/QueryEngineManagerLanguagesTest.java
+++ b/engine/src/test/java/com/arcadedb/query/QueryEngineManagerLanguagesTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the contract of {@link QueryEngineManager#getAvailableLanguages()}: each registered
+ * language alias appears exactly once. Two entries (e.g. {@code cypher} and {@code opencypher})
+ * may point at the same factory instance, but each alias must still be surfaced as a distinct
+ * entry rather than dropped or duplicated.
+ */
+class QueryEngineManagerLanguagesTest {
+
+  @Test
+  void availableLanguagesHaveNoDuplicates() {
+    final List<String> languages = QueryEngineManager.getInstance().getAvailableLanguages();
+    assertThat(languages).hasSameSizeAs(new HashSet<>(languages));
+  }
+
+  @Test
+  void availableLanguagesIncludeBuiltInEngines() {
+    final List<String> languages = QueryEngineManager.getInstance().getAvailableLanguages();
+    // The four engines registered eagerly in the QueryEngineManager constructor are always
+    // present regardless of which optional engines (opencypher, gremlin, mongo, etc.) are on
+    // the classpath.
+    assertThat(languages).contains("java", "sql", "sqlscript", "js");
+  }
+
+  @Test
+  void availableLanguagesIncludeBothCypherAliasesWhenOpenCypherIsAvailable() {
+    final List<String> languages = QueryEngineManager.getInstance().getAvailableLanguages();
+    // When OpenCypher is on the classpath, both 'opencypher' and 'cypher' alias entries must
+    // surface as distinct list entries so callers can probe either name. The factory instance
+    // behind both keys is the same, but the registration must not collapse them.
+    if (languages.contains("opencypher"))
+      assertThat(languages).contains("cypher");
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/QueryEngineManagerLanguagesTest.java
+++ b/engine/src/test/java/com/arcadedb/query/QueryEngineManagerLanguagesTest.java
@@ -49,12 +49,12 @@ class QueryEngineManagerLanguagesTest {
   }
 
   @Test
-  void availableLanguagesIncludeBothCypherAliasesWhenOpenCypherIsAvailable() {
+  void availableLanguagesIncludeBothCypherAliases() {
     final List<String> languages = QueryEngineManager.getInstance().getAvailableLanguages();
-    // When OpenCypher is on the classpath, both 'opencypher' and 'cypher' alias entries must
-    // surface as distinct list entries so callers can probe either name. The factory instance
-    // behind both keys is the same, but the registration must not collapse them.
-    if (languages.contains("opencypher"))
-      assertThat(languages).contains("cypher");
+    // OpenCypher lives in the engine module so the 'opencypher' factory is always registered.
+    // Both 'opencypher' and 'cypher' aliases must surface as distinct list entries so callers
+    // can probe either name; the factory instance behind both keys is the same, but the
+    // registration must not collapse them.
+    assertThat(languages).contains("opencypher", "cypher");
   }
 }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
@@ -34,7 +34,8 @@ import java.util.logging.Level;
 
 /**
  * ServerPlugin implementation that bootstraps the Raft-based HA subsystem.
- * Discovered via Java ServiceLoader when {@code HA_ENABLED=true}.
+ * Discovered via Java ServiceLoader when either {@code HA_ENABLED=true} or
+ * {@code HA_SERVER_LIST} is non-blank (a configured server list implies HA intent).
  */
 public class RaftHAPlugin implements HAServerPlugin {
 
@@ -272,17 +273,14 @@ public class RaftHAPlugin implements HAServerPlugin {
   }
 
   private boolean isRaftEnabled() {
-    if (configuration == null)
-      return false;
-    if (configuration.getValueAsBoolean(GlobalConfiguration.HA_ENABLED))
-      return true;
-    final String serverList = configuration.getValueAsString(GlobalConfiguration.HA_SERVER_LIST);
-    return serverList != null && !serverList.isEmpty();
+    return configuration != null
+        && (configuration.getValueAsBoolean(GlobalConfiguration.HA_ENABLED)
+            || configuration.isHAImplicitlyEnabled());
   }
 
   private void validateConfiguration() {
     final String serverList = configuration.getValueAsString(GlobalConfiguration.HA_SERVER_LIST);
-    if (serverList == null || serverList.isEmpty())
+    if (serverList == null || serverList.isBlank())
       throw new RuntimeException("HA_SERVER_LIST must be configured for Raft HA");
 
     // Validate quorum early - will throw ConfigurationException for invalid values

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
@@ -272,8 +272,12 @@ public class RaftHAPlugin implements HAServerPlugin {
   }
 
   private boolean isRaftEnabled() {
-    return configuration != null
-        && configuration.getValueAsBoolean(GlobalConfiguration.HA_ENABLED);
+    if (configuration == null)
+      return false;
+    if (configuration.getValueAsBoolean(GlobalConfiguration.HA_ENABLED))
+      return true;
+    final String serverList = configuration.getValueAsString(GlobalConfiguration.HA_SERVER_LIST);
+    return serverList != null && !serverList.isEmpty();
   }
 
   private void validateConfiguration() {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHTTP2ServersIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHTTP2ServersIT.java
@@ -50,6 +50,15 @@ class RaftHTTP2ServersIT extends BaseRaftHATest {
         LogManager.instance().log(this, Level.FINE, "Response: %s", null, response);
         assertThat(connection.getResponseCode()).isEqualTo(200);
         assertThat(connection.getResponseMessage()).isEqualTo("OK");
+
+        final JSONObject parsed = new JSONObject(response);
+        assertThat(parsed.has("ha")).as("?mode=cluster must include 'ha' section when HA is running").isTrue();
+
+        final JSONObject ha = parsed.getJSONObject("ha");
+        assertThat(ha.has("clusterName")).isTrue();
+        assertThat(ha.has("leader")).isTrue();
+        assertThat(ha.has("network")).isTrue();
+        assertThat(ha.getJSONObject("network").has("replicas")).isTrue();
       } finally {
         connection.disconnect();
       }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHTTP2ServersIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHTTP2ServersIT.java
@@ -59,6 +59,9 @@ class RaftHTTP2ServersIT extends BaseRaftHATest {
         assertThat(ha.has("leader")).isTrue();
         assertThat(ha.has("network")).isTrue();
         assertThat(ha.getJSONObject("network").has("replicas")).isTrue();
+        // With Raft, every node knows all peers from the group config, so the replicas array
+        // is populated even on followers without the old leader-forwarding round trip.
+        assertThat(ha.getJSONObject("network").getJSONArray("replicas").length()).isPositive();
       } finally {
         connection.disconnect();
       }

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetServerHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetServerHandler.java
@@ -39,7 +39,6 @@ import io.micrometer.core.instrument.Metrics;
 import io.undertow.server.HttpServerExchange;
 
 import java.io.*;
-import java.net.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.logging.*;
@@ -91,36 +90,6 @@ public class GetServerHandler extends AbstractServerHttpHandler {
       haJSON.put("leader", ha.getLeaderName());
       haJSON.put("electionStatus", ha.getElectionStatus().toString());
       haJSON.put("network", ha.getStats());
-
-      if (!ha.isLeader()) {
-        // ASK TO THE LEADER THE NETWORK COMPOSITION
-        HttpURLConnection connection;
-        try {
-          connection = (HttpURLConnection) new URL(
-              "http://" + ha.getLeaderAddress() + "/api/v1/server?mode=cluster").openConnection();
-        } catch (RuntimeException e) {
-          throw e;
-        } catch (Exception e) {
-          throw new RuntimeException(e);
-        }
-
-        try {
-          connection.setRequestMethod("GET");
-          connection.setRequestProperty("Authorization", exchange.getRequestHeaders().get("Authorization").getFirst());
-          connection.connect();
-
-          JSONObject leaderResponse = new JSONObject(readResponse(connection));
-          final JSONObject network = leaderResponse.getJSONObject("ha").getJSONObject("network");
-          haJSON.getJSONObject("network").put("replicas", network.getJSONArray("replicas"));
-
-        } catch (RuntimeException e) {
-          throw e;
-        } catch (Exception e) {
-          throw new RuntimeException(e);
-        } finally {
-          connection.disconnect();
-        }
-      }
 
       final JSONArray databases = new JSONArray();
 
@@ -256,21 +225,6 @@ public class GetServerHandler extends AbstractServerHttpHandler {
       }
     }
     response.put("settings", settings);
-  }
-
-  private String readResponse(final HttpURLConnection connection) throws IOException {
-    connection.setConnectTimeout(5000);
-    connection.setReadTimeout(5000);
-    final InputStream in = connection.getInputStream();
-    final Scanner scanner = new Scanner(in);
-
-    final StringBuilder buffer = new StringBuilder();
-
-    while (scanner.hasNext()) {
-      buffer.append(scanner.next().replace('\n', ' '));
-    }
-
-    return buffer.toString();
   }
 
   private Object convertValue(final String key, Object value) {

--- a/server/src/main/java/com/arcadedb/server/plugin/PluginManager.java
+++ b/server/src/main/java/com/arcadedb/server/plugin/PluginManager.java
@@ -110,7 +110,10 @@ public class PluginManager {
   }
 
   private boolean isHAEnabled() {
-    return configuration.getValueAsBoolean(GlobalConfiguration.HA_ENABLED);
+    if (configuration.getValueAsBoolean(GlobalConfiguration.HA_ENABLED))
+      return true;
+    final String serverList = configuration.getValueAsString(GlobalConfiguration.HA_SERVER_LIST);
+    return serverList != null && !serverList.isEmpty();
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/plugin/PluginManager.java
+++ b/server/src/main/java/com/arcadedb/server/plugin/PluginManager.java
@@ -110,10 +110,8 @@ public class PluginManager {
   }
 
   private boolean isHAEnabled() {
-    if (configuration.getValueAsBoolean(GlobalConfiguration.HA_ENABLED))
-      return true;
-    final String serverList = configuration.getValueAsString(GlobalConfiguration.HA_SERVER_LIST);
-    return serverList != null && !serverList.isEmpty();
+    return configuration.getValueAsBoolean(GlobalConfiguration.HA_ENABLED)
+        || configuration.isHAImplicitlyEnabled();
   }
 
   /**

--- a/server/src/test/java/com/arcadedb/server/BaseGraphServerTest.java
+++ b/server/src/test/java/com/arcadedb/server/BaseGraphServerTest.java
@@ -299,9 +299,14 @@ public abstract class BaseGraphServerTest extends StaticBaseServerTest {
       final ContextConfiguration config = new ContextConfiguration();
       config.setValue(GlobalConfiguration.SERVER_NAME, Constants.PRODUCT + "_" + i);
       config.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY, "./target/databases" + i);
-      config.setValue(GlobalConfiguration.HA_SERVER_LIST, getServerAddresses());
       config.setValue(GlobalConfiguration.SERVER_HTTP_INCOMING_HOST, "localhost");
-      config.setValue(GlobalConfiguration.HA_ENABLED, getServerCount() > 1);
+      // HA_SERVER_LIST and HA_ENABLED are only meaningful for multi-server tests. Setting the
+      // server list unconditionally would auto-enable HA via ContextConfiguration.isHAImplicitlyEnabled(),
+      // which would start Raft for every single-server test and corrupt their write path.
+      if (getServerCount() > 1) {
+        config.setValue(GlobalConfiguration.HA_SERVER_LIST, getServerAddresses());
+        config.setValue(GlobalConfiguration.HA_ENABLED, true);
+      }
       //config.setValue(GlobalConfiguration.NETWORK_SOCKET_TIMEOUT, 2000);
 
       onServerConfiguration(config);


### PR DESCRIPTION
## Summary

Fixes #4261. After the legacy `HAServer` was replaced by `RaftHAPlugin` (#3731), the `/api/v1/server?mode=cluster` endpoint stopped returning the `ha` section for HA clusters.

- **Root cause (missing `ha` section):** Both `PluginManager.isHAEnabled()` and `RaftHAPlugin.isRaftEnabled()` only checked `HA_ENABLED` (default `false`). Users who configured `HA_SERVER_LIST` but didn't explicitly set `HA_ENABLED=true` got no HA plugin started, so `server.getHA()` returned `null` and the `ha` section was omitted. A non-empty `HA_SERVER_LIST` now implicitly enables HA in both places.

- **Follower forwarding removed:** `GetServerHandler.exportCluster()` used to call back to the leader over HTTP to fetch the replica list. The old HAServer needed this because followers lacked the full peer list; with Raft, every node already has the complete peer list from the group config. The forwarding also crashed with `MalformedURLException` when `getLeaderAddress()` returned `null` during leader election.

- **Duplicate `opencypher` in languages:** `QueryEngineManager.getAvailableLanguages()` iterated `implementations.values().getLanguage()`, but `"cypher"` and `"opencypher"` point at the same `OpenCypherQueryEngineFactory` instance, so `getLanguage()` returned `"opencypher"` twice. Returning `implementations.keySet()` preserves distinct aliases and removes the duplicate.

## Test plan

- [x] `RaftHTTP2ServersIT.serverInfo()` extended with assertions on `ha.clusterName`, `ha.leader`, `ha.network`, and `ha.network.replicas` so the regression cannot return undetected
- [x] `RaftHTTP2ServersIT` (5/5) and `RaftHAPluginTest` (4/4) pass locally
- [x] `HTTPDocumentIT#serverClusterInfo` (single-server, no HA) still passes - `ha` correctly absent
- [x] All `server` module tests pass (81/81)