### PR TITLE
fix(#4405): simplify AND-true/OR-false boolean constants in Cypher WHERE clauses

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherASTBuilder.java
@@ -1017,8 +1017,9 @@ public class CypherASTBuilder extends Cypher25ParserBaseVisitor<Object> {
   }
 
   public WhereClause visitWhereClause(final Cypher25Parser.WhereClauseContext ctx) {
-    // Parse the WHERE condition as a boolean expression
-    final BooleanExpression condition = parseBooleanExpression(ctx.expression());
+    // Parse the WHERE condition as a boolean expression, then simplify boolean constants
+    final BooleanExpression parsed = parseBooleanExpression(ctx.expression());
+    final BooleanExpression condition = (BooleanExpression) AST_REWRITER.rewrite(parsed);
     return new WhereClause(condition);
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/rewriter/BooleanSimplifier.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/rewriter/BooleanSimplifier.java
@@ -143,29 +143,36 @@ public class BooleanSimplifier extends ExpressionRewriter {
 
   /**
    * Check if boolean expression wraps literal true.
-   * In Cypher AST, literals implement Expression, not BooleanExpression.
-   * They get wrapped in BooleanWrapperExpression when used in boolean context.
+   * Boolean literals in WHERE clauses are represented as a
+   * {@link BooleanCoercionExpression} wrapping a {@link LiteralExpression} with
+   * value {@link Boolean#TRUE}.
    */
   private boolean isWrappedTrue(final BooleanExpression expr) {
-    if (expr instanceof BooleanWrapperExpression wrapper) {
-      // Check if wrapper contains literal true
-      // Note: BooleanWrapperExpression doesn't expose inner expression yet
-      // For now, return false - this will be implemented when wrapper API is available
-      return false;
-    }
+    if (expr instanceof BooleanCoercionExpression coercion)
+      return Boolean.TRUE.equals(booleanLiteralValue(coercion));
     return false;
   }
 
   /**
    * Check if boolean expression wraps literal false.
+   * Boolean literals in WHERE clauses are represented as a
+   * {@link BooleanCoercionExpression} wrapping a {@link LiteralExpression} with
+   * value {@link Boolean#FALSE}.
    */
   private boolean isWrappedFalse(final BooleanExpression expr) {
-    if (expr instanceof BooleanWrapperExpression wrapper) {
-      // Check if wrapper contains literal false
-      // Note: BooleanWrapperExpression doesn't expose inner expression yet
-      // For now, return false - this will be implemented when wrapper API is available
-      return false;
-    }
+    if (expr instanceof BooleanCoercionExpression coercion)
+      return Boolean.FALSE.equals(booleanLiteralValue(coercion));
     return false;
+  }
+
+  /**
+   * Returns the {@link Boolean} value when the coercion wraps a boolean literal,
+   * or {@code null} otherwise.
+   */
+  private static Boolean booleanLiteralValue(final BooleanCoercionExpression coercion) {
+    final Expression inner = coercion.getExpression();
+    if (inner instanceof LiteralExpression lit && lit.getValue() instanceof Boolean b)
+      return b;
+    return null;
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/rewriter/ExpressionRewriter.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/rewriter/ExpressionRewriter.java
@@ -49,6 +49,8 @@ public abstract class ExpressionRewriter {
 
     // Dispatch to specific visit methods based on concrete type
     // BooleanExpression implementers
+    if (expression instanceof BooleanCoercionExpression)
+      return visitBooleanCoercion((BooleanCoercionExpression) expression);
     if (expression instanceof ComparisonExpression)
       return visitComparison((ComparisonExpression) expression);
     if (expression instanceof LogicalExpression)
@@ -112,6 +114,15 @@ public abstract class ExpressionRewriter {
 
     // Unknown expression type: return as-is
     return expression;
+  }
+
+  /**
+   * Rewrite a boolean coercion expression (wraps an Expression as a BooleanExpression).
+   * Default: return as-is (the wrapped expression is a leaf-level value).
+   * Note: BooleanCoercionExpression implements BooleanExpression, not Expression.
+   */
+  protected BooleanExpression visitBooleanCoercion(final BooleanCoercionExpression expr) {
+    return expr;
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue4405Test.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue4405Test.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for <a href="https://github.com/ArcadeData/arcadedb/issues/4405">issue #4405</a>:
+ * Missed optimization - redundant AND-true OR-false branch raises ArcadeDB PROFILE rows.
+ *
+ * The predicate {@code base AND true OR false AND expr} should be simplified to {@code base}
+ * at parse time before reaching the optimizer, so both the base and transformed queries
+ * produce identical execution plans.
+ */
+class Issue4405Test {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/issue4405");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+
+    database.getSchema().createVertexType("L1");
+
+    database.transaction(() -> {
+      // Create vertices with k5 values: one matching -1 (used as a proxy for -1862396709),
+      // several non-matching; plus k6 and k10 properties for the UNWIND.
+      database.command("opencypher", "CREATE (:L1 {k5: -1, k6: 10, k10: 20})");
+      database.command("opencypher", "CREATE (:L1 {k5: -1, k6: 11, k10: 21})");
+      database.command("opencypher", "CREATE (:L1 {k5: 0,  k6: 12, k10: 22})");
+      database.command("opencypher", "CREATE (:L1 {k5: 1,  k6: 13, k10: 23})");
+      database.command("opencypher", "CREATE (:L1 {k5: 2,  k6: 14, k10: 24})");
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null && database.isOpen())
+      database.drop();
+  }
+
+  /**
+   * Both the base query and the semantically-equivalent transformed query
+   * ({@code base AND true OR false AND expr}) must return identical result sets.
+   */
+  @Test
+  void baseAndTransformedQueryReturnSameResults() {
+    final String baseQuery = """
+        MATCH (n0 :L1)
+        WHERE (n0.k5) = -1
+        UNWIND [(n0.k6), (n0.k10)] AS a0
+        RETURN a0
+        """;
+
+    final String transformedQuery = """
+        MATCH (n0 :L1)
+        WHERE ((n0.k5) = -1) AND true OR false AND (n0.k5 IS NULL OR n0.k5 IS NOT NULL)
+        UNWIND [(n0.k6), (n0.k10)] AS a0
+        RETURN a0
+        """;
+
+    final List<Object> baseResults = collectResults(baseQuery, "a0");
+    final List<Object> transformedResults = collectResults(transformedQuery, "a0");
+
+    assertThat(transformedResults)
+        .as("transformed query (base AND true OR false AND expr) should return same rows as base query")
+        .containsExactlyInAnyOrderElementsOf(baseResults);
+  }
+
+  /**
+   * WHERE clause with only redundant boolean constants that simplify to false
+   * (false OR false) should return no results.
+   */
+  @Test
+  void whereAlwaysFalseReturnsEmpty() {
+    final String query = "MATCH (n0 :L1) WHERE false OR false RETURN n0";
+
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      assertThat(rs.hasNext()).as("WHERE false OR false should return no rows").isFalse();
+    }
+  }
+
+  /**
+   * WHERE clause with only redundant boolean constants that simplify to true
+   * (true AND true) should return all vertices.
+   */
+  @Test
+  void whereAlwaysTrueReturnsAll() {
+    final String query = "MATCH (n0 :L1) WHERE true AND true RETURN n0";
+    final List<Object> results = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext()) {
+        results.add(rs.next().getProperty("n0"));
+      }
+    }
+    assertThat(results).as("WHERE true AND true should return all 5 vertices").hasSize(5);
+  }
+
+  /**
+   * WHERE predicate AND true should behave identically to the predicate alone.
+   */
+  @Test
+  void predicateAndTrueEquivalentToPredicateAlone() {
+    final String baseQuery = "MATCH (n0 :L1) WHERE n0.k5 = -1 RETURN n0";
+    final String withTrueQuery = "MATCH (n0 :L1) WHERE n0.k5 = -1 AND true RETURN n0";
+
+    final List<Object> base = collectResults(baseQuery, "n0");
+    final List<Object> withTrue = collectResults(withTrueQuery, "n0");
+
+    assertThat(withTrue)
+        .as("predicate AND true must return same results as predicate alone")
+        .containsExactlyInAnyOrderElementsOf(base);
+    assertThat(withTrue).hasSize(2);
+  }
+
+  /**
+   * WHERE predicate OR false should behave identically to the predicate alone.
+   */
+  @Test
+  void predicateOrFalseEquivalentToPredicateAlone() {
+    final String baseQuery = "MATCH (n0 :L1) WHERE n0.k5 = -1 RETURN n0";
+    final String withFalseQuery = "MATCH (n0 :L1) WHERE n0.k5 = -1 OR false RETURN n0";
+
+    final List<Object> base = collectResults(baseQuery, "n0");
+    final List<Object> withFalse = collectResults(withFalseQuery, "n0");
+
+    assertThat(withFalse)
+        .as("predicate OR false must return same results as predicate alone")
+        .containsExactlyInAnyOrderElementsOf(base);
+    assertThat(withFalse).hasSize(2);
+  }
+
+  private List<Object> collectResults(final String query, final String propertyName) {
+    final List<Object> results = new ArrayList<>();
+    try (final ResultSet rs = database.query("opencypher", query)) {
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        results.add(row.getProperty(propertyName));
+      }
+    }
+    return results;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/rewriter/BooleanSimplifierTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/rewriter/BooleanSimplifierTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.rewriter;
+
+import com.arcadedb.query.opencypher.ast.*;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for BooleanSimplifier rewrite rule.
+ * Verifies boolean algebra identities applied at parse time:
+ * - x AND true  → x
+ * - x AND false → false
+ * - x OR true   → true
+ * - x OR false  → x
+ * - true AND x  → x (commutative forms)
+ * - false AND x → false
+ * - true OR x   → true
+ * - false OR x  → x
+ * - NOT (NOT x) → x
+ *
+ * Also verifies that the compound pattern from issue #4405
+ * (base AND true OR false AND expr) reduces to the base predicate.
+ */
+class BooleanSimplifierTest {
+
+  private final BooleanSimplifier simplifier = new BooleanSimplifier();
+
+  // --- helpers to build boolean literal coercions ---
+
+  private BooleanExpression trueLiteral() {
+    return new BooleanCoercionExpression(new LiteralExpression(Boolean.TRUE, "true"));
+  }
+
+  private BooleanExpression falseLiteral() {
+    return new BooleanCoercionExpression(new LiteralExpression(Boolean.FALSE, "false"));
+  }
+
+  private BooleanExpression someExpr() {
+    // Represents a non-constant predicate, e.g. n.k5 = -1862396709
+    return new ComparisonExpression(
+        new PropertyAccessExpression("n0", "k5"),
+        ComparisonExpression.Operator.EQUALS,
+        new LiteralExpression(-1862396709, "-1862396709")
+    );
+  }
+
+  // --- AND identity: x AND true → x ---
+
+  @Test
+  void andTrueRightReducesToLeft() {
+    final BooleanExpression expr = new LogicalExpression(
+        LogicalExpression.Operator.AND, someExpr(), trueLiteral());
+
+    final BooleanExpression result = (BooleanExpression) simplifier.rewrite(expr);
+
+    assertThat(result).isInstanceOf(ComparisonExpression.class);
+  }
+
+  @Test
+  void andTrueLeftReducesToRight() {
+    final BooleanExpression expr = new LogicalExpression(
+        LogicalExpression.Operator.AND, trueLiteral(), someExpr());
+
+    final BooleanExpression result = (BooleanExpression) simplifier.rewrite(expr);
+
+    assertThat(result).isInstanceOf(ComparisonExpression.class);
+  }
+
+  // --- AND annihilator: x AND false → false ---
+
+  @Test
+  void andFalseRightReducesToFalse() {
+    final BooleanExpression expr = new LogicalExpression(
+        LogicalExpression.Operator.AND, someExpr(), falseLiteral());
+
+    final BooleanExpression result = (BooleanExpression) simplifier.rewrite(expr);
+
+    assertThat(result).isInstanceOf(BooleanCoercionExpression.class);
+    final BooleanCoercionExpression coerced = (BooleanCoercionExpression) result;
+    assertThat(coerced.getExpression()).isInstanceOf(LiteralExpression.class);
+    assertThat(((LiteralExpression) coerced.getExpression()).getValue()).isEqualTo(Boolean.FALSE);
+  }
+
+  @Test
+  void andFalseLeftReducesToFalse() {
+    final BooleanExpression expr = new LogicalExpression(
+        LogicalExpression.Operator.AND, falseLiteral(), someExpr());
+
+    final BooleanExpression result = (BooleanExpression) simplifier.rewrite(expr);
+
+    assertThat(result).isInstanceOf(BooleanCoercionExpression.class);
+    final BooleanCoercionExpression coerced = (BooleanCoercionExpression) result;
+    assertThat(((LiteralExpression) coerced.getExpression()).getValue()).isEqualTo(Boolean.FALSE);
+  }
+
+  // --- OR annihilator: x OR true → true ---
+
+  @Test
+  void orTrueRightReducesToTrue() {
+    final BooleanExpression expr = new LogicalExpression(
+        LogicalExpression.Operator.OR, someExpr(), trueLiteral());
+
+    final BooleanExpression result = (BooleanExpression) simplifier.rewrite(expr);
+
+    assertThat(result).isInstanceOf(BooleanCoercionExpression.class);
+    assertThat(((LiteralExpression) ((BooleanCoercionExpression) result).getExpression()).getValue()).isEqualTo(Boolean.TRUE);
+  }
+
+  @Test
+  void orTrueLeftReducesToTrue() {
+    final BooleanExpression expr = new LogicalExpression(
+        LogicalExpression.Operator.OR, trueLiteral(), someExpr());
+
+    final BooleanExpression result = (BooleanExpression) simplifier.rewrite(expr);
+
+    assertThat(result).isInstanceOf(BooleanCoercionExpression.class);
+    assertThat(((LiteralExpression) ((BooleanCoercionExpression) result).getExpression()).getValue()).isEqualTo(Boolean.TRUE);
+  }
+
+  // --- OR identity: x OR false → x ---
+
+  @Test
+  void orFalseRightReducesToLeft() {
+    final BooleanExpression expr = new LogicalExpression(
+        LogicalExpression.Operator.OR, someExpr(), falseLiteral());
+
+    final BooleanExpression result = (BooleanExpression) simplifier.rewrite(expr);
+
+    assertThat(result).isInstanceOf(ComparisonExpression.class);
+  }
+
+  @Test
+  void orFalseLeftReducesToRight() {
+    final BooleanExpression expr = new LogicalExpression(
+        LogicalExpression.Operator.OR, falseLiteral(), someExpr());
+
+    final BooleanExpression result = (BooleanExpression) simplifier.rewrite(expr);
+
+    assertThat(result).isInstanceOf(ComparisonExpression.class);
+  }
+
+  // --- NOT (NOT x) → x ---
+
+  @Test
+  void doubleNegationElimination() {
+    final BooleanExpression inner = someExpr();
+    final BooleanExpression notInner = new LogicalExpression(LogicalExpression.Operator.NOT, inner);
+    final BooleanExpression notNotInner = new LogicalExpression(LogicalExpression.Operator.NOT, notInner);
+
+    final BooleanExpression result = (BooleanExpression) simplifier.rewrite(notNotInner);
+
+    assertThat(result).isInstanceOf(ComparisonExpression.class);
+  }
+
+  // --- Compound pattern from issue #4405: base AND true OR false AND expr → base ---
+
+  @Test
+  void compoundPatternIssue4405() {
+    // Construct: (base AND true) OR (false AND irrelevantExpr)
+    // Expected: base (a ComparisonExpression)
+    final BooleanExpression base = someExpr();
+
+    // irrelevant expression: n0.k5 IS NULL OR n0.k5 IS NOT NULL
+    final BooleanExpression irrelevantExpr = new LogicalExpression(
+        LogicalExpression.Operator.OR,
+        new IsNullExpression(new PropertyAccessExpression("n0", "k5"), false),
+        new IsNullExpression(new PropertyAccessExpression("n0", "k5"), true)
+    );
+
+    final BooleanExpression andTrue = new LogicalExpression(
+        LogicalExpression.Operator.AND, base, trueLiteral());
+
+    final BooleanExpression falseAndIrrelevant = new LogicalExpression(
+        LogicalExpression.Operator.AND, falseLiteral(), irrelevantExpr);
+
+    final BooleanExpression compound = new LogicalExpression(
+        LogicalExpression.Operator.OR, andTrue, falseAndIrrelevant);
+
+    final BooleanExpression result = (BooleanExpression) simplifier.rewrite(compound);
+
+    // Should simplify: (base AND true) → base, (false AND x) → false, base OR false → base
+    assertThat(result).isInstanceOf(ComparisonExpression.class);
+  }
+
+  // --- No simplification when no constants ---
+
+  @Test
+  void andWithTwoNonConstantsIsUnchanged() {
+    final BooleanExpression left = someExpr();
+    final BooleanExpression right = new ComparisonExpression(
+        new PropertyAccessExpression("n0", "k10"),
+        ComparisonExpression.Operator.EQUALS,
+        new LiteralExpression(42, "42")
+    );
+    final BooleanExpression expr = new LogicalExpression(
+        LogicalExpression.Operator.AND, left, right);
+
+    final BooleanExpression result = (BooleanExpression) simplifier.rewrite(expr);
+
+    assertThat(result).isInstanceOf(LogicalExpression.class);
+    assertThat(((LogicalExpression) result).getOperator()).isEqualTo(LogicalExpression.Operator.AND);
+  }
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes #4405 - missed optimization where `base AND true OR false AND expr` in a Cypher WHERE clause was not simplified to `base`, causing inflated optimizer row/cost estimates (10x in the reported case).

Three gaps were present:

- `BooleanSimplifier.isWrappedTrue`/`isWrappedFalse` always returned `false` - they checked for `BooleanWrapperExpression` but boolean literals in WHERE clauses arrive as `BooleanCoercionExpression` wrapping a `LiteralExpression`
- `ExpressionRewriter.rewrite()` had no dispatch entry for `BooleanCoercionExpression`, so the visitor could not traverse into coercion nodes during recursive child-rewriting
- `CypherASTBuilder.visitWhereClause()` never applied `AST_REWRITER` to the parsed condition, so no rewrite rule ever ran on WHERE predicates

## Changes

- **`BooleanSimplifier`**: implemented `isWrappedTrue`/`isWrappedFalse` to detect `BooleanCoercionExpression` wrapping a boolean literal
- **`ExpressionRewriter`**: added `BooleanCoercionExpression` dispatch in `rewrite()` and default `visitBooleanCoercion()` method
- **`CypherASTBuilder`**: `visitWhereClause()` now applies `AST_REWRITER` to the condition after parsing

## Test plan

- [ ] `BooleanSimplifierTest` (11 unit tests) - covers all 8 boolean algebra identities plus the compound pattern from the issue
- [ ] `Issue4405Test` (5 integration tests) - verifies that `base AND true OR false AND expr` returns the same result set as the bare `base` predicate, plus `WHERE false OR false`, `WHERE true AND true`, `WHERE pred AND true`, `WHERE pred OR false`
- [ ] Existing rewriter tests pass: `ConstantFolderTest`, `ComparisonNormalizerTest`, `CompositeRewriterTest`
- [ ] Existing WHERE/optimizer tests pass: `OpenCypherWhereClauseTest`, `OpenCypherPredicatePushdownTest`, `OpenCypherOptimizerVerificationTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)