### PR TITLE
fix: RemoteSchema.reload() crashes when schema contains timeseries types (#4265)

### DIFF
--- a/network/src/main/java/com/arcadedb/remote/RemoteSchema.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteSchema.java
@@ -23,12 +23,12 @@ import com.arcadedb.engine.Component;
 import com.arcadedb.engine.Dictionary;
 import com.arcadedb.engine.LocalBucket;
 import com.arcadedb.exception.SchemaException;
-import com.arcadedb.log.LogManager;
 import com.arcadedb.function.FunctionDefinition;
 import com.arcadedb.function.FunctionLibraryDefinition;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.*;
@@ -37,12 +37,12 @@ import com.arcadedb.serializer.json.JSONObject;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.logging.Level;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 /**
@@ -759,13 +759,14 @@ public class RemoteSchema implements Schema {
           type = new RemoteEdgeType(remoteDatabase, record,
               record.hasProperty("bidirectional") ? (Boolean) record.getProperty("bidirectional") : true);
           break;
-        case "t": // timeseries: represented as document type for remote schema navigation
+        case LocalTimeSeriesType.KIND_CODE: // timeseries: represented as document type for remote schema navigation
           type = new RemoteDocumentType(remoteDatabase, record);
           break;
         default:
           LogManager.instance().log(this, Level.WARNING, "Unknown schema type code '" + record.getProperty("type") + "' for type '"
               + typeName + "' - treating as document type");
           type = new RemoteDocumentType(remoteDatabase, record);
+          break;
         }
       } else
         type.reload(record);

--- a/network/src/main/java/com/arcadedb/remote/RemoteSchema.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteSchema.java
@@ -748,7 +748,11 @@ public class RemoteSchema implements Schema {
       final String typeName = record.getProperty("name");
       RemoteDocumentType type = previous != null ? previous.get(typeName) : null;
       if (type == null) {
-        switch ((String) record.getProperty("type")) {
+        // Type codes here come from FetchFromSchemaTypesStep: full names for document/vertex/edge,
+        // KIND_CODE ("t") for timeseries. The single-char codes from LocalDocumentType.toJSON
+        // ("d"/"v"/"e"/"t") are NOT used on this path.
+        final String typeCode = record.getProperty("type");
+        switch (typeCode) {
         case "document":
           type = new RemoteDocumentType(remoteDatabase, record);
           break;
@@ -763,8 +767,8 @@ public class RemoteSchema implements Schema {
           type = new RemoteDocumentType(remoteDatabase, record);
           break;
         default:
-          LogManager.instance().log(this, Level.WARNING, "Unknown schema type code '" + record.getProperty("type") + "' for type '"
-              + typeName + "' - treating as document type");
+          LogManager.instance().log(this, Level.WARNING,
+              "Unknown schema type code '%s' for type '%s' - treating as document type", typeCode, typeName);
           type = new RemoteDocumentType(remoteDatabase, record);
           break;
         }

--- a/network/src/main/java/com/arcadedb/remote/RemoteSchema.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteSchema.java
@@ -23,6 +23,7 @@ import com.arcadedb.engine.Component;
 import com.arcadedb.engine.Dictionary;
 import com.arcadedb.engine.LocalBucket;
 import com.arcadedb.exception.SchemaException;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.function.FunctionDefinition;
 import com.arcadedb.function.FunctionLibraryDefinition;
 import com.arcadedb.index.Index;
@@ -36,6 +37,7 @@ import com.arcadedb.serializer.json.JSONObject;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.logging.Level;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -757,8 +759,13 @@ public class RemoteSchema implements Schema {
           type = new RemoteEdgeType(remoteDatabase, record,
               record.hasProperty("bidirectional") ? (Boolean) record.getProperty("bidirectional") : true);
           break;
+        case "t": // timeseries: represented as document type for remote schema navigation
+          type = new RemoteDocumentType(remoteDatabase, record);
+          break;
         default:
-          throw new IllegalArgumentException("Unknown record type for " + typeName);
+          LogManager.instance().log(this, Level.WARNING, "Unknown schema type code '" + record.getProperty("type") + "' for type '"
+              + typeName + "' - treating as document type");
+          type = new RemoteDocumentType(remoteDatabase, record);
         }
       } else
         type.reload(record);

--- a/network/src/test/java/com/arcadedb/remote/RemoteSchemaTest.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteSchemaTest.java
@@ -19,17 +19,23 @@
 package com.arcadedb.remote;
 
 import com.arcadedb.engine.Bucket;
+import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.ZoneId;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.TimeZone;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class RemoteSchemaTest {
 
@@ -394,5 +400,66 @@ class RemoteSchemaTest {
   void createTriggerThrowsUnsupported() {
     assertThatThrownBy(() -> schema.createTrigger(null))
         .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  // reload() tests for mixed-schema support (#4265)
+
+  @Test
+  void reloadWithTimeSeriesTypeDoesNotThrow() {
+    final ResultSet rs = buildSchemaResultSet(buildTypeRecord("MySeries", "t"));
+    when(mockDatabase.command("sql", "select from schema:types")).thenReturn(rs);
+
+    schema.reload();
+
+    assertThat(schema.existsType("MySeries")).isTrue();
+    final DocumentType t = schema.getType("MySeries");
+    assertThat(t.getName()).isEqualTo("MySeries");
+  }
+
+  @Test
+  void reloadWithUnknownTypeCodeDoesNotThrow() {
+    final ResultSet rs = buildSchemaResultSet(buildTypeRecord("FutureType", "x"));
+    when(mockDatabase.command("sql", "select from schema:types")).thenReturn(rs);
+
+    schema.reload();
+
+    assertThat(schema.existsType("FutureType")).isTrue();
+  }
+
+  @Test
+  void reloadWithMixedTypesIncludingTimeSeriesLoadsAll() {
+    final ResultSet rs = buildSchemaResultSet(
+        buildTypeRecord("Person", "vertex"),
+        buildTypeRecord("Knows", "edge"),
+        buildTypeRecord("Readings", "t")
+    );
+    when(mockDatabase.command("sql", "select from schema:types")).thenReturn(rs);
+
+    schema.reload();
+
+    assertThat(schema.existsType("Person")).isTrue();
+    assertThat(schema.existsType("Knows")).isTrue();
+    assertThat(schema.existsType("Readings")).isTrue();
+  }
+
+  private static ResultInternal buildTypeRecord(final String name, final String typeCode) {
+    final ResultInternal r = new ResultInternal();
+    r.setProperty("name", name);
+    r.setProperty("type", typeCode);
+    r.setProperty("records", 0L);
+    r.setProperty("buckets", Collections.emptyList());
+    r.setProperty("bucketSelectionStrategy", "round-robin");
+    r.setProperty("parentTypes", Collections.emptyList());
+    r.setProperty("properties", Collections.emptyList());
+    r.setProperty("custom", new HashMap<>());
+    return r;
+  }
+
+  private static ResultSet buildSchemaResultSet(final ResultInternal... records) {
+    final ResultSet rs = mock(ResultSet.class);
+    final int[] idx = { 0 };
+    when(rs.hasNext()).thenAnswer(inv -> idx[0] < records.length);
+    when(rs.next()).thenAnswer(inv -> records[idx[0]++]);
+    return rs;
   }
 }

--- a/network/src/test/java/com/arcadedb/remote/RemoteSchemaTest.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteSchemaTest.java
@@ -402,8 +402,6 @@ class RemoteSchemaTest {
         .isInstanceOf(UnsupportedOperationException.class);
   }
 
-  // reload() tests for mixed-schema support (#4265)
-
   @Test
   void reloadWithTimeSeriesTypeDoesNotThrow() {
     final ResultSet rs = buildSchemaResultSet(buildTypeRecord("MySeries", "t"));


### PR DESCRIPTION
## Summary

- `RemoteSchema.reload()` threw `IllegalArgumentException: Unknown record type for ...` whenever the schema contained any type other than document/vertex/edge (e.g. timeseries), making the remote driver unusable against mixed-model databases.
- Root cause: `FetchFromSchemaTypesStep` emits `"t"` as the type code for timeseries types, but the `reload()` switch only handled `"document"`, `"vertex"`, `"edge"` and threw on anything else.
- Fix: handle `"t"` as a `RemoteDocumentType` (no dedicated `RemoteTimeSeriesType` exists yet) and turn the `default:` branch into a `WARNING` log with the same fallback, so future unknown type codes do not break schema loading.

## Test plan

- [x] New unit tests in `RemoteSchemaTest`:
  - `reloadWithTimeSeriesTypeDoesNotThrow` - verifies `"t"` type code loads without exception
  - `reloadWithUnknownTypeCodeDoesNotThrow` - verifies unknown codes use the safe fallback
  - `reloadWithMixedTypesIncludingTimeSeriesLoadsAll` - verifies vertex + edge + timeseries all load
- [x] Full network module test suite: 359 tests, 0 failures, 0 errors

Closes #4265