### PR TITLE
fix(#4546): guard PaginatedComponentFile channel swaps with a read/write lock

### DIFF
--- a/docs/4546-rename-channel-lock.md
+++ b/docs/4546-rename-channel-lock.md
@@ -57,6 +57,28 @@ against a real `PaginatedComponentFile` while a rename runs in a loop, asserting
   `main` baseline (2 of 4 runs fail there with zero source changes). It is unrelated to this
   fix and is left untouched per the no-modify-existing-tests rule.
 
+## Pull request
+
+- PR: https://github.com/ArcadeData/arcadedb/pull/4567
+
+## Review cycles
+
+- **Cycle 1** - head `c778b03b` (initial fix).
+  - `gemini-code-assist`: flagged a real race in the `ClosedChannelException` reopen fallback
+    of `force()`/`write()`/`read()`: calling `open()` while holding only the (shared) read lock
+    lets two concurrent callers reopen the channel at once, leaking file descriptors.
+    **Actionable, applied** - extracted `reopenChannelUnderWriteLock()` which releases the read
+    lock, takes the exclusive write lock, double-checks `channel == null || !channel.isOpen()`
+    before reopening, then downgrades back to the read lock (in a `finally`, so the caller's
+    `finally` always has the read lock to release even if `open()` throws).
+  - `claude`: no review posted within the 15-minute poll window (timeout).
+
+## Final state
+
+- `timeout` - the per-cycle gating waited 15 minutes for both bots; `gemini-code-assist`
+  reviewed and its one actionable item was addressed and pushed, but `claude` never posted a
+  review on the PR. Loop stopped per the timeout rule. PR left open for the developer.
+
 ## Status
 
 - [x] Worktree + branch created
@@ -64,3 +86,5 @@ against a real `PaginatedComponentFile` while a rename runs in a loop, asserting
 - [x] Failing regression test (reproduces NPE)
 - [x] Fix (per-file ReentrantReadWriteLock)
 - [x] Verify (new test passes, no regressions in rename-related suites)
+- [x] PR opened (#4567)
+- [x] Cycle 1 review addressed (Gemini reopen-under-read-lock race)

--- a/docs/4546-rename-channel-lock.md
+++ b/docs/4546-rename-channel-lock.md
@@ -1,0 +1,66 @@
+# Issue #4546 - `PaginatedComponentFile.rename` closes the channel outside any lock visible to PageManager
+
+- Issue: https://github.com/ArcadeData/arcadedb/issues/4546
+- Type: bug fix
+- Component: `com.arcadedb.engine.PaginatedComponentFile`
+- Severity: MEDIUM
+
+## Summary
+
+`rename(newName)` performs `close() -> Files.move(ATOMIC_MOVE) -> open(newPath)` with no
+lock that blocks concurrent flush (`PageManager.flushPage -> file.write(page)`) or load
+(`file.read`). An in-flight write/read concurrent with a rename (most commonly compaction
+renaming a temporary index file into place) throws
+`IllegalArgumentException("... is closed")` from the flush thread, leaving the database in
+an inconsistent state.
+
+## Root cause
+
+The `channel`/`file` fields in `PaginatedComponentFile` are mutated by `close()`, `rename()`
+and `open()` while the I/O methods (`read`, `write`, `force`, `readPage`, `getSize`,
+`getTotalPages`, `calculateChecksum`) read them, with no synchronization between the two
+groups. `PageManager.concurrentPageAccess` only serializes I/O per `pageId`; it does not
+gate against a rename/close that swaps the channel out from under an in-flight operation on
+a different page of the same file.
+
+## Fix
+
+Add a per-file `ReentrantReadWriteLock` to `PaginatedComponentFile`:
+- I/O operations acquire the shared READ lock so independent pages still proceed
+  concurrently (no throughput regression for the hot path).
+- `close()` and `rename()` acquire the exclusive WRITE lock so they cannot run while any
+  I/O holds the channel, and so I/O cannot start mid-rename. Once `rename()` reopens the
+  channel under the write lock, queued I/O resumes against the new channel.
+
+This keeps the coordination local to the file object (no new dependency on PageManager) and
+preserves the existing reopen-and-retry fallbacks.
+
+## Tests
+
+`PaginatedComponentFileRenameConcurrencyTest` (engine) - drives concurrent writers/readers
+against a real `PaginatedComponentFile` while a rename runs in a loop, asserting no
+`IllegalArgumentException("... is closed")` / `NullPointerException` escapes.
+
+## Verification
+
+- New test `PaginatedComponentFileRenameConcurrencyTest` FAILS on the unpatched code with
+  `NullPointerException: ... this.channel is null` (read overlapping a rename), and PASSES
+  with the fix.
+- Existing `PaginatedComponentFileRoundTripTest` (3 tests) still passes.
+- Rename / schema / index regression suites pass: `SchemaTest`, `AlterTypeExecutionTest`,
+  `AlterTypeAtomicRepartitionTest`, `LSMSparseVectorIndexLifecycleTest`,
+  `WALVersionGapRecoveryTest`, `ApplyChangesPartialReplayTest`, `Issue4420TolerantDeleteTest`,
+  `Issue4432CorruptVertexDeleteTest`.
+- Note: `Issue4510ForceApplyPartialDeltaTest` is a PRE-EXISTING, non-deterministic
+  test-isolation flake (it relies on shared static `PageManager` page-version state that
+  bleeds across tests in the same fork). Verified it flakes identically on the unmodified
+  `main` baseline (2 of 4 runs fail there with zero source changes). It is unrelated to this
+  fix and is left untouched per the no-modify-existing-tests rule.
+
+## Status
+
+- [x] Worktree + branch created
+- [x] Tracking doc
+- [x] Failing regression test (reproduces NPE)
+- [x] Fix (per-file ReentrantReadWriteLock)
+- [x] Verify (new test passes, no regressions in rename-related suites)

--- a/engine/src/main/java/com/arcadedb/engine/PaginatedComponentFile.java
+++ b/engine/src/main/java/com/arcadedb/engine/PaginatedComponentFile.java
@@ -34,6 +34,7 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.spi.AbstractInterruptibleChannel;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
 import java.util.zip.CRC32;
 
@@ -43,6 +44,14 @@ public class PaginatedComponentFile extends ComponentFile {
   private                 FileChannel      channel;
   private                 int              pageSize;
   private static volatile boolean          warningPrinted = false;
+
+  /**
+   * Guards the {@link #channel}/{@link #file} fields against concurrent I/O while they are swapped.
+   * I/O methods (read/write/force/...) acquire the shared READ lock, so independent pages still run
+   * concurrently; {@link #close()} and {@link #rename(String)} acquire the exclusive WRITE lock so a
+   * channel can never be closed or replaced from under an in-flight operation.
+   */
+  private final ReentrantReadWriteLock channelLock = new ReentrantReadWriteLock();
 
   public static class InterruptibleInvocationHandler implements InvocationHandler {
     @Override
@@ -60,19 +69,25 @@ public class PaginatedComponentFile extends ComponentFile {
   }
 
   public void force(final boolean metaData) throws IOException {
-    if (channel == null)
-      return;
+    channelLock.readLock().lock();
     try {
-      channel.force(metaData);
-    } catch (final ClosedChannelException e) {
-      LogManager.instance().log(this, Level.SEVERE, "File '%s' was closed on force. Reopen it and retry...", null, fileName);
-      open(filePath, mode);
-      channel.force(metaData);
+      if (channel == null)
+        return;
+      try {
+        channel.force(metaData);
+      } catch (final ClosedChannelException e) {
+        LogManager.instance().log(this, Level.SEVERE, "File '%s' was closed on force. Reopen it and retry...", null, fileName);
+        open(filePath, mode);
+        channel.force(metaData);
+      }
+    } finally {
+      channelLock.readLock().unlock();
     }
   }
 
   @Override
   public void close() {
+    channelLock.writeLock().lock();
     try {
       LogManager.instance().log(this, Level.FINE, "Closing file %s (id=%d)...", null, filePath, fileId);
 
@@ -88,71 +103,93 @@ public class PaginatedComponentFile extends ComponentFile {
 
     } catch (final IOException e) {
       LogManager.instance().log(this, Level.SEVERE, "Error on closing file %s (id=%d)", e, filePath, fileId);
+    } finally {
+      this.open = false;
+      channelLock.writeLock().unlock();
     }
-    this.open = false;
   }
 
   public void rename(final String newFileName) throws IOException {
-    close();
-    LogManager.instance().log(this, Level.FINE, "Renaming file %s (id=%d) to %s...", null, filePath, fileId, newFileName);
-
-    final File newFile;
-    if (newFileName.contains(File.separator) || (File.separatorChar != '/' && newFileName.contains("/"))) {
-      // newFileName is an absolute path (e.g., from removeTempSuffix)
-      newFile = new File(newFileName);
-    } else if (newFileName.contains(".") && newFileName.contains("_")) {
-      // newFileName is already a complete filename, but not an absolute path
-      newFile = new File(osFile.getParentFile(), newFileName);
-    } else {
-      // newFileName is a component name, append the suffix from original file
-      final int suffixStart = osFile.getName().indexOf("_");
-      if (suffixStart < 0)
-        throw new IOException("Original file name '" + osFile.getName() + "' does not contain '_' to extract suffix");
-      final String newFilePath = newFileName + osFile.getName().substring(suffixStart);
-      newFile = new File(osFile.getParentFile(), newFilePath);
-    }
+    channelLock.writeLock().lock();
     try {
-      Files.move(osFile.getAbsoluteFile().toPath(), newFile.getAbsoluteFile().toPath(), StandardCopyOption.ATOMIC_MOVE);
-      open(newFile.getAbsolutePath(), mode);
-    } catch (Exception e) {
-      open(filePath, mode);
-      throw new IOException("Error renaming file " + filePath + " to " + newFile.getAbsolutePath(), e);
+      close();
+      LogManager.instance().log(this, Level.FINE, "Renaming file %s (id=%d) to %s...", null, filePath, fileId, newFileName);
+
+      final File newFile;
+      if (newFileName.contains(File.separator) || (File.separatorChar != '/' && newFileName.contains("/"))) {
+        // newFileName is an absolute path (e.g., from removeTempSuffix)
+        newFile = new File(newFileName);
+      } else if (newFileName.contains(".") && newFileName.contains("_")) {
+        // newFileName is already a complete filename, but not an absolute path
+        newFile = new File(osFile.getParentFile(), newFileName);
+      } else {
+        // newFileName is a component name, append the suffix from original file
+        final int suffixStart = osFile.getName().indexOf("_");
+        if (suffixStart < 0)
+          throw new IOException("Original file name '" + osFile.getName() + "' does not contain '_' to extract suffix");
+        final String newFilePath = newFileName + osFile.getName().substring(suffixStart);
+        newFile = new File(osFile.getParentFile(), newFilePath);
+      }
+      try {
+        Files.move(osFile.getAbsoluteFile().toPath(), newFile.getAbsoluteFile().toPath(), StandardCopyOption.ATOMIC_MOVE);
+        open(newFile.getAbsolutePath(), mode);
+      } catch (Exception e) {
+        open(filePath, mode);
+        throw new IOException("Error renaming file " + filePath + " to " + newFile.getAbsolutePath(), e);
+      }
+    } finally {
+      channelLock.writeLock().unlock();
     }
   }
 
   @Override
   public long getSize() throws IOException {
-    return channel.size();
+    channelLock.readLock().lock();
+    try {
+      return channel.size();
+    } finally {
+      channelLock.readLock().unlock();
+    }
   }
 
   public long getTotalPages() throws IOException {
-    return channel.size() / pageSize;
+    channelLock.readLock().lock();
+    try {
+      return channel.size() / pageSize;
+    } finally {
+      channelLock.readLock().unlock();
+    }
   }
 
   public long calculateChecksum() throws IOException {
-    final CRC32 crc = new CRC32();
+    channelLock.readLock().lock();
+    try {
+      final CRC32 crc = new CRC32();
 
-    final ByteBuffer buffer = ByteBuffer.allocate(getPageSize());
+      final ByteBuffer buffer = ByteBuffer.allocate(getPageSize());
 
-    final long totalPages = getTotalPages();
-    for (int i = 0; i < totalPages; i++) {
-      buffer.clear();
-      long pos = pageSize * (long) i;
-      while (buffer.hasRemaining()) {
-        final int r = channel.read(buffer, pos);
-        if (r < 0)
-          throw new IOException("Unexpected EOF calculating checksum at page " + i + " of file '" + getFileName() + "'");
-        pos += r;
+      final long totalPages = channel.size() / pageSize;
+      for (int i = 0; i < totalPages; i++) {
+        buffer.clear();
+        long pos = pageSize * (long) i;
+        while (buffer.hasRemaining()) {
+          final int r = channel.read(buffer, pos);
+          if (r < 0)
+            throw new IOException("Unexpected EOF calculating checksum at page " + i + " of file '" + getFileName() + "'");
+          pos += r;
+        }
+
+        buffer.rewind();
+        for (int j = 0; j < pageSize; j++) {
+          final int read = buffer.get(j);
+          crc.update(read);
+        }
       }
 
-      buffer.rewind();
-      for (int j = 0; j < pageSize; j++) {
-        final int read = buffer.get(j);
-        crc.update(read);
-      }
+      return crc.getValue();
+    } finally {
+      channelLock.readLock().unlock();
     }
-
-    return crc.getValue();
   }
 
   /**
@@ -164,25 +201,30 @@ public class PaginatedComponentFile extends ComponentFile {
     if (pageNumber < 0)
       throw new IllegalArgumentException("Invalid page number to write: " + pageNumber);
 
-    if (channel == null)
-      throw new IllegalArgumentException("Cannot write page " + pageNumber + " because the file '" + getFileName() + "' is closed");
-
-    assert page.pageId.getFileId() == fileId;
-    final ByteBuffer buffer = page.getContent();
-
-    // NO NEED TO SYNCHRONIZE THE BUFFER BECAUSE MUTABLE PAGES ARE NOT SHARED
-    buffer.clear();
+    channelLock.readLock().lock();
     try {
-      long pos = page.getPhysicalSize() * (long) pageNumber;
-      while (buffer.hasRemaining())
-        pos += channel.write(buffer, pos);
-    } catch (final ClosedChannelException e) {
-      LogManager.instance().log(this, Level.SEVERE, "File '%s' was closed on write. Reopen it and retry...", null, fileName);
-      open(filePath, mode);
+      if (channel == null)
+        throw new IllegalArgumentException("Cannot write page " + pageNumber + " because the file '" + getFileName() + "' is closed");
+
+      assert page.pageId.getFileId() == fileId;
+      final ByteBuffer buffer = page.getContent();
+
+      // NO NEED TO SYNCHRONIZE THE BUFFER BECAUSE MUTABLE PAGES ARE NOT SHARED
       buffer.clear();
-      long pos = page.getPhysicalSize() * (long) pageNumber;
-      while (buffer.hasRemaining())
-        pos += channel.write(buffer, pos);
+      try {
+        long pos = page.getPhysicalSize() * (long) pageNumber;
+        while (buffer.hasRemaining())
+          pos += channel.write(buffer, pos);
+      } catch (final ClosedChannelException e) {
+        LogManager.instance().log(this, Level.SEVERE, "File '%s' was closed on write. Reopen it and retry...", null, fileName);
+        open(filePath, mode);
+        buffer.clear();
+        long pos = page.getPhysicalSize() * (long) pageNumber;
+        while (buffer.hasRemaining())
+          pos += channel.write(buffer, pos);
+      }
+    } finally {
+      channelLock.readLock().unlock();
     }
 
     return pageSize;
@@ -214,43 +256,53 @@ public class PaginatedComponentFile extends ComponentFile {
     if (page.getPageId().getPageNumber() < 0)
       throw new IllegalArgumentException("Invalid page number to read: " + pageNumber);
 
-    if (channel == null)
-      throw new IllegalArgumentException("Cannot read page " + pageNumber + " because the file '" + getFileName() + "' is closed");
-
-    assert page.getPageId().getFileId() == fileId;
-    final ByteBuffer buffer = page.getByteBuffer();
-    buffer.clear();
-
+    channelLock.readLock().lock();
     try {
-      long pos = page.getPhysicalSize() * (long) pageNumber;
-      while (buffer.hasRemaining()) {
-        final int r = channel.read(buffer, pos);
-        if (r < 0)
-          throw new IOException("Unexpected EOF reading page " + pageNumber + " from file '" + getFileName() + "'");
-        pos += r;
-      }
-    } catch (final ClosedChannelException e) {
-      LogManager.instance().log(this, Level.SEVERE, "File '%s' was closed on read. Reopen it and retry...", null, fileName);
-      open(filePath, mode);
+      if (channel == null)
+        throw new IllegalArgumentException("Cannot read page " + pageNumber + " because the file '" + getFileName() + "' is closed");
+
+      assert page.getPageId().getFileId() == fileId;
+      final ByteBuffer buffer = page.getByteBuffer();
       buffer.clear();
-      long pos = page.getPhysicalSize() * (long) pageNumber;
-      while (buffer.hasRemaining()) {
-        final int r = channel.read(buffer, pos);
-        if (r < 0)
-          throw new IOException("Unexpected EOF reading page " + pageNumber + " from file '" + getFileName() + "'");
-        pos += r;
+
+      try {
+        long pos = page.getPhysicalSize() * (long) pageNumber;
+        while (buffer.hasRemaining()) {
+          final int r = channel.read(buffer, pos);
+          if (r < 0)
+            throw new IOException("Unexpected EOF reading page " + pageNumber + " from file '" + getFileName() + "'");
+          pos += r;
+        }
+      } catch (final ClosedChannelException e) {
+        LogManager.instance().log(this, Level.SEVERE, "File '%s' was closed on read. Reopen it and retry...", null, fileName);
+        open(filePath, mode);
+        buffer.clear();
+        long pos = page.getPhysicalSize() * (long) pageNumber;
+        while (buffer.hasRemaining()) {
+          final int r = channel.read(buffer, pos);
+          if (r < 0)
+            throw new IOException("Unexpected EOF reading page " + pageNumber + " from file '" + getFileName() + "'");
+          pos += r;
+        }
       }
+    } finally {
+      channelLock.readLock().unlock();
     }
   }
 
   public void readPage(final int pageNum, final ByteBuffer buf) throws IOException {
-    buf.clear();
-    long pos = pageSize * (long) pageNum;
-    while (buf.hasRemaining()) {
-      final int r = channel.read(buf, pos);
-      if (r < 0)
-        throw new IOException("Unexpected EOF reading page " + pageNum + " from file '" + getFileName() + "'");
-      pos += r;
+    channelLock.readLock().lock();
+    try {
+      buf.clear();
+      long pos = pageSize * (long) pageNum;
+      while (buf.hasRemaining()) {
+        final int r = channel.read(buf, pos);
+        if (r < 0)
+          throw new IOException("Unexpected EOF reading page " + pageNum + " from file '" + getFileName() + "'");
+        pos += r;
+      }
+    } finally {
+      channelLock.readLock().unlock();
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/engine/PaginatedComponentFile.java
+++ b/engine/src/main/java/com/arcadedb/engine/PaginatedComponentFile.java
@@ -68,6 +68,31 @@ public class PaginatedComponentFile extends ComponentFile {
     super(filePath, mode);
   }
 
+  /**
+   * Reopens the channel after a {@link ClosedChannelException} while the caller holds the READ lock.
+   * The read lock cannot be upgraded in place, so it is released, the exclusive WRITE lock is taken to
+   * reopen the channel (double-checked so concurrent callers reopen it only once, avoiding leaked file
+   * descriptors), then the read lock is reacquired before returning. The caller resumes its I/O under
+   * the read lock exactly as before.
+   */
+  private void reopenChannelUnderWriteLock() throws FileNotFoundException {
+    channelLock.readLock().unlock();
+    channelLock.writeLock().lock();
+    try {
+      try {
+        if (channel == null || !channel.isOpen())
+          open(filePath, mode);
+      } finally {
+        // DOWNGRADE: reacquire the read lock before releasing the write lock so no rename/close
+        // slips in, and so the caller's finally block always has the read lock to release - even
+        // when open() fails.
+        channelLock.readLock().lock();
+      }
+    } finally {
+      channelLock.writeLock().unlock();
+    }
+  }
+
   public void force(final boolean metaData) throws IOException {
     channelLock.readLock().lock();
     try {
@@ -77,7 +102,7 @@ public class PaginatedComponentFile extends ComponentFile {
         channel.force(metaData);
       } catch (final ClosedChannelException e) {
         LogManager.instance().log(this, Level.SEVERE, "File '%s' was closed on force. Reopen it and retry...", null, fileName);
-        open(filePath, mode);
+        reopenChannelUnderWriteLock();
         channel.force(metaData);
       }
     } finally {
@@ -217,7 +242,7 @@ public class PaginatedComponentFile extends ComponentFile {
           pos += channel.write(buffer, pos);
       } catch (final ClosedChannelException e) {
         LogManager.instance().log(this, Level.SEVERE, "File '%s' was closed on write. Reopen it and retry...", null, fileName);
-        open(filePath, mode);
+        reopenChannelUnderWriteLock();
         buffer.clear();
         long pos = page.getPhysicalSize() * (long) pageNumber;
         while (buffer.hasRemaining())
@@ -275,7 +300,7 @@ public class PaginatedComponentFile extends ComponentFile {
         }
       } catch (final ClosedChannelException e) {
         LogManager.instance().log(this, Level.SEVERE, "File '%s' was closed on read. Reopen it and retry...", null, fileName);
-        open(filePath, mode);
+        reopenChannelUnderWriteLock();
         buffer.clear();
         long pos = page.getPhysicalSize() * (long) pageNumber;
         while (buffer.hasRemaining()) {

--- a/engine/src/test/java/com/arcadedb/engine/PaginatedComponentFileRenameConcurrencyTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PaginatedComponentFileRenameConcurrencyTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.database.BasicDatabase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4546: {@code PaginatedComponentFile.rename} swaps the underlying
+ * {@code FileChannel} (close -&gt; move -&gt; reopen) without any lock that blocks concurrent
+ * page flush ({@code write}) or load ({@code read}). An in-flight I/O operation overlapping a
+ * rename used to observe a closed/null channel and throw
+ * {@code IllegalArgumentException("... is closed")} or {@code NullPointerException}.
+ *
+ * The test drives concurrent writers and readers against a real {@code PaginatedComponentFile}
+ * while a rename loop swaps the channel underneath them and asserts that no such exception
+ * escapes and that every I/O ultimately succeeds.
+ */
+class PaginatedComponentFileRenameConcurrencyTest {
+
+  private static final int PAGE_SIZE     = 1024;
+  private static final int FILE_ID       = 1;
+  private static final int PAGE_COUNT    = 8;
+  private static final int RENAME_CYCLES = 60;
+
+  @TempDir
+  Path tempDir;
+
+  private PaginatedComponentFile pcf;
+  private BasicDatabase          db;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    db = Mockito.mock(BasicDatabase.class);
+    final String filePath = tempDir.resolve("page." + FILE_ID + "." + PAGE_SIZE + ".v0.arc").toString();
+    pcf = new PaginatedComponentFile(filePath, ComponentFile.MODE.READ_WRITE);
+
+    // Pre-populate all pages so reads have content to fetch.
+    for (int p = 0; p < PAGE_COUNT; p++) {
+      final byte[] data = new byte[PAGE_SIZE];
+      Arrays.fill(data, (byte) (0x10 + p));
+      pcf.write(new MutablePage(new PageId(db, FILE_ID, p), PAGE_SIZE, data, 1, PAGE_SIZE));
+    }
+    pcf.force(true);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (pcf != null)
+      pcf.close();
+  }
+
+  @Test
+  void concurrentIoDuringRenameDoesNotSeeClosedChannel() throws Exception {
+    final AtomicBoolean    stop       = new AtomicBoolean(false);
+    final List<Throwable>  failures   = new CopyOnWriteArrayList<>();
+    final CountDownLatch   ready      = new CountDownLatch(2);
+    final CountDownLatch   go         = new CountDownLatch(1);
+
+    final Thread writer = new Thread(() -> {
+      ready.countDown();
+      await(go);
+      int p = 0;
+      while (!stop.get()) {
+        try {
+          final byte[] data = new byte[PAGE_SIZE];
+          Arrays.fill(data, (byte) (0x40 + (p % PAGE_COUNT)));
+          pcf.write(new MutablePage(new PageId(db, FILE_ID, p % PAGE_COUNT), PAGE_SIZE, data, 2, PAGE_SIZE));
+          p++;
+        } catch (final Throwable t) {
+          failures.add(t);
+          return;
+        }
+      }
+    }, "writer");
+
+    final Thread reader = new Thread(() -> {
+      ready.countDown();
+      await(go);
+      int p = 0;
+      while (!stop.get()) {
+        try {
+          final CachedPage page = new CachedPage((PageManager) null, new PageId(db, FILE_ID, p % PAGE_COUNT), PAGE_SIZE);
+          pcf.read(page);
+          p++;
+        } catch (final Throwable t) {
+          failures.add(t);
+          return;
+        }
+      }
+    }, "reader");
+
+    writer.start();
+    reader.start();
+    await(ready);
+    go.countDown();
+
+    // Rename loop on the main thread: the file is swapped between two physical names repeatedly.
+    final Path nameA = pcf.getOSFile().toPath();
+    final Path nameB = tempDir.resolve("renamed." + FILE_ID + "." + PAGE_SIZE + ".v0.arc");
+    String current = nameA.toString();
+    final String other = nameB.toString();
+    try {
+      for (int i = 0; i < RENAME_CYCLES && failures.isEmpty(); i++) {
+        final String target = current.equals(nameA.toString()) ? other : nameA.toString();
+        pcf.rename(target);
+        current = target;
+        Thread.yield();
+      }
+    } finally {
+      stop.set(true);
+      writer.join(10_000);
+      reader.join(10_000);
+    }
+
+    if (!failures.isEmpty())
+      throw new AssertionError("Concurrent I/O during rename observed a closed/invalid channel: " + failures.get(0), failures.get(0));
+
+    assertThat(failures).isEmpty();
+    assertThat(pcf.isOpen()).isTrue();
+  }
+
+  private static void await(final CountDownLatch latch) {
+    try {
+      latch.await();
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
Closes #4546

## Summary

`PaginatedComponentFile.rename()` swapped the underlying `FileChannel` via `close() -> Files.move(ATOMIC_MOVE) -> open(newPath)` with no lock that blocked concurrent flush (`PageManager.flushPage -> file.write(page)`) or load (`file.read`). `PageManager.concurrentPageAccess` only serializes I/O per `pageId`; it does nothing to gate a rename/close that replaces the channel out from under an in-flight operation on a different page of the same file. The result was an `IllegalArgumentException("... is closed")` / `NullPointerException` thrown from the flush thread (most commonly during compaction renaming a temporary index file into place), leaving the database inconsistent.

The fix adds a per-file `ReentrantReadWriteLock` to `PaginatedComponentFile`:
- I/O methods (`read`/`write`/`force`/`readPage`/`getSize`/`getTotalPages`/`calculateChecksum`) take the shared **read** lock, so independent pages still proceed concurrently (no throughput regression on the hot path).
- `close()` and `rename()` take the exclusive **write** lock, so the channel can never be closed or replaced while any I/O is touching it, and queued I/O resumes against the reopened channel.

This keeps the coordination local to the file object (no new dependency on `PageManager`) and preserves the existing reopen-and-retry fallbacks.

## Test plan

- [x] New `PaginatedComponentFileRenameConcurrencyTest` drives concurrent writers/readers against a real `PaginatedComponentFile` while a rename loop swaps the channel; it FAILS on the unpatched code (`NullPointerException: this.channel is null`) and PASSES with the fix.
- [x] Existing `PaginatedComponentFileRoundTripTest` still passes (no behavioral change to read/write).
- [x] Rename / schema / index regression suites pass: `SchemaTest`, `AlterTypeExecutionTest`, `AlterTypeAtomicRepartitionTest`, `LSMSparseVectorIndexLifecycleTest`, `WALVersionGapRecoveryTest`, `ApplyChangesPartialReplayTest`, `Issue4420TolerantDeleteTest`, `Issue4432CorruptVertexDeleteTest`.
- [ ] Note: `Issue4510ForceApplyPartialDeltaTest` is a pre-existing, non-deterministic test-isolation flake (shared static `PageManager` page-version state bleeding across tests in the same fork). Verified it flakes identically on the unmodified `main` baseline (2 of 4 runs fail there with zero source changes); unrelated to this fix and left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)