### PR TITLE
feat(#4394): add show/hide toggle for Appearance section in graph side panel

### DIFF
--- a/docs/4394-hide-node-config-side-panel.md
+++ b/docs/4394-hide-node-config-side-panel.md
@@ -1,0 +1,36 @@
+# Issue #4394: Hide Node Config on Side Panel
+
+## Summary
+
+Added a show/hide toggle button for the Appearance section in the graph record editor side panel.
+
+## Problem
+
+The graph node side panel always showed the Appearance (node config) section, and there was no way to collapse it. After the initial configuration, this section occupies half the panel space unnecessarily.
+
+## Solution
+
+Added a chevron toggle button next to the "Appearance" section header that:
+
+- Collapses/expands the appearance settings body with a single click
+- Persists the collapsed/expanded state in `localStorage` under key `graphAppearanceCollapsed`
+- Restores the correct state on subsequent node selections (the state is read every time `renderGraphAppearanceSection` is called)
+- Uses a chevron-up icon when expanded and chevron-down when collapsed
+
+## Files Changed
+
+- `studio/src/main/resources/static/js/studio-record-editor.js`
+  - `renderGraphAppearanceSection()`: wrapped appearance body in `#geAppearanceBody` div; added toggle button with class `record-editor-appearance-toggle`; reads `graphAppearanceCollapsed` from localStorage to set initial state
+  - `toggleGraphAppearanceSection()`: new function that toggles body visibility, swaps chevron icon, and persists state to localStorage
+
+## Testing
+
+This is a pure frontend (JavaScript/HTML) change with no backend impact. Verification steps:
+
+1. Open ArcadeDB Studio
+2. Run a graph query that returns vertices
+3. Click a node - the side panel opens showing Properties, Actions, and Appearance sections
+4. Click the chevron button next to "Appearance" - the section collapses
+5. Click again - the section expands
+6. Close and reopen the panel (click another node) - the state is restored from localStorage
+7. Reload the page - the state is still preserved

--- a/studio/src/main/resources/static/js/studio-record-editor.js
+++ b/studio/src/main/resources/static/js/studio-record-editor.js
@@ -119,11 +119,16 @@ function renderGraphAppearanceSection(type, rid) {
   html += "</div></div>";
 
   // --- Appearance Section ---
+  var appearanceCollapsed = globalStorageLoad("graphAppearanceCollapsed", "false") === "true";
   html += "<div class='record-editor-section'>";
   html += "<div class='d-flex align-items-center justify-content-between'>";
   html += "<div class='record-editor-section-header' style='margin-bottom:0'><i class='fa fa-palette'></i> Appearance <small>(" + escapeHtml(type) + ")</small></div>";
+  html += "<div class='d-flex gap-1'>";
+  html += "<button class='btn btn-sm btn-outline-secondary record-editor-appearance-toggle' style='font-size:0.68rem; padding:1px 6px;' onclick='toggleGraphAppearanceSection()' title='Show/hide appearance'><i class='fa fa-chevron-" + (appearanceCollapsed ? "down" : "up") + "'></i></button>";
   html += "<button class='btn btn-sm btn-outline-secondary' style='font-size:0.68rem; padding:1px 6px;' onclick='resetGraphTypeStyle(\"" + escapeHtml(type).replace(/"/g, "&quot;") + "\")' title='Reset to defaults'><i class='fa fa-rotate-left'></i> Reset</button>";
-  html += "</div><div style='margin-top:10px'></div>";
+  html += "</div>";
+  html += "</div>";
+  html += "<div id='geAppearanceBody'" + (appearanceCollapsed ? " style='display:none'" : "") + "><div style='margin-top:10px'></div>";
 
   // Label
   var labelText = getOrCreateStyleTypeAttrib(type, "labelText");
@@ -208,7 +213,8 @@ function renderGraphAppearanceSection(type, rid) {
     html += "</div></div>";
   }
 
-  html += "</div>";
+  html += "</div>"; // close geAppearanceBody
+  html += "</div>"; // close record-editor-section
   return html;
 }
 
@@ -311,6 +317,20 @@ function bindGraphAppearanceEvents(type) {
       renderGraph();
     });
   }
+}
+
+function toggleGraphAppearanceSection() {
+  var body = $("#geAppearanceBody");
+  var btn = $(".record-editor-appearance-toggle i");
+  var collapsed = body.is(":visible");
+  if (collapsed) {
+    body.hide();
+    btn.removeClass("fa-chevron-up").addClass("fa-chevron-down");
+  } else {
+    body.show();
+    btn.removeClass("fa-chevron-down").addClass("fa-chevron-up");
+  }
+  globalStorageSave("graphAppearanceCollapsed", collapsed ? "true" : "false");
 }
 
 function saveRecordEditor() {

--- a/studio/src/main/resources/static/js/studio-record-editor.js
+++ b/studio/src/main/resources/static/js/studio-record-editor.js
@@ -322,15 +322,15 @@ function bindGraphAppearanceEvents(type) {
 function toggleGraphAppearanceSection() {
   var body = $("#geAppearanceBody");
   var btn = $(".record-editor-appearance-toggle i");
-  var collapsed = body.is(":visible");
-  if (collapsed) {
+  var isVisible = body.is(":visible");
+  if (isVisible) {
     body.hide();
     btn.removeClass("fa-chevron-up").addClass("fa-chevron-down");
   } else {
     body.show();
     btn.removeClass("fa-chevron-down").addClass("fa-chevron-up");
   }
-  globalStorageSave("graphAppearanceCollapsed", collapsed ? "true" : "false");
+  globalStorageSave("graphAppearanceCollapsed", isVisible ? "true" : "false");
 }
 
 function saveRecordEditor() {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes #4394. The Appearance (node config) section in the graph record editor side panel is now collapsible.

- Adds a chevron toggle button next to the "Appearance" section header
- Collapses or expands all appearance controls (label, size, color, border, etc.) with one click
- Persists the collapsed/expanded state in `localStorage` (key: `graphAppearanceCollapsed`) so it survives panel close/reopen and full page reload
- Default state is expanded (no behavior change for first-time users)

## Changes

Single file changed: `studio/src/main/resources/static/js/studio-record-editor.js`

- `renderGraphAppearanceSection()`: wrapped appearance body in `#geAppearanceBody` div; added chevron toggle button with class `record-editor-appearance-toggle`; reads `graphAppearanceCollapsed` from localStorage to set the initial render state
- `toggleGraphAppearanceSection()`: new function that toggles body visibility, swaps the chevron icon direction, and persists state to localStorage

## Test plan

- [ ] Run a graph query that returns vertices/edges
- [ ] Click a node - the side panel opens with Appearance section visible (expanded by default)
- [ ] Click the chevron button next to "Appearance" - the section collapses, chevron points down
- [ ] Click again - the section expands, chevron points up
- [ ] Close and reopen the panel (click another node) - collapsed state is restored
- [ ] Reload the page and click a node - collapsed state is preserved across reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)