### PR TITLE
fix(#4329): use readFully instead of read in JavaBinarySerializer.readExternal

### DIFF
--- a/docs/4329-javabinaryserializer-readfully.md
+++ b/docs/4329-javabinaryserializer-readfully.md
@@ -1,0 +1,43 @@
+# Fix #4329 — JavaBinarySerializer.readExternal partial read corruption
+
+## Issue
+
+`JavaBinarySerializer.readExternal` calls `in.read(array)` to read serialized property bytes.
+`ObjectInput.read(byte[])` is permitted by contract to return fewer bytes than the array length (short read).
+On compressed or networked `ObjectInput` implementations this can happen; the remaining bytes are silently lost,
+corrupting every subsequent property in the record.
+
+## Root cause
+
+`engine/src/main/java/com/arcadedb/serializer/JavaBinarySerializer.java` line 129:
+
+```java
+in.read(array);   // may short-read
+```
+
+The correct API that guarantees the buffer is fully populated is `DataInput.readFully(byte[])`.
+
+## Verification plan
+
+1. Write a regression test `readExternalSurvivesShortReadInput` that wraps the deserialization
+   stream in a `ThrottledObjectInput` that returns at most 1 byte per `read(byte[], off, len)` call.
+2. Run the test — it must FAIL before the fix (corrupt values or stream format exception).
+3. Apply the one-line fix: `in.readFully(array)`.
+4. Re-run — test must PASS.
+5. Run the full `JavaBinarySerializerTest` suite to confirm no regressions.
+
+## Changes
+
+- `engine/src/main/java/com/arcadedb/serializer/JavaBinarySerializer.java` — `in.read(array)` → `in.readFully(array)` (line 129).
+- `engine/src/test/java/com/arcadedb/serializer/JavaBinarySerializerTest.java` — added `readExternalSurvivesShortReadInput` regression test.
+
+## Test results
+
+- `readExternalSurvivesShortReadInput` — FAILED before fix (UTFDataFormatException: stream misaligned after 1-byte read)
+- `readExternalSurvivesShortReadInput` — PASSED after fix
+- Full `JavaBinarySerializerTest` suite: 6/6 passed
+- All serializer tests (`*Serializer*`): 30/30 passed, zero regressions
+
+## Status
+
+Done

--- a/docs/4329-javabinaryserializer-readfully.md
+++ b/docs/4329-javabinaryserializer-readfully.md
@@ -38,6 +38,26 @@ The correct API that guarantees the buffer is fully populated is `DataInput.read
 - Full `JavaBinarySerializerTest` suite: 6/6 passed
 - All serializer tests (`*Serializer*`): 30/30 passed, zero regressions
 
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/4348
+
+## Review cycles
+
+**Cycle 1** — HEAD `b038b84d`
+- gemini-code-assist: COMMENTED - two medium suggestions: add bounds checks to `ThrottledObjectInput.read(byte[],int,int)` and `readFully(byte[],int,int)`
+- Applied: added `if (off < 0 || len < 0 || len > b.length - off) throw new IndexOutOfBoundsException()` to both methods
+- Commit: `4f40314c5`
+
+**Cycle 2** — HEAD `4f40314c5`
+- gemini-code-assist: COMMENTED - same suggestions repeated but changes are already applied (stale feedback)
+- No actionable items; working tree clean
+- Early-exit: clean-approval
+
+## Final state
+
+`clean-approval` - all review items addressed, no new actionable feedback on cycle 2
+
 ## Status
 
 Done

--- a/engine/src/main/java/com/arcadedb/serializer/JavaBinarySerializer.java
+++ b/engine/src/main/java/com/arcadedb/serializer/JavaBinarySerializer.java
@@ -126,7 +126,7 @@ public class JavaBinarySerializer {
       final int propertySize = in.readInt();
 
       final byte[] array = new byte[propertySize];
-      in.read(array);
+      in.readFully(array);
 
       final Binary buffer = new Binary(array);
       final byte propType = buffer.getByte();

--- a/engine/src/test/java/com/arcadedb/serializer/JavaBinarySerializerTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/JavaBinarySerializerTest.java
@@ -34,6 +34,128 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class JavaBinarySerializerTest extends TestHelper {
 
+  /**
+   * readExternal must correctly populate every property even when the ObjectInput.read(byte[]) delivers
+   * only one byte at a time (short-read scenario valid on compressed / networked streams).
+   * Using readFully() instead of read() is the contract-safe way to fill the buffer.
+   */
+  @Test
+  void readExternalSurvivesShortReadInput() throws Exception {
+    final DocumentType type = database.getSchema().createDocumentType("Doc");
+    type.createProperty("id", Type.LONG);
+
+    final MutableDocument doc1 = database.newDocument("Doc").set("id", 100L, "name", "Alice", "score", 3.14);
+    try (final ByteArrayOutputStream arrayOut = new ByteArrayOutputStream();
+        final ObjectOutput buffer = new ObjectOutputStream(arrayOut)) {
+      doc1.writeExternal(buffer);
+      buffer.flush();
+
+      final MutableDocument doc2 = database.newDocument("Doc");
+      try (final ByteArrayInputStream arrayIn = new ByteArrayInputStream(arrayOut.toByteArray());
+          final ObjectInputStream rawIn = new ObjectInputStream(arrayIn)) {
+        doc2.readExternal(new ThrottledObjectInput(rawIn));
+        assertThat(doc2.toMap()).isEqualTo(doc1.toMap());
+      }
+    }
+  }
+
+  /**
+   * ObjectInput wrapper that returns at most one byte per read(byte[],int,int) call,
+   * simulating the short-read behaviour permitted on compressed or network-backed streams.
+   * readFully delegates through this same throttled path and therefore must loop to completion.
+   */
+  private static final class ThrottledObjectInput implements ObjectInput {
+    private final ObjectInput delegate;
+
+    ThrottledObjectInput(final ObjectInput delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public int read() throws IOException {
+      return delegate.read();
+    }
+
+    @Override
+    public int read(final byte[] b, final int off, final int len) throws IOException {
+      if (len == 0)
+        return 0;
+      return delegate.read(b, off, 1);
+    }
+
+    @Override
+    public int read(final byte[] b) throws IOException {
+      return read(b, 0, b.length);
+    }
+
+    @Override
+    public void readFully(final byte[] b) throws IOException {
+      readFully(b, 0, b.length);
+    }
+
+    @Override
+    public void readFully(final byte[] b, final int off, final int len) throws IOException {
+      int total = 0;
+      while (total < len) {
+        final int n = read(b, off + total, len - total);
+        if (n < 0)
+          throw new EOFException();
+        total += n;
+      }
+    }
+
+    @Override
+    public int skipBytes(final int n) throws IOException { return delegate.skipBytes(n); }
+
+    @Override
+    public boolean readBoolean() throws IOException { return delegate.readBoolean(); }
+
+    @Override
+    public byte readByte() throws IOException { return delegate.readByte(); }
+
+    @Override
+    public int readUnsignedByte() throws IOException { return delegate.readUnsignedByte(); }
+
+    @Override
+    public short readShort() throws IOException { return delegate.readShort(); }
+
+    @Override
+    public int readUnsignedShort() throws IOException { return delegate.readUnsignedShort(); }
+
+    @Override
+    public char readChar() throws IOException { return delegate.readChar(); }
+
+    @Override
+    public int readInt() throws IOException { return delegate.readInt(); }
+
+    @Override
+    public long readLong() throws IOException { return delegate.readLong(); }
+
+    @Override
+    public float readFloat() throws IOException { return delegate.readFloat(); }
+
+    @Override
+    public double readDouble() throws IOException { return delegate.readDouble(); }
+
+    @Override
+    public String readLine() throws IOException { return delegate.readLine(); }
+
+    @Override
+    public String readUTF() throws IOException { return delegate.readUTF(); }
+
+    @Override
+    public Object readObject() throws ClassNotFoundException, IOException { return delegate.readObject(); }
+
+    @Override
+    public long skip(final long n) throws IOException { return delegate.skip(n); }
+
+    @Override
+    public int available() throws IOException { return delegate.available(); }
+
+    @Override
+    public void close() throws IOException { delegate.close(); }
+  }
+
   @Test
   void documentTransient() throws Exception {
     final DocumentType type = database.getSchema().createDocumentType("Doc");

--- a/engine/src/test/java/com/arcadedb/serializer/JavaBinarySerializerTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/JavaBinarySerializerTest.java
@@ -78,6 +78,8 @@ class JavaBinarySerializerTest extends TestHelper {
 
     @Override
     public int read(final byte[] b, final int off, final int len) throws IOException {
+      if (off < 0 || len < 0 || len > b.length - off)
+        throw new IndexOutOfBoundsException();
       if (len == 0)
         return 0;
       return delegate.read(b, off, 1);
@@ -95,6 +97,8 @@ class JavaBinarySerializerTest extends TestHelper {
 
     @Override
     public void readFully(final byte[] b, final int off, final int len) throws IOException {
+      if (off < 0 || len < 0 || len > b.length - off)
+        throw new IndexOutOfBoundsException();
       int total = 0;
       while (total < len) {
         final int n = read(b, off + total, len - total);


### PR DESCRIPTION
Closes #4329

`ObjectInput.read(byte[])` is permitted by contract to return fewer bytes than the array length (a short read). On compressed or network-backed `ObjectInput` implementations this is possible. `JavaBinarySerializer.readExternal` called `in.read(array)` and ignored the return value, so on a short read the remaining bytes were silently lost, misaligning the stream and corrupting every subsequent property in the record.

The fix is a one-character change: replace `in.read(array)` with `in.readFully(array)`, which loops until the buffer is completely filled or throws `EOFException`.

## Test plan

- New regression test `readExternalSurvivesShortReadInput` wraps the deserialization stream in a `ThrottledObjectInput` that returns at most 1 byte per `read(byte[], off, len)` call, directly exercising the short-read path.
- Test confirmed **FAIL** before the fix (`UTFDataFormatException` from stream misalignment) and **PASS** after.
- Full `JavaBinarySerializerTest` suite: 6/6 passed.
- All serializer tests (`*Serializer*`): 30/30 passed, no regressions.