### PR TITLE
fix(#4274): getReplicaAddresses excludes localPeer instead of leader

### DIFF
--- a/docs/4274-cluster-topology-consistency.md
+++ b/docs/4274-cluster-topology-consistency.md
@@ -1,0 +1,31 @@
+# Fix #4274: Cluster topology inconsistency across nodes
+
+## Root Cause
+
+`RaftHAServer.getReplicaAddresses()` excluded `localPeerId` (the node serving the HTTP request)
+from the replica list, instead of excluding the **leader**.
+
+On a follower node this caused two anomalies:
+1. The leader appeared inside `replicaAddresses` (it was not the local peer, so it was included).
+2. The follower itself was missing from `replicaAddresses` (it was the local peer, so it was excluded).
+
+The leader node happened to produce the correct view because `localPeerId == leaderId` there.
+
+## Fix
+
+Changed `getReplicaAddresses()` to exclude the leader ID. When no leader is known (election in
+progress), it falls back to excluding `localPeerId` to preserve prior behavior.
+
+File: `ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java`
+
+## Regression Test
+
+Added `clusterTopologyIsConsistentAcrossNodes` to `RaftHTTP2ServersIT`. The test queries every
+node's `?mode=cluster` endpoint and asserts:
+- `leaderAddress` is identical across all responses.
+- `replicaAddresses` does not contain the `leaderAddress` (leader was never a replica).
+- `replicaAddresses` is identical across all responses.
+
+## Test Results
+
+All 6 tests in `RaftHTTP2ServersIT` pass (including the new regression test).

--- a/docs/4274-cluster-topology-consistency.md
+++ b/docs/4274-cluster-topology-consistency.md
@@ -29,3 +29,27 @@ node's `?mode=cluster` endpoint and asserts:
 ## Test Results
 
 All 6 tests in `RaftHTTP2ServersIT` pass (including the new regression test).
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/4280
+
+## Review Cycles
+
+### Cycle 1 - 28c5e7c61
+
+Gemini-code-assist reviewed with one actionable comment:
+
+> `getStats()` has the same `localPeerId` exclusion bug in its `network.replicas` list.
+
+Applied: same `leaderId != null ? leaderId : localPeerId` pattern to `getStats()`.
+Pushed follow-up commit `8edad8077`. All 6 tests pass.
+
+### Cycle 2
+
+Per repo policy, gemini-code-assist does not re-review follow-up commits.
+No claude bot on this repo. Loop exited with **timeout** state - all known feedback addressed.
+
+## Final State
+
+`timeout` - all review items resolved, no bot re-review available.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -681,9 +681,11 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   }
 
   public String getReplicaAddresses() {
+    final RaftPeerId leaderId = getLeaderId();
+    final RaftPeerId excludeId = leaderId != null ? leaderId : localPeerId;
     final StringBuilder sb = new StringBuilder();
     for (final RaftPeer peer : raftGroup.getPeers()) {
-      if (!peer.getId().equals(localPeerId)) {
+      if (!peer.getId().equals(excludeId)) {
         final String httpAddr = httpAddresses.get(peer.getId());
         if (httpAddr != null) {
           if (!sb.isEmpty())

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -664,9 +664,11 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
         stats.put("replicaLags", lags);
     }
 
+    final RaftPeerId statsLeaderId = getLeaderId();
+    final RaftPeerId statsExcludeId = statsLeaderId != null ? statsLeaderId : localPeerId;
     final List<Map<String, String>> replicas = new ArrayList<>();
     for (final RaftPeer peer : raftGroup.getPeers()) {
-      if (!peer.getId().equals(localPeerId)) {
+      if (!peer.getId().equals(statsExcludeId)) {
         final Map<String, String> replicaInfo = new HashMap<>();
         replicaInfo.put("id", peer.getId().toString());
         replicaInfo.put("address", peer.getAddress().toString());

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHTTP2ServersIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHTTP2ServersIT.java
@@ -163,6 +163,50 @@ class RaftHTTP2ServersIT extends BaseRaftHATest {
   }
 
   @Test
+  void clusterTopologyIsConsistentAcrossNodes() throws Exception {
+    // Every node must report the same leaderAddress and the same set of replicaAddresses.
+    // Regression: follower nodes were excluding themselves (localPeerId) from replicaAddresses
+    // instead of excluding the leader, causing the leader to appear inside replicaAddresses
+    // and the follower itself to be missing from the list.
+    String firstLeaderAddress = null;
+    String firstReplicaAddresses = null;
+
+    for (int i = 0; i < getServerCount(); i++) {
+      final HttpURLConnection connection = (HttpURLConnection) new URL(
+          "http://127.0.0.1:" + getServer(i).getHttpServer().getPort() + "/api/v1/server?mode=cluster").openConnection();
+      connection.setRequestMethod("GET");
+      connection.setRequestProperty("Authorization",
+          "Basic " + Base64.getEncoder().encodeToString(("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+      try {
+        connection.connect();
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        final JSONObject parsed = new JSONObject(readResponse(connection));
+        final JSONObject ha = parsed.getJSONObject("ha");
+
+        final String leaderAddress = ha.getString("leaderAddress");
+        final String replicaAddresses = ha.getString("replicaAddresses");
+
+        // The leader must not appear in the replica list
+        assertThat(replicaAddresses).as("server %d: leaderAddress must not appear in replicaAddresses", i)
+            .doesNotContain(leaderAddress);
+
+        // All responses must agree on the same leader
+        if (firstLeaderAddress == null) {
+          firstLeaderAddress = leaderAddress;
+          firstReplicaAddresses = replicaAddresses;
+        } else {
+          assertThat(leaderAddress).as("server %d: leaderAddress must be consistent across all nodes", i)
+              .isEqualTo(firstLeaderAddress);
+          assertThat(replicaAddresses).as("server %d: replicaAddresses must be consistent across all nodes", i)
+              .isEqualTo(firstReplicaAddresses);
+        }
+      } finally {
+        connection.disconnect();
+      }
+    }
+  }
+
+  @Test
   void hAConfiguration() throws Exception {
     // Verify the cluster endpoint reports exactly one leader across both nodes
     int leaderCount = 0;


### PR DESCRIPTION
Closes #4274

## Summary

`RaftHAServer.getReplicaAddresses()` was filtering out `localPeerId` (the node that happens to serve the HTTP request) instead of the Raft leader. On a follower node this caused two anomalies:
- The leader appeared inside `replicaAddresses` (it was not the local peer, so it was included).
- The serving follower was missing from `replicaAddresses` (it was the local peer, so it was excluded).

The leader node produced the correct view only by coincidence, because `localPeerId == leaderId` there.

Fix: exclude the leader ID when known; fall back to `localPeerId` during elections (no leader elected yet) to preserve prior behavior.

## Test plan

- New regression test `clusterTopologyIsConsistentAcrossNodes` in `RaftHTTP2ServersIT`:
  - Queries every node's `?mode=cluster` endpoint
  - Asserts `leaderAddress` is identical across all nodes
  - Asserts `replicaAddresses` does not contain the `leaderAddress`
  - Asserts `replicaAddresses` is identical across all nodes
- All 6 tests in `RaftHTTP2ServersIT` pass locally