### PR TITLE
fix: [#4592] align numeric types in SQL min()/max() over collections

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionMax.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionMax.java
@@ -48,7 +48,13 @@ public class SQLFunctionMax extends SQLAggregatedFunction {
     Object max = null;
     for (Object item : params) {
       if (item instanceof Collection<?> collection) {
-        for (final Object subitem : collection) {
+        for (Object subitem : collection) {
+          if (subitem instanceof Number number && max instanceof Number number1 &&//
+              !subitem.getClass().equals(max.getClass())) {
+            final Number[] converted = Type.castComparableNumber(number, number1);
+            subitem = converted[0];
+            max = converted[1];
+          }
           if (max == null || subitem != null && ((Comparable) subitem).compareTo(max) > 0)
             max = subitem;
         }

--- a/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionMin.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/math/SQLFunctionMin.java
@@ -49,7 +49,13 @@ public class SQLFunctionMin extends SQLAggregatedFunction {
     Object min = null;
     for (Object item : params) {
       if (item instanceof Collection<?> collection) {
-        for (final Object subitem : collection) {
+        for (Object subitem : collection) {
+          if (subitem instanceof Number number && min instanceof Number number1 &&//
+              !subitem.getClass().equals(min.getClass())) {
+            final Number[] converted = Type.castComparableNumber(number, number1);
+            subitem = converted[0];
+            min = converted[1];
+          }
           if (min == null || subitem != null && ((Comparable) subitem).compareTo(min) < 0)
             min = subitem;
         }

--- a/engine/src/test/java/com/arcadedb/function/AggregatedFunctionTest.java
+++ b/engine/src/test/java/com/arcadedb/function/AggregatedFunctionTest.java
@@ -19,8 +19,13 @@
 package com.arcadedb.function;
 
 import com.arcadedb.database.Identifiable;
+import com.arcadedb.function.sql.math.SQLFunctionMax;
+import com.arcadedb.function.sql.math.SQLFunctionMin;
 import com.arcadedb.query.sql.executor.CommandContext;
 import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -86,6 +91,32 @@ class AggregatedFunctionTest {
     fn.execute(null, null, null, new Object[]{20}, null);
 
     assertThat(fn.getResult()).isEqualTo(30);
+  }
+
+  @Test
+  void minOnCollectionWithMixedNumericTypes() {
+    // GH #4592: the collection branch must align numeric types before compareTo,
+    // otherwise min([5L, 3.0d]) triggers Double.compareTo(Long) and throws CCE.
+    final SQLFunctionMin fn = new SQLFunctionMin();
+    final Object result = fn.execute(null, null, null, new Object[] { Arrays.asList(5L, 3.0d) }, null);
+    assertThat(((Number) result).doubleValue()).isEqualTo(3.0);
+  }
+
+  @Test
+  void maxOnCollectionWithMixedNumericTypes() {
+    // GH #4592
+    final SQLFunctionMax fn = new SQLFunctionMax();
+    final Object result = fn.execute(null, null, null, new Object[] { Arrays.asList(5L, 3.0d) }, null);
+    assertThat(((Number) result).doubleValue()).isEqualTo(5.0);
+  }
+
+  @Test
+  void minOnCollectionWithNullSubitemsAndMixedTypes() {
+    // GH #4592: null subitems stay ignored even with type alignment in place.
+    final SQLFunctionMin fn = new SQLFunctionMin();
+    final List<Object> values = Arrays.asList(5L, null, 2.0d, null);
+    final Object result = fn.execute(null, null, null, new Object[] { values }, null);
+    assertThat(((Number) result).doubleValue()).isEqualTo(2.0);
   }
 
   private AggregatedFunction createCountFunction() {


### PR DESCRIPTION
Fixes #4592.

## Problem

`SQLFunctionMin` / `SQLFunctionMax` align numeric types with `Type.castComparableNumber` before calling `compareTo` in the non-collection branch, but the collection branch did not. So a collection with mixed numeric types, e.g. `min([5L, 3.0d])`, reached `Double.compareTo(Long)` and threw a `ClassCastException`. MIN/MAX over collection-valued fields with heterogeneous numeric types crashed the query.

## Fix

Apply the same `castComparableNumber` alignment inside the collection loop, mirroring the non-collection branch in both `SQLFunctionMin` and `SQLFunctionMax`. Null subitems remain ignored, exactly as before.

## Verification

Added three regression tests to `AggregatedFunctionTest` (mixed-type min over a collection, mixed-type max over a collection, and a null-subitem case). They throw the reported `ClassCastException` on `main` and pass with the fix.

Connected function/SQL suites stay green: `AggregatedFunctionTest` (10), `SQLFunctionsTest` (32), `SQLFunctionAdditionalCoverageTest` (48), `MathFunctionLargeDoubleTest` (10).

Done under my direction with AI assistance.
