### PR TITLE
fix: resolve CodeQL Java code-scanning alerts at their true sources

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/math/RandFunction.java
+++ b/engine/src/main/java/com/arcadedb/function/math/RandFunction.java
@@ -21,10 +21,15 @@ package com.arcadedb.function.math;
 import com.arcadedb.function.StatelessFunction;
 import com.arcadedb.query.sql.executor.CommandContext;
 
+import java.security.SecureRandom;
+
 /**
  * rand() function - returns a random float between 0.0 (inclusive) and 1.0 (exclusive).
  */
 public class RandFunction implements StatelessFunction {
+  // Per-thread SecureRandom: cryptographically strong source without cross-thread lock contention on the query hot path.
+  private static final ThreadLocal<SecureRandom> RANDOM = ThreadLocal.withInitial(SecureRandom::new);
+
   @Override
   public String getName() {
     return "rand";
@@ -32,6 +37,6 @@ public class RandFunction implements StatelessFunction {
 
   @Override
   public Object execute(final Object[] args, final CommandContext context) {
-    return Math.random();
+    return RANDOM.get().nextDouble();
   }
 }

--- a/engine/src/main/java/com/arcadedb/serializer/BinarySerializer.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinarySerializer.java
@@ -648,7 +648,7 @@ public class BinarySerializer {
       break;
     }
     default:
-      LogManager.instance().log(this, Level.INFO, "Error on serializing value '" + value + "', type not supported");
+      LogManager.instance().log(this, Level.INFO, "Error on serializing value '%s', type not supported", value);
     }
 
     if (encrypt) {

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/CountStepTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/CountStepTest.java
@@ -78,7 +78,7 @@ class CountStepTest extends TestHelper {
     });
 
     final ResultSet result = database.query("sql", "SELECT status, count(*) as total FROM Order GROUP BY status");
-    int totalRecords = 0;
+    long totalRecords = 0;
     while (result.hasNext()) {
       final Result item = result.next();
       final long count = item.<Number>getProperty("total").longValue();

--- a/engine/src/test/java/performance/RandFunctionBenchmark.java
+++ b/engine/src/test/java/performance/RandFunctionBenchmark.java
@@ -33,9 +33,11 @@ import java.util.concurrent.ThreadLocalRandom;
  */
 @Tag("benchmark")
 class RandFunctionBenchmark {
-  private static final int N          = 5_000_000;
-  private static final int WARMUP     = 5;
-  private static final int ITERATIONS = 10;
+  private static final int      N          = 5_000_000;
+  private static final int      WARMUP     = 5;
+  private static final int      ITERATIONS = 10;
+  // Reused (not allocated per call) so the empty-args setup does not add noise to the measured loop.
+  private static final Object[] NO_ARGS    = new Object[0];
 
   @Test
   void compareRandomSources() {
@@ -43,7 +45,7 @@ class RandFunctionBenchmark {
 
     System.out.println("\n=== rand() per-call cost: SecureRandom (current) vs ThreadLocalRandom vs Math.random() ===");
 
-    bench("RandFunction (ThreadLocal<SecureRandom>)", () -> ((Number) rand.execute(null, null)).doubleValue());
+    bench("RandFunction (ThreadLocal<SecureRandom>)", () -> ((Number) rand.execute(NO_ARGS, null)).doubleValue());
     bench("ThreadLocalRandom.nextDouble()", () -> ThreadLocalRandom.current().nextDouble());
     bench("Math.random()", Math::random);
   }

--- a/engine/src/test/java/performance/RandFunctionBenchmark.java
+++ b/engine/src/test/java/performance/RandFunctionBenchmark.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package performance;
+
+import com.arcadedb.function.math.RandFunction;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Measures the per-call cost of the SQL {@code rand()} function. The function uses a thread-local
+ * {@link java.security.SecureRandom} so that the CodeQL {@code java/insecure-randomness} taint from
+ * {@code rand()} into security sinks stays clear; this benchmark quantifies the overhead versus the
+ * insecure {@link ThreadLocalRandom} and {@link Math#random()} alternatives.
+ */
+@Tag("benchmark")
+class RandFunctionBenchmark {
+  private static final int N          = 5_000_000;
+  private static final int WARMUP     = 5;
+  private static final int ITERATIONS = 10;
+
+  @Test
+  void compareRandomSources() {
+    final RandFunction rand = new RandFunction();
+
+    System.out.println("\n=== rand() per-call cost: SecureRandom (current) vs ThreadLocalRandom vs Math.random() ===");
+
+    bench("RandFunction (ThreadLocal<SecureRandom>)", () -> ((Number) rand.execute(null, null)).doubleValue());
+    bench("ThreadLocalRandom.nextDouble()", () -> ThreadLocalRandom.current().nextDouble());
+    bench("Math.random()", Math::random);
+  }
+
+  private static void bench(final String name, final DoubleOp op) {
+    for (int w = 0; w < WARMUP; w++) {
+      double s = 0;
+      for (int i = 0; i < N; i++) s += op.next();
+      blackhole(s);
+    }
+
+    long best = Long.MAX_VALUE;
+    for (int it = 0; it < ITERATIONS; it++) {
+      final long t0 = System.nanoTime();
+      double s = 0;
+      for (int i = 0; i < N; i++) s += op.next();
+      final long t1 = System.nanoTime();
+      blackhole((long) s);
+      if (t1 - t0 < best) best = t1 - t0;
+    }
+    System.out.printf(Locale.ROOT, "%-42s best=%7.2f ms   (%.2f ns/op)%n", name, best / 1_000_000.0, (double) best / N);
+  }
+
+  private interface DoubleOp {
+    double next();
+  }
+
+  @SuppressWarnings("unused") private static long sink;
+
+  private static void blackhole(final double v) { sink ^= (long) v; }
+
+  private static void blackhole(final long v) { sink ^= v; }
+}

--- a/engine/src/test/java/performance/RandFunctionBenchmark.java
+++ b/engine/src/test/java/performance/RandFunctionBenchmark.java
@@ -38,6 +38,7 @@ class RandFunctionBenchmark {
   private static final int      ITERATIONS = 10;
   // Reused (not allocated per call) so the empty-args setup does not add noise to the measured loop.
   private static final Object[] NO_ARGS    = new Object[0];
+  private static       long     sink;
 
   @Test
   void compareRandomSources() {
@@ -53,7 +54,8 @@ class RandFunctionBenchmark {
   private static void bench(final String name, final DoubleOp op) {
     for (int w = 0; w < WARMUP; w++) {
       double s = 0;
-      for (int i = 0; i < N; i++) s += op.next();
+      for (int i = 0; i < N; i++)
+        s += op.next();
       blackhole(s);
     }
 
@@ -61,10 +63,12 @@ class RandFunctionBenchmark {
     for (int it = 0; it < ITERATIONS; it++) {
       final long t0 = System.nanoTime();
       double s = 0;
-      for (int i = 0; i < N; i++) s += op.next();
+      for (int i = 0; i < N; i++)
+        s += op.next();
       final long t1 = System.nanoTime();
       blackhole((long) s);
-      if (t1 - t0 < best) best = t1 - t0;
+      if (t1 - t0 < best)
+        best = t1 - t0;
     }
     System.out.printf(Locale.ROOT, "%-42s best=%7.2f ms   (%.2f ns/op)%n", name, best / 1_000_000.0, (double) best / N);
   }
@@ -73,9 +77,12 @@ class RandFunctionBenchmark {
     double next();
   }
 
-  @SuppressWarnings("unused") private static long sink;
 
-  private static void blackhole(final double v) { sink ^= (long) v; }
+  private static void blackhole(final double v) {
+    sink ^= (long) v;
+  }
 
-  private static void blackhole(final long v) { sink ^= v; }
+  private static void blackhole(final long v) {
+    sink ^= v;
+  }
 }

--- a/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
@@ -238,7 +238,7 @@ public class Neo4jImporter {
         break;
 
       case "relationship":
-        final String edgeLabel = json.has("label") && !json.isNull("label") ? json.getString("label") : null;
+        final String edgeLabel = json.has("label") && !json.isNull("label") ? validateLabel(json.getString("label")) : null;
         if (edgeLabel != null)
           database.getSchema().buildEdgeType().withName(edgeLabel).withTotalBuckets(bucketsPerType).withIgnoreIfExists(true)
               .create();
@@ -401,7 +401,7 @@ public class Neo4jImporter {
                 (context.createdEdges.get() / elapsed * 1000));
           }
 
-          final String type = json.getString("label");
+          final String type = validateLabel(json.getString("label"));
           if (type == null) {
             log("- found edge in line %d without labels. Skip it.", lineNumber.get());
             context.warnings.incrementAndGet();
@@ -672,13 +672,24 @@ public class Neo4jImporter {
     if (nodeLabels != null && !nodeLabels.isEmpty()) {
       if (nodeLabels.length() > 1) {
         // MULTI LABEL, CREATE A NEW MIXED TYPE THAT EXTEND ALL THE LABELS BY USING INHERITANCE
-        final List<String> list = nodeLabels.toList().stream().map(String.class::cast).sorted(Comparator.naturalOrder())
-            .collect(Collectors.toList());
+        final List<String> list = nodeLabels.toList().stream().map(String.class::cast).map(Neo4jImporter::validateLabel)
+            .sorted(Comparator.naturalOrder()).collect(Collectors.toList());
         return new Pair<>(String.join(Labels.LABEL_SEPARATOR, list), list);
       } else
-        return new Pair<>((String) nodeLabels.get(0), null);
+        return new Pair<>(validateLabel((String) nodeLabels.get(0)), null);
     }
     return null;
+  }
+
+  /**
+   * Validates a label coming from the (untrusted) import source before it is turned into a schema type and, in turn,
+   * into an on-disk bucket file name. Rejects path separators and parent-directory traversal so that a crafted input
+   * file cannot drive writes outside the database directory.
+   */
+  private static String validateLabel(final String label) {
+    if (label != null && (label.indexOf('/') >= 0 || label.indexOf('\\') >= 0 || label.indexOf('\0') >= 0 || label.contains("..")))
+      throw new ImportException("Invalid label: must not contain path separators or '..'");
+    return label;
   }
 
   private void log(final String text, final Object... args) {

--- a/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/Neo4jImporter.java
@@ -681,11 +681,7 @@ public class Neo4jImporter {
     return null;
   }
 
-  /**
-   * Validates a label coming from the (untrusted) import source before it is turned into a schema type and, in turn,
-   * into an on-disk bucket file name. Rejects path separators and parent-directory traversal so that a crafted input
-   * file cannot drive writes outside the database directory.
-   */
+  // Rejects untrusted import labels that could become path-traversal sequences in on-disk bucket file names.
   private static String validateLabel(final String label) {
     if (label != null && (label.indexOf('/') >= 0 || label.indexOf('\\') >= 0 || label.indexOf('\0') >= 0 || label.contains("..")))
       throw new ImportException("Invalid label: must not contain path separators or '..'");

--- a/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterIT.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/Neo4jImporterIT.java
@@ -322,6 +322,41 @@ class Neo4jImporterIT {
   }
 
   @Test
+  void rejectNodeLabelWithPathTraversal() {
+    final File databaseDirectory = new File(DATABASE_PATH);
+    try {
+      final String content = "{\"type\":\"node\",\"id\":\"0\",\"labels\":[\"../../etc/evil\"],\"properties\":{\"name\":\"x\"}}\n";
+      final ByteArrayInputStream is = new ByteArrayInputStream(content.getBytes());
+      final Neo4jImporter importer = new Neo4jImporter(is, (" -d " + DATABASE_PATH + " -o").split(" "));
+      assertThatThrownBy(importer::run)
+          .isInstanceOf(ImportException.class)
+          .hasMessageContaining("path separators");
+    } finally {
+      FileUtils.deleteRecursively(databaseDirectory);
+    }
+  }
+
+  @Test
+  void rejectEdgeLabelWithPathTraversal() {
+    final File databaseDirectory = new File(DATABASE_PATH);
+    try {
+      final StringBuilder content = new StringBuilder();
+      content.append("{\"type\":\"node\",\"id\":\"0\",\"labels\":[\"Person\"],\"properties\":{\"name\":\"Alice\"}}\n");
+      content.append("{\"type\":\"node\",\"id\":\"1\",\"labels\":[\"Person\"],\"properties\":{\"name\":\"Bob\"}}\n");
+      content.append("{\"id\":\"r0\",\"type\":\"relationship\",\"label\":\"..\\\\..\\\\evil\",\"properties\":{},");
+      content.append("\"start\":{\"id\":\"0\",\"labels\":[\"Person\"]},\"end\":{\"id\":\"1\",\"labels\":[\"Person\"]}}\n");
+
+      final ByteArrayInputStream is = new ByteArrayInputStream(content.toString().getBytes());
+      final Neo4jImporter importer = new Neo4jImporter(is, (" -d " + DATABASE_PATH + " -o").split(" "));
+      assertThatThrownBy(importer::run)
+          .isInstanceOf(ImportException.class)
+          .hasMessageContaining("path separators");
+    } finally {
+      FileUtils.deleteRecursively(databaseDirectory);
+    }
+  }
+
+  @Test
   void importNeo4jMultiTypes() throws Exception {
     final File databaseDirectory = new File(DATABASE_PATH);
 


### PR DESCRIPTION
## Summary

Resolves the 30 open CodeQL (`language:java`) code-scanning alerts on `main`. Triaging the SARIF code-flows showed the reported sink locations collapse to **four root causes** - the alert `path:line` is the sink, while the real source lives upstream in the flow.

| Rule | Alerts | Root cause | Fix |
|---|---|---|---|
| `java/insecure-randomness` | 24 | `RandFunction.execute()` returned `Math.random()`; CodeQL follows the SQL `rand()` value through config-string resolution into 24 security sinks (BoltSslHelper, SocketFactory, ServerSecurity, ArcadeDBServer, HttpServer, etc.) | `ThreadLocal<SecureRandom>` - cryptographically strong source without cross-thread lock contention on the query hot path |
| `java/tainted-format-string` | 4 | `BinarySerializer` concatenated an untrusted `value` into a log message | Pass `value` as a `%s` argument instead of concatenating into the template |
| `java/path-injection` | 1 | Untrusted Neo4j import labels became schema type names and on-disk bucket file names | `validateLabel()` at the import boundary rejects `/`, `\`, NUL and `..` |
| `java/implicit-cast-in-compound-assignment` | 1 | `int += long` narrowing in a test | Widen `totalRecords` to `long` |

The path-injection fix is at the import trust boundary rather than the file-open sink because at the sink the trusted directory and untrusted name are a single indistinguishable string, and ArcadeDB database paths can legitimately be relative (contain `..`), so a sink-side `..` rejection would break valid usage.

## Test plan

- [x] `engine` and `integration` modules compile
- [x] `CountStepTest`, `BinarySerializerTest`, `JavaBinarySerializerTest`, `JsonSerializerTest`
- [x] Cypher math tests exercising `rand()` (`OpenCypherMathNumericFunctionsComprehensiveTest`, `CypherFunctionFactoryExtendedTest`, `FunctionCachingTest`)
- [x] `Neo4jImporterIT` - 8 tests incl. 2 new regressions (`rejectNodeLabelWithPathTraversal`, `rejectEdgeLabelWithPathTraversal`)
- [ ] CodeQL re-scan on the PR confirms the alerts clear

## Performance (rand() SecureRandom)

`rand()` now uses a thread-local `SecureRandom`. Measured per-call cost (`RandFunctionBenchmark`, `@Tag("benchmark")`):

| source | ns/op |
|---|---|
| RandFunction (ThreadLocal<SecureRandom>) | ~95 |
| ThreadLocalRandom.nextDouble() | ~2.6 |
| Math.random() | ~9.6 |

**Verdict: within budget.** `RandFunction` has no internal engine callers - it backs only the user-facing `rand()` (Cypher + SQL). The ~95 ns/op is incurred only when a user writes `rand()`, and it sits on top of per-row record fetch + binary deserialization (hundreds of ns to several µs/row) that dominates by 1-2 orders of magnitude. Worst realistic case `ORDER BY rand()` over 1M rows adds ~92 ms vs ThreadLocalRandom, behind a sort+materialization that already costs far more. The benchmark stays so the tradeoff is re-checkable if a heavy random-sampling workload ever justifies revisiting.