### PR TITLE
fix: [#4597] return NaN for empty MIN/MAX buckets instead of the init sentinel

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/timeseries/MultiColumnAggregationResult.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/MultiColumnAggregationResult.java
@@ -280,12 +280,29 @@ public final class MultiColumnAggregationResult {
   public double getValue(final long bucketTs, final int requestIndex) {
     if (flatMode) {
       final int idx = flatIndex(bucketTs);
-      if (idx >= 0 && idx < maxBuckets && bucketUsed[idx])
+      if (idx >= 0 && idx < maxBuckets && bucketUsed[idx]) {
+        if (isUnusedMinMax(flatCounts[idx], requestIndex))
+          return Double.NaN;
         return flatValues[idx][requestIndex];
+      }
       return 0.0;
     }
     final double[] vals = valuesByBucket.get(bucketTs);
-    return vals != null ? vals[requestIndex] : 0.0;
+    if (vals == null)
+      return 0.0;
+    if (isUnusedMinMax(countsByBucket.get(bucketTs), requestIndex))
+      return Double.NaN;
+    return vals[requestIndex];
+  }
+
+  /**
+   * A bucket is flagged used as soon as any request touches it, but a MIN/MAX request that received
+   * no data keeps its {@code Double.MAX_VALUE} / {@code -Double.MAX_VALUE} init sentinel. Surface that
+   * as NaN (the absent marker, issue #4596) instead of leaking the sentinel as if it were data.
+   */
+  private boolean isUnusedMinMax(final long[] counts, final int requestIndex) {
+    final AggregationType type = types[requestIndex];
+    return (type == AggregationType.MIN || type == AggregationType.MAX) && counts != null && counts[requestIndex] == 0;
   }
 
   public long getCount(final long bucketTs, final int requestIndex) {

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/MultiColumnAggregationResultTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/MultiColumnAggregationResultTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4592 sibling #4597: {@code getValue} must not leak the internal
+ * {@code Double.MAX_VALUE} / {@code -Double.MAX_VALUE} MIN/MAX sentinel when a bucket is touched by
+ * another request (e.g. COUNT) but the MIN/MAX request itself received no data. The agreed
+ * NaN-as-absent policy (issue #4596) applies here too.
+ */
+class MultiColumnAggregationResultTest {
+
+  private static List<MultiColumnAggregationRequest> minThenCount() {
+    return List.of(new MultiColumnAggregationRequest(1, AggregationType.MIN, "minA"),
+        new MultiColumnAggregationRequest(2, AggregationType.COUNT, "countB"));
+  }
+
+  private static List<MultiColumnAggregationRequest> maxThenCount() {
+    return List.of(new MultiColumnAggregationRequest(1, AggregationType.MAX, "maxA"),
+        new MultiColumnAggregationRequest(2, AggregationType.COUNT, "countB"));
+  }
+
+  @Test
+  void mapModeEmptyMinReturnsNaNWhenBucketTouchedByAnotherRequest() {
+    final MultiColumnAggregationResult result = new MultiColumnAggregationResult(minThenCount());
+    // only the COUNT request gets data in this bucket; the MIN request stays empty
+    result.accumulate(1000L, 1, 7.0);
+    assertThat(result.getCount(1000L, 0)).isZero();
+    assertThat(result.getValue(1000L, 0)).isNaN();
+    assertThat(result.getValue(1000L, 1)).isEqualTo(1.0); // COUNT is real
+  }
+
+  @Test
+  void mapModeEmptyMaxReturnsNaN() {
+    final MultiColumnAggregationResult result = new MultiColumnAggregationResult(maxThenCount());
+    result.accumulate(1000L, 1, 7.0);
+    assertThat(result.getValue(1000L, 0)).isNaN();
+  }
+
+  @Test
+  void flatModeEmptyMinReturnsNaN() {
+    final MultiColumnAggregationResult result = new MultiColumnAggregationResult(minThenCount(), 0L, 1000L, 16);
+    result.accumulate(1000L, 1, 7.0);
+    assertThat(result.isFlatMode()).isTrue();
+    assertThat(result.getValue(1000L, 0)).isNaN();
+  }
+
+  @Test
+  void populatedMinReturnsRealValueNotSentinelNorNaN() {
+    final MultiColumnAggregationResult result = new MultiColumnAggregationResult(minThenCount());
+    result.accumulate(1000L, 0, 4.0);
+    result.accumulate(1000L, 0, 2.0);
+    result.accumulate(1000L, 1, 9.0);
+    assertThat(result.getValue(1000L, 0)).isEqualTo(2.0);
+  }
+
+  @Test
+  void emptySumAndCountStayZeroNotNaN() {
+    final MultiColumnAggregationResult result = new MultiColumnAggregationResult(
+        List.of(new MultiColumnAggregationRequest(1, AggregationType.SUM, "sumA"),
+            new MultiColumnAggregationRequest(2, AggregationType.COUNT, "countB")));
+    result.accumulate(1000L, 1, 7.0);
+    // SUM/COUNT of nothing is 0, not NaN
+    assertThat(result.getValue(1000L, 0)).isEqualTo(0.0);
+  }
+}


### PR DESCRIPTION
Fixes #4597.

### Problem

`MultiColumnAggregationResult.getValue` returned a bucket's stored value whenever `bucketUsed[idx]` was set. But `bucketUsed` is per-bucket, not per-request: a bucket is flagged used as soon as **any** request touches it. When a MIN/MAX request received no data (its column was all-null in that bucket while, say, a COUNT on another column had rows), its slot kept the `newInitializedValues` sentinel (`Double.MAX_VALUE` for MIN, `-Double.MAX_VALUE` for MAX) and `getValue` returned it verbatim. `AggregateFromTimeSeriesStep` writes that straight onto the output row, so a multi-column query mixing MIN/MAX with COUNT could report `min = 1.7976931348623157E308`.

### Fix

In `getValue`, when the request is MIN/MAX and its per-request count for the bucket is `0`, return `Double.NaN` instead of the sentinel. NaN is already the agreed absent marker across the time-series MIN/MAX paths (issue #4596), so this is consistent with the rest of the engine. SUM/COUNT keep returning `0` for an empty bucket, and the internal sentinel is left untouched so the flat-mode `mergeFrom` and map-mode merge logic (which rely on it) are unaffected.

### Tests

New `MultiColumnAggregationResultTest` (5 cases, both flat and map mode): an empty MIN and MAX in a COUNT-touched bucket now return NaN; a populated MIN still returns the real minimum; empty SUM/COUNT still return 0. The three sentinel cases fail on `main` (`1.79e308`/`-1.79e308`) and pass with the fix. The existing time-series suites (NaN-handling, block-stats, accuracy, single-bucket-anchor, negative-timestamp, metrics) stay green.