### PR TITLE
fix: LSM_VECTOR inactivity rebuild timer never re-armed after skip (#4215)

### DIFF
--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -4870,8 +4870,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
                 }
               } else {
                 LogManager.instance().log(this, Level.INFO,
-                    "Skipping inactivity rebuild for index %s: another rebuild is already in progress",
-                    indexName);
+                    "Skipping inactivity rebuild for index %s: another rebuild is already in progress, will retry in %d ms",
+                    indexName, timeoutMs);
+                scheduleInactivityRebuild();
               }
             }
           }

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -4872,7 +4872,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
                   REBUILD_SEMAPHORE.release();
                 }
               } else {
-                LogManager.instance().log(this, Level.INFO,
+                LogManager.instance().log(this, Level.FINE,
                     "Skipping inactivity rebuild for index %s: another rebuild is already in progress, will retry in %d ms",
                     indexName, timeoutMs);
                 scheduleInactivityRebuild();

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -214,7 +214,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
   private final    AtomicInteger           currentMutablePages;
   private final    int                     minPagesToScheduleACompaction;
   private          LSMVectorIndexCompacted compactedSubIndex;
-  private          boolean                 valid      = true;
+  private volatile boolean                 valid      = true;
   private volatile BUILD_STATE             buildState = BUILD_STATE.READY;
 
   // Page tracking for inserts (avoids getTotalPages() issue with transaction-local pages)

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -4828,7 +4828,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * effectively resetting the inactivity window.
    * When the timer fires, it triggers an async graph rebuild regardless of the mutation count.
    */
-  private void scheduleInactivityRebuild() {
+  private synchronized void scheduleInactivityRebuild() {
+    if (!isValid())
+      return; // Index closed or dropped - no point scheduling
+
     final int timeoutMs = getInactivityRebuildTimeoutMs();
     if (timeoutMs <= 0)
       return; // Disabled
@@ -4859,8 +4862,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
           } else {
             // Small graph: synchronous rebuild on the timer thread.
             // Use tryAcquire to avoid blocking the timer thread indefinitely.
-            // If a large rebuild is already running, skip this small one - the next
-            // inactivity timeout or mutation threshold will pick it up.
+            // If another rebuild holds the permit, re-arm the timer so this index
+            // retries at the next interval rather than staying stuck with pending mutations.
             if (mutationsSinceSerialize.get() > 0) {
               if (REBUILD_SEMAPHORE.tryAcquire()) {
                 try {
@@ -4893,7 +4896,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
   /**
    * Cancel the inactivity rebuild timer if one is scheduled.
    */
-  private void cancelInactivityRebuildTimer() {
+  private synchronized void cancelInactivityRebuildTimer() {
     final java.util.TimerTask task = inactivityRebuildTask;
     if (task != null) {
       task.cancel();

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -4082,7 +4082,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
   @Override
   public void close() {
-    // Cancel inactivity rebuild timer (issue #3737)
+    // Invalidate first so a concurrent timer thread that wins the monitor after
+    // cancelInactivityRebuildTimer() nulls inactivityTimer cannot bypass the isValid()
+    // guard and resurrect a fresh Timer.
+    valid = false;
     cancelInactivityRebuildTimer();
 
     // Shut down the dedicated graph build pool to cancel any in-progress build operations.

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -98,6 +98,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -207,8 +209,8 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
   // Inactivity rebuild timer (issue #3737): when mutations exist but haven't reached the threshold,
   // a timer triggers an async rebuild after a period of inactivity.
-  private volatile java.util.TimerTask inactivityRebuildTask;
-  private volatile java.util.Timer     inactivityTimer;
+  private volatile TimerTask inactivityRebuildTask;
+  private volatile Timer     inactivityTimer;
 
   // Compaction support
   private final    AtomicInteger           currentMutablePages;
@@ -4844,14 +4846,14 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
     // Cancel any previously scheduled task (reset on new mutation) and purge the cancelled
     // entry from the Timer's queue so a high write rate does not let cancelled tasks pile up.
-    final java.util.TimerTask existing = inactivityRebuildTask;
+    final TimerTask existing = inactivityRebuildTask;
     if (existing != null) {
       existing.cancel();
       if (inactivityTimer != null)
         inactivityTimer.purge();
     }
 
-    final java.util.TimerTask task = new java.util.TimerTask() {
+    final TimerTask task = new TimerTask() {
       @Override
       public void run() {
         // Double-check: only rebuild if there are still pending mutations
@@ -4894,7 +4896,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
     inactivityRebuildTask = task;
 
     if (inactivityTimer == null)
-      inactivityTimer = new java.util.Timer("VectorIndex-InactivityTimer-" + indexName, true);
+      inactivityTimer = new Timer("VectorIndex-InactivityTimer-" + indexName, true);
     inactivityTimer.schedule(task, timeoutMs);
   }
 
@@ -4902,12 +4904,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
    * Cancel the inactivity rebuild timer if one is scheduled.
    */
   private synchronized void cancelInactivityRebuildTimer() {
-    final java.util.TimerTask task = inactivityRebuildTask;
+    final TimerTask task = inactivityRebuildTask;
     if (task != null) {
       task.cancel();
       inactivityRebuildTask = null;
     }
-    final java.util.Timer timer = inactivityTimer;
+    final Timer timer = inactivityTimer;
     if (timer != null) {
       timer.cancel();
       inactivityTimer = null;

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -4839,10 +4839,14 @@ public class LSMVectorIndex implements Index, IndexInternal {
     if (mutationsSinceSerialize.get() <= 0)
       return; // Nothing to rebuild
 
-    // Cancel any previously scheduled task (reset on new mutation)
+    // Cancel any previously scheduled task (reset on new mutation) and purge the cancelled
+    // entry from the Timer's queue so a high write rate does not let cancelled tasks pile up.
     final java.util.TimerTask existing = inactivityRebuildTask;
-    if (existing != null)
+    if (existing != null) {
       existing.cancel();
+      if (inactivityTimer != null)
+        inactivityTimer.purge();
+    }
 
     final java.util.TimerTask task = new java.util.TimerTask() {
       @Override
@@ -4864,19 +4868,17 @@ public class LSMVectorIndex implements Index, IndexInternal {
             // Use tryAcquire to avoid blocking the timer thread indefinitely.
             // If another rebuild holds the permit, re-arm the timer so this index
             // retries at the next interval rather than staying stuck with pending mutations.
-            if (mutationsSinceSerialize.get() > 0) {
-              if (REBUILD_SEMAPHORE.tryAcquire()) {
-                try {
-                  buildGraphFromScratch();
-                } finally {
-                  REBUILD_SEMAPHORE.release();
-                }
-              } else {
-                LogManager.instance().log(this, Level.FINE,
-                    "Skipping inactivity rebuild for index %s: another rebuild is already in progress, will retry in %d ms",
-                    indexName, timeoutMs);
-                scheduleInactivityRebuild();
+            if (REBUILD_SEMAPHORE.tryAcquire()) {
+              try {
+                buildGraphFromScratch();
+              } finally {
+                REBUILD_SEMAPHORE.release();
               }
+            } else {
+              LogManager.instance().log(this, Level.FINE,
+                  "Skipping inactivity rebuild for index %s: another rebuild is already in progress, will retry in %d ms",
+                  indexName, timeoutMs);
+              scheduleInactivityRebuild();
             }
           }
         } catch (final Exception e) {

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRebuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRebuildTest.java
@@ -29,9 +29,11 @@ import com.arcadedb.schema.LSMVectorIndexMetadata;
 import com.arcadedb.schema.Type;
 import com.arcadedb.utility.Pair;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -778,11 +780,13 @@ class LSMVectorIndexRebuildTest extends TestHelper {
     assertThat(GlobalConfiguration.VECTOR_INDEX_MAX_CONCURRENT_REBUILDS.getValueAsInteger()).isEqualTo(1);
   }
 
-  // Issue #4215: when the inactivity-rebuild timer fires on a small graph and tryAcquire() fails, the timer must
-  // re-arm itself so the index eventually rebuilds once the semaphore is free (not stuck with pending mutations).
+  // When two small-graph vector indexes share the single-permit rebuild semaphore, the loser of
+  // tryAcquire() must re-arm its inactivity timer so it eventually rebuilds once the winner
+  // releases the permit. Without the re-arm the loser is stuck with pending mutations
+  // indefinitely (no further writes = nothing else to re-arm the timer).
   @Test
   @Tag("slow")
-  void skippedInactivityRebuildShouldRetryUntilServed() throws Exception {
+  void skippedInactivityRebuildShouldRetryUntilServed() {
     final int timeoutMs = 300;
     final int highThreshold = 10_000; // never reached via mutations
 
@@ -822,17 +826,13 @@ class LSMVectorIndexRebuildTest extends TestHelper {
     assertThat(indexA.getStats().get("mutationsSinceRebuild")).isGreaterThan(0L);
     assertThat(indexB.getStats().get("mutationsSinceRebuild")).isGreaterThan(0L);
 
-    // Wait generously: both timers fire near-simultaneously; one acquires REBUILD_SEMAPHORE and
-    // rebuilds, the other is skipped. Without the fix the skipped index stays stuck forever.
-    // With the fix it re-arms and clears its pending mutations in the next timer cycle.
-    Thread.sleep(timeoutMs * 15L);
-
-    assertThat(indexA.getStats().get("mutationsSinceRebuild"))
-        .as("SmallA must have rebuilt all pending mutations after the inactivity timer cycles")
-        .isEqualTo(0L);
-    assertThat(indexB.getStats().get("mutationsSinceRebuild"))
-        .as("SmallB must have rebuilt all pending mutations even if its first timer fire was skipped")
-        .isEqualTo(0L);
+    Awaitility.await("both small-graph indexes drain pending mutations after at least one skip cycle")
+        .atMost(Duration.ofMillis(timeoutMs * 25L))
+        .pollInterval(Duration.ofMillis(50))
+        .untilAsserted(() -> {
+          assertThat(indexA.getStats().get("mutationsSinceRebuild")).isEqualTo(0L);
+          assertThat(indexB.getStats().get("mutationsSinceRebuild")).isEqualTo(0L);
+        });
   }
 
   private float[] generateRandomVector(final Random random) {

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRebuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRebuildTest.java
@@ -29,6 +29,7 @@ import com.arcadedb.schema.LSMVectorIndexMetadata;
 import com.arcadedb.schema.Type;
 import com.arcadedb.utility.Pair;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -775,6 +776,63 @@ class LSMVectorIndexRebuildTest extends TestHelper {
   void rebuildSemaphoreDefaultIsOne() {
     // The default max concurrent rebuilds should be 1
     assertThat(GlobalConfiguration.VECTOR_INDEX_MAX_CONCURRENT_REBUILDS.getValueAsInteger()).isEqualTo(1);
+  }
+
+  // Issue #4215: when the inactivity-rebuild timer fires on a small graph and tryAcquire() fails, the timer must
+  // re-arm itself so the index eventually rebuilds once the semaphore is free (not stuck with pending mutations).
+  @Test
+  @Tag("slow")
+  void skippedInactivityRebuildShouldRetryUntilServed() throws Exception {
+    final int timeoutMs = 300;
+    final int highThreshold = 10_000; // never reached via mutations
+
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_MUTATIONS_BEFORE_REBUILD, highThreshold);
+    database.getConfiguration().setValue(GlobalConfiguration.VECTOR_INDEX_INACTIVITY_REBUILD_TIMEOUT_MS, timeoutMs);
+
+    // Two small-graph indexes on the same database (< ASYNC_REBUILD_MIN_GRAPH_SIZE = 1000 vectors each)
+    database.transaction(() -> {
+      database.getSchema().createVertexType("SmallA");
+      database.getSchema().getType("SmallA").createProperty("vector", Type.ARRAY_OF_FLOATS);
+      database.command("sql", """
+          CREATE INDEX ON SmallA (vector) LSM_VECTOR
+          METADATA {"dimensions": %d, "similarity": "EUCLIDEAN"}""".formatted(EMBEDDING_DIM));
+
+      database.getSchema().createVertexType("SmallB");
+      database.getSchema().getType("SmallB").createProperty("vector", Type.ARRAY_OF_FLOATS);
+      database.command("sql", """
+          CREATE INDEX ON SmallB (vector) LSM_VECTOR
+          METADATA {"dimensions": %d, "similarity": "EUCLIDEAN"}""".formatted(EMBEDDING_DIM));
+    });
+
+    final Random random = new Random(42);
+
+    // Insert into both indexes in one batch so their inactivity timers start at the same time
+    database.transaction(() -> {
+      for (int i = 0; i < 50; i++) {
+        database.command("sql", "INSERT INTO SmallA SET vector = ?", (Object) generateRandomVector(random));
+        database.command("sql", "INSERT INTO SmallB SET vector = ?", (Object) generateRandomVector(random));
+      }
+    });
+
+    final TypeIndex typeIndexA = (TypeIndex) database.getSchema().getIndexByName("SmallA[vector]");
+    final LSMVectorIndex indexA = (LSMVectorIndex) typeIndexA.getIndexesOnBuckets()[0];
+    final TypeIndex typeIndexB = (TypeIndex) database.getSchema().getIndexByName("SmallB[vector]");
+    final LSMVectorIndex indexB = (LSMVectorIndex) typeIndexB.getIndexesOnBuckets()[0];
+
+    assertThat(indexA.getStats().get("mutationsSinceRebuild")).isGreaterThan(0L);
+    assertThat(indexB.getStats().get("mutationsSinceRebuild")).isGreaterThan(0L);
+
+    // Wait generously: both timers fire near-simultaneously; one acquires REBUILD_SEMAPHORE and
+    // rebuilds, the other is skipped. Without the fix the skipped index stays stuck forever.
+    // With the fix it re-arms and clears its pending mutations in the next timer cycle.
+    Thread.sleep(timeoutMs * 15L);
+
+    assertThat(indexA.getStats().get("mutationsSinceRebuild"))
+        .as("SmallA must have rebuilt all pending mutations after the inactivity timer cycles")
+        .isEqualTo(0L);
+    assertThat(indexB.getStats().get("mutationsSinceRebuild"))
+        .as("SmallB must have rebuilt all pending mutations even if its first timer fire was skipped")
+        .isEqualTo(0L);
   }
 
   private float[] generateRandomVector(final Random random) {

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRebuildTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexRebuildTest.java
@@ -826,6 +826,8 @@ class LSMVectorIndexRebuildTest extends TestHelper {
     assertThat(indexA.getStats().get("mutationsSinceRebuild")).isGreaterThan(0L);
     assertThat(indexB.getStats().get("mutationsSinceRebuild")).isGreaterThan(0L);
 
+    // 25x = first timer cycle + retry cycle for the skipped index + two synchronous rebuilds
+    // (well under 1s each at 50 vectors) + slack for GC pauses on loaded CI runners.
     Awaitility.await("both small-graph indexes drain pending mutations after at least one skip cycle")
         .atMost(Duration.ofMillis(timeoutMs * 25L))
         .pollInterval(Duration.ofMillis(50))


### PR DESCRIPTION
## Summary
- Fixes #4215. When a small-graph `LSM_VECTOR` index's inactivity-rebuild timer fired and `REBUILD_SEMAPHORE.tryAcquire()` failed (another rebuild was holding the single permit), the task logged "Skipping..." and terminated without rescheduling itself. Since only `put()`/`putBatch()` re-arm the timer, any index that was skipped during a quiet period stayed stuck with pending mutations indefinitely.
- The fix re-schedules the timer from the skipping branch so the index polls again after `timeoutMs` and rebuilds as soon as the semaphore is free.
- The large-graph path (`startAsyncGraphRebuild`) was unaffected because it starts a background thread that does a blocking `acquire()` and always eventually runs.

## Test plan
- [x] New regression test `LSMVectorIndexRebuildTest#skippedInactivityRebuildShouldRetryUntilServed` creates two small-graph indexes that compete for the single-permit semaphore; without the fix one index stays stuck at 50 pending mutations, with the fix both clear to 0 within ~15x the timeout window.
- [x] Confirmed test fails on the unfixed code and passes after the fix.
- [x] All 155 vector index tests pass with no regressions (`mvn test -pl engine -Dtest="LSMVectorIndex*,VectorUtils*,DeltaScan*,VectorIndex*,GraphRAGTest"`).