### PR TITLE
Harden IMPORT DATABASE source validation and require admin privilege

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -622,6 +622,18 @@ public enum GlobalConfiguration {
       "Number of iterations to generate the salt or user password. Changing this setting does not affect stored passwords",
       Integer.class, 65536),
 
+  SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS("arcadedb.server.security.importBlockLocalNetworks", SCOPE.SERVER,
+      "When enabled (default), the SQL `IMPORT DATABASE` command refuses HTTP(S) URLs that resolve to loopback, link-local, "
+          + "private (site-local), wildcard or multicast addresses. This mitigates Server-Side Request Forgery (SSRF) against "
+          + "cloud metadata endpoints (e.g. 169.254.169.254) and internal services. Disable only in trusted environments that "
+          + "legitimately import from internal hosts", Boolean.class, true),
+
+  SERVER_SECURITY_IMPORT_ALLOWED_LOCAL_PATHS("arcadedb.server.security.importAllowedLocalPaths", SCOPE.SERVER,
+      "Comma-separated list of directories the SQL `IMPORT DATABASE` command is allowed to read local files from (`file://` "
+          + "and plain paths). When empty (default) no restriction is applied. When set, any import from a path outside the "
+          + "listed directories is rejected, mitigating arbitrary local file read. `classpath://` resources are always allowed",
+      String.class, ""),
+
   // HA
   HA_ENABLED("arcadedb.ha.enabled", SCOPE.SERVER, "True if HA is enabled for the current server", Boolean.class, false),
 

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ImportDatabaseStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ImportDatabaseStatement.java
@@ -28,6 +28,7 @@ import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.InternalResultSet;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.security.SecurityDatabaseUser;
 
 import java.lang.reflect.*;
 import java.util.*;
@@ -45,6 +46,10 @@ public class ImportDatabaseStatement extends SimpleExecStatement {
 
   @Override
   public ResultSet executeSimple(final CommandContext context) {
+    // IMPORT DATABASE can create schema, overwrite data and read local files / remote URLs (SSRF/LFI surface), so it is
+    // restricted to administrative users. In embedded mode (no security configured) this check is a no-op.
+    context.getDatabase().checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SECURITY);
+
     final ResultInternal result = new ResultInternal(context.getDatabase());
     result.setProperty("operation", "import database");
 
@@ -77,6 +82,11 @@ public class ImportDatabaseStatement extends SimpleExecStatement {
     } catch (final ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InstantiationException e) {
       throw new CommandExecutionException("Error on importing database, importer libs not found in classpath", e);
     } catch (final InvocationTargetException e) {
+      // SURFACE A SECURITY VIOLATION (SSRF/LFI GUARD IN THE IMPORTER) DIRECTLY SO IT MAPS TO HTTP 403 INSTEAD OF 500
+      for (Throwable cause = e.getTargetException(); cause != null; cause = cause.getCause())
+        if (cause instanceof SecurityException se)
+          throw se;
+
       if (e.getCause().getClass().getSimpleName().equals("IllegalArgumentException"))
         result.setProperty("result", "FAIL");
       else

--- a/integration/src/main/java/com/arcadedb/integration/importer/ImportSecurityValidator.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/ImportSecurityValidator.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.GlobalConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.nio.file.Path;
+
+/**
+ * Validates the source URL/path of an {@code IMPORT DATABASE} command to mitigate Server-Side Request Forgery (SSRF,
+ * CWE-918) and arbitrary local file read (path traversal, CWE-22).
+ *
+ * <p>Two independent, configuration-driven policies are enforced:</p>
+ * <ul>
+ *   <li><b>SSRF</b>: when {@link GlobalConfiguration#SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS} is enabled (default),
+ *   HTTP(S) URLs that resolve to loopback, link-local, private (site-local), wildcard or multicast addresses are
+ *   rejected. This blocks access to cloud metadata endpoints (e.g. 169.254.169.254) and internal services.</li>
+ *   <li><b>Local file read</b>: when {@link GlobalConfiguration#SERVER_SECURITY_IMPORT_ALLOWED_LOCAL_PATHS} is set,
+ *   {@code file://} and plain-path imports are restricted to the listed directories. {@code classpath://} resources are
+ *   always allowed because they are bundled with the server, not attacker controlled.</li>
+ * </ul>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class ImportSecurityValidator {
+  private static final String RESOURCE_SEPARATOR = ":::";
+  private static final String FILE_PREFIX        = "file://";
+  private static final String CLASSPATH_PREFIX   = "classpath://";
+
+  private ImportSecurityValidator() {
+  }
+
+  /**
+   * Validates an HTTP(S) import URL. Throws {@link SecurityException} if the host resolves to a blocked
+   * private/local network address and the SSRF protection is enabled.
+   */
+  public static void validateRemoteURL(final String url) {
+    if (!GlobalConfiguration.SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS.getValueAsBoolean())
+      return;
+
+    final int sep = url.lastIndexOf(RESOURCE_SEPARATOR);
+    final String urlPath = sep > -1 ? url.substring(0, sep) : url;
+
+    final String host;
+    try {
+      host = new URL(urlPath).getHost();
+    } catch (final MalformedURLException e) {
+      throw new SecurityException("IMPORT DATABASE: malformed URL");
+    }
+
+    if (host == null || host.isEmpty())
+      throw new SecurityException("IMPORT DATABASE: URL is missing a host");
+
+    final InetAddress[] addresses;
+    try {
+      addresses = InetAddress.getAllByName(host);
+    } catch (final UnknownHostException e) {
+      throw new SecurityException("IMPORT DATABASE: cannot resolve host '" + host + "'");
+    }
+
+    for (final InetAddress address : addresses) {
+      if (isBlockedAddress(address))
+        throw new SecurityException("IMPORT DATABASE: access to host '" + host + "' (" + address.getHostAddress()
+            + ") is blocked because it resolves to a private/local network address. Set '"
+            + GlobalConfiguration.SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS.getKey()
+            + "=false' to allow imports from internal hosts in trusted environments");
+    }
+  }
+
+  /**
+   * Validates a local file import URL/path against the configured allow-list. {@code classpath://} resources are
+   * always allowed. When the allow-list is empty (default) no restriction is applied.
+   */
+  public static void validateLocalURL(final String url) throws IOException {
+    final String allowed = GlobalConfiguration.SERVER_SECURITY_IMPORT_ALLOWED_LOCAL_PATHS.getValueAsString();
+    if (allowed == null || allowed.isBlank())
+      // NO RESTRICTION CONFIGURED: BACKWARD COMPATIBLE BEHAVIOUR
+      return;
+
+    final int sep = url.lastIndexOf(RESOURCE_SEPARATOR);
+    String filePath = sep > -1 ? url.substring(0, sep) : url;
+
+    if (filePath.startsWith(CLASSPATH_PREFIX))
+      // SERVER-BUNDLED RESOURCES ARE ALWAYS ALLOWED
+      return;
+
+    if (filePath.startsWith(FILE_PREFIX))
+      filePath = filePath.substring(FILE_PREFIX.length());
+
+    // CANONICALIZE TO RESOLVE SYMLINKS AND '..' TRAVERSAL
+    final Path target = new File(filePath).getCanonicalFile().toPath();
+
+    for (final String dir : allowed.split(",")) {
+      final String trimmed = dir.trim();
+      if (trimmed.isEmpty())
+        continue;
+
+      final Path base = new File(trimmed).getCanonicalFile().toPath();
+      if (target.startsWith(base))
+        return;
+    }
+
+    throw new SecurityException("IMPORT DATABASE: access to local path '" + filePath
+        + "' is not allowed. Permitted directories: " + allowed);
+  }
+
+  /**
+   * Returns {@code true} if the address belongs to a network range that must not be reachable through
+   * {@code IMPORT DATABASE} (loopback, link-local, site-local/private, wildcard or multicast).
+   */
+  static boolean isBlockedAddress(final InetAddress address) {
+    return address.isLoopbackAddress()      // 127.0.0.0/8, ::1
+        || address.isLinkLocalAddress()     // 169.254.0.0/16 (cloud metadata), fe80::/10
+        || address.isSiteLocalAddress()     // 10/8, 172.16/12, 192.168/16
+        || address.isAnyLocalAddress()      // 0.0.0.0, ::
+        || address.isMulticastAddress();    // 224.0.0.0/4, ff00::/8
+  }
+}

--- a/integration/src/main/java/com/arcadedb/integration/importer/SourceDiscovery.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/SourceDiscovery.java
@@ -95,10 +95,13 @@ public class SourceDiscovery {
 
   public Source getSource() throws IOException {
     final Source source;
-    if (url.startsWith("http://") || url.startsWith("https://"))
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+      ImportSecurityValidator.validateRemoteURL(url);
       source = getSourceFromURL(url);
-    else
+    } else {
+      ImportSecurityValidator.validateLocalURL(url);
       source = getSourceFromFile(url);
+    }
     return source;
   }
 

--- a/integration/src/main/java/com/arcadedb/integration/importer/format/XMLImporterFormat.java
+++ b/integration/src/main/java/com/arcadedb/integration/importer/format/XMLImporterFormat.java
@@ -52,6 +52,9 @@ public class XMLImporterFormat implements FormatImporter {
       final XMLInputFactory xmlFactory = XMLInputFactory.newInstance();
       xmlFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
       xmlFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+      // DISABLE DTD PROCESSING AND EXTERNAL ENTITIES TO PREVENT XXE AND ENTITY-EXPANSION (BILLION LAUGHS) ATTACKS
+      xmlFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+      xmlFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
       final XMLStreamReader xmlReader = xmlFactory.createXMLStreamReader(parser.getInputStream());
 
       int nestLevel = 0;
@@ -201,6 +204,9 @@ public class XMLImporterFormat implements FormatImporter {
       final XMLInputFactory xmlFactory = XMLInputFactory.newInstance();
       xmlFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
       xmlFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+      // DISABLE DTD PROCESSING AND EXTERNAL ENTITIES TO PREVENT XXE AND ENTITY-EXPANSION (BILLION LAUGHS) ATTACKS
+      xmlFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+      xmlFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
 
       final XMLStreamReader xmlReader = xmlFactory.createXMLStreamReader(parser.getInputStream());
 

--- a/integration/src/test/java/com/arcadedb/integration/importer/ImportSecurityValidatorTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/ImportSecurityValidatorTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.integration.importer;
+
+import com.arcadedb.GlobalConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for the SSRF (CWE-918) and arbitrary local file read (CWE-22) hardening of {@code IMPORT DATABASE}.
+ */
+class ImportSecurityValidatorTest {
+
+  @AfterEach
+  void reset() {
+    GlobalConfiguration.SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS.reset();
+    GlobalConfiguration.SERVER_SECURITY_IMPORT_ALLOWED_LOCAL_PATHS.reset();
+  }
+
+  @Test
+  void blocksAwsMetadataEndpoint() {
+    // 169.254.169.254 is link-local: the canonical cloud-metadata SSRF target
+    assertThatThrownBy(() -> ImportSecurityValidator.validateRemoteURL("http://169.254.169.254/latest/meta-data/"))
+        .isInstanceOf(SecurityException.class)
+        .hasMessageContaining("169.254.169.254");
+  }
+
+  @Test
+  void blocksLoopbackAndPrivateRanges() {
+    assertThatThrownBy(() -> ImportSecurityValidator.validateRemoteURL("http://127.0.0.1:8080/x"))
+        .isInstanceOf(SecurityException.class);
+    assertThatThrownBy(() -> ImportSecurityValidator.validateRemoteURL("https://10.0.0.5/internal"))
+        .isInstanceOf(SecurityException.class);
+    assertThatThrownBy(() -> ImportSecurityValidator.validateRemoteURL("http://192.168.1.10/x"))
+        .isInstanceOf(SecurityException.class);
+    assertThatThrownBy(() -> ImportSecurityValidator.validateRemoteURL("http://172.16.0.1/x"))
+        .isInstanceOf(SecurityException.class);
+    assertThatThrownBy(() -> ImportSecurityValidator.validateRemoteURL("http://0.0.0.0/x"))
+        .isInstanceOf(SecurityException.class);
+  }
+
+  @Test
+  void allowsPublicAddress() {
+    // A public literal IP does not require DNS resolution and must be allowed
+    assertThatNoException().isThrownBy(() -> ImportSecurityValidator.validateRemoteURL("http://8.8.8.8/data.json"));
+  }
+
+  @Test
+  void allowsAnyRemoteWhenProtectionDisabled() {
+    GlobalConfiguration.SERVER_SECURITY_IMPORT_BLOCK_LOCAL_NETWORKS.setValue(false);
+    assertThatNoException().isThrownBy(() -> ImportSecurityValidator.validateRemoteURL("http://127.0.0.1/x"));
+    assertThatNoException().isThrownBy(() -> ImportSecurityValidator.validateRemoteURL("http://169.254.169.254/x"));
+  }
+
+  @Test
+  void localPathUnrestrictedByDefault() throws Exception {
+    assertThat(GlobalConfiguration.SERVER_SECURITY_IMPORT_ALLOWED_LOCAL_PATHS.getValueAsString()).isEmpty();
+    // No allow-list configured: backward-compatible, anything is permitted
+    assertThatNoException().isThrownBy(() -> ImportSecurityValidator.validateLocalURL("file:///etc/passwd"));
+    assertThatNoException().isThrownBy(() -> ImportSecurityValidator.validateLocalURL("/etc/passwd"));
+  }
+
+  @Test
+  void localPathBlockedOutsideAllowList() {
+    GlobalConfiguration.SERVER_SECURITY_IMPORT_ALLOWED_LOCAL_PATHS.setValue("./target/imports");
+    assertThatThrownBy(() -> ImportSecurityValidator.validateLocalURL("file:///etc/passwd"))
+        .isInstanceOf(SecurityException.class)
+        .hasMessageContaining("not allowed");
+    // Path traversal escaping the allowed dir must also be rejected
+    assertThatThrownBy(() -> ImportSecurityValidator.validateLocalURL("file://./target/imports/../../../etc/passwd"))
+        .isInstanceOf(SecurityException.class);
+  }
+
+  @Test
+  void localPathAllowedInsideAllowList() throws Exception {
+    final File allowedDir = new File("./target/imports");
+    allowedDir.mkdirs();
+    final File data = new File(allowedDir, "data.csv");
+    data.createNewFile();
+
+    GlobalConfiguration.SERVER_SECURITY_IMPORT_ALLOWED_LOCAL_PATHS.setValue(allowedDir.getPath());
+    assertThatNoException().isThrownBy(() -> ImportSecurityValidator.validateLocalURL("file://" + data.getCanonicalPath()));
+  }
+
+  @Test
+  void classpathResourcesAlwaysAllowed() {
+    GlobalConfiguration.SERVER_SECURITY_IMPORT_ALLOWED_LOCAL_PATHS.setValue("./target/imports");
+    assertThatNoException().isThrownBy(() -> ImportSecurityValidator.validateLocalURL("classpath://orientdb-export-small.gz"));
+  }
+}

--- a/integration/src/test/java/com/arcadedb/integration/importer/XMLImporterFormatTest.java
+++ b/integration/src/test/java/com/arcadedb/integration/importer/XMLImporterFormatTest.java
@@ -114,6 +114,43 @@ class XMLImporterFormatTest extends TestHelper {
   }
 
   /**
+   * Security regression test: DTD processing must be disabled so an internal entity (Billion Laughs / XXE vector,
+   * CWE-776/CWE-611) is never expanded into imported data.
+   */
+  @Test
+  void dtdEntityExpansionIsDisabled() throws Exception {
+    final File xmlFile = createTempXMLFile("test-xxe.xml",
+        """
+        <?xml version="1.0"?>
+        <!DOCTYPE records [
+          <!ENTITY lol "LOL-EXPANDED-SECRET">
+        ]>
+        <records>
+          <record id="1" payload="&lol;"/>
+        </records>""");
+
+    try {
+      try {
+        database.command("sql",
+            "IMPORT DATABASE file://" + xmlFile.getAbsolutePath() + " WITH objectNestLevel=1, entityType='VERTEX'");
+      } catch (final Exception e) {
+        // ACCEPTABLE: THE PARSER REJECTS THE DTD. THE GUARANTEE WE ASSERT IS THAT NO ENTITY EXPANSION HAPPENED.
+      }
+
+      if (database.getSchema().existsType("v_record")) {
+        final ResultSet rs = database.query("sql", "SELECT FROM v_record");
+        while (rs.hasNext()) {
+          final Result r = rs.next();
+          assertThat(r.<String>getProperty("payload")).doesNotContain("LOL-EXPANDED-SECRET");
+        }
+        rs.close();
+      }
+    } finally {
+      xmlFile.delete();
+    }
+  }
+
+  /**
    * Helper method to create a temporary XML file for testing.
    */
   private File createTempXMLFile(final String fileName, final String content) throws IOException {

--- a/server/src/test/java/com/arcadedb/server/security/ImportDatabaseSecurityIT.java
+++ b/server/src/test/java/com/arcadedb/server/security/ImportDatabaseSecurityIT.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.security;
+
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the SSRF (CWE-918) / arbitrary local file read (CWE-22) report on {@code IMPORT DATABASE}.
+ *
+ * <p>The core fix is a privilege gate: {@code IMPORT DATABASE} requires the administrative {@code updateSecurity}
+ * permission, so a low-privilege authenticated SQL user can no longer trigger imports (and therefore neither SSRF nor
+ * arbitrary file read). This test reproduces the reporter's scenario: a non-admin user attempting to import a
+ * {@code file://} path and a link-local SSRF URL must be rejected with HTTP 403.</p>
+ */
+class ImportDatabaseSecurityIT extends BaseGraphServerTest {
+
+  @Test
+  void nonAdminUserCannotImportLocalFile() throws Exception {
+    testEachServer((serverIndex) -> {
+      final String userAuth = createNonAdminUser(serverIndex, "pwn", "pwn123secret");
+      try {
+        final int status = commandStatus(serverIndex, getDatabaseName(), userAuth,
+            "IMPORT DATABASE WITH vertices = \"file:///etc/passwd\", verticesFileType = \"csv\", vertexType = \"PwLeak\"");
+        assertThat(status).as("non-admin user must not read local files via IMPORT DATABASE").isEqualTo(403);
+      } finally {
+        dropUser(serverIndex, "pwn");
+      }
+    });
+  }
+
+  @Test
+  void nonAdminUserCannotImportRemoteSSRF() throws Exception {
+    testEachServer((serverIndex) -> {
+      final String userAuth = createNonAdminUser(serverIndex, "pwn2", "pwn123secret");
+      try {
+        final int status = commandStatus(serverIndex, getDatabaseName(), userAuth,
+            "IMPORT DATABASE \"http://169.254.169.254/latest/meta-data/\" WITH vertexType = \"Leak\"");
+        assertThat(status).as("non-admin user must not trigger SSRF via IMPORT DATABASE").isEqualTo(403);
+      } finally {
+        dropUser(serverIndex, "pwn2");
+      }
+    });
+  }
+
+  /**
+   * Creates a user that is a member of the database but only of the default (non-admin) group, so it has none of the
+   * {@code updateSecurity / updateSchema / updateDatabaseSettings} permissions.
+   */
+  private String createNonAdminUser(final int serverIndex, final String name, final String password) throws Exception {
+    if (getServer(serverIndex).getSecurity().existsUser(name))
+      getServer(serverIndex).getSecurity().dropUser(name);
+
+    final JSONObject payload = new JSONObject();
+    payload.put("name", name);
+    payload.put("password", password);
+    // "reader" is not a defined group, so the user falls back to the default group which has empty access
+    payload.put("databases", new JSONObject().put(getDatabaseName(), new JSONArray().put("reader")));
+
+    final HttpURLConnection connection = open(serverIndex, "/api/v1/server/users", "POST", basicAuth());
+    connection.setDoOutput(true);
+    connection.setRequestProperty("Content-Type", "application/json");
+    connection.getOutputStream().write(payload.toString().getBytes());
+    connection.connect();
+    try {
+      assertThat(connection.getResponseCode()).isEqualTo(201);
+    } finally {
+      connection.disconnect();
+    }
+    return "Basic " + Base64.getEncoder().encodeToString((name + ":" + password).getBytes());
+  }
+
+  private void dropUser(final int serverIndex, final String name) {
+    try {
+      if (getServer(serverIndex) != null && getServer(serverIndex).getSecurity().existsUser(name))
+        getServer(serverIndex).getSecurity().dropUser(name);
+    } catch (final Exception ignore) {
+    }
+  }
+
+  private int commandStatus(final int serverIndex, final String database, final String auth, final String sql) throws Exception {
+    final HttpURLConnection connection = open(serverIndex, "/api/v1/command/" + database, "POST", auth);
+    connection.setDoOutput(true);
+    connection.setRequestProperty("Content-Type", "application/json");
+    final JSONObject payload = new JSONObject().put("language", "sql").put("command", sql);
+    connection.getOutputStream().write(payload.toString().getBytes());
+    connection.connect();
+    try {
+      return connection.getResponseCode();
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private HttpURLConnection open(final int serverIndex, final String path, final String method, final String auth)
+      throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URL("http://127.0.0.1:248" + serverIndex + path).openConnection();
+    connection.setRequestMethod(method);
+    connection.setRequestProperty("Authorization", auth);
+    return connection;
+  }
+
+  private String basicAuth() {
+    return "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes());
+  }
+}


### PR DESCRIPTION
## Summary

Hardens the SQL `IMPORT DATABASE` statement and its underlying source discovery.

- **Privilege gate:** `IMPORT DATABASE` now requires the administrative `updateSecurity` permission. This is a no-op in embedded mode (no security configured), so library/CLI usage is unaffected.
- **Source validation** (`SourceDiscovery.getSource()`, the single chokepoint for both branches):
  - HTTP(S) URLs that resolve to loopback / link-local / private (site-local) / wildcard / multicast addresses are blocked by default. Controlled by `arcadedb.server.security.importBlockLocalNetworks` (default `true`). Public hosts are unaffected.
  - `file://` and plain local paths can be restricted to an allow-list via `arcadedb.server.security.importAllowedLocalPaths` (default empty = unrestricted, backward compatible). Canonicalized to defeat `..` traversal; `classpath://` resources are always allowed.
- **XML importer:** DTD processing and external entities are disabled (XXE / entity-expansion hardening).
- Security violations now surface as HTTP 403.

`EXPORT DATABASE` / `BACKUP DATABASE` were reviewed and left unchanged: they already contain their output paths (reject `..`/separators, force the exports/backup directory).

## Tests

- `ImportSecurityValidatorTest` (unit, offline) - SSRF host blocking and local-path allow-list.
- `ImportDatabaseSecurityIT` (server) - a non-admin user is rejected with HTTP 403.
- DTD/entity-expansion regression test added to `XMLImporterFormatTest`.
- Regression-checked: `SQLLocalImporterIT`, `SQLRemoteImporterIT`, `DatabaseAdminStatementsTest`, `ServerImportDatabaseIT`, `CSVImporterIT`, `JsonLImporterIT`.

## Note

SSRF blocking defaults to on, including embedded mode; environments that legitimately import from internal hosts can set `arcadedb.server.security.importBlockLocalNetworks=false`.