### PR TITLE
fix(#4396): MultiIterator.countEntries discards count for non-resettable iterables

### DIFF
--- a/engine/src/main/java/com/arcadedb/utility/MultiIterator.java
+++ b/engine/src/main/java/com/arcadedb/utility/MultiIterator.java
@@ -154,7 +154,7 @@ public class MultiIterator<T> implements ResettableIterator<T>, IterableGraph<T>
           if (iter instanceof ResettableIterator<?> iterator)
             size += iterator.countEntries();
           else
-            CollectionUtils.countEntries(iter);
+            size += CollectionUtils.countEntries(iter);
         } else
           size++;
     }

--- a/engine/src/test/java/com/arcadedb/utility/IteratorTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/IteratorTest.java
@@ -178,6 +178,20 @@ class IteratorTest {
   }
 
   @Test
+  void multiIteratorCountEntriesWithNonResettableIterable() {
+    // Regression test for #4396: countEntries() was discarding the count
+    // returned by CollectionUtils.countEntries(iter) for non-resettable iterables.
+    final MultiIterator<String> multi = new MultiIterator<>();
+
+    // Plain Iterable backed by a non-resettable iterator (not a Collection or ResettableIterator)
+    final Iterable<String> nonResettable = () -> Arrays.asList("x", "y", "z").iterator();
+    multi.addIterator(nonResettable);
+    multi.addIterator(Arrays.asList("a", "b"));
+
+    assertThat(multi.countEntries()).isEqualTo(5);
+  }
+
+  @Test
   void multiIteratorGetBrowsed() {
     final MultiIterator<String> multi = new MultiIterator<>();
     multi.addIterator(Arrays.asList("a", "b", "c"));


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Fixes a one-line bug in `MultiIterator.countEntries()` where the non-resettable `Iterable` branch called `CollectionUtils.countEntries(iter)` but discarded the return value with `size +=` missing
- The iterator was drained as a side effect, making subsequent iteration of the same source yield nothing, while the count was silently under-reported
- Fix: `size += CollectionUtils.countEntries(iter)` - a single `size +=` prefix

## Test plan

- [x] Added regression test `multiIteratorCountEntriesWithNonResettableIterable()` in `IteratorTest` - wraps a plain `Iterable` (anonymous lambda backed by non-resettable iterator) and asserts `countEntries()` returns the correct total
- [x] Test was confirmed to FAIL before the fix (returned 2 instead of 5) and PASS after
- [x] Full `IteratorTest` suite (19 tests) passes
- [x] Related tests (`MultiValueTest`, `TypeTest`, `BasicGraphTest`) pass - 130 tests total, 0 failures

Fixes #4396

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)