### PR TITLE
fix(#4320): WALFile.getTransaction distinguishes I/O error from truncation

### DIFF
--- a/docs/4320-walfile-io-error-vs-truncation.md
+++ b/docs/4320-walfile-io-error-vs-truncation.md
@@ -76,3 +76,51 @@ All 3 passed after the fix. Pre-fix: `ioErrorOnChannelThrowsWALException` failed
 - Garbage page content from short reads is no longer possible.
 - Clean EOF and truncated WAL still return `null` as before (no behaviour change for the
   normal path).
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/4338
+
+## Review cycles
+
+### Cycle 1 - HEAD acd9fdf2
+
+Reviewer: gemini-code-assist[bot]
+
+Two inline comments:
+
+1. **HIGH/security at WALFile.java:203** - validate page deltaSize / boundaries before
+   `ByteBuffer.allocate`. Applied with a modification: dropped the suggested
+   `currentPageSize > 1MB` cap (currentPageSize is the page CONTENT size, not the physical
+   size; ArcadeDB's configurable page sizes can legitimately exceed 1MB) and the
+   `changesTo >= currentPageSize` check (incorrectly rejected valid WAL transactions where
+   the modified range extends past the content marker, breaking 3 ACIDTransactionTest
+   recovery tests). Kept `deltaSize <= 0 || changesFrom < 0` which is sufficient to prevent
+   the `IllegalArgumentException` from `ByteBuffer.allocate(negative)`.
+
+2. **MEDIUM at test:126** - use single temp file + `setLength()` instead of 70 create/delete
+   cycles. Skipped: suggested form uses `try (WALFile wf = ...)` but `WALFile` is not
+   `AutoCloseable`, so the code would not compile. Microscopic gain (current test runs in
+   0.074s). Rationale recorded in `docs/review-deferred-acd9fdf2.md`.
+
+### Cycle 2 - HEAD bac415b5
+
+Reviewer: gemini-code-assist[bot]
+
+Both inline comments were **byte-identical re-emissions** of cycle 1 (just shifted line
+numbers because the cycle-1 patch added lines). This matches the known behaviour captured in
+memory `reference_arcadedb_repo_bot_reviewers`: gemini does not engage with code changes
+that address prior feedback - it regenerates the same comments each cycle.
+
+Cycle 1 already addressed both items. Loop exited.
+
+## Deferred items
+
+- [docs/review-deferred-acd9fdf2.md](review-deferred-acd9fdf2.md) - test-perf optimization,
+  not applied because the suggested code does not compile (WALFile is not AutoCloseable) and
+  the gain is negligible.
+
+## Final state
+
+`deferred-items` (one item deferred, recorded above). Loop exited at cycle 2 because all
+feedback on the new HEAD was byte-identical to cycle 1.

--- a/docs/4320-walfile-io-error-vs-truncation.md
+++ b/docs/4320-walfile-io-error-vs-truncation.md
@@ -1,0 +1,78 @@
+# Fix #4320: WALFile.getTransaction confuses I/O error with truncation
+
+## Issue
+
+`WALFile.getTransaction()` had two bugs:
+
+1. **Short read not detected**: `channel.read(buffer, pos)` return value was never checked.
+   A short or zero-byte read left the delta `ByteBuffer` only partially populated, resulting
+   in garbage page content silently applied to disk during recovery.
+
+2. **I/O error swallowed**: `catch (Exception e) { return null; }` returned the same `null`
+   sentinel used for "end of WAL" or "truncated WAL". Any `IOException` during replay was
+   indistinguishable from a clean EOF, causing recovery to stop mid-replay and silently drop
+   every committed transaction after the failing read.
+
+## Root Cause
+
+`engine/src/main/java/com/arcadedb/engine/WALFile.java`, lines 203-221 (pre-fix):
+
+```java
+final ByteBuffer buffer = ByteBuffer.allocate(deltaSize);
+tx.pages[i].currentContent = new Binary(buffer);
+channel.read(buffer, pos);   // return value never checked
+pos += deltaSize;
+...
+} catch (final Exception e) {
+  return null;               // same value as "truncated WAL"
+}
+```
+
+## Fix
+
+Two targeted changes in `getTransaction()`:
+
+1. **Loop the delta read** until the buffer is full, treating EOF (`n == -1`) as truncation:
+   ```java
+   long readPos = pos;
+   while (buffer.hasRemaining()) {
+     final int n = channel.read(buffer, readPos);
+     if (n == -1)
+       return null; // truncated WAL: EOF before delta is complete
+     readPos += n;
+   }
+   ```
+
+2. **Split the catch block** so `IOException` re-throws as `WALException` rather than
+   returning `null`:
+   ```java
+   } catch (final IOException e) {
+     throw new WALException("Error reading WAL file " + filePath, e);
+   } catch (final Exception e) {
+     return null;
+   }
+   ```
+
+## Files Changed
+
+- `engine/src/main/java/com/arcadedb/engine/WALFile.java` - the fix
+- `engine/src/test/java/com/arcadedb/engine/WALFileGetTransactionTest.java` - regression tests
+
+## Tests
+
+`WALFileGetTransactionTest` covers three scenarios:
+
+| Test | Expected |
+|---|---|
+| `validTransactionIsReadCorrectly` | All fields read back correctly |
+| `truncatedWalReturnsNull` | Returns `null` at every truncation point |
+| `ioErrorOnChannelThrowsWALException` | Throws `WALException`, not `null` |
+
+All 3 passed after the fix. Pre-fix: `ioErrorOnChannelThrowsWALException` failed.
+
+## Impact
+
+- Recovery now throws `WALException` on I/O errors instead of silently stopping.
+- Garbage page content from short reads is no longer possible.
+- Clean EOF and truncated WAL still return `null` as before (no behaviour change for the
+  normal path).

--- a/docs/review-deferred-acd9fdf2.md
+++ b/docs/review-deferred-acd9fdf2.md
@@ -1,0 +1,25 @@
+# Deferred review items for PR #4338 (cycle 1, HEAD acd9fdf2)
+
+## Skipped: test optimization using setLength() (gemini-code-assist, MEDIUM)
+
+**Path:** `engine/src/test/java/com/arcadedb/engine/WALFileGetTransactionTest.java:126`
+
+**Suggestion (verbatim):**
+
+> Creating and deleting 70 temporary files in a loop is highly inefficient and can significantly
+> slow down test execution. We can optimize this by creating a single temporary file, writing the
+> valid transaction once, and then truncating it backwards from `fullSize - 1` down to `0` using
+> `RandomAccessFile.setLength()`.
+
+**Rationale for skipping:**
+
+1. The suggested code uses `try (WALFile wf = new WALFile(...))`. `WALFile extends LockContext`
+   and `LockContext` does not implement `AutoCloseable`, so the try-with-resources form would
+   not compile.
+2. The current test runs in 0.074s for all three test methods combined. The "70 temp files"
+   inefficiency is microscopic in absolute terms.
+3. Adapting the suggestion to compile (explicit `try { } finally { wf.close(); }`) ends up
+   longer than the current implementation while gaining no observable benefit.
+
+The current implementation is correct and fast. Skipped to keep the diff minimal and focused on
+the I/O-error vs truncation fix that issue #4320 asks for.

--- a/engine/src/main/java/com/arcadedb/engine/WALFile.java
+++ b/engine/src/main/java/com/arcadedb/engine/WALFile.java
@@ -200,6 +200,13 @@ public class WALFile extends LockContext {
         tx.pages[i].currentPageSize = readInt(pos);
         pos += Binary.INT_SERIALIZED_SIZE;
 
+        // Reject obviously corrupted page headers so ByteBuffer.allocate cannot blow up with a
+        // negative size and a garbage delta cannot be applied to disk. The outer segment-size
+        // check above already bounds total memory by file size, so a per-page upper cap is not
+        // needed here.
+        if (deltaSize <= 0 || tx.pages[i].changesFrom < 0)
+          return null;
+
         final ByteBuffer buffer = ByteBuffer.allocate(deltaSize);
 
         tx.pages[i].currentContent = new Binary(buffer);

--- a/engine/src/main/java/com/arcadedb/engine/WALFile.java
+++ b/engine/src/main/java/com/arcadedb/engine/WALFile.java
@@ -203,7 +203,14 @@ public class WALFile extends LockContext {
         final ByteBuffer buffer = ByteBuffer.allocate(deltaSize);
 
         tx.pages[i].currentContent = new Binary(buffer);
-        channel.read(buffer, pos);
+
+        long readPos = pos;
+        while (buffer.hasRemaining()) {
+          final int n = channel.read(buffer, readPos);
+          if (n == -1)
+            return null; // truncated WAL: EOF before delta is complete
+          readPos += n;
+        }
 
         pos += deltaSize;
       }
@@ -216,6 +223,8 @@ public class WALFile extends LockContext {
       tx.endPositionInLog = pos + Binary.INT_SERIALIZED_SIZE + Binary.LONG_SERIALIZED_SIZE;
 
       return tx;
+    } catch (final IOException e) {
+      throw new WALException("Error reading WAL file " + filePath, e);
     } catch (final Exception e) {
       return null;
     }

--- a/engine/src/test/java/com/arcadedb/engine/WALFileGetTransactionTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/WALFileGetTransactionTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link WALFile#getTransaction(long)}.
+ *
+ * Covers:
+ * 1. Valid transactions are read back with all fields intact.
+ * 2. Truncated WAL files return {@code null} at every truncation point.
+ * 3. An I/O error on the channel throws {@link WALException} instead of returning {@code null}.
+ */
+class WALFileGetTransactionTest {
+
+  // Layout constants mirroring the private statics in WALFile
+  // TX_HEADER: txId(8) + timestamp(8) + pages(4) + segmentSize(4) = 24
+  private static final int TX_HEADER_SIZE = 24;
+  // PAGE_HEADER: fileId(4) + pageNumber(4) + changesFrom(4) + changesTo(4) + pageVersion(4) + pageSize(4) = 24
+  private static final int PAGE_HEADER_SIZE = 24;
+  // TX_FOOTER: segmentSize(4) + MAGIC_NUMBER(8) = 12
+  private static final int TX_FOOTER_SIZE = 12;
+
+  private static final byte[] DELTA = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+
+  private static final long   TX_ID      = 42L;
+  private static final long   TIMESTAMP  = 987654321L;
+  private static final int    FILE_ID    = 7;
+  private static final int    PAGE_NUM   = 3;
+  private static final int    FROM       = 0;
+  private static final int    TO         = DELTA.length - 1;   // 9
+  private static final int    PAGE_VER   = 5;
+  private static final int    PAGE_SIZE  = 4096;
+  private static final int    DELTA_SIZE = TO - FROM + 1;       // 10
+  private static final int    SEG_SIZE   = PAGE_HEADER_SIZE + DELTA_SIZE; // 34
+
+  private File    tempFile;
+  private WALFile walFile;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    tempFile = File.createTempFile("wal-test-", ".wal");
+    tempFile.deleteOnExit();
+    writeValidTransaction(tempFile);
+    walFile = new WALFile(tempFile.getAbsolutePath());
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    if (walFile != null)
+      walFile.close();
+    if (tempFile != null)
+      tempFile.delete();
+  }
+
+  @Test
+  void validTransactionIsReadCorrectly() {
+    final WALFile.WALTransaction tx = walFile.getTransaction(0);
+
+    assertThat(tx).isNotNull();
+    assertThat(tx.txId).isEqualTo(TX_ID);
+    assertThat(tx.timestamp).isEqualTo(TIMESTAMP);
+    assertThat(tx.pages).hasSize(1);
+
+    final WALFile.WALPage page = tx.pages[0];
+    assertThat(page.fileId).isEqualTo(FILE_ID);
+    assertThat(page.pageNumber).isEqualTo(PAGE_NUM);
+    assertThat(page.changesFrom).isEqualTo(FROM);
+    assertThat(page.changesTo).isEqualTo(TO);
+    assertThat(page.currentPageVersion).isEqualTo(PAGE_VER);
+    assertThat(page.currentPageSize).isEqualTo(PAGE_SIZE);
+    assertThat(page.currentContent.getContent()).startsWith(DELTA);
+
+    // endPositionInLog must point past the footer
+    assertThat(tx.endPositionInLog).isEqualTo(TX_HEADER_SIZE + SEG_SIZE + TX_FOOTER_SIZE);
+  }
+
+  @Test
+  void truncatedWalReturnsNull() throws Exception {
+    // Truncate one byte before the magic-number footer completes
+    final int fullSize = TX_HEADER_SIZE + SEG_SIZE + TX_FOOTER_SIZE;
+    for (int truncPoint = 0; truncPoint < fullSize; truncPoint++) {
+      final File truncFile = File.createTempFile("wal-trunc-", ".wal");
+      truncFile.deleteOnExit();
+      WALFile wf = null;
+      try {
+        writeTruncatedTransaction(truncFile, truncPoint);
+        wf = new WALFile(truncFile.getAbsolutePath());
+        assertThat(wf.getTransaction(0))
+            .as("truncated at byte %d should return null", truncPoint)
+            .isNull();
+      } finally {
+        if (wf != null)
+          wf.close();
+        truncFile.delete();
+      }
+    }
+  }
+
+  @Test
+  void ioErrorOnChannelThrowsWALException() throws Exception {
+    // Close the underlying FileChannel via reflection to induce IOException on the next read.
+    // Prior to the fix this returned null (swallowed IOException); the fix must throw WALException.
+    final FileChannel channel = extractChannel(walFile);
+    channel.close();
+
+    assertThatThrownBy(() -> walFile.getTransaction(0))
+        .isInstanceOf(WALException.class);
+  }
+
+  // --- helpers ---
+
+  private static void writeValidTransaction(final File file) throws Exception {
+    final ByteBuffer buf = buildValidTransactionBuffer();
+    try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
+      buf.rewind();
+      raf.getChannel().write(buf, 0);
+    }
+  }
+
+  private static void writeTruncatedTransaction(final File file, final int bytes) throws Exception {
+    if (bytes == 0)
+      return; // leave file empty
+    final ByteBuffer full = buildValidTransactionBuffer();
+    full.rewind();
+    final byte[] truncated = new byte[bytes];
+    full.get(truncated);
+    try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
+      raf.getChannel().write(ByteBuffer.wrap(truncated), 0);
+    }
+  }
+
+  /** Builds a complete, valid WAL transaction ByteBuffer in BIG_ENDIAN order. */
+  private static ByteBuffer buildValidTransactionBuffer() {
+    final ByteBuffer buf = ByteBuffer.allocate(TX_HEADER_SIZE + SEG_SIZE + TX_FOOTER_SIZE);
+    // TX header
+    buf.putLong(TX_ID);
+    buf.putLong(TIMESTAMP);
+    buf.putInt(1);            // page count
+    buf.putInt(SEG_SIZE);
+    // Page header
+    buf.putInt(FILE_ID);
+    buf.putInt(PAGE_NUM);
+    buf.putInt(FROM);
+    buf.putInt(TO);
+    buf.putInt(PAGE_VER);
+    buf.putInt(PAGE_SIZE);
+    // Delta bytes
+    buf.put(DELTA);
+    // TX footer
+    buf.putInt(SEG_SIZE);
+    buf.putLong(WALFile.MAGIC_NUMBER);
+    buf.rewind();
+    return buf;
+  }
+
+  private static FileChannel extractChannel(final WALFile wf) throws Exception {
+    final Field f = WALFile.class.getDeclaredField("channel");
+    f.setAccessible(true);
+    return (FileChannel) f.get(wf);
+  }
+}


### PR DESCRIPTION
Closes #4320

## Summary

`WALFile.getTransaction()` had two bugs that made WAL recovery silently drop committed transactions on transient I/O errors:

1. **Unchecked short reads** - `channel.read(buffer, pos)` return value was never inspected. A short read left the delta `ByteBuffer` partially populated, producing garbage page deltas that were then applied to disk.
2. **Swallowed `IOException`** - `catch (Exception e) { return null; }` used the same `null` sentinel that signals clean EOF / truncated WAL. Any `IOException` mid-replay was indistinguishable from end-of-WAL, so recovery stopped without surfacing the error.

## Fix

Two targeted changes in `getTransaction()`:

1. Loop `channel.read()` until the delta buffer is full, treating `n == -1` as truncation (return `null`).
2. Split the catch block: `IOException` re-throws as `WALException`; the broad `catch (Exception)` is retained so non-I/O parse errors still return `null` as before.

Clean EOF, truncated WAL, and invalid magic-number cases continue to return `null` - no behaviour change on the normal path.

## Test plan

`WALFileGetTransactionTest` (new) covers:

- [x] `validTransactionIsReadCorrectly` - all fields read back from a valid WAL transaction
- [x] `truncatedWalReturnsNull` - returns `null` at every truncation point inside a transaction
- [x] `ioErrorOnChannelThrowsWALException` - closing the channel before reading now throws `WALException`, not `null` (pre-fix: failed)
- [x] Full engine test suite: 7403 tests, 0 failures, 0 errors