### PR TITLE
feat: [observability] Pillar 1 metrics depth - RED timers, engine gauges, opt-in OTLP (#4465)

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -234,8 +234,8 @@ The following table lists runtime dependencies bundled with ArcadeDB distributio
 
 | Group ID | Artifact ID | Version | License | Homepage |
 |----------|-------------|---------|---------|----------|
-| io.micrometer | micrometer-core | 1.16.2 | Apache 2.0 | https://micrometer.io/ |
-| io.micrometer | micrometer-observation | 1.16.2 | Apache 2.0 | https://micrometer.io/ |
+| io.micrometer | micrometer-core | 1.16.5 | Apache 2.0 | https://micrometer.io/ |
+| io.micrometer | micrometer-observation | 1.16.5 | Apache 2.0 | https://micrometer.io/ |
 | io.micrometer | micrometer-registry-otlp | 1.16.5 | Apache 2.0 | https://micrometer.io/ |
 | org.hdrhistogram | HdrHistogram | 2.2.2 | Public Domain / CC0 | https://hdrhistogram.github.io/HdrHistogram/ |
 

--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -236,6 +236,7 @@ The following table lists runtime dependencies bundled with ArcadeDB distributio
 |----------|-------------|---------|---------|----------|
 | io.micrometer | micrometer-core | 1.16.2 | Apache 2.0 | https://micrometer.io/ |
 | io.micrometer | micrometer-observation | 1.16.2 | Apache 2.0 | https://micrometer.io/ |
+| io.micrometer | micrometer-registry-otlp | 1.16.5 | Apache 2.0 | https://micrometer.io/ |
 | org.hdrhistogram | HdrHistogram | 2.2.2 | Public Domain / CC0 | https://hdrhistogram.github.io/HdrHistogram/ |
 
 ---

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -38,6 +38,7 @@ import com.arcadedb.bolt.structure.BoltStructureMapper;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseContext;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.ProtocolContext;
 import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.TypeIndex;
@@ -165,6 +166,7 @@ public class BoltNetworkExecutor extends Thread {
 
   @Override
   public void run() {
+    ProtocolContext.set("bolt");
     try {
       state = State.NEGOTIATION;
 
@@ -218,6 +220,7 @@ public class BoltNetworkExecutor extends Thread {
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.SEVERE, "BOLT connection error", e);
     } finally {
+      ProtocolContext.clear();
       cleanup();
     }
   }

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltQueryMetricsIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltQueryMetricsIT.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Config;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that queries executed over a Bolt connection are tagged with protocol="bolt"
+ * in the arcadedb.query.duration Micrometer timer.
+ */
+public class BoltQueryMetricsIT extends BaseGraphServerTest {
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("Bolt:com.arcadedb.bolt.BoltProtocolPlugin");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+
+  private Driver getDriver() {
+    return GraphDatabase.driver(
+        "bolt://localhost:7687",
+        AuthTokens.basic("root", DEFAULT_PASSWORD_FOR_TESTS),
+        Config.builder()
+            .withoutEncryption()
+            .build()
+    );
+  }
+
+  @Test
+  void boltQueriesTaggedWithBoltProtocol() {
+    try (Driver driver = getDriver()) {
+      try (Session session = driver.session(SessionConfig.forDatabase(getDatabaseName()))) {
+        session.run("RETURN 1 AS one").consume();
+      }
+    }
+
+    final Timer timer = Metrics.globalRegistry.find("arcadedb.query.duration").tag("protocol", "bolt").timer();
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isGreaterThanOrEqualTo(1L);
+  }
+}

--- a/docs/4465-observability-pillar-1-metrics.md
+++ b/docs/4465-observability-pillar-1-metrics.md
@@ -1,0 +1,100 @@
+# Issue #4465 - Observability Pillar 1: Metrics Depth
+
+**Branch:** `feat/4465-observability-pillar-1-metrics-depth`
+**Type:** feature
+**Parent:** #4463 (Cloud Observability Architecture)
+**Spec:** `docs/superpowers/specs/2026-06-03-observability-cloud-design.md`
+**Plan:** `docs/superpowers/plans/2026-06-03-observability-p1-metrics.md`
+
+## Goal
+
+Add always-on RED (Rate/Errors/Duration) latency timers on the HTTP and query paths,
+bridge engine `Profiler` stats into Micrometer gauges (`EngineMetricsBinder`), and add an
+optional OTLP metrics registry - all surfaced in the existing `/prometheus` endpoint without
+changing its current series. Default-off / behavior-preserving.
+
+## Verification strategy
+
+TDD. JUnit 5 + AssertJ. Per task: write a failing test, implement, confirm green, then run
+the broader `*Metrics*` suites in `server` and `metrics`. Retro-compat guarded by asserting
+the pre-existing `system_cpu_usage` series still renders in `/prometheus`.
+
+## Pre-implementation analysis (deviations from the plan)
+
+The plan was followed structurally; the following facts were verified against the code and
+required adjustments to the plan's literal snippets:
+
+1. **`Profiler.toJSON()` nests every stat** as `{count|space|value: N}` (e.g.
+   `pageCacheHits -> {"count": N}`, `walBytesWritten -> {"space": N}`); only `walTotalFiles`
+   is a bare scalar. The plan's `json.getLong(key, 0L)` would throw on the nested object, so
+   `EngineMetricsBinder` reads the inner numeric (`count`/`space`/`value`).
+2. **Test root password** is `BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS`
+   (`"DefaultPasswordForTests"`), not `root:root` as the plan's snippet hard-coded.
+3. **HTTP `path` tag** uses Undertow's `PathTemplateMatch` matched template (e.g.
+   `/command/{database}`) instead of the plan's naive last-segment collapse, which would have
+   mangled fixed endpoints like `/ready`. A `db` tag is added from the `database` path param
+   (issue asks for `method`, `path-template`, `status`, `db`).
+4. **Per-database gauge tagging:** the metrics block binds at `ArcadeDBServer` startup
+   *before* `loadDatabases()`, and the page-cache / WAL / MVCC counters are JVM-global
+   singletons (`PageManager.INSTANCE`), not per-DB. `EngineMetricsBinder` therefore exposes
+   engine-wide gauges read live from `Profiler.INSTANCE` on each scrape (the Profiler
+   aggregates whatever databases are registered at scrape time). Per-database-tagged
+   breakdown would require a scheduler-refreshed `MultiGauge`; deferred as a scoped follow-up
+   (noted on the issue). DB-level counters (writeTx/readTx/queries/commands/records) are still
+   exposed as aggregate gauges.
+
+## Tasks
+
+- [x] T1: HTTP RED timer `arcadedb.http.requests` (AbstractServerHttpHandler)
+- [x] T2: Query/command RED timer `arcadedb.query.duration` (Post{Query,Command}Handler)
+- [x] T3: `EngineMetricsBinder` Profiler->gauges
+- [x] T4: Bind `EngineMetricsBinder` at server startup
+- [x] T5: Add `micrometer-registry-otlp` dependency
+- [x] T6: `OtlpMetricsPlugin` opt-in
+- [x] T7: `/prometheus` retro-compat + engine gauges IT
+- [x] T8: Run broader affected suites
+
+## Decisions & notes
+
+- **Micrometer weak-gauge trap (caught by T7).** `Gauge.builder(name, obj, fn)` keeps a *weak*
+  reference to `obj`. `EngineMetricsBinder` is constructed inline in `ArcadeDBServer` and not
+  stored, so the instance was garbage-collected between startup and the first scrape and its
+  gauges silently went dead (the `/prometheus` body had the pool gauges but not the engine
+  gauges). Switched to the `Gauge.builder(name, Supplier<Number>)` form, whose captured lambda
+  strongly references the binder - mirroring how `PoolMetrics` survives by capturing long-lived
+  singletons. This was a real production defect, not just a test artifact.
+- **Config value coercion.** `ContextConfiguration.getValue(key, default)` infers its return type
+  from the default; a `Boolean` stored via `setValue` would `ClassCastException` against a
+  `String` default. `OtlpMetricsPlugin` reads with an `Object` default and coerces, accepting
+  both `Boolean` (programmatic / tests) and `String` (config file / system property).
+- **`SERVER_METRICS` defaults to `true`**, so "default-off" for OTLP is enforced by the
+  `arcadedb.serverMetrics.otlp.enabled` flag (default false) plus the plugin not being listed in
+  `SERVER_PLUGINS`. Verified the plugin is a no-op unless both flags are on.
+- **Snapshot caching.** `Profiler.toJSON()` is heavy (JMX, free-disk, per-DB iteration). The
+  binder memoizes the snapshot for 1s so a scrape rebuilds it at most once instead of once per
+  gauge.
+
+## Final summary
+
+All 8 tasks implemented TDD-first and green. New always-on RED timers `arcadedb.http.requests`
+(tagged `method`/`path-template`/`status`/`db`) and `arcadedb.query.duration` (tagged
+`db`/`language`/`type`); `EngineMetricsBinder` exposes `arcadedb.engine.*` gauges read live from
+`Profiler`; opt-in `OtlpMetricsPlugin` (default-off) pushes alongside the untouched `/prometheus`
+scrape. Path tag uses Undertow's `PathTemplateMatch` so cardinality stays bounded (guarded by a
+test asserting the raw database name never appears in a path tag).
+
+**Test results:**
+- New: `HttpRedMetricsIT`, `QueryRedMetricsIT` (x2), `EngineMetricsBinderTest` (x2),
+  `EngineMetricsExposedIT`, `OtlpMetricsPluginTest` (x3), `PrometheusEngineMetricsIT` - all green.
+- Regression: full `metrics` module (5, incl. both existing Prometheus tests) + 58 server HTTP
+  handler tests (`HealthProbesIT`, `AutoCommitParameterTest`, `QueryEndpointReadOnlyTest`,
+  `ApiTokenAuthenticationIT`, `HTTPAuthSessionIT`, etc.) - all green.
+
+**Retro-compat:** `/prometheus` still serves and keeps `system_cpu_usage`; all new series are
+additive; OTLP confined to the optional `metrics` module and off by default.
+
+**Scoped follow-up (documented on the issue):** per-database-*tagged* gauge breakdown is deferred -
+the metrics binder binds before `loadDatabases()` and the page-cache/WAL counters are JVM-global,
+so a periodically-refreshed `MultiGauge` would be required. DB-level counters are exposed as
+engine-wide aggregates here. Transaction-commit and Raft Observations are deferred to Pillar 2,
+where they also yield spans (tx latency is captured at the HTTP boundary in this pillar).

--- a/docs/observability-metrics.md
+++ b/docs/observability-metrics.md
@@ -1,0 +1,118 @@
+# ArcadeDB Observability: Metrics Catalogue
+
+This document describes the always-on Micrometer metrics emitted by ArcadeDB.
+All series are additive and backward-compatible: enabling server metrics does not
+remove or rename any pre-existing Prometheus series.
+
+---
+
+## `arcadedb.query.duration` - Query/command RED timer
+
+**Prometheus name:** `arcadedb_query_duration_seconds_{count,sum,bucket,max}`
+
+Records the end-to-end execution duration of every query and command that passes
+through the ArcadeDB query engine. The timer is registered with a per-percentile
+histogram so Prometheus can compute arbitrary quantiles server-side.
+
+### Tags
+
+| Tag        | Values                                                                           | Notes |
+|------------|---------------------------------------------------------------------------------|-------|
+| `protocol` | `http`, `bolt`, `postgres`, `mongo`, `grpc`, `redis`, `internal`                | Originating wire protocol. `internal` = engine-internal or embedded-API callers. |
+| `db`        | database name                                                                   | Taken from the active database at execution time. |
+| `language`  | `sql`, `opencypher`, `gremlin`, `graphql`, `mongo`, ...                         | Query language as declared by the caller. |
+| `type`      | `query`, `command`                                                               | `query` for read-only SELECT / MATCH; `command` for DDL and write statements. |
+
+The `protocol` tag cardinality is bounded to the seven values above. Tag values
+never contain query text; each tag carries only a short symbolic constant.
+
+### Filtering for wire RED (excluding embedded callers)
+
+To compute the RED rate for external wire-protocol traffic only, exclude
+`protocol="internal"`:
+
+```promql
+-- Request rate (requests per second, all wire protocols)
+sum(rate(arcadedb_query_duration_seconds_count{protocol!="internal"}[1m])) by (protocol)
+
+-- p95 latency per protocol
+histogram_quantile(0.95,
+  sum(rate(arcadedb_query_duration_seconds_bucket{protocol!="internal"}[5m]))
+  by (le, protocol))
+```
+
+### Sample PromQL - p95 latency by protocol
+
+```promql
+histogram_quantile(0.95,
+  sum(rate(arcadedb_query_duration_seconds_bucket{protocol!="internal"}[5m]))
+  by (le, protocol))
+```
+
+---
+
+## Pillar-1 siblings
+
+### `arcadedb.http.requests` - HTTP RED timer
+
+Records every request dispatched by the Undertow handler chain.
+
+Tags: `method` (GET / POST / ...), `path` (Undertow path template, e.g.
+`/query/{database}`), `status` (HTTP status code as a string, e.g. `200`, `401`),
+`db` (database path-parameter when present, otherwise absent).
+
+The `path` tag uses Undertow's matched path template so the raw database name never
+appears in the tag value, keeping cardinality bounded.
+
+### `arcadedb.engine.*` - Engine gauges
+
+`EngineMetricsBinder` exposes live engine counters as Micrometer gauges, scraped
+on demand from the internal `Profiler` singleton:
+
+| Metric name                         | Description |
+|-------------------------------------|-------------|
+| `arcadedb.engine.pageCacheHits`     | Cumulative page cache hits |
+| `arcadedb.engine.pageCacheMiss`     | Cumulative page cache misses |
+| `arcadedb.engine.walBytesWritten`   | Cumulative WAL bytes written |
+| `arcadedb.engine.walTotalFiles`     | Current number of open WAL files |
+| `arcadedb.engine.queries`           | Cumulative query executions (engine-wide) |
+| `arcadedb.engine.commands`          | Cumulative command executions (engine-wide) |
+| `arcadedb.engine.readTx`            | Cumulative read transactions |
+| `arcadedb.engine.writeTx`           | Cumulative write transactions |
+
+All gauges are engine-wide aggregates (not per-database). A per-database breakdown
+would require a periodically-refreshed `MultiGauge`; this is deferred as a follow-up.
+
+---
+
+## Coverage and known limitations
+
+- **Postgres:** Both the simple query protocol and the extended/prepared-statement
+  protocol are covered. `ProtocolContext` is set to `postgres` in both code paths
+  before the query reaches the engine, and cleared in the handler's finally block.
+
+- **MongoDB:** Explicit `find` / `runCommand` requests set `protocol=mongo` before
+  dispatch. However, unfiltered collection scans that use the engine's internal
+  iterate path (rather than going through `query`/`command`) are not timed by this
+  metric.
+
+- **gRPC:** The unary `Query` RPC, the server-streaming `StreamQuery` RPC, and the
+  unary `BulkInsert` RPC all set `protocol=grpc`. The client-streaming `insertStream`
+  RPC's per-message callbacks are NOT yet tagged - each message arrives on a separate
+  callback invocation and the per-stream context wiring is tracked as a follow-up.
+
+- **Redis:** The Redis wire-protocol adapter does not route through the ArcadeDB
+  query/command engine. It handles key-value operations directly at the protocol
+  layer, so no `arcadedb.query.duration` observations are emitted for Redis clients.
+  The `redis` value in the `protocol` tag's bounded set is reserved defensively; any
+  future engine-routed Redis commands would appear there automatically.
+
+- **Bolt:** All Cypher queries sent over the Neo4j Bolt protocol are covered.
+
+- **HTTP:** All POST `/query/{db}` and POST `/command/{db}` requests are covered.
+  The `http` protocol tag also appears on GET `/query/{db}` requests (URL-encoded
+  query parameter form).
+
+- **Internal / embedded:** Engine-internal callers and applications using the
+  embedded Java API default to `protocol=internal`. These are excluded from wire RED
+  dashboards by filtering `protocol!="internal"`.

--- a/docs/superpowers/plans/2026-06-10-observability-protocol-agnostic-query-metrics.md
+++ b/docs/superpowers/plans/2026-06-10-observability-protocol-agnostic-query-metrics.md
@@ -1,0 +1,1021 @@
+# Protocol-Agnostic Query Metrics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**GitHub issue:** [#4535](https://github.com/ArcadeData/arcadedb/issues/4535) - follow-up to #4465 (Observability Pillar 1), part of #4463.
+
+**Goal:** Record the `arcadedb.query.duration` RED timer once at the engine boundary (`LocalDatabase.query()/command()`), tagged by the originating wire `protocol`, so Bolt, Postgres, Mongo, Redis, gRPC and HTTP are all covered by a single instrumentation point.
+
+**Architecture:** The engine module has Micrometer only at **test** scope, so engine main code cannot call Micrometer (the same constraint that put `PoolMetrics`/`EngineMetricsBinder` in `server`). The engine therefore exposes a framework-agnostic `QueryMetricsRecorder` hook (plain Java) plus a `ProtocolContext` thread-local; `LocalDatabase` times each query/command and invokes the hook. The `server` module registers a Micrometer-backed recorder that emits `arcadedb.query.duration{protocol, db, language, type}`. Each wire listener sets `ProtocolContext` at its request boundary and clears it in `finally`. The HTTP path drops its now-redundant per-handler timer.
+
+**Tech Stack:** Java 21, Micrometer 1.16.5 (server scope only), JUnit 5 + AssertJ. Modules touched: `engine`, `server`, `bolt`, `postgresw`, `mongodbw`, `redisw`, `grpcw`.
+
+---
+
+## File Structure
+
+- **Create** `engine/src/main/java/com/arcadedb/database/QueryMetricsRecorder.java` - framework-agnostic hook interface + static `Holder` (no-op default, `startNanos()`/`record()` helpers). No Micrometer.
+- **Create** `engine/src/main/java/com/arcadedb/database/ProtocolContext.java` - `ThreadLocal<String>` carrying the originating wire protocol (default `internal`).
+- **Modify** `engine/src/main/java/com/arcadedb/database/LocalDatabase.java` - wrap the 7 terminal `query`/`command` call sites with gated timing.
+- **Create** `server/src/main/java/com/arcadedb/server/monitor/MicrometerQueryMetricsRecorder.java` - Micrometer impl emitting `arcadedb.query.duration`.
+- **Modify** `server/src/main/java/com/arcadedb/server/ArcadeDBServer.java` - register the recorder in the `SERVER_METRICS` block.
+- **Modify** `server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java` - set/clear `ProtocolContext` = `http`.
+- **Modify** `server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java` and `PostQueryHandler.java` - remove the now-redundant `timeExecution` wrapper.
+- **Modify** the wire listeners: `bolt/.../BoltNetworkExecutor.java`, `postgresw/.../PostgresNetworkExecutor.java`, `mongodbw/.../MongoDBDatabaseWrapper.java`, `redisw/.../RedisNetworkExecutor.java`, `grpcw/.../ArcadeDbGrpcService.java` - set/clear `ProtocolContext`.
+- **Create** tests under each affected module's `src/test`.
+
+---
+
+## Phasing
+
+- **Phase A (engine core):** Tasks 1-3. Hook + thread-local + engine timing. Self-contained, no behavior change (no-op until a recorder registers).
+- **Phase B (server + HTTP):** Task 4. Micrometer recorder, registration, HTTP refactor. After this, `arcadedb.query.duration{protocol=http}` is live and Pillar 1's `QueryRedMetricsIT` still passes.
+- **Phase C (other protocols):** Tasks 5-9 (Bolt, Postgres, Mongo, gRPC, Redis). Each independent.
+- **Phase D:** Task 10. Cardinality guard, docs, broader suites.
+
+---
+
+## Task 1: `QueryMetricsRecorder` hook (engine, no Micrometer)
+
+**Files:**
+- Create: `engine/src/main/java/com/arcadedb/database/QueryMetricsRecorder.java`
+- Test: `engine/src/test/java/com/arcadedb/database/QueryMetricsRecorderTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+package com.arcadedb.database;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QueryMetricsRecorderTest {
+  @AfterEach
+  void reset() {
+    QueryMetricsRecorder.Holder.register(null); // back to NO_OP
+  }
+
+  @Test
+  void defaultIsNoOpAndStartNanosReturnsZero() {
+    assertThat(QueryMetricsRecorder.Holder.get()).isSameAs(QueryMetricsRecorder.NO_OP);
+    assertThat(QueryMetricsRecorder.Holder.startNanos()).isZero();
+  }
+
+  @Test
+  void registeredRecorderReceivesRecordWhenTimingActive() {
+    final AtomicReference<String> captured = new AtomicReference<>();
+    QueryMetricsRecorder.Holder.register(
+        (protocol, database, language, type, durationNanos) -> captured.set(protocol + "/" + database + "/" + language + "/" + type));
+
+    final long start = QueryMetricsRecorder.Holder.startNanos();
+    assertThat(start).isNotZero(); // an active recorder makes startNanos() time
+    QueryMetricsRecorder.Holder.record(start, "db1", "sql", "query");
+
+    assertThat(captured.get()).isEqualTo(ProtocolContext.get() + "/db1/sql/query");
+  }
+
+  @Test
+  void recordWithZeroStartIsIgnored() {
+    final AtomicReference<Boolean> called = new AtomicReference<>(false);
+    QueryMetricsRecorder.Holder.register((p, d, l, t, n) -> called.set(true));
+    QueryMetricsRecorder.Holder.record(0L, "db1", "sql", "query");
+    assertThat(called.get()).isFalse();
+  }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvn -q -pl engine test -Dtest=QueryMetricsRecorderTest`
+Expected: FAIL - `QueryMetricsRecorder` does not exist (compile error). (`ProtocolContext` is created in Task 2; if compilation blocks, create Task 2's file first, then return.)
+
+- [ ] **Step 3: Implement `QueryMetricsRecorder`**
+
+```java
+package com.arcadedb.database;
+
+/**
+ * Framework-agnostic hook the engine calls to report the duration of a query/command execution.
+ * Lives in the engine (which has Micrometer only at test scope); the server registers a
+ * Micrometer-backed implementation. Default is a no-op, so when no recorder is registered the
+ * engine pays only a volatile read and a sentinel check per query - no timing, no allocation.
+ */
+@FunctionalInterface
+public interface QueryMetricsRecorder {
+  QueryMetricsRecorder NO_OP = (protocol, database, language, type, durationNanos) -> {
+  };
+
+  /**
+   * @param protocol     originating wire protocol (e.g. http, bolt, postgres, internal)
+   * @param database     database name
+   * @param language     query language (sql, opencypher, ...)
+   * @param type         query or command
+   * @param durationNanos elapsed nanoseconds
+   */
+  void record(String protocol, String database, String language, String type, long durationNanos);
+
+  /** Static registration + timing helpers, kept off the interface's public surface. */
+  final class Holder {
+    private static volatile QueryMetricsRecorder current = NO_OP;
+
+    private Holder() {
+    }
+
+    public static void register(final QueryMetricsRecorder recorder) {
+      current = recorder != null ? recorder : NO_OP;
+    }
+
+    public static QueryMetricsRecorder get() {
+      return current;
+    }
+
+    /** Returns System.nanoTime() when a recorder is active, otherwise 0 (the "not timing" sentinel). */
+    public static long startNanos() {
+      return current == NO_OP ? 0L : System.nanoTime();
+    }
+
+    /** Records elapsed time since {@code start}; a {@code start} of 0 means timing was inactive and is ignored. */
+    public static void record(final long start, final String database, final String language, final String type) {
+      if (start == 0L)
+        return;
+      current.record(ProtocolContext.get(), database, language, type, System.nanoTime() - start);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `mvn -q -pl engine test -Dtest=QueryMetricsRecorderTest`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add engine/src/main/java/com/arcadedb/database/QueryMetricsRecorder.java \
+        engine/src/test/java/com/arcadedb/database/QueryMetricsRecorderTest.java
+git commit -m "feat(observability): engine QueryMetricsRecorder hook (no Micrometer) (#4535)"
+```
+
+---
+
+## Task 2: `ProtocolContext` thread-local (engine)
+
+**Files:**
+- Create: `engine/src/main/java/com/arcadedb/database/ProtocolContext.java`
+- Test: `engine/src/test/java/com/arcadedb/database/ProtocolContextTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+package com.arcadedb.database;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProtocolContextTest {
+  @Test
+  void defaultsToInternal() {
+    ProtocolContext.clear();
+    assertThat(ProtocolContext.get()).isEqualTo(ProtocolContext.INTERNAL);
+  }
+
+  @Test
+  void setAndClear() {
+    ProtocolContext.set("bolt");
+    assertThat(ProtocolContext.get()).isEqualTo("bolt");
+    ProtocolContext.clear();
+    assertThat(ProtocolContext.get()).isEqualTo(ProtocolContext.INTERNAL);
+  }
+
+  @Test
+  void nullResetsToInternal() {
+    ProtocolContext.set("http");
+    ProtocolContext.set(null);
+    assertThat(ProtocolContext.get()).isEqualTo(ProtocolContext.INTERNAL);
+  }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvn -q -pl engine test -Dtest=ProtocolContextTest`
+Expected: FAIL - `ProtocolContext` does not exist.
+
+- [ ] **Step 3: Implement `ProtocolContext`**
+
+```java
+package com.arcadedb.database;
+
+/**
+ * Carries the originating wire protocol of the current request on a thread-local so the engine can
+ * tag {@code arcadedb.query.duration} without each protocol re-implementing query timing. Wire
+ * listeners {@link #set} it at the request boundary and {@link #clear} it in a finally block (worker
+ * and connection threads are pooled/reused). Defaults to {@link #INTERNAL} for engine-internal and
+ * embedded-API callers.
+ */
+public final class ProtocolContext {
+  public static final String INTERNAL = "internal";
+
+  private static final ThreadLocal<String> CURRENT = ThreadLocal.withInitial(() -> INTERNAL);
+
+  private ProtocolContext() {
+  }
+
+  public static void set(final String protocol) {
+    CURRENT.set(protocol != null ? protocol : INTERNAL);
+  }
+
+  public static String get() {
+    return CURRENT.get();
+  }
+
+  public static void clear() {
+    CURRENT.remove();
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `mvn -q -pl engine test -Dtest=ProtocolContextTest`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add engine/src/main/java/com/arcadedb/database/ProtocolContext.java \
+        engine/src/test/java/com/arcadedb/database/ProtocolContextTest.java
+git commit -m "feat(observability): engine ProtocolContext thread-local (#4535)"
+```
+
+---
+
+## Task 3: Time query/command in `LocalDatabase`
+
+**Files:**
+- Modify: `engine/src/main/java/com/arcadedb/database/LocalDatabase.java` (the 7 terminal `query`/`command` overloads, ~lines 1559-1631)
+- Test: `engine/src/test/java/com/arcadedb/database/LocalDatabaseQueryMetricsTest.java`
+
+Context: each terminal overload increments `stats.{queries,commands}` then calls `getQueryEngine(language).{query,command}(...)`. We wrap each engine call in a gated try/finally. The gate (`startNanos()` returns 0 when no recorder is registered) keeps the disabled path allocation-free with negligible overhead.
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+package com.arcadedb.database;
+
+import com.arcadedb.engine.ComponentFile;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LocalDatabaseQueryMetricsTest {
+  private final String dbPath = "./target/databases/LocalDatabaseQueryMetricsTest";
+
+  @AfterEach
+  void reset() {
+    QueryMetricsRecorder.Holder.register(null);
+    ProtocolContext.clear();
+  }
+
+  @Test
+  void queryAndCommandAreRecordedWithProtocolAndType() {
+    final AtomicReference<String> lastQuery = new AtomicReference<>();
+    final AtomicReference<String> lastCommand = new AtomicReference<>();
+    QueryMetricsRecorder.Holder.register((protocol, database, language, type, nanos) -> {
+      if ("query".equals(type)) lastQuery.set(protocol + "|" + language + "|" + type);
+      else if ("command".equals(type)) lastCommand.set(protocol + "|" + language + "|" + type);
+    });
+
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      if (factory.exists()) factory.open().drop();
+      try (final Database db = factory.create()) {
+        ProtocolContext.set("test");
+        db.command("sql", "CREATE DOCUMENT TYPE Doc");
+        db.query("sql", "SELECT FROM Doc");
+      }
+    }
+
+    assertThat(lastCommand.get()).isEqualTo("test|sql|command");
+    assertThat(lastQuery.get()).isEqualTo("test|sql|query");
+  }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvn -q -pl engine test -Dtest=LocalDatabaseQueryMetricsTest`
+Expected: FAIL - recorder never invoked (no timing wired yet); `lastCommand`/`lastQuery` are null.
+
+- [ ] **Step 3: Wrap the 7 terminal overloads**
+
+In `LocalDatabase.java`, replace each terminal `command`/`query` body. The no-parameter command overload (~line 1559) becomes:
+
+```java
+  @Override
+  public ResultSet command(final String language, final String query) {
+    checkDatabaseIsOpen(true, "Cannot execute command on a read only database");
+    stats.commands.incrementAndGet();
+    final long start = QueryMetricsRecorder.Holder.startNanos();
+    try {
+      return getQueryEngine(language).command(query, new ContextConfiguration());
+    } finally {
+      QueryMetricsRecorder.Holder.record(start, name, language, "command");
+    }
+  }
+```
+
+The varargs command overload (~line 1566):
+
+```java
+  @Override
+  public ResultSet command(final String language, final String query, final Object... parameters) {
+    checkDatabaseIsOpen(true, "Cannot execute command on a read only database");
+    stats.commands.incrementAndGet();
+    final long start = QueryMetricsRecorder.Holder.startNanos();
+    try {
+      return getQueryEngine(language).command(query, new ContextConfiguration(), parameters);
+    } finally {
+      QueryMetricsRecorder.Holder.record(start, name, language, "command");
+    }
+  }
+```
+
+The configuration+varargs command overload (~line 1573):
+
+```java
+  @Override
+  public ResultSet command(final String language, final String query, final ContextConfiguration configuration,
+      final Object... parameters) {
+    checkDatabaseIsOpen(true, "Cannot execute command on a read only database");
+    stats.commands.incrementAndGet();
+    final long start = QueryMetricsRecorder.Holder.startNanos();
+    try {
+      return getQueryEngine(language).command(query, configuration, parameters);
+    } finally {
+      QueryMetricsRecorder.Holder.record(start, name, language, "command");
+    }
+  }
+```
+
+The configuration+Map command overload (~line 1586) (note: the `command(language, query, Map)` overload at ~1581 just delegates here, so leave it untouched to avoid double counting):
+
+```java
+  @Override
+  public ResultSet command(final String language, final String query, final ContextConfiguration configuration,
+      final Map<String, Object> parameters) {
+    checkDatabaseIsOpen(true, "Cannot execute command on a read only database");
+    stats.commands.incrementAndGet();
+    final long start = QueryMetricsRecorder.Holder.startNanos();
+    try {
+      return getQueryEngine(language).command(query, configuration, parameters);
+    } finally {
+      QueryMetricsRecorder.Holder.record(start, name, language, "command");
+    }
+  }
+```
+
+The no-parameter query overload (~line 1613):
+
+```java
+  @Override
+  public ResultSet query(final String language, final String query) {
+    checkDatabaseIsOpen();
+    stats.queries.incrementAndGet();
+    final long start = QueryMetricsRecorder.Holder.startNanos();
+    try {
+      return getQueryEngine(language).query(query, new ContextConfiguration());
+    } finally {
+      QueryMetricsRecorder.Holder.record(start, name, language, "query");
+    }
+  }
+```
+
+The varargs query overload (~line 1620):
+
+```java
+  @Override
+  public ResultSet query(final String language, final String query, final Object... parameters) {
+    checkDatabaseIsOpen();
+    stats.queries.incrementAndGet();
+    final long start = QueryMetricsRecorder.Holder.startNanos();
+    try {
+      return getQueryEngine(language).query(query, new ContextConfiguration(), parameters);
+    } finally {
+      QueryMetricsRecorder.Holder.record(start, name, language, "query");
+    }
+  }
+```
+
+The Map query overload (~line 1627):
+
+```java
+  @Override
+  public ResultSet query(final String language, final String query, final Map<String, Object> parameters) {
+    checkDatabaseIsOpen();
+    stats.queries.incrementAndGet();
+    final long start = QueryMetricsRecorder.Holder.startNanos();
+    try {
+      return getQueryEngine(language).query(query, new ContextConfiguration(), parameters);
+    } finally {
+      QueryMetricsRecorder.Holder.record(start, name, language, "query");
+    }
+  }
+```
+
+(`name` is the existing `LocalDatabase` database-name field used by `getName()`. Verify it is in scope; if the field is named differently, use the accessor `getName()`.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `mvn -q -pl engine test -Dtest=LocalDatabaseQueryMetricsTest`
+Expected: PASS.
+
+- [ ] **Step 5: Run nearby engine query tests for regressions**
+
+Run: `mvn -q -pl engine test -Dtest="*Query*Test,LocalDatabaseQueryMetricsTest"`
+Expected: PASS (timing is transparent; no behavior change).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add engine/src/main/java/com/arcadedb/database/LocalDatabase.java \
+        engine/src/test/java/com/arcadedb/database/LocalDatabaseQueryMetricsTest.java
+git commit -m "feat(observability): time query/command at the engine boundary (#4535)"
+```
+
+---
+
+## Task 4: Micrometer recorder + register + HTTP refactor (server)
+
+**Files:**
+- Create: `server/src/main/java/com/arcadedb/server/monitor/MicrometerQueryMetricsRecorder.java`
+- Modify: `server/src/main/java/com/arcadedb/server/ArcadeDBServer.java`
+- Modify: `server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java`
+- Modify: `server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java`
+- Modify: `server/src/main/java/com/arcadedb/server/http/handler/PostQueryHandler.java`
+- Test: `server/src/test/java/com/arcadedb/server/monitor/QueryMetricsProtocolIT.java`
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+package com.arcadedb.server.monitor;
+
+import com.arcadedb.server.BaseGraphServerTest;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QueryMetricsProtocolIT extends BaseGraphServerTest {
+  @Override
+  protected int getServerCount() {
+    return 1;
+  }
+
+  @Test
+  void httpQueryRecordedWithProtocolTag() throws Exception {
+    final HttpURLConnection c = (HttpURLConnection) new URL("http://localhost:2480/api/v1/query/graph").openConnection();
+    c.setRequestMethod("POST");
+    c.setDoOutput(true);
+    c.setRequestProperty("Authorization",
+        "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+    c.setRequestProperty("Content-Type", "application/json");
+    c.getOutputStream().write("{\"language\":\"sql\",\"command\":\"select 1 as one\"}".getBytes(StandardCharsets.UTF_8));
+    c.connect();
+    assertThat(c.getResponseCode()).isEqualTo(200);
+    c.disconnect();
+
+    final Timer timer = Metrics.globalRegistry.find("arcadedb.query.duration")
+        .tag("protocol", "http").tag("db", "graph").tag("language", "sql").tag("type", "query").timer();
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isGreaterThanOrEqualTo(1L);
+  }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvn -q -pl server test -Dtest=QueryMetricsProtocolIT`
+Expected: FAIL - no `protocol` tag (recorder not registered; HTTP doesn't set `ProtocolContext`).
+
+- [ ] **Step 3: Implement `MicrometerQueryMetricsRecorder`**
+
+```java
+package com.arcadedb.server.monitor;
+
+import com.arcadedb.database.QueryMetricsRecorder;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Server-side {@link QueryMetricsRecorder} that emits the always-on {@code arcadedb.query.duration}
+ * RED timer tagged by originating protocol, database, language and type. Registered when server
+ * metrics are enabled; otherwise the engine keeps the no-op recorder and pays no timing cost.
+ */
+public final class MicrometerQueryMetricsRecorder implements QueryMetricsRecorder {
+  @Override
+  public void record(final String protocol, final String database, final String language, final String type,
+      final long durationNanos) {
+    Timer.builder("arcadedb.query.duration")
+        .description("Query/command execution duration")
+        .tag("protocol", protocol)
+        .tag("db", database)
+        .tag("language", language)
+        .tag("type", type)
+        .publishPercentileHistogram()
+        .register(Metrics.globalRegistry)
+        .record(durationNanos, TimeUnit.NANOSECONDS);
+  }
+}
+```
+
+- [ ] **Step 4: Register it at server startup**
+
+In `ArcadeDBServer.java`, inside the `if (configuration.getValueAsBoolean(GlobalConfiguration.SERVER_METRICS)) { ... }` block, immediately after `new EngineMetricsBinder().bindTo(Metrics.globalRegistry);`, add:
+
+```java
+      QueryMetricsRecorder.Holder.register(new MicrometerQueryMetricsRecorder());
+```
+
+Add imports `import com.arcadedb.database.QueryMetricsRecorder;` and `import com.arcadedb.server.monitor.MicrometerQueryMetricsRecorder;`.
+
+- [ ] **Step 5: Set/clear `ProtocolContext` on the HTTP path**
+
+In `AbstractServerHttpHandler.handleRequest`, add `import com.arcadedb.database.ProtocolContext;`. Immediately after `final long httpStartNanos = System.nanoTime();` set the protocol:
+
+```java
+    ProtocolContext.set("http");
+```
+
+In the existing `finally` block (next to `LogManager.instance().setContext(null);` and the `arcadedb.http.requests` timer), add:
+
+```java
+      ProtocolContext.clear();
+```
+
+- [ ] **Step 6: Remove the redundant HTTP query timer**
+
+In `PostCommandHandler.java`, revert `executeCommand` to the un-timed body and delete the `timeExecution` helper (the engine now times it):
+
+```java
+  protected ResultSet executeCommand(final Database database, final String language, final String command,
+      final Map<String, Object> paramMap) {
+    final Object params = mapParams(paramMap);
+    if (params instanceof Object[] objects)
+      return database.command(language, command, httpServer.getServer().getConfiguration(), objects);
+    return database.command(language, command, httpServer.getServer().getConfiguration(), (Map<String, Object>) params);
+  }
+```
+
+Remove the now-unused imports `io.micrometer.core.instrument.Timer` and `java.util.function.Supplier` if they are no longer referenced elsewhere in the file (keep `Metrics` and `TimeUnit` - they are still used by `recordProfilerMetrics`).
+
+In `PostQueryHandler.java`, revert `executeCommand` to:
+
+```java
+  protected ResultSet executeCommand(final Database database, final String language, final String command, final Map<String, Object> paramMap) {
+    final Object params = mapParams(paramMap);
+    if (params instanceof Object[] objects)
+      return database.query(language, command, objects);
+    return database.query(language, command, (Map<String, Object>) params);
+  }
+```
+
+- [ ] **Step 7: Run the new test and the Pillar-1 query test**
+
+Run: `mvn -q -pl server install -DskipTests`
+Run: `mvn -pl server test -Dtest="QueryMetricsProtocolIT,QueryRedMetricsIT,HttpRedMetricsIT"`
+Expected: PASS. `QueryRedMetricsIT` still passes because the engine emits `arcadedb.query.duration` with the same `db`/`language`/`type` tags (now plus `protocol=http`); its `find().tag(...)` assertions match a superset.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add server/src/main/java/com/arcadedb/server/monitor/MicrometerQueryMetricsRecorder.java \
+        server/src/main/java/com/arcadedb/server/ArcadeDBServer.java \
+        server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java \
+        server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java \
+        server/src/main/java/com/arcadedb/server/http/handler/PostQueryHandler.java \
+        server/src/test/java/com/arcadedb/server/monitor/QueryMetricsProtocolIT.java
+git commit -m "feat(observability): Micrometer query recorder + HTTP protocol tag, drop redundant HTTP timer (#4535)"
+```
+
+---
+
+## Task 5: Bolt protocol tag
+
+**Files:**
+- Modify: `bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java` (the `run()` loop, ~line 167; `processMessage` dispatch ~line 333)
+- Test: `bolt/src/test/java/com/arcadedb/bolt/BoltQueryMetricsIT.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Model the server bootstrap and Bolt client connection on the existing Bolt IT in `bolt/src/test/java/com/arcadedb/bolt/` (use the same `BaseGraphServerTest` subclass + Neo4j Java driver the other Bolt tests use). The assertion is the new part:
+
+```java
+package com.arcadedb.bolt;
+
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// extends the same base + @BeforeEach/@AfterEach server setup the other Bolt ITs use
+class BoltQueryMetricsIT extends BaseBoltServerTest {
+  @Test
+  void boltQueryRecordedWithProtocolTag() {
+    runCypherViaBoltDriver("RETURN 1 AS one"); // helper that opens a Bolt session and runs a query
+
+    final Timer timer = Metrics.globalRegistry.find("arcadedb.query.duration").tag("protocol", "bolt").timer();
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isGreaterThanOrEqualTo(1L);
+  }
+}
+```
+
+(If the module has no shared `BaseBoltServerTest`, place the server bootstrap + driver call inline in this test, copied from the existing Bolt IT in the module.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvn -q -pl bolt test -Dtest=BoltQueryMetricsIT`
+Expected: FAIL - no timer with `protocol=bolt`.
+
+- [ ] **Step 3: Set/clear `ProtocolContext` in the message loop**
+
+In `BoltNetworkExecutor.java`, add `import com.arcadedb.database.ProtocolContext;`. In `run()` (~line 167), set the protocol once before the message loop and clear it in the loop's `finally` (~line 221):
+
+```java
+    ProtocolContext.set("bolt");
+    try {
+      // ... existing while (state != State.DISCONNECTED) { ... processMessage(message); } ...
+    } finally {
+      ProtocolContext.clear();
+    }
+```
+
+(Bolt is thread-per-connection, so setting once per connection covers every message that connection runs. If `run()` already has a `try/finally`, add the two lines into the existing blocks rather than nesting a new one.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `mvn -q -pl bolt test -Dtest=BoltQueryMetricsIT`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java \
+        bolt/src/test/java/com/arcadedb/bolt/BoltQueryMetricsIT.java
+git commit -m "feat(observability): tag Bolt queries with protocol=bolt (#4535)"
+```
+
+---
+
+## Task 6: Postgres protocol tag
+
+**Files:**
+- Modify: `postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java` (the `run()` loop ~line 142, finally ~line 222)
+- Test: `postgresw/src/test/java/com/arcadedb/postgres/PostgresQueryMetricsIT.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Model the server bootstrap + JDBC connection on the existing Postgres IT in `postgresw/src/test/java/com/arcadedb/postgres/`. Assertion:
+
+```java
+package com.arcadedb.postgres;
+
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.Statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PostgresQueryMetricsIT extends BasePostgresServerTest {
+  @Test
+  void postgresQueryRecordedWithProtocolTag() throws Exception {
+    try (final Connection conn = openJdbc(); final Statement st = conn.createStatement()) {
+      st.executeQuery("SELECT 1");
+    }
+    final Timer timer = Metrics.globalRegistry.find("arcadedb.query.duration").tag("protocol", "postgres").timer();
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isGreaterThanOrEqualTo(1L);
+  }
+}
+```
+
+(Use the same JDBC URL/credentials helper the existing Postgres ITs use; inline the bootstrap if no shared base exists.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvn -q -pl postgresw test -Dtest=PostgresQueryMetricsIT`
+Expected: FAIL - no `protocol=postgres` timer.
+
+- [ ] **Step 3: Set/clear `ProtocolContext` in the message loop**
+
+In `PostgresNetworkExecutor.java`, add `import com.arcadedb.database.ProtocolContext;`. In `run()` (~line 142), set the protocol before the dispatch loop and clear it in the existing `finally` (~line 222):
+
+```java
+    ProtocolContext.set("postgres");
+    try {
+      // ... existing message read/dispatch loop ...
+    } finally {
+      ProtocolContext.clear();
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `mvn -q -pl postgresw test -Dtest=PostgresQueryMetricsIT`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java \
+        postgresw/src/test/java/com/arcadedb/postgres/PostgresQueryMetricsIT.java
+git commit -m "feat(observability): tag Postgres queries with protocol=postgres (#4535)"
+```
+
+---
+
+## Task 7: MongoDB protocol tag
+
+**Files:**
+- Modify: `mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java` (`handleCommand`, ~line 84)
+- Test: `mongodbw/src/test/java/com/arcadedb/mongo/MongoQueryMetricsIT.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Model the server bootstrap + Mongo driver call on the existing Mongo IT in `mongodbw/src/test/java/com/arcadedb/mongo/`. Assertion:
+
+```java
+package com.arcadedb.mongo;
+
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MongoQueryMetricsIT extends BaseMongoServerTest {
+  @Test
+  void mongoQueryRecordedWithProtocolTag() {
+    runMongoFind(); // helper that issues a find() over the Mongo wire protocol
+
+    final Timer timer = Metrics.globalRegistry.find("arcadedb.query.duration").tag("protocol", "mongo").timer();
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isGreaterThanOrEqualTo(1L);
+  }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvn -q -pl mongodbw test -Dtest=MongoQueryMetricsIT`
+Expected: FAIL - no `protocol=mongo` timer.
+
+- [ ] **Step 3: Set/clear `ProtocolContext` in `handleCommand`**
+
+In `MongoDBDatabaseWrapper.java`, add `import com.arcadedb.database.ProtocolContext;`. Wrap the body of `handleCommand` (~line 84):
+
+```java
+  public Document handleCommand(final Channel channel, final String command, final Document document,
+      final DatabaseResolver databaseResolver, final Oplog opLog) {
+    ProtocolContext.set("mongo");
+    try {
+      // ... existing handleCommand body ...
+    } finally {
+      ProtocolContext.clear();
+    }
+  }
+```
+
+(The library calls `handleCommand` once per client request on its network thread, so set/clear per call.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `mvn -q -pl mongodbw test -Dtest=MongoQueryMetricsIT`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java \
+        mongodbw/src/test/java/com/arcadedb/mongo/MongoQueryMetricsIT.java
+git commit -m "feat(observability): tag Mongo queries with protocol=mongo (#4535)"
+```
+
+---
+
+## Task 8: gRPC protocol tag
+
+**Files:**
+- Modify: `grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java` (`executeQueryInternal` ~line 906, `executeCommandInternal` ~line 263; or set once in `GrpcMetricsInterceptor`)
+- Test: `grpcw/src/test/java/com/arcadedb/server/grpc/GrpcQueryMetricsIT.java`
+
+Context: the gRPC service executes on gRPC's own threads. Setting `ProtocolContext` in `GrpcMetricsInterceptor` (the universal per-RPC chokepoint) is cleanest, but interceptor `onMessage`/`onHalfClose` may run on a different thread than the service method in streaming cases. For unary query/command (the RED-relevant paths) the simplest robust placement is at the start of `executeQueryInternal`/`executeCommandInternal`, cleared in a finally.
+
+- [ ] **Step 1: Write the failing test**
+
+Model the server bootstrap + gRPC stub on the existing gRPC IT in `grpcw/src/test/java/com/arcadedb/server/grpc/`. Assertion:
+
+```java
+package com.arcadedb.server.grpc;
+
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GrpcQueryMetricsIT extends BaseGrpcServerTest {
+  @Test
+  void grpcQueryRecordedWithProtocolTag() {
+    executeQueryViaStub("SELECT 1"); // helper using the generated blocking stub
+
+    final Timer timer = Metrics.globalRegistry.find("arcadedb.query.duration").tag("protocol", "grpc").timer();
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isGreaterThanOrEqualTo(1L);
+  }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvn -q -pl grpcw test -Dtest=GrpcQueryMetricsIT`
+Expected: FAIL - the query is tagged `protocol=internal`, not `grpc`.
+
+- [ ] **Step 3: Set/clear `ProtocolContext` around the query/command execution**
+
+In `ArcadeDbGrpcService.java`, add `import com.arcadedb.database.ProtocolContext;`. Wrap the bodies of `executeQueryInternal` (~line 906) and `executeCommandInternal` (~line 263):
+
+```java
+    ProtocolContext.set("grpc");
+    try {
+      // ... existing method body that calls database.query(...) / db.command(...) ...
+    } finally {
+      ProtocolContext.clear();
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `mvn -q -pl grpcw test -Dtest=GrpcQueryMetricsIT`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java \
+        grpcw/src/test/java/com/arcadedb/server/grpc/GrpcQueryMetricsIT.java
+git commit -m "feat(observability): tag gRPC queries with protocol=grpc (#4535)"
+```
+
+---
+
+## Task 9: Redis protocol tag
+
+**Files:**
+- Modify: `redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java` (`run()` loop ~line 86)
+- Test: `redisw/src/test/java/com/arcadedb/redis/RedisQueryMetricsIT.java`
+
+Context: Redis mostly serves in-memory key/value ops and only touches `database.*` inside transaction blocks, so `arcadedb.query.duration` will fire rarely (or never) for pure Redis traffic. Setting the protocol is still correct so any DB-backed path is attributed to `redis` rather than `internal`. Keep the test tolerant: assert the protocol tag is correct *when* the timer fires by issuing a Redis command that hits the database; if the module has no such command, assert only that no Redis op is mis-tagged as `internal` by checking the executor sets the context (a unit test on the run loop is acceptable here instead of an IT).
+
+- [ ] **Step 1: Write the test**
+
+```java
+package com.arcadedb.redis;
+
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RedisQueryMetricsIT extends BaseRedisServerTest {
+  @Test
+  void redisDbBackedOpRecordedWithProtocolTag() {
+    runRedisCommandThatPersists(); // a command whose handler enters a database transaction
+
+    final Timer timer = Metrics.globalRegistry.find("arcadedb.query.duration").tag("protocol", "redis").timer();
+    // Redis rarely runs engine queries; if it did, it must be tagged redis (never internal).
+    if (timer != null)
+      assertThat(timer.count()).isGreaterThanOrEqualTo(1L);
+    assertThat(Metrics.globalRegistry.find("arcadedb.query.duration").tag("protocol", "internal").timer())
+        .as("a Redis-thread DB op must not leak as protocol=internal")
+        .isNull();
+  }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails (or is inconclusive)**
+
+Run: `mvn -q -pl redisw test -Dtest=RedisQueryMetricsIT`
+Expected: FAIL if a DB-backed Redis op is mis-tagged `internal`.
+
+- [ ] **Step 3: Set/clear `ProtocolContext` in the run loop**
+
+In `RedisNetworkExecutor.java`, add `import com.arcadedb.database.ProtocolContext;`. In `run()` (~line 86), set before the loop and clear in the catch/exit (~line 95):
+
+```java
+    ProtocolContext.set("redis");
+    try {
+      // ... existing while loop: executeCommand(parseNext()); ...
+    } finally {
+      ProtocolContext.clear();
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `mvn -q -pl redisw test -Dtest=RedisQueryMetricsIT`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java \
+        redisw/src/test/java/com/arcadedb/redis/RedisQueryMetricsIT.java
+git commit -m "feat(observability): tag Redis DB ops with protocol=redis (#4535)"
+```
+
+---
+
+## Task 10: Cardinality guard, docs, broader suites
+
+**Files:**
+- Create: `docs/observability-metrics.md` (operator-facing metrics catalogue)
+- Test: extend `server/src/test/java/com/arcadedb/server/monitor/QueryMetricsProtocolIT.java`
+
+- [ ] **Step 1: Add a cardinality guard assertion**
+
+Add to `QueryMetricsProtocolIT` a test asserting the `protocol` tag is one of the known bounded values and the query text never appears as a tag:
+
+```java
+  @Test
+  void protocolTagIsBoundedAndQueryTextIsNeverATag() throws Exception {
+    httpQueryRecordedWithProtocolTag(); // reuse to populate at least one series
+
+    final var timers = Metrics.globalRegistry.find("arcadedb.query.duration").timers();
+    assertThat(timers).isNotEmpty();
+    for (final Timer t : timers) {
+      final String protocol = t.getId().getTag("protocol");
+      assertThat(protocol).isIn("http", "bolt", "postgres", "mongo", "grpc", "redis", "internal");
+      // No tag value should contain SQL/Cypher text.
+      t.getId().getTags().forEach(tag -> assertThat(tag.getValue()).doesNotContain("select").doesNotContain("SELECT"));
+    }
+  }
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `mvn -q -pl server test -Dtest=QueryMetricsProtocolIT`
+Expected: PASS.
+
+- [ ] **Step 3: Write the metrics catalogue doc**
+
+Create `docs/observability-metrics.md` documenting `arcadedb.query.duration` (tags: `protocol`, `db`, `language`, `type`; note `protocol=internal` covers engine-internal/embedded callers and dashboards filter it out for wire RED), alongside the Pillar-1 `arcadedb.http.requests` and `arcadedb.engine.*` gauges. Include a sample PromQL: `histogram_quantile(0.95, sum(rate(arcadedb_query_duration_seconds_bucket{protocol!="internal"}[5m])) by (le, protocol))`.
+
+- [ ] **Step 4: Run the broader suites**
+
+Run: `mvn -q -pl engine test -Dtest="QueryMetricsRecorderTest,ProtocolContextTest,LocalDatabaseQueryMetricsTest"`
+Run: `mvn -q -pl server test -Dtest="*Metrics*,*RedMetrics*"`
+Run: `mvn -q -pl bolt,postgresw,mongodbw,grpcw,redisw test -Dtest="*QueryMetrics*"`
+Expected: PASS. Investigate any meter-count test that breaks on the additive series and switch it to containment assertions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/observability-metrics.md \
+        server/src/test/java/com/arcadedb/server/monitor/QueryMetricsProtocolIT.java
+git commit -m "test(observability): cardinality guard + metrics catalogue doc (#4535)"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec/issue coverage:** engine hook (T1) + protocol thread-local (T2) + engine timing (T3) = the single instrumentation point; server Micrometer recorder + registration + HTTP refactor (T4); Bolt/Postgres/Mongo/gRPC/Redis tags (T5-T9); cardinality guard + docs (T10). Acceptance criteria from #4535: emitted for all protocols (T4-T9), no HTTP double-count (T4 step 6 removes the old timer), engine has no Micrometer dependency (T1 hook is plain Java), per-protocol regression tests (each task).
+- **No-Micrometer-in-engine invariant:** verified - `QueryMetricsRecorder`/`ProtocolContext`/`LocalDatabase` use only plain Java; the Micrometer type appears only in `MicrometerQueryMetricsRecorder` (server).
+- **Allocation/perf:** the disabled path is `startNanos()` (one volatile read + ref compare returning 0) + a `record()` call that returns on the `start==0` sentinel - no `System.nanoTime()`, no lambda, no allocation. Aligned with the GC mantra.
+- **Retro-compat with Pillar 1:** moving the timer to the engine keeps `db`/`language`/`type` tags and adds `protocol`; `QueryRedMetricsIT`'s subset `find().tag(...)` assertions still match, so no existing test is modified (only `PostCommandHandler`/`PostQueryHandler` lose the duplicate timer).
+- **Type consistency:** `record(String protocol, String database, String language, String type, long durationNanos)` and `Holder.record(long start, String database, String language, String type)` are used identically across T1, T3, T4. `ProtocolContext.set/get/clear`/`INTERNAL` consistent across T2 and all protocol tasks. Tag names `protocol`/`db`/`language`/`type` identical in T4 recorder and all assertions.
+- **Known limitation (documented in T10 doc):** timing wraps the `query()/command()` invocation (parse/plan/open), not full lazy-`ResultSet` iteration - identical semantics to Pillar 1's HTTP timer.
+- **Per-module test harness:** each protocol task says to mirror that module's existing IT bootstrap (the exact base class / client helper varies per module); the executor reads the existing IT in the module before writing the new one.

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -1559,14 +1559,24 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
   public ResultSet command(final String language, final String query) {
     checkDatabaseIsOpen(true, "Cannot execute command on a read only database");
     stats.commands.incrementAndGet();
-    return getQueryEngine(language).command(query, new ContextConfiguration());
+    final long start = QueryMetricsRecorder.Holder.startNanos();
+    try {
+      return getQueryEngine(language).command(query, new ContextConfiguration());
+    } finally {
+      QueryMetricsRecorder.Holder.record(start, name, language, "command");
+    }
   }
 
   @Override
   public ResultSet command(final String language, final String query, final Object... parameters) {
     checkDatabaseIsOpen(true, "Cannot execute command on a read only database");
     stats.commands.incrementAndGet();
-    return getQueryEngine(language).command(query, new ContextConfiguration(), parameters);
+    final long start = QueryMetricsRecorder.Holder.startNanos();
+    try {
+      return getQueryEngine(language).command(query, new ContextConfiguration(), parameters);
+    } finally {
+      QueryMetricsRecorder.Holder.record(start, name, language, "command");
+    }
   }
 
   @Override
@@ -1574,7 +1584,12 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
       final Object... parameters) {
     checkDatabaseIsOpen(true, "Cannot execute command on a read only database");
     stats.commands.incrementAndGet();
-    return getQueryEngine(language).command(query, configuration, parameters);
+    final long start = QueryMetricsRecorder.Holder.startNanos();
+    try {
+      return getQueryEngine(language).command(query, configuration, parameters);
+    } finally {
+      QueryMetricsRecorder.Holder.record(start, name, language, "command");
+    }
   }
 
   @Override
@@ -1587,7 +1602,12 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
       final Map<String, Object> parameters) {
     checkDatabaseIsOpen(true, "Cannot execute command on a read only database");
     stats.commands.incrementAndGet();
-    return getQueryEngine(language).command(query, configuration, parameters);
+    final long start = QueryMetricsRecorder.Holder.startNanos();
+    try {
+      return getQueryEngine(language).command(query, configuration, parameters);
+    } finally {
+      QueryMetricsRecorder.Holder.record(start, name, language, "command");
+    }
   }
 
   @Deprecated
@@ -1613,21 +1633,36 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
   public ResultSet query(final String language, final String query) {
     checkDatabaseIsOpen();
     stats.queries.incrementAndGet();
-    return getQueryEngine(language).query(query, new ContextConfiguration());
+    final long start = QueryMetricsRecorder.Holder.startNanos();
+    try {
+      return getQueryEngine(language).query(query, new ContextConfiguration());
+    } finally {
+      QueryMetricsRecorder.Holder.record(start, name, language, "query");
+    }
   }
 
   @Override
   public ResultSet query(final String language, final String query, final Object... parameters) {
     checkDatabaseIsOpen();
     stats.queries.incrementAndGet();
-    return getQueryEngine(language).query(query, new ContextConfiguration(), parameters);
+    final long start = QueryMetricsRecorder.Holder.startNanos();
+    try {
+      return getQueryEngine(language).query(query, new ContextConfiguration(), parameters);
+    } finally {
+      QueryMetricsRecorder.Holder.record(start, name, language, "query");
+    }
   }
 
   @Override
   public ResultSet query(final String language, final String query, final Map<String, Object> parameters) {
     checkDatabaseIsOpen();
     stats.queries.incrementAndGet();
-    return getQueryEngine(language).query(query, new ContextConfiguration(), parameters);
+    final long start = QueryMetricsRecorder.Holder.startNanos();
+    try {
+      return getQueryEngine(language).query(query, new ContextConfiguration(), parameters);
+    } finally {
+      QueryMetricsRecorder.Holder.record(start, name, language, "query");
+    }
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/database/ProtocolContext.java
+++ b/engine/src/main/java/com/arcadedb/database/ProtocolContext.java
@@ -1,0 +1,29 @@
+package com.arcadedb.database;
+
+/**
+ * Carries the originating wire protocol of the current request on a thread-local so the engine can
+ * tag {@code arcadedb.query.duration} without each protocol re-implementing query timing. Wire
+ * listeners {@link #set} it at the request boundary and {@link #clear} it in a finally block (worker
+ * and connection threads are pooled/reused). Defaults to {@link #INTERNAL} for engine-internal and
+ * embedded-API callers.
+ */
+public final class ProtocolContext {
+  public static final String INTERNAL = "internal";
+
+  private static final ThreadLocal<String> CURRENT = ThreadLocal.withInitial(() -> INTERNAL);
+
+  private ProtocolContext() {
+  }
+
+  public static void set(final String protocol) {
+    CURRENT.set(protocol != null ? protocol : INTERNAL);
+  }
+
+  public static String get() {
+    return CURRENT.get();
+  }
+
+  public static void clear() {
+    CURRENT.remove();
+  }
+}

--- a/engine/src/main/java/com/arcadedb/database/QueryMetricsRecorder.java
+++ b/engine/src/main/java/com/arcadedb/database/QueryMetricsRecorder.java
@@ -1,0 +1,50 @@
+package com.arcadedb.database;
+
+/**
+ * Framework-agnostic hook the engine calls to report the duration of a query/command execution.
+ * Lives in the engine (which has Micrometer only at test scope); the server registers a
+ * Micrometer-backed implementation. Default is a no-op, so when no recorder is registered the
+ * engine pays only a volatile read and a sentinel check per query - no timing, no allocation.
+ */
+@FunctionalInterface
+public interface QueryMetricsRecorder {
+  QueryMetricsRecorder NO_OP = (protocol, database, language, type, durationNanos) -> {
+  };
+
+  /**
+   * @param protocol      originating wire protocol (e.g. http, bolt, postgres, internal)
+   * @param database      database name
+   * @param language      query language (sql, opencypher, ...)
+   * @param type          query or command
+   * @param durationNanos elapsed nanoseconds
+   */
+  void record(String protocol, String database, String language, String type, long durationNanos);
+
+  /** Static registration + timing helpers, kept off the interface's public surface. */
+  final class Holder {
+    private static volatile QueryMetricsRecorder current = NO_OP;
+
+    private Holder() {
+    }
+
+    public static void register(final QueryMetricsRecorder recorder) {
+      current = recorder != null ? recorder : NO_OP;
+    }
+
+    public static QueryMetricsRecorder get() {
+      return current;
+    }
+
+    /** Returns System.nanoTime() when a recorder is active, otherwise 0 (the "not timing" sentinel). */
+    public static long startNanos() {
+      return current == NO_OP ? 0L : System.nanoTime();
+    }
+
+    /** Records elapsed time since {@code start}; a {@code start} of 0 means timing was inactive and is ignored. */
+    public static void record(final long start, final String database, final String language, final String type) {
+      if (start == 0L)
+        return;
+      current.record(ProtocolContext.get(), database, language, type, System.nanoTime() - start);
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/LocalDatabaseQueryMetricsTest.java
+++ b/engine/src/test/java/com/arcadedb/database/LocalDatabaseQueryMetricsTest.java
@@ -1,0 +1,43 @@
+package com.arcadedb.database;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LocalDatabaseQueryMetricsTest {
+  private final String dbPath = "./target/databases/LocalDatabaseQueryMetricsTest";
+
+  @AfterEach
+  void reset() {
+    QueryMetricsRecorder.Holder.register(null);
+    ProtocolContext.clear();
+  }
+
+  @Test
+  void queryAndCommandAreRecordedWithProtocolAndType() {
+    final AtomicReference<String> lastQuery = new AtomicReference<>();
+    final AtomicReference<String> lastCommand = new AtomicReference<>();
+    QueryMetricsRecorder.Holder.register((protocol, database, language, type, nanos) -> {
+      if ("query".equals(type))
+        lastQuery.set(protocol + "|" + language + "|" + type);
+      else if ("command".equals(type))
+        lastCommand.set(protocol + "|" + language + "|" + type);
+    });
+
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      if (factory.exists())
+        factory.open().drop();
+      try (final Database db = factory.create()) {
+        ProtocolContext.set("test");
+        db.command("sql", "CREATE DOCUMENT TYPE Doc");
+        db.query("sql", "SELECT FROM Doc");
+      }
+    }
+
+    assertThat(lastCommand.get()).isEqualTo("test|sql|command");
+    assertThat(lastQuery.get()).isEqualTo("test|sql|query");
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/ProtocolContextTest.java
+++ b/engine/src/test/java/com/arcadedb/database/ProtocolContextTest.java
@@ -1,0 +1,28 @@
+package com.arcadedb.database;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProtocolContextTest {
+  @Test
+  void defaultsToInternal() {
+    ProtocolContext.clear();
+    assertThat(ProtocolContext.get()).isEqualTo(ProtocolContext.INTERNAL);
+  }
+
+  @Test
+  void setAndClear() {
+    ProtocolContext.set("bolt");
+    assertThat(ProtocolContext.get()).isEqualTo("bolt");
+    ProtocolContext.clear();
+    assertThat(ProtocolContext.get()).isEqualTo(ProtocolContext.INTERNAL);
+  }
+
+  @Test
+  void nullResetsToInternal() {
+    ProtocolContext.set("http");
+    ProtocolContext.set(null);
+    assertThat(ProtocolContext.get()).isEqualTo(ProtocolContext.INTERNAL);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/QueryMetricsRecorderTest.java
+++ b/engine/src/test/java/com/arcadedb/database/QueryMetricsRecorderTest.java
@@ -1,0 +1,42 @@
+package com.arcadedb.database;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QueryMetricsRecorderTest {
+  @AfterEach
+  void reset() {
+    QueryMetricsRecorder.Holder.register(null); // back to NO_OP
+  }
+
+  @Test
+  void defaultIsNoOpAndStartNanosReturnsZero() {
+    assertThat(QueryMetricsRecorder.Holder.get()).isSameAs(QueryMetricsRecorder.NO_OP);
+    assertThat(QueryMetricsRecorder.Holder.startNanos()).isZero();
+  }
+
+  @Test
+  void registeredRecorderReceivesRecordWhenTimingActive() {
+    final AtomicReference<String> captured = new AtomicReference<>();
+    QueryMetricsRecorder.Holder.register(
+        (protocol, database, language, type, durationNanos) -> captured.set(protocol + "/" + database + "/" + language + "/" + type));
+
+    final long start = QueryMetricsRecorder.Holder.startNanos();
+    assertThat(start).isNotZero(); // an active recorder makes startNanos() time
+    QueryMetricsRecorder.Holder.record(start, "db1", "sql", "query");
+
+    assertThat(captured.get()).isEqualTo(ProtocolContext.get() + "/db1/sql/query");
+  }
+
+  @Test
+  void recordWithZeroStartIsIgnored() {
+    final AtomicReference<Boolean> called = new AtomicReference<>(false);
+    QueryMetricsRecorder.Holder.register((p, d, l, t, n) -> called.set(true));
+    QueryMetricsRecorder.Holder.record(0L, "db1", "sql", "query");
+    assertThat(called.get()).isFalse();
+  }
+}

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -19,6 +19,7 @@
 package com.arcadedb.server.grpc;
 
 import com.arcadedb.database.Database;
+import com.arcadedb.database.ProtocolContext;
 import com.arcadedb.database.DatabaseContext;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
@@ -266,6 +267,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     boolean beganHere = false;
     final QueryProfile profile = new QueryProfile();
     QueryProfile.pushCurrent(profile);
+    ProtocolContext.set("grpc");
     String profileLanguage = null;
 
     try {
@@ -450,6 +452,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           .setExecutionTimeMs(ms)
           .build();
     } finally {
+      ProtocolContext.clear();
       recordGrpcProfile("grpc.command", profile, db != null ? db.getName() : req.getDatabase(),
           profileLanguage != null ? profileLanguage : req.getLanguage(), req.getCommand());
       QueryProfile.popCurrent();
@@ -906,6 +909,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   private ExecuteQueryResponse executeQueryInternal(final ExecuteQueryRequest request, final Database database) {
     final QueryProfile profile = new QueryProfile();
     QueryProfile.pushCurrent(profile);
+    ProtocolContext.set("grpc");
     String profileLanguage = null;
     try {
       final long deserStart = System.nanoTime();
@@ -986,6 +990,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         return response;
       }
     } finally {
+      ProtocolContext.clear();
       recordGrpcProfile("grpc.query", profile, database != null ? database.getName() : request.getDatabase(),
           profileLanguage != null ? profileLanguage : request.getLanguage(), request.getQuery());
       QueryProfile.popCurrent();

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -1202,22 +1202,22 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
   @Override
   public void streamQuery(StreamQueryRequest request, StreamObserver<QueryResult> responseObserver) {
-    ProtocolContext.set("grpc");
     final QueryProfile profile = new QueryProfile();
     QueryProfile.pushCurrent(profile);
     final long engineStart = System.nanoTime();
-    ProjectionConfig projectionConfig = getProjectionConfigFromRequest(request);
-
-    final ServerCallStreamObserver<QueryResult> scso = (ServerCallStreamObserver<QueryResult>) responseObserver;
-
     final AtomicBoolean cancelled = new AtomicBoolean(false);
-    scso.setOnCancelHandler(() -> cancelled.set(true));
 
     Database db = null;
     boolean beganHere = false;
     String profileLanguage = null;
 
+    ProtocolContext.set("grpc");
     try {
+      ProjectionConfig projectionConfig = getProjectionConfigFromRequest(request);
+
+      final ServerCallStreamObserver<QueryResult> scso = (ServerCallStreamObserver<QueryResult>) responseObserver;
+      scso.setOnCancelHandler(() -> cancelled.set(true));
+
       db = getDatabase(request.getDatabase(), request.getCredentials());
       final int batchSize = Math.max(1, request.getBatchSize());
 
@@ -1564,18 +1564,21 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   // --- 1) Unary bulk ---
   @Override
   public void bulkInsert(BulkInsertRequest req, StreamObserver<InsertSummary> resp) {
-    ProtocolContext.set("grpc");
-    final InsertOptions opts = defaults(req.getOptions()); // apply defaults (batch size, tx mode, etc.)
     final long started = System.currentTimeMillis();
 
-    try (InsertContext ctx = new InsertContext(opts)) {
+    ProtocolContext.set("grpc");
+    try {
+      final InsertOptions opts = defaults(req.getOptions()); // apply defaults (batch size, tx mode, etc.)
 
-      Counts totals = insertRows(ctx, req.getRowsList().iterator());
+      try (InsertContext ctx = new InsertContext(opts)) {
 
-      ctx.flushCommit(true);
+        Counts totals = insertRows(ctx, req.getRowsList().iterator());
 
-      resp.onNext(ctx.summary(totals, started));
-      resp.onCompleted();
+        ctx.flushCommit(true);
+
+        resp.onNext(ctx.summary(totals, started));
+        resp.onCompleted();
+      }
     } catch (Exception e) {
       resp.onError(Status.INTERNAL.withDescription("bulkInsert: " + e.getMessage()).asException());
     } finally {

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -1202,6 +1202,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
   @Override
   public void streamQuery(StreamQueryRequest request, StreamObserver<QueryResult> responseObserver) {
+    ProtocolContext.set("grpc");
     final QueryProfile profile = new QueryProfile();
     QueryProfile.pushCurrent(profile);
     final long engineStart = System.nanoTime();
@@ -1301,6 +1302,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       recordGrpcProfile("grpc.stream", profile, db != null ? db.getName() : request.getDatabase(),
           profileLanguage != null ? profileLanguage : request.getLanguage(), request.getQuery());
       QueryProfile.popCurrent();
+      ProtocolContext.clear();
     }
   }
 
@@ -1562,7 +1564,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   // --- 1) Unary bulk ---
   @Override
   public void bulkInsert(BulkInsertRequest req, StreamObserver<InsertSummary> resp) {
-
+    ProtocolContext.set("grpc");
     final InsertOptions opts = defaults(req.getOptions()); // apply defaults (batch size, tx mode, etc.)
     final long started = System.currentTimeMillis();
 
@@ -1576,6 +1578,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       resp.onCompleted();
     } catch (Exception e) {
       resp.onError(Status.INTERNAL.withDescription("bulkInsert: " + e.getMessage()).asException());
+    } finally {
+      ProtocolContext.clear();
     }
   }
 

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcQueryMetricsIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcQueryMetricsIT.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GrpcQueryMetricsIT extends BaseGraphServerTest {
+
+  private static final int GRPC_PORT = 50051;
+
+  private static final Metadata.Key<String> USER_HEADER =
+      Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER =
+      Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER =
+      Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  private ManagedChannel channel;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub authenticatedStub;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue(
+        "GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void setupGrpcClient() {
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT)
+        .usePlaintext()
+        .build();
+    final Channel authenticatedChannel = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+    authenticatedStub = ArcadeDbServiceGrpc.newBlockingStub(authenticatedChannel);
+  }
+
+  @AfterEach
+  void teardownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private class AuthClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        final MethodDescriptor<ReqT, RespT> method, final CallOptions callOptions, final Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+          next.newCall(method, callOptions)) {
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata headers) {
+          headers.put(USER_HEADER, "root");
+          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
+          headers.put(DATABASE_HEADER, getDatabaseName());
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+
+  @Test
+  void executeQueryTagsProtocolAsGrpc() {
+    final long countBefore = grpcTimerCount();
+
+    final ExecuteQueryRequest request = ExecuteQueryRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(DatabaseCredentials.newBuilder()
+            .setUsername("root")
+            .setPassword(DEFAULT_PASSWORD_FOR_TESTS)
+            .build())
+        .setQuery("SELECT FROM V1 LIMIT 1")
+        .build();
+
+    authenticatedStub.executeQuery(request);
+
+    assertThat(grpcTimerCount()).isGreaterThan(countBefore);
+  }
+
+  @Test
+  void executeCommandTagsProtocolAsGrpc() {
+    final long countBefore = grpcTimerCount();
+
+    final ExecuteCommandRequest request = ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(DatabaseCredentials.newBuilder()
+            .setUsername("root")
+            .setPassword(DEFAULT_PASSWORD_FOR_TESTS)
+            .build())
+        .setCommand("SELECT FROM V1 LIMIT 1")
+        .build();
+
+    authenticatedStub.executeCommand(request);
+
+    assertThat(grpcTimerCount()).isGreaterThan(countBefore);
+  }
+
+  /**
+   * Returns the total count across all {@code arcadedb.query.duration} timers tagged with
+   * {@code protocol=grpc}. Multiple timers exist when different language/type tag combinations are
+   * present in the same JVM run.
+   */
+  private long grpcTimerCount() {
+    return Metrics.globalRegistry.find("arcadedb.query.duration")
+        .tag("protocol", "grpc")
+        .timers()
+        .stream()
+        .mapToLong(Timer::count)
+        .sum();
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcStreamMetricsIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcStreamMetricsIT.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GrpcStreamMetricsIT extends BaseGraphServerTest {
+
+  private static final int GRPC_PORT = 50051;
+
+  private static final Metadata.Key<String> USER_HEADER =
+      Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER =
+      Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER =
+      Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  private ManagedChannel channel;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub authenticatedStub;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue(
+        "GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void setupGrpcClient() {
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT)
+        .usePlaintext()
+        .build();
+    final Channel authenticatedChannel = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+    authenticatedStub = ArcadeDbServiceGrpc.newBlockingStub(authenticatedChannel);
+  }
+
+  @AfterEach
+  void teardownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private class AuthClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        final MethodDescriptor<ReqT, RespT> method, final CallOptions callOptions, final Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+          next.newCall(method, callOptions)) {
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata headers) {
+          headers.put(USER_HEADER, "root");
+          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
+          headers.put(DATABASE_HEADER, getDatabaseName());
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+
+  /**
+   * Returns the total count across all {@code arcadedb.query.duration} timers tagged with
+   * {@code protocol=grpc}.
+   */
+  private long grpcTimerCount() {
+    return Metrics.globalRegistry.find("arcadedb.query.duration")
+        .tag("protocol", "grpc")
+        .timers()
+        .stream()
+        .mapToLong(Timer::count)
+        .sum();
+  }
+
+  @Test
+  void streamQueryTagsProtocolAsGrpc() {
+    final long countBefore = grpcTimerCount();
+
+    final StreamQueryRequest request = StreamQueryRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(DatabaseCredentials.newBuilder()
+            .setUsername("root")
+            .setPassword(DEFAULT_PASSWORD_FOR_TESTS)
+            .build())
+        .setQuery("SELECT FROM V1 LIMIT 5")
+        .setBatchSize(10)
+        .build();
+
+    // Consume the full stream so the server-side finally block runs
+    final Iterator<QueryResult> results = authenticatedStub.streamQuery(request);
+    while (results.hasNext())
+      results.next();
+
+    assertThat(grpcTimerCount()).isGreaterThan(countBefore);
+  }
+}

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -50,6 +50,11 @@
             <version>${micrometer.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-otlp</artifactId>
+            <version>${micrometer.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.arcadedb</groupId>
             <artifactId>arcadedb-server</artifactId>
             <version>${project.parent.version}</version>

--- a/metrics/src/main/java/com/arcadedb/metrics/otlp/OtlpMetricsPlugin.java
+++ b/metrics/src/main/java/com/arcadedb/metrics/otlp/OtlpMetricsPlugin.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.metrics.otlp;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.ServerPlugin;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.registry.otlp.OtlpConfig;
+import io.micrometer.registry.otlp.OtlpMeterRegistry;
+
+import java.util.logging.Level;
+
+/**
+ * Optional {@link ServerPlugin} that pushes Micrometer metrics to an OTLP endpoint, alongside (never
+ * replacing) the Prometheus scrape endpoint. Disabled unless both {@code arcadedb.serverMetrics} and
+ * {@code arcadedb.serverMetrics.otlp.enabled} are true, so the default behavior is byte-for-byte
+ * unchanged. The Prometheus scrape path is untouched whether or not OTLP is enabled.
+ */
+public class OtlpMetricsPlugin implements ServerPlugin {
+  private OtlpMeterRegistry registry;
+  private boolean           enabled;
+
+  @Override
+  public void configure(final ArcadeDBServer server, final ContextConfiguration configuration) {
+    final boolean metricsOn = configuration.getValueAsBoolean(GlobalConfiguration.SERVER_METRICS);
+    final boolean otlpOn = asBoolean(configuration.getValue("arcadedb.serverMetrics.otlp.enabled", (Object) Boolean.FALSE));
+    enabled = metricsOn && otlpOn;
+    if (!enabled)
+      return;
+
+    final String endpoint = asString(configuration.getValue("arcadedb.serverMetrics.otlp.endpoint", (Object) "http://localhost:4317"));
+    final OtlpConfig otlpConfig = key -> "otlp.url".equals(key) ? endpoint : null;
+    registry = new OtlpMeterRegistry(otlpConfig, Clock.SYSTEM);
+    Metrics.addRegistry(registry);
+  }
+
+  @Override
+  public void startService() {
+    if (enabled)
+      LogManager.instance().log(this, Level.INFO, "OTLP metrics export enabled");
+  }
+
+  @Override
+  public void stopService() {
+    if (registry != null) {
+      Metrics.removeRegistry(registry);
+      registry.close();
+      registry = null;
+    }
+  }
+
+  /**
+   * Coerces a config value to a boolean. The value may be a {@link Boolean} (set programmatically /
+   * in tests) or a {@link String} (read from a config file or system property).
+   */
+  private static boolean asBoolean(final Object value) {
+    if (value instanceof Boolean b)
+      return b;
+    return value != null && Boolean.parseBoolean(value.toString());
+  }
+
+  private static String asString(final Object value) {
+    return value != null ? value.toString() : null;
+  }
+}

--- a/metrics/src/main/resources/META-INF/services/com.arcadedb.server.ServerPlugin
+++ b/metrics/src/main/resources/META-INF/services/com.arcadedb.server.ServerPlugin
@@ -1,1 +1,2 @@
 com.arcadedb.metrics.prometheus.PrometheusMetricsPlugin
+com.arcadedb.metrics.otlp.OtlpMetricsPlugin

--- a/metrics/src/test/java/com/arcadedb/metrics/otlp/OtlpMetricsPluginTest.java
+++ b/metrics/src/test/java/com/arcadedb/metrics/otlp/OtlpMetricsPluginTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.metrics.otlp;
+
+import com.arcadedb.ContextConfiguration;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the opt-in {@link OtlpMetricsPlugin}: it registers an OTLP registry only when both
+ * server metrics and the OTLP flag are enabled, and is a no-op otherwise (default-off).
+ */
+class OtlpMetricsPluginTest {
+
+  @AfterEach
+  void cleanup() {
+    // Remove any registry this test added so it does not leak into other tests sharing the JVM-global registry.
+    final List<MeterRegistry> registries = new ArrayList<>(Metrics.globalRegistry.getRegistries());
+    registries.forEach(Metrics::removeRegistry);
+  }
+
+  @Test
+  void disabledByDefaultRegistersNothing() {
+    final int before = Metrics.globalRegistry.getRegistries().size();
+    final OtlpMetricsPlugin plugin = new OtlpMetricsPlugin();
+    plugin.configure(null, new ContextConfiguration());
+    assertThat(Metrics.globalRegistry.getRegistries().size()).isEqualTo(before);
+  }
+
+  @Test
+  void enabledRequiresBothFlags() {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    // OTLP flag on but server metrics explicitly off (SERVER_METRICS defaults to true): still a no-op.
+    cfg.setValue("arcadedb.serverMetrics", false);
+    cfg.setValue("arcadedb.serverMetrics.otlp.enabled", true);
+    final int before = Metrics.globalRegistry.getRegistries().size();
+    new OtlpMetricsPlugin().configure(null, cfg);
+    assertThat(Metrics.globalRegistry.getRegistries().size()).isEqualTo(before);
+  }
+
+  @Test
+  void enabledRegistersOtlpRegistry() {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.setValue("arcadedb.serverMetrics", true);
+    cfg.setValue("arcadedb.serverMetrics.otlp.enabled", true);
+    final int before = Metrics.globalRegistry.getRegistries().size();
+
+    final OtlpMetricsPlugin plugin = new OtlpMetricsPlugin();
+    plugin.configure(null, cfg);
+    assertThat(Metrics.globalRegistry.getRegistries().size()).isEqualTo(before + 1);
+
+    // stopService must unregister and close cleanly.
+    plugin.stopService();
+    assertThat(Metrics.globalRegistry.getRegistries().size()).isEqualTo(before);
+  }
+}

--- a/metrics/src/test/java/com/arcadedb/metrics/prometheus/PrometheusEngineMetricsIT.java
+++ b/metrics/src/test/java/com/arcadedb/metrics/prometheus/PrometheusEngineMetricsIT.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.metrics.prometheus;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Retro-compatibility guard: {@code /prometheus} still serves the pre-existing series and now also
+ * renders the additive {@link com.arcadedb.server.monitor.EngineMetricsBinder} engine gauges.
+ */
+class PrometheusEngineMetricsIT extends BaseGraphServerTest {
+
+  @Override
+  protected int getServerCount() {
+    return 1;
+  }
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    System.setProperty("arcadedb.serverMetrics.prometheus.requireAuthentication", "false");
+    GlobalConfiguration.SERVER_PLUGINS.setValue("PrometheusMetricsPlugin");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    System.clearProperty("arcadedb.serverMetrics.prometheus.requireAuthentication");
+    super.endTest();
+  }
+
+  @Test
+  void prometheusStillServesAndExposesEngineGauges() throws Exception {
+    // Exercise the engine so non-zero engine counters exist.
+    getServerDatabase(0, getDatabaseName()).query("sql", "select 1 as one");
+
+    final HttpClient client = HttpClient.newHttpClient();
+    // Warm-up HTTP request so the always-on arcadedb.http.requests timer is registered before scraping.
+    client.send(HttpRequest.newBuilder().uri(URI.create("http://localhost:2480/api/v1/ready")).GET().build(),
+        HttpResponse.BodyHandlers.ofString());
+
+    final HttpResponse<String> response = client.send(
+        HttpRequest.newBuilder().uri(URI.create("http://localhost:2480/prometheus")).GET().build(),
+        HttpResponse.BodyHandlers.ofString());
+
+    assertThat(response.statusCode()).isEqualTo(200);
+    // Pre-existing series still present (retro-compat):
+    assertThat(response.body()).contains("system_cpu_usage");
+    // New engine gauge present:
+    assertThat(response.body()).contains("arcadedb_engine_page_cache_hits");
+    // New RED timer series present (HTTP request timer is always-on):
+    assertThat(response.body()).contains("arcadedb_http_requests");
+  }
+}

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
@@ -19,6 +19,7 @@
 package com.arcadedb.mongo;
 
 import com.arcadedb.database.Database;
+import com.arcadedb.database.ProtocolContext;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.query.sql.executor.IteratorResultSet;
 import com.arcadedb.query.sql.executor.Result;
@@ -84,6 +85,7 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
   public Document handleCommand(final Channel channel, final String command, final Document document,
       final DatabaseResolver databaseResolver,
       final Oplog opLog) {
+    ProtocolContext.set("mongo");
     try {
       if ("find".equalsIgnoreCase(command))
         return find(document);
@@ -104,6 +106,8 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
       }
     } catch (final Exception e) {
       throw new MongoServerException("Error on executing MongoDB '" + command + "' command", e);
+    } finally {
+      ProtocolContext.clear();
     }
   }
 

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoQueryMetricsIT.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoQueryMetricsIT.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.mongo;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.mongodb.MongoClient;
+import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoCollection;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import org.bson.BsonDocument;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that queries executed over a MongoDB connection are tagged with protocol="mongo"
+ * in the arcadedb.query.duration Micrometer timer.
+ */
+public class MongoQueryMetricsIT extends BaseGraphServerTest {
+
+  private static final int DEF_PORT = 27017;
+
+  private MongoClient client;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("MongoDB:com.arcadedb.mongo.MongoDBProtocolPlugin");
+  }
+
+  @BeforeEach
+  @Override
+  public void beginTest() {
+    super.beginTest();
+    getDatabase(0);
+    client = new MongoClient(new ServerAddress("localhost", DEF_PORT));
+    client.getDatabase(getDatabaseName()).createCollection("MongoMetricsCollection");
+    final MongoCollection<Document> collection = client.getDatabase(getDatabaseName()).getCollection("MongoMetricsCollection");
+    collection.insertOne(new Document("name", "test"));
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    client.close();
+    super.endTest();
+  }
+
+  @Test
+  void mongoQueriesTaggedWithMongoProtocol() {
+    final MongoCollection<Document> collection = client.getDatabase(getDatabaseName()).getCollection("MongoMetricsCollection");
+    collection.find(BsonDocument.parse("{ name: { $eq: \"test\" } }")).first();
+
+    final Timer timer = Metrics.globalRegistry.find("arcadedb.query.duration").tag("protocol", "mongo").timer();
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isGreaterThanOrEqualTo(1L);
+  }
+}

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -26,6 +26,7 @@ import com.arcadedb.database.DatabaseContext;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.Document;
+import com.arcadedb.database.ProtocolContext;
 import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.exception.DatabaseOperationException;
 import com.arcadedb.graph.Edge;
@@ -140,6 +141,7 @@ public class PostgresNetworkExecutor extends Thread {
 
   @Override
   public void run() {
+    ProtocolContext.set("postgres");
     try {
       if (!readStartupMessage(true))
         return;
@@ -219,6 +221,7 @@ public class PostgresNetworkExecutor extends Thread {
       }
 
     } finally {
+      ProtocolContext.clear();
       close();
     }
   }

--- a/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
+++ b/postgresw/src/main/java/com/arcadedb/postgres/PostgresNetworkExecutor.java
@@ -27,6 +27,7 @@ import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.ProtocolContext;
+import com.arcadedb.database.QueryMetricsRecorder;
 import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.exception.DatabaseOperationException;
 import com.arcadedb.graph.Edge;
@@ -288,7 +289,13 @@ public class PostgresNetworkExecutor extends Thread {
     if (type == 'P') {
       if (portal.sqlStatement != null) {
         final Object[] parameters = portal.parameterValues != null ? portal.parameterValues.toArray() : new Object[0];
-        final ResultSet resultSet = portal.sqlStatement.execute(database, parameters, createCommandContext());
+        final long metricsStart = QueryMetricsRecorder.Holder.startNanos();
+        final ResultSet resultSet;
+        try {
+          resultSet = portal.sqlStatement.execute(database, parameters, createCommandContext());
+        } finally {
+          QueryMetricsRecorder.Holder.record(metricsStart, database.getName(), portal.language, "command");
+        }
         portal.executed = true;
         if (portal.isExpectingResult) {
           portal.cachedResultSet = browseAndCacheResultSet(resultSet, 0);
@@ -364,7 +371,12 @@ public class PostgresNetworkExecutor extends Thread {
           ResultSet resultSet;
           if (portal.sqlStatement != null) {
             final Object[] parameters = portal.parameterValues != null ? portal.parameterValues.toArray() : new Object[0];
-            resultSet = portal.sqlStatement.execute(database, parameters, createCommandContext());
+            final long metricsStart = QueryMetricsRecorder.Holder.startNanos();
+            try {
+              resultSet = portal.sqlStatement.execute(database, parameters, createCommandContext());
+            } finally {
+              QueryMetricsRecorder.Holder.record(metricsStart, database.getName(), portal.language, "command");
+            }
           } else {
             resultSet = database.command(portal.language, portal.query, server.getConfiguration(), getParams(portal));
           }

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresPreparedStatementMetricsIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresPreparedStatementMetricsIT.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that SQL queries executed via the Postgres extended protocol (PreparedStatement /
+ * PARSE+BIND+EXECUTE) are timed and emitted as {@code arcadedb.query.duration} with
+ * {@code protocol=postgres} and {@code language=sql}.
+ */
+public class PostgresPreparedStatementMetricsIT extends BaseGraphServerTest {
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("Postgres:com.arcadedb.postgres.PostgresProtocolPlugin");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+
+  private Connection getConnection() throws Exception {
+    Class.forName("org.postgresql.Driver");
+    final String url = "jdbc:postgresql://localhost/" + getDatabaseName();
+    final Properties props = new Properties();
+    props.setProperty("user", "root");
+    props.setProperty("password", DEFAULT_PASSWORD_FOR_TESTS);
+    props.setProperty("ssl", "false");
+    return DriverManager.getConnection(url, props);
+  }
+
+  @Override
+  protected String getDatabaseName() {
+    return "postgresdb";
+  }
+
+  @Test
+  void extendedProtocolSqlQueryIsTimedWithPostgresTag() throws Exception {
+    try (final Connection conn = getConnection()) {
+      // Force extended protocol: PreparedStatement sends PARSE + BIND + EXECUTE
+      try (final PreparedStatement ps = conn.prepareStatement("SELECT * FROM schema:types")) {
+        final ResultSet rs = ps.executeQuery();
+        rs.close();
+      }
+    }
+
+    final Timer timer = Metrics.globalRegistry.find("arcadedb.query.duration")
+        .tag("protocol", "postgres")
+        .tag("language", "sql")
+        .timer();
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isGreaterThanOrEqualTo(1L);
+  }
+}

--- a/postgresw/src/test/java/com/arcadedb/postgres/PostgresQueryMetricsIT.java
+++ b/postgresw/src/test/java/com/arcadedb/postgres/PostgresQueryMetricsIT.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.postgres;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that queries executed over a Postgres connection are tagged with protocol="postgres"
+ * in the arcadedb.query.duration Micrometer timer.
+ */
+public class PostgresQueryMetricsIT extends BaseGraphServerTest {
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("Postgres:com.arcadedb.postgres.PostgresProtocolPlugin");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+
+  private Connection getConnection() throws Exception {
+    Class.forName("org.postgresql.Driver");
+    final var url = "jdbc:postgresql://localhost/" + getDatabaseName();
+    final var props = new Properties();
+    props.setProperty("user", "root");
+    props.setProperty("password", DEFAULT_PASSWORD_FOR_TESTS);
+    props.setProperty("ssl", "false");
+    return DriverManager.getConnection(url, props);
+  }
+
+  @Test
+  void postgresQueriesTaggedWithPostgresProtocol() throws Exception {
+    try (Connection conn = getConnection()) {
+      try (Statement st = conn.createStatement()) {
+        final ResultSet rs = st.executeQuery("{cypher}RETURN 1 AS one");
+        rs.close();
+      }
+    }
+
+    final Timer timer = Metrics.globalRegistry.find("arcadedb.query.duration").tag("protocol", "postgres").timer();
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isGreaterThanOrEqualTo(1L);
+  }
+}

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -84,20 +84,25 @@ public class RedisNetworkExecutor extends Thread {
 
   @Override
   public void run() {
-    while (!shutdown) {
-      try {
-        executeCommand(parseNext());
+    ProtocolContext.set("redis");
+    try {
+      while (!shutdown) {
+        try {
+          executeCommand(parseNext());
 
-        replyToClient(value);
+          replyToClient(value);
 
-      } catch (final EOFException | SocketException e) {
-        LogManager.instance().log(this, Level.FINE, "Redis wrapper: Error on reading request", e);
-        close();
-      } catch (final SocketTimeoutException e) {
-        // IGNORE IT
-      } catch (final IOException e) {
-        LogManager.instance().log(this, Level.SEVERE, "Redis wrapper: Error on reading request", e);
+        } catch (final EOFException | SocketException e) {
+          LogManager.instance().log(this, Level.FINE, "Redis wrapper: Error on reading request", e);
+          close();
+        } catch (final SocketTimeoutException e) {
+          // IGNORE IT
+        } catch (final IOException e) {
+          LogManager.instance().log(this, Level.SEVERE, "Redis wrapper: Error on reading request", e);
+        }
       }
+    } finally {
+      ProtocolContext.clear();
     }
   }
 

--- a/redisw/src/test/java/com/arcadedb/redis/RedisQueryMetricsIT.java
+++ b/redisw/src/test/java/com/arcadedb/redis/RedisQueryMetricsIT.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.redis;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Protocol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Defensive regression test for protocol labelling on the Redis connection thread.
+ *
+ * Redis wire commands do not route through database.query/command, so
+ * arcadedb.query.duration will never fire for Redis traffic. The important
+ * invariant is that if in the future any Redis command path does reach the
+ * query engine, it must be tagged protocol="redis" and not "internal". This
+ * test guards that invariant: it snapshot-counts the internal-protocol timer
+ * before Redis commands run, drives several commands, then asserts the count
+ * did not increase (i.e. no Redis-thread work was mis-labelled as "internal").
+ */
+public class RedisQueryMetricsIT extends BaseGraphServerTest {
+
+  private static final int DEF_PORT = GlobalConfiguration.REDIS_PORT.getValueAsInteger();
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("Redis Protocol:com.arcadedb.redis.RedisProtocolPlugin");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+
+  @Test
+  void redisCommandsDoNotLeakInternalProtocolTag() {
+    // Snapshot the internal-protocol timer count before any Redis commands execute.
+    // The timer may already exist if other tests in the suite created it.
+    final long beforeCount = internalTimerCount();
+
+    try (final Jedis jedis = new Jedis("localhost", DEF_PORT)) {
+      // PING
+      jedis.ping();
+
+      // SET / GET / EXISTS / GETDEL via default (connection-local) bucket
+      jedis.set("metricsKey", "metricsValue");
+      jedis.get("metricsKey");
+      jedis.exists("metricsKey");
+      jedis.getDel("metricsKey");
+
+      // SELECT then INCR / DECR via database globalVariables
+      jedis.sendCommand(Protocol.Command.SELECT, getDatabaseName());
+      jedis.incr("metricsCounter");
+      jedis.decr("metricsCounter");
+    }
+
+    // The internal-protocol count must not have grown: no Redis-thread engine
+    // query should be labelled "internal".
+    final long afterCount = internalTimerCount();
+    assertThat(afterCount)
+        .as("arcadedb.query.duration{protocol=internal} count must not increase due to Redis commands")
+        .isEqualTo(beforeCount);
+  }
+
+  private long internalTimerCount() {
+    final Timer t = Metrics.globalRegistry
+        .find("arcadedb.query.duration")
+        .tag("protocol", "internal")
+        .timer();
+    return t == null ? 0L : t.count();
+  }
+
+  @Override
+  protected void populateDatabase() {
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -40,6 +40,7 @@ import com.arcadedb.server.event.FileServerEventLog;
 import com.arcadedb.server.event.ServerEventLog;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.mcp.MCPConfiguration;
+import com.arcadedb.server.monitor.EngineMetricsBinder;
 import com.arcadedb.server.monitor.PoolMetrics;
 import com.arcadedb.server.monitor.ServerQueryProfiler;
 import com.arcadedb.server.plugin.PluginManager;
@@ -208,6 +209,9 @@ public class ArcadeDBServer {
       // Engine executor pools (query parallelism + sparse-vector scoring) - exposes
       // arcadedb.executor.pool.{size,active,...} gauges tagged with pool=<name>.
       new PoolMetrics().bindTo(Metrics.globalRegistry);
+      // Engine-wide Profiler stats (cache hit/miss, pages, WAL, MVCC conflicts, open files, tx,
+      // queries) - exposes arcadedb.engine.* gauges read live from the Profiler on each scrape.
+      new EngineMetricsBinder().bindTo(Metrics.globalRegistry);
 
       if (configuration.getValueAsBoolean(GlobalConfiguration.SERVER_METRICS_LOGGING)) {
         LogManager.instance().log(this, Level.INFO, "- Logging metrics enabled...");

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -40,7 +40,9 @@ import com.arcadedb.server.event.FileServerEventLog;
 import com.arcadedb.server.event.ServerEventLog;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.mcp.MCPConfiguration;
+import com.arcadedb.database.QueryMetricsRecorder;
 import com.arcadedb.server.monitor.EngineMetricsBinder;
+import com.arcadedb.server.monitor.MicrometerQueryMetricsRecorder;
 import com.arcadedb.server.monitor.PoolMetrics;
 import com.arcadedb.server.monitor.ServerQueryProfiler;
 import com.arcadedb.server.plugin.PluginManager;
@@ -212,6 +214,7 @@ public class ArcadeDBServer {
       // Engine-wide Profiler stats (cache hit/miss, pages, WAL, MVCC conflicts, open files, tx,
       // queries) - exposes arcadedb.engine.* gauges read live from the Profiler on each scrape.
       new EngineMetricsBinder().bindTo(Metrics.globalRegistry);
+      QueryMetricsRecorder.Holder.register(new MicrometerQueryMetricsRecorder());
 
       if (configuration.getValueAsBoolean(GlobalConfiguration.SERVER_METRICS_LOGGING)) {
         LogManager.instance().log(this, Level.INFO, "- Logging metrics enabled...");

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -20,6 +20,7 @@ package com.arcadedb.server.http.handler;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.ProtocolContext;
 import com.arcadedb.exception.*;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
@@ -100,6 +101,7 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
     // do not dispatch) request handling. Recorded in the finally block below into the
     // arcadedb.http.requests Micrometer timer. When no tracer is registered this is metrics-only.
     final long httpStartNanos = System.nanoTime();
+    ProtocolContext.set("http");
 
     try {
       LogManager.instance().setContext(httpServer.getServer().getServerName());
@@ -348,6 +350,7 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
               .log(this, getErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(), e.getMessage());
       sendErrorResponse(exchange, 500, "Internal error", e, null);
     } finally {
+      ProtocolContext.clear();
       LogManager.instance().setContext(null);
 
       Timer.builder("arcadedb.http.requests")

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -30,16 +30,20 @@ import com.arcadedb.server.http.IdempotencyCache;
 import com.arcadedb.server.security.ApiTokenConfiguration;
 import com.arcadedb.server.security.ServerSecurityException;
 import com.arcadedb.server.security.ServerSecurityUser;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HeaderValues;
 import io.undertow.util.Headers;
 import io.undertow.util.HttpString;
+import io.undertow.util.PathTemplateMatch;
 import io.undertow.util.StatusCodes;
 
 import java.security.MessageDigest;
 import java.util.Base64;
 import java.util.Deque;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 
@@ -91,6 +95,11 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
           error2json("Server is installing a snapshot, please retry", "", null, null, null));
       return;
     }
+
+    // Always-on RED timer: capture the start of the worker-thread (or IO-thread for handlers that
+    // do not dispatch) request handling. Recorded in the finally block below into the
+    // arcadedb.http.requests Micrometer timer. When no tracer is registered this is metrics-only.
+    final long httpStartNanos = System.nanoTime();
 
     try {
       LogManager.instance().setContext(httpServer.getServer().getServerName());
@@ -340,7 +349,44 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
       sendErrorResponse(exchange, 500, "Internal error", e, null);
     } finally {
       LogManager.instance().setContext(null);
+
+      Timer.builder("arcadedb.http.requests")
+          .description("HTTP request duration")
+          .tag("method", exchange.getRequestMethod().toString())
+          .tag("path", pathTemplate(exchange))
+          .tag("status", Integer.toString(exchange.getStatusCode()))
+          .tag("db", databaseTag(exchange))
+          .publishPercentileHistogram()
+          .register(Metrics.globalRegistry)
+          .record(System.nanoTime() - httpStartNanos, TimeUnit.NANOSECONDS);
     }
+  }
+
+  /**
+   * Returns a bounded, low-cardinality path tag for the request: the route template
+   * (e.g. {@code /command/{database}}) resolved by the Undertow routing handler, never the raw URI
+   * carrying the concrete database name. Falls back to the relative path for fixed routes
+   * registered without a path template.
+   */
+  private static String pathTemplate(final HttpServerExchange exchange) {
+    final PathTemplateMatch match = exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY);
+    if (match != null)
+      return match.getMatchedTemplate();
+    return exchange.getRelativePath();
+  }
+
+  /**
+   * Returns the database name resolved from the route's {@code {database}} path parameter, or
+   * {@code none} for routes that are not database-scoped (e.g. {@code /ready}, {@code /server}).
+   */
+  private static String databaseTag(final HttpServerExchange exchange) {
+    final PathTemplateMatch match = exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY);
+    if (match != null) {
+      final String db = match.getParameters().get("database");
+      if (db != null)
+        return db;
+    }
+    return "none";
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
@@ -32,13 +32,11 @@ import com.arcadedb.server.monitor.QueryProfile;
 import com.arcadedb.server.monitor.ServerQueryProfiler;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.micrometer.core.instrument.Metrics;
-import io.micrometer.core.instrument.Timer;
 import io.undertow.server.HttpServerExchange;
 
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 import java.util.logging.Level;
 
 public class PostCommandHandler extends AbstractQueryHandler {
@@ -274,35 +272,10 @@ public class PostCommandHandler extends AbstractQueryHandler {
 
   protected ResultSet executeCommand(final Database database, final String language, final String command,
       final Map<String, Object> paramMap) {
-    return timeExecution(database.getName(), language, "command", () -> {
-      final Object params = mapParams(paramMap);
-
-      if (params instanceof Object[] objects)
-        return database.command(language, command, httpServer.getServer().getConfiguration(), objects);
-      return database.command(language, command, httpServer.getServer().getConfiguration(), (Map<String, Object>) params);
-    });
-  }
-
-  /**
-   * Records the duration of a query/command execution into the always-on {@code arcadedb.query.duration}
-   * RED timer, tagged with the database, language and execution type ({@code query} or {@code command}).
-   * The query text itself is never used as a tag to keep metric cardinality bounded.
-   */
-  protected static ResultSet timeExecution(final String databaseName, final String language, final String type,
-      final Supplier<ResultSet> execution) {
-    final long start = System.nanoTime();
-    try {
-      return execution.get();
-    } finally {
-      Timer.builder("arcadedb.query.duration")
-          .description("Query/command execution duration")
-          .tag("db", databaseName)
-          .tag("language", language)
-          .tag("type", type)
-          .publishPercentileHistogram()
-          .register(Metrics.globalRegistry)
-          .record(System.nanoTime() - start, TimeUnit.NANOSECONDS);
-    }
+    final Object params = mapParams(paramMap);
+    if (params instanceof Object[] objects)
+      return database.command(language, command, httpServer.getServer().getConfiguration(), objects);
+    return database.command(language, command, httpServer.getServer().getConfiguration(), (Map<String, Object>) params);
   }
 
   protected void executeCommandAsync(final Database database, final String language, final String command,

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
@@ -32,11 +32,13 @@ import com.arcadedb.server.monitor.QueryProfile;
 import com.arcadedb.server.monitor.ServerQueryProfiler;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
 import io.undertow.server.HttpServerExchange;
 
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 
 public class PostCommandHandler extends AbstractQueryHandler {
@@ -272,11 +274,35 @@ public class PostCommandHandler extends AbstractQueryHandler {
 
   protected ResultSet executeCommand(final Database database, final String language, final String command,
       final Map<String, Object> paramMap) {
-    final Object params = mapParams(paramMap);
+    return timeExecution(database.getName(), language, "command", () -> {
+      final Object params = mapParams(paramMap);
 
-    if (params instanceof Object[] objects)
-      return database.command(language, command, httpServer.getServer().getConfiguration(), objects);
-    return database.command(language, command, httpServer.getServer().getConfiguration(), (Map<String, Object>) params);
+      if (params instanceof Object[] objects)
+        return database.command(language, command, httpServer.getServer().getConfiguration(), objects);
+      return database.command(language, command, httpServer.getServer().getConfiguration(), (Map<String, Object>) params);
+    });
+  }
+
+  /**
+   * Records the duration of a query/command execution into the always-on {@code arcadedb.query.duration}
+   * RED timer, tagged with the database, language and execution type ({@code query} or {@code command}).
+   * The query text itself is never used as a tag to keep metric cardinality bounded.
+   */
+  protected static ResultSet timeExecution(final String databaseName, final String language, final String type,
+      final Supplier<ResultSet> execution) {
+    final long start = System.nanoTime();
+    try {
+      return execution.get();
+    } finally {
+      Timer.builder("arcadedb.query.duration")
+          .description("Query/command execution duration")
+          .tag("db", databaseName)
+          .tag("language", language)
+          .tag("type", type)
+          .publishPercentileHistogram()
+          .register(Metrics.globalRegistry)
+          .record(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+    }
   }
 
   protected void executeCommandAsync(final Database database, final String language, final String command,

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostQueryHandler.java
@@ -30,11 +30,13 @@ public class PostQueryHandler extends PostCommandHandler {
   }
 
   protected ResultSet executeCommand(final Database database, final String language, final String command, final Map<String, Object> paramMap) {
-    final Object params = mapParams(paramMap);
+    return timeExecution(database.getName(), language, "query", () -> {
+      final Object params = mapParams(paramMap);
 
-    if (params instanceof Object[] objects)
-      return database.query(language, command, objects);
+      if (params instanceof Object[] objects)
+        return database.query(language, command, objects);
 
-    return database.query(language, command, (Map<String, Object>) params);
+      return database.query(language, command, (Map<String, Object>) params);
+    });
   }
 }

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostQueryHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostQueryHandler.java
@@ -30,13 +30,9 @@ public class PostQueryHandler extends PostCommandHandler {
   }
 
   protected ResultSet executeCommand(final Database database, final String language, final String command, final Map<String, Object> paramMap) {
-    return timeExecution(database.getName(), language, "query", () -> {
-      final Object params = mapParams(paramMap);
-
-      if (params instanceof Object[] objects)
-        return database.query(language, command, objects);
-
-      return database.query(language, command, (Map<String, Object>) params);
-    });
+    final Object params = mapParams(paramMap);
+    if (params instanceof Object[] objects)
+      return database.query(language, command, objects);
+    return database.query(language, command, (Map<String, Object>) params);
   }
 }

--- a/server/src/main/java/com/arcadedb/server/monitor/EngineMetricsBinder.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/EngineMetricsBinder.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.monitor;
+
+import com.arcadedb.Profiler;
+import com.arcadedb.serializer.json.JSONObject;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Exposes engine-wide statistics from {@link Profiler} as Micrometer gauges so they appear in
+ * {@code /prometheus} and any other registered registry (e.g. OTLP). Each gauge re-reads a cached
+ * {@link Profiler} snapshot on scrape, so values track the running engine without keeping extra state.
+ * <p>
+ * The {@code Profiler} aggregates JVM-global counters ({@link com.arcadedb.engine.PageManager} cache
+ * and WAL totals) plus the sum of per-database counters. Its JSON wraps every stat under an inner
+ * {@code count} / {@code space} / {@code value} key (only {@code walTotalFiles} is a bare scalar), so
+ * the reader extracts the inner numeric rather than treating the wrapper object as a number.
+ * <p>
+ * Building the snapshot is comparatively expensive (it queries JMX, free disk space and iterates the
+ * open databases), and on a scrape all gauges fire near-simultaneously; the snapshot is therefore
+ * memoized for a short TTL so one scrape rebuilds it at most once instead of once per gauge.
+ * <p>
+ * Per-database tagging is intentionally not done here: the binder is bound at server startup before
+ * databases are loaded, and the page-cache / WAL counters are JVM-global singletons. A
+ * per-database-tagged breakdown would require a periodically refreshed {@code MultiGauge}.
+ */
+public final class EngineMetricsBinder implements MeterBinder {
+
+  private static final long SNAPSHOT_TTL_NANOS = TimeUnit.SECONDS.toNanos(1);
+
+  private volatile JSONObject cachedSnapshot;
+  private volatile long       cachedAtNanos;
+
+  @Override
+  public void bindTo(final MeterRegistry registry) {
+    gauge(registry, "arcadedb.engine.page.cache.hits", "Page cache hits", "pageCacheHits");
+    gauge(registry, "arcadedb.engine.page.cache.misses", "Page cache misses", "pageCacheMiss");
+    gauge(registry, "arcadedb.engine.pages.read", "Pages read from disk", "pagesRead");
+    gauge(registry, "arcadedb.engine.pages.written", "Pages written to disk", "pagesWritten");
+    gauge(registry, "arcadedb.engine.wal.bytes.written", "WAL bytes written", "walBytesWritten");
+    gauge(registry, "arcadedb.engine.wal.files", "WAL files", "walTotalFiles");
+    gauge(registry, "arcadedb.engine.mvcc.conflicts", "Concurrent modification exceptions", "concurrentModificationExceptions");
+    gauge(registry, "arcadedb.engine.files.open", "Open file descriptors", "totalOpenFiles");
+    gauge(registry, "arcadedb.engine.tx.write", "Write transactions", "writeTx");
+    gauge(registry, "arcadedb.engine.tx.read", "Read transactions", "readTx");
+    gauge(registry, "arcadedb.engine.tx.rollbacks", "Transaction rollbacks", "txRollbacks");
+    gauge(registry, "arcadedb.engine.queries", "Queries executed", "queries");
+    gauge(registry, "arcadedb.engine.commands", "Commands executed", "commands");
+    gauge(registry, "arcadedb.engine.databases", "Open databases", "totalDatabases");
+  }
+
+  private void gauge(final MeterRegistry registry, final String name, final String description, final String jsonKey) {
+    // Use the Supplier form (not the weak-referenced (obj, fn) form): the lambda strongly captures
+    // this binder so it is not garbage-collected after bindTo() returns, which would silently kill
+    // the gauges. This mirrors PoolMetrics, whose suppliers capture long-lived singletons.
+    Gauge.builder(name, () -> readMetric(jsonKey))
+        .description(description)
+        .register(registry);
+  }
+
+  private double readMetric(final String jsonKey) {
+    final JSONObject json = snapshot();
+    if (!json.has(jsonKey))
+      return 0d;
+
+    final Object value = json.get(jsonKey);
+    if (value instanceof JSONObject nested) {
+      // Profiler wraps each stat under exactly one of these inner keys.
+      if (nested.has("count"))
+        return nested.getLong("count", 0L);
+      if (nested.has("space"))
+        return nested.getLong("space", 0L);
+      if (nested.has("value"))
+        return nested.getLong("value", 0L);
+      return 0d;
+    }
+    if (value instanceof Number n)
+      return n.doubleValue();
+    return 0d;
+  }
+
+  private JSONObject snapshot() {
+    final long now = System.nanoTime();
+    JSONObject snap = cachedSnapshot;
+    if (snap == null || now - cachedAtNanos > SNAPSHOT_TTL_NANOS) {
+      snap = Profiler.INSTANCE.toJSON();
+      cachedSnapshot = snap;
+      cachedAtNanos = now;
+    }
+    return snap;
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/monitor/EngineMetricsBinder.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/EngineMetricsBinder.java
@@ -25,6 +25,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Exposes engine-wide statistics from {@link Profiler} as Micrometer gauges so they appear in
@@ -48,8 +49,12 @@ public final class EngineMetricsBinder implements MeterBinder {
 
   private static final long SNAPSHOT_TTL_NANOS = TimeUnit.SECONDS.toNanos(1);
 
-  private volatile JSONObject cachedSnapshot;
-  private volatile long       cachedAtNanos;
+  /** The snapshot and the timestamp it was taken at, swapped atomically so a reader never sees a new
+   * snapshot paired with a stale timestamp. */
+  private record CachedSnapshot(JSONObject json, long atNanos) {
+  }
+
+  private final AtomicReference<CachedSnapshot> cache = new AtomicReference<>();
 
   @Override
   public void bindTo(final MeterRegistry registry) {
@@ -101,12 +106,14 @@ public final class EngineMetricsBinder implements MeterBinder {
 
   private JSONObject snapshot() {
     final long now = System.nanoTime();
-    JSONObject snap = cachedSnapshot;
-    if (snap == null || now - cachedAtNanos > SNAPSHOT_TTL_NANOS) {
-      snap = Profiler.INSTANCE.toJSON();
-      cachedSnapshot = snap;
-      cachedAtNanos = now;
+    final CachedSnapshot current = cache.get();
+    if (current == null || now - current.atNanos() > SNAPSHOT_TTL_NANOS) {
+      // Last-writer-wins: two threads may both rebuild on the TTL boundary (Profiler.toJSON() is
+      // synchronized, so concurrent rebuilds are safe), but snapshot and timestamp stay consistent.
+      final JSONObject snap = Profiler.INSTANCE.toJSON();
+      cache.set(new CachedSnapshot(snap, now));
+      return snap;
     }
-    return snap;
+    return current.json();
   }
 }

--- a/server/src/main/java/com/arcadedb/server/monitor/MicrometerQueryMetricsRecorder.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/MicrometerQueryMetricsRecorder.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.monitor;
+
+import com.arcadedb.database.QueryMetricsRecorder;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Server-side {@link QueryMetricsRecorder} that emits the always-on {@code arcadedb.query.duration}
+ * RED timer tagged by originating protocol, database, language and type. Registered when server
+ * metrics are enabled; otherwise the engine keeps the no-op recorder and pays no timing cost.
+ */
+public final class MicrometerQueryMetricsRecorder implements QueryMetricsRecorder {
+  @Override
+  public void record(final String protocol, final String database, final String language, final String type,
+      final long durationNanos) {
+    Timer.builder("arcadedb.query.duration")
+        .description("Query/command execution duration")
+        .tag("protocol", protocol)
+        .tag("db", database)
+        .tag("language", language)
+        .tag("type", type)
+        .publishPercentileHistogram()
+        .register(Metrics.globalRegistry)
+        .record(durationNanos, TimeUnit.NANOSECONDS);
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/monitor/EngineMetricsBinderTest.java
+++ b/server/src/test/java/com/arcadedb/server/monitor/EngineMetricsBinderTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.monitor;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit test for {@link EngineMetricsBinder}: every curated engine gauge is registered and reads a
+ * finite numeric value from the live {@code Profiler} snapshot, whose stats are nested JSON objects.
+ */
+class EngineMetricsBinderTest {
+
+  @Test
+  void registersEngineGauges() {
+    final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    new EngineMetricsBinder().bindTo(registry);
+
+    final Gauge cacheHits = registry.find("arcadedb.engine.page.cache.hits").gauge();
+    assertThat(cacheHits).isNotNull();
+
+    final Gauge openFiles = registry.find("arcadedb.engine.files.open").gauge();
+    assertThat(openFiles).isNotNull();
+
+    final Gauge walBytes = registry.find("arcadedb.engine.wal.bytes.written").gauge();
+    assertThat(walBytes).isNotNull();
+  }
+
+  @Test
+  void gaugesReadNestedProfilerValuesWithoutThrowing() {
+    final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    new EngineMetricsBinder().bindTo(registry);
+
+    // Profiler nests each stat as {count|space|value: N}; reading the gauge must extract the inner
+    // numeric, not throw on the wrapping object, and never return NaN.
+    final Gauge cacheHits = registry.find("arcadedb.engine.page.cache.hits").gauge();
+    assertThat(cacheHits).isNotNull();
+    assertThat(Double.isNaN(cacheHits.value())).isFalse();
+
+    final Gauge walFiles = registry.find("arcadedb.engine.wal.files").gauge();
+    assertThat(walFiles).isNotNull();
+    assertThat(Double.isNaN(walFiles.value())).isFalse();
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/monitor/EngineMetricsExposedIT.java
+++ b/server/src/test/java/com/arcadedb/server/monitor/EngineMetricsExposedIT.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.monitor;
+
+import com.arcadedb.server.BaseGraphServerTest;
+import io.micrometer.core.instrument.Metrics;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the {@link EngineMetricsBinder} gauges are bound into the global registry by the running
+ * server when metrics are enabled, alongside the executor-pool gauges.
+ */
+class EngineMetricsExposedIT extends BaseGraphServerTest {
+
+  @Override
+  protected int getServerCount() {
+    return 1;
+  }
+
+  @Test
+  void engineGaugesRegisteredInGlobalRegistry() {
+    assertThat(Metrics.globalRegistry.find("arcadedb.engine.page.cache.hits").gauge()).isNotNull();
+    assertThat(Metrics.globalRegistry.find("arcadedb.engine.files.open").gauge()).isNotNull();
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/monitor/HttpRedMetricsIT.java
+++ b/server/src/test/java/com/arcadedb/server/monitor/HttpRedMetricsIT.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.monitor;
+
+import com.arcadedb.server.BaseGraphServerTest;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the always-on HTTP RED timer {@code arcadedb.http.requests} records every request
+ * served by the universal handler entry, with a bounded path-template tag (never the raw URI).
+ */
+class HttpRedMetricsIT extends BaseGraphServerTest {
+
+  @Override
+  protected int getServerCount() {
+    return 1;
+  }
+
+  @Test
+  void httpRequestsTimerRecordsRequestsWithBoundedPathTag() throws Exception {
+    // Issue a request against a database-parameterized route so the path tag would carry the
+    // database name unless it is collapsed to a template.
+    issueReady();
+    issueQuery();
+
+    final Timer anyTimer = Metrics.globalRegistry.find("arcadedb.http.requests").timer();
+    assertThat(anyTimer).isNotNull();
+
+    // The query route must be tagged with the template, not the concrete database name "graph".
+    final Timer queryTimer = Metrics.globalRegistry.find("arcadedb.http.requests").tag("path", "/query/{database}").timer();
+    assertThat(queryTimer).isNotNull();
+    assertThat(queryTimer.count()).isGreaterThanOrEqualTo(1L);
+
+    // Cardinality guard: no timer should carry the raw database name in its path tag.
+    final Timer rawPathTimer = Metrics.globalRegistry.find("arcadedb.http.requests").tag("path", "/query/graph").timer();
+    assertThat(rawPathTimer).isNull();
+  }
+
+  private void issueReady() throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URL("http://localhost:2480/api/v1/ready").openConnection();
+    connection.setRequestMethod("GET");
+    connection.connect();
+    connection.getResponseCode();
+    connection.disconnect();
+  }
+
+  private void issueQuery() throws Exception {
+    final HttpURLConnection c = (HttpURLConnection) new URL("http://localhost:2480/api/v1/query/graph").openConnection();
+    c.setRequestMethod("POST");
+    c.setDoOutput(true);
+    c.setRequestProperty("Authorization",
+        "Basic " + java.util.Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+    c.setRequestProperty("Content-Type", "application/json");
+    c.getOutputStream().write("{\"language\":\"sql\",\"command\":\"select 1 as one\"}".getBytes());
+    c.connect();
+    c.getResponseCode();
+    c.disconnect();
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/monitor/HttpRedMetricsIT.java
+++ b/server/src/test/java/com/arcadedb/server/monitor/HttpRedMetricsIT.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -59,6 +60,25 @@ class HttpRedMetricsIT extends BaseGraphServerTest {
     assertThat(rawPathTimer).isNull();
   }
 
+  @Test
+  void httpRequestsTimerRecordsErrorStatus() throws Exception {
+    // An unauthenticated request to a protected endpoint returns 401, exercising the error path.
+    final HttpURLConnection c = (HttpURLConnection) new URL("http://localhost:2480/api/v1/command/graph").openConnection();
+    c.setRequestMethod("POST");
+    c.setDoOutput(true);
+    c.setRequestProperty("Content-Type", "application/json");
+    c.getOutputStream().write("{\"language\":\"sql\",\"command\":\"select 1\"}".getBytes(StandardCharsets.UTF_8));
+    c.connect();
+    assertThat(c.getResponseCode()).isEqualTo(401);
+    c.disconnect();
+
+    // RED metrics must record errors too, tagged with the failing status code.
+    final Timer errorTimer = Metrics.globalRegistry.find("arcadedb.http.requests")
+        .tag("path", "/command/{database}").tag("status", "401").timer();
+    assertThat(errorTimer).isNotNull();
+    assertThat(errorTimer.count()).isGreaterThanOrEqualTo(1L);
+  }
+
   private void issueReady() throws Exception {
     final HttpURLConnection connection = (HttpURLConnection) new URL("http://localhost:2480/api/v1/ready").openConnection();
     connection.setRequestMethod("GET");
@@ -74,7 +94,7 @@ class HttpRedMetricsIT extends BaseGraphServerTest {
     c.setRequestProperty("Authorization",
         "Basic " + java.util.Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
     c.setRequestProperty("Content-Type", "application/json");
-    c.getOutputStream().write("{\"language\":\"sql\",\"command\":\"select 1 as one\"}".getBytes());
+    c.getOutputStream().write("{\"language\":\"sql\",\"command\":\"select 1 as one\"}".getBytes(StandardCharsets.UTF_8));
     c.connect();
     c.getResponseCode();
     c.disconnect();

--- a/server/src/test/java/com/arcadedb/server/monitor/QueryMetricsProtocolIT.java
+++ b/server/src/test/java/com/arcadedb/server/monitor/QueryMetricsProtocolIT.java
@@ -54,4 +54,18 @@ class QueryMetricsProtocolIT extends BaseGraphServerTest {
     assertThat(timer).isNotNull();
     assertThat(timer.count()).isGreaterThanOrEqualTo(1L);
   }
+
+  @Test
+  void protocolTagIsBoundedAndQueryTextIsNeverATag() throws Exception {
+    httpQueryRecordedWithProtocolTag(); // populate at least one series
+
+    final var timers = Metrics.globalRegistry.find("arcadedb.query.duration").timers();
+    assertThat(timers).isNotEmpty();
+    for (final Timer t : timers) {
+      final String protocol = t.getId().getTag("protocol");
+      assertThat(protocol).isIn("http", "bolt", "postgres", "mongo", "grpc", "redis", "internal");
+      t.getId().getTags().forEach(tag ->
+          assertThat(tag.getValue().toLowerCase()).doesNotContain("select"));
+    }
+  }
 }

--- a/server/src/test/java/com/arcadedb/server/monitor/QueryMetricsProtocolIT.java
+++ b/server/src/test/java/com/arcadedb/server/monitor/QueryMetricsProtocolIT.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.monitor;
+
+import com.arcadedb.server.BaseGraphServerTest;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QueryMetricsProtocolIT extends BaseGraphServerTest {
+  @Override
+  protected int getServerCount() {
+    return 1;
+  }
+
+  @Test
+  void httpQueryRecordedWithProtocolTag() throws Exception {
+    final HttpURLConnection c = (HttpURLConnection) new URL("http://localhost:2480/api/v1/query/graph").openConnection();
+    c.setRequestMethod("POST");
+    c.setDoOutput(true);
+    c.setRequestProperty("Authorization",
+        "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+    c.setRequestProperty("Content-Type", "application/json");
+    c.getOutputStream().write("{\"language\":\"sql\",\"command\":\"select 1 as one\"}".getBytes(StandardCharsets.UTF_8));
+    c.connect();
+    assertThat(c.getResponseCode()).isEqualTo(200);
+    c.disconnect();
+
+    final Timer timer = Metrics.globalRegistry.find("arcadedb.query.duration")
+        .tag("protocol", "http").tag("db", "graph").tag("language", "sql").tag("type", "query").timer();
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isGreaterThanOrEqualTo(1L);
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/monitor/QueryRedMetricsIT.java
+++ b/server/src/test/java/com/arcadedb/server/monitor/QueryRedMetricsIT.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.monitor;
+
+import com.arcadedb.server.BaseGraphServerTest;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the always-on query/command RED timer {@code arcadedb.query.duration} records executions
+ * tagged by database, language and type, never by the (high-cardinality) query text.
+ */
+class QueryRedMetricsIT extends BaseGraphServerTest {
+
+  @Override
+  protected int getServerCount() {
+    return 1;
+  }
+
+  @Test
+  void queryDurationTimerIsTaggedByDatabaseAndLanguage() throws Exception {
+    post("/api/v1/query/graph", "{\"language\":\"sql\",\"command\":\"select 1 as one\"}");
+
+    final Timer queryTimer = Metrics.globalRegistry.find("arcadedb.query.duration")
+        .tag("db", "graph").tag("language", "sql").tag("type", "query").timer();
+    assertThat(queryTimer).isNotNull();
+    assertThat(queryTimer.count()).isGreaterThanOrEqualTo(1L);
+  }
+
+  @Test
+  void commandDurationTimerIsTaggedAsCommand() throws Exception {
+    post("/api/v1/command/graph", "{\"language\":\"sql\",\"command\":\"select 1 as one\"}");
+
+    final Timer commandTimer = Metrics.globalRegistry.find("arcadedb.query.duration")
+        .tag("db", "graph").tag("language", "sql").tag("type", "command").timer();
+    assertThat(commandTimer).isNotNull();
+    assertThat(commandTimer.count()).isGreaterThanOrEqualTo(1L);
+  }
+
+  private void post(final String path, final String body) throws Exception {
+    final HttpURLConnection c = (HttpURLConnection) new URL("http://localhost:2480" + path).openConnection();
+    c.setRequestMethod("POST");
+    c.setDoOutput(true);
+    c.setRequestProperty("Authorization",
+        "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+    c.setRequestProperty("Content-Type", "application/json");
+    c.getOutputStream().write(body.getBytes(StandardCharsets.UTF_8));
+    c.connect();
+    assertThat(c.getResponseCode()).isEqualTo(200);
+    c.disconnect();
+  }
+}


### PR DESCRIPTION
Closes #4465. Part of #4463 (Cloud Observability Architecture, Pillar 1 of 4).

## What

Always-on RED (Rate/Errors/Duration) latency metrics plus engine internals in Prometheus, with optional OTLP export. Default-off / behavior-preserving: with no new config, `/prometheus` output and `/api/v1/server` JSON are unchanged; all new series are additive.

### New RED timers (percentile histograms)
- **`arcadedb.http.requests`** - wrapped in `AbstractServerHttpHandler` (the universal handler entry), tagged `method` / `path` / `status` / `db`. The `path` tag uses Undertow's `PathTemplateMatch` matched template (e.g. `/query/{database}`), so the concrete database name never inflates cardinality. A test asserts the raw `/query/graph` is never emitted.
- **`arcadedb.query.duration`** - wrapped in `PostQueryHandler` / `PostCommandHandler` via a shared `timeExecution` helper, tagged `db` / `language` / `type`. The query text is never a tag.

### `EngineMetricsBinder`
A `MeterBinder` (modeled on `PoolMetrics`) exposing `arcadedb.engine.*` gauges read live from `Profiler.INSTANCE` on each scrape: page cache hits/misses, pages read/written, WAL bytes/files, MVCC conflicts, open files, tx, queries/commands. Bound next to `PoolMetrics` at server startup.

### Optional OTLP export
`OtlpMetricsPlugin` in the `metrics` module (adds `micrometer-registry-otlp`, Apache 2.0). SPI-registered, default-off, gated on `arcadedb.serverMetrics.otlp.enabled` (+ endpoint `arcadedb.serverMetrics.otlp.endpoint`). Registers an `OtlpMeterRegistry` alongside the untouched Prometheus scrape.

## Notable correctness details
- **`Profiler.toJSON()` nests every stat** as `{count|space|value: N}` (only `walTotalFiles` is a bare scalar); the binder extracts the inner numeric. The heavy snapshot is memoized for 1s so a scrape doesn't rebuild it per gauge.
- **Micrometer weak-gauge trap:** `Gauge.builder(name, obj, fn)` keeps only a *weak* reference to `obj`. An inline-constructed binder gets GC'd and its gauges silently go dead (the `/prometheus` body had the pool gauges but not the engine gauges). Switched to the `Supplier` form whose lambda strongly captures the binder - mirroring how `PoolMetrics` survives via long-lived singletons. Caught by the scrape IT.

## Config (all new, default-off)
| Key | Default | Effect |
|---|---|---|
| `arcadedb.serverMetrics.otlp.enabled` | `false` | register OTLP metrics registry alongside Prometheus |
| `arcadedb.serverMetrics.otlp.endpoint` | `http://localhost:4317` | OTLP metrics endpoint |

## Tests
- New: `HttpRedMetricsIT`, `QueryRedMetricsIT`, `EngineMetricsBinderTest`, `EngineMetricsExposedIT`, `OtlpMetricsPluginTest`, `PrometheusEngineMetricsIT` - all green.
- Regression: full `metrics` module (incl. both existing Prometheus tests = retro-compat guard) + 58 server HTTP-handler tests - all green.

## Scoped follow-ups
- Per-database **tagged** gauge breakdown: deferred. The metrics binder binds before `loadDatabases()` and the page-cache/WAL counters are JVM-global, so it needs a periodically-refreshed `MultiGauge`. DB-level counters are exposed as engine-wide aggregates here.
- Transaction-commit and Raft Observations: deferred to Pillar 2, where they also yield spans (tx latency is captured at the HTTP boundary in this pillar).


---

# Part 2: Protocol-agnostic query metrics (also closes #4535)

This PR also folds in the follow-up (#4535): the `arcadedb.query.duration` timer is now recorded **once at the engine boundary** (`LocalDatabase.query()/command()`) and tagged by the originating wire `protocol`, so **all** wire protocols are covered, not just HTTP.

## Approach
The `engine` module has Micrometer only at test scope, so engine main code can't call Micrometer (the same constraint that put `PoolMetrics`/`EngineMetricsBinder` in `server`). The engine therefore exposes a framework-agnostic hook:
- **Engine:** `QueryMetricsRecorder` (plain-Java functional interface, static `Holder` with a no-op default and `startNanos()`/`record()` helpers) + a `ProtocolContext` thread-local (default `internal`). `LocalDatabase` times its 7 terminal query/command overloads. The metrics-disabled path is allocation-free (a volatile read + a `0` sentinel - no `nanoTime`, no lambda).
- **Server:** registers `MicrometerQueryMetricsRecorder` (gated on `arcadedb.serverMetrics`) emitting `arcadedb.query.duration{protocol, db, language, type}`. The HTTP per-handler timer added earlier in this PR is removed so HTTP flows through the engine path as `protocol=http` (no double counting).
- **Each wire listener** sets/clears `ProtocolContext`: HTTP, Bolt, Postgres (simple **and** extended/prepared protocol), Mongo, gRPC (unary + `streamQuery` + `bulkInsert`), Redis (defensive).

## Coverage and known limitations (documented in `docs/observability-metrics.md`)
- Postgres covers both the simple-query and the extended/prepared-statement protocols (the latter bypassed `database.command()` and was wrapped, single-counted via the `portal.executed` guard).
- Mongo unfiltered scans use the engine iterate path (not `query/command`) and are not timed; filtered finds are.
- gRPC unary, `streamQuery`, and `bulkInsert` are tagged; the client-streaming `insertStream` per-message callbacks are a noted follow-up.
- Redis does not route through the engine query path, so it emits no `arcadedb.query.duration`; the protocol tag is defensive.

Dashboards filter `protocol!="internal"` for wire RED. Engine main code remains free of any Micrometer dependency.

## Tests
Per-protocol regression ITs across `bolt`, `postgresw`, `mongodbw`, `grpcw`, `redisw`, plus engine unit tests and a server cardinality guard - all green. The Part-1 `QueryRedMetricsIT`/`HttpRedMetricsIT` still pass unchanged (the timer gained a `protocol` tag; their subset assertions still match).
