### PR TITLE
fix(#4327): use parameter binding in RemoteVertex.newEdge to prevent SQL injection

### DIFF
--- a/docs/4327-remotevertex-newedge-sql-injection.md
+++ b/docs/4327-remotevertex-newedge-sql-injection.md
@@ -28,6 +28,26 @@ suggested approach from the issue reporter.
 `mvn test -pl network` - 373 tests, 0 failures, 0 errors.
 New tests: `RemoteVertexTest` (5 tests) - all pass.
 
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/4340
+
+## Review Cycles
+
+### Cycle 1 - fc636fe0
+
+gemini-code-assist posted 4 comments (state: COMMENTED), all variations of the same claim:
+"map keys should not have a leading colon - use `p0` instead of `:p0`."
+
+**Verdict: rejected (technically incorrect).** `NamedParameter.getValue()` tries
+`params.get(":" + key)` first, so `:p0` map keys resolve correctly. This is also
+the established convention in `QueryTest.java` (`params.put(":name", "Jay")`).
+Pushed back with technical reasoning in the comment thread.
+
+Working tree: clean after review - no changes needed.
+
+**Final state: clean-approval** (no actionable review items)
+
 ## Verification
 
 Run: `mvn test -pl network -Dtest=RemoteVertexTest`

--- a/docs/4327-remotevertex-newedge-sql-injection.md
+++ b/docs/4327-remotevertex-newedge-sql-injection.md
@@ -1,0 +1,33 @@
+# Fix #4327: RemoteVertex.newEdge SQL injection via unescaped property values
+
+## Summary
+
+`RemoteVertex.newEdge()` builds the `CREATE EDGE … SET prop = 'value'` SQL by concatenating
+property values with no escaping. A value containing a single quote (`O'Brien`) breaks the
+query; a malicious value injects arbitrary SQL.
+
+## Root Cause
+
+Lines 212-228 of `network/.../RemoteVertex.java`: the property-value loop writes string values
+directly into the query `StringBuilder` wrapped in literal single quotes. No escaping of the
+value content.
+
+## Fix
+
+Replace string interpolation with named SQL parameters (`:p0`, `:p1`, …) and pass the values
+via the existing `command(language, sql, Map<String,Object>)` overload. This is the
+suggested approach from the issue reporter.
+
+## Files Changed
+
+- `network/src/main/java/com/arcadedb/remote/RemoteVertex.java` — parameter binding in `newEdge`
+- `network/src/test/java/com/arcadedb/remote/RemoteVertexTest.java` — new test class (regression)
+
+## Test Results
+
+`mvn test -pl network` - 373 tests, 0 failures, 0 errors.
+New tests: `RemoteVertexTest` (5 tests) - all pass.
+
+## Verification
+
+Run: `mvn test -pl network -Dtest=RemoteVertexTest`

--- a/network/src/main/java/com/arcadedb/remote/RemoteVertex.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteVertex.java
@@ -190,6 +190,8 @@ public class RemoteVertex {
 
     query.append(" from " + vertex.getIdentity() + " to " + toVertex.getIdentity());
 
+    final Map<String, Object> params = new HashMap<>();
+
     if (properties != null && properties.length > 0) {
       query.append(" set ");
 
@@ -212,6 +214,7 @@ public class RemoteVertex {
       for (int i = 0; i < properties.length; i += 2) {
         final String propName = (String) properties[i];
         final Object propValue = properties[i + 1];
+        final String paramName = ":p" + (i / 2);
 
         if (i > 0)
           query.append(", ");
@@ -219,15 +222,12 @@ public class RemoteVertex {
         query.append("`");
         query.append(propName);
         query.append("` = ");
+        query.append(paramName);
 
-        if (propValue instanceof String)
-          query.append("'");
-        query.append(propValue);
-        if (propValue instanceof String)
-          query.append("'");
+        params.put(paramName, propValue);
       }
     }
-    final ResultSet resultSet = remoteDatabase.command("sql", query.toString());
+    final ResultSet resultSet = remoteDatabase.command("sql", query.toString(), params);
 
     return new RemoteMutableEdge((RemoteImmutableEdge) resultSet.next().getEdge().get());
   }

--- a/network/src/test/java/com/arcadedb/remote/RemoteVertexTest.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteVertexTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote;
+
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RemoteVertexTest {
+
+  private RemoteDatabase mockDatabase;
+  private Vertex         mockVertex;
+  private Identifiable   mockToVertex;
+  private RemoteVertex   remoteVertex;
+
+  @BeforeEach
+  void setUp() {
+    mockDatabase = mock(RemoteDatabase.class);
+    mockVertex = mock(Vertex.class);
+    mockToVertex = mock(Identifiable.class);
+
+    when(mockVertex.getIdentity()).thenReturn(new RID(1, 0));
+    when(mockToVertex.getIdentity()).thenReturn(new RID(2, 0));
+
+    // Return an incomplete result so command() is called but edge construction fails.
+    // Mockito records the command() call before the exception, so ArgumentCaptor still works.
+    final Result mockResult = mock(Result.class);
+    when(mockResult.getEdge()).thenReturn(Optional.empty());
+    final ResultSet mockResultSet = mock(ResultSet.class);
+    when(mockResultSet.next()).thenReturn(mockResult);
+
+    when(mockDatabase.command(eq("sql"), any(String.class), any(Map.class))).thenReturn(mockResultSet);
+
+    remoteVertex = new RemoteVertex(mockVertex, mockDatabase);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void newEdgeDoesNotInterpolateStringPropertyIntoSql() {
+    // String values with apostrophes must be passed as SQL parameters, not interpolated.
+    final ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    final ArgumentCaptor<Map> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+
+    assertThatThrownBy(() -> remoteVertex.newEdge("FriendOf", mockToVertex, "lastName", "O'Brien"))
+        .isInstanceOf(Exception.class);
+
+    verify(mockDatabase).command(eq("sql"), sqlCaptor.capture(), paramsCaptor.capture());
+    assertThat(sqlCaptor.getValue()).doesNotContain("O'Brien");
+    assertThat(sqlCaptor.getValue()).contains(":p0");
+    final Map<String, Object> params = (Map<String, Object>) paramsCaptor.getValue();
+    assertThat(params).containsEntry(":p0", "O'Brien");
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void newEdgePassesNonStringPropertyAsParameter() {
+    final ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    final ArgumentCaptor<Map> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+
+    assertThatThrownBy(() -> remoteVertex.newEdge("FriendOf", mockToVertex, "score", 42))
+        .isInstanceOf(Exception.class);
+
+    verify(mockDatabase).command(eq("sql"), sqlCaptor.capture(), paramsCaptor.capture());
+    assertThat(sqlCaptor.getValue()).contains(":p0");
+    final Map<String, Object> params = (Map<String, Object>) paramsCaptor.getValue();
+    assertThat(params).containsEntry(":p0", 42);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void newEdgePassesMultiplePropertiesAsParameters() {
+    final ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    final ArgumentCaptor<Map> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+
+    assertThatThrownBy(() -> remoteVertex.newEdge("FriendOf", mockToVertex, "name", "O'Brien", "since", 2023))
+        .isInstanceOf(Exception.class);
+
+    verify(mockDatabase).command(eq("sql"), sqlCaptor.capture(), paramsCaptor.capture());
+    final String sql = sqlCaptor.getValue();
+    assertThat(sql).doesNotContain("O'Brien");
+    assertThat(sql).contains("`name` = :p0");
+    assertThat(sql).contains("`since` = :p1");
+    final Map<String, Object> params = (Map<String, Object>) paramsCaptor.getValue();
+    assertThat(params).containsEntry(":p0", "O'Brien");
+    assertThat(params).containsEntry(":p1", 2023);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void newEdgeWithMapPropertiesUsesParameterBinding() {
+    final ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    final ArgumentCaptor<Map> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+
+    assertThatThrownBy(() -> remoteVertex.newEdge("FriendOf", mockToVertex, Map.of("label", "it's a test")))
+        .isInstanceOf(Exception.class);
+
+    verify(mockDatabase).command(eq("sql"), sqlCaptor.capture(), paramsCaptor.capture());
+    assertThat(sqlCaptor.getValue()).doesNotContain("it's a test");
+    final Map<String, Object> params = (Map<String, Object>) paramsCaptor.getValue();
+    assertThat(params).containsValue("it's a test");
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void newEdgeWithNoPropertiesCallsCommandWithEmptyParams() {
+    final ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    final ArgumentCaptor<Map> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+
+    assertThatThrownBy(() -> remoteVertex.newEdge("FriendOf", mockToVertex))
+        .isInstanceOf(Exception.class);
+
+    verify(mockDatabase).command(eq("sql"), sqlCaptor.capture(), paramsCaptor.capture());
+    assertThat(sqlCaptor.getValue()).doesNotContain("set");
+    assertThat(paramsCaptor.getValue()).isEmpty();
+  }
+}


### PR DESCRIPTION
Closes #4327

`RemoteVertex.newEdge()` was building `CREATE EDGE … SET prop = 'value'` SQL by concatenating property values directly into the query string with no escaping. A value containing a single quote (`O'Brien`) caused a parse error; a malicious value could inject arbitrary SQL.

The fix replaces the string interpolation with named SQL parameters (`:p0`, `:p1`, …) and passes the values via the existing `command(language, sql, Map<String,Object>)` overload. The SQL template now contains only backtick-quoted property names and `:pN` placeholders — no user data ever appears in the query string.

## Test plan

- [x] New `RemoteVertexTest` (5 tests) verifies that `command()` is invoked with a parameterised query and that raw property values — including apostrophes — never appear in the SQL string
- [x] `mvn test -pl network` — 373 tests, 0 failures, 0 errors
- [x] Both the pair-list form (`newEdge(type, to, "name", "O'Brien")`) and the map form (`newEdge(type, to, Map.of("name", "O'Brien"))`) are covered