### PR TITLE
fix(#4337): unwrap single-property Result in executeQuery so IN (SELECT …) matches correctly

### DIFF
--- a/docs/4337-incondition-subquery-scalar-unwrap.md
+++ b/docs/4337-incondition-subquery-scalar-unwrap.md
@@ -37,3 +37,26 @@ In `executeQuery`, unwrap single-property non-element `Result` rows to their sca
 ## Test Results
 
 All 5 tests in `InConditionSubqueryTest` pass. No regressions in `QueryTest` (66), `QueryAndIndexesTest` (2), `SQLScriptTest` (27), or related suites.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/4344
+
+## Review Cycles
+
+### Cycle 1 - HEAD `334640ca4`
+
+- gemini-code-assist reviewed (COMMENTED)
+- Feedback: also unwrap `iLeft` at the top of `evaluateExpression` for Set fast-path symmetry when `iLeft` itself is a single-property non-element `Result`
+- Applied: yes - added `iLeft` unwrap before the `MultiValue.isMultiValue(iRight)` block
+- Follow-up commit: `29b72391e` - "address review: unwrap iLeft Result in evaluateExpression for Set fast-path symmetry"
+
+### Cycle 2 - HEAD `29b72391e`
+
+- gemini-code-assist: no re-review (known behavior - bot does not re-review follow-up pushes)
+- claude: no review (bot not installed in this repository)
+- Exited loop: known bot limitation, not a code quality concern
+
+## Final State
+
+`timeout` - per-repository bot behavior: only gemini-code-assist is installed, and it does not re-review follow-up commits.

--- a/docs/4337-incondition-subquery-scalar-unwrap.md
+++ b/docs/4337-incondition-subquery-scalar-unwrap.md
@@ -1,0 +1,39 @@
+# Fix #4337 — `InCondition` subquery collects `Result` objects, `IN (SELECT …)` always returns empty
+
+## Root Cause
+
+`InCondition.executeQuery()` materialises the subquery `ResultSet` into a `Set<Result>`:
+
+```java
+return result.stream().collect(Collectors.toSet());
+```
+
+`evaluateExpression()` then takes the `Set<?>` fast-path:
+
+```java
+if (iRight instanceof Set<?> set)
+    return set.contains(iLeft);
+```
+
+`set.contains(iLeft)` calls `iLeft.equals(Result)` (Java `HashSet` logic). A scalar like `String` or `Integer` is never equal to a `Result` object, so this always returns `false`. The downstream unwrapping loop that uses `QueryOperatorEquals.equals()` (which correctly handles `Result` → scalar) is never reached.
+
+## Fix
+
+In `executeQuery`, unwrap single-property non-element `Result` rows to their scalar values before collecting into the `Set`. This makes `set.contains(scalar)` work correctly for the common `IN (SELECT field FROM type)` pattern, while multi-property results and vertex/edge rows pass through unchanged.
+
+## Affected Files
+
+- `engine/src/main/java/com/arcadedb/query/sql/parser/InCondition.java`
+- `engine/src/test/java/com/arcadedb/query/sql/InConditionSubqueryTest.java` (new)
+
+## Test Plan
+
+- `IN (SELECT name FROM type)` returns matching rows (via standard planner path)
+- `NOT IN (SELECT name FROM type)` returns non-matching rows
+- `IN (SELECT age FROM type WHERE ...)` with integer subquery works
+- `count(*)` with IN subquery returns correct count
+- Direct `InCondition.evaluate()` without planner returns correct match (regression for the `executeQuery` path)
+
+## Test Results
+
+All 5 tests in `InConditionSubqueryTest` pass. No regressions in `QueryTest` (66), `QueryAndIndexesTest` (2), `SQLScriptTest` (27), or related suites.

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/InCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/InCondition.java
@@ -146,7 +146,12 @@ public class InCondition extends BooleanExpression {
         .collect(Collectors.toSet());
   }
 
-  protected static boolean evaluateExpression(final Object iLeft, final Object iRight) {
+  protected static boolean evaluateExpression(Object iLeft, final Object iRight) {
+    if (iLeft instanceof Result r && !r.isElement()) {
+      final Set<String> names = r.getPropertyNames();
+      if (names.size() == 1)
+        iLeft = r.getProperty(names.iterator().next());
+    }
     if (MultiValue.isMultiValue(iRight)) {
       if (iRight instanceof Set<?> set)
         return set.contains(iLeft);

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/InCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/InCondition.java
@@ -134,7 +134,16 @@ public class InCondition extends BooleanExpression {
 
   protected static Object executeQuery(final SelectStatement rightStatement, final CommandContext context) {
     final ResultSet result = rightStatement.execute(context.getDatabase(), context.getInputParameters());
-    return result.stream().collect(Collectors.toSet());
+    return result.stream()
+        .map(r -> {
+          if (!r.isElement()) {
+            final Set<String> names = r.getPropertyNames();
+            if (names.size() == 1)
+              return r.getProperty(names.iterator().next());
+          }
+          return (Object) r;
+        })
+        .collect(Collectors.toSet());
   }
 
   protected static boolean evaluateExpression(final Object iLeft, final Object iRight) {

--- a/engine/src/test/java/com/arcadedb/query/sql/InConditionSubqueryTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/InConditionSubqueryTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.antlr.SQLAntlrParser;
+import com.arcadedb.query.sql.executor.BasicCommandContext;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultInternal;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.query.sql.parser.AndBlock;
+import com.arcadedb.query.sql.parser.BooleanExpression;
+import com.arcadedb.query.sql.parser.InCondition;
+import com.arcadedb.query.sql.parser.OrBlock;
+import com.arcadedb.query.sql.parser.WhereClause;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for IN (SELECT …) subquery evaluation.
+ * <p>
+ * Two code paths are covered:
+ * <ul>
+ *   <li>Standard SELECT path — subquery is extracted into a LET variable by
+ *       SelectExecutionPlanner and materialised as List&lt;Result&gt;. The loop in
+ *       InCondition.evaluateExpression handles the comparison via QueryOperatorEquals.</li>
+ *   <li>Direct-evaluation path — no planner extractSubQueries is called, so evaluateRight
+ *       calls executeQuery which returns Set&lt;Result&gt;. Before the fix, the Set fast-path
+ *       in evaluateExpression called set.contains(scalar), which was always false because
+ *       scalar.equals(Result{name:scalar}) is never true.</li>
+ * </ul>
+ */
+class InConditionSubqueryTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Person4337");
+      database.getSchema().createDocumentType("AllowedName4337");
+
+      database.command("SQL", "INSERT INTO Person4337 SET name = 'Alice', age = 30");
+      database.command("SQL", "INSERT INTO Person4337 SET name = 'Bob', age = 25");
+      database.command("SQL", "INSERT INTO Person4337 SET name = 'Charlie', age = 40");
+
+      database.command("SQL", "INSERT INTO AllowedName4337 SET name = 'Alice'");
+      database.command("SQL", "INSERT INTO AllowedName4337 SET name = 'Charlie'");
+    });
+  }
+
+  @Test
+  void inWithScalarSubqueryReturnsMatchingRows() {
+    final ResultSet rs = database.query("SQL",
+        "SELECT name FROM Person4337 WHERE name IN (SELECT name FROM AllowedName4337) ORDER BY name");
+
+    final List<String> names = new ArrayList<>();
+    while (rs.hasNext()) {
+      final Result r = rs.next();
+      names.add(r.getProperty("name"));
+    }
+
+    assertThat(names).containsExactly("Alice", "Charlie");
+  }
+
+  @Test
+  void notInWithScalarSubqueryExcludesMatchingRows() {
+    final ResultSet rs = database.query("SQL",
+        "SELECT name FROM Person4337 WHERE name NOT IN (SELECT name FROM AllowedName4337) ORDER BY name");
+
+    final List<String> names = new ArrayList<>();
+    while (rs.hasNext()) {
+      final Result r = rs.next();
+      names.add(r.getProperty("name"));
+    }
+
+    assertThat(names).containsExactly("Bob");
+  }
+
+  @Test
+  void inWithIntegerSubqueryReturnsMatchingRows() {
+    final ResultSet rs = database.query("SQL",
+        "SELECT name FROM Person4337 WHERE age IN (SELECT age FROM Person4337 WHERE name = 'Alice' OR name = 'Bob') ORDER BY name");
+
+    final List<String> names = new ArrayList<>();
+    while (rs.hasNext()) {
+      final Result r = rs.next();
+      names.add(r.getProperty("name"));
+    }
+
+    assertThat(names).containsExactly("Alice", "Bob");
+  }
+
+  @Test
+  void inWithSubqueryCountMatchesExpected() {
+    final ResultSet rs = database.query("SQL",
+        "SELECT count(*) as cnt FROM Person4337 WHERE name IN (SELECT name FROM AllowedName4337)");
+
+    assertThat(rs.hasNext()).isTrue();
+    final Result r = rs.next();
+    assertThat(r.<Long>getProperty("cnt")).isEqualTo(2L);
+  }
+
+  /**
+   * Direct-evaluation path: the InCondition is evaluated without going through
+   * SelectExecutionPlanner.extractSubQueries, so evaluateRight calls executeQuery which
+   * returns Set&lt;Result&gt;. Before the fix, set.contains(scalar) always returned false.
+   * After the fix, executeQuery unwraps single-property Results to scalars, and
+   * set.contains("Alice") returns true.
+   */
+  @Test
+  void directEvalWithoutPlannerReturnsCorrectMatch() {
+    database.transaction(() -> {
+      final WhereClause where = new SQLAntlrParser(database)
+          .parseCondition("name IN (SELECT name FROM AllowedName4337)");
+
+      final BasicCommandContext ctx = new BasicCommandContext();
+      ctx.setDatabase(database);
+
+      // Extract the InCondition from the parsed WHERE clause tree.
+      final InCondition inCond = extractInCondition(where);
+      assertThat(inCond).as("InCondition should be present in parsed WHERE clause").isNotNull();
+      assertThat(inCond.rightStatement).as("rightStatement should be non-null before extractSubQueries").isNotNull();
+
+      // Evaluate against a record that IS in the allowed set — must return true.
+      final ResultInternal alice = new ResultInternal(Map.of("name", "Alice"));
+      assertThat(inCond.evaluate(alice, ctx)).isTrue();
+
+      // Evaluate against a record that is NOT in the allowed set — must return false.
+      final ResultInternal bob = new ResultInternal(Map.of("name", "Bob"));
+      assertThat(inCond.evaluate(bob, ctx)).isFalse();
+    });
+  }
+
+  private InCondition extractInCondition(final WhereClause where) {
+    final BooleanExpression base = where.getBaseExpression();
+    if (base instanceof InCondition ic)
+      return ic;
+    if (base instanceof AndBlock ab) {
+      for (final BooleanExpression sub : ab.getSubBlocks())
+        if (sub instanceof InCondition ic)
+          return ic;
+    }
+    if (base instanceof OrBlock ob) {
+      for (final BooleanExpression ab : ob.getSubBlocks()) {
+        if (ab instanceof InCondition ic)
+          return ic;
+        if (ab instanceof AndBlock andB) {
+          for (final BooleanExpression sub : andB.getSubBlocks())
+            if (sub instanceof InCondition ic)
+              return ic;
+        }
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #4337

`InCondition.executeQuery` materialised the subquery `ResultSet` into a `Set<Result>`. The Set fast-path in `evaluateExpression` then called `set.contains(scalar)`, which always returned `false` because `scalar.equals(Result{prop:scalar})` is never true. This made every `IN (SELECT …)` clause silently return no rows for any code path that calls `evaluateRight` without first running `SelectExecutionPlanner.extractSubQueries` (e.g. TRAVERSE WHERE, IF/WHILE conditions, direct AST evaluation).

The standard SELECT path was unaffected because the planner extracts the subquery into a LET variable stored as `List<Result>`, which bypasses the Set fast-path and reaches the `QueryOperatorEquals` loop that already handles Result unwrapping.

**Fix:** in `executeQuery`, map each single-property non-element `Result` to its scalar value before collecting into the Set. Multi-property rows and vertex/edge elements (where the identity, not a projection, is meaningful) pass through unchanged.

## Test plan

- `InConditionSubqueryTest.inWithScalarSubqueryReturnsMatchingRows` — `WHERE name IN (SELECT name FROM …)` via planner returns matching rows
- `InConditionSubqueryTest.notInWithScalarSubqueryExcludesMatchingRows` — `NOT IN` variant excludes matching rows
- `InConditionSubqueryTest.inWithIntegerSubqueryReturnsMatchingRows` — integer subquery works
- `InConditionSubqueryTest.inWithSubqueryCountMatchesExpected` — `count(*)` with IN subquery is correct
- `InConditionSubqueryTest.directEvalWithoutPlannerReturnsCorrectMatch` — parses the condition and calls `evaluate()` directly without the planner; fails before the fix, passes after
