### PR TITLE
fix: bump e2e-js CI to Node 24 for require(ESM) support (#4634)

### DIFF
--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -352,7 +352,9 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          # Node 24.9+ required: testcontainers@12 pulls archiver@8 (pure ESM), and
+          # Jest's require(ESM) bridge only works on Node 24.9+ (synchronous vm module APIs).
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: "e2e-js/package-lock.json"
 


### PR DESCRIPTION
## Problem

The `js-e2e-tests` CI job fails to load both test suites with:

```
Must use import to load ES Module: .../e2e-js/node_modules/archiver/index.js
Jest's require(ESM) requires Node v24.9+ for synchronous vm module APIs;
the current Node version does not expose them.
```

## Root cause

`testcontainers@12` depends on `archiver@8`, which is now pure ESM (`"type": "module"`). The CJS Jest test files do `require("testcontainers")`, which transitively `require`s archiver and hits Jest 30's `require(ESM)` bridge. That bridge only works on **Node 24.9+** (it needs the synchronous vm module APIs). CI runs Node **22**, so both suites fail at module-load time, before any container starts.

The earlier fix (#4634) added `NODE_OPTIONS=--experimental-vm-modules`, but that flag only enables the `import` path for ESM test files - it does nothing for the `require(ESM)` path the CJS test files take, so it could not resolve this.

## Fix

Bump the `js-e2e-tests` job from Node `22` to `24` (current LTS, ≥24.9) in `.github/workflows/mvn-test.yml`.

## Verification

Confirmed `require("testcontainers")` (and its transitive pure-ESM `archiver@8`) loads cleanly on Node ≥24.9 locally. The failure reproduces only on Node <24.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)