### PR TITLE
fix(#4538): refresh cached cursorKeys after removedKeys branch in LSMTreeIndexCursor

### DIFF
--- a/docs/4538-lsmtreeindexcursor-stale-cursorkeys.md
+++ b/docs/4538-lsmtreeindexcursor-stale-cursorkeys.md
@@ -1,0 +1,37 @@
+# Issue #4538 — LSMTreeIndexCursor uses stale `cursorKeys[i]` after the `removedKeys` branch
+
+## Summary
+
+`LSMTreeIndexCursor`'s constructor validates each underlying page cursor. In the
+`removedKeys.contains(keys)` branch (around lines 188-196) the code advances the
+page cursor with `pageCursor.next()` and `continue`s the loop, but it does NOT
+update `cursorKeys[i]`. The subsequent iteration's exclusive-`fromKeys` check
+(line ~199) reads the stale `cursorKeys[i]` while the `removedKeys` check (line
+~188) and the `toKeys` check (line ~212) read the fresh `pageCursor.getKeys()`.
+
+Result: the predicate that decides whether the exclusive lower-bound key must be
+skipped runs against the previous (stale) key, so a `range(..., exclusive)` scan
+that follows a delete-then-reinsert sequence may include the excluded boundary
+key or skip a valid entry.
+
+## Root cause
+
+`cursorKeys[i]` is the cached "current key" for page cursor `i`. Every place that
+advances the cursor must keep this cache in sync. The `removedKeys` branch was
+the only advance site that forgot to refresh the cache before `continue`.
+
+## Fix
+
+After `pageCursor.next()` in the `removedKeys` branch, refresh
+`cursorKeys[i] = pageCursor.getKeys()` before `continue`, mirroring the
+exclusive-`fromKeys` branch that already does this.
+
+## Affected components
+
+- `engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCursor.java`
+
+## Verification
+
+- New regression test exercising an exclusive-lower-bound range scan after a
+  delete-then-reinsert sequence on an LSM tree index spanning multiple pages.
+- Existing `LSMTreeIndexTest` range/scan suite to confirm no regression.

--- a/docs/4538-lsmtreeindexcursor-stale-cursorkeys.md
+++ b/docs/4538-lsmtreeindexcursor-stale-cursorkeys.md
@@ -32,6 +32,42 @@ exclusive-`fromKeys` branch that already does this.
 
 ## Verification
 
-- New regression test exercising an exclusive-lower-bound range scan after a
-  delete-then-reinsert sequence on an LSM tree index spanning multiple pages.
-- Existing `LSMTreeIndexTest` range/scan suite to confirm no regression.
+- New regression test `LSMTreeIndexCursorStaleKeyTest` reproducing the bug: a
+  key-wide tombstone on the minimum key isolated on the newest page while older
+  pages hold live copies. Fails on the unfixed code (the entry right after the
+  removed key is dropped) and passes with the fix. A second method guards the
+  delete-then-reinsert variant from the issue.
+- Existing `LSMTreeIndexTest` range/scan suite (inclusive/exclusive bounds,
+  `rangeFromHead`) and related index tests confirm no regression. The
+  `LockFilesInOrderFileMigrationTest` failure on this checkout is pre-existing and
+  unrelated (verified on the unmodified baseline).
+
+## Pull request
+
+- PR: https://github.com/ArcadeData/arcadedb/pull/4570
+
+## Review cycles
+
+### Cycle 1 - head 7d42ea6a
+
+- Reviews: `claude[bot]` (PR comment), `gemini-code-assist` (no actionable items),
+  `codacy-production` (0 issues). Core fix approved as correct, minimal, and safe.
+- Applied (actionable & clear):
+  - Trimmed the source comment to a single short line, matching the sibling
+    exclusive-`fromKeys` branch that does the same assignment uncommented.
+  - Trimmed the test class-level Javadoc to one concise sentence (method Javadocs
+    already explain the page topology).
+- Skipped (with rationale):
+  - Removing this tracking doc: kept intentionally - the resolve-issue workflow
+    mandates and updates it; it is a workflow-owned artifact, not ad-hoc docs.
+- Deferred to a follow-up issue (out of scope for #4538):
+  - The `validIterators == 0` advance path also calls `pageCursor.next()` without
+    refreshing `cursorKeys[i]`. claude flags it as a narrower, structurally-similar
+    defect "worth a follow-up issue"; folding it in would broaden scope beyond the
+    reported bug.
+
+## Final state
+
+- max-cycles-reached / handed off: both gating bots reviewed cycle 1; actionable
+  cosmetic feedback applied and pushed. Merge remains the developer's
+  responsibility.

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCursor.java
@@ -189,6 +189,9 @@ public class LSMTreeIndexCursor implements IndexCursor {
         if (removedKeys.contains(keys)) {
           if (pageCursor.hasNext()) {
             pageCursor.next();
+            // KEEP THE CACHED KEY IN SYNC WITH THE ADVANCED CURSOR, OTHERWISE THE fromKeys/toKeys CHECKS
+            // BELOW (AND next()'s MINOR-KEY SELECTION) WOULD EVALUATE AGAINST THE PREVIOUS, STALE KEY.
+            cursorKeys[i] = pageCursor.getKeys();
             continue;
           }
           pageCursors[i] = null;

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCursor.java
@@ -189,9 +189,7 @@ public class LSMTreeIndexCursor implements IndexCursor {
         if (removedKeys.contains(keys)) {
           if (pageCursor.hasNext()) {
             pageCursor.next();
-            // KEEP THE CACHED KEY IN SYNC WITH THE ADVANCED CURSOR, OTHERWISE THE fromKeys/toKeys CHECKS
-            // BELOW (AND next()'s MINOR-KEY SELECTION) WOULD EVALUATE AGAINST THE PREVIOUS, STALE KEY.
-            cursorKeys[i] = pageCursor.getKeys();
+            cursorKeys[i] = pageCursor.getKeys(); // keep cache in sync with the advanced cursor
             continue;
           }
           pageCursors[i] = null;

--- a/engine/src/test/java/com/arcadedb/index/LSMTreeIndexCursorStaleKeyTest.java
+++ b/engine/src/test/java/com/arcadedb/index/LSMTreeIndexCursorStaleKeyTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.index.lsm.LSMTreeIndex;
+import com.arcadedb.index.lsm.LSMTreeIndexMutable;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4538.
+ * <p>
+ * In {@code LSMTreeIndexCursor}'s constructor the {@code removedKeys.contains(keys)} branch advanced the
+ * underlying page cursor with {@code pageCursor.next()} and {@code continue}d the validation loop WITHOUT
+ * refreshing the cached {@code cursorKeys[i]}. The subsequent {@code fromKeys}/{@code toKeys} checks - and,
+ * more importantly, {@code next()}'s minor-key selection - then evaluated against the previous, stale key
+ * while the {@code removedKeys} check itself read the fresh {@code pageCursor.getKeys()}. The inconsistency
+ * made a range scan run right after a delete (or delete-then-reinsert) sequence drop a valid entry that
+ * happens to sit immediately after a key-wide tombstone shared across pages.
+ * <p>
+ * The scenario below makes the minimum key a key-wide tombstone that is isolated on the newest page while
+ * older pages still hold live copies of that same minimum key. Because the cursor validates pages
+ * newest-first, the tombstone page seeds {@code removedKeys} with the minimum key, and the older live
+ * pages then enter the buggy branch: they advance past the removed minimum and - before the fix - kept the
+ * stale cached key, which suppressed the very next key from the scan output.
+ */
+class LSMTreeIndexCursorStaleKeyTest extends TestHelper {
+  private static final String TYPE_NAME = "Item";
+  private static final int    PAGE_SIZE = 4096;
+
+  /**
+   * The minimum key (0) is removed but never re-inserted, so an ascending scan must omit it while still
+   * returning every following key. Before the fix the stale cached key suppressed key 1 (the entry right
+   * after the removed minimum) from the scan; both an inclusive and an exclusive lower bound must return
+   * the full {@code 1..N} tail exactly once.
+   */
+  @Test
+  void scanAfterKeyWideTombstoneOnMinimumKeyDoesNotDropFollowingEntry() {
+    final int firstBatch = 300;
+    final int secondBatch = 300;
+    final int totalKeys = firstBatch + secondBatch;
+    final int removedKey = 0;
+
+    createSchema();
+    final LSMTreeIndexMutable mutable = bucketMutableIndex();
+    final int bucketId = database.getSchema().getType(TYPE_NAME).getFirstBucketId();
+
+    // Live copies of keys 0..firstBatch-1 on the older pages (the minimum key 0 included).
+    database.transaction(() -> {
+      for (int i = 0; i < firstBatch; ++i)
+        mutable.put(new Object[] { i }, new RID[] { new RID(bucketId, i) });
+    });
+
+    // A second, newer live copy of the minimum key.
+    database.transaction(() -> mutable.put(new Object[] { removedKey }, new RID[] { new RID(bucketId, 100000L) }));
+
+    // Append the rest of the keys so the page that will hold the tombstone is fresh, keeping the tombstone
+    // isolated (no live copy of the minimum key sharing its page).
+    database.transaction(() -> {
+      for (int i = firstBatch; i < totalKeys; ++i)
+        mutable.put(new Object[] { i }, new RID[] { new RID(bucketId, i) });
+    });
+
+    // Key-wide removal of the minimum key. With no RID it writes the REMOVED_ENTRY_RID full-key tombstone
+    // collected into removedKeys; being the minimum key it sorts first on its page, so the page cursor
+    // surfaces it as a pure tombstone and seeds removedKeys before the older live pages are validated.
+    database.transaction(() -> mutable.remove(new Object[] { removedKey }));
+
+    database.transaction(() -> {
+      assertThat(mutable.getTotalPages()).as("index must span multiple pages to open multiple cursors").isGreaterThan(1);
+
+      final List<Integer> expectedTail = new ArrayList<>();
+      for (int i = removedKey + 1; i < totalKeys; ++i)
+        expectedTail.add(i);
+
+      // The stale-key bug dropped the entry (key 1) immediately following the removed minimum, so the scan
+      // is asserted on membership: the removed key must be gone and every following key must survive.
+      final List<Integer> inclusive = collectKeys(mutable, removedKey, true, totalKeys);
+      assertThat(inclusive).as("removed minimum key must be absent").doesNotContain(removedKey);
+      assertThat(inclusive).as("inclusive lower bound must not drop the entry right after the removed minimum")
+          .containsExactlyInAnyOrderElementsOf(expectedTail);
+
+      final List<Integer> exclusive = collectKeys(mutable, removedKey, false, totalKeys);
+      assertThat(exclusive).as("removed minimum key must be absent").doesNotContain(removedKey);
+      assertThat(exclusive).as("exclusive lower bound must not drop the entry right after the removed minimum")
+          .containsExactlyInAnyOrderElementsOf(expectedTail);
+    });
+  }
+
+  /**
+   * Same topology, but the removed minimum key is re-inserted with a fresh RID on the newest page. The
+   * delete-then-reinsert sequence from the issue must yield the complete {@code 0..N} set with an inclusive
+   * lower bound (boundary present once) and the {@code 1..N} tail with an exclusive lower bound.
+   */
+  @Test
+  void scanAfterDeleteThenReinsertOfMinimumKeyReturnsCompleteSet() {
+    final int firstBatch = 300;
+    final int secondBatch = 300;
+    final int totalKeys = firstBatch + secondBatch;
+    final int boundaryKey = 0;
+
+    createSchema();
+    final LSMTreeIndexMutable mutable = bucketMutableIndex();
+    final int bucketId = database.getSchema().getType(TYPE_NAME).getFirstBucketId();
+
+    database.transaction(() -> {
+      for (int i = 0; i < firstBatch; ++i)
+        mutable.put(new Object[] { i }, new RID[] { new RID(bucketId, i) });
+    });
+    database.transaction(() -> mutable.put(new Object[] { boundaryKey }, new RID[] { new RID(bucketId, 100000L) }));
+    database.transaction(() -> {
+      for (int i = firstBatch; i < totalKeys; ++i)
+        mutable.put(new Object[] { i }, new RID[] { new RID(bucketId, i) });
+    });
+    database.transaction(() -> mutable.remove(new Object[] { boundaryKey }));
+    // Re-insert the boundary key on the newest page (delete-then-reinsert).
+    database.transaction(() -> mutable.put(new Object[] { boundaryKey }, new RID[] { new RID(bucketId, 200000L) }));
+
+    database.transaction(() -> {
+      final List<Integer> inclusive = collectKeys(mutable, boundaryKey, true, totalKeys);
+      final List<Integer> expectedFull = new ArrayList<>();
+      for (int i = boundaryKey; i < totalKeys; ++i)
+        expectedFull.add(i);
+      assertThat(inclusive).containsExactlyInAnyOrderElementsOf(expectedFull);
+
+      final List<Integer> exclusive = collectKeys(mutable, boundaryKey, false, totalKeys);
+      final List<Integer> expectedTail = new ArrayList<>();
+      for (int i = boundaryKey + 1; i < totalKeys; ++i)
+        expectedTail.add(i);
+      assertThat(exclusive).containsExactlyInAnyOrderElementsOf(expectedTail);
+    });
+  }
+
+  private void createSchema() {
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(1).create();
+      type.createProperty("id", Integer.class);
+      // NON-unique index: a key-wide remove() writes the REMOVED_ENTRY_RID full-key tombstone that the
+      // cursor collects into removedKeys, which is the precondition for the buggy branch.
+      database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "id" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(false).withPageSize(PAGE_SIZE).create();
+    });
+  }
+
+  private static List<Integer> collectKeys(final LSMTreeIndexMutable mutable, final int fromKey, final boolean fromInclusive,
+      final int toKeyExclusiveUpper) {
+    try {
+      final List<Integer> seen = new ArrayList<>();
+      final IndexCursor cursor = mutable.range(true, new Object[] { fromKey }, fromInclusive, new Object[] { toKeyExclusiveUpper },
+          false);
+      while (cursor.hasNext()) {
+        cursor.next();
+        seen.add((Integer) cursor.getKeys()[0]);
+      }
+      return seen;
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private LSMTreeIndexMutable bucketMutableIndex() {
+    final TypeIndex typeIndex = database.getSchema().getType(TYPE_NAME).getIndexesByProperties("id").getFirst();
+    for (final Index bucketIndex : typeIndex.getIndexesOnBuckets())
+      if (bucketIndex instanceof LSMTreeIndex lsmIndex)
+        return lsmIndex.getMutableIndex();
+    throw new IllegalStateException("No LSM bucket index found for type " + TYPE_NAME);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/LSMTreeIndexCursorStaleKeyTest.java
+++ b/engine/src/test/java/com/arcadedb/index/LSMTreeIndexCursorStaleKeyTest.java
@@ -34,21 +34,9 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Regression test for issue #4538.
- * <p>
- * In {@code LSMTreeIndexCursor}'s constructor the {@code removedKeys.contains(keys)} branch advanced the
- * underlying page cursor with {@code pageCursor.next()} and {@code continue}d the validation loop WITHOUT
- * refreshing the cached {@code cursorKeys[i]}. The subsequent {@code fromKeys}/{@code toKeys} checks - and,
- * more importantly, {@code next()}'s minor-key selection - then evaluated against the previous, stale key
- * while the {@code removedKeys} check itself read the fresh {@code pageCursor.getKeys()}. The inconsistency
- * made a range scan run right after a delete (or delete-then-reinsert) sequence drop a valid entry that
- * happens to sit immediately after a key-wide tombstone shared across pages.
- * <p>
- * The scenario below makes the minimum key a key-wide tombstone that is isolated on the newest page while
- * older pages still hold live copies of that same minimum key. Because the cursor validates pages
- * newest-first, the tombstone page seeds {@code removedKeys} with the minimum key, and the older live
- * pages then enter the buggy branch: they advance past the removed minimum and - before the fix - kept the
- * stale cached key, which suppressed the very next key from the scan output.
+ * Regression test for a stale cached key in {@code LSMTreeIndexCursor}: when a key-wide tombstone is shared
+ * across pages, the constructor advanced a page cursor past the removed key without refreshing
+ * {@code cursorKeys[i]}, dropping the valid entry that follows it from a range scan.
  */
 class LSMTreeIndexCursorStaleKeyTest extends TestHelper {
   private static final String TYPE_NAME = "Item";


### PR DESCRIPTION
Closes #4538

## Summary

`LSMTreeIndexCursor`'s constructor validates each underlying page cursor. In the `removedKeys.contains(keys)` branch it advanced the page cursor with `pageCursor.next()` and `continue`d the validation loop without refreshing the cached `cursorKeys[i]`. The next iteration's `fromKeys`/`toKeys` checks - and, more importantly, `next()`'s minor-key selection - then evaluated against the previous, stale key, while the `removedKeys` check itself read the fresh `pageCursor.getKeys()`.

When a key-wide tombstone is shared across pages (a delete, or delete-then-reinsert, sequence) this inconsistency made a range scan drop the valid entry that sits immediately after the removed key. The fix refreshes `cursorKeys[i] = pageCursor.getKeys()` right after the advance, mirroring the exclusive-`fromKeys` branch immediately below it. This matches the fix suggested in the issue.

## Test plan

- [x] New regression test `LSMTreeIndexCursorStaleKeyTest`:
  - `scanAfterKeyWideTombstoneOnMinimumKeyDoesNotDropFollowingEntry` - reproduces the bug (a key-wide tombstone on the minimum key, isolated on the newest page while older pages hold live copies); FAILS on the unfixed code (key `1` dropped from the scan) and PASSES with the fix.
  - `scanAfterDeleteThenReinsertOfMinimumKeyReturnsCompleteSet` - guards the delete-then-reinsert case from the issue.
- [x] Existing range/scan suite in `LSMTreeIndexTest` (inclusive/exclusive bounds, `rangeFromHead`) passes with `-Dgroups=slow`.
- [x] Related index tests pass: `LSMTreeIndexCompositeTest`, `TypeLSMTreeIndexTest`, `LSMTreeIndexCompactionTest`, `CompositeIndexPartialKeySelectTest`, `LSMTreeIndexPolymorphicTest`.
- [x] Engine module compiles.

Note: `LockFilesInOrderFileMigrationTest` fails on this checkout independently of this change (verified on the unmodified baseline); it is a pre-existing, unrelated failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)