### PR TITLE
fix(#4547): reject READ_ONLY open of a recovering DB without leaking the lock file

### DIFF
--- a/docs/4547-readonly-recovery-lock-leak.md
+++ b/docs/4547-readonly-recovery-lock-leak.md
@@ -1,0 +1,96 @@
+# Issue #4547 - LocalDatabase leaks the lock file when checkForRecovery rejects a READ_ONLY recovering DB
+
+## Summary
+
+`checkForRecovery()` calls `lockDatabase()` (storing `FileLock` + `lockFileIO*` into
+instance fields), then if the mode is `READ_ONLY` throws `DatabaseMetadataException`.
+The issue reports that the file lock is leaked because the lock-release block in
+`closeInternal()` is never reached (`open` is set `false`, short-circuiting future
+`close()` calls).
+
+## Analysis
+
+### Affected component
+`engine/src/main/java/com/arcadedb/database/LocalDatabase.java`
+
+### Current state on main (post issue #4511)
+
+Issue #4511 (commit 8ee1ebd7d) already added `releaseResourcesOnOpenFailure()` and
+wired it into the OUTER catch of `openInternal()`. That release path closes the
+`FileLock`, the lock-file I/O channels, the `FileManager` and the `TransactionManager`
+on any open failure, so the `READ_WRITE` recovery-failure leak is already covered.
+
+However, there is a remaining gap for the exact `READ_ONLY` scenario the issue
+describes:
+
+1. `checkForRecovery()` is invoked only when `mode == READ_WRITE`
+   (`openInternal()` guards the call with `if (mode == ComponentFile.MODE.READ_WRITE)`).
+2. Therefore, the `READ_ONLY` rejection branch inside `checkForRecovery()`
+   (`throw new DatabaseMetadataException("Database needs recovery but has been open in read only mode")`)
+   is currently UNREACHABLE from `openInternal()`.
+3. The practical effect on main is that a crashed database (with a `database.lck`
+   marker present) opened in `READ_ONLY` mode silently SKIPS recovery and opens
+   successfully, never validating that recovery is required. The intended guard is
+   never enforced.
+
+### Root cause / expected vs. actual
+
+- Expected: opening a not-cleanly-closed database in `READ_ONLY` mode should refuse
+  (it needs recovery, which `READ_ONLY` cannot perform) AND must not leak the OS
+  file lock.
+- Actual on main: the recovery check is skipped for `READ_ONLY`, so the guard never
+  fires. If the guard were reached without the `READ_ONLY` gate (as in the affected
+  26.x releases), the lock acquired by `lockDatabase()` would leak.
+
+### Fix
+
+Enforce the recovery guard for `READ_ONLY` databases too, while making sure the file
+lock acquired during the check is released on rejection:
+
+1. Always run the lock-file presence detection in `checkForRecovery()` regardless of
+   mode, so a `READ_ONLY` open of a crashed database is rejected as intended.
+2. Acquire the lock and immediately release it (or rely on the outer-catch
+   `releaseResourcesOnOpenFailure()`) so no `FileLock` is leaked when the rejection
+   fires.
+
+The minimal, safe change is to detect the recovery-needed condition for `READ_ONLY`
+WITHOUT acquiring the exclusive write lock at all (a `READ_ONLY` open must not take a
+write lock on `database.lck`), so there is nothing to leak; and to route any failure
+after a successful `lockDatabase()` through `releaseResourcesOnOpenFailure()`.
+
+## Tests
+
+`engine/src/test/java/com/arcadedb/database/Issue4547ReadOnlyRecoveryLockLeakTest.java`
+
+## Implementation
+
+`engine/src/main/java/com/arcadedb/database/LocalDatabase.java`:
+
+1. `openInternal()` now calls `checkForRecovery()` for BOTH modes (removed the
+   `if (mode == READ_WRITE)` gate), so a `READ_ONLY` open of a crashed database is
+   actually validated.
+2. `checkForRecovery()` now, when the lock marker exists and `mode == READ_ONLY`,
+   rejects with `DatabaseMetadataException` BEFORE calling `lockDatabase()`, and
+   nulls `lockFile`. Because the exclusive write lock is never acquired on the
+   `READ_ONLY` path, there is no OS file lock to leak by construction. The marker is
+   left on disk so the next `READ_WRITE` open still recovers.
+3. The outer catch in `openInternal()` now re-throws `DatabaseMetadataException`
+   unwrapped (alongside the existing `DatabaseOperationException` passthrough), so the
+   caller sees the "needs recovery" reason instead of an opaque wrapped message.
+   The issue #4511 `releaseResourcesOnOpenFailure()` safety net remains in place.
+
+## Test results
+
+- New test `Issue4547ReadOnlyRecoveryLockLeakTest` (red before fix, green after).
+- Regression run (all green): `Issue4511OpenFailureLockLeakTest`, `TransactionTypeTest`,
+  `TransactionBucketTest`, `ExternalPropertyTest`, `PolymorphicIndexConflictTest`,
+  `FileManagerTest`, `DatabaseFactoryTest`, `ACIDTransactionTest`,
+  `Issue4508TornWALRecoveryTest`, `WALVersionGapRecoveryTest`, `CheckDatabaseTest`,
+  `TransactionCallbackTest`.
+
+## Status
+
+- [x] Analysis
+- [x] Test (TDD)
+- [x] Fix
+- [x] Verification

--- a/docs/4547-readonly-recovery-lock-leak.md
+++ b/docs/4547-readonly-recovery-lock-leak.md
@@ -88,6 +88,33 @@ after a successful `lockDatabase()` through `releaseResourcesOnOpenFailure()`.
   `Issue4508TornWALRecoveryTest`, `WALVersionGapRecoveryTest`, `CheckDatabaseTest`,
   `TransactionCallbackTest`.
 
+## Pull Request
+
+https://github.com/ArcadeData/arcadedb/pull/4569
+
+## Review cycles
+
+- Cycle 1 (head `e019c234`):
+  - `gemini-code-assist`: COMMENTED, no actionable feedback.
+  - `claude`: approved correctness/fix/test (posted as a PR issue comment, not a
+    SHA-tied review, so the strict gating loop timed out waiting for it). Two
+    suggestions:
+    - Remove the tracking doc - DISAGREED with justification (committed tracking doc is
+      the workflow convention; precedents #4538/#4545/#4546/#4515/#4514). See
+      `review-deferred-e019c234.md`.
+    - Flatten the test-class Javadoc - APPLIED.
+
+## Deferred items
+
+- `docs/review-deferred-e019c234.md` - records the disagree-with-justification for the
+  tracking-doc removal and the applied Javadoc nit.
+
+## Final state
+
+`timeout` (the `claude` reviewer did not post a head-SHA-tied review within the 15-minute
+gate; it posted an equivalent PR issue comment, whose actionable nit was applied). PR left
+open for the developer to merge.
+
 ## Status
 
 - [x] Analysis

--- a/docs/review-deferred-e019c234.md
+++ b/docs/review-deferred-e019c234.md
@@ -1,0 +1,21 @@
+# Review-deferred notes - PR #4569 (head e019c234)
+
+Cycle 1 review feedback evaluation (claude + gemini-code-assist).
+
+## gemini-code-assist
+- COMMENTED, no review comments, no actionable feedback. Nothing to apply.
+
+## claude (issue comment)
+Approved correctness, fix, and test. Two suggestions:
+
+1. **"Remove `docs/4547-readonly-recovery-lock-leak.md` before merging."**
+   - Decision: DISAGREE-WITH-JUSTIFICATION (not applied).
+   - Rationale: the per-issue tracking doc at `docs/<issue>-<name>.md` is created and
+     committed by design in the resolve-issue / resolve-issue-with-review workflow
+     (Phase 6 explicitly updates and commits it). Multiple recent sibling fixes on
+     `main` committed the same artifact: #4538, #4545, #4546, #4515, #4514. Removing it
+     would contradict the orchestrator's documented convention. Left in place.
+
+2. **Minor nit: flatten the multi-paragraph test-class Javadoc to a one-liner.**
+   - Decision: APPLIED. `Issue4547ReadOnlyRecoveryLockLeakTest` Javadoc condensed to a
+     single concise paragraph.

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -2116,13 +2116,18 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     lockFile = new File(databasePath + "/database.lck");
 
     if (lockFile.exists()) {
+      if (mode == ComponentFile.MODE.READ_ONLY) {
+        // A READ_ONLY open cannot perform recovery: reject WITHOUT acquiring the exclusive write lock, so the OS file
+        // lock on database.lck is never taken (and therefore cannot be leaked). The marker is left untouched so the
+        // next READ_WRITE open still recovers.
+        lockFile = null;
+        throw new DatabaseMetadataException("Database needs recovery but has been open in read only mode");
+      }
+
       lockDatabase();
 
       // RECOVERY
       LogManager.instance().log(this, Level.WARNING, "Database '%s' was not closed properly last time", null, name);
-
-      if (mode == ComponentFile.MODE.READ_ONLY)
-        throw new DatabaseMetadataException("Database needs recovery but has been open in read only mode");
 
       // RESET THE COUNT OF RECORD IN CASE THE DATABASE WAS NOT CLOSED PROPERLY
       for (Bucket b : schema.getBuckets())
@@ -2161,8 +2166,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
         serializer.setDateImplementation(configuration.getValue(GlobalConfiguration.DATE_IMPLEMENTATION));
         serializer.setDateTimeImplementation(configuration.getValue(GlobalConfiguration.DATE_TIME_IMPLEMENTATION));
 
-        if (mode == ComponentFile.MODE.READ_WRITE)
-          checkForRecovery();
+        checkForRecovery();
 
         if (security != null)
           security.updateSchema(this);
@@ -2188,6 +2192,11 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
       releaseResourcesOnOpenFailure();
 
       if (e instanceof DatabaseOperationException exception)
+        throw exception;
+
+      // PRESERVE THE READ_ONLY-NEEDS-RECOVERY REJECTION (AND ANY OTHER METADATA ERROR) SO THE CALLER SEES THE REASON
+      // INSTEAD OF AN OPAQUE WRAPPED MESSAGE.
+      if (e instanceof DatabaseMetadataException exception)
         throw exception;
 
       throw new DatabaseOperationException("Error on creating new database instance", e);

--- a/engine/src/test/java/com/arcadedb/database/Issue4547ReadOnlyRecoveryLockLeakTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue4547ReadOnlyRecoveryLockLeakTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.exception.DatabaseMetadataException;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #4547: opening a not-cleanly-closed database (its {@code database.lck}
+ * marker still present on disk, so recovery is required) in {@code READ_ONLY} mode must:
+ * <ol>
+ *   <li>be rejected, because a {@code READ_ONLY} open cannot perform recovery; and</li>
+ *   <li>not leak the OS file lock on {@code database.lck}.</li>
+ * </ol>
+ *
+ * <p>The leak is observable by attempting a subsequent {@code READ_WRITE} open: if the rejected
+ * {@code READ_ONLY} open leaked the file lock, the {@code READ_WRITE} open fails with a
+ * {@code LockException} ("locked by another process"). With the fix, the lock is never leaked, so
+ * the recovery-capable {@code READ_WRITE} open succeeds.
+ */
+class Issue4547ReadOnlyRecoveryLockLeakTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.getSchema().createDocumentType("Issue4547Type");
+  }
+
+  @Test
+  void readOnlyOpenOfRecoveringDatabaseIsRejectedAndDoesNotLeakLock() {
+    // Produce some content and crash without a clean close so the next open runs recovery on a present lock file.
+    database.transaction(() -> database.newDocument("Issue4547Type").set("k", 1).save());
+    ((DatabaseInternal) database).kill();
+    // Deregister the killed instance from the active-instances registry (the database.lck marker stays on disk).
+    database.close();
+
+    final File lockFile = new File(getDatabasePath() + "/database.lck");
+    assertThat(lockFile.exists()).as("lock marker must be present so recovery is required").isTrue();
+
+    // A READ_ONLY open of a database that needs recovery must be rejected.
+    assertThatThrownBy(() -> factory.open(ComponentFile.MODE.READ_ONLY))
+        .isInstanceOf(DatabaseMetadataException.class);
+
+    // If the rejected READ_ONLY open leaked the file lock, this READ_WRITE open fails with a
+    // LockException ("locked by another process"). With the fix the lock was never leaked, so the
+    // recovery-capable READ_WRITE open succeeds.
+    database = factory.open();
+    assertThat(database.isOpen()).isTrue();
+    assertThat(database.getSchema().existsType("Issue4547Type")).isTrue();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/Issue4547ReadOnlyRecoveryLockLeakTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue4547ReadOnlyRecoveryLockLeakTest.java
@@ -29,17 +29,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Regression test for issue #4547: opening a not-cleanly-closed database (its {@code database.lck}
- * marker still present on disk, so recovery is required) in {@code READ_ONLY} mode must:
- * <ol>
- *   <li>be rejected, because a {@code READ_ONLY} open cannot perform recovery; and</li>
- *   <li>not leak the OS file lock on {@code database.lck}.</li>
- * </ol>
- *
- * <p>The leak is observable by attempting a subsequent {@code READ_WRITE} open: if the rejected
- * {@code READ_ONLY} open leaked the file lock, the {@code READ_WRITE} open fails with a
- * {@code LockException} ("locked by another process"). With the fix, the lock is never leaked, so
- * the recovery-capable {@code READ_WRITE} open succeeds.
+ * Regression test for issue #4547: a {@code READ_ONLY} open of a not-cleanly-closed database (its
+ * {@code database.lck} marker present, so recovery is required) must be rejected and must not leak
+ * the OS file lock, so a subsequent recovery-capable {@code READ_WRITE} open still succeeds.
  */
 class Issue4547ReadOnlyRecoveryLockLeakTest extends TestHelper {
 


### PR DESCRIPTION
Closes #4547

## Summary

A database that was not closed cleanly leaves the `database.lck` marker on disk, so the next open must run recovery. `LocalDatabase.checkForRecovery()` was only invoked for `READ_WRITE`, so a `READ_ONLY` open silently skipped the recovery guard entirely; and the historical `READ_ONLY` rejection branch acquired the file lock via `lockDatabase()` before throwing, leaking the OS file lock for the JVM lifetime (subsequent opens then failed with "locked by another process").

This change runs `checkForRecovery()` for both modes. On `READ_ONLY` with the marker present it rejects with `DatabaseMetadataException` **before** acquiring the exclusive write lock, so no OS file lock is ever taken (nothing to leak by construction); the marker is preserved on disk so a later `READ_WRITE` open still recovers. `openInternal()` now re-throws `DatabaseMetadataException` unwrapped so the caller sees the reason instead of an opaque wrapped message. The issue #4511 `releaseResourcesOnOpenFailure()` safety net remains in place.

## Test plan

- [x] New regression test `Issue4547ReadOnlyRecoveryLockLeakTest`: crash a DB (leave the `.lck` marker), open `READ_ONLY` (must be rejected with `DatabaseMetadataException`), then a subsequent `READ_WRITE` open must succeed (proves the lock was not leaked). Red before the fix, green after.
- [x] Regression suite (all green): `Issue4511OpenFailureLockLeakTest`, `ACIDTransactionTest`, `Issue4508TornWALRecoveryTest`, `WALVersionGapRecoveryTest`, `CheckDatabaseTest`, `TransactionCallbackTest`, `TransactionTypeTest`, `TransactionBucketTest`, `ExternalPropertyTest`, `PolymorphicIndexConflictTest`, `FileManagerTest`, `DatabaseFactoryTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)