### PR TITLE
fix(#4514): LCC double-counts when forward+backward neighbours overlap

### DIFF
--- a/docs/4514-lcc-double-count-overlapping-neighbors.md
+++ b/docs/4514-lcc-double-count-overlapping-neighbors.md
@@ -1,0 +1,39 @@
+# Issue #4514 — `GraphAlgorithms.localClusteringCoefficient` double-counts overlapping forward/backward neighbours
+
+URL: https://github.com/ArcadeData/arcadedb/issues/4514
+
+## Summary
+
+`localClusteringCoefficient` builds an "undirected" adjacency list by concatenating, per node,
+the CSR forward neighbours and CSR backward neighbours. When a vertex pair `(u, v)` is connected by
+both an out-edge `u -> v` and an in-edge `u <- v` (reciprocal edges, or importers that materialise
+both directions), `v` appears **twice** in `neighbors[u]`.
+
+Consequences:
+- The degree used in the LCC formula is `offsets[u+1] - offsets[u]`, i.e. the raw merged length,
+  which over-counts (the denominator `deg*(deg-1)` grows quadratically).
+- The sorted-merge triangle intersection treats each duplicate as a separate neighbour, so a single
+  shared neighbour `w` that appears twice in both `N(u)` and `N(v)` is counted as multiple triangles.
+
+Net result: LCC is materially wrong for any graph with reciprocal/bidirectional edges.
+
+## Root cause
+
+`lccBuildAndIntersect` never de-duplicates the merged adjacency list. The undirected neighbour set
+must contain each distinct neighbour at most once.
+
+## Fix
+
+After building the sorted merged adjacency, compact each per-node list in place to remove duplicate
+neighbours (and any self-loops, which are not valid for an undirected simple-graph LCC). Re-derive
+the per-node degree and offsets from the compacted lengths, then run triangle counting and the LCC
+formula against the compacted structure. The list is already sorted per node, so compaction is a
+single linear walk per node.
+
+## Verification
+
+- New regression tests in `GraphAlgorithmsTest` covering reciprocal edges and a bidirectional
+  triangle, asserting LCC equals the simple-graph value (1.0 for a triangle, 1/3 for a partial
+  clique) rather than an inflated/deflated value.
+- Existing LCC tests (`lccTriangle`, `lccStar`, `lccPartialClique`) must still pass.
+- `AlgoLocalClusteringCoefficientTest` (Cypher procedure) must still pass.

--- a/docs/review-deferred-14ac5c1.md
+++ b/docs/review-deferred-14ac5c1.md
@@ -1,0 +1,18 @@
+# Review notes for #4514 PR (cycle 2, head 14ac5c1)
+
+## Applied
+- Claude #3: replaced `Integer.MIN_VALUE` sentinel with `-1` (node IDs are non-negative).
+- Claude #4: eliminated the `compactOffsets` allocation and `System.arraycopy` by capturing
+  `offsets[u]` into local read bounds and overwriting `offsets[u]` in the same pass. No extra
+  allocation; same O(merged-edges) complexity.
+- Claude #2 (partial): trimmed the verbose comment block and removed the inline `TODO`.
+
+## Declined (with rationale)
+- Claude #1: "remove the `docs/4514-*.md` analysis file". Declined. A per-issue tracking doc under
+  `docs/` is an established repository convention (see `docs/4334-*.md`, `docs/3971-*.md`, and many
+  others) and is an explicit deliverable of the resolve-issue workflow (its Phase 6 updates and
+  commits this file with PR + review history). Removing it would diverge from precedent rather than
+  follow it. Kept.
+- Claude #2 (TODO-as-GitHub-issue): not filing a new GitHub issue unprompted. The sequential-vs-
+  parallel de-dup observation is minor and the inline TODO was removed, so nothing is lost.
+- Gemini cycle 1: no actionable items (approving summary only).

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
@@ -1313,33 +1313,24 @@ public final class GraphAlgorithms {
       });
     }
 
-    // De-duplicate each (now sorted) adjacency list in place. A vertex pair (u, v) connected by
-    // both an out-edge u->v and an in-edge u<-v produces two copies of v in N(u); reciprocal or
-    // bidirectional edges (common with importers) are the typical source. Self-loops (u itself)
-    // are dropped too: the undirected neighbour set used for a simple-graph LCC contains each
-    // distinct neighbour exactly once and never the node itself. Both the single-type merge and
-    // the multi-type sort above leave equal neighbours adjacent, so this is a single linear walk
-    // per node. The write cursor never overtakes the read cursor, so compaction is safe in place.
-    // TODO: this pass is sequential while the multi-type sort above is parallel; for very large
-    // graphs it could be parallelized via a two-phase prefix-sum (per-node compacted sizes, then
-    // a parallel compaction), at the cost of extra complexity.
-    final int[] compactOffsets = new int[n + 1];
+    // Both merge paths produce per-node sorted adjacency. Compact in place: drop self-loops and
+    // duplicates from reciprocal edges (same neighbour in both the fwd and bwd CSR lists), so the
+    // undirected neighbour set used for the simple-graph LCC holds each distinct neighbour once.
+    // offsets[u] is captured before being overwritten, and the write cursor never overtakes the
+    // read cursor, so the mutation is safe in place with no extra allocation.
     int write = 0;
     for (int u = 0; u < n; u++) {
-      compactOffsets[u] = write;
-      final int end = offsets[u + 1];
-      int last = Integer.MIN_VALUE;
-      for (int j = offsets[u]; j < end; j++) {
+      final int readStart = offsets[u];
+      final int readEnd = offsets[u + 1];
+      offsets[u] = write;
+      int last = -1; // node IDs are non-negative sequential integers, so -1 never matches
+      for (int j = readStart; j < readEnd; j++) {
         final int neighbor = neighbors[j];
-        if (neighbor == u || neighbor == last)
-          continue;
-        neighbors[write++] = neighbor;
-        last = neighbor;
+        if (neighbor != u && neighbor != last)
+          neighbors[write++] = last = neighbor;
       }
     }
-    compactOffsets[n] = write;
-    // The compacted layout supersedes the raw merged layout for triangle counting and the degree.
-    System.arraycopy(compactOffsets, 0, offsets, 0, n + 1);
+    offsets[n] = write;
 
     // Count triangles using the "forward" technique: for each edge (u, v) where v > u,
     // count common neighbors w > v via sorted-merge intersection.

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
@@ -1313,6 +1313,31 @@ public final class GraphAlgorithms {
       });
     }
 
+    // De-duplicate each (now sorted) adjacency list in place. A vertex pair (u, v) connected by
+    // both an out-edge u->v and an in-edge u<-v produces two copies of v in N(u); reciprocal or
+    // bidirectional edges (common with importers) are the typical source. Self-loops (u itself)
+    // are dropped too: the undirected neighbour set used for a simple-graph LCC contains each
+    // distinct neighbour exactly once and never the node itself. Both the single-type merge and
+    // the multi-type sort above leave equal neighbours adjacent, so this is a single linear walk
+    // per node. The write cursor never overtakes the read cursor, so compaction is safe in place.
+    final int[] compactOffsets = new int[n + 1];
+    int write = 0;
+    for (int u = 0; u < n; u++) {
+      compactOffsets[u] = write;
+      final int end = offsets[u + 1];
+      int last = Integer.MIN_VALUE;
+      for (int j = offsets[u]; j < end; j++) {
+        final int neighbor = neighbors[j];
+        if (neighbor == u || neighbor == last)
+          continue;
+        neighbors[write++] = neighbor;
+        last = neighbor;
+      }
+    }
+    compactOffsets[n] = write;
+    // The compacted layout supersedes the raw merged layout for triangle counting and the degree.
+    System.arraycopy(compactOffsets, 0, offsets, 0, n + 1);
+
     // Count triangles using the "forward" technique: for each edge (u, v) where v > u,
     // count common neighbors w > v via sorted-merge intersection.
     // Each triangle {u, v, w} is found exactly once (u < v < w), then credited to all 3 nodes.

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAlgorithms.java
@@ -1320,6 +1320,9 @@ public final class GraphAlgorithms {
     // distinct neighbour exactly once and never the node itself. Both the single-type merge and
     // the multi-type sort above leave equal neighbours adjacent, so this is a single linear walk
     // per node. The write cursor never overtakes the read cursor, so compaction is safe in place.
+    // TODO: this pass is sequential while the multi-type sort above is parallel; for very large
+    // graphs it could be parallelized via a two-phase prefix-sum (per-node compacted sizes, then
+    // a parallel compaction), at the cost of extra complexity.
     final int[] compactOffsets = new int[n + 1];
     int write = 0;
     for (int u = 0; u < n; u++) {

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAlgorithmsTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAlgorithmsTest.java
@@ -687,6 +687,12 @@ class GraphAlgorithmsTest extends TestHelper {
 
     final int aId = gav.getNodeId(a.getIdentity());
     assertThat(lcc[aId]).isCloseTo(1.0 / 3.0, Offset.offset(1e-9));
+    // B and C each have 2 distinct undirected neighbours forming the single A-B-C triangle => LCC = 1.0;
+    // D has a single distinct neighbour (A), degree < 2 => LCC = 0.0. The inflated (un-deduplicated)
+    // degree would corrupt B and C too, so asserting them makes the regression airtight.
+    assertThat(lcc[gav.getNodeId(b.getIdentity())]).isCloseTo(1.0, Offset.offset(1e-9));
+    assertThat(lcc[gav.getNodeId(c.getIdentity())]).isCloseTo(1.0, Offset.offset(1e-9));
+    assertThat(lcc[gav.getNodeId(d.getIdentity())]).isCloseTo(0.0, Offset.offset(1e-9));
 
     gav.drop();
   }

--- a/engine/src/test/java/com/arcadedb/graph/olap/GraphAlgorithmsTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/olap/GraphAlgorithmsTest.java
@@ -623,6 +623,75 @@ class GraphAlgorithmsTest extends TestHelper {
   }
 
   @Test
+  void lccReciprocalTriangle() {
+    // Triangle A-B-C, but every edge is materialised in BOTH directions (reciprocal edges).
+    // Undirected LCC must still be 1.0 for all three nodes: the duplicate forward/backward
+    // neighbour must be de-duplicated so that deg(u) == 2 and triangles(u) == 1.
+    database.getSchema().createVertexType("Node");
+    database.getSchema().createEdgeType("LINK");
+
+    database.begin();
+    final MutableVertex a = database.newVertex("Node").set("name", "A").save();
+    final MutableVertex b = database.newVertex("Node").set("name", "B").save();
+    final MutableVertex c = database.newVertex("Node").set("name", "C").save();
+    // forward edges
+    a.newEdge("LINK", b);
+    b.newEdge("LINK", c);
+    c.newEdge("LINK", a);
+    // reciprocal edges: each pair now has both an out- and an in-edge, so the merged
+    // forward+backward adjacency contains every neighbour twice.
+    b.newEdge("LINK", a);
+    c.newEdge("LINK", b);
+    a.newEdge("LINK", c);
+    database.commit();
+
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withVertexTypes("Node").withEdgeTypes("LINK").build();
+    final double[] lcc = GraphAlgorithms.localClusteringCoefficient(gav, "LINK");
+
+    assertThat(lcc).hasSize(3);
+    // Each node has 2 distinct undirected neighbours forming a single triangle => LCC = 1.0.
+    // Without de-duplication the inflated degree and over-counted triangles produce a wrong value.
+    for (final double coeff : lcc)
+      assertThat(coeff).isCloseTo(1.0, Offset.offset(1e-9));
+
+    gav.drop();
+  }
+
+  @Test
+  void lccReciprocalPartialClique() {
+    // A--B, A--C, A--D, B--C with every edge reciprocated (both directions stored).
+    // A has 3 distinct undirected neighbours (B, C, D) and exactly 1 triangle (A-B-C),
+    // so LCC(A) = 2 * 1 / (3 * 2) = 1/3 even though each neighbour is stored twice.
+    database.getSchema().createVertexType("Node");
+    database.getSchema().createEdgeType("LINK");
+
+    database.begin();
+    final MutableVertex a = database.newVertex("Node").set("name", "A").save();
+    final MutableVertex b = database.newVertex("Node").set("name", "B").save();
+    final MutableVertex c = database.newVertex("Node").set("name", "C").save();
+    final MutableVertex d = database.newVertex("Node").set("name", "D").save();
+    a.newEdge("LINK", b);
+    b.newEdge("LINK", a);
+    a.newEdge("LINK", c);
+    c.newEdge("LINK", a);
+    a.newEdge("LINK", d);
+    d.newEdge("LINK", a);
+    b.newEdge("LINK", c);
+    c.newEdge("LINK", b);
+    database.commit();
+
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withVertexTypes("Node").withEdgeTypes("LINK").build();
+    final double[] lcc = GraphAlgorithms.localClusteringCoefficient(gav, "LINK");
+
+    final int aId = gav.getNodeId(a.getIdentity());
+    assertThat(lcc[aId]).isCloseTo(1.0 / 3.0, Offset.offset(1e-9));
+
+    gav.drop();
+  }
+
+  @Test
   void compactionThresholdBuilder() {
     database.getSchema().createVertexType("Node");
     database.getSchema().createEdgeType("LINK");


### PR DESCRIPTION
Closes #4514

## Summary

`GraphAlgorithms.localClusteringCoefficient` built the undirected adjacency for each node by concatenating its CSR forward neighbours with its CSR backward neighbours. When a vertex pair `(u, v)` is connected by both an out-edge `u -> v` and an in-edge `u <- v` (reciprocal/bidirectional edges, which importers commonly materialise), `v` ended up duplicated in `N(u)`. That inflated the degree used in the LCC denominator `deg*(deg-1)` and caused the sorted-merge triangle counter to over-count shared neighbours, so LCC was materially wrong for any graph storing both edge directions.

The fix de-duplicates each (already sorted) merged adjacency list in place - also dropping self-loops, which are not valid neighbours for a simple-graph LCC - and re-derives the per-node offsets/degree from the compacted length before counting triangles and applying the LCC formula. Compaction is a single linear walk per node and the write cursor never overtakes the read cursor, so it is safe in place. Both the single-edge-type merge path and the multi-edge-type sort path already leave equal neighbours adjacent, so one compaction pass covers both.

## Test plan

- [ ] `mvn test -Dtest=GraphAlgorithmsTest` (engine) - existing `lccTriangle`, `lccStar`, `lccPartialClique` still pass; new `lccReciprocalTriangle` (expects 1.0) and `lccReciprocalPartialClique` (expects 1/3) pass.
- [ ] `mvn test -Dtest=AlgoLocalClusteringCoefficientTest` (Cypher procedure) still passes.
- [ ] New regression tests fail on the pre-fix code (triangle returned 0.667 instead of 1.0; partial clique returned 0.267 instead of 0.333) and pass after the fix.