### PR TITLE
fix(#4373): throw TransactionException on HA server switch with active session

### DIFF
--- a/docs/4373-ha-failover-session-id-reuse.md
+++ b/docs/4373-ha-failover-session-id-reuse.md
@@ -42,9 +42,33 @@ New test in `RemoteDatabaseTest`:
 cd network && mvn test -Dtest=RemoteDatabaseTest -pl .
 ```
 
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/4377
+
+## Review cycles
+
+### Cycle 1 - SHA 64f4b6f0c0203010be8e642694bad79e6efa8274
+
+gemini-code-assist reviewed with 3 medium-priority comments (all applied):
+1. Pass IOException cause `e` to `TransactionException` constructor for better stack traces.
+2. Use `127.0.0.1` instead of `"replica-server"` in both test replica entries to avoid DNS lookups.
+3. (Same as #2, second test.)
+
+Follow-up SHA: `76076726b611663477f1df992d177cebee92781f`
+
+### Cycle 2 - SHA 76076726b611663477f1df992d177cebee92781f
+
+No review - gemini-code-assist does not re-review follow-up pushes (known repo behavior).
+Loop exited with `timeout` state.
+
+## Final state: timeout (gemini does not re-review follow-up pushes)
+
 ## Status
 
 - [x] Test written (failing before fix)
 - [x] Fix implemented
 - [x] Tests passing (375 tests, 0 failures, full network module)
-- [ ] PR opened
+- [x] PR opened: https://github.com/ArcadeData/arcadedb/pull/4377
+- [x] Cycle 1 review addressed
+- [ ] PR merged (developer's responsibility)

--- a/docs/4373-ha-failover-session-id-reuse.md
+++ b/docs/4373-ha-failover-session-id-reuse.md
@@ -1,0 +1,50 @@
+# Fix #4373: RemoteDatabase reuses session id across servers on HA failover
+
+## Root Cause
+
+`RemoteHttpComponent.httpCommand()` retries failed HTTP calls against a different cluster
+member when `autoReconnect=true` and more retries remain. In the server-switch branch
+(not `FIXED`, not `stickyPinned`), the code moves to the next server without checking
+whether a transaction session is currently open.
+
+Because `RemoteDatabase.createRequestBuilder()` always injects the `arcadedb-session-id`
+header when `getSessionId() != null`, the retry request arrives at the new server carrying
+a session id that was issued by the original (now unreachable) server. The new server
+either rejects the session or treats the request as session-less, while the client still
+believes its transaction is alive - silently corrupting or losing the transaction.
+
+## Affected components
+
+- `network/src/main/java/com/arcadedb/remote/RemoteHttpComponent.java` - `httpCommand()`
+  IOException retry branch (the `else` block that switches to a new server)
+
+## Fix
+
+In the `else` block (server-switch path), before calling `reloadClusterConfiguration()`,
+check whether `this` is a `RemoteDatabase` with an active session. If so:
+1. Clear the (now invalid) session id so the object is left in a consistent state.
+2. Throw `TransactionException("Server failover during active transaction")`.
+
+The caller is responsible for starting a new transaction.
+
+## Test
+
+New test in `RemoteDatabaseTest`:
+- `haFailoverDuringActiveTransactionThrowsTransactionException` - uses a replica entry
+  in `replicaServerList` so `maxRetry = 2`, then manually sets a session id and calls
+  `query()`. The first HTTP attempt fails with IOException (no server), the retry path
+  enters the server-switch branch, detects the active session, and must throw
+  `TransactionException`. Asserts the session is cleared afterwards.
+
+## Verification
+
+```
+cd network && mvn test -Dtest=RemoteDatabaseTest -pl .
+```
+
+## Status
+
+- [x] Test written (failing before fix)
+- [x] Fix implemented
+- [x] Tests passing (375 tests, 0 failures, full network module)
+- [ ] PR opened

--- a/network/src/main/java/com/arcadedb/remote/RemoteHttpComponent.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteHttpComponent.java
@@ -343,7 +343,7 @@ public class RemoteHttpComponent extends RWLockContext {
         } else {
           if (this instanceof RemoteDatabase remoteDb && remoteDb.getSessionId() != null) {
             remoteDb.setSessionId(null);
-            throw new TransactionException("Server failover during active transaction");
+            throw new TransactionException("Server failover during active transaction", e);
           }
 
           if (!reloadClusterConfiguration())

--- a/network/src/main/java/com/arcadedb/remote/RemoteHttpComponent.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteHttpComponent.java
@@ -341,6 +341,11 @@ public class RemoteHttpComponent extends RWLockContext {
               .log(this, Level.WARNING, "Remote server (%s:%d) seems unreachable, retrying...",
                   connectToServer.getFirst(), connectToServer.getSecond());
         } else {
+          if (this instanceof RemoteDatabase remoteDb && remoteDb.getSessionId() != null) {
+            remoteDb.setSessionId(null);
+            throw new TransactionException("Server failover during active transaction");
+          }
+
           if (!reloadClusterConfiguration())
             throw new RemoteException("Error on executing remote operation " + operation + ", no server available", e);
 

--- a/network/src/test/java/com/arcadedb/remote/RemoteDatabaseTest.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteDatabaseTest.java
@@ -277,7 +277,7 @@ class RemoteDatabaseTest {
     final TestableRemoteDatabase db = new TestableRemoteDatabase("127.0.0.1", unreachablePort, "testdb", "root", "test");
     try {
       // Expose a replica entry so maxRetry = 2, allowing the server-switch retry path.
-      db.getReplicaServerList().add(new Pair<>("replica-server", 9999));
+      db.getReplicaServerList().add(new Pair<>("127.0.0.1", 9999));
       // Simulate an in-flight transaction (session issued by the original server).
       db.setSessionId("live-session-id");
 
@@ -306,7 +306,7 @@ class RemoteDatabaseTest {
 
     final TestableRemoteDatabase db = new TestableRemoteDatabase("127.0.0.1", unreachablePort, "testdb", "root", "test");
     try {
-      db.getReplicaServerList().add(new Pair<>("replica-server", 9999));
+      db.getReplicaServerList().add(new Pair<>("127.0.0.1", 9999));
       // No setSessionId - no active transaction.
 
       assertThatThrownBy(() -> db.query("sql", "select 1"))

--- a/network/src/test/java/com/arcadedb/remote/RemoteDatabaseTest.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteDatabaseTest.java
@@ -266,6 +266,56 @@ class RemoteDatabaseTest {
     }
   }
 
+  @Test
+  void haFailoverDuringActiveTransactionThrowsTransactionException() throws Exception {
+    // Bind an ephemeral port then immediately close it; connect attempts will fail fast.
+    final int unreachablePort;
+    try (final ServerSocket probe = new ServerSocket(0)) {
+      unreachablePort = probe.getLocalPort();
+    }
+
+    final TestableRemoteDatabase db = new TestableRemoteDatabase("127.0.0.1", unreachablePort, "testdb", "root", "test");
+    try {
+      // Expose a replica entry so maxRetry = 2, allowing the server-switch retry path.
+      db.getReplicaServerList().add(new Pair<>("replica-server", 9999));
+      // Simulate an in-flight transaction (session issued by the original server).
+      db.setSessionId("live-session-id");
+
+      // query() uses leaderIsPreferable=false, so a replica-sized retry budget applies.
+      // The HTTP call fails (ConnectException), the retry path detects an active session,
+      // and must reject the server switch with TransactionException.
+      assertThatThrownBy(() -> db.query("sql", "select 1"))
+          .isInstanceOf(TransactionException.class)
+          .hasMessageContaining("failover");
+
+      // Session must be cleared so the object is in a consistent, retryable state.
+      assertThat(db.isTransactionActive()).isFalse();
+    } finally {
+      db.close();
+    }
+  }
+
+  @Test
+  void haFailoverWithoutActiveTransactionContinuesRetry() throws Exception {
+    // With no active session the retry path should proceed to a normal connectivity error,
+    // not a TransactionException.
+    final int unreachablePort;
+    try (final ServerSocket probe = new ServerSocket(0)) {
+      unreachablePort = probe.getLocalPort();
+    }
+
+    final TestableRemoteDatabase db = new TestableRemoteDatabase("127.0.0.1", unreachablePort, "testdb", "root", "test");
+    try {
+      db.getReplicaServerList().add(new Pair<>("replica-server", 9999));
+      // No setSessionId - no active transaction.
+
+      assertThatThrownBy(() -> db.query("sql", "select 1"))
+          .isNotInstanceOf(TransactionException.class);
+    } finally {
+      db.close();
+    }
+  }
+
   /**
    * Testable subclass that injects a fake leader address via the cluster-configuration hook.
    */


### PR DESCRIPTION
Closes #4373

## Summary

- `RemoteHttpComponent.httpCommand()` retries failed HTTP calls against a different cluster member when `autoReconnect=true`. Previously, the server-switch path (ROUND_ROBIN strategy) silently forwarded the existing `arcadedb-session-id` header to the new server. That session was issued by the original (now unreachable) server; the new server does not know about it, causing silent transaction loss or corruption on HA failover.
- Fix: before calling `reloadClusterConfiguration()` in the server-switch branch, check whether `this` is a `RemoteDatabase` with an active session. If so, clear the stale session and throw `TransactionException("Server failover during active transaction")`. The `FIXED` and `STICKY` (pinned) strategies are unaffected - they retry the same server.
- Two regression tests added to `RemoteDatabaseTest`: one verifying `TransactionException` is thrown when a session is active, and one verifying that without an active session the normal connectivity error is produced.

## Test plan

- [x] `RemoteDatabaseTest.haFailoverDuringActiveTransactionThrowsTransactionException` - fails before fix (gets `RemoteException`), passes after fix.
- [x] `RemoteDatabaseTest.haFailoverWithoutActiveTransactionContinuesRetry` - passes both before and after fix, confirming no regression for session-less retry.
- [x] Full `network` module test suite: 375 tests, 0 failures.
- [ ] Manual: start two-node cluster, begin transaction on node A, kill node A, attempt query - observe `TransactionException` instead of silent corruption.