### PR TITLE
fix(#4319): MutablePage.move mis-tracked WAL range for backward shifts

### DIFF
--- a/docs/4319-mutablepage-move-wal-tracking.md
+++ b/docs/4319-mutablepage-move-wal-tracking.md
@@ -42,3 +42,26 @@ New test class: `engine/src/test/java/com/arcadedb/engine/MutablePageMoveTest.ja
 - `forwardShiftModifiedRangeStartsAtSource` — verifies forward shifts are unaffected
 - `backwardShiftModifiedRangeCoversWrittenBytes` — verifies full written range is covered
 - `samePositionShiftTracksRange` — verifies no-op shift still tracks correctly
+- `moveToEndOfPageDoesNotThrow` — boundary regression: move to last content byte
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/4325
+
+## Review cycles
+
+### Cycle 1 — `809a11f5`
+
+Reviewer: `gemini-code-assist` (state: COMMENTED)
+
+Changes applied:
+- Use inclusive upper bound `Math.max(start, dest) + length - 1` instead of `destPosition + length`
+- Add `if (length > 0)` guard to prevent inverted range when length is zero
+- Add `moveToEndOfPageDoesNotThrow` test for boundary regression
+
+Follow-up commit: `33b7da7c`
+
+### Final state: timeout
+
+`claude` bot is not configured in this repository; `gemini-code-assist` does not
+re-review follow-up pushes. Cycle 2 would time out with no new feedback.

--- a/docs/4319-mutablepage-move-wal-tracking.md
+++ b/docs/4319-mutablepage-move-wal-tracking.md
@@ -1,0 +1,46 @@
+# Fix #4319: MutablePage.move WAL tracking for backward shifts
+
+## Summary
+
+`MutablePage.move(startPosition, destPosition, length)` called
+`updateModifiedRange(startPosition, destPosition + length)`. For backward shifts
+(`destPosition < startPosition` — the case in `LocalBucket.defragPage`), the
+lower bound was `startPosition` instead of `destPosition`, leaving the range
+`[destPosition, startPosition)` untracked in the WAL delta. A crash after
+`defragPage` would replay WAL without those bytes, corrupting the bucket page.
+
+## Root cause
+
+`defragPage` calls `page.move(from, to, length)` with `to < from` (shifting records
+leftward into freed holes). The old `updateModifiedRange(startPosition, destPosition + length)`
+used `startPosition` (= `from + PAGE_HEADER_SIZE`) as the lower bound, but the
+`System.arraycopy` in `Binary.move` writes to `[destPosition, destPosition + length - 1]`,
+so bytes `[destPosition, startPosition)` were written but not logged.
+
+## Fix
+
+`engine/src/main/java/com/arcadedb/engine/MutablePage.java:223`
+
+```diff
+- updateModifiedRange(startPosition, destPosition + length);
++ updateModifiedRange(Math.min(startPosition, destPosition), destPosition + length);
+```
+
+The lower bound is now `min(start, dest)` so backward shifts correctly start
+tracking at `destPosition`. The upper bound stays `destPosition + length`,
+which is always safe — `content.move` already validates that
+`destPosition + length <= content.length` before we reach this call.
+
+Note: the issue's suggested fix used `Math.max(start, dest) + length` for the
+upper bound, but that over-extends the range for backward shifts where
+`start + length` can reach the page boundary and trigger the bounds check in
+`updateModifiedRange`. Using `destPosition + length` is both correct and safe.
+
+## Test
+
+New test class: `engine/src/test/java/com/arcadedb/engine/MutablePageMoveTest.java`
+
+- `backwardShiftModifiedRangeStartsAtDest` — verifies range starts at `dest + HEADER`
+- `forwardShiftModifiedRangeStartsAtSource` — verifies forward shifts are unaffected
+- `backwardShiftModifiedRangeCoversWrittenBytes` — verifies full written range is covered
+- `samePositionShiftTracksRange` — verifies no-op shift still tracks correctly

--- a/docs/4319-mutablepage-move-wal-tracking.md
+++ b/docs/4319-mutablepage-move-wal-tracking.md
@@ -23,18 +23,16 @@ so bytes `[destPosition, startPosition)` were written but not logged.
 
 ```diff
 - updateModifiedRange(startPosition, destPosition + length);
-+ updateModifiedRange(Math.min(startPosition, destPosition), destPosition + length);
++ if (length > 0)
++   updateModifiedRange(Math.min(startPosition, destPosition), Math.max(startPosition, destPosition) + length - 1);
 ```
 
-The lower bound is now `min(start, dest)` so backward shifts correctly start
-tracking at `destPosition`. The upper bound stays `destPosition + length`,
-which is always safe — `content.move` already validates that
-`destPosition + length <= content.length` before we reach this call.
-
-Note: the issue's suggested fix used `Math.max(start, dest) + length` for the
-upper bound, but that over-extends the range for backward shifts where
-`start + length` can reach the page boundary and trigger the bounds check in
-`updateModifiedRange`. Using `destPosition + length` is both correct and safe.
+The lower bound is `min(start, dest)` so backward shifts start tracking at
+`destPosition`. The upper bound uses inclusive semantics (`+ length - 1`)
+consistent with all other `updateModifiedRange` call sites. The `length > 0`
+guard prevents an inverted range when `length == 0`. For a full-page backward
+shift the upper bound evaluates to `physicalSize - 1`, which is the last
+valid byte index.
 
 ## Test
 

--- a/engine/src/main/java/com/arcadedb/engine/MutablePage.java
+++ b/engine/src/main/java/com/arcadedb/engine/MutablePage.java
@@ -220,7 +220,7 @@ public class MutablePage extends BasePage implements TrackableContent {
               + destPosition + " length=" + length + " pageSize=" + size + ")");
     startPosition += PAGE_HEADER_SIZE;
     destPosition += PAGE_HEADER_SIZE;
-    updateModifiedRange(startPosition, destPosition + length);
+    updateModifiedRange(Math.min(startPosition, destPosition), destPosition + length);
     content.move(startPosition, destPosition, length);
   }
 

--- a/engine/src/main/java/com/arcadedb/engine/MutablePage.java
+++ b/engine/src/main/java/com/arcadedb/engine/MutablePage.java
@@ -220,7 +220,8 @@ public class MutablePage extends BasePage implements TrackableContent {
               + destPosition + " length=" + length + " pageSize=" + size + ")");
     startPosition += PAGE_HEADER_SIZE;
     destPosition += PAGE_HEADER_SIZE;
-    updateModifiedRange(Math.min(startPosition, destPosition), destPosition + length);
+    if (length > 0)
+      updateModifiedRange(Math.min(startPosition, destPosition), Math.max(startPosition, destPosition) + length - 1);
     content.move(startPosition, destPosition, length);
   }
 

--- a/engine/src/test/java/com/arcadedb/engine/MutablePageMoveTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/MutablePageMoveTest.java
@@ -76,4 +76,13 @@ class MutablePageMoveTest {
     final int[] range = page.getModifiedRange();
     assertThat(range[0]).isEqualTo(50 + BasePage.PAGE_HEADER_SIZE);
   }
+
+  @Test
+  void moveToEndOfPageDoesNotThrow() {
+    final MutablePage page = freshPage();
+    // dest=1006, length=10: last byte is at 1006+8+10-1 = 1023 = PAGE_SIZE-1 (inclusive upper bound)
+    page.move(0, 1006, 10);
+    final int[] range = page.getModifiedRange();
+    assertThat(range[1]).isEqualTo(PAGE_SIZE - 1);
+  }
 }

--- a/engine/src/test/java/com/arcadedb/engine/MutablePageMoveTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/MutablePageMoveTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.database.BasicDatabase;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for MutablePage.move() mis-tracking the modified range for backward shifts.
+ * When destPosition < startPosition the written bytes start at destPosition, but the buggy code
+ * passed startPosition as the lower bound to updateModifiedRange, leaving [destPosition, startPosition)
+ * untracked in the WAL delta.
+ */
+class MutablePageMoveTest {
+
+  private static final int PAGE_SIZE = 1024;
+
+  private MutablePage freshPage() {
+    final BasicDatabase db = Mockito.mock(BasicDatabase.class);
+    final PageId pageId = new PageId(db, 1, 0);
+    // Use the 5-arg constructor so modifiedRangeFrom/To start at their sentinel values
+    return new MutablePage(pageId, PAGE_SIZE, new byte[PAGE_SIZE], 0, PAGE_SIZE);
+  }
+
+  @Test
+  void backwardShiftModifiedRangeStartsAtDest() {
+    final MutablePage page = freshPage();
+    // dest(50) < start(100): backward shift — written bytes begin at destPosition
+    page.move(100, 50, 60);
+    final int[] range = page.getModifiedRange();
+    assertThat(range[0]).isEqualTo(50 + BasePage.PAGE_HEADER_SIZE);
+  }
+
+  @Test
+  void forwardShiftModifiedRangeStartsAtSource() {
+    final MutablePage page = freshPage();
+    // dest(100) > start(50): forward shift — written bytes start at destPosition but range from source
+    page.move(50, 100, 60);
+    final int[] range = page.getModifiedRange();
+    assertThat(range[0]).isEqualTo(50 + BasePage.PAGE_HEADER_SIZE);
+  }
+
+  @Test
+  void backwardShiftModifiedRangeCoversWrittenBytes() {
+    final MutablePage page = freshPage();
+    // dest=50, start=100, length=60 — written bytes: [50+HEADER, 50+HEADER+60-1]
+    page.move(100, 50, 60);
+    final int[] range = page.getModifiedRange();
+    assertThat(range[0]).isLessThanOrEqualTo(50 + BasePage.PAGE_HEADER_SIZE);
+    assertThat(range[1]).isGreaterThanOrEqualTo(50 + BasePage.PAGE_HEADER_SIZE + 60 - 1);
+  }
+
+  @Test
+  void samePositionShiftTracksRange() {
+    final MutablePage page = freshPage();
+    page.move(50, 50, 60);
+    final int[] range = page.getModifiedRange();
+    assertThat(range[0]).isEqualTo(50 + BasePage.PAGE_HEADER_SIZE);
+  }
+}


### PR DESCRIPTION
Closes #4319

## Summary

`MutablePage.move()` called `updateModifiedRange(startPosition, destPosition + length)`. For backward shifts (`destPosition < startPosition` — the `LocalBucket.defragPage` case), the lower bound was `startPosition` instead of `destPosition`, leaving the range `[destPosition, startPosition)` untracked in the WAL delta. A crash after `defragPage` would replay WAL without those bytes, silently corrupting the bucket page.

**Fix:** use `Math.min(startPosition, destPosition)` as the lower bound. The upper bound stays `destPosition + length`, which is always within page bounds (validated by `Binary.move` before `updateModifiedRange` is reached). The issue's suggested `Math.max(start, dest) + length` variant was not used because for a backward shift it can equal the physical page size and trigger `updateModifiedRange`'s bounds check.

## Test plan

- [x] New `MutablePageMoveTest` unit tests verify correct `getModifiedRange()` after backward shift, forward shift, same-position shift
- [x] `RecordRecyclingTest` (which exercises `defragPage` via record deletion and recycling) continues to pass
- [x] All 4 new tests pass, no regressions in the engine test suite

🤖 Generated with [Claude Code](https://claude.ai/claude-code)