### PR TITLE
fix: [timeseries] TimeSeriesMaintenanceScheduler leaks DatabaseContext ThreadLocal across databases

### DIFF
--- a/docs/4519-ts-maintenance-scheduler-context-leak.md
+++ b/docs/4519-ts-maintenance-scheduler-context-leak.md
@@ -1,0 +1,53 @@
+# Issue #4519: TimeSeriesMaintenanceScheduler leaks DatabaseContext.INSTANCE ThreadLocal
+
+## Root cause
+
+`TimeSeriesMaintenanceScheduler.schedule()` ran each periodic maintenance pass on a fixed-size
+`ScheduledExecutorService` pool (4 threads) shared across every database registered with the
+scheduler. Each pass called `DatabaseContext.INSTANCE.init((DatabaseInternal) db)` to install the
+database into the worker thread's ThreadLocal, but there was no matching cleanup in a `finally`
+block.
+
+Because the pool threads are reused across databases:
+
+- The thread kept a strong reference to a (possibly closed) `DatabaseInternal`, adding GC pressure.
+- A maintenance pass for DB-B could inherit DB-A's still-installed transaction context, so
+  begin/commit could target the wrong database.
+
+## Fix
+
+`engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesMaintenanceScheduler.java`
+
+- Extracted the maintenance body into a package-private static `runMaintenance(Database, LocalTimeSeriesType, String)`
+  so the init/cleanup contract is directly testable. The scheduled lambda now delegates to it.
+- Wrapped the body in `try { ... } finally { DatabaseContext.INSTANCE.removeContext(dbInternal.getDatabasePath()); }`.
+
+`removeContext(databasePath)` is preferred over the raw `ThreadLocal.remove()` suggested in the
+issue: it removes only this database's per-thread entry and, when the thread's map becomes empty,
+also clears the inherited ThreadLocal plus the `CONTEXTS` registry entry, keeping both structures
+consistent. The `finally` also guarantees cleanup on the early `return` paths inside the body
+(null engine) and on any thrown error.
+
+## Tests
+
+`engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesMaintenanceSchedulerContextLeakTest.java`
+
+- `maintenancePassRemovesDatabaseContextFromWorkerThread` - after a single pass on a pooled worker
+  thread, the thread's `DatabaseContext` for the DB path is null.
+- `maintenancePassDoesNotLeakContextAcrossDatabasesOnSameThread` - runs a pass for DB-A then DB-B on
+  the same single-thread executor and asserts DB-A's context never survives into the DB-B pass and
+  both contexts are cleaned afterward.
+
+Both tests were confirmed to FAIL against the un-fixed code (DB-A context survived; AssertionFailedError)
+and PASS with the fix.
+
+## Verification
+
+- `mvn -pl engine test -Dtest=TimeSeriesMaintenanceSchedulerContextLeakTest` -> 2/2 pass.
+- Regression run with related TS tests (`TimeSeriesRetentionTest`, `TimeSeriesDownsamplingTest`,
+  `DropTimeSeriesTypeTest`, `TimeSeriesGapAnalysisTest`) -> 42/42 pass.
+
+## Impact
+
+Behavior of maintenance passes is unchanged; the only difference is the per-thread context is now
+removed after each pass. No public API change. The extracted static method is package-private.

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesMaintenanceScheduler.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesMaintenanceScheduler.java
@@ -85,45 +85,63 @@ public class TimeSeriesMaintenanceScheduler {
         return;
       }
 
-      // Under HA, destructive maintenance (compaction, retention, downsampling) is leader-only:
-      // it mutates the replicated mutable bucket and the sealed store, and the leader ships the
-      // result to followers. Followers running it independently would diverge. The individual
-      // engine operations also self-gate via runWithCompactionReplication, but skipping here avoids
-      // the wasted DatabaseContext init + transaction churn on every follower tick.
-      final DatabaseInternal dbInternal = (DatabaseInternal) db;
-      if (dbInternal.isReplicated() && !dbInternal.isLeader())
+      runMaintenance(db, type, typeName);
+    }, 5_000, DEFAULT_CHECK_INTERVAL_MS, TimeUnit.MILLISECONDS));
+  }
+
+  /**
+   * Runs a single maintenance pass (compaction, retention, downsampling) for the given type.
+   * <p>
+   * The maintenance threads come from a fixed-size {@link ScheduledExecutorService} pool that is
+   * shared across every database registered with the scheduler. Each pass therefore installs the
+   * target database into the worker thread's {@link DatabaseContext} ThreadLocal and MUST remove it
+   * again in a {@code finally} block: leaving it installed keeps a strong reference to a (possibly
+   * closed) database and, worse, lets the next pass for a different database inherit the previous
+   * database's transaction context and commit against the wrong store.
+   */
+  static void runMaintenance(final Database db, final LocalTimeSeriesType type, final String typeName) {
+    // Under HA, destructive maintenance (compaction, retention, downsampling) is leader-only:
+    // it mutates the replicated mutable bucket and the sealed store, and the leader ships the
+    // result to followers. Followers running it independently would diverge. The individual
+    // engine operations also self-gate via runWithCompactionReplication, but skipping here avoids
+    // the wasted DatabaseContext init + transaction churn on every follower tick.
+    final DatabaseInternal dbInternal = (DatabaseInternal) db;
+    if (dbInternal.isReplicated() && !dbInternal.isLeader())
+      return;
+
+    // The maintenance thread is created by a ScheduledExecutorService and does not
+    // have a DatabaseContext initialized.  We must initialize it before calling any
+    // database operation (begin/commit) or we get "Transaction context not found".
+    DatabaseContext.INSTANCE.init(dbInternal);
+    try {
+      final TimeSeriesEngine engine = type.getEngine();
+      if (engine == null)
         return;
 
-      // The maintenance thread is created by a ScheduledExecutorService and does not
-      // have a DatabaseContext initialized.  We must initialize it before calling any
-      // database operation (begin/commit) or we get "Transaction context not found".
-      DatabaseContext.INSTANCE.init(dbInternal);
-      try {
-        final TimeSeriesEngine engine = type.getEngine();
-        if (engine == null)
-          return;
+      final long nowMs = System.currentTimeMillis();
 
-        final long nowMs = System.currentTimeMillis();
+      // Compact mutable data before retention/downsampling so that
+      // all samples are in the sealed store and subject to truncation.
+      engine.compactAll();
 
-        // Compact mutable data before retention/downsampling so that
-        // all samples are in the sealed store and subject to truncation.
-        engine.compactAll();
-
-        // Apply retention policy
-        if (type.getRetentionMs() > 0) {
-          final long cutoff = nowMs - type.getRetentionMs();
-          engine.applyRetention(cutoff);
-        }
-
-        // Apply downsampling tiers
-        if (!type.getDownsamplingTiers().isEmpty())
-          engine.applyDownsampling(type.getDownsamplingTiers(), nowMs);
-
-      } catch (final Throwable e) {
-        LogManager.instance().log(this, Level.WARNING,
-            "Error in TimeSeries maintenance for type '%s'", e, typeName);
+      // Apply retention policy
+      if (type.getRetentionMs() > 0) {
+        final long cutoff = nowMs - type.getRetentionMs();
+        engine.applyRetention(cutoff);
       }
-    }, 5_000, DEFAULT_CHECK_INTERVAL_MS, TimeUnit.MILLISECONDS));
+
+      // Apply downsampling tiers
+      if (!type.getDownsamplingTiers().isEmpty())
+        engine.applyDownsampling(type.getDownsamplingTiers(), nowMs);
+
+    } catch (final Throwable e) {
+      LogManager.instance().log(TimeSeriesMaintenanceScheduler.class, Level.WARNING,
+          "Error in TimeSeries maintenance for type '%s'", e, typeName);
+    } finally {
+      // Pooled threads are reused across databases: never leave this DB's context behind, or the
+      // next pass on the same thread could commit against the wrong database (see issue #4519).
+      DatabaseContext.INSTANCE.removeContext(dbInternal.getDatabasePath());
+    }
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesMaintenanceSchedulerContextLeakTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesMaintenanceSchedulerContextLeakTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseContext;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4519: {@link TimeSeriesMaintenanceScheduler} must not leak the
+ * {@link DatabaseContext} ThreadLocal on the shared maintenance worker threads.
+ *
+ * <p>The scheduler runs maintenance passes on a fixed-size {@link ScheduledExecutorService} pool
+ * that is reused across every database. If a pass installs a database into the worker thread's
+ * {@code DatabaseContext} ThreadLocal but never removes it, the thread keeps a strong reference to
+ * a (possibly closed) database and, worse, the next pass for a different database inherits the
+ * previous database's transaction context, so commits target the wrong store.
+ */
+class TimeSeriesMaintenanceSchedulerContextLeakTest extends TestHelper {
+
+  @Test
+  void maintenancePassRemovesDatabaseContextFromWorkerThread() throws Exception {
+    database.command("sql",
+        "CREATE TIMESERIES TYPE Ticker TIMESTAMP ts TAGS (name STRING) FIELDS (f1 DOUBLE) SHARDS 1");
+    final LocalTimeSeriesType tsType = (LocalTimeSeriesType) database.getSchema().getType("Ticker");
+    final String dbPath = ((DatabaseInternal) database).getDatabasePath();
+
+    final ScheduledExecutorService worker = Executors.newSingleThreadScheduledExecutor(r -> {
+      final Thread t = new Thread(r, "TS-Maintenance-Test");
+      t.setDaemon(true);
+      return t;
+    });
+    try {
+      final AtomicReference<DatabaseContext.DatabaseContextTL> contextAfterRun = new AtomicReference<>();
+
+      worker.submit(() -> {
+        // The pooled thread starts with no DatabaseContext installed.
+        assertThat(DatabaseContext.INSTANCE.getContextIfExists(dbPath)).isNull();
+
+        TimeSeriesMaintenanceScheduler.runMaintenance(database, tsType, "Ticker");
+
+        // After the pass, the context MUST have been removed: nothing left behind on the thread.
+        contextAfterRun.set(DatabaseContext.INSTANCE.getContextIfExists(dbPath));
+      }).get(30, TimeUnit.SECONDS);
+
+      assertThat(contextAfterRun.get())
+          .as("DatabaseContext must be removed from the worker thread after a maintenance pass")
+          .isNull();
+    } finally {
+      worker.shutdownNow();
+    }
+  }
+
+  @Test
+  void maintenancePassDoesNotLeakContextAcrossDatabasesOnSameThread() throws Exception {
+    // DB-A is the base 'database' from TestHelper.
+    database.command("sql",
+        "CREATE TIMESERIES TYPE TickerA TIMESTAMP ts TAGS (name STRING) FIELDS (f1 DOUBLE) SHARDS 1");
+    final LocalTimeSeriesType typeA = (LocalTimeSeriesType) database.getSchema().getType("TickerA");
+    final String dbPathA = ((DatabaseInternal) database).getDatabasePath();
+
+    // DB-B is a second, independent database that shares the same maintenance worker thread.
+    final String dbBPath = "./target/databases/" + getClass().getSimpleName() + "-B";
+    FileUtils.deleteRecursively(new File(dbBPath));
+    final DatabaseFactory factoryB = new DatabaseFactory(dbBPath);
+    final Database databaseB = factoryB.create();
+    try {
+      databaseB.command("sql",
+          "CREATE TIMESERIES TYPE TickerB TIMESTAMP ts TAGS (name STRING) FIELDS (f1 DOUBLE) SHARDS 1");
+      final LocalTimeSeriesType typeB = (LocalTimeSeriesType) databaseB.getSchema().getType("TickerB");
+      final String dbPathB = ((DatabaseInternal) databaseB).getDatabasePath();
+
+      final ScheduledExecutorService worker = Executors.newSingleThreadScheduledExecutor(r -> {
+        final Thread t = new Thread(r, "TS-Maintenance-Test");
+        t.setDaemon(true);
+        return t;
+      });
+      try {
+        final AtomicReference<DatabaseContext.DatabaseContextTL> leakedAContext = new AtomicReference<>();
+        final AtomicReference<DatabaseContext.DatabaseContextTL> bContext = new AtomicReference<>();
+
+        worker.submit(() -> {
+          // Pass for DB-A on the shared thread.
+          TimeSeriesMaintenanceScheduler.runMaintenance(database, typeA, "TickerA");
+
+          // Pass for DB-B on the SAME thread. If DB-A's context leaked, DB-B's pass would have run
+          // with DB-A still installed in the ThreadLocal.
+          assertThat(DatabaseContext.INSTANCE.getContextIfExists(dbPathA))
+              .as("DB-A context must not survive into the DB-B maintenance pass on the same thread")
+              .isNull();
+
+          TimeSeriesMaintenanceScheduler.runMaintenance(databaseB, typeB, "TickerB");
+
+          leakedAContext.set(DatabaseContext.INSTANCE.getContextIfExists(dbPathA));
+          bContext.set(DatabaseContext.INSTANCE.getContextIfExists(dbPathB));
+        }).get(30, TimeUnit.SECONDS);
+
+        assertThat(leakedAContext.get())
+            .as("DB-A context must not be present on the worker thread after the DB-B pass")
+            .isNull();
+        assertThat(bContext.get())
+            .as("DB-B context must also be cleaned up after its own pass")
+            .isNull();
+      } finally {
+        worker.shutdownNow();
+      }
+    } finally {
+      databaseB.drop();
+      factoryB.close();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #4519.

`TimeSeriesMaintenanceScheduler` runs each periodic maintenance pass on a fixed-size, shared `ScheduledExecutorService` pool. Each pass installed the database into the worker thread's `DatabaseContext` ThreadLocal via `init()` but never removed it. Because the pool threads are reused across databases, this caused:

- a strong reference to a possibly-closed `DatabaseInternal` (GC pressure), and
- a pass for DB-B inheriting DB-A's transaction context, so begin/commit could target the wrong database.

## Fix

`engine/.../timeseries/TimeSeriesMaintenanceScheduler.java`

- Extracted the maintenance body into a package-private static `runMaintenance(Database, LocalTimeSeriesType, String)` so the init/cleanup contract is directly testable; the scheduled lambda delegates to it.
- Wrapped the body in `try { ... } finally { DatabaseContext.INSTANCE.removeContext(dbInternal.getDatabasePath()); }`.

`removeContext(databasePath)` is preferred over the raw `ThreadLocal.remove()` from the issue: it removes only this database's per-thread entry and, when the thread's map becomes empty, also clears the inherited ThreadLocal plus the `CONTEXTS` registry entry, keeping both consistent. The `finally` also covers the early `return` paths and any thrown error.

## Tests

`engine/.../timeseries/TimeSeriesMaintenanceSchedulerContextLeakTest.java` (new):

- `maintenancePassRemovesDatabaseContextFromWorkerThread` - after one pass on a pooled worker thread, the thread's context for the DB path is null.
- `maintenancePassDoesNotLeakContextAcrossDatabasesOnSameThread` - runs DB-A then DB-B on the same single-thread executor; DB-A's context never survives into the DB-B pass and both are cleaned up afterward.

Both were confirmed to FAIL against the un-fixed code and PASS with the fix.

## Verification

- New test: 2/2 pass.
- Regression run (`TimeSeriesRetentionTest`, `TimeSeriesDownsamplingTest`, `DropTimeSeriesTypeTest`, `TimeSeriesGapAnalysisTest` + new test): 42/42 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)