### PR TITLE
feat: [#4141] GQL strict numeric types - write side (schema round-trip)

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
@@ -412,7 +412,11 @@ public class OpenCypherQueryEngine implements QueryEngine {
   }
 
   /**
-   * Maps a Cypher type name (from IS TYPED constraints) to an ArcadeDB Type.
+   * Maps a Cypher type name (from IS TYPED constraints) to an ArcadeDB Type. The GQL numeric width types map
+   * onto ArcadeDB's existing widths (INT8->BYTE, INT16->SHORT, INT32->INTEGER, INT64->LONG, FLOAT32->FLOAT,
+   * FLOAT64->DOUBLE) so a declared property persists and reloads at that width. The mapping mirrors the read
+   * side ({@link com.arcadedb.query.opencypher.ast.IsTypedExpression}): INTEGER is the 64-bit generic, INT
+   * aliases INT32. Keeping the two sides aligned is what makes a declared column satisfy its own IS TYPED.
    */
   private static Type mapCypherType(final String cypherType) {
     switch (cypherType) {
@@ -422,12 +426,23 @@ public class OpenCypherQueryEngine implements QueryEngine {
     case "STRING":
     case "VARCHAR":
       return Type.STRING;
-    case "INTEGER":
+    case "INT8":
+    case "INTEGER8":
+      return Type.BYTE;
+    case "INT16":
+    case "INTEGER16":
+      return Type.SHORT;
     case "INT":
+    case "INT32":
+    case "INTEGER32":
+      return Type.INTEGER;
+    case "INTEGER":
     case "SIGNED INTEGER":
     case "INTEGER64":
     case "INT64":
       return Type.LONG;
+    case "FLOAT32":
+      return Type.FLOAT;
     case "FLOAT":
     case "FLOAT64":
       return Type.DOUBLE;

--- a/engine/src/test/java/com/arcadedb/query/opencypher/Issue4141StrictNumericTypesTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/Issue4141StrictNumericTypesTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.Document;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #4141 (ISO/IEC 39075 GQL, section 3): strict numeric types - write side. A property declared with a
+ * GQL width type ({@code INT8/16/32/64}, {@code FLOAT32/64}) must round-trip exactly: the schema property is
+ * created at that width, a value written to it is stored and reloaded at that width, and it satisfies the
+ * matching {@code IS TYPED} predicate (whose subtype hierarchy was already implemented for the read side).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue4141StrictNumericTypesTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp(final TestInfo testInfo) {
+    final DatabaseFactory factory = new DatabaseFactory(
+        "./target/databases/testIssue4141StrictNumeric-" + testInfo.getTestMethod().get().getName());
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Measure");
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null) {
+      database.drop();
+      database = null;
+    }
+  }
+
+  // ---- Schema declaration: each GQL width maps to the matching ArcadeDB Type --------------------
+
+  @ParameterizedTest
+  @CsvSource({
+      "INT8, BYTE", "INTEGER8, BYTE",
+      "INT16, SHORT", "INTEGER16, SHORT",
+      "INT32, INTEGER", "INTEGER32, INTEGER", "INT, INTEGER",
+      "INT64, LONG", "INTEGER64, LONG", "INTEGER, LONG", "SIGNED INTEGER, LONG",
+      "FLOAT32, FLOAT",
+      "FLOAT64, DOUBLE", "FLOAT, DOUBLE" })
+  void gqlNumericTypeMapsToArcadeWidth(final String gqlType, final Type expected) {
+    database.command("opencypher", "CREATE CONSTRAINT FOR (m:Measure) REQUIRE m.v IS TYPED " + gqlType).close();
+    assertThat(database.getSchema().getType("Measure").getProperty("v").getType()).isEqualTo(expected);
+  }
+
+  // ---- Persistence round-trip: a value keeps its declared width through store + reload ----------
+
+  @ParameterizedTest
+  @CsvSource({
+      "INT8, 5, Byte",
+      "INT16, 5, Short",
+      "INT32, 5, Integer",
+      "INT64, 5, Long",
+      "FLOAT32, 1.5, Float",
+      "FLOAT64, 1.5, Double" })
+  void valueRoundTripsAtDeclaredWidth(final String gqlType, final String literal, final String javaType) {
+    database.command("opencypher", "CREATE CONSTRAINT FOR (m:Measure) REQUIRE m.v IS TYPED " + gqlType).close();
+    database.command("opencypher", "CREATE (m:Measure {v: " + literal + "})").close();
+
+    // The reloaded record holds the value at the declared Java width (not widened to Long/Double).
+    database.transaction(() -> {
+      final Document doc = (Document) database.iterateType("Measure", true).next();
+      assertThat(doc.get("v").getClass().getSimpleName()).isEqualTo(javaType);
+    });
+
+    // And the value still satisfies its declared IS TYPED predicate after the round-trip.
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (m:Measure) RETURN m.v IS TYPED " + gqlType + " AS ok")) {
+      assertThat(rs.next().<Boolean>getProperty("ok")).isTrue();
+    }
+  }
+
+  // ---- INT is the 32-bit alias (consistent with the IS TYPED read side) ------------------------
+
+  @ParameterizedTest
+  @CsvSource({
+      "INT16, INT8",   // a Short is not an INT8
+      "INT32, INT16",  // an Integer is not an INT16
+      "FLOAT64, FLOAT32" }) // a Double is not a FLOAT32
+  void declaredWidthIsNotMatchedByANarrowerType(final String declared, final String narrower) {
+    database.command("opencypher", "CREATE CONSTRAINT FOR (m:Measure) REQUIRE m.v IS TYPED " + declared).close();
+    database.command("opencypher", "CREATE (m:Measure {v: 1})").close();
+
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (m:Measure) RETURN m.v IS TYPED " + narrower + " AS ok")) {
+      assertThat(rs.next().<Boolean>getProperty("ok")).isFalse();
+    }
+  }
+}


### PR DESCRIPTION
## ⚠️ BREAKING CHANGE

`CREATE CONSTRAINT ... IS TYPED INT` now declares a **32-bit `INTEGER`** column, where it previously declared a 64-bit `LONG`. `INT` is the ISO/IEC 39075 alias for `INT32`. A property declared with the bare `IS TYPED INT` keyword can no longer hold values outside the 32-bit range (`> 2,147,483,647`); use `IS TYPED INTEGER` (or `INT64`) for 64-bit columns.

Scope of impact is small: this only affects schemas that used the **bare `INT`** keyword (not `INTEGER`) in a Cypher `IS TYPED` constraint, and is in fact a *correctness* fix - since 26.5.1 the read side (`x IS TYPED INT`) already evaluated `INT` as 32-bit, so a value `> Integer.MAX_VALUE` stored in such a column already failed its own predicate. The two sides are now consistent. **Migration:** change `IS TYPED INT` to `IS TYPED INTEGER` (or `INT64`) where 64-bit width is required. Needs a release-note / upgrade-doc mention.

---

## Summary

Implements ISO/IEC 39075 (GQL) **strict numeric types - write side** for the OpenCypher engine - issue #4141, section 3. A property declared with a GQL numeric width type now persists and reloads at that width.

```cypher
CREATE CONSTRAINT FOR (m:Measure) REQUIRE m.v IS TYPED INT16   -- creates a 16-bit SHORT column
CREATE (m:Measure {v: 5})                                      -- 5 is stored as a Short...
MATCH (m:Measure) RETURN m.v IS TYPED INT16                    -- ...and satisfies its own predicate (true)
```

## The fix

`mapCypherType` (used by `CREATE CONSTRAINT ... IS TYPED <type>`) collapsed every integer to `LONG` and every float to `DOUBLE`, and rejected `INT8`/`INT16`/`INT32`/`FLOAT32` with "Unsupported Cypher type". It now maps the full GQL width hierarchy onto ArcadeDB's existing widths:

| GQL type | ArcadeDB `Type` | Java |
|---|---|---|
| `INT8` / `INTEGER8` | `BYTE` | `Byte` |
| `INT16` / `INTEGER16` | `SHORT` | `Short` |
| `INT` / `INT32` / `INTEGER32` | `INTEGER` | `Integer` |
| `INTEGER` / `INT64` / `INTEGER64` / `SIGNED INTEGER` | `LONG` | `Long` |
| `FLOAT32` | `FLOAT` | `Float` |
| `FLOAT` / `FLOAT64` | `DOUBLE` | `Double` |

## Why this is the whole fix (no new storage types)

ArcadeDB's existing `BYTE/SHORT/INTEGER/LONG/FLOAT/DOUBLE` **are** the GQL widths, and the lower layers already preserve them:

- the binary serializer round-trips `Byte/Short/Integer/Long/Float/Double` at their width;
- `MutableDocument.convertValueToSchemaType` already coerces a written value to the declared property's Java type on every set.

So once the schema property is declared at the right width, a value written to it is stored, reloaded, and read back at that width. The only gap was the type-name mapping.

## Consistency with the read side (26.5.1)

This **aligns the write side with the read side** already shipped in 26.5.1 (`IsTypedExpression`): `INTEGER` is the 64-bit generic, `INT` aliases `INT32`. Previously the two disagreed - a property declared `IS TYPED INT` was created as `LONG`, yet the `x IS TYPED INT` predicate checks for a 32-bit `Integer`, so a stored value failed its own constraint. (Behavior change: `IS TYPED INT` now declares `INTEGER`, not `LONG`.)

## Tests

`Issue4141StrictNumericTypesTest` (parameterized, 23 cases):
- each GQL width maps to the expected ArcadeDB `Type`;
- a value round-trips at its declared Java width (asserted on the reloaded record) and still satisfies its `IS TYPED` predicate;
- a narrower predicate correctly does **not** match (a `Short` is not `INT8`, an `Integer` is not `INT16`, a `Double` is not `FLOAT32`).

## Scope / deferred

- **Literal preservation** is covered for declared columns (the literal is coerced to the declared width on write). An *undeclared* property keeps the parser default (`Long`/`Double`), which is fine - GQL mandates no width without a declared type.
- **Arithmetic-result typing** (e.g. `INT16 + INT16` widening to `Long`) is a separate, murkier concern that touches the shared arithmetic-evaluation path; deferred from this change. Happy to file a follow-up issue if wanted.

## Verification

Full `com.arcadedb.query.opencypher.**` suite: **6607 tests, 0 failures** (incl. the 23 new cases; existing `OpenCypherConstraintTest` 24/24 and `OpenCypherCypher25ClausesTest` 40/40 unaffected).

Related to #4141

