### PR TITLE
fix: resolve CodeQL JavaScript code-scanning alerts in Studio

### DIFF
--- a/studio/src/main/resources/static/index.html
+++ b/studio/src/main/resources/static/index.html
@@ -120,10 +120,12 @@
         toastEl.innerHTML =
           '<div class="toast-header">' +
             '<i class="fa ' + iconClass + ' me-2" style="color:' + iconColor + '"></i>' +
-            '<strong class="me-auto">' + (title || '') + '</strong>' +
+            '<strong class="me-auto"></strong>' +
             '<button type="button" class="btn-close" data-bs-dismiss="toast"></button>' +
           '</div>' +
-          '<div class="toast-body">' + (message || '') + '</div>';
+          '<div class="toast-body"></div>';
+        toastEl.querySelector('.toast-header strong').textContent = title || '';
+        toastEl.querySelector('.toast-body').textContent = message || '';
 
         container.appendChild(toastEl);
         // Errors and warnings stay visible until the user dismisses them; informational toasts auto-hide.

--- a/studio/src/main/resources/static/js/studio-database.js
+++ b/studio/src/main/resources/static/js/studio-database.js
@@ -450,7 +450,7 @@ function updateDatabases(callback, preferSelected) {
 
       // Update current database display
       try {
-        $("#currentDatabase").html(getCurrentDatabase());
+        $("#currentDatabase").text(getCurrentDatabase());
       } catch (e) {
         console.warn("Error updating current database display:", e);
       }
@@ -854,7 +854,7 @@ function resetDatabase() {
 }
 
 function backupDatabase() {
-  let database = getCurrentDatabase();
+  let database = escapeHtml(getCurrentDatabase());
   if (database == "") {
     globalNotify("Error", "Database not selected", "danger");
     return;
@@ -5165,9 +5165,19 @@ function dropMaterializedView(name) {
 
 // ===== Flame Graph Visualization =====
 
+// Tooltip HTML is built from already-escaped data and kept in JS, keyed by index,
+// so it is never round-tripped through a DOM attribute and re-parsed as HTML.
+var flameTips = [];
+
+function flameTipAttr(tipHtml) {
+  flameTips.push(tipHtml);
+  return " data-flame-tip-idx='" + (flameTips.length - 1) + "'";
+}
+
 function renderFlameGraph(plan, profile) {
   var container = $("#flameGraphContainer");
   var html = "";
+  flameTips = [];
 
   if (profile)
     html += renderProfileBreakdown(profile);
@@ -5185,7 +5195,7 @@ function renderFlameGraph(plan, profile) {
         html += "<div class='flame-graph'>";
         html += "<div class='flame-graph-header'><i class='fa fa-fire'></i> Engine Execution Flame Graph</div>";
         html += "<div class='flame-bar flame-depth-0' style='width:100%'";
-        html += " data-flame-tip='Engine execution &mdash; " + escapeHtml(formatCostNanos(totalCost)) + "'>";
+        html += flameTipAttr("Engine execution &mdash; " + escapeHtml(formatCostNanos(totalCost))) + ">";
         html += "<span class='flame-label'>Engine <small>" + formatCostNanos(totalCost) + "</small></span>";
         html += "</div>";
         html += renderFlameRow(steps, totalCost, 1);
@@ -5227,7 +5237,7 @@ function renderProfileBreakdown(profile) {
     var widthPct = Math.max(pct, 2);
     var tip = escapeHtml(p.name) + " &mdash; " + escapeHtml(formatCostNanos(p.nanos)) + " (" + pct.toFixed(1) + "%)";
     html += "<div class='profile-seg " + p.cls + "' style='width:" + widthPct + "%'";
-    html += " data-flame-tip='" + tip.replace(/'/g, "&#39;") + "'>";
+    html += flameTipAttr(tip) + ">";
     html += "<span class='flame-label'>" + escapeHtml(p.name) + " <small>" + formatCostNanos(p.nanos) + "</small></span>";
     html += "</div>";
   }
@@ -5269,7 +5279,7 @@ function renderFlameRow(steps, rootCost, depth) {
     var tipHtml = escapeHtml(name) + " &mdash; " + escapeHtml(costLabel) + " (" + pctOfRoot.toFixed(1) + "% of total)";
     if (desc) tipHtml += "<br>" + escapeHtml(desc);
     html += "<div class='flame-bar " + depthClass + "'";
-    html += " data-flame-tip='" + tipHtml.replace(/'/g, "&#39;") + "'>";
+    html += flameTipAttr(tipHtml) + ">";
     html += "<span class='flame-label'>" + escapeHtml(name) + " <small>" + costLabel + "</small></span>";
     html += "</div>";
     // Recursively render sub-steps inside this cell (inherits parent width)
@@ -5287,8 +5297,9 @@ function initFlameTooltips() {
     $("body").append("<div id='flameTooltip' class='flame-tooltip'></div>");
     tip = $("#flameTooltip");
   }
-  $("[data-flame-tip]").on("mouseenter", function(e) {
-    tip.html($(this).attr("data-flame-tip")).css({
+  $("[data-flame-tip-idx]").on("mouseenter", function(e) {
+    var idx = parseInt($(this).attr("data-flame-tip-idx"), 10);
+    tip.html(flameTips[idx] || "").css({
       left: e.pageX + 12,
       top: e.pageY - 10
     }).addClass("visible");
@@ -5463,12 +5474,15 @@ function displayMvHealth(views) {
     html += "<td class='text-end'>" + formatMs(v.refreshMaxTimeMs) + "</td>";
     html += "<td class='text-end'>" + formatMs(v.lastRefreshDurationMs) + "</td>";
     html += "<td class='text-end'>" + (v.errorCount > 0 ? '<span class="text-danger">' + formatNumber(v.errorCount) + '</span>' : '0') + "</td>";
-    html += '<td><button class="btn btn-sm db-action-btn" onclick="refreshMvFromMetrics(\'' + escapeHtml(v.name).replace(/'/g, "\\'") + '\')"><i class="fa fa-sync"></i></button></td>';
+    html += '<td><button class="btn btn-sm db-action-btn" data-mv-name="' + escapeHtml(v.name) + '"><i class="fa fa-sync"></i></button></td>';
     html += "</tr>";
   }
 
   html += "</tbody></table></div>";
   container.html(html);
+  container.find(".db-action-btn[data-mv-name]").on("click", function () {
+    refreshMvFromMetrics($(this).attr("data-mv-name"));
+  });
 }
 
 function refreshMvFromMetrics(name) {

--- a/studio/src/main/resources/static/js/studio-profiler.js
+++ b/studio/src/main/resources/static/js/studio-profiler.js
@@ -105,10 +105,12 @@ function profilerLoadSavedRuns() {
         var f = files[i];
         var sizeKb = Math.round(f.size / 1024);
         var dateStr = new Date(f.lastModified).toLocaleString();
-        menu.append('<li><a class="dropdown-item" style="cursor:pointer;" onclick="profilerLoadRun(\'' +
-          f.fileName.replace(/'/g, "\\'") + '\')">' + escapeHtml(f.fileName) +
-          ' <small class="text-muted">(' + sizeKb + ' KB, ' + dateStr + ')</small></a></li>');
+        menu.append('<li><a class="dropdown-item profiler-load-run" style="cursor:pointer;" data-run-file="' + escapeHtml(f.fileName) + '">' + escapeHtml(f.fileName) +
+          ' <small class="text-muted">(' + sizeKb + ' KB, ' + escapeHtml(dateStr) + ')</small></a></li>');
       }
+      menu.find(".profiler-load-run").on("click", function () {
+        profilerLoadRun(jQuery(this).attr("data-run-file"));
+      });
     },
     error: function() { /* silent */ }
   });

--- a/studio/src/main/resources/static/js/studio-record-editor.js
+++ b/studio/src/main/resources/static/js/studio-record-editor.js
@@ -344,10 +344,10 @@ function saveRecordEditor() {
         JSON.parse(current);
         sqlValue = current;
       } catch (e) {
-        sqlValue = "'" + current.replace(/'/g, "\\'") + "'";
+        sqlValue = "'" + current.replace(/\\/g, "\\\\").replace(/'/g, "\\'") + "'";
       }
     } else
-      sqlValue = "'" + current.replace(/'/g, "\\'") + "'";
+      sqlValue = "'" + current.replace(/\\/g, "\\\\").replace(/'/g, "\\'") + "'";
 
     setParts.push("`" + prop + "` = " + sqlValue);
   });


### PR DESCRIPTION
## Summary

Resolves the 8 live CodeQL JavaScript code-scanning alerts on `main`. All are in Studio application JS (`studio/src/main/resources/static/`); the latest CodeQL analysis at HEAD contains exactly these 8 results.

### xss-through-dom
- **`studio-database.js`** (#702): render the current database name with `.text()` instead of `.html()`.
- **`studio-utils.js`** (#1417): `escapeHtml()` the database name fed into the `backupDatabase()` confirm dialog, matching the existing `dropDatabase`/`resetDatabase` pattern.
- **`index.html`** (#1420): set toast `title`/`message` via `textContent` instead of building `innerHTML`.
- **`studio-database.js`** (#1421): serve flame-graph tooltips from an in-memory array keyed by index (`data-flame-tip-idx`) instead of round-tripping already-escaped HTML through a `data-flame-tip` attribute and re-parsing it via `.html()`.

### incomplete-sanitization
- **`studio-record-editor.js`** (#1418, #1654): escape backslash before the single quote when building SQL string literals (`\\` then `\'`, per ArcadeDB SQL escaping).
- **`studio-database.js`** (#1424) and **`studio-profiler.js`** (#1457): replace fragile inline `onclick="fn('...')"` string interpolation with `data-*` attributes and delegated click handlers.

### Note on the other ~31 "open" JS alerts
Those reference `studio/src/main/resources/static/components/DataTables/**` (deleted in #2260) or code that was refactored away. They are absent from the current analysis and only lingered open because the CodeQL analysis category was renamed (`javascript` → `javascript-typescript`), which prevented GitHub's auto-close. They have been dismissed separately as stale.

## Test plan
- [x] `node --check` passes on all three edited `.js` files
- [x] Pre-commit hooks pass
- [ ] Manual Studio smoke test: database switch, backup confirm dialog, toast notifications, query flame-graph tooltips, record editor save, materialized-view refresh button, profiler saved-runs menu
- [ ] CodeQL re-scan on merge confirms the 8 alerts close

Note: webpack does not process Studio application JS (it only copies vendor libs), so there is no bundling/build step for these files.