### PR TITLE
fix(#4334): convert JVector EUCLIDEAN similarity to L2² distance in all search paths

### DIFF
--- a/docs/4334-euclidean-knn-wrong-order.md
+++ b/docs/4334-euclidean-knn-wrong-order.md
@@ -52,6 +52,28 @@ All five locations fixed with the same formula.
 
 - [x] Write failing tests
 - [x] Apply fix to all five code locations
-- [x] Regression tests pass: 2/2
+- [x] Regression tests pass: 4/4
 - [x] Full vector index suite passes: 139/139 tests
-- [x] Related query tests pass: CypherCallVectorNeighborsTest, SelectVectorTest
+- [x] Related query tests pass: CypherCallVectorNeighborsTest, SelectVectorTest, SQLFunctionVectorNeighborsTest
+
+## PR
+
+PR #4343 - https://github.com/ArcadeData/arcadedb/pull/4343
+
+## Review cycles
+
+| Cycle | HEAD SHA | Change | Bot outcome |
+|---|---|---|---|
+| 1 | b88dbbd1 | Initial fix to 5 EUCLIDEAN sites | gemini: extract helper; claude: DbIndexVectorQueryNodes regression + exhaustive switch + trim Javadoc |
+| 2 | ffae8cdc | Extract `scoreToDistance` helper | no new reviews |
+| 3 | 1d777ee6 | Fix DbIndexVectorQueryNodes EUCLIDEAN score, exhaustive switch, trim Javadoc, add 2 tests | claude: 3 items, all out of scope (see below) |
+
+## Cycle 3 declined items
+
+1. **Mixed similarity functions across shards** - theoretical only. A `TypeIndex`'s bucket-level `LSMVectorIndex` instances share one `LSMVectorIndexMetadata` by construction; no realistic codepath produces shards with divergent similarity functions. Defensive validation would add noise without addressing a real risk.
+2. **COSINE score in `DbIndexVectorQueryNodes` can be negative** - pre-existing behavior unchanged by this PR. Before fix: `score = 1 - 2*(1-rawScore) = 2*rawScore - 1 = cos`. After fix: identical formula, identical result. Pre-existing COSINE/DOT_PRODUCT score semantics are out of scope for #4334 (EUCLIDEAN ordering).
+3. **Remove `docs/4334-*.md`** - contradicts repo convention. 10+ recent merged fix PRs commit identically-shaped tracking docs (#4339, #4341, #4338, #4340, #4322, #4323, #4325, #4281, #4280, #4279).
+
+## Final state
+
+clean-approval (cycle-3 review provided feedback but none actionable for issue scope)

--- a/docs/4334-euclidean-knn-wrong-order.md
+++ b/docs/4334-euclidean-knn-wrong-order.md
@@ -1,0 +1,57 @@
+# Fix #4334 — LSMVectorIndex EUCLIDEAN K-NN returns worst matches first
+
+## Root Cause
+
+JVector's `VectorSimilarityFunction.EUCLIDEAN.compare(u, v)` returns a **similarity** value:
+
+```
+similarity = 1 / (1 + L2²)
+```
+
+Larger similarity means closer vectors. ArcadeDB's three distance-conversion paths in
+`LSMVectorIndex.java` incorrectly treat this similarity as a distance and sort ascending,
+placing the *least similar* (farthest) candidates first.
+
+### Affected code locations
+
+| Method | Lines | Bug |
+|---|---|---|
+| `findNeighborsFromVector` (graph path) | ~2971–2982 | `case EUCLIDEAN -> score` |
+| `mergeWithDeltaScan` (delta path) | ~2733–2738 | `case EUCLIDEAN -> score` |
+| `bruteForceScan` (brute-force path) | ~2779–2784 | `case EUCLIDEAN -> score` |
+
+All three sort ascending by the computed "distance" value. With similarity as distance, the
+sort places far vectors (low similarity) first.
+
+## Fix
+
+Convert similarity back to squared L2 distance (preserves sort order, avoids sqrt):
+
+```java
+case EUCLIDEAN -> score > 0 ? (1.0f / score) - 1.0f : Float.MAX_VALUE;
+```
+
+Math: `similarity = 1/(1+L2²)` → `L2² = 1/similarity - 1`. Sorted ascending → closest first.
+
+## Verification
+
+Test class: `LSMVectorIndexEuclideanOrderingTest`
+
+- `euclideanKnnReturnClosestFirst`: k=1 from three vectors, nearest vector returned.
+- `euclideanKnnOrdering`: k=3, all three results in correct L2² ascending order.
+
+## Additional fix locations
+
+The issue reported three locations. Two additional conversion paths were also affected:
+- `findNeighborsFromVectorGroupBy` grouped search path (~line 3171)
+- Zero-disk-I/O PQ search path (~line 3321)
+
+All five locations fixed with the same formula.
+
+## Status
+
+- [x] Write failing tests
+- [x] Apply fix to all five code locations
+- [x] Regression tests pass: 2/2
+- [x] Full vector index suite passes: 139/139 tests
+- [x] Related query tests pass: CypherCallVectorNeighborsTest, SelectVectorTest

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -2732,7 +2732,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
       final float score = metadata.similarityFunction.compare(queryVectorFloat, deltaVf);
       final float distance = switch (metadata.similarityFunction) {
         case COSINE -> 2.0f * (1.0f - score);
-        case EUCLIDEAN -> score;
+        case EUCLIDEAN -> score > 0 ? (1.0f / score) - 1.0f : Float.MAX_VALUE;
         case DOT_PRODUCT -> -score;
         default -> score;
       };
@@ -2778,7 +2778,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
       final float score = metadata.similarityFunction.compare(queryVectorFloat, vec);
       final float distance = switch (metadata.similarityFunction) {
         case COSINE -> 2.0f * (1.0f - score);
-        case EUCLIDEAN -> score;
+        case EUCLIDEAN -> score > 0 ? (1.0f / score) - 1.0f : Float.MAX_VALUE;
         case DOT_PRODUCT -> -score;
         default -> score;
       };
@@ -2973,8 +2973,9 @@ public class LSMVectorIndex implements Index, IndexInternal {
                   // JVector COSINE score = (1 + cos) / 2, so cos = 2*score - 1, distance = 1 - cos
                     2.0f * (1.0f - score);
                 case EUCLIDEAN ->
-                  // For euclidean, the score is already the distance
-                    score;
+                  // JVector EUCLIDEAN score = 1/(1+L2²) (similarity, larger = closer).
+                  // Convert back to L2² so ascending sort places nearest candidates first.
+                    score > 0 ? (1.0f / score) - 1.0f : Float.MAX_VALUE;
                 case DOT_PRODUCT ->
                   // For dot product, higher score is better (closer), so negate it
                     -score;
@@ -3167,7 +3168,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
           final float score = nodeScore.score;
           final float distance = switch (metadata.similarityFunction) {
             case COSINE -> 2.0f * (1.0f - score);
-            case EUCLIDEAN -> score;
+            case EUCLIDEAN -> score > 0 ? (1.0f / score) - 1.0f : Float.MAX_VALUE;
             case DOT_PRODUCT -> -score;
             default -> score;
           };
@@ -3317,7 +3318,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
                 case COSINE ->
                   // JVector COSINE score = (1 + cos) / 2, so cos = 2*score - 1, distance = 1 - cos
                     2.0f * (1.0f - score);
-                case EUCLIDEAN -> score;
+                case EUCLIDEAN ->
+                  // JVector EUCLIDEAN score = 1/(1+L2²) (similarity, larger = closer).
+                  // Convert back to L2² so ascending sort places nearest candidates first.
+                    score > 0 ? (1.0f / score) - 1.0f : Float.MAX_VALUE;
                 case DOT_PRODUCT -> -score;
                 default -> score;
               };

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -2702,18 +2702,12 @@ public class LSMVectorIndex implements Index, IndexInternal {
     return page;
   }
 
-  /**
-   * Convert a JVector similarity score into a distance value suitable for ascending sort (nearest first).
-   * JVector returns similarity (larger = closer) for every metric, so each branch maps back to a true distance:
-   * COSINE score=(1+cos)/2 → 2*(1-score); EUCLIDEAN score=1/(1+L2²) → L2² via (1/score)-1; DOT_PRODUCT is negated.
-   * The EUCLIDEAN branch guards against a zero similarity (vectors at infinity) with Float.MAX_VALUE.
-   */
-  private static float scoreToDistance(final VectorSimilarityFunction similarityFunction, final float score) {
+  /** Map JVector similarity (larger = closer) back to a distance so ascending sort returns nearest first. */
+  static float scoreToDistance(final VectorSimilarityFunction similarityFunction, final float score) {
     return switch (similarityFunction) {
       case COSINE -> 2.0f * (1.0f - score);
       case EUCLIDEAN -> score > 0 ? (1.0f / score) - 1.0f : Float.MAX_VALUE;
       case DOT_PRODUCT -> -score;
-      default -> score;
     };
   }
 

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -2703,6 +2703,21 @@ public class LSMVectorIndex implements Index, IndexInternal {
   }
 
   /**
+   * Convert a JVector similarity score into a distance value suitable for ascending sort (nearest first).
+   * JVector returns similarity (larger = closer) for every metric, so each branch maps back to a true distance:
+   * COSINE score=(1+cos)/2 → 2*(1-score); EUCLIDEAN score=1/(1+L2²) → L2² via (1/score)-1; DOT_PRODUCT is negated.
+   * The EUCLIDEAN branch guards against a zero similarity (vectors at infinity) with Float.MAX_VALUE.
+   */
+  private static float scoreToDistance(final VectorSimilarityFunction similarityFunction, final float score) {
+    return switch (similarityFunction) {
+      case COSINE -> 2.0f * (1.0f - score);
+      case EUCLIDEAN -> score > 0 ? (1.0f / score) - 1.0f : Float.MAX_VALUE;
+      case DOT_PRODUCT -> -score;
+      default -> score;
+    };
+  }
+
+  /**
    * Brute-force scan of delta vectors (inserted since last graph rebuild) and merge with graph search results.
    * Cost is negligible for small delta buffers (microseconds for ≤100 vectors).
    */
@@ -2730,13 +2745,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
       final VectorFloat<?> deltaVf = vts.createFloatVector(delta.vector);
       final float score = metadata.similarityFunction.compare(queryVectorFloat, deltaVf);
-      final float distance = switch (metadata.similarityFunction) {
-        case COSINE -> 2.0f * (1.0f - score);
-        case EUCLIDEAN -> score > 0 ? (1.0f / score) - 1.0f : Float.MAX_VALUE;
-        case DOT_PRODUCT -> -score;
-        default -> score;
-      };
-      results.add(new Pair<>(bindRid(delta.rid), distance));
+      results.add(new Pair<>(bindRid(delta.rid), scoreToDistance(metadata.similarityFunction, score)));
       added = true;
     }
 
@@ -2776,13 +2785,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
         continue;
 
       final float score = metadata.similarityFunction.compare(queryVectorFloat, vec);
-      final float distance = switch (metadata.similarityFunction) {
-        case COSINE -> 2.0f * (1.0f - score);
-        case EUCLIDEAN -> score > 0 ? (1.0f / score) - 1.0f : Float.MAX_VALUE;
-        case DOT_PRODUCT -> -score;
-        default -> score;
-      };
-      results.add(new Pair<>(bindRid(loc.rid), distance));
+      results.add(new Pair<>(bindRid(loc.rid), scoreToDistance(metadata.similarityFunction, score)));
       added = true;
     }
 
@@ -2965,23 +2968,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
               if (allowedRIDs != null && !allowedRIDs.isEmpty() && !allowedRIDs.contains(loc.rid))
                 continue;
 
-              // JVector returns similarity scores - convert to distance based on similarity function
-              // Note: JVector's COSINE returns (1 + cos(a,b)) / 2 mapped to [0, 1]
-              final float score = nodeScore.score;
-              final float distance = switch (metadata.similarityFunction) {
-                case COSINE ->
-                  // JVector COSINE score = (1 + cos) / 2, so cos = 2*score - 1, distance = 1 - cos
-                    2.0f * (1.0f - score);
-                case EUCLIDEAN ->
-                  // JVector EUCLIDEAN score = 1/(1+L2²) (similarity, larger = closer).
-                  // Convert back to L2² so ascending sort places nearest candidates first.
-                    score > 0 ? (1.0f / score) - 1.0f : Float.MAX_VALUE;
-                case DOT_PRODUCT ->
-                  // For dot product, higher score is better (closer), so negate it
-                    -score;
-                default -> score;
-              };
-              results.add(new Pair<>(bindRid(loc.rid), distance));
+              results.add(new Pair<>(bindRid(loc.rid), scoreToDistance(metadata.similarityFunction, nodeScore.score)));
             } else {
               skippedDeletedOrNull++;
             }
@@ -3165,14 +3152,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
           if (allowedRIDs != null && !allowedRIDs.isEmpty() && !allowedRIDs.contains(loc.rid))
             continue;
 
-          final float score = nodeScore.score;
-          final float distance = switch (metadata.similarityFunction) {
-            case COSINE -> 2.0f * (1.0f - score);
-            case EUCLIDEAN -> score > 0 ? (1.0f / score) - 1.0f : Float.MAX_VALUE;
-            case DOT_PRODUCT -> -score;
-            default -> score;
-          };
-          results.add(new Pair<>(bindRid(loc.rid), distance));
+          results.add(new Pair<>(bindRid(loc.rid), scoreToDistance(metadata.similarityFunction, nodeScore.score)));
         }
 
         LogManager.instance()
@@ -3311,20 +3291,7 @@ public class LSMVectorIndex implements Index, IndexInternal {
             final int vectorId = ordinalToVectorId[ordinal];
             final VectorLocationIndex.VectorLocation loc = vectorIndex.getLocation(vectorId);
             if (loc != null && !loc.deleted) {
-              // Convert similarity score to distance
-              // Note: JVector's COSINE returns (1 + cos(a,b)) / 2 mapped to [0, 1]
-              final float score = nodeScore.score;
-              final float distance = switch (metadata.similarityFunction) {
-                case COSINE ->
-                  // JVector COSINE score = (1 + cos) / 2, so cos = 2*score - 1, distance = 1 - cos
-                    2.0f * (1.0f - score);
-                case EUCLIDEAN ->
-                  // JVector EUCLIDEAN score = 1/(1+L2²) (similarity, larger = closer).
-                  // Convert back to L2² so ascending sort places nearest candidates first.
-                    score > 0 ? (1.0f / score) - 1.0f : Float.MAX_VALUE;
-                case DOT_PRODUCT -> -score;
-                default -> score;
-              };
+              final float distance = scoreToDistance(metadata.similarityFunction, nodeScore.score);
               results.add(new Pair<>(bindRid(loc.rid), distance));
             } else {
               skippedDeletedOrNull++;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbIndexVectorQueryNodes.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/db/DbIndexVectorQueryNodes.java
@@ -32,6 +32,7 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.utility.Pair;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -121,7 +122,9 @@ public class DbIndexVectorQueryNodes implements CypherProcedure {
     // Sort by distance (ascending - closer is better)
     allNeighbors.sort(Comparator.comparing(Pair::getSecond));
 
-    // Take top k results, converting distance to score (similarity)
+    // Take top k results, converting distance to score (similarity).
+    // EUCLIDEAN distance is L2² in [0, ∞); map it back to a (0, 1] similarity so callers receive a comparable score.
+    final VectorSimilarityFunction similarityFunction = vectorIndexes.getFirst().getSimilarityFunction();
     final int resultCount = Math.min(limit, allNeighbors.size());
     final List<Result> results = new ArrayList<>(resultCount);
 
@@ -130,9 +133,13 @@ public class DbIndexVectorQueryNodes implements CypherProcedure {
       final Document record = neighbor.getFirst().asDocument();
       final float distance = neighbor.getSecond();
 
+      final float score = similarityFunction == VectorSimilarityFunction.EUCLIDEAN
+          ? 1.0f / (1.0f + distance)
+          : 1.0f - distance;
+
       final ResultInternal r = new ResultInternal();
       r.setProperty("node", record);
-      r.setProperty("score", 1.0f - distance);
+      r.setProperty("score", score);
       results.add(r);
     }
 

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexEuclideanOrderingTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexEuclideanOrderingTest.java
@@ -21,10 +21,15 @@ package com.arcadedb.index.vector;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.RID;
 import com.arcadedb.index.TypeIndex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.utility.Pair;
+import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -126,5 +131,65 @@ class LSMVectorIndexEuclideanOrderingTest extends TestHelper {
     assertThat(results.get(1).getSecond())
         .as("distances must be non-decreasing")
         .isLessThanOrEqualTo(results.get(2).getSecond());
+  }
+
+  @Test
+  void scoreToDistanceHelperRoundsTripEuclidean() {
+    // Verify the helper formula directly: similarity = 1/(1+L2²) → distance = (1/similarity)-1 = L2²
+    final float l2Squared = 4.0f;
+    final float similarity = 1.0f / (1.0f + l2Squared);
+    final float distance = LSMVectorIndex.scoreToDistance(VectorSimilarityFunction.EUCLIDEAN, similarity);
+    assertThat(distance).isEqualTo(l2Squared);
+
+    // Defensive branch: zero similarity (vectors at infinity) must produce a max-distance sentinel
+    assertThat(LSMVectorIndex.scoreToDistance(VectorSimilarityFunction.EUCLIDEAN, 0.0f))
+        .isEqualTo(Float.MAX_VALUE);
+  }
+
+  @Test
+  void queryNodesEuclideanScoreIsPositiveSimilarity() {
+    // Neo4j-compatible db.index.vector.queryNodes must yield a (0, 1] similarity score for EUCLIDEAN,
+    // not 1 - L2² (which would be hugely negative once the LSMVectorIndex distance is squared L2).
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE EuclidQN IF NOT EXISTS");
+      database.command("sql", "CREATE PROPERTY EuclidQN.name IF NOT EXISTS STRING");
+      database.command("sql", "CREATE PROPERTY EuclidQN.embedding IF NOT EXISTS ARRAY_OF_FLOATS");
+      database.command("sql", """
+          CREATE INDEX IF NOT EXISTS ON EuclidQN (embedding) LSM_VECTOR
+          METADATA {
+            "dimensions": 2,
+            "similarity": "EUCLIDEAN",
+            "idPropertyName": "name"
+          }""");
+    });
+
+    database.transaction(() -> {
+      database.newVertex("EuclidQN").set("name", "near")
+          .set("embedding", new float[] { 0.1f, 0.1f }).save();
+      database.newVertex("EuclidQN").set("name", "far")
+          .set("embedding", new float[] { 10.0f, 10.0f }).save();
+    });
+
+    final Map<String, Object> params = new HashMap<>();
+    params.put("vec", new float[] { 0.0f, 0.0f });
+    params.put("k", 2);
+
+    try (final ResultSet results = database.query("opencypher",
+        "CALL db.index.vector.queryNodes('EuclidQN[embedding]', $k, $vec) YIELD node, score RETURN node.name AS name, score",
+        params)) {
+
+      assertThat(results.hasNext()).isTrue();
+      final Result first = results.next();
+      assertThat((String) first.getProperty("name")).isEqualTo("near");
+      final double nearScore = ((Number) first.getProperty("score")).doubleValue();
+      assertThat(nearScore).as("near vector score must be a positive similarity in (0, 1]").isBetween(0.0, 1.0);
+
+      assertThat(results.hasNext()).isTrue();
+      final Result second = results.next();
+      assertThat((String) second.getProperty("name")).isEqualTo("far");
+      final double farScore = ((Number) second.getProperty("score")).doubleValue();
+      assertThat(farScore).as("far vector score must be a positive similarity in (0, 1]").isBetween(0.0, 1.0);
+      assertThat(nearScore).as("nearer vector must have a higher similarity score").isGreaterThan(farScore);
+    }
   }
 }

--- a/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexEuclideanOrderingTest.java
+++ b/engine/src/test/java/com/arcadedb/index/vector/LSMVectorIndexEuclideanOrderingTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.vector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.utility.Pair;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #4334.
+ *
+ * JVector's EUCLIDEAN compare() returns similarity = 1/(1+L2²), not a distance.
+ * K-NN must return closest matches first (ascending L2²).
+ * Before the fix the sort used raw similarity, placing farthest candidates first.
+ */
+class LSMVectorIndexEuclideanOrderingTest extends TestHelper {
+
+  @Test
+  void euclideanKnnReturnClosestFirst() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE EuclidVec IF NOT EXISTS");
+      database.command("sql", "CREATE PROPERTY EuclidVec.name IF NOT EXISTS STRING");
+      database.command("sql", "CREATE PROPERTY EuclidVec.embedding IF NOT EXISTS ARRAY_OF_FLOATS");
+      database.command("sql", """
+          CREATE INDEX IF NOT EXISTS ON EuclidVec (embedding) LSM_VECTOR
+          METADATA {
+            "dimensions": 2,
+            "similarity": "EUCLIDEAN",
+            "maxConnections": 16,
+            "beamWidth": 100
+          }""");
+    });
+
+    // near: L2²=0.02, far: L2²=200 from query [0,0]
+    final RID[] nearRid = new RID[1];
+    database.transaction(() -> {
+      nearRid[0] = database.newVertex("EuclidVec")
+          .set("name", "near")
+          .set("embedding", new float[] { 0.1f, 0.1f })
+          .save()
+          .getIdentity();
+      database.newVertex("EuclidVec")
+          .set("name", "far")
+          .set("embedding", new float[] { 10.0f, 10.0f })
+          .save();
+    });
+
+    final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("EuclidVec[embedding]");
+    final LSMVectorIndex index = (LSMVectorIndex) typeIndex.getIndexesOnBuckets()[0];
+
+    final List<Pair<RID, Float>> results = index.findNeighborsFromVector(new float[] { 0.0f, 0.0f }, 1);
+
+    assertThat(results).hasSize(1);
+    assertThat(results.get(0).getFirst()).as("k=1 must return the closest vector").isEqualTo(nearRid[0]);
+  }
+
+  @Test
+  void euclideanKnnOrdering() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE VERTEX TYPE EuclidOrder IF NOT EXISTS");
+      database.command("sql", "CREATE PROPERTY EuclidOrder.name IF NOT EXISTS STRING");
+      database.command("sql", "CREATE PROPERTY EuclidOrder.embedding IF NOT EXISTS ARRAY_OF_FLOATS");
+      database.command("sql", """
+          CREATE INDEX IF NOT EXISTS ON EuclidOrder (embedding) LSM_VECTOR
+          METADATA {
+            "dimensions": 2,
+            "similarity": "EUCLIDEAN",
+            "maxConnections": 16,
+            "beamWidth": 100
+          }""");
+    });
+
+    // Three vectors at known L2² from query [0,0]:
+    //   near: [0.1, 0.1] → L2²=0.02
+    //   mid:  [3.0, 4.0] → L2²=25.0
+    //   far:  [10.0,10.0] → L2²=200.0
+    final RID[] rids = new RID[3];
+    database.transaction(() -> {
+      rids[0] = database.newVertex("EuclidOrder")
+          .set("name", "near")
+          .set("embedding", new float[] { 0.1f, 0.1f })
+          .save().getIdentity();
+      rids[1] = database.newVertex("EuclidOrder")
+          .set("name", "mid")
+          .set("embedding", new float[] { 3.0f, 4.0f })
+          .save().getIdentity();
+      rids[2] = database.newVertex("EuclidOrder")
+          .set("name", "far")
+          .set("embedding", new float[] { 10.0f, 10.0f })
+          .save().getIdentity();
+    });
+
+    final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("EuclidOrder[embedding]");
+    final LSMVectorIndex index = (LSMVectorIndex) typeIndex.getIndexesOnBuckets()[0];
+
+    final List<Pair<RID, Float>> results = index.findNeighborsFromVector(new float[] { 0.0f, 0.0f }, 3);
+
+    assertThat(results).hasSize(3);
+    assertThat(results.get(0).getFirst()).as("first result must be the nearest vector").isEqualTo(rids[0]);
+    assertThat(results.get(2).getFirst()).as("last result must be the farthest vector").isEqualTo(rids[2]);
+    assertThat(results.get(0).getSecond())
+        .as("distances must be non-decreasing")
+        .isLessThanOrEqualTo(results.get(1).getSecond());
+    assertThat(results.get(1).getSecond())
+        .as("distances must be non-decreasing")
+        .isLessThanOrEqualTo(results.get(2).getSecond());
+  }
+}


### PR DESCRIPTION
Closes #4334

JVector's `VectorSimilarityFunction.EUCLIDEAN.compare(u, v)` returns a **similarity** value of the form `1/(1+L2²)` (larger = closer), not a distance. All five distance-conversion switch expressions in `LSMVectorIndex` were using `score` as-is and then sorting ascending, which placed the *least similar* (farthest) candidates first.

The fix converts similarity back to squared L2 distance before sorting:

```java
case EUCLIDEAN -> score > 0 ? (1.0f / score) - 1.0f : Float.MAX_VALUE;
```

Since `similarity = 1/(1+L2²)`, inverting gives `L2² = 1/similarity - 1`. Ascending sort on L2² correctly returns nearest neighbours first. The `score > 0` guard is defensive; JVector's EUCLIDEAN score is always positive.

**Affected paths fixed (all in `LSMVectorIndex.java`):**
- `mergeWithDeltaScan` - delta vectors inserted since last graph rebuild
- `bruteForceScan` - brute-force fallback when graph returns too few results
- `findNeighborsFromVector` - primary graph search path
- `findNeighborsFromVectorGroupBy` - grouped search path
- Zero-disk-I/O PQ search path

## Test plan

- [x] `LSMVectorIndexEuclideanOrderingTest.euclideanKnnReturnClosestFirst` - k=1 with a near and far vector: verifies the near vector is returned
- [x] `LSMVectorIndexEuclideanOrderingTest.euclideanKnnOrdering` - k=3 with three vectors at known L2² distances: verifies results are in non-decreasing distance order and nearest is first
- [x] Full `LSMVectorIndex*` test suite: 139 tests, 0 failures
- [x] `CypherCallVectorNeighborsTest`, `SelectVectorTest`: no regressions