### PR TITLE
fix(#4468): expand primitive-array IN params through indexed path

### DIFF
--- a/docs/4468-sql-in-param-index-expansion.md
+++ b/docs/4468-sql-in-param-index-expansion.md
@@ -35,8 +35,12 @@ so `WHERE (field + 0) IN :param` worked fine.
 
 `engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java`
 
-Extended the predicate in `cartesianProduct()` to also match arrays, and instantiate an
-`IterableObjectArray` wrapper (already in the utility package) when the value is not `Iterable`:
+Replaced the `Iterable<?>`-only predicate in `cartesianProduct()` with the existing `MultiValue`
+utility, which already detects and iterates every array type (`long[]`, `int[]`, `double[]`,
+`Object[]`) as well as `Collection`/`Iterable`. This is the same utility the sibling
+`processInCondition()` path uses (lines 258-261 of the same file), so both multi-value detection
+sites now share one code path. `MultiValue.isMultiValue(null)` is internally null-safe, so no
+explicit null guard is needed.
 
 ```java
 // Before
@@ -44,9 +48,8 @@ if (value instanceof Iterable<?> iterable && !(value instanceof Identifiable)) {
     for (final Object elemInKey : iterable) {
 
 // After
-if (!(value instanceof Identifiable) && (value instanceof Iterable<?> || (value != null && value.getClass().isArray()))) {
-    final Iterable<?> iterable = value instanceof Iterable<?> iter ? iter : new IterableObjectArray<>(value);
-    for (final Object elemInKey : iterable) {
+if (!(value instanceof Identifiable) && MultiValue.isMultiValue(value)) {
+    for (final Object elemInKey : MultiValue.getMultiValueIterable(value)) {
 ```
 
 ## Files Changed
@@ -56,10 +59,12 @@ if (!(value instanceof Identifiable) && (value instanceof Iterable<?> || (value 
 
 ## Test Results
 
-New regression test `InParamIndexExpansionTest` (9 test methods):
+New regression test `InParamIndexExpansionTest` (11 test methods):
 - `literalInListUsesIndexAndReturnsRows` - passes before and after fix (baseline)
 - `namedListParamInWithIndexReturnsRows` - passes before and after fix (`List<Long>` is Iterable)
-- `namedPrimitiveArrayParamInWithIndexReturnsRows` - **failed before fix, passes after**
+- `namedPrimitiveLongArrayParamInWithIndexReturnsRows` - **failed before fix, passes after**
+- `namedPrimitiveIntArrayParamInWithIndexReturnsRows` - **failed before fix, passes after**
+- `namedPrimitiveDoubleArrayParamInWithIndexReturnsRows` - **failed before fix, passes after** (double coerces to INTEGER key)
 - `namedObjectArrayParamInWithIndexReturnsRows` - **failed before fix, passes after**
 - `positionalListParamInWithIndexReturnsRows` - passes (List is Iterable in embedded mode)
 - `namedListParamInExplainUsesIndex` - confirms index is used
@@ -67,4 +72,23 @@ New regression test `InParamIndexExpansionTest` (9 test methods):
 - `namedListParamInWithIndexReturnsPartialRows` - partial match works
 - `namedListParamInWithIndexReturnsSingleRow` - single-element list works
 
-Broader suite: 314 index and SQL query tests, 0 failures, 0 errors.
+Broader suite: index (embedded list, list-by-item, composite, map) and SQL query tests pass with
+0 failures, 0 errors.
+
+## Review cycles
+
+### Cycle 1 - `b940f325`
+
+- **gemini-code-assist** (1 comment): hoist the `value != null` null check to the front of the
+  `cartesianProduct` condition. Subsumed by the cycle-1 change below - switching to
+  `MultiValue.isMultiValue` (internally null-safe) removed the need for any explicit null guard.
+- **claude** (review comment): suggested reusing the already-imported `MultiValue` utility instead
+  of `IterableObjectArray` for consistency with `processInCondition`; add `int[]`/`double[]` test
+  cases; remove issue-reference comments from test method bodies; remove the docs file.
+  - Applied: switched to `MultiValue.isMultiValue` + `getMultiValueIterable` (verified safe across
+    embedded-list, list-by-item, map, and composite index suites); added `int[]` and `double[]`
+    test cases; removed issue-reference comments and em-dashes from test method bodies.
+  - Declined: removing this docs file. The `docs/<issue>-<name>.md` tracking doc is an established,
+    committed convention (38 such files already in the repo, e.g. `docs/4337-*`, `docs/4364-*`) and
+    is produced by the resolve-issue workflow. The claim that the convention does not exist is not
+    accurate.

--- a/docs/4468-sql-in-param-index-expansion.md
+++ b/docs/4468-sql-in-param-index-expansion.md
@@ -92,3 +92,16 @@ Broader suite: index (embedded list, list-by-item, composite, map) and SQL query
     committed convention (38 such files already in the repo, e.g. `docs/4337-*`, `docs/4364-*`) and
     is produced by the resolve-issue workflow. The claim that the convention does not exist is not
     accurate.
+
+### Cycle 2 - `342fd2b2`
+
+- **claude** (Approved with minor suggestions):
+  - Noted that switching to `MultiValue` quietly broadens behavior for `Map` parameters (expanded by
+    `map.values()`), consistent with `processInCondition` but previously not reached. Added a concise
+    behavioral comment above the condition explaining the multi-value expansion. Did not add a `Map`
+    test, since that would lock incidental Map-expansion into a tested contract; the fix targets the
+    array/collection shapes produced by JSON parameter deserialization.
+  - Declined: trimming the class Javadoc per a cited "never write multi-paragraph docstrings" rule -
+    that rule is not present in CLAUDE.md, and the Javadoc documents a non-obvious root cause.
+  - Declined: removing the "Review cycles" section from this doc. 15+ committed tracking docs in the
+    repo (e.g. `docs/4274-*`, `docs/4331-*`) contain exactly this section; it is a convention.

--- a/docs/4468-sql-in-param-index-expansion.md
+++ b/docs/4468-sql-in-param-index-expansion.md
@@ -1,0 +1,70 @@
+# Issue #4468 - SQL `IN :param` with a collection parameter returns no rows when an index is used
+
+## Summary
+
+SQL queries using `IN :param` (named parameter) or `IN ?` (positional parameter) with a collection
+value return no rows when the field has an index and the index path is chosen by the planner.
+
+The same collection works on the non-indexed path (`WHERE (field + 0) IN :param`) and the literal
+form (`WHERE field IN [1, 2, 3]`) works without restriction.
+
+## Root Cause
+
+`PostCommandHandler.PostCommandHandler` uses `json.toMap(true)` to deserialize the HTTP request body.
+The `true` flag enables an optimized path that converts JSON numeric arrays (`[1, 2, 3]`) to
+primitive arrays (`long[]`, `double[]`) rather than `List<Long>` to reduce boxing allocations.
+
+When a parameter value like `codes = [1, 2, 3]` arrives at the server, the deserialized map entry
+is `"codes" -> long[]`.
+
+`FetchFromIndexStep.cartesianProduct()` is responsible for expanding a multi-value expression into
+one index lookup per element. Before this fix its check was:
+
+```java
+if (value instanceof Iterable<?> iterable && !(value instanceof Identifiable)) {
+```
+
+Primitive arrays (`long[]`, `int[]`, `Object[]`) are **not** `Iterable<?>` in Java.
+The condition was false, the `else` branch ran, and the whole array was passed as a single index
+key - matching nothing.
+
+The non-indexed evaluator uses `MultiValue.getMultiValueIterable()` which handles arrays correctly,
+so `WHERE (field + 0) IN :param` worked fine.
+
+## Fix
+
+`engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java`
+
+Extended the predicate in `cartesianProduct()` to also match arrays, and instantiate an
+`IterableObjectArray` wrapper (already in the utility package) when the value is not `Iterable`:
+
+```java
+// Before
+if (value instanceof Iterable<?> iterable && !(value instanceof Identifiable)) {
+    for (final Object elemInKey : iterable) {
+
+// After
+if (!(value instanceof Identifiable) && (value instanceof Iterable<?> || (value != null && value.getClass().isArray()))) {
+    final Iterable<?> iterable = value instanceof Iterable<?> iter ? iter : new IterableObjectArray<>(value);
+    for (final Object elemInKey : iterable) {
+```
+
+## Files Changed
+
+- `engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java` - fix
+- `engine/src/test/java/com/arcadedb/index/InParamIndexExpansionTest.java` - regression tests
+
+## Test Results
+
+New regression test `InParamIndexExpansionTest` (9 test methods):
+- `literalInListUsesIndexAndReturnsRows` - passes before and after fix (baseline)
+- `namedListParamInWithIndexReturnsRows` - passes before and after fix (`List<Long>` is Iterable)
+- `namedPrimitiveArrayParamInWithIndexReturnsRows` - **failed before fix, passes after**
+- `namedObjectArrayParamInWithIndexReturnsRows` - **failed before fix, passes after**
+- `positionalListParamInWithIndexReturnsRows` - passes (List is Iterable in embedded mode)
+- `namedListParamInExplainUsesIndex` - confirms index is used
+- `namedListParamInWithoutIndexReturnsRows` - control: non-indexed path works
+- `namedListParamInWithIndexReturnsPartialRows` - partial match works
+- `namedListParamInWithIndexReturnsSingleRow` - single-element list works
+
+Broader suite: 314 index and SQL query tests, 0 failures, 0 errors.

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -41,7 +41,6 @@ import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
 import com.arcadedb.query.sql.parser.LtOperator;
 import com.arcadedb.query.sql.parser.PCollection;
 import com.arcadedb.query.sql.parser.ValueExpression;
-import com.arcadedb.utility.IterableObjectArray;
 import com.arcadedb.utility.MultiIterator;
 import com.arcadedb.utility.Pair;
 
@@ -422,10 +421,9 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
 
     final Expression nextElementInKey = key.getExpressions().getFirst();
     final Object value = nextElementInKey.execute(new ResultInternal(context.getDatabase()), context);
-    if (!(value instanceof Identifiable) && (value instanceof Iterable<?> || (value != null && value.getClass().isArray()))) {
+    if (!(value instanceof Identifiable) && MultiValue.isMultiValue(value)) {
       final List<PCollection> result = new ArrayList<>();
-      final Iterable<?> iterable = value instanceof Iterable<?> iter ? iter : new IterableObjectArray<>(value);
-      for (final Object elemInKey : iterable) {
+      for (final Object elemInKey : MultiValue.getMultiValueIterable(value)) {
         final PCollection newHead = new PCollection(-1);
         for (final Expression exp : head.getExpressions())
           newHead.add(exp.copy());

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -421,6 +421,9 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
 
     final Expression nextElementInKey = key.getExpressions().getFirst();
     final Object value = nextElementInKey.execute(new ResultInternal(context.getDatabase()), context);
+    // A multi-value key expands into one index lookup per element. MultiValue covers every shape a
+    // parameter can take, including primitive arrays (long[]/int[]/double[]) that are not Iterable,
+    // consistent with the multi-value handling in processInCondition().
     if (!(value instanceof Identifiable) && MultiValue.isMultiValue(value)) {
       final List<PCollection> result = new ArrayList<>();
       for (final Object elemInKey : MultiValue.getMultiValueIterable(value)) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -41,6 +41,7 @@ import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
 import com.arcadedb.query.sql.parser.LtOperator;
 import com.arcadedb.query.sql.parser.PCollection;
 import com.arcadedb.query.sql.parser.ValueExpression;
+import com.arcadedb.utility.IterableObjectArray;
 import com.arcadedb.utility.MultiIterator;
 import com.arcadedb.utility.Pair;
 
@@ -421,8 +422,9 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
 
     final Expression nextElementInKey = key.getExpressions().getFirst();
     final Object value = nextElementInKey.execute(new ResultInternal(context.getDatabase()), context);
-    if (value instanceof Iterable<?> iterable && !(value instanceof Identifiable)) {
+    if (!(value instanceof Identifiable) && (value instanceof Iterable<?> || (value != null && value.getClass().isArray()))) {
       final List<PCollection> result = new ArrayList<>();
+      final Iterable<?> iterable = value instanceof Iterable<?> iter ? iter : new IterableObjectArray<>(value);
       for (final Object elemInKey : iterable) {
         final PCollection newHead = new PCollection(-1);
         for (final Expression exp : head.getExpressions())

--- a/engine/src/test/java/com/arcadedb/index/InParamIndexExpansionTest.java
+++ b/engine/src/test/java/com/arcadedb/index/InParamIndexExpansionTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4468: SQL `IN :param` with a collection parameter
+ * returns no rows when an index is used on the left-hand field.
+ *
+ * Root cause: FetchFromIndexStep.cartesianProduct() only expanded Iterable<?>,
+ * but JSON deserialization via toMap(true) yields primitive arrays (long[], double[])
+ * which are not Iterable. The entire array was treated as a single index key,
+ * matching nothing.
+ */
+class InParamIndexExpansionTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("IssueItem");
+      database.getSchema().getType("IssueItem").createProperty("code", Type.INTEGER);
+      database.getSchema().buildTypeIndex("IssueItem", new String[] { "code" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE)
+          .withUnique(false)
+          .create();
+
+      database.newDocument("IssueItem").set("code", 1, "name", "one").save();
+      database.newDocument("IssueItem").set("code", 2, "name", "two").save();
+      database.newDocument("IssueItem").set("code", 3, "name", "three").save();
+    });
+  }
+
+  // Baseline: literal IN list must use the index and return all three rows.
+  @Test
+  void literalInListUsesIndexAndReturnsRows() {
+    database.transaction(() -> {
+      final ResultSet rs = database.query("sql", "select code from IssueItem where code in [1, 2, 3] order by code");
+      final List<Integer> codes = rs.stream().map(r -> r.<Integer>getProperty("code")).toList();
+      assertThat(codes).containsExactly(1, 2, 3);
+    });
+  }
+
+  // Issue #4468: named List<Long> param — this is the primary failing form.
+  @Test
+  void namedListParamInWithIndexReturnsRows() {
+    database.transaction(() -> {
+      final ResultSet rs = database.query("sql",
+          "select code from IssueItem where code in :codes order by code",
+          Map.of("codes", List.of(1L, 2L, 3L)));
+      final List<Integer> codes = rs.stream().map(r -> r.<Integer>getProperty("code")).toList();
+      assertThat(codes).containsExactly(1, 2, 3);
+    });
+  }
+
+  // Issue #4468: named primitive long[] param — simulates HTTP JSON deserialization via toMap(true).
+  @Test
+  void namedPrimitiveArrayParamInWithIndexReturnsRows() {
+    database.transaction(() -> {
+      final ResultSet rs = database.query("sql",
+          "select code from IssueItem where code in :codes order by code",
+          Map.of("codes", new long[] { 1L, 2L, 3L }));
+      final List<Integer> codes = rs.stream().map(r -> r.<Integer>getProperty("code")).toList();
+      assertThat(codes).containsExactly(1, 2, 3);
+    });
+  }
+
+  // Issue #4468: named Object[] param — covers mixed boxed-array case.
+  @Test
+  void namedObjectArrayParamInWithIndexReturnsRows() {
+    database.transaction(() -> {
+      final ResultSet rs = database.query("sql",
+          "select code from IssueItem where code in :codes order by code",
+          Map.of("codes", new Object[] { 1L, 2L, 3L }));
+      final List<Integer> codes = rs.stream().map(r -> r.<Integer>getProperty("code")).toList();
+      assertThat(codes).containsExactly(1, 2, 3);
+    });
+  }
+
+  // Issue #4468: positional List<Long> param — the other reported failing form.
+  @Test
+  void positionalListParamInWithIndexReturnsRows() {
+    database.transaction(() -> {
+      final ResultSet rs = database.query("sql",
+          "select code from IssueItem where code in ? order by code",
+          List.of(1L, 2L, 3L));
+      final List<Integer> codes = rs.stream().map(r -> r.<Integer>getProperty("code")).toList();
+      assertThat(codes).containsExactly(1, 2, 3);
+    });
+  }
+
+  // Confirm the execution plan uses the index for the IN :codes form.
+  @Test
+  void namedListParamInExplainUsesIndex() {
+    database.transaction(() -> {
+      final ResultSet rs = database.query("sql",
+          "explain select code from IssueItem where code in :codes",
+          Map.of("codes", List.of(1L, 2L, 3L)));
+      final String plan = rs.getExecutionPlan().get().prettyPrint(0, 2);
+      assertThat(plan).contains("FETCH FROM INDEX");
+    });
+  }
+
+  // Verify the non-indexed path (arithmetic prevents index use) still works as a control.
+  @Test
+  void namedListParamInWithoutIndexReturnsRows() {
+    database.transaction(() -> {
+      final ResultSet rs = database.query("sql",
+          "select code from IssueItem where (code + 0) in :codes order by code",
+          Map.of("codes", List.of(1L, 2L, 3L)));
+      final List<Integer> codes = rs.stream().map(r -> r.<Integer>getProperty("code")).toList();
+      assertThat(codes).containsExactly(1, 2, 3);
+    });
+  }
+
+  // Partial match: only 2 of 3 codes present in the collection.
+  @Test
+  void namedListParamInWithIndexReturnsPartialRows() {
+    database.transaction(() -> {
+      final ResultSet rs = database.query("sql",
+          "select code from IssueItem where code in :codes order by code",
+          Map.of("codes", List.of(1L, 3L)));
+      final List<Integer> codes = rs.stream().map(r -> r.<Integer>getProperty("code")).toList();
+      assertThat(codes).containsExactly(1, 3);
+    });
+  }
+
+  // Single-element list param must also find exactly one row.
+  @Test
+  void namedListParamInWithIndexReturnsSingleRow() {
+    database.transaction(() -> {
+      final ResultSet rs = database.query("sql",
+          "select code from IssueItem where code in :codes",
+          Map.of("codes", List.of(2L)));
+      final List<Integer> codes = rs.stream().map(r -> r.<Integer>getProperty("code")).toList();
+      assertThat(codes).containsExactly(2);
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/InParamIndexExpansionTest.java
+++ b/engine/src/test/java/com/arcadedb/index/InParamIndexExpansionTest.java
@@ -30,13 +30,14 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Regression test for issue #4468: SQL `IN :param` with a collection parameter
- * returns no rows when an index is used on the left-hand field.
- *
- * Root cause: FetchFromIndexStep.cartesianProduct() only expanded Iterable<?>,
- * but JSON deserialization via toMap(true) yields primitive arrays (long[], double[])
- * which are not Iterable. The entire array was treated as a single index key,
- * matching nothing.
+ * SQL {@code IN :param} with a collection parameter must use the index and return the same rows as
+ * the literal list form {@code IN [1, 2, 3]}.
+ * <p>
+ * The HTTP layer deserializes JSON numeric arrays into primitive arrays (long[], int[], double[])
+ * via toMap(true). The indexed expansion in FetchFromIndexStep.cartesianProduct() must treat those
+ * primitive arrays as multi-value keys and look each element up individually, exactly like the
+ * non-indexed IN evaluator. When it did not, the whole array was used as a single index key and
+ * matched nothing.
  */
 class InParamIndexExpansionTest extends TestHelper {
 
@@ -56,7 +57,6 @@ class InParamIndexExpansionTest extends TestHelper {
     });
   }
 
-  // Baseline: literal IN list must use the index and return all three rows.
   @Test
   void literalInListUsesIndexAndReturnsRows() {
     database.transaction(() -> {
@@ -66,7 +66,6 @@ class InParamIndexExpansionTest extends TestHelper {
     });
   }
 
-  // Issue #4468: named List<Long> param — this is the primary failing form.
   @Test
   void namedListParamInWithIndexReturnsRows() {
     database.transaction(() -> {
@@ -78,9 +77,9 @@ class InParamIndexExpansionTest extends TestHelper {
     });
   }
 
-  // Issue #4468: named primitive long[] param — simulates HTTP JSON deserialization via toMap(true).
+  // long[] reproduces the HTTP JSON deserialization that toMap(true) performs for integer arrays.
   @Test
-  void namedPrimitiveArrayParamInWithIndexReturnsRows() {
+  void namedPrimitiveLongArrayParamInWithIndexReturnsRows() {
     database.transaction(() -> {
       final ResultSet rs = database.query("sql",
           "select code from IssueItem where code in :codes order by code",
@@ -90,7 +89,30 @@ class InParamIndexExpansionTest extends TestHelper {
     });
   }
 
-  // Issue #4468: named Object[] param — covers mixed boxed-array case.
+  // int[] is another primitive-array shape toMap(true) can produce for small integer JSON arrays.
+  @Test
+  void namedPrimitiveIntArrayParamInWithIndexReturnsRows() {
+    database.transaction(() -> {
+      final ResultSet rs = database.query("sql",
+          "select code from IssueItem where code in :codes order by code",
+          Map.of("codes", new int[] { 1, 2, 3 }));
+      final List<Integer> codes = rs.stream().map(r -> r.<Integer>getProperty("code")).toList();
+      assertThat(codes).containsExactly(1, 2, 3);
+    });
+  }
+
+  // double[] is produced for floating-point JSON arrays; values must coerce to the INTEGER index key.
+  @Test
+  void namedPrimitiveDoubleArrayParamInWithIndexReturnsRows() {
+    database.transaction(() -> {
+      final ResultSet rs = database.query("sql",
+          "select code from IssueItem where code in :codes order by code",
+          Map.of("codes", new double[] { 1.0, 2.0, 3.0 }));
+      final List<Integer> codes = rs.stream().map(r -> r.<Integer>getProperty("code")).toList();
+      assertThat(codes).containsExactly(1, 2, 3);
+    });
+  }
+
   @Test
   void namedObjectArrayParamInWithIndexReturnsRows() {
     database.transaction(() -> {
@@ -102,7 +124,6 @@ class InParamIndexExpansionTest extends TestHelper {
     });
   }
 
-  // Issue #4468: positional List<Long> param — the other reported failing form.
   @Test
   void positionalListParamInWithIndexReturnsRows() {
     database.transaction(() -> {
@@ -114,7 +135,6 @@ class InParamIndexExpansionTest extends TestHelper {
     });
   }
 
-  // Confirm the execution plan uses the index for the IN :codes form.
   @Test
   void namedListParamInExplainUsesIndex() {
     database.transaction(() -> {
@@ -126,7 +146,7 @@ class InParamIndexExpansionTest extends TestHelper {
     });
   }
 
-  // Verify the non-indexed path (arithmetic prevents index use) still works as a control.
+  // Control: arithmetic on the left side forces the non-indexed evaluator, which already worked.
   @Test
   void namedListParamInWithoutIndexReturnsRows() {
     database.transaction(() -> {
@@ -138,7 +158,6 @@ class InParamIndexExpansionTest extends TestHelper {
     });
   }
 
-  // Partial match: only 2 of 3 codes present in the collection.
   @Test
   void namedListParamInWithIndexReturnsPartialRows() {
     database.transaction(() -> {
@@ -150,7 +169,6 @@ class InParamIndexExpansionTest extends TestHelper {
     });
   }
 
-  // Single-element list param must also find exactly one row.
   @Test
   void namedListParamInWithIndexReturnsSingleRow() {
     database.transaction(() -> {


### PR DESCRIPTION
## Summary

Closes #4468

`WHERE field IN :param` returned no rows when `field` had an index and the parameter value was a collection. The non-indexed path (`WHERE (field + 0) IN :param`) and the literal form (`WHERE field IN [1, 2, 3]`) worked correctly.

**Root cause:** `PostCommandHandler` uses `json.toMap(true)` to deserialize the HTTP request body. The optimized flag converts JSON numeric arrays (`[1, 2, 3]`) to `long[]`/`double[]` primitive arrays to avoid boxing allocations. Primitive arrays are **not** `Iterable<?>` in Java.

`FetchFromIndexStep.cartesianProduct()` expanded collection parameters into one index lookup per element using:

```java
if (value instanceof Iterable<?> iterable && !(value instanceof Identifiable)) {
```

A `long[]` parameter failed this check, so the entire array was passed as a single index key - matching nothing.

**Fix:** Extended the predicate in `cartesianProduct()` to also handle arrays, wrapping them with the existing `IterableObjectArray` utility:

```java
if (!(value instanceof Identifiable) && (value instanceof Iterable<?> || (value != null && value.getClass().isArray()))) {
    final Iterable<?> iterable = value instanceof Iterable<?> iter ? iter : new IterableObjectArray<>(value);
    for (final Object elemInKey : iterable) {
```

## Test plan

- New regression test `InParamIndexExpansionTest` (9 test methods) covers:
  - Named `List<Long>` parameter via `IN :codes` with an indexed field
  - Named primitive `long[]` parameter (simulates HTTP JSON deserialization via `toMap(true)`)
  - Named `Object[]` parameter
  - Positional `List<Long>` parameter via `IN ?`
  - Execution plan verification that the index is used
  - Non-indexed control path to confirm no regression there
  - Partial match (subset of inserted values)
  - Single-element list
- 314 index and SQL query tests pass with no failures
