### PR TITLE
fix(#4371): synchronize FileManager.files ArrayList to prevent CME and AIOOBE

### DIFF
--- a/docs/4371-filemanager-thread-safety.md
+++ b/docs/4371-filemanager-thread-safety.md
@@ -44,3 +44,28 @@ New test in `FileManagerTest`: `getFiles_concurrentWithNewFileId_noConcurrentMod
 
 - New test reproduces CME with current code; passes after fix
 - Existing `FileManagerTest` tests continue to pass
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/4399
+
+## Review Cycles
+
+### Cycle 1 - SHA 08b5b07a
+
+Gemini reviewed (3 medium-priority inline comments); Claude did not respond (timeout after 15 min).
+
+Gemini feedback applied:
+- `dropFile()`: narrowed lock scope - `file.drop()` moved outside the synchronized block so blocking disk I/O does not hold the mutex. Early `return` inside the lock replaced with `else` branch to preserve the existing behavior of always calling `file.drop()` when the file is non-null (Gemini's suggestion had a subtle bug in this path that was corrected).
+- `getOrCreateFile(String, String, MODE)`: lock-free first lookup on `fileNameMap` (ConcurrentHashMap), double-checked inside `synchronized` block only when absent.
+- `getOrCreateFile(int, String)`: same double-checked locking pattern using `fileIdMap`.
+
+Commit: eb83aee2
+
+### Cycle 2 - SHA eb83aee2
+
+Neither bot responded within the 15-minute timeout.
+
+## Final State
+
+`timeout` - loop stopped after cycle 2 timeout with no bot reviews on the post-review push. PR is left open for developer merge.

--- a/docs/4371-filemanager-thread-safety.md
+++ b/docs/4371-filemanager-thread-safety.md
@@ -1,0 +1,46 @@
+# Issue #4371 - FileManager thread-safety fix
+
+## Root Cause
+
+`FileManager.files` is a plain `ArrayList<ComponentFile>` (line 31). Several methods mutate
+or iterate it without holding the intrinsic lock:
+
+| Method | Access | Synchronized? |
+|---|---|---|
+| `newFileId()` | `files.add(RESERVED_SLOT)` | YES (method-level) |
+| `registerFile()` | `files.size()`, `files.add(null)`, `files.set()` | NO |
+| `dropFile()` | `files.set(fileId, null)` | NO |
+| `getFiles()` | wraps live list in unmodifiable view | NO |
+| `close()` | `files.clear()` | NO |
+
+Because `newFileId()` holds the lock on `this` while other methods access `files` without it,
+the backing ArrayList is exposed to concurrent structural modification. This causes:
+
+- `ConcurrentModificationException` when `getFiles()` is iterated while `newFileId()` adds a slot
+- `ArrayIndexOutOfBoundsException` when `registerFile()` grows the list while `newFileId()` also modifies it
+- Torn reads: `fileIdMap.containsKey(id) == true` while `files.get(id) == null`
+
+## Fix
+
+Guard all mutations and reads of `files` with the same `this` lock that `newFileId()` already uses:
+
+1. `dropFile()` - add `synchronized`
+2. `getOrCreateFile(String, String, MODE)` - add `synchronized`
+3. `getOrCreateFile(int, String)` - add `synchronized`
+4. `getFiles()` - add `synchronized` and return a snapshot copy (not a live view) to prevent CME on callers iterating the returned list
+5. `close()` - add `synchronized`
+
+`registerFile()` (private) is called from the constructor (single-threaded) and from `getOrCreateFile()` (now synchronized), so it remains undecorated - it is always called under the lock after the fix.
+
+## Test
+
+New test in `FileManagerTest`: `getFiles_concurrentWithNewFileId_noConcurrentModificationException`
+- 8 writer threads each call `newFileId()` 500 times
+- 8 reader threads each call `getFiles()` and fully iterate the result 500 times
+- Both sets of threads start simultaneously via a `CountDownLatch`
+- Asserts no `ConcurrentModificationException` was thrown
+
+## Verification
+
+- New test reproduces CME with current code; passes after fix
+- Existing `FileManagerTest` tests continue to pass

--- a/engine/src/main/java/com/arcadedb/engine/FileManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/FileManager.java
@@ -193,30 +193,34 @@ public class FileManager {
     fileIdMap.clear();
   }
 
-  public synchronized void dropFile(final int fileId) throws IOException {
-    final ComponentFile file = fileIdMap.remove(fileId);
-    if (file != null) {
-      fileNameMap.remove(file.getComponentName());
-      files.set(fileId, null);
-      modificationCount.incrementAndGet();
-      file.drop();
+  public void dropFile(final int fileId) throws IOException {
+    final ComponentFile file;
+    synchronized (this) {
+      file = fileIdMap.remove(fileId);
+      if (file != null) {
+        fileNameMap.remove(file.getComponentName());
+        files.set(fileId, null);
+        modificationCount.incrementAndGet();
 
-      final FileChange entry = new FileChange(false, fileId, file.getFileName());
-      if (recordedChanges != null) {
-        if (recordedChanges.remove(entry)) {
-          LogManager.instance().log(this, Level.FINE,
-              "dropFile fileId=%d cancels prior CREATE entry (componentName='%s', fileName='%s')",
-              null, fileId, file.getComponentName(), file.getFileName());
-          // JUST ADDED: REMOVE THE ENTRY
-          return;
+        final FileChange entry = new FileChange(false, fileId, file.getFileName());
+        if (recordedChanges != null) {
+          if (recordedChanges.remove(entry)) {
+            LogManager.instance().log(this, Level.FINE,
+                "dropFile fileId=%d cancels prior CREATE entry (componentName='%s', fileName='%s')",
+                null, fileId, file.getComponentName(), file.getFileName());
+            // JUST ADDED: REMOVE THE ENTRY
+          } else {
+            recordedChanges.add(entry);
+            LogManager.instance().log(this, Level.FINE,
+                "recorded DROP fileId=%d fileName='%s' componentName='%s'",
+                null, fileId, file.getFileName(), file.getComponentName());
+          }
         }
-
-        recordedChanges.add(entry);
-        LogManager.instance().log(this, Level.FINE,
-            "recorded DROP fileId=%d fileName='%s' componentName='%s'",
-            null, fileId, file.getFileName(), file.getComponentName());
       }
     }
+
+    if (file != null)
+      file.drop();
   }
 
   public FileManagerStats getStats() {
@@ -252,28 +256,17 @@ public class FileManager {
     return f;
   }
 
-  public synchronized ComponentFile getOrCreateFile(final String fileName, final String filePath, final ComponentFile.MODE mode)
+  public ComponentFile getOrCreateFile(final String fileName, final String filePath, final ComponentFile.MODE mode)
       throws IOException {
     ComponentFile file = fileNameMap.get(fileName);
     if (file != null)
       return file;
 
-    file = new PaginatedComponentFile(filePath, mode);
-    registerFile(file);
+    synchronized (this) {
+      file = fileNameMap.get(fileName);
+      if (file != null)
+        return file;
 
-    if (recordedChanges != null) {
-      recordedChanges.add(new FileChange(true, file.getFileId(), file.getFileName()));
-      LogManager.instance().log(this, Level.FINE,
-          "recorded CREATE fileId=%d fileName='%s' componentName='%s'",
-          null, file.getFileId(), file.getFileName(), file.getComponentName());
-    }
-
-    return file;
-  }
-
-  public synchronized ComponentFile getOrCreateFile(final int fileId, final String filePath) throws IOException {
-    ComponentFile file = fileIdMap.get(fileId);
-    if (file == null) {
       file = new PaginatedComponentFile(filePath, mode);
       registerFile(file);
 
@@ -283,9 +276,32 @@ public class FileManager {
             "recorded CREATE fileId=%d fileName='%s' componentName='%s'",
             null, file.getFileId(), file.getFileName(), file.getComponentName());
       }
-    }
 
-    return file;
+      return file;
+    }
+  }
+
+  public ComponentFile getOrCreateFile(final int fileId, final String filePath) throws IOException {
+    ComponentFile file = fileIdMap.get(fileId);
+    if (file != null)
+      return file;
+
+    synchronized (this) {
+      file = fileIdMap.get(fileId);
+      if (file == null) {
+        file = new PaginatedComponentFile(filePath, mode);
+        registerFile(file);
+
+        if (recordedChanges != null) {
+          recordedChanges.add(new FileChange(true, file.getFileId(), file.getFileName()));
+          LogManager.instance().log(this, Level.FINE,
+              "recorded CREATE fileId=%d fileName='%s' componentName='%s'",
+              null, file.getFileId(), file.getFileName(), file.getComponentName());
+        }
+      }
+
+      return file;
+    }
   }
 
   public synchronized int newFileId() {

--- a/engine/src/main/java/com/arcadedb/engine/FileManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/FileManager.java
@@ -184,7 +184,7 @@ public class FileManager {
     }
   }
 
-  public void close() {
+  public synchronized void close() {
     for (final ComponentFile f : fileNameMap.values())
       f.close();
 
@@ -193,7 +193,7 @@ public class FileManager {
     fileIdMap.clear();
   }
 
-  public void dropFile(final int fileId) throws IOException {
+  public synchronized void dropFile(final int fileId) throws IOException {
     final ComponentFile file = fileIdMap.remove(fileId);
     if (file != null) {
       fileNameMap.remove(file.getComponentName());
@@ -226,8 +226,8 @@ public class FileManager {
     return stats;
   }
 
-  public List<ComponentFile> getFiles() {
-    return Collections.unmodifiableList(files);
+  public synchronized List<ComponentFile> getFiles() {
+    return Collections.unmodifiableList(new ArrayList<>(files));
   }
 
   /**
@@ -252,7 +252,7 @@ public class FileManager {
     return f;
   }
 
-  public ComponentFile getOrCreateFile(final String fileName, final String filePath, final ComponentFile.MODE mode)
+  public synchronized ComponentFile getOrCreateFile(final String fileName, final String filePath, final ComponentFile.MODE mode)
       throws IOException {
     ComponentFile file = fileNameMap.get(fileName);
     if (file != null)
@@ -271,7 +271,7 @@ public class FileManager {
     return file;
   }
 
-  public ComponentFile getOrCreateFile(final int fileId, final String filePath) throws IOException {
+  public synchronized ComponentFile getOrCreateFile(final int fileId, final String filePath) throws IOException {
     ComponentFile file = fileIdMap.get(fileId);
     if (file == null) {
       file = new PaginatedComponentFile(filePath, mode);

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/PaginatedSparseVectorEngine.java
@@ -1159,14 +1159,10 @@ public final class PaginatedSparseVectorEngine implements AutoCloseable {
    * lookups, no reader opens.
    */
   private long computeFileFingerprint() {
-    // Index-based walk over the FileManager's view, with a {@code size()} snapshot up front.
-    // Avoids both the {@code toArray()} allocation (one full-list copy per fingerprint compute,
-    // O(total files) bytes) and the {@code ConcurrentModificationException} risk that direct
-    // iterator-based traversal would carry: {@link FileManager} only ever appends slots or
-    // nulls them in place, never truncates, so {@code get(i)} for {@code i < snapshotSize}
-    // returns a stable value even under concurrent registerFile/dropFile. Files appended after
-    // we snapshot {@code size} are missed by this pass; the next bump of
-    // {@link FileManager#getModificationCount} will trigger a re-walk that picks them up.
+    // getFiles() returns a thread-safe snapshot of the FileManager's file list (since #4371),
+    // so iteration here is safe even though this method is called without holding mutatorLock.
+    // Files registered after the snapshot is taken are invisible to this pass; the next bump of
+    // FileManager#getModificationCount will trigger a re-walk that picks them up.
     final var files = database.getFileManager().getFiles();
     final int size = files.size();
     long count = 0L;

--- a/engine/src/test/java/com/arcadedb/engine/FileManagerTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/FileManagerTest.java
@@ -29,8 +29,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
@@ -99,5 +103,63 @@ public class FileManagerTest {
     assertThat(fileManager.getFiles().isEmpty()).isTrue();
     // cleanup
     Files.deleteIfExists(dir);
+  }
+
+  @Test
+  void getFiles_concurrentWithNewFileId_noConcurrentModificationException(@TempDir Path dir) throws Exception {
+    // Regression test for #4371: concurrent newFileId() + getFiles() iteration must not throw CME.
+    // newFileId() adds to the backing list under its own lock; getFiles() must return a snapshot
+    // so that iterating the returned list is safe even while writers add slots concurrently.
+    final FileManager fileManager = new FileManager(dir.toFile().getAbsolutePath(), ComponentFile.MODE.READ_WRITE, Set.of());
+    final int threadCount = 8;
+    final int iterationsPerThread = 500;
+    final AtomicReference<Throwable> caughtError = new AtomicReference<>();
+    final CountDownLatch startLatch = new CountDownLatch(1);
+
+    final List<Thread> writers = new ArrayList<>();
+    for (int i = 0; i < threadCount; i++) {
+      writers.add(new Thread(() -> {
+        try {
+          startLatch.await();
+          for (int j = 0; j < iterationsPerThread; j++)
+            fileManager.newFileId();
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }));
+    }
+
+    final List<Thread> readers = new ArrayList<>();
+    for (int i = 0; i < threadCount; i++) {
+      readers.add(new Thread(() -> {
+        try {
+          startLatch.await();
+          for (int j = 0; j < iterationsPerThread; j++) {
+            // iterate the full snapshot returned by getFiles() - must not throw CME
+            for (final ComponentFile ignored : fileManager.getFiles()) {
+              // just traverse
+            }
+          }
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        } catch (final Throwable t) {
+          caughtError.compareAndSet(null, t);
+        }
+      }));
+    }
+
+    writers.forEach(Thread::start);
+    readers.forEach(Thread::start);
+    startLatch.countDown();
+
+    for (final Thread t : writers)
+      t.join(10_000);
+    for (final Thread t : readers)
+      t.join(10_000);
+
+    assertThat(caughtError.get())
+        .as("concurrent getFiles() iteration must not throw ConcurrentModificationException")
+        .isNull();
+    assertThat(fileManager.getFiles()).hasSize(threadCount * iterationsPerThread);
   }
 }


### PR DESCRIPTION
Closes #4371

## Summary

`FileManager.files` is a plain `ArrayList<ComponentFile>` accessed from multiple threads without consistent locking. `newFileId()` already holds `synchronized` on `this` when it appends to the list, but `dropFile()`, `registerFile()` (called from `getOrCreateFile()`), `close()`, and `getFiles()` did not acquire the same lock, leaving the backing array exposed to concurrent structural modification.

This caused sporadic `ConcurrentModificationException` (CME) when callers iterated the list returned by `getFiles()` while another thread called `newFileId()`, and potential `ArrayIndexOutOfBoundsException` during concurrent list growth in `registerFile()`.

The fix adds `synchronized` to `close()`, `dropFile()`, and both `getOrCreateFile()` overloads so that all mutations of `files` are serialized on the same `this` lock. `getFiles()` is also synchronized and now returns a snapshot copy (`new ArrayList<>(files)`) instead of a live view, so callers can iterate the returned list safely without holding the lock.

## Test plan

- New regression test `FileManagerTest.getFiles_concurrentWithNewFileId_noConcurrentModificationException`: 8 writer threads call `newFileId()` 500 times each while 8 reader threads call `getFiles()` and iterate the result 500 times each; asserts no exception is thrown. Confirmed to fail (`ConcurrentModificationException`) before the fix and pass after.
- All 5 `FileManagerTest` tests pass.
- No regressions in `LSMTreeIndexTest`, `TypeIndexTest`, `LSMTreeFullTextIndexTest`, related engine tests.