### PR TITLE
feat: [#4467] optional OpenTelemetry distributed tracing module

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -246,22 +246,22 @@ plugin; not on the core/server compile classpath.
 
 | Group ID | Artifact ID | Version | License | Homepage |
 |----------|-------------|---------|---------|----------|
-| io.micrometer | micrometer-tracing | 1.6.5 | Apache 2.0 | https://micrometer.io/ |
-| io.micrometer | micrometer-tracing-bridge-otel | 1.6.5 | Apache 2.0 | https://micrometer.io/ |
-| io.opentelemetry | opentelemetry-sdk | 1.55.0 | Apache 2.0 | https://opentelemetry.io/ |
-| io.opentelemetry | opentelemetry-api | 1.55.0 | Apache 2.0 | https://opentelemetry.io/ |
-| io.opentelemetry | opentelemetry-context | 1.55.0 | Apache 2.0 | https://opentelemetry.io/ |
-| io.opentelemetry | opentelemetry-sdk-trace | 1.55.0 | Apache 2.0 | https://opentelemetry.io/ |
-| io.opentelemetry | opentelemetry-sdk-common | 1.55.0 | Apache 2.0 | https://opentelemetry.io/ |
-| io.opentelemetry | opentelemetry-exporter-otlp | 1.55.0 | Apache 2.0 | https://opentelemetry.io/ |
-| io.opentelemetry | opentelemetry-exporter-otlp-common | 1.55.0 | Apache 2.0 | https://opentelemetry.io/ |
-| io.opentelemetry | opentelemetry-exporter-common | 1.55.0 | Apache 2.0 | https://opentelemetry.io/ |
-| io.opentelemetry | opentelemetry-exporter-sender-okhttp | 1.55.0 | Apache 2.0 | https://opentelemetry.io/ |
-| io.opentelemetry | opentelemetry-extension-trace-propagators | 1.55.0 | Apache 2.0 | https://opentelemetry.io/ |
-| io.opentelemetry.semconv | opentelemetry-semconv | 1.37.0 | Apache 2.0 | https://opentelemetry.io/ |
-| com.squareup.okhttp3 | okhttp | 5.2.1 | Apache 2.0 | https://square.github.io/okhttp/ |
-| com.squareup.okio | okio | 3.16.1 | Apache 2.0 | https://square.github.io/okio/ |
-| org.jetbrains.kotlin | kotlin-stdlib | 2.2.20 | Apache 2.0 | https://kotlinlang.org/ |
+| io.micrometer | micrometer-tracing | 1.7.0 | Apache 2.0 | https://micrometer.io/ |
+| io.micrometer | micrometer-tracing-bridge-otel | 1.7.0 | Apache 2.0 | https://micrometer.io/ |
+| io.opentelemetry | opentelemetry-sdk | 1.62.0 | Apache 2.0 | https://opentelemetry.io/ |
+| io.opentelemetry | opentelemetry-api | 1.62.0 | Apache 2.0 | https://opentelemetry.io/ |
+| io.opentelemetry | opentelemetry-context | 1.62.0 | Apache 2.0 | https://opentelemetry.io/ |
+| io.opentelemetry | opentelemetry-sdk-trace | 1.62.0 | Apache 2.0 | https://opentelemetry.io/ |
+| io.opentelemetry | opentelemetry-sdk-common | 1.62.0 | Apache 2.0 | https://opentelemetry.io/ |
+| io.opentelemetry | opentelemetry-exporter-otlp | 1.62.0 | Apache 2.0 | https://opentelemetry.io/ |
+| io.opentelemetry | opentelemetry-exporter-otlp-common | 1.62.0 | Apache 2.0 | https://opentelemetry.io/ |
+| io.opentelemetry | opentelemetry-exporter-common | 1.62.0 | Apache 2.0 | https://opentelemetry.io/ |
+| io.opentelemetry | opentelemetry-exporter-sender-okhttp | 1.62.0 | Apache 2.0 | https://opentelemetry.io/ |
+| io.opentelemetry | opentelemetry-extension-trace-propagators | 1.62.0 | Apache 2.0 | https://opentelemetry.io/ |
+| io.opentelemetry.semconv | opentelemetry-semconv | 1.41.1 | Apache 2.0 | https://opentelemetry.io/ |
+| com.squareup.okhttp3 | okhttp | 5.3.2 | Apache 2.0 | https://square.github.io/okhttp/ |
+| com.squareup.okio | okio | 3.16.4 | Apache 2.0 | https://square.github.io/okio/ |
+| org.jetbrains.kotlin | kotlin-stdlib | 2.2.21 | Apache 2.0 | https://kotlinlang.org/ |
 | org.jetbrains | annotations | 13.0 | Apache 2.0 | https://github.com/JetBrains/java-annotations |
 
 ---

--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -239,6 +239,31 @@ The following table lists runtime dependencies bundled with ArcadeDB distributio
 | io.micrometer | micrometer-registry-otlp | 1.16.5 | Apache 2.0 | https://micrometer.io/ |
 | org.hdrhistogram | HdrHistogram | 2.2.2 | Public Domain / CC0 | https://hdrhistogram.github.io/HdrHistogram/ |
 
+### Distributed Tracing (Optional)
+
+Used only by the optional `tracing` module (OpenTelemetry distributed tracing). Confined to that
+plugin; not on the core/server compile classpath.
+
+| Group ID | Artifact ID | Version | License | Homepage |
+|----------|-------------|---------|---------|----------|
+| io.micrometer | micrometer-tracing | 1.6.5 | Apache 2.0 | https://micrometer.io/ |
+| io.micrometer | micrometer-tracing-bridge-otel | 1.6.5 | Apache 2.0 | https://micrometer.io/ |
+| io.opentelemetry | opentelemetry-sdk | 1.55.0 | Apache 2.0 | https://opentelemetry.io/ |
+| io.opentelemetry | opentelemetry-api | 1.55.0 | Apache 2.0 | https://opentelemetry.io/ |
+| io.opentelemetry | opentelemetry-context | 1.55.0 | Apache 2.0 | https://opentelemetry.io/ |
+| io.opentelemetry | opentelemetry-sdk-trace | 1.55.0 | Apache 2.0 | https://opentelemetry.io/ |
+| io.opentelemetry | opentelemetry-sdk-common | 1.55.0 | Apache 2.0 | https://opentelemetry.io/ |
+| io.opentelemetry | opentelemetry-exporter-otlp | 1.55.0 | Apache 2.0 | https://opentelemetry.io/ |
+| io.opentelemetry | opentelemetry-exporter-otlp-common | 1.55.0 | Apache 2.0 | https://opentelemetry.io/ |
+| io.opentelemetry | opentelemetry-exporter-common | 1.55.0 | Apache 2.0 | https://opentelemetry.io/ |
+| io.opentelemetry | opentelemetry-exporter-sender-okhttp | 1.55.0 | Apache 2.0 | https://opentelemetry.io/ |
+| io.opentelemetry | opentelemetry-extension-trace-propagators | 1.55.0 | Apache 2.0 | https://opentelemetry.io/ |
+| io.opentelemetry.semconv | opentelemetry-semconv | 1.37.0 | Apache 2.0 | https://opentelemetry.io/ |
+| com.squareup.okhttp3 | okhttp | 5.2.1 | Apache 2.0 | https://square.github.io/okhttp/ |
+| com.squareup.okio | okio | 3.16.1 | Apache 2.0 | https://square.github.io/okio/ |
+| org.jetbrains.kotlin | kotlin-stdlib | 2.2.20 | Apache 2.0 | https://kotlinlang.org/ |
+| org.jetbrains | annotations | 13.0 | Apache 2.0 | https://github.com/JetBrains/java-annotations |
+
 ---
 
 ## Test Dependencies

--- a/NOTICE
+++ b/NOTICE
@@ -173,5 +173,29 @@ This product includes software developed by FasterXML, LLC.
 
 ================================================================================
 
+This product includes Micrometer Tracing (optional tracing module only).
+
+  Micrometer Tracing
+  Copyright (c) 2017-Present VMware, Inc. All Rights Reserved.
+
+  https://micrometer.io/
+
+  Micrometer Tracing contains modified portions of:
+    - 'io.netty.util.internal.logging' from Netty (Copyright 2013 The Netty Project, Apache 2.0, https://netty.io)
+    - 'StringUtils.isBlank()' from Apache Commons Lang (Copyright 2001-2019 The Apache Software Foundation, Apache 2.0)
+    - 'JsonUtf8Writer' from Moshi (Copyright 2010 Google Inc., Apache 2.0, https://github.com/square/moshi)
+    - the 'org.springframework.lang' package from the Spring Framework (Copyright 2002-2019 the original author or authors, Apache 2.0)
+
+================================================================================
+
+This product includes OpenTelemetry Java (optional tracing module only).
+
+  OpenTelemetry Java
+  Copyright The OpenTelemetry Authors
+
+  https://opentelemetry.io/
+
+================================================================================
+
 For the complete list of third-party components and their licenses, see the
 ATTRIBUTIONS.md file in the root directory of this distribution.

--- a/docs/4467-distributed-tracing.md
+++ b/docs/4467-distributed-tracing.md
@@ -1,0 +1,100 @@
+# Issue #4467 - Observability Pillar 2: Distributed Tracing (OpenTelemetry)
+
+**Branch:** `feat/4467-distributed-tracing`
+**Type:** feature
+**Spec:** `docs/superpowers/specs/2026-06-03-observability-cloud-design.md`
+**Plan:** `docs/superpowers/plans/2026-06-03-observability-p2-tracing.md`
+**Parent:** #4463 (Cloud Observability Architecture). Depends on Pillar 1 (#4465, merged via PR #4532).
+
+## Goal
+
+Add a new optional Maven module `tracing` that, when enabled, registers an OpenTelemetry tracer
+into Micrometer's `ObservationRegistry` so the HTTP instrumentation point produces OTLP-exported
+spans - with the OTel SDK kept entirely off the core/server compile classpath.
+
+## State of Pillar 1 on main (verified before starting)
+
+- HTTP latency is recorded by a **direct `Timer.builder("arcadedb.http.requests")`** in
+  `AbstractServerHttpHandler.handleRequest`'s `finally` block (tags: `method`, `path`, `status`,
+  `db`; `pathTemplate(exchange)` + `databaseTag(exchange)` helpers). It is **not** an `Observation`.
+- That timer is asserted by `server/.../monitor/HttpRedMetricsIT` and
+  `metrics/.../prometheus/PrometheusEngineMetricsIT`.
+- No `ObservationRegistry` exists on `ArcadeDBServer`.
+- No `arcadedb.serverMetrics.tracing.*` keys in `GlobalConfiguration` (only `SERVER_METRICS`,
+  `SERVER_METRICS_LOGGING`).
+- `LogManager` has `setContext(String)`/`getContext()`; **no** `clearCorrelation()` (idiom is
+  `setContext(null)`, already called in the handler's `finally`).
+- `metrics/pom.xml` parent uses a **literal** `26.7.1-SNAPSHOT` (not `${revision}`); micrometer
+  pinned by `${micrometer.version}=1.16.5`; no micrometer-bom import.
+- SPI: `metrics/src/main/resources/META-INF/services/com.arcadedb.server.ServerPlugin` lists the
+  two metrics plugins. `ServerPlugin` requires only `startService()`; `configure`, `stopService`
+  are defaults.
+- Builder: `SHADED_MODULES="gremlin redisw mongodbw postgresw grpcw metrics"`; `get_module_description()`
+  case block lists each module.
+
+## Key design decisions (deviations from the plan, justified)
+
+1. **Do not register `DefaultMeterObservationHandler` on the server registry; do not remove or
+   rename Pillar 1's `arcadedb.http.requests` timer.** The plan proposed a second
+   `arcadedb.http.server.requests` meter + deleting/editing Pillar 1's test. That is rejected
+   because (a) project constraint forbids modifying existing tests, and (b) it would add a new
+   timer to `/prometheus` even when tracing is disabled (default), weakening the "default-off =
+   byte-for-byte identical" guarantee. Instead the Observation is **span-only**: with no tracer
+   attached the server's `ObservationRegistry` has zero handlers, so the wrap is a true no-op and
+   metrics come solely from Pillar 1's untouched timer. When the tracing plugin attaches its
+   tracing handler, the same wrapped code emits spans. Single instrumentation point preserved;
+   no duplicate metrics.
+
+2. **Raft outbound trace-context propagation is deferred** (per the plan's own self-review note):
+   it requires Observations inside `ArcadeStateMachine.applyTransaction` plus trace-context
+   serialization into the Raft log entry - a larger change beyond this pillar's minimum. Inbound
+   HTTP `traceparent` continuation and in-process span nesting are delivered. Documented as a
+   known limitation.
+
+## How this change is verified
+
+- `tracing` module unit tests with OTel `InMemorySpanExporter`: spans created for Observations;
+  inbound `traceparent` continuation; **zero** spans when no tracer attached.
+- `server` IT: `ObservationRegistry` exposed; HTTP request drives the Observation (probe handler).
+- Classpath isolation: `mvn -pl server dependency:tree | grep opentelemetry` -> none.
+- Retro-compat: existing `HttpRedMetricsIT` / `PrometheusEngineMetricsIT` stay green untouched.
+
+## Files changed
+
+- `pom.xml` - `micrometer-tracing` (1.6.5) + `opentelemetry` (1.55.0) version properties, two
+  import-scope BOMs, `tracing` module registration.
+- `tracing/` (new module) - `pom.xml`, SPI registration, `package-info`, `TracingPlugin`, tests
+  (`TracingPluginTest`, `TraceparentPropagationTest`, `ServerTracingIT`).
+- `engine/.../GlobalConfiguration.java` - `SERVER_METRICS_TRACING_ENABLED/ENDPOINT/SAMPLING_RATE`.
+- `server/.../ArcadeDBServer.java` - shared `ObservationRegistry` + getter.
+- `server/.../http/handler/AbstractServerHttpHandler.java` - span-only Observation wrapper +
+  lazy `RequestReplyReceiverContext` for inbound `traceparent`. Pillar 1 timer untouched.
+- `server/.../ObservationRegistryIT.java`, `.../http/HttpObservationIT.java` - new server tests.
+- `package/arcadedb-builder.sh` - `tracing` in `SHADED_MODULES` + module description.
+- `ATTRIBUTIONS.md`, `NOTICE` - OpenTelemetry + Micrometer Tracing (Apache-2.0; folded the
+  micrometer-tracing NOTICE).
+
+## Test results
+
+- `tracing` module: `TracingPluginTest` (2), `TraceparentPropagationTest` (1), `ServerTracingIT` (1) - green (verify/failsafe).
+- `server`: `ObservationRegistryIT` (1), `HttpObservationIT` (1) green; existing `HttpRedMetricsIT` (2)
+  and 433 server unit tests green (no regressions).
+- `metrics`: 5 tests green (retro-compat: `/prometheus` + OTLP unaffected).
+- `engine` `ConfigurationTest`: green (new keys don't break config snapshot).
+- Classpath isolation: `mvn -pl server dependency:tree | grep -i opentelemetry` -> none.
+- Version alignment: tracing module resolves `micrometer-observation:1.16.5` (matches core).
+
+## Self-review (1 cycle, code-reviewer agent)
+
+Applied: BatchSpanProcessor in production (non-blocking export; tests use SimpleSpanProcessor seam);
+sampling key `Float`-typed to avoid double->float precision loss; single `getTracer` local; single
+`attachForTest` seam; `isActive()` returns `enabled`; endpoint null/blank guard; effective
+endpoint+samplingRate logged at startup; micrometer-tracing pinned to 1.6.5 to align with core
+1.16.5. Deferred (per plan): outbound Raft span propagation.
+
+## Progress log
+
+- T0: analysis complete; tracking doc created.
+- T1-T10: module scaffolded, config keys, ObservationRegistry, HTTP Observation, TracingPlugin,
+  traceparent continuation, builder flag, attributions, full build + isolation verified, self-review
+  applied. Complete.

--- a/docs/4467-distributed-tracing.md
+++ b/docs/4467-distributed-tracing.md
@@ -59,6 +59,20 @@ spans - with the OTel SDK kept entirely off the core/server compile classpath.
 - Classpath isolation: `mvn -pl server dependency:tree | grep opentelemetry` -> none.
 - Retro-compat: existing `HttpRedMetricsIT` / `PrometheusEngineMetricsIT` stay green untouched.
 
+## Packaging
+
+The optional `tracing` module ships in the **full** distribution (`arcadedb-*.tar.gz` and the
+`arcadedata/arcadedb` Docker image), mirroring `metrics`: `package/pom.xml` depends on
+`arcadedb-tracing` (shaded classifier), and `package/src/main/assembly/full.xml` excludes it from the
+wildcard `/lib` set then re-includes it in the plugin set. The lean flavors (`minimal`, `headless`,
+`base`) exclude it (like `metrics`), so the OTel SDK is not carried there. The OTel SDK is bundled
+inside the tracing shaded jar (not loose in `/lib`). The modular builder (`arcadedb-builder.sh`) also
+exposes it via `SHADED_MODULES` for custom distributions.
+
+Version alignment: `micrometer-tracing` tracks the `micrometer` line - with `micrometer` at `1.17.0`,
+`micrometer-tracing` is `1.7.0` (OTel `1.62.0`). The tracing BOM must match, otherwise its
+`micrometer-bom` import would pin the whole reactor's micrometer-observation to the older line.
+
 ## Multi-protocol tracing (extension beyond HTTP)
 
 Goal: cover the other wire protocols (Postgres/Bolt/Redis/Mongo/gRPC), not just HTTP.

--- a/docs/4467-distributed-tracing.md
+++ b/docs/4467-distributed-tracing.md
@@ -98,3 +98,34 @@ endpoint+samplingRate logged at startup; micrometer-tracing pinned to 1.6.5 to a
 - T1-T10: module scaffolded, config keys, ObservationRegistry, HTTP Observation, TracingPlugin,
   traceparent continuation, builder flag, attributions, full build + isolation verified, self-review
   applied. Complete.
+- Code review (Gemini bot, PR #4604): isolated optional-tracing cleanup from the core HTTP path
+  (per-step try/catch) and added graceful endpoint-init failure handling in TracingPlugin.
+
+## Multi-protocol tracing (extension beyond HTTP)
+
+Goal: cover the other wire protocols (Postgres/Bolt/Redis/Mongo/gRPC), not just HTTP.
+
+Design: a single **engine-boundary** instrumentation point rather than five handler passes, mirroring
+the existing `QueryMetricsRecorder` decoupling (engine has Micrometer only at test scope):
+
+- **`engine` `QueryTracer`** SPI (`com.arcadedb.database`): `beginQuery(protocol,db,language,type,query)`
+  returns a `Span` (AutoCloseable); `Holder` is a volatile NO_OP-default registry; `Holder.begin(...)`
+  reads the protocol from `ProtocolContext`. No Micrometer types in engine main.
+- **`LocalDatabase.query()/command()`** (the 7 terminal overloads) wrap execution in
+  `try (QueryTracer.Span span = QueryTracer.Holder.begin(...))`, alongside the existing metric recorder.
+  Every protocol that funnels through `Database.query/command` (HTTP, Bolt, Postgres, Mongo, gRPC) is
+  covered from this one point; spans nest under the HTTP request span and are root spans otherwise.
+- **`server` `MicrometerQueryTracer`** opens a span-only `Observation` (`arcadedb.query`) on the shared
+  registry: low-card tags `protocol/db/language/type`; query text as a high-card span attribute
+  (`db.statement`). `isNoop()` short-circuit => zero allocation when tracing is off. Registered
+  unconditionally in `ArcadeDBServer`. Defensive close (failure can't disturb the query path).
+- **Redis**: `RedisNetworkExecutor.executeCommand` maps commands directly to engine ops (it does not
+  call `Database.query/command`), so a `QueryTracer` span is opened there directly (protocol=redis,
+  type=command, statement=command verb).
+- **Deferred (per spec)**: gRPC inbound `traceparent` continuation (needs OTel on the gRPC
+  interceptor + io.grpc.Metadata extraction). Query spans still give gRPC root spans.
+
+Tests: `LocalDatabaseQueryTracerTest` (engine, fake tracer: protocol/language/type/query + span
+close, and NO_OP default); `ServerTracingIT.httpCommandProducesQuerySpanNestedUnderTheHttpSpan`
+(real server: HTTP POST /command -> `arcadedb.query` span tagged protocol=http, child of the HTTP
+span). Regression: 157 SQL execution tests, redisw 32, server HTTP ITs - all green.

--- a/docs/4467-distributed-tracing.md
+++ b/docs/4467-distributed-tracing.md
@@ -59,48 +59,6 @@ spans - with the OTel SDK kept entirely off the core/server compile classpath.
 - Classpath isolation: `mvn -pl server dependency:tree | grep opentelemetry` -> none.
 - Retro-compat: existing `HttpRedMetricsIT` / `PrometheusEngineMetricsIT` stay green untouched.
 
-## Files changed
-
-- `pom.xml` - `micrometer-tracing` (1.6.5) + `opentelemetry` (1.55.0) version properties, two
-  import-scope BOMs, `tracing` module registration.
-- `tracing/` (new module) - `pom.xml`, SPI registration, `package-info`, `TracingPlugin`, tests
-  (`TracingPluginTest`, `TraceparentPropagationTest`, `ServerTracingIT`).
-- `engine/.../GlobalConfiguration.java` - `SERVER_METRICS_TRACING_ENABLED/ENDPOINT/SAMPLING_RATE`.
-- `server/.../ArcadeDBServer.java` - shared `ObservationRegistry` + getter.
-- `server/.../http/handler/AbstractServerHttpHandler.java` - span-only Observation wrapper +
-  lazy `RequestReplyReceiverContext` for inbound `traceparent`. Pillar 1 timer untouched.
-- `server/.../ObservationRegistryIT.java`, `.../http/HttpObservationIT.java` - new server tests.
-- `package/arcadedb-builder.sh` - `tracing` in `SHADED_MODULES` + module description.
-- `ATTRIBUTIONS.md`, `NOTICE` - OpenTelemetry + Micrometer Tracing (Apache-2.0; folded the
-  micrometer-tracing NOTICE).
-
-## Test results
-
-- `tracing` module: `TracingPluginTest` (2), `TraceparentPropagationTest` (1), `ServerTracingIT` (1) - green (verify/failsafe).
-- `server`: `ObservationRegistryIT` (1), `HttpObservationIT` (1) green; existing `HttpRedMetricsIT` (2)
-  and 433 server unit tests green (no regressions).
-- `metrics`: 5 tests green (retro-compat: `/prometheus` + OTLP unaffected).
-- `engine` `ConfigurationTest`: green (new keys don't break config snapshot).
-- Classpath isolation: `mvn -pl server dependency:tree | grep -i opentelemetry` -> none.
-- Version alignment: tracing module resolves `micrometer-observation:1.16.5` (matches core).
-
-## Self-review (1 cycle, code-reviewer agent)
-
-Applied: BatchSpanProcessor in production (non-blocking export; tests use SimpleSpanProcessor seam);
-sampling key `Float`-typed to avoid double->float precision loss; single `getTracer` local; single
-`attachForTest` seam; `isActive()` returns `enabled`; endpoint null/blank guard; effective
-endpoint+samplingRate logged at startup; micrometer-tracing pinned to 1.6.5 to align with core
-1.16.5. Deferred (per plan): outbound Raft span propagation.
-
-## Progress log
-
-- T0: analysis complete; tracking doc created.
-- T1-T10: module scaffolded, config keys, ObservationRegistry, HTTP Observation, TracingPlugin,
-  traceparent continuation, builder flag, attributions, full build + isolation verified, self-review
-  applied. Complete.
-- Code review (Gemini bot, PR #4604): isolated optional-tracing cleanup from the core HTTP path
-  (per-step try/catch) and added graceful endpoint-init failure handling in TracingPlugin.
-
 ## Multi-protocol tracing (extension beyond HTTP)
 
 Goal: cover the other wire protocols (Postgres/Bolt/Redis/Mongo/gRPC), not just HTTP.
@@ -125,7 +83,7 @@ the existing `QueryMetricsRecorder` decoupling (engine has Micrometer only at te
 - **Deferred (per spec)**: gRPC inbound `traceparent` continuation (needs OTel on the gRPC
   interceptor + io.grpc.Metadata extraction). Query spans still give gRPC root spans.
 
-Tests: `LocalDatabaseQueryTracerTest` (engine, fake tracer: protocol/language/type/query + span
-close, and NO_OP default); `ServerTracingIT.httpCommandProducesQuerySpanNestedUnderTheHttpSpan`
-(real server: HTTP POST /command -> `arcadedb.query` span tagged protocol=http, child of the HTTP
-span). Regression: 157 SQL execution tests, redisw 32, server HTTP ITs - all green.
+Test coverage: `LocalDatabaseQueryTracerTest` (engine, fake tracer: protocol/language/type/query +
+span close, and the NO_OP default); `ServerTracingIT.httpCommandProducesQuerySpanNestedUnderTheHttpSpan`
+(real server: HTTP POST /command -> `arcadedb.query` span tagged `protocol=http`, child of the HTTP
+span).

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -546,7 +546,8 @@ public enum GlobalConfiguration {
   SERVER_METRICS_LOGGING("arcadedb.serverMetrics.logging", SCOPE.SERVER, "True to enable metrics logging", Boolean.class, false),
 
   SERVER_METRICS_TRACING_ENABLED("arcadedb.serverMetrics.tracing.enabled", SCOPE.SERVER,
-      "Enable OpenTelemetry distributed tracing (requires the optional tracing plugin on the classpath)", Boolean.class, false),
+      "Enable OpenTelemetry distributed tracing (requires the optional tracing plugin on the classpath). Note: query/command spans include the statement text as the db.statement span attribute, which may contain sensitive data, so secure the OTLP collector endpoint",
+      Boolean.class, false),
 
   SERVER_METRICS_TRACING_ENDPOINT("arcadedb.serverMetrics.tracing.endpoint", SCOPE.SERVER, "OTLP trace export endpoint", String.class,
       "http://localhost:4317"),

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -545,6 +545,15 @@ public enum GlobalConfiguration {
 
   SERVER_METRICS_LOGGING("arcadedb.serverMetrics.logging", SCOPE.SERVER, "True to enable metrics logging", Boolean.class, false),
 
+  SERVER_METRICS_TRACING_ENABLED("arcadedb.serverMetrics.tracing.enabled", SCOPE.SERVER,
+      "Enable OpenTelemetry distributed tracing (requires the optional tracing plugin on the classpath)", Boolean.class, false),
+
+  SERVER_METRICS_TRACING_ENDPOINT("arcadedb.serverMetrics.tracing.endpoint", SCOPE.SERVER, "OTLP trace export endpoint", String.class,
+      "http://localhost:4317"),
+
+  SERVER_METRICS_TRACING_SAMPLING_RATE("arcadedb.serverMetrics.tracing.samplingRate", SCOPE.SERVER,
+      "Parent-based trace sampling ratio in [0.0,1.0]", Float.class, 0.0f),
+
   SERVER_READINESS_REQUIRES_HA("arcadedb.server.readinessRequiresHA", SCOPE.SERVER,
       "When true and HA is active, /api/v1/ready also requires the node to have joined the Raft group and be caught up. Default false preserves current readiness behavior.",
       Boolean.class, false),

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -1565,7 +1565,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     checkDatabaseIsOpen(true, "Cannot execute command on a read only database");
     stats.commands.incrementAndGet();
     final long start = QueryMetricsRecorder.Holder.startNanos();
-    try {
+    try (final QueryTracer.Span span = QueryTracer.Holder.begin(name, language, "command", query)) {
       return getQueryEngine(language).command(query, new ContextConfiguration());
     } finally {
       QueryMetricsRecorder.Holder.record(start, name, language, "command");
@@ -1577,7 +1577,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     checkDatabaseIsOpen(true, "Cannot execute command on a read only database");
     stats.commands.incrementAndGet();
     final long start = QueryMetricsRecorder.Holder.startNanos();
-    try {
+    try (final QueryTracer.Span span = QueryTracer.Holder.begin(name, language, "command", query)) {
       return getQueryEngine(language).command(query, new ContextConfiguration(), parameters);
     } finally {
       QueryMetricsRecorder.Holder.record(start, name, language, "command");
@@ -1590,7 +1590,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     checkDatabaseIsOpen(true, "Cannot execute command on a read only database");
     stats.commands.incrementAndGet();
     final long start = QueryMetricsRecorder.Holder.startNanos();
-    try {
+    try (final QueryTracer.Span span = QueryTracer.Holder.begin(name, language, "command", query)) {
       return getQueryEngine(language).command(query, configuration, parameters);
     } finally {
       QueryMetricsRecorder.Holder.record(start, name, language, "command");
@@ -1608,7 +1608,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     checkDatabaseIsOpen(true, "Cannot execute command on a read only database");
     stats.commands.incrementAndGet();
     final long start = QueryMetricsRecorder.Holder.startNanos();
-    try {
+    try (final QueryTracer.Span span = QueryTracer.Holder.begin(name, language, "command", query)) {
       return getQueryEngine(language).command(query, configuration, parameters);
     } finally {
       QueryMetricsRecorder.Holder.record(start, name, language, "command");
@@ -1639,7 +1639,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     checkDatabaseIsOpen();
     stats.queries.incrementAndGet();
     final long start = QueryMetricsRecorder.Holder.startNanos();
-    try {
+    try (final QueryTracer.Span span = QueryTracer.Holder.begin(name, language, "query", query)) {
       return getQueryEngine(language).query(query, new ContextConfiguration());
     } finally {
       QueryMetricsRecorder.Holder.record(start, name, language, "query");
@@ -1651,7 +1651,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     checkDatabaseIsOpen();
     stats.queries.incrementAndGet();
     final long start = QueryMetricsRecorder.Holder.startNanos();
-    try {
+    try (final QueryTracer.Span span = QueryTracer.Holder.begin(name, language, "query", query)) {
       return getQueryEngine(language).query(query, new ContextConfiguration(), parameters);
     } finally {
       QueryMetricsRecorder.Holder.record(start, name, language, "query");
@@ -1663,7 +1663,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     checkDatabaseIsOpen();
     stats.queries.incrementAndGet();
     final long start = QueryMetricsRecorder.Holder.startNanos();
-    try {
+    try (final QueryTracer.Span span = QueryTracer.Holder.begin(name, language, "query", query)) {
       return getQueryEngine(language).query(query, new ContextConfiguration(), parameters);
     } finally {
       QueryMetricsRecorder.Holder.record(start, name, language, "query");

--- a/engine/src/main/java/com/arcadedb/database/QueryTracer.java
+++ b/engine/src/main/java/com/arcadedb/database/QueryTracer.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database;
+
+/**
+ * Framework-agnostic hook the engine calls to open a tracing span around a query/command execution.
+ * Lives in the engine (which has Micrometer only at test scope); the server registers a
+ * Micrometer/OpenTelemetry-backed implementation. The default is a no-op, so when no tracer is
+ * registered the engine pays only a volatile read and a sentinel check per query - no span, no
+ * allocation. Mirrors {@link QueryMetricsRecorder}: a single engine-boundary instrumentation point
+ * that serves every wire protocol, with the originating protocol read from {@link ProtocolContext}.
+ */
+@FunctionalInterface
+public interface QueryTracer {
+  QueryTracer NO_OP = (protocol, database, language, type, query) -> Span.NO_OP;
+
+  /**
+   * Opens a span for an executing query/command. The returned {@link Span} must be closed when the
+   * execution completes (use try-with-resources).
+   *
+   * @param protocol originating wire protocol (e.g. http, bolt, postgres, internal)
+   * @param database database name
+   * @param language query language (sql, opencypher, ...)
+   * @param type     {@code query} or {@code command}
+   * @param query    the query/command text (recorded as a span attribute only, never a metric tag)
+   */
+  Span beginQuery(String protocol, String database, String language, String type, String query);
+
+  /** Handle for an open span. Closing it ends the span; closing is idempotent and never throws. */
+  interface Span extends AutoCloseable {
+    Span NO_OP = () -> {
+    };
+
+    @Override
+    void close();
+  }
+
+  /** Static registration + helpers, kept off the interface's public surface. */
+  final class Holder {
+    private static volatile QueryTracer current = NO_OP;
+
+    private Holder() {
+    }
+
+    public static void register(final QueryTracer tracer) {
+      current = tracer != null ? tracer : NO_OP;
+    }
+
+    public static QueryTracer get() {
+      return current;
+    }
+
+    /**
+     * Opens a span for the current execution, reading the originating protocol from
+     * {@link ProtocolContext}. Returns the no-op span (zero allocation) when no tracer is registered.
+     */
+    public static Span begin(final String database, final String language, final String type, final String query) {
+      final QueryTracer tracer = current;
+      return tracer == NO_OP ? Span.NO_OP : tracer.beginQuery(ProtocolContext.get(), database, language, type, query);
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/LocalDatabaseQueryTracerTest.java
+++ b/engine/src/test/java/com/arcadedb/database/LocalDatabaseQueryTracerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the engine query/command boundary opens a {@link QueryTracer} span carrying the
+ * originating protocol (from {@link ProtocolContext}), language, type and query text - the single
+ * instrumentation point every wire protocol funnels through. Uses a fake tracer (no Micrometer).
+ */
+class LocalDatabaseQueryTracerTest {
+  private final String dbPath = "./target/databases/LocalDatabaseQueryTracerTest";
+
+  @AfterEach
+  void reset() {
+    QueryTracer.Holder.register(null);
+    ProtocolContext.clear();
+  }
+
+  @Test
+  void queryAndCommandOpenSpansWithProtocolLanguageTypeAndQuery() {
+    final List<String> begun = new ArrayList<>();
+    final List<String> ended = new ArrayList<>();
+    QueryTracer.Holder.register((protocol, database, language, type, query) -> {
+      begun.add(protocol + "|" + database + "|" + language + "|" + type + "|" + query);
+      return () -> ended.add(type);
+    });
+
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      if (factory.exists())
+        factory.open().drop();
+      try (final Database db = factory.create()) {
+        ProtocolContext.set("postgres");
+        db.command("sql", "CREATE DOCUMENT TYPE Doc");
+        db.query("sql", "SELECT FROM Doc");
+      }
+    }
+
+    assertThat(begun).contains(
+        "postgres|LocalDatabaseQueryTracerTest|sql|command|CREATE DOCUMENT TYPE Doc",
+        "postgres|LocalDatabaseQueryTracerTest|sql|query|SELECT FROM Doc");
+    // Every opened span must have been closed (try-with-resources at the boundary).
+    assertThat(ended).contains("command", "query");
+    assertThat(ended).hasSameSizeAs(begun);
+  }
+
+  @Test
+  void noTracerRegisteredIsANoOp() {
+    // Default holder is NO_OP: queries run without opening any span and without error.
+    try (final DatabaseFactory factory = new DatabaseFactory(dbPath)) {
+      if (factory.exists())
+        factory.open().drop();
+      try (final Database db = factory.create()) {
+        db.command("sql", "CREATE DOCUMENT TYPE Doc");
+        assertThat(db.query("sql", "SELECT FROM Doc").stream().count()).isZero();
+      }
+    }
+    assertThat(QueryTracer.Holder.get()).isSameAs(QueryTracer.NO_OP);
+  }
+}

--- a/package/arcadedb-builder.sh
+++ b/package/arcadedb-builder.sh
@@ -26,7 +26,7 @@ MAVEN_CENTRAL_BASE="https://repo1.maven.org/maven2/com/arcadedb"
 GITHUB_RELEASES_BASE="https://github.com/arcadedata/arcadedb/releases/download"
 
 # Module metadata
-SHADED_MODULES="gremlin redisw mongodbw postgresw grpcw metrics"
+SHADED_MODULES="gremlin redisw mongodbw postgresw grpcw metrics tracing"
 REGULAR_MODULES="console studio graphql"
 
 # Module descriptions for interactive menu
@@ -43,6 +43,7 @@ get_module_description() {
   grpcw) echo "gRPC wire protocol support" ;;
   graphql) echo "GraphQL API support" ;;
   metrics) echo "Prometheus metrics integration" ;;
+  tracing) echo "OpenTelemetry distributed tracing (OTLP export) - optional plugin" ;;
   *) echo "Unknown module" ;;
   esac
 }

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -185,6 +185,18 @@
         </dependency>
         <dependency>
             <groupId>com.arcadedb</groupId>
+            <artifactId>arcadedb-tracing</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>shaded</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.arcadedb</groupId>
             <artifactId>arcadedb-gremlin</artifactId>
             <version>${project.parent.version}</version>
             <classifier>shaded</classifier>

--- a/package/src/main/assembly/base.xml
+++ b/package/src/main/assembly/base.xml
@@ -123,6 +123,7 @@
                 <exclude>com.arcadedb:arcadedb-graphql</exclude>
                 <exclude>com.arcadedb:arcadedb-studio</exclude>
                 <exclude>com.arcadedb:arcadedb-metrics</exclude>
+                <exclude>com.arcadedb:arcadedb-tracing</exclude>
             </excludes>
         </dependencySet>
         <!-- Plugin modules in separate directory (none for base) -->

--- a/package/src/main/assembly/full.xml
+++ b/package/src/main/assembly/full.xml
@@ -120,6 +120,7 @@
                 <exclude>com.arcadedb:arcadedb-grpcw</exclude>
                 <exclude>com.arcadedb:arcadedb-graphql</exclude>
                 <exclude>com.arcadedb:arcadedb-metrics</exclude>
+                <exclude>com.arcadedb:arcadedb-tracing</exclude>
             </excludes>
         </dependencySet>
         <!-- Plugin modules in separate directory -->
@@ -136,6 +137,7 @@
                 <include>com.arcadedb:arcadedb-grpcw</include>
                 <include>com.arcadedb:arcadedb-graphql</include>
                 <include>com.arcadedb:arcadedb-metrics</include>
+                <include>com.arcadedb:arcadedb-tracing</include>
             </includes>
             <useTransitiveDependencies>false</useTransitiveDependencies>
         </dependencySet>

--- a/package/src/main/assembly/headless.xml
+++ b/package/src/main/assembly/headless.xml
@@ -120,6 +120,7 @@
                 <exclude>com.arcadedb:arcadedb-graphql</exclude>
                 <exclude>com.arcadedb:arcadedb-studio</exclude>
                 <exclude>com.arcadedb:arcadedb-metrics</exclude>
+                <exclude>com.arcadedb:arcadedb-tracing</exclude>
             </excludes>
         </dependencySet>
         <!-- Plugin modules in separate directory -->

--- a/package/src/main/assembly/minimal.xml
+++ b/package/src/main/assembly/minimal.xml
@@ -119,6 +119,7 @@
                 <exclude>com.arcadedb:arcadedb-grpcw</exclude>
                 <exclude>com.arcadedb:arcadedb-graphql</exclude>
                 <exclude>com.arcadedb:arcadedb-metrics</exclude>
+                <exclude>com.arcadedb:arcadedb-tracing</exclude>
             </excludes>
         </dependencySet>
         <!-- Plugin modules in separate directory -->

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,8 @@
         <testcontainers.version>2.0.5</testcontainers.version>
         <logback-classic.version>1.5.34</logback-classic.version>
         <micrometer.version>1.17.0</micrometer.version>
+        <micrometer-tracing.version>1.6.5</micrometer-tracing.version>
+        <opentelemetry.version>1.55.0</opentelemetry.version>
         <postgres.version>42.7.11</postgres.version>
 
         <assertj-core.version>3.27.7</assertj-core.version>
@@ -131,6 +133,7 @@
         <module>server</module>
         <module>ha-raft</module>
         <module>metrics</module>
+        <module>tracing</module>
         <module>integration</module>
         <module>console</module>
         <module>gremlin</module>
@@ -490,6 +493,22 @@
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-bom</artifactId>
                 <version>${assertj-core.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- OpenTelemetry + Micrometer Tracing BOMs: consumed only by the optional `tracing`
+                 module so the OTel SDK stays off the core/server compile classpath. -->
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-tracing-bom</artifactId>
+                <version>${micrometer-tracing.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>${opentelemetry.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -80,8 +80,8 @@
         <testcontainers.version>2.0.5</testcontainers.version>
         <logback-classic.version>1.5.34</logback-classic.version>
         <micrometer.version>1.17.0</micrometer.version>
-        <micrometer-tracing.version>1.6.5</micrometer-tracing.version>
-        <opentelemetry.version>1.55.0</opentelemetry.version>
+        <micrometer-tracing.version>1.7.0</micrometer-tracing.version>
+        <opentelemetry.version>1.62.0</opentelemetry.version>
         <postgres.version>42.7.11</postgres.version>
 
         <assertj-core.version>3.27.7</assertj-core.version>

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -142,9 +142,11 @@ public class RedisNetworkExecutor extends Thread {
 
       // Redis maps commands directly to engine operations rather than going through
       // Database.query/command, so the engine-boundary span never fires for it. Open one here so
-      // Redis is traced like the other protocols. No-op unless the tracing plugin is active.
+      // Redis is traced like the other protocols (protocol=redis comes from ProtocolContext, set in
+      // run()). No query language applies to a native Redis command, so language is null. No-op
+      // unless the tracing plugin is active.
       try (final QueryTracer.Span span = QueryTracer.Holder.begin(
-          selectedDatabase != null ? selectedDatabase.getName() : null, "redis", "command", cmdString)) {
+          selectedDatabase != null ? selectedDatabase.getName() : null, null, "command", cmdString)) {
         switch (cmdString) {
           case "DECR":
             decrBy(list);

--- a/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
+++ b/redisw/src/main/java/com/arcadedb/redis/RedisNetworkExecutor.java
@@ -140,7 +140,11 @@ public class RedisNetworkExecutor extends Thread {
 
       final String cmdString = ((String) cmd).toUpperCase(Locale.ENGLISH);
 
-      try {
+      // Redis maps commands directly to engine operations rather than going through
+      // Database.query/command, so the engine-boundary span never fires for it. Open one here so
+      // Redis is traced like the other protocols. No-op unless the tracing plugin is active.
+      try (final QueryTracer.Span span = QueryTracer.Holder.begin(
+          selectedDatabase != null ? selectedDatabase.getName() : null, "redis", "command", cmdString)) {
         switch (cmdString) {
           case "DECR":
             decrBy(list);

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -41,8 +41,10 @@ import com.arcadedb.server.event.ServerEventLog;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.mcp.MCPConfiguration;
 import com.arcadedb.database.QueryMetricsRecorder;
+import com.arcadedb.database.QueryTracer;
 import com.arcadedb.server.monitor.EngineMetricsBinder;
 import com.arcadedb.server.monitor.MicrometerQueryMetricsRecorder;
+import com.arcadedb.server.monitor.MicrometerQueryTracer;
 import com.arcadedb.server.monitor.PoolMetrics;
 import com.arcadedb.server.monitor.ServerQueryProfiler;
 import com.arcadedb.server.plugin.PluginManager;
@@ -236,6 +238,11 @@ public class ArcadeDBServer {
       }
       LogManager.instance().log(this, Level.INFO, "Metrics Collection Started");
     }
+
+    // Register the engine-boundary query tracer regardless of the metrics flag: it opens a span only
+    // when the optional tracing plugin has attached a tracer to the ObservationRegistry, and is a
+    // zero-cost no-op otherwise. This gives every wire protocol query/command spans from one point.
+    QueryTracer.Holder.register(new MicrometerQueryTracer(observationRegistry));
 
     security = new ServerSecurity(this, configuration, serverRootPath + "/config");
     security.startService();

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -60,6 +60,7 @@ import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.core.instrument.logging.LoggingMeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
 
 import java.io.File;
 import java.io.IOException;
@@ -89,6 +90,10 @@ public class ArcadeDBServer {
   private final       String                                serverName;
   private             String                                hostAddress;
   private final       boolean                               replicationLifecycleEventsEnabled;
+  // Shared spine for Micrometer Observations. Starts with no handlers, so Observations are no-ops
+  // (zero overhead) until the optional tracing plugin attaches a tracing handler. Metrics continue
+  // to be recorded by the dedicated Micrometer timers, independently of this registry.
+  private final       ObservationRegistry                   observationRegistry                  = ObservationRegistry.create();
   private             FileServerEventLog                    eventLog;
   private             PluginManager                         pluginManager;
   private             String                                serverRootPath;
@@ -135,6 +140,15 @@ public class ArcadeDBServer {
 
   public ContextConfiguration getConfiguration() {
     return configuration;
+  }
+
+  /**
+   * Shared Micrometer {@link ObservationRegistry} used to instrument server hot paths once and emit
+   * both metrics and (when the optional tracing plugin registers a tracer) spans. With no tracer
+   * attached the registry has no handlers and Observations are no-ops.
+   */
+  public ObservationRegistry getObservationRegistry() {
+    return observationRegistry;
   }
 
   public void setSnapshotInstallInProgress(final boolean inProgress) {

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -373,10 +373,24 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
               .log(this, getErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(), e.getMessage());
       sendErrorResponse(exchange, 500, "Internal error", e, null);
     } finally {
-      // Finish the span (status known now) and detach the trace scope before recording metrics.
-      observation.lowCardinalityKeyValue("status", Integer.toString(exchange.getStatusCode()));
-      observationScope.close();
-      observation.stop();
+      // Finalize the optional tracing span. Each step is isolated so a failure in the optional
+      // tracing layer can never skip the core cleanup or the RED timer below; closing the scope is
+      // attempted independently to avoid thread-local context leaking across pooled worker threads.
+      try {
+        observation.lowCardinalityKeyValue("status", Integer.toString(exchange.getStatusCode()));
+      } catch (final Throwable t) {
+        LogManager.instance().log(this, Level.WARNING, "Error tagging tracing observation", t);
+      }
+      try {
+        observationScope.close();
+      } catch (final Throwable t) {
+        LogManager.instance().log(this, Level.WARNING, "Error closing tracing observation scope", t);
+      }
+      try {
+        observation.stop();
+      } catch (final Throwable t) {
+        LogManager.instance().log(this, Level.WARNING, "Error stopping tracing observation", t);
+      }
 
       ProtocolContext.clear();
       LogManager.instance().setContext(null);

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -124,9 +124,13 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
         .lowCardinalityKeyValue("path", pathTemplate(exchange))
         .lowCardinalityKeyValue("db", databaseTag(exchange));
     observation.start();
-    final Observation.Scope observationScope = observation.openScope();
+    // Open the scope inside the try so that if a misbehaving handler throws on scope-open the
+    // catch/finally still runs: the observation is stopped (not leaked) and the request is answered
+    // with an error rather than propagating an uncaught exception.
+    Observation.Scope observationScope = null;
 
     try {
+      observationScope = observation.openScope();
       LogManager.instance().setContext(httpServer.getServer().getServerName());
 
       exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
@@ -382,7 +386,8 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
         LogManager.instance().log(this, Level.WARNING, "Error tagging tracing observation", t);
       }
       try {
-        observationScope.close();
+        if (observationScope != null)
+          observationScope.close();
       } catch (final Throwable t) {
         LogManager.instance().log(this, Level.WARNING, "Error closing tracing observation scope", t);
       }

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -33,6 +33,8 @@ import com.arcadedb.server.security.ServerSecurityException;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.transport.RequestReplyReceiverContext;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HeaderValues;
@@ -102,6 +104,27 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
     // arcadedb.http.requests Micrometer timer. When no tracer is registered this is metrics-only.
     final long httpStartNanos = System.nanoTime();
     ProtocolContext.set("http");
+
+    // Span-only Observation wrapping request handling. With no tracer registered the server's
+    // ObservationRegistry has no handlers, so this is a zero-overhead no-op and the default
+    // (tracing-disabled) behavior is unchanged. When the optional tracing plugin attaches a tracer
+    // the same code emits an OTLP span (continuing an inbound traceparent when present). HTTP
+    // latency metrics remain on the dedicated arcadedb.http.requests timer recorded in finally.
+    final Observation observation = Observation.createNotStarted("arcadedb.http.server.requests",
+            () -> {
+              // Built lazily: the supplier is only invoked when a tracer is attached, so the
+              // default (tracing-disabled) path allocates nothing. The carrier lets the tracing
+              // handler read an inbound W3C traceparent header to continue an upstream trace.
+              final RequestReplyReceiverContext<HttpServerExchange, Object> ctx = new RequestReplyReceiverContext<>(
+                  (carrier, key) -> carrier.getRequestHeaders().getFirst(key));
+              ctx.setCarrier(exchange);
+              return ctx;
+            }, httpServer.getServer().getObservationRegistry())
+        .lowCardinalityKeyValue("method", exchange.getRequestMethod().toString())
+        .lowCardinalityKeyValue("path", pathTemplate(exchange))
+        .lowCardinalityKeyValue("db", databaseTag(exchange));
+    observation.start();
+    final Observation.Scope observationScope = observation.openScope();
 
     try {
       LogManager.instance().setContext(httpServer.getServer().getServerName());
@@ -350,6 +373,11 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
               .log(this, getErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(), e.getMessage());
       sendErrorResponse(exchange, 500, "Internal error", e, null);
     } finally {
+      // Finish the span (status known now) and detach the trace scope before recording metrics.
+      observation.lowCardinalityKeyValue("status", Integer.toString(exchange.getStatusCode()));
+      observationScope.close();
+      observation.stop();
+
       ProtocolContext.clear();
       LogManager.instance().setContext(null);
 

--- a/server/src/main/java/com/arcadedb/server/monitor/MicrometerQueryTracer.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/MicrometerQueryTracer.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.monitor;
+
+import com.arcadedb.database.QueryTracer;
+import com.arcadedb.log.LogManager;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+
+import java.util.logging.Level;
+
+/**
+ * Server-side {@link QueryTracer} that opens a span-only Micrometer {@link Observation}
+ * ({@code arcadedb.query}) on the shared {@link ObservationRegistry} for every query/command at the
+ * engine boundary - so all wire protocols emit spans from one instrumentation point. Low-cardinality
+ * tags carry {@code protocol/db/language/type}; the query text is a high-cardinality span attribute
+ * only (never a metric tag). When the optional tracing plugin has not attached a tracer the registry
+ * is a no-op, so this opens nothing and allocates nothing. Latency metrics stay on the dedicated
+ * {@code arcadedb.query.duration} timer ({@link MicrometerQueryMetricsRecorder}).
+ */
+public final class MicrometerQueryTracer implements QueryTracer {
+  private final ObservationRegistry observationRegistry;
+
+  public MicrometerQueryTracer(final ObservationRegistry observationRegistry) {
+    this.observationRegistry = observationRegistry;
+  }
+
+  @Override
+  public Span beginQuery(final String protocol, final String database, final String language, final String type,
+      final String query) {
+    // No tracer attached -> no handlers -> skip entirely (zero allocation on the hot path).
+    if (observationRegistry.isNoop())
+      return Span.NO_OP;
+
+    final Observation observation = Observation.createNotStarted("arcadedb.query", observationRegistry)
+        .lowCardinalityKeyValue("protocol", protocol != null ? protocol : "internal")
+        .lowCardinalityKeyValue("db", database != null ? database : "none")
+        .lowCardinalityKeyValue("language", language != null ? language : "unknown")
+        .lowCardinalityKeyValue("type", type != null ? type : "query")
+        .highCardinalityKeyValue("db.statement", query != null ? query : "");
+    observation.start();
+    final Observation.Scope scope = observation.openScope();
+
+    return () -> {
+      // A failure finalizing the optional span must never disturb the query path.
+      try {
+        scope.close();
+      } catch (final Throwable t) {
+        LogManager.instance().log(this, Level.WARNING, "Error closing query tracing scope", t);
+      }
+      try {
+        observation.stop();
+      } catch (final Throwable t) {
+        LogManager.instance().log(this, Level.WARNING, "Error stopping query tracing observation", t);
+      }
+    };
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/ObservationRegistryIT.java
+++ b/server/src/test/java/com/arcadedb/server/ObservationRegistryIT.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the server exposes a shared {@link ObservationRegistry} that the optional tracing plugin
+ * attaches to. By default the registry carries no handlers, so Observations are no-ops.
+ */
+class ObservationRegistryIT extends BaseGraphServerTest {
+
+  @Override
+  protected int getServerCount() {
+    return 1;
+  }
+
+  @Test
+  void serverExposesObservationRegistry() {
+    final ObservationRegistry registry = getServer(0).getObservationRegistry();
+    assertThat(registry).isNotNull();
+    // With no tracing plugin attached, the registry has no handlers, so it reports itself as a
+    // no-op: Observations are zero-overhead until the tracing plugin registers a handler. This
+    // guarantees the default (tracing-disabled) configuration behaves identically to before.
+    assertThat(registry.isNoop()).isTrue();
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/HttpObservationIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/HttpObservationIT.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http;
+
+import com.arcadedb.server.BaseGraphServerTest;
+import io.micrometer.common.KeyValue;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationHandler;
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies HTTP request handling is wrapped in a Micrometer {@link Observation} on the server's
+ * shared registry. A probe {@link ObservationHandler} stands in for the tracing handler the
+ * optional plugin would attach, proving the instrumentation point fires with bounded tags. In
+ * production with no tracer attached the same Observation is a zero-overhead no-op.
+ */
+class HttpObservationIT extends BaseGraphServerTest {
+
+  @Override
+  protected int getServerCount() {
+    return 1;
+  }
+
+  @Test
+  void httpHandlingIsWrappedInObservation() throws Exception {
+    final List<Observation.Context> stopped = new CopyOnWriteArrayList<>();
+
+    final ObservationRegistry registry = getServer(0).getObservationRegistry();
+    final ObservationHandler<Observation.Context> probe = new ObservationHandler<>() {
+      @Override
+      public boolean supportsContext(final Observation.Context context) {
+        return true;
+      }
+
+      @Override
+      public void onStop(final Observation.Context context) {
+        stopped.add(context);
+      }
+    };
+    // Attach the probe for the lifetime of this test's server. It plays the role the tracing
+    // plugin's handler would: it makes the otherwise no-op Observation observable.
+    registry.observationConfig().observationHandler(probe);
+
+    final HttpURLConnection c = (HttpURLConnection) new URL("http://localhost:2480/api/v1/ready").openConnection();
+    c.setRequestMethod("GET");
+    c.connect();
+    assertThat(c.getResponseCode()).isEqualTo(204);
+    c.disconnect();
+
+    // The server records the Observation in the handler's finally block, which can complete just
+    // after the client receives the response. Poll briefly for the observation to be reported.
+    Observation.Context httpContext = null;
+    for (int attempt = 0; attempt < 100 && httpContext == null; attempt++) {
+      httpContext = stopped.stream()
+          .filter(ctx -> "arcadedb.http.server.requests".equals(ctx.getName()))
+          .findFirst()
+          .orElse(null);
+      if (httpContext == null)
+        Thread.sleep(20);
+    }
+
+    assertThat(httpContext).as("an arcadedb.http.server.requests Observation must be produced").isNotNull();
+    assertThat(tag(httpContext, "method")).isEqualTo("GET");
+    // The path tag must be the bounded route template, never the concrete URI.
+    assertThat(tag(httpContext, "path")).isNotNull();
+    assertThat(tag(httpContext, "status")).isEqualTo("204");
+  }
+
+  private static String tag(final Observation.Context context, final String key) {
+    for (final KeyValue kv : context.getLowCardinalityKeyValues())
+      if (kv.getKey().equals(key))
+        return kv.getValue();
+    return null;
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/HttpObservationIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/HttpObservationIT.java
@@ -23,6 +23,7 @@ import io.micrometer.common.KeyValue;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;
 import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
@@ -38,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * optional plugin would attach, proving the instrumentation point fires with bounded tags. In
  * production with no tracer attached the same Observation is a zero-overhead no-op.
  */
+@Tag("slow")
 class HttpObservationIT extends BaseGraphServerTest {
 
   @Override

--- a/server/src/test/java/com/arcadedb/server/http/HttpObservationIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/HttpObservationIT.java
@@ -23,6 +23,7 @@ import io.micrometer.common.KeyValue;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;
 import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -30,6 +31,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,9 +44,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Tag("slow")
 class HttpObservationIT extends BaseGraphServerTest {
 
+  // The ObservationRegistry has no remove-handler API, so the probe is gated by this flag and
+  // deactivated after the test, leaving it inert even though it stays registered.
+  private final AtomicBoolean probeActive = new AtomicBoolean(true);
+
   @Override
   protected int getServerCount() {
     return 1;
+  }
+
+  @AfterEach
+  void deactivateProbe() {
+    probeActive.set(false);
   }
 
   @Test
@@ -55,16 +66,17 @@ class HttpObservationIT extends BaseGraphServerTest {
     final ObservationHandler<Observation.Context> probe = new ObservationHandler<>() {
       @Override
       public boolean supportsContext(final Observation.Context context) {
-        return true;
+        return probeActive.get();
       }
 
       @Override
       public void onStop(final Observation.Context context) {
-        stopped.add(context);
+        if (probeActive.get())
+          stopped.add(context);
       }
     };
-    // Attach the probe for the lifetime of this test's server. It plays the role the tracing
-    // plugin's handler would: it makes the otherwise no-op Observation observable.
+    // Attach the probe for this test. It plays the role the tracing plugin's handler would: it makes
+    // the otherwise no-op Observation observable.
     registry.observationConfig().observationHandler(probe);
 
     final HttpURLConnection c = (HttpURLConnection) new URL("http://localhost:2480/api/v1/ready").openConnection();

--- a/tracing/pom.xml
+++ b/tracing/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+    SPDX-License-Identifier: Apache-2.0
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.arcadedb</groupId>
+        <artifactId>arcadedb-parent</artifactId>
+        <version>26.7.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>arcadedb-tracing</artifactId>
+    <packaging>jar</packaging>
+    <name>ArcadeDB Tracing</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.arcadedb</groupId>
+            <artifactId>arcadedb-server</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-otel</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.arcadedb</groupId>
+            <artifactId>arcadedb-server</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/tracing/src/main/java/com/arcadedb/tracing/TracingPlugin.java
+++ b/tracing/src/main/java/com/arcadedb/tracing/TracingPlugin.java
@@ -44,6 +44,7 @@ import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
 /**
@@ -53,10 +54,11 @@ import java.util.logging.Level;
  * is confined to this module and never reaches the core/server compile classpath.
  */
 public class TracingPlugin implements ServerPlugin {
-  private boolean           enabled;
-  private String            endpoint;
-  private double            samplingRate;
-  private SdkTracerProvider tracerProvider;
+  private boolean                       enabled;
+  private String                        endpoint;
+  private double                        samplingRate;
+  private SdkTracerProvider             tracerProvider;
+  private DeactivatableObservationHandler attachedHandler;
 
   @Override
   public void configure(final ArcadeDBServer server, final ContextConfiguration configuration) {
@@ -98,6 +100,13 @@ public class TracingPlugin implements ServerPlugin {
 
   @Override
   public void stopService() {
+    // Deactivate the handler BEFORE closing the provider: the ObservationRegistry has no
+    // remove-handler API, so the handler stays registered, but once deactivated it is a no-op and
+    // never touches the closed tracer provider.
+    if (attachedHandler != null) {
+      attachedHandler.deactivate();
+      attachedHandler = null;
+    }
     if (tracerProvider != null) {
       tracerProvider.close();
       tracerProvider = null;
@@ -133,9 +142,10 @@ public class TracingPlugin implements ServerPlugin {
     });
     final Propagator propagator = new OtelPropagator(otel.getPropagators(), otelTracer);
 
-    registry.observationConfig().observationHandler(new ObservationHandler.FirstMatchingCompositeObservationHandler(
+    attachedHandler = new DeactivatableObservationHandler(new ObservationHandler.FirstMatchingCompositeObservationHandler(
         new PropagatingReceiverTracingObservationHandler<>(tracer, propagator),
         new DefaultTracingObservationHandler(tracer)));
+    registry.observationConfig().observationHandler(attachedHandler);
   }
 
   /**
@@ -144,5 +154,72 @@ public class TracingPlugin implements ServerPlugin {
    */
   void attachForTest(final ObservationRegistry registry, final SpanExporter exporter) {
     attach(registry, SimpleSpanProcessor.create(exporter), 1.0);
+  }
+
+  /**
+   * Wraps the tracing handler so it can be turned off on {@link #stopService()}. The
+   * {@link ObservationRegistry} offers no API to remove a handler, so once the plugin stops this
+   * gates every callback to a no-op - preventing the (now closed) tracer provider from being used by
+   * later Observations.
+   */
+  private static final class DeactivatableObservationHandler implements ObservationHandler<io.micrometer.observation.Observation.Context> {
+    private final ObservationHandler<io.micrometer.observation.Observation.Context> delegate;
+    private final AtomicBoolean                                                     active = new AtomicBoolean(true);
+
+    private DeactivatableObservationHandler(final ObservationHandler<io.micrometer.observation.Observation.Context> delegate) {
+      this.delegate = delegate;
+    }
+
+    private void deactivate() {
+      active.set(false);
+    }
+
+    @Override
+    public boolean supportsContext(final io.micrometer.observation.Observation.Context context) {
+      return active.get() && delegate.supportsContext(context);
+    }
+
+    @Override
+    public void onStart(final io.micrometer.observation.Observation.Context context) {
+      if (active.get())
+        delegate.onStart(context);
+    }
+
+    @Override
+    public void onError(final io.micrometer.observation.Observation.Context context) {
+      if (active.get())
+        delegate.onError(context);
+    }
+
+    @Override
+    public void onEvent(final io.micrometer.observation.Observation.Event event,
+        final io.micrometer.observation.Observation.Context context) {
+      if (active.get())
+        delegate.onEvent(event, context);
+    }
+
+    @Override
+    public void onScopeOpened(final io.micrometer.observation.Observation.Context context) {
+      if (active.get())
+        delegate.onScopeOpened(context);
+    }
+
+    @Override
+    public void onScopeClosed(final io.micrometer.observation.Observation.Context context) {
+      if (active.get())
+        delegate.onScopeClosed(context);
+    }
+
+    @Override
+    public void onScopeReset(final io.micrometer.observation.Observation.Context context) {
+      if (active.get())
+        delegate.onScopeReset(context);
+    }
+
+    @Override
+    public void onStop(final io.micrometer.observation.Observation.Context context) {
+      if (active.get())
+        delegate.onStop(context);
+    }
   }
 }

--- a/tracing/src/main/java/com/arcadedb/tracing/TracingPlugin.java
+++ b/tracing/src/main/java/com/arcadedb/tracing/TracingPlugin.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.tracing;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.ServerPlugin;
+import io.micrometer.observation.ObservationHandler;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.handler.DefaultTracingObservationHandler;
+import io.micrometer.tracing.handler.PropagatingReceiverTracingObservationHandler;
+import io.micrometer.tracing.otel.bridge.OtelCurrentTraceContext;
+import io.micrometer.tracing.otel.bridge.OtelPropagator;
+import io.micrometer.tracing.otel.bridge.OtelTracer;
+import io.micrometer.tracing.propagation.Propagator;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+
+import java.util.logging.Level;
+
+/**
+ * Optional OpenTelemetry tracing plugin. When enabled it bridges an OTel tracer into the server's
+ * shared {@link ObservationRegistry}, so the existing Observations also emit OTLP-exported spans
+ * (continuing an inbound W3C {@code traceparent} when present). Disabled by default; the OTel SDK
+ * is confined to this module and never reaches the core/server compile classpath.
+ */
+public class TracingPlugin implements ServerPlugin {
+  private boolean           enabled;
+  private String            endpoint;
+  private double            samplingRate;
+  private SdkTracerProvider tracerProvider;
+
+  @Override
+  public void configure(final ArcadeDBServer server, final ContextConfiguration configuration) {
+    enabled = configuration.getValueAsBoolean(GlobalConfiguration.SERVER_METRICS_TRACING_ENABLED);
+    if (!enabled)
+      return;
+
+    endpoint = configuration.getValueAsString(GlobalConfiguration.SERVER_METRICS_TRACING_ENDPOINT);
+    if (endpoint == null || endpoint.isBlank()) {
+      enabled = false;
+      LogManager.instance().log(this, Level.WARNING, "OpenTelemetry tracing endpoint not configured, tracing disabled");
+      return;
+    }
+    samplingRate = configuration.getValueAsFloat(GlobalConfiguration.SERVER_METRICS_TRACING_SAMPLING_RATE);
+
+    // Export off the request thread: BatchSpanProcessor buffers spans and ships them on a background
+    // worker, so observation.stop() in the HTTP handler never blocks on a network call.
+    final SpanExporter exporter = OtlpGrpcSpanExporter.builder().setEndpoint(endpoint).build();
+    attach(server.getObservationRegistry(), BatchSpanProcessor.builder(exporter).build(), samplingRate);
+  }
+
+  @Override
+  public void startService() {
+    if (enabled)
+      LogManager.instance()
+          .log(this, Level.INFO, "OpenTelemetry tracing enabled (endpoint=%s, samplingRate=%s)", endpoint, samplingRate);
+  }
+
+  @Override
+  public void stopService() {
+    if (tracerProvider != null) {
+      tracerProvider.close();
+      tracerProvider = null;
+    }
+  }
+
+  @Override
+  public boolean isActive() {
+    return enabled;
+  }
+
+  /**
+   * Builds an OTel tracer feeding {@code processor} and registers a first-matching composite handler
+   * on the registry: the propagating receiver handler claims contexts carrying an inbound
+   * {@code traceparent} (continuing the upstream trace); everything else opens a fresh span.
+   */
+  private void attach(final ObservationRegistry registry, final SpanProcessor processor, final double samplingRate) {
+    tracerProvider = SdkTracerProvider.builder()
+        .addSpanProcessor(processor)
+        .setSampler(Sampler.parentBased(samplingRate >= 1.0 ?
+            Sampler.alwaysOn() :
+            samplingRate <= 0.0 ? Sampler.alwaysOff() : Sampler.traceIdRatioBased(samplingRate)))
+        .build();
+
+    final OpenTelemetry otel = OpenTelemetrySdk.builder()
+        .setTracerProvider(tracerProvider)
+        .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+        .build();
+
+    final io.opentelemetry.api.trace.Tracer otelTracer = otel.getTracer("arcadedb");
+    final Tracer tracer = new OtelTracer(otelTracer, new OtelCurrentTraceContext(), event -> {
+      // no event handling required
+    });
+    final Propagator propagator = new OtelPropagator(otel.getPropagators(), otelTracer);
+
+    registry.observationConfig().observationHandler(new ObservationHandler.FirstMatchingCompositeObservationHandler(
+        new PropagatingReceiverTracingObservationHandler<>(tracer, propagator),
+        new DefaultTracingObservationHandler(tracer)));
+  }
+
+  /**
+   * Test seam: attach a tracer that always samples and exports synchronously (in-process) to the
+   * supplied exporter, so tests can assert spans immediately without a background flush.
+   */
+  void attachForTest(final ObservationRegistry registry, final SpanExporter exporter) {
+    attach(registry, SimpleSpanProcessor.create(exporter), 1.0);
+  }
+}

--- a/tracing/src/main/java/com/arcadedb/tracing/TracingPlugin.java
+++ b/tracing/src/main/java/com/arcadedb/tracing/TracingPlugin.java
@@ -73,9 +73,20 @@ public class TracingPlugin implements ServerPlugin {
     samplingRate = configuration.getValueAsFloat(GlobalConfiguration.SERVER_METRICS_TRACING_SAMPLING_RATE);
 
     // Export off the request thread: BatchSpanProcessor buffers spans and ships them on a background
-    // worker, so observation.stop() in the HTTP handler never blocks on a network call.
-    final SpanExporter exporter = OtlpGrpcSpanExporter.builder().setEndpoint(endpoint).build();
-    attach(server.getObservationRegistry(), BatchSpanProcessor.builder(exporter).build(), samplingRate);
+    // worker, so observation.stop() in the HTTP handler never blocks on a network call. A malformed
+    // endpoint must degrade gracefully (tracing disabled) rather than fail server startup.
+    try {
+      final SpanExporter exporter = OtlpGrpcSpanExporter.builder().setEndpoint(endpoint).build();
+      attach(server.getObservationRegistry(), BatchSpanProcessor.builder(exporter).build(), samplingRate);
+    } catch (final Exception e) {
+      enabled = false;
+      if (tracerProvider != null) {
+        tracerProvider.close();
+        tracerProvider = null;
+      }
+      LogManager.instance()
+          .log(this, Level.SEVERE, "Failed to initialize OpenTelemetry tracing (endpoint=%s), tracing disabled", e, endpoint);
+    }
   }
 
   @Override

--- a/tracing/src/main/java/com/arcadedb/tracing/package-info.java
+++ b/tracing/src/main/java/com/arcadedb/tracing/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Optional OpenTelemetry distributed-tracing plugin for ArcadeDB. Loaded via the ServerPlugin SPI
+ * and isolated from the core/server compile classpath: the OpenTelemetry SDK lives only in this
+ * module. Enabled with {@code arcadedb.serverMetrics.tracing.enabled=true}; a no-op otherwise.
+ */
+package com.arcadedb.tracing;

--- a/tracing/src/main/resources/META-INF/services/com.arcadedb.server.ServerPlugin
+++ b/tracing/src/main/resources/META-INF/services/com.arcadedb.server.ServerPlugin
@@ -1,0 +1,1 @@
+com.arcadedb.tracing.TracingPlugin

--- a/tracing/src/test/java/com/arcadedb/tracing/ServerTracingIT.java
+++ b/tracing/src/test/java/com/arcadedb/tracing/ServerTracingIT.java
@@ -19,6 +19,7 @@
 package com.arcadedb.tracing;
 
 import com.arcadedb.server.BaseGraphServerTest;
+import io.opentelemetry.api.common.AttributeKey;
 import io.micrometer.observation.ObservationRegistry;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -26,6 +27,8 @@ import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -78,6 +81,49 @@ class ServerTracingIT extends BaseGraphServerTest {
       // It must be a child of the inbound span carried by the traceparent header.
       assertThat(span.getTraceId()).isEqualTo(parentTraceId);
       assertThat(span.getParentSpanId()).isEqualTo("00f067aa0ba902b7");
+    } finally {
+      plugin.stopService();
+    }
+  }
+
+  @Test
+  void httpCommandProducesQuerySpanNestedUnderTheHttpSpan() throws Exception {
+    final ObservationRegistry registry = getServer(0).getObservationRegistry();
+    final InMemorySpanExporter exporter = InMemorySpanExporter.create();
+    final TracingPlugin plugin = new TracingPlugin();
+    plugin.attachForTest(registry, exporter);
+
+    try {
+      final HttpURLConnection c = (HttpURLConnection) new URL("http://localhost:2480/api/v1/command/graph").openConnection();
+      c.setRequestMethod("POST");
+      c.setDoOutput(true);
+      c.setRequestProperty("Authorization",
+          "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+      c.setRequestProperty("Content-Type", "application/json");
+      c.getOutputStream().write("{\"language\":\"sql\",\"command\":\"SELECT 1 AS one\"}".getBytes(StandardCharsets.UTF_8));
+      c.connect();
+      assertThat(c.getResponseCode()).isEqualTo(200);
+      c.disconnect();
+
+      // The engine-boundary QueryTracer must produce an arcadedb.query span tagged with the
+      // originating protocol (http here), nested under the HTTP request span.
+      SpanData querySpan = null;
+      SpanData httpSpan = null;
+      for (int attempt = 0; attempt < 100 && querySpan == null; attempt++) {
+        final List<SpanData> spans = exporter.getFinishedSpanItems();
+        querySpan = spans.stream().filter(s -> "arcadedb.query".equals(s.getName())).findFirst().orElse(null);
+        httpSpan = spans.stream().filter(s -> "arcadedb.http.server.requests".equals(s.getName())).findFirst().orElse(null);
+        if (querySpan == null)
+          Thread.sleep(20);
+      }
+
+      assertThat(querySpan).as("an arcadedb.query span must be produced for the command").isNotNull();
+      // The span must be tagged with the originating wire protocol.
+      assertThat(querySpan.getAttributes().get(AttributeKey.stringKey("protocol"))).isEqualTo("http");
+      assertThat(httpSpan).as("the enclosing HTTP span must be present").isNotNull();
+      // In-process nesting: the query span is a child of the HTTP request span (same trace).
+      assertThat(querySpan.getTraceId()).isEqualTo(httpSpan.getTraceId());
+      assertThat(querySpan.getParentSpanId()).isEqualTo(httpSpan.getSpanId());
     } finally {
       plugin.stopService();
     }

--- a/tracing/src/test/java/com/arcadedb/tracing/ServerTracingIT.java
+++ b/tracing/src/test/java/com/arcadedb/tracing/ServerTracingIT.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.tracing;
+
+import com.arcadedb.server.BaseGraphServerTest;
+import io.micrometer.observation.ObservationRegistry;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end verification that, with the tracing plugin attached to a real running server, an HTTP
+ * request produces an exported span, and an inbound W3C {@code traceparent} header is continued by
+ * the production handler wiring. Uses an in-memory exporter rather than the OTLP exporter.
+ */
+class ServerTracingIT extends BaseGraphServerTest {
+
+  @Override
+  protected int getServerCount() {
+    return 1;
+  }
+
+  @Test
+  void httpRequestProducesSpanAndContinuesInboundTrace() throws Exception {
+    final ObservationRegistry registry = getServer(0).getObservationRegistry();
+    final InMemorySpanExporter exporter = InMemorySpanExporter.create();
+    final TracingPlugin plugin = new TracingPlugin();
+    // Attach a tracer that exports to the in-memory exporter onto the live server registry.
+    plugin.attachForTest(registry, exporter);
+
+    try {
+      final String parentTraceId = "4bf92f3577b34da6a3ce929d0e0e4736";
+      final HttpURLConnection c = (HttpURLConnection) new URL("http://localhost:2480/api/v1/ready").openConnection();
+      c.setRequestMethod("GET");
+      c.setRequestProperty("traceparent", "00-" + parentTraceId + "-00f067aa0ba902b7-01");
+      c.connect();
+      assertThat(c.getResponseCode()).isEqualTo(204);
+      c.disconnect();
+
+      // The span is exported in the handler's finally block, just after the client gets the
+      // response; poll for the HTTP span that continues the inbound trace (other unrelated spans
+      // may also be exported, so match on the upstream trace id rather than taking the first one).
+      SpanData span = null;
+      for (int attempt = 0; attempt < 100 && span == null; attempt++) {
+        final List<SpanData> spans = exporter.getFinishedSpanItems();
+        span = spans.stream()
+            .filter(s -> "arcadedb.http.server.requests".equals(s.getName()))
+            .filter(s -> parentTraceId.equals(s.getTraceId()))
+            .findFirst()
+            .orElse(null);
+        if (span == null)
+          Thread.sleep(20);
+      }
+
+      assertThat(span).as("an HTTP span continuing the inbound traceparent must be exported").isNotNull();
+      // It must be a child of the inbound span carried by the traceparent header.
+      assertThat(span.getTraceId()).isEqualTo(parentTraceId);
+      assertThat(span.getParentSpanId()).isEqualTo("00f067aa0ba902b7");
+    } finally {
+      plugin.stopService();
+    }
+  }
+}

--- a/tracing/src/test/java/com/arcadedb/tracing/ServerTracingIT.java
+++ b/tracing/src/test/java/com/arcadedb/tracing/ServerTracingIT.java
@@ -23,6 +23,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.micrometer.observation.ObservationRegistry;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.data.SpanData;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
@@ -38,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * request produces an exported span, and an inbound W3C {@code traceparent} header is continued by
  * the production handler wiring. Uses an in-memory exporter rather than the OTLP exporter.
  */
+@Tag("slow")
 class ServerTracingIT extends BaseGraphServerTest {
 
   @Override

--- a/tracing/src/test/java/com/arcadedb/tracing/TraceparentPropagationTest.java
+++ b/tracing/src/test/java/com/arcadedb/tracing/TraceparentPropagationTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.tracing;
+
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.transport.RequestReplyReceiverContext;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TraceparentPropagationTest {
+
+  @Test
+  void continuesUpstreamTraceFromTraceparentHeader() {
+    final ObservationRegistry registry = ObservationRegistry.create();
+    final InMemorySpanExporter exporter = InMemorySpanExporter.create();
+    final TracingPlugin plugin = new TracingPlugin();
+    plugin.attachForTest(registry, exporter);
+
+    final String parentTraceId = "4bf92f3577b34da6a3ce929d0e0e4736";
+    final Map<String, String> headers = Map.of("traceparent", "00-" + parentTraceId + "-00f067aa0ba902b7-01");
+
+    final RequestReplyReceiverContext<Map<String, String>, Object> ctx =
+        new RequestReplyReceiverContext<>((carrier, key) -> carrier.get(key));
+    ctx.setCarrier(headers);
+
+    Observation.createNotStarted("http.in", () -> ctx, registry).observe(() -> {
+      // handle the request inside the continued trace
+    });
+
+    assertThat(exporter.getFinishedSpanItems()).isNotEmpty();
+    assertThat(exporter.getFinishedSpanItems().get(0).getTraceId()).isEqualTo(parentTraceId);
+
+    plugin.stopService();
+  }
+}

--- a/tracing/src/test/java/com/arcadedb/tracing/TracingBadEndpointIT.java
+++ b/tracing/src/test/java/com/arcadedb/tracing/TracingBadEndpointIT.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.tracing;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that enabling tracing with a malformed OTLP endpoint degrades gracefully: the
+ * {@link TracingPlugin} catches the exporter-init failure, disables itself, and the server starts
+ * and serves requests normally instead of failing startup.
+ */
+@Tag("slow")
+class TracingBadEndpointIT extends BaseGraphServerTest {
+
+  @Override
+  protected int getServerCount() {
+    return 1;
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    config.setValue(GlobalConfiguration.SERVER_METRICS_TRACING_ENABLED, true);
+    config.setValue(GlobalConfiguration.SERVER_METRICS_TRACING_ENDPOINT, "not-a-valid-url");
+  }
+
+  @Test
+  void serverStartsDespiteInvalidTracingEndpoint() throws Exception {
+    // If TracingPlugin.configure() did not catch the exporter-init failure, the server would have
+    // failed to start and @BeforeEach would have thrown. Reaching here means it degraded gracefully.
+    assertThat(getServer(0).isStarted()).isTrue();
+
+    // And the server still serves requests with tracing silently disabled.
+    final HttpURLConnection c = (HttpURLConnection) new URL("http://localhost:2480/api/v1/ready").openConnection();
+    c.setRequestMethod("GET");
+    c.connect();
+    assertThat(c.getResponseCode()).isEqualTo(204);
+    c.disconnect();
+  }
+}

--- a/tracing/src/test/java/com/arcadedb/tracing/TracingPluginTest.java
+++ b/tracing/src/test/java/com/arcadedb/tracing/TracingPluginTest.java
@@ -24,6 +24,7 @@ import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 class TracingPluginTest {
 
@@ -44,6 +45,26 @@ class TracingPluginTest {
     assertThat(exporter.getFinishedSpanItems().get(0).getName()).contains("test.op");
 
     plugin.stopService();
+  }
+
+  @Test
+  void observingAfterStopIsInertAndDoesNotTouchTheClosedProvider() {
+    final ObservationRegistry registry = ObservationRegistry.create();
+    final InMemorySpanExporter exporter = InMemorySpanExporter.create();
+
+    final TracingPlugin plugin = new TracingPlugin();
+    plugin.attachForTest(registry, exporter);
+
+    Observation.createNotStarted("before.stop", registry).observe(() -> {
+    });
+    assertThat(exporter.getFinishedSpanItems()).isNotEmpty();
+
+    // The registry has no remove-handler API, so the handler stays registered after stop. It must be
+    // deactivated so a later Observation is a no-op and never drives the now-closed tracer provider
+    // (which would otherwise risk errors). Asserting the observation runs cleanly proves it.
+    plugin.stopService();
+    assertThatCode(() -> Observation.createNotStarted("after.stop", registry).observe(() -> {
+    })).doesNotThrowAnyException();
   }
 
   @Test

--- a/tracing/src/test/java/com/arcadedb/tracing/TracingPluginTest.java
+++ b/tracing/src/test/java/com/arcadedb/tracing/TracingPluginTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.tracing;
+
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TracingPluginTest {
+
+  @Test
+  void enabledPluginProducesSpansForObservations() {
+    final ObservationRegistry registry = ObservationRegistry.create();
+    final InMemorySpanExporter exporter = InMemorySpanExporter.create();
+
+    final TracingPlugin plugin = new TracingPlugin();
+    // Test seam: attach a tracer that exports to the in-memory exporter onto the given registry.
+    plugin.attachForTest(registry, exporter);
+
+    Observation.createNotStarted("test.op", registry).observe(() -> {
+      // work inside the span
+    });
+
+    assertThat(exporter.getFinishedSpanItems()).isNotEmpty();
+    assertThat(exporter.getFinishedSpanItems().get(0).getName()).contains("test.op");
+
+    plugin.stopService();
+  }
+
+  @Test
+  void disabledByDefaultAttachesNothing() {
+    final ObservationRegistry registry = ObservationRegistry.create();
+    final InMemorySpanExporter exporter = InMemorySpanExporter.create();
+
+    // No attach: the registry has no tracing handler, so Observations are no-ops and no span is
+    // exported. This mirrors a server running without the tracing flag enabled.
+    Observation.createNotStarted("test.op", registry).observe(() -> {
+    });
+
+    assertThat(exporter.getFinishedSpanItems()).isEmpty();
+  }
+}


### PR DESCRIPTION
## Summary

Implements **Observability Pillar 2: Distributed Tracing** (#4467, part of #4463). Adds a new optional `tracing` Maven module that, when enabled, bridges OpenTelemetry into Micrometer's `ObservationRegistry` so HTTP request handling emits OTLP-exported spans - with the OpenTelemetry SDK confined to this module and kept **off the core/server compile classpath** (`provided` scope, SPI-loaded, mirroring `metrics`).

Builds on Pillar 1 (#4465 / #4532). Default-off; with no new config the behavior is unchanged.

## What's included

- **`tracing` module** - `TracingPlugin implements ServerPlugin` builds an `SdkTracerProvider` + OTLP span exporter and registers a `FirstMatchingCompositeObservationHandler` (propagating-receiver + default) so exactly one handler runs per Observation. Production uses a non-blocking `BatchSpanProcessor`; a `SimpleSpanProcessor` test seam enables synchronous in-memory assertions.
- **Shared `ObservationRegistry`** on `ArcadeDBServer` (`getObservationRegistry()`), with **no handlers by default**.
- **HTTP instrumentation** - `AbstractServerHttpHandler` wraps request handling in a span-only `Observation` (`arcadedb.http.server.requests`) and continues an inbound **W3C `traceparent`** via a lazily-built `RequestReplyReceiverContext` (zero allocation when no tracer is attached).
- **Config keys** - `arcadedb.serverMetrics.tracing.enabled` (false), `.endpoint` (`http://localhost:4317`), `.samplingRate` (0.0).
- **Packaging** - `tracing` added to the modular builder's `SHADED_MODULES` + description.
- **Licensing** - `ATTRIBUTIONS.md` + `NOTICE` updated (OpenTelemetry + Micrometer Tracing, all Apache-2.0).
- **Versions** - micrometer-tracing 1.6.5 + opentelemetry 1.55.0 via import-scope BOMs (1.6.5 pinned to align with micrometer-core 1.16.5, no version skew).

## Retro-compatibility

- Pillar 1's `arcadedb.http.requests` timer is **left untouched** - existing `HttpRedMetricsIT` / `PrometheusEngineMetricsIT` stay green and `/prometheus` output is unchanged.
- The new HTTP Observation is **span-only**: with no tracer attached the registry has no handlers, so it is a true no-op and the default (tracing-disabled) config behaves identically. This is stronger than a meter-handler approach, which would have added a new timer even when tracing is off.
- OTel SDK never reaches the server/core compile classpath (`mvn -pl server dependency:tree | grep opentelemetry` → none).

## Testing

- **tracing**: `TracingPluginTest` (spans created when enabled; zero spans when disabled), `TraceparentPropagationTest` (continues an upstream `traceparent`), `ServerTracingIT` (real HTTP request → exported span continuing the inbound trace, via `InMemorySpanExporter`).
- **server**: `ObservationRegistryIT`, `HttpObservationIT`; existing `HttpRedMetricsIT` and 433 server unit tests pass (no regressions).
- **engine** `ConfigurationTest` and **metrics** suite green.

## Out of scope (deferred per plan)

- Outbound Raft leader→follower span propagation (requires Observations in `ArcadeStateMachine` + trace-context serialization in the Raft log; larger change beyond this pillar).
- Wire-protocol (Postgres/Bolt/Redis/Mongo/gRPC) propagation beyond fresh root spans.

Closes #4467
