### PR TITLE
fix(#4282): resolve Cypher numeric RID as SQL FROM target

### DIFF
--- a/engine/src/main/antlr4/com/arcadedb/query/sql/grammar/SQLParser.g4
+++ b/engine/src/main/antlr4/com/arcadedb/query/sql/grammar/SQLParser.g4
@@ -1099,6 +1099,7 @@ fromClause
 
 fromItem
     : rid (COMMA rid)*                                               # fromRids
+    | integer                                                       # fromCypherRid
     | LBRACKET RBRACKET                                              # fromEmptyArray
     | LBRACKET rid (COMMA rid)* RBRACKET                            # fromRidArray
     | LBRACKET inputParameter (COMMA inputParameter)* RBRACKET      # fromParamArray

--- a/engine/src/main/java/com/arcadedb/function/graph/IdFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/graph/IdFunction.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.function.graph;
 
+import com.arcadedb.database.BasicDatabase;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.CommandExecutionException;
@@ -66,5 +67,13 @@ public class IdFunction implements StatelessFunction {
     final int bucketId = (int) (encoded >>> 32);
     final long offset = encoded & 0xFFFFFFFFL;
     return "#" + bucketId + ":" + offset;
+  }
+
+  /**
+   * Reverses {@link #encodeRidAsLong(RID)} into a native {@link RID}, allowing a Cypher-style numeric id to be resolved back to a record in O(1) via
+   * {@code lookupByRID} (e.g. {@code SELECT FROM :longId}). The bucketId is taken from the upper 32 bits and the offset from the lower 32 bits.
+   */
+  public static RID decodeLongToRid(final BasicDatabase database, final long encoded) {
+    return RID.create(database, (int) (encoded >>> 32), encoded & 0xFFFFFFFFL);
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.sql.antlr;
 
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.engine.timeseries.DownsamplingTier;
+import com.arcadedb.function.graph.IdFunction;
 import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -1578,6 +1579,21 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     for (final SQLParser.RidContext ridCtx : ctx.rid()) {
       fromItem.rids.add((Rid) visit(ridCtx));
     }
+
+    return fromItem;
+  }
+
+  /**
+   * FROM target given as a bare integer literal: it is a Cypher-style id() value (issue #4282). Since the value is a literal constant we decode it back to a
+   * native RID at parse time (#bucketId:offset), reusing the inverse of {@link IdFunction#encodeRidAsLong}.
+   */
+  @Override
+  public FromItem visitFromCypherRid(final SQLParser.FromCypherRidContext ctx) {
+    final FromItem fromItem = new FromItem(-1);
+    fromItem.rids = new ArrayList<>();
+
+    final long encoded = ((PInteger) visit(ctx.integer())).getValue().longValue();
+    fromItem.rids.add(new Rid(IdFunction.decodeLongToRid(null, encoded)));
 
     return fromItem;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -27,6 +27,7 @@ import com.arcadedb.database.bucketselectionstrategy.BucketSelectionStrategy;
 import com.arcadedb.database.bucketselectionstrategy.PartitionedBucketSelectionStrategy;
 import com.arcadedb.schema.LocalDocumentType;
 import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.function.graph.IdFunction;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexInternal;
 import com.arcadedb.index.RangeIndex;
@@ -1396,6 +1397,9 @@ public class SelectExecutionPlanner {
 
     if (paramValue instanceof String string && RID.is(paramValue))
       paramValue = context.getDatabase().newRID(string);
+    else if (paramValue instanceof Number number)
+      // a numeric target is a Cypher-style id() value: decode it back to a native RID so it resolves in O(1) (issue #4282)
+      paramValue = IdFunction.decodeLongToRid(context.getDatabase(), number.longValue());
 
     if (paramValue == null) {
       result.chain(new EmptyStep(context));//nothing to return

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Rid.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Rid.java
@@ -23,6 +23,7 @@ package com.arcadedb.query.sql.parser;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.function.graph.IdFunction;
 import com.arcadedb.query.sql.executor.BasicCommandContext;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -72,6 +73,10 @@ public class Rid extends SimpleNode {
 
       if (result instanceof Identifiable identifiable)
         return identifiable.getIdentity();
+
+      if (result instanceof Number number)
+        // a numeric value is a Cypher-style id(): decode it back to a native RID (issue #4282)
+        return IdFunction.decodeLongToRid(context.getDatabase(), number.longValue());
 
       if (result instanceof String string) {
         if (!(string.startsWith("#") && (string.contains(":"))))

--- a/engine/src/test/java/com/arcadedb/query/sql/Issue4282SelectByCypherRidTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/Issue4282SelectByCypherRidTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4282: a Cypher-style numeric id (the value returned by {@code id()} / {@code .asCypherRID()}) can be passed as the FROM target of
+ * a SQL SELECT and is resolved back to the original record in O(1), exactly like a native {@code #bucketId:offset} RID literal.
+ */
+class Issue4282SelectByCypherRidTest {
+
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory("./target/databases/test-issue4282-" + UUID.randomUUID()).create();
+    database.getSchema().createVertexType("Person");
+
+    database.transaction(() -> {
+      database.newVertex("Person").set("name", "Alice").save();
+      database.newVertex("Person").set("name", "Bob").save();
+      database.newVertex("Person").set("name", "Charlie").save();
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null && database.isOpen())
+      database.drop();
+  }
+
+  @Test
+  void selectFromNamedParameterWithCypherId() {
+    final RID aliceRid = resolveRid("Alice");
+    final long cypherId = cypherId("Alice");
+
+    try (final ResultSet rs = database.query("sql", "SELECT FROM :id LIMIT 1", Map.of("id", cypherId))) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().getIdentity().orElseThrow()).isEqualTo(aliceRid);
+    }
+  }
+
+  @Test
+  void selectFromPositionalParameterWithCypherId() {
+    final RID bobRid = resolveRid("Bob");
+    final long cypherId = cypherId("Bob");
+
+    try (final ResultSet rs = database.query("sql", "SELECT FROM ? LIMIT 1", cypherId)) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().getIdentity().orElseThrow()).isEqualTo(bobRid);
+    }
+  }
+
+  @Test
+  void selectFromBareIntegerLiteralWithCypherId() {
+    final RID aliceRid = resolveRid("Alice");
+    final long cypherId = cypherId("Alice");
+
+    try (final ResultSet rs = database.query("sql", "SELECT FROM " + cypherId + " LIMIT 1")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().getIdentity().orElseThrow()).isEqualTo(aliceRid);
+    }
+  }
+
+  @Test
+  void updateByBareIntegerLiteralWithCypherId() {
+    final RID aliceRid = resolveRid("Alice");
+    final long cypherId = cypherId("Alice");
+
+    database.transaction(() -> {
+      try (final ResultSet rs = database.command("sql",
+          "UPDATE " + cypherId + " SET tag = 'literal' RETURN AFTER @rid")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<RID>getProperty("@rid")).isEqualTo(aliceRid);
+      }
+    });
+
+    try (final ResultSet rs = database.query("sql", "SELECT tag FROM " + cypherId + " LIMIT 1")) {
+      assertThat(rs.next().<String>getProperty("tag")).isEqualTo("literal");
+    }
+  }
+
+  // Non-regression: a bare integer must only be treated as a Cypher RID in a FROM target, never in a normal expression/projection.
+  @Test
+  void bareIntegerInProjectionStaysANumber() {
+    try (final ResultSet rs = database.query("sql", "SELECT 30064771072 AS n, 2 + 3 AS sum")) {
+      assertThat(rs.hasNext()).isTrue();
+      final var row = rs.next();
+      assertThat(row.<Number>getProperty("n").longValue()).isEqualTo(30064771072L);
+      assertThat(row.<Number>getProperty("sum").longValue()).isEqualTo(5L);
+    }
+  }
+
+  // Non-regression: the native RID literal forms (#bucket:offset and legacy bucket:offset) keep working.
+  @Test
+  void nativeRidLiteralFormsStillWork() {
+    final RID aliceRid = resolveRid("Alice");
+
+    try (final ResultSet rs = database.query("sql", "SELECT FROM " + aliceRid + " LIMIT 1")) {
+      assertThat(rs.next().getIdentity().orElseThrow()).isEqualTo(aliceRid);
+    }
+    try (final ResultSet rs = database.query("sql",
+        "SELECT FROM " + aliceRid.getBucketId() + ":" + aliceRid.getPosition() + " LIMIT 1")) {
+      assertThat(rs.next().getIdentity().orElseThrow()).isEqualTo(aliceRid);
+    }
+  }
+
+  @Test
+  void cypherIdRoundTripMatchesCypherIdFunction() {
+    // The id used by SELECT FROM must be the very same value the OpenCypher id() function produces.
+    final long cypherId;
+    try (final ResultSet rs = database.query("opencypher", "MATCH (p:Person {name:'Charlie'}) RETURN id(p) AS ident")) {
+      assertThat(rs.hasNext()).isTrue();
+      cypherId = rs.next().<Number>getProperty("ident").longValue();
+    }
+
+    try (final ResultSet rs = database.query("sql", "SELECT name FROM :id LIMIT 1", Map.of("id", cypherId))) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<String>getProperty("name")).isEqualTo("Charlie");
+    }
+  }
+
+  @Test
+  void updateByCypherIdParameter() {
+    final RID aliceRid = resolveRid("Alice");
+    final long cypherId = cypherId("Alice");
+
+    database.transaction(() -> {
+      try (final ResultSet rs = database.command("sql",
+          "UPDATE :id SET tag = :tag RETURN AFTER @rid", Map.of("id", cypherId, "tag", "updated"))) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat(rs.next().<RID>getProperty("@rid")).isEqualTo(aliceRid);
+      }
+    });
+
+    try (final ResultSet rs = database.query("sql", "SELECT tag FROM :id LIMIT 1", Map.of("id", cypherId))) {
+      assertThat(rs.next().<String>getProperty("tag")).isEqualTo("updated");
+    }
+  }
+
+  @Test
+  void selectFromCypherIdResolvedViaAsCypherRID() {
+    // End-to-end: take the Cypher id produced by the SQL .asCypherRID() method and feed it straight back into a FROM target.
+    final long cypherId;
+    try (final ResultSet rs = database.query("sql", "SELECT @rid.asCypherRID() AS ident FROM Person WHERE name = 'Alice'")) {
+      assertThat(rs.hasNext()).isTrue();
+      cypherId = rs.next().<Number>getProperty("ident").longValue();
+    }
+
+    try (final ResultSet rs = database.query("sql", "SELECT name FROM :id LIMIT 1", Map.of("id", cypherId))) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<String>getProperty("name")).isEqualTo("Alice");
+    }
+  }
+
+  private RID resolveRid(final String name) {
+    try (final ResultSet rs = database.query("sql", "SELECT FROM Person WHERE name = ?", name)) {
+      return ((Vertex) rs.next().getElement().orElseThrow()).getIdentity();
+    }
+  }
+
+  private long cypherId(final String name) {
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (p:Person {name:$n}) RETURN id(p) AS ident", Map.of("n", name))) {
+      return rs.next().<Number>getProperty("ident").longValue();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #4282.

Follow-up to #4269 (`.asCypherRID()` / `id()` returning a Cypher-style numeric RID encoded as `bucketId << 32 | offset`). This PR lets that numeric id be used as the **target of a SQL `SELECT` / `UPDATE` / `DELETE`**, resolving back to the original record in **O(1)** via `lookupByRID`, exactly like a native `#bucketId:offset` RID literal.

Two forms are supported, both decoding back to a native RID through the new `IdFunction.decodeLongToRid` (inverse of `IdFunction.encodeRidAsLong`):

1. **Parameter form** - `SELECT FROM :id LIMIT 1`, positional `SELECT FROM ? LIMIT 1`, `UPDATE :id SET ... RETURN AFTER @rid`. Decoded at execution time in `SelectExecutionPlanner.handleInputParamAsTarget` (Number branch) and `Rid.toRecordId` (Number branch). `UPDATE`/`DELETE` work for free because they delegate target resolution to the same code paths.
2. **Bare integer literal** - `SELECT FROM 30064771072 LIMIT 1`, `UPDATE 30064771072 SET ...`. Added a dedicated `| integer # fromCypherRid` alternative to the `fromItem` grammar rule, decoded at parse time in `SQLASTBuilder.visitFromCypherRid`.

### Why a dedicated `fromItem` alternative (and not extending the `rid` rule)

The `rid` grammar rule is reused inside `expression` (ridLiteral), array selectors, `truncateRecordBody`, and `findReferencesTarget`. Adding a bare-integer alternative to `rid` would make every integer literal in any expression parse as a RID. Isolating it to `fromItem` keeps the change scoped to `FROM`/`UPDATE`/`DELETE` targets only, so a numeric literal in a normal projection/expression still behaves as a number.

## Test plan

New regression test `Issue4282SelectByCypherRidTest` (9 tests, all green), covering:

- [x] `SELECT FROM :id` (named parameter)
- [x] `SELECT FROM ?` (positional parameter)
- [x] `SELECT FROM <bare integer literal>`
- [x] `UPDATE <bare integer literal> SET ... RETURN AFTER @rid`
- [x] `UPDATE :id SET ... RETURN AFTER @rid`
- [x] round-trip with the OpenCypher `id()` function
- [x] end-to-end via the SQL `.asCypherRID()` method
- [x] non-regression: a bare integer in a projection stays a number
- [x] non-regression: native RID literal forms (`#bucket:offset` and legacy `bucket:offset`) keep working

Also re-ran the SQL parser test package and the `SELECT`/`UPDATE`/`DELETE` execution test suites - all green, no ambiguity regressions from the grammar change.