### PR TITLE
test(load): time series load tests for single node and 3-node cluster

### DIFF
--- a/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesConcurrentInsertTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesConcurrentInsertTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for silent sample loss when many concurrent single-row INSERTs target the same
+ * time series type. Each INSERT runs in its own transaction (as it does over the HTTP/wire path),
+ * and the engine append must not drop a sample under concurrency.
+ */
+@Tag("slow")
+class TimeSeriesConcurrentInsertTest extends TestHelper {
+
+  @Test
+  @Disabled("Reproduces a known sample-loss under many concurrent single-row INSERTs into a time "
+      + "series type: serialized per-shard appends can read a stale per-page sample count and write the "
+      + "same row slot, so one sample is overwritten. Enable once the time series append path makes the "
+      + "slot read-modify-write durable under the per-shard append lock.")
+  void concurrentSingleRowInsertsDoNotLoseSamples() throws Exception {
+    // One shard maximizes contention: every concurrent append serializes on the same shard and
+    // contends for the same mutable-bucket data page, which is exactly where the lost update occurs.
+    database.command("sql",
+        "CREATE TIMESERIES TYPE Reading TIMESTAMP ts TAGS (sid STRING) FIELDS (v DOUBLE) SHARDS 1");
+
+    final int threads = 48;
+    final int perThread = 5000;
+    final int expected = threads * perThread;
+
+    final ExecutorService executor = Executors.newFixedThreadPool(threads);
+    final List<Throwable> errors = new ArrayList<>();
+    final AtomicInteger committed = new AtomicInteger();
+
+    for (int t = 0; t < threads; t++) {
+      final int threadIndex = t;
+      executor.submit(() -> {
+        final long base = 1_000_000_000L + (long) threadIndex * 10_000_000L;
+        for (int i = 0; i < perThread; i++) {
+          final long ts = base + i;
+          final double v = i;
+          try {
+            // Each INSERT is its own transaction, mirroring the per-command transaction the wire
+            // protocols use. Unique (sid, ts) per row means none should overwrite another.
+            database.transaction(() ->
+                database.command("sql", "INSERT INTO Reading SET ts = ?, sid = ?, v = ?", ts, "s" + threadIndex, v));
+            committed.incrementAndGet();
+          } catch (final Throwable e) {
+            synchronized (errors) {
+              errors.add(e);
+            }
+          }
+        }
+      });
+    }
+
+    executor.shutdown();
+    assertThat(executor.awaitTermination(5, TimeUnit.MINUTES)).isTrue();
+
+    assertThat(errors).as("no insert should fail").isEmpty();
+    assertThat(committed.get()).as("all inserts reported committed").isEqualTo(expected);
+
+    final ResultSet rs = database.query("sql", "SELECT count(*) AS cnt FROM Reading");
+    final long actual = ((Number) rs.next().getProperty("cnt")).longValue();
+
+    assertThat(actual).as("no samples lost under concurrent single-row inserts").isEqualTo(expected);
+  }
+}

--- a/load-tests/src/test/java/com/arcadedb/test/load/SingleServerTimeSeriesLoadTestIT.java
+++ b/load-tests/src/test/java/com/arcadedb/test/load/SingleServerTimeSeriesLoadTestIT.java
@@ -47,69 +47,69 @@ class SingleServerTimeSeriesLoadTestIT extends ContainersTestTemplate {
     createArcadeContainer("arcade", network);
     final ServerWrapper server = startContainers().getFirst();
 
-    final TimeSeriesDatabaseWrapper admin = new TimeSeriesDatabaseWrapper(server, protocol);
-    admin.createDatabase();
-    admin.createSchema();
+    // try-with-resources so the admin connection is closed even if an assertion below fails.
+    try (final TimeSeriesDatabaseWrapper admin = new TimeSeriesDatabaseWrapper(server, protocol)) {
+      admin.createDatabase();
+      admin.createSchema();
 
-    final int bulkPoints = NUM_THREADS * POINTS_PER_THREAD;
-    final long expectedTotal = bulkPoints + 4L; // + verification series
+      final int bulkPoints = NUM_THREADS * POINTS_PER_THREAD;
+      final long expectedTotal = bulkPoints + 4L; // + verification series
 
-    final LocalDateTime startedAt = LocalDateTime.now();
-    logger.info("Starting TS load test on protocol {}", protocol.name());
-    logger.info("Ingesting {} bulk points using {} threads (+4 verification points)", bulkPoints, NUM_THREADS);
-    logger.info("Starting at {}", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(startedAt));
+      final LocalDateTime startedAt = LocalDateTime.now();
+      logger.info("Starting TS load test on protocol {}", protocol.name());
+      logger.info("Ingesting {} bulk points using {} threads (+4 verification points)", bulkPoints, NUM_THREADS);
+      logger.info("Starting at {}", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(startedAt));
 
-    final ExecutorService executor = Executors.newFixedThreadPool(NUM_THREADS);
-    for (int t = 0; t < NUM_THREADS; t++) {
-      final int threadIndex = t;
-      executor.submit(() -> {
-        final TimeSeriesDatabaseWrapper w = new TimeSeriesDatabaseWrapper(server, protocol);
+      final ExecutorService executor = Executors.newFixedThreadPool(NUM_THREADS);
+      for (int t = 0; t < NUM_THREADS; t++) {
+        final int threadIndex = t;
+        executor.submit(() -> {
+          final TimeSeriesDatabaseWrapper w = new TimeSeriesDatabaseWrapper(server, protocol);
+          try {
+            final long base = 1_000_000_000L + threadIndex * 100_000_000L;
+            w.ingestSeries("sensor-" + threadIndex, "region-" + (threadIndex % 3), base, POINTS_PER_THREAD);
+          } finally {
+            w.close();
+          }
+        });
+      }
+      executor.shutdown();
+
+      while (!executor.isTerminated()) {
         try {
-          final long base = 1_000_000_000L + threadIndex * 100_000_000L;
-          w.ingestSeries("sensor-" + threadIndex, "region-" + (threadIndex % 3), base, POINTS_PER_THREAD);
-        } finally {
-          w.close();
+          logger.info("Current points: {}", admin.countPoints());
+        } catch (final Exception e) {
+          logger.error(e.getMessage(), e);
         }
-      });
-    }
-    executor.shutdown();
-
-    while (!executor.isTerminated()) {
-      try {
-        logger.info("Current points: {}", admin.countPoints());
-      } catch (final Exception e) {
-        logger.error(e.getMessage(), e);
+        try {
+          TimeUnit.SECONDS.sleep(5);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
       }
-      try {
-        TimeUnit.SECONDS.sleep(5);
-      } catch (final InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
+
+      // Deterministic verification series, ingested after the bulk load completes.
+      admin.ingestVerificationSeries();
+
+      final LocalDateTime finishedAt = LocalDateTime.now();
+      logger.info("Finishing at {}", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(finishedAt));
+      logger.info("Total time: {} minutes", Duration.between(startedAt, finishedAt).toMinutes());
+
+      Metrics.globalRegistry.getMeters().forEach(meter -> logger.info("Meter: {} - {}", meter.getId().getName(), meter.measure()));
+
+      // Exact total count.
+      admin.assertThatPointCountIs(expectedTotal);
+
+      // Aggregation correctness over a sealed bulk sensor (sensor-0). This is also a tag-filtered query
+      // (WHERE sensor_id = 'sensor-0'). temperature = 15.0 + (i % 20) cycles 15.0..34.0 every 20 points,
+      // so the time-bucket min/max settle at 15.0/34.0. The aggregation (and any tag-filtered query)
+      // reflects only the asynchronously-sealed subset, so the exact aggregated count/avg are not
+      // deterministic; extremes are asserted here and the exact total via assertThatPointCountIs.
+      admin.assertAggregateExtremes("sensor-0", 15.0, 34.0);
+
+      // Latest value (tag-filtered) over the verification series. The /latest endpoint reads the
+      // mutable buffer too, so it sees the just-written points immediately.
+      assertThat(admin.latestTimestamp("sensor_id:" + TimeSeriesDatabaseWrapper.VERIFY_SENSOR)).isEqualTo(3000L);
     }
-
-    // Deterministic verification series, ingested after the bulk load completes.
-    admin.ingestVerificationSeries();
-
-    final LocalDateTime finishedAt = LocalDateTime.now();
-    logger.info("Finishing at {}", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(finishedAt));
-    logger.info("Total time: {} minutes", Duration.between(startedAt, finishedAt).toMinutes());
-
-    Metrics.globalRegistry.getMeters().forEach(meter -> logger.info("Meter: {} - {}", meter.getId().getName(), meter.measure()));
-
-    // Exact total count.
-    admin.assertThatPointCountIs(expectedTotal);
-
-    // Aggregation correctness over a sealed bulk sensor (sensor-0). This is also a tag-filtered query
-    // (WHERE sensor_id = 'sensor-0'). temperature = 15.0 + (i % 20) cycles 15.0..34.0 every 20 points,
-    // so the time-bucket min/max settle at 15.0/34.0. The aggregation (and any tag-filtered query)
-    // reflects only the asynchronously-sealed subset, so the exact aggregated count/avg are not
-    // deterministic; extremes are asserted here and the exact total via assertThatPointCountIs.
-    admin.assertAggregateExtremes("sensor-0", 15.0, 34.0);
-
-    // Latest value (tag-filtered) over the verification series. The /latest endpoint reads the
-    // mutable buffer too, so it sees the just-written points immediately.
-    assertThat(admin.latestTimestamp("sensor_id:" + TimeSeriesDatabaseWrapper.VERIFY_SENSOR)).isEqualTo(3000L);
-
-    admin.close();
   }
 }

--- a/load-tests/src/test/java/com/arcadedb/test/load/SingleServerTimeSeriesLoadTestIT.java
+++ b/load-tests/src/test/java/com/arcadedb/test/load/SingleServerTimeSeriesLoadTestIT.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.test.load;
+
+import com.arcadedb.test.support.ContainersTestTemplate;
+import com.arcadedb.test.support.ServerWrapper;
+import com.arcadedb.test.support.TimeSeriesDatabaseWrapper;
+import io.micrometer.core.instrument.Metrics;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SingleServerTimeSeriesLoadTestIT extends ContainersTestTemplate {
+
+  private static final int NUM_THREADS       = 5;
+  private static final int POINTS_PER_THREAD = 10000;
+
+  @DisplayName("Single server time series load test")
+  @ParameterizedTest(name = "TS load test with {0} ingestion")
+  @EnumSource(TimeSeriesDatabaseWrapper.Protocol.class)
+  void singleServerTimeSeriesLoadTest(final TimeSeriesDatabaseWrapper.Protocol protocol) throws Exception {
+    createArcadeContainer("arcade", network);
+    final ServerWrapper server = startContainers().getFirst();
+
+    final TimeSeriesDatabaseWrapper admin = new TimeSeriesDatabaseWrapper(server, protocol);
+    admin.createDatabase();
+    admin.createSchema();
+
+    final int bulkPoints = NUM_THREADS * POINTS_PER_THREAD;
+    final long expectedTotal = bulkPoints + 4L; // + verification series
+
+    final LocalDateTime startedAt = LocalDateTime.now();
+    logger.info("Starting TS load test on protocol {}", protocol.name());
+    logger.info("Ingesting {} bulk points using {} threads (+4 verification points)", bulkPoints, NUM_THREADS);
+    logger.info("Starting at {}", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(startedAt));
+
+    final ExecutorService executor = Executors.newFixedThreadPool(NUM_THREADS);
+    for (int t = 0; t < NUM_THREADS; t++) {
+      final int threadIndex = t;
+      executor.submit(() -> {
+        final TimeSeriesDatabaseWrapper w = new TimeSeriesDatabaseWrapper(server, protocol);
+        final long base = 1_000_000_000L + threadIndex * 100_000_000L;
+        w.ingestSeries("sensor-" + threadIndex, "region-" + (threadIndex % 3), base, POINTS_PER_THREAD);
+        w.close();
+      });
+    }
+    executor.shutdown();
+
+    while (!executor.isTerminated()) {
+      try {
+        logger.info("Current points: {}", admin.countPoints());
+      } catch (final Exception e) {
+        logger.error(e.getMessage(), e);
+      }
+      try {
+        TimeUnit.SECONDS.sleep(5);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+
+    // Deterministic verification series, ingested after the bulk load completes.
+    admin.ingestVerificationSeries();
+
+    final LocalDateTime finishedAt = LocalDateTime.now();
+    logger.info("Finishing at {}", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(finishedAt));
+    logger.info("Total time: {} minutes", Duration.between(startedAt, finishedAt).toMinutes());
+
+    Metrics.globalRegistry.getMeters().forEach(meter -> logger.info("Meter: {} - {}", meter.getId().getName(), meter.measure()));
+
+    // Exact total count.
+    admin.assertThatPointCountIs(expectedTotal);
+
+    // Aggregation correctness over a sealed bulk sensor (sensor-0). This is also a tag-filtered query
+    // (WHERE sensor_id = 'sensor-0'). temperature = 15.0 + (i % 20) cycles 15.0..34.0 every 20 points,
+    // so the time-bucket min/max settle at 15.0/34.0. The aggregation (and any tag-filtered query)
+    // reflects only the asynchronously-sealed subset, so the exact aggregated count/avg are not
+    // deterministic; extremes are asserted here and the exact total via assertThatPointCountIs.
+    admin.assertAggregateExtremes("sensor-0", 15.0, 34.0);
+
+    // Latest value (tag-filtered) over the verification series. The /latest endpoint reads the
+    // mutable buffer too, so it sees the just-written points immediately.
+    assertThat(admin.latestTimestamp("sensor_id:" + TimeSeriesDatabaseWrapper.VERIFY_SENSOR)).isEqualTo(3000L);
+
+    admin.close();
+  }
+}

--- a/load-tests/src/test/java/com/arcadedb/test/load/SingleServerTimeSeriesLoadTestIT.java
+++ b/load-tests/src/test/java/com/arcadedb/test/load/SingleServerTimeSeriesLoadTestIT.java
@@ -64,9 +64,12 @@ class SingleServerTimeSeriesLoadTestIT extends ContainersTestTemplate {
       final int threadIndex = t;
       executor.submit(() -> {
         final TimeSeriesDatabaseWrapper w = new TimeSeriesDatabaseWrapper(server, protocol);
-        final long base = 1_000_000_000L + threadIndex * 100_000_000L;
-        w.ingestSeries("sensor-" + threadIndex, "region-" + (threadIndex % 3), base, POINTS_PER_THREAD);
-        w.close();
+        try {
+          final long base = 1_000_000_000L + threadIndex * 100_000_000L;
+          w.ingestSeries("sensor-" + threadIndex, "region-" + (threadIndex % 3), base, POINTS_PER_THREAD);
+        } finally {
+          w.close();
+        }
       });
     }
     executor.shutdown();

--- a/load-tests/src/test/java/com/arcadedb/test/load/ThreeNodesTimeSeriesLoadTestIT.java
+++ b/load-tests/src/test/java/com/arcadedb/test/load/ThreeNodesTimeSeriesLoadTestIT.java
@@ -65,104 +65,101 @@ class ThreeNodesTimeSeriesLoadTestIT extends ContainersTestTemplate {
     logger.info("Starting all containers");
     final List<ServerWrapper> servers = startCluster();
 
-    // Ingest wrapper (parameter protocol) targets node 0; writes auto-forward to the leader.
-    final TimeSeriesDatabaseWrapper ingest = new TimeSeriesDatabaseWrapper(servers.get(0), protocol);
-    // Reader/asserter wrappers always use HTTP, one per node (mirrors ThreeNodesLoadTestIT).
-    final TimeSeriesDatabaseWrapper r0 = new TimeSeriesDatabaseWrapper(servers.get(0), Protocol.SQL_HTTP);
-    final TimeSeriesDatabaseWrapper r1 = new TimeSeriesDatabaseWrapper(servers.get(1), Protocol.SQL_HTTP);
-    final TimeSeriesDatabaseWrapper r2 = new TimeSeriesDatabaseWrapper(servers.get(2), Protocol.SQL_HTTP);
+    // Ingest wrapper (parameter protocol) targets node 0 and writes auto-forward to the leader;
+    // reader/asserter wrappers always use HTTP, one per node (mirrors ThreeNodesLoadTestIT).
+    // try-with-resources so all four connections close even if an assertion below fails.
+    try (final TimeSeriesDatabaseWrapper ingest = new TimeSeriesDatabaseWrapper(servers.getFirst(), protocol);
+        final TimeSeriesDatabaseWrapper r0 = new TimeSeriesDatabaseWrapper(servers.getFirst(), Protocol.SQL_HTTP);
+        final TimeSeriesDatabaseWrapper r1 = new TimeSeriesDatabaseWrapper(servers.get(1), Protocol.SQL_HTTP);
+        final TimeSeriesDatabaseWrapper r2 = new TimeSeriesDatabaseWrapper(servers.get(2), Protocol.SQL_HTTP)) {
 
-    logger.info("Creating database and schema");
-    ingest.createDatabase();
-    ingest.createSchema();
+      logger.info("Creating database and schema");
+      ingest.createDatabase();
+      ingest.createSchema();
 
-    logger.info("Checking schema replicated to all nodes");
-    r0.checkSchema();
-    r1.checkSchema();
-    r2.checkSchema();
+      logger.info("Checking schema replicated to all nodes");
+      r0.checkSchema();
+      r1.checkSchema();
+      r2.checkSchema();
 
-    final int bulkPoints = NUM_THREADS * POINTS_PER_THREAD;
-    final long expectedTotal = bulkPoints + 4L;
+      final int bulkPoints = NUM_THREADS * POINTS_PER_THREAD;
+      final long expectedTotal = bulkPoints + 4L;
 
-    final LocalDateTime startedAt = LocalDateTime.now();
-    logger.info("Starting TS HA load test on protocol {}", protocol.name());
-    logger.info("Ingesting {} bulk points using {} threads (+4 verification points)", bulkPoints, NUM_THREADS);
-    logger.info("Starting at {}", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(startedAt));
+      final LocalDateTime startedAt = LocalDateTime.now();
+      logger.info("Starting TS HA load test on protocol {}", protocol.name());
+      logger.info("Ingesting {} bulk points using {} threads (+4 verification points)", bulkPoints, NUM_THREADS);
+      logger.info("Starting at {}", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(startedAt));
 
-    final ExecutorService executor = Executors.newFixedThreadPool(NUM_THREADS);
-    for (int t = 0; t < NUM_THREADS; t++) {
-      final int threadIndex = t;
-      executor.submit(() -> {
-        final TimeSeriesDatabaseWrapper w = new TimeSeriesDatabaseWrapper(servers.getFirst(), protocol);
-        try {
-          final long base = 1_000_000_000L + threadIndex * 100_000_000L;
-          w.ingestSeries("sensor-" + threadIndex, "region-" + (threadIndex % 3), base, POINTS_PER_THREAD);
-        } finally {
-          w.close();
-        }
-      });
-    }
-    executor.shutdown();
-
-    while (!executor.isTerminated()) {
-      try {
-        logger.info("Points n0/n1/n2: {} / {} / {}", r0.countPoints(), r1.countPoints(), r2.countPoints());
-      } catch (final Exception e) {
-        logger.error(e.getMessage(), e);
-      }
-      try {
-        TimeUnit.SECONDS.sleep(5);
-      } catch (final InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
-    }
-
-    // Deterministic verification series, ingested after the bulk load completes.
-    ingest.ingestVerificationSeries();
-
-    final LocalDateTime finishedAt = LocalDateTime.now();
-    logger.info("Finishing at {}", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(finishedAt));
-    logger.info("Total time: {} minutes", Duration.between(startedAt, finishedAt).toMinutes());
-
-    // Wait for all three nodes to converge to the expected total.
-    Awaitility.await()
-        .atMost(2, TimeUnit.MINUTES)
-        .pollInterval(5, TimeUnit.SECONDS)
-        .until(() -> {
+      final ExecutorService executor = Executors.newFixedThreadPool(NUM_THREADS);
+      for (int t = 0; t < NUM_THREADS; t++) {
+        final int threadIndex = t;
+        executor.submit(() -> {
+          final TimeSeriesDatabaseWrapper w = new TimeSeriesDatabaseWrapper(servers.getFirst(), protocol);
           try {
-            final long c0 = r0.countPoints();
-            final long c1 = r1.countPoints();
-            final long c2 = r2.countPoints();
-            logger.info("Convergence check: {} / {} / {} (expected {})", c0, c1, c2, expectedTotal);
-            return c0 == expectedTotal && c1 == expectedTotal && c2 == expectedTotal;
-          } catch (final RemoteException e) {
-            logger.debug("Convergence check transient failure: {}", e.getMessage());
-            return false;
-          } catch (final RuntimeException e) {
-            logger.warn("Convergence check threw unexpected exception, will keep polling", e);
-            return false;
+            final long base = 1_000_000_000L + threadIndex * 100_000_000L;
+            w.ingestSeries("sensor-" + threadIndex, "region-" + (threadIndex % 3), base, POINTS_PER_THREAD);
+          } finally {
+            w.close();
           }
         });
+      }
+      executor.shutdown();
 
-    Metrics.globalRegistry.getMeters().forEach(meter -> logger.info("Meter: {} - {}", meter.getId().getName(), meter.measure()));
+      while (!executor.isTerminated()) {
+        try {
+          logger.info("Points n0/n1/n2: {} / {} / {}", r0.countPoints(), r1.countPoints(), r2.countPoints());
+        } catch (final Exception e) {
+          logger.error(e.getMessage(), e);
+        }
+        try {
+          TimeUnit.SECONDS.sleep(5);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
 
-    // Assert exact count + query correctness on each node. The exact total (mutable + sealed) is
-    // verified via assertThatPointCountIs. Aggregation (a tag-filtered query, WHERE sensor_id =
-    // 'sensor-0') reflects only the asynchronously-sealed-and-replicated subset, so its exact count is
-    // NOT deterministic; only the temperature extremes 15.0/34.0 are (the cycle 15.0..34.0 settles
-    // once a full cycle is sealed). The /latest endpoint reads the mutable buffer, so latest(verify)
-    // is deterministic once the verify points have replicated (guaranteed by the convergence wait).
-    for (final TimeSeriesDatabaseWrapper r : List.of(r0, r1, r2)) {
-      r.assertThatPointCountIs(expectedTotal);
+      // Deterministic verification series, ingested after the bulk load completes.
+      ingest.ingestVerificationSeries();
 
-      r.assertAggregateExtremes("sensor-0", 15.0, 34.0);
+      final LocalDateTime finishedAt = LocalDateTime.now();
+      logger.info("Finishing at {}", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(finishedAt));
+      logger.info("Total time: {} minutes", Duration.between(startedAt, finishedAt).toMinutes());
 
-      assertThat(r.latestTimestamp("sensor_id:" + TimeSeriesDatabaseWrapper.VERIFY_SENSOR)).isEqualTo(3000L);
+      // Wait for all three nodes to converge to the expected total.
+      Awaitility.await()
+          .atMost(2, TimeUnit.MINUTES)
+          .pollInterval(5, TimeUnit.SECONDS)
+          .until(() -> {
+            try {
+              final long c0 = r0.countPoints();
+              final long c1 = r1.countPoints();
+              final long c2 = r2.countPoints();
+              logger.info("Convergence check: {} / {} / {} (expected {})", c0, c1, c2, expectedTotal);
+              return c0 == expectedTotal && c1 == expectedTotal && c2 == expectedTotal;
+            } catch (final RemoteException e) {
+              logger.debug("Convergence check transient failure: {}", e.getMessage());
+              return false;
+            } catch (final RuntimeException e) {
+              logger.warn("Convergence check threw unexpected exception, will keep polling", e);
+              return false;
+            }
+          });
+
+      Metrics.globalRegistry.getMeters().forEach(meter -> logger.info("Meter: {} - {}", meter.getId().getName(), meter.measure()));
+
+      // Assert exact count + query correctness on each node. The exact total (mutable + sealed) is
+      // verified via assertThatPointCountIs. Aggregation (a tag-filtered query, WHERE sensor_id =
+      // 'sensor-0') reflects only the asynchronously-sealed-and-replicated subset, so its exact count is
+      // NOT deterministic; only the temperature extremes 15.0/34.0 are (the cycle 15.0..34.0 settles
+      // once a full cycle is sealed). The /latest endpoint reads the mutable buffer, so latest(verify)
+      // is deterministic once the verify points have replicated (guaranteed by the convergence wait).
+      for (final TimeSeriesDatabaseWrapper r : List.of(r0, r1, r2)) {
+        r.assertThatPointCountIs(expectedTotal);
+
+        r.assertAggregateExtremes("sensor-0", 15.0, 34.0);
+
+        assertThat(r.latestTimestamp("sensor_id:" + TimeSeriesDatabaseWrapper.VERIFY_SENSOR)).isEqualTo(3000L);
+      }
     }
-
-    ingest.close();
-    r0.close();
-    r1.close();
-    r2.close();
   }
 }

--- a/load-tests/src/test/java/com/arcadedb/test/load/ThreeNodesTimeSeriesLoadTestIT.java
+++ b/load-tests/src/test/java/com/arcadedb/test/load/ThreeNodesTimeSeriesLoadTestIT.java
@@ -94,9 +94,12 @@ class ThreeNodesTimeSeriesLoadTestIT extends ContainersTestTemplate {
       final int threadIndex = t;
       executor.submit(() -> {
         final TimeSeriesDatabaseWrapper w = new TimeSeriesDatabaseWrapper(servers.getFirst(), protocol);
-        final long base = 1_000_000_000L + threadIndex * 100_000_000L;
-        w.ingestSeries("sensor-" + threadIndex, "region-" + (threadIndex % 3), base, POINTS_PER_THREAD);
-        w.close();
+        try {
+          final long base = 1_000_000_000L + threadIndex * 100_000_000L;
+          w.ingestSeries("sensor-" + threadIndex, "region-" + (threadIndex % 3), base, POINTS_PER_THREAD);
+        } finally {
+          w.close();
+        }
       });
     }
     executor.shutdown();

--- a/load-tests/src/test/java/com/arcadedb/test/load/ThreeNodesTimeSeriesLoadTestIT.java
+++ b/load-tests/src/test/java/com/arcadedb/test/load/ThreeNodesTimeSeriesLoadTestIT.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.test.load;
+
+import com.arcadedb.remote.RemoteException;
+import com.arcadedb.test.support.ContainersTestTemplate;
+import com.arcadedb.test.support.ServerWrapper;
+import com.arcadedb.test.support.TimeSeriesDatabaseWrapper;
+import com.arcadedb.test.support.TimeSeriesDatabaseWrapper.Protocol;
+import io.micrometer.core.instrument.Metrics;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ThreeNodesTimeSeriesLoadTestIT extends ContainersTestTemplate {
+
+  private static final String SERVER_LIST       = "arcadedb-0:2434:2480,arcadedb-1:2434:2480,arcadedb-2:2434:2480";
+  private static final int    NUM_THREADS       = 3;
+  private static final int    POINTS_PER_THREAD = 10000;
+
+  @AfterEach
+  @Override
+  public void tearDown() {
+    // Skip compareAllDatabases(): with non-persistent containers, database files are not on the
+    // host after stop. The test body already verifies convergence via Awaitility.
+    super.tearDown();
+  }
+
+  @ParameterizedTest(name = "Three-node Raft HA TS load test with {0} ingestion")
+  @EnumSource(TimeSeriesDatabaseWrapper.Protocol.class)
+  @DisplayName("Three-node Raft HA: time series replication consistency")
+  void threeNodeTimeSeriesReplication(final TimeSeriesDatabaseWrapper.Protocol protocol) throws Exception {
+    createArcadeContainer("arcadedb-0", SERVER_LIST, "majority", network);
+    createArcadeContainer("arcadedb-1", SERVER_LIST, "majority", network);
+    createArcadeContainer("arcadedb-2", SERVER_LIST, "majority", network);
+
+    logger.info("Starting all containers");
+    final List<ServerWrapper> servers = startCluster();
+
+    // Ingest wrapper (parameter protocol) targets node 0; writes auto-forward to the leader.
+    final TimeSeriesDatabaseWrapper ingest = new TimeSeriesDatabaseWrapper(servers.get(0), protocol);
+    // Reader/asserter wrappers always use HTTP, one per node (mirrors ThreeNodesLoadTestIT).
+    final TimeSeriesDatabaseWrapper r0 = new TimeSeriesDatabaseWrapper(servers.get(0), Protocol.SQL_HTTP);
+    final TimeSeriesDatabaseWrapper r1 = new TimeSeriesDatabaseWrapper(servers.get(1), Protocol.SQL_HTTP);
+    final TimeSeriesDatabaseWrapper r2 = new TimeSeriesDatabaseWrapper(servers.get(2), Protocol.SQL_HTTP);
+
+    logger.info("Creating database and schema");
+    ingest.createDatabase();
+    ingest.createSchema();
+
+    logger.info("Checking schema replicated to all nodes");
+    r0.checkSchema();
+    r1.checkSchema();
+    r2.checkSchema();
+
+    final int bulkPoints = NUM_THREADS * POINTS_PER_THREAD;
+    final long expectedTotal = bulkPoints + 4L;
+
+    final LocalDateTime startedAt = LocalDateTime.now();
+    logger.info("Starting TS HA load test on protocol {}", protocol.name());
+    logger.info("Ingesting {} bulk points using {} threads (+4 verification points)", bulkPoints, NUM_THREADS);
+    logger.info("Starting at {}", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(startedAt));
+
+    final ExecutorService executor = Executors.newFixedThreadPool(NUM_THREADS);
+    for (int t = 0; t < NUM_THREADS; t++) {
+      final int threadIndex = t;
+      executor.submit(() -> {
+        final TimeSeriesDatabaseWrapper w = new TimeSeriesDatabaseWrapper(servers.getFirst(), protocol);
+        final long base = 1_000_000_000L + threadIndex * 100_000_000L;
+        w.ingestSeries("sensor-" + threadIndex, "region-" + (threadIndex % 3), base, POINTS_PER_THREAD);
+        w.close();
+      });
+    }
+    executor.shutdown();
+
+    while (!executor.isTerminated()) {
+      try {
+        logger.info("Points n0/n1/n2: {} / {} / {}", r0.countPoints(), r1.countPoints(), r2.countPoints());
+      } catch (final Exception e) {
+        logger.error(e.getMessage(), e);
+      }
+      try {
+        TimeUnit.SECONDS.sleep(5);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+
+    // Deterministic verification series, ingested after the bulk load completes.
+    ingest.ingestVerificationSeries();
+
+    final LocalDateTime finishedAt = LocalDateTime.now();
+    logger.info("Finishing at {}", DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(finishedAt));
+    logger.info("Total time: {} minutes", Duration.between(startedAt, finishedAt).toMinutes());
+
+    // Wait for all three nodes to converge to the expected total.
+    Awaitility.await()
+        .atMost(2, TimeUnit.MINUTES)
+        .pollInterval(5, TimeUnit.SECONDS)
+        .until(() -> {
+          try {
+            final long c0 = r0.countPoints();
+            final long c1 = r1.countPoints();
+            final long c2 = r2.countPoints();
+            logger.info("Convergence check: {} / {} / {} (expected {})", c0, c1, c2, expectedTotal);
+            return c0 == expectedTotal && c1 == expectedTotal && c2 == expectedTotal;
+          } catch (final RemoteException e) {
+            logger.debug("Convergence check transient failure: {}", e.getMessage());
+            return false;
+          } catch (final RuntimeException e) {
+            logger.warn("Convergence check threw unexpected exception, will keep polling", e);
+            return false;
+          }
+        });
+
+    Metrics.globalRegistry.getMeters().forEach(meter -> logger.info("Meter: {} - {}", meter.getId().getName(), meter.measure()));
+
+    // Assert exact count + query correctness on each node. The exact total (mutable + sealed) is
+    // verified via assertThatPointCountIs. Aggregation (a tag-filtered query, WHERE sensor_id =
+    // 'sensor-0') reflects only the asynchronously-sealed-and-replicated subset, so its exact count is
+    // NOT deterministic; only the temperature extremes 15.0/34.0 are (the cycle 15.0..34.0 settles
+    // once a full cycle is sealed). The /latest endpoint reads the mutable buffer, so latest(verify)
+    // is deterministic once the verify points have replicated (guaranteed by the convergence wait).
+    for (final TimeSeriesDatabaseWrapper r : List.of(r0, r1, r2)) {
+      r.assertThatPointCountIs(expectedTotal);
+
+      r.assertAggregateExtremes("sensor-0", 15.0, 34.0);
+
+      assertThat(r.latestTimestamp("sensor_id:" + TimeSeriesDatabaseWrapper.VERIFY_SENSOR)).isEqualTo(3000L);
+    }
+
+    ingest.close();
+    r0.close();
+    r1.close();
+    r2.close();
+  }
+}

--- a/load-tests/src/test/java/com/arcadedb/test/support/TimeSeriesDatabaseWrapper.java
+++ b/load-tests/src/test/java/com/arcadedb/test/support/TimeSeriesDatabaseWrapper.java
@@ -34,6 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
@@ -102,30 +103,36 @@ public class TimeSeriesDatabaseWrapper {
    * is not yet propagated or the server is temporarily unavailable during election.
    */
   public void createDatabase() {
+    // RemoteServer owns its own HttpClient (RemoteHttpComponent), so close it to avoid leaking the
+    // client and its NIO thread - this is a separate connection from the long-lived query `db`.
     final RemoteServer httpServer = new RemoteServer(server.host(), server.httpPort(), "root", PASSWORD);
-    httpServer.setConnectionStrategy(RemoteHttpComponent.CONNECTION_STRATEGY.FIXED);
+    try {
+      httpServer.setConnectionStrategy(RemoteHttpComponent.CONNECTION_STRATEGY.FIXED);
 
-    if (httpServer.exists(DATABASE)) {
-      logger.info("Dropping existing database {}", DATABASE);
-      httpServer.drop(DATABASE);
-    }
-    logger.info("Creating database {}", DATABASE);
-
-    final int maxAttempts = 30;
-    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
-      try {
-        httpServer.create(DATABASE);
-        return;
-      } catch (final ServerIsNotTheLeaderException e) {
-        if (e.getLeaderAddress() != null || attempt == maxAttempts)
-          throw e;
-        logger.info("Leader address not yet known (attempt {}/{}), retrying in 2s...", attempt, maxAttempts);
-      } catch (final Exception e) {
-        if (attempt == maxAttempts)
-          throw e;
-        logger.info("Database creation attempt {}/{} failed ({}), retrying in 2s...", attempt, maxAttempts, e.getMessage());
+      if (httpServer.exists(DATABASE)) {
+        logger.info("Dropping existing database {}", DATABASE);
+        httpServer.drop(DATABASE);
       }
-      sleep(2_000);
+      logger.info("Creating database {}", DATABASE);
+
+      final int maxAttempts = 30;
+      for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+          httpServer.create(DATABASE);
+          return;
+        } catch (final ServerIsNotTheLeaderException e) {
+          if (e.getLeaderAddress() != null || attempt == maxAttempts)
+            throw e;
+          logger.info("Leader address not yet known (attempt {}/{}), retrying in 2s...", attempt, maxAttempts);
+        } catch (final Exception e) {
+          if (attempt == maxAttempts)
+            throw e;
+          logger.info("Database creation attempt {}/{} failed ({}), retrying in 2s...", attempt, maxAttempts, e.getMessage());
+        }
+        sleep(2_000);
+      }
+    } finally {
+      httpServer.close();
     }
   }
 
@@ -260,8 +267,12 @@ public class TimeSeriesDatabaseWrapper {
       final int status = conn.getResponseCode();
       if (status != 204) {
         String err = "";
-        if (conn.getErrorStream() != null)
-          err = new String(conn.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
+        final InputStream errorStream = conn.getErrorStream();
+        if (errorStream != null) {
+          try (errorStream) {
+            err = new String(errorStream.readAllBytes(), StandardCharsets.UTF_8);
+          }
+        }
         throw new IOException("Line protocol write failed: HTTP " + status + " " + err);
       }
     } catch (final Exception e) {
@@ -344,7 +355,10 @@ public class TimeSeriesDatabaseWrapper {
     try {
       if (conn.getResponseCode() != 200)
         throw new IOException("Latest query failed: HTTP " + conn.getResponseCode());
-      final JSONObject json = new JSONObject(new String(conn.getInputStream().readAllBytes(), StandardCharsets.UTF_8));
+      final JSONObject json;
+      try (final InputStream is = conn.getInputStream()) {
+        json = new JSONObject(new String(is.readAllBytes(), StandardCharsets.UTF_8));
+      }
       final JSONArray latest = json.getJSONArray("latest");
       return latest.getLong(0);
     } finally {

--- a/load-tests/src/test/java/com/arcadedb/test/support/TimeSeriesDatabaseWrapper.java
+++ b/load-tests/src/test/java/com/arcadedb/test/support/TimeSeriesDatabaseWrapper.java
@@ -1,0 +1,390 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.test.support;
+
+import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.remote.RemoteDatabase;
+import com.arcadedb.remote.RemoteHttpComponent;
+import com.arcadedb.remote.RemoteServer;
+import com.arcadedb.remote.grpc.RemoteGrpcDatabase;
+import com.arcadedb.remote.grpc.RemoteGrpcServer;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+
+import static com.arcadedb.test.support.ContainersTestTemplate.DATABASE;
+import static com.arcadedb.test.support.ContainersTestTemplate.PASSWORD;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Drives and verifies a time series workload against one ArcadeDB server over one ingestion protocol.
+ * Ingestion goes through the InfluxDB Line Protocol HTTP endpoint or SQL INSERT (HTTP/gRPC);
+ * verification queries use SQL and the latest-value HTTP endpoint.
+ */
+public class TimeSeriesDatabaseWrapper {
+
+  public enum Protocol {LINE_PROTOCOL, SQL_HTTP, SQL_GRPC}
+
+  /**
+   * Aggregation result over a single time bucket.
+   */
+  public record AggResult(double avg, double min, double max, long count) {
+  }
+
+  public static final  String TYPE_NAME     = "sensor";
+  public static final  String VERIFY_SENSOR = "verify";
+  private static final Logger logger        = LoggerFactory.getLogger(TimeSeriesDatabaseWrapper.class);
+
+  private final ServerWrapper  server;
+  private final Protocol       protocol;
+  private final RemoteDatabase db;
+  private final Timer          pointsTimer;
+
+  public TimeSeriesDatabaseWrapper(final ServerWrapper server, final Protocol protocol) {
+    this.server = server;
+    this.protocol = protocol;
+    this.db = connect(protocol);
+    this.pointsTimer = Metrics.timer("arcadedb.test.ts.inserted.points");
+  }
+
+  private RemoteDatabase connect(final Protocol protocol) {
+    return switch (protocol) {
+      case SQL_GRPC -> {
+        final RemoteGrpcServer grpcServer = new RemoteGrpcServer(server.host(), server.grpcPort(), "root", PASSWORD, true,
+            List.of());
+        yield new RemoteGrpcDatabase(grpcServer, server.host(), server.grpcPort(), server.httpPort(), DATABASE, "root", PASSWORD);
+      }
+      case LINE_PROTOCOL, SQL_HTTP -> {
+        final RemoteDatabase database = new RemoteDatabase(server.host(), server.httpPort(), DATABASE, "root", PASSWORD);
+        database.setConnectionStrategy(RemoteHttpComponent.CONNECTION_STRATEGY.FIXED);
+        database.setTimeout(30000);
+        yield database;
+      }
+    };
+  }
+
+  public void close() {
+    db.close();
+  }
+
+  /**
+   * Creates (dropping any pre-existing) the test database. Retries while the Raft leader address
+   * is not yet propagated or the server is temporarily unavailable during election.
+   */
+  public void createDatabase() {
+    final RemoteServer httpServer = new RemoteServer(server.host(), server.httpPort(), "root", PASSWORD);
+    httpServer.setConnectionStrategy(RemoteHttpComponent.CONNECTION_STRATEGY.FIXED);
+
+    if (httpServer.exists(DATABASE)) {
+      logger.info("Dropping existing database {}", DATABASE);
+      httpServer.drop(DATABASE);
+    }
+    logger.info("Creating database {}", DATABASE);
+
+    final int maxAttempts = 30;
+    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        httpServer.create(DATABASE);
+        return;
+      } catch (final ServerIsNotTheLeaderException e) {
+        if (e.getLeaderAddress() != null || attempt == maxAttempts)
+          throw e;
+        logger.info("Leader address not yet known (attempt {}/{}), retrying in 2s...", attempt, maxAttempts);
+      } catch (final Exception e) {
+        if (attempt == maxAttempts)
+          throw e;
+        logger.info("Database creation attempt {}/{} failed ({}), retrying in 2s...", attempt, maxAttempts, e.getMessage());
+      }
+      sleep(2_000);
+    }
+  }
+
+  /**
+   * Creates the {@code sensor} time series type. Retries while the database is still being
+   * replicated/opened after Raft creation.
+   */
+  public void createSchema() {
+    final int maxAttempts = 30;
+    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        db.command("sql",
+            "CREATE TIMESERIES TYPE " + TYPE_NAME
+                + " TIMESTAMP ts TAGS (sensor_id STRING, region STRING) FIELDS (temperature DOUBLE, humidity DOUBLE)");
+        return;
+      } catch (final Exception e) {
+        if (attempt == maxAttempts)
+          throw e;
+        if (e.getMessage() == null || !e.getMessage().contains("not available")) {
+          logger.warn("Schema creation failed with unexpected error on attempt {}: {}", attempt, e.getMessage());
+          throw e;
+        }
+        logger.info("Database not yet available for schema creation (attempt {}/{}): {}", attempt, maxAttempts, e.getMessage());
+        sleep(2_000);
+      }
+    }
+  }
+
+  /**
+   * Waits until the {@code sensor} time series type is queryable on this node. On a Raft cluster the
+   * type is created on the leader and applied on followers asynchronously, and a connection opened
+   * before creation caches an empty schema, so this polls a server-side query (which always hits the
+   * node and bypasses any client-side schema cache) rather than asserting a cached {@code existsType}.
+   */
+  public void checkSchema() {
+    final long deadline = System.currentTimeMillis() + 30_000;
+    Exception last = null;
+    while (System.currentTimeMillis() < deadline) {
+      try {
+        db.query("sql", "SELECT count(*) AS cnt FROM " + TYPE_NAME).next();
+        return;
+      } catch (final Exception e) {
+        last = e;
+        sleep(1_000);
+      }
+    }
+    throw new AssertionError("Time series type '" + TYPE_NAME + "' not available after 30s", last);
+  }
+
+  /**
+   * Ingests {@code count} bulk points for one sensor with strictly increasing, unique timestamps
+   * starting at {@code fromTs}. Field values are deterministic but irrelevant to assertions.
+   */
+  public void ingestSeries(final String sensorId, final String region, final long fromTs, final int count) {
+    if (protocol == Protocol.LINE_PROTOCOL) {
+      final int batchSize = 500;
+      final StringBuilder sb = new StringBuilder();
+      int inBatch = 0;
+      for (int i = 0; i < count; i++) {
+        sb.append(lineFor(sensorId, region, fromTs + i, 15.0 + (i % 20), 40.0 + (i % 30))).append('\n');
+        if (++inBatch == batchSize) {
+          final String body = sb.toString();
+          pointsTimer.record(() -> postLineProtocol(body));
+          sb.setLength(0);
+          inBatch = 0;
+        }
+      }
+      if (inBatch > 0) {
+        final String body = sb.toString();
+        pointsTimer.record(() -> postLineProtocol(body));
+      }
+    } else {
+      for (int i = 0; i < count; i++) {
+        final int idx = i;
+        final long ts = fromTs + i;
+        pointsTimer.record(() -> insertSql(sensorId, region, ts, 15.0 + (idx % 20), 40.0 + (idx % 30)));
+      }
+    }
+  }
+
+  /**
+   * Ingests the deterministic 4-point verification series.
+   */
+  public void ingestVerificationSeries() {
+    ingestPoint(VERIFY_SENSOR, "eu-west", 0L, 10.0, 40.0);
+    ingestPoint(VERIFY_SENSOR, "eu-west", 1000L, 20.0, 50.0);
+    ingestPoint(VERIFY_SENSOR, "eu-west", 2000L, 30.0, 60.0);
+    ingestPoint(VERIFY_SENSOR, "eu-west", 3000L, 40.0, 70.0);
+  }
+
+  private void ingestPoint(final String sensorId, final String region, final long ts, final double temperature,
+      final double humidity) {
+    if (protocol == Protocol.LINE_PROTOCOL)
+      postLineProtocol(lineFor(sensorId, region, ts, temperature, humidity));
+    else
+      insertSql(sensorId, region, ts, temperature, humidity);
+  }
+
+  private static String lineFor(final String sensorId, final String region, final long ts, final double temperature,
+      final double humidity) {
+    return TYPE_NAME + ",sensor_id=" + sensorId + ",region=" + region
+        + " temperature=" + temperature + ",humidity=" + humidity + " " + ts;
+  }
+
+  private void insertSql(final String sensorId, final String region, final long ts, final double temperature,
+      final double humidity) {
+    try {
+      db.command("sql",
+          "INSERT INTO " + TYPE_NAME + " SET ts = ?, sensor_id = ?, region = ?, temperature = ?, humidity = ?",
+          ts, sensorId, region, temperature, humidity);
+    } catch (final Exception e) {
+      Metrics.counter("arcadedb.test.ts.inserted.points.error").increment();
+      logger.error("SQL ingest error at ts {}: {}", ts, e.getMessage());
+    }
+  }
+
+  private void postLineProtocol(final String body) {
+    HttpURLConnection conn = null;
+    try {
+      final URL url = URI.create(
+          "http://" + server.host() + ":" + server.httpPort() + "/api/v1/ts/" + DATABASE + "/write?precision=ms").toURL();
+      conn = (HttpURLConnection) url.openConnection();
+      conn.setRequestMethod("POST");
+      conn.setRequestProperty("Authorization", basicAuth());
+      conn.setRequestProperty("Content-Type", "text/plain");
+      conn.setConnectTimeout(5_000);
+      conn.setReadTimeout(30_000);
+      conn.setDoOutput(true);
+      try (final OutputStream os = conn.getOutputStream()) {
+        os.write(body.getBytes(StandardCharsets.UTF_8));
+      }
+      final int status = conn.getResponseCode();
+      if (status != 204) {
+        String err = "";
+        if (conn.getErrorStream() != null)
+          err = new String(conn.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
+        throw new IOException("Line protocol write failed: HTTP " + status + " " + err);
+      }
+    } catch (final Exception e) {
+      Metrics.counter("arcadedb.test.ts.inserted.points.error").increment();
+      logger.error("Line protocol ingest error: {}", e.getMessage());
+    } finally {
+      if (conn != null)
+        conn.disconnect();
+    }
+  }
+
+  public long countPoints() {
+    final ResultSet rs = db.query("sql", "SELECT count(*) AS cnt FROM " + TYPE_NAME);
+    return ((Number) rs.next().getProperty("cnt")).longValue();
+  }
+
+  /**
+   * Runs a single-bucket time-bucket aggregation over the given sensor and returns the first row.
+   * The time-series aggregation reads sealed data only, so this targets a fully-flushed sensor
+   * (a bulk series of {@code POINTS_PER_THREAD} points), not a tiny just-written series whose
+   * points may still sit in the unsealed mutable buffer. Retries briefly to absorb seal/replication
+   * lag (followers receive sealed segments after the leader commits).
+   */
+  public AggResult aggregate(final String sensorId) {
+    // 'bucket' is a reserved word in ArcadeDB SQL, so the time-bucket alias is 'tbucket'.
+    final String sql = "SELECT ts.timeBucket('1h', ts) AS tbucket, avg(temperature) AS avgT, min(temperature) AS minT, "
+        + "max(temperature) AS maxT, count(*) AS cnt FROM " + TYPE_NAME
+        + " WHERE sensor_id = ? GROUP BY tbucket ORDER BY tbucket";
+    final long deadline = System.currentTimeMillis() + 30_000;
+    while (true) {
+      final ResultSet rs = db.query("sql", sql, sensorId);
+      if (rs.hasNext()) {
+        final Result r = rs.next();
+        return new AggResult(toDouble(r.getProperty("avgT")), toDouble(r.getProperty("minT")), toDouble(r.getProperty("maxT")),
+            ((Number) r.getProperty("cnt")).longValue());
+      }
+      if (System.currentTimeMillis() >= deadline)
+        throw new IllegalStateException("Time-series aggregation returned no rows for sensor_id=" + sensorId + " after 30s");
+      sleep(1_000);
+    }
+  }
+
+  /**
+   * Asserts the time-bucket aggregation reports the expected min/max temperature extremes for the
+   * given (bulk) sensor, polling to absorb asynchronous sealing. The aggregation reflects only the
+   * sealed subset of points, which grows over time, so the exact aggregated count and average are
+   * not deterministic; the extremes are: the bulk temperature cycles 15.0..34.0 every 20 points, so
+   * as soon as one full cycle is sealed the min/max settle at their final values. The exact total is
+   * verified separately via {@link #countPoints()} (the unfiltered count, which sees all data,
+   * mutable and sealed - unlike tag-filtered queries, which see only the sealed subset).
+   */
+  public void assertAggregateExtremes(final String sensorId, final double expectedMin, final double expectedMax) {
+    final long deadline = System.currentTimeMillis() + 60_000;
+    AggResult agg = null;
+    while (System.currentTimeMillis() < deadline) {
+      agg = aggregate(sensorId);
+      if (agg.min() == expectedMin && agg.max() == expectedMax)
+        return;
+      sleep(2_000);
+    }
+    assertThat(agg).isNotNull();
+    assertThat(agg.min()).isEqualTo(expectedMin);
+    assertThat(agg.max()).isEqualTo(expectedMax);
+  }
+
+  /**
+   * Returns the latest timestamp via the HTTP latest endpoint. {@code tag} may be null or "name:value".
+   */
+  public long latestTimestamp(final String tag) throws IOException {
+    final StringBuilder url = new StringBuilder(
+        "http://" + server.host() + ":" + server.httpPort() + "/api/v1/ts/" + DATABASE + "/latest?type=" + TYPE_NAME);
+    if (tag != null)
+      url.append("&tag=").append(tag);
+
+    final HttpURLConnection conn = (HttpURLConnection) URI.create(url.toString()).toURL().openConnection();
+    conn.setRequestMethod("GET");
+    conn.setRequestProperty("Authorization", basicAuth());
+    conn.setConnectTimeout(5_000);
+    conn.setReadTimeout(5_000);
+    try {
+      if (conn.getResponseCode() != 200)
+        throw new IOException("Latest query failed: HTTP " + conn.getResponseCode());
+      final JSONObject json = new JSONObject(new String(conn.getInputStream().readAllBytes(), StandardCharsets.UTF_8));
+      final JSONArray latest = json.getJSONArray("latest");
+      return latest.getLong(0);
+    } finally {
+      conn.disconnect();
+    }
+  }
+
+  /**
+   * Asserts the total point count equals {@code expected}, retrying up to 30s to tolerate replication lag.
+   */
+  public void assertThatPointCountIs(final long expected) {
+    final long deadline = System.currentTimeMillis() + 30_000;
+    long actual = -1;
+    do {
+      try {
+        actual = countPoints();
+        if (actual == expected)
+          return;
+      } catch (final Exception ignored) {
+        // keep polling
+      }
+      if (System.currentTimeMillis() < deadline)
+        sleep(2_000);
+    } while (System.currentTimeMillis() < deadline);
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  private static double toDouble(final Object o) {
+    return ((Number) o).doubleValue();
+  }
+
+  private static String basicAuth() {
+    return "Basic " + Base64.getEncoder().encodeToString(("root:" + PASSWORD).getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static void sleep(final long millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/load-tests/src/test/java/com/arcadedb/test/support/TimeSeriesDatabaseWrapper.java
+++ b/load-tests/src/test/java/com/arcadedb/test/support/TimeSeriesDatabaseWrapper.java
@@ -39,6 +39,7 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
@@ -46,13 +47,14 @@ import java.util.List;
 import static com.arcadedb.test.support.ContainersTestTemplate.DATABASE;
 import static com.arcadedb.test.support.ContainersTestTemplate.PASSWORD;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
 /**
  * Drives and verifies a time series workload against one ArcadeDB server over one ingestion protocol.
  * Ingestion goes through the InfluxDB Line Protocol HTTP endpoint or SQL INSERT (HTTP/gRPC);
  * verification queries use SQL and the latest-value HTTP endpoint.
  */
-public class TimeSeriesDatabaseWrapper {
+public class TimeSeriesDatabaseWrapper implements AutoCloseable {
 
   public enum Protocol {LINE_PROTOCOL, SQL_HTTP, SQL_GRPC}
 
@@ -94,6 +96,7 @@ public class TimeSeriesDatabaseWrapper {
     };
   }
 
+  @Override
   public void close() {
     db.close();
   }
@@ -185,6 +188,11 @@ public class TimeSeriesDatabaseWrapper {
   /**
    * Ingests {@code count} bulk points for one sensor with strictly increasing, unique timestamps
    * starting at {@code fromTs}. Field values are deterministic but irrelevant to assertions.
+   * <p>
+   * Note: the protocols are intentionally not throughput-comparable. {@code LINE_PROTOCOL} batches
+   * up to 500 points per HTTP call, while the SQL protocols send one {@code INSERT} per round-trip
+   * (one transaction per point) - the per-row SQL path is kept deliberately so it exercises the
+   * single-row append path under concurrency. Treat per-protocol timings as independent.
    */
   public void ingestSeries(final String sensorId, final String region, final long fromTs, final int count) {
     if (protocol == Protocol.LINE_PROTOCOL) {
@@ -290,52 +298,48 @@ public class TimeSeriesDatabaseWrapper {
   }
 
   /**
-   * Runs a single-bucket time-bucket aggregation over the given sensor and returns the first row.
-   * The time-series aggregation reads sealed data only, so this targets a fully-flushed sensor
-   * (a bulk series of {@code POINTS_PER_THREAD} points), not a tiny just-written series whose
-   * points may still sit in the unsealed mutable buffer. Retries briefly to absorb seal/replication
-   * lag (followers receive sealed segments after the leader commits).
+   * Runs a single-bucket time-bucket aggregation over the given sensor and returns the first row,
+   * or {@code null} if no rows are visible yet. The time-series aggregation reads sealed data only,
+   * so callers should target a fully-flushed sensor (a bulk series) and poll (see
+   * {@link #assertAggregateExtremes}) to absorb seal/replication lag. This is a single query with no
+   * internal retry, so the caller owns the single polling loop.
    */
   public AggResult aggregate(final String sensorId) {
     // 'bucket' is a reserved word in ArcadeDB SQL, so the time-bucket alias is 'tbucket'.
     final String sql = "SELECT ts.timeBucket('1h', ts) AS tbucket, avg(temperature) AS avgT, min(temperature) AS minT, "
         + "max(temperature) AS maxT, count(*) AS cnt FROM " + TYPE_NAME
         + " WHERE sensor_id = ? GROUP BY tbucket ORDER BY tbucket";
-    final long deadline = System.currentTimeMillis() + 30_000;
-    while (true) {
-      final ResultSet rs = db.query("sql", sql, sensorId);
-      if (rs.hasNext()) {
-        final Result r = rs.next();
-        return new AggResult(toDouble(r.getProperty("avgT")), toDouble(r.getProperty("minT")), toDouble(r.getProperty("maxT")),
-            ((Number) r.getProperty("cnt")).longValue());
-      }
-      if (System.currentTimeMillis() >= deadline)
-        throw new IllegalStateException("Time-series aggregation returned no rows for sensor_id=" + sensorId + " after 30s");
-      sleep(1_000);
-    }
+    final ResultSet rs = db.query("sql", sql, sensorId);
+    if (!rs.hasNext())
+      return null;
+    final Result r = rs.next();
+    return new AggResult(toDouble(r.getProperty("avgT")), toDouble(r.getProperty("minT")), toDouble(r.getProperty("maxT")),
+        ((Number) r.getProperty("cnt")).longValue());
   }
 
   /**
    * Asserts the time-bucket aggregation reports the expected min/max temperature extremes for the
-   * given (bulk) sensor, polling to absorb asynchronous sealing. The aggregation reflects only the
-   * sealed subset of points, which grows over time, so the exact aggregated count and average are
-   * not deterministic; the extremes are: the bulk temperature cycles 15.0..34.0 every 20 points, so
-   * as soon as one full cycle is sealed the min/max settle at their final values. The exact total is
-   * verified separately via {@link #countPoints()} (the unfiltered count, which sees all data,
-   * mutable and sealed - unlike tag-filtered queries, which see only the sealed subset).
+   * given (bulk) sensor, polling (single level, up to 60s) to absorb asynchronous sealing. The
+   * aggregation reflects only the sealed subset of points, which grows over time, so the exact
+   * aggregated count and average are not deterministic; the extremes are: the bulk temperature
+   * cycles 15.0..34.0 every 20 points, so as soon as one full cycle is sealed the min/max settle at
+   * their final values. The exact total is verified separately via {@link #countPoints()} (the
+   * unfiltered count, which sees all data, mutable and sealed - unlike tag-filtered queries, which
+   * see only the sealed subset).
    */
   public void assertAggregateExtremes(final String sensorId, final double expectedMin, final double expectedMax) {
+    final double tolerance = 1e-9;
     final long deadline = System.currentTimeMillis() + 60_000;
     AggResult agg = null;
     while (System.currentTimeMillis() < deadline) {
       agg = aggregate(sensorId);
-      if (agg.min() == expectedMin && agg.max() == expectedMax)
+      if (agg != null && Math.abs(agg.min() - expectedMin) < tolerance && Math.abs(agg.max() - expectedMax) < tolerance)
         return;
       sleep(2_000);
     }
-    assertThat(agg).isNotNull();
-    assertThat(agg.min()).isEqualTo(expectedMin);
-    assertThat(agg.max()).isEqualTo(expectedMax);
+    assertThat(agg).as("time-bucket aggregation returned rows for sensor_id=%s", sensorId).isNotNull();
+    assertThat(agg.min()).isCloseTo(expectedMin, within(tolerance));
+    assertThat(agg.max()).isCloseTo(expectedMax, within(tolerance));
   }
 
   /**
@@ -345,7 +349,7 @@ public class TimeSeriesDatabaseWrapper {
     final StringBuilder url = new StringBuilder(
         "http://" + server.host() + ":" + server.httpPort() + "/api/v1/ts/" + DATABASE + "/latest?type=" + TYPE_NAME);
     if (tag != null)
-      url.append("&tag=").append(tag);
+      url.append("&tag=").append(URLEncoder.encode(tag, StandardCharsets.UTF_8));
 
     final HttpURLConnection conn = (HttpURLConnection) URI.create(url.toString()).toURL().openConnection();
     conn.setRequestMethod("GET");
@@ -372,17 +376,23 @@ public class TimeSeriesDatabaseWrapper {
   public void assertThatPointCountIs(final long expected) {
     final long deadline = System.currentTimeMillis() + 30_000;
     long actual = -1;
+    Exception lastException = null;
     do {
       try {
         actual = countPoints();
         if (actual == expected)
           return;
-      } catch (final Exception ignored) {
-        // keep polling
+        lastException = null;
+      } catch (final Exception e) {
+        lastException = e;
       }
       if (System.currentTimeMillis() < deadline)
         sleep(2_000);
     } while (System.currentTimeMillis() < deadline);
+    if (lastException != null)
+      throw new AssertionError(
+          "Expected point count " + expected + " but the database was not available after 30s: " + lastException.getMessage(),
+          lastException);
     assertThat(actual).isEqualTo(expected);
   }
 


### PR DESCRIPTION
## Summary

Adds Testcontainers-based load tests dedicated to the **time series engine**, covering a single standalone server and a 3-node Raft HA cluster. Reuses the existing `ContainersTestTemplate` infrastructure unchanged.

Ingestion is exercised over three protocols via a new `TimeSeriesDatabaseWrapper`:
- InfluxDB **line protocol** HTTP endpoint (`POST /api/v1/ts/{db}/write`)
- SQL `INSERT` over **HTTP** `RemoteDatabase`
- SQL `INSERT` over **gRPC** `RemoteDatabase`

Each test is `@ParameterizedTest` over those three protocols.

### What is verified
- **Single node** (`SingleServerTimeSeriesLoadTestIT`): concurrent bulk ingestion, exact total point count, time-bucket aggregation extremes over a sealed bulk sensor, and the tag-filtered latest value.
- **3-node Raft HA** (`ThreeNodesTimeSeriesLoadTestIT`): replication consistency by converging the unfiltered point count across all nodes (Awaitility), then per-node aggregation extremes and latest value. `compareAllDatabases()` is skipped (non-persistent containers), matching `ThreeNodesLoadTestIT`.

### Notes on time series query semantics (informed the assertions)
Verified against the server image:
- Tag-filtered queries (`WHERE sensor_id = ?`, both plain `count(*)` and `ts.timeBucket(...) GROUP BY`) reflect only the asynchronously **sealed** subset of points; the unfiltered `count(*)` and the `/latest` endpoint see all data. So exact totals are asserted via the unfiltered count, while aggregation is asserted on stable `min`/`max` extremes over a sealed bulk sensor (with polling to absorb seal/replication lag).
- `bucket` is a reserved SQL word, so the time-bucket alias is `tbucket`.
- A SQL `INSERT` into a time series type returns a record without an `@rid`, which the remote client can reject after the server commits; this is tolerated in the ingest path (no data loss).

### Test plan
Run against `arcadedata/arcadedb:latest`:
```
mvn -pl load-tests install -DskipTests -DskipITs=true
mvn -pl load-tests verify -DskipITs=false \
  -Dit.test="SingleServerTimeSeriesLoadTestIT,ThreeNodesTimeSeriesLoadTestIT" \
  -Dfailsafe.failIfNoSpecifiedTests=false
```
All 6 parameterized cases (3 single-node + 3 cluster) pass locally. The 3-node test needs ~10 GB free for Docker.