### PR TITLE
fix(#4458): eliminate TS compaction/append deadlock causing WAL version gap on Raft followers

### DIFF
--- a/docs/4458-ts-raft-wal-page0-version-gap.md
+++ b/docs/4458-ts-raft-wal-page0-version-gap.md
@@ -1,0 +1,60 @@
+# Fix #4458: WAL page-version gap on TS shard page-0 under compaction + concurrent appends in Raft HA
+
+## Root cause
+
+`TimeSeriesShard.appendSamples()` held `compactionLock.readLock()` for the entire
+begin-write-commit lifecycle. Under Raft HA, `commit()` calls
+`RaftReplicatedDatabase.waitForActiveRecordingSession()`, which spins until the compaction
+recording session ends. The session ends only after Phase 4c (which needs `compactionLock.writeLock()`),
+but Phase 4c cannot acquire the write lock while this thread holds the read lock.
+
+Deadlock:
+- Append: holds readLock, waiting for recording session to end
+- Phase 4c: waiting for writeLock (blocked by append's readLock)
+- Recording session: ends only after Phase 4c completes
+
+`waitForActiveRecordingSession()` has a `HA_QUORUM_TIMEOUT` escape hatch. When that fires:
+- Append ships TX_ENTRY (page-0 at V+1) immediately
+- Phase 4c eventually gets writeLock, commits, replicateSchema() ships SCHEMA_ENTRY (page-0 at V + clear at V+1)
+- Follower receives TX_ENTRY[V+1] before SCHEMA_ENTRY[V, V+1] → WALVersionGapException → snapshot resync
+
+## Fix
+
+Release `compactionLock.readLock()` BEFORE calling `db.commit()`. This eliminates the deadlock:
+Phase 4c can always acquire writeLock, complete, and trigger `replicateSchema()` promptly.
+`waitForActiveRecordingSession()` then sees the session end quickly and does not time out.
+
+If Phase 4c commits its page-0 clear between the readLock release and our commit, we receive
+a `ConcurrentModificationException` (MVCC conflict) and transparently retry on the freshly
+cleared page. The retry succeeds because the recording session has ended by this point, so
+`waitForActiveRecordingSession()` returns immediately and the TX_ENTRY ships in the correct
+Raft log order (after the SCHEMA_ENTRY).
+
+### Files changed
+
+- `engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java`
+  - `appendSamples()` refactored to serialize via `appendLock` first
+  - `appendSamplesAttempt()`: on Raft HA leaders, releases `compactionLock.readLock()` before
+    `commit()` to eliminate the deadlock; adds CME retry for Phase 4c race
+  - Phase 0 `compactInternal()`: CME retry loop for in-flight append commits
+  - `TEST_PRE_PHASE4C_HOOK` added for deterministic HA testing
+- `ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java`
+  - `TEST_PRE_REPLICATE_SCHEMA_HOOK` added for deterministic testing
+- `ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java`
+  - `TEST_WAL_GAP_COUNTER` added for deterministic testing
+
+### Tests added
+
+- `engine/src/test/java/com/arcadedb/engine/timeseries/Issue4458AppendCompactionRaceTest.java`
+  - Embedded DB: verifies CME-retry preserves all data when compaction races concurrent appends
+- `ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4458TsWalVersionGapIT.java`
+  - 2-node Raft HA: uses TEST_PRE_PHASE4C_HOOK to deterministically race an append against
+    Phase 4c, verifies no WAL gap on the follower
+
+## Verification plan
+
+1. Compile engine + ha-raft modules
+2. Run engine test: `mvn test -pl engine -Dtest=Issue4458AppendCompactionRaceTest`
+3. Run HA test: `mvn test -pl ha-raft -Dtest=Issue4458TsWalVersionGapIT`
+4. Run existing regression: `mvn test -pl grpcw -Dtest=TimeSeriesGrpcHaConcurrentInsertIT`
+5. Run related TS suite: `mvn test -pl engine -Dtest="TimeSeries*"`

--- a/docs/4458-ts-raft-wal-page0-version-gap.md
+++ b/docs/4458-ts-raft-wal-page0-version-gap.md
@@ -56,3 +56,42 @@ Raft log order (after the SCHEMA_ENTRY).
 3. Run HA test: `mvn test -pl ha-raft -Dtest=Issue4458TsWalVersionGapIT`
 4. Run existing regression: `mvn test -pl grpcw -Dtest=TimeSeriesGrpcHaConcurrentInsertIT`
 5. Run related TS suite: `mvn test -pl engine -Dtest="TimeSeries*"`
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/4460
+
+## Review cycles
+
+- cycle 1 (`c1ca65e9`): removed unused `TEST_PRE_REPLICATE_SCHEMA_HOOK` (gemini); fixed CME
+  import ordering; converted recursive retry to a loop; clarified embedded-test Javadoc scope;
+  hoisted the test latch countdown (claude). Bots: gemini APPROVE-equivalent (single nit), claude
+  no blocking issues.
+- cycle 2 (`22f74da7`): added FINE log on CME retry; standardized Phase 0 retry to count-down;
+  added Phase 0 invariant guard; documented the TEST hook reset requirement (claude).
+- cycle 3 (`1ef061d9c`): replaced the Phase 0 `assert` with an explicit `IllegalStateException`
+  guard (assertions are disabled in production); renamed `phase0Retrieved` -> `capturedPageCount`;
+  documented the residual `HA_QUORUM_TIMEOUT` safety net; corrected the doc's stale
+  `RaftReplicatedDatabase` reference; removed the unused `committed` counter; normalized alignment.
+- cycle 4 (`fd819e9f`): signal in-flight append from inside the transaction in the embedded test
+  so the append/compaction overlap is reliable on slow CI runners (claude).
+- cycle 5 (`1b7d5dd6`): documented the canonical lock-ordering invariant
+  (`appendLock` before `compactionLock`); named the ascending retry counter in the log; added a
+  leader-side data-integrity assertion to the HA test (claude).
+
+### Deferred / not applied (with rationale)
+
+- "Remove `docs/<issue>.md` from source": this tracking doc is an established repo convention
+  (the resolve-issue workflow creates it; `docs/` already holds many `<issue>-*.md` files).
+- "Add `©` to the IT test copyright header": the `ha-raft` module omits `©`
+  (RaftReplicatedDatabase, BaseRaftHATest); the IT test matches its module. The engine embedded
+  test uses `©` to match the engine module. Both headers are already correct per module.
+- "`@VisibleForTesting` / test-support class for the TEST_* hooks": noted by the reviewer as not a
+  blocker; the established codebase pattern is `public static volatile` test hooks in production
+  classes (e.g. `TEST_POST_REPLICATION_HOOK`).
+
+## Final state
+
+`max-cycles-reached` (5 cycles). All actionable review feedback was applied; no blocking issues
+were raised in any cycle. Remaining items are the justified skips listed above. Merge remains the
+developer's decision.

--- a/docs/4458-ts-raft-wal-page0-version-gap.md
+++ b/docs/4458-ts-raft-wal-page0-version-gap.md
@@ -33,13 +33,11 @@ Raft log order (after the SCHEMA_ENTRY).
 ### Files changed
 
 - `engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java`
-  - `appendSamples()` refactored to serialize via `appendLock` first
-  - `appendSamplesAttempt()`: on Raft HA leaders, releases `compactionLock.readLock()` before
-    `commit()` to eliminate the deadlock; adds CME retry for Phase 4c race
+  - `appendSamples()` refactored to serialize via `appendLock` first, then on Raft HA leaders
+    release `compactionLock.readLock()` before `commit()` (with a CME retry loop) to eliminate
+    the deadlock; standalone mode holds the read lock through commit as before
   - Phase 0 `compactInternal()`: CME retry loop for in-flight append commits
   - `TEST_PRE_PHASE4C_HOOK` added for deterministic HA testing
-- `ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java`
-  - `TEST_PRE_REPLICATE_SCHEMA_HOOK` added for deterministic testing
 - `ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java`
   - `TEST_WAL_GAP_COUNTER` added for deterministic testing
 

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
@@ -57,6 +57,9 @@ public class TimeSeriesShard implements AutoCloseable {
   private final long                   compactionBucketIntervalMs;
   private final TimeSeriesBucket       mutableBucket;
   private final TimeSeriesSealedStore  sealedStore;
+  // LOCK ORDERING: any code path that takes both {@link #appendLock} and {@link #compactionLock}
+  // MUST acquire appendLock FIRST (see appendSamples()). compact() takes only compactionLock
+  // (never appendLock), so no inversion exists today; preserve this order to keep it that way.
   // Read lock: held by scan/iterate (concurrent reads allowed).
   // Write lock: held by compact() to prevent queries from seeing data twice
   // during the window where sealed blocks are written but mutable not yet cleared.
@@ -222,9 +225,10 @@ public class TimeSeriesShard implements AutoCloseable {
               db.rollback();
             if (attempt == 1)
               throw new IOException("Failed to append timeseries samples after compaction-race retries", e);
+            final int attemptNumber = 4 - attempt; // ascending 1..3 for human-readable logging
             LogManager.instance().log(this, Level.FINE,
                 "CME on TimeSeries append for shard %d (attempt %d/3) - retrying after compaction Phase 4c race",
-                shardIndex, 4 - attempt);
+                shardIndex, attemptNumber);
             // else loop again
           } catch (final Exception e) {
             if (db.isTransactionActive())

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
@@ -418,7 +418,7 @@ public class TimeSeriesShard implements AutoCloseable {
     final int snapshotDataPageCount;
     compactionLock.writeLock().lock();
     try {
-      int phase0Retrieved = -1;
+      int capturedPageCount = -1;
       // Count down to mirror the retry convention used in appendSamples().
       for (int attempt = 3; attempt > 0; attempt--) {
         db.begin();
@@ -444,7 +444,7 @@ public class TimeSeriesShard implements AutoCloseable {
           mutableBucket.setCompactionInProgress(true);
           mutableBucket.setCompactionWatermark(initialBlockCount);
           db.commit();
-          phase0Retrieved = pageCount;
+          capturedPageCount = pageCount;
           break;
         } catch (final ConcurrentModificationException e) {
           if (db.isTransactionActive())
@@ -459,10 +459,13 @@ public class TimeSeriesShard implements AutoCloseable {
           throw e instanceof IOException ? (IOException) e : new IOException("Compaction failed in phase 0", e);
         }
       }
-      // Every loop iteration that does not break either returns or throws, so a successful
-      // exit always sets phase0Retrieved to the snapshot page count. Make the invariant explicit.
-      assert phase0Retrieved >= 0 : "Phase 0 exited the retry loop without a valid page count";
-      snapshotDataPageCount = phase0Retrieved;
+      // Every loop iteration that does not break either returns or throws, so a successful exit
+      // always sets capturedPageCount. Enforce the invariant with an explicit guard (not an assert,
+      // which is disabled by default in production) so a future regression cannot silently propagate
+      // a -1 page count into Phase 4.
+      if (capturedPageCount < 0)
+        throw new IllegalStateException("Phase 0 exited the retry loop without a valid page count");
+      snapshotDataPageCount = capturedPageCount;
     } finally {
       compactionLock.writeLock().unlock();
     }

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.util.logging.Level;
 import java.util.ArrayList;
 import java.util.Arrays;
+import com.arcadedb.exception.ConcurrentModificationException;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -75,6 +76,12 @@ public class TimeSeriesShard implements AutoCloseable {
   // Throttle (60s window) for the oversized-sealed-store WARNING so a permanently-too-large shard
   // does not spam the log every maintenance cycle.
   private volatile long                lastOversizedWarnMs = 0;
+
+  /**
+   * Test-only hook. When non-null, fires in {@link #compactInternal()} immediately before Phase 4c
+   * acquires the write lock. Used to race concurrent appends against Phase 4c deterministically.
+   */
+  public static volatile Runnable TEST_PRE_PHASE4C_HOOK = null;
 
   public TimeSeriesShard(final DatabaseInternal database, final String baseName, final int shardIndex,
                          final List<ColumnDefinition> columns) throws IOException {
@@ -161,54 +168,72 @@ public class TimeSeriesShard implements AutoCloseable {
   /**
    * Appends samples to the mutable bucket.
    * <p>
-   * The read lock is held for the <em>entire</em> internal transaction lifecycle
-   * (begin → write → commit), not just during the page writes.  This is the key invariant
-   * that prevents MVCC conflicts with Phase 4:
-   * <ul>
-   *   <li>Phase 4 acquires the <em>write</em> lock to clear the mutable bucket.</li>
-   *   <li>The write lock can only be granted after all read-lock holders have released.</li>
-   *   <li>Because this method releases the read lock only <em>after</em> the commit, Phase 4
-   *       is guaranteed that every in-flight append has already persisted its page-0 modifications
-   *       before Phase 4 starts its own transaction.  Phase 4 always sees the latest page-0
-   *       version and commits without conflict; insert transactions are never affected.</li>
-   * </ul>
-   * <p>
-   * This method always manages its own transaction.  If the caller already has an active
-   * transaction, ArcadeDB creates a nested transaction (a new {@code TransactionContext} pushed
-   * onto the per-thread stack).  The nested transaction commits independently; the caller's outer
-   * transaction remains unaffected because it holds none of the modified pages in its dirty set.
-   * <p>
    * Concurrent calls on the <em>same shard</em> are serialized by {@link #appendLock} so that
    * MVCC page-version conflicts can never arise between two concurrent appends.  Writes to
    * different shards still proceed in parallel.
+   * <p>
+   * On Raft HA leaders, the compaction read lock is released before {@code commit()} to prevent a
+   * deadlock. {@code commit()} calls {@code waitForActiveRecordingSession()}, which waits for the
+   * compaction recording session to end; but the session ends only after Phase 4c (which needs the
+   * write lock); and Phase 4c cannot acquire the write lock while this thread holds the read lock.
+   * Releasing the lock early lets Phase 4c proceed.  If Phase 4c clears the mutable bucket before
+   * our commit, we get a {@code ConcurrentModificationException} and retry transparently on the
+   * freshly-cleared page (see issue #4458). In standalone mode the lock is held through commit as
+   * before, since there is no recording-session deadlock.
    */
   public void appendSamples(final long[] timestamps, final Object[]... columnValues) throws IOException {
-    compactionLock.readLock().lock();
+    appendLock.lock();
     try {
-      // Serialize concurrent appends on this shard to prevent MVCC conflicts.
-      // Two concurrent nested transactions both modifying page 0 would otherwise produce a
-      // ConcurrentModificationException at commit time (current v.X <> database v.Y).
-      appendLock.lock();
+      appendSamplesAttempt(3, timestamps, columnValues);
+    } finally {
+      appendLock.unlock();
+    }
+  }
+
+  private void appendSamplesAttempt(final int retriesLeft, final long[] timestamps, final Object[]... columnValues)
+      throws IOException {
+    // Route the append transaction through the HA wrapper so the mutable-bucket page writes are
+    // shipped to followers via the Raft WAL (TX_ENTRY). On a standalone database,
+    // getWrappedDatabaseInstance() returns the same instance.
+    final DatabaseInternal db = database.getWrappedDatabaseInstance();
+    compactionLock.readLock().lock();
+    boolean readLockHeld = true;
+    try {
+      db.begin();
       try {
-        // Route the append transaction through the HA wrapper so the mutable-bucket page writes are
-        // shipped to followers via the Raft WAL (TX_ENTRY). Committing on the inner LocalDatabase here
-        // would persist the pages locally only, leaving followers with an empty bucket (issue #4382).
-        // On a standalone database getWrappedDatabaseInstance() returns the same instance.
-        final DatabaseInternal db = database.getWrappedDatabaseInstance();
-        db.begin();
-        try {
-          mutableBucket.appendSamples(timestamps, columnValues);
-          db.commit();
-        } catch (final Exception e) {
-          if (db.isTransactionActive())
-            db.rollback();
-          throw e instanceof IOException ? (IOException) e : new IOException("Failed to append timeseries samples", e);
-        }
-      } finally {
-        appendLock.unlock();
+        mutableBucket.appendSamples(timestamps, columnValues);
+      } catch (final Exception e) {
+        if (db.isTransactionActive())
+          db.rollback();
+        throw e instanceof IOException ? (IOException) e : new IOException("Failed to append timeseries samples", e);
+      }
+      // On Raft HA leaders, release the read lock BEFORE commit. See appendSamples() javadoc for
+      // why. In standalone (non-replicated) mode there is no waitForActiveRecordingSession()
+      // call in commit(), so no deadlock is possible and the read lock must be held through
+      // commit to protect Phase 4c from MVCC conflicts.
+      if (db.isReplicated()) {
+        compactionLock.readLock().unlock();
+        readLockHeld = false;
+      }
+      try {
+        db.commit();
+      } catch (final ConcurrentModificationException e) {
+        // Phase 4c committed a page-0 clear between the read-lock release and our commit (HA only).
+        // Roll back and retry on the freshly-cleared page.
+        if (db.isTransactionActive())
+          db.rollback();
+        if (retriesLeft > 0)
+          appendSamplesAttempt(retriesLeft - 1, timestamps, columnValues);
+        else
+          throw new IOException("Failed to append timeseries samples after compaction-race retries", e);
+      } catch (final Exception e) {
+        if (db.isTransactionActive())
+          db.rollback();
+        throw e instanceof IOException ? (IOException) e : new IOException("Failed to append timeseries samples", e);
       }
     } finally {
-      compactionLock.readLock().unlock();
+      if (readLockHeld)
+        compactionLock.readLock().unlock();
     }
   }
 
@@ -378,43 +403,58 @@ public class TimeSeriesShard implements AutoCloseable {
     final DatabaseInternal db = database.getWrappedDatabaseInstance();
 
     // ── Phase 0 (brief writeLock + brief TX): snapshot page count, set crash flag ─────────
-    // The write lock blocks concurrent appendSamples() so the TX modifying page-0 cannot
-    // get an MVCC conflict from a concurrent insert.
+    // Holds the write lock to block new appendSamples() calls. However, an in-flight append
+    // (one that released compactionLock.readLock() before its own commit, per the fix for
+    // issue #4458) may still be executing its DB-level commit concurrently. If that commit
+    // applies page-0 between Phase 0's begin and commit, Phase 0 gets a
+    // ConcurrentModificationException. A brief retry inside the same write lock ensures
+    // Phase 0 always sees the latest page-0 version and commits without conflict. Since
+    // appendLock serializes appends one at a time, at most one in-flight commit can be
+    // outstanding, so one retry is sufficient in practice; the loop uses 3 for safety.
     final int snapshotDataPageCount;
     compactionLock.writeLock().lock();
     try {
-      db.begin();
-      try {
-        final int pageCount = mutableBucket.getDataPageCount();
-        if (pageCount == 0) {
-          db.rollback();
-          return;
-        }
-
-        // HA safety valve (issue #4382): if the rewritten sealed store would be too large to ship
-        // inline in a single Raft entry, skip compaction entirely this cycle. The data stays in the
-        // mutable bucket, which IS fully replicated, so there is no divergence or data loss - just no
-        // sealing. The projected size over-estimates (raw mutable bytes are a ceiling on the
-        // compressed sealed delta), so we always stay safely under the transport cap.
-        if (db.isReplicated()) {
-          final long cap = database.getConfiguration().getValueAsLong(GlobalConfiguration.HA_TS_MAX_SEALED_INLINE_SIZE);
-          final long projected = sealedStore.getFileSizeBytes() + (long) pageCount * mutableBucket.getPageSize();
-          if (projected > cap) {
+      int phase0Retrieved = -1;
+      for (int attempt = 0; attempt < 3; attempt++) {
+        db.begin();
+        try {
+          final int pageCount = mutableBucket.getDataPageCount();
+          if (pageCount == 0) {
             db.rollback();
-            warnOversizedSealedSkip(projected, cap);
             return;
           }
-        }
 
-        snapshotDataPageCount = pageCount;
-        mutableBucket.setCompactionInProgress(true);
-        mutableBucket.setCompactionWatermark(initialBlockCount);
-        db.commit();
-      } catch (final Exception e) {
-        if (db.isTransactionActive())
-          db.rollback();
-        throw e instanceof IOException ? (IOException) e : new IOException("Compaction failed in phase 0", e);
+          // HA safety valve (issue #4382): if the rewritten sealed store would be too large to ship
+          // inline in a single Raft entry, skip compaction entirely this cycle.
+          if (db.isReplicated()) {
+            final long cap = database.getConfiguration().getValueAsLong(GlobalConfiguration.HA_TS_MAX_SEALED_INLINE_SIZE);
+            final long projected = sealedStore.getFileSizeBytes() + (long) pageCount * mutableBucket.getPageSize();
+            if (projected > cap) {
+              db.rollback();
+              warnOversizedSealedSkip(projected, cap);
+              return;
+            }
+          }
+
+          mutableBucket.setCompactionInProgress(true);
+          mutableBucket.setCompactionWatermark(initialBlockCount);
+          db.commit();
+          phase0Retrieved = pageCount;
+          break;
+        } catch (final ConcurrentModificationException e) {
+          if (db.isTransactionActive())
+            db.rollback();
+          if (attempt == 2)
+            throw new IOException("Compaction failed in phase 0 after retries", e);
+          // An in-flight append committed page-0 between begin and commit; retry with the
+          // latest version.
+        } catch (final Exception e) {
+          if (db.isTransactionActive())
+            db.rollback();
+          throw e instanceof IOException ? (IOException) e : new IOException("Compaction failed in phase 0", e);
+        }
       }
+      snapshotDataPageCount = phase0Retrieved;
     } finally {
       compactionLock.writeLock().unlock();
     }
@@ -529,6 +569,9 @@ public class TimeSeriesShard implements AutoCloseable {
     // ── Phase 4c (brief writeLock + brief TX): read tail pages, swap + clear ──────────────
     // Only pages created DURING Phase 4b need to be processed under the lock.  This is
     // typically just 0-2 pages worth of data, keeping the lock hold time minimal.
+    final Runnable prePhase4cHook = TEST_PRE_PHASE4C_HOOK;
+    if (prePhase4cHook != null)
+      prePhase4cHook.run();
     compactionLock.writeLock().lock();
     try {
       db.begin();

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
@@ -24,6 +24,7 @@ import com.arcadedb.engine.Component;
 import com.arcadedb.engine.timeseries.codec.DeltaOfDeltaCodec;
 import com.arcadedb.engine.timeseries.codec.DictionaryCodec;
 import com.arcadedb.engine.timeseries.codec.TimeSeriesCodec;
+import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.LocalSchema;
 
@@ -31,7 +32,6 @@ import java.io.IOException;
 import java.util.logging.Level;
 import java.util.ArrayList;
 import java.util.Arrays;
-import com.arcadedb.exception.ConcurrentModificationException;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -182,58 +182,56 @@ public class TimeSeriesShard implements AutoCloseable {
    * before, since there is no recording-session deadlock.
    */
   public void appendSamples(final long[] timestamps, final Object[]... columnValues) throws IOException {
-    appendLock.lock();
-    try {
-      appendSamplesAttempt(3, timestamps, columnValues);
-    } finally {
-      appendLock.unlock();
-    }
-  }
-
-  private void appendSamplesAttempt(final int retriesLeft, final long[] timestamps, final Object[]... columnValues)
-      throws IOException {
     // Route the append transaction through the HA wrapper so the mutable-bucket page writes are
     // shipped to followers via the Raft WAL (TX_ENTRY). On a standalone database,
     // getWrappedDatabaseInstance() returns the same instance.
     final DatabaseInternal db = database.getWrappedDatabaseInstance();
-    compactionLock.readLock().lock();
-    boolean readLockHeld = true;
+
+    appendLock.lock();
     try {
-      db.begin();
-      try {
-        mutableBucket.appendSamples(timestamps, columnValues);
-      } catch (final Exception e) {
-        if (db.isTransactionActive())
-          db.rollback();
-        throw e instanceof IOException ? (IOException) e : new IOException("Failed to append timeseries samples", e);
-      }
-      // On Raft HA leaders, release the read lock BEFORE commit. See appendSamples() javadoc for
-      // why. In standalone (non-replicated) mode there is no waitForActiveRecordingSession()
-      // call in commit(), so no deadlock is possible and the read lock must be held through
-      // commit to protect Phase 4c from MVCC conflicts.
-      if (db.isReplicated()) {
-        compactionLock.readLock().unlock();
-        readLockHeld = false;
-      }
-      try {
-        db.commit();
-      } catch (final ConcurrentModificationException e) {
-        // Phase 4c committed a page-0 clear between the read-lock release and our commit (HA only).
-        // Roll back and retry on the freshly-cleared page.
-        if (db.isTransactionActive())
-          db.rollback();
-        if (retriesLeft > 0)
-          appendSamplesAttempt(retriesLeft - 1, timestamps, columnValues);
-        else
-          throw new IOException("Failed to append timeseries samples after compaction-race retries", e);
-      } catch (final Exception e) {
-        if (db.isTransactionActive())
-          db.rollback();
-        throw e instanceof IOException ? (IOException) e : new IOException("Failed to append timeseries samples", e);
+      for (int attempt = 3; attempt > 0; attempt--) {
+        compactionLock.readLock().lock();
+        boolean readLockHeld = true;
+        try {
+          db.begin();
+          try {
+            mutableBucket.appendSamples(timestamps, columnValues);
+          } catch (final Exception e) {
+            if (db.isTransactionActive())
+              db.rollback();
+            throw e instanceof IOException ? (IOException) e : new IOException("Failed to append timeseries samples", e);
+          }
+          // On Raft HA leaders, release the read lock BEFORE commit. See appendSamples() javadoc for
+          // why. In standalone (non-replicated) mode there is no waitForActiveRecordingSession()
+          // call in commit(), so no deadlock is possible and the read lock must be held through
+          // commit to protect Phase 4c from MVCC conflicts.
+          if (db.isReplicated()) {
+            compactionLock.readLock().unlock();
+            readLockHeld = false;
+          }
+          try {
+            db.commit();
+            return; // success
+          } catch (final ConcurrentModificationException e) {
+            // Phase 4c committed a page-0 clear between the read-lock release and our commit (HA only).
+            // Roll back and retry on the freshly-cleared page.
+            if (db.isTransactionActive())
+              db.rollback();
+            if (attempt == 1)
+              throw new IOException("Failed to append timeseries samples after compaction-race retries", e);
+            // else loop again
+          } catch (final Exception e) {
+            if (db.isTransactionActive())
+              db.rollback();
+            throw e instanceof IOException ? (IOException) e : new IOException("Failed to append timeseries samples", e);
+          }
+        } finally {
+          if (readLockHeld)
+            compactionLock.readLock().unlock();
+        }
       }
     } finally {
-      if (readLockHeld)
-        compactionLock.readLock().unlock();
+      appendLock.unlock();
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesShard.java
@@ -80,6 +80,9 @@ public class TimeSeriesShard implements AutoCloseable {
   /**
    * Test-only hook. When non-null, fires in {@link #compactInternal()} immediately before Phase 4c
    * acquires the write lock. Used to race concurrent appends against Phase 4c deterministically.
+   * <p>
+   * Tests that set this MUST reset it to {@code null} in an {@code @AfterEach} method, otherwise
+   * it leaks into subsequent tests in the same JVM and silently alters their compaction timing.
    */
   public static volatile Runnable TEST_PRE_PHASE4C_HOOK = null;
 
@@ -219,6 +222,9 @@ public class TimeSeriesShard implements AutoCloseable {
               db.rollback();
             if (attempt == 1)
               throw new IOException("Failed to append timeseries samples after compaction-race retries", e);
+            LogManager.instance().log(this, Level.FINE,
+                "CME on TimeSeries append for shard %d (attempt %d/3) - retrying after compaction Phase 4c race",
+                shardIndex, 4 - attempt);
             // else loop again
           } catch (final Exception e) {
             if (db.isTransactionActive())
@@ -413,7 +419,8 @@ public class TimeSeriesShard implements AutoCloseable {
     compactionLock.writeLock().lock();
     try {
       int phase0Retrieved = -1;
-      for (int attempt = 0; attempt < 3; attempt++) {
+      // Count down to mirror the retry convention used in appendSamples().
+      for (int attempt = 3; attempt > 0; attempt--) {
         db.begin();
         try {
           final int pageCount = mutableBucket.getDataPageCount();
@@ -442,7 +449,7 @@ public class TimeSeriesShard implements AutoCloseable {
         } catch (final ConcurrentModificationException e) {
           if (db.isTransactionActive())
             db.rollback();
-          if (attempt == 2)
+          if (attempt == 1)
             throw new IOException("Compaction failed in phase 0 after retries", e);
           // An in-flight append committed page-0 between begin and commit; retry with the
           // latest version.
@@ -452,6 +459,9 @@ public class TimeSeriesShard implements AutoCloseable {
           throw e instanceof IOException ? (IOException) e : new IOException("Compaction failed in phase 0", e);
         }
       }
+      // Every loop iteration that does not break either returns or throws, so a successful
+      // exit always sets phase0Retrieved to the snapshot page count. Make the invariant explicit.
+      assert phase0Retrieved >= 0 : "Phase 0 exited the retry loop without a valid page count";
       snapshotDataPageCount = phase0Retrieved;
     } finally {
       compactionLock.writeLock().unlock();

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue4458AppendCompactionRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue4458AppendCompactionRaceTest.java
@@ -30,7 +30,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -87,9 +86,8 @@ class Issue4458AppendCompactionRaceTest extends TestHelper {
       }
     };
 
-    final List<Throwable> errors     = new ArrayList<>();
-    final AtomicInteger   committed  = new AtomicInteger();
-    final ExecutorService executor   = Executors.newFixedThreadPool(appendThreads + 1);
+    final List<Throwable> errors = new ArrayList<>();
+    final ExecutorService executor = Executors.newFixedThreadPool(appendThreads + 1);
 
     // Append threads: wait for the hook to fire, then insert as fast as possible.
     for (int t = 0; t < appendThreads; t++) {
@@ -109,7 +107,6 @@ class Issue4458AppendCompactionRaceTest extends TestHelper {
           try {
             database.transaction(() ->
                 database.command("sql", "INSERT INTO sensor SET ts = ?, v = ?", ts, val));
-            committed.incrementAndGet();
           } catch (final Throwable e) {
             synchronized (errors) {
               errors.add(e);

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue4458AppendCompactionRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue4458AppendCompactionRaceTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4458: concurrent appends must not lose samples when they race
+ * against compaction Phase 4c. The fix releases {@code compactionLock.readLock()} before
+ * {@code db.commit()} so Phase 4c is never deadlocked by an in-flight append transaction.
+ * A {@code ConcurrentModificationException} from Phase 4c committing between the lock release
+ * and the append commit is handled by a transparent retry, preserving all data.
+ */
+@Tag("slow")
+class Issue4458AppendCompactionRaceTest extends TestHelper {
+
+  @AfterEach
+  void cleanupHook() {
+    TimeSeriesShard.TEST_PRE_PHASE4C_HOOK = null;
+  }
+
+  @Test
+  void concurrentAppendsRacingPhase4cRetainAllSamples() throws Exception {
+    database.command("sql",
+        "CREATE TIMESERIES TYPE sensor TIMESTAMP ts FIELDS (v DOUBLE) SHARDS 1");
+
+    // Insert enough initial data to make compaction non-trivial.
+    for (int i = 0; i < 300; i++) {
+      final long ts = i;
+      database.transaction(() ->
+          database.command("sql", "INSERT INTO sensor SET ts = ?, v = ?", ts, (double) ts));
+    }
+
+    final int appendThreads  = 8;
+    final int appendsPerThread = 200;
+    final int initialCount   = 300;
+    final int expectedTotal  = initialCount + appendThreads * appendsPerThread;
+
+    // Latch: fired when TEST_PRE_PHASE4C_HOOK runs, signalling append threads to start.
+    final CountDownLatch hookFired   = new CountDownLatch(1);
+    // Latch: fired when all append threads have submitted their first INSERT, signalling
+    // the hook to proceed (ensuring appends are in-flight before Phase 4c runs).
+    final CountDownLatch appendsBusy = new CountDownLatch(appendThreads);
+
+    TimeSeriesShard.TEST_PRE_PHASE4C_HOOK = () -> {
+      hookFired.countDown();
+      // Wait briefly so append threads have time to begin their transactions and
+      // reach the commit/readLock-release point, maximising the CME-race window.
+      try {
+        appendsBusy.await(10, TimeUnit.SECONDS);
+        Thread.sleep(50);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    };
+
+    final List<Throwable> errors     = new ArrayList<>();
+    final AtomicInteger   committed  = new AtomicInteger();
+    final ExecutorService executor   = Executors.newFixedThreadPool(appendThreads + 1);
+
+    // Append threads: wait for the hook to fire, then insert as fast as possible.
+    for (int t = 0; t < appendThreads; t++) {
+      final int ti = t;
+      executor.submit(() -> {
+        try {
+          hookFired.await(30, TimeUnit.SECONDS);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return;
+        }
+        final long base = 1_000_000L + (long) ti * 100_000L;
+        for (int i = 0; i < appendsPerThread; i++) {
+          final long ts = base + i;
+          final double val = i;
+          try {
+            appendsBusy.countDown(); // signal we're running (idempotent after first)
+            database.transaction(() ->
+                database.command("sql", "INSERT INTO sensor SET ts = ?, v = ?", ts, val));
+            committed.incrementAndGet();
+          } catch (final Throwable e) {
+            synchronized (errors) {
+              errors.add(e);
+            }
+          }
+        }
+      });
+    }
+
+    // Compaction thread: triggers while append threads are racing.
+    executor.submit(() -> {
+      try {
+        ((LocalTimeSeriesType) database.getSchema().getType("sensor")).getEngine().compactAll();
+      } catch (final Throwable e) {
+        synchronized (errors) {
+          errors.add(e);
+        }
+      }
+    });
+
+    executor.shutdown();
+    assertThat(executor.awaitTermination(2, TimeUnit.MINUTES))
+        .as("all tasks complete within timeout").isTrue();
+
+    assertThat(errors)
+        .as("no errors during concurrent append+compaction: %s", errors).isEmpty();
+
+    final long actualCount = ((Number) database.command("sql", "SELECT count(*) AS cnt FROM sensor")
+        .next().getProperty("cnt")).longValue();
+    assertThat(actualCount)
+        .as("all %d samples (initial + concurrent) present after compaction race", expectedTotal)
+        .isEqualTo(expectedTotal);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue4458AppendCompactionRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue4458AppendCompactionRaceTest.java
@@ -36,10 +36,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Regression test for issue #4458: concurrent appends must not lose samples when they race
- * against compaction Phase 4c. The fix releases {@code compactionLock.readLock()} before
- * {@code db.commit()} so Phase 4c is never deadlocked by an in-flight append transaction.
- * A {@code ConcurrentModificationException} from Phase 4c committing between the lock release
- * and the append commit is handled by a transparent retry, preserving all data.
+ * against compaction Phase 4c on an embedded (standalone) database.
+ * <p>
+ * NOTE: in standalone mode {@code appendSamples()} holds {@code compactionLock.readLock()} through
+ * {@code db.commit()} (the {@code db.isReplicated()} early-release branch is not taken), so the
+ * HA-only CME-retry path is NOT exercised here. This test verifies that the standalone locking
+ * path remains correct - concurrent appends + compaction lose no data. The actual CME-retry path
+ * introduced by the fix is covered by the HA integration test {@code Issue4458TsWalVersionGapIT}.
  */
 @Tag("slow")
 class Issue4458AppendCompactionRaceTest extends TestHelper {
@@ -98,12 +101,12 @@ class Issue4458AppendCompactionRaceTest extends TestHelper {
           Thread.currentThread().interrupt();
           return;
         }
+        appendsBusy.countDown(); // signal this thread is running
         final long base = 1_000_000L + (long) ti * 100_000L;
         for (int i = 0; i < appendsPerThread; i++) {
           final long ts = base + i;
           final double val = i;
           try {
-            appendsBusy.countDown(); // signal we're running (idempotent after first)
             database.transaction(() ->
                 database.command("sql", "INSERT INTO sensor SET ts = ?, v = ?", ts, val));
             committed.incrementAndGet();

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue4458AppendCompactionRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue4458AppendCompactionRaceTest.java
@@ -63,23 +63,24 @@ class Issue4458AppendCompactionRaceTest extends TestHelper {
           database.command("sql", "INSERT INTO sensor SET ts = ?, v = ?", ts, (double) ts));
     }
 
-    final int appendThreads  = 8;
+    final int appendThreads = 8;
     final int appendsPerThread = 200;
-    final int initialCount   = 300;
-    final int expectedTotal  = initialCount + appendThreads * appendsPerThread;
+    final int initialCount = 300;
+    final int expectedTotal = initialCount + appendThreads * appendsPerThread;
 
     // Latch: fired when TEST_PRE_PHASE4C_HOOK runs, signalling append threads to start.
-    final CountDownLatch hookFired   = new CountDownLatch(1);
-    // Latch: fired when all append threads have submitted their first INSERT, signalling
-    // the hook to proceed (ensuring appends are in-flight before Phase 4c runs).
-    final CountDownLatch appendsBusy = new CountDownLatch(appendThreads);
+    final CountDownLatch hookFired = new CountDownLatch(1);
+    // Latch: each append thread counts this down from INSIDE its first transaction (after the
+    // append write, before commit), so when the hook proceeds the threads are guaranteed to have
+    // an open transaction in flight - not merely scheduled - maximising the append/compaction
+    // overlap regardless of CI runner scheduling latency.
+    final CountDownLatch appendsInFlight = new CountDownLatch(appendThreads);
 
     TimeSeriesShard.TEST_PRE_PHASE4C_HOOK = () -> {
       hookFired.countDown();
-      // Wait briefly so append threads have time to begin their transactions and
-      // reach the commit/readLock-release point, maximising the CME-race window.
+      // Wait until append threads actually have a transaction in flight, then let Phase 4c run.
       try {
-        appendsBusy.await(10, TimeUnit.SECONDS);
+        appendsInFlight.await(10, TimeUnit.SECONDS);
         Thread.sleep(50);
       } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();
@@ -99,14 +100,18 @@ class Issue4458AppendCompactionRaceTest extends TestHelper {
           Thread.currentThread().interrupt();
           return;
         }
-        appendsBusy.countDown(); // signal this thread is running
         final long base = 1_000_000L + (long) ti * 100_000L;
         for (int i = 0; i < appendsPerThread; i++) {
           final long ts = base + i;
           final double val = i;
+          final boolean firstInsert = i == 0;
           try {
-            database.transaction(() ->
-                database.command("sql", "INSERT INTO sensor SET ts = ?, v = ?", ts, val));
+            database.transaction(() -> {
+              database.command("sql", "INSERT INTO sensor SET ts = ?, v = ?", ts, val);
+              // Signal in-flight status from within the transaction, before it commits.
+              if (firstInsert)
+                appendsInFlight.countDown();
+            });
           } catch (final Throwable e) {
             synchronized (errors) {
               errors.add(e);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -99,6 +99,9 @@ public class ArcadeStateMachine extends BaseStateMachine {
   /**
    * Test-only WAL gap counter. When non-null, incremented each time a follower detects a
    * WAL page-version gap. Used by deterministic tests to verify no gap occurred.
+   * <p>
+   * Tests that set this MUST reset it to {@code null} in an {@code @AfterEach} method, otherwise
+   * it leaks into subsequent tests in the same JVM.
    */
   public static volatile AtomicInteger TEST_WAL_GAP_COUNTER = null;
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -65,6 +65,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 
@@ -94,6 +95,12 @@ import java.util.logging.Level;
  * interrupted by a process crash.
  */
 public class ArcadeStateMachine extends BaseStateMachine {
+
+  /**
+   * Test-only WAL gap counter. When non-null, incremented each time a follower detects a
+   * WAL page-version gap. Used by deterministic tests to verify no gap occurred.
+   */
+  public static volatile AtomicInteger TEST_WAL_GAP_COUNTER = null;
 
   private final    SimpleStateMachineStorage storage          = new SimpleStateMachineStorage();
   private final    AtomicLong                lastAppliedIndex = new AtomicLong(-1);
@@ -577,6 +584,9 @@ public class ArcadeStateMachine extends BaseStateMachine {
     } catch (final WALVersionGapException e) {
       // Version gap: WAL page version > DB page version + 1 - an intermediate transaction
       // was never applied on this node. State has diverged; trigger snapshot resync.
+      final AtomicInteger gapCounter = TEST_WAL_GAP_COUNTER;
+      if (gapCounter != null)
+        gapCounter.incrementAndGet();
       LogManager.instance().log(this, Level.SEVERE,
           "WAL version gap on follower - state divergence detected, triggering snapshot resync (db=%s, txId=%d): %s",
           decoded.databaseName(), walTx.txId, e.getMessage());

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -144,6 +144,13 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    */
   static volatile Consumer<String> TEST_POST_REPLICATION_HOOK = null;
 
+  /**
+   * Test-only hook. Fires in {@link #runWithCompactionReplication} just before {@code replicateSchema()}
+   * is called. Used to inject delays and verify that concurrent appends correctly wait for the
+   * recording session to end rather than timing out and shipping TX_ENTRY before the SCHEMA_ENTRY.
+   */
+  static volatile Consumer<String> TEST_PRE_REPLICATE_SCHEMA_HOOK = null;
+
   public record ReadConsistencyContext(Database.READ_CONSISTENCY consistency, long readAfterIndex) {
   }
 
@@ -1238,6 +1245,10 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
 
       if (addFiles.isEmpty() && removeFiles.isEmpty() && walEntries.isEmpty() && sealedBlobs.isEmpty())
         return result;
+
+      final Consumer<String> preReplicateHook = TEST_PRE_REPLICATE_SCHEMA_HOOK;
+      if (preReplicateHook != null)
+        preReplicateHook.accept(getName());
 
       final String serializedSchema = proxied.getSchema().getEmbedded().toJSON().toString();
       requireRaftServer().getTransactionBroker()

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -1277,6 +1277,12 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * {@link GlobalConfiguration#HA_QUORUM_TIMEOUT} so we never deadlock if a recorder thread
    * crashed without releasing the session; on timeout we proceed with the original ordering
    * race rather than locking up writes indefinitely.
+   * <p>
+   * Note: the TimeSeries compaction/append deadlock (issue #4458) is fixed at the source -
+   * {@code TimeSeriesShard.appendSamples} no longer holds the compaction read lock while calling
+   * this method, so Phase 4c can complete and end the recording session promptly. This timeout
+   * remains as a defensive safety net for any other recorder thread that crashes mid-session; it
+   * is intentionally retained, not dead code.
    */
   private void waitForActiveRecordingSession() {
     if (proxied.getFileManager().getRecordedChanges() == null)

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -144,13 +144,6 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    */
   static volatile Consumer<String> TEST_POST_REPLICATION_HOOK = null;
 
-  /**
-   * Test-only hook. Fires in {@link #runWithCompactionReplication} just before {@code replicateSchema()}
-   * is called. Used to inject delays and verify that concurrent appends correctly wait for the
-   * recording session to end rather than timing out and shipping TX_ENTRY before the SCHEMA_ENTRY.
-   */
-  static volatile Consumer<String> TEST_PRE_REPLICATE_SCHEMA_HOOK = null;
-
   public record ReadConsistencyContext(Database.READ_CONSISTENCY consistency, long readAfterIndex) {
   }
 
@@ -1245,10 +1238,6 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
 
       if (addFiles.isEmpty() && removeFiles.isEmpty() && walEntries.isEmpty() && sealedBlobs.isEmpty())
         return result;
-
-      final Consumer<String> preReplicateHook = TEST_PRE_REPLICATE_SCHEMA_HOOK;
-      if (preReplicateHook != null)
-        preReplicateHook.accept(getName());
 
       final String serializedSchema = proxied.getSchema().getEmbedded().toJSON().toString();
       requireRaftServer().getTransactionBroker()

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4458TsWalVersionGapIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4458TsWalVersionGapIT.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.engine.timeseries.TimeSeriesShard;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4458: WAL page-version gap on TimeSeries shard page-0 when
+ * compaction Phase 4c races with concurrent Raft-replicated appends.
+ * <p>
+ * The root cause was that {@code appendSamples()} held {@code compactionLock.readLock()} through
+ * {@code db.commit()}. On the leader, {@code commit()} calls {@code waitForActiveRecordingSession()}
+ * which waits for the compaction recording session to end. The session ends only after Phase 4c
+ * (which needs the write lock), but Phase 4c cannot acquire the write lock while any thread holds
+ * the read lock - a deadlock resolved only by {@code waitForActiveRecordingSession()}'s timeout.
+ * When the timeout fires, the append ships its {@code TX_ENTRY} before the buffered
+ * {@code SCHEMA_ENTRY}, causing a WAL page-version gap on the follower.
+ * <p>
+ * The fix releases the read lock before {@code commit()}. This test uses
+ * {@link TimeSeriesShard#TEST_PRE_PHASE4C_HOOK} to inject a brief delay just before Phase 4c
+ * acquires the write lock. During this delay, append threads start and reach
+ * {@code waitForActiveRecordingSession()} (where they wait without holding the read lock).
+ * Phase 4c then runs unblocked, {@code replicateSchema()} ships the {@code SCHEMA_ENTRY},
+ * the session ends, and appends ship their {@code TX_ENTRY} afterward - in the correct order.
+ */
+@Tag("slow")
+class Issue4458TsWalVersionGapIT extends BaseRaftHATest {
+
+  @Override
+  protected int getServerCount() {
+    return 2;
+  }
+
+  @AfterEach
+  void cleanupHooks() {
+    TimeSeriesShard.TEST_PRE_PHASE4C_HOOK = null;
+    RaftReplicatedDatabase.TEST_PRE_REPLICATE_SCHEMA_HOOK = null;
+    ArcadeStateMachine.TEST_WAL_GAP_COUNTER = null;
+  }
+
+  @Test
+  void noWalVersionGapWhenAppendsRacePhase4c() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("leader elected").isGreaterThanOrEqualTo(0);
+
+    final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+    leaderDb.command("sql",
+        "CREATE TIMESERIES TYPE sensor TIMESTAMP ts FIELDS (v DOUBLE) SHARDS 1");
+    waitForAllServers();
+
+    // Insert initial data so the shard has enough to compact.
+    for (int i = 0; i < 250; i++) {
+      final long ts = i;
+      leaderDb.command("sql", "INSERT INTO sensor SET ts = ?, v = ?", ts, (double) i);
+    }
+
+    // Install WAL gap counter before starting the race.
+    ArcadeStateMachine.TEST_WAL_GAP_COUNTER = new AtomicInteger(0);
+
+    final int appendThreads    = 4;
+    final int appendsPerThread = 60;
+
+    // The hook fires just before Phase 4c acquires the write lock.
+    // Append threads wait for the hook signal, then start sending INSERTs.
+    // A brief sleep in the hook gives the append threads time to reach their
+    // waitForActiveRecordingSession() call (where they wait without holding the read lock).
+    // Phase 4c then proceeds unblocked - if the fix is correct, no timeout fires.
+    final CountDownLatch hookFired = new CountDownLatch(1);
+
+    TimeSeriesShard.TEST_PRE_PHASE4C_HOOK = () -> {
+      hookFired.countDown();
+      // Sleep long enough for append threads to reach waitForActiveRecordingSession().
+      // They will block there (recording session is active) without holding the read lock,
+      // allowing Phase 4c to acquire the write lock immediately after this sleep.
+      try {
+        Thread.sleep(200);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    };
+
+    final List<Throwable> errors  = new ArrayList<>();
+    final ExecutorService exec    = Executors.newFixedThreadPool(appendThreads + 1);
+
+    for (int t = 0; t < appendThreads; t++) {
+      final int ti = t;
+      exec.submit(() -> {
+        try {
+          // Wait until Phase 4c is imminent, then flood concurrent INSERTs.
+          // These INSERTs will reach waitForActiveRecordingSession() and wait
+          // there (without the compaction read lock) until the session ends.
+          hookFired.await(30, TimeUnit.SECONDS);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return;
+        }
+        final long base = 1_000_000L + (long) ti * 100_000L;
+        for (int i = 0; i < appendsPerThread; i++) {
+          final long ts  = base + i;
+          final double v = i;
+          try {
+            leaderDb.command("sql", "INSERT INTO sensor SET ts = ?, v = ?", ts, v);
+          } catch (final Exception e) {
+            synchronized (errors) {
+              errors.add(e);
+            }
+          }
+        }
+      });
+    }
+
+    // Compaction thread: triggers Phase 0, 1, 2, 3, 4a, 4b, hook, Phase 4c.
+    exec.submit(() -> {
+      try {
+        ((LocalTimeSeriesType) leaderDb.getSchema().getType("sensor")).getEngine().compactAll();
+      } catch (final Throwable e) {
+        synchronized (errors) {
+          errors.add(e);
+        }
+      }
+    });
+
+    exec.shutdown();
+    assertThat(exec.awaitTermination(3, TimeUnit.MINUTES))
+        .as("all tasks complete within timeout").isTrue();
+
+    assertThat(errors)
+        .as("no ingest errors during compaction race: %s", errors).isEmpty();
+
+    // The critical assertion: no WAL version gap on the follower.
+    final AtomicInteger gapCounter = ArcadeStateMachine.TEST_WAL_GAP_COUNTER;
+    assertThat(gapCounter.get())
+        .as("follower must see zero WAL version gaps during compaction race").isZero();
+
+    // Data-integrity: both nodes must converge to the same count.
+    final long leaderCount = ((Number) leaderDb.command("sql", "SELECT count(*) AS cnt FROM sensor")
+        .next().getProperty("cnt")).longValue();
+    final int followerIndex = 1 - leaderIndex;
+    final Database followerDb = getServerDatabase(followerIndex, getDatabaseName());
+    final long deadline = System.currentTimeMillis() + 30_000;
+    long followerCount = -1;
+    while (System.currentTimeMillis() < deadline) {
+      followerCount = ((Number) followerDb.command("sql", "SELECT count(*) AS cnt FROM sensor")
+          .next().getProperty("cnt")).longValue();
+      if (followerCount == leaderCount)
+        break;
+      Thread.sleep(500);
+    }
+    assertThat(followerCount)
+        .as("follower converges to leader count after compaction race").isEqualTo(leaderCount);
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4458TsWalVersionGapIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4458TsWalVersionGapIT.java
@@ -162,9 +162,14 @@ class Issue4458TsWalVersionGapIT extends BaseRaftHATest {
     assertThat(gapCounter.get())
         .as("follower must see zero WAL version gaps during compaction race").isZero();
 
-    // Data-integrity: both nodes must converge to the same count.
+    // Data-integrity: the leader must not have lost samples, and both nodes must converge to the
+    // same count. The lower-bound check guards against the degenerate case where the leader itself
+    // dropped data (e.g. retry exhaustion) and the follower merely agrees on the lower count.
+    final long expectedMinimum = 250L + (long) appendThreads * appendsPerThread;
     final long leaderCount = ((Number) leaderDb.command("sql", "SELECT count(*) AS cnt FROM sensor")
         .next().getProperty("cnt")).longValue();
+    assertThat(leaderCount)
+        .as("no samples lost on the leader during the compaction race").isEqualTo(expectedMinimum);
     final int followerIndex = 1 - leaderIndex;
     final Database followerDb = getServerDatabase(followerIndex, getDatabaseName());
     final long deadline = System.currentTimeMillis() + 30_000;

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4458TsWalVersionGapIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4458TsWalVersionGapIT.java
@@ -65,7 +65,6 @@ class Issue4458TsWalVersionGapIT extends BaseRaftHATest {
   @AfterEach
   void cleanupHooks() {
     TimeSeriesShard.TEST_PRE_PHASE4C_HOOK = null;
-    RaftReplicatedDatabase.TEST_PRE_REPLICATE_SCHEMA_HOOK = null;
     ArcadeStateMachine.TEST_WAL_GAP_COUNTER = null;
   }
 

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4458TsWalVersionGapIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4458TsWalVersionGapIT.java
@@ -87,7 +87,7 @@ class Issue4458TsWalVersionGapIT extends BaseRaftHATest {
     // Install WAL gap counter before starting the race.
     ArcadeStateMachine.TEST_WAL_GAP_COUNTER = new AtomicInteger(0);
 
-    final int appendThreads    = 4;
+    final int appendThreads = 4;
     final int appendsPerThread = 60;
 
     // The hook fires just before Phase 4c acquires the write lock.
@@ -109,8 +109,8 @@ class Issue4458TsWalVersionGapIT extends BaseRaftHATest {
       }
     };
 
-    final List<Throwable> errors  = new ArrayList<>();
-    final ExecutorService exec    = Executors.newFixedThreadPool(appendThreads + 1);
+    final List<Throwable> errors = new ArrayList<>();
+    final ExecutorService exec = Executors.newFixedThreadPool(appendThreads + 1);
 
     for (int t = 0; t < appendThreads; t++) {
       final int ti = t;
@@ -126,7 +126,7 @@ class Issue4458TsWalVersionGapIT extends BaseRaftHATest {
         }
         final long base = 1_000_000L + (long) ti * 100_000L;
         for (int i = 0; i < appendsPerThread; i++) {
-          final long ts  = base + i;
+          final long ts = base + i;
           final double v = i;
           try {
             leaderDb.command("sql", "INSERT INTO sensor SET ts = ?, v = ?", ts, v);


### PR DESCRIPTION
Closes #4458

## Summary

On Raft HA leaders, `appendSamples()` held `compactionLock.readLock()` through `db.commit()`. `db.commit()` calls `waitForActiveRecordingSession()`, which spins until the compaction recording session ends. The session ends only after Phase 4c (which needs `compactionLock.writeLock()`), but Phase 4c cannot acquire the write lock while any thread holds the read lock — a deadlock broken only by `HA_QUORUM_TIMEOUT`. When that timeout fired, `TX_ENTRY` shipped before the buffered `SCHEMA_ENTRY`, causing `WALVersionGapException` on the follower and forcing a snapshot resync.

**Fix**: on replicated databases, release `compactionLock.readLock()` before `db.commit()` so Phase 4c can always acquire the write lock without deadlock. If Phase 4c commits a page-0 clear between the lock release and the commit, the append gets a `ConcurrentModificationException` and retries transparently on the freshly-cleared page (at most 3 retries). Phase 0 also gains a CME retry loop to handle in-flight append commits. Standalone databases keep the original locking (read lock through commit) since they have no recording-session deadlock.

**Files changed**:
- `engine/.../TimeSeriesShard.java`: serialize via `appendLock` first; on replicated DBs release `compactionLock.readLock()` before commit with a CME retry loop; add a Phase 0 CME retry loop; add `TEST_PRE_PHASE4C_HOOK` for deterministic testing
- `ha-raft/.../ArcadeStateMachine.java`: add `TEST_WAL_GAP_COUNTER` for deterministic testing

## Test plan

- [x] `Issue4458AppendCompactionRaceTest` (engine, embedded) - regression guard for concurrent appends + compaction on the standalone path (Javadoc notes the HA-only CME-retry path is exercised by the HA test below)
- [x] `Issue4458TsWalVersionGapIT` (ha-raft) - 2-node Raft HA, uses `TEST_PRE_PHASE4C_HOOK` to race appends against Phase 4c deterministically, verifies `TEST_WAL_GAP_COUNTER == 0` on the follower
- [x] Full `TimeSeries*` engine suite (173 tests) - no regressions
- [x] `TimeSeriesConcurrentInsertTest` (48-thread concurrent insert + auto-compaction) - passes
- [x] `TimeSeriesGrpcHaConcurrentInsertIT` (existing 3-thread gRPC HA smoke test) - passes