### PR TITLE
feat(ci): auto-label issues from GitHub Sponsors as high_priority

### DIFF
--- a/.github/workflows/sponsor-priority.yml
+++ b/.github/workflows/sponsor-priority.yml
@@ -111,7 +111,7 @@ jobs:
             }
 
             if (dryRun) {
-              audit(true, "labeled");
+              audit(true, "dry_run");
               return;
             }
 

--- a/.github/workflows/sponsor-priority.yml
+++ b/.github/workflows/sponsor-priority.yml
@@ -25,6 +25,137 @@ jobs:
     steps:
       - name: Evaluate sponsorship and label
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          SPONSORABLE_LOGIN: ArcadeData
+          LABEL_NAME: high_priority
+          LABEL_COLOR: B60205
+          LABEL_DESCRIPTION: Issue opened by a GitHub Sponsor of ArcadeData
         with:
           script: |
-            core.info("sponsor-priority: scaffold reached, no-op");
+            const sponsorable = process.env.SPONSORABLE_LOGIN;
+            const labelName = process.env.LABEL_NAME;
+            const labelColor = process.env.LABEL_COLOR;
+            const labelDescription = process.env.LABEL_DESCRIPTION;
+
+            // Resolve the target issue. For issues events, use the payload directly.
+            // For workflow_dispatch, fetch the issue specified by the input.
+            let issue;
+            let dryRun = false;
+            if (context.eventName === "workflow_dispatch") {
+              dryRun = context.payload.inputs.dry_run !== "false";
+              const issueNumber = Number(context.payload.inputs.issue_number);
+              try {
+                const { data } = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                });
+                issue = data;
+              } catch (err) {
+                core.warning(`sponsor-priority: dispatch issues.get failed: ${err.message}`);
+                core.info(
+                  `sponsor-priority: issue_number=${context.payload.inputs.issue_number}, ` +
+                  `isSponsor=unknown, action=errored` +
+                  (dryRun ? " (dry_run)" : "")
+                );
+                return;
+              }
+            } else {
+              issue = context.payload.issue;
+            }
+
+            const login = issue.user.login;
+            const userType = issue.user.type;
+            const association = issue.author_association;
+
+            const audit = (isSponsor, action) => {
+              core.info(
+                `sponsor-priority: user=${login}, association=${association}, ` +
+                `isSponsor=${isSponsor}, action=${action}` +
+                (dryRun ? " (dry_run)" : "")
+              );
+            };
+
+            // Skip bots and internal contributors before any external call.
+            const isBot = userType === "Bot" || login.endsWith("[bot]");
+            const isInternal =
+              association === "OWNER" ||
+              association === "MEMBER" ||
+              association === "COLLABORATOR";
+            if (isBot || isInternal) {
+              audit("n/a", "skipped");
+              return;
+            }
+
+            // Probe sponsorship.
+            let isSponsor = null;
+            try {
+              const result = await github.graphql(
+                `query($login: String!, $sponsorable: String!) {
+                   organization(login: $sponsorable) {
+                     isSponsoredBy(accountLogin: $login)
+                   }
+                 }`,
+                { login, sponsorable }
+              );
+              isSponsor = Boolean(result?.organization?.isSponsoredBy);
+            } catch (err) {
+              core.warning(`sponsor-priority: graphql failed: ${err.message}`);
+              audit("unknown", "errored");
+              return;
+            }
+
+            if (!isSponsor) {
+              audit(false, "skipped");
+              return;
+            }
+
+            if (dryRun) {
+              audit(true, "labeled");
+              return;
+            }
+
+            // Ensure the label exists, then apply it.
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: labelName,
+              });
+            } catch (err) {
+              if (err.status === 404) {
+                try {
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: labelName,
+                    color: labelColor,
+                    description: labelDescription,
+                  });
+                } catch (createErr) {
+                  // 422 = lost the race to a concurrent run; the label now exists, fall through.
+                  if (createErr.status !== 422) {
+                    core.warning(`sponsor-priority: createLabel failed: ${createErr.message}`);
+                    audit(true, "errored");
+                    return;
+                  }
+                }
+              } else {
+                core.warning(`sponsor-priority: getLabel failed: ${err.message}`);
+                audit(true, "errored");
+                return;
+              }
+            }
+
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: [labelName],
+              });
+              audit(true, "labeled");
+            } catch (err) {
+              core.warning(`sponsor-priority: addLabels failed: ${err.message}`);
+              audit(true, "errored");
+            }

--- a/.github/workflows/sponsor-priority.yml
+++ b/.github/workflows/sponsor-priority.yml
@@ -1,0 +1,30 @@
+name: Sponsor Priority Label
+
+on:
+  issues:
+    types: [opened, reopened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to evaluate (manual dry-run)"
+        required: true
+        type: number
+      dry_run:
+        description: "If true, log the decision without applying the label"
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  label-sponsor-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate sponsorship and label
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            core.info("sponsor-priority: scaffold reached, no-op");

--- a/.github/workflows/sponsor-priority.yml
+++ b/.github/workflows/sponsor-priority.yml
@@ -28,6 +28,7 @@ jobs:
         env:
           SPONSORABLE_LOGIN: ArcadeData
           LABEL_NAME: high_priority
+          # 6-char hex without the leading '#'; that's the form the REST labels API expects.
           LABEL_COLOR: B60205
           LABEL_DESCRIPTION: Issue opened by a GitHub Sponsor of ArcadeData
         with:
@@ -52,6 +53,8 @@ jobs:
                 });
                 issue = data;
               } catch (err) {
+                // audit() needs the issue user/association; on dispatch fetch failure we don't
+                // have those yet, so emit a substitute info line keyed by issue_number instead.
                 core.warning(`sponsor-priority: dispatch issues.get failed: ${err.message}`);
                 core.info(
                   `sponsor-priority: issue_number=${context.payload.inputs.issue_number}, ` +


### PR DESCRIPTION
## Summary

- New workflow `.github/workflows/sponsor-priority.yml` that auto-applies the `high_priority` label to issues opened (or reopened) by a current GitHub Sponsor of the `ArcadeData` organization.
- Uses the default `GITHUB_TOKEN` and a single `actions/github-script@v9` step probing `Organization.isSponsoredBy(...)` via GraphQL. The `high_priority` label is auto-created on first use (color `#B60205`).
- Every external call is wrapped in try/catch with `core.warning` + a single `core.info` audit line per run; the workflow never blocks issue creation.

## Behavior at a glance

- Skips bot accounts and internal contributors (`OWNER` / `MEMBER` / `COLLABORATOR`) before any API call.
- Tolerates the `createLabel` 422 race from concurrent runs and falls through to `addLabels`.
- `workflow_dispatch` trigger accepts `issue_number` and `dry_run` (default `true`) for manual smoke tests; the dispatch path is also wrapped in try/catch.
- Audit log line format: `sponsor-priority: user=<login>, association=<assoc>, isSponsor=<true|false|unknown>, action=<labeled|skipped|errored|dry_run>` with a `(dry_run)` suffix for manual dispatches.

## Known risk to watch after merge

`GITHUB_TOKEN` is not documented to grant read access to GitHub Sponsors data. If the first organic runs show `core.warning: sponsor-priority: graphql failed: ...` lines, the mitigation is to provision a fine-grained PAT (`SPONSORS_READ_TOKEN`) with the org sponsorships:read permission and pass it to `actions/github-script` via `github-token:`. The script body does not change.

## Test plan

- [ ] Merge to `main` and confirm the workflow appears under Actions.
- [ ] Manually trigger via `workflow_dispatch` with `issue_number` set to any open issue and `dry_run: true`. Confirm a `core.info` audit line is emitted and no label is applied.
- [ ] If a sponsor can be identified, dispatch against one of their open issues with `dry_run: true` and confirm `isSponsor=true, action=dry_run`.
- [ ] Let the workflow start firing on real `issues.opened` events; monitor the first ~5 runs for `core.warning` lines (graphql scope failures). Pivot to PAT mitigation if observed.