### PR TITLE
fix(#4364): return Status.NOT_FOUND for RecordNotFoundException in gRPC lookupByRid

### DIFF
--- a/docs/4364-grpc-recordnotfoundexception.md
+++ b/docs/4364-grpc-recordnotfoundexception.md
@@ -49,3 +49,20 @@ record-not-found in the same class.
 - `ArcadeDbGrpcServiceCoverageIT` (35 tests) - all pass
 - `GrpcServerIT` (28 tests) - all pass
 - `grpc-client` full suite (90 tests) - all pass
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/4365
+
+## Review Cycles
+
+### Cycle 1: `380d6d6dc`
+
+- **claude[bot]**: Clean approval. "Overall: Looks good - clean, minimal fix with solid test coverage." Two minor pre-existing observations (IllegalArgumentException not mapped to INVALID_ARGUMENT; no logging in generic catch) - both explicitly out of scope.
+- **gemini-code-assist[bot]**: Encountered an error creating the review. No actionable items.
+
+No changes applied.
+
+## Final State
+
+`clean-approval` - no follow-up commits needed.

--- a/docs/4364-grpc-recordnotfoundexception.md
+++ b/docs/4364-grpc-recordnotfoundexception.md
@@ -1,0 +1,51 @@
+# Issue #4364 - Incorrect exception thrown on gRPC lookupByRID
+
+## Problem
+
+`RemoteGrpcDatabase.lookupByRID()` throws `RemoteException` instead of
+`RecordNotFoundException` when the record does not exist. The same operation on
+`RemoteDatabase` (HTTP) correctly throws `RecordNotFoundException`.
+
+## Root Cause
+
+In `ArcadeDbGrpcService.lookupByRid()` (server side), all exceptions are caught
+by a single `catch (Exception e)` block and mapped to `Status.INTERNAL`:
+
+```java
+} catch (Exception e) {
+    resp.onError(Status.INTERNAL.withDescription("LookupByRid: " + e.getMessage()).asException());
+}
+```
+
+When `db.lookupByRID()` throws `RecordNotFoundException`, the server returns
+`Status.INTERNAL` instead of `Status.NOT_FOUND`.
+
+On the client side, `handleGrpcException` maps:
+- `NOT_FOUND` → `RecordNotFoundException` ✓
+- `INTERNAL` → `RemoteException` (the bug)
+
+The `INTERNAL` code reaches the default branch in `handleGrpcException`, producing
+`RemoteException("gRPC error: LookupByRid: Record #21:99999 not found", ...)`.
+
+## Fix
+
+Add a specific `catch (RecordNotFoundException e)` before the generic
+`catch (Exception e)` in `lookupByRid`, returning `Status.NOT_FOUND`.
+This is consistent with how `updateRecord` and `deleteRecord` handle
+record-not-found in the same class.
+
+## Files Changed
+
+- `grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java`
+  - Add `catch (RecordNotFoundException e)` in `lookupByRid` returning `NOT_FOUND`
+  - Remove stale comment referring to the commented-out `found=false` path
+- `grpc-client/src/test/java/com/arcadedb/remote/grpc/ErrorHandlingIT.java`
+  - Tighten `recordNotFound_throwsRecordNotFoundException` to require
+    `RecordNotFoundException` strictly (removes the `satisfiesAnyOf` leniency)
+
+## Test Results
+
+- `ErrorHandlingIT` (8 tests) - all pass
+- `ArcadeDbGrpcServiceCoverageIT` (35 tests) - all pass
+- `GrpcServerIT` (28 tests) - all pass
+- `grpc-client` full suite (90 tests) - all pass

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/ErrorHandlingIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/ErrorHandlingIT.java
@@ -136,7 +136,7 @@ class ErrorHandlingIT extends BaseGraphServerTest {
   }
 
   @Test
-  @DisplayName("lookupByRID with non-existent RID throws appropriate exception")
+  @DisplayName("lookupByRID with non-existent RID throws RecordNotFoundException")
   void recordNotFound_throwsRecordNotFoundException() {
     // First insert a record to get a valid bucket ID
     database.command("sql", "INSERT INTO `" + TYPE + "` SET id = 'temp', name = 'temp'");
@@ -151,11 +151,9 @@ class ErrorHandlingIT extends BaseGraphServerTest {
     int bucketId = Integer.parseInt(ridStr.split(":")[0].substring(1));
     RID fakeRid = new RID(bucketId, 999999L);
 
-    // The server throws RecordNotFoundException or the client maps it to one
+    // gRPC must map server NOT_FOUND status to RecordNotFoundException, matching HTTP behaviour
     assertThatThrownBy(() -> database.lookupByRID(fakeRid))
-        .satisfiesAnyOf(
-            e -> assertThat(e).isInstanceOf(RecordNotFoundException.class),
-            e -> assertThat(e).hasMessageContaining("not found"));
+        .isInstanceOf(RecordNotFoundException.class);
   }
 
   @Test

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -604,10 +604,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
       resp.onNext(LookupByRidResponse.newBuilder().setFound(true).setRecord(convertToGrpcRecord(el.getRecord(), db)).build());
       resp.onCompleted();
-// CURRENT IMPL EXPECTS AN EXCEPTION INSTEAD
-//    } catch (RecordNotFoundException e) {
-//      resp.onNext(LookupByRidResponse.newBuilder().setFound(false).build());
-//      resp.onCompleted();
+    } catch (RecordNotFoundException e) {
+      resp.onError(Status.NOT_FOUND.withDescription("LookupByRid: " + e.getMessage()).asException());
     } catch (Exception e) {
       resp.onError(Status.INTERNAL.withDescription("LookupByRid: " + e.getMessage()).asException());
     }


### PR DESCRIPTION
Closes #4364

## Summary

`RemoteGrpcDatabase.lookupByRID()` was throwing `RemoteException` instead of `RecordNotFoundException` when the requested record does not exist, breaking parity with the HTTP `RemoteDatabase` behaviour. The root cause was in `ArcadeDbGrpcService.lookupByRid()`: a `RecordNotFoundException` thrown by `db.lookupByRID()` was caught by the generic `catch (Exception e)` block and wrapped as `Status.INTERNAL`. The client's `handleGrpcException` only maps `Status.NOT_FOUND` to `RecordNotFoundException`; `INTERNAL` falls through to the default case and becomes `RemoteException`. The fix adds a specific `catch (RecordNotFoundException e)` before the generic catch and returns `Status.NOT_FOUND`, consistent with how `updateRecord` and `deleteRecord` already handle the same exception in the same class.

## Test plan

- `ErrorHandlingIT#recordNotFound_throwsRecordNotFoundException` - tightened from `satisfiesAnyOf` (accepted any "not found" message) to a strict `isInstanceOf(RecordNotFoundException.class)` assertion; confirms the exact exception type that the HTTP client also throws
- `ErrorHandlingIT` full class (8 tests) - all pass
- `ArcadeDbGrpcServiceCoverageIT` (35 tests) - all pass, no regression in `lookupByRid` success path or other gRPC operations
- `GrpcServerIT` (28 tests) - all pass
- `grpc-client` full suite (90 unit/regression tests) - all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)