### PR TITLE
fix: [#4529] ConcurrentModificationException on commit during background index compaction

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -59,6 +59,12 @@ import java.util.stream.Collectors;
  * txId:long|pages:int|&lt;segmentSize:int|fileId:int|pageNumber:long|pageModifiedFrom:int|pageModifiedTo:int|&lt;prevContent&gt;&lt;newContent&gt;segmentSize:int&gt;MagicNumber:long
  */
 public class TransactionContext implements Transaction {
+  // Bounded internal retry budget for the snapshot-vs-lock race against compaction-induced file migration during
+  // commit lock acquisition (see lockFilesInOrder). Each retry only re-resolves file ids and re-acquires locks (no
+  // rollback, no page reload), so it converges in microseconds. Sized for the worst legitimate case of concurrent
+  // compactions across all indexes of a multi-indexed type; exhausting it signals a real concurrency problem.
+  private static final int                           MAX_LOCK_MIGRATION_RETRIES = 10;
+
   private final DatabaseInternal                     database;
   private final Map<Integer, Integer>                newPageCounters       = new ConcurrentHashMap<>();
   // Per-tx record-count delta per bucket. Single-threaded (HashMap was used, not ConcurrentHashMap),
@@ -895,25 +901,63 @@ public class TransactionContext implements Transaction {
 
   private List<Integer> lockFilesInOrder(final IntHashSet files) {
     final long timeout = database.getConfiguration().getValueAsLong(GlobalConfiguration.COMMIT_LOCK_TIMEOUT);
+    final LocalSchema schema = database.getSchema().getEmbedded();
 
-    final List<Integer> locked = database.getTransactionManager().tryLockFiles(files.toArray(), timeout, getRequester());
+    // Work on a private copy so the caller's set is never mutated by the migration re-resolution below
+    // (the explicit-lock path passes its own filesToLock set).
+    IntHashSet filesToLock = new IntHashSet(files.size() + 4);
+    files.forEach(filesToLock::add);
 
-    // CHECK IF ALL THE LOCKED FILES STILL EXIST. FILE MISSING CAN HAPPEN IN CASE OF INDEX COMPACTION OR DROP OF A BUCKET OR AN INDEX.
-    // Transaction rollback is the caller's responsibility: commit1stPhase catches and rolls back; the explicit-lock path retries
-    // internally with refreshed file IDs (see LocalTransactionExplicitLock.lock()) since no modifications exist yet at that point.
-    for (Integer f : locked)
-      if (!database.getFileManager().existsFile(f)) {
-        database.getTransactionManager().unlockFilesInOrder(locked, getRequester());
-        final Integer migrated = database.getSchema().getEmbedded().getMigratedFileId(f);
-        if (migrated != null) {
-          LogManager.instance().log(this, Level.FINE, "Found upgraded file '%d' to '%d' during transaction commit", f, migrated);
-          throw new ConcurrentModificationException(
-              "Error on commit transaction: file '" + f + "' has been migrated to '" + migrated + "' (likely by an index compaction). Please retry the operation.");
+    // Bounded internal retry for the snapshot-vs-lock race against a background index compaction.
+    // A compaction can migrate an index file (registerFile + setMigratedFileId, old file removed) between the
+    // moment the file id is resolved (lockFilesFromChanges/addFilesToLock or an explicit-lock collection) and the
+    // moment we acquire and verify the lock here. When that happens the old file id no longer exists. Re-resolving
+    // the migrated id and retrying converges transparently without surfacing a ConcurrentModificationException to
+    // the caller: at this point no transaction modification has been applied yet (record updates and index entries
+    // are written later in commit1stPhase, after this method returns), so re-locking is side-effect free. The new
+    // file id is authoritative because the buffered index entries are resolved by index name at commit time and
+    // therefore land in the current (migrated) file regardless of which id we lock here.
+    for (int attempt = 0; ; ++attempt) {
+      final List<Integer> locked = database.getTransactionManager().tryLockFiles(filesToLock.toArray(), timeout, getRequester());
+
+      // CHECK IF ALL THE LOCKED FILES STILL EXIST. FILE MISSING CAN HAPPEN IN CASE OF INDEX COMPACTION OR DROP OF A BUCKET OR AN INDEX.
+      int missingFile = -1;
+      for (final Integer f : locked)
+        if (!database.getFileManager().existsFile(f)) {
+          missingFile = f;
+          break;
         }
-        throw new ConcurrentModificationException("File with id '" + f + "' has been removed");
-      }
 
-    return locked;
+      if (missingFile == -1)
+        return locked;
+
+      // FOUND A MISSING FILE: RELEASE EVERY LOCK ACQUIRED IN THIS ATTEMPT BEFORE DECIDING WHAT TO DO.
+      database.getTransactionManager().unlockFilesInOrder(locked, getRequester());
+
+      final Integer migrated = schema.getMigratedFileId(missingFile);
+      if (migrated == null)
+        throw new ConcurrentModificationException("File with id '" + missingFile + "' has been removed");
+
+      if (attempt >= MAX_LOCK_MIGRATION_RETRIES)
+        throw new ConcurrentModificationException(
+            "Error on commit transaction: file '" + missingFile + "' has been migrated to '" + migrated
+                + "' (likely by an index compaction). Please retry the operation.");
+
+      LogManager.instance().log(this, Level.FINE,
+          "Retrying lock acquisition after compaction migrated file '%d' to '%d' (attempt %d/%d, threadId=%d)", missingFile, migrated,
+          attempt + 1, MAX_LOCK_MIGRATION_RETRIES, Thread.currentThread().threadId());
+
+      // RE-RESOLVE THE MIGRATED FILE ID AND RETRY TRANSPARENTLY. IntHashSet has no remove(), so rebuild the set
+      // replacing the migrated id (rare path: only taken when a compaction raced this commit).
+      final int removed = missingFile;
+      final IntHashSet next = new IntHashSet(filesToLock.size() + 1);
+      filesToLock.forEach(id -> {
+        if (id != removed)
+          next.add(id);
+      });
+      next.add(migrated);
+      filesToLock = next;
+    }
   }
 
   private void checkExplicitLocks(final IntHashSet modifiedFiles) {

--- a/engine/src/test/java/com/arcadedb/index/LocalTransactionCommitLockRetryTest.java
+++ b/engine/src/test/java/com/arcadedb/index/LocalTransactionCommitLockRetryTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.TransactionContext;
+import com.arcadedb.index.lsm.LSMTreeIndex;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.utility.IntHashSet;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4529: a background index compaction migrates an indexed file between the moment its
+ * file id is resolved for locking and the moment the commit acquires + verifies that lock. Before the fix the
+ * implicit (non-explicit-lock) commit path surfaced a {@code ConcurrentModificationException} ("file has been
+ * migrated to ... Please retry the operation"). After the fix {@code TransactionContext.lockFilesInOrder} re-resolves
+ * the migrated id and retries transparently, mirroring the explicit-lock internal-retry behavior.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class LocalTransactionCommitLockRetryTest extends TestHelper {
+
+  private static final int PAGE_SIZE = 2 * 1024;
+
+  @Test
+  void commitLockSucceedsAfterCompactionMigratesSnapshottedFile() throws Exception {
+    database.transaction(() -> {
+      final var type = database.getSchema().buildDocumentType().withName("City").withTotalBuckets(1).create();
+      type.createProperty("id", Integer.class);
+      database.getSchema().buildTypeIndex("City", new String[] { "id" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE)
+          .withUnique(true)
+          .withPageSize(PAGE_SIZE)
+          .create();
+    });
+
+    // Populate so the mutable index has >= 2 pages (compaction requires >= 2 pages).
+    database.transaction(() -> {
+      for (int i = 0; i < 1_000; i++)
+        database.newDocument("City").set("id", i).save();
+    });
+
+    final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("City[id]");
+    final LSMTreeIndex bucketIndex = (LSMTreeIndex) typeIndex.getIndexesOnBuckets()[0];
+
+    assertThat(bucketIndex.getMutableIndex().getTotalPages()).isGreaterThanOrEqualTo(2);
+
+    final int staleMutableFid = bucketIndex.getMutableIndex().getFileId();
+
+    // Compact OUTSIDE any active transaction: this migrates staleMutableFid to a new file id, removes the old file,
+    // and registers the migration entry. This reproduces the post-condition of the production race where a commit
+    // had already snapshotted the now-stale file id before the compaction ran.
+    bucketIndex.scheduleCompaction();
+    assertThat(bucketIndex.compact()).isTrue();
+
+    assertThat(((DatabaseInternal) database).getFileManager().existsFile(staleMutableFid)).isFalse();
+    final Integer migratedFid = database.getSchema().getEmbedded().getMigratedFileId(staleMutableFid);
+    assertThat(migratedFid).isNotNull();
+
+    // Acquire the commit lock over the STALE file id, emulating lockFilesFromChanges having resolved it just before
+    // the compaction migrated it. lockFilesInOrder must converge via internal retry on the migrated id instead of
+    // throwing ConcurrentModificationException.
+    database.begin();
+    try {
+      final TransactionContext tx = (TransactionContext) ((DatabaseInternal) database).getTransaction();
+
+      final IntHashSet staleFiles = new IntHashSet(4);
+      staleFiles.add(staleMutableFid);
+
+      final Method lockFilesInOrder = TransactionContext.class.getDeclaredMethod("lockFilesInOrder", IntHashSet.class);
+      lockFilesInOrder.setAccessible(true);
+
+      @SuppressWarnings("unchecked")
+      final List<Integer> locked = (List<Integer>) lockFilesInOrder.invoke(tx, staleFiles);
+
+      // The lock was transparently re-resolved to the migrated file id, not the removed stale one.
+      assertThat(locked).contains(migratedFid);
+      assertThat(locked).doesNotContain(staleMutableFid);
+
+      // Release the locks acquired directly via reflection (the context never recorded them).
+      tx.getDatabase().getTransactionManager().unlockFilesInOrder(locked, Thread.currentThread());
+    } finally {
+      database.rollback();
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Closes #4529.

Under heavy, continuous batch inserts (e.g. `INSERT INTO ...` / `CREATE EDGE ...` inside explicit `begin()/commit()` blocks on an embedded instance), commit intermittently fails with:

```
ConcurrentModificationException: file 'X' has been migrated to 'Y' (likely by an index compaction). Please retry the operation.
```

## Root cause

A TOCTOU race in `TransactionContext.lockFilesInOrder`. During commit the engine resolves the set of file ids to lock (`lockFilesFromChanges` → `TransactionIndexContext.addFilesToLock` → `index.getFileId()`), then acquires and verifies those locks. A background LSM index compaction (`LSMTreeIndex.splitIndex` → `LocalSchema.setMigratedFileId(old, new)`, old file dropped) can migrate an index file in the window between resolution and verification, so the old file id no longer exists and commit throws.

Users driving transactions with explicit `begin()/commit()` around SQL commands (no `database.transaction()` retry wrapper) see it surface directly.

## Fix

Add a bounded internal retry (`MAX_LOCK_MIGRATION_RETRIES = 10`) in `lockFilesInOrder`: on a missing-but-migrated file, unlock, substitute the old id with `getMigratedFileId(old)`, and re-lock (handles migration chains).

This is safe because at lock-acquisition time **no transaction modification has been applied yet** - record updates and `indexChanges.commit()` run later in `commit1stPhase`, after this method returns. Buffered index entries resolve by index **name**, so they land in the current/migrated file regardless of which id is locked. The approach mirrors the existing internal-retry pattern in `LocalTransactionExplicitLock.lock()`.

Genuine bucket/index drops (no migration entry) still fail fast with "File with id X has been removed", and exhausting the retry budget still surfaces the original CME.

## Tests

New deterministic regression test `LocalTransactionCommitLockRetryTest`: builds an indexed type, populates so the mutable index has ≥2 pages, runs a real compaction that migrates the file, then drives `lockFilesInOrder` with the stale file id and asserts it transparently converges on the migrated id. Verified it throws the CME with retries set to 0 and passes with the fix. Database is dropped via the `TestHelper` lifecycle.

Existing `LocalTransactionExplicitLockRetryTest`, `TransactionContextRemoveFileTest`, `TransactionCallbackTest`, `LSMTreeIndexTest`, `LSMTreeIndexCompactionTest`, `ConcurrentCompactionTest`, and `ConcurrentMultiPageRecordReadTest` all still pass.