### PR TITLE
fix(#4456): bind authenticated user on DatabaseContext in BoltNetworkExecutor

### DIFF
--- a/bolt/pom.xml
+++ b/bolt/pom.xml
@@ -54,6 +54,19 @@
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
+        <dependency>
+            <groupId>com.arcadedb</groupId>
+            <artifactId>arcadedb-ha-raft</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.arcadedb</groupId>
+            <artifactId>arcadedb-ha-raft</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -36,6 +36,7 @@ import com.arcadedb.bolt.packstream.PackStreamReader;
 import com.arcadedb.bolt.packstream.PackStreamWriter;
 import com.arcadedb.bolt.structure.BoltStructureMapper;
 import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseContext;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.index.Index;
@@ -967,6 +968,8 @@ public class BoltNetworkExecutor extends Thread {
         state = State.FAILED;
         return false;
       }
+      if (user != null)
+        DatabaseContext.INSTANCE.init((DatabaseInternal) database).setCurrentUser(user.getDatabaseUser(database));
       return true;
     } catch (final Exception e) {
       final String message = e.getMessage() != null ? e.getMessage() : "Unknown error";

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -939,6 +939,14 @@ public class BoltNetworkExecutor extends Thread {
         // Database name changed, need to switch
         database = null;
       } else {
+        // Update current user on the existing context to handle LOGOFF/LOGON re-authentication
+        // on the same connection without disrupting any open transactions.
+        if (user != null) {
+          final DatabaseContext.DatabaseContextTL ctx =
+              DatabaseContext.INSTANCE.getContextIfExists(((DatabaseInternal) database).getDatabasePath());
+          if (ctx != null)
+            ctx.setCurrentUser(user.getDatabaseUser(database));
+        }
         return true;
       }
     }

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltFollowerForwardingIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltFollowerForwardingIT.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.server.ha.raft.BaseRaftHATest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Config;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test: a Bolt write issued to a follower must be forwarded to the leader.
+ *
+ * Before the fix, BoltNetworkExecutor.ensureDatabase() resolved the database but never
+ * propagated the authenticated user onto DatabaseContext, so
+ * RaftReplicatedDatabase.forwardCommandToLeaderViaRaft threw
+ * "Cannot forward command to leader: no authenticated user in the current security context"
+ * and every write hitting a follower failed.
+ */
+@Tag("slow")
+class BoltFollowerForwardingIT extends BaseRaftHATest {
+
+  private static final int    BASE_BOLT_PORT = 57687;
+  private static final String VERTEX_TYPE    = "BoltFollowerWrite";
+
+  private Driver driver;
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+
+    final String serverName = config.getValueAsString(GlobalConfiguration.SERVER_NAME);
+    final int index = Integer.parseInt(serverName.substring(serverName.lastIndexOf('_') + 1));
+
+    config.setValue(GlobalConfiguration.SERVER_PLUGINS.getKey(), "Bolt:com.arcadedb.bolt.BoltProtocolPlugin");
+    config.setValue(GlobalConfiguration.BOLT_PORT.getKey(), String.valueOf(BASE_BOLT_PORT + index));
+  }
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @AfterEach
+  void teardownBoltClient() {
+    if (driver != null) {
+      driver.close();
+      driver = null;
+    }
+  }
+
+  @Test
+  void writeCommandThroughFollowerIsForwardedToLeader() {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    int followerIndex = -1;
+    for (int i = 0; i < getServerCount(); i++) {
+      if (i != leaderIndex) {
+        followerIndex = i;
+        break;
+      }
+    }
+    assertThat(followerIndex).as("At least one follower must exist").isGreaterThanOrEqualTo(0);
+
+    // Schema creation goes through the leader to avoid mixing schema replication with the forwarding under test.
+    final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+    leaderDb.transaction(() -> {
+      if (!leaderDb.getSchema().existsType(VERTEX_TYPE))
+        leaderDb.getSchema().createVertexType(VERTEX_TYPE);
+    });
+    waitForAllServers();
+
+    // Open the Bolt driver against the follower deliberately.
+    driver = GraphDatabase.driver(
+        "bolt://localhost:" + (BASE_BOLT_PORT + followerIndex),
+        AuthTokens.basic("root", DEFAULT_PASSWORD_FOR_TESTS),
+        Config.builder().withoutEncryption().build());
+
+    try (Session session = driver.session(SessionConfig.builder().withDatabase(getDatabaseName()).build())) {
+      // Write via Cypher command - the follower must forward to leader, which requires an authenticated
+      // user on the DatabaseContext. Before the fix this surfaced a SecurityException to the caller.
+      session.run("CREATE (n:" + VERTEX_TYPE + " {name: 'forwarded'})").consume();
+    }
+
+    waitForAllServers();
+
+    for (int i = 0; i < getServerCount(); i++) {
+      final Database serverDb = getServerDatabase(i, getDatabaseName());
+      assertThat(serverDb.countType(VERTEX_TYPE, true))
+          .as("Server %d (leader=%d, write went through Bolt follower=%d) must see the forwarded vertex",
+              i, leaderIndex, followerIndex)
+          .isEqualTo(1);
+    }
+  }
+}

--- a/docs/4456-bolt-follower-forwarding-no-user.md
+++ b/docs/4456-bolt-follower-forwarding-no-user.md
@@ -1,0 +1,56 @@
+# Fix #4456 - Bolt follower forwarding: no authenticated user in security context
+
+## Issue
+
+Bolt protocol write queries (`CREATE`, `MERGE`, etc.) fail with
+`Cannot forward command to leader: no authenticated user in the current security context`
+when the connection lands on a Raft HA follower instead of the leader.
+
+REST/HTTP is unaffected. Reported against an EKS deployment with the Helm chart.
+
+## Root Cause
+
+`BoltNetworkExecutor.ensureDatabase()` resolves the database via `server.getDatabase(targetName)`
+but never calls `DatabaseContext.INSTANCE.init(...).setCurrentUser(...)`.
+
+On a follower write, `RaftReplicatedDatabase.forwardCommandToLeaderViaRaft` reads
+`proxied.getCurrentUserName()` (line 1523) to build the `X-ArcadeDB-Forwarded-User` header.
+Because the current user was never bound to the thread-local `DatabaseContext`, this returns
+`null` and a `SecurityException` is thrown (line 1526).
+
+### Identical bug fixed previously in gRPC
+
+`GrpcFollowerForwardingIT` tests the same fix for the gRPC module. Recorded guidance:
+> "any new wire-protocol module (Bolt, MongoDB, Redis) MUST set current user on DatabaseContext
+> after init or HA follower writes fail silently under load."
+
+Bolt never received that treatment.
+
+### Also affected: mongodbw and redisw
+
+Both `mongodbw` and `redisw` also have zero `DatabaseContext`/`setCurrentUser` references.
+Whether their write paths hit the same `.command()` forwarding code needs verification
+during implementation; follow-up issues will be filed if their failure mode differs.
+
+## Fix
+
+In `BoltNetworkExecutor.ensureDatabase()`, after `database = server.getDatabase(targetName)`,
+bind the already-authenticated `ServerSecurityUser user` onto the thread-local context:
+
+```java
+DatabaseContext.INSTANCE.init((DatabaseInternal) database).setCurrentUser(user.getDatabaseUser(database));
+```
+
+This mirrors `PostgresNetworkExecutor.openDatabase()` line 1509 and the gRPC fix.
+
+## Files Changed
+
+- `bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java` - bind user in `ensureDatabase()`
+- `bolt/src/test/java/com/arcadedb/bolt/BoltFollowerForwardingIT.java` - new 3-node HA regression test
+- `bolt/pom.xml` - add arcadedb-ha-raft test+test-jar deps (mirrors grpcw/pom.xml)
+
+## Test Plan
+
+1. `BoltFollowerForwardingIT`: 3-node Raft cluster, Neo4j driver writes to a follower,
+   asserts write succeeds and replicates to all 3 nodes.
+2. Existing Bolt tests: `mvn -pl bolt -am test` - must all pass.

--- a/docs/4456-bolt-follower-forwarding-no-user.md
+++ b/docs/4456-bolt-follower-forwarding-no-user.md
@@ -73,6 +73,24 @@ so the DatabaseContext is NOT updated with the new user - privilege escalation r
 to update the current user without disturbing any open transactions (calling `init()` again would
 rollback transactions, so `getContextIfExists().setCurrentUser()` is the correct approach).
 
-### Cycle 2 - SHA 0985a30bd
+### Cycle 2 - SHA 0985a30bd (+ docs SHA a85a1cbf6)
 
-(Pending bot reviews)
+**Gemini:** No new findings on the updated commit within the 15-minute window. Its original
+inline security comment persists (GitHub re-points `commit_id` to the latest SHA as the line
+still exists) but the issue is resolved by the cycle-1 change.
+
+**claude-review CI check:** PASS (in this repo "claude" reviews via a GitHub Actions check named
+`claude-review`, not as a PR review author - so the orchestrator's poll for a "claude" review
+author never matches by design).
+
+**CI status:** All checks pass except `Meterian client scan`, which fails on an UNRELATED
+pre-existing tooling error - `Unable to generate lockfile in folder /github/workspace/e2e-python`
+(Python uv lockfile generation). This PR changes only `bolt/` Java files and a test-scoped
+`arcadedb-ha-raft` pom dependency; no Python dependencies are touched.
+
+## Final State
+
+- **timeout** on bot re-review (no new actionable feedback); the one substantive review item
+  (Gemini's re-authentication security issue) was addressed in cycle 1.
+- `claude-review` CI check: PASS. Java build + all e2e CI checks: PASS.
+- Merge is the developer's responsibility.

--- a/docs/4456-bolt-follower-forwarding-no-user.md
+++ b/docs/4456-bolt-follower-forwarding-no-user.md
@@ -54,3 +54,25 @@ This mirrors `PostgresNetworkExecutor.openDatabase()` line 1509 and the gRPC fix
 1. `BoltFollowerForwardingIT`: 3-node Raft cluster, Neo4j driver writes to a follower,
    asserts write succeeds and replicates to all 3 nodes.
 2. Existing Bolt tests: `mvn -pl bolt -am test` - must all pass.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/4457
+
+## Review Cycles
+
+### Cycle 1 - SHA 6ea4b08fa
+
+**Gemini (COMMENTED):** Flagged critical security vulnerability: LOGOFF/LOGON re-authentication on
+the same connection changes `user` but `ensureDatabase()` returns early (database already open),
+so the DatabaseContext is NOT updated with the new user - privilege escalation risk.
+
+**Claude:** Did not review within 15-minute window.
+
+**Changes applied:** In the early-return block of `ensureDatabase()`, use `getContextIfExists()`
+to update the current user without disturbing any open transactions (calling `init()` again would
+rollback transactions, so `getContextIfExists().setCurrentUser()` is the correct approach).
+
+### Cycle 2 - SHA 0985a30bd
+
+(Pending bot reviews)


### PR DESCRIPTION
Closes #4456

## Summary

- `BoltNetworkExecutor.ensureDatabase()` never called `DatabaseContext.INSTANCE.init().setCurrentUser()` after resolving the database. On a Raft HA follower, `RaftReplicatedDatabase.forwardCommandToLeaderViaRaft` reads `proxied.getCurrentUserName()` to set the `X-ArcadeDB-Forwarded-User` header; because it was never bound, it returned `null` and threw `SecurityException("Cannot forward command to leader: no authenticated user in the current security context")`, surfaced to the client as `Neo.DatabaseError.General.UnknownError`.
- One-line fix mirrors `PostgresNetworkExecutor.openDatabase()` (line 1509) and the prior gRPC fix: after `server.getDatabase()` succeeds, bind `user.getDatabaseUser(database)` onto the thread-local `DatabaseContext`.
- Adds `BoltFollowerForwardingIT`: 3-node Raft cluster, Neo4j driver writes `CREATE` to a follower, asserts replication to all 3 nodes. Adds `arcadedb-ha-raft` test deps to `bolt/pom.xml` following the `grpcw/pom.xml` precedent.

## Test plan

- [x] `BoltFollowerForwardingIT` (new, `@Tag("slow")`): 3-node cluster, write via follower succeeds and vertex count is 1 on every node
- [x] `BoltProtocolIT` (existing, 71 tests): all pass — `concurrentSessions` skipped (pre-existing failure on `main`)
- [x] `BoltMultiLabelIT`, `BoltPortConfigIT` (existing): pass
- [x] All 212 unit tests in `BoltStructureTest`, `BoltMessageTest`, `BoltVersionNegotiationTest`, `BoltChunkedIOTest`, `PackStreamTest`, `PackStreamEdgeCasesTest`, `BoltExceptionTest`, `BoltSslHelperTest`: pass
- [x] Compilation: `mvn -pl bolt -am clean install -DskipTests` succeeds

🤖 Generated with [Claude Code](https://claude.ai/claude-code)