### PR TITLE
fix(#4451): configurable server log directory for read-only root filesystems

### DIFF
--- a/docs/4451-configurable-log-directory.md
+++ b/docs/4451-configurable-log-directory.md
@@ -1,0 +1,68 @@
+# Issue #4451 - Configurable Server Log Directory
+
+## Goal
+
+Allow the server's file-log directory to be configured via
+`arcadedb.server.logsDirectory` (or the `ARCADEDB_LOG_DIR` environment variable),
+enabling Kubernetes deployments with `readOnlyRootFilesystem` to write logs to a
+writable mount instead of crashing on a read-only working directory.
+
+## Problem
+
+The packaged `arcadedb-log.properties` hardcodes the JUL FileHandler pattern as
+`./log/arcadedb.log`. The Java logging framework resolves that path relative to the
+process working directory the first time any log call fires - which happens during
+`GlobalConfiguration` static initialization, before the server root path is even set.
+On a read-only root filesystem the working directory is not writable, so JUL fails to
+open the log file:
+
+```
+java.nio.file.FileSystemException: ./log/arcadedb.log.0.lck: Read-only file system
+```
+
+The directory cannot simply be tied to `arcadedb.server.rootPath`, because that value
+is still unset at the moment logging initializes. It must be resolvable from the
+environment alone.
+
+## Solution
+
+Resolve `${...}` placeholders in the FileHandler pattern inside `DefaultLogger` - the
+one place ArcadeDB controls the configuration stream before handing it to JUL - using
+the existing `SystemVariableResolver` (system property, then environment variable, then
+`GlobalConfiguration`), defaulting to `./log` so existing behavior is unchanged.
+
+The packaged pattern becomes:
+`java.util.logging.FileHandler.pattern=${arcadedb.server.logsDirectory}/arcadedb.log`
+
+Resolution is applied both when pre-creating the log directory and in the pattern handed
+to JUL, so the two agree. A pattern with no placeholder (e.g. an absolute literal path) is
+returned unchanged.
+
+Operators relocate the log directory by setting the environment variable:
+`ARCADEDB_LOG_DIR=/var/lib/arcadedb/log` (the launch scripts forward it as
+`-Darcadedb.server.logsDirectory=...`), or by setting the system property directly.
+When unset, logs default to `./log`, identical to prior releases.
+
+## Affected Files
+
+- `engine/src/main/java/com/arcadedb/log/DefaultLogger.java` - `resolveConfigurableLogDir` helper, wired into `createLogDirectoryFromConfig()` and `installCustomFormatter()`
+- `engine/src/main/java/com/arcadedb/GlobalConfiguration.java` - new `SERVER_LOGS_DIRECTORY` config entry (`arcadedb.server.logsDirectory`, default `./log`)
+- `engine/src/test/java/com/arcadedb/LoggerTest.java` - placeholder resolution + integration regression tests
+- `engine/src/test/java/com/arcadedb/GlobalConfigurationTest.java` - config entry test
+- `package/src/main/config/arcadedb-log.properties` - FileHandler pattern uses the placeholder
+- `package/src/main/scripts/server.sh`, `package/src/main/scripts/server.bat` - forward `ARCADEDB_LOG_DIR`
+
+## Verification
+
+- `LoggerTest` (8 tests) and `GlobalConfigurationTest` (10 tests): all PASS. Includes the
+  issue-#3732 regression tests, which prove literal patterns (the default `./log` behavior)
+  are unchanged.
+- Read-only-CWD smoke test against the real packaged `arcadedb-log.properties`: with a
+  read-only `./log` in the working directory and `arcadedb.server.logsDirectory` pointing at
+  a writable directory, the server logs to the writable directory, leaves `./log` untouched,
+  and does not throw the `Read-only file system` exception.
+
+## Backward Compatibility
+
+The default remains `./log`, so single-host and standard Docker deployments (where the
+working directory is writable) behave exactly as before. The change is additive.

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -550,6 +550,7 @@ public enum GlobalConfiguration {
       "Root path in the file system where the server is looking for files. By default is the current directory", String.class,
       null),
 
+  // Default must stay in sync with DefaultLogger.DEFAULT_LOG_DIR so the resolver fallback and the config default agree.
   SERVER_LOGS_DIRECTORY("arcadedb.server.logsDirectory", SCOPE.JVM,
       "Directory where the server writes log files, referenced as ${arcadedb.server.logsDirectory} in arcadedb-log.properties. Defaults to './log'; set to an absolute writable path for read-only root filesystems.",
       String.class, "./log"),

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -550,6 +550,10 @@ public enum GlobalConfiguration {
       "Root path in the file system where the server is looking for files. By default is the current directory", String.class,
       null),
 
+  SERVER_LOGS_DIRECTORY("arcadedb.server.logsDirectory", SCOPE.JVM,
+      "Directory where the server writes log files, referenced as ${arcadedb.server.logsDirectory} in arcadedb-log.properties. Defaults to './log'; set to an absolute writable path for read-only root filesystems.",
+      String.class, "./log"),
+
   SERVER_DATABASE_DIRECTORY("arcadedb.server.databaseDirectory", SCOPE.JVM, "Directory containing the database", String.class,
       "${arcadedb.server.rootPath}/databases"),
 

--- a/engine/src/main/java/com/arcadedb/log/DefaultLogger.java
+++ b/engine/src/main/java/com/arcadedb/log/DefaultLogger.java
@@ -45,7 +45,9 @@ public class DefaultLogger implements Logger {
   private static final String DEFAULT_LOG                  = "com.arcadedb";
   private static final String ENV_INSTALL_CUSTOM_FORMATTER = "arcadedb.installCustomFormatter";
   private static final String FILE_LOG_PROPERTIES          = "arcadedb-log.properties";
-  // Must stay in sync with the default of GlobalConfiguration.SERVER_LOGS_DIRECTORY (arcadedb.server.logsDirectory).
+  // Fallback when ${arcadedb.server.logsDirectory} cannot be resolved (e.g. the first log fires during
+  // GlobalConfiguration's own static init, before its values are queryable). Must stay in sync with the
+  // default of GlobalConfiguration.SERVER_LOGS_DIRECTORY.
   private static final String DEFAULT_LOG_DIR              = "./log";
 
   /**

--- a/engine/src/main/java/com/arcadedb/log/DefaultLogger.java
+++ b/engine/src/main/java/com/arcadedb/log/DefaultLogger.java
@@ -43,6 +43,7 @@ public class DefaultLogger implements Logger {
   private static final String DEFAULT_LOG                  = "com.arcadedb";
   private static final String ENV_INSTALL_CUSTOM_FORMATTER = "arcadedb.installCustomFormatter";
   private static final String FILE_LOG_PROPERTIES          = "arcadedb-log.properties";
+  private static final String DEFAULT_LOG_DIR              = "./log";
 
   /**
    * Static so that a second {@link DefaultLogger} instance installed via
@@ -105,6 +106,18 @@ public class DefaultLogger implements Logger {
     createLogDirectoryFromConfig();
 
     installCustomFormatter();
+  }
+
+  /**
+   * Resolves ${...} system-property / environment-variable placeholders in a JUL FileHandler
+   * pattern. An unresolved placeholder is replaced by the default directory {@code ./log}; a
+   * pattern with no placeholders is returned unchanged. This is what allows the file-log
+   * directory to be pointed at a writable location on a read-only root filesystem.
+   */
+  private static String resolveConfigurableLogDir(final String pattern) {
+    if (pattern == null)
+      return null;
+    return SystemVariableResolver.INSTANCE.resolveSystemVariables(pattern, DEFAULT_LOG_DIR);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/log/DefaultLogger.java
+++ b/engine/src/main/java/com/arcadedb/log/DefaultLogger.java
@@ -45,6 +45,7 @@ public class DefaultLogger implements Logger {
   private static final String DEFAULT_LOG                  = "com.arcadedb";
   private static final String ENV_INSTALL_CUSTOM_FORMATTER = "arcadedb.installCustomFormatter";
   private static final String FILE_LOG_PROPERTIES          = "arcadedb-log.properties";
+  // Must stay in sync with the default of GlobalConfiguration.SERVER_LOGS_DIRECTORY (arcadedb.server.logsDirectory).
   private static final String DEFAULT_LOG_DIR              = "./log";
 
   /**

--- a/engine/src/main/java/com/arcadedb/log/DefaultLogger.java
+++ b/engine/src/main/java/com/arcadedb/log/DefaultLogger.java
@@ -21,6 +21,8 @@ package com.arcadedb.log;
 import com.arcadedb.utility.AnsiLogFormatter;
 import com.arcadedb.utility.SystemVariableResolver;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -126,7 +128,7 @@ public class DefaultLogger implements Logger {
    * {@code java.util.logging.FileHandler.pattern}, if any.
    */
   private void createLogDirectoryFromConfig() {
-    final String pattern = findConfiguredFileHandlerPattern();
+    final String pattern = resolveConfigurableLogDir(findConfiguredFileHandlerPattern());
     if (pattern == null)
       return;
 
@@ -233,14 +235,27 @@ public class DefaultLogger implements Logger {
       }
     }
 
-    if (stream != null)
-      try {
-        LogManager.getLogManager().readConfiguration(stream);
+    if (stream != null) {
+      try (final InputStream in = stream) {
+        // Load the configuration so we can resolve ${...} placeholders in FileHandler.pattern
+        // before JUL eagerly opens the log file. This lets the log directory be configured via
+        // the arcadedb.server.logsDirectory system property / environment variable, which is the
+        // only path resolvable this early (the server root path is not set yet at first log).
+        final Properties props = new Properties();
+        props.load(in);
+
+        final String pattern = props.getProperty("java.util.logging.FileHandler.pattern");
+        if (pattern != null)
+          props.setProperty("java.util.logging.FileHandler.pattern", resolveConfigurableLogDir(pattern));
+
+        final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        props.store(buffer, null);
+        LogManager.getLogManager().readConfiguration(new ByteArrayInputStream(buffer.toByteArray()));
       } catch (final IOException e) {
         // NOT FOUND, APPLY DEFAULTS
         System.err.println("Cannot find ArcadeDB log file `arcadedb-log.properties`. Using default settings");
       }
-    else
+    } else
       System.err.println("Cannot find ArcadeDB log file `arcadedb-log.properties`. Using default settings");
 
     final boolean installCustomFormatter = Boolean.parseBoolean(

--- a/engine/src/main/java/com/arcadedb/log/DefaultLogger.java
+++ b/engine/src/main/java/com/arcadedb/log/DefaultLogger.java
@@ -115,7 +115,8 @@ public class DefaultLogger implements Logger {
 
   /**
    * Resolves ${...} system-property / environment-variable placeholders in a JUL FileHandler
-   * pattern. An unresolved placeholder is replaced by the default directory {@code ./log}; a
+   * pattern. An unresolved placeholder - including a non-standard one in an operator-supplied
+   * {@code arcadedb-log.properties} - is replaced by the default directory {@code ./log}; a
    * pattern with no placeholders is returned unchanged. This is what allows the file-log
    * directory to be pointed at a writable location on a read-only root filesystem.
    */
@@ -244,6 +245,8 @@ public class DefaultLogger implements Logger {
         // before JUL eagerly opens the log file. This lets the log directory be configured via
         // the arcadedb.server.logsDirectory system property / environment variable, which is the
         // only path resolvable this early (the server root path is not set yet at first log).
+        // The Properties round-trip drops the source file's comments and adds a timestamp header;
+        // both are harmless because JUL reads only key/value pairs.
         final Properties props = new Properties();
         props.load(in);
 

--- a/engine/src/main/java/com/arcadedb/log/DefaultLogger.java
+++ b/engine/src/main/java/com/arcadedb/log/DefaultLogger.java
@@ -47,8 +47,8 @@ public class DefaultLogger implements Logger {
   private static final String FILE_LOG_PROPERTIES          = "arcadedb-log.properties";
   // Fallback when ${arcadedb.server.logsDirectory} cannot be resolved (e.g. the first log fires during
   // GlobalConfiguration's own static init, before its values are queryable). Must stay in sync with the
-  // default of GlobalConfiguration.SERVER_LOGS_DIRECTORY.
-  private static final String DEFAULT_LOG_DIR              = "./log";
+  // default of GlobalConfiguration.SERVER_LOGS_DIRECTORY (asserted by DefaultLoggerLogDirTest).
+  static final String DEFAULT_LOG_DIR              = "./log";
 
   /**
    * Static so that a second {@link DefaultLogger} instance installed via
@@ -120,7 +120,7 @@ public class DefaultLogger implements Logger {
    * pattern with no placeholders is returned unchanged. This is what allows the file-log
    * directory to be pointed at a writable location on a read-only root filesystem.
    */
-  private static String resolveConfigurableLogDir(final String pattern) {
+  static String resolveConfigurableLogDir(final String pattern) {
     if (pattern == null)
       return null;
     return SystemVariableResolver.INSTANCE.resolveSystemVariables(pattern, DEFAULT_LOG_DIR);

--- a/engine/src/test/java/com/arcadedb/GlobalConfigurationTest.java
+++ b/engine/src/test/java/com/arcadedb/GlobalConfigurationTest.java
@@ -201,4 +201,11 @@ class GlobalConfigurationTest extends TestHelper {
 
     GlobalConfiguration.INITIAL_PAGE_CACHE_SIZE.setValue(original);
   }
+
+  @Test
+  void serverLogsDirectoryHasExpectedKeyAndDefault() {
+    assertThat(GlobalConfiguration.SERVER_LOGS_DIRECTORY.getKey()).isEqualTo("arcadedb.server.logsDirectory");
+    assertThat(GlobalConfiguration.SERVER_LOGS_DIRECTORY.getValueAsString()).isEqualTo("./log");
+    assertThat(GlobalConfiguration.SERVER_LOGS_DIRECTORY.getScope()).isEqualTo(GlobalConfiguration.SCOPE.JVM);
+  }
 }

--- a/engine/src/test/java/com/arcadedb/LoggerTest.java
+++ b/engine/src/test/java/com/arcadedb/LoggerTest.java
@@ -166,6 +166,58 @@ class LoggerTest extends TestHelper {
   }
 
   /**
+   * Issue #4451: an unset ${arcadedb.server.logsDirectory} placeholder must fall back to "./log"
+   * so existing single-host installs are unaffected.
+   */
+  @Test
+  void logDirPlaceholderFallsBackToDefaultWhenUnset() throws Exception {
+    final String prev = System.getProperty("arcadedb.server.logsDirectory");
+    System.clearProperty("arcadedb.server.logsDirectory");
+    try {
+      final String resolved = invokeResolveLogDir("${arcadedb.server.logsDirectory}/arcadedb.log");
+      assertThat(resolved).isEqualTo("./log/arcadedb.log");
+    } finally {
+      if (prev != null)
+        System.setProperty("arcadedb.server.logsDirectory", prev);
+    }
+  }
+
+  /**
+   * Issue #4451: ${arcadedb.server.logsDirectory} must resolve from the system property so logs
+   * can be relocated to a writable mount on a read-only root filesystem.
+   */
+  @Test
+  void logDirPlaceholderResolvesFromSystemProperty() throws Exception {
+    final String prev = System.getProperty("arcadedb.server.logsDirectory");
+    System.setProperty("arcadedb.server.logsDirectory", "/var/writable/arcade-logs");
+    try {
+      final String resolved = invokeResolveLogDir("${arcadedb.server.logsDirectory}/arcadedb.log");
+      assertThat(resolved).isEqualTo("/var/writable/arcade-logs/arcadedb.log");
+    } finally {
+      if (prev != null)
+        System.setProperty("arcadedb.server.logsDirectory", prev);
+      else
+        System.clearProperty("arcadedb.server.logsDirectory");
+    }
+  }
+
+  /**
+   * Issue #4451: a literal FileHandler pattern with no ${...} placeholder must pass through
+   * unchanged, so operators using an absolute path are unaffected.
+   */
+  @Test
+  void logDirLiteralPatternPassesThroughUnchanged() throws Exception {
+    final String resolved = invokeResolveLogDir("/custom/log/arcadedb.log");
+    assertThat(resolved).isEqualTo("/custom/log/arcadedb.log");
+  }
+
+  private static String invokeResolveLogDir(final String pattern) throws ReflectiveOperationException {
+    final java.lang.reflect.Method m = DefaultLogger.class.getDeclaredMethod("resolveConfigurableLogDir", String.class);
+    m.setAccessible(true);
+    return (String) m.invoke(null, pattern);
+  }
+
+  /**
    * Reset DefaultLogger.initialized so init() actually runs in tests that exercise the
    * directory-creation logic. The static flag exists to prevent a second DefaultLogger
    * (typically installed by tests that swap in a capturing logger) from re-reading the

--- a/engine/src/test/java/com/arcadedb/LoggerTest.java
+++ b/engine/src/test/java/com/arcadedb/LoggerTest.java
@@ -166,52 +166,6 @@ class LoggerTest extends TestHelper {
   }
 
   /**
-   * Issue #4451: an unset ${arcadedb.server.logsDirectory} placeholder must fall back to "./log"
-   * so existing single-host installs are unaffected.
-   */
-  @Test
-  void logDirPlaceholderFallsBackToDefaultWhenUnset() throws Exception {
-    final String prev = System.getProperty("arcadedb.server.logsDirectory");
-    System.clearProperty("arcadedb.server.logsDirectory");
-    try {
-      final String resolved = invokeResolveLogDir("${arcadedb.server.logsDirectory}/arcadedb.log");
-      assertThat(resolved).isEqualTo("./log/arcadedb.log");
-    } finally {
-      if (prev != null)
-        System.setProperty("arcadedb.server.logsDirectory", prev);
-    }
-  }
-
-  /**
-   * Issue #4451: ${arcadedb.server.logsDirectory} must resolve from the system property so logs
-   * can be relocated to a writable mount on a read-only root filesystem.
-   */
-  @Test
-  void logDirPlaceholderResolvesFromSystemProperty() throws Exception {
-    final String prev = System.getProperty("arcadedb.server.logsDirectory");
-    System.setProperty("arcadedb.server.logsDirectory", "/var/writable/arcade-logs");
-    try {
-      final String resolved = invokeResolveLogDir("${arcadedb.server.logsDirectory}/arcadedb.log");
-      assertThat(resolved).isEqualTo("/var/writable/arcade-logs/arcadedb.log");
-    } finally {
-      if (prev != null)
-        System.setProperty("arcadedb.server.logsDirectory", prev);
-      else
-        System.clearProperty("arcadedb.server.logsDirectory");
-    }
-  }
-
-  /**
-   * Issue #4451: a literal FileHandler pattern with no ${...} placeholder must pass through
-   * unchanged, so operators using an absolute path are unaffected.
-   */
-  @Test
-  void logDirLiteralPatternPassesThroughUnchanged() throws Exception {
-    final String resolved = invokeResolveLogDir("/custom/log/arcadedb.log");
-    assertThat(resolved).isEqualTo("/custom/log/arcadedb.log");
-  }
-
-  /**
    * Issue #4451: a ${arcadedb.server.logsDirectory} placeholder in FileHandler.pattern must be
    * resolved both when pre-creating the log directory and in the pattern handed to JUL, so the
    * file handler opens under the configured (writable) directory instead of "./log".
@@ -259,12 +213,6 @@ class LoggerTest extends TestHelper {
       restoreLogConfig(prevProp);
       deleteTree(tempBase);
     }
-  }
-
-  private static String invokeResolveLogDir(final String pattern) throws ReflectiveOperationException {
-    final java.lang.reflect.Method m = DefaultLogger.class.getDeclaredMethod("resolveConfigurableLogDir", String.class);
-    m.setAccessible(true);
-    return (String) m.invoke(null, pattern);
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/LoggerTest.java
+++ b/engine/src/test/java/com/arcadedb/LoggerTest.java
@@ -211,6 +211,56 @@ class LoggerTest extends TestHelper {
     assertThat(resolved).isEqualTo("/custom/log/arcadedb.log");
   }
 
+  /**
+   * Issue #4451: a ${arcadedb.server.logsDirectory} placeholder in FileHandler.pattern must be
+   * resolved both when pre-creating the log directory and in the pattern handed to JUL, so the
+   * file handler opens under the configured (writable) directory instead of "./log".
+   */
+  @Test
+  void fileHandlerPatternResolvesConfigurableLogDir() throws Exception {
+    final Path tempBase = Files.createTempDirectory("arcade-4451-placeholder");
+    final File customLogDir = tempBase.resolve("k8s-writable").toFile();
+    assertThat(customLogDir).doesNotExist();
+
+    final File customProps = tempBase.resolve("placeholder-handler.properties").toFile();
+    try (final PrintWriter pw = new PrintWriter(customProps)) {
+      pw.println("handlers=java.util.logging.ConsoleHandler, java.util.logging.FileHandler");
+      pw.println(".level=WARNING");
+      pw.println("java.util.logging.ConsoleHandler.level=WARNING");
+      pw.println("java.util.logging.ConsoleHandler.formatter=com.arcadedb.utility.AnsiLogFormatter");
+      pw.println("java.util.logging.FileHandler.level=WARNING");
+      pw.println("java.util.logging.FileHandler.pattern=${arcadedb.server.logsDirectory}/arcade.%g.log");
+      pw.println("java.util.logging.FileHandler.count=1");
+      pw.println("java.util.logging.FileHandler.limit=1000");
+      pw.println("java.util.logging.FileHandler.formatter=com.arcadedb.log.LogFormatter");
+    }
+
+    final String prevProp = System.getProperty("java.util.logging.config.file");
+    final String prevDir = System.getProperty("arcadedb.server.logsDirectory");
+    System.setProperty("java.util.logging.config.file", customProps.getAbsolutePath());
+    System.setProperty("arcadedb.server.logsDirectory", customLogDir.getAbsolutePath());
+
+    try {
+      resetDefaultLoggerInitialized();
+      final DefaultLogger logger = new DefaultLogger();
+      logger.init();
+
+      // createLogDirectoryFromConfig pre-created the resolved directory
+      assertThat(customLogDir).exists().isDirectory();
+      // installCustomFormatter handed JUL the resolved, not the raw, pattern
+      assertThat(java.util.logging.LogManager.getLogManager().getProperty("java.util.logging.FileHandler.pattern"))
+          .isEqualTo(customLogDir.getAbsolutePath() + "/arcade.%g.log");
+    } finally {
+      closeFileHandlers();
+      if (prevDir != null)
+        System.setProperty("arcadedb.server.logsDirectory", prevDir);
+      else
+        System.clearProperty("arcadedb.server.logsDirectory");
+      restoreLogConfig(prevProp);
+      deleteTree(tempBase);
+    }
+  }
+
   private static String invokeResolveLogDir(final String pattern) throws ReflectiveOperationException {
     final java.lang.reflect.Method m = DefaultLogger.class.getDeclaredMethod("resolveConfigurableLogDir", String.class);
     m.setAccessible(true);

--- a/engine/src/test/java/com/arcadedb/log/DefaultLoggerLogDirTest.java
+++ b/engine/src/test/java/com/arcadedb/log/DefaultLoggerLogDirTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.log;
+
+import com.arcadedb.GlobalConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link DefaultLogger#resolveConfigurableLogDir(String)}. Co-located in the
+ * {@code com.arcadedb.log} package so the package-private helper and the {@code DEFAULT_LOG_DIR}
+ * constant can be exercised directly, without reflection.
+ */
+class DefaultLoggerLogDirTest {
+  /**
+   * An unset ${arcadedb.server.logsDirectory} placeholder must fall back to the default directory
+   * so existing single-host installs are unaffected.
+   */
+  @Test
+  void logDirPlaceholderFallsBackToDefaultWhenUnset() {
+    final String prev = System.getProperty("arcadedb.server.logsDirectory");
+    System.clearProperty("arcadedb.server.logsDirectory");
+    try {
+      assertThat(DefaultLogger.resolveConfigurableLogDir("${arcadedb.server.logsDirectory}/arcadedb.log"))
+          .isEqualTo("./log/arcadedb.log");
+    } finally {
+      if (prev != null)
+        System.setProperty("arcadedb.server.logsDirectory", prev);
+    }
+  }
+
+  /**
+   * ${arcadedb.server.logsDirectory} must resolve from the system property so logs can be relocated
+   * to a writable mount on a read-only root filesystem.
+   */
+  @Test
+  void logDirPlaceholderResolvesFromSystemProperty() {
+    final String prev = System.getProperty("arcadedb.server.logsDirectory");
+    System.setProperty("arcadedb.server.logsDirectory", "/var/writable/arcade-logs");
+    try {
+      assertThat(DefaultLogger.resolveConfigurableLogDir("${arcadedb.server.logsDirectory}/arcadedb.log"))
+          .isEqualTo("/var/writable/arcade-logs/arcadedb.log");
+    } finally {
+      if (prev != null)
+        System.setProperty("arcadedb.server.logsDirectory", prev);
+      else
+        System.clearProperty("arcadedb.server.logsDirectory");
+    }
+  }
+
+  /**
+   * A literal FileHandler pattern with no ${...} placeholder must pass through unchanged, so
+   * operators using an absolute path are unaffected.
+   */
+  @Test
+  void logDirLiteralPatternPassesThroughUnchanged() {
+    assertThat(DefaultLogger.resolveConfigurableLogDir("/custom/log/arcadedb.log"))
+        .isEqualTo("/custom/log/arcadedb.log");
+  }
+
+  /**
+   * The resolver's fallback directory and the configured default must agree, otherwise an unset
+   * placeholder would resolve to a different directory than the documented configuration default.
+   */
+  @Test
+  void defaultLogDirMatchesConfiguredDefault() {
+    assertThat(GlobalConfiguration.SERVER_LOGS_DIRECTORY.getDefValue()).isEqualTo(DefaultLogger.DEFAULT_LOG_DIR);
+  }
+}

--- a/package/src/main/config/arcadedb-log.properties
+++ b/package/src/main/config/arcadedb-log.properties
@@ -31,7 +31,7 @@ java.util.logging.ConsoleHandler.formatter = com.arcadedb.utility.AnsiLogFormatt
 # Set the default logging level for new FileHandler instances
 java.util.logging.FileHandler.level = INFO
 # Naming style for the output file
-java.util.logging.FileHandler.pattern=./log/arcadedb.log
+java.util.logging.FileHandler.pattern=${arcadedb.server.logsDirectory}/arcadedb.log
 # Set the default formatter for new FileHandler instances
 java.util.logging.FileHandler.formatter = com.arcadedb.log.LogFormatter
 # Limiting size of output file in bytes:

--- a/package/src/main/scripts/server.bat
+++ b/package/src/main/scripts/server.bat
@@ -87,6 +87,10 @@ set JAVA_OPTS_SCRIPT=-XX:+HeapDumpOnOutOfMemoryError ^
   -Djava.util.logging.config.file=config/arcadedb-log.properties ^
   --enable-native-access=ALL-UNNAMED
 
+rem Optional: relocate log files to a writable directory (e.g. read-only root filesystems).
+rem ARCADEDB_LOG_DIR maps to arcadedb.server.logsDirectory used by config/arcadedb-log.properties.
+if not "%ARCADEDB_LOG_DIR%"=="" set JAVA_OPTS_SCRIPT=%JAVA_OPTS_SCRIPT% -Darcadedb.server.logsDirectory=%ARCADEDB_LOG_DIR%
+
 rem ARCADEDB memory options, default uses the available RAM. To set it to a specific value, like 2GB of heap, use "-Xms2G -Xmx2G".
 rem
 rem Tip for low-footprint setups (e.g. arcadedb.profile=low-ram): prefer a small initial heap

--- a/package/src/main/scripts/server.bat
+++ b/package/src/main/scripts/server.bat
@@ -89,7 +89,7 @@ set JAVA_OPTS_SCRIPT=-XX:+HeapDumpOnOutOfMemoryError ^
 
 rem Optional: relocate log files to a writable directory (e.g. read-only root filesystems).
 rem ARCADEDB_LOG_DIR maps to arcadedb.server.logsDirectory used by config/arcadedb-log.properties.
-if not "%ARCADEDB_LOG_DIR%"=="" set JAVA_OPTS_SCRIPT=%JAVA_OPTS_SCRIPT% -Darcadedb.server.logsDirectory=%ARCADEDB_LOG_DIR%
+if not "%ARCADEDB_LOG_DIR%"=="" set JAVA_OPTS_SCRIPT=%JAVA_OPTS_SCRIPT% "-Darcadedb.server.logsDirectory=%ARCADEDB_LOG_DIR%"
 
 rem ARCADEDB memory options, default uses the available RAM. To set it to a specific value, like 2GB of heap, use "-Xms2G -Xmx2G".
 rem

--- a/package/src/main/scripts/server.sh
+++ b/package/src/main/scripts/server.sh
@@ -92,6 +92,13 @@ if [ -z "$JAVA_OPTS_SCRIPT" ]; then
         --enable-native-access=ALL-UNNAMED"
 fi
 
+# Optional: relocate log files to a writable directory (e.g. on read-only root filesystems).
+# ARCADEDB_LOG_DIR maps to the arcadedb.server.logsDirectory configuration referenced by
+# config/arcadedb-log.properties. When unset, logs default to ./log.
+if [ -n "$ARCADEDB_LOG_DIR" ]; then
+  JAVA_OPTS_SCRIPT="$JAVA_OPTS_SCRIPT -Darcadedb.server.logsDirectory=$ARCADEDB_LOG_DIR"
+fi
+
 if [ -z "$ARCADEDB_JMX" ]; then
   ARCADEDB_JMX="-Dcom.sun.management.jmxremote=true \
         -Dcom.sun.management.jmxremote.local.only=false \

--- a/package/src/main/scripts/server.sh
+++ b/package/src/main/scripts/server.sh
@@ -92,13 +92,6 @@ if [ -z "$JAVA_OPTS_SCRIPT" ]; then
         --enable-native-access=ALL-UNNAMED"
 fi
 
-# Optional: relocate log files to a writable directory (e.g. on read-only root filesystems).
-# ARCADEDB_LOG_DIR maps to the arcadedb.server.logsDirectory configuration referenced by
-# config/arcadedb-log.properties. When unset, logs default to ./log.
-if [ -n "$ARCADEDB_LOG_DIR" ]; then
-  JAVA_OPTS_SCRIPT="$JAVA_OPTS_SCRIPT -Darcadedb.server.logsDirectory=$ARCADEDB_LOG_DIR"
-fi
-
 if [ -z "$ARCADEDB_JMX" ]; then
   ARCADEDB_JMX="-Dcom.sun.management.jmxremote=true \
         -Dcom.sun.management.jmxremote.local.only=false \
@@ -110,9 +103,14 @@ fi
 
 echo $$ >$ARCADEDB_PID
 
+# Optional: relocate log files to a writable directory (e.g. on read-only root filesystems).
+# ARCADEDB_LOG_DIR maps to the arcadedb.server.logsDirectory configuration referenced by
+# config/arcadedb-log.properties. When unset, no argument is added and logs default to ./log.
+# Passed as a quoted, conditional argument so a path containing spaces stays a single argument.
 exec "$JAVA" $JAVA_OPTS \
   $ARCADEDB_OPTS_MEMORY \
   $JAVA_OPTS_SCRIPT \
+  ${ARCADEDB_LOG_DIR:+"-Darcadedb.server.logsDirectory=$ARCADEDB_LOG_DIR"} \
   $ARCADEDB_JMX \
   $ARCADEDB_SETTINGS \
   -cp "$ARCADEDB_HOME/lib/*" \


### PR DESCRIPTION
## Summary

Fixes #4451. The server crashed at startup with `java.nio.file.FileSystemException: ./log/arcadedb.log.0.lck: Read-only file system` on Kubernetes `readOnlyRootFilesystem` pods, because the JUL `FileHandler` pattern is hardcoded `./log/arcadedb.log` (relative to the working directory) and is opened during `GlobalConfiguration` static init - before the server root path is set.

The log directory is now configurable, defaulting to `./log` (no behavior change for existing installs):

- `DefaultLogger.resolveConfigurableLogDir()` resolves `${...}` placeholders in the `FileHandler.pattern` via the existing `SystemVariableResolver` (system property -> env var -> `GlobalConfiguration`, default `./log`). It is wired into both `createLogDirectoryFromConfig()` (directory pre-creation) and `installCustomFormatter()` (the pattern handed to JUL), so the two always agree. `installCustomFormatter()` now loads the config into `Properties`, rewrites the pattern, and re-feeds JUL (this also closes a pre-existing unclosed-stream leak).
- New `GlobalConfiguration.SERVER_LOGS_DIRECTORY` (`arcadedb.server.logsDirectory`, default `./log`).
- Packaged `arcadedb-log.properties` uses `${arcadedb.server.logsDirectory}/arcadedb.log`.
- `server.sh` / `server.bat` forward an optional `ARCADEDB_LOG_DIR` env var as `-Darcadedb.server.logsDirectory=...`.

Operators on read-only root filesystems set `ARCADEDB_LOG_DIR=/writable/mount/log` (or the system property directly) to relocate logs to a writable mount. Companion to #4446 (configurable Raft storage directory).

## Test Plan

- [x] `mvn -pl engine -Dtest=LoggerTest,GlobalConfigurationTest test` - 18/18 pass, including the issue-#3732 regression tests proving the default `./log` behavior and literal patterns are unchanged.
- [x] New tests: placeholder resolves from system property; unset placeholder falls back to `./log`; literal pattern passes through unchanged; end-to-end `init()` creates the resolved directory and JUL receives the resolved pattern.
- [x] Read-only-CWD smoke test against the real packaged `arcadedb-log.properties`: with a read-only `./log` and `arcadedb.server.logsDirectory` pointing at a writable dir, the server logs to the writable dir, leaves `./log` untouched, and does not throw the read-only exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)