### PR TITLE
fix(#4549): join async worker threads in DatabaseAsyncExecutorImpl.kill()

### DIFF
--- a/docs/4549-async-executor-kill-join-workers.md
+++ b/docs/4549-async-executor-kill-join-workers.md
@@ -54,8 +54,23 @@ workers were still mutating now-closed structures.
 
 ## Review Cycles
 
-_(none yet)_
+### Cycle 1 (PR #4573)
+
+- **gemini-code-assist + claude bot:** `InterruptedException` in the join loop re-asserted the
+  interrupt flag mid-loop, so the next `join(1000)` threw immediately and remaining threads were
+  skipped without waiting. Adopted the deferred-reinterrupt pattern: record `interrupted` in a
+  local, keep joining every thread, re-assert the interrupt status once after the loop. Chosen
+  over gemini's `break` because `kill()`'s contract is to stop *all* workers - breaking would
+  abandon the remaining threads. Mirrors the single-span interrupt handling in
+  `shutdownThreadsLocked()`.
+- **claude bot (soft, non-blocking):** added a WARNING log when a thread is still alive after its
+  1s join timeout, to aid production diagnosis of hangs.
+- **claude bot - "remove this docs file":** declined. Committed `docs/<issue>-*.md` tracking docs
+  with `Review cycles` + `Final state` sections are an established repo convention (e.g.
+  docs/4397, 4393, 4446, 4332). The stale "not committed" line was the only genuine issue and is
+  corrected below.
 
 ## Final State
 
-Fix staged, not committed (standalone invocation - developer reviews before committing).
+Fix committed and pushed; PR #4573. Cycle-1 review items addressed (deferred-reinterrupt join
+loop + timeout warning log).

--- a/docs/4549-async-executor-kill-join-workers.md
+++ b/docs/4549-async-executor-kill-join-workers.md
@@ -70,7 +70,22 @@ workers were still mutating now-closed structures.
   docs/4397, 4393, 4446, 4332). The stale "not committed" line was the only genuine issue and is
   corrected below.
 
+### Cycle 2 (PR #4573)
+
+- **claude bot:** confirmed all cycle-1 fixes correct and agreed the tracking doc follows the
+  established `docs/` convention (59 sibling per-issue docs). Two new items:
+  - **Redundant `t.isAlive()` in the test filter** - `Thread.getAllStackTraces()` only reports
+    live threads, so the extra `isAlive()` check was dead. Removed; the post-kill filter now
+    mirrors the pre-kill one.
+  - **`shutdownThreadsLocked()` has the same interrupt-skip pattern** - declined for this PR.
+    Reviewer itself labelled it "pre-existing, out of scope." That method interleaves a blocking,
+    interruptible `queue.put(FORCE_EXIT)` with `join(10000)` and sits on the production `close()`
+    path (not the test-only `kill()` path), so a deferred-reinterrupt refactor there is separate
+    work with its own regression surface. Tracked as a follow-up rather than widening #4549.
+
 ## Final State
 
-Fix committed and pushed; PR #4573. Cycle-1 review items addressed (deferred-reinterrupt join
-loop + timeout warning log).
+Fix committed and pushed; PR #4573. Cycle-1 (deferred-reinterrupt join loop + timeout warning
+log) and cycle-2 (redundant test filter removed) review items addressed. One deliberate
+out-of-scope follow-up noted: apply the same deferred-reinterrupt pattern to
+`shutdownThreadsLocked()`.

--- a/docs/4549-async-executor-kill-join-workers.md
+++ b/docs/4549-async-executor-kill-join-workers.md
@@ -83,9 +83,17 @@ workers were still mutating now-closed structures.
     path (not the test-only `kill()` path), so a deferred-reinterrupt refactor there is separate
     work with its own regression surface. Tracked as a follow-up rather than widening #4549.
 
+### Cycle 3 (PR #4573)
+
+- **claude bot:** approved ("Ready to merge"). All fixes confirmed correct, the
+  `shutdownThreadsLocked()` follow-up agreed as correctly deferred. One optional observation
+  (explicitly "this is fine"): the test asserted only thread death, not post-`kill()` database
+  state. `LocalDatabase.kill()` sets `open = false` in its `finally`, so that invariant is
+  well-defined - added `assertThat(database.isOpen()).isFalse()` to make the contract explicit.
+
 ## Final State
 
-Fix committed and pushed; PR #4573. Cycle-1 (deferred-reinterrupt join loop + timeout warning
-log) and cycle-2 (redundant test filter removed) review items addressed. One deliberate
-out-of-scope follow-up noted: apply the same deferred-reinterrupt pattern to
-`shutdownThreadsLocked()`.
+Fix committed and pushed; PR #4573, approved at cycle 3. Cycle-1 (deferred-reinterrupt join loop
++ timeout warning log), cycle-2 (redundant test filter removed), and cycle-3 (post-kill
+`isOpen()==false` assertion) review items addressed. One deliberate out-of-scope follow-up noted:
+apply the same deferred-reinterrupt pattern to `shutdownThreadsLocked()`.

--- a/docs/4549-async-executor-kill-join-workers.md
+++ b/docs/4549-async-executor-kill-join-workers.md
@@ -1,0 +1,61 @@
+# Fix #4549: `DatabaseAsyncExecutorImpl.kill()` does not join worker threads
+
+## Issue Summary
+
+`kill()` sets `forceShutdown = true` on each `AsyncThread` but then returns immediately.
+The comment read "WAIT FOR SHUTDOWN, MAX 1S EACH" yet no `interrupt()` or `join()` call was
+present. Worker threads continued running after `kill()` returned, operating on structures
+already closed by `LocalDatabase.closeInternal()` and producing spurious errors.
+
+## Root Cause
+
+`kill()` (lines 670-681 before fix) did:
+1. Unpublish `executorThreads` (set to null)
+2. Set `forceShutdown = true` on each thread
+
+Missing:
+- `interrupt()` - without this a thread blocked in `queue.poll(500, MILLISECONDS)` takes up to
+  500 ms to notice the flag flip
+- `join(1000)` - without this the method returns before threads have stopped
+
+## Fix
+
+In `kill()`, after setting `forceShutdown = true`, call `interrupt()` on every thread (outside
+the synchronized block to avoid holding `lifecycleLock` while blocking), then `join(1000)` on
+each. The `AsyncThread.run()` already handles `InterruptedException` correctly (clears the queue
+and breaks the loop at lines 182-185), so interrupt is always safe to call.
+
+## Files Changed
+
+- `engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java`
+  - `kill()` method: interrupt threads, then join with 1-second timeout per thread
+- `engine/src/test/java/com/arcadedb/database/async/DatabaseAsyncExecutorKillTest.java` (new)
+  - Regression test verifying no async worker threads survive after `kill()` returns
+
+## Test Results
+
+All 30 related tests pass with no regressions (`mvn test -pl engine -Dtest="DatabaseAsync*,AsyncTest,ACIDTransactionTest"`):
+- `DatabaseAsyncExecutorKillTest#killWaitsForWorkerThreadsToStop` (new) - fails before fix
+  (2 worker threads alive after `kill()`), passes after
+- `ACIDTransactionTest` (11 tests, direct `kill()` callers) - green
+- `DatabaseAsyncExecutorLifecycleRaceTest#concurrentLifecycleChangesDoNotNPE` - green
+- `AsyncTest` (11), `DatabaseAsyncRecordRollbackOnExceptionTest` (4), retry tests - green
+
+## Impact Analysis
+
+`kill()` now interrupts every worker (waking any blocked in the 500 ms `queue.poll`) and
+joins with a 1-second timeout each before returning. The interrupt/join loop runs OUTSIDE the
+`lifecycleLock` so the lock is not held while blocking - concurrent `getThreadCount`/`getStats`
+readers (which already null-check the snapshot) are unaffected since `executorThreads` was set
+to null inside the lock before releasing it. `AsyncThread.run()` already handles
+`InterruptedException` (clears queue, breaks) so interrupt is always safe. This closes the
+window in which `LocalDatabase.kill()` -> `schema.close()`/`fileManager.close()` ran while async
+workers were still mutating now-closed structures.
+
+## Review Cycles
+
+_(none yet)_
+
+## Final State
+
+Fix staged, not committed (standalone invocation - developer reviews before committing).

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -668,15 +668,25 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
    */
   @Override
   public void kill() {
+    final AsyncThread[] threads;
     synchronized (lifecycleLock) {
-      final AsyncThread[] threads = executorThreads;
+      threads = executorThreads;
       if (threads == null)
         return;
       // Unpublish first so concurrent callers stop targeting the about-to-die threads.
       executorThreads = null;
-      // WAIT FOR SHUTDOWN, MAX 1S EACH
       for (int i = 0; i < threads.length; ++i)
         threads[i].forceShutdown = true;
+    }
+    // WAIT FOR SHUTDOWN, MAX 1S EACH - interrupt to wake threads from blocking queue poll
+    for (int i = 0; i < threads.length; ++i)
+      threads[i].interrupt();
+    for (int i = 0; i < threads.length; ++i) {
+      try {
+        threads[i].join(1000);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -681,13 +681,21 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     // WAIT FOR SHUTDOWN, MAX 1S EACH - interrupt to wake threads from blocking queue poll
     for (int i = 0; i < threads.length; ++i)
       threads[i].interrupt();
+    // Defer re-asserting the caller's interrupt status until every thread has been joined: setting
+    // it mid-loop makes the next join() throw immediately, skipping the remaining threads.
+    boolean interrupted = false;
     for (int i = 0; i < threads.length; ++i) {
       try {
         threads[i].join(1000);
       } catch (final InterruptedException e) {
-        Thread.currentThread().interrupt();
+        interrupted = true;
       }
+      if (threads[i].isAlive())
+        LogManager.instance()
+            .log(this, Level.WARNING, "AsyncThread %s did not stop within 1s after kill()", threads[i].getName());
     }
+    if (interrupted)
+      Thread.currentThread().interrupt();
   }
 
   public void close() {

--- a/engine/src/test/java/com/arcadedb/database/async/DatabaseAsyncExecutorKillTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/DatabaseAsyncExecutorKillTest.java
@@ -53,9 +53,10 @@ class DatabaseAsyncExecutorKillTest extends TestHelper {
     // kill() must block until all workers have terminated.
     ((DatabaseInternal) database).kill();
 
-    // After kill() returns, all AsyncExecutor-* threads for this database must be dead.
+    // After kill() returns, no AsyncExecutor-* thread for this database may remain.
+    // Thread.getAllStackTraces() only reports live threads, so a matching name here means alive.
     final Set<Thread> workersAfter = Thread.getAllStackTraces().keySet().stream()
-        .filter(t -> t.getName().startsWith(threadPrefix) && t.isAlive())
+        .filter(t -> t.getName().startsWith(threadPrefix))
         .collect(Collectors.toSet());
     assertThat(workersAfter).as("async worker threads still alive after kill()").isEmpty();
   }

--- a/engine/src/test/java/com/arcadedb/database/async/DatabaseAsyncExecutorKillTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/DatabaseAsyncExecutorKillTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression for {@code DatabaseAsyncExecutorImpl.kill()} returning before worker threads have
+ * actually stopped. Without the fix, threads continued running (polling the queue, mutating the
+ * database) after {@code kill()} returned, causing spurious errors when
+ * {@code LocalDatabase.closeInternal()} closed internal components while async workers were still
+ * active.
+ */
+class DatabaseAsyncExecutorKillTest extends TestHelper {
+
+  @Test
+  void killWaitsForWorkerThreadsToStop() throws Exception {
+    final int parallelLevel = 2;
+    database.async().setParallelLevel(parallelLevel);
+
+    final String threadPrefix = "AsyncExecutor-" + database.getName() + "-";
+
+    // Confirm the worker threads are alive before kill.
+    final Set<Thread> workersBefore = Thread.getAllStackTraces().keySet().stream()
+        .filter(t -> t.getName().startsWith(threadPrefix))
+        .collect(Collectors.toSet());
+    assertThat(workersBefore).as("expected %d async worker threads before kill()", parallelLevel)
+        .hasSize(parallelLevel);
+
+    // kill() must block until all workers have terminated.
+    ((DatabaseInternal) database).kill();
+
+    // After kill() returns, all AsyncExecutor-* threads for this database must be dead.
+    final Set<Thread> workersAfter = Thread.getAllStackTraces().keySet().stream()
+        .filter(t -> t.getName().startsWith(threadPrefix) && t.isAlive())
+        .collect(Collectors.toSet());
+    assertThat(workersAfter).as("async worker threads still alive after kill()").isEmpty();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/async/DatabaseAsyncExecutorKillTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/DatabaseAsyncExecutorKillTest.java
@@ -59,5 +59,8 @@ class DatabaseAsyncExecutorKillTest extends TestHelper {
         .filter(t -> t.getName().startsWith(threadPrefix))
         .collect(Collectors.toSet());
     assertThat(workersAfter).as("async worker threads still alive after kill()").isEmpty();
+
+    // kill() leaves the database closed and unusable - the defined post-kill invariant.
+    assertThat(database.isOpen()).as("database must be closed after kill()").isFalse();
   }
 }


### PR DESCRIPTION
## Summary

Fixes #4549. `DatabaseAsyncExecutorImpl.kill()` set `forceShutdown = true` on each `AsyncThread` and nulled the `executorThreads` reference, then returned without interrupting or joining the workers. The comment claimed "WAIT FOR SHUTDOWN, MAX 1S EACH" but no `join()` was present, so worker threads kept polling the queue and mutating the database after `kill()` returned.

`LocalDatabase.kill()` then closed internal components (`schema`, `fileManager`, `transactionManager`) while async threads were still active, producing spurious errors on the now-closed structures.

## Fix

`kill()` now:
1. Inside `synchronized (lifecycleLock)`: captures the thread snapshot, nulls `executorThreads`, sets `forceShutdown = true`.
2. **Outside** the lock: `interrupt()` each thread (waking any blocked in the 500 ms `queue.poll`), then `join(1000)` each.

The interrupt/join loop runs outside `lifecycleLock` so the lock is not held while blocking. `executorThreads` is still nulled inside the lock before release, so concurrent `getThreadCount`/`getStats` readers (which null-check the snapshot) are unaffected. `AsyncThread.run()` already handles `InterruptedException` (clears the queue, breaks the loop), so the interrupt is always safe.

## Testing

New regression test `DatabaseAsyncExecutorKillTest#killWaitsForWorkerThreadsToStop`:
- Asserts the `AsyncExecutor-<db>-*` worker threads are alive before `kill()`, and none survive after.
- **Fails before the fix** (2 worker threads still alive after `kill()`), passes after.

No regressions: all 30 related tests green, including `ACIDTransactionTest` (11 tests that call `kill()` directly), `DatabaseAsyncExecutorLifecycleRaceTest`, and `AsyncTest`.
