### PR TITLE
fix(#4395): EdgeLinkedList.removeVertex iterates all segments to remove all matching entries

### DIFF
--- a/engine/src/main/java/com/arcadedb/graph/EdgeLinkedList.java
+++ b/engine/src/main/java/com/arcadedb/graph/EdgeLinkedList.java
@@ -290,11 +290,10 @@ public class EdgeLinkedList {
     EdgeSegment current = lastSegment;
     while (current != null) {
       final EdgeSegment next = current.getPrevious();
-      int deleted = 0;
-      int segDeleted;
-      while ((segDeleted = current.removeVertex(vertexRID)) > 0)
-        deleted += segDeleted;
-      if (deleted > 0) {
+      boolean deleted = false;
+      while (current.removeVertex(vertexRID) > 0)
+        deleted = true;
+      if (deleted) {
         final boolean segmentWillBeDeleted = prevBrowsed != null && current.isEmpty() && next != null;
         updateSegment(current, prevBrowsed);
         if (!segmentWillBeDeleted)

--- a/engine/src/main/java/com/arcadedb/graph/EdgeLinkedList.java
+++ b/engine/src/main/java/com/arcadedb/graph/EdgeLinkedList.java
@@ -289,12 +289,19 @@ public class EdgeLinkedList {
     EdgeSegment prevBrowsed = null;
     EdgeSegment current = lastSegment;
     while (current != null) {
-      if (current.removeVertex(vertexRID) > 0) {
+      final EdgeSegment next = current.getPrevious();
+      int deleted = 0;
+      int segDeleted;
+      while ((segDeleted = current.removeVertex(vertexRID)) > 0)
+        deleted += segDeleted;
+      if (deleted > 0) {
+        final boolean segmentWillBeDeleted = prevBrowsed != null && current.isEmpty() && next != null;
         updateSegment(current, prevBrowsed);
-        break;
-      }
-      prevBrowsed = current;
-      current = current.getPrevious();
+        if (!segmentWillBeDeleted)
+          prevBrowsed = current;
+      } else
+        prevBrowsed = current;
+      current = next;
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/graph/EdgeLinkedListRemoveAllSegmentsTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/EdgeLinkedListRemoveAllSegmentsTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.DatabaseChecker;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #4395:
+ * EdgeLinkedList.removeVertex stopped after the first matching segment,
+ * leaving orphaned edge references in older segments.
+ */
+class EdgeLinkedListRemoveAllSegmentsTest extends TestHelper {
+
+  private static final String VERTEX_TYPE = "Node";
+  private static final String EDGE_TYPE   = "Link";
+
+  /**
+   * Directly tests that EdgeLinkedList.removeVertex(RID) removes ALL entries
+   * referencing the given vertex across ALL segments, not just the first
+   * matching segment.
+   *
+   * The initial edge-list segment is 64 bytes with a 17-byte header, holding
+   * approximately 11 entries. Creating 25 bidirectional light edges forces
+   * at least three segments. A single call to removeVertex must clean all of
+   * them; before the fix it stopped at the first matching segment.
+   */
+  @Test
+  void removeVertexCleansAllSegmentsInSingleCall() {
+    database.getSchema().buildVertexType().withName(VERTEX_TYPE).create();
+    database.getSchema().buildEdgeType().withName(EDGE_TYPE).create();
+
+    final RID[] srcRID = new RID[1];
+    final RID[] dstRID = new RID[1];
+    final int edgeCount = 25;
+
+    database.transaction(() -> {
+      final MutableVertex src = database.newVertex(VERTEX_TYPE).set("name", "src").save();
+      final MutableVertex dst = database.newVertex(VERTEX_TYPE).set("name", "dst").save();
+      srcRID[0] = src.getIdentity();
+      dstRID[0] = dst.getIdentity();
+      for (int i = 0; i < edgeCount; i++)
+        src.newLightEdge(EDGE_TYPE, dst);
+    });
+
+    // Verify precondition: all edges are counted on the source OUT list
+    database.transaction(() -> {
+      final Vertex src = srcRID[0].asVertex(true);
+      final long countBefore = src.countEdges(Vertex.DIRECTION.OUT, null);
+      assertThat(countBefore).as("OUT edge count before removal").isEqualTo(edgeCount);
+    });
+
+    // Directly call removeVertex ONCE and verify ALL entries are removed.
+    // Before the fix, only the first matching segment was cleaned, leaving
+    // count > 0 after a single call.
+    database.transaction(() -> {
+      final EdgeLinkedList outEdges = ((DatabaseInternal) database)
+          .getGraphEngine()
+          .getEdgeHeadChunk((VertexInternal) srcRID[0].asVertex(true), Vertex.DIRECTION.OUT);
+      assertThat(outEdges).as("OUT edge list must not be null").isNotNull();
+      outEdges.removeVertex(dstRID[0]);
+    });
+
+    database.transaction(() -> {
+      final Vertex src = srcRID[0].asVertex(true);
+      final long countAfter = src.countEdges(Vertex.DIRECTION.OUT, null);
+      assertThat(countAfter)
+          .as("A single removeVertex call must clean ALL segments - orphaned entries remain without the fix")
+          .isEqualTo(0);
+    });
+  }
+
+  /**
+   * Regression test: deleting a vertex with many bidirectional light edges
+   * that span multiple edge-list segments must leave the neighbor with zero
+   * edge references. This exercises the full deleteVertex path.
+   */
+  @Test
+  void deleteVertexCleansNeighborEdgeListAcrossSegments() {
+    database.getSchema().buildVertexType().withName(VERTEX_TYPE).create();
+    database.getSchema().buildEdgeType().withName(EDGE_TYPE).create();
+
+    final RID[] srcRID = new RID[1];
+    final RID[] dstRID = new RID[1];
+    final int edgeCount = 25;
+
+    database.transaction(() -> {
+      final MutableVertex src = database.newVertex(VERTEX_TYPE).set("name", "src").save();
+      final MutableVertex dst = database.newVertex(VERTEX_TYPE).set("name", "dst").save();
+      srcRID[0] = src.getIdentity();
+      dstRID[0] = dst.getIdentity();
+      for (int i = 0; i < edgeCount; i++)
+        src.newLightEdge(EDGE_TYPE, dst);
+    });
+
+    // Delete the destination vertex
+    database.transaction(() -> database.deleteRecord(dstRID[0].asVertex(true)));
+
+    database.transaction(() -> {
+      final Vertex src = srcRID[0].asVertex(true);
+      final long countAfter = src.countEdges(Vertex.DIRECTION.OUT, null);
+      assertThat(countAfter)
+          .as("OUT edge count after deleting destination vertex must be 0")
+          .isEqualTo(0);
+    });
+
+    new DatabaseChecker(database).setVerboseLevel(0).check();
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #4395.

`EdgeLinkedList.removeVertex(RID)` stopped at the first segment containing a match, leaving orphaned edge references in older segments when a vertex has multiple edges to the same neighbour distributed across more than one segment.

**Root cause:** The outer segment-walking loop called `updateSegment` and immediately `break`ed on the first matching segment. Older segments with additional entries for the same vertex were never visited.

**Fix:** Removed the early `break`. The method now:
- Iterates ALL segments from newest to oldest
- For each segment, exhausts ALL occurrences of the vertex RID using an inner loop
- Calls `updateSegment` on each segment that changed, correctly maintaining the linked-list pointer when a segment becomes empty and is deleted
- Does NOT advance `prevBrowsed` when a segment is deleted (since `updateSegment` already re-links `prevBrowsed` past the deleted segment)

## Test plan

- Added `EdgeLinkedListRemoveAllSegmentsTest` with two tests:
  - `removeVertexCleansAllSegmentsInSingleCall`: directly calls `removeVertex` once on an `EdgeLinkedList` with 25 bidirectional light edges spanning 3+ segments, then asserts count drops to 0. This test **fails before the fix** (only 1 entry removed, 24 remain).
  - `deleteVertexCleansNeighborEdgeListAcrossSegments`: regression test for the normal vertex-deletion path with many light edges spanning multiple segments.
- All existing graph tests pass: `BasicGraphTest` (19), `GraphBatchTest` (8), `TxGraphTest` (1), `EdgeIndexCorruptionTest` (1), `EdgeIndexDuplicateKeyTest` (1), `CheckDatabaseTest` (6), `GraphBatchUniqueIndexTest` (3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)