### PR TITLE
fix(#4368): rollback active transaction in CME catch before retrying

### DIFF
--- a/docs/4368-async-transaction-rollback-before-retry.md
+++ b/docs/4368-async-transaction-rollback-before-retry.md
@@ -3,17 +3,24 @@
 ## Issue
 
 [#4368](https://github.com/ArcadeData/arcadedb/issues/4368) - When `tx.execute()` throws
-`ConcurrentModificationException`, the transaction is still active. The next retry's
-`database.begin()` fails with `TransactionException("Transaction already begun")`.
+`ConcurrentModificationException`, the transaction is still active. On the next retry,
+`LocalDatabase.begin()` detects the active transaction and creates a nested sub-transaction
+instead of a fresh one. Any partial writes made by the failed attempt remain in the outer
+(uncommitted) transaction. That outer transaction is later committed - for example when
+`waitCompletion()` sends a `DatabaseAsyncCompletion` semaphore task that calls
+`database.commit()` on any active transaction on the thread - causing partial or duplicate
+records to be persisted.
 
 ## Root Cause
 
 In `DatabaseAsyncTransaction.execute()`, the CME catch block only stored the exception and
-continued to the next loop iteration. It never called `database.rollback()`. Since
-`tx.execute()` may have started work inside the active transaction, the transaction remains
-open. The next `database.begin()` then throws "Transaction already begun", which is caught
-by the generic `Exception` handler and propagated as an error - defeating the entire retry
-mechanism.
+continued to the next loop iteration without calling `database.rollback()`. Because
+`tx.execute()` may have partially modified data inside the active transaction, that
+transaction stays open with uncommitted changes. When the retry calls `database.begin()`,
+`LocalDatabase.begin()` pushes the dirty transaction onto the nested-tx stack and starts a
+sub-transaction with a fresh view. The retry's successful commit only commits the
+sub-transaction; the outer transaction carrying the partial writes is still active and will
+be committed later, producing extra records in the database.
 
 ## Affected File
 

--- a/docs/4368-async-transaction-rollback-before-retry.md
+++ b/docs/4368-async-transaction-rollback-before-retry.md
@@ -1,0 +1,50 @@
+# Fix #4368: DatabaseAsyncTransaction does not rollback before retrying after ConcurrentModificationException
+
+## Issue
+
+[#4368](https://github.com/ArcadeData/arcadedb/issues/4368) - When `tx.execute()` throws
+`ConcurrentModificationException`, the transaction is still active. The next retry's
+`database.begin()` fails with `TransactionException("Transaction already begun")`.
+
+## Root Cause
+
+In `DatabaseAsyncTransaction.execute()`, the CME catch block only stored the exception and
+continued to the next loop iteration. It never called `database.rollback()`. Since
+`tx.execute()` may have started work inside the active transaction, the transaction remains
+open. The next `database.begin()` then throws "Transaction already begun", which is caught
+by the generic `Exception` handler and propagated as an error - defeating the entire retry
+mechanism.
+
+## Affected File
+
+- `engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncTransaction.java` (line 64-66)
+
+## Fix
+
+Add `if (database.isTransactionActive()) database.rollback();` in the CME catch block,
+before the loop continues to the next retry. This mirrors what the generic Exception handler
+already does at line 69-70.
+
+## Test
+
+New test: `engine/src/test/java/com/arcadedb/database/async/DatabaseAsyncTransactionRetryTest.java`
+
+- `asyncTransactionRetriesAfterConcurrentModificationException`: TransactionScope throws CME on
+  the first attempt, succeeds on the second. Verifies okCallback is called and no error is
+  reported.
+
+## Verification
+
+```
+cd engine && mvn test -Dtest=DatabaseAsyncTransactionRetryTest
+```
+
+## Test results
+
+- `DatabaseAsyncTransactionRetryTest`: PASS (1 test)
+- All async tests (`DatabaseAsync*`, `AsyncTest`): PASS (13 tests)
+- Transaction tests (`*Transaction*`): PASS (62/63 tests - 1 pre-existing failure in `ACIDTransactionTest.asyncIOExceptionAfterWALIsWrittenManyRecords` that also fails on main)
+
+## Status
+
+Implementation complete, tests passing.

--- a/docs/4368-async-transaction-rollback-before-retry.md
+++ b/docs/4368-async-transaction-rollback-before-retry.md
@@ -36,9 +36,9 @@ already does at line 69-70.
 
 New test: `engine/src/test/java/com/arcadedb/database/async/DatabaseAsyncTransactionRetryTest.java`
 
-- `asyncTransactionRetriesAfterConcurrentModificationException`: TransactionScope throws CME on
-  the first attempt, succeeds on the second. Verifies okCallback is called and no error is
-  reported.
+- `partialWriteFromFailedAttemptIsNotCommitted`: TransactionScope saves a document and throws
+  CME on the first attempt, then succeeds on the second. After `waitCompletion()`, asserts
+  exactly one document exists. Fails before the fix (count = 2), passes after.
 
 ## Verification
 
@@ -52,6 +52,27 @@ cd engine && mvn test -Dtest=DatabaseAsyncTransactionRetryTest
 - All async tests (`DatabaseAsync*`, `AsyncTest`): PASS (13 tests)
 - Transaction tests (`*Transaction*`): PASS (62/63 tests - 1 pre-existing failure in `ACIDTransactionTest.asyncIOExceptionAfterWALIsWrittenManyRecords` that also fails on main)
 
-## Status
+## PR
 
-Implementation complete, tests passing.
+https://github.com/ArcadeData/arcadedb/pull/4376
+
+## Review cycles
+
+**Cycle 1** — HEAD `06056e118`
+
+- gemini-code-assist reviewed (state: COMMENTED)
+- 1 actionable inline comment: tracking-doc Issue/Root-Cause sections described the wrong
+  failure mode ("Transaction already begun" vs. the actual nested-tx behavior). Corrected in
+  follow-up commit `31ae2769a`.
+- claude bot not configured on this repo; waited but never appeared.
+
+**Cycle 2** — HEAD `31ae2769a`
+
+- gemini-code-assist did not re-review (known constraint: bot does not review follow-up
+  pushes on ArcadeData/arcadedb). Final state: timeout.
+- No unaddressed feedback remains.
+
+## Final State
+
+`timeout` (cycle 2 - gemini does not re-review follow-up pushes; all feedback from cycle 1
+was addressed)

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncTransaction.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncTransaction.java
@@ -64,6 +64,8 @@ public class DatabaseAsyncTransaction implements DatabaseAsyncTask {
       } catch (final ConcurrentModificationException e) {
         // RETRY
         lastException = e;
+        if (database.isTransactionActive())
+          database.rollback();
 
       } catch (final Exception e) {
         if (database.getTransaction().isActive())

--- a/engine/src/test/java/com/arcadedb/database/async/DatabaseAsyncTransactionRetryTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/DatabaseAsyncTransactionRetryTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.ConcurrentModificationException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression for the missing rollback in {@link DatabaseAsyncTransaction} when
+ * {@code tx.execute()} throws {@link ConcurrentModificationException}.
+ *
+ * <p>Without the fix, the failed attempt's transaction is still active when the retry begins.
+ * {@code LocalDatabase.begin()} then creates a nested sub-transaction for the retry, leaving the
+ * partial writes from attempt 0 in the outer (uncommitted) transaction. That outer transaction is
+ * committed later (e.g. by the {@code waitCompletion} semaphore task), producing a duplicate
+ * record in the database.
+ *
+ * <p>With the fix, the CME catch rolls back the active transaction before continuing to the next
+ * retry, so each attempt starts with a clean slate.
+ */
+class DatabaseAsyncTransactionRetryTest extends TestHelper {
+
+  private static final String TYPE = "TestAsyncDoc";
+
+  /**
+   * A CME on attempt 0 must not cause the partial writes from that attempt to appear in the
+   * database. Only the successful retry's writes should be committed.
+   */
+  @Test
+  void partialWriteFromFailedAttemptIsNotCommitted() throws InterruptedException {
+    database.getSchema().createDocumentType(TYPE);
+
+    final AtomicInteger attempts = new AtomicInteger(0);
+    final AtomicBoolean okCalled = new AtomicBoolean(false);
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+    database.async().transaction(
+        () -> {
+          database.newDocument(TYPE).set("attempt", attempts.get()).save();
+          if (attempts.getAndIncrement() == 0)
+            throw new ConcurrentModificationException("simulated conflict");
+          // attempt 1 succeeds with the document already saved above
+        },
+        3,
+        () -> okCalled.set(true),
+        e -> errorRef.set(e));
+
+    // waitCompletion issues a DatabaseAsyncCompletion task per thread, which commits any
+    // active transaction on that thread.  Without the fix, it would commit the orphan
+    // transaction that still holds the document from the failed attempt 0.
+    database.async().waitCompletion(5_000);
+
+    assertThat(errorRef.get()).isNull();
+    assertThat(okCalled.get()).isTrue();
+
+    // exactly one document must exist - only from the committed retry
+    final long count = ((Number)
+        database.query("sql", "SELECT count(*) as cnt FROM " + TYPE).next().getProperty("cnt")).longValue();
+    assertThat(count).isEqualTo(1L);
+  }
+}


### PR DESCRIPTION
Closes #4368

When `tx.execute()` throws `ConcurrentModificationException` inside `DatabaseAsyncTransaction`, the active transaction is left open. On the next retry, `LocalDatabase.begin()` detects an active transaction and creates a nested sub-transaction instead of a fresh one. This leaves any partial writes from the failed attempt in the outer (uncommitted) transaction. That outer transaction is eventually committed (for example, by the `DatabaseAsyncCompletion` semaphore task that `waitCompletion()` sends to each thread), producing duplicate or unwanted records in the database. The fix mirrors what the generic `Exception` catch already does: call `database.rollback()` if a transaction is active before continuing to the next retry, ensuring each retry starts with a clean slate.

## Test plan

- `DatabaseAsyncTransactionRetryTest.partialWriteFromFailedAttemptIsNotCommitted`: schedules an async transaction whose `TransactionScope` saves a document and throws `ConcurrentModificationException` on the first attempt, then succeeds on the second. After `waitCompletion()`, asserts exactly one document exists - not two. This test **fails** on the unfixed code (count = 2) and **passes** after the fix (count = 1).
- All existing async tests (`DatabaseAsync*`, `AsyncTest`) continue to pass.
- All transaction tests (`*Transaction*`) continue to pass (one pre-existing failure in `ACIDTransactionTest.asyncIOExceptionAfterWALIsWrittenManyRecords` is unrelated and also fails on `main`).
