### PR TITLE
fix(#4550): guard RemoteHttpComponent.getLeaderAddress against null leader

### DIFF
--- a/docs/4550-remote-http-component-get-leader-address-npe.md
+++ b/docs/4550-remote-http-component-get-leader-address-npe.md
@@ -46,4 +46,18 @@ public String getLeaderAddress() {
 
 ## Review Cycles
 
-None yet.
+### Cycle 1 (gemini-code-assist + claude bot)
+
+- **Empty contact-point list (gemini + claude):** With a null leader and no replicas,
+  `remoteAddresses` was empty, producing an empty `hosts[]` that made
+  `Cluster.addContactPoints` throw and log a misleading "plugin not available"
+  warning. Fixed: `ArcadeGraph.traversal()` now falls back to `Graph.super.traversal()`
+  when `remoteAddresses` is empty.
+- **Pre-existing `getFirst()` vs `get(i)` (claude):** The host-building loop used
+  `remoteAddresses.getFirst()` instead of `get(i)`, so every contact point was the
+  first address. Fixed since it sits in the same loop and my change made it reachable
+  with replica-only topologies.
+- **Remove docs file (claude):** Declined. `docs/<issue>-*.md` tracking docs are an
+  established committed convention in this repo (4274...4446, 4448).
+- **Reflection in test (claude):** Declined. The suggested override still uses
+  reflection internally and matches the existing #4372 race test in the same file.

--- a/docs/4550-remote-http-component-get-leader-address-npe.md
+++ b/docs/4550-remote-http-component-get-leader-address-npe.md
@@ -61,3 +61,21 @@ public String getLeaderAddress() {
   established committed convention in this repo (4274...4446, 4448).
 - **Reflection in test (claude):** Declined. The suggested override still uses
   reflection internally and matches the existing #4372 race test in the same file.
+
+### Cycle 2 (claude bot)
+
+- **Fallback caching after failover (claude):** Added a Javadoc note on
+  `ArcadeGraph.traversal()` documenting that the embedded fallback is cached for the
+  instance lifetime, so callers must recreate the `ArcadeGraph` to re-resolve topology
+  after a failover. (The permanent caching is pre-existing via the catch block.)
+- **Test gap for null-leader traversal (claude):** Added
+  `ArcadeGraphRemoteTraversalTest` (package `com.arcadedb.remote`, gremlin test tree)
+  asserting `traversal()` returns a usable fallback - no NPE - when leader and replicas
+  are both unknown. It guards the external contract; the pre-existing catch block also
+  yields a fallback, so it does not isolate the clean branch in isolation.
+- **Package-private setter / reflection (claude):** Declined again, same reasoning as
+  cycle 1.
+- **Trim Review Cycles section (claude):** Declined. Established committed convention
+  (4393, 4397, 4446, 4448).
+- **`String.valueOf` vs `"" +` (claude):** Declined. Pre-existing, cosmetic only; kept
+  the diff focused on the fix.

--- a/docs/4550-remote-http-component-get-leader-address-npe.md
+++ b/docs/4550-remote-http-component-get-leader-address-npe.md
@@ -1,0 +1,49 @@
+# Fix #4550: RemoteHttpComponent.getLeaderAddress NPE when no leader
+
+## Summary
+
+`RemoteHttpComponent.getLeaderAddress()` dereferences `leaderServer` at line 411-412
+without a null guard. `leaderServer` is `volatile` and is set to `null` by
+`reloadClusterConfiguration()` (line 550) during HA failover, and starts as `null`
+when `requestClusterConfiguration()` cannot populate it (e.g. non-HA server or
+network failure that triggers the fallback path at lines 459/466/511).
+
+## Root Cause
+
+```java
+public String getLeaderAddress() {
+  return leaderServer.getFirst() + ":" + leaderServer.getSecond(); // NPE when null
+}
+```
+
+## Affected Components
+
+- `network/src/main/java/com/arcadedb/remote/RemoteHttpComponent.java` (primary fix)
+- `gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java` (caller hardening)
+
+## Fix
+
+1. `getLeaderAddress()` - snapshot the volatile field once, return `null` if null.
+2. `ArcadeGraph.traversal()` - skip null leader address, still try replicas.
+
+## Test
+
+`RemoteHttpComponentTest` - two new unit tests using `TestableRemoteHttpComponent`
+(which keeps `requestClusterConfiguration()` as a no-op so `leaderServer` starts null).
+
+## Test Results
+
+- `network` module: 52 tests, 0 failures (2 new regression tests added)
+- `gremlin` module: 230 tests, 0 failures, 42 skipped
+
+## Status
+
+- [x] Analysis complete
+- [x] Tests written
+- [x] Fix implemented
+- [x] Build verified
+- [x] Tests passing
+
+## Review Cycles
+
+None yet.

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
@@ -170,9 +170,16 @@ public class ArcadeGraph implements Graph, Closeable {
           remoteAddresses.add(leaderAddress);
         remoteAddresses.addAll(remoteDatabase.getReplicaAddresses());
 
+        if (remoteAddresses.isEmpty()) {
+          // No leader and no replicas are known (e.g. non-HA server or mid-failover): fall back to the
+          // slower remote implementation rather than building a cluster with no contact points.
+          traversal = Graph.super.traversal();
+          return traversal;
+        }
+
         final String[] hosts = new String[remoteAddresses.size()];
         for (int i = 0; i < remoteAddresses.size(); i++)
-          hosts[i] = HostUtil.parseHostAddress(remoteAddresses.getFirst(), "" + GREMLIN_SERVER_PORT)[0];
+          hosts[i] = HostUtil.parseHostAddress(remoteAddresses.get(i), "" + GREMLIN_SERVER_PORT)[0];
 
         final GraphBinaryMessageSerializerV1 serializer = new GraphBinaryMessageSerializerV1(
             new TypeSerializerRegistry.Builder().addRegistry(new ArcadeIoRegistry()));

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
@@ -165,7 +165,9 @@ public class ArcadeGraph implements Graph, Closeable {
       try {
         final List<String> remoteAddresses = new ArrayList<>();
 
-        remoteAddresses.add(remoteDatabase.getLeaderAddress());
+        final String leaderAddress = remoteDatabase.getLeaderAddress();
+        if (leaderAddress != null)
+          remoteAddresses.add(leaderAddress);
         remoteAddresses.addAll(remoteDatabase.getReplicaAddresses());
 
         final String[] hosts = new String[remoteAddresses.size()];

--- a/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
+++ b/gremlin/src/main/java/com/arcadedb/gremlin/ArcadeGraph.java
@@ -156,6 +156,11 @@ public class ArcadeGraph implements Graph, Closeable {
 
   /**
    * Returns a Gremlin traversal. This traversal is executed outside the database's transaction if any.
+   * <p>
+   * The resolved traversal is cached for the lifetime of this instance. When the remote cluster topology is
+   * unknown at the time of the first call (no leader and no replicas, e.g. mid-failover), the slower embedded
+   * fallback is cached: callers that need to re-resolve the topology after a failover must recreate the
+   * {@code ArcadeGraph} instance.
    */
   public GraphTraversalSource traversal() {
     if (traversal != null)

--- a/gremlin/src/test/java/com/arcadedb/remote/ArcadeGraphRemoteTraversalTest.java
+++ b/gremlin/src/test/java/com/arcadedb/remote/ArcadeGraphRemoteTraversalTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.gremlin.ArcadeGraph;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that ArcadeGraph.traversal() degrades to the embedded fallback when the remote cluster topology
+ * is unknown (no leader and no replicas), instead of propagating a NullPointerException from
+ * RemoteHttpComponent.getLeaderAddress(). Lives in com.arcadedb.remote so the stub can override the
+ * package-private requestClusterConfiguration() and leave leaderServer null.
+ */
+class ArcadeGraphRemoteTraversalTest {
+
+  /**
+   * RemoteDatabase whose cluster configuration is never fetched, so leaderServer stays null and the
+   * replica list stays empty - the exact state that triggered the #4550 NPE.
+   */
+  static class NoLeaderRemoteDatabase extends RemoteDatabase {
+    NoLeaderRemoteDatabase() {
+      super("localhost", 2480, "test", "root", "test", new ContextConfiguration());
+    }
+
+    @Override
+    void requestClusterConfiguration() {
+      // No-op: leave leaderServer null and replicaServerList empty.
+    }
+  }
+
+  @Test
+  void traversalFallsBackWhenNoLeaderAndNoReplicas() {
+    final NoLeaderRemoteDatabase database = new NoLeaderRemoteDatabase();
+    assertThat(database.getLeaderAddress()).isNull();
+    assertThat(database.getReplicaAddresses()).isEmpty();
+
+    // ArcadeGraph.close() closes the wrapped database, so the try-with-resources covers both.
+    try (final ArcadeGraph graph = ArcadeGraph.open(database)) {
+      final GraphTraversalSource source = graph.traversal();
+      assertThat(source).isNotNull();
+    }
+  }
+}

--- a/network/src/main/java/com/arcadedb/remote/RemoteHttpComponent.java
+++ b/network/src/main/java/com/arcadedb/remote/RemoteHttpComponent.java
@@ -409,7 +409,8 @@ public class RemoteHttpComponent extends RWLockContext {
   }
 
   public String getLeaderAddress() {
-    return leaderServer.getFirst() + ":" + leaderServer.getSecond();
+    final Pair<String, Integer> snapshot = leaderServer;
+    return snapshot != null ? snapshot.getFirst() + ":" + snapshot.getSecond() : null;
   }
 
   public List<String> getReplicaAddresses() {

--- a/network/src/test/java/com/arcadedb/remote/RemoteHttpComponentTest.java
+++ b/network/src/test/java/com/arcadedb/remote/RemoteHttpComponentTest.java
@@ -640,4 +640,22 @@ class RemoteHttpComponentTest {
 
     assertThat(component.getUrl("command")).isEqualTo("http://localhost:2480/api/v1/command");
   }
+
+  // Regression tests for issue #4550: getLeaderAddress NPE when leaderServer is null
+
+  @Test
+  void getLeaderAddressReturnsNullWhenNoLeader() {
+    // TestableRemoteHttpComponent keeps requestClusterConfiguration() as a no-op,
+    // so leaderServer stays null after construction.
+    assertThat(component.getLeaderAddress()).isNull();
+  }
+
+  @Test
+  void getLeaderAddressFormatsAddressWhenLeaderIsKnown() throws Exception {
+    final Field f = RemoteHttpComponent.class.getDeclaredField("leaderServer");
+    f.setAccessible(true);
+    f.set(component, new Pair<>("db-leader.example.com", 2480));
+
+    assertThat(component.getLeaderAddress()).isEqualTo("db-leader.example.com:2480");
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #4550. `RemoteHttpComponent.getLeaderAddress()` dereferenced the volatile `leaderServer` field without a null guard, throwing an NPE whenever no leader was known.

`leaderServer` is legitimately `null` in two cases:
- After `reloadClusterConfiguration()` resets it to `null` during HA failover.
- When the client connects to a non-HA server (or a network failure triggers the direct-connection fallback before a leader is resolved).

Any caller checking the leader during/after an HA failure (or against a non-HA server) got an NPE instead of a clean answer.

## Changes

- **`network/.../RemoteHttpComponent.java`** - `getLeaderAddress()` snapshots the volatile field once and returns `null` when no leader is known, instead of NPE.
- **`gremlin/.../ArcadeGraph.java`** - `traversal()` skips a `null` leader address when building the Gremlin contact-point list, so replica addresses are still tried.

## Tests

Added two regression tests to `RemoteHttpComponentTest`:
- `getLeaderAddressReturnsNullWhenNoLeader` - returns `null` when no cluster config is loaded.
- `getLeaderAddressFormatsAddressWhenLeaderIsKnown` - still formats `host:port` when a leader is set.

Results: `network` 52/52, `gremlin` 230/230 (42 skipped by annotation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)