### PR TITLE
fix: [#4559] LRUCache holds cacheSize - 1 entries

### DIFF
--- a/engine/src/main/java/com/arcadedb/utility/LRUCache.java
+++ b/engine/src/main/java/com/arcadedb/utility/LRUCache.java
@@ -40,6 +40,8 @@ public class LRUCache<K, V> extends LinkedHashMap<K, V> {
   }
 
   protected boolean removeEldestEntry(final Map.Entry<K, V> eldest) {
-    return size() >= cacheSize;
+    // called after the new entry has been inserted, so evict only when the
+    // capacity is exceeded, not when it is exactly reached
+    return size() > cacheSize;
   }
 }

--- a/engine/src/test/java/com/arcadedb/utility/IteratorTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/IteratorTest.java
@@ -240,7 +240,6 @@ class IteratorTest {
 
   @Test
   void lruCacheBasicOperations() {
-    // LRUCache evicts when size >= cacheSize, so with size 3, it holds max 2 elements
     final LRUCache<String, Integer> cache = new LRUCache<>(4);
 
     cache.put("a", 1);
@@ -254,18 +253,23 @@ class IteratorTest {
 
   @Test
   void lruCacheEviction() {
-    // LRUCache with size 3 evicts when size reaches 3
-    // So it effectively holds at most 2 entries
+    // LRUCache with size 3 holds 3 entries; the eldest is evicted only once
+    // the capacity is exceeded
     final LRUCache<String, Integer> cache = new LRUCache<>(3);
 
     cache.put("a", 1);
     cache.put("b", 2);
-    // At this point, adding "c" would make size 3, so eldest ("a") is evicted
     cache.put("c", 3);
+
+    assertThat(cache.keySet()).containsExactlyInAnyOrder("a", "b", "c");
+
+    // Adding "d" exceeds the capacity, so the eldest ("a") is evicted
+    cache.put("d", 4);
 
     assertThat(cache.containsKey("a")).isFalse();
     assertThat(cache.containsKey("b")).isTrue();
     assertThat(cache.containsKey("c")).isTrue();
+    assertThat(cache.containsKey("d")).isTrue();
   }
 
   @Test
@@ -275,15 +279,17 @@ class IteratorTest {
 
     cache.put("a", 1);
     cache.put("b", 2);
+    cache.put("c", 3);
 
     // Access "a" to make it more recently used
     cache.get("a");
 
-    // Adding "c" evicts "b" (the oldest in access order)
-    cache.put("c", 3);
+    // Adding "d" evicts "b" (the oldest in access order)
+    cache.put("d", 4);
 
     assertThat(cache.containsKey("a")).isTrue();
     assertThat(cache.containsKey("b")).isFalse();
     assertThat(cache.containsKey("c")).isTrue();
+    assertThat(cache.containsKey("d")).isTrue();
   }
 }

--- a/engine/src/test/java/com/arcadedb/utility/LRUCacheTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/LRUCacheTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.utility;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LRUCacheTest {
+
+  /**
+   * removeEldestEntry is called after the new entry has been inserted, so the
+   * eviction threshold must be size() &gt; cacheSize; with &gt;= the cache held
+   * only cacheSize - 1 entries (issue #4559).
+   */
+  @Test
+  void shouldHoldConfiguredNumberOfEntries() {
+    final LRUCache<Integer, String> cache = new LRUCache<>(3);
+    cache.put(1, "one");
+    cache.put(2, "two");
+    cache.put(3, "three");
+
+    assertThat(cache).hasSize(3);
+    assertThat(cache.keySet()).containsExactlyInAnyOrder(1, 2, 3);
+  }
+
+  @Test
+  void shouldEvictEldestOnlyBeyondCapacity() {
+    final LRUCache<Integer, String> cache = new LRUCache<>(3);
+    cache.put(1, "one");
+    cache.put(2, "two");
+    cache.put(3, "three");
+    cache.put(4, "four");
+
+    assertThat(cache).hasSize(3);
+    assertThat(cache.keySet()).containsExactlyInAnyOrder(2, 3, 4);
+  }
+
+  @Test
+  void shouldEvictLeastRecentlyAccessedEntry() {
+    final LRUCache<Integer, String> cache = new LRUCache<>(3);
+    cache.put(1, "one");
+    cache.put(2, "two");
+    cache.put(3, "three");
+
+    cache.get(1); // 2 becomes the least recently used
+    cache.put(4, "four");
+
+    assertThat(cache.keySet()).containsExactlyInAnyOrder(1, 3, 4);
+  }
+
+  @Test
+  void shouldKeepSingleEntryWithCapacityOne() {
+    final LRUCache<Integer, String> cache = new LRUCache<>(1);
+    cache.put(1, "one");
+
+    assertThat(cache).hasSize(1);
+    assertThat(cache.get(1)).isEqualTo("one");
+
+    cache.put(2, "two");
+    assertThat(cache).hasSize(1);
+    assertThat(cache.get(2)).isEqualTo("two");
+  }
+}


### PR DESCRIPTION
Fixes #4559.

`LinkedHashMap` calls `removeEldestEntry` after the new entry has been inserted, so evicting when `size() >= cacheSize` removes one entry early: the cache effectively holds `cacheSize - 1` entries, and a cache of capacity 1 stays permanently empty. Evict when `size() > cacheSize` instead, which matches every other `removeEldestEntry` implementation in the codebase (`StatementCache`, `ExecutionPlanCache`, `VectorLocationIndex`, `PromQLEvaluator`).

Note: the two `IteratorTest` cases (`lruCacheEviction`, `lruCacheAccessOrder`) asserted the old behavior, with comments describing it as holding "at most 2 entries" for capacity 3. I updated them to the corrected semantics (fill to capacity, then overflow evicts the eldest / least recently accessed); flagging in case that behavior was intentional, though the consistent `>` idiom elsewhere suggests it was not.

Verification: new `LRUCacheTest` (4 cases: capacity is respected, eviction beyond capacity, access-order eviction, capacity 1) fails on `main` and passes with the fix; `IteratorTest` (19) and `StatementCacheTest` pass.