### PR TITLE
fix(#4654): handle temporal types in JSONObject.objectToElement for array serialization

### DIFF
--- a/docs/4654-localdatetime-array-serialization.md
+++ b/docs/4654-localdatetime-array-serialization.md
@@ -49,6 +49,42 @@ Test `temporalTypesInArrays` covers:
 
 Run: `mvn test -pl engine -Dtest=JSONTest`
 
+## Release-note callout
+
+The `Duration` serialization formula was corrected in both `put(String, Object)` and
+`objectToElement()`. The old `"%d.%d".formatted(toSeconds(), toNanosPart())` form was lossy
+(e.g. a 5.000000005s duration serialized as `5.5`, and negative durations as `-6.999999995`).
+The new arithmetic form (`toSeconds() + toNanosPart()/1e9`) is correct. Applications that
+previously stored a `Duration` via JSON and parsed it back numerically will see a different
+(now correct) value. This is a behavioral change worth a release note.
+
+The `LocalDate` epoch-millis path in `put()` was also unified with `objectToElement()` to use
+the DST-correct `atStartOfDay(ZoneId.systemDefault())` form, so the two paths no longer diverge
+on dates that fall in a different DST period than the moment of serialization.
+
+## Known limitation (out of scope)
+
+`Duration` is serialized as a `double` of seconds. For very large second counts (> ~10^7) the
+nanosecond part can be lost to floating-point rounding. Preserving sub-nanosecond precision for
+large durations would require a different wire format (e.g. total nanoseconds as a `long`) and is
+out of scope for this fix.
+
+## Review cycles
+
+- **a972ec9** (initial): added temporal/Enum cases to `objectToElement()`, regression test.
+  gemini-code-assist flagged 3 high-priority issues (LocalDate DST offset, TemporalAccessor null
+  NPE, Duration precision/sign).
+- **318c3ca**: applied all 3 gemini fixes + 2 edge-case tests. claude bot review: align Duration
+  between `put()` and array path, add `Class<?>` case, replace tautological assertions with concrete
+  values, add Enum coverage; declined removing this docs file (established convention).
+- **090d4eb**: fixed `put()` Duration to match the array path (kills latent bug), added `Class<?>`
+  case to `objectToElement()`, concrete value assertions, Enum/Class tests, cross-path consistency
+  test. claude bot review: unify `LocalDate` path between `put()` and array path (the remaining
+  divergence), noted Duration-double precision limit and breaking-change release note.
+- **(this commit)**: unified `put()` LocalDate on the DST-correct form, removed now-unused `Instant`
+  import, added `localDateConsistentBetweenPutAndArrayPaths` test, documented the release-note
+  callout and known limitation above.
+
 ## Status
 
-Implementation complete, tests passing.
+Implementation complete, all tests passing.

--- a/docs/4654-localdatetime-array-serialization.md
+++ b/docs/4654-localdatetime-array-serialization.md
@@ -85,6 +85,20 @@ out of scope for this fix.
   import, added `localDateConsistentBetweenPutAndArrayPaths` test, documented the release-note
   callout and known limitation above.
 
+- **e8b2d8e** (final): post-review poll returned only a non-actionable `test` stub comment from
+  the claude bot; no further substantive feedback. gemini-code-assist (being sunset 2026-06-18)
+  did not re-review after cycle 1; all its cycle-1 findings were addressed. All actionable items
+  across all cycles are resolved.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/4655
+
+## Final state
+
+max-cycles-reached (4 cycles) - all actionable bot feedback resolved; remaining notes are
+documented out-of-scope/pre-existing items. Working tree clean, all tests passing.
+
 ## Status
 
 Implementation complete, all tests passing.

--- a/docs/4654-localdatetime-array-serialization.md
+++ b/docs/4654-localdatetime-array-serialization.md
@@ -1,0 +1,54 @@
+# Fix #4654: LocalDateTime inside arrays fails JSON serialization
+
+## Summary
+
+`JSONObject.objectToElement()` is the static method used when placing objects into `JSONArray`.
+It handles common types (String, Number, Boolean, JSONObject, JSONArray, Collection, Map,
+Document, Identifiable) but was missing branches for temporal types:
+`Date`, `LocalDate`, `TemporalAccessor` (covers LocalDateTime, ZonedDateTime, Instant, etc.),
+and `Duration`.
+
+Because `objectToElement()` is `static` it has no access to configured date/datetime formats.
+Temporal values are therefore serialized as epoch-millisecond timestamps (the default when no
+format string is configured), which matches the existing behavior in `JSONObject.put(String,
+Object)` when `dateFormatAsString == null`.
+
+The default `throw` in the old switch statement has also been replaced with a `toString()`
+fallback, consistent with the generic case in `put(String, Object)`.
+
+## Root Cause
+
+`JSONObject.objectToElement()` switch statement lacked cases for:
+- `Date`
+- `LocalDate`
+- `TemporalAccessor` (LocalDateTime, ZonedDateTime, Instant, OffsetDateTime, etc.)
+- `Duration`
+- `Enum`
+
+`JSONArray.put(Object)`, `new JSONArray(Collection)`, and `new JSONArray(Object[])` all route
+through `objectToElement()`, so any temporal value nested in an array hit the default `throw`.
+
+## Fix
+
+Added the missing branches to `JSONObject.objectToElement()` in:
+`engine/src/main/java/com/arcadedb/serializer/json/JSONObject.java`
+
+## Verification
+
+Regression test added to:
+`engine/src/test/java/com/arcadedb/serializer/json/JSONTest.java`
+
+Test `temporalTypesInArrays` covers:
+- `LocalDateTime` in a `List`
+- `LocalDate` in a `List`
+- `Date` in a `List`
+- `LocalDateTime` in `JSONArray.put(Object)`
+- `JSONArray(Collection)` constructor with temporal elements
+- `JSONArray(Object[])` constructor with temporal elements
+- Mixed temporal types in one array
+
+Run: `mvn test -pl engine -Dtest=JSONTest`
+
+## Status
+
+Implementation complete, tests passing.

--- a/engine/src/main/java/com/arcadedb/serializer/json/JSONObject.java
+++ b/engine/src/main/java/com/arcadedb/serializer/json/JSONObject.java
@@ -590,7 +590,13 @@ public class JSONObject implements Map<String, Object> {
       case Map map -> new JSONObject(map).getInternal();
       case Document document -> document.toJSON(false).getInternal();
       case Identifiable identifiable -> new JsonPrimitive(identifiable.getIdentity().toString());
-      default -> throw new IllegalArgumentException("Object of type " + object.getClass() + " not supported");
+      case Enum<?> enumValue -> new JsonPrimitive(enumValue.name());
+      case Date date -> new JsonPrimitive(date.getTime());
+      case LocalDate localDate ->
+          new JsonPrimitive(localDate.atStartOfDay().toInstant(ZoneId.systemDefault().getRules().getOffset(Instant.now())).toEpochMilli());
+      case TemporalAccessor temporalAccessor -> new JsonPrimitive(DateUtils.dateTimeToTimestamp(temporalAccessor, ChronoUnit.MILLIS));
+      case Duration duration -> new JsonPrimitive(Double.valueOf("%d.%d".formatted(duration.toSeconds(), duration.toNanosPart())));
+      default -> new JsonPrimitive(object.toString());
     };
   }
 

--- a/engine/src/main/java/com/arcadedb/serializer/json/JSONObject.java
+++ b/engine/src/main/java/com/arcadedb/serializer/json/JSONObject.java
@@ -177,8 +177,7 @@ public class JSONObject implements Map<String, Object> {
         // SAVE AS STRING
         object.addProperty(name, dateTimeFormat.format(temporalAccessor));
     }
-    case Duration duration -> object.addProperty(name,
-        Double.valueOf("%d.%d".formatted(duration.toSeconds(), duration.toNanosPart())));
+    case Duration duration -> object.addProperty(name, duration.toSeconds() + (duration.toNanosPart() / 1_000_000_000.0));
     case Identifiable identifiable -> object.addProperty(name, identifiable.getIdentity().toString());
     case Map map -> object.add(name, new JSONObject(map).getInternal());
     case Class<?> clazz -> object.addProperty(name, clazz.getName());
@@ -598,6 +597,7 @@ public class JSONObject implements Map<String, Object> {
         yield timestamp != null ? new JsonPrimitive(timestamp) : new JsonPrimitive(temporalAccessor.toString());
       }
       case Duration duration -> new JsonPrimitive(duration.toSeconds() + (duration.toNanosPart() / 1_000_000_000.0));
+      case Class<?> clazz -> new JsonPrimitive(clazz.getName());
       default -> new JsonPrimitive(object.toString());
     };
   }

--- a/engine/src/main/java/com/arcadedb/serializer/json/JSONObject.java
+++ b/engine/src/main/java/com/arcadedb/serializer/json/JSONObject.java
@@ -592,10 +592,12 @@ public class JSONObject implements Map<String, Object> {
       case Identifiable identifiable -> new JsonPrimitive(identifiable.getIdentity().toString());
       case Enum<?> enumValue -> new JsonPrimitive(enumValue.name());
       case Date date -> new JsonPrimitive(date.getTime());
-      case LocalDate localDate ->
-          new JsonPrimitive(localDate.atStartOfDay().toInstant(ZoneId.systemDefault().getRules().getOffset(Instant.now())).toEpochMilli());
-      case TemporalAccessor temporalAccessor -> new JsonPrimitive(DateUtils.dateTimeToTimestamp(temporalAccessor, ChronoUnit.MILLIS));
-      case Duration duration -> new JsonPrimitive(Double.valueOf("%d.%d".formatted(duration.toSeconds(), duration.toNanosPart())));
+      case LocalDate localDate -> new JsonPrimitive(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli());
+      case TemporalAccessor temporalAccessor -> {
+        final Long timestamp = DateUtils.dateTimeToTimestamp(temporalAccessor, ChronoUnit.MILLIS);
+        yield timestamp != null ? new JsonPrimitive(timestamp) : new JsonPrimitive(temporalAccessor.toString());
+      }
+      case Duration duration -> new JsonPrimitive(duration.toSeconds() + (duration.toNanosPart() / 1_000_000_000.0));
       default -> new JsonPrimitive(object.toString());
     };
   }

--- a/engine/src/main/java/com/arcadedb/serializer/json/JSONObject.java
+++ b/engine/src/main/java/com/arcadedb/serializer/json/JSONObject.java
@@ -35,7 +35,6 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.math.BigDecimal;
 import java.time.Duration;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -160,10 +159,8 @@ public class JSONObject implements Map<String, Object> {
     }
     case LocalDate localDate -> {
       if (dateFormatAsString == null)
-        // SAVE AS TIMESTAMP
-        object.addProperty(name,
-            localDate.atStartOfDay().toInstant(ZoneId.systemDefault().getRules().getOffset(Instant.now()))
-                .toEpochMilli());
+        // SAVE AS TIMESTAMP (resolve the offset for the target date's midnight, DST-correct)
+        object.addProperty(name, localDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli());
       else
         // SAVE AS STRING
         object.addProperty(name, dateFormat.format(localDate.atStartOfDay()));

--- a/engine/src/test/java/com/arcadedb/serializer/json/JSONTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/json/JSONTest.java
@@ -309,6 +309,16 @@ class JSONTest extends TestHelper {
   }
 
   @Test
+  void localDateConsistentBetweenPutAndArrayPaths() {
+    // put(String, Object) and the array path (objectToElement) must produce the same epoch-millis
+    // for a LocalDate, both using the DST-correct atStartOfDay(ZoneId) form.
+    final LocalDate ld = LocalDate.of(2024, 6, 15);
+    final long viaPut = new JSONObject().put("d", ld).getLong("d");
+    final long viaArray = ((Number) new JSONArray(List.of(ld)).get(0)).longValue();
+    assertThat(viaPut).isEqualTo(viaArray);
+  }
+
+  @Test
   void durationConsistentBetweenPutAndArrayPaths() {
     // put(String, Object) and the array path (objectToElement) must produce the same value.
     final Duration duration = Duration.ofSeconds(5, 5); // 5.000000005s

--- a/engine/src/test/java/com/arcadedb/serializer/json/JSONTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/json/JSONTest.java
@@ -21,9 +21,10 @@ package com.arcadedb.serializer.json;
 import com.arcadedb.TestHelper;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
+import java.time.LocalTime;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -268,6 +269,29 @@ class JSONTest extends TestHelper {
     assertThat(deserialized.getJSONArray("mixed").length()).isEqualTo(2);
     for (int i = 0; i < 2; i++)
       assertThat(deserialized.getJSONArray("mixed").get(i)).isInstanceOf(Number.class);
+  }
+
+  @Test
+  void unsupportedTemporalInArrayFallsBackToString() {
+    // LocalTime is a TemporalAccessor that DateUtils.dateTimeToTimestamp does not support and
+    // returns null for; the array serializer must fall back to toString() rather than NPE.
+    final LocalTime time = LocalTime.of(13, 45, 30);
+    final JSONArray arr = new JSONArray(List.of(time));
+    assertThat(arr.length()).isEqualTo(1);
+    assertThat(arr.get(0)).isEqualTo(time.toString());
+  }
+
+  @Test
+  void durationInArrayPreservesPrecisionAndSign() {
+    // Leading-zero nanoseconds must not be lost (5ns -> 0.000000005, not collapsed).
+    final JSONArray smallNanos = new JSONArray(List.of(Duration.ofSeconds(5, 5)));
+    assertThat(smallNanos.getDouble(0)).isEqualTo(5 + 5 / 1_000_000_000.0);
+
+    // Negative durations stored as (negative seconds, positive nanos) must serialize correctly.
+    final Duration negative = Duration.ofSeconds(-5).minusNanos(5); // -5.000000005s
+    final JSONArray neg = new JSONArray(List.of(negative));
+    assertThat(neg.getDouble(0)).isEqualTo(negative.toSeconds() + negative.toNanosPart() / 1_000_000_000.0);
+    assertThat(neg.getDouble(0)).isLessThan(0.0);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/serializer/json/JSONTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/json/JSONTest.java
@@ -28,6 +28,7 @@ import java.time.LocalTime;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
 /**
  * Test JSON parser and it support for types.
@@ -240,10 +241,10 @@ class JSONTest extends TestHelper {
     assertThat(json.getJSONArray("dates").length()).isEqualTo(1);
     assertThat(json.getJSONArray("dates").get(0)).isInstanceOf(Number.class);
 
-    // java.util.Date inside a List
+    // java.util.Date inside a List - value is deterministic (epoch millis)
     json = new JSONObject().put("dates", List.of(d));
     assertThat(json.getJSONArray("dates").length()).isEqualTo(1);
-    assertThat(json.getJSONArray("dates").get(0)).isInstanceOf(Number.class);
+    assertThat(((Number) json.getJSONArray("dates").get(0)).longValue()).isEqualTo(1_000_000L);
 
     // JSONArray.put(Object) with LocalDateTime
     final JSONArray arr = new JSONArray();
@@ -283,15 +284,38 @@ class JSONTest extends TestHelper {
 
   @Test
   void durationInArrayPreservesPrecisionAndSign() {
-    // Leading-zero nanoseconds must not be lost (5ns -> 0.000000005, not collapsed).
+    // Leading-zero nanoseconds must not be lost (5ns must not collapse to 0.5s).
     final JSONArray smallNanos = new JSONArray(List.of(Duration.ofSeconds(5, 5)));
-    assertThat(smallNanos.getDouble(0)).isEqualTo(5 + 5 / 1_000_000_000.0);
+    assertThat(smallNanos.getDouble(0)).isCloseTo(5.000000005, within(1e-12));
 
-    // Negative durations stored as (negative seconds, positive nanos) must serialize correctly.
+    // Negative durations stored as (negative seconds, positive nanos) must serialize correctly,
+    // not as the naive "-6.999999995" that "%d.%d" formatting would produce.
     final Duration negative = Duration.ofSeconds(-5).minusNanos(5); // -5.000000005s
     final JSONArray neg = new JSONArray(List.of(negative));
-    assertThat(neg.getDouble(0)).isEqualTo(negative.toSeconds() + negative.toNanosPart() / 1_000_000_000.0);
+    assertThat(neg.getDouble(0)).isCloseTo(-5.000000005, within(1e-12));
     assertThat(neg.getDouble(0)).isLessThan(0.0);
+  }
+
+  @Test
+  void enumAndClassInArrays() {
+    // Enum serializes to its name(); the array path must mirror put(String, Object).
+    final JSONArray enums = new JSONArray(List.of(java.time.DayOfWeek.MONDAY, java.time.Month.JUNE));
+    assertThat(enums.getString(0)).isEqualTo("MONDAY");
+    assertThat(enums.getString(1)).isEqualTo("JUNE");
+
+    // Class serializes to its fully-qualified name (matching put(String, Object)), not toString().
+    final JSONArray classes = new JSONArray(List.of(String.class));
+    assertThat(classes.getString(0)).isEqualTo("java.lang.String");
+  }
+
+  @Test
+  void durationConsistentBetweenPutAndArrayPaths() {
+    // put(String, Object) and the array path (objectToElement) must produce the same value.
+    final Duration duration = Duration.ofSeconds(5, 5); // 5.000000005s
+    final double viaPut = new JSONObject().put("d", duration).getDouble("d");
+    final double viaArray = new JSONArray(List.of(duration)).getDouble(0);
+    assertThat(viaPut).isEqualTo(viaArray);
+    assertThat(viaPut).isCloseTo(5.000000005, within(1e-12));
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/serializer/json/JSONTest.java
+++ b/engine/src/test/java/com/arcadedb/serializer/json/JSONTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -220,6 +221,53 @@ class JSONTest extends TestHelper {
     assertThat(deserialized.getString("singleQuote")).isEqualTo("It's a test");
     assertThat(deserialized.getString("allTogether")).isEqualTo("& < > \" '");
     assertThat(deserialized.getString("multipleAmpersands")).isEqualTo("a && b &&& c");
+  }
+
+  @Test
+  void temporalTypesInArrays() {
+    final LocalDateTime ldt = LocalDateTime.of(2024, 6, 15, 10, 30, 0);
+    final LocalDate ld = LocalDate.of(2024, 6, 15);
+    final Date d = new Date(1_000_000L);
+
+    // LocalDateTime inside a List → put(String, Object) → JSONArray constructor
+    JSONObject json = new JSONObject().put("dates", List.of(ldt));
+    assertThat(json.getJSONArray("dates").length()).isEqualTo(1);
+    assertThat(json.getJSONArray("dates").get(0)).isInstanceOf(Number.class);
+
+    // LocalDate inside a List
+    json = new JSONObject().put("dates", List.of(ld));
+    assertThat(json.getJSONArray("dates").length()).isEqualTo(1);
+    assertThat(json.getJSONArray("dates").get(0)).isInstanceOf(Number.class);
+
+    // java.util.Date inside a List
+    json = new JSONObject().put("dates", List.of(d));
+    assertThat(json.getJSONArray("dates").length()).isEqualTo(1);
+    assertThat(json.getJSONArray("dates").get(0)).isInstanceOf(Number.class);
+
+    // JSONArray.put(Object) with LocalDateTime
+    final JSONArray arr = new JSONArray();
+    arr.put((Object) ldt);
+    assertThat(arr.length()).isEqualTo(1);
+    assertThat(arr.get(0)).isInstanceOf(Number.class);
+
+    // JSONArray(Collection) constructor with temporal elements
+    final JSONArray arrFromColl = new JSONArray(List.of(ldt, ld, d));
+    assertThat(arrFromColl.length()).isEqualTo(3);
+    for (int i = 0; i < 3; i++)
+      assertThat(arrFromColl.get(i)).isInstanceOf(Number.class);
+
+    // JSONArray(Object[]) constructor with temporal elements
+    final JSONArray arrFromArr = new JSONArray(new Object[] { ldt, ld, d });
+    assertThat(arrFromArr.length()).isEqualTo(3);
+    for (int i = 0; i < 3; i++)
+      assertThat(arrFromArr.get(i)).isInstanceOf(Number.class);
+
+    // Mixed temporal types round-trip through JSON string
+    json = new JSONObject().put("mixed", List.of(ldt, ld));
+    final JSONObject deserialized = new JSONObject(json.toString());
+    assertThat(deserialized.getJSONArray("mixed").length()).isEqualTo(2);
+    for (int i = 0; i < 2; i++)
+      assertThat(deserialized.getJSONArray("mixed").get(i)).isInstanceOf(Number.class);
   }
 
   @Test


### PR DESCRIPTION
Closes #4654

## Summary

`JSONObject.objectToElement()` is the static helper used by `JSONArray.put(Object)`, `new JSONArray(Collection)`, and `new JSONArray(Object[])` to convert Java objects into Gson `JsonElement` values. The method handled common types but was missing branches for temporal types, causing `IllegalArgumentException: Object of type class java.time.LocalDateTime not supported` whenever a temporal value appeared inside an array or collection projection.

- Added `Date`, `LocalDate`, `TemporalAccessor` (covers `LocalDateTime`, `ZonedDateTime`, `Instant`, etc.), `Duration`, and `Enum` cases to `objectToElement()`.
- Because the method is `static` and has no access to configured date/datetime format strings, temporal values are serialized as epoch-millisecond timestamps - matching the existing default behavior in `JSONObject.put(String, Object)` when no format is configured.
- Changed the `default` branch from throwing `IllegalArgumentException` to a `toString()` fallback, consistent with the generic case in `put(String, Object)`.

## Test plan

- [x] New regression test `temporalTypesInArrays` in `JSONTest` covers: `LocalDateTime`, `LocalDate`, and `java.util.Date` inside a `List`, via `JSONArray.put(Object)`, via `JSONArray(Collection)` constructor, and via `JSONArray(Object[])` constructor - all serialize to a `Number` without throwing.
- [x] All 38 existing JSON serializer tests continue to pass.
- [x] All 174 existing datetime/temporal engine tests continue to pass.
- [x] Run: `mvn test -pl engine -Dtest=JSONTest`