### PR TITLE
fix: [timeseries] aggregate() anchors single-bucket result to caller-supplied fromTs (#4520)

### DIFF
--- a/docs/4520-timeseries-single-bucket-fromts-sentinel.md
+++ b/docs/4520-timeseries-single-bucket-fromts-sentinel.md
@@ -1,0 +1,59 @@
+# Issue #4520 - `aggregate()` anchors single-bucket result to caller-supplied `fromTs`
+
+## Summary
+
+When time-series aggregation runs in single-bucket mode (`bucketIntervalMs <= 0`), the resulting
+bucket timestamp was anchored to the caller-supplied `fromTs`. Callers use `Long.MIN_VALUE` as the
+"no lower bound" sentinel, so every row's bucket key became `Long.MIN_VALUE`. Downstream consumers
+(e.g. `AggregateFromTimeSeriesStep`, which converts the bucket key to a `LocalDateTime`) then
+misformatted that sentinel as a real epoch.
+
+## Root Cause
+
+Four single-bucket sites used `fromTs` directly as the bucket key:
+
+- `TimeSeriesEngine.aggregate()` (mutable + sealed merge iterator)
+- `TimeSeriesEngine.aggregateMulti()` sequential path (mutable rows)
+- `TimeSeriesSealedStore.aggregate()` (single-column sealed blocks)
+- `TimeSeriesSealedStore.aggregateMultiBlocks()` (multi-column sealed blocks, no-interval branch)
+
+All rows in single-bucket mode must share one bucket key; that key must be a valid epoch, not the
+sentinel.
+
+## Fix
+
+Added a shared helper `TimeSeriesEngine.singleBucketAnchor(long fromTs)`:
+
+```java
+static long singleBucketAnchor(final long fromTs) {
+  return fromTs == Long.MIN_VALUE ? 0L : fromTs;
+}
+```
+
+Returns `0L` (Unix epoch) when `fromTs` is the `Long.MIN_VALUE` sentinel, otherwise keeps the
+caller-supplied lower bound (unchanged behavior for real bounds). All four sites now route their
+single-bucket anchor through this helper, keeping sealed-store and mutable-bucket results consistent
+(they must agree so sealed + mutable rows merge into the same bucket).
+
+`0L` was chosen over "min observed ts" because the sealed store and the parallel shard path each
+aggregate independently; threading a globally-observed minimum across all of them would be fragile,
+and `0L` is the value endorsed by the issue, is a valid epoch, and is identical across every path.
+
+## Tests
+
+New regression test `TimeSeriesSingleBucketAnchorTest`:
+
+- `aggregateSingleBucketWithMinValueFromTsIsNotSentinel` - mutable single-bucket SUM, MIN_VALUE fromTs.
+- `aggregateSingleBucketWithRealFromTsKeepsAnchor` - real lower bound still anchors at `fromTs`.
+- `aggregateMultiSingleBucketWithMinValueFromTsIsNotSentinel` - multi-column single-bucket.
+- `aggregateMultiSingleBucketReadsSealedData` - exercises the sealed-store path after `compactAll()`.
+
+Confirmed failing before the fix (bucket key `Long.MIN_VALUE`), passing after.
+
+## Verification
+
+- New test: 4/4 pass.
+- Regression suite (78 tests): `TimeSeriesEngineTest`, `TimeSeriesSealedStoreTest`,
+  `TimeSeriesAggregationPushDownTest`, `TimeSeriesAccuracyTest`, `TimeSeriesShardTest`,
+  `TimeSeriesSQLTest`, `TimeSeriesPhase2SQLTest`, `SQLFunctionTimeBucketTest`,
+  `ContinuousAggregateTest`, `TimeSeriesDownsamplingTest` - all pass.

--- a/docs/4520-timeseries-single-bucket-fromts-sentinel.md
+++ b/docs/4520-timeseries-single-bucket-fromts-sentinel.md
@@ -43,16 +43,19 @@ and `0L` is the value endorsed by the issue, is a valid epoch, and is identical 
 
 New regression test `TimeSeriesSingleBucketAnchorTest`:
 
+- `singleBucketAnchorMapsSentinelToEpoch` - direct unit test of the helper contract (`MIN_VALUE` -> `0L`, real `fromTs` preserved).
 - `aggregateSingleBucketWithMinValueFromTsIsNotSentinel` - mutable single-bucket SUM, MIN_VALUE fromTs.
 - `aggregateSingleBucketWithRealFromTsKeepsAnchor` - real lower bound still anchors at `fromTs`.
+- `aggregateSingleBucketWithRealFromTsKeepsAnchorOnSealedData` - real lower bound preserved on the sealed path after `compactAll()`.
 - `aggregateMultiSingleBucketWithMinValueFromTsIsNotSentinel` - multi-column single-bucket.
-- `aggregateMultiSingleBucketReadsSealedData` - exercises the sealed-store path after `compactAll()`.
+- `aggregateSingleColumnSingleBucketReadsSealedData` - single-column sealed path after `compactAll()`.
+- `aggregateMultiSingleBucketReadsSealedData` - multi-column sealed-store path after `compactAll()`.
 
 Confirmed failing before the fix (bucket key `Long.MIN_VALUE`), passing after.
 
 ## Verification
 
-- New test: 4/4 pass.
+- New test: 7/7 pass.
 - Regression suite (78 tests): `TimeSeriesEngineTest`, `TimeSeriesSealedStoreTest`,
   `TimeSeriesAggregationPushDownTest`, `TimeSeriesAccuracyTest`, `TimeSeriesShardTest`,
   `TimeSeriesSQLTest`, `TimeSeriesPhase2SQLTest`, `SQLFunctionTimeBucketTest`,

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
@@ -261,10 +261,13 @@ public class TimeSeriesEngine implements AutoCloseable {
     final Iterator<Object[]> iter = iterateQuery(fromTs, toTs, null, tagFilter);
     final AggregationResult result = new AggregationResult();
 
+    // Loop-invariant: resolve the single-bucket anchor once outside the hot loop.
+    final long singleBucketTs = singleBucketAnchor(fromTs);
+
     while (iter.hasNext()) {
       final Object[] row = iter.next();
       final long ts = (long) row[0];
-      final long bucketTs = bucketIntervalMs > 0 ? (ts / bucketIntervalMs) * bucketIntervalMs : singleBucketAnchor(fromTs);
+      final long bucketTs = bucketIntervalMs > 0 ? (ts / bucketIntervalMs) * bucketIntervalMs : singleBucketTs;
       final double value;
 
       if (columnIndex + 1 < row.length && row[columnIndex + 1] instanceof Number)
@@ -438,6 +441,9 @@ public class TimeSeriesEngine implements AutoCloseable {
 
       final double[] rowValues = new double[reqCount];
 
+      // Loop-invariant: resolve the single-bucket anchor once outside the per-shard hot loops.
+      final long singleBucketTs = singleBucketAnchor(fromTs);
+
       for (final TimeSeriesShard shard : shards) {
         // Hold the compaction read lock for sealed+mutable reads to prevent data loss
         // if compaction completes between reading the two layers.
@@ -451,7 +457,7 @@ public class TimeSeriesEngine implements AutoCloseable {
             if (tagFilter != null && !tagFilter.matches(row))
               continue;
             final long ts = (long) row[0];
-            final long bucketTs = bucketIntervalMs > 0 ? (ts / bucketIntervalMs) * bucketIntervalMs : singleBucketAnchor(fromTs);
+            final long bucketTs = bucketIntervalMs > 0 ? (ts / bucketIntervalMs) * bucketIntervalMs : singleBucketTs;
 
             for (int r = 0; r < reqCount; r++) {
               if (isCount[r])

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
@@ -261,7 +261,6 @@ public class TimeSeriesEngine implements AutoCloseable {
     final Iterator<Object[]> iter = iterateQuery(fromTs, toTs, null, tagFilter);
     final AggregationResult result = new AggregationResult();
 
-    // Loop-invariant: resolve the single-bucket anchor once outside the hot loop.
     final long singleBucketTs = singleBucketAnchor(fromTs);
 
     while (iter.hasNext()) {
@@ -441,7 +440,6 @@ public class TimeSeriesEngine implements AutoCloseable {
 
       final double[] rowValues = new double[reqCount];
 
-      // Loop-invariant: resolve the single-bucket anchor once outside the per-shard hot loops.
       final long singleBucketTs = singleBucketAnchor(fromTs);
 
       for (final TimeSeriesShard shard : shards) {

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
@@ -264,7 +264,7 @@ public class TimeSeriesEngine implements AutoCloseable {
     while (iter.hasNext()) {
       final Object[] row = iter.next();
       final long ts = (long) row[0];
-      final long bucketTs = bucketIntervalMs > 0 ? (ts / bucketIntervalMs) * bucketIntervalMs : fromTs;
+      final long bucketTs = bucketIntervalMs > 0 ? (ts / bucketIntervalMs) * bucketIntervalMs : singleBucketAnchor(fromTs);
       final double value;
 
       if (columnIndex + 1 < row.length && row[columnIndex + 1] instanceof Number)
@@ -451,7 +451,7 @@ public class TimeSeriesEngine implements AutoCloseable {
             if (tagFilter != null && !tagFilter.matches(row))
               continue;
             final long ts = (long) row[0];
-            final long bucketTs = bucketIntervalMs > 0 ? (ts / bucketIntervalMs) * bucketIntervalMs : fromTs;
+            final long bucketTs = bucketIntervalMs > 0 ? (ts / bucketIntervalMs) * bucketIntervalMs : singleBucketAnchor(fromTs);
 
             for (int r = 0; r < reqCount; r++) {
               if (isCount[r])
@@ -661,6 +661,16 @@ public class TimeSeriesEngine implements AutoCloseable {
       peeked = delegate.hasNext() ? delegate.next() : null;
       return result;
     }
+  }
+
+  /**
+   * Resolves the bucket-timestamp anchor for single-bucket aggregation (when {@code bucketIntervalMs <= 0}).
+   * The caller-supplied {@code fromTs} can be the {@link Long#MIN_VALUE} "no lower bound" sentinel; anchoring
+   * the single bucket to that sentinel would make downstream consumers misformat it as a real epoch. In that
+   * case the bucket is anchored at the Unix epoch ({@code 0L}) instead.
+   */
+  static long singleBucketAnchor(final long fromTs) {
+    return fromTs == Long.MIN_VALUE ? 0L : fromTs;
   }
 
   private void accumulateToBucket(final AggregationResult result, final long bucketTs, final double value,

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
@@ -498,7 +498,9 @@ public class TimeSeriesSealedStore implements AutoCloseable {
           if (timestamps[i] < fromTs || timestamps[i] > toTs)
             continue;
 
-          final long bucketTs = bucketIntervalMs > 0 ? (timestamps[i] / bucketIntervalMs) * bucketIntervalMs : fromTs;
+          final long bucketTs = bucketIntervalMs > 0
+              ? (timestamps[i] / bucketIntervalMs) * bucketIntervalMs
+              : TimeSeriesEngine.singleBucketAnchor(fromTs);
 
           accumulateSample(result, bucketTs, values[i], type);
         }
@@ -703,6 +705,7 @@ public class TimeSeriesSealedStore implements AutoCloseable {
           }
         } else {
           // No bucket interval — accumulate all into one bucket
+          final long singleBucketTs = TimeSeriesEngine.singleBucketAnchor(fromTs);
           for (int i = 0; i < tsCount; i++) {
             final long ts = timestamps[i];
             if (ts < fromTs || ts > toTs)
@@ -714,7 +717,7 @@ public class TimeSeriesSealedStore implements AutoCloseable {
             for (int r = 0; r < reqCount; r++)
               rowValues[r] = isCount[r] ? 1.0 : decompressedCols[schemaColIndices[r]][i];
 
-            result.accumulateRow(fromTs, rowValues);
+            result.accumulateRow(singleBucketTs, rowValues);
           }
         }
         if (metrics != null)

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
@@ -483,6 +483,9 @@ public class TimeSeriesSealedStore implements AutoCloseable {
     final int tsColIdx = findTimestampColumnIndex();
     final int targetColSchemaIdx = findNonTsColumnSchemaIndex(columnIndex);
 
+    // Loop-invariant: resolve the single-bucket anchor once outside the block/sample hot loops.
+    final long singleBucketTs = TimeSeriesEngine.singleBucketAnchor(fromTs);
+
     // Hold the read lock for the entire scan including file I/O to prevent stale offsets
     // after atomic file replacement by concurrent writers (truncate/downsample).
     directoryLock.readLock().lock();
@@ -500,7 +503,7 @@ public class TimeSeriesSealedStore implements AutoCloseable {
 
           final long bucketTs = bucketIntervalMs > 0
               ? (timestamps[i] / bucketIntervalMs) * bucketIntervalMs
-              : TimeSeriesEngine.singleBucketAnchor(fromTs);
+              : singleBucketTs;
 
           accumulateSample(result, bucketTs, values[i], type);
         }

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
@@ -543,6 +543,9 @@ public class TimeSeriesSealedStore implements AutoCloseable {
     final long[] reusableTsBuf = new long[MAX_BLOCK_SIZE];
     final double[] reusableValBuf = new double[MAX_BLOCK_SIZE];
 
+    // Loop-invariant: resolve the single-bucket anchor once outside the per-block loop.
+    final long singleBucketTs = TimeSeriesEngine.singleBucketAnchor(fromTs);
+
     // Hold the read lock for the entire scan including file I/O to prevent stale offsets
     // after atomic file replacement by concurrent writers (truncate/downsample).
     directoryLock.readLock().lock();
@@ -707,7 +710,6 @@ public class TimeSeriesSealedStore implements AutoCloseable {
           }
         } else {
           // No bucket interval — accumulate all into one bucket
-          final long singleBucketTs = TimeSeriesEngine.singleBucketAnchor(fromTs);
           for (int i = 0; i < tsCount; i++) {
             final long ts = timestamps[i];
             if (ts < fromTs || ts > toTs)

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
@@ -543,7 +543,6 @@ public class TimeSeriesSealedStore implements AutoCloseable {
     final long[] reusableTsBuf = new long[MAX_BLOCK_SIZE];
     final double[] reusableValBuf = new double[MAX_BLOCK_SIZE];
 
-    // Loop-invariant: resolve the single-bucket anchor once outside the per-block loop.
     final long singleBucketTs = TimeSeriesEngine.singleBucketAnchor(fromTs);
 
     // Hold the read lock for the entire scan including file I/O to prevent stale offsets

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesSealedStore.java
@@ -483,7 +483,6 @@ public class TimeSeriesSealedStore implements AutoCloseable {
     final int tsColIdx = findTimestampColumnIndex();
     final int targetColSchemaIdx = findNonTsColumnSchemaIndex(columnIndex);
 
-    // Loop-invariant: resolve the single-bucket anchor once outside the block/sample hot loops.
     final long singleBucketTs = TimeSeriesEngine.singleBucketAnchor(fromTs);
 
     // Hold the read lock for the entire scan including file I/O to prevent stale offsets

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesSingleBucketAnchorTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesSingleBucketAnchorTest.java
@@ -53,6 +53,14 @@ class TimeSeriesSingleBucketAnchorTest extends TestHelper {
   }
 
   @Test
+  void singleBucketAnchorMapsSentinelToEpoch() {
+    // The MIN_VALUE "no lower bound" sentinel maps to the epoch anchor; any real fromTs is preserved.
+    assertThat(TimeSeriesEngine.singleBucketAnchor(Long.MIN_VALUE)).isEqualTo(0L);
+    assertThat(TimeSeriesEngine.singleBucketAnchor(0L)).isEqualTo(0L);
+    assertThat(TimeSeriesEngine.singleBucketAnchor(1000L)).isEqualTo(1000L);
+  }
+
+  @Test
   void aggregateSingleBucketWithMinValueFromTsIsNotSentinel() throws Exception {
     database.begin();
     engine = new TimeSeriesEngine((DatabaseInternal) database, "ts_single_bucket", COLS, 1);
@@ -66,9 +74,8 @@ class TimeSeriesSingleBucketAnchorTest extends TestHelper {
 
     // All three rows collapse into one bucket
     assertThat(result.size()).isEqualTo(1);
-    // The bug: the bucket key was Long.MIN_VALUE (the sentinel). It must be a valid epoch instead.
-    assertThat(result.getBucketTimestamp(0)).isNotEqualTo(Long.MIN_VALUE);
-    assertThat(result.getBucketTimestamp(0)).isGreaterThanOrEqualTo(0L);
+    // The bug: the bucket key was Long.MIN_VALUE (the sentinel). It must be the epoch anchor instead.
+    assertThat(result.getBucketTimestamp(0)).isEqualTo(0L);
     // SUM is unaffected by the anchor
     assertThat(result.getValue(0)).isEqualTo(60.0);
     assertThat(result.getCount(0)).isEqualTo(3);
@@ -134,8 +141,7 @@ class TimeSeriesSingleBucketAnchorTest extends TestHelper {
 
     final List<Long> buckets = result.getBucketTimestamps();
     assertThat(buckets).hasSize(1);
-    assertThat(buckets.get(0)).isNotEqualTo(Long.MIN_VALUE);
-    assertThat(buckets.get(0)).isGreaterThanOrEqualTo(0L);
+    assertThat(buckets.get(0)).isEqualTo(0L);
     assertThat(result.getValue(buckets.get(0), 0)).isEqualTo(60.0);
     database.commit();
   }
@@ -157,8 +163,7 @@ class TimeSeriesSingleBucketAnchorTest extends TestHelper {
         AggregationType.SUM, 0, null);
 
     assertThat(result.size()).isEqualTo(1);
-    assertThat(result.getBucketTimestamp(0)).isNotEqualTo(Long.MIN_VALUE);
-    assertThat(result.getBucketTimestamp(0)).isGreaterThanOrEqualTo(0L);
+    assertThat(result.getBucketTimestamp(0)).isEqualTo(0L);
     assertThat(result.getValue(0)).isEqualTo(100.0);
     assertThat(result.getCount(0)).isEqualTo(4);
     database.commit();
@@ -185,8 +190,7 @@ class TimeSeriesSingleBucketAnchorTest extends TestHelper {
 
     final List<Long> buckets = result.getBucketTimestamps();
     assertThat(buckets).hasSize(1);
-    assertThat(buckets.get(0)).isNotEqualTo(Long.MIN_VALUE);
-    assertThat(buckets.get(0)).isGreaterThanOrEqualTo(0L);
+    assertThat(buckets.get(0)).isEqualTo(0L);
     assertThat(result.getValue(buckets.get(0), 0)).isEqualTo(100.0);
     database.commit();
   }

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesSingleBucketAnchorTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesSingleBucketAnchorTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.engine.timeseries;
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -40,10 +41,21 @@ class TimeSeriesSingleBucketAnchorTest extends TestHelper {
       new ColumnDefinition("value", Type.DOUBLE, ColumnDefinition.ColumnRole.FIELD)
   );
 
+  // Closed in @AfterEach so the engine/files are released even when an assertion fails mid-test.
+  private TimeSeriesEngine engine;
+
+  @AfterEach
+  void closeEngine() throws Exception {
+    if (engine != null) {
+      engine.close();
+      engine = null;
+    }
+  }
+
   @Test
   void aggregateSingleBucketWithMinValueFromTsIsNotSentinel() throws Exception {
     database.begin();
-    final TimeSeriesEngine engine = new TimeSeriesEngine((DatabaseInternal) database, "ts_single_bucket", COLS, 1);
+    engine = new TimeSeriesEngine((DatabaseInternal) database, "ts_single_bucket", COLS, 1);
     engine.appendSamples(new long[] { 1000L, 2000L, 3000L }, new Object[] { 10.0, 20.0, 30.0 });
     database.commit();
 
@@ -61,34 +73,54 @@ class TimeSeriesSingleBucketAnchorTest extends TestHelper {
     assertThat(result.getValue(0)).isEqualTo(60.0);
     assertThat(result.getCount(0)).isEqualTo(3);
     database.commit();
-
-    engine.close();
   }
 
   @Test
   void aggregateSingleBucketWithRealFromTsKeepsAnchor() throws Exception {
     database.begin();
-    final TimeSeriesEngine engine = new TimeSeriesEngine((DatabaseInternal) database, "ts_single_bucket_real", COLS, 1);
+    engine = new TimeSeriesEngine((DatabaseInternal) database, "ts_single_bucket_real", COLS, 1);
     engine.appendSamples(new long[] { 1000L, 2000L, 3000L }, new Object[] { 10.0, 20.0, 30.0 });
     database.commit();
 
     database.begin();
     // A real lower bound must still anchor the single bucket at fromTs (unchanged behavior).
     final AggregationResult result = engine.aggregate(1000L, Long.MAX_VALUE, 0,
-        AggregationType.COUNT, 0, null);
+        AggregationType.SUM, 0, null);
 
     assertThat(result.size()).isEqualTo(1);
     assertThat(result.getBucketTimestamp(0)).isEqualTo(1000L);
+    assertThat(result.getValue(0)).isEqualTo(60.0);
     assertThat(result.getCount(0)).isEqualTo(3);
     database.commit();
+  }
 
-    engine.close();
+  @Test
+  void aggregateSingleBucketWithRealFromTsKeepsAnchorOnSealedData() throws Exception {
+    database.begin();
+    engine = new TimeSeriesEngine((DatabaseInternal) database, "ts_single_bucket_real_sealed", COLS, 1);
+    engine.appendSamples(new long[] { 1000L, 2000L, 3000L, 4000L }, new Object[] { 10.0, 20.0, 30.0, 40.0 });
+    database.commit();
+
+    // Force the sealed-store path so a real lower bound is preserved there too.
+    database.begin();
+    engine.compactAll();
+    database.commit();
+
+    database.begin();
+    final AggregationResult result = engine.aggregate(1000L, Long.MAX_VALUE, 0,
+        AggregationType.SUM, 0, null);
+
+    assertThat(result.size()).isEqualTo(1);
+    assertThat(result.getBucketTimestamp(0)).isEqualTo(1000L);
+    assertThat(result.getValue(0)).isEqualTo(100.0);
+    assertThat(result.getCount(0)).isEqualTo(4);
+    database.commit();
   }
 
   @Test
   void aggregateMultiSingleBucketWithMinValueFromTsIsNotSentinel() throws Exception {
     database.begin();
-    final TimeSeriesEngine engine = new TimeSeriesEngine((DatabaseInternal) database, "ts_single_bucket_multi", COLS, 1);
+    engine = new TimeSeriesEngine((DatabaseInternal) database, "ts_single_bucket_multi", COLS, 1);
     engine.appendSamples(new long[] { 1000L, 2000L, 3000L }, new Object[] { 10.0, 20.0, 30.0 });
     database.commit();
 
@@ -106,14 +138,12 @@ class TimeSeriesSingleBucketAnchorTest extends TestHelper {
     assertThat(buckets.get(0)).isGreaterThanOrEqualTo(0L);
     assertThat(result.getValue(buckets.get(0), 0)).isEqualTo(60.0);
     database.commit();
-
-    engine.close();
   }
 
   @Test
   void aggregateSingleColumnSingleBucketReadsSealedData() throws Exception {
     database.begin();
-    final TimeSeriesEngine engine = new TimeSeriesEngine((DatabaseInternal) database, "ts_single_bucket_sealed_col", COLS, 1);
+    engine = new TimeSeriesEngine((DatabaseInternal) database, "ts_single_bucket_sealed_col", COLS, 1);
     engine.appendSamples(new long[] { 1000L, 2000L, 3000L, 4000L }, new Object[] { 10.0, 20.0, 30.0, 40.0 });
     database.commit();
 
@@ -132,14 +162,12 @@ class TimeSeriesSingleBucketAnchorTest extends TestHelper {
     assertThat(result.getValue(0)).isEqualTo(100.0);
     assertThat(result.getCount(0)).isEqualTo(4);
     database.commit();
-
-    engine.close();
   }
 
   @Test
   void aggregateMultiSingleBucketReadsSealedData() throws Exception {
     database.begin();
-    final TimeSeriesEngine engine = new TimeSeriesEngine((DatabaseInternal) database, "ts_single_bucket_sealed", COLS, 1);
+    engine = new TimeSeriesEngine((DatabaseInternal) database, "ts_single_bucket_sealed", COLS, 1);
     engine.appendSamples(new long[] { 1000L, 2000L, 3000L, 4000L }, new Object[] { 10.0, 20.0, 30.0, 40.0 });
     database.commit();
 
@@ -161,7 +189,5 @@ class TimeSeriesSingleBucketAnchorTest extends TestHelper {
     assertThat(buckets.get(0)).isGreaterThanOrEqualTo(0L);
     assertThat(result.getValue(buckets.get(0), 0)).isEqualTo(100.0);
     database.commit();
-
-    engine.close();
   }
 }

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesSingleBucketAnchorTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesSingleBucketAnchorTest.java
@@ -111,6 +111,32 @@ class TimeSeriesSingleBucketAnchorTest extends TestHelper {
   }
 
   @Test
+  void aggregateSingleColumnSingleBucketReadsSealedData() throws Exception {
+    database.begin();
+    final TimeSeriesEngine engine = new TimeSeriesEngine((DatabaseInternal) database, "ts_single_bucket_sealed_col", COLS, 1);
+    engine.appendSamples(new long[] { 1000L, 2000L, 3000L, 4000L }, new Object[] { 10.0, 20.0, 30.0, 40.0 });
+    database.commit();
+
+    // Force the sealed-store path so TimeSeriesSealedStore.aggregate() (single-column) is exercised.
+    database.begin();
+    engine.compactAll();
+    database.commit();
+
+    database.begin();
+    final AggregationResult result = engine.aggregate(Long.MIN_VALUE, Long.MAX_VALUE, 0,
+        AggregationType.SUM, 0, null);
+
+    assertThat(result.size()).isEqualTo(1);
+    assertThat(result.getBucketTimestamp(0)).isNotEqualTo(Long.MIN_VALUE);
+    assertThat(result.getBucketTimestamp(0)).isGreaterThanOrEqualTo(0L);
+    assertThat(result.getValue(0)).isEqualTo(100.0);
+    assertThat(result.getCount(0)).isEqualTo(4);
+    database.commit();
+
+    engine.close();
+  }
+
+  @Test
   void aggregateMultiSingleBucketReadsSealedData() throws Exception {
     database.begin();
     final TimeSeriesEngine engine = new TimeSeriesEngine((DatabaseInternal) database, "ts_single_bucket_sealed", COLS, 1);

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesSingleBucketAnchorTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/TimeSeriesSingleBucketAnchorTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.schema.Type;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression for issue #4520: single-bucket aggregation (bucketIntervalMs &lt;= 0) must not anchor the
+ * resulting bucket timestamp to the caller-supplied {@code fromTs} when {@code fromTs} is the
+ * {@link Long#MIN_VALUE} "no lower bound" sentinel. A {@code Long.MIN_VALUE} bucket key gets misformatted
+ * by downstream consumers as a real epoch. The single bucket must instead be anchored at a valid epoch.
+ */
+class TimeSeriesSingleBucketAnchorTest extends TestHelper {
+
+  private static final List<ColumnDefinition> COLS = List.of(
+      new ColumnDefinition("ts", Type.LONG, ColumnDefinition.ColumnRole.TIMESTAMP),
+      new ColumnDefinition("value", Type.DOUBLE, ColumnDefinition.ColumnRole.FIELD)
+  );
+
+  @Test
+  void aggregateSingleBucketWithMinValueFromTsIsNotSentinel() throws Exception {
+    database.begin();
+    final TimeSeriesEngine engine = new TimeSeriesEngine((DatabaseInternal) database, "ts_single_bucket", COLS, 1);
+    engine.appendSamples(new long[] { 1000L, 2000L, 3000L }, new Object[] { 10.0, 20.0, 30.0 });
+    database.commit();
+
+    database.begin();
+    // bucketIntervalMs = 0 -> single bucket; fromTs = Long.MIN_VALUE -> "no lower bound" sentinel
+    final AggregationResult result = engine.aggregate(Long.MIN_VALUE, Long.MAX_VALUE, 0,
+        AggregationType.SUM, 0, null);
+
+    // All three rows collapse into one bucket
+    assertThat(result.size()).isEqualTo(1);
+    // The bug: the bucket key was Long.MIN_VALUE (the sentinel). It must be a valid epoch instead.
+    assertThat(result.getBucketTimestamp(0)).isNotEqualTo(Long.MIN_VALUE);
+    assertThat(result.getBucketTimestamp(0)).isGreaterThanOrEqualTo(0L);
+    // SUM is unaffected by the anchor
+    assertThat(result.getValue(0)).isEqualTo(60.0);
+    assertThat(result.getCount(0)).isEqualTo(3);
+    database.commit();
+
+    engine.close();
+  }
+
+  @Test
+  void aggregateSingleBucketWithRealFromTsKeepsAnchor() throws Exception {
+    database.begin();
+    final TimeSeriesEngine engine = new TimeSeriesEngine((DatabaseInternal) database, "ts_single_bucket_real", COLS, 1);
+    engine.appendSamples(new long[] { 1000L, 2000L, 3000L }, new Object[] { 10.0, 20.0, 30.0 });
+    database.commit();
+
+    database.begin();
+    // A real lower bound must still anchor the single bucket at fromTs (unchanged behavior).
+    final AggregationResult result = engine.aggregate(1000L, Long.MAX_VALUE, 0,
+        AggregationType.COUNT, 0, null);
+
+    assertThat(result.size()).isEqualTo(1);
+    assertThat(result.getBucketTimestamp(0)).isEqualTo(1000L);
+    assertThat(result.getCount(0)).isEqualTo(3);
+    database.commit();
+
+    engine.close();
+  }
+
+  @Test
+  void aggregateMultiSingleBucketWithMinValueFromTsIsNotSentinel() throws Exception {
+    database.begin();
+    final TimeSeriesEngine engine = new TimeSeriesEngine((DatabaseInternal) database, "ts_single_bucket_multi", COLS, 1);
+    engine.appendSamples(new long[] { 1000L, 2000L, 3000L }, new Object[] { 10.0, 20.0, 30.0 });
+    database.commit();
+
+    database.begin();
+    // columnIndex 1 = the "value" column in the full schema (index 0 = timestamp)
+    final List<MultiColumnAggregationRequest> requests = List.of(
+        new MultiColumnAggregationRequest(1, AggregationType.SUM, "sum_value"));
+
+    final MultiColumnAggregationResult result = engine.aggregateMulti(Long.MIN_VALUE, Long.MAX_VALUE,
+        requests, 0, null);
+
+    final List<Long> buckets = result.getBucketTimestamps();
+    assertThat(buckets).hasSize(1);
+    assertThat(buckets.get(0)).isNotEqualTo(Long.MIN_VALUE);
+    assertThat(buckets.get(0)).isGreaterThanOrEqualTo(0L);
+    assertThat(result.getValue(buckets.get(0), 0)).isEqualTo(60.0);
+    database.commit();
+
+    engine.close();
+  }
+
+  @Test
+  void aggregateMultiSingleBucketReadsSealedData() throws Exception {
+    database.begin();
+    final TimeSeriesEngine engine = new TimeSeriesEngine((DatabaseInternal) database, "ts_single_bucket_sealed", COLS, 1);
+    engine.appendSamples(new long[] { 1000L, 2000L, 3000L, 4000L }, new Object[] { 10.0, 20.0, 30.0, 40.0 });
+    database.commit();
+
+    // Force sealed-store path so the sealed-store single-bucket anchor is also exercised.
+    database.begin();
+    engine.compactAll();
+    database.commit();
+
+    database.begin();
+    final List<MultiColumnAggregationRequest> requests = List.of(
+        new MultiColumnAggregationRequest(1, AggregationType.SUM, "sum_value"));
+
+    final MultiColumnAggregationResult result = engine.aggregateMulti(Long.MIN_VALUE, Long.MAX_VALUE,
+        requests, 0, null);
+
+    final List<Long> buckets = result.getBucketTimestamps();
+    assertThat(buckets).hasSize(1);
+    assertThat(buckets.get(0)).isNotEqualTo(Long.MIN_VALUE);
+    assertThat(buckets.get(0)).isGreaterThanOrEqualTo(0L);
+    assertThat(result.getValue(buckets.get(0), 0)).isEqualTo(100.0);
+    database.commit();
+
+    engine.close();
+  }
+}


### PR DESCRIPTION
## Issue

Fixes #4520

When time-series aggregation runs in single-bucket mode (`bucketIntervalMs <= 0`), the resulting bucket timestamp was anchored to the caller-supplied `fromTs`. Callers use `Long.MIN_VALUE` as the "no lower bound" sentinel (as the same file already does at lines 316-319), so every row's bucket key became `Long.MIN_VALUE`. Downstream consumers - notably `AggregateFromTimeSeriesStep`, which converts the bucket key to a `LocalDateTime` - then misformatted that sentinel as a real epoch.

## Root cause

Four single-bucket sites used `fromTs` directly as the bucket key:

- `TimeSeriesEngine.aggregate()`
- `TimeSeriesEngine.aggregateMulti()` sequential path (mutable rows)
- `TimeSeriesSealedStore.aggregate()` (single-column sealed blocks)
- `TimeSeriesSealedStore.aggregateMultiBlocks()` (multi-column sealed blocks, no-interval branch)

All rows in single-bucket mode must share one bucket key, and that key must be a valid epoch, not the sentinel. The sealed-store and mutable-bucket paths must agree so their results merge into the same bucket.

## Fix

Added a shared helper `TimeSeriesEngine.singleBucketAnchor(long fromTs)`:

```java
static long singleBucketAnchor(final long fromTs) {
  return fromTs == Long.MIN_VALUE ? 0L : fromTs;
}
```

Returns `0L` (Unix epoch) when `fromTs` is the `Long.MIN_VALUE` sentinel, otherwise keeps the caller-supplied lower bound (unchanged behavior for real bounds). All four sites route their single-bucket anchor through it, with the anchor resolved once per call (loop-invariant) outside the hot loops.

`0L` was chosen over "min observed ts" because the sealed store and the parallel shard path each aggregate independently; threading a globally-observed minimum across all of them would be fragile. `0L` is the value endorsed by the issue, is a valid epoch, and is identical across every path.

The parallel multi-shard path in `aggregateMulti` is unaffected: it is gated by `useFlatMode = bucketIntervalMs > 0`, so single-bucket mode always takes the sequential path that is patched here.

## Tests

New regression test `TimeSeriesSingleBucketAnchorTest` (7 cases):

- `aggregateSingleBucketWithMinValueFromTsIsNotSentinel` - mutable single-bucket, `Long.MIN_VALUE` fromTs.
- `aggregateSingleBucketWithRealFromTsKeepsAnchor` - real lower bound still anchors at `fromTs` (mutable).
- `aggregateSingleBucketWithRealFromTsKeepsAnchorOnSealedData` - real lower bound preserved on the sealed path.
- `aggregateMultiSingleBucketWithMinValueFromTsIsNotSentinel` - multi-column single-bucket.
- `aggregateSingleColumnSingleBucketReadsSealedData` - single-column sealed path after `compactAll()`.
- `aggregateMultiSingleBucketReadsSealedData` - multi-column sealed path after `compactAll()`.

The engine is closed in `@AfterEach` so files are released even if an assertion fails mid-test. Confirmed failing before the fix (bucket key `Long.MIN_VALUE`), passing after.

Regression suite (`TimeSeriesEngineTest`, `TimeSeriesSealedStoreTest`, `TimeSeriesAggregationPushDownTest`, `TimeSeriesAccuracyTest`, `TimeSeriesShardTest`, `TimeSeriesSQLTest`, `TimeSeriesPhase2SQLTest`, `SQLFunctionTimeBucketTest`, `ContinuousAggregateTest`, `TimeSeriesDownsamplingTest`) - all pass, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
