### PR TITLE
fix(#4369): invoke per-task onErrorCallback and rollback on retry exhaustion in DatabaseAsyncTransaction

### DIFF
--- a/docs/4369-async-transaction-error-callback.md
+++ b/docs/4369-async-transaction-error-callback.md
@@ -45,3 +45,27 @@ worker loop also sees the failure and can clean up stale state.
 - `DatabaseAsyncTransactionRetryExhaustedTest`: 1/1 pass
 - `AsyncTest`: 11/11 pass
 - `DatabaseAsyncExecutorLifecycleRaceTest`: 1/1 pass
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/4374
+
+## Review Cycles
+
+### Cycle 1 - SHA `5adc3ed3216323343d406209721c17eece1b7cba`
+
+**Reviewer:** gemini-code-assist (COMMENTED)
+
+**Changes applied:**
+- Removed redundant `async.onError(lastException)` call before the re-throw (re-throwing already causes `AsyncThread.run()` to call `onError`, so the explicit call caused double notification)
+- Replaced `database.getTransaction().isActive()` with `database.isTransactionActive()` for consistency with line 47 of the same file
+
+### Cycle 2 - SHA `b7e08e6f86fba0342aa34e0eae8eedb3a10cf217`
+
+**Reviewer:** gemini-code-assist (COMMENTED)
+
+**Assessment:** Stale repeat of cycle-1 feedback. The code already matches the suggested snippet. No changes needed.
+
+## Final State
+
+`clean-approval` - all review feedback addressed, working tree clean.

--- a/docs/4369-async-transaction-error-callback.md
+++ b/docs/4369-async-transaction-error-callback.md
@@ -1,0 +1,47 @@
+# Fix #4369: `DatabaseAsyncTransaction` silently swallows final-retry failure
+
+## Issue
+
+After retries are exhausted in `DatabaseAsyncTransaction.execute()`, only the global `onError`
+listener was notified. The per-task `onErrorCallback` was never called, and no exception was
+re-thrown - so the async worker considered the task "complete" and never rolled back the
+still-active transaction.
+
+## Root Cause
+
+`DatabaseAsyncTransaction.java` lines 81-83 (before fix):
+
+```java
+if (lastException != null)
+  async.onError(lastException);
+// missing: no rollback, no onErrorCallback, no re-throw
+```
+
+The non-`ConcurrentModificationException` catch block (lines 68-78) correctly calls rollback,
+notifies the per-task `onErrorCallback`, and re-throws. The retry-exhausted path did none of
+these.
+
+## Fix
+
+Mirror the non-CME exception handling: rollback the transaction if still active, call the
+per-task `onErrorCallback` if non-null, and re-throw `lastException` so the `AsyncThread`
+worker loop also sees the failure and can clean up stale state.
+
+## Files Changed
+
+- `engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncTransaction.java`
+- `engine/src/test/java/com/arcadedb/database/async/DatabaseAsyncTransactionRetryExhaustedTest.java` (new)
+
+## Verification
+
+1. New regression test `DatabaseAsyncTransactionRetryExhaustedTest` verifies:
+   - Per-task `onErrorCallback` is invoked with the `ConcurrentModificationException`
+   - Global `onError` listener is also invoked (existing behavior preserved)
+   - The active transaction is rolled back after failure
+2. Existing `AsyncTest` suite passes (no regressions).
+
+## Test Results
+
+- `DatabaseAsyncTransactionRetryExhaustedTest`: 1/1 pass
+- `AsyncTest`: 11/11 pass
+- `DatabaseAsyncExecutorLifecycleRaceTest`: 1/1 pass

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncTransaction.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncTransaction.java
@@ -78,8 +78,14 @@ public class DatabaseAsyncTransaction implements DatabaseAsyncTask {
       }
     }
 
-    if (lastException != null)
+    if (lastException != null) {
+      if (database.getTransaction().isActive())
+        database.rollback();
       async.onError(lastException);
+      if (onErrorCallback != null)
+        onErrorCallback.call(lastException);
+      throw lastException;
+    }
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncTransaction.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncTransaction.java
@@ -79,9 +79,8 @@ public class DatabaseAsyncTransaction implements DatabaseAsyncTask {
     }
 
     if (lastException != null) {
-      if (database.getTransaction().isActive())
+      if (database.isTransactionActive())
         database.rollback();
-      async.onError(lastException);
       if (onErrorCallback != null)
         onErrorCallback.call(lastException);
       throw lastException;

--- a/engine/src/test/java/com/arcadedb/database/async/DatabaseAsyncTransactionRetryExhaustedTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/DatabaseAsyncTransactionRetryExhaustedTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.ConcurrentModificationException;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for #4369: after retries are exhausted in {@link DatabaseAsyncTransaction},
+ * the per-task {@code onErrorCallback} must be invoked and the transaction rolled back.
+ * Before the fix the per-task callback was silently skipped and no exception was propagated
+ * to the async worker, leaving a stale open transaction.
+ */
+class DatabaseAsyncTransactionRetryExhaustedTest extends TestHelper {
+
+  @Test
+  void perTaskErrorCallbackInvokedWhenRetriesExhausted() throws InterruptedException {
+    final AtomicBoolean okCalled = new AtomicBoolean(false);
+    final AtomicReference<Throwable> perTaskError = new AtomicReference<>();
+    final AtomicReference<Throwable> globalError = new AtomicReference<>();
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    database.async().onError(e -> globalError.set(e));
+
+    // Submit a transaction that always throws ConcurrentModificationException.
+    // retries=2 means 3 total attempts before the error path is reached.
+    database.async().transaction(
+        () -> {
+          throw new ConcurrentModificationException("simulated conflict");
+        },
+        2,
+        () -> okCalled.set(true),
+        e -> {
+          perTaskError.set(e);
+          latch.countDown();
+        }
+    );
+
+    assertThat(latch.await(5, TimeUnit.SECONDS)).as("per-task error callback must fire within 5 s").isTrue();
+    database.async().waitCompletion();
+
+    assertThat(okCalled.get()).as("ok callback must not be invoked on failure").isFalse();
+    assertThat(perTaskError.get()).as("per-task error callback must receive the ConcurrentModificationException")
+        .isInstanceOf(ConcurrentModificationException.class);
+    assertThat(globalError.get()).as("global onError must also be notified")
+        .isInstanceOf(ConcurrentModificationException.class);
+    assertThat(database.isTransactionActive()).as("stale transaction must be rolled back after exhaustion").isFalse();
+  }
+}


### PR DESCRIPTION
Closes #4369

After retries are exhausted in `DatabaseAsyncTransaction.execute()`, only the global `onError` listener was notified while the per-task `onErrorCallback` was silently skipped. The active transaction was also never rolled back, and no exception was propagated to the async worker thread - so the task appeared complete despite the failure. This fix mirrors the existing non-`ConcurrentModificationException` error path: roll back the transaction if still active, invoke the per-task `onErrorCallback` if non-null, and re-throw the exception so the `AsyncThread` worker loop can also observe and log the failure.

## Test plan

- New regression test `DatabaseAsyncTransactionRetryExhaustedTest.perTaskErrorCallbackInvokedWhenRetriesExhausted`:
  - Submits an async transaction whose `TransactionScope` always throws `ConcurrentModificationException` (with `retries=2`, so 3 total attempts)
  - Asserts the per-task `onErrorCallback` is called with the `ConcurrentModificationException`
  - Asserts the global `onError` listener is also notified
  - Asserts `database.isTransactionActive()` is `false` after exhaustion (stale transaction rolled back)
  - Asserts the `onOkCallback` is never invoked
- Existing `AsyncTest` (11 tests) and `DatabaseAsyncExecutorLifecycleRaceTest` pass without modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)