### PR TITLE
fix: skip ON MATCH SET write when the value is unchanged (reduce MERGE contention)

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -1104,7 +1104,8 @@ public class MergeStep extends AbstractExecutionStep {
       return b == null;
     if (a.equals(b))
       return true;
-    // Numeric type-safe comparison: Integer(1) should equal Long(1)
+    // Numeric type-safe comparison: Integer(1) equals Long(1). Float vs Double may report unequal
+    // after widening (0.1f != 0.1d): conservative on purpose, the only cost is a redundant write.
     if (a instanceof Number && b instanceof Number)
       return ((Number) a).longValue() == ((Number) b).longValue()
           && Double.compare(((Number) a).doubleValue(), ((Number) b).doubleValue()) == 0;
@@ -1270,8 +1271,7 @@ public class MergeStep extends AbstractExecutionStep {
           final String property = item.getProperty();
           final Object value = evaluator.evaluate(item.getValueExpression(), result, context);
           if (value == null) {
-            // Removing an absent property is a no-op: skip the write so the
-            // record version is not bumped (see equality skip below).
+            // Removing an absent property is a no-op: skip to avoid bumping the MVCC version.
             if (doc.has(property)) {
               final MutableDocument mutableDoc = doc.modify();
               mutableDoc.remove(property);
@@ -1280,14 +1280,8 @@ public class MergeStep extends AbstractExecutionStep {
             }
           } else {
             final Object coerced = TemporalUtil.toCoreJavaType(value);
-            // Skip the write entirely when the stored value already equals the
-            // new one. Writing identical values back still marks the record
-            // dirty and bumps its MVCC version on save(), which makes every
-            // concurrent transaction that read the same record fail with
-            // ConcurrentModificationException. This is the dominant source of
-            // retry storms for ON MATCH SET on shared vertices: the new value
-            // typically never changes for an already-matched record, so the
-            // MERGE can stay a read-only operation for it.
+            // Skip write when value is unchanged to avoid a needless MVCC version bump (which would
+            // make concurrent readers of this record fail with ConcurrentModificationException).
             if (!valuesEqual(doc.get(property), coerced)) {
               final MutableDocument mutableDoc = doc.modify();
               mutableDoc.set(property, coerced);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -1267,14 +1267,34 @@ public class MergeStep extends AbstractExecutionStep {
         case PROPERTY: {
           if (!(obj instanceof Document doc))
             break;
-          final MutableDocument mutableDoc = doc.modify();
-          Object value = evaluator.evaluate(item.getValueExpression(), result, context);
-          if (value == null)
-            mutableDoc.remove(item.getProperty());
-          else
-            mutableDoc.set(item.getProperty(), TemporalUtil.toCoreJavaType(value));
-          mutableDoc.save();
-          ((ResultInternal) result).setProperty(variable, mutableDoc);
+          final String property = item.getProperty();
+          final Object value = evaluator.evaluate(item.getValueExpression(), result, context);
+          if (value == null) {
+            // Removing an absent property is a no-op: skip the write so the
+            // record version is not bumped (see equality skip below).
+            if (doc.has(property)) {
+              final MutableDocument mutableDoc = doc.modify();
+              mutableDoc.remove(property);
+              mutableDoc.save();
+              ((ResultInternal) result).setProperty(variable, mutableDoc);
+            }
+          } else {
+            final Object coerced = TemporalUtil.toCoreJavaType(value);
+            // Skip the write entirely when the stored value already equals the
+            // new one. Writing identical values back still marks the record
+            // dirty and bumps its MVCC version on save(), which makes every
+            // concurrent transaction that read the same record fail with
+            // ConcurrentModificationException. This is the dominant source of
+            // retry storms for ON MATCH SET on shared vertices: the new value
+            // typically never changes for an already-matched record, so the
+            // MERGE can stay a read-only operation for it.
+            if (!valuesEqual(doc.get(property), coerced)) {
+              final MutableDocument mutableDoc = doc.modify();
+              mutableDoc.set(property, coerced);
+              mutableDoc.save();
+              ((ResultInternal) result).setProperty(variable, mutableDoc);
+            }
+          }
           break;
         }
         case REPLACE_MAP: {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherMergeActionsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherMergeActionsTest.java
@@ -29,6 +29,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 ;
@@ -236,5 +240,99 @@ public class OpenCypherMergeActionsTest {
     final Edge edge = (Edge) result.next().toElement();
     assertThat(((Number) edge.get("since")).intValue()).isEqualTo(2021);
     assertThat((Boolean) edge.get("promoted")).isTrue();
+  }
+
+  /**
+   * ON MATCH SET with values identical to the stored ones must not rewrite the
+   * record. Re-writing the same values keeps the matched vertex unchanged but
+   * is otherwise a no-op for callers.
+   */
+  @Test
+  void mergeOnMatchSetWithUnchangedValuesKeepsValues() {
+    database.command("opencypher", "CREATE (n:Person {name: 'Kim', bank: 'ACME', branch: 'HQ'})");
+
+    final ResultSet result = database.command("opencypher",
+        """
+        MERGE (n:Person {name: 'Kim'}) \
+        ON MATCH SET n.bank = 'ACME', n.branch = 'HQ' \
+        RETURN n""");
+
+    assertThat(result.hasNext()).isTrue();
+    final Vertex person = (Vertex) result.next().toElement();
+    assertThat(person.get("bank")).isEqualTo("ACME");
+    assertThat(person.get("branch")).isEqualTo("HQ");
+  }
+
+  /**
+   * The equality skip must not suppress genuine updates. When a value actually
+   * changes, ON MATCH SET still writes it.
+   */
+  @Test
+  void mergeOnMatchSetWithChangedValueStillWrites() {
+    database.command("opencypher", "CREATE (n:Person {name: 'Leo', counter: 1})");
+
+    final ResultSet result = database.command("opencypher",
+        """
+        MERGE (n:Person {name: 'Leo'}) \
+        ON MATCH SET n.counter = 2 \
+        RETURN n""");
+
+    assertThat(result.hasNext()).isTrue();
+    final Vertex person = (Vertex) result.next().toElement();
+    assertThat(((Number) person.get("counter")).intValue()).isEqualTo(2);
+
+    // Verify persistence
+    final ResultSet verify = database.query("opencypher", "MATCH (n:Person {name: 'Leo'}) RETURN n.counter AS c");
+    assertThat(((Number) verify.next().<Number>getProperty("c")).intValue()).isEqualTo(2);
+  }
+
+  /**
+   * Regression: ON MATCH SET that writes back identical values bumps the
+   * record's MVCC version on every match, so concurrent transactions that
+   * read the same shared vertex fail with ConcurrentModificationException and
+   * have to retry. With the equality skip the MERGE becomes read-only for the
+   * matched vertex, so two transactions that both only re-assert the existing
+   * values can commit without conflicting.
+   */
+  @Test
+  void mergeOnMatchSetWithUnchangedValuesDoesNotConflictConcurrently() throws Exception {
+    // Pre-create the shared vertex both transactions will MERGE-match.
+    database.command("opencypher", "CREATE (n:Person {name: 'Shared', bank: 'ACME', branch: 'HQ'})");
+
+    final CyclicBarrier bothMatched = new CyclicBarrier(2);
+    final AtomicInteger conflicts = new AtomicInteger();
+    final AtomicReference<Throwable> unexpected = new AtomicReference<>();
+
+    final Runnable worker = () -> {
+      try {
+        database.begin();
+        // Reads the shared vertex into this transaction; with the bug it also
+        // rewrites the unchanged values, dirtying the record's page.
+        database.command("opencypher",
+            "MERGE (n:Person {name: 'Shared'}) ON MATCH SET n.bank = 'ACME', n.branch = 'HQ' RETURN n").close();
+        // Ensure both transactions have matched before either commits, so a
+        // write by one would invalidate the version the other read.
+        bothMatched.await();
+        database.commit();
+      } catch (final com.arcadedb.exception.ConcurrentModificationException e) {
+        conflicts.incrementAndGet();
+        if (database.isTransactionActive())
+          database.rollback();
+      } catch (final Throwable t) {
+        unexpected.compareAndSet(null, t);
+        if (database.isTransactionActive())
+          database.rollback();
+      }
+    };
+
+    final Thread t1 = new Thread(worker);
+    final Thread t2 = new Thread(worker);
+    t1.start();
+    t2.start();
+    t1.join();
+    t2.join();
+
+    assertThat(unexpected.get()).isNull();
+    assertThat(conflicts.get()).isZero();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherMergeActionsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherMergeActionsTest.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.Result;
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -242,11 +244,7 @@ public class OpenCypherMergeActionsTest {
     assertThat((Boolean) edge.get("promoted")).isTrue();
   }
 
-  /**
-   * ON MATCH SET with values identical to the stored ones must not rewrite the
-   * record. Re-writing the same values keeps the matched vertex unchanged but
-   * is otherwise a no-op for callers.
-   */
+  /** ON MATCH SET with values identical to the stored ones still returns the matched values. */
   @Test
   void mergeOnMatchSetWithUnchangedValuesKeepsValues() {
     database.command("opencypher", "CREATE (n:Person {name: 'Kim', bank: 'ACME', branch: 'HQ'})");
@@ -263,10 +261,7 @@ public class OpenCypherMergeActionsTest {
     assertThat(person.get("branch")).isEqualTo("HQ");
   }
 
-  /**
-   * The equality skip must not suppress genuine updates. When a value actually
-   * changes, ON MATCH SET still writes it.
-   */
+  /** The equality skip must not suppress genuine updates: a changed value is still written. */
   @Test
   void mergeOnMatchSetWithChangedValueStillWrites() {
     database.command("opencypher", "CREATE (n:Person {name: 'Leo', counter: 1})");
@@ -286,14 +281,7 @@ public class OpenCypherMergeActionsTest {
     assertThat(((Number) verify.next().<Number>getProperty("c")).intValue()).isEqualTo(2);
   }
 
-  /**
-   * Regression: ON MATCH SET that writes back identical values bumps the
-   * record's MVCC version on every match, so concurrent transactions that
-   * read the same shared vertex fail with ConcurrentModificationException and
-   * have to retry. With the equality skip the MERGE becomes read-only for the
-   * matched vertex, so two transactions that both only re-assert the existing
-   * values can commit without conflicting.
-   */
+  /** Regression: re-asserting unchanged values in ON MATCH SET must not bump the MVCC version, so two concurrent MERGEs of the same shared vertex commit without ConcurrentModificationException. */
   @Test
   void mergeOnMatchSetWithUnchangedValuesDoesNotConflictConcurrently() throws Exception {
     // Pre-create the shared vertex both transactions will MERGE-match.
@@ -311,10 +299,11 @@ public class OpenCypherMergeActionsTest {
         database.command("opencypher",
             "MERGE (n:Person {name: 'Shared'}) ON MATCH SET n.bank = 'ACME', n.branch = 'HQ' RETURN n").close();
         // Ensure both transactions have matched before either commits, so a
-        // write by one would invalidate the version the other read.
-        bothMatched.await();
+        // write by one would invalidate the version the other read. Bounded wait so a
+        // worker that died before reaching the barrier can't hang the other indefinitely.
+        bothMatched.await(15, TimeUnit.SECONDS);
         database.commit();
-      } catch (final com.arcadedb.exception.ConcurrentModificationException e) {
+      } catch (final ConcurrentModificationException e) {
         conflicts.incrementAndGet();
         if (database.isTransactionActive())
           database.rollback();
@@ -334,5 +323,17 @@ public class OpenCypherMergeActionsTest {
 
     assertThat(unexpected.get()).isNull();
     assertThat(conflicts.get()).isZero();
+  }
+
+  /** ON MATCH SET of an absent property to null is a no-op: the property stays absent. */
+  @Test
+  void mergeOnMatchSetNullOnAbsentPropertyIsNoOp() {
+    database.command("opencypher", "CREATE (n:Person {name: 'Kim'})");
+
+    database.command("opencypher",
+        "MERGE (n:Person {name: 'Kim'}) ON MATCH SET n.bank = null RETURN n").close();
+
+    final ResultSet rs = database.query("opencypher", "MATCH (n:Person {name: 'Kim'}) RETURN n.bank AS b");
+    assertThat(rs.next().<Object>getProperty("b")).isNull();
   }
 }


### PR DESCRIPTION
## Problem

`MergeStep.applySetClause()` (OpenCypher `MERGE ... ON MATCH SET` / `ON CREATE SET`) unconditionally called `MutableDocument.set()` + `save()` for every property item, even when the new value was identical to the value already stored.

`MutableDocument.set()`/`save()` always mark the record dirty and bump its MVCC version. So re-asserting unchanged values on a matched vertex rewrites the record and invalidates the version that every concurrent transaction reading the same vertex had seen, surfacing as `ConcurrentModificationException` and forcing retries.

For high-throughput `MERGE` on **shared** vertices — the common pattern of `ON MATCH SET` re-writing constant attributes on every message — this turns what should be read-only matches into a write-conflict storm. It is badly amplified in HA, where each redundant write also costs a Raft consensus round.

This was reported by a production user running ~1000 Kafka messages across a 3-node embedded HA cluster: ~7300 retries for 1001 messages, with `ON MATCH SET` re-writing constant `Account` attributes (bank/branch/number/type) that never change for a given account.

## Fix

In the `PROPERTY` case, before writing:
- compare the coerced new value with the stored value using the existing numeric-safe `valuesEqual()` helper, and skip `set()` + `save()` when they are equal;
- for a `null` assignment (property removal), skip when the property is absent.

The matched `MERGE` then stays a **read-only** operation for that vertex: no dirty flag, no version bump, no replication. Genuine updates (a value that actually changes) are unaffected.

## Tests

Added to `OpenCypherMergeActionsTest`:
- `mergeOnMatchSetWithUnchangedValuesKeepsValues` — unchanged values leave the vertex correct
- `mergeOnMatchSetWithChangedValueStillWrites` — a real change still writes and persists
- `mergeOnMatchSetWithUnchangedValuesDoesNotConflictConcurrently` — two concurrent transactions issuing `ON MATCH SET` with unchanged values no longer conflict. Verified this test **fails before** the fix (one `ConcurrentModificationException`) and **passes after**.

Full `OpenCypher*` suite is green (5682 tests, 0 failures).

## Notes

This addresses the dominant root cause (phantom writes). Splitting work across two transactions per message and re-running both on retry is a secondary, client-side amplifier; combining them and/or pre-seeding known vertices remains a good complementary practice but is out of scope for this engine change.