### PR TITLE
fix: harden FileUtils path-traversal guard and CRLF lookahead (#4560,…

### DIFF
--- a/engine/src/main/java/com/arcadedb/utility/FileUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/FileUtils.java
@@ -153,7 +153,10 @@ public class FileUtils {
   }
 
   public static void checkValidName(final String iFileName) throws IOException {
-    if (iFileName.contains("..") || iFileName.contains(File.separator))
+    // Reject both '/' and '\' on every platform (the OS/JVM treat both as separators) and the '.'/'..' directory sentinels.
+    // The substring ".." is allowed inside a name (e.g. "a..b"); only a name equal to ".." is a traversal.
+    if (iFileName == null || iFileName.isEmpty() || iFileName.indexOf('/') > -1 || iFileName.indexOf('\\') > -1
+        || iFileName.equals(".") || iFileName.equals(".."))
       throw new IOException("Invalid file name '" + iFileName + "'");
   }
 
@@ -453,7 +456,7 @@ public class FileUtils {
     int line = 1;
     for (int i = 0; i < text.length(); i++) {
       final char current = text.charAt(i);
-      final Character next = i + 1 < text.length() ? text.charAt(i) : null;
+      final Character next = i + 1 < text.length() ? text.charAt(i + 1) : null;
       if (current == '\n') {
         ++line;
         result.append(String.format("\n%-" + maxLineDigits + "d: ", line));

--- a/engine/src/test/java/com/arcadedb/utility/FileUtilsTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/FileUtilsTest.java
@@ -22,12 +22,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class FileUtilsTest {
 
@@ -249,5 +252,66 @@ class FileUtilsTest {
     assertThat(FileUtils.escapeHTML(">")).contains("&#62;");
     assertThat(FileUtils.escapeHTML("&")).contains("&#38;");
     assertThat(FileUtils.escapeHTML("\"")).contains("&#34;");
+  }
+
+  // Issue #4561: checkValidName must reject both separators on any platform and treat ".." as a path segment.
+  @Test
+  void checkValidNameAcceptsPlainNames() {
+    assertThatCode(() -> FileUtils.checkValidName("database.json")).doesNotThrowAnyException();
+    assertThatCode(() -> FileUtils.checkValidName("backup-2026.tgz")).doesNotThrowAnyException();
+    // A ".." that is not the whole name is a legal file name (only an exact "." or ".." is rejected).
+    assertThatCode(() -> FileUtils.checkValidName("a..b")).doesNotThrowAnyException();
+    assertThatCode(() -> FileUtils.checkValidName("file..bak")).doesNotThrowAnyException();
+    assertThatCode(() -> FileUtils.checkValidName("....")).doesNotThrowAnyException();
+    assertThatCode(() -> FileUtils.checkValidName("...")).doesNotThrowAnyException();
+  }
+
+  @Test
+  void checkValidNameRejectsForwardSlash() {
+    assertThatThrownBy(() -> FileUtils.checkValidName("../etc/passwd")).isInstanceOf(IOException.class);
+    assertThatThrownBy(() -> FileUtils.checkValidName("dir/file")).isInstanceOf(IOException.class);
+  }
+
+  @Test
+  void checkValidNameRejectsBackslash() {
+    // On Linux the JVM File.separator is '/', so a backslash used to slip through.
+    assertThatThrownBy(() -> FileUtils.checkValidName("..\\windows\\system32")).isInstanceOf(IOException.class);
+    assertThatThrownBy(() -> FileUtils.checkValidName("dir\\file")).isInstanceOf(IOException.class);
+  }
+
+  @Test
+  void checkValidNameRejectsDirectorySentinels() {
+    // Both the parent ("..") and current (".") directory sentinels are rejected as whole names.
+    assertThatThrownBy(() -> FileUtils.checkValidName("..")).isInstanceOf(IOException.class);
+    assertThatThrownBy(() -> FileUtils.checkValidName(".")).isInstanceOf(IOException.class);
+  }
+
+  @Test
+  void checkValidNameRejectsNullAndEmpty() {
+    assertThatThrownBy(() -> FileUtils.checkValidName(null)).isInstanceOf(IOException.class);
+    assertThatThrownBy(() -> FileUtils.checkValidName("")).isInstanceOf(IOException.class);
+  }
+
+  // Issue #4560: printWithLineNumbers must collapse a CRLF into a single line break and consume the '\r'.
+  @Test
+  void printWithLineNumbersCollapsesCRLF() {
+    final String result = FileUtils.printWithLineNumbers("line1\r\nline2");
+    // Two source lines must produce exactly two numbered lines: "1:" and "2:".
+    assertThat(result).contains("1:");
+    assertThat(result).contains("2:");
+    assertThat(result).doesNotContain("3:");
+    assertThat(result).contains("line1");
+    assertThat(result).contains("line2");
+    // The carriage return must be consumed by the lookahead, not emitted as a literal character.
+    assertThat(result).doesNotContain("\r");
+  }
+
+  @Test
+  void printWithLineNumbersHandlesUnixNewline() {
+    final String result = FileUtils.printWithLineNumbers("line1\nline2\nline3");
+    assertThat(result).contains("1:");
+    assertThat(result).contains("2:");
+    assertThat(result).contains("3:");
+    assertThat(result).doesNotContain("4:");
   }
 }


### PR DESCRIPTION
… #4561)

#4561: checkValidName now rejects both '/' and '\\' on every platform (not just the platform File.separator) and treats '..' as a full path segment instead of a raw substring, so traversal names like '..\\x' and 'dir/file' are blocked while legal names such as 'a..b' are allowed. Null and empty names are also rejected.

#4560: printWithLineNumbers read the current char (charAt(i)) instead of the lookahead (charAt(i+1)), so the CRLF-collapse branch never fired and a stray '\\r' leaked into the output. Fixed the index so '\\r\\n' collapses to a single line break.

Adds regression tests for both fixes in FileUtilsTest.

## What does this PR do?

A brief description of the change being made with this pull request.

## Motivation

What inspired you to submit this pull request?

## Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

## Additional Notes

Anything else we should know when reviewing?

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
