### PR TITLE
fix: [#4548] cancel the previous task when re-scheduling a materialized view refresh

### DIFF
--- a/engine/src/main/java/com/arcadedb/schema/MaterializedViewScheduler.java
+++ b/engine/src/main/java/com/arcadedb/schema/MaterializedViewScheduler.java
@@ -47,6 +47,11 @@ public class MaterializedViewScheduler {
     if (interval <= 0)
       return;
 
+    // Cancel any task already scheduled for this view, otherwise re-scheduling (for example
+    // when the schema is reloaded) leaves the previous task running and refreshing forever,
+    // as TimeSeriesMaintenanceScheduler.schedule() already does
+    cancel(view.getName());
+
     final WeakReference<Database> dbRef = new WeakReference<>(database);
     final ScheduledFuture<?> future = executor.scheduleAtFixedRate(() -> {
       final Database db = dbRef.get();

--- a/engine/src/test/java/com/arcadedb/schema/MaterializedViewSchedulerTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/MaterializedViewSchedulerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Database;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MaterializedViewSchedulerTest {
+
+  @Test
+  void reschedulingCancelsThePreviousTask() throws Exception {
+    TestHelper.executeInNewDatabase("MaterializedViewSchedulerTest", (database) -> {
+      final MaterializedViewScheduler scheduler = new MaterializedViewScheduler();
+      try {
+        final MaterializedViewImpl view = newPeriodicView(database);
+
+        scheduler.schedule(database, view);
+        final ScheduledFuture<?> first = scheduledTask(scheduler, view.getName());
+
+        scheduler.schedule(database, view);
+        final ScheduledFuture<?> second = scheduledTask(scheduler, view.getName());
+
+        assertThat((Object) second).isNotSameAs(first);
+        assertThat(first.isCancelled()).isTrue();
+        assertThat(second.isCancelled()).isFalse();
+      } finally {
+        scheduler.shutdown();
+      }
+    });
+  }
+
+  @Test
+  void cancelStopsTheScheduledTask() throws Exception {
+    TestHelper.executeInNewDatabase("MaterializedViewSchedulerTest", (database) -> {
+      final MaterializedViewScheduler scheduler = new MaterializedViewScheduler();
+      try {
+        final MaterializedViewImpl view = newPeriodicView(database);
+
+        scheduler.schedule(database, view);
+        final ScheduledFuture<?> task = scheduledTask(scheduler, view.getName());
+
+        scheduler.cancel(view.getName());
+
+        assertThat(task.isCancelled()).isTrue();
+        assertThat((Object) scheduledTask(scheduler, view.getName())).isNull();
+      } finally {
+        scheduler.shutdown();
+      }
+    });
+  }
+
+  private static MaterializedViewImpl newPeriodicView(final Database database) {
+    // interval is long enough that the refresh task never fires during the test
+    return new MaterializedViewImpl(database, "SchedulerView", "SELECT name FROM Source", "SchedulerView_backing",
+        List.of("Source"), MaterializedViewRefreshMode.PERIODIC, true, TimeUnit.HOURS.toMillis(1));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static ScheduledFuture<?> scheduledTask(final MaterializedViewScheduler scheduler, final String viewName)
+      throws Exception {
+    final Field field = MaterializedViewScheduler.class.getDeclaredField("tasks");
+    field.setAccessible(true);
+    return ((Map<String, ScheduledFuture<?>>) field.get(scheduler)).get(viewName);
+  }
+}


### PR DESCRIPTION
## What it does

Fixes #4548. `MaterializedViewScheduler.schedule()` replaced the entry in the `tasks` map without cancelling the previous `ScheduledFuture`, so re-scheduling the same view (for example when the schema is reloaded, `LocalSchema` line 1802) left the previous refresh task running forever, multiplying refresh load on the backing type.

The orphaned task also makes the cleanup guard misfire: its database-closed branch calls `cancel(view.getName())`, which removes the NEW task from the map while the orphan itself keeps running.

## Fix

`schedule()` now cancels any task already registered for the view before scheduling the new one. This is the same pattern `TimeSeriesMaintenanceScheduler.schedule()` already uses (remove + `cancel(false)` before put).

## Tests

New `MaterializedViewSchedulerTest` drives the scheduler directly with a 1 hour interval so no refresh ever fires during the test:

- `reschedulingCancelsThePreviousTask`: schedules the same view twice and asserts the first future is cancelled and the second is live. Red on main, green with the fix.
- `cancelStopsTheScheduledTask`: guards the existing `cancel()` behavior.

The captured futures are read from the private `tasks` map via reflection since the previous future is otherwise unreachable after the replacement (that unreachability is the leak itself). `MaterializedViewTest` and `MaterializedViewEdgeCaseTest` pass unchanged (29 tests total).
