### PR TITLE
fix(#4317): pass decompressedLength instead of data.size() in LZ4Compression.compress(Binary)

### DIFF
--- a/docs/4317-lz4-compression-srclen-bug.md
+++ b/docs/4317-lz4-compression-srclen-bug.md
@@ -43,5 +43,39 @@ The new test `compressionWithNonZeroPosition` reproduces the bug (throws
 
 ## Impact Analysis
 
-Any caller that passes a `Binary` with `position() > 0` would get corrupted output or an
-exception. Page-level compression and snapshot compression are the primary risk paths.
+Any caller that passes a `Binary` with `position() > 0` or a slice `Binary` (non-zero
+`getContentBeginOffset()`) would get corrupted output or an exception. Page-level compression
+and snapshot compression are the primary risk paths.
+
+---
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/4322
+
+## Review Cycles
+
+### Cycle 1 — head SHA 54a0ce60a
+
+Gemini reviewed with COMMENTED state. Two comments:
+
+1. **[High] compress(Binary): add getContentBeginOffset() to srcOff** — for slice Binaries,
+   `position()` is relative to the slice start but the backing array has a non-zero
+   `arrayOffset()`. Fix: `getContentBeginOffset() + position()` as srcOff. Applied.
+
+2. **[Medium] Same issue in decompress(Binary, int)** — same structural bug in the decompress
+   path. Fixed together with compress for consistency. Test updated to use `Binary.slice()`.
+
+### Cycle 1 resolution — head SHA 463507bc0
+
+Applied both comments:
+- `compress(Binary)`: `data.position()` → `data.getContentBeginOffset() + data.position()`
+- `decompress(Binary, int)`: same fix
+- Added `compressionOfSlicedBinary` test covering the slice/offset case
+- All 4 CompressionTest tests pass
+
+## Final State
+
+`timeout` — only `gemini-code-assist` is active in this repo; `claude` bot is not installed.
+The skill requires both bot logins before declaring a clean approval. Gemini's single review
+was fully addressed in cycle 1. PR is ready for developer review and merge.

--- a/docs/4317-lz4-compression-srclen-bug.md
+++ b/docs/4317-lz4-compression-srclen-bug.md
@@ -1,0 +1,47 @@
+# Fix #4317: LZ4Compression.compress passes total size() where srcLen is expected
+
+## Summary
+
+`LZ4Compression.compress(Binary)` was passing `data.size()` (total backing array length)
+as the third argument to `LZ4Compressor.compress()`, which expects the number of bytes to
+compress (`srcLen`). The correct value is `data.size() - data.position()`, already computed
+as `decompressedLength` two lines earlier.
+
+When `data.position() > 0`, the compressor read past the intended slice into the unrelated
+tail of the buffer. The destination was sized for the correct (smaller) length, so the call
+could throw `ArrayIndexOutOfBoundsException` or silently corrupt the output.
+
+The `decompress(Binary, …)` overload immediately above already subtracted position correctly,
+so round-trips with a non-zero position either threw or returned garbage.
+
+## Root Cause
+
+Single off-by-one in `LZ4Compression.java` line 88:
+
+```java
+// Before (wrong)
+compressor.compress(data.getContent(), data.position(), data.size(), …)
+// After (correct)
+compressor.compress(data.getContent(), data.position(), decompressedLength, …)
+```
+
+`decompressedLength` is already assigned to `data.size() - data.position()` two lines above.
+
+## Files Changed
+
+- `engine/src/main/java/com/arcadedb/compression/LZ4Compression.java` — one-line fix
+- `engine/src/test/java/com/arcadedb/compression/CompressionTest.java` — regression test
+
+## Test Results
+
+```
+Tests run: 3, Failures: 0, Errors: 0, Skipped: 0  (CompressionTest)
+```
+
+The new test `compressionWithNonZeroPosition` reproduces the bug (throws
+`ArrayIndexOutOfBoundsException` at line 88 before fix) and passes cleanly after.
+
+## Impact Analysis
+
+Any caller that passes a `Binary` with `position() > 0` would get corrupted output or an
+exception. Page-level compression and snapshot compression are the primary risk paths.

--- a/engine/src/main/java/com/arcadedb/compression/LZ4Compression.java
+++ b/engine/src/main/java/com/arcadedb/compression/LZ4Compression.java
@@ -85,8 +85,8 @@ public class LZ4Compression implements Compression {
     final int decompressedLength = data.size() - data.position();
     final int maxCompressedLength = compressor.maxCompressedLength(decompressedLength);
     final byte[] compressed = new byte[maxCompressedLength];
-    final int compressedLength = compressor.compress(data.getContent(), data.position(), decompressedLength, compressed, 0,
-        maxCompressedLength);
+    final int compressedLength = compressor.compress(data.getContent(), data.getContentBeginOffset() + data.position(),
+        decompressedLength, compressed, 0, maxCompressedLength);
 
     return new Binary(compressed, compressedLength);
   }
@@ -108,7 +108,7 @@ public class LZ4Compression implements Compression {
       return EMPTY_BINARY;
 
     final byte[] decompressed = new byte[decompressedLength];
-    decompressor.decompress(data.getContent(), data.position(), decompressed, 0, decompressedLength);
+    decompressor.decompress(data.getContent(), data.getContentBeginOffset() + data.position(), decompressed, 0, decompressedLength);
     return new Binary(decompressed);
   }
 }

--- a/engine/src/main/java/com/arcadedb/compression/LZ4Compression.java
+++ b/engine/src/main/java/com/arcadedb/compression/LZ4Compression.java
@@ -85,7 +85,7 @@ public class LZ4Compression implements Compression {
     final int decompressedLength = data.size() - data.position();
     final int maxCompressedLength = compressor.maxCompressedLength(decompressedLength);
     final byte[] compressed = new byte[maxCompressedLength];
-    final int compressedLength = compressor.compress(data.getContent(), data.position(), data.size(), compressed, 0,
+    final int compressedLength = compressor.compress(data.getContent(), data.position(), decompressedLength, compressed, 0,
         maxCompressedLength);
 
     return new Binary(compressed, compressedLength);

--- a/engine/src/test/java/com/arcadedb/compression/CompressionTest.java
+++ b/engine/src/test/java/com/arcadedb/compression/CompressionTest.java
@@ -43,4 +43,24 @@ class CompressionTest {
 
     assertThat(decompressed).isEqualTo(buffer);
   }
+
+  @Test
+  void compressionWithNonZeroPosition() {
+    // Regression test for #4317: compress(Binary) passed data.size() instead of decompressedLength
+    // when position > 0, causing silent corruption or ArrayIndexOutOfBoundsException.
+    final byte[] prefix = "HEADER".getBytes();
+    final byte[] payload = "This is the actual payload to compress".getBytes();
+    final Binary buffer = new Binary(prefix.length + payload.length);
+    buffer.putByteArray(prefix);
+    buffer.putByteArray(payload);
+    // Advance position past the prefix so only the payload slice is to be compressed
+    buffer.position(prefix.length);
+
+    final int decompressedLength = buffer.size() - buffer.position();
+    final Binary compressed = CompressionFactory.getDefault().compress(buffer);
+    final Binary decompressed = CompressionFactory.getDefault().decompress(compressed, decompressedLength);
+
+    assertThat(decompressed.getContent()).startsWith(payload);
+    assertThat(decompressed.size()).isEqualTo(decompressedLength);
+  }
 }

--- a/engine/src/test/java/com/arcadedb/compression/CompressionTest.java
+++ b/engine/src/test/java/com/arcadedb/compression/CompressionTest.java
@@ -63,4 +63,24 @@ class CompressionTest {
     assertThat(decompressed.getContent()).startsWith(payload);
     assertThat(decompressed.size()).isEqualTo(decompressedLength);
   }
+
+  @Test
+  void compressionOfSlicedBinary() {
+    // Regression test for #4317: compress(Binary) must account for getContentBeginOffset()
+    // when the Binary is a slice (arrayOffset > 0 in the backing ByteBuffer).
+    final byte[] prefix = "HEADER".getBytes();
+    final byte[] payload = "This is the actual payload to compress".getBytes();
+    final Binary buffer = new Binary(prefix.length + payload.length);
+    buffer.putByteArray(prefix);
+    buffer.putByteArray(payload);
+    buffer.flip();
+    final Binary slice = buffer.slice(prefix.length);
+
+    final int decompressedLength = slice.size();
+    final Binary compressed = CompressionFactory.getDefault().compress(slice);
+    final Binary decompressed = CompressionFactory.getDefault().decompress(compressed, decompressedLength);
+
+    assertThat(decompressed.getContent()).startsWith(payload);
+    assertThat(decompressed.size()).isEqualTo(decompressedLength);
+  }
 }


### PR DESCRIPTION
Closes #4317

## Summary

`LZ4Compression.compress(Binary)` was passing `data.size()` (total backing-array length) as the `srcLen` argument to the LZ4 compressor. The correct value — already computed two lines above as `decompressedLength = data.size() - data.position()` — was ignored. When `data.position() > 0`, the compressor read past the intended slice, causing either `ArrayIndexOutOfBoundsException` or silent output corruption on every compress→decompress round-trip.

The companion `decompress(Binary, …)` overload already subtracted position correctly, making the asymmetry the direct source of corruption.

**Change:** replace `data.size()` with `decompressedLength` at the single call site in `LZ4Compression.java`.

## Test plan

- [x] New regression test `CompressionTest#compressionWithNonZeroPosition`: creates a `Binary` with a non-zero position (simulating a partially-consumed buffer), compresses it, decompresses, and asserts byte-for-byte equality. Confirmed failing before the fix (`ArrayIndexOutOfBoundsException`) and passing after.
- [x] Existing `CompressionTest#compression` and `#emptyCompression` continue to pass.
- Run: `mvn test -Dtest=CompressionTest -pl engine`

🤖 Generated with [Claude Code](https://claude.com/claude-code)