### PR TITLE
fix(#4333): persist migratedFileIds in schema.json to survive restart

### DIFF
--- a/docs/4333-persist-migrated-file-ids.md
+++ b/docs/4333-persist-migrated-file-ids.md
@@ -1,0 +1,42 @@
+# Fix #4333: Persist migratedFileIds in schema.json
+
+## Issue
+
+`LocalSchema.migratedFileIds` (the `oldFileId -> newFileId` map written by LSM/vector index compaction) is a heap-only `ConcurrentHashMap`. It is never included in `schema.json`. After a restart the map is empty. WAL records addressed to the old fileId hit `!existsFile(...)` in `applyChanges` and are silently skipped with only a FINE-level log.
+
+## Root Cause
+
+- `LocalSchema.toJSON()` does not serialize `migratedFileIds`
+- `LocalSchema` loading code does not deserialize `migratedFileIds`
+- `TransactionManager.applyChanges()` cannot distinguish a safe compaction-migration skip from a
+  genuinely unexpected missing file because the migration map is always empty after restart
+
+## Files Changed
+
+- `engine/src/main/java/com/arcadedb/schema/LocalSchema.java`
+  - `toJSON()`: serialize `migratedFileIds` as a JSON object under key `"migratedFileIds"`
+  - loading block: deserialize `migratedFileIds` from JSON (near the `extensions` loading section)
+- `engine/src/main/java/com/arcadedb/engine/TransactionManager.java`
+  - `applyChanges()`: consult `migratedFileIds` when a fileId is missing; log FINE for known
+    migrations, WARNING for genuinely unknown missing files
+
+## Test
+
+`engine/src/test/java/com/arcadedb/index/MigratedFileIdsPersistenceTest.java`
+
+Two tests:
+1. `migratedFileIdsArePersisted` - after compaction triggers `setMigratedFileId`, close and reopen
+   the database; migration map must still be populated (proves persistence)
+2. `migratedFileIdsAreLoadedOnReopen` - verifies the loaded map has the same content as before
+   close (proves deserialization correctness)
+
+## Verification
+
+Run: `mvn test -pl engine -Dtest=MigratedFileIdsPersistenceTest`
+Run: `mvn test -pl engine -Dtest=LSMTreeIndexCompactionTest`
+
+## Status
+
+- [x] Tests written
+- [x] Implementation complete
+- [x] Tests pass

--- a/docs/4333-persist-migrated-file-ids.md
+++ b/docs/4333-persist-migrated-file-ids.md
@@ -35,8 +35,33 @@ Two tests:
 Run: `mvn test -pl engine -Dtest=MigratedFileIdsPersistenceTest`
 Run: `mvn test -pl engine -Dtest=LSMTreeIndexCompactionTest`
 
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/4342
+
+## Review Cycles
+
+### Cycle 1 - a47f16b11
+
+**gemini-code-assist** reviewed (COMMENTED):
+
+1. HIGH - `setMigratedFileId` does not call `saveConfiguration()`, so if no other schema change follows compaction the map is not saved. Applied: added `saveConfiguration()` call inside `setMigratedFileId`.
+2. MEDIUM - `root.getJSONObject("migratedFileIds")` throws if value is JSON null. Applied: added `!root.isNull("migratedFileIds")` guard.
+3. MEDIUM - WARNING log too noisy for schema-drop deletions during Raft replay. Applied: downgraded to INFO level.
+
+Follow-up commit: `3098f1590`
+
+### Cycle 2+
+
+gemini-code-assist does not re-review follow-up pushes on this repo (documented in memory). State: `timeout`.
+
+## Final State
+
+`timeout` - cycle 1 review addressed and pushed; gemini does not re-review. Developer should verify and merge PR #4342.
+
 ## Status
 
 - [x] Tests written
 - [x] Implementation complete
+- [x] Cycle-1 review addressed
 - [x] Tests pass

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -330,12 +330,19 @@ public class TransactionManager {
       final PageId pageId = new PageId(database, txPage.fileId, txPage.pageNumber);
 
       if (!database.getFileManager().existsFile(txPage.fileId)) {
-        // Referencing a deleted file is expected during Raft replay and crash recovery -
-        // schema changes may delete files before their prior TX entries are replayed.
-        // Always skip to avoid aborting the entire multi-page transaction.
-        LogManager.instance()
-            .log(this, Level.FINE,
-                "Skipping page for deleted file %d during transaction apply", null, txPage.fileId);
+        // Referencing a missing file is expected in two safe cases:
+        // 1. LSM compaction migrated the file to a new ID - data is already in the new file.
+        // 2. A schema change (DROP TYPE / DROP INDEX) deleted the file intentionally.
+        // In both cases we skip. For case 1 the migration map is populated so we can log at FINE.
+        // For case 2 (or any unexpected missing file) we log at WARNING so operators notice.
+        final Integer migratedTo = database.getSchema().getEmbedded().getMigratedFileId(txPage.fileId);
+        if (migratedTo != null)
+          LogManager.instance().log(this, Level.FINE,
+              "Skipping page for compaction-migrated file %d (now %d) during transaction apply", null, txPage.fileId, migratedTo);
+        else
+          LogManager.instance().log(this, Level.WARNING,
+              "Skipping page for missing file %d during transaction apply, file was deleted or migration map is incomplete", null,
+              txPage.fileId);
         continue;
       }
 

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -340,7 +340,7 @@ public class TransactionManager {
           LogManager.instance().log(this, Level.FINE,
               "Skipping page for compaction-migrated file %d (now %d) during transaction apply", null, txPage.fileId, migratedTo);
         else
-          LogManager.instance().log(this, Level.WARNING,
+          LogManager.instance().log(this, Level.INFO,
               "Skipping page for missing file %d during transaction apply, file was deleted or migration map is incomplete", null,
               txPage.fileId);
         continue;

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -1828,7 +1828,7 @@ public class LocalSchema implements Schema {
       // Restore compaction file-migration map so WAL recovery can redirect or safely skip
       // pages that reference old (pre-compaction) file IDs.
       migratedFileIds.clear();
-      if (root.has("migratedFileIds")) {
+      if (root.has("migratedFileIds") && !root.isNull("migratedFileIds")) {
         final JSONObject migratedJSON = root.getJSONObject("migratedFileIds");
         for (final String key : migratedJSON.keySet())
           migratedFileIds.put(Integer.parseInt(key), migratedJSON.getInt(key));
@@ -1999,6 +1999,7 @@ public class LocalSchema implements Schema {
   public void setMigratedFileId(final int oldFileId, final int newFileId) {
     LogManager.instance().log(this, Level.FINE, "Migrating file id %d to %d", null, oldFileId, newFileId);
     migratedFileIds.put(oldFileId, newFileId);
+    saveConfiguration();
   }
 
   public Integer getMigratedFileId(final int oldFileId) {

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -1825,6 +1825,15 @@ public class LocalSchema implements Schema {
           extensions.put(extName, extJSON.getJSONObject(extName));
       }
 
+      // Restore compaction file-migration map so WAL recovery can redirect or safely skip
+      // pages that reference old (pre-compaction) file IDs.
+      migratedFileIds.clear();
+      if (root.has("migratedFileIds")) {
+        final JSONObject migratedJSON = root.getJSONObject("migratedFileIds");
+        for (final String key : migratedJSON.keySet())
+          migratedFileIds.put(Integer.parseInt(key), migratedJSON.getInt(key));
+      }
+
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.SEVERE, "Error on loading schema. The schema will be reset", e);
     } finally {
@@ -1909,6 +1918,15 @@ public class LocalSchema implements Schema {
       for (final Map.Entry<String, JSONObject> entry : extensions.entrySet())
         extJSON.put(entry.getKey(), entry.getValue());
       root.put("extensions", extJSON);
+    }
+
+    // Serialize compaction file-migration map so WAL recovery after a restart can distinguish
+    // safe compaction skips from genuinely unexpected missing files.
+    if (!migratedFileIds.isEmpty()) {
+      final JSONObject migratedJSON = new JSONObject();
+      for (final Map.Entry<Integer, Integer> entry : migratedFileIds.entrySet())
+        migratedJSON.put(String.valueOf(entry.getKey()), entry.getValue());
+      root.put("migratedFileIds", migratedJSON);
     }
 
     return root;

--- a/engine/src/test/java/com/arcadedb/index/MigratedFileIdsPersistenceTest.java
+++ b/engine/src/test/java/com/arcadedb/index/MigratedFileIdsPersistenceTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.index.lsm.LSMTreeIndex;
+import com.arcadedb.schema.LocalSchema;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for #4333: LocalSchema.migratedFileIds must be persisted in schema.json so that
+ * after a restart the WAL recovery path can distinguish safe compaction-migration skips from
+ * genuinely unexpected missing files.
+ */
+class MigratedFileIdsPersistenceTest {
+
+  private static final String DB_PATH   = "target/databases/MigratedFileIdsPersistenceTest";
+  private static final int    PAGE_SIZE = 2 * 1024;
+
+  private DatabaseFactory factory;
+  private Database        database;
+
+  @BeforeEach
+  void setUp() {
+    FileUtils.deleteRecursively(new File(DB_PATH));
+    factory = new DatabaseFactory(DB_PATH);
+    database = factory.create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null && database.isOpen())
+      database.drop();
+    else
+      FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+  // Migration map populated by compaction must be present in schema after close + reopen.
+  @Test
+  void migratedFileIdsArePersisted() throws Exception {
+    database.transaction(() -> {
+      final var type = database.getSchema().buildDocumentType().withName("Item").withTotalBuckets(1).create();
+      type.createProperty("id", Integer.class);
+      database.getSchema().buildTypeIndex("Item", new String[] { "id" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE)
+          .withUnique(true)
+          .withPageSize(PAGE_SIZE)
+          .create();
+    });
+
+    database.transaction(() -> {
+      for (int i = 0; i < 1_000; i++)
+        database.newDocument("Item").set("id", i).save();
+    });
+
+    final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("Item[id]");
+    final LSMTreeIndex bucketIndex = (LSMTreeIndex) typeIndex.getIndexesOnBuckets()[0];
+
+    assertThat(bucketIndex.getMutableIndex().getTotalPages())
+        .as("Mutable index must have >= 2 pages for compaction to proceed")
+        .isGreaterThanOrEqualTo(2);
+
+    final int oldMutableFid = bucketIndex.getMutableIndex().getFileId();
+
+    final CountDownLatch done = new CountDownLatch(1);
+    final AtomicReference<Throwable> error = new AtomicReference<>();
+    new Thread(() -> {
+      try {
+        bucketIndex.scheduleCompaction();
+        final boolean compacted = bucketIndex.compact();
+        if (!compacted)
+          error.set(new AssertionError("compact() returned false"));
+      } catch (final Throwable e) {
+        error.set(e);
+      } finally {
+        done.countDown();
+      }
+    }, "compaction-thread").start();
+
+    assertThat(done.await(30, TimeUnit.SECONDS)).as("Compaction did not complete in time").isTrue();
+    assertThat(error.get()).as("Compaction threw: %s", error.get()).isNull();
+
+    final Integer newFid = database.getSchema().getEmbedded().getMigratedFileId(oldMutableFid);
+    assertThat(newFid).as("Migration entry must be present after compaction").isNotNull();
+
+    // Close and reopen to verify the map survives serialisation/deserialisation.
+    database.close();
+    database = factory.open();
+
+    final Integer restoredNewFid = database.getSchema().getEmbedded().getMigratedFileId(oldMutableFid);
+    assertThat(restoredNewFid)
+        .as("migratedFileIds must survive close+reopen (oldFileId=%d)", oldMutableFid)
+        .isNotNull()
+        .isEqualTo(newFid);
+  }
+
+  // Migration map must round-trip: same old->new entries before and after serialisation.
+  @Test
+  void migratedFileIdsRoundTrip() throws Exception {
+    database.transaction(() -> {
+      final var type = database.getSchema().buildDocumentType().withName("Widget").withTotalBuckets(1).create();
+      type.createProperty("code", Integer.class);
+      database.getSchema().buildTypeIndex("Widget", new String[] { "code" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE)
+          .withUnique(true)
+          .withPageSize(PAGE_SIZE)
+          .create();
+    });
+
+    database.transaction(() -> {
+      for (int i = 0; i < 1_000; i++)
+        database.newDocument("Widget").set("code", i).save();
+    });
+
+    final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("Widget[code]");
+    final LSMTreeIndex bucketIndex = (LSMTreeIndex) typeIndex.getIndexesOnBuckets()[0];
+    final int oldMutableFid = bucketIndex.getMutableIndex().getFileId();
+
+    final CountDownLatch done = new CountDownLatch(1);
+    final AtomicReference<Throwable> error = new AtomicReference<>();
+    new Thread(() -> {
+      try {
+        bucketIndex.scheduleCompaction();
+        bucketIndex.compact();
+      } catch (final Throwable e) {
+        error.set(e);
+      } finally {
+        done.countDown();
+      }
+    }, "compaction-thread").start();
+
+    assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+    assertThat(error.get()).isNull();
+
+    final LocalSchema schemaBefore = database.getSchema().getEmbedded();
+    final Integer newFidBefore = schemaBefore.getMigratedFileId(oldMutableFid);
+    assertThat(newFidBefore).isNotNull();
+
+    database.close();
+    database = factory.open();
+
+    final LocalSchema schemaAfter = database.getSchema().getEmbedded();
+    assertThat(schemaAfter.getMigratedFileId(oldMutableFid))
+        .as("Round-tripped migration entry must equal pre-close value")
+        .isEqualTo(newFidBefore);
+  }
+}


### PR DESCRIPTION
Closes #4333

## Summary

`LocalSchema.migratedFileIds` (the old->new fileId map written by LSM/vector index compaction) was a heap-only `ConcurrentHashMap` that was never included in `schema.json`. After a restart the map was always empty, so `TransactionManager.applyChanges` could not distinguish a safe compaction-migration skip from an unknown missing-file condition, silently dropping WAL pages at FINE level after every compaction+restart.

**Changes:**

- `LocalSchema.toJSON()`: serialize `migratedFileIds` as a JSON object under the key `"migratedFileIds"` (only emitted when non-empty, so existing schema files without the key remain compatible)
- `LocalSchema` loading: restore `migratedFileIds` from the JSON block on open, clearing the map first for idempotency
- `TransactionManager.applyChanges()`: consult the migration map when a fileId is missing; log FINE for known compaction-migrations (safe skip, data already in the new file), WARNING for unknown missing files (deleted by schema change or incomplete migration map)

## Test plan

- [x] `MigratedFileIdsPersistenceTest#migratedFileIdsArePersisted` - after compaction triggers `setMigratedFileId`, close and reopen the database; migration map must still be populated
- [x] `MigratedFileIdsPersistenceTest#migratedFileIdsRoundTrip` - round-trip the map through close+reopen and verify exact old->new entries
- [x] `LSMTreeIndexCompactionTest` - all existing compaction tests pass
- [x] `LockFilesInOrderFileMigrationTest` - existing file-migration regression test passes
- [x] `ConcurrentCompactionTest` - concurrent compaction tests pass