### PR TITLE
Require UPDATE_SCHEMA permission on all schema mutators

### DIFF
--- a/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalDocumentType.java
@@ -129,6 +129,14 @@ public class LocalDocumentType implements DocumentType {
     return set;
   }
 
+  /**
+   * Enforces the UPDATE_SCHEMA permission for any schema-mutating operation. No-op in embedded mode or when no
+   * current user is bound to the thread (e.g. schema load at startup, replication apply).
+   */
+  protected void checkForSchemaMutation() {
+    ((DatabaseInternal) schema.getDatabase()).checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);
+  }
+
   @Override
   public DocumentType addSuperType(final String superName) {
     return addSuperType(schema.getType(superName));
@@ -163,6 +171,7 @@ public class LocalDocumentType implements DocumentType {
    */
   @Override
   public DocumentType removeSuperType(final DocumentType superType) {
+    checkForSchemaMutation();
     recordFileChanges(() -> {
       if (!superTypes.remove(superType))
         // ALREADY REMOVED SUPER TYPE
@@ -180,6 +189,7 @@ public class LocalDocumentType implements DocumentType {
   }
 
   public void rename(final String newName) {
+    checkForSchemaMutation();
     if (schema.existsType(newName))
       throw new IllegalArgumentException("Type with name '" + newName + "' already exists");
 
@@ -281,6 +291,7 @@ public class LocalDocumentType implements DocumentType {
    */
   @Override
   public DocumentType setSuperTypes(List<DocumentType> newSuperTypes) {
+    checkForSchemaMutation();
     if (newSuperTypes == null)
       newSuperTypes = Collections.emptyList();
 
@@ -321,6 +332,7 @@ public class LocalDocumentType implements DocumentType {
    * Sets the list of aliases for the type. Any previous configuration will be lost.
    */
   public LocalDocumentType setAliases(final Set<String> aliases) {
+    checkForSchemaMutation();
     final Set<String> newAliases = new HashSet<>(aliases);
     newAliases.removeAll(this.aliases);
     for (String alias : newAliases) {
@@ -434,7 +446,7 @@ public class LocalDocumentType implements DocumentType {
    */
   @Override
   public LocalProperty createProperty(final String propertyName, final Type propertyType, final String ofType) {
-    ((DatabaseInternal) schema.getDatabase()).checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);
+    checkForSchemaMutation();
 
     if (properties.containsKey(propertyName))
       throw new SchemaException(
@@ -530,6 +542,7 @@ public class LocalDocumentType implements DocumentType {
    */
   @Override
   public Property dropProperty(final String propertyName) {
+    checkForSchemaMutation();
     for (final TypeIndex index : getAllIndexes(true)) {
       if (index.getPropertyNames().contains(propertyName))
         throw new SchemaException(
@@ -613,6 +626,7 @@ public class LocalDocumentType implements DocumentType {
 
   @Override
   public DocumentType addBucket(final Bucket bucket) {
+    checkForSchemaMutation();
     recordFileChanges(() -> {
       addBucketInternal(bucket);
       return null;
@@ -622,6 +636,7 @@ public class LocalDocumentType implements DocumentType {
 
   @Override
   public DocumentType removeBucket(final Bucket bucket) {
+    checkForSchemaMutation();
     recordFileChanges(() -> {
       removeBucketInternal(bucket);
       return null;
@@ -1596,6 +1611,7 @@ public class LocalDocumentType implements DocumentType {
   }
 
   DocumentType addSuperType(final DocumentType superType, final boolean createIndexes) {
+    checkForSchemaMutation();
     if (this.equals(superType))
       return this;
 

--- a/engine/src/main/java/com/arcadedb/schema/LocalProperty.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalProperty.java
@@ -19,7 +19,9 @@
 package com.arcadedb.schema;
 
 import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.exception.SchemaException;
+import com.arcadedb.security.SecurityDatabaseUser;
 
 import java.util.*;
 
@@ -29,8 +31,18 @@ public class LocalProperty extends AbstractProperty {
     super(owner, name, type, owner.getSchema().getDictionary().getIdByName(name, true));
   }
 
+  /**
+   * Enforces the UPDATE_SCHEMA permission for any property-level schema mutation. No-op in embedded mode or when no
+   * current user is bound to the thread (e.g. schema load at startup, replication apply).
+   */
+  private void checkForSchemaMutation() {
+    ((DatabaseInternal) owner.getSchema().getEmbedded().getDatabase())
+        .checkPermissionsOnDatabase(SecurityDatabaseUser.DATABASE_ACCESS.UPDATE_SCHEMA);
+  }
+
   @Override
   public Property setDefaultValue(final Object defaultValue) {
+    checkForSchemaMutation();
     final Database database = owner.getSchema().getEmbedded().getDatabase();
 
     // TODO: OPTIMIZE THE CASE WHERE FUNCTIONS ARE DEFAULT
@@ -56,6 +68,7 @@ public class LocalProperty extends AbstractProperty {
 
   @Override
   public Property setOfType(String ofType) {
+    checkForSchemaMutation();
     final boolean changed = !Objects.equals(this.ofType, ofType);
     if (changed) {
       final LocalSchema schema = (LocalSchema) owner.getSchema();
@@ -81,6 +94,7 @@ public class LocalProperty extends AbstractProperty {
 
   @Override
   public Property setReadonly(final boolean readonly) {
+    checkForSchemaMutation();
     final boolean changed = !Objects.equals(this.readonly, readonly);
     if (changed) {
       this.readonly = readonly;
@@ -91,6 +105,7 @@ public class LocalProperty extends AbstractProperty {
 
   @Override
   public Property setMandatory(final boolean mandatory) {
+    checkForSchemaMutation();
     final boolean changed = !Objects.equals(this.mandatory, mandatory);
     if (changed) {
       this.mandatory = mandatory;
@@ -104,6 +119,7 @@ public class LocalProperty extends AbstractProperty {
    */
   @Override
   public Property setNotNull(final boolean notNull) {
+    checkForSchemaMutation();
     final boolean changed = !Objects.equals(this.notNull, notNull);
     if (changed) {
       this.notNull = notNull;
@@ -114,6 +130,7 @@ public class LocalProperty extends AbstractProperty {
 
   @Override
   public Property setHidden(final boolean hidden) {
+    checkForSchemaMutation();
     final boolean changed = !Objects.equals(this.hidden, hidden);
     if (changed) {
       this.hidden = hidden;
@@ -124,6 +141,7 @@ public class LocalProperty extends AbstractProperty {
 
   @Override
   public Property setExternal(final boolean external) {
+    checkForSchemaMutation();
     final boolean changed = !Objects.equals(this.external, external);
     if (changed) {
       final LocalDocumentType localOwner = (LocalDocumentType) owner;
@@ -151,6 +169,7 @@ public class LocalProperty extends AbstractProperty {
 
   @Override
   public Property setCompression(final String compression) {
+    checkForSchemaMutation();
     final String normalized;
     if (compression == null || compression.isEmpty() || "none".equalsIgnoreCase(compression))
       normalized = null;
@@ -173,6 +192,7 @@ public class LocalProperty extends AbstractProperty {
 
   @Override
   public Property setMax(final String max) {
+    checkForSchemaMutation();
     final boolean changed = !Objects.equals(this.max, max);
     if (changed) {
       switch (type) {
@@ -198,6 +218,7 @@ public class LocalProperty extends AbstractProperty {
 
   @Override
   public Property setMin(final String min) {
+    checkForSchemaMutation();
     final boolean changed = !Objects.equals(this.min, min);
     if (changed) {
       switch (type) {
@@ -223,6 +244,7 @@ public class LocalProperty extends AbstractProperty {
 
   @Override
   public Property setRegexp(final String regexp) {
+    checkForSchemaMutation();
     final boolean changed = !Objects.equals(this.regexp, regexp);
     if (changed) {
       this.regexp = regexp;
@@ -233,6 +255,7 @@ public class LocalProperty extends AbstractProperty {
 
   @Override
   public Object setCustomValue(final String key, final Object value) {
+    checkForSchemaMutation();
     final Object prev;
     if (value == null)
       prev = custom.remove(key);

--- a/server/src/test/java/com/arcadedb/server/security/SchemaMutationAuthorizationIT.java
+++ b/server/src/test/java/com/arcadedb/server/security/SchemaMutationAuthorizationIT.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.security;
+
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the incomplete-fix sibling of CVE-2026-44221: the original fix added an UPDATE_SCHEMA permission
+ * check to {@code LocalDocumentType.createProperty} only, leaving the other schema mutators (DROP PROPERTY, ALTER TYPE
+ * SUPERTYPE +/-, ALTER TYPE NAME, ALTER PROPERTY ...) reachable by a read-only identity.
+ *
+ * <p>A read-only API token (no {@code updateSchema}) must be rejected with HTTP 403 on every schema mutation, while an
+ * administrator must still be able to perform them.</p>
+ */
+class SchemaMutationAuthorizationIT extends BaseGraphServerTest {
+
+  @Test
+  void readOnlyTokenCannotMutateSchema() throws Exception {
+    testEachServer((serverIndex) -> {
+      // ARRANGE (as admin): a type with a property, a second type, and a subtype candidate
+      assertThat(adminCommand(serverIndex, "CREATE DOCUMENT TYPE Memory")).isEqualTo(200);
+      assertThat(adminCommand(serverIndex, "CREATE PROPERTY Memory.salience DOUBLE")).isEqualTo(200);
+      assertThat(adminCommand(serverIndex, "CREATE DOCUMENT TYPE Persisted")).isEqualTo(200);
+
+      final String token = "Bearer " + createReadOnlyToken(serverIndex, "schema-probe-token");
+      try {
+        // Each of these reaches a previously-unchecked mutator and must be denied
+        assertThat(command(serverIndex, token, "DROP PROPERTY Memory.salience"))
+            .as("read-only token must not DROP PROPERTY").isEqualTo(403);
+        assertThat(command(serverIndex, token, "ALTER TYPE Memory SUPERTYPE +Persisted"))
+            .as("read-only token must not add a SUPERTYPE").isEqualTo(403);
+        assertThat(command(serverIndex, token, "ALTER TYPE Memory SUPERTYPE -Persisted"))
+            .as("read-only token must not remove a SUPERTYPE").isEqualTo(403);
+        assertThat(command(serverIndex, token, "ALTER TYPE Memory NAME MemoryRenamed"))
+            .as("read-only token must not rename a type").isEqualTo(403);
+        assertThat(command(serverIndex, token, "ALTER PROPERTY Memory.salience MANDATORY true"))
+            .as("read-only token must not alter a property constraint").isEqualTo(403);
+      } finally {
+        deleteToken(serverIndex, "schema-probe-token");
+      }
+    });
+  }
+
+  @Test
+  void adminCanStillMutateSchema() throws Exception {
+    testEachServer((serverIndex) -> {
+      assertThat(adminCommand(serverIndex, "CREATE DOCUMENT TYPE Doc")).isEqualTo(200);
+      assertThat(adminCommand(serverIndex, "CREATE PROPERTY Doc.title STRING")).isEqualTo(200);
+      assertThat(adminCommand(serverIndex, "CREATE DOCUMENT TYPE Base")).isEqualTo(200);
+
+      // Positive controls: an administrator (root) must not be blocked by the new checks
+      assertThat(adminCommand(serverIndex, "ALTER TYPE Doc SUPERTYPE +Base")).isEqualTo(200);
+      assertThat(adminCommand(serverIndex, "ALTER PROPERTY Doc.title MANDATORY true")).isEqualTo(200);
+      assertThat(adminCommand(serverIndex, "DROP PROPERTY Doc.title")).isEqualTo(200);
+    });
+  }
+
+  private int adminCommand(final int serverIndex, final String sql) throws Exception {
+    return command(serverIndex, basicAuth(), sql);
+  }
+
+  private int command(final int serverIndex, final String auth, final String sql) throws Exception {
+    final HttpURLConnection connection = open(serverIndex, "/api/v1/command/" + getDatabaseName(), "POST", auth);
+    connection.setDoOutput(true);
+    connection.setRequestProperty("Content-Type", "application/json");
+    final JSONObject payload = new JSONObject().put("language", "sql").put("command", sql);
+    connection.getOutputStream().write(payload.toString().getBytes());
+    connection.connect();
+    try {
+      return connection.getResponseCode();
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private String createReadOnlyToken(final int serverIndex, final String name) throws Exception {
+    final ApiTokenConfiguration tokenConfig = getServer(serverIndex).getSecurity().getApiTokenConfiguration();
+    tokenConfig.listTokens().stream()
+        .filter(t -> name.equals(t.getString("name", "")))
+        .forEach(t -> tokenConfig.deleteToken(t.getString("tokenHash")));
+
+    final JSONObject permissions = new JSONObject()
+        .put("types", new JSONObject().put("*", new JSONObject().put("access", new JSONArray().put("readRecord"))))
+        .put("database", new JSONArray()); // no updateSchema
+
+    final HttpURLConnection connection = open(serverIndex, "/api/v1/server/api-tokens", "POST", basicAuth());
+    connection.setDoOutput(true);
+    connection.setRequestProperty("Content-Type", "application/json");
+    final JSONObject payload = new JSONObject()
+        .put("name", name)
+        .put("database", getDatabaseName())
+        .put("expiresAt", 0)
+        .put("permissions", permissions);
+    connection.getOutputStream().write(payload.toString().getBytes());
+    connection.connect();
+    try {
+      assertThat(connection.getResponseCode()).isEqualTo(201);
+      return new JSONObject(readResponse(connection)).getJSONObject("result").getString("token");
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private void deleteToken(final int serverIndex, final String name) {
+    try {
+      final ApiTokenConfiguration tokenConfig = getServer(serverIndex).getSecurity().getApiTokenConfiguration();
+      tokenConfig.listTokens().stream()
+          .filter(t -> name.equals(t.getString("name", "")))
+          .forEach(t -> tokenConfig.deleteToken(t.getString("tokenHash")));
+    } catch (final Exception ignore) {
+    }
+  }
+
+  private HttpURLConnection open(final int serverIndex, final String path, final String method, final String auth)
+      throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URL("http://127.0.0.1:248" + serverIndex + path).openConnection();
+    connection.setRequestMethod(method);
+    connection.setRequestProperty("Authorization", auth);
+    return connection;
+  }
+
+  private String basicAuth() {
+    return "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes());
+  }
+}


### PR DESCRIPTION
## Summary

Extends the `UPDATE_SCHEMA` authorization check (previously applied only to `createProperty`) to every public schema-mutating method, closing an incorrect-authorization gap where a non-administrator identity could still alter the database schema.

- **`LocalDocumentType`** - added a shared `checkForSchemaMutation()` helper and gated: `rename`, `dropProperty`, `addSuperType` (chokepoint covering all overloads), `removeSuperType` (chokepoint), `setSuperTypes`, `setAliases`, `addBucket`, `removeBucket`. The existing `createProperty` check now uses the same helper.
- **`LocalProperty`** - gated all 12 setters: `setDefaultValue`, `setOfType`, `setReadonly`, `setMandatory`, `setNotNull`, `setHidden`, `setExternal`, `setCompression`, `setMax`, `setMin`, `setRegexp`, `setCustomValue`.

## Safety of internal paths

The check is a no-op in embedded mode and in system contexts with no bound user. Schema reload (`DocumentType.createProperty(String, JSONObject)`) calls the already-gated `createProperty` plus every `LocalProperty` setter, and has shipped that way since 26.4.2 without breaking reload - so reload and HA replication apply run in a no-current-user context where the new checks are no-ops. `dropType` and `TypeBuilder` already check `UPDATE_SCHEMA` at entry, so their internal mutator calls are harmless redundant re-checks.

## Tests

- New `SchemaMutationAuthorizationIT` (server): a read-only API token gets HTTP 403 on `DROP PROPERTY`, `ALTER TYPE SUPERTYPE +/-`, `ALTER TYPE NAME`, and `ALTER PROPERTY MANDATORY`, while an administrator still succeeds (positive control).
- Regression-checked: 159 embedded engine schema tests, `CrossDatabaseAccessIT`, HA `RaftReplicationChangeSchemaIT` (replication intact), OpenCypher label tests.