### PR TITLE
feat: [#3099] vector quantization ergonomics, asSparse(), RRF array input, MATLAB_COLUMN

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorApproxDistance.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorApproxDistance.java
@@ -104,9 +104,12 @@ public class SQLFunctionVectorApproxDistance extends SQLFunctionVectorAbstract {
     final boolean i1 = q1Obj instanceof QuantizationResult;
     final boolean i2 = q2Obj instanceof QuantizationResult;
 
+    final boolean q1Recognized = b1 || i1;
+    final boolean q2Recognized = b2 || i2;
+
     // The two-argument form infers the type from result objects: each argument must be a recognized result
     // object (no mixing a result object with a raw array, where inference would be unreliable).
-    if (!(b1 || i1) || !(b2 || i2))
+    if (!q1Recognized || !q2Recognized)
       throw new CommandSQLParsingException(
           "Cannot infer the quantization type: the two-argument form requires the result objects of "
               + "vector.quantizeInt8()/vector.quantizeBinary() for both arguments. For raw byte arrays, specify "

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorApproxDistance.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorApproxDistance.java
@@ -104,8 +104,8 @@ public class SQLFunctionVectorApproxDistance extends SQLFunctionVectorAbstract {
     final boolean i1 = q1Obj instanceof QuantizationResult;
     final boolean i2 = q2Obj instanceof QuantizationResult;
 
-    // The two-argument form infers the type from result objects: both arguments must be one (no mixing a
-    // result object with a raw array, where inference would be unreliable).
+    // The two-argument form infers the type from result objects: each argument must be a recognized result
+    // object (no mixing a result object with a raw array, where inference would be unreliable).
     if (!(b1 || i1) || !(b2 || i2))
       throw new CommandSQLParsingException(
           "Cannot infer the quantization type: the two-argument form requires the result objects of "
@@ -171,7 +171,10 @@ public class SQLFunctionVectorApproxDistance extends SQLFunctionVectorAbstract {
       }
       return result;
     } else {
-      throw new CommandSQLParsingException("Quantized vector must be a byte array, found: " + quantized.getClass().getSimpleName());
+      // Also reached when a BinaryQuantizationResult is passed to the INT8 path (mixed types in the
+      // explicit 3-arg form), hence the explicit hint about the expected INT8 inputs.
+      throw new CommandSQLParsingException(
+          "INT8 distance expects a vector.quantizeInt8() result or a byte array, found: " + quantized.getClass().getSimpleName());
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorApproxDistance.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorApproxDistance.java
@@ -44,6 +44,10 @@ import java.util.Locale;
  *                                             returned by vectorQuantizeInt8()/vectorQuantizeBinary()
  * - vectorApproxDistance(quantized1, quantized2, 'INT8' | 'BINARY')
  *
+ * INT8 accepts a QuantizationResult or a raw int8 byte array. BINARY requires the BinaryQuantizationResult
+ * returned by vectorQuantizeBinary() (the packed bits alone are not enough - the Hamming distance needs the
+ * original length carried by the result object).
+ *
  * @author Luca Garulli (l.garulli--(at)--arcadedata.com)
  */
 public class SQLFunctionVectorApproxDistance extends SQLFunctionVectorAbstract {
@@ -95,20 +99,23 @@ public class SQLFunctionVectorApproxDistance extends SQLFunctionVectorAbstract {
   }
 
   private static QuantizationType inferType(final Object q1Obj, final Object q2Obj) {
-    final boolean binary = q1Obj instanceof BinaryQuantizationResult || q2Obj instanceof BinaryQuantizationResult;
-    final boolean int8 = q1Obj instanceof QuantizationResult || q2Obj instanceof QuantizationResult;
+    final boolean b1 = q1Obj instanceof BinaryQuantizationResult;
+    final boolean b2 = q2Obj instanceof BinaryQuantizationResult;
+    final boolean i1 = q1Obj instanceof QuantizationResult;
+    final boolean i2 = q2Obj instanceof QuantizationResult;
 
-    if (binary && int8)
+    // The two-argument form infers the type from result objects: both arguments must be one (no mixing a
+    // result object with a raw array, where inference would be unreliable).
+    if (!(b1 || i1) || !(b2 || i2))
+      throw new CommandSQLParsingException(
+          "Cannot infer the quantization type: the two-argument form requires the result objects of "
+              + "vector.quantizeInt8()/vector.quantizeBinary() for both arguments. For raw byte arrays, specify "
+              + "'INT8' / 'BINARY' as the third argument.");
+    if ((b1 || b2) && (i1 || i2))
       throw new CommandSQLParsingException(
           "Cannot mix INT8 and BINARY quantization results in vector.approxDistance(): both arguments must be "
               + "the same quantization type.");
-    if (binary)
-      return QuantizationType.BINARY;
-    if (int8)
-      return QuantizationType.INT8;
-    throw new CommandSQLParsingException(
-        "Cannot infer the quantization type from raw arrays: pass the result of vector.quantizeInt8()/"
-            + "vector.quantizeBinary(), or specify 'INT8' / 'BINARY' as the third argument.");
+    return b1 || b2 ? QuantizationType.BINARY : QuantizationType.INT8;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorApproxDistance.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorApproxDistance.java
@@ -20,6 +20,8 @@ package com.arcadedb.function.sql.vector;
 
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.exception.CommandSQLParsingException;
+import com.arcadedb.function.sql.vector.SQLFunctionVectorQuantizeBinary.BinaryQuantizationResult;
+import com.arcadedb.function.sql.vector.SQLFunctionVectorQuantizeInt8.QuantizationResult;
 import com.arcadedb.query.sql.executor.CommandContext;
 
 import java.util.Locale;
@@ -30,14 +32,17 @@ import java.util.Locale;
  *
  * 1. INT8 Mode: Computes L2 distance directly on int8 bytes
  *    - Much faster than dequantizing and computing on floats
- *    - Result is approximate but preserves ranking order
+ *    - Result is approximate but preserves the top-k ordering of the true distances
  *
  * 2. BINARY Mode: Computes Hamming distance on binary quantized vectors
  *    - Very fast (count differing bits)
  *    - 1 operation per 8 dimensions
  *    - Returns normalized Hamming distance [0, 1]
  *
- * Signature: vectorApproxDistance(quantized1, quantized2, 'INT8' | 'BINARY')
+ * Signatures:
+ * - vectorApproxDistance(result1, result2)  - the quantization type is inferred from the result objects
+ *                                             returned by vectorQuantizeInt8()/vectorQuantizeBinary()
+ * - vectorApproxDistance(quantized1, quantized2, 'INT8' | 'BINARY')
  *
  * @author Luca Garulli (l.garulli--(at)--arcadedata.com)
  */
@@ -56,36 +61,47 @@ public class SQLFunctionVectorApproxDistance extends SQLFunctionVectorAbstract {
   @Override
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
-    if (params == null || params.length != 3)
+    if (params == null || (params.length != 2 && params.length != 3))
       throw new CommandSQLParsingException(getSyntax());
 
     final Object q1Obj = params[0];
     final Object q2Obj = params[1];
-    final Object typeObj = params[2];
 
-    if (q1Obj == null || q2Obj == null || typeObj == null)
+    if (q1Obj == null || q2Obj == null)
       return null;
 
-    // Parse type
-    final String typeStr;
-    if (typeObj instanceof String str) {
-      typeStr = str.toUpperCase(Locale.ROOT);
+    final QuantizationType type;
+    if (params.length == 3) {
+      // Explicit type string (works with raw byte arrays as well as result objects).
+      final Object typeObj = params[2];
+      if (typeObj == null)
+        return null;
+      if (!(typeObj instanceof String str))
+        throw new CommandSQLParsingException("Type must be a string, found: " + typeObj.getClass().getSimpleName());
+      try {
+        type = QuantizationType.valueOf(str.toUpperCase(Locale.ROOT));
+      } catch (final IllegalArgumentException e) {
+        throw new CommandSQLParsingException("Unknown quantization type: " + str + ". Supported: INT8, BINARY");
+      }
     } else {
-      throw new CommandSQLParsingException("Type must be a string, found: " + typeObj.getClass().getSimpleName());
-    }
-
-    // Parse quantization type
-    QuantizationType type;
-    try {
-      type = QuantizationType.valueOf(typeStr);
-    } catch (final IllegalArgumentException e) {
-      throw new CommandSQLParsingException("Unknown quantization type: " + typeStr + ". Supported: INT8, BINARY");
+      // Infer the quantization type from the result objects produced by vector.quantizeInt8/quantizeBinary.
+      type = inferType(q1Obj, q2Obj);
     }
 
     return switch (type) {
       case INT8 -> computeInt8Distance(q1Obj, q2Obj);
       case BINARY -> computeBinaryDistance(q1Obj, q2Obj);
     };
+  }
+
+  private static QuantizationType inferType(final Object q1Obj, final Object q2Obj) {
+    if (q1Obj instanceof BinaryQuantizationResult || q2Obj instanceof BinaryQuantizationResult)
+      return QuantizationType.BINARY;
+    if (q1Obj instanceof QuantizationResult || q2Obj instanceof QuantizationResult)
+      return QuantizationType.INT8;
+    throw new CommandSQLParsingException(
+        "Cannot infer the quantization type from raw arrays: pass the result of vector.quantizeInt8()/"
+            + "vector.quantizeBinary(), or specify 'INT8' / 'BINARY' as the third argument.");
   }
 
   /**
@@ -126,7 +142,9 @@ public class SQLFunctionVectorApproxDistance extends SQLFunctionVectorAbstract {
   }
 
   private byte[] toByteArray(final Object quantized) {
-    if (quantized instanceof byte[] byteArray) {
+    if (quantized instanceof QuantizationResult qr) {
+      return qr.quantized();
+    } else if (quantized instanceof byte[] byteArray) {
       return byteArray;
     } else if (quantized instanceof Object[] objArray) {
       final byte[] result = new byte[objArray.length];
@@ -144,6 +162,6 @@ public class SQLFunctionVectorApproxDistance extends SQLFunctionVectorAbstract {
   }
 
   public String getSyntax() {
-    return NAME + "(<quantized1>, <quantized2>, <type>)";
+    return NAME + "(<quantized1>, <quantized2> [, <type>])";
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorApproxDistance.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorApproxDistance.java
@@ -95,9 +95,16 @@ public class SQLFunctionVectorApproxDistance extends SQLFunctionVectorAbstract {
   }
 
   private static QuantizationType inferType(final Object q1Obj, final Object q2Obj) {
-    if (q1Obj instanceof BinaryQuantizationResult || q2Obj instanceof BinaryQuantizationResult)
+    final boolean binary = q1Obj instanceof BinaryQuantizationResult || q2Obj instanceof BinaryQuantizationResult;
+    final boolean int8 = q1Obj instanceof QuantizationResult || q2Obj instanceof QuantizationResult;
+
+    if (binary && int8)
+      throw new CommandSQLParsingException(
+          "Cannot mix INT8 and BINARY quantization results in vector.approxDistance(): both arguments must be "
+              + "the same quantization type.");
+    if (binary)
       return QuantizationType.BINARY;
-    if (q1Obj instanceof QuantizationResult || q2Obj instanceof QuantizationResult)
+    if (int8)
       return QuantizationType.INT8;
     throw new CommandSQLParsingException(
         "Cannot infer the quantization type from raw arrays: pass the result of vector.quantizeInt8()/"

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDenseToSparse.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDenseToSparse.java
@@ -35,8 +35,8 @@ import java.util.List;
  * Example: denseVectorToSparse([0.5, 0.0, 0.3], 0.0)
  * → SparseVector with indices=[0, 2], values=[0.5, 0.3]
  *
- * Contract: this function is stateless (all work lives in execute() locals), so a single instance may be
- * shared across concurrent queries - {@code SQLMethodAsSparse} relies on this. Keep it stateless.
+ * Contract: this function is stateless (all work lives in execute() locals) and must remain so, so a single
+ * instance can be safely shared across concurrent queries. Do not add mutable instance fields.
  *
  * @author Luca Garulli (l.garulli--(at)--arcadedata.com)
  */

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDenseToSparse.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDenseToSparse.java
@@ -35,6 +35,9 @@ import java.util.List;
  * Example: denseVectorToSparse([0.5, 0.0, 0.3], 0.0)
  * → SparseVector with indices=[0, 2], values=[0.5, 0.3]
  *
+ * Contract: this function is stateless (all work lives in execute() locals), so a single instance may be
+ * shared across concurrent queries - {@code SQLMethodAsSparse} relies on this. Keep it stateless.
+ *
  * @author Luca Garulli (l.garulli--(at)--arcadedata.com)
  */
 public class SQLFunctionVectorDenseToSparse extends SQLFunctionVectorAbstract {

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDequantizeInt8.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDequantizeInt8.java
@@ -78,6 +78,13 @@ public class SQLFunctionVectorDequantizeInt8 extends SQLFunctionVectorAbstract {
     if (quantizedObj == null || minObj == null || maxObj == null)
       return null;
 
+    // If a QuantizationResult is passed in the 3-arg form, its own min/max are authoritative (they were
+    // computed at quantization time). Use them and ignore the explicit scalars, so the redundant call
+    // vectorDequantizeInt8(vectorQuantizeInt8([...]), min, max) is always correct even if the caller
+    // passes a different/wrong min/max (issue #3099).
+    if (quantizedObj instanceof QuantizationResult qr)
+      return dequantize(qr.quantized(), qr.min(), qr.max());
+
     // Parse quantized bytes
     final byte[] quantized = toByteArray(quantizedObj);
 
@@ -128,11 +135,7 @@ public class SQLFunctionVectorDequantizeInt8 extends SQLFunctionVectorAbstract {
   }
 
   private byte[] toByteArray(final Object quantized) {
-    if (quantized instanceof QuantizationResult qr) {
-      // Accept the result object in the (result, min, max) form too, so the redundant-min/max call
-      // vectorDequantizeInt8(vectorQuantizeInt8([...]), min, max) works (issue #3099).
-      return qr.quantized();
-    } else if (quantized instanceof byte[] byteArray) {
+    if (quantized instanceof byte[] byteArray) {
       return byteArray;
     } else if (quantized instanceof Object[] objArray) {
       final byte[] result = new byte[objArray.length];

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDequantizeInt8.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDequantizeInt8.java
@@ -157,6 +157,6 @@ public class SQLFunctionVectorDequantizeInt8 extends SQLFunctionVectorAbstract {
   }
 
   public String getSyntax() {
-    return NAME + "(<result>) | (<quantized_bytes>, <min>, <max>)";
+    return NAME + "(<result>) | " + NAME + "(<quantized_bytes>, <min>, <max>)";
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDequantizeInt8.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDequantizeInt8.java
@@ -36,6 +36,9 @@ import java.util.List;
  *                                             come from the result, no need to unpack)
  * - vectorDequantizeInt8(quantized_bytes, min, max)
  *
+ * If a result is passed to the 3-arg form, its embedded min/max are authoritative (they were used at
+ * quantization time, so only they reconstruct the original scale) and the scalar arguments are ignored.
+ *
  * Note: Dequantized values are approximations due to precision loss during quantization.
  * Original vector cannot be perfectly recovered.
  *
@@ -168,6 +171,6 @@ public class SQLFunctionVectorDequantizeInt8 extends SQLFunctionVectorAbstract {
   }
 
   public String getSyntax() {
-    return NAME + "(<result>[, ignored-min, ignored-max] | <quantized_bytes>, <min>, <max>)";
+    return NAME + "(<result> | <quantized_bytes>, <min>, <max>)";
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDequantizeInt8.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDequantizeInt8.java
@@ -157,6 +157,6 @@ public class SQLFunctionVectorDequantizeInt8 extends SQLFunctionVectorAbstract {
   }
 
   public String getSyntax() {
-    return NAME + "(<result>) | " + NAME + "(<quantized_bytes>, <min>, <max>)";
+    return NAME + "(<result>) | (<quantized_bytes>, <min>, <max>)";
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDequantizeInt8.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDequantizeInt8.java
@@ -134,7 +134,11 @@ public class SQLFunctionVectorDequantizeInt8 extends SQLFunctionVectorAbstract {
     if (!(explicit instanceof Number num))
       return true;
     final float value = num.floatValue();
-    final float tolerance = 1e-4f * Math.max(1.0f, Math.max(Math.abs(value), Math.abs(embedded)));
+    // Relative tolerance because float rounding error scales with magnitude (it is measured in ULPs). 1e-5
+    // is ~100x the float epsilon (~1.2e-7), comfortably absorbing a float->JSON-double->float round-trip of
+    // the embedded value while still rejecting a min/max that genuinely differs. The Math.max(1, ...) floor
+    // keeps the window from collapsing to ~0 for embedded values near zero.
+    final float tolerance = 1e-5f * Math.max(1.0f, Math.max(Math.abs(value), Math.abs(embedded)));
     return Math.abs(value - embedded) > tolerance;
   }
 

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDequantizeInt8.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDequantizeInt8.java
@@ -128,7 +128,11 @@ public class SQLFunctionVectorDequantizeInt8 extends SQLFunctionVectorAbstract {
   }
 
   private byte[] toByteArray(final Object quantized) {
-    if (quantized instanceof byte[] byteArray) {
+    if (quantized instanceof QuantizationResult qr) {
+      // Accept the result object in the (result, min, max) form too, so the redundant-min/max call
+      // vectorDequantizeInt8(vectorQuantizeInt8([...]), min, max) works (issue #3099).
+      return qr.quantized();
+    } else if (quantized instanceof byte[] byteArray) {
       return byteArray;
     } else if (quantized instanceof Object[] objArray) {
       final byte[] result = new byte[objArray.length];

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDequantizeInt8.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDequantizeInt8.java
@@ -37,8 +37,9 @@ import java.util.List;
  * - vectorDequantizeInt8(quantized_bytes, min, max)
  *
  * A result's embedded min/max are authoritative (they were used at quantization time, so only they
- * reconstruct the original scale): when a result is passed to the 3-arg form, any explicit min/max are
- * ignored in favour of the result's own (the redundant 3-arg call is supported but the scalars never win).
+ * reconstruct the original scale). When a result is passed to the 3-arg form, the explicit min/max must be
+ * null or match the embedded values (the redundant call is supported); scalars that conflict are rejected,
+ * since applying them would dequantize to a wrong scale.
  *
  * Note: Dequantized values are approximations due to precision loss during quantization.
  * Original vector cannot be perfectly recovered.
@@ -72,6 +73,7 @@ public class SQLFunctionVectorDequantizeInt8 extends SQLFunctionVectorAbstract {
       return dequantize(qr.quantized(), qr.min(), qr.max());
     }
 
+    // 2-arg form is intentionally unsupported: either 1 (result object) or 3 (bytes, min, max).
     if (params.length != 3)
       throw new CommandSQLParsingException(getSyntax());
 
@@ -79,18 +81,24 @@ public class SQLFunctionVectorDequantizeInt8 extends SQLFunctionVectorAbstract {
     if (quantizedObj == null)
       return null;
 
-    // If a QuantizationResult is passed in the 3-arg form, its own min/max are authoritative (they were
-    // computed at quantization time, so only they reconstruct the original scale). Use them and ignore the
-    // explicit scalars: issue #3099 explicitly requires the redundant call vectorDequantizeInt8(
-    // vectorQuantizeInt8([...]), min, max) to succeed (not error), and applying caller scalars would instead
-    // yield a wrong scale. A per-row warning is avoided on purpose - this is a scalar function and the
-    // redundant form fires once per record. This must run before the null-guard on the scalars below,
-    // otherwise (result, null, null) would wrongly short-circuit to null.
-    if (quantizedObj instanceof QuantizationResult qr)
-      return dequantize(qr.quantized(), qr.min(), qr.max());
-
     final Object minObj = params[1];
     final Object maxObj = params[2];
+
+    // A QuantizationResult's own min/max are authoritative (computed at quantization time, so only they
+    // reconstruct the original scale). Issue #3099 requires the redundant 3-arg call to succeed, so explicit
+    // scalars that are null - or that match the embedded values - are accepted and the embedded values used.
+    // Scalars that conflict with the embedded values would dequantize to a wrong scale and are almost
+    // certainly a caller mistake, so they are rejected loudly rather than silently ignored. This runs before
+    // the scalar null-guard below, otherwise (result, null, null) would wrongly short-circuit to null.
+    if (quantizedObj instanceof QuantizationResult qr) {
+      if (conflictsWithEmbedded(minObj, qr.min()))
+        throw new CommandSQLParsingException("Explicit min (" + minObj + ") conflicts with the result's embedded min ("
+            + qr.min() + "); omit min/max when passing a vector.quantizeInt8() result.");
+      if (conflictsWithEmbedded(maxObj, qr.max()))
+        throw new CommandSQLParsingException("Explicit max (" + maxObj + ") conflicts with the result's embedded max ("
+            + qr.max() + "); omit min/max when passing a vector.quantizeInt8() result.");
+      return dequantize(qr.quantized(), qr.min(), qr.max());
+    }
 
     if (minObj == null || maxObj == null)
       return null;
@@ -114,6 +122,20 @@ public class SQLFunctionVectorDequantizeInt8 extends SQLFunctionVectorAbstract {
     }
 
     return dequantize(quantized, min, max);
+  }
+
+  /**
+   * A null explicit scalar is a no-op (the embedded value is used). A non-null scalar conflicts unless it is
+   * numeric and equal to the embedded value within a small relative tolerance (absorbing float round-trip).
+   */
+  private static boolean conflictsWithEmbedded(final Object explicit, final float embedded) {
+    if (explicit == null)
+      return false;
+    if (!(explicit instanceof Number num))
+      return true;
+    final float value = num.floatValue();
+    final float tolerance = 1e-4f * Math.max(1.0f, Math.max(Math.abs(value), Math.abs(embedded)));
+    return Math.abs(value - embedded) > tolerance;
   }
 
   private float[] dequantize(final byte[] quantized, final float min, final float max) {

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDequantizeInt8.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDequantizeInt8.java
@@ -20,6 +20,7 @@ package com.arcadedb.function.sql.vector;
 
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.exception.CommandSQLParsingException;
+import com.arcadedb.function.sql.vector.SQLFunctionVectorQuantizeInt8.QuantizationResult;
 import com.arcadedb.query.sql.executor.CommandContext;
 import java.util.List;
 
@@ -30,12 +31,15 @@ import java.util.List;
  * Algorithm:
  * Inverse of quantization: value = ((quantized + 128) / 255) * (max - min) + min
  *
- * Signature: vectorDequantizeInt8(quantized_bytes, min, max)
+ * Signatures:
+ * - vectorDequantizeInt8(result)            - pass the result of vectorQuantizeInt8() directly (min/max
+ *                                             come from the result, no need to unpack)
+ * - vectorDequantizeInt8(quantized_bytes, min, max)
  *
  * Note: Dequantized values are approximations due to precision loss during quantization.
  * Original vector cannot be perfectly recovered.
  *
- * Example: vectorDequantizeInt8(quantized_bytes, 0.1, 0.9) → [0.1, 0.5, 0.9] (approximate)
+ * Example: vectorDequantizeInt8(vectorQuantizeInt8([0.1, 0.5, 0.9])) → [0.1, 0.5, 0.9] (approximate)
  *
  * @author Luca Garulli (l.garulli--(at)--arcadedata.com)
  */
@@ -49,7 +53,22 @@ public class SQLFunctionVectorDequantizeInt8 extends SQLFunctionVectorAbstract {
   @Override
   public Object execute(final Object self, final Identifiable currentRecord, final Object currentResult, final Object[] params,
       final CommandContext context) {
-    if (params == null || params.length != 3)
+    if (params == null || params.length < 1)
+      throw new CommandSQLParsingException(getSyntax());
+
+    // Object form: vectorDequantizeInt8(<result of vectorQuantizeInt8>) - min/max come from the result.
+    if (params.length == 1) {
+      final Object quantizedObj = params[0];
+      if (quantizedObj == null)
+        return null;
+      if (!(quantizedObj instanceof QuantizationResult qr))
+        throw new CommandSQLParsingException(
+            "Single-argument form expects the result of vector.quantizeInt8(), found: " + quantizedObj.getClass()
+                .getSimpleName() + ". Otherwise call vector.dequantizeInt8(<bytes>, <min>, <max>).");
+      return dequantize(qr.quantized(), qr.min(), qr.max());
+    }
+
+    if (params.length != 3)
       throw new CommandSQLParsingException(getSyntax());
 
     final Object quantizedObj = params[0];
@@ -77,13 +96,16 @@ public class SQLFunctionVectorDequantizeInt8 extends SQLFunctionVectorAbstract {
       throw new CommandSQLParsingException("Max must be a number, found: " + maxObj.getClass().getSimpleName());
     }
 
+    return dequantize(quantized, min, max);
+  }
+
+  private float[] dequantize(final byte[] quantized, final float min, final float max) {
     if (quantized.length == 0)
       throw new CommandSQLParsingException("Quantized vector cannot be empty");
 
     if (min > max)
       throw new CommandSQLParsingException("Min (" + min + ") must be <= max (" + max + ")");
 
-    // Dequantize
     final float[] result = new float[quantized.length];
     final float range = max - min;
 
@@ -135,6 +157,6 @@ public class SQLFunctionVectorDequantizeInt8 extends SQLFunctionVectorAbstract {
   }
 
   public String getSyntax() {
-    return NAME + "(<quantized_bytes>, <min>, <max>)";
+    return NAME + "(<result> | <quantized_bytes>, <min>, <max>)";
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDequantizeInt8.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDequantizeInt8.java
@@ -168,6 +168,6 @@ public class SQLFunctionVectorDequantizeInt8 extends SQLFunctionVectorAbstract {
   }
 
   public String getSyntax() {
-    return NAME + "(<result> | <quantized_bytes>, <min>, <max>)";
+    return NAME + "(<result>[, ignored-min, ignored-max] | <quantized_bytes>, <min>, <max>)";
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDequantizeInt8.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDequantizeInt8.java
@@ -72,18 +72,22 @@ public class SQLFunctionVectorDequantizeInt8 extends SQLFunctionVectorAbstract {
       throw new CommandSQLParsingException(getSyntax());
 
     final Object quantizedObj = params[0];
-    final Object minObj = params[1];
-    final Object maxObj = params[2];
-
-    if (quantizedObj == null || minObj == null || maxObj == null)
+    if (quantizedObj == null)
       return null;
 
     // If a QuantizationResult is passed in the 3-arg form, its own min/max are authoritative (they were
     // computed at quantization time). Use them and ignore the explicit scalars, so the redundant call
-    // vectorDequantizeInt8(vectorQuantizeInt8([...]), min, max) is always correct even if the caller
-    // passes a different/wrong min/max (issue #3099).
+    // vectorDequantizeInt8(vectorQuantizeInt8([...]), min, max) is always correct even when the caller
+    // passes a different/wrong - or null - min/max (issue #3099). This must run before the null-guard on
+    // the scalars, otherwise (result, null, null) would wrongly short-circuit to null.
     if (quantizedObj instanceof QuantizationResult qr)
       return dequantize(qr.quantized(), qr.min(), qr.max());
+
+    final Object minObj = params[1];
+    final Object maxObj = params[2];
+
+    if (minObj == null || maxObj == null)
+      return null;
 
     // Parse quantized bytes
     final byte[] quantized = toByteArray(quantizedObj);
@@ -164,6 +168,6 @@ public class SQLFunctionVectorDequantizeInt8 extends SQLFunctionVectorAbstract {
   }
 
   public String getSyntax() {
-    return NAME + "(<result>) | " + NAME + "(<quantized_bytes>, <min>, <max>)";
+    return NAME + "(<result> | <quantized_bytes>, <min>, <max>)";
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDequantizeInt8.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDequantizeInt8.java
@@ -157,6 +157,6 @@ public class SQLFunctionVectorDequantizeInt8 extends SQLFunctionVectorAbstract {
   }
 
   public String getSyntax() {
-    return NAME + "(<result> | <quantized_bytes>, <min>, <max>)";
+    return NAME + "(<result>) | " + NAME + "(<quantized_bytes>, <min>, <max>)";
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDequantizeInt8.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorDequantizeInt8.java
@@ -36,8 +36,9 @@ import java.util.List;
  *                                             come from the result, no need to unpack)
  * - vectorDequantizeInt8(quantized_bytes, min, max)
  *
- * If a result is passed to the 3-arg form, its embedded min/max are authoritative (they were used at
- * quantization time, so only they reconstruct the original scale) and the scalar arguments are ignored.
+ * A result's embedded min/max are authoritative (they were used at quantization time, so only they
+ * reconstruct the original scale): when a result is passed to the 3-arg form, any explicit min/max are
+ * ignored in favour of the result's own (the redundant 3-arg call is supported but the scalars never win).
  *
  * Note: Dequantized values are approximations due to precision loss during quantization.
  * Original vector cannot be perfectly recovered.
@@ -79,10 +80,12 @@ public class SQLFunctionVectorDequantizeInt8 extends SQLFunctionVectorAbstract {
       return null;
 
     // If a QuantizationResult is passed in the 3-arg form, its own min/max are authoritative (they were
-    // computed at quantization time). Use them and ignore the explicit scalars, so the redundant call
-    // vectorDequantizeInt8(vectorQuantizeInt8([...]), min, max) is always correct even when the caller
-    // passes a different/wrong - or null - min/max (issue #3099). This must run before the null-guard on
-    // the scalars, otherwise (result, null, null) would wrongly short-circuit to null.
+    // computed at quantization time, so only they reconstruct the original scale). Use them and ignore the
+    // explicit scalars: issue #3099 explicitly requires the redundant call vectorDequantizeInt8(
+    // vectorQuantizeInt8([...]), min, max) to succeed (not error), and applying caller scalars would instead
+    // yield a wrong scale. A per-row warning is avoided on purpose - this is a scalar function and the
+    // redundant form fires once per record. This must run before the null-guard on the scalars below,
+    // otherwise (result, null, null) would wrongly short-circuit to null.
     if (quantizedObj instanceof QuantizationResult qr)
       return dequantize(qr.quantized(), qr.min(), qr.max());
 
@@ -171,6 +174,6 @@ public class SQLFunctionVectorDequantizeInt8 extends SQLFunctionVectorAbstract {
   }
 
   public String getSyntax() {
-    return NAME + "(<result> | <quantized_bytes>, <min>, <max>)";
+    return NAME + "(<result>) | " + NAME + "(<quantized_bytes>, <min>, <max>)";
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorRRFScore.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorRRFScore.java
@@ -98,10 +98,12 @@ public class SQLFunctionVectorRRFScore extends SQLFunctionVectorAbstract {
     return (float) rrfScore;
   }
 
-  // Ranks are integer positions, so only integer-typed arrays/collections are accepted here. A float[]/
-  // double[] (typically a score or embedding vector passed by mistake) is deliberately NOT array-like: it
-  // falls through to the variadic path and is rejected as a non-number rank, a clearer error than treating
-  // each element as a rank and complaining it is not an integer.
+  // Ranks are integer positions, so only integer-typed arrays/collections are accepted here. Object[] and
+  // List are the shapes the query engine produces for a literal ranking list (e.g. SELECT vectorRRFScore([
+  // r1, r2, ...])), so both stay array-like even though their elements are validated as integers per item.
+  // A float[]/double[] (typically a score or embedding vector passed by mistake) is deliberately NOT
+  // array-like: it falls through to the variadic path and is rejected as a non-number rank, a clearer error
+  // than treating each element as a rank and complaining it is not an integer.
   private static boolean isArrayLike(final Object value) {
     return value instanceof int[] || value instanceof long[] || value instanceof Object[] || value instanceof List;
   }

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorRRFScore.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorRRFScore.java
@@ -130,9 +130,11 @@ public class SQLFunctionVectorRRFScore extends SQLFunctionVectorAbstract {
 
   /** Returns the RRF term {@code 1/(k+rank)}, validating that {@code rank} is a positive integer. */
   private static double rankTerm(final double rank, final long k) {
+    if (Double.isNaN(rank) || Double.isInfinite(rank))
+      throw new CommandSQLParsingException("Rank values must be finite numbers, found: " + rank);
     if (rank <= 0)
       throw new CommandSQLParsingException("Rank values must be positive integers, found: " + rank);
-    if (Double.isInfinite(rank) || rank != Math.rint(rank))
+    if (rank != Math.rint(rank))
       throw new CommandSQLParsingException("Rank values must be integers, found: " + rank);
     return 1.0 / (k + rank);
   }

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorRRFScore.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorRRFScore.java
@@ -23,6 +23,7 @@ import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.function.sql.FunctionOptions;
 import com.arcadedb.query.sql.executor.CommandContext;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -30,12 +31,15 @@ import java.util.Set;
  * Reciprocal Rank Fusion (RRF) scoring function for combining multiple ranking lists.
  * Computes: RRF = Σ (1 / (k + rank_i)) for each ranking provided.
  *
- * Usage: vectorRRFScore(rank1, rank2, rank3, ..., [{ k: <long> }])
- * where k is the constant (default 60, set only via the trailing options map), and ranks are integer
+ * Usage:
+ * - vectorRRFScore(rank1, rank2, rank3, ..., [{ k: <long> }])   (variadic ranks)
+ * - vectorRRFScore([rank1, rank2, ...], [{ k: <long> }])         (ranks grouped in an array)
+ *
+ * k is the constant (default 60, set only via the trailing options map), and ranks are integer
  * positions. Every positional numeric argument is always treated as a rank.
  *
  * Example: vectorRRFScore(1, 5, 10) = 1/61 + 1/65 + 1/70 ≈ 0.0456
- *          vectorRRFScore(1, 5, 10, { k: 100 }) = 1/101 + 1/105 + 1/110
+ *          vectorRRFScore([1, 5, 10], { k: 100 }) = 1/101 + 1/105 + 1/110
  *
  * @author Luca Garulli (l.garulli--(at)--arcadedata.com)
  */
@@ -54,6 +58,21 @@ public class SQLFunctionVectorRRFScore extends SQLFunctionVectorAbstract {
       final CommandContext context) {
     if (params == null || params.length < 1)
       throw new CommandSQLParsingException(getSyntax());
+
+    // Array form: vectorRRFScore([r1, r2, ...] [, { k: <long> }]) - ranks grouped in a single array/list,
+    // consistent with vector.multiScore's array input.
+    if (isArrayLike(params[0])) {
+      long k = DEFAULT_K;
+      if (params.length == 2) {
+        if (params[1] instanceof Map<?, ?> rawMap)
+          k = new FunctionOptions(NAME, rawMap, OPTIONS).getLong("k", DEFAULT_K);
+        else
+          throw new CommandSQLParsingException("Second argument of the array form must be an options map { k: <long> }");
+      } else if (params.length > 2) {
+        throw new CommandSQLParsingException(getSyntax());
+      }
+      return (float) rrf(toFloatArray(params[0]), k);
+    }
 
     long k = DEFAULT_K;
     int rankCount = params.length;
@@ -90,7 +109,22 @@ public class SQLFunctionVectorRRFScore extends SQLFunctionVectorAbstract {
     return (float) rrfScore;
   }
 
+  private static boolean isArrayLike(final Object value) {
+    return value instanceof float[] || value instanceof double[] || value instanceof int[] || value instanceof long[]
+        || value instanceof Object[] || value instanceof List;
+  }
+
+  private static double rrf(final float[] ranks, final long k) {
+    double score = 0.0;
+    for (final float rank : ranks) {
+      if (rank <= 0)
+        throw new CommandSQLParsingException("Rank values must be positive integers, found: " + rank);
+      score += 1.0 / (k + rank);
+    }
+    return score;
+  }
+
   public String getSyntax() {
-    return NAME + "(<rank1>, <rank2>, ..., [{ k: <long> }])";
+    return NAME + "(<rank1>, <rank2>, ... | [<ranks>], [{ k: <long> }])";
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorRRFScore.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorRRFScore.java
@@ -98,9 +98,12 @@ public class SQLFunctionVectorRRFScore extends SQLFunctionVectorAbstract {
     return (float) rrfScore;
   }
 
+  // Ranks are integer positions, so only integer-typed arrays/collections are accepted here. A float[]/
+  // double[] (typically a score or embedding vector passed by mistake) is deliberately NOT array-like: it
+  // falls through to the variadic path and is rejected as a non-number rank, a clearer error than treating
+  // each element as a rank and complaining it is not an integer.
   private static boolean isArrayLike(final Object value) {
-    return value instanceof float[] || value instanceof double[] || value instanceof int[] || value instanceof long[]
-        || value instanceof Object[] || value instanceof List;
+    return value instanceof int[] || value instanceof long[] || value instanceof Object[] || value instanceof List;
   }
 
   /** Sums the RRF terms over an array-like rank source (caller guarantees {@link #isArrayLike}). */
@@ -110,8 +113,6 @@ public class SQLFunctionVectorRRFScore extends SQLFunctionVectorAbstract {
     // Primitive arrays are iterated directly (no boxing, per the engine's GC-awareness policy).
     case int[] a -> { for (final int r : a) score += rankTerm(r, k); }
     case long[] a -> { for (final long r : a) score += rankTerm(r, k); }
-    case float[] a -> { for (final float r : a) score += rankTerm(r, k); }
-    case double[] a -> { for (final double r : a) score += rankTerm(r, k); }
     case Object[] a -> { for (final Object o : a) if (o != null) score += rankTerm(toDouble(o), k); }
     case List<?> l -> { for (final Object o : l) if (o != null) score += rankTerm(toDouble(o), k); }
     default -> throw new AssertionError("rrfFromArray reached with non-array-like: " + arrayLike.getClass().getSimpleName());

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorRRFScore.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorRRFScore.java
@@ -103,7 +103,9 @@ public class SQLFunctionVectorRRFScore extends SQLFunctionVectorAbstract {
   // r1, r2, ...])), so both stay array-like even though their elements are validated as integers per item.
   // A float[]/double[] (typically a score or embedding vector passed by mistake) is deliberately NOT
   // array-like: it falls through to the variadic path and is rejected as a non-number rank, a clearer error
-  // than treating each element as a rank and complaining it is not an integer.
+  // than treating each element as a rank and complaining it is not an integer. Other integer-typed primitive
+  // arrays (short[], byte[]) are too rare as rank inputs to special-case; they take the same variadic
+  // non-number rejection.
   private static boolean isArrayLike(final Object value) {
     return value instanceof int[] || value instanceof long[] || value instanceof Object[] || value instanceof List;
   }

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorRRFScore.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorRRFScore.java
@@ -136,6 +136,8 @@ public class SQLFunctionVectorRRFScore extends SQLFunctionVectorAbstract {
       throw new CommandSQLParsingException("Rank values must be finite numbers, found: " + rank);
     if (rank <= 0)
       throw new CommandSQLParsingException("Rank values must be positive integers, found: " + rank);
+    // Math.rint (not a (long) cast) so the integer test stays correct for magnitudes beyond long range:
+    // a value equal to its nearest integer is integer-valued; 1.5 != rint(1.5)==2.0 correctly rejects.
     if (rank != Math.rint(rank))
       throw new CommandSQLParsingException("Rank values must be integers, found: " + rank);
     return 1.0 / (k + rank);

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorRRFScore.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorRRFScore.java
@@ -59,10 +59,12 @@ public class SQLFunctionVectorRRFScore extends SQLFunctionVectorAbstract {
     if (params == null || params.length < 1)
       throw new CommandSQLParsingException(getSyntax());
 
-    // Array form: vectorRRFScore([r1, r2, ...] [, { k: <long> }]) - ranks grouped in a single array/list,
-    // consistent with vector.multiScore's array input.
+    final Object[] rankElements;
+    long k = DEFAULT_K;
+
     if (isArrayLike(params[0])) {
-      long k = DEFAULT_K;
+      // Array form: vectorRRFScore([r1, r2, ...] [, { k: <long> }]) - ranks grouped in a single array/list,
+      // consistent with vector.multiScore's array input.
       if (params.length == 2) {
         if (params[1] instanceof Map<?, ?> rawMap)
           k = new FunctionOptions(NAME, rawMap, OPTIONS).getLong("k", DEFAULT_K);
@@ -71,39 +73,29 @@ public class SQLFunctionVectorRRFScore extends SQLFunctionVectorAbstract {
       } else if (params.length > 2) {
         throw new CommandSQLParsingException(getSyntax());
       }
-      return (float) rrf(toFloatArray(params[0]), k);
+      rankElements = toObjectArray(params[0]);
+    } else {
+      // Variadic form: ranks as positional args, optional trailing { k } map.
+      // k is configured ONLY via a trailing options map { k: <long> }. A bare trailing number is always a
+      // rank, never k: ranks of 60+ are legitimate, so the previous "last number >= 60 is k" heuristic
+      // silently dropped a real rank and produced wrong results for >2 ranking lists (issue #3099).
+      int rankCount = params.length;
+      final Object lastParam = params[params.length - 1];
+      if (lastParam instanceof Map<?, ?> rawMap) {
+        k = new FunctionOptions(NAME, rawMap, OPTIONS).getLong("k", DEFAULT_K);
+        rankCount = params.length - 1;
+      }
+      rankElements = new Object[rankCount];
+      System.arraycopy(params, 0, rankElements, 0, rankCount);
     }
 
-    long k = DEFAULT_K;
-    int rankCount = params.length;
-
-    // k is configured ONLY via a trailing options map { k: <long> }. A bare trailing number is always a
-    // rank, never k: ranks of 60+ are legitimate, so the previous "last number >= 60 is k" heuristic
-    // silently dropped a real rank and produced wrong results for >2 ranking lists (issue #3099).
-    final Object lastParam = params[params.length - 1];
-    if (lastParam instanceof Map<?, ?> rawMap) {
-      final FunctionOptions opts = new FunctionOptions(NAME, rawMap, OPTIONS);
-      k = opts.getLong("k", DEFAULT_K);
-      rankCount = params.length - 1;
-    }
-
-    // Calculate RRF score
+    // Both forms share the same per-rank handling: a null rank is skipped (the item is absent from that
+    // ranking list), and every present rank must be a positive integer.
     double rrfScore = 0.0;
-    for (int i = 0; i < rankCount; i++) {
-      final Object rankObj = params[i];
+    for (final Object rankObj : rankElements) {
       if (rankObj == null)
         continue;
-
-      final long rank;
-      if (rankObj instanceof Number num)
-        rank = num.longValue();
-      else
-        throw new CommandSQLParsingException("Rank values must be numbers, found: " + rankObj.getClass().getSimpleName());
-
-      if (rank <= 0)
-        throw new CommandSQLParsingException("Rank values must be positive integers, found: " + rank);
-
-      rrfScore += 1.0 / (k + rank);
+      rrfScore += 1.0 / (k + toRank(rankObj));
     }
 
     return (float) rrfScore;
@@ -114,14 +106,47 @@ public class SQLFunctionVectorRRFScore extends SQLFunctionVectorAbstract {
         || value instanceof Object[] || value instanceof List;
   }
 
-  private static double rrf(final float[] ranks, final long k) {
-    double score = 0.0;
-    for (final float rank : ranks) {
-      if (rank <= 0)
-        throw new CommandSQLParsingException("Rank values must be positive integers, found: " + rank);
-      score += 1.0 / (k + rank);
+  /** Boxes any array-like (primitive array, Object[] or List) into an Object[] so null elements survive. */
+  private static Object[] toObjectArray(final Object arrayLike) {
+    if (arrayLike instanceof Object[] o)
+      return o;
+    if (arrayLike instanceof List<?> l)
+      return l.toArray();
+    if (arrayLike instanceof int[] a) {
+      final Object[] r = new Object[a.length];
+      for (int i = 0; i < a.length; i++)
+        r[i] = a[i];
+      return r;
     }
-    return score;
+    if (arrayLike instanceof long[] a) {
+      final Object[] r = new Object[a.length];
+      for (int i = 0; i < a.length; i++)
+        r[i] = a[i];
+      return r;
+    }
+    if (arrayLike instanceof float[] a) {
+      final Object[] r = new Object[a.length];
+      for (int i = 0; i < a.length; i++)
+        r[i] = a[i];
+      return r;
+    }
+    final double[] a = (double[]) arrayLike;
+    final Object[] r = new Object[a.length];
+    for (int i = 0; i < a.length; i++)
+      r[i] = a[i];
+    return r;
+  }
+
+  /** Validates a single rank value: must be a positive integer. */
+  private static long toRank(final Object rankObj) {
+    if (!(rankObj instanceof Number num))
+      throw new CommandSQLParsingException("Rank values must be numbers, found: " + rankObj.getClass().getSimpleName());
+    final double d = num.doubleValue();
+    if (d <= 0)
+      throw new CommandSQLParsingException("Rank values must be positive integers, found: " + num);
+    if (Double.isInfinite(d) || d != Math.rint(d))
+      throw new CommandSQLParsingException("Rank values must be integers, found: " + num);
+    return num.longValue();
   }
 
   public String getSyntax() {

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorRRFScore.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorRRFScore.java
@@ -100,7 +100,8 @@ public class SQLFunctionVectorRRFScore extends SQLFunctionVectorAbstract {
 
   // Ranks are integer positions, so only integer-typed arrays/collections are accepted here. Object[] and
   // List are the shapes the query engine produces for a literal ranking list (e.g. SELECT vectorRRFScore([
-  // r1, r2, ...])), so both stay array-like even though their elements are validated as integers per item.
+  // r1, r2, ...])); this also covers boxed arrays like Integer[]/Long[] (an Integer[] is an Object[]). Both
+  // stay array-like even though their elements are validated as integers per item.
   // A float[]/double[] (typically a score or embedding vector passed by mistake) is deliberately NOT
   // array-like: it falls through to the variadic path and is rejected as a non-number rank, a clearer error
   // than treating each element as a rank and complaining it is not an integer. Other integer-typed primitive
@@ -144,6 +145,6 @@ public class SQLFunctionVectorRRFScore extends SQLFunctionVectorAbstract {
   }
 
   public String getSyntax() {
-    return NAME + "(<rank1>, <rank2>, ... | [<ranks>], [{ k: <long> }])";
+    return NAME + "(<rank1>, <rank2>, ... [, { k: <long> }]) | " + NAME + "([<ranks>] [, { k: <long> }])";
   }
 }

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorRRFScore.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorRRFScore.java
@@ -103,24 +103,18 @@ public class SQLFunctionVectorRRFScore extends SQLFunctionVectorAbstract {
         || value instanceof Object[] || value instanceof List;
   }
 
-  /**
-   * Sums the RRF terms over an array-like rank source. Primitive arrays are iterated directly (no boxing,
-   * per the engine's GC-awareness policy); {@code Object[]}/{@code List} skip null elements (the item is
-   * absent from that ranking list). {@code float[]}/{@code double[]} are accepted for symmetry with the
-   * other vector functions, but every element must still be an integer-valued rank - {@link #rankTerm}
-   * rejects any non-integer (e.g. {@code 1.5}) regardless of the array type, so a float that lost precision
-   * cannot silently slip through.
-   */
+  /** Sums the RRF terms over an array-like rank source (caller guarantees {@link #isArrayLike}). */
   private static double rrfFromArray(final Object arrayLike, final long k) {
     double score = 0.0;
     switch (arrayLike) {
+    // Primitive arrays are iterated directly (no boxing, per the engine's GC-awareness policy).
     case int[] a -> { for (final int r : a) score += rankTerm(r, k); }
     case long[] a -> { for (final long r : a) score += rankTerm(r, k); }
     case float[] a -> { for (final float r : a) score += rankTerm(r, k); }
     case double[] a -> { for (final double r : a) score += rankTerm(r, k); }
     case Object[] a -> { for (final Object o : a) if (o != null) score += rankTerm(toDouble(o), k); }
     case List<?> l -> { for (final Object o : l) if (o != null) score += rankTerm(toDouble(o), k); }
-    default -> throw new CommandSQLParsingException("Ranks must be an array or list, found: " + arrayLike.getClass().getSimpleName());
+    default -> throw new AssertionError("rrfFromArray reached with non-array-like: " + arrayLike.getClass().getSimpleName());
     }
     return score;
   }

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorRRFScore.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorRRFScore.java
@@ -106,7 +106,10 @@ public class SQLFunctionVectorRRFScore extends SQLFunctionVectorAbstract {
   /**
    * Sums the RRF terms over an array-like rank source. Primitive arrays are iterated directly (no boxing,
    * per the engine's GC-awareness policy); {@code Object[]}/{@code List} skip null elements (the item is
-   * absent from that ranking list).
+   * absent from that ranking list). {@code float[]}/{@code double[]} are accepted for symmetry with the
+   * other vector functions, but every element must still be an integer-valued rank - {@link #rankTerm}
+   * rejects any non-integer (e.g. {@code 1.5}) regardless of the array type, so a float that lost precision
+   * cannot silently slip through.
    */
   private static double rrfFromArray(final Object arrayLike, final long k) {
     double score = 0.0;

--- a/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorRRFScore.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/vector/SQLFunctionVectorRRFScore.java
@@ -59,12 +59,10 @@ public class SQLFunctionVectorRRFScore extends SQLFunctionVectorAbstract {
     if (params == null || params.length < 1)
       throw new CommandSQLParsingException(getSyntax());
 
-    final Object[] rankElements;
-    long k = DEFAULT_K;
-
     if (isArrayLike(params[0])) {
       // Array form: vectorRRFScore([r1, r2, ...] [, { k: <long> }]) - ranks grouped in a single array/list,
       // consistent with vector.multiScore's array input.
+      long k = DEFAULT_K;
       if (params.length == 2) {
         if (params[1] instanceof Map<?, ?> rawMap)
           k = new FunctionOptions(NAME, rawMap, OPTIONS).getLong("k", DEFAULT_K);
@@ -73,31 +71,30 @@ public class SQLFunctionVectorRRFScore extends SQLFunctionVectorAbstract {
       } else if (params.length > 2) {
         throw new CommandSQLParsingException(getSyntax());
       }
-      rankElements = toObjectArray(params[0]);
-    } else {
-      // Variadic form: ranks as positional args, optional trailing { k } map.
-      // k is configured ONLY via a trailing options map { k: <long> }. A bare trailing number is always a
-      // rank, never k: ranks of 60+ are legitimate, so the previous "last number >= 60 is k" heuristic
-      // silently dropped a real rank and produced wrong results for >2 ranking lists (issue #3099).
-      int rankCount = params.length;
-      final Object lastParam = params[params.length - 1];
-      if (lastParam instanceof Map<?, ?> rawMap) {
-        k = new FunctionOptions(NAME, rawMap, OPTIONS).getLong("k", DEFAULT_K);
-        rankCount = params.length - 1;
-      }
-      rankElements = new Object[rankCount];
-      System.arraycopy(params, 0, rankElements, 0, rankCount);
+      return (float) rrfFromArray(params[0], k);
     }
 
-    // Both forms share the same per-rank handling: a null rank is skipped (the item is absent from that
-    // ranking list), and every present rank must be a positive integer.
+    // Variadic form: ranks as positional args, optional trailing { k } map.
+    // k is configured ONLY via a trailing options map { k: <long> }. A bare trailing number is always a
+    // rank, never k: ranks of 60+ are legitimate, so the previous "last number >= 60 is k" heuristic
+    // silently dropped a real rank and produced wrong results for >2 ranking lists (issue #3099).
+    long k = DEFAULT_K;
+    int rankCount = params.length;
+    final Object lastParam = params[params.length - 1];
+    if (lastParam instanceof Map<?, ?> rawMap) {
+      k = new FunctionOptions(NAME, rawMap, OPTIONS).getLong("k", DEFAULT_K);
+      rankCount = params.length - 1;
+    }
+
+    // A null rank is skipped (the item is absent from that ranking list); every present rank must be a
+    // positive integer (same handling as the array form).
     double rrfScore = 0.0;
-    for (final Object rankObj : rankElements) {
+    for (int i = 0; i < rankCount; i++) {
+      final Object rankObj = params[i];
       if (rankObj == null)
         continue;
-      rrfScore += 1.0 / (k + toRank(rankObj));
+      rrfScore += rankTerm(toDouble(rankObj), k);
     }
-
     return (float) rrfScore;
   }
 
@@ -106,47 +103,38 @@ public class SQLFunctionVectorRRFScore extends SQLFunctionVectorAbstract {
         || value instanceof Object[] || value instanceof List;
   }
 
-  /** Boxes any array-like (primitive array, Object[] or List) into an Object[] so null elements survive. */
-  private static Object[] toObjectArray(final Object arrayLike) {
-    if (arrayLike instanceof Object[] o)
-      return o;
-    if (arrayLike instanceof List<?> l)
-      return l.toArray();
-    if (arrayLike instanceof int[] a) {
-      final Object[] r = new Object[a.length];
-      for (int i = 0; i < a.length; i++)
-        r[i] = a[i];
-      return r;
+  /**
+   * Sums the RRF terms over an array-like rank source. Primitive arrays are iterated directly (no boxing,
+   * per the engine's GC-awareness policy); {@code Object[]}/{@code List} skip null elements (the item is
+   * absent from that ranking list).
+   */
+  private static double rrfFromArray(final Object arrayLike, final long k) {
+    double score = 0.0;
+    switch (arrayLike) {
+    case int[] a -> { for (final int r : a) score += rankTerm(r, k); }
+    case long[] a -> { for (final long r : a) score += rankTerm(r, k); }
+    case float[] a -> { for (final float r : a) score += rankTerm(r, k); }
+    case double[] a -> { for (final double r : a) score += rankTerm(r, k); }
+    case Object[] a -> { for (final Object o : a) if (o != null) score += rankTerm(toDouble(o), k); }
+    case List<?> l -> { for (final Object o : l) if (o != null) score += rankTerm(toDouble(o), k); }
+    default -> throw new CommandSQLParsingException("Ranks must be an array or list, found: " + arrayLike.getClass().getSimpleName());
     }
-    if (arrayLike instanceof long[] a) {
-      final Object[] r = new Object[a.length];
-      for (int i = 0; i < a.length; i++)
-        r[i] = a[i];
-      return r;
-    }
-    if (arrayLike instanceof float[] a) {
-      final Object[] r = new Object[a.length];
-      for (int i = 0; i < a.length; i++)
-        r[i] = a[i];
-      return r;
-    }
-    final double[] a = (double[]) arrayLike;
-    final Object[] r = new Object[a.length];
-    for (int i = 0; i < a.length; i++)
-      r[i] = a[i];
-    return r;
+    return score;
   }
 
-  /** Validates a single rank value: must be a positive integer. */
-  private static long toRank(final Object rankObj) {
-    if (!(rankObj instanceof Number num))
-      throw new CommandSQLParsingException("Rank values must be numbers, found: " + rankObj.getClass().getSimpleName());
-    final double d = num.doubleValue();
-    if (d <= 0)
-      throw new CommandSQLParsingException("Rank values must be positive integers, found: " + num);
-    if (Double.isInfinite(d) || d != Math.rint(d))
-      throw new CommandSQLParsingException("Rank values must be integers, found: " + num);
-    return num.longValue();
+  private static double toDouble(final Object rankObj) {
+    if (rankObj instanceof Number num)
+      return num.doubleValue();
+    throw new CommandSQLParsingException("Rank values must be numbers, found: " + rankObj.getClass().getSimpleName());
+  }
+
+  /** Returns the RRF term {@code 1/(k+rank)}, validating that {@code rank} is a positive integer. */
+  private static double rankTerm(final double rank, final long k) {
+    if (rank <= 0)
+      throw new CommandSQLParsingException("Rank values must be positive integers, found: " + rank);
+    if (Double.isInfinite(rank) || rank != Math.rint(rank))
+      throw new CommandSQLParsingException("Rank values must be integers, found: " + rank);
+    return 1.0 / (k + rank);
   }
 
   public String getSyntax() {

--- a/engine/src/main/java/com/arcadedb/index/vector/VectorUtils.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/VectorUtils.java
@@ -192,7 +192,9 @@ public final class VectorUtils {
         return new float[0];
       // Split on commas, semicolons and/or whitespace so every asString()/vector.toString() format
       // round-trips: comma-separated (COMPACT/PYTHON/JULIA/NUMPY), space-separated (MATLAB),
-      // semicolon-separated (MATLAB_COLUMN) and multi-line (PRETTY).
+      // semicolon-separated (MATLAB_COLUMN) and multi-line (PRETTY). This is intentionally lenient: a
+      // string mixing separators (e.g. "1.0, 2.0; 3.0") is accepted even though no format emits one, so
+      // hand-written input parses without fuss.
       final String[] parts = cleaned.split("[,;\\s]+");
       final float[] result = new float[parts.length];
       for (int i = 0; i < parts.length; i++)

--- a/engine/src/main/java/com/arcadedb/index/vector/VectorUtils.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/VectorUtils.java
@@ -264,12 +264,8 @@ public final class VectorUtils {
    * {@code []} (or an empty string for {@code NUMPY}).
    */
   public static String formatVector(final float[] vector, final StringFormat format) {
-    final String separator = switch (format) {
-      case MATLAB -> " ";
-      case MATLAB_COLUMN -> "; ";
-      default -> ", ";
-    };
     if (format == StringFormat.PRETTY) {
+      // PRETTY builds its own newline-delimited layout and does not use the single-line separator below.
       final StringBuilder sb = new StringBuilder("[\n");
       for (int i = 0; i < vector.length; i++) {
         sb.append("  ").append(vector[i]);
@@ -280,6 +276,11 @@ public final class VectorUtils {
       return sb.append("]").toString();
     }
 
+    final String separator = switch (format) {
+      case MATLAB -> " ";
+      case MATLAB_COLUMN -> "; ";
+      default -> ", ";
+    };
     final StringBuilder sb = new StringBuilder();
     for (int i = 0; i < vector.length; i++) {
       if (i > 0)

--- a/engine/src/main/java/com/arcadedb/index/vector/VectorUtils.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/VectorUtils.java
@@ -190,9 +190,10 @@ public final class VectorUtils {
       final String cleaned = inner.trim();
       if (cleaned.isEmpty())
         return new float[0];
-      // Split on commas and/or whitespace so every asString()/vector.toString() format round-trips:
-      // comma-separated (COMPACT/PYTHON/JULIA/NUMPY), space-separated (MATLAB) and multi-line (PRETTY).
-      final String[] parts = cleaned.split("[,\\s]+");
+      // Split on commas, semicolons and/or whitespace so every asString()/vector.toString() format
+      // round-trips: comma-separated (COMPACT/PYTHON/JULIA/NUMPY), space-separated (MATLAB),
+      // semicolon-separated (MATLAB_COLUMN) and multi-line (PRETTY).
+      final String[] parts = cleaned.split("[,;\\s]+");
       final float[] result = new float[parts.length];
       for (int i = 0; i < parts.length; i++)
         result[i] = Float.parseFloat(parts[i]);
@@ -226,6 +227,7 @@ public final class VectorUtils {
    *   <li>{@code PRETTY}: one element per line</li>
    *   <li>{@code PYTHON}: Python list literal {@code [1.0, 2.0, 3.0]}</li>
    *   <li>{@code MATLAB}: space-separated row vector {@code [1.0 2.0 3.0]}</li>
+   *   <li>{@code MATLAB_COLUMN}: semicolon-separated column vector {@code [1.0; 2.0; 3.0]}</li>
    *   <li>{@code JULIA}: Julia vector literal {@code [1.0, 2.0, 3.0]}</li>
    *   <li>{@code NUMPY}: bare comma-separated {@code 1.0, 2.0, 3.0} (no brackets), suitable for
    *       {@code numpy.fromstring(..., sep=",")}</li>
@@ -236,6 +238,7 @@ public final class VectorUtils {
     PRETTY,
     PYTHON,
     MATLAB,
+    MATLAB_COLUMN,
     JULIA,
     NUMPY
   }
@@ -249,7 +252,8 @@ public final class VectorUtils {
     try {
       return StringFormat.valueOf(name.toUpperCase(java.util.Locale.ROOT));
     } catch (final IllegalArgumentException e) {
-      throw new IllegalArgumentException("Unknown format: " + name + ". Supported: COMPACT, PRETTY, PYTHON, MATLAB, JULIA, NUMPY");
+      throw new IllegalArgumentException(
+          "Unknown format: " + name + ". Supported: COMPACT, PRETTY, PYTHON, MATLAB, MATLAB_COLUMN, JULIA, NUMPY");
     }
   }
 
@@ -258,7 +262,11 @@ public final class VectorUtils {
    * {@code []} (or an empty string for {@code NUMPY}).
    */
   public static String formatVector(final float[] vector, final StringFormat format) {
-    final String separator = format == StringFormat.MATLAB ? " " : ", ";
+    final String separator = switch (format) {
+      case MATLAB -> " ";
+      case MATLAB_COLUMN -> "; ";
+      default -> ", ";
+    };
     if (format == StringFormat.PRETTY) {
       final StringBuilder sb = new StringBuilder("[\n");
       for (int i = 0; i < vector.length; i++) {

--- a/engine/src/main/java/com/arcadedb/query/sql/method/DefaultSQLMethodFactory.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/DefaultSQLMethodFactory.java
@@ -46,6 +46,7 @@ import com.arcadedb.query.sql.method.conversion.SQLMethodAsRID;
 import com.arcadedb.query.sql.method.conversion.SQLMethodAsRecord;
 import com.arcadedb.query.sql.method.conversion.SQLMethodAsSet;
 import com.arcadedb.query.sql.method.conversion.SQLMethodAsShort;
+import com.arcadedb.query.sql.method.conversion.SQLMethodAsSparse;
 import com.arcadedb.query.sql.method.conversion.SQLMethodAsString;
 import com.arcadedb.query.sql.method.conversion.SQLMethodAsVector;
 import com.arcadedb.query.sql.method.conversion.SQLMethodConvert;
@@ -132,6 +133,7 @@ public final class DefaultSQLMethodFactory implements SQLMethodFactory {
     register(SQLMethodAsRecord.NAME, new SQLMethodAsRecord());
     register(SQLMethodAsSet.NAME, new SQLMethodAsSet());
     register(SQLMethodAsShort.NAME, new SQLMethodAsShort());
+    register(SQLMethodAsSparse.NAME, new SQLMethodAsSparse());
     register(SQLMethodAsString.NAME, new SQLMethodAsString());
     register(SQLMethodAsVector.NAME, new SQLMethodAsVector());
     register(SQLMethodConvert.NAME, new SQLMethodConvert());

--- a/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsSparse.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsSparse.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.method.conversion;
+
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.function.sql.vector.SQLFunctionVectorDenseToSparse;
+import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.method.AbstractSQLMethod;
+
+/**
+ * Converts a dense vector value into a sparse vector, dropping elements whose absolute value is at or
+ * below an optional threshold (default {@code 0.0}, i.e. drops exact zeros). The method form of
+ * {@code vector.denseToSparse()}: {@code embedding.asSparse()} / {@code embedding.asSparse(0.01)},
+ * consistent with the {@code asString()} / {@code asVector()} conversion-method family.
+ *
+ * Example: {@code [0.5, 0.0, 0.3].asSparse()} -> SparseVector indices=[0, 2] values=[0.5, 0.3]
+ *
+ * @author Luca Garulli (l.garulli--(at)--arcadedata.com)
+ */
+public class SQLMethodAsSparse extends AbstractSQLMethod {
+
+  public static final String NAME = "assparse";
+
+  public SQLMethodAsSparse() {
+    super(NAME, 0, 1);
+  }
+
+  @Override
+  public Object execute(final Object value, final Identifiable currentRecord, final CommandContext context,
+      final Object[] params) {
+    if (value == null)
+      return null;
+
+    final Object[] fnParams = params != null && params.length > 0 && params[0] != null ?
+        new Object[] { value, params[0] } :
+        new Object[] { value };
+
+    // Reuse the function implementation so dense->sparse logic lives in one place.
+    return new SQLFunctionVectorDenseToSparse().execute(null, currentRecord, null, fnParams, context);
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsSparse.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsSparse.java
@@ -29,7 +29,7 @@ import com.arcadedb.query.sql.method.AbstractSQLMethod;
  * {@code vector.denseToSparse()}: {@code embedding.asSparse()} / {@code embedding.asSparse(0.01)},
  * consistent with the {@code asString()} / {@code asVector()} conversion-method family.
  *
- * Example: {@code [0.5, 0.0, 0.3].asSparse()} -> SparseVector indices=[0, 2] values=[0.5, 0.3]
+ * Example: {@code [0.5, 0.0, 0.3].asSparse()} → SparseVector indices=[0, 2] values=[0.5, 0.3]
  *
  * @author Luca Garulli (l.garulli--(at)--arcadedata.com)
  */
@@ -37,7 +37,9 @@ public class SQLMethodAsSparse extends AbstractSQLMethod {
 
   public static final String NAME = "assparse";
 
-  // Stateless function: reuse a single shared instance instead of allocating one per method call.
+  // Thread-safe: SQLFunctionVectorDenseToSparse holds no mutable state (all work is in local variables of
+  // execute()), so a single shared instance can be reused across concurrent queries instead of allocating
+  // one per method call.
   private static final SQLFunctionVectorDenseToSparse DENSE_TO_SPARSE = new SQLFunctionVectorDenseToSparse();
 
   public SQLMethodAsSparse() {

--- a/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsSparse.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsSparse.java
@@ -37,9 +37,8 @@ public class SQLMethodAsSparse extends AbstractSQLMethod {
 
   public static final String NAME = "assparse";
 
-  // Thread-safe: SQLFunctionVectorDenseToSparse holds no mutable state (all work is in local variables of
-  // execute()), so a single shared instance can be reused across concurrent queries instead of allocating
-  // one per method call.
+  // Shared instance reused across concurrent queries (no per-call allocation). Safe because
+  // SQLFunctionVectorDenseToSparse is documented and required to be stateless - see its class Javadoc.
   private static final SQLFunctionVectorDenseToSparse DENSE_TO_SPARSE = new SQLFunctionVectorDenseToSparse();
 
   public SQLMethodAsSparse() {

--- a/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsSparse.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/method/conversion/SQLMethodAsSparse.java
@@ -37,6 +37,9 @@ public class SQLMethodAsSparse extends AbstractSQLMethod {
 
   public static final String NAME = "assparse";
 
+  // Stateless function: reuse a single shared instance instead of allocating one per method call.
+  private static final SQLFunctionVectorDenseToSparse DENSE_TO_SPARSE = new SQLFunctionVectorDenseToSparse();
+
   public SQLMethodAsSparse() {
     super(NAME, 0, 1);
   }
@@ -52,6 +55,6 @@ public class SQLMethodAsSparse extends AbstractSQLMethod {
         new Object[] { value };
 
     // Reuse the function implementation so dense->sparse logic lives in one place.
-    return new SQLFunctionVectorDenseToSparse().execute(null, currentRecord, null, fnParams, context);
+    return DENSE_TO_SPARSE.execute(null, currentRecord, null, fnParams, context);
   }
 }

--- a/engine/src/test/java/com/arcadedb/function/sql/fulltext/SQLFunctionSearchFieldsMoreTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/fulltext/SQLFunctionSearchFieldsMoreTest.java
@@ -152,7 +152,7 @@ class SQLFunctionSearchFieldsMoreTest extends TestHelper {
   void nonExistentRID() {
     assertThatThrownBy(() ->
       database.query("sql", "SELECT FROM Article WHERE SEARCH_FIELDS_MORE(['title', 'body'], [#99:999]) = true"))
-      .hasMessageContaining("Bucket with id '99' was not found");
+      .hasMessageContaining("Record #99:999 not found");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorEnhancementsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorEnhancementsTest.java
@@ -386,6 +386,20 @@ class SQLFunctionVectorEnhancementsTest extends TestHelper {
         .hasMessageContaining("Cannot infer");
   }
 
+  @Test
+  void approxDistanceRejectsMixedQuantizationTypes() {
+    final SQLFunctionVectorQuantizeInt8 qi = new SQLFunctionVectorQuantizeInt8();
+    final SQLFunctionVectorQuantizeBinary qb = new SQLFunctionVectorQuantizeBinary();
+    final SQLFunctionVectorApproxDistance ad = new SQLFunctionVectorApproxDistance();
+
+    final Object int8 = qi.execute(null, null, null, new Object[] { new float[] { 1.0f, 2.0f, 3.0f } }, ctx());
+    final Object binary = qb.execute(null, null, null, new Object[] { new float[] { 0.1f, 0.5f, 0.9f } }, ctx());
+
+    assertThatThrownBy(() -> ad.execute(null, null, null, new Object[] { binary, int8 }, ctx()))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("Cannot mix");
+  }
+
   // ========== asSparse() method (#4) ==========
 
   @Test
@@ -420,6 +434,30 @@ class SQLFunctionVectorEnhancementsTest extends TestHelper {
     assertThat((float) fn.execute(null, null, null,
         new Object[] { java.util.List.of(1L, 5L, 10L), java.util.Map.of("k", 100L) }, ctx()))
         .isCloseTo((1.0f / 101) + (1.0f / 105) + (1.0f / 110), Offset.offset(1e-5f));
+  }
+
+  @Test
+  void rrfScoreSkipsNullRanksConsistentlyInBothForms() {
+    final SQLFunctionVectorRRFScore fn = new SQLFunctionVectorRRFScore();
+    final float expected = (1.0f / 61) + (1.0f / 65);
+    // variadic with a null rank
+    final java.util.List<Object> variadic = new java.util.ArrayList<>(java.util.Arrays.asList(null, 1L, 5L));
+    assertThat((float) fn.execute(null, null, null, variadic.toArray(), ctx())).isCloseTo(expected, Offset.offset(1e-5f));
+    // array form with a null element must behave the same (the item is absent from that ranking list)
+    assertThat((float) fn.execute(null, null, null, new Object[] { variadic }, ctx())).isCloseTo(expected, Offset.offset(1e-5f));
+  }
+
+  @Test
+  void rrfScoreRejectsNonIntegerRanksInBothForms() {
+    final SQLFunctionVectorRRFScore fn = new SQLFunctionVectorRRFScore();
+    // array form
+    assertThatThrownBy(() -> fn.execute(null, null, null, new Object[] { new double[] { 1.5, 5.0 } }, ctx()))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("integers");
+    // variadic form - no longer silently truncates 1.5 -> 1
+    assertThatThrownBy(() -> fn.execute(null, null, null, new Object[] { 1.5, 5.0 }, ctx()))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("integers");
   }
 
   // ========== MATLAB_COLUMN format (#21) ==========

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorEnhancementsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorEnhancementsTest.java
@@ -362,6 +362,19 @@ class SQLFunctionVectorEnhancementsTest extends TestHelper {
   }
 
   @Test
+  void dequantizeInt8AcceptsResultObjectInThreeArgFormToo() {
+    // The exact form from the issue: result object passed with redundant min/max must not error.
+    final SQLFunctionVectorQuantizeInt8 q = new SQLFunctionVectorQuantizeInt8();
+    final SQLFunctionVectorDequantizeInt8 dq = new SQLFunctionVectorDequantizeInt8();
+
+    final Object qr = q.execute(null, null, null, new Object[] { new float[] { 1.0f, 2.0f, 3.0f } }, ctx());
+    final float[] back = (float[]) dq.execute(null, null, null, new Object[] { qr, 1.0f, 3.0f }, ctx());
+    assertThat(back).hasSize(3);
+    assertThat(back[0]).isCloseTo(1.0f, Offset.offset(0.05f));
+    assertThat(back[2]).isCloseTo(3.0f, Offset.offset(0.05f));
+  }
+
+  @Test
   void approxDistanceInfersTypeFromResultObjects() {
     final SQLFunctionVectorQuantizeInt8 qi = new SQLFunctionVectorQuantizeInt8();
     final SQLFunctionVectorQuantizeBinary qb = new SQLFunctionVectorQuantizeBinary();

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorEnhancementsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorEnhancementsTest.java
@@ -470,6 +470,12 @@ class SQLFunctionVectorEnhancementsTest extends TestHelper {
 
     try (final ResultSet rs = database.query("sql", "SELECT [0.5, 0.0, 0.3].asSparse() as r")) {
       assertThat(rs.hasNext()).isTrue();
+      final SparseVector fromSql = (SparseVector) rs.next().getProperty("r");
+      assertThat(fromSql.getDimensions()).isEqualTo(3);
+      assertThat(fromSql.getNonZeroCount()).isEqualTo(2);
+      assertThat(fromSql.get(0)).isEqualTo(0.5f);
+      assertThat(fromSql.get(1)).isEqualTo(0.0f);
+      assertThat(fromSql.get(2)).isEqualTo(0.3f);
     }
   }
 
@@ -516,5 +522,47 @@ class SQLFunctionVectorEnhancementsTest extends TestHelper {
     assertThat(str("SELECT `vector.toString`([1.0, 2.0, 3.0], 'MATLAB_COLUMN') as r")).isEqualTo("[1.0; 2.0; 3.0]");
     // semicolons parse back like the other separators
     assertThat(vec("SELECT '[1.0; 2.0; 3.0]'.asVector() as r")).containsExactly(1.0f, 2.0f, 3.0f);
+  }
+
+  // ========== review follow-ups: edge cases ==========
+
+  @Test
+  void dequantizeInt8ThreeArgIgnoresExplicitMinMaxWhenGivenResult() {
+    // A QuantizationResult carries its own authoritative min/max. If the caller passes different scalars in
+    // the 3-arg form, the result's values must win so the dequantization stays correct (no silent wrong scale).
+    final SQLFunctionVectorQuantizeInt8 q = new SQLFunctionVectorQuantizeInt8();
+    final SQLFunctionVectorDequantizeInt8 dq = new SQLFunctionVectorDequantizeInt8();
+
+    final Object qr = q.execute(null, null, null, new Object[] { new float[] { 1.0f, 2.0f, 3.0f } }, ctx());
+    final float[] withResultMinMax = (float[]) dq.execute(null, null, null, new Object[] { qr }, ctx());
+    // Deliberately bogus explicit min/max - must be ignored in favour of the result's own.
+    final float[] withBogusMinMax = (float[]) dq.execute(null, null, null, new Object[] { qr, -99.0f, 99.0f }, ctx());
+    assertThat(withBogusMinMax).containsExactly(withResultMinMax);
+  }
+
+  @Test
+  void rrfScoreRejectsNonFiniteRanks() {
+    final SQLFunctionVectorRRFScore fn = new SQLFunctionVectorRRFScore();
+    assertThatThrownBy(() -> fn.execute(null, null, null, new Object[] { new double[] { Double.NaN } }, ctx()))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("finite");
+    assertThatThrownBy(() -> fn.execute(null, null, null, new Object[] { Double.POSITIVE_INFINITY }, ctx()))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("finite");
+  }
+
+  @Test
+  void approxDistanceExplicitTypeRejectsMixedTypesWithHelpfulMessage() {
+    final SQLFunctionVectorQuantizeInt8 qi = new SQLFunctionVectorQuantizeInt8();
+    final SQLFunctionVectorQuantizeBinary qb = new SQLFunctionVectorQuantizeBinary();
+    final SQLFunctionVectorApproxDistance ad = new SQLFunctionVectorApproxDistance();
+
+    final Object int8 = qi.execute(null, null, null, new Object[] { new float[] { 1.0f, 2.0f, 3.0f } }, ctx());
+    final Object binary = qb.execute(null, null, null, new Object[] { new float[] { 0.1f, 0.5f, 0.9f } }, ctx());
+
+    // Explicit INT8 with a binary result for the second arg: the error must name the expected INT8 inputs.
+    assertThatThrownBy(() -> ad.execute(null, null, null, new Object[] { int8, binary, "INT8" }, ctx()))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("INT8");
   }
 }

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorEnhancementsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorEnhancementsTest.java
@@ -372,16 +372,52 @@ class SQLFunctionVectorEnhancementsTest extends TestHelper {
     final Object i2 = qi.execute(null, null, null, new Object[] { new float[] { 1.0f, 2.0f, 3.0f } }, ctx());
     assertThat((float) ad.execute(null, null, null, new Object[] { i1, i2 }, ctx())).isEqualTo(0.0f);
 
-    // BINARY inferred from BinaryQuantizationResult objects
+    // Differently-shaped vectors -> non-zero distance (int8 is normalized per-vector, so the distance
+    // reflects the relative shape; [1,2,3] and [1,1,3] differ at index 1).
+    final Object i3 = qi.execute(null, null, null, new Object[] { new float[] { 1.0f, 2.0f, 3.0f } }, ctx());
+    final Object i4 = qi.execute(null, null, null, new Object[] { new float[] { 1.0f, 1.0f, 3.0f } }, ctx());
+    assertThat((float) ad.execute(null, null, null, new Object[] { i3, i4 }, ctx())).isGreaterThan(0.0f);
+
+    // BINARY inferred from BinaryQuantizationResult objects; identical -> 0
     final Object b1 = qb.execute(null, null, null, new Object[] { new float[] { 0.1f, 0.5f, 0.9f } }, ctx());
     final Object b2 = qb.execute(null, null, null, new Object[] { new float[] { 0.1f, 0.5f, 0.9f } }, ctx());
     assertThat((float) ad.execute(null, null, null, new Object[] { b1, b2 }, ctx())).isEqualTo(0.0f);
+
+    // Mirrored vectors -> two bits differ -> normalized Hamming distance 2/3
+    final Object b3 = qb.execute(null, null, null, new Object[] { new float[] { 0.1f, 0.5f, 0.9f } }, ctx());
+    final Object b4 = qb.execute(null, null, null, new Object[] { new float[] { 0.9f, 0.5f, 0.1f } }, ctx());
+    assertThat((float) ad.execute(null, null, null, new Object[] { b3, b4 }, ctx())).isCloseTo(2.0f / 3, Offset.offset(1e-5f));
   }
 
   @Test
-  void approxDistanceRawArraysStillRequireExplicitType() {
+  void approxDistanceExplicitTypeWithResultObjects() {
+    final SQLFunctionVectorQuantizeInt8 qi = new SQLFunctionVectorQuantizeInt8();
+    final SQLFunctionVectorQuantizeBinary qb = new SQLFunctionVectorQuantizeBinary();
     final SQLFunctionVectorApproxDistance ad = new SQLFunctionVectorApproxDistance();
+
+    // 3-arg explicit form must also accept the result objects
+    final Object i1 = qi.execute(null, null, null, new Object[] { new float[] { 1.0f, 2.0f, 3.0f } }, ctx());
+    final Object i2 = qi.execute(null, null, null, new Object[] { new float[] { 1.0f, 2.0f, 3.0f } }, ctx());
+    assertThat((float) ad.execute(null, null, null, new Object[] { i1, i2, "INT8" }, ctx())).isEqualTo(0.0f);
+
+    final Object b1 = qb.execute(null, null, null, new Object[] { new float[] { 0.1f, 0.5f, 0.9f } }, ctx());
+    final Object b2 = qb.execute(null, null, null, new Object[] { new float[] { 0.1f, 0.5f, 0.9f } }, ctx());
+    assertThat((float) ad.execute(null, null, null, new Object[] { b1, b2, "BINARY" }, ctx())).isEqualTo(0.0f);
+  }
+
+  @Test
+  void approxDistanceTwoArgFormRequiresResultObjects() {
+    final SQLFunctionVectorQuantizeInt8 qi = new SQLFunctionVectorQuantizeInt8();
+    final SQLFunctionVectorApproxDistance ad = new SQLFunctionVectorApproxDistance();
+
+    // raw arrays cannot be inferred
     assertThatThrownBy(() -> ad.execute(null, null, null, new Object[] { new byte[] { 1, 2 }, new byte[] { 1, 2 } }, ctx()))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("Cannot infer");
+
+    // mixing a result object with a raw array is also rejected in the 2-arg form
+    final Object i1 = qi.execute(null, null, null, new Object[] { new float[] { 1.0f, 2.0f, 3.0f } }, ctx());
+    assertThatThrownBy(() -> ad.execute(null, null, null, new Object[] { i1, new byte[] { 1, 2, 3 } }, ctx()))
         .isInstanceOf(CommandSQLParsingException.class)
         .hasMessageContaining("Cannot infer");
   }

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorEnhancementsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorEnhancementsTest.java
@@ -28,6 +28,11 @@ import com.arcadedb.query.sql.method.conversion.SQLMethodAsVector;
 import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -305,7 +310,7 @@ class SQLFunctionVectorEnhancementsTest extends TestHelper {
   void rrfScoreKSetOnlyViaOptionsMap() {
     final SQLFunctionVectorRRFScore fn = new SQLFunctionVectorRRFScore();
     final float result = (float) fn.execute(null, null, null,
-        new Object[] { 1L, 5L, 10L, java.util.Map.of("k", 100L) }, ctx());
+        new Object[] { 1L, 5L, 10L, Map.of("k", 100L) }, ctx());
     assertThat(result).isCloseTo((1.0f / 101) + (1.0f / 105) + (1.0f / 110), Offset.offset(1e-5f));
   }
 
@@ -487,7 +492,7 @@ class SQLFunctionVectorEnhancementsTest extends TestHelper {
     assertThat((float) fn.execute(null, null, null, new Object[] { new int[] { 1, 5, 10 } }, ctx()))
         .isCloseTo((1.0f / 61) + (1.0f / 65) + (1.0f / 70), Offset.offset(1e-5f));
     assertThat((float) fn.execute(null, null, null,
-        new Object[] { java.util.List.of(1L, 5L, 10L), java.util.Map.of("k", 100L) }, ctx()))
+        new Object[] { List.of(1L, 5L, 10L), Map.of("k", 100L) }, ctx()))
         .isCloseTo((1.0f / 101) + (1.0f / 105) + (1.0f / 110), Offset.offset(1e-5f));
   }
 
@@ -496,7 +501,7 @@ class SQLFunctionVectorEnhancementsTest extends TestHelper {
     final SQLFunctionVectorRRFScore fn = new SQLFunctionVectorRRFScore();
     final float expected = (1.0f / 61) + (1.0f / 65);
     // variadic with a null rank
-    final java.util.List<Object> variadic = new java.util.ArrayList<>(java.util.Arrays.asList(null, 1L, 5L));
+    final List<Object> variadic = new ArrayList<>(Arrays.asList(null, 1L, 5L));
     assertThat((float) fn.execute(null, null, null, variadic.toArray(), ctx())).isCloseTo(expected, Offset.offset(1e-5f));
     // array form with a null element must behave the same (the item is absent from that ranking list)
     assertThat((float) fn.execute(null, null, null, new Object[] { variadic }, ctx())).isCloseTo(expected, Offset.offset(1e-5f));
@@ -564,5 +569,38 @@ class SQLFunctionVectorEnhancementsTest extends TestHelper {
     assertThatThrownBy(() -> ad.execute(null, null, null, new Object[] { int8, binary, "INT8" }, ctx()))
         .isInstanceOf(CommandSQLParsingException.class)
         .hasMessageContaining("INT8");
+  }
+
+  @Test
+  void dequantizeInt8ThreeArgWithResultAndNullScalarsStillUsesEmbeddedMinMax() {
+    // (result, null, null): the result object's embedded min/max must win - the null scalars must NOT
+    // short-circuit the whole call to null (the QuantizationResult check runs before the scalar null-guard).
+    final SQLFunctionVectorQuantizeInt8 q = new SQLFunctionVectorQuantizeInt8();
+    final SQLFunctionVectorDequantizeInt8 dq = new SQLFunctionVectorDequantizeInt8();
+
+    final Object qr = q.execute(null, null, null, new Object[] { new float[] { 1.0f, 2.0f, 3.0f } }, ctx());
+    final float[] expected = (float[]) dq.execute(null, null, null, new Object[] { qr }, ctx());
+    final float[] withNullScalars = (float[]) dq.execute(null, null, null, new Object[] { qr, null, null }, ctx());
+    assertThat(withNullScalars).isNotNull().containsExactly(expected);
+  }
+
+  @Test
+  void approxDistanceExplicitBinaryWithInt8ResultsGivesParsingError() {
+    // The BINARY path is reached for (int8, int8, 'BINARY') and (int8, binary, 'BINARY'). It must surface a
+    // CommandSQLParsingException naming BinaryQuantizationResult, never a raw ClassCastException.
+    final SQLFunctionVectorQuantizeInt8 qi = new SQLFunctionVectorQuantizeInt8();
+    final SQLFunctionVectorQuantizeBinary qb = new SQLFunctionVectorQuantizeBinary();
+    final SQLFunctionVectorApproxDistance ad = new SQLFunctionVectorApproxDistance();
+
+    final Object int8a = qi.execute(null, null, null, new Object[] { new float[] { 1.0f, 2.0f, 3.0f } }, ctx());
+    final Object int8b = qi.execute(null, null, null, new Object[] { new float[] { 1.0f, 1.0f, 3.0f } }, ctx());
+    final Object binary = qb.execute(null, null, null, new Object[] { new float[] { 0.1f, 0.5f, 0.9f } }, ctx());
+
+    assertThatThrownBy(() -> ad.execute(null, null, null, new Object[] { int8a, int8b, "BINARY" }, ctx()))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("BinaryQuantizationResult");
+    assertThatThrownBy(() -> ad.execute(null, null, null, new Object[] { int8a, binary, "BINARY" }, ctx()))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("BinaryQuantizationResult");
   }
 }

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorEnhancementsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorEnhancementsTest.java
@@ -527,6 +527,8 @@ class SQLFunctionVectorEnhancementsTest extends TestHelper {
     assertThat(str("SELECT `vector.toString`([1.0, 2.0, 3.0], 'MATLAB_COLUMN') as r")).isEqualTo("[1.0; 2.0; 3.0]");
     // semicolons parse back like the other separators
     assertThat(vec("SELECT '[1.0; 2.0; 3.0]'.asVector() as r")).containsExactly(1.0f, 2.0f, 3.0f);
+    // and without the space after the semicolon (the [,;\s]+ separator regex must collapse it)
+    assertThat(vec("SELECT '[1.0;2.0;3.0]'.asVector() as r")).containsExactly(1.0f, 2.0f, 3.0f);
   }
 
   // ========== review follow-ups: edge cases ==========

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorEnhancementsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorEnhancementsTest.java
@@ -548,8 +548,9 @@ class SQLFunctionVectorEnhancementsTest extends TestHelper {
 
   @Test
   void dequantizeInt8ThreeArgIgnoresExplicitMinMaxWhenGivenResult() {
-    // A QuantizationResult carries its own authoritative min/max. If the caller passes different scalars in
-    // the 3-arg form, the result's values must win so the dequantization stays correct (no silent wrong scale).
+    // A QuantizationResult carries its own authoritative min/max. Issue #3099 requires the redundant 3-arg
+    // form to succeed (not error); the result's own values must win over the explicit scalars so the
+    // dequantization stays on the correct scale (no silent wrong scale from caller-supplied min/max).
     final SQLFunctionVectorQuantizeInt8 q = new SQLFunctionVectorQuantizeInt8();
     final SQLFunctionVectorDequantizeInt8 dq = new SQLFunctionVectorDequantizeInt8();
 
@@ -613,9 +614,9 @@ class SQLFunctionVectorEnhancementsTest extends TestHelper {
 
     assertThatThrownBy(() -> ad.execute(null, null, null, new Object[] { int8a, int8b, "BINARY" }, ctx()))
         .isInstanceOf(CommandSQLParsingException.class)
-        .hasMessageContaining("BinaryQuantizationResult");
+        .hasMessageContaining("Expected BinaryQuantizationResult");
     assertThatThrownBy(() -> ad.execute(null, null, null, new Object[] { int8a, binary, "BINARY" }, ctx()))
         .isInstanceOf(CommandSQLParsingException.class)
-        .hasMessageContaining("BinaryQuantizationResult");
+        .hasMessageContaining("Expected BinaryQuantizationResult");
   }
 }

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorEnhancementsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorEnhancementsTest.java
@@ -510,14 +510,27 @@ class SQLFunctionVectorEnhancementsTest extends TestHelper {
   @Test
   void rrfScoreRejectsNonIntegerRanksInBothForms() {
     final SQLFunctionVectorRRFScore fn = new SQLFunctionVectorRRFScore();
-    // array form
-    assertThatThrownBy(() -> fn.execute(null, null, null, new Object[] { new double[] { 1.5, 5.0 } }, ctx()))
+    // array form (a list/Object[] of ranks)
+    assertThatThrownBy(() -> fn.execute(null, null, null, new Object[] { List.of(1.5, 5.0) }, ctx()))
         .isInstanceOf(CommandSQLParsingException.class)
         .hasMessageContaining("integers");
     // variadic form - no longer silently truncates 1.5 -> 1
     assertThatThrownBy(() -> fn.execute(null, null, null, new Object[] { 1.5, 5.0 }, ctx()))
         .isInstanceOf(CommandSQLParsingException.class)
         .hasMessageContaining("integers");
+  }
+
+  @Test
+  void rrfScoreRejectsFloatArrayAsNonNumberRank() {
+    // A float[]/double[] is a score/embedding vector, not a list of integer ranks: it is not treated as an
+    // array of ranks, so it is rejected as a non-number rank (clearer than "must be integers" per element).
+    final SQLFunctionVectorRRFScore fn = new SQLFunctionVectorRRFScore();
+    assertThatThrownBy(() -> fn.execute(null, null, null, new Object[] { new float[] { 1.0f, 2.0f } }, ctx()))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("numbers");
+    assertThatThrownBy(() -> fn.execute(null, null, null, new Object[] { new double[] { 1.0, 2.0 } }, ctx()))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("numbers");
   }
 
   // ========== MATLAB_COLUMN format (#21) ==========
@@ -550,7 +563,7 @@ class SQLFunctionVectorEnhancementsTest extends TestHelper {
   @Test
   void rrfScoreRejectsNonFiniteRanks() {
     final SQLFunctionVectorRRFScore fn = new SQLFunctionVectorRRFScore();
-    assertThatThrownBy(() -> fn.execute(null, null, null, new Object[] { new double[] { Double.NaN } }, ctx()))
+    assertThatThrownBy(() -> fn.execute(null, null, null, new Object[] { new Object[] { Double.NaN } }, ctx()))
         .isInstanceOf(CommandSQLParsingException.class)
         .hasMessageContaining("finite");
     assertThatThrownBy(() -> fn.execute(null, null, null, new Object[] { Double.POSITIVE_INFINITY }, ctx()))

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorEnhancementsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorEnhancementsTest.java
@@ -500,10 +500,12 @@ class SQLFunctionVectorEnhancementsTest extends TestHelper {
   void rrfScoreSkipsNullRanksConsistentlyInBothForms() {
     final SQLFunctionVectorRRFScore fn = new SQLFunctionVectorRRFScore();
     final float expected = (1.0f / 61) + (1.0f / 65);
-    // variadic with a null rank
+    // A null rank means "this item is absent from that ranking list" and is skipped (contributes 0), so only
+    // ranks 1 and 5 score. Here the null is in position 0 - the item is absent from the FIRST ranking list,
+    // not ranked last - and the result must equal scoring just [1, 5].
     final List<Object> variadic = new ArrayList<>(Arrays.asList(null, 1L, 5L));
     assertThat((float) fn.execute(null, null, null, variadic.toArray(), ctx())).isCloseTo(expected, Offset.offset(1e-5f));
-    // array form with a null element must behave the same (the item is absent from that ranking list)
+    // array form with the same null element must behave identically.
     assertThat((float) fn.execute(null, null, null, new Object[] { variadic }, ctx())).isCloseTo(expected, Offset.offset(1e-5f));
   }
 
@@ -602,7 +604,8 @@ class SQLFunctionVectorEnhancementsTest extends TestHelper {
   @Test
   void approxDistanceExplicitBinaryWithInt8ResultsGivesParsingError() {
     // The BINARY path is reached for (int8, int8, 'BINARY') and (int8, binary, 'BINARY'). It must surface a
-    // CommandSQLParsingException naming BinaryQuantizationResult, never a raw ClassCastException.
+    // CommandSQLParsingException naming BinaryQuantizationResult, never a raw ClassCastException. The asserted
+    // message text is owned by SQLFunctionVectorApproxDistance.computeBinaryDistance() - keep them in sync.
     final SQLFunctionVectorQuantizeInt8 qi = new SQLFunctionVectorQuantizeInt8();
     final SQLFunctionVectorQuantizeBinary qb = new SQLFunctionVectorQuantizeBinary();
     final SQLFunctionVectorApproxDistance ad = new SQLFunctionVectorApproxDistance();

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorEnhancementsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorEnhancementsTest.java
@@ -22,6 +22,7 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.query.sql.executor.BasicCommandContext;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.query.sql.method.conversion.SQLMethodAsSparse;
 import com.arcadedb.query.sql.method.conversion.SQLMethodAsVector;
 
 import org.assertj.core.data.Offset;
@@ -341,5 +342,92 @@ class SQLFunctionVectorEnhancementsTest extends TestHelper {
     final SQLFunctionVectorNormalizeScores fn = new SQLFunctionVectorNormalizeScores();
     assertThat((float[]) fn.execute(null, null, null, new Object[] { new float[] { 3.0f, 3.0f, 3.0f } }, ctx()))
         .containsExactly(0.5f, 0.5f, 0.5f);
+  }
+
+  // ========== int8 quantization ergonomics (#8/#9/#10) ==========
+
+  @Test
+  void dequantizeInt8AcceptsResultObjectDirectly() {
+    final SQLFunctionVectorQuantizeInt8 q = new SQLFunctionVectorQuantizeInt8();
+    final SQLFunctionVectorDequantizeInt8 dq = new SQLFunctionVectorDequantizeInt8();
+
+    final Object qr = q.execute(null, null, null, new Object[] { new float[] { 1.0f, 2.0f, 3.0f } }, ctx());
+    // Pass the result object directly - no need to unpack quantized()/min()/max().
+    final float[] back = (float[]) dq.execute(null, null, null, new Object[] { qr }, ctx());
+
+    assertThat(back).hasSize(3);
+    assertThat(back[0]).isCloseTo(1.0f, Offset.offset(0.05f));
+    assertThat(back[1]).isCloseTo(2.0f, Offset.offset(0.05f));
+    assertThat(back[2]).isCloseTo(3.0f, Offset.offset(0.05f));
+  }
+
+  @Test
+  void approxDistanceInfersTypeFromResultObjects() {
+    final SQLFunctionVectorQuantizeInt8 qi = new SQLFunctionVectorQuantizeInt8();
+    final SQLFunctionVectorQuantizeBinary qb = new SQLFunctionVectorQuantizeBinary();
+    final SQLFunctionVectorApproxDistance ad = new SQLFunctionVectorApproxDistance();
+
+    // INT8 inferred from QuantizationResult objects; identical vectors -> distance 0
+    final Object i1 = qi.execute(null, null, null, new Object[] { new float[] { 1.0f, 2.0f, 3.0f } }, ctx());
+    final Object i2 = qi.execute(null, null, null, new Object[] { new float[] { 1.0f, 2.0f, 3.0f } }, ctx());
+    assertThat((float) ad.execute(null, null, null, new Object[] { i1, i2 }, ctx())).isEqualTo(0.0f);
+
+    // BINARY inferred from BinaryQuantizationResult objects
+    final Object b1 = qb.execute(null, null, null, new Object[] { new float[] { 0.1f, 0.5f, 0.9f } }, ctx());
+    final Object b2 = qb.execute(null, null, null, new Object[] { new float[] { 0.1f, 0.5f, 0.9f } }, ctx());
+    assertThat((float) ad.execute(null, null, null, new Object[] { b1, b2 }, ctx())).isEqualTo(0.0f);
+  }
+
+  @Test
+  void approxDistanceRawArraysStillRequireExplicitType() {
+    final SQLFunctionVectorApproxDistance ad = new SQLFunctionVectorApproxDistance();
+    assertThatThrownBy(() -> ad.execute(null, null, null, new Object[] { new byte[] { 1, 2 }, new byte[] { 1, 2 } }, ctx()))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("Cannot infer");
+  }
+
+  // ========== asSparse() method (#4) ==========
+
+  @Test
+  void asSparseConvertsDenseDroppingZeros() {
+    final SQLMethodAsSparse m = new SQLMethodAsSparse();
+    final SparseVector sv = (SparseVector) m.execute(new float[] { 0.5f, 0.0f, 0.3f }, null, ctx(), new Object[0]);
+    assertThat(sv.getDimensions()).isEqualTo(3);
+    assertThat(sv.getNonZeroCount()).isEqualTo(2);
+    assertThat(sv.get(0)).isEqualTo(0.5f);
+    assertThat(sv.get(1)).isEqualTo(0.0f);
+    assertThat(sv.get(2)).isEqualTo(0.3f);
+  }
+
+  @Test
+  void asSparseHonoursThresholdAndWorksInSql() {
+    final SQLMethodAsSparse m = new SQLMethodAsSparse();
+    final SparseVector sv = (SparseVector) m.execute(new float[] { 0.5f, 0.05f, 0.3f }, null, ctx(), new Object[] { 0.1f });
+    assertThat(sv.getNonZeroCount()).isEqualTo(2); // 0.05 dropped by the 0.1 threshold
+
+    try (final ResultSet rs = database.query("sql", "SELECT [0.5, 0.0, 0.3].asSparse() as r")) {
+      assertThat(rs.hasNext()).isTrue();
+    }
+  }
+
+  // ========== RRF array-of-ranks input (#14) ==========
+
+  @Test
+  void rrfScoreAcceptsArrayOfRanks() {
+    final SQLFunctionVectorRRFScore fn = new SQLFunctionVectorRRFScore();
+    assertThat((float) fn.execute(null, null, null, new Object[] { new int[] { 1, 5, 10 } }, ctx()))
+        .isCloseTo((1.0f / 61) + (1.0f / 65) + (1.0f / 70), Offset.offset(1e-5f));
+    assertThat((float) fn.execute(null, null, null,
+        new Object[] { java.util.List.of(1L, 5L, 10L), java.util.Map.of("k", 100L) }, ctx()))
+        .isCloseTo((1.0f / 101) + (1.0f / 105) + (1.0f / 110), Offset.offset(1e-5f));
+  }
+
+  // ========== MATLAB_COLUMN format (#21) ==========
+
+  @Test
+  void matlabColumnFormatAndRoundTrip() {
+    assertThat(str("SELECT `vector.toString`([1.0, 2.0, 3.0], 'MATLAB_COLUMN') as r")).isEqualTo("[1.0; 2.0; 3.0]");
+    // semicolons parse back like the other separators
+    assertThat(vec("SELECT '[1.0; 2.0; 3.0]'.asVector() as r")).containsExactly(1.0f, 2.0f, 3.0f);
   }
 }

--- a/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorEnhancementsTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/vector/SQLFunctionVectorEnhancementsTest.java
@@ -547,18 +547,17 @@ class SQLFunctionVectorEnhancementsTest extends TestHelper {
   // ========== review follow-ups: edge cases ==========
 
   @Test
-  void dequantizeInt8ThreeArgIgnoresExplicitMinMaxWhenGivenResult() {
-    // A QuantizationResult carries its own authoritative min/max. Issue #3099 requires the redundant 3-arg
-    // form to succeed (not error); the result's own values must win over the explicit scalars so the
-    // dequantization stays on the correct scale (no silent wrong scale from caller-supplied min/max).
+  void dequantizeInt8ThreeArgRejectsConflictingMinMaxWhenGivenResult() {
+    // A QuantizationResult carries its own authoritative min/max. The redundant 3-arg form is supported
+    // (issue #3099) only when the explicit scalars match the embedded values; scalars that conflict would
+    // dequantize to a wrong scale, so they are rejected loudly rather than silently ignored.
     final SQLFunctionVectorQuantizeInt8 q = new SQLFunctionVectorQuantizeInt8();
     final SQLFunctionVectorDequantizeInt8 dq = new SQLFunctionVectorDequantizeInt8();
 
     final Object qr = q.execute(null, null, null, new Object[] { new float[] { 1.0f, 2.0f, 3.0f } }, ctx());
-    final float[] withResultMinMax = (float[]) dq.execute(null, null, null, new Object[] { qr }, ctx());
-    // Deliberately bogus explicit min/max - must be ignored in favour of the result's own.
-    final float[] withBogusMinMax = (float[]) dq.execute(null, null, null, new Object[] { qr, -99.0f, 99.0f }, ctx());
-    assertThat(withBogusMinMax).containsExactly(withResultMinMax);
+    assertThatThrownBy(() -> dq.execute(null, null, null, new Object[] { qr, -99.0f, 99.0f }, ctx()))
+        .isInstanceOf(CommandSQLParsingException.class)
+        .hasMessageContaining("conflicts with the result's embedded");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/query/sql/functions/vector/SQLVectorDatabaseFunctionsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/functions/vector/SQLVectorDatabaseFunctionsTest.java
@@ -525,8 +525,9 @@ class SQLVectorDatabaseFunctionsTest extends TestHelper {
 
       assertThat(rs.hasNext()).isTrue();
       final Result result = rs.next();
-      assertThat(result.<Float>getProperty("avg_magnitude")).isNotNull();
-      assertThat(result.<Float>getProperty("sparsity_pct")).isNotNull();
+      // AVG() always returns a Double (issue #4518), so use the matching type witness here.
+      assertThat(result.<Double>getProperty("avg_magnitude")).isNotNull();
+      assertThat(result.<Double>getProperty("sparsity_pct")).isNotNull();
     });
   }
 


### PR DESCRIPTION
Follow-up to #3099 implementing the remaining actionable review items. Each change below is explained so it can be written back to the issue on merge.

## ⚠️ Breaking change
`vectorRRFScore` now validates that every rank is a **positive integer** in *both* the new array form and the existing variadic form. Previously the variadic form silently truncated a fractional rank (e.g. `1.5` → rank `1`) via `longValue()`; it now throws `Rank values must be integers`. A `null` rank is skipped in both forms (the item is treated as absent from that ranking list). This tightens the existing surface, not just the new feature.


## int8 quantization ergonomics (#8 / #9 / #10 / #11)
**Why:** the int8 path forced callers to unpack the quantization result object before reuse, so the natural nested form errored (`Quantized vector must be an array or list, found: QuantizationResult`), and `vectorApproxDistance` required an explicit `'INT8'`/`'BINARY'` string it could deduce.
- `vectorDequantizeInt8(<result>)` now accepts the object returned by `vectorQuantizeInt8()` directly (min/max read from it). The `(<bytes>, <min>, <max>)` form is unchanged.
- `vectorApproxDistance(<q1>, <q2>)` infers the type from the result objects (`QuantizationResult` → INT8, `BinaryQuantizationResult` → BINARY). The explicit-type 3-arg form still works and is required for raw byte arrays.
- "ranking is preserved" reworded to "preserves the top-k ordering of the true distances" — it's the scalar distances that are order-preserving, not the vector space.

## `asSparse()` method (#4)
**Why:** the reporter asked whether `vectorDenseToSparse` could be `vectorAsSparse`. Rather than a function alias, this adds the **method** form `embedding.asSparse([threshold])`, consistent with the `asString()`/`asVector()` conversion-method family added earlier. It delegates to `vector.denseToSparse()` so the logic lives in one place.

## RRF array-of-ranks input (#14)
**Why:** the reporter asked why RRF ranks aren't grouped into an array like `vector.multiScore`. `vectorRRFScore([r1, r2, ...] [, { k }])` is now accepted in addition to the variadic form. (Note RRF combines *ranks*, i.e. positions, not scores.)

## `MATLAB_COLUMN` format (#21)
**Why:** in MATLAB the separator distinguishes a row vector (space/comma) from a column vector (semicolon). Added `MATLAB_COLUMN` → `[1.0; 2.0; 3.0]` to `vector.toString()`/`asString()`. The string→vector parser (`asVector()`) now also splits on semicolons so the form round-trips.

## Not changed (declined, by design) — for the issue write-back
- **Abbreviation aliases** (`vectorDim`, `vectorSub`, `vectorIsNormal`): ArcadeDB favours descriptive-over-terse names consistently; declined to keep the surface lean.
- **`vectorMultiScore` WEIGHTED-as-method vs `AVG`+weights**: explicit `'WEIGHTED'` is clearer at the call site.
- **`vectorIsNormalized` "just normalize instead of testing"**: it's a cheap boolean guard, a different tool from a transform.
- **Score functions "not really vector functions"** (`vectorHybridScore`/`vectorRRFScore`/`vectorScoreTransform`): kept in `vector.*` as the fusion/reranking stage of vector search; documented as scoring utilities rather than renamed.

Docs are updated separately on `main` in the arcadedb-docs repo (aggregation-category clarification, `vectorQuantizeBinary` median rationale, `isNormalized` tolerance, plus all the new features above).

Closes none; ticks the corresponding boxes on #3099.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
