### PR TITLE
fix(#4284): coerce numeric-array parameters to lists in Cypher list operations

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/coll/HeadFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/HeadFunction.java
@@ -21,6 +21,7 @@ package com.arcadedb.function.coll;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.MultiValue;
 
 import java.util.List;
 
@@ -37,10 +38,10 @@ public class HeadFunction implements StatelessFunction {
   public Object execute(final Object[] args, final CommandContext context) {
     if (args.length != 1)
       throw new CommandExecutionException("head() requires exactly one argument");
-    if (args[0] instanceof List) {
-      final List<?> list = (List<?>) args[0];
+    // Accept List/Collection/array (incl. primitive arrays from numeric-array parameters, issue #4284).
+    final List<Object> list = MultiValue.getMultiValueAsList(args[0]);
+    if (list != null)
       return list.isEmpty() ? null : list.get(0);
-    }
     return null;
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/coll/LastFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/LastFunction.java
@@ -21,6 +21,7 @@ package com.arcadedb.function.coll;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.MultiValue;
 
 import java.util.List;
 
@@ -37,10 +38,10 @@ public class LastFunction implements StatelessFunction {
   public Object execute(final Object[] args, final CommandContext context) {
     if (args.length != 1)
       throw new CommandExecutionException("last() requires exactly one argument");
-    if (args[0] instanceof List) {
-      final List<?> list = (List<?>) args[0];
+    // Accept List/Collection/array (incl. primitive arrays from numeric-array parameters, issue #4284).
+    final List<Object> list = MultiValue.getMultiValueAsList(args[0]);
+    if (list != null)
       return list.isEmpty() ? null : list.get(list.size() - 1);
-    }
     return null;
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/coll/TailFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/coll/TailFunction.java
@@ -21,6 +21,7 @@ package com.arcadedb.function.coll;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.MultiValue;
 
 import java.util.Collections;
 import java.util.List;
@@ -40,10 +41,10 @@ public class TailFunction implements StatelessFunction {
       throw new CommandExecutionException("tail() requires exactly one argument");
     if (args[0] == null)
       return null;
-    if (args[0] instanceof List) {
-      final List<?> list = (List<?>) args[0];
+    // Accept List/Collection/array (incl. primitive arrays from numeric-array parameters, issue #4284).
+    final List<Object> list = MultiValue.getMultiValueAsList(args[0]);
+    if (list != null)
       return list.size() <= 1 ? Collections.emptyList() : list.subList(1, list.size());
-    }
     return Collections.emptyList();
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/misc/ReverseFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/misc/ReverseFunction.java
@@ -21,6 +21,7 @@ package com.arcadedb.function.misc;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.MultiValue;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -44,8 +45,10 @@ public class ReverseFunction implements StatelessFunction {
     if (args[0] instanceof String) {
       final String str = (String) args[0];
       return new StringBuilder(str).reverse().toString();
-    } else if (args[0] instanceof List) {
-      final List<?> list = (List<?>) args[0];
+    }
+    // Accept List/Collection/array (incl. primitive arrays from numeric-array parameters, issue #4284).
+    final List<Object> list = MultiValue.getMultiValueAsList(args[0]);
+    if (list != null) {
       final List<Object> reversed = new ArrayList<>(list);
       Collections.reverse(reversed);
       return reversed;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ArithmeticExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ArithmeticExpression.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher.ast;
 
 import com.arcadedb.query.opencypher.temporal.*;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.executor.Result;
 
 import java.time.LocalDate;
@@ -97,22 +98,25 @@ public class ArithmeticExpression implements Expression {
     if (leftValue == null || rightValue == null)
       return null;
 
-    // List concatenation/append for + operator (must be checked before string concatenation)
+    // List concatenation/append for + operator (must be checked before string concatenation).
+    // Coerce List/Collection/array (incl. primitive arrays from numeric-array parameters, issue #4284) to a List.
     if (operator == Operator.ADD) {
-      if (leftValue instanceof List && rightValue instanceof List) {
-        final List<Object> combined = new ArrayList<>((List<?>) leftValue);
-        combined.addAll((List<?>) rightValue);
+      final List<Object> leftList = MultiValue.getMultiValueAsList(leftValue);
+      final List<Object> rightList = MultiValue.getMultiValueAsList(rightValue);
+      if (leftList != null && rightList != null) {
+        final List<Object> combined = new ArrayList<>(leftList);
+        combined.addAll(rightList);
         return combined;
       }
-      if (leftValue instanceof List) {
-        final List<Object> appended = new ArrayList<>((List<?>) leftValue);
+      if (leftList != null) {
+        final List<Object> appended = new ArrayList<>(leftList);
         appended.add(rightValue);
         return appended;
       }
-      if (rightValue instanceof List) {
+      if (rightList != null) {
         final List<Object> prepended = new ArrayList<>();
         prepended.add(leftValue);
-        prepended.addAll((List<?>) rightValue);
+        prepended.addAll(rightList);
         return prepended;
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ComparisonExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ComparisonExpression.java
@@ -23,6 +23,7 @@ import com.arcadedb.function.graph.IdFunction;
 import com.arcadedb.query.opencypher.query.OpenCypherQueryEngine;
 import com.arcadedb.query.opencypher.temporal.CypherTemporalValue;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.executor.Result;
 
 import java.util.List;
@@ -199,10 +200,11 @@ public class ComparisonExpression implements BooleanExpression {
       };
     }
 
-    // List comparison (element-wise with null propagation)
-    if (left instanceof List && right instanceof List) {
-      final List<?> leftList = (List<?>) left;
-      final List<?> rightList = (List<?>) right;
+    // List comparison (element-wise with null propagation).
+    // Coerce List/Collection/array (incl. primitive arrays from numeric-array parameters, issue #4284) to a List.
+    final List<Object> leftList = MultiValue.getMultiValueAsList(left);
+    final List<Object> rightList = MultiValue.getMultiValueAsList(right);
+    if (leftList != null && rightList != null) {
       if (operator == Operator.EQUALS || operator == Operator.NOT_EQUALS) {
         if (leftList.size() != rightList.size())
           return operator == Operator.NOT_EQUALS;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/InExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/InExpression.java
@@ -22,10 +22,10 @@ import com.arcadedb.database.RID;
 import com.arcadedb.function.graph.IdFunction;
 import com.arcadedb.query.opencypher.query.OpenCypherQueryEngine;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.executor.Result;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -73,12 +73,11 @@ public class InExpression implements BooleanExpression {
 
       if (listValue == null)
         return null; // x IN null -> null
-      if (listValue instanceof List)
-        valuesToCheck.addAll((List<?>) listValue);
-      else if (listValue instanceof Collection)
-        valuesToCheck.addAll((Collection<?>) listValue);
-      else
+      // Coerce List/Collection/array (incl. primitive arrays from numeric-array parameters, issue #4284) to a List.
+      final List<Object> coerced = MultiValue.getMultiValueAsList(listValue);
+      if (coerced == null)
         throw new IllegalArgumentException("InvalidArgumentType: IN requires a list on the right side, got " + listValue.getClass().getSimpleName());
+      valuesToCheck.addAll(coerced);
     } else {
       // Multiple expressions (parsed list literal items)
       for (final Expression listItem : list) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ListIndexExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ListIndexExpression.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher.ast;
 import com.arcadedb.database.Document;
 import com.arcadedb.query.opencypher.query.OpenCypherQueryEngine;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.executor.Result;
 
 import java.util.List;
@@ -56,6 +57,9 @@ public class ListIndexExpression implements Expression {
       return null;
     }
 
+    // Coerce List/Collection/array (incl. primitive arrays from numeric-array parameters, issue #4284) to a List.
+    final List<Object> list = MultiValue.getMultiValueAsList(listValue);
+
     // Map/Document property access via bracket notation: map['key']
     if (indexValue instanceof String) {
       final String key = (String) indexValue;
@@ -66,7 +70,7 @@ public class ListIndexExpression implements Expression {
       if (listValue instanceof Result)
         return ((Result) listValue).getProperty(key);
       // List with string index is a type error in Cypher
-      if (listValue instanceof List)
+      if (list != null)
         throw new IllegalArgumentException("List index must be a number, got: String");
       return null;
     }
@@ -77,24 +81,23 @@ public class ListIndexExpression implements Expression {
       index = ((Number) indexValue).intValue();
     else if (indexValue instanceof Double || indexValue instanceof Float) {
       // Float indices are a type error for lists in Cypher
-      if (listValue instanceof List)
+      if (list != null)
         throw new IllegalArgumentException("TypeError: list index must be an integer, got Float");
       index = ((Number) indexValue).intValue();
     } else if (indexValue instanceof Boolean) {
-      if (listValue instanceof List)
+      if (list != null)
         throw new IllegalArgumentException("TypeError: list index must be an integer, got Boolean");
       return null;
     } else if (indexValue instanceof Number)
       index = ((Number) indexValue).intValue();
     else {
-      if (listValue instanceof List)
+      if (list != null)
         throw new IllegalArgumentException("TypeError: list index must be an integer, got " + indexValue.getClass().getSimpleName());
       return null;
     }
 
-    // Handle list types
-    if (listValue instanceof List) {
-      final List<?> list = (List<?>) listValue;
+    // Handle list/array types uniformly
+    if (list != null) {
       if (list.isEmpty()) {
         return null;
       }
@@ -107,23 +110,6 @@ public class ListIndexExpression implements Expression {
       }
 
       return list.get(actualIndex);
-    }
-
-    // Handle array types
-    if (listValue.getClass().isArray()) {
-      final Object[] array = (Object[]) listValue;
-      if (array.length == 0) {
-        return null;
-      }
-
-      // Support negative indices
-      final int actualIndex = index < 0 ? array.length + index : index;
-
-      if (actualIndex < 0 || actualIndex >= array.length) {
-        return null;
-      }
-
-      return array[actualIndex];
     }
 
     // In Cypher, numeric indexing is only valid for lists, not for strings or other types

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ListSliceExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ListSliceExpression.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.ast;
 
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.executor.Result;
 
 import java.util.ArrayList;
@@ -58,9 +59,11 @@ public class ListSliceExpression implements Expression {
     if (listValue == null)
       return null;
 
+    // Coerce List/Collection/array (incl. primitive arrays from numeric-array parameters, issue #4284) to a List.
+    final List<Object> list = MultiValue.getMultiValueAsList(listValue);
     final int size;
-    if (listValue instanceof List)
-      size = ((List<?>) listValue).size();
+    if (list != null)
+      size = list.size();
     else if (listValue instanceof String)
       size = ((String) listValue).length();
     else
@@ -107,8 +110,8 @@ public class ListSliceExpression implements Expression {
       return new ArrayList<>();
     }
 
-    if (listValue instanceof List)
-      return new ArrayList<>(((List<?>) listValue).subList(from, to));
+    if (list != null)
+      return new ArrayList<>(list.subList(from, to));
     else
       return ((String) listValue).substring(from, to);
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/ExpressionEvaluator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/ExpressionEvaluator.java
@@ -36,6 +36,7 @@ import com.arcadedb.query.opencypher.ast.MapExpression;
 import com.arcadedb.query.opencypher.ast.PropertyAccessExpression;
 import com.arcadedb.query.opencypher.ast.VariableExpression;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 
@@ -165,22 +166,25 @@ public class ExpressionEvaluator {
     if (leftValue == null || rightValue == null)
       return null;
 
-    // List concatenation/append for + operator (must be checked before string concatenation)
+    // List concatenation/append for + operator (must be checked before string concatenation).
+    // Coerce List/Collection/array (incl. primitive arrays from numeric-array parameters, issue #4284) to a List.
     if (expression.getOperator() == ArithmeticExpression.Operator.ADD) {
-      if (leftValue instanceof List && rightValue instanceof List) {
-        final List<Object> combined = new ArrayList<>((List<?>) leftValue);
-        combined.addAll((List<?>) rightValue);
+      final List<Object> leftList = MultiValue.getMultiValueAsList(leftValue);
+      final List<Object> rightList = MultiValue.getMultiValueAsList(rightValue);
+      if (leftList != null && rightList != null) {
+        final List<Object> combined = new ArrayList<>(leftList);
+        combined.addAll(rightList);
         return combined;
       }
-      if (leftValue instanceof List) {
-        final List<Object> appended = new ArrayList<>((List<?>) leftValue);
+      if (leftList != null) {
+        final List<Object> appended = new ArrayList<>(leftList);
         appended.add(rightValue);
         return appended;
       }
-      if (rightValue instanceof List) {
+      if (rightList != null) {
         final List<Object> prepended = new ArrayList<>();
         prepended.add(leftValue);
-        prepended.addAll((List<?>) rightValue);
+        prepended.addAll(rightList);
         return prepended;
       }
     }
@@ -360,9 +364,11 @@ public class ExpressionEvaluator {
     if (listValue == null)
       return null;
 
+    // Coerce List/Collection/array (incl. primitive arrays from numeric-array parameters, issue #4284) to a List.
+    final List<Object> list = MultiValue.getMultiValueAsList(listValue);
     final int size;
-    if (listValue instanceof List)
-      size = ((List<?>) listValue).size();
+    if (list != null)
+      size = list.size();
     else if (listValue instanceof String)
       size = ((String) listValue).length();
     else
@@ -394,8 +400,8 @@ public class ExpressionEvaluator {
     if (from >= to)
       return listValue instanceof String ? "" : new ArrayList<>();
 
-    if (listValue instanceof List)
-      return new ArrayList<>(((List<?>) listValue).subList(from, to));
+    if (list != null)
+      return new ArrayList<>(list.subList(from, to));
     return ((String) listValue).substring(from, to);
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/MultiValue.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/MultiValue.java
@@ -799,4 +799,27 @@ public class MultiValue {
     list.add(item);
     return list;
   }
+
+  /**
+   * Coerces a list-like value into a {@link List}. Returns the value itself if it is already a {@link List}, a copy if it is a
+   * {@link Collection}, and a boxed copy if it is an array (including primitive arrays such as {@code long[]} or {@code double[]});
+   * returns {@code null} for any other (scalar) value. Query parameters that are JSON numeric arrays arrive as primitive arrays,
+   * so consumers needing Cypher/SQL list semantics use this to treat them uniformly.
+   */
+  public static List<Object> getMultiValueAsList(final Object iObject) {
+    if (iObject == null)
+      return null;
+    if (iObject instanceof List)
+      return (List<Object>) iObject;
+    if (iObject instanceof Collection)
+      return new ArrayList<>((Collection<Object>) iObject);
+    if (iObject.getClass().isArray()) {
+      final int length = Array.getLength(iObject);
+      final List<Object> list = new ArrayList<>(length);
+      for (int i = 0; i < length; i++)
+        list.add(Array.get(iObject, i));
+      return list;
+    }
+    return null;
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherArrayParameterTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherArrayParameterTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #4284: query parameters that are JSON numeric arrays arrive in the engine
+ * as Java primitive arrays ({@code long[]}, {@code int[]}, {@code double[]}) rather than {@link List}.
+ * Cypher list operations (IN, indexing, slicing, head/tail/last/reverse/size, concatenation, equality)
+ * must treat these arrays as lists instead of failing.
+ */
+class CypherArrayParameterTest {
+  private static final String DB_PATH = "./target/testarrayparams";
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    database = new DatabaseFactory(DB_PATH).create();
+    database.getSchema().getOrCreateVertexType("Item");
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (n:Item {val: 10})");
+      database.command("opencypher", "CREATE (n:Item {val: 20})");
+      database.command("opencypher", "CREATE (n:Item {val: 30})");
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null && database.isOpen())
+      database.drop();
+    FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+  /**
+   * Exact reproduction of issue #4284: collect the integer-encoded RIDs from id(), pass them back as a
+   * long[] parameter, and filter with {@code ID(n) IN $ids}.
+   */
+  @Test
+  void idInLongArrayParameter() {
+    final List<Long> idList = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", "MATCH (n:Item) RETURN ID(n) AS id")) {
+      while (rs.hasNext())
+        idList.add(((Number) rs.next().getProperty("id")).longValue());
+    }
+    assertThat(idList).hasSize(3);
+
+    final long[] ids = new long[idList.size()];
+    for (int i = 0; i < ids.length; i++)
+      ids[i] = idList.get(i);
+
+    int count = 0;
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (n:Item) WHERE ID(n) IN $ids RETURN n.val AS val, ID(n) AS id", Map.of("ids", ids))) {
+      while (rs.hasNext()) {
+        rs.next();
+        count++;
+      }
+    }
+    assertThat(count).isEqualTo(3);
+  }
+
+  @Test
+  void inOperatorWithLongArrayParameter() {
+    assertThat(matchValuesIn(new long[] { 10, 30 })).containsExactlyInAnyOrder(10L, 30L);
+  }
+
+  @Test
+  void inOperatorWithIntArrayParameter() {
+    assertThat(matchValuesIn(new int[] { 10, 30 })).containsExactlyInAnyOrder(10L, 30L);
+  }
+
+  @Test
+  void inOperatorWithDoubleArrayParameter() {
+    assertThat(matchValuesIn(new double[] { 10.0, 30.0 })).containsExactlyInAnyOrder(10L, 30L);
+  }
+
+  @Test
+  void inOperatorWithObjectArrayParameter() {
+    assertThat(matchValuesIn(new Object[] { 10, 30 })).containsExactlyInAnyOrder(10L, 30L);
+  }
+
+  @Test
+  void listFunctionsWithLongArrayParameter() {
+    final Map<String, Object> params = Map.of("list", new long[] { 1, 2, 3 });
+    try (final ResultSet rs = database.query("opencypher",
+        "RETURN head($list) AS h, last($list) AS l, size($list) AS s, tail($list) AS t, reverse($list) AS r", params)) {
+      final Result row = rs.next();
+      assertThat(((Number) row.getProperty("h")).longValue()).isEqualTo(1L);
+      assertThat(((Number) row.getProperty("l")).longValue()).isEqualTo(3L);
+      assertThat(((Number) row.getProperty("s")).longValue()).isEqualTo(3L);
+      assertThat(asLongList(row.getProperty("t"))).containsExactly(2L, 3L);
+      assertThat(asLongList(row.getProperty("r"))).containsExactly(3L, 2L, 1L);
+    }
+  }
+
+  @Test
+  void indexingWithLongArrayParameter() {
+    final Map<String, Object> params = Map.of("list", new long[] { 1, 2, 3 });
+    try (final ResultSet rs = database.query("opencypher", "RETURN $list[0] AS first, $list[-1] AS lastEl", params)) {
+      final Result row = rs.next();
+      assertThat(((Number) row.getProperty("first")).longValue()).isEqualTo(1L);
+      assertThat(((Number) row.getProperty("lastEl")).longValue()).isEqualTo(3L);
+    }
+  }
+
+  @Test
+  void slicingWithLongArrayParameter() {
+    final Map<String, Object> params = Map.of("list", new long[] { 1, 2, 3, 4 });
+    try (final ResultSet rs = database.query("opencypher", "RETURN $list[1..3] AS slice", params)) {
+      assertThat(asLongList(rs.next().getProperty("slice"))).containsExactly(2L, 3L);
+    }
+  }
+
+  @Test
+  void concatenationWithLongArrayParameter() {
+    final Map<String, Object> params = Map.of("list", new long[] { 1, 2, 3 });
+    try (final ResultSet rs = database.query("opencypher", "RETURN $list + 4 AS c", params)) {
+      assertThat(asLongList(rs.next().getProperty("c"))).containsExactly(1L, 2L, 3L, 4L);
+    }
+  }
+
+  @Test
+  void equalityWithLongArrayParameter() {
+    final Map<String, Object> params = Map.of("list", new long[] { 1, 2, 3 });
+    try (final ResultSet rs = database.query("opencypher", "RETURN $list = [1, 2, 3] AS eq, $list = [1, 2] AS neq", params)) {
+      final Result row = rs.next();
+      assertThat((Boolean) row.getProperty("eq")).isTrue();
+      assertThat((Boolean) row.getProperty("neq")).isFalse();
+    }
+  }
+
+  private List<Long> matchValuesIn(final Object arrayParam) {
+    final List<Long> values = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (n:Item) WHERE n.val IN $vals RETURN n.val AS val", Map.of("vals", arrayParam))) {
+      while (rs.hasNext())
+        values.add(((Number) rs.next().getProperty("val")).longValue());
+    }
+    return values;
+  }
+
+  private static List<Long> asLongList(final Object value) {
+    final List<?> source = (List<?>) value;
+    final List<Long> result = new ArrayList<>(source.size());
+    for (final Object o : source)
+      result.add(((Number) o).longValue());
+    return result;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #4284.

JSON numeric-array query parameters (e.g. `$ids = [1, 2, 3]`) arrive in the engine as Java **primitive arrays** (`long[]`, `int[]`, `double[]`) rather than `java.util.List`, because `JSONArray` packs numeric arrays via `toPrimitiveNumericArrayOrNull` (an optimization tied to vector embeddings, #3864). Cypher list operations that only checked `instanceof List`/`Collection` then failed or crashed:

- `MATCH (n:CHUNK) WHERE ID(n) IN $ids RETURN ...` -> `InvalidArgumentType: IN requires a list on the right side, got long[]`
- `$list[0]` -> `ClassCastException` from a `(Object[])` cast on a primitive array

This only surfaced via the JSON/HTTP/driver path: the in-process Java API passes a real `List` in the parameter map, so existing tests never exercised the primitive-array form. It became common because `id()` now returns an integer-encoded RID, making `WHERE ID(n) IN $ids` (with `$ids` a numeric array) a frequent pattern.

A blanket normalization of array params to `List` at the binding layer is not viable because vector functions legitimately need `float[]`/`double[]`, so the fix coerces at each list consumer instead (matching the existing per-consumer pattern already used by `UnwindStep`, `SizeFunction`, etc.).

## Changes

- Add `MultiValue.getMultiValueAsList(Object)` as the canonical coercion: `List` / `Collection` / array (incl. primitive arrays) -> `List`, else `null`.
- Route every list consumer through it, on **both** the AST classes and the duplicated `ExpressionEvaluator` execution path:
  - `IN` operator (`InExpression`)
  - list indexing (`ListIndexExpression`) and slicing (`ListSliceExpression`)
  - `head` / `tail` / `last` / `reverse` collection functions
  - list equality/ordering (`ComparisonExpression`)
  - list concatenation with `+` (`ArithmeticExpression`, `ExpressionEvaluator`)
  - arithmetic / slice in `ExpressionEvaluator`

## Test plan

- [x] New `CypherArrayParameterTest` (10 cases): exact issue repro (`ID(n) IN $ids` round-trip) plus IN / indexing / slicing / head-tail-last-reverse-size / concatenation / equality with `long[]`, `int[]`, `double[]`, `Object[]` parameters.
- [x] Related Cypher suites pass (expression, function, list-predicate, slicing, comparison, parameter, subquery tests).

> Note: implemented with the help of AI (Claude).