### PR TITLE
fix(#4358): handle LocalDateTime/LocalDate in gRPC ProtoUtils and ISO string fallback in convertWithSchemaType

### DIFF
--- a/docs/4358-datetime-format-exception-grpc.md
+++ b/docs/4358-datetime-format-exception-grpc.md
@@ -1,0 +1,53 @@
+# Issue #4358 - DateTime format exception when using gRPC
+
+## Summary
+
+Setting a `LocalDateTime` property on a vertex via `RemoteGrpcDatabase.newVertex().set(...)` fails with
+`NumberFormatException: For input string: "2026-05-26T14:27:38.470"` in
+`ArcadeDbGrpcService.convertWithSchemaType`.
+
+## Root Cause
+
+Two-part problem:
+
+**Client (`ProtoUtils.toGrpcValue`):** No `LocalDateTime`, `LocalDate`, `Instant`, or `ZonedDateTime`
+branch exists. These types fall through to the catch-all `setStringValue(String.valueOf(value))` at line
+321, producing an ISO 8601 string like `"2026-05-26T14:27:38.470"` instead of a `TIMESTAMP_VALUE`.
+
+The server-side `GrpcTypeConverter.toGrpcValue()` already has these branches (fixed in issue #4149),
+but that fix was never ported to the client-side `ProtoUtils.toGrpcValue()`.
+
+**Server (`ArcadeDbGrpcService.convertWithSchemaType`):** The `STRING_VALUE` case for `DATE`/`DATETIME`
+does `Long.parseLong(v.getStringValue())` unconditionally. This works for epoch-ms strings but throws
+`NumberFormatException` for ISO 8601 strings.
+
+## Affected Components
+
+- `grpc-client/src/main/java/com/arcadedb/remote/grpc/utils/ProtoUtils.java`
+- `grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java`
+
+## Fix
+
+1. **`ProtoUtils.toGrpcValue()`**: Add `LocalDateTime`, `LocalDate`, `Instant`, `ZonedDateTime` branches
+   that emit `TIMESTAMP_VALUE` - mirroring the implementation already in `GrpcTypeConverter.toGrpcValue()`.
+
+2. **`ArcadeDbGrpcService.convertWithSchemaType()`**: Change the `STRING_VALUE` case for `DATE`/`DATETIME`
+   to try `Long.parseLong` first (backward compat), then fall back to ISO parsing via
+   `DateUtils.dateTimeToTimestamp(db, s, ChronoUnit.MILLIS)`.
+
+## Tests
+
+- Unit: `ProtoUtilsTest.toGrpcValueLocalDateTime` - verifies client emits `TIMESTAMP_VALUE`
+- Unit: `ProtoUtilsTest.toGrpcValueLocalDate` - verifies client emits `TIMESTAMP_VALUE`
+- Integration: `Issue4358GrpcDateTimeIT` - end-to-end vertex creation with `LocalDateTime` property via gRPC
+
+## Test Results
+
+- `ProtoUtilsTest`: 39/39 pass (includes 4 new unit tests for LocalDateTime, LocalDate, Instant, ZonedDateTime)
+- `Issue4358GrpcDateTimeIT`: 2/2 pass (end-to-end LocalDateTime and LocalDate round-trip via gRPC)
+- `GrpcTypeConverterTest`, `Issue4149GrpcTypeConverterTest`, `Issue4181GrpcDateCorruptionIT`, `ArcadeDbGrpcServiceExtendedTest`: 71/71 pass (no regressions)
+- `Issue4260ReloadInsideTransactionIT`, `RemoteGrpcDatabaseCoverageIT`: 33/33 pass
+
+## Status
+
+Implementation complete. All tests pass. Ready for PR.

--- a/docs/4358-datetime-format-exception-grpc.md
+++ b/docs/4358-datetime-format-exception-grpc.md
@@ -48,6 +48,20 @@ does `Long.parseLong(v.getStringValue())` unconditionally. This works for epoch-
 - `GrpcTypeConverterTest`, `Issue4149GrpcTypeConverterTest`, `Issue4181GrpcDateCorruptionIT`, `ArcadeDbGrpcServiceExtendedTest`: 71/71 pass (no regressions)
 - `Issue4260ReloadInsideTransactionIT`, `RemoteGrpcDatabaseCoverageIT`: 33/33 pass
 
-## Status
+## PR
 
-Implementation complete. All tests pass. Ready for PR.
+https://github.com/ArcadeData/arcadedb/pull/4362
+
+## Review Cycles
+
+**Cycle 1** - HEAD `d7c8c429`:
+- gemini-code-assist (COMMENTED): One inline suggestion on `ProtoUtils.java` line 287 - use `ld.toEpochDay() * 86400L` instead of `ld.atStartOfDay(ZoneOffset.UTC).toEpochSecond()` to avoid object allocations. Applied.
+- claude bot: not present on this repo, did not respond.
+
+**Cycle 2** - HEAD `788cc3c9`:
+- gemini-code-assist: no new actionable comments (stale cycle-1 comment only, already addressed).
+- claude bot: not present on this repo.
+
+## Final State
+
+`timeout` (claude bot does not exist on ArcadeData/arcadedb; gemini reviewed cycle 1 and the cycle 1 feedback was fully addressed).

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/utils/ProtoUtils.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/utils/ProtoUtils.java
@@ -39,6 +39,11 @@ import com.arcadedb.log.LogManager;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.logging.Level;
 
@@ -271,6 +276,36 @@ public class ProtoUtils {
       return dbgEnc("toGrpcValue", value,
           GrpcValue.newBuilder().setTimestampValue(Timestamp.newBuilder()
                   .setSeconds(Math.floorDiv(v.getTime(), 1000L)).setNanos((int) Math.floorMod(v.getTime(), 1000L) * 1_000_000).build())
+              .setLogicalType("datetime").build());
+    }
+
+    if (value instanceof LocalDate ld) {
+      final long seconds = ld.atStartOfDay(ZoneOffset.UTC).toEpochSecond();
+      return dbgEnc("toGrpcValue", value,
+          GrpcValue.newBuilder().setTimestampValue(Timestamp.newBuilder().setSeconds(seconds).setNanos(0).build())
+              .setLogicalType("date").build());
+    }
+
+    if (value instanceof LocalDateTime ldt) {
+      final Instant instant = ldt.toInstant(ZoneOffset.UTC);
+      return dbgEnc("toGrpcValue", value,
+          GrpcValue.newBuilder()
+              .setTimestampValue(Timestamp.newBuilder().setSeconds(instant.getEpochSecond()).setNanos(instant.getNano()).build())
+              .setLogicalType("datetime").build());
+    }
+
+    if (value instanceof Instant instant) {
+      return dbgEnc("toGrpcValue", value,
+          GrpcValue.newBuilder()
+              .setTimestampValue(Timestamp.newBuilder().setSeconds(instant.getEpochSecond()).setNanos(instant.getNano()).build())
+              .setLogicalType("datetime").build());
+    }
+
+    if (value instanceof ZonedDateTime zdt) {
+      final Instant instant = zdt.toInstant();
+      return dbgEnc("toGrpcValue", value,
+          GrpcValue.newBuilder()
+              .setTimestampValue(Timestamp.newBuilder().setSeconds(instant.getEpochSecond()).setNanos(instant.getNano()).build())
               .setLogicalType("datetime").build());
     }
 

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/utils/ProtoUtils.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/utils/ProtoUtils.java
@@ -280,7 +280,7 @@ public class ProtoUtils {
     }
 
     if (value instanceof LocalDate ld) {
-      final long seconds = ld.atStartOfDay(ZoneOffset.UTC).toEpochSecond();
+      final long seconds = ld.toEpochDay() * 86400L;
       return dbgEnc("toGrpcValue", value,
           GrpcValue.newBuilder().setTimestampValue(Timestamp.newBuilder().setSeconds(seconds).setNanos(0).build())
               .setLogicalType("date").build());

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue4358GrpcDateTimeIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/Issue4358GrpcDateTimeIT.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4358: setting a LocalDateTime or LocalDate property on a vertex via
+ * RemoteGrpcDatabase.newVertex().set(...) threw NumberFormatException because
+ * ProtoUtils.toGrpcValue(LocalDateTime) had no explicit branch and fell through to
+ * setStringValue(value.toString()), producing an ISO 8601 string that the server
+ * then tried to parse as a Long epoch millisecond value.
+ */
+public class Issue4358GrpcDateTimeIT extends BaseGraphServerTest {
+
+  private static final int    GRPC_PORT   = 50051;
+  private static final int    HTTP_PORT   = 2480;
+  private static final String VERTEX_TYPE = "SimpleVertex4358";
+
+  private RemoteGrpcServer   grpcServer;
+  private RemoteGrpcDatabase grpc;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GRPC:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void openAndPrepare() {
+    grpcServer = new RemoteGrpcServer("localhost", GRPC_PORT, "root", DEFAULT_PASSWORD_FOR_TESTS, true, List.of());
+    grpc = new RemoteGrpcDatabase(grpcServer, "localhost", GRPC_PORT, HTTP_PORT, getDatabaseName(), "root", DEFAULT_PASSWORD_FOR_TESTS);
+    grpc.command("sql", "CREATE VERTEX TYPE `" + VERTEX_TYPE + "` IF NOT EXISTS");
+    grpc.command("sql", "CREATE PROPERTY `" + VERTEX_TYPE + "`.fecha IF NOT EXISTS DATETIME");
+    grpc.command("sql", "CREATE PROPERTY `" + VERTEX_TYPE + "`.startDate IF NOT EXISTS DATE");
+    grpc.command("sql", "DELETE FROM `" + VERTEX_TYPE + "`");
+  }
+
+  @AfterEach
+  void closeClient() {
+    if (grpc != null) {
+      try {
+        grpc.rollback();
+      } catch (final Throwable ignore) {
+        // ignore
+      }
+      grpc.close();
+    }
+    if (grpcServer != null)
+      grpcServer.close();
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+
+  @Test
+  void localDateTimePropertyRoundTripsViaGrpc() {
+    // Truncate to millis: DATETIME stores millisecond precision by default
+    final LocalDateTime target = LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS);
+
+    grpc.begin();
+    final MutableVertex v = grpc.newVertex(VERTEX_TYPE);
+    v.set("fecha", target);
+    v.save();
+    grpc.commit();
+
+    try (final ResultSet rs = grpc.query("sql", "SELECT fecha FROM `" + VERTEX_TYPE + "`")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result r = rs.next();
+      final Object fechaRaw = r.getProperty("fecha");
+      assertThat(fechaRaw).as("'fecha' property must be present").isNotNull();
+
+      // The gRPC wire layer returns TIMESTAMP_VALUE as epoch milliseconds (Long).
+      // Convert back to LocalDateTime at UTC for comparison.
+      final LocalDateTime fechaBack;
+      if (fechaRaw instanceof LocalDateTime ldt)
+        fechaBack = ldt;
+      else if (fechaRaw instanceof Date d)
+        fechaBack = d.toInstant().atOffset(ZoneOffset.UTC).toLocalDateTime();
+      else if (fechaRaw instanceof Long epochMs)
+        fechaBack = LocalDateTime.ofEpochSecond(epochMs / 1000, (int) ((epochMs % 1000) * 1_000_000), ZoneOffset.UTC);
+      else
+        throw new AssertionError("Unexpected type for 'fecha': " + fechaRaw.getClass());
+
+      assertThat(fechaBack).isEqualTo(target);
+    }
+  }
+
+  @Test
+  void localDatePropertyRoundTripsViaGrpc() {
+    final LocalDate targetDate = LocalDate.now();
+
+    grpc.begin();
+    final MutableVertex v = grpc.newVertex(VERTEX_TYPE);
+    v.set("startDate", targetDate);
+    v.save();
+    grpc.commit();
+
+    try (final ResultSet rs = grpc.query("sql", "SELECT startDate FROM `" + VERTEX_TYPE + "`")) {
+      assertThat(rs.hasNext()).isTrue();
+      final Result r = rs.next();
+      final Object dateRaw = r.getProperty("startDate");
+      assertThat(dateRaw).as("'startDate' property must be present").isNotNull();
+
+      // The gRPC wire layer returns TIMESTAMP_VALUE as epoch milliseconds (Long).
+      // Convert back to LocalDate at UTC for comparison.
+      final LocalDate dateBack;
+      if (dateRaw instanceof LocalDate ld)
+        dateBack = ld;
+      else if (dateRaw instanceof Date d)
+        dateBack = d.toInstant().atOffset(ZoneOffset.UTC).toLocalDate();
+      else if (dateRaw instanceof Long epochMs)
+        dateBack = LocalDate.ofEpochDay(epochMs / 86_400_000L);
+      else
+        throw new AssertionError("Unexpected type for 'startDate': " + dateRaw.getClass());
+
+      assertThat(dateBack).isEqualTo(targetDate);
+    }
+  }
+}

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/utils/ProtoUtilsTest.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/utils/ProtoUtilsTest.java
@@ -31,6 +31,11 @@ import com.google.protobuf.Timestamp;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -173,6 +178,52 @@ class ProtoUtilsTest {
     assertThat(value.getMapValue().getEntriesMap().get("name").getStringValue()).isEqualTo("Alice");
     assertThat(value.getMapValue().getEntriesMap().get("age").getInt32Value()).isEqualTo(30);
     assertThat(value.getMapValue().getEntriesMap().get("active").getBoolValue()).isTrue();
+  }
+
+  @Test
+  void toGrpcValueLocalDateTime() {
+    // LocalDateTime had no explicit branch in ProtoUtils.toGrpcValue() - it fell through
+    // to setStringValue(value.toString()) producing an ISO string that the server could not
+    // parse as epoch milliseconds (issue #4358).
+    final LocalDateTime ldt = LocalDateTime.of(2026, 5, 26, 14, 27, 38, 470_000_000);
+    final GrpcValue value = ProtoUtils.toGrpcValue(ldt);
+
+    assertThat(value.hasTimestampValue()).as("LocalDateTime must serialize to TIMESTAMP_VALUE, not STRING_VALUE").isTrue();
+    final Timestamp ts = value.getTimestampValue();
+    final LocalDateTime roundTrip = LocalDateTime.ofEpochSecond(ts.getSeconds(), ts.getNanos(), ZoneOffset.UTC);
+    assertThat(roundTrip).isEqualTo(ldt);
+  }
+
+  @Test
+  void toGrpcValueLocalDate() {
+    // LocalDate must also serialize to TIMESTAMP_VALUE at midnight UTC (issue #4358).
+    final LocalDate ld = LocalDate.of(2026, 5, 26);
+    final GrpcValue value = ProtoUtils.toGrpcValue(ld);
+
+    assertThat(value.hasTimestampValue()).as("LocalDate must serialize to TIMESTAMP_VALUE, not STRING_VALUE").isTrue();
+    final long expectedSeconds = ld.atStartOfDay(ZoneOffset.UTC).toEpochSecond();
+    assertThat(value.getTimestampValue().getSeconds()).isEqualTo(expectedSeconds);
+    assertThat(value.getTimestampValue().getNanos()).isZero();
+  }
+
+  @Test
+  void toGrpcValueInstant() {
+    final Instant instant = Instant.ofEpochSecond(1_000_000_000L, 123_456_789);
+    final GrpcValue value = ProtoUtils.toGrpcValue(instant);
+
+    assertThat(value.hasTimestampValue()).as("Instant must serialize to TIMESTAMP_VALUE").isTrue();
+    assertThat(value.getTimestampValue().getSeconds()).isEqualTo(1_000_000_000L);
+    assertThat(value.getTimestampValue().getNanos()).isEqualTo(123_456_789);
+  }
+
+  @Test
+  void toGrpcValueZonedDateTime() {
+    final ZonedDateTime zdt = ZonedDateTime.of(2026, 5, 26, 14, 27, 38, 470_000_000, ZoneOffset.UTC);
+    final GrpcValue value = ProtoUtils.toGrpcValue(zdt);
+
+    assertThat(value.hasTimestampValue()).as("ZonedDateTime must serialize to TIMESTAMP_VALUE").isTrue();
+    assertThat(value.getTimestampValue().getSeconds()).isEqualTo(zdt.toEpochSecond());
+    assertThat(value.getTimestampValue().getNanos()).isEqualTo(zdt.getNano());
   }
 
   // testToGrpcValueEmbeddedDocument removed - requires database, tested in integration tests

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -65,6 +65,8 @@ import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import org.jspecify.annotations.NonNull;
 
+import com.arcadedb.utility.DateUtils;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -73,6 +75,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -3260,11 +3263,19 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
       case DATE:
       case DATETIME:
-        // Prefer timestamp_value; else accept epoch ms in int64; else parse string
+        // Prefer timestamp_value; else accept epoch ms in int64; else parse string (epoch ms or ISO 8601)
         return switch (v.getKindCase()) {
           case TIMESTAMP_VALUE -> new Date(GrpcTypeConverter.tsToMillis(v.getTimestampValue()));
           case INT64_VALUE -> new Date(v.getInt64Value());
-          case STRING_VALUE -> new Date(Long.parseLong(v.getStringValue())); // or parse ISO if you emit it
+          case STRING_VALUE -> {
+            final String s = v.getStringValue();
+            try {
+              yield new Date(Long.parseLong(s));
+            } catch (NumberFormatException ignored) {
+              final Long millis = DateUtils.dateTimeToTimestamp(db, s, ChronoUnit.MILLIS);
+              yield millis != null ? new Date(millis) : null;
+            }
+          }
           default -> null;
         };
 


### PR DESCRIPTION
Closes #4358

## Summary

Setting a `LocalDateTime` (or `LocalDate`, `Instant`, `ZonedDateTime`) property on a vertex via `RemoteGrpcDatabase.newVertex().set("fecha", LocalDateTime.now())` threw `NumberFormatException: For input string: "2026-05-26T14:27:38.470"` in `ArcadeDbGrpcService.convertWithSchemaType`.

**Root cause (two-part):**

1. **Client side (`ProtoUtils.toGrpcValue`)** had no branch for `LocalDateTime`, `LocalDate`, `Instant`, or `ZonedDateTime`. These types fell through to the catch-all `setStringValue(String.valueOf(value))`, producing an ISO 8601 string instead of a `TIMESTAMP_VALUE`. The server-side `GrpcTypeConverter.toGrpcValue()` already had these branches (added in #4149), but they were never ported to the client.

2. **Server side (`convertWithSchemaType`)** the `STRING_VALUE` case for `DATE`/`DATETIME` called `Long.parseLong(v.getStringValue())` unconditionally. While the client fix makes this a secondary concern, the server fallback now also handles ISO 8601 strings via `DateUtils.dateTimeToTimestamp()` for robustness.

**Changes:**
- `grpc-client/ProtoUtils.toGrpcValue()`: add `LocalDateTime`, `LocalDate`, `Instant`, `ZonedDateTime` branches emitting `TIMESTAMP_VALUE`, mirroring `GrpcTypeConverter`
- `grpcw/ArcadeDbGrpcService.convertWithSchemaType()`: `STRING_VALUE` for `DATE`/`DATETIME` now tries epoch-ms parse first, then falls back to ISO 8601 via `DateUtils`

## Test plan

- `ProtoUtilsTest`: 4 new unit tests verify that `LocalDateTime`, `LocalDate`, `Instant`, and `ZonedDateTime` serialize to `TIMESTAMP_VALUE` (not `STRING_VALUE`)
- `Issue4358GrpcDateTimeIT`: 2 new integration tests create a vertex with `LocalDateTime` / `LocalDate` property and assert the value round-trips correctly end-to-end via `RemoteGrpcDatabase`
- Existing regression tests: `GrpcTypeConverterTest`, `Issue4149GrpcTypeConverterTest`, `Issue4181GrpcDateCorruptionIT`, `ArcadeDbGrpcServiceExtendedTest`, `RemoteGrpcDatabaseCoverageIT`, `Issue4260ReloadInsideTransactionIT` - all pass (71 + 33 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)