### PR TITLE
fix(test): target leader for create-user in UserSeedOnPeerAddScenarioIT

### DIFF
--- a/e2e-ha/src/test/java/com/arcadedb/containers/ha/SplitBrainIT.java
+++ b/e2e-ha/src/test/java/com/arcadedb/containers/ha/SplitBrainIT.java
@@ -48,7 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * new leader and accept writes. This eliminates the possibility of divergent data.
  */
 @Testcontainers
-class   SplitBrainIT extends ContainersTestTemplate {
+class SplitBrainIT extends ContainersTestTemplate {
 
   private static final String SERVER_LIST = "arcadedb-0:2434:2480,arcadedb-1:2434:2480,arcadedb-2:2434:2480";
 
@@ -421,7 +421,8 @@ class   SplitBrainIT extends ContainersTestTemplate {
 
       // Wait for Raft to elect a leader with the restarted node in the cluster
       // before starting the convergence check.
-      assertThat(waitForRaftLeader(servers, 60)).as("Cycle %d: Raft leader must be elected before convergence check", cycle).isGreaterThanOrEqualTo(0);
+      assertThat(waitForRaftLeader(servers, 60)).as("Cycle %d: Raft leader must be elected before convergence check", cycle)
+          .isGreaterThanOrEqualTo(0);
 
       final int currentCycle = cycle;
       logger.info("Cycle {}: Verifying convergence to {} users", cycle, cycleLeaderCount);

--- a/e2e-ha/src/test/java/com/arcadedb/containers/ha/UserSeedOnPeerAddScenarioIT.java
+++ b/e2e-ha/src/test/java/com/arcadedb/containers/ha/UserSeedOnPeerAddScenarioIT.java
@@ -64,15 +64,17 @@ class UserSeedOnPeerAddScenarioIT extends ContainersTestTemplate {
     createArcadeContainer("arcadedb-2", SERVER_LIST, "majority", network);
 
     logger.info("Starting cluster");
-    final List<ServerWrapper> servers = startCluster();
+    final List<ServerWrapper> servers = startContainers();
+    final int leaderIdx = waitForRaftLeader(servers, 60);
+    assertThat(leaderIdx).as("Raft leader index").isGreaterThanOrEqualTo(0);
 
     // Step A: create alice on the leader
     final JSONObject alice = new JSONObject()
         .put("name", "alice")
         .put("password", ALICE_PASSWORD)
         .put("databases", new JSONObject().put("*", new JSONArray().put("admin")));
-    logger.info("Creating user alice on leader");
-    final int createStatus = postServerCommand(servers.get(0), "create user " + alice, "root", PASSWORD, 30_000);
+    logger.info("Creating user alice on leader (node {})", leaderIdx);
+    final int createStatus = postServerCommand(servers.get(leaderIdx), "create user " + alice, "root", PASSWORD, 30_000);
     assertThat(createStatus).as("create user HTTP status").isEqualTo(200);
 
     // Step B: verify alice login works on all three nodes
@@ -90,7 +92,7 @@ class UserSeedOnPeerAddScenarioIT extends ContainersTestTemplate {
     // unreliable here: a duplicate peer ID causes Ratis to reject setConfiguration with a 500,
     // and a bogus peer ID triggers a 90-second Raft retry loop before failing.
     logger.info("POSTing peer-add with empty peerId (validation smoke test)");
-    final int peerAddStatus = postPeerAdd(servers.get(0), "", "", 10_000);
+    final int peerAddStatus = postPeerAdd(servers.get(leaderIdx), "", "", 10_000);
     logger.info("peer-add returned HTTP {} (expected: 400)", peerAddStatus);
     assertThat(peerAddStatus)
         .as("peer-add endpoint should return 400 for missing required fields")

--- a/engine/src/main/java/com/arcadedb/database/LocalTransactionExplicitLock.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalTransactionExplicitLock.java
@@ -20,11 +20,14 @@
 package com.arcadedb.database;
 
 import com.arcadedb.engine.Bucket;
+import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.index.IndexInternal;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.utility.IntHashSet;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Level;
 
 /**
@@ -33,8 +36,16 @@ import java.util.logging.Level;
  * @author Luca Garulli (l.garulli--(at)--arcadedata.com)
  */
 public class LocalTransactionExplicitLock implements TransactionExplicitLock {
+  // Bounded internal retry budget for the snapshot-vs-lock race against compaction-induced
+  // file migration. Safe to retry here because no transaction modifications exist when lock()
+  // runs, so each attempt is cheap (no rollback, no page reload). Converges in microseconds
+  // instead of burning user-level COMMIT RETRY attempts that incur full BEGIN+...+COMMIT cost.
+  private static final int MAX_INTERNAL_RETRIES = 50;
+
   private final TransactionContext transactionContext;
   private final IntHashSet         filesToLock = new IntHashSet();
+  private final List<String>       typeNames   = new ArrayList<>();
+  private final List<String>       bucketNames = new ArrayList<>();
 
   public LocalTransactionExplicitLock(final TransactionContext transactionContext) {
     this.transactionContext = transactionContext;
@@ -42,6 +53,44 @@ public class LocalTransactionExplicitLock implements TransactionExplicitLock {
 
   @Override
   public LocalTransactionExplicitLock bucket(final String bucketName) {
+    bucketNames.add(bucketName);
+    collectBucketFileIds(bucketName);
+    return this;
+  }
+
+  @Override
+  public LocalTransactionExplicitLock type(final String typeName) {
+    typeNames.add(typeName);
+    collectTypeFileIds(typeName);
+    return this;
+  }
+
+  @Override
+  public void lock() {
+    ConcurrentModificationException last = null;
+    for (int attempt = 0; attempt < MAX_INTERNAL_RETRIES; attempt++) {
+      try {
+        transactionContext.explicitLock(filesToLock);
+        return;
+      } catch (final ConcurrentModificationException e) {
+        // A compaction migrated one of the snapshotted file IDs between collection and lock check.
+        // Re-resolve and try again; the new file ID is visible via mutable.getFileId() after splitIndex swap.
+        last = e;
+        refreshFileIds();
+      }
+    }
+    throw last;
+  }
+
+  private void refreshFileIds() {
+    filesToLock.clear();
+    for (final String b : bucketNames)
+      collectBucketFileIds(b);
+    for (final String t : typeNames)
+      collectTypeFileIds(t);
+  }
+
+  private void collectBucketFileIds(final String bucketName) {
     final Bucket bucket = transactionContext.getDatabase().getSchema().getBucketByName(bucketName);
     addNonNegative(bucket.getFileId());
     final DocumentType associatedType = transactionContext.getDatabase().getSchema().getInvolvedTypeByBucketId(bucket.getFileId());
@@ -49,12 +98,9 @@ public class LocalTransactionExplicitLock implements TransactionExplicitLock {
       for (final var typeIndex : associatedType.getAllIndexes(true))
         for (final IndexInternal idx : typeIndex.getIndexesOnBuckets())
           addNonNegative(idx.getFileId());
-
-    return this;
   }
 
-  @Override
-  public LocalTransactionExplicitLock type(final String typeName) {
+  private void collectTypeFileIds(final String typeName) {
     final DocumentType type = transactionContext.getDatabase().getSchema().getType(typeName);
 
     // Lock all indexes for this type
@@ -74,13 +120,6 @@ public class LocalTransactionExplicitLock implements TransactionExplicitLock {
     LogManager.instance().log(this, Level.FINE,
       "Explicit lock for type '%s' will lock %d bucket files (threadId=%d)",
       typeName, filesToLock.size(), Thread.currentThread().threadId());
-
-    return this;
-  }
-
-  @Override
-  public void lock() {
-    transactionContext.explicitLock(filesToLock);
   }
 
   private void addNonNegative(final int fileId) {

--- a/engine/src/main/java/com/arcadedb/database/LocalTransactionExplicitLock.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalTransactionExplicitLock.java
@@ -40,7 +40,9 @@ public class LocalTransactionExplicitLock implements TransactionExplicitLock {
   // file migration. Safe to retry here because no transaction modifications exist when lock()
   // runs, so each attempt is cheap (no rollback, no page reload). Converges in microseconds
   // instead of burning user-level COMMIT RETRY attempts that incur full BEGIN+...+COMMIT cost.
-  private static final int MAX_INTERNAL_RETRIES = 50;
+  // Sized for the worst legitimate case (concurrent compactions across all indexes of a
+  // multi-indexed type); persistent retry exhaustion past this signals a real concurrency bug.
+  private static final int MAX_INTERNAL_RETRIES = 10;
 
   private final TransactionContext transactionContext;
   private final IntHashSet         filesToLock = new IntHashSet();
@@ -76,10 +78,15 @@ public class LocalTransactionExplicitLock implements TransactionExplicitLock {
         // A compaction migrated one of the snapshotted file IDs between collection and lock check.
         // Re-resolve and try again; the new file ID is visible via mutable.getFileId() after splitIndex swap.
         last = e;
+        LogManager.instance().log(this, Level.WARNING,
+            "Retrying explicit lock acquisition after compaction-induced file migration (attempt %d/%d, threadId=%d): %s",
+            attempt + 1, MAX_INTERNAL_RETRIES, Thread.currentThread().threadId(), e.getMessage());
         refreshFileIds();
       }
     }
-    throw last;
+    throw new ConcurrentModificationException(
+        "Exhausted " + MAX_INTERNAL_RETRIES + " internal retries acquiring explicit lock after compaction-induced file migration. Last error: "
+            + last.getMessage());
   }
 
   private void refreshFileIds() {

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -899,11 +899,12 @@ public class TransactionContext implements Transaction {
 
     final List<Integer> locked = database.getTransactionManager().tryLockFiles(files.toArray(), timeout, getRequester());
 
-    // CHECK IF ALL THE LOCKED FILES STILL EXIST. FILE MISSING CAN HAPPEN IN CASE OF INDEX COMPACTION OR DROP OF A BUCKET OR AN INDEX
+    // CHECK IF ALL THE LOCKED FILES STILL EXIST. FILE MISSING CAN HAPPEN IN CASE OF INDEX COMPACTION OR DROP OF A BUCKET OR AN INDEX.
+    // Transaction rollback is the caller's responsibility: commit1stPhase catches and rolls back; the explicit-lock path retries
+    // internally with refreshed file IDs (see LocalTransactionExplicitLock.lock()) since no modifications exist yet at that point.
     for (Integer f : locked)
       if (!database.getFileManager().existsFile(f)) {
         database.getTransactionManager().unlockFilesInOrder(locked, getRequester());
-        rollback();
         final Integer migrated = database.getSchema().getEmbedded().getMigratedFileId(f);
         if (migrated != null) {
           LogManager.instance().log(this, Level.FINE, "Found upgraded file '%d' to '%d' during transaction commit", f, migrated);

--- a/engine/src/test/java/com/arcadedb/index/LocalTransactionExplicitLockRetryTest.java
+++ b/engine/src/test/java/com/arcadedb/index/LocalTransactionExplicitLockRetryTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.LocalTransactionExplicitLock;
+import com.arcadedb.index.lsm.LSMTreeIndex;
+import com.arcadedb.schema.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the internal-retry behavior of LocalTransactionExplicitLock.lock().
+ * When a compaction migrates an indexed file between snapshot (.type()) and lock acquisition
+ * (.lock()), lock() must re-resolve current file IDs from the schema and retry transparently
+ * rather than surfacing ConcurrentModificationException to the caller.
+ */
+class LocalTransactionExplicitLockRetryTest extends TestHelper {
+
+  private static final int PAGE_SIZE = 2 * 1024;
+
+  @Test
+  void lockSucceedsAfterCompactionMigratesSnapshottedFile() throws Exception {
+    database.transaction(() -> {
+      final var type = database.getSchema().buildDocumentType().withName("Article").withTotalBuckets(1).create();
+      type.createProperty("id", Integer.class);
+      database.getSchema().buildTypeIndex("Article", new String[] { "id" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE)
+          .withUnique(true)
+          .withPageSize(PAGE_SIZE)
+          .create();
+    });
+
+    // Populate so the mutable index has >= 2 pages (compaction requires >= 2 pages).
+    database.transaction(() -> {
+      for (int i = 0; i < 1_000; i++)
+        database.newDocument("Article").set("id", i).save();
+    });
+
+    final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("Article[id]");
+    final LSMTreeIndex bucketIndex = (LSMTreeIndex) typeIndex.getIndexesOnBuckets()[0];
+
+    assertThat(bucketIndex.getMutableIndex().getTotalPages()).isGreaterThanOrEqualTo(2);
+
+    final int oldMutableFid = bucketIndex.getMutableIndex().getFileId();
+
+    // Snapshot file IDs BEFORE compaction by calling .type() on the explicit-lock builder.
+    // This emulates the production race: a LOCK TYPE statement reads idx.getFileId() and
+    // the index then gets compacted before lockFilesInOrder runs.
+    database.begin();
+    final LocalTransactionExplicitLock explicitLock = (LocalTransactionExplicitLock) database.acquireLock().type("Article");
+
+    // Force compaction from a background thread (transactions are thread-local; splitIndex must run
+    // outside an active TX). After compaction, oldMutableFid is gone and migrated to a new file ID.
+    final CountDownLatch compactionDone = new CountDownLatch(1);
+    final AtomicReference<Throwable> compactionError = new AtomicReference<>();
+
+    new Thread(() -> {
+      try {
+        bucketIndex.scheduleCompaction();
+        if (!bucketIndex.compact())
+          compactionError.set(new AssertionError("compact() returned false - mutable must have >= 2 pages"));
+      } catch (final Throwable e) {
+        compactionError.set(e);
+      } finally {
+        compactionDone.countDown();
+      }
+    }, "compaction-thread").start();
+
+    assertThat(compactionDone.await(30, TimeUnit.SECONDS)).isTrue();
+    assertThat(compactionError.get()).isNull();
+
+    // Confirm the race condition is set up: snapshotted file is gone, migration entry exists.
+    assertThat(((DatabaseInternal) database).getFileManager().existsFile(oldMutableFid)).isFalse();
+    assertThat(database.getSchema().getEmbedded().getMigratedFileId(oldMutableFid)).isNotNull();
+
+    // The actual assertion: lock() must converge via internal retry with re-resolved file IDs.
+    // Before the fix this would surface ConcurrentModificationException; after the fix it succeeds silently.
+    explicitLock.lock();
+
+    database.rollback();
+  }
+}

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -2905,11 +2905,17 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         // X-ArcadeDB-Forwarded-User header. Without this, every command issued through a
         // follower throws "Cannot forward command to leader: no authenticated user in the
         // current security context". Mirrors PostgresNetworkExecutor.openDatabase().
-        final String authenticatedUser = resolveAuthenticatedUser(credentials);
+        final String authenticatedUser = resolvedUsername(credentials);
         if (authenticatedUser != null && arcadeServer.getSecurity() != null) {
           final ServerSecurityUser secUser = arcadeServer.getSecurity().getUser(authenticatedUser);
           if (secUser != null)
             ctx.setCurrentUser(secUser.getDatabaseUser(db));
+          else
+            // A race between credential validation and concurrent user mutation can land here.
+            // Leaving the user unset would silently break HA leader-forwarding, so surface it.
+            LogManager.instance().log(this, Level.WARNING,
+                "gRPC request authenticated as '%s' but server security has no matching user; HA leader-forwarding will fail for this request",
+                authenticatedUser);
         }
 
         return db;
@@ -2966,9 +2972,11 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   /**
    * Resolves the authenticated username for the current request. Prefers the interceptor-set
    * gRPC context (Bearer or basic auth flows) and falls back to the credentials carried by the
-   * request payload, mirroring the precedence applied in {@link #validateCredentials}.
+   * request payload. Single source of truth for username precedence; both
+   * {@link #validateCredentials(DatabaseCredentials)} and {@link #getDatabase(String, DatabaseCredentials)}
+   * delegate here so the rule cannot drift between callers.
    */
-  private String resolveAuthenticatedUser(final DatabaseCredentials credentials) {
+  private String resolvedUsername(final DatabaseCredentials credentials) {
     final String contextUser = GrpcAuthInterceptor.USER_CONTEXT_KEY.get();
     if (contextUser != null && !contextUser.isEmpty())
       return contextUser;
@@ -2981,21 +2989,11 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   }
 
   private void validateCredentials(DatabaseCredentials credentials) {
-    // Check if user is already authenticated via the interceptor (e.g., via Bearer token)
-    final String authenticatedUser = GrpcAuthInterceptor.USER_CONTEXT_KEY.get();
-    if (authenticatedUser != null && !authenticatedUser.isEmpty()) {
-      // User already authenticated via interceptor, no need to validate credentials
-      LogManager.instance().log(this, Level.FINE, """
-          validateCredentials(): user already authenticated via interceptor:\
-           %s""", authenticatedUser);
-      return;
-    }
-
-    // Implement credential validation logic
-    // This is a placeholder - integrate with ArcadeDB's security system
-    if (credentials == null || credentials.getUsername().isEmpty()) {
+    final String authenticatedUser = resolvedUsername(credentials);
+    if (authenticatedUser == null)
       throw new IllegalArgumentException("Invalid credentials");
-    }
+
+    LogManager.instance().log(this, Level.FINE, "validateCredentials(): resolved user '%s'", authenticatedUser);
   }
 
   /**

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -52,6 +52,7 @@ import com.arcadedb.server.grpc.InsertOptions.TransactionMode;
 import com.arcadedb.server.grpc.ProjectionSettings.ProjectionEncoding;
 import com.arcadedb.server.monitor.QueryProfile;
 import com.arcadedb.server.monitor.ServerQueryProfiler;
+import com.arcadedb.server.security.ServerSecurityUser;
 import io.micrometer.core.instrument.Metrics;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -2897,7 +2898,20 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         // transaction management). Other wire protocols (HTTP, Postgres) do this as well.
         // Always call init() to ensure the context references the correct database instance,
         // since gRPC reuses threads from its pool and a stale context may exist.
-        DatabaseContext.INSTANCE.init((DatabaseInternal) db);
+        final DatabaseContext.DatabaseContextTL ctx = DatabaseContext.INSTANCE.init((DatabaseInternal) db);
+
+        // Propagate the authenticated user so HA-Raft can forward commands to the leader:
+        // forwardCommandToLeaderViaRaft reads proxied.getCurrentUserName() to set the
+        // X-ArcadeDB-Forwarded-User header. Without this, every command issued through a
+        // follower throws "Cannot forward command to leader: no authenticated user in the
+        // current security context". Mirrors PostgresNetworkExecutor.openDatabase().
+        final String authenticatedUser = resolveAuthenticatedUser(credentials);
+        if (authenticatedUser != null && arcadeServer.getSecurity() != null) {
+          final ServerSecurityUser secUser = arcadeServer.getSecurity().getUser(authenticatedUser);
+          if (secUser != null)
+            ctx.setCurrentUser(secUser.getDatabaseUser(db));
+        }
+
         return db;
       }
     }
@@ -2947,6 +2961,23 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         throw new RuntimeException("Cannot open database: " + databaseName + " - " + e.getMessage(), e);
       }
     }
+  }
+
+  /**
+   * Resolves the authenticated username for the current request. Prefers the interceptor-set
+   * gRPC context (Bearer or basic auth flows) and falls back to the credentials carried by the
+   * request payload, mirroring the precedence applied in {@link #validateCredentials}.
+   */
+  private String resolveAuthenticatedUser(final DatabaseCredentials credentials) {
+    final String contextUser = GrpcAuthInterceptor.USER_CONTEXT_KEY.get();
+    if (contextUser != null && !contextUser.isEmpty())
+      return contextUser;
+    if (credentials != null) {
+      final String credUser = credentials.getUsername();
+      if (credUser != null && !credUser.isEmpty())
+        return credUser;
+    }
+    return null;
   }
 
   private void validateCredentials(DatabaseCredentials credentials) {

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcFollowerForwardingIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcFollowerForwardingIT.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.server.ha.raft.BaseRaftHATest;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test: a gRPC write issued to a follower must be forwarded to the leader. Before the
+ * fix, ArcadeDbGrpcService.getDatabase() called DatabaseContext.init() but never propagated the
+ * authenticated user, so RaftReplicatedDatabase.forwardCommandToLeaderViaRaft threw
+ * "Cannot forward command to leader: no authenticated user in the current security context"
+ * and every write hitting a follower was silently dropped on the client side.
+ */
+class GrpcFollowerForwardingIT extends BaseRaftHATest {
+
+  private static final int    BASE_GRPC_PORT = 51071;
+  private static final String VERTEX_TYPE    = "GrpcFollowerWrite";
+
+  private static final Metadata.Key<String> USER_HEADER     =
+      Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER =
+      Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER =
+      Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  private ManagedChannel channel;
+
+  private final class AuthClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(final MethodDescriptor<ReqT, RespT> method,
+        final CallOptions callOptions, final Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata headers) {
+          headers.put(USER_HEADER, "root");
+          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
+          headers.put(DATABASE_HEADER, getDatabaseName());
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+
+    final String serverName = config.getValueAsString(GlobalConfiguration.SERVER_NAME);
+    final int index = Integer.parseInt(serverName.substring(serverName.lastIndexOf('_') + 1));
+
+    config.setValue("arcadedb.grpc.enabled", "true");
+    config.setValue("arcadedb.grpc.port", String.valueOf(BASE_GRPC_PORT + index));
+    config.setValue("arcadedb.grpc.host", "localhost");
+    config.setValue("arcadedb.grpc.reflection.enabled", "false");
+    config.setValue("arcadedb.grpc.health.enabled", "false");
+
+    final String existingPlugins = config.getValueAsString(GlobalConfiguration.SERVER_PLUGINS);
+    final String pluginEntry = "GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin";
+    if (existingPlugins == null || existingPlugins.isEmpty())
+      config.setValue(GlobalConfiguration.SERVER_PLUGINS, pluginEntry);
+    else if (!existingPlugins.contains(pluginEntry))
+      config.setValue(GlobalConfiguration.SERVER_PLUGINS, existingPlugins + "," + pluginEntry);
+  }
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @AfterEach
+  void teardownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+      channel = null;
+    }
+  }
+
+  @Test
+  void executeCommandThroughFollowerIsForwardedToLeader() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    int followerIndex = -1;
+    for (int i = 0; i < getServerCount(); i++)
+      if (i != leaderIndex) {
+        followerIndex = i;
+        break;
+      }
+    assertThat(followerIndex).as("At least one follower must exist").isGreaterThanOrEqualTo(0);
+
+    // Schema goes through the leader to avoid mixing schema replication with the forwarding under test.
+    final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+    leaderDb.transaction(() -> {
+      if (!leaderDb.getSchema().existsType(VERTEX_TYPE))
+        leaderDb.getSchema().createVertexType(VERTEX_TYPE);
+    });
+    waitForAllServers();
+
+    // Open the gRPC channel against the follower deliberately.
+    channel = ManagedChannelBuilder
+        .forAddress("localhost", BASE_GRPC_PORT + followerIndex)
+        .usePlaintext()
+        .build();
+    final Channel authenticated = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+    final ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub stub = ArcadeDbServiceGrpc.newBlockingStub(authenticated);
+
+    final DatabaseCredentials credentials = DatabaseCredentials.newBuilder()
+        .setUsername("root")
+        .setPassword(DEFAULT_PASSWORD_FOR_TESTS)
+        .build();
+
+    // Write via SQL command - the follower must forward to leader, which requires an authenticated
+    // user on the DatabaseContext. Before the fix this surfaced a SecurityException to the caller.
+    final ExecuteCommandRequest request = ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(credentials)
+        .setLanguage("sql")
+        .setCommand("CREATE VERTEX " + VERTEX_TYPE + " SET name = 'forwarded'")
+        .build();
+
+    final ExecuteCommandResponse response = stub.executeCommand(request);
+    assertThat(response).as("Follower-forwarded executeCommand must return a response").isNotNull();
+
+    waitForAllServers();
+
+    for (int i = 0; i < getServerCount(); i++) {
+      final Database serverDb = getServerDatabase(i, getDatabaseName());
+      assertThat(serverDb.countType(VERTEX_TYPE, true))
+          .as("Server %d (leader=%d, write went through follower=%d) must see the forwarded vertex",
+              i, leaderIndex, followerIndex)
+          .isEqualTo(1);
+    }
+  }
+}

--- a/load-tests/src/test/java/com/arcadedb/test/load/ThreeNodesLoadTestIT.java
+++ b/load-tests/src/test/java/com/arcadedb/test/load/ThreeNodesLoadTestIT.java
@@ -22,6 +22,7 @@ import com.arcadedb.test.support.ContainersTestTemplate;
 import com.arcadedb.test.support.DatabaseWrapper;
 import com.arcadedb.test.support.ServerWrapper;
 import io.micrometer.core.instrument.Metrics;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -35,7 +36,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-class ThreeINodesLoadtTestIT extends ContainersTestTemplate {
+class ThreeNodesLoadTestIT extends ContainersTestTemplate {
 
   private static final String SERVER_LIST = "arcadedb-0:2434:2480,arcadedb-1:2434:2480,arcadedb-2:2434:2480";
 
@@ -132,6 +133,27 @@ class ThreeINodesLoadtTestIT extends ContainersTestTemplate {
         Thread.currentThread().interrupt();
       }
     }
+
+    Awaitility.await()
+        .atMost(1, TimeUnit.MINUTES)
+        .pollInterval(5, TimeUnit.SECONDS)
+        .until(() -> {
+          try {
+            final long users1 = db1.countUsers();
+            final long photos1 = db1.countPhotos();
+            final long users2 = db2.countUsers();
+            final long photos2 = db2.countPhotos();
+            final long users3 = db3.countUsers();
+            final long photos3 = db3.countPhotos();
+            logger.info("Final check - Users: {} / {} / {} | Photos: {} / {} / {}", users1, users2, users3, photos1, photos2,
+                photos3);
+            return users1 == users2 && users1 == users3 && photos1 == photos2 && photos1 == photos3;
+          } catch (final Exception e) {
+            logger.warn("Quorum recovery check failed: {}", e.getMessage());
+            return false;
+          }
+        });
+
     LocalDateTime finishedAt = LocalDateTime.now();
     logger.info("Finishing at {}", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(finishedAt));
     logger.info("Total time: {} minutes", Duration.between(startedAt, finishedAt).toMinutes());

--- a/load-tests/src/test/java/com/arcadedb/test/load/ThreeNodesLoadTestIT.java
+++ b/load-tests/src/test/java/com/arcadedb/test/load/ThreeNodesLoadTestIT.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.test.load;
 
+import com.arcadedb.remote.RemoteException;
 import com.arcadedb.test.support.ContainersTestTemplate;
 import com.arcadedb.test.support.DatabaseWrapper;
 import com.arcadedb.test.support.ServerWrapper;
@@ -134,6 +135,10 @@ class ThreeNodesLoadTestIT extends ContainersTestTemplate {
       }
     }
 
+    LocalDateTime finishedAt = LocalDateTime.now();
+    logger.info("Finishing at {}", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(finishedAt));
+    logger.info("Total time: {} minutes", Duration.between(startedAt, finishedAt).toMinutes());
+
     Awaitility.await()
         .atMost(1, TimeUnit.MINUTES)
         .pollInterval(5, TimeUnit.SECONDS)
@@ -148,15 +153,17 @@ class ThreeNodesLoadTestIT extends ContainersTestTemplate {
             logger.info("Final check - Users: {} / {} / {} | Photos: {} / {} / {}", users1, users2, users3, photos1, photos2,
                 photos3);
             return users1 == users2 && users1 == users3 && photos1 == photos2 && photos1 == photos3;
-          } catch (final Exception e) {
-            logger.warn("Quorum recovery check failed: {}", e.getMessage());
+          } catch (final RemoteException e) {
+            // Transient: a node has not caught up or a connection blip - keep polling.
+            logger.debug("Quorum recovery check transient failure: {}", e.getMessage());
+            return false;
+          } catch (final RuntimeException e) {
+            // Unexpected: programming error or infra failure. Log loudly so the cause is visible
+            // before the 1-minute timeout instead of after.
+            logger.warn("Quorum recovery check threw unexpected exception, will keep polling", e);
             return false;
           }
         });
-
-    LocalDateTime finishedAt = LocalDateTime.now();
-    logger.info("Finishing at {}", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(finishedAt));
-    logger.info("Total time: {} minutes", Duration.between(startedAt, finishedAt).toMinutes());
 
     Metrics.globalRegistry.getMeters().forEach(meter -> {
       logger.info("Meter: {} - {}", meter.getId().getName(), meter.measure());


### PR DESCRIPTION
## Summary

- `peerAddEndpointPreservesExistingUsers` failed at line 76 with `expected 200, but was 400` on the `create user alice` step.
- Root cause: `startCluster()` only waits until one node reports `isLeader:true`. Followers can still have a `null` leader HTTP address mapping when the test fires the next request. Posting `create user` to `servers.get(0)` (a follower in that window) routes through `forwardToLeaderIfReplica`, where `getLeaderHttpAddress()` returns null and the handler throws `ServerIsNotTheLeaderException`, surfaced as HTTP 400 by `AbstractServerHttpHandler`.
- Fix: replace `startCluster()` with `startContainers()` + `waitForRaftLeader(servers, 60)` so the leader index is known. Post both the `create user` command and the peer-add smoke test (which is also leader-only) directly to `servers.get(leaderIdx)`.

## Test plan

- [ ] `mvn -pl e2e-ha -Dit.test=UserSeedOnPeerAddScenarioIT verify` passes locally
- [ ] CI run on the branch is green