### PR TITLE
fix(#4331): abort crash recovery on WAL version gap and preserve WAL files

### DIFF
--- a/docs/4331-wal-version-gap-recovery.md
+++ b/docs/4331-wal-version-gap-recovery.md
@@ -58,3 +58,21 @@ Changed `checkIntegrity()` to:
 - All new tests pass
 - `TransactionManagerCloseWALFsyncTest` still passes (no regression)
 - `ApplyChangesPartialReplayTest` still passes (no regression)
+- `LocalDatabaseLastTransactionIdTest`, `WALFileGetTransactionTest` still pass
+
+## PR
+
+- https://github.com/ArcadeData/arcadedb/pull/4356
+
+## Review cycles
+
+- cycle 1 (`99242ac`): gemini-code-assist commented with three findings
+  - critical: `lastTxId = lowerTxId` set before `applyChanges` succeeds - on gap detection lastTxId reflected a failed tx
+  - critical: `transactionIds.set(lastTxId + 1)` with `lastTxId=-1` overwrites the persistedLastTxId loaded in the constructor
+  - high: `activeWALFilePool` may contain null entries (FileNotFoundException at init); cleanup loops must null-check
+  - all three applied in commit `5b600c9`
+- cycle 2 (`5b600c9`): no re-review from gemini-code-assist (expected per repo behaviour - bot does not re-review follow-up pushes); loop timed out at 15 min
+
+## Final state
+
+- timeout (cycle 2): PR open with cycle-1 feedback addressed, awaiting human merge

--- a/docs/4331-wal-version-gap-recovery.md
+++ b/docs/4331-wal-version-gap-recovery.md
@@ -1,0 +1,60 @@
+# Fix #4331 - TransactionManager WAL Version Gap Recovery
+
+## Issue
+
+`TransactionManager.applyChanges(ignoreErrors=true)` silently skips WAL version gaps during crash
+recovery. When the WAL page version is more than one ahead of the on-disk page version, the code
+logs a WARNING and `continue`s past that page but still applies sibling pages in the same
+multi-page transaction. Result: torn transaction on disk. After "successful" recovery all WAL
+files are dropped, making the inconsistency permanent and undiagnosable.
+
+## Root Cause
+
+In `checkIntegrity()` (line 275 before fix):
+```java
+applyChanges(walPositions[lowerTx], Collections.emptyMap(), true); // ignoreErrors=true
+```
+
+In `applyChanges`, when `ignoreErrors=true` and a version gap is detected:
+```java
+if (txPage.currentPageVersion > page.getVersion() + 1) {
+    if (!tx.forceApply) {
+        LogManager.instance().log(this, Level.WARNING, ...);
+        if (ignoreErrors)
+            continue;  // skips only THIS page, continues other pages in same tx - torn transaction!
+        throw new WALVersionGapException(...);
+    }
+}
+```
+
+The `continue` skips the gapped page but continues applying sibling pages of the same
+transaction. After recovery the WAL is unconditionally dropped, making corruption permanent.
+
+## Fix
+
+Changed `checkIntegrity()` to:
+1. Pass `ignoreErrors=false` to `applyChanges` - this throws `WALVersionGapException` on any gap,
+   stopping the entire transaction replay immediately (no torn transactions).
+2. Catch `WALVersionGapException` and log SEVERE.
+3. Close WAL files without deleting them (preserve for manual inspection).
+4. Break the recovery loop - no more transactions are applied after the gap.
+5. Always create a new WAL pool and clear page cache so the database can continue operating.
+
+## Files Changed
+
+- `engine/src/main/java/com/arcadedb/engine/TransactionManager.java`
+  - `checkIntegrity()`: uses `ignoreErrors=false`, catches `WALVersionGapException`, preserves WAL
+
+## Tests Written
+
+- `engine/src/test/java/com/arcadedb/engine/WALVersionGapRecoveryTest.java`
+  - `applyChangesThrowsOnVersionGap`: verifies `WALVersionGapException` thrown with gap
+  - `versionGapPageNotApplied`: verifies gapped page leaves on-disk version unchanged
+  - `checkIntegrityPreservesWALOnVersionGap`: integration test - injects a gap WAL file,
+    reopens DB, verifies WAL files preserved
+
+## Test Results
+
+- All new tests pass
+- `TransactionManagerCloseWALFsyncTest` still passes (no regression)
+- `ApplyChangesPartialReplayTest` still passes (no regression)

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -271,10 +271,11 @@ public class TransactionManager {
             // FINISHED
             break;
 
-          lastTxId = lowerTxId;
-
           try {
             applyChanges(walPositions[lowerTx], Collections.emptyMap(), false);
+            // Only advance lastTxId after a successful apply, otherwise a failed transaction
+            // would wrongly increment the next-tx counter past data that was never written.
+            lastTxId = lowerTxId;
           } catch (WALVersionGapException e) {
             LogManager.instance().log(this, Level.SEVERE,
                 "Recovery aborted for database '%s': version gap in WAL (txId=%d). WAL files have been preserved for manual inspection. No further transactions will be replayed.",
@@ -286,12 +287,17 @@ public class TransactionManager {
           walPositions[lowerTx] = activeWALFilePool[lowerTx].getTransaction(walPositions[lowerTx].endPositionInLog);
         }
 
-        // CONTINUE FROM LAST TXID
-        transactionIds.set(lastTxId + 1);
+        // Only update the next-tx counter if recovery actually applied a transaction. When
+        // lastTxId is still -1 the counter must keep the persistedLastTxId value loaded by the
+        // constructor; overwriting it with 0 would lose recency and risk transaction-id reuse.
+        if (lastTxId != -1)
+          transactionIds.set(lastTxId + 1);
 
         if (!walGapDetected) {
           // REMOVE ALL WAL FILES
           for (final WALFile file : activeWALFilePool) {
+            if (file == null)
+              continue;
             try {
               file.drop();
               LogManager.instance().log(this, Level.FINE, "Dropped WAL file '%s'", null, file);
@@ -302,6 +308,8 @@ public class TransactionManager {
         } else {
           // Close WAL files without deleting: preserve for manual inspection after gap detection
           for (final WALFile file : activeWALFilePool) {
+            if (file == null)
+              continue;
             try {
               file.close();
             } catch (final IOException e) {

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -251,6 +251,7 @@ public class TransactionManager {
         }
 
         long lastTxId = -1;
+        boolean walGapDetected = false;
 
         while (true) {
           int lowerTx = -1;
@@ -272,7 +273,15 @@ public class TransactionManager {
 
           lastTxId = lowerTxId;
 
-          applyChanges(walPositions[lowerTx], Collections.emptyMap(), true);
+          try {
+            applyChanges(walPositions[lowerTx], Collections.emptyMap(), false);
+          } catch (WALVersionGapException e) {
+            LogManager.instance().log(this, Level.SEVERE,
+                "Recovery aborted for database '%s': version gap in WAL (txId=%d). WAL files have been preserved for manual inspection. No further transactions will be replayed.",
+                null, database, lowerTxId);
+            walGapDetected = true;
+            break;
+          }
 
           walPositions[lowerTx] = activeWALFilePool[lowerTx].getTransaction(walPositions[lowerTx].endPositionInLog);
         }
@@ -280,14 +289,28 @@ public class TransactionManager {
         // CONTINUE FROM LAST TXID
         transactionIds.set(lastTxId + 1);
 
-        // REMOVE ALL WAL FILES
-        for (final WALFile file : activeWALFilePool) {
-          try {
-            file.drop();
-            LogManager.instance().log(this, Level.FINE, "Dropped WAL file '%s'", null, file);
-          } catch (final IOException e) {
-            LogManager.instance().log(this, Level.SEVERE, "Error on dropping WAL file '%s'", e, file);
+        if (!walGapDetected) {
+          // REMOVE ALL WAL FILES
+          for (final WALFile file : activeWALFilePool) {
+            try {
+              file.drop();
+              LogManager.instance().log(this, Level.FINE, "Dropped WAL file '%s'", null, file);
+            } catch (final IOException e) {
+              LogManager.instance().log(this, Level.SEVERE, "Error on dropping WAL file '%s'", e, file);
+            }
           }
+        } else {
+          // Close WAL files without deleting: preserve for manual inspection after gap detection
+          for (final WALFile file : activeWALFilePool) {
+            try {
+              file.close();
+            } catch (final IOException e) {
+              LogManager.instance().log(this, Level.WARNING, "Error on closing WAL file '%s'", e, file);
+            }
+          }
+          LogManager.instance().log(this, Level.SEVERE,
+              "WAL files for database '%s' have been preserved in '%s' for manual inspection.",
+              null, database, database.getDatabasePath());
         }
         createWALFilePool();
         database.getPageManager().removeAllReadPagesOfDatabase(database);

--- a/engine/src/test/java/com/arcadedb/engine/WALVersionGapRecoveryTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/WALVersionGapRecoveryTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Binary;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.exception.WALVersionGapException;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for WAL version-gap handling during crash recovery (issue #4331).
+ *
+ * <p>Verifies that a version gap detected during recovery:
+ * <ul>
+ *   <li>Throws WALVersionGapException immediately (no sibling-page application)</li>
+ *   <li>Aborts recovery without dropping WAL files (WAL preserved for inspection)</li>
+ * </ul>
+ */
+class WALVersionGapRecoveryTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.getSchema().createDocumentType("GapTestType");
+  }
+
+  @Test
+  void applyChangesThrowsOnVersionGap() throws IOException {
+    database.transaction(() -> database.newDocument("GapTestType").set("k", 1).save());
+
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final int fileId = db.getSchema().getType("GapTestType").getBuckets(false).get(0).getFileId();
+    final PaginatedComponentFile file = (PaginatedComponentFile) db.getFileManager().getFile(fileId);
+    final int pageSize = file.getPageSize();
+
+    final PageId pageId = new PageId(db, fileId, 0);
+    final ImmutablePage page = db.getPageManager().getImmutablePage(pageId, pageSize, false, true);
+    final int currentVersion = (int) page.getVersion();
+
+    final WALFile.WALPage gappedPage = buildWALPage(fileId, 0, currentVersion + 2, page.getContentSize());
+
+    final WALFile.WALTransaction tx = new WALFile.WALTransaction();
+    tx.txId = 99999L;
+    tx.timestamp = System.currentTimeMillis();
+    tx.pages = new WALFile.WALPage[] { gappedPage };
+
+    assertThatThrownBy(() -> db.getTransactionManager().applyChanges(tx, Collections.emptyMap(), false))
+        .isInstanceOf(WALVersionGapException.class);
+  }
+
+  @Test
+  void versionGapPageNotApplied() throws IOException {
+    database.transaction(() -> database.newDocument("GapTestType").set("k", 2).save());
+
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final int fileId = db.getSchema().getType("GapTestType").getBuckets(false).get(0).getFileId();
+    final PaginatedComponentFile file = (PaginatedComponentFile) db.getFileManager().getFile(fileId);
+    final int pageSize = file.getPageSize();
+
+    final PageId pageId = new PageId(db, fileId, 0);
+    final ImmutablePage page = db.getPageManager().getImmutablePage(pageId, pageSize, false, true);
+    final int versionBefore = (int) page.getVersion();
+
+    final WALFile.WALPage gappedPage = buildWALPage(fileId, 0, versionBefore + 2, page.getContentSize());
+
+    final WALFile.WALTransaction tx = new WALFile.WALTransaction();
+    tx.txId = 88888L;
+    tx.timestamp = System.currentTimeMillis();
+    tx.pages = new WALFile.WALPage[] { gappedPage };
+
+    assertThatThrownBy(() -> db.getTransactionManager().applyChanges(tx, Collections.emptyMap(), false))
+        .isInstanceOf(WALVersionGapException.class);
+
+    // Page must be unchanged - the exception must have prevented the write
+    db.getPageManager().removePageFromCache(pageId);
+    final ImmutablePage pageAfter = db.getPageManager().getImmutablePage(pageId, pageSize, false, true);
+    assertThat(pageAfter.getVersion())
+        .as("Version-gap page must not be applied to disk")
+        .isEqualTo(versionBefore);
+  }
+
+  @Test
+  void checkIntegrityPreservesWALOnVersionGap() throws Exception {
+    for (int i = 0; i < 3; i++) {
+      final int n = i;
+      database.transaction(() -> database.newDocument("GapTestType").set("n", n).save());
+    }
+
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final String dbPath = database.getDatabasePath();
+    final int fileId = db.getSchema().getType("GapTestType").getBuckets(false).get(0).getFileId();
+
+    // Simulate a crash: kill without flush, WAL files remain
+    db.kill();
+
+    final File dbDir = new File(dbPath);
+    final File[] walFilesAfterKill = dbDir.listFiles((d, n) -> n.endsWith(".wal"));
+    assertThat(walFilesAfterKill)
+        .as("WAL files must be present after kill()")
+        .isNotEmpty();
+
+    // Find the max page version and max txId across all WAL transactions
+    int maxPageVersion = 0;
+    long maxTxId = 0;
+    for (final File walFile : walFilesAfterKill) {
+      final WALFile wal = new WALFile(walFile.getAbsolutePath());
+      WALFile.WALTransaction tx = wal.getFirstTransaction();
+      while (tx != null) {
+        maxTxId = Math.max(maxTxId, tx.txId);
+        for (final WALFile.WALPage p : tx.pages) {
+          if (p.fileId == fileId)
+            maxPageVersion = Math.max(maxPageVersion, p.currentPageVersion);
+        }
+        tx = wal.getTransaction(tx.endPositionInLog);
+      }
+      wal.close();
+    }
+
+    // Write a new WAL file containing a transaction with a version gap:
+    // maxPageVersion+2 skips maxPageVersion+1, triggering the gap check after the
+    // existing WAL transactions are replayed and the page is at maxPageVersion.
+    final long gapTxId = maxTxId + 1;
+    final int gapVersion = maxPageVersion + 2;
+    writeGapWALFile(dbPath, gapTxId, fileId, 0, gapVersion);
+
+    // Reopen: checkIntegrity runs, detects the gap, must preserve WAL files
+    database.close();
+    final AtomicBoolean recoveryRan = new AtomicBoolean(false);
+    factory.registerCallback(DatabaseInternal.CALLBACK_EVENT.DB_NOT_CLOSED, () -> {
+      recoveryRan.set(true);
+      return null;
+    });
+    database = factory.open();
+
+    assertThat(recoveryRan.get())
+        .as("DB_NOT_CLOSED callback must fire - recovery must have run")
+        .isTrue();
+
+    final File[] walFilesAfterReopen = dbDir.listFiles((d, n) -> n.endsWith(".wal"));
+    assertThat(walFilesAfterReopen)
+        .as("WAL files must be preserved when a version gap is detected during recovery")
+        .isNotEmpty();
+  }
+
+  // Builds a WALPage for applyChanges tests (1 byte of content at PAGE_HEADER_SIZE offset)
+  private WALFile.WALPage buildWALPage(final int fileId, final int pageNumber, final int version, final int contentSize) {
+    final WALFile.WALPage p = new WALFile.WALPage();
+    p.fileId = fileId;
+    p.pageNumber = pageNumber;
+    p.changesFrom = BasePage.PAGE_HEADER_SIZE;
+    p.changesTo = BasePage.PAGE_HEADER_SIZE;
+    p.currentPageVersion = version;
+    p.currentPageSize = contentSize;
+    p.currentContent = new Binary(new byte[1]);
+    return p;
+  }
+
+  /**
+   * Writes a minimal valid WAL file containing one transaction with the given page version.
+   * WAL binary format (all big-endian):
+   *   TX header (24 bytes): txId(8) timestamp(8) pageCount(4) segmentSize(4)
+   *   Per page  (24 bytes + delta): fileId(4) pageNumber(4) changesFrom(4) changesTo(4)
+   *             currentPageVersion(4) currentPageSize(4) delta(1)
+   *   TX footer (12 bytes): segmentSize(4) MAGIC_NUMBER(8)
+   */
+  private void writeGapWALFile(final String dbPath, final long txId, final int fileId,
+      final int pageNumber, final int pageVersion) throws IOException {
+    // 1 byte delta: changesFrom == changesTo
+    final int deltaSize = 1;
+    // PAGE_HEADER = 6 ints = 24 bytes
+    final int pageSegmentSize = 24 + deltaSize;
+    // TX_HEADER = 2 longs + 2 ints = 24 bytes; TX_FOOTER = 1 int + 1 long = 12 bytes
+    final int totalBytes = 24 + pageSegmentSize + 12;
+
+    final ByteBuffer buf = ByteBuffer.allocate(totalBytes); // big-endian by default
+    // TX header
+    buf.putLong(txId);
+    buf.putLong(System.currentTimeMillis());
+    buf.putInt(1);               // 1 page
+    buf.putInt(pageSegmentSize);
+    // Page header
+    buf.putInt(fileId);
+    buf.putInt(pageNumber);
+    buf.putInt(BasePage.PAGE_HEADER_SIZE);     // changesFrom
+    buf.putInt(BasePage.PAGE_HEADER_SIZE);     // changesTo (single byte)
+    buf.putInt(pageVersion);
+    buf.putInt(512);             // currentPageSize - small safe value
+    buf.put((byte) 0);           // 1 byte of delta content
+    // TX footer
+    buf.putInt(pageSegmentSize);
+    buf.putLong(WALFile.MAGIC_NUMBER);
+
+    final String walPath = dbPath + File.separator + "txlog_gap_" + txId + ".wal";
+    try (final RandomAccessFile raf = new RandomAccessFile(walPath, "rw");
+        final FileChannel ch = raf.getChannel()) {
+      buf.rewind();
+      ch.write(buf);
+    }
+  }
+}


### PR DESCRIPTION
Closes #4331

`checkIntegrity()` passed `ignoreErrors=true` to `applyChanges()`. When a WAL page version was more than one ahead of the on-disk version (a version gap), the code logged a WARNING and called `continue`, skipping that page but continuing to apply sibling pages in the same multi-page transaction. The result was a torn transaction on disk. All WAL files were then dropped unconditionally, making the corruption permanent and undiagnosable.

The fix passes `ignoreErrors=false` so `WALVersionGapException` is thrown immediately on the first gap, stopping the entire transaction replay before any sibling pages are written. The exception is caught in `checkIntegrity()`: WAL files are closed without deletion (preserved for manual inspection at the database path), a SEVERE log is emitted, and a new WAL pool is created so the database remains writable after partial recovery.

## Test plan

- `WALVersionGapRecoveryTest.applyChangesThrowsOnVersionGap`: confirms `WALVersionGapException` is raised when the WAL page version skips ahead
- `WALVersionGapRecoveryTest.versionGapPageNotApplied`: confirms the gapped page is not written to disk (no torn transaction)
- `WALVersionGapRecoveryTest.checkIntegrityPreservesWALOnVersionGap`: integration test - kills the database, injects a crafted WAL file with a version gap, reopens (triggering `checkIntegrity()`), and verifies WAL files are still present on disk rather than dropped
- All existing WAL and transaction tests continue to pass (`TransactionManagerCloseWALFsyncTest`, `ApplyChangesPartialReplayTest`, `WALFileGetTransactionTest`, 65 tests total)