### PR TITLE
fix(#4545): coordinate PageManager.deleteFile with flush thread index/queue

### DIFF
--- a/docs/4545-pagemanager-deletefile-flush-coordination.md
+++ b/docs/4545-pagemanager-deletefile-flush-coordination.md
@@ -62,3 +62,35 @@ TDD verification:
 Low risk: the new per-file drain reuses the same proven pattern as the per-database drain
 and only touches the file being dropped. No behavioral change for the common path other
 than guaranteeing the flush thread no longer retains pages for dropped files.
+
+## Pull request
+
+https://github.com/ArcadeData/arcadedb/pull/4568 (Closes #4545)
+
+## Review cycles
+
+- cycle 1: head `9c4c4da7` - both bots reviewed. claude (issue comment) and gemini (inline,
+  high) flagged that `removeAllPagesOfFile` drained only the live `queue`, leaving
+  suspend-deferred batches in `deferredByDatabase` (RAM leak window), and that
+  `pagesToFlush.pages` needed a null-guard for the `SHUTDOWN_THREAD` marker. Also: fully
+  qualified names in the test and multi-line comments. Addressed in `408777186`: extracted a
+  shared `removePagesOfFileFromBatch` helper that null-guards and now also drains
+  `deferredByDatabase`; replaced FQNs with imports; trimmed comments/Javadoc to single lines.
+  Two items skipped with justification (see deferred notes).
+- cycle 2: head `408777186` - gemini re-posted the SAME cycle-1 suggestion (it diffs against
+  base, not the prior commit); the committed code already implements that exact change, so the
+  comment is a stale duplicate with nothing actionable. The `claude` bot did not post a review
+  on this SHA within the 15-minute per-iteration window.
+
+## Deferred items
+
+- `docs/review-deferred-9c4c4da7.md` - records the two review points skipped with rationale
+  (keep the package-private `getFlushThread()` test accessor rather than a racy `loadPage`
+  black-box assertion; empty drained batch left in queue is safe, same as
+  `removeAllPagesOfDatabase`).
+
+## Final state
+
+`timeout` - cycle-1 feedback fully addressed and pushed; cycle-2 surfaced only a stale
+gemini duplicate (already satisfied) and no `claude` review landed within the polling window.
+PR left open for the developer. Merge is the developer's responsibility.

--- a/docs/4545-pagemanager-deletefile-flush-coordination.md
+++ b/docs/4545-pagemanager-deletefile-flush-coordination.md
@@ -1,0 +1,64 @@
+# Issue #4545 - `PageManager.deleteFile` doesn't coordinate with `flushThread.pageIndex` / queue
+
+## Summary
+
+`PageManager.deleteFile(database, fileId)` evicted only `readCache` entries for the
+dropped fileId. The asynchronous flush thread (`PageManagerFlushThread`) still held
+`MutablePage`s for that same fileId inside its `pageIndex` (O(1) lookup map) and its
+flush `queue`. Consequences:
+
+- **RAM leak** in `pageIndex`: index entries for the dropped file were never removed.
+- A page for a just-dropped file could still be picked up by the flush loop. The
+  existing `flushPage` existence guard (`fileManager.existsFile`) silently skips the
+  disk write, but the stale `MutablePage`/index entry lingered.
+- A concurrent `loadPage` for the same fileId could be served the stale queued page via
+  `getCachedPageFromMutablePageInQueue`.
+
+## Root cause
+
+`deleteFile` did not touch the flush thread at all. The class already had a per-database
+drain (`PageManagerFlushThread.removeAllPagesOfDatabase`, used by `simulateKillOfDatabase`
+and `removeModifiedPagesOfDatabase`) but no per-file equivalent for the file-drop path.
+
+## Fix
+
+1. Added `PageManagerFlushThread.removeAllPagesOfFile(Database, int fileId)`, mirroring the
+   existing `removeAllPagesOfDatabase`. It removes matching pages from queued batches and
+   purges the `pageIndex` of every entry whose `PageId` belongs to that database+fileId
+   (covers queued, in-flight, and suspend-deferred pages).
+2. `PageManager.deleteFile` now calls `flushThread.removeAllPagesOfFile(database, fileId)`
+   before evicting the `readCache`, draining the flush thread in the same operation that
+   drops the file (null-guarded for the pre-`configure()` state).
+3. Added a package-private `PageManager.getFlushThread()` accessor so the regression test
+   can assert flush-thread state.
+
+Files changed:
+- `engine/src/main/java/com/arcadedb/engine/PageManager.java`
+- `engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java`
+
+## Test
+
+`engine/src/test/java/com/arcadedb/engine/PageManagerDeleteFileFlushCoordinationTest.java`
+
+The test suspends async flushing for the database, schedules a batch of `MutablePage`s for
+a synthetic fileId (so they park in `pageIndex`/queue without being written to disk),
+asserts they are indexed, then calls `deleteFile` and asserts none remain indexed for that
+fileId.
+
+TDD verification:
+- With the drain call removed, the test fails on assertion
+  *"After deleteFile no page for the dropped fileId may remain in the flush thread index"*.
+- With the fix, the test passes.
+
+## Regression runs (engine module)
+
+- `PageManagerDeleteFileFlushCoordinationTest` - pass
+- `PageManagerFlushQueueRaceTest`, `PageManagerReadCacheRamAccountingTest`,
+  `PageManagerStressTest` (skipped/benchmark), `FileManagerTest`, `DropBucketTest` - pass
+- `DropIndexTest`, `LSMTreeIndexTest`, `TypeIndexTest` (exercise `deleteFile` on index drop) - pass
+
+## Impact / monitoring
+
+Low risk: the new per-file drain reuses the same proven pattern as the per-database drain
+and only touches the file being dropped. No behavioral change for the common path other
+than guaranteeing the flush thread no longer retains pages for dropped files.

--- a/docs/review-deferred-9c4c4da7.md
+++ b/docs/review-deferred-9c4c4da7.md
@@ -1,0 +1,30 @@
+# Review notes - PR #4568, HEAD 9c4c4da7
+
+Items from the claude / gemini-code-assist bot reviews that were intentionally NOT applied,
+with rationale. (Per resolve-issue-with-review Phase 3b: "Nitpick / disagree-with-justification - skip; record rationale".)
+
+## Skipped with justification
+
+### claude: remove the package-private `getFlushThread()` accessor; assert at PageManager level via `loadPage`
+Skipped. The regression test deterministically asserts the exact invariant the fix targets:
+no `MutablePage` for the dropped fileId remains in the flush thread's `pageIndex`. A black-box
+assertion through `loadPage` would require reproducing the precise async-flush timing window,
+which is inherently racy and would make the test flaky. The accessor is package-private (only
+visible inside `com.arcadedb.engine`), so production API exposure is minimal. Keeping the
+white-box test is the more reliable choice for this concurrency invariant.
+
+### claude / gemini: "empty PagesToFlush batch left in queue after draining all its pages"
+No action needed. Both reviewers confirm this is safe: the flush loop guards with
+`!pagesToFlush.pages.isEmpty()`, identical to the existing `removeAllPagesOfDatabase` behavior
+(which uses `pages.clear()`). Leaving the empty batch object in the queue is harmless and is
+consumed/dropped on the next poll.
+
+## Applied (for the record)
+
+- gemini (high) / claude: drain `deferredByDatabase` batches for the dropped fileId, not just
+  the live queue - applied; extracted a shared `removePagesOfFileFromBatch` helper.
+- gemini: null-guard `pagesToFlush.pages` (SHUTDOWN_THREAD marker) before synchronizing - applied
+  in the helper.
+- claude: replace fully-qualified `java.util.List`/`java.util.ArrayList` in the test with imports - applied.
+- claude: trim multi-line Javadoc/comments to single lines per the style guide - applied to the
+  new method Javadoc, the `deleteFile` inline comment, and the test class Javadoc.

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -165,9 +165,7 @@ public class PageManager extends LockContext {
   }
 
   public void deleteFile(final Database database, final int fileId) {
-    // Drain the asynchronous flush thread first: any MutablePage still parked in the flush
-    // queue or index for this fileId would otherwise leak RAM (issue #4545) and could be
-    // flushed to - or served back from - a file that no longer exists.
+    // Drain the async flush thread for this fileId first, otherwise its parked pages leak RAM and could be flushed to a dropped file.
     if (flushThread != null)
       flushThread.removeAllPagesOfFile(database, fileId);
 

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -165,6 +165,12 @@ public class PageManager extends LockContext {
   }
 
   public void deleteFile(final Database database, final int fileId) {
+    // Drain the asynchronous flush thread first: any MutablePage still parked in the flush
+    // queue or index for this fileId would otherwise leak RAM (issue #4545) and could be
+    // flushed to - or served back from - a file that no longer exists.
+    if (flushThread != null)
+      flushThread.removeAllPagesOfFile(database, fileId);
+
     for (final Iterator<CachedPage> it = readCache.values().iterator(); it.hasNext(); ) {
       final CachedPage p = it.next();
       final PageId pageId = p.getPageId();
@@ -173,6 +179,10 @@ public class PageManager extends LockContext {
         it.remove();
       }
     }
+  }
+
+  PageManagerFlushThread getFlushThread() {
+    return flushThread;
   }
 
   private int getMostRecentVersionOfPage(final PageId pageId, final int pageSize) throws IOException {

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -26,6 +26,7 @@ import com.arcadedb.exception.DatabaseMetadataException;
 import com.arcadedb.log.LogManager;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
@@ -290,5 +291,28 @@ public class PageManagerFlushThread extends Thread {
 
     // Also clean index entries for pages currently being flushed
     pageIndex.entrySet().removeIf(e -> database.equals(e.getKey().getDatabase()));
+  }
+
+  /**
+   * Drops every queued or in-flight {@link MutablePage} that belongs to a single dropped file.
+   * Invoked by {@link PageManager#deleteFile} so that, after a file is removed, no page for that
+   * fileId leaks in {@link #pageIndex} nor gets flushed back to a file that no longer exists.
+   */
+  public void removeAllPagesOfFile(final Database database, final int fileId) {
+    for (final PagesToFlush pagesToFlush : queue.stream().toList())
+      if (database.equals(pagesToFlush.database))
+        synchronized (pagesToFlush.pages) {
+          for (final Iterator<MutablePage> it = pagesToFlush.pages.iterator(); it.hasNext(); ) {
+            final MutablePage page = it.next();
+            if (page.getPageId().getFileId() == fileId) {
+              pageIndex.remove(page.getPageId());
+              it.remove();
+            }
+          }
+        }
+
+    // Also clean index entries for pages currently being flushed or deferred while suspended
+    pageIndex.entrySet()
+        .removeIf(e -> database.equals(e.getKey().getDatabase()) && e.getKey().getFileId() == fileId);
   }
 }

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -293,26 +293,36 @@ public class PageManagerFlushThread extends Thread {
     pageIndex.entrySet().removeIf(e -> database.equals(e.getKey().getDatabase()));
   }
 
-  /**
-   * Drops every queued or in-flight {@link MutablePage} that belongs to a single dropped file.
-   * Invoked by {@link PageManager#deleteFile} so that, after a file is removed, no page for that
-   * fileId leaks in {@link #pageIndex} nor gets flushed back to a file that no longer exists.
-   */
+  /** Drops every pending {@link MutablePage} of a single dropped file from the queue, the deferred batches and the index. */
   public void removeAllPagesOfFile(final Database database, final int fileId) {
     for (final PagesToFlush pagesToFlush : queue.stream().toList())
-      if (database.equals(pagesToFlush.database))
-        synchronized (pagesToFlush.pages) {
-          for (final Iterator<MutablePage> it = pagesToFlush.pages.iterator(); it.hasNext(); ) {
-            final MutablePage page = it.next();
-            if (page.getPageId().getFileId() == fileId) {
-              pageIndex.remove(page.getPageId());
-              it.remove();
-            }
-          }
-        }
+      removePagesOfFileFromBatch(pagesToFlush, database, fileId);
 
-    // Also clean index entries for pages currently being flushed or deferred while suspended
+    // Also drain batches deferred while the database is suspended (e.g. during a backup): they are
+    // no longer in the main queue, so their MutablePages would otherwise leak until the unsuspend flush.
+    final ConcurrentLinkedQueue<PagesToFlush> deferred = deferredByDatabase.get(database);
+    if (deferred != null)
+      for (final PagesToFlush pagesToFlush : deferred)
+        removePagesOfFileFromBatch(pagesToFlush, database, fileId);
+
+    // Finally clean any index entry for a page currently being flushed.
     pageIndex.entrySet()
         .removeIf(e -> database.equals(e.getKey().getDatabase()) && e.getKey().getFileId() == fileId);
+  }
+
+  private void removePagesOfFileFromBatch(final PagesToFlush pagesToFlush, final Database database, final int fileId) {
+    // pages is null for the SHUTDOWN_THREAD marker.
+    if (pagesToFlush.pages == null || !database.equals(pagesToFlush.database))
+      return;
+
+    synchronized (pagesToFlush.pages) {
+      for (final Iterator<MutablePage> it = pagesToFlush.pages.iterator(); it.hasNext(); ) {
+        final MutablePage page = it.next();
+        if (page.getPageId().getFileId() == fileId) {
+          pageIndex.remove(page.getPageId());
+          it.remove();
+        }
+      }
+    }
   }
 }

--- a/engine/src/test/java/com/arcadedb/engine/PageManagerDeleteFileFlushCoordinationTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageManagerDeleteFileFlushCoordinationTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4545: {@code PageManager.deleteFile} evicted only the
+ * {@code readCache} entries for the dropped fileId, while the asynchronous flush thread
+ * still held {@link MutablePage}s for that same fileId inside its {@code pageIndex} and
+ * flush queue.
+ * <p>
+ * That left a per-fileId memory leak in {@code pageIndex} and a window where a page for a
+ * dropped file could still be flushed or served back to {@code loadPage}. The fix drains
+ * the flush thread's queue and index for the fileId in the same call that drops the file.
+ */
+class PageManagerDeleteFileFlushCoordinationTest extends TestHelper {
+
+  private static final int FILE_ID    = 9_999;
+  private static final int PAGE_SIZE  = 4_096;
+  private static final int NUM_PAGES  = 8;
+
+  @Test
+  void deleteFileDrainsFlushThreadIndexAndQueue() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManager pageManager = db.getPageManager();
+    final PageManagerFlushThread flushThread = pageManager.getFlushThread();
+
+    // Suspend asynchronous flushing for this database so the scheduled pages stay parked
+    // in the flush thread's pageIndex/queue and are NOT drained to disk before we assert.
+    flushThread.setSuspended(db, true);
+    try {
+      // Schedule a batch of mutable pages for a synthetic fileId that does not exist in the
+      // FileManager. They land in the flush thread's pageIndex (and queue) but are never
+      // written to disk because flushPage() skips non-existent files.
+      final java.util.List<MutablePage> pages = new java.util.ArrayList<>(NUM_PAGES);
+      for (int i = 0; i < NUM_PAGES; i++)
+        pages.add(new MutablePage(new PageId(db, FILE_ID, i), PAGE_SIZE));
+
+      flushThread.scheduleFlushOfPages(pages);
+
+      // Sanity: at least one of the scheduled pages must be visible in the flush thread index
+      // before the drop, otherwise the test would pass vacuously.
+      assertThat(anyPageStillIndexed(flushThread))
+          .as("Scheduled pages must be present in the flush thread index before deleteFile")
+          .isTrue();
+
+      // Drop the file: this must also drain the flush thread's index/queue for that fileId.
+      pageManager.deleteFile(db, FILE_ID);
+
+      assertThat(anyPageStillIndexed(flushThread))
+          .as("After deleteFile no page for the dropped fileId may remain in the flush thread index")
+          .isFalse();
+    } finally {
+      flushThread.setSuspended(db, false);
+    }
+  }
+
+  private boolean anyPageStillIndexed(final PageManagerFlushThread flushThread) {
+    for (int i = 0; i < NUM_PAGES; i++)
+      if (flushThread.getCachedPageFromMutablePageInQueue(new PageId((DatabaseInternal) database, FILE_ID, i)) != null)
+        return true;
+    return false;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/PageManagerDeleteFileFlushCoordinationTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageManagerDeleteFileFlushCoordinationTest.java
@@ -22,17 +22,13 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Regression test for issue #4545: {@code PageManager.deleteFile} evicted only the
- * {@code readCache} entries for the dropped fileId, while the asynchronous flush thread
- * still held {@link MutablePage}s for that same fileId inside its {@code pageIndex} and
- * flush queue.
- * <p>
- * That left a per-fileId memory leak in {@code pageIndex} and a window where a page for a
- * dropped file could still be flushed or served back to {@code loadPage}. The fix drains
- * the flush thread's queue and index for the fileId in the same call that drops the file.
+ * Regression test for issue #4545: deleteFile must also drain the async flush thread's pageIndex/queue for the dropped fileId.
  */
 class PageManagerDeleteFileFlushCoordinationTest extends TestHelper {
 
@@ -53,7 +49,7 @@ class PageManagerDeleteFileFlushCoordinationTest extends TestHelper {
       // Schedule a batch of mutable pages for a synthetic fileId that does not exist in the
       // FileManager. They land in the flush thread's pageIndex (and queue) but are never
       // written to disk because flushPage() skips non-existent files.
-      final java.util.List<MutablePage> pages = new java.util.ArrayList<>(NUM_PAGES);
+      final List<MutablePage> pages = new ArrayList<>(NUM_PAGES);
       for (int i = 0; i < NUM_PAGES; i++)
         pages.add(new MutablePage(new PageId(db, FILE_ID, i), PAGE_SIZE));
 


### PR DESCRIPTION
Closes #4545

## Summary

`PageManager.deleteFile(database, fileId)` evicted only `readCache` entries for the dropped fileId. The asynchronous flush thread (`PageManagerFlushThread`) still held `MutablePage`s for that same fileId in its `pageIndex` (O(1) lookup map) and flush `queue`, leaking RAM in `pageIndex` and leaving a window where a dropped file's page could be flushed to - or served back from `loadPage` for - a file that no longer exists.

The fix adds `PageManagerFlushThread.removeAllPagesOfFile(database, fileId)` (mirroring the existing per-database `removeAllPagesOfDatabase`) and calls it from `deleteFile` before evicting the read cache, draining the flush thread's queued batches and index entries for that fileId in the same operation that drops the file.

## Test plan

- [ ] `mvn -pl engine test -Dtest=PageManagerDeleteFileFlushCoordinationTest` passes (new regression test).
- [ ] The test fails when the `removeAllPagesOfFile` drain call is removed (verified locally - assertion "After deleteFile no page for the dropped fileId may remain in the flush thread index").
- [ ] No regressions in flush/file/index drop paths: `PageManagerFlushQueueRaceTest`, `PageManagerReadCacheRamAccountingTest`, `FileManagerTest`, `DropBucketTest`, `DropIndexTest`, `LSMTreeIndexTest`, `TypeIndexTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)