### PR TITLE
fix: [#4557] map and path functions return insertion-ordered maps

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/map/MapClean.java
+++ b/engine/src/main/java/com/arcadedb/function/map/MapClean.java
@@ -20,7 +20,7 @@ package com.arcadedb.function.map;
 
 import com.arcadedb.query.sql.executor.CommandContext;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -67,7 +67,7 @@ public class MapClean extends AbstractMapFunction {
     final List<?> valuesToRemove = (List<?>) args[2];
 
     if (map == null)
-      return new HashMap<>();
+      return new LinkedHashMap<>();
 
     // Build sets for efficient lookup
     final Set<String> keysSet = new HashSet<>();
@@ -79,7 +79,7 @@ public class MapClean extends AbstractMapFunction {
     final Set<Object> valuesSet = new HashSet<>(valuesToRemove);
 
     // Build result, excluding specified keys and values
-    final Map<String, Object> result = new HashMap<>();
+    final Map<String, Object> result = new LinkedHashMap<>();
     for (final Map.Entry<String, Object> entry : map.entrySet()) {
       if (!keysSet.contains(entry.getKey()) && !valuesSet.contains(entry.getValue())) {
         result.put(entry.getKey(), entry.getValue());

--- a/engine/src/main/java/com/arcadedb/function/map/MapFlatten.java
+++ b/engine/src/main/java/com/arcadedb/function/map/MapFlatten.java
@@ -20,7 +20,7 @@ package com.arcadedb.function.map;
 
 import com.arcadedb.query.sql.executor.CommandContext;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -55,9 +55,9 @@ public class MapFlatten extends AbstractMapFunction {
     final String delimiter = args.length > 1 && args[1] != null ? args[1].toString() : ".";
 
     if (map == null)
-      return new HashMap<>();
+      return new LinkedHashMap<>();
 
-    final Map<String, Object> result = new HashMap<>();
+    final Map<String, Object> result = new LinkedHashMap<>();
     flatten("", map, delimiter, result);
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/function/map/MapFromLists.java
+++ b/engine/src/main/java/com/arcadedb/function/map/MapFromLists.java
@@ -20,7 +20,7 @@ package com.arcadedb.function.map;
 
 import com.arcadedb.query.sql.executor.CommandContext;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -62,7 +62,7 @@ public class MapFromLists extends AbstractMapFunction {
     final List<?> keys = (List<?>) args[0];
     final List<?> values = (List<?>) args[1];
 
-    final Map<String, Object> result = new HashMap<>();
+    final Map<String, Object> result = new LinkedHashMap<>();
     final int size = Math.min(keys.size(), values.size());
 
     for (int i = 0; i < size; i++) {

--- a/engine/src/main/java/com/arcadedb/function/map/MapFromPairs.java
+++ b/engine/src/main/java/com/arcadedb/function/map/MapFromPairs.java
@@ -20,7 +20,7 @@ package com.arcadedb.function.map;
 
 import com.arcadedb.query.sql.executor.CommandContext;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -57,7 +57,7 @@ public class MapFromPairs extends AbstractMapFunction {
     }
 
     final List<?> pairs = (List<?>) args[0];
-    final Map<String, Object> result = new HashMap<>();
+    final Map<String, Object> result = new LinkedHashMap<>();
 
     for (final Object pair : pairs) {
       if (pair instanceof List) {

--- a/engine/src/main/java/com/arcadedb/function/map/MapGroupBy.java
+++ b/engine/src/main/java/com/arcadedb/function/map/MapGroupBy.java
@@ -21,7 +21,7 @@ package com.arcadedb.function.map;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -64,7 +64,7 @@ public class MapGroupBy extends AbstractMapFunction {
     }
 
     final List<?> list = (List<?>) args[0];
-    final Map<Object, List<Object>> result = new HashMap<>();
+    final Map<Object, List<Object>> result = new LinkedHashMap<>();
 
     for (final Object item : list) {
       if (item instanceof Map) {

--- a/engine/src/main/java/com/arcadedb/function/map/MapMerge.java
+++ b/engine/src/main/java/com/arcadedb/function/map/MapMerge.java
@@ -20,7 +20,7 @@ package com.arcadedb.function.map;
 
 import com.arcadedb.query.sql.executor.CommandContext;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -54,7 +54,7 @@ public class MapMerge extends AbstractMapFunction {
     final Map<String, Object> map1 = asMap(args[0]);
     final Map<String, Object> map2 = asMap(args[1]);
 
-    final Map<String, Object> result = new HashMap<>();
+    final Map<String, Object> result = new LinkedHashMap<>();
 
     if (map1 != null)
       result.putAll(map1);

--- a/engine/src/main/java/com/arcadedb/function/map/MapMergeList.java
+++ b/engine/src/main/java/com/arcadedb/function/map/MapMergeList.java
@@ -20,7 +20,7 @@ package com.arcadedb.function.map;
 
 import com.arcadedb.query.sql.executor.CommandContext;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -54,14 +54,14 @@ public class MapMergeList extends AbstractMapFunction {
   @SuppressWarnings("unchecked")
   public Object execute(final Object[] args, final CommandContext context) {
     if (args[0] == null)
-      return new HashMap<>();
+      return new LinkedHashMap<>();
 
     if (!(args[0] instanceof List)) {
       throw new IllegalArgumentException("map.mergeList() requires a list argument");
     }
 
     final List<?> list = (List<?>) args[0];
-    final Map<String, Object> result = new HashMap<>();
+    final Map<String, Object> result = new LinkedHashMap<>();
 
     for (final Object item : list) {
       if (item instanceof Map) {

--- a/engine/src/main/java/com/arcadedb/function/map/MapRemoveKey.java
+++ b/engine/src/main/java/com/arcadedb/function/map/MapRemoveKey.java
@@ -20,7 +20,7 @@ package com.arcadedb.function.map;
 
 import com.arcadedb.query.sql.executor.CommandContext;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -55,9 +55,9 @@ public class MapRemoveKey extends AbstractMapFunction {
     final String key = args[1] != null ? args[1].toString() : null;
 
     if (map == null)
-      return new HashMap<>();
+      return new LinkedHashMap<>();
 
-    final Map<String, Object> result = new HashMap<>(map);
+    final Map<String, Object> result = new LinkedHashMap<>(map);
     if (key != null) {
       result.remove(key);
     }

--- a/engine/src/main/java/com/arcadedb/function/map/MapRemoveKeys.java
+++ b/engine/src/main/java/com/arcadedb/function/map/MapRemoveKeys.java
@@ -20,7 +20,7 @@ package com.arcadedb.function.map;
 
 import com.arcadedb.query.sql.executor.CommandContext;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -61,9 +61,9 @@ public class MapRemoveKeys extends AbstractMapFunction {
     final List<?> keys = (List<?>) args[1];
 
     if (map == null)
-      return new HashMap<>();
+      return new LinkedHashMap<>();
 
-    final Map<String, Object> result = new HashMap<>(map);
+    final Map<String, Object> result = new LinkedHashMap<>(map);
     for (final Object key : keys) {
       if (key != null) {
         result.remove(key.toString());

--- a/engine/src/main/java/com/arcadedb/function/map/MapSetKey.java
+++ b/engine/src/main/java/com/arcadedb/function/map/MapSetKey.java
@@ -20,7 +20,7 @@ package com.arcadedb.function.map;
 
 import com.arcadedb.query.sql.executor.CommandContext;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -59,7 +59,7 @@ public class MapSetKey extends AbstractMapFunction {
       throw new IllegalArgumentException("map.setKey() key cannot be null");
     }
 
-    final Map<String, Object> result = new HashMap<>();
+    final Map<String, Object> result = new LinkedHashMap<>();
     if (map != null)
       result.putAll(map);
 

--- a/engine/src/main/java/com/arcadedb/function/map/MapSubmap.java
+++ b/engine/src/main/java/com/arcadedb/function/map/MapSubmap.java
@@ -20,7 +20,7 @@ package com.arcadedb.function.map;
 
 import com.arcadedb.query.sql.executor.CommandContext;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -61,9 +61,9 @@ public class MapSubmap extends AbstractMapFunction {
     final List<?> keys = (List<?>) args[1];
 
     if (map == null)
-      return new HashMap<>();
+      return new LinkedHashMap<>();
 
-    final Map<String, Object> result = new HashMap<>();
+    final Map<String, Object> result = new LinkedHashMap<>();
     for (final Object key : keys) {
       if (key != null) {
         final String keyStr = key.toString();

--- a/engine/src/main/java/com/arcadedb/function/map/MapUnflatten.java
+++ b/engine/src/main/java/com/arcadedb/function/map/MapUnflatten.java
@@ -20,7 +20,7 @@ package com.arcadedb.function.map;
 
 import com.arcadedb.query.sql.executor.CommandContext;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -56,9 +56,9 @@ public class MapUnflatten extends AbstractMapFunction {
     final String delimiter = args.length > 1 && args[1] != null ? args[1].toString() : ".";
 
     if (map == null)
-      return new HashMap<>();
+      return new LinkedHashMap<>();
 
-    final Map<String, Object> result = new HashMap<>();
+    final Map<String, Object> result = new LinkedHashMap<>();
     final String delimiterRegex = Pattern.quote(delimiter);
 
     for (final Map.Entry<String, Object> entry : map.entrySet()) {
@@ -78,11 +78,11 @@ public class MapUnflatten extends AbstractMapFunction {
       Object next = current.get(key);
 
       if (next == null) {
-        next = new HashMap<String, Object>();
+        next = new LinkedHashMap<String, Object>();
         current.put(key, next);
       } else if (!(next instanceof Map)) {
         // Key already exists with non-map value, create a map anyway
-        next = new HashMap<String, Object>();
+        next = new LinkedHashMap<String, Object>();
         current.put(key, next);
       }
 

--- a/engine/src/main/java/com/arcadedb/function/path/PathCombine.java
+++ b/engine/src/main/java/com/arcadedb/function/path/PathCombine.java
@@ -22,7 +22,7 @@ import com.arcadedb.query.sql.executor.CommandContext;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -97,7 +97,7 @@ public class PathCombine extends AbstractPathFunction {
       }
     }
 
-    final Map<String, Object> result = new HashMap<>();
+    final Map<String, Object> result = new LinkedHashMap<>();
     result.put("_type", "path");
     result.put("nodes", allNodes);
     result.put("relationships", allRels);

--- a/engine/src/main/java/com/arcadedb/function/path/PathCreate.java
+++ b/engine/src/main/java/com/arcadedb/function/path/PathCreate.java
@@ -22,7 +22,7 @@ import com.arcadedb.query.sql.executor.CommandContext;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -61,7 +61,7 @@ public class PathCreate extends AbstractPathFunction {
     final List<Object> relationships = toList(args[1]);
 
     // Create path representation
-    final Map<String, Object> path = new HashMap<>();
+    final Map<String, Object> path = new LinkedHashMap<>();
     path.put("_type", "path");
 
     final List<Object> nodes = new ArrayList<>();

--- a/engine/src/main/java/com/arcadedb/function/path/PathSlice.java
+++ b/engine/src/main/java/com/arcadedb/function/path/PathSlice.java
@@ -21,7 +21,7 @@ package com.arcadedb.function.path;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -105,7 +105,7 @@ public class PathSlice extends AbstractPathFunction {
       slicedRels.add(rels.get(i));
     }
 
-    final Map<String, Object> result = new HashMap<>();
+    final Map<String, Object> result = new LinkedHashMap<>();
     result.put("_type", "path");
     result.put("nodes", slicedNodes);
     result.put("relationships", slicedRels);

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherBuiltInFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherBuiltInFunctionsTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -1465,6 +1466,86 @@ class CypherBuiltInFunctionsTest extends TestHelper {
       assertThat(rs.hasNext()).isTrue();
       assertThat((boolean) rs.next().getProperty("result")).isTrue();
     });
+  }
+
+  @Test
+  void mapFromListsPreservesKeyOrder() {
+    // APOC-style map functions must return insertion-ordered maps so keys(),
+    // values() and JSON serialization are deterministic (issue #4557)
+    final StatelessFunction fn = CypherFunctionRegistry.get("map.fromLists");
+    final List<Object> keys = List.of("zeta", "year", "x1", "world", "v0", "uber", "tango", "sierra", "romeo", "quebec");
+    final List<Object> values = List.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+    @SuppressWarnings("unchecked")
+    final Map<String, Object> result = (Map<String, Object>) fn.execute(new Object[] { keys, values }, null);
+    assertThat(result.keySet()).containsExactly("zeta", "year", "x1", "world", "v0", "uber", "tango", "sierra", "romeo", "quebec");
+  }
+
+  @Test
+  void mapFromPairsPreservesKeyOrder() {
+    final StatelessFunction fn = CypherFunctionRegistry.get("map.fromPairs");
+    final List<Object> pairs = List.of(List.of("zeta", 0), List.of("year", 1), List.of("x1", 2), List.of("world", 3),
+        List.of("v0", 4), List.of("uber", 5), List.of("tango", 6), List.of("sierra", 7), List.of("romeo", 8),
+        List.of("quebec", 9));
+    @SuppressWarnings("unchecked")
+    final Map<String, Object> result = (Map<String, Object>) fn.execute(new Object[] { pairs }, null);
+    assertThat(result.keySet()).containsExactly("zeta", "year", "x1", "world", "v0", "uber", "tango", "sierra", "romeo", "quebec");
+  }
+
+  @Test
+  void mapMergePreservesKeyOrder() {
+    final StatelessFunction fn = CypherFunctionRegistry.get("map.merge");
+    final Map<String, Object> first = new LinkedHashMap<>();
+    first.put("zeta", 0);
+    first.put("year", 1);
+    first.put("x1", 2);
+    first.put("world", 3);
+    first.put("v0", 4);
+    final Map<String, Object> second = new LinkedHashMap<>();
+    second.put("uber", 5);
+    second.put("tango", 6);
+    second.put("sierra", 7);
+    second.put("romeo", 8);
+    second.put("quebec", 9);
+    @SuppressWarnings("unchecked")
+    final Map<String, Object> result = (Map<String, Object>) fn.execute(new Object[] { first, second }, null);
+    assertThat(result.keySet()).containsExactly("zeta", "year", "x1", "world", "v0", "uber", "tango", "sierra", "romeo", "quebec");
+  }
+
+  @Test
+  void mapSetKeyPreservesKeyOrder() {
+    final StatelessFunction fn = CypherFunctionRegistry.get("map.setKey");
+    final Map<String, Object> map = new LinkedHashMap<>();
+    map.put("zeta", 0);
+    map.put("year", 1);
+    map.put("x1", 2);
+    map.put("world", 3);
+    map.put("v0", 4);
+    map.put("uber", 5);
+    map.put("tango", 6);
+    map.put("sierra", 7);
+    map.put("romeo", 8);
+    @SuppressWarnings("unchecked")
+    final Map<String, Object> result = (Map<String, Object>) fn.execute(new Object[] { map, "quebec", 9 }, null);
+    assertThat(result.keySet()).containsExactly("zeta", "year", "x1", "world", "v0", "uber", "tango", "sierra", "romeo", "quebec");
+  }
+
+  @Test
+  void mapRemoveKeyPreservesKeyOrder() {
+    final StatelessFunction fn = CypherFunctionRegistry.get("map.removeKey");
+    final Map<String, Object> map = new LinkedHashMap<>();
+    map.put("zeta", 0);
+    map.put("year", 1);
+    map.put("x1", 2);
+    map.put("world", 3);
+    map.put("v0", 4);
+    map.put("uber", 5);
+    map.put("tango", 6);
+    map.put("sierra", 7);
+    map.put("romeo", 8);
+    map.put("quebec", 9);
+    @SuppressWarnings("unchecked")
+    final Map<String, Object> result = (Map<String, Object>) fn.execute(new Object[] { map, "world" }, null);
+    assertThat(result.keySet()).containsExactly("zeta", "year", "x1", "v0", "uber", "tango", "sierra", "romeo", "quebec");
   }
 
   // Note: Integration tests for Cypher queries with built-in functions


### PR DESCRIPTION
Fixes #4557.

The Cypher/APOC-style functions in `function/map` and `function/path` built their result maps with `HashMap`, so key iteration order (and therefore `keys()`, `values()` and JSON serialization of results) varied between JVM runs. APOC returns order-preserving maps, so this also broke compatibility.

Replaced `HashMap` with `LinkedHashMap` in every result-map construction site of the family: `map.fromLists`, `map.fromPairs`, `map.merge`, `map.mergeList`, `map.setKey`, `map.removeKey`, `map.removeKeys`, `map.submap`, `map.clean`, `map.flatten`, `map.unflatten`, `map.groupBy`, `path.create`, `path.slice` and `path.combine` (the issue's named functions plus the same pattern in the rest of the package, as suggested). Copy-constructed results (`removeKey(s)`) now also preserve the source map's order.

Verification: five new tests in `CypherBuiltInFunctionsTest` assert `keySet()` matches insertion order for `fromLists`, `fromPairs`, `merge`, `setKey` and `removeKey` using 10 keys chosen so `HashMap` scrambles them; all five fail on `main` and pass with the fix. `CypherBuiltInFunctionsTest` (142), `Issue4141DeprecatedSyntaxTest` (15) and `WithAndUnwindTest` (25) pass unchanged; the only failure, `cypherFunctionInstancesAreSameInBothRegistries`, fails identically on clean `main`.