### PR TITLE
fix(#4389): expand() AS alias now used as property name for plain values

### DIFF
--- a/docs/4389-expand-as-alias.md
+++ b/docs/4389-expand-as-alias.md
@@ -1,0 +1,96 @@
+# Issue #4389 - SQL expand() projection ignores AS alias
+
+## Problem
+
+`SELECT expand([1,2,3,4]) AS test` returns results with property `"value"` instead of `"test"`.
+
+The `AS` alias on an `expand()` call is silently dropped when plain (non-document) values are expanded.
+
+## Root Cause
+
+In `ProjectionItem.getExpandContent()`, the alias is not preserved when extracting the expand content.
+More critically, in `ExpandStep.fetchNext()`, for plain values (not `Identifiable`, `Result`, `Iterator`, or `Iterable`),
+the property name is hardcoded as `"value"` regardless of any alias:
+
+```java
+} else {
+    nextElement = new ResultInternal(context.getDatabase());
+    ((ResultInternal) nextElement).setProperty("value", nextElementObj);
+}
+```
+
+## Fix
+
+1. Add `expandAlias` field to `QueryPlanningInfo` to carry the alias from the expand projection item.
+2. In `SelectExecutionPlanner.optimizeQuery()`, when detecting an expand projection, capture the alias
+   from the original `ProjectionItem` and store it in `info.expandAlias`.
+3. Pass the alias to `ExpandStep` constructor.
+4. In `ExpandStep.fetchNext()`, use the alias instead of hardcoded `"value"` for plain values.
+5. Backward compatibility: when no alias is given, falls back to `"value"` as before.
+
+## Status
+
+- [x] Regression tests written (3 new tests in cycle 1)
+- [x] Implementation complete
+- [x] Tests pass (20 total, all pass)
+- [x] Review cycles complete
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/4411
+
+## Review Cycles
+
+### Cycle 1 (HEAD: b9f7dba)
+
+**Gemini COMMENTED (inline):**
+- Chain constructors in ExpandStep to avoid duplicating super(context)
+
+**Claude COMMENTED (issue comment at 15:13:38):**
+- Fully qualified `java.util.List.of` in test violates CLAUDE.md (minor)
+- The no-arg constructor is unreachable (minor)
+- Remove block comments before test methods (nit)
+- Suggestion: test actual values not just property names (optional)
+
+**Actions taken:**
+- Chained single-arg constructor via `this(context, null)` - satisfies both bots
+- Replaced `java.util.List.of()` with `List.of()` using existing import
+- Removed block comments before the three new test methods
+- Committed as `8a334dd49`
+
+### Cycle 2 (HEAD: 8a334dd)
+
+**Gemini COMMENTED (inline):**
+- Same constructor chaining suggestion - already applied (stale)
+
+**Claude COMMENTED (issue comment at 15:26:34):**
+- `alias` field should be `final` per CLAUDE.md (actionable)
+- `expandAlias` in `QueryPlanningInfo` could be `final` (minor/observation)
+- Add test for document-expand with alias to confirm alias does not affect document path
+- Minor comment style observation
+
+**Actions taken:**
+- Made `alias` field `final` in `ExpandStep` (using constructor chaining so single-arg always assigns it)
+- Added `expandDocumentListWithAliasPreservesDocumentProperties` test
+- Committed as `bd01650bd`
+
+### Cycle 3 (HEAD: bd01650)
+
+**Gemini COMMENTED (inline):**
+- Same constructor chaining suggestion - already applied (stale, repetitive)
+
+**Claude Code Review CI workflow:**
+- `claude-review` job ran and completed with success (no new issues posted)
+- No new issue comment - clean approval
+
+**Outcome:** Clean approval - no actionable items from either bot on this HEAD.
+
+## Final State
+
+`clean-approval` - 3 cycles run, all review feedback addressed.
+
+Files changed:
+- `engine/src/main/java/com/arcadedb/query/sql/executor/ExpandStep.java` - alias field + constructor chaining
+- `engine/src/main/java/com/arcadedb/query/sql/executor/QueryPlanningInfo.java` - expandAlias field
+- `engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java` - capture alias in optimizeQuery
+- `engine/src/test/java/com/arcadedb/query/sql/executor/ExpandStepTest.java` - 4 new regression tests

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ExpandStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ExpandStep.java
@@ -38,7 +38,7 @@ public class ExpandStep extends AbstractExecutionStep {
   Iterator  nextSubsequence = null;
   Result    nextElement     = null;
   Result    sourceResult    = null; // Source result from which we're expanding, used to preserve metadata
-  String    alias           = null; // Optional alias to use as property name for plain (non-document) values
+  final String alias;
 
   public ExpandStep(final CommandContext context) {
     this(context, null);

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ExpandStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ExpandStep.java
@@ -41,7 +41,7 @@ public class ExpandStep extends AbstractExecutionStep {
   String    alias           = null; // Optional alias to use as property name for plain (non-document) values
 
   public ExpandStep(final CommandContext context) {
-    super(context);
+    this(context, null);
   }
 
   public ExpandStep(final CommandContext context, final String alias) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ExpandStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ExpandStep.java
@@ -38,9 +38,15 @@ public class ExpandStep extends AbstractExecutionStep {
   Iterator  nextSubsequence = null;
   Result    nextElement     = null;
   Result    sourceResult    = null; // Source result from which we're expanding, used to preserve metadata
+  String    alias           = null; // Optional alias to use as property name for plain (non-document) values
 
   public ExpandStep(final CommandContext context) {
     super(context);
+  }
+
+  public ExpandStep(final CommandContext context, final String alias) {
+    super(context);
+    this.alias = alias;
   }
 
   @Override
@@ -101,7 +107,7 @@ public class ExpandStep extends AbstractExecutionStep {
             nextElement = new ResultInternal(map);
           } else {
             nextElement = new ResultInternal(context.getDatabase());
-            ((ResultInternal) nextElement).setProperty("value", nextElementObj);
+            ((ResultInternal) nextElement).setProperty(alias != null ? alias : "value", nextElementObj);
           }
           // Copy metadata from source result to the expanded result (e.g., LET variables like $nrid)
           if (sourceResult != null && nextElement instanceof ResultInternal resultInternal) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/QueryPlanningInfo.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/QueryPlanningInfo.java
@@ -38,8 +38,9 @@ import java.util.*;
 public class QueryPlanningInfo {
 
   protected Timeout timeout;
-  boolean distinct = false;
-  boolean expand   = false;
+  boolean distinct    = false;
+  boolean expand      = false;
+  String  expandAlias = null;
 
   Projection preAggregateProjection;
   Projection aggregateProjection;
@@ -85,6 +86,7 @@ public class QueryPlanningInfo {
     final QueryPlanningInfo result = new QueryPlanningInfo();
     result.distinct = this.distinct;
     result.expand = this.expand;
+    result.expandAlias = this.expandAlias;
     result.preAggregateProjection = this.preAggregateProjection;
     result.aggregateProjection = this.aggregateProjection;
     result.projection = this.projection;

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/SelectExecutionPlanner.java
@@ -698,6 +698,9 @@ public class SelectExecutionPlanner {
     extractSubQueries(info);
     if (info.projection != null && info.projection.isExpand()) {
       info.expand = true;
+      final ProjectionItem expandItem = info.projection.getItems().getFirst();
+      if (expandItem.getAlias() != null)
+        info.expandAlias = expandItem.getAlias().getStringValue();
       info.projection = info.projection.getExpandContent();
     }
     if (info.whereClause != null) {
@@ -1612,7 +1615,7 @@ public class SelectExecutionPlanner {
 
   private static void handleExpand(final SelectExecutionPlan result, final QueryPlanningInfo info, final CommandContext context) {
     if (info.expand) {
-      result.chain(new ExpandStep(context));
+      result.chain(new ExpandStep(context, info.expandAlias));
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ExpandStepTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ExpandStepTest.java
@@ -310,4 +310,29 @@ class ExpandStepTest extends TestHelper {
     assertThat(count).isEqualTo(3);
     result.close();
   }
+
+  @Test
+  void expandDocumentListWithAliasPreservesDocumentProperties() {
+    database.getSchema().createDocumentType("DocParent");
+    database.getSchema().createDocumentType("DocChild");
+
+    database.transaction(() -> {
+      final MutableDocument c1 = database.newDocument("DocChild").set("x", 1).save();
+      final MutableDocument c2 = database.newDocument("DocChild").set("x", 2).save();
+      database.newDocument("DocParent").set("children", List.of(c1, c2)).save();
+    });
+
+    final ResultSet result = database.query("sql", "SELECT expand(children) AS ignored FROM DocParent");
+
+    int count = 0;
+    while (result.hasNext()) {
+      final Result item = result.next();
+      assertThat(item.getPropertyNames()).contains("x");
+      assertThat(item.getPropertyNames()).doesNotContain("ignored");
+      count++;
+    }
+
+    assertThat(count).isEqualTo(2);
+    result.close();
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ExpandStepTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ExpandStepTest.java
@@ -258,7 +258,6 @@ class ExpandStepTest extends TestHelper {
     result.close();
   }
 
-  // Regression test for issue #4389: expand() AS alias must use the alias as property name for plain values
   @Test
   void expandWithAliasUsesAliasAsPropertyName() {
     final ResultSet result = database.query("sql", "SELECT expand([1,2,3,4]) AS test");
@@ -275,7 +274,6 @@ class ExpandStepTest extends TestHelper {
     result.close();
   }
 
-  // Regression test for issue #4389: expand() without alias still uses "value" as property name
   @Test
   void expandWithoutAliasUsesValueAsPropertyName() {
     final ResultSet result = database.query("sql", "SELECT expand([1,2,3,4])");
@@ -291,13 +289,12 @@ class ExpandStepTest extends TestHelper {
     result.close();
   }
 
-  // Regression test for issue #4389: expand() AS alias works on string values
   @Test
   void expandStringListWithAliasUsesAliasAsPropertyName() {
     database.getSchema().createDocumentType("AliasTest");
 
     database.transaction(() -> {
-      database.newDocument("AliasTest").set("tags", java.util.List.of("a", "b", "c")).save();
+      database.newDocument("AliasTest").set("tags", List.of("a", "b", "c")).save();
     });
 
     final ResultSet result = database.query("sql", "SELECT expand(tags) AS tag FROM AliasTest");

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ExpandStepTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ExpandStepTest.java
@@ -257,4 +257,60 @@ class ExpandStepTest extends TestHelper {
     assertThat(result.hasNext()).isFalse();
     result.close();
   }
+
+  // Regression test for issue #4389: expand() AS alias must use the alias as property name for plain values
+  @Test
+  void expandWithAliasUsesAliasAsPropertyName() {
+    final ResultSet result = database.query("sql", "SELECT expand([1,2,3,4]) AS test");
+
+    int count = 0;
+    while (result.hasNext()) {
+      final Result item = result.next();
+      assertThat(item.getPropertyNames()).containsExactly("test");
+      assertThat(item.getPropertyNames()).doesNotContain("value");
+      count++;
+    }
+
+    assertThat(count).isEqualTo(4);
+    result.close();
+  }
+
+  // Regression test for issue #4389: expand() without alias still uses "value" as property name
+  @Test
+  void expandWithoutAliasUsesValueAsPropertyName() {
+    final ResultSet result = database.query("sql", "SELECT expand([1,2,3,4])");
+
+    int count = 0;
+    while (result.hasNext()) {
+      final Result item = result.next();
+      assertThat(item.getPropertyNames()).containsExactly("value");
+      count++;
+    }
+
+    assertThat(count).isEqualTo(4);
+    result.close();
+  }
+
+  // Regression test for issue #4389: expand() AS alias works on string values
+  @Test
+  void expandStringListWithAliasUsesAliasAsPropertyName() {
+    database.getSchema().createDocumentType("AliasTest");
+
+    database.transaction(() -> {
+      database.newDocument("AliasTest").set("tags", java.util.List.of("a", "b", "c")).save();
+    });
+
+    final ResultSet result = database.query("sql", "SELECT expand(tags) AS tag FROM AliasTest");
+
+    int count = 0;
+    while (result.hasNext()) {
+      final Result item = result.next();
+      assertThat(item.getPropertyNames()).containsExactly("tag");
+      assertThat(item.getPropertyNames()).doesNotContain("value");
+      count++;
+    }
+
+    assertThat(count).isEqualTo(3);
+    result.close();
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #4389

`SELECT expand([1,2,3,4]) AS test` returned rows with property `"value"` instead of `"test"`. The `AS` alias on an `expand()` projection was silently dropped for plain (non-document, non-map) values.

**Root cause:** In `ExpandStep.fetchNext()`, when an expanded element is a plain value (integer, string, etc.), the property name was hardcoded to `"value"` regardless of any `AS` alias on the `expand()` call. The alias was also stripped in `ProjectionItem.getExpandContent()` without being preserved anywhere.

**Fix:**
- Added `expandAlias` field to `QueryPlanningInfo` to carry the explicit alias from the expand projection item.
- In `SelectExecutionPlanner.optimizeQuery()`, when detecting an expand projection, capture the alias from the original `ProjectionItem` and store it in `info.expandAlias`.
- Updated `ExpandStep` to accept an optional alias and use it instead of the hardcoded `"value"` for plain-value elements. Falls back to `"value"` when no alias is given (preserving existing behavior).

## Test plan

- [x] `expandWithAliasUsesAliasAsPropertyName` - verifies `SELECT expand([1,2,3,4]) AS test` yields rows with property `test` not `value`
- [x] `expandWithoutAliasUsesValueAsPropertyName` - verifies `SELECT expand([1,2,3,4])` (no alias) still uses `value` as before
- [x] `expandStringListWithAliasUsesAliasAsPropertyName` - verifies alias works for string values from a document field
- [x] All 13 `ExpandStepTest` tests pass
- [x] All 6 `ExpandParseTest` tests pass (including issue #2965 regression tests)
- [x] All 157 `SelectStatementExecutionTest` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)