### PR TITLE
fix(#4389): omit @props type hint for JSON-faithful column types

### DIFF
--- a/engine/src/main/java/com/arcadedb/serializer/JsonSerializer.java
+++ b/engine/src/main/java/com/arcadedb/serializer/JsonSerializer.java
@@ -46,6 +46,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -62,6 +63,11 @@ import static com.arcadedb.schema.Property.TYPE_PROPERTY;
 import static com.arcadedb.utility.CollectionUtils.arrayToList;
 
 public class JsonSerializer {
+  // Types JSON round-trips to the same Java type (decimals -> Double, 32-bit-signed-range integers -> Integer), so
+  // the per-column @props hint is omitted for them; lossy types (LONG, FLOAT, SHORT, BYTE, DECIMAL, temporals, ...) keep it.
+  private static final Set<Type> JSON_ROUND_TRIP_FAITHFUL_TYPES = EnumSet.of(Type.BOOLEAN, Type.INTEGER, Type.DOUBLE,
+      Type.STRING);
+
   private boolean  useCollectionSize         = false;
   private boolean  includeVertexEdges        = true;
   private boolean  useVertexEdgeSize         = true;
@@ -165,7 +171,7 @@ public class JsonSerializer {
       else
         propertyType = null;
 
-      if (propertyType != null) {
+      if (propertyType != null && !JSON_ROUND_TRIP_FAITHFUL_TYPES.contains(propertyType)) {
         if (!propertyTypes.isEmpty())
           propertyTypes.append(",");
         propertyTypes.append(propertyName).append(":").append(propertyType.getId());
@@ -224,6 +230,7 @@ public class JsonSerializer {
       else
         propertyType = null;
 
+      // Unlike serializeResult (which omits JSON-faithful types), this opt-in metadata path is exhaustive by design.
       if (includeMetadata && propertyType != null) {
         if (propertyTypes.length() > 0)
           propertyTypes.append(",");

--- a/engine/src/test/java/com/arcadedb/serializer/JsonSerializerTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/JsonSerializerTest.java
@@ -22,8 +22,12 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.database.MutableDocument;
 import com.arcadedb.graph.MutableEdge;
 import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Property;
 import com.arcadedb.schema.Type;
+import com.arcadedb.serializer.json.JSONObject;
 import com.jayway.jsonpath.JsonPath;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -96,5 +100,126 @@ class JsonSerializerTest extends TestHelper {
       assertThat(JsonPath.<String>read(json, "$.@in")).isEqualTo(vertex2.getIdentity().toString());
       assertThat(JsonPath.<String>read(json, "$.@out")).isEqualTo(vertex1.getIdentity().toString());
     });
+  }
+
+  @Test
+  void expandScalarListDoesNotEmitPropsHint() {
+    try (final ResultSet rs = database.query("sql", "SELECT expand([1,2,3,4]) AS test")) {
+      int count = 0;
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        final JSONObject json = jsonSerializer.serializeResult(database, row);
+        assertThat(json.has(Property.PROPERTY_TYPES_PROPERTY)).isFalse();
+        assertThat(json.has("test")).isTrue();
+        count++;
+      }
+      assertThat(count).isEqualTo(4);
+    }
+  }
+
+  @Test
+  void stringExpandDoesNotEmitPropsHint() {
+    try (final ResultSet rs = database.query("sql", "SELECT expand(['a','b','c']) AS tag")) {
+      int count = 0;
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        final JSONObject json = jsonSerializer.serializeResult(database, row);
+        assertThat(json.has(Property.PROPERTY_TYPES_PROPERTY)).isFalse();
+        assertThat(json.has("tag")).isTrue();
+        count++;
+      }
+      assertThat(count).isEqualTo(3);
+    }
+  }
+
+  @Test
+  void scalarProjectionDoesNotEmitPropsHintForJsonFaithfulTypes() {
+    try (final ResultSet rs = database.query("sql", "SELECT 1 AS i, 'x' AS s, true AS b")) {
+      assertThat(rs.hasNext()).isTrue();
+      final JSONObject json = jsonSerializer.serializeResult(database, rs.next());
+      assertThat(json.has(Property.PROPERTY_TYPES_PROPERTY)).isFalse();
+      assertThat(json.getInt("i")).isEqualTo(1);
+      assertThat(json.getString("s")).isEqualTo("x");
+      assertThat(json.getBoolean("b")).isTrue();
+    }
+  }
+
+  @Test
+  void doublePropertyDoesNotEmitPropsHint() {
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().createDocumentType("DoubleType");
+      type.createProperty("d", Type.DOUBLE);
+      database.newDocument("DoubleType").set("d", 2.5d).save();
+    });
+
+    try (final ResultSet rs = database.query("sql", "SELECT d FROM DoubleType")) {
+      assertThat(rs.hasNext()).isTrue();
+      final JSONObject json = jsonSerializer.serializeResult(database, rs.next());
+      assertThat(json.has(Property.PROPERTY_TYPES_PROPERTY)).isFalse();
+    }
+  }
+
+  @Test
+  void floatProjectionStillEmitsPropsHint() {
+    // 2.5 is inferred as FLOAT by the SQL parser (not DOUBLE); FLOAT is lossy through JSON (deserializes to Double), so the hint must stay.
+    try (final ResultSet rs = database.query("sql", "SELECT 2.5 AS f")) {
+      assertThat(rs.hasNext()).isTrue();
+      final JSONObject json = jsonSerializer.serializeResult(database, rs.next());
+      assertThat(json.has(Property.PROPERTY_TYPES_PROPERTY)).isTrue();
+      assertThat(json.getString(Property.PROPERTY_TYPES_PROPERTY)).contains("f:" + Type.FLOAT.getId());
+    }
+  }
+
+  @Test
+  void floatSchemaPropertyStillEmitsPropsHint() {
+    // Schema-backed FLOAT, independent of how the SQL parser types a decimal literal.
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().createDocumentType("FloatType");
+      type.createProperty("f", Type.FLOAT);
+      database.newDocument("FloatType").set("f", 2.5f).save();
+    });
+
+    try (final ResultSet rs = database.query("sql", "SELECT f FROM FloatType")) {
+      assertThat(rs.hasNext()).isTrue();
+      final JSONObject json = jsonSerializer.serializeResult(database, rs.next());
+      assertThat(json.has(Property.PROPERTY_TYPES_PROPERTY)).isTrue();
+      assertThat(json.getString(Property.PROPERTY_TYPES_PROPERTY)).contains("f:" + Type.FLOAT.getId());
+    }
+  }
+
+  @Test
+  void mixedFaithfulAndLossyColumnsEmitHintOnlyForLossy() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("MixedType");
+      for (int i = 0; i < 2; i++)
+        database.newDocument("MixedType").save();
+    });
+
+    try (final ResultSet rs = database.query("sql", "SELECT 1 AS i, count(*) AS c FROM MixedType")) {
+      assertThat(rs.hasNext()).isTrue();
+      final JSONObject json = jsonSerializer.serializeResult(database, rs.next());
+      // i is an Integer (JSON-faithful) so it is absent from the hint; c is a Long (lossy) so it stays.
+      assertThat(json.has(Property.PROPERTY_TYPES_PROPERTY)).isTrue();
+      final String hint = json.getString(Property.PROPERTY_TYPES_PROPERTY);
+      assertThat(hint).contains("c:" + Type.LONG.getId());
+      assertThat(hint).doesNotContain("i:");
+    }
+  }
+
+  @Test
+  void countStarStillEmitsPropsHintForLong() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("CountType");
+      for (int i = 0; i < 3; i++)
+        database.newDocument("CountType").save();
+    });
+
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS c FROM CountType")) {
+      assertThat(rs.hasNext()).isTrue();
+      final JSONObject json = jsonSerializer.serializeResult(database, rs.next());
+      // count(*) yields a Long, which JSON cannot round-trip (collapses to Integer), so the hint stays.
+      assertThat(json.has(Property.PROPERTY_TYPES_PROPERTY)).isTrue();
+      assertThat(json.getString(Property.PROPERTY_TYPES_PROPERTY)).contains("c:" + Type.LONG.getId());
+    }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up on #4389. After PR #4411 fixed the `AS` alias (`value` → `test`), the reporter [observed](https://github.com/ArcadeData/arcadedb/issues/4389#issuecomment-4581903575) that `SELECT expand([1,2,3,4]) AS test` now returns each row with a stray internal property `@props`:

```json
{"result":[{"test":1,"@props":"test:1"},{"test":2,"@props":"test:1"},{"test":3,"@props":"test:1"},{"test":4,"@props":"test:1"}]}
```

**Root cause (not expand-specific):** `JsonSerializer.serializeResult` (#4267) emits the per-column `@props` type hint for **every** synthetic (non-element) result row, even when JSON already round-trips the type. So `SELECT 1 AS test` leaks it too. The Java `RemoteDatabase` strips `@props` (it's in `METADATA_PROPERTIES`), but raw HTTP/Studio consumers see it. PR #4411 only renamed the column; #4267 introduced the hint, and the reporter noticed it after upgrading.

**Fix:** Only include a column in the `@props` hint when JSON cannot round-trip its type. The JSON-faithful set `{BOOLEAN, INTEGER, DOUBLE, STRING}` matches `JSONObject`'s number parsing (decimals → `Double`, int-range integers → `Integer`). Lossy types keep the hint: `LONG` (collapses to `Integer`), `FLOAT` (→ `Double`), `SHORT`, `BYTE`, `DECIMAL`, temporals, binary, collections, links. `count(*)` is a `Long` and still emits its hint, so HTTP type fidelity from #4267 is fully preserved.

Scope limited to `serializeResult`. `map2json` (the explicit `toJSON(true)` document path that carries `@type`/`@rid`) is unchanged.

After the fix:
```json
{"result":[{"test":1},{"test":2},{"test":3},{"test":4}]}
```

## Test plan

New `JsonSerializerTest` cases:
- `expandScalarListDoesNotEmitPropsHint` - `SELECT expand([1,2,3,4]) AS test` → no `@props`
- `stringExpandDoesNotEmitPropsHint` - `SELECT expand(['a','b','c']) AS tag` → no `@props`
- `scalarProjectionDoesNotEmitPropsHintForJsonFaithfulTypes` - `SELECT 1 AS i, 'x' AS s, true AS b` → no `@props`
- `doublePropertyDoesNotEmitPropsHint` - stored `DOUBLE` projection → no `@props`
- `floatProjectionStillEmitsPropsHint` - `FLOAT` (`2.5`) keeps the hint (JSON `2.5` → `Double`)
- `countStarStillEmitsPropsHintForLong` - `count(*)` (`Long`) keeps the hint

Connected suites pass: `JsonSerializerTest` (9), `ExpandStepTest` (14), `ExpandParseTest` (6), `SelectStatementExecutionTest` (157), `Issue4267CountTypeIT` (2), `RemoteDatabaseIT` (10), `RemoteTypesIT` (1), `QueryEndpointReadOnlyTest` (3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)