### PR TITLE
fix: [#3099] correctness bugs in vector SQL functions

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/sql/DefaultSQLFunctionFactory.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/DefaultSQLFunctionFactory.java
@@ -318,11 +318,14 @@ public final class DefaultSQLFunctionFactory extends SQLFunctionFactoryTemplate 
     register(SQLFunctionVectorSubtract.NAME, new SQLFunctionVectorSubtract());
     register(SQLFunctionVectorMultiply.NAME, new SQLFunctionVectorMultiply());
     register(SQLFunctionVectorScale.NAME, new SQLFunctionVectorScale());
-    // Vector Aggregations
-    register(SQLFunctionVectorSum.NAME, new SQLFunctionVectorSum());
-    register(SQLFunctionVectorAvg.NAME, new SQLFunctionVectorAvg());
-    register(SQLFunctionVectorMin.NAME, new SQLFunctionVectorMin());
-    register(SQLFunctionVectorMax.NAME, new SQLFunctionVectorMax());
+    // Vector Aggregations: registered as classes (not instances) so a fresh, isolated instance is created
+    // per query. These functions accumulate per-row state in instance fields; sharing a single instance
+    // leaked that state across independent queries (issue #3099: repeated SELECT vector.sum(...) returned
+    // increasing results) and was not thread-safe for concurrent queries.
+    register(SQLFunctionVectorSum.NAME, SQLFunctionVectorSum.class);
+    register(SQLFunctionVectorAvg.NAME, SQLFunctionVectorAvg.class);
+    register(SQLFunctionVectorMin.NAME, SQLFunctionVectorMin.class);
+    register(SQLFunctionVectorMax.NAME, SQLFunctionVectorMax.class);
     // Reranking Functions
     register(SQLFunctionVectorRRFScore.NAME, new SQLFunctionVectorRRFScore());
     register(SQLFunctionVectorNormalizeScores.NAME, new SQLFunctionVectorNormalizeScores());

--- a/engine/src/main/java/com/arcadedb/function/sql/SQLFunctionAbstract.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/SQLFunctionAbstract.java
@@ -103,4 +103,24 @@ public abstract class SQLFunctionAbstract implements SQLFunction {
       throw new CommandSQLParsingException(e.getMessage());
     }
   }
+
+  /**
+   * Null-tolerant variant of {@link #toFloatArray(Object)} that maps {@code null} collection elements to
+   * {@link Float#NaN}. Used by the validity-check functions (vector.hasNaN / vector.hasInf) so a NULL produced
+   * by an invalid SQL math op (e.g. sqrt(-1.0), coerced to NULL inside a collection) is detected as NaN rather
+   * than crashing the conversion. Delegates to {@link com.arcadedb.index.vector.VectorUtils#toFloatArrayNaNForNull(Object)}.
+   *
+   * @param vector The input vector (can be float[], double[], Object[], or List)
+   *
+   * @return float array representation, with null elements replaced by {@link Float#NaN}
+   *
+   * @throws CommandSQLParsingException if input type is invalid or contains non-numeric, non-null elements
+   */
+  protected float[] toFloatArrayNaNForNull(final Object vector) {
+    try {
+      return VectorUtils.toFloatArrayNaNForNull(vector);
+    } catch (final IllegalArgumentException e) {
+      throw new CommandSQLParsingException(e.getMessage());
+    }
+  }
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/SQLFunctionFactoryTemplate.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/SQLFunctionFactoryTemplate.java
@@ -89,6 +89,28 @@ public abstract class SQLFunctionFactoryTemplate implements SQLFunctionFactory {
         functions.put(alias.toLowerCase(Locale.ENGLISH), function);
       }
       FunctionRegistry.register(sqlFunction);
+    } else if (function instanceof Class<?> clazz && SQLFunction.class.isAssignableFrom(clazz)) {
+      // Class-based (stateful) registration: getFunctionInstance() creates a fresh instance per call, so we
+      // do not register in the unified FunctionRegistry. We still honor the function's alias by mapping the
+      // alias name to the same class, otherwise backward-compatible names (e.g. vectorSum -> vector.sum)
+      // would stop resolving once a stateful function moves from instance to class registration.
+      final String alias = aliasOfFunctionClass(clazz);
+      if (alias != null) {
+        functions.put(alias.toLowerCase(Locale.ENGLISH), function);
+      }
+    }
+  }
+
+  /**
+   * Probes a function class for its declared alias by instantiating it via the no-arg constructor (the same
+   * constructor {@link #getFunctionInstance(String)} relies on). Returns {@code null} when the function has no
+   * alias or cannot be instantiated, in which case only the primary name is registered.
+   */
+  private static String aliasOfFunctionClass(final Class<?> clazz) {
+    try {
+      return ((SQLFunction) clazz.getConstructor().newInstance()).getAlias();
+    } catch (final Exception e) {
+      return null;
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDimension.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDimension.java
@@ -45,7 +45,9 @@ public class SQLFunctionVectorDimension extends SQLFunctionVectorAbstract {
     final Object vector = params[0];
 
     return switch (vector) {
-      case null -> throw new CommandSQLParsingException("Vector cannot be null");
+      // Issue #3099: a NULL argument returns 0, consistent with .size()/.length() on a null collection,
+      // instead of throwing.
+      case null -> 0;
       case float[] floatArray -> floatArray.length;
       case Object[] objArray -> objArray.length;
       case List<?> list -> list.size();

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorHasInf.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorHasInf.java
@@ -48,7 +48,9 @@ public class SQLFunctionVectorHasInf extends SQLFunctionVectorAbstract {
     if (vectorObj == null)
       return null;
 
-    final float[] vector = toFloatArray(vectorObj);
+    // Null-tolerant conversion (issue #3099): a NULL element is mapped to NaN, which is not infinite, so it
+    // is correctly ignored here instead of crashing the conversion.
+    final float[] vector = toFloatArrayNaNForNull(vectorObj);
 
     if (vector.length == 0)
       throw new CommandSQLParsingException("Vector cannot be empty");

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorHasNaN.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorHasNaN.java
@@ -48,7 +48,9 @@ public class SQLFunctionVectorHasNaN extends SQLFunctionVectorAbstract {
     if (vectorObj == null)
       return null;
 
-    final float[] vector = toFloatArray(vectorObj);
+    // Null-tolerant conversion (issue #3099): a NULL element (e.g. from sqrt(-1.0) coerced to NULL inside a
+    // collection) is mapped to NaN and detected below, instead of crashing the conversion.
+    final float[] vector = toFloatArrayNaNForNull(vectorObj);
 
     if (vector.length == 0)
       throw new CommandSQLParsingException("Vector cannot be empty");

--- a/engine/src/main/java/com/arcadedb/index/vector/VectorUtils.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/VectorUtils.java
@@ -123,6 +123,28 @@ public final class VectorUtils {
    *                                  or contains non-numeric elements
    */
   public static float[] toFloatArray(final Object vectorObj) {
+    return toFloatArray(vectorObj, false);
+  }
+
+  /**
+   * Variant of {@link #toFloatArray(Object)} that maps {@code null} collection elements to
+   * {@link Float#NaN} instead of throwing. Used by the validity-check functions
+   * {@code vector.hasNaN} and {@code vector.hasInf} (issue #3099): an invalid SQL math op such as
+   * {@code sqrt(-1.0)} is coerced to {@code NULL} inside a collection literal, so
+   * {@code vector.hasNaN([1.0, sqrt(-1.0), 3.0])} must detect it as a NaN rather than crashing the
+   * conversion with a {@code NullPointerException}. By substituting {@code NaN} for {@code null},
+   * {@code hasNaN} naturally returns {@code true} and {@code hasInf} naturally ignores it (NaN is not
+   * infinite), keeping both functions symmetric without per-function null handling.
+   *
+   * @param vectorObj the object to convert
+   *
+   * @return float array representation, with null elements replaced by {@link Float#NaN}
+   */
+  public static float[] toFloatArrayNaNForNull(final Object vectorObj) {
+    return toFloatArray(vectorObj, true);
+  }
+
+  private static float[] toFloatArray(final Object vectorObj, final boolean nullElementAsNaN) {
     if (vectorObj instanceof float[] f)
       return f;
     if (vectorObj instanceof byte[])
@@ -152,23 +174,14 @@ public final class VectorUtils {
     }
     if (vectorObj instanceof Object[] objArray) {
       final float[] result = new float[objArray.length];
-      for (int i = 0; i < objArray.length; i++) {
-        if (objArray[i] instanceof Number num)
-          result[i] = num.floatValue();
-        else
-          throw new IllegalArgumentException("Vector elements must be numbers, found: " + objArray[i].getClass().getSimpleName());
-      }
+      for (int i = 0; i < objArray.length; i++)
+        result[i] = elementToFloat(objArray[i], nullElementAsNaN);
       return result;
     }
     if (vectorObj instanceof List<?> list) {
       final float[] result = new float[list.size()];
-      for (int i = 0; i < list.size(); i++) {
-        final Object elem = list.get(i);
-        if (elem instanceof Number num)
-          result[i] = num.floatValue();
-        else
-          throw new IllegalArgumentException("Vector elements must be numbers, found: " + elem.getClass().getSimpleName());
-      }
+      for (int i = 0; i < list.size(); i++)
+        result[i] = elementToFloat(list.get(i), nullElementAsNaN);
       return result;
     }
     if (vectorObj instanceof String s) {
@@ -183,6 +196,23 @@ public final class VectorUtils {
       return result;
     }
     throw new IllegalArgumentException("Vector must be an array or list, found: " + vectorObj.getClass().getSimpleName());
+  }
+
+  /**
+   * Converts a single collection element to a float. A {@code null} element either becomes
+   * {@link Float#NaN} (when {@code nullElementAsNaN} is set, for the validity-check functions) or
+   * triggers a clear {@link IllegalArgumentException} - never a {@link NullPointerException} from
+   * calling {@code getClass()} on a null (issue #3099).
+   */
+  private static float elementToFloat(final Object elem, final boolean nullElementAsNaN) {
+    if (elem instanceof Number num)
+      return num.floatValue();
+    if (elem == null) {
+      if (nullElementAsNaN)
+        return Float.NaN;
+      throw new IllegalArgumentException("Vector elements must be numbers, found: null");
+    }
+    throw new IllegalArgumentException("Vector elements must be numbers, found: " + elem.getClass().getSimpleName());
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorIssue3099Test.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorIssue3099Test.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.sql.vector;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.assertj.core.data.Offset;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #3099 (review of new vector functions). Covers three correctness bugs:
+ * <ol>
+ *   <li>vector.sum/avg/min/max leaked accumulated state across independent queries (repeated calls
+ *       returned increasing results) because they were registered as shared singleton instances.</li>
+ *   <li>vector.hasNaN / vector.hasInf threw a NullPointerException on a NULL collection element
+ *       (e.g. from sqrt(-1.0) coerced to NULL).</li>
+ *   <li>vector.dimension threw on a NULL argument instead of returning 0.</li>
+ * </ol>
+ *
+ * @author Luca Garulli (l.garulli--(at)--arcadedata.com)
+ */
+class SQLFunctionVectorIssue3099Test extends TestHelper {
+
+  // ========== Bug 1: aggregate state must not leak across queries ==========
+
+  @Test
+  void vectorSumDoesNotAccumulateAcrossQueries() {
+    // The issue reported that repeated SELECT vector.sum([1.0,2.0,3.0]) returned [1,2,3], then [2,4,6],
+    // then [3,6,9]. A fresh per-query instance must always return [1,2,3].
+    final String query = "SELECT `vector.sum`([1.0, 2.0, 3.0]) as s";
+    for (int i = 0; i < 3; i++) {
+      try (final ResultSet results = database.query("sql", query)) {
+        assertThat(results.hasNext()).isTrue();
+        final float[] s = results.next().getProperty("s");
+        assertThat(s).as("iteration %d", i).containsExactly(1.0f, 2.0f, 3.0f);
+      }
+    }
+  }
+
+  @Test
+  void vectorAggregatesAcrossRowsAreStableAndCorrect() {
+    database.command("sql", "CREATE DOCUMENT TYPE Emb");
+    database.command("sql", "CREATE PROPERTY Emb.v ARRAY_OF_FLOATS");
+    database.transaction(() -> {
+      database.command("sql", "INSERT INTO Emb SET v = [1.0, 2.0, 3.0]");
+      database.command("sql", "INSERT INTO Emb SET v = [4.0, 5.0, 6.0]");
+    });
+
+    // Run the same aggregation twice; the second run must not be polluted by the first one's state.
+    for (int i = 0; i < 2; i++) {
+      final String query = "SELECT `vector.sum`(v) as s, `vector.avg`(v) as a, `vector.min`(v) as mn, `vector.max`(v) as mx FROM Emb";
+      try (final ResultSet results = database.query("sql", query)) {
+        assertThat(results.hasNext()).isTrue();
+        final var r = results.next();
+        assertThat(r.<float[]>getProperty("s")).as("sum iteration %d", i).containsExactly(5.0f, 7.0f, 9.0f);
+
+        final float[] avg = r.getProperty("a");
+        assertThat(avg[0]).isCloseTo(2.5f, Offset.offset(0.001f));
+        assertThat(avg[1]).isCloseTo(3.5f, Offset.offset(0.001f));
+        assertThat(avg[2]).isCloseTo(4.5f, Offset.offset(0.001f));
+
+        assertThat(r.<float[]>getProperty("mn")).as("min iteration %d", i).containsExactly(1.0f, 2.0f, 3.0f);
+        assertThat(r.<float[]>getProperty("mx")).as("max iteration %d", i).containsExactly(4.0f, 5.0f, 6.0f);
+      }
+    }
+  }
+
+  @Test
+  void vectorSumAliasStillResolvesAfterClassRegistration() {
+    // Switching from instance to class registration must keep the backward-compatible camelCase alias working.
+    final String query = "SELECT vectorSum([1.0, 2.0, 3.0]) as s";
+    try (final ResultSet results = database.query("sql", query)) {
+      assertThat(results.hasNext()).isTrue();
+      assertThat(results.next().<float[]>getProperty("s")).containsExactly(1.0f, 2.0f, 3.0f);
+    }
+  }
+
+  // ========== Bug 2: hasNaN / hasInf must not NPE on a NULL element ==========
+
+  @Test
+  void vectorHasNaNDetectsNullElementAsNaN() {
+    // sqrt(-1.0) is coerced to NULL inside the collection; hasNaN must treat it as NaN, not crash.
+    final String query = "SELECT `vector.hasNaN`([1.0, sqrt(-1.0), 3.0]) as r";
+    try (final ResultSet results = database.query("sql", query)) {
+      assertThat(results.hasNext()).isTrue();
+      assertThat(results.next().<Boolean>getProperty("r")).isTrue();
+    }
+  }
+
+  @Test
+  void vectorHasNaNFalseForCleanVector() {
+    final String query = "SELECT `vector.hasNaN`([1.0, 2.0, 3.0]) as r";
+    try (final ResultSet results = database.query("sql", query)) {
+      assertThat(results.hasNext()).isTrue();
+      assertThat(results.next().<Boolean>getProperty("r")).isFalse();
+    }
+  }
+
+  @Test
+  void vectorHasInfIgnoresNullElement() {
+    // A NULL element maps to NaN, which is not infinite: hasInf must return false (and must not crash).
+    final String query = "SELECT `vector.hasInf`([1.0, sqrt(-1.0), 3.0]) as r";
+    try (final ResultSet results = database.query("sql", query)) {
+      assertThat(results.hasNext()).isTrue();
+      assertThat(results.next().<Boolean>getProperty("r")).isFalse();
+    }
+  }
+
+  // ========== Bug 3: vector.dimension on NULL returns 0 ==========
+
+  @Test
+  void vectorDimensionOfNullReturnsZero() {
+    final String query = "SELECT `vector.dimension`(null) as d";
+    try (final ResultSet results = database.query("sql", query)) {
+      assertThat(results.hasNext()).isTrue();
+      assertThat(results.next().<Integer>getProperty("d")).isEqualTo(0);
+    }
+  }
+}


### PR DESCRIPTION
Fixes three confirmed bugs surfaced by the review in issue #3099:

1. vector.sum/avg/min/max leaked accumulated state across independent queries (repeated SELECT vector.sum([...]) returned increasing results) and were not thread-safe, because they were registered as shared singleton instances. They are now registered as classes so a fresh, isolated instance is created per query, matching the scalar aggregate pattern (SQLFunctionSum.class). SQLFunctionFactoryTemplate now also maps a stateful class's alias to that class, so the backward-compatible vectorSum/vectorAvg/... names keep resolving.

2. vector.hasNaN / vector.hasInf threw a NullPointerException on a NULL collection element (e.g. sqrt(-1.0) coerced to NULL inside a collection literal). VectorUtils.toFloatArray now routes element conversion through a helper that gives a clear error on null, and a new toFloatArrayNaNForNull variant maps null -> NaN. hasNaN detects it as NaN (true); hasInf ignores it (NaN is not infinite).

3. vector.dimension(null) threw instead of returning 0; it now returns 0, consistent with .size()/.length() on a null collection.

Adds SQLFunctionVectorIssue3099Test regression coverage for all three.

## What does this PR do?

A brief description of the change being made with this pull request.

## Motivation

What inspired you to submit this pull request?

## Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

## Additional Notes

Anything else we should know when reviewing?

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
