### PR TITLE
fix: [#4657] tolerate ghost (dangling) edges in OpenCypher queries an…

### DIFF
--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
@@ -25,6 +25,7 @@ import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
 import com.arcadedb.graph.Vertex;
@@ -277,8 +278,9 @@ public class SQLFunctionAstar extends SQLFunctionHeuristicPathFinderAbstract {
         final Vertex neighbor = getNeighbor(node, edge, ctx.getDatabase());
         if (neighbor != null)
           result.put(neighbor, getDistance(edge));
-      } catch (final RecordNotFoundException ignored) {
+      } catch (final RecordNotFoundException rnf) {
         // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+        GhostEdgeReporter.reportSkipped(rnf);
       }
     }
     return result;
@@ -348,8 +350,9 @@ public class SQLFunctionAstar extends SQLFunctionHeuristicPathFinderAbstract {
           e = next;
           break;
         }
-      } catch (final RecordNotFoundException ignored) {
+      } catch (final RecordNotFoundException rnf) {
         // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+        GhostEdgeReporter.reportSkipped(rnf);
       }
     }
     if (e != null) {

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
@@ -278,8 +278,8 @@ public class SQLFunctionAstar extends SQLFunctionHeuristicPathFinderAbstract {
         final Vertex neighbor = getNeighbor(node, edge, ctx.getDatabase());
         if (neighbor != null)
           result.put(neighbor, getDistance(edge));
-      } catch (final RecordNotFoundException rnf) {
-        GhostEdgeReporter.reportSkipped(rnf);
+      } catch (final RecordNotFoundException e) {
+        GhostEdgeReporter.reportSkipped(e);
       }
     }
     return result;
@@ -349,7 +349,7 @@ public class SQLFunctionAstar extends SQLFunctionHeuristicPathFinderAbstract {
           e = next;
           break;
         }
-      } catch (final RecordNotFoundException rnf) {
+      } catch (final RecordNotFoundException rnf) {  // 'rnf' not 'e' here: 'e' is the Edge loop variable in this scope
         GhostEdgeReporter.reportSkipped(rnf);
       }
     }

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
@@ -279,7 +279,6 @@ public class SQLFunctionAstar extends SQLFunctionHeuristicPathFinderAbstract {
         if (neighbor != null)
           result.put(neighbor, getDistance(edge));
       } catch (final RecordNotFoundException rnf) {
-        // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
         GhostEdgeReporter.reportSkipped(rnf);
       }
     }
@@ -351,7 +350,6 @@ public class SQLFunctionAstar extends SQLFunctionHeuristicPathFinderAbstract {
           break;
         }
       } catch (final RecordNotFoundException rnf) {
-        // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
         GhostEdgeReporter.reportSkipped(rnf);
       }
     }

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionAstar.java
@@ -23,6 +23,7 @@ import com.arcadedb.database.Document;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
@@ -272,9 +273,13 @@ public class SQLFunctionAstar extends SQLFunctionHeuristicPathFinderAbstract {
 
     // OLTP fallback
     for (final Edge edge : node.getEdges(paramDirection, paramEdgeTypeNames)) {
-      final Vertex neighbor = getNeighbor(node, edge, ctx.getDatabase());
-      if (neighbor != null)
-        result.put(neighbor, getDistance(edge));
+      try {
+        final Vertex neighbor = getNeighbor(node, edge, ctx.getDatabase());
+        if (neighbor != null)
+          result.put(neighbor, getDistance(edge));
+      } catch (final RecordNotFoundException ignored) {
+        // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+      }
     }
     return result;
   }
@@ -338,9 +343,13 @@ public class SQLFunctionAstar extends SQLFunctionHeuristicPathFinderAbstract {
     Edge e = null;
     while (edges.hasNext()) {
       final Edge next = edges.next();
-      if (next.getOut().equals(target.getIdentity()) || next.getIn().equals(target.getIdentity())) {
-        e = next;
-        break;
+      try {
+        if (next.getOut().equals(target.getIdentity()) || next.getIn().equals(target.getIdentity())) {
+          e = next;
+          break;
+        }
+      } catch (final RecordNotFoundException ignored) {
+        // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
       }
     }
     if (e != null) {

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionBellmanFord.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionBellmanFord.java
@@ -23,6 +23,7 @@ import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.Record;
 import com.arcadedb.function.sql.FunctionOptions;
 import com.arcadedb.function.sql.math.SQLFunctionMathAbstract;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
@@ -144,26 +145,30 @@ public class SQLFunctionBellmanFord extends SQLFunctionMathAbstract {
 
       // OLTP fallback
       for (final Edge edge : v.getEdges(dir)) {
-        final Vertex neighbor;
-        if (dir == Vertex.DIRECTION.OUT)
-          neighbor = edge.getInVertex();
-        else if (dir == Vertex.DIRECTION.IN)
-          neighbor = edge.getOutVertex();
-        else
-          neighbor = edge.getOut().equals(v.getIdentity()) ? edge.getInVertex() : edge.getOutVertex();
+        try {
+          final Vertex neighbor;
+          if (dir == Vertex.DIRECTION.OUT)
+            neighbor = edge.getInVertex();
+          else if (dir == Vertex.DIRECTION.IN)
+            neighbor = edge.getOutVertex();
+          else
+            neighbor = edge.getOut().equals(v.getIdentity()) ? edge.getInVertex() : edge.getOutVertex();
 
-        final Integer j = vertexIndex.get(neighbor);
-        if (j == null)
-          continue;
+          final Integer j = vertexIndex.get(neighbor);
+          if (j == null)
+            continue;
 
-        double w = 1.0;
-        if (weightProperty != null && !weightProperty.isEmpty()) {
-          final Object wObj = edge.get(weightProperty);
-          if (wObj instanceof Number num)
-            w = num.doubleValue();
+          double w = 1.0;
+          if (weightProperty != null && !weightProperty.isEmpty()) {
+            final Object wObj = edge.get(weightProperty);
+            if (wObj instanceof Number num)
+              w = num.doubleValue();
+          }
+          edgeList.add(new int[] { i, j });
+          edgeWeights.add(w);
+        } catch (final RecordNotFoundException ignored) {
+          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
         }
-        edgeList.add(new int[] { i, j });
-        edgeWeights.add(w);
       }
     }
 

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionBellmanFord.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionBellmanFord.java
@@ -21,10 +21,11 @@ package com.arcadedb.function.sql.graph;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.Record;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.function.sql.FunctionOptions;
 import com.arcadedb.function.sql.math.SQLFunctionMathAbstract;
-import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
 import com.arcadedb.graph.Vertex;
@@ -166,8 +167,9 @@ public class SQLFunctionBellmanFord extends SQLFunctionMathAbstract {
           }
           edgeList.add(new int[] { i, j });
           edgeWeights.add(w);
-        } catch (final RecordNotFoundException ignored) {
+        } catch (final RecordNotFoundException e) {
           // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+          GhostEdgeReporter.reportSkipped(e);
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionBellmanFord.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionBellmanFord.java
@@ -168,7 +168,6 @@ public class SQLFunctionBellmanFord extends SQLFunctionMathAbstract {
           edgeList.add(new int[] { i, j });
           edgeWeights.add(w);
         } catch (final RecordNotFoundException rnf) {
-          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           GhostEdgeReporter.reportSkipped(rnf);
         }
       }

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionBellmanFord.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionBellmanFord.java
@@ -167,8 +167,8 @@ public class SQLFunctionBellmanFord extends SQLFunctionMathAbstract {
           }
           edgeList.add(new int[] { i, j });
           edgeWeights.add(w);
-        } catch (final RecordNotFoundException rnf) {
-          GhostEdgeReporter.reportSkipped(rnf);
+        } catch (final RecordNotFoundException e) {
+          GhostEdgeReporter.reportSkipped(e);
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionBellmanFord.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionBellmanFord.java
@@ -167,9 +167,9 @@ public class SQLFunctionBellmanFord extends SQLFunctionMathAbstract {
           }
           edgeList.add(new int[] { i, j });
           edgeWeights.add(w);
-        } catch (final RecordNotFoundException e) {
+        } catch (final RecordNotFoundException rnf) {
           // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
-          GhostEdgeReporter.reportSkipped(e);
+          GhostEdgeReporter.reportSkipped(rnf);
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionDuanSSSP.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionDuanSSSP.java
@@ -24,6 +24,7 @@ import com.arcadedb.database.RID;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.MultiValue;
@@ -145,8 +146,9 @@ public class SQLFunctionDuanSSSP extends SQLFunctionMathAbstract {
               pq.offer(new VertexDistance(neighborRID, newDist));
             }
           }
-        } catch (final RecordNotFoundException ignored) {
+        } catch (final RecordNotFoundException e) {
           // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+          GhostEdgeReporter.reportSkipped(e);
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionDuanSSSP.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionDuanSSSP.java
@@ -147,7 +147,6 @@ public class SQLFunctionDuanSSSP extends SQLFunctionMathAbstract {
             }
           }
         } catch (final RecordNotFoundException e) {
-          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           GhostEdgeReporter.reportSkipped(e);
         }
       }

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionDuanSSSP.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionDuanSSSP.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.Document;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -130,18 +131,22 @@ public class SQLFunctionDuanSSSP extends SQLFunctionMathAbstract {
       final Vertex v = current.rid.asVertex();
 
       for (final Edge edge : v.getEdges(direction)) {
-        final RID neighborRID = getNeighborRID(v, edge, direction);
+        try {
+          final RID neighborRID = getNeighborRID(v, edge, direction);
 
-        if (!visited.contains(neighborRID)) {
-          final double edgeWeight = getEdgeWeight(weightField, edge);
-          final double newDist = current.distance + edgeWeight;
-          final double oldDist = distances.getOrDefault(neighborRID, Double.POSITIVE_INFINITY);
+          if (!visited.contains(neighborRID)) {
+            final double edgeWeight = getEdgeWeight(weightField, edge);
+            final double newDist = current.distance + edgeWeight;
+            final double oldDist = distances.getOrDefault(neighborRID, Double.POSITIVE_INFINITY);
 
-          if (newDist < oldDist) {
-            distances.put(neighborRID, newDist);
-            predecessors.put(neighborRID, current.rid);
-            pq.offer(new VertexDistance(neighborRID, newDist));
+            if (newDist < oldDist) {
+              distances.put(neighborRID, newDist);
+              predecessors.put(neighborRID, current.rid);
+              pq.offer(new VertexDistance(neighborRID, newDist));
+            }
           }
+        } catch (final RecordNotFoundException ignored) {
+          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionMove.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionMove.java
@@ -21,6 +21,7 @@ package com.arcadedb.function.sql.graph;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.Identifiable;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.CSRVertexIterable;
 import com.arcadedb.graph.GraphTraversalProvider;
@@ -103,13 +104,20 @@ public abstract class SQLFunctionMove extends SQLFunctionConfigurableAbstract {
       final String[] iLabels) {
     final Document rec = (Document) iRecord.getRecord();
     if (rec instanceof Edge edge) {
-      if (iDirection == Vertex.DIRECTION.BOTH) {
-        var results = new ArrayList<Vertex>();
-        results.add(edge.getOutVertex());
-        results.add(edge.getInVertex());
-        return results;
+      // Tolerate a ghost edge (dangling segment pointer whose backing edge record is gone): it has no
+      // resolvable endpoints, so return an empty/null result instead of throwing RecordNotFoundException.
+      try {
+        if (iDirection == Vertex.DIRECTION.BOTH) {
+          var results = new ArrayList<Vertex>();
+          results.add(edge.getOutVertex());
+          results.add(edge.getInVertex());
+          return results;
+        }
+        return edge.getVertex(iDirection);
+      } catch (final RecordNotFoundException ignored) {
+        // Ghost edge: backing record missing; no endpoint to resolve.
+        return iDirection == Vertex.DIRECTION.BOTH ? new ArrayList<Vertex>() : null;
       }
-      return edge.getVertex(iDirection);
     }
 
     return null;

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionMove.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionMove.java
@@ -24,6 +24,7 @@ import com.arcadedb.database.Identifiable;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.CSRVertexIterable;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
 import com.arcadedb.graph.Vertex;
@@ -114,9 +115,10 @@ public abstract class SQLFunctionMove extends SQLFunctionConfigurableAbstract {
           return results;
         }
         return edge.getVertex(iDirection);
-      } catch (final RecordNotFoundException ignored) {
+      } catch (final RecordNotFoundException e) {
         // Ghost edge: backing record missing; no endpoint to resolve.
-        return iDirection == Vertex.DIRECTION.BOTH ? new ArrayList<Vertex>() : null;
+        GhostEdgeReporter.reportSkipped(e);
+        return iDirection == Vertex.DIRECTION.BOTH ? new ArrayList<>() : null;
       }
     }
 

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionShortestPath.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionShortestPath.java
@@ -372,7 +372,9 @@ public class SQLFunctionShortestPath extends SQLFunctionMathAbstract {
         while (vertexIterator.hasNext() && edgeIterator.hasNext()) {
           // Advance the edge iterator first (getIdentity never loads the record); then resolve the
           // neighbor vertex, which lazily loads the edge. A ghost edge throws there - both iterators
-          // have advanced once, so skipping keeps them in lockstep.
+          // have advanced once, so skipping keeps them in lockstep. This relies on getFirst() being an
+          // EdgeToVertexIterable (see getVerticesAndEdges): it is vertexIterator.next(), not
+          // v.getIdentity(), that triggers the edge-record load. Keep that coupling if refactoring.
           final RID neighborEdgeIdentity = edgeIterator.next().getIdentity();
           final Vertex v;
           final RID neighborVertexIdentity;
@@ -444,7 +446,9 @@ public class SQLFunctionShortestPath extends SQLFunctionMathAbstract {
         while (vertexIterator.hasNext() && edgeIterator.hasNext()) {
           // Advance the edge iterator first (getIdentity never loads the record); then resolve the
           // neighbor vertex, which lazily loads the edge. A ghost edge throws there - both iterators
-          // have advanced once, so skipping keeps them in lockstep.
+          // have advanced once, so skipping keeps them in lockstep. This relies on getFirst() being an
+          // EdgeToVertexIterable (see getVerticesAndEdges): it is vertexIterator.next(), not
+          // v.getIdentity(), that triggers the edge-record load. Keep that coupling if refactoring.
           final RID neighborEdgeIdentity = edgeIterator.next().getIdentity();
           final Vertex v;
           final RID neighborVertexIdentity;

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionShortestPath.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionShortestPath.java
@@ -374,7 +374,9 @@ public class SQLFunctionShortestPath extends SQLFunctionMathAbstract {
           // neighbor vertex, which lazily loads the edge. A ghost edge throws there - both iterators
           // have advanced once, so skipping keeps them in lockstep. This relies on getFirst() being an
           // EdgeToVertexIterable (see getVerticesAndEdges): it is vertexIterator.next(), not
-          // v.getIdentity(), that triggers the edge-record load. Keep that coupling if refactoring.
+          // v.getIdentity(), that triggers the edge-record load. If that iterable is ever refactored to
+          // peek-then-advance (advancing both sides before the deref), the two would desync silently on
+          // a ghost - keep the next()-triggers-load coupling.
           final RID neighborEdgeIdentity = edgeIterator.next().getIdentity();
           final Vertex v;
           final RID neighborVertexIdentity;
@@ -448,7 +450,9 @@ public class SQLFunctionShortestPath extends SQLFunctionMathAbstract {
           // neighbor vertex, which lazily loads the edge. A ghost edge throws there - both iterators
           // have advanced once, so skipping keeps them in lockstep. This relies on getFirst() being an
           // EdgeToVertexIterable (see getVerticesAndEdges): it is vertexIterator.next(), not
-          // v.getIdentity(), that triggers the edge-record load. Keep that coupling if refactoring.
+          // v.getIdentity(), that triggers the edge-record load. If that iterable is ever refactored to
+          // peek-then-advance (advancing both sides before the deref), the two would desync silently on
+          // a ghost - keep the next()-triggers-load coupling.
           final RID neighborEdgeIdentity = edgeIterator.next().getIdentity();
           final Vertex v;
           final RID neighborVertexIdentity;

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionShortestPath.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionShortestPath.java
@@ -27,6 +27,7 @@ import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.CSRVertexIterable;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.EdgeToVertexIterable;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
 import com.arcadedb.graph.Vertex;
@@ -378,8 +379,9 @@ public class SQLFunctionShortestPath extends SQLFunctionMathAbstract {
           try {
             v = vertexIterator.next();
             neighborVertexIdentity = v.getIdentity();
-          } catch (final RecordNotFoundException ignored) {
+          } catch (final RecordNotFoundException e) {
             // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+            GhostEdgeReporter.reportSkipped(e);
             continue;
           }
 
@@ -450,8 +452,9 @@ public class SQLFunctionShortestPath extends SQLFunctionMathAbstract {
           try {
             v = vertexIterator.next();
             neighborVertexIdentity = v.getIdentity();
-          } catch (final RecordNotFoundException ignored) {
+          } catch (final RecordNotFoundException e) {
             // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+            GhostEdgeReporter.reportSkipped(e);
             continue;
           }
 

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionShortestPath.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionShortestPath.java
@@ -333,6 +333,35 @@ public class SQLFunctionShortestPath extends SQLFunctionMathAbstract {
          | { direction, edgeType | edgeTypeNames, maxDepth, edge })""";
   }
 
+  /** A neighbor reached across one live edge: the neighbor vertex plus the RIDs of the vertex and the edge. */
+  private record Neighbor(Vertex vertex, RID vertexRID, RID edgeRID) {
+  }
+
+  /**
+   * Advances the (vertex, edge) iterator pair by one in lockstep and resolves the neighbor reached.
+   * <p>
+   * Read order is load-bearing: the edge iterator is advanced first ({@code getIdentity} never loads the
+   * record), then the neighbor vertex is resolved, which lazily loads the edge record. A ghost edge throws
+   * there - and because both iterators have advanced exactly once, returning {@code null} (skip) keeps them
+   * in lockstep for the next iteration. This relies on {@code getFirst()} being an {@link EdgeToVertexIterable}
+   * (see {@link #getVerticesAndEdges}): it is {@code vertexIterator.next()}, not {@code vertex.getIdentity()},
+   * that triggers the edge-record load. If that iterable is ever refactored to peek-then-advance (advancing
+   * both sides before the deref), the two would desync silently on a ghost - keep the next()-triggers-load
+   * coupling.
+   *
+   * @return the resolved neighbor, or {@code null} if the edge was a ghost (already reported and skipped)
+   */
+  private static Neighbor advanceNeighbor(final Iterator<Vertex> vertexIterator, final Iterator<Edge> edgeIterator) {
+    final RID neighborEdgeIdentity = edgeIterator.next().getIdentity();
+    try {
+      final Vertex v = vertexIterator.next();
+      return new Neighbor(v, v.getIdentity(), neighborEdgeIdentity);
+    } catch (final RecordNotFoundException e) {
+      GhostEdgeReporter.reportSkipped(e);
+      return null;
+    }
+  }
+
   protected List<RID> walkLeft(final ShortestPathContext context) {
     final ArrayDeque<Vertex> nextLevelQueue = new ArrayDeque<>();
     if (!Boolean.TRUE.equals(context.edge)) {
@@ -370,23 +399,12 @@ public class SQLFunctionShortestPath extends SQLFunctionMathAbstract {
         final Iterator<Vertex> vertexIterator = neighbors.getFirst().iterator();
         final Iterator<Edge> edgeIterator = neighbors.getSecond().iterator();
         while (vertexIterator.hasNext() && edgeIterator.hasNext()) {
-          // Advance the edge iterator first (getIdentity never loads the record); then resolve the
-          // neighbor vertex, which lazily loads the edge. A ghost edge throws there - both iterators
-          // have advanced once, so skipping keeps them in lockstep. This relies on getFirst() being an
-          // EdgeToVertexIterable (see getVerticesAndEdges): it is vertexIterator.next(), not
-          // v.getIdentity(), that triggers the edge-record load. If that iterable is ever refactored to
-          // peek-then-advance (advancing both sides before the deref), the two would desync silently on
-          // a ghost - keep the next()-triggers-load coupling.
-          final RID neighborEdgeIdentity = edgeIterator.next().getIdentity();
-          final Vertex v;
-          final RID neighborVertexIdentity;
-          try {
-            v = vertexIterator.next();
-            neighborVertexIdentity = v.getIdentity();
-          } catch (final RecordNotFoundException e) {
-            GhostEdgeReporter.reportSkipped(e);
-            continue;
-          }
+          final Neighbor neighbor = advanceNeighbor(vertexIterator, edgeIterator);
+          if (neighbor == null)
+            continue; // ghost edge: reported and skipped, iterators stay in lockstep
+          final Vertex v = neighbor.vertex();
+          final RID neighborVertexIdentity = neighbor.vertexRID();
+          final RID neighborEdgeIdentity = neighbor.edgeRID();
 
           if (context.rightVisited.contains(neighborVertexIdentity)) {
             context.previouses.put(neighborVertexIdentity, neighborEdgeIdentity);
@@ -446,23 +464,12 @@ public class SQLFunctionShortestPath extends SQLFunctionMathAbstract {
         final Iterator<Vertex> vertexIterator = neighbors.getFirst().iterator();
         final Iterator<Edge> edgeIterator = neighbors.getSecond().iterator();
         while (vertexIterator.hasNext() && edgeIterator.hasNext()) {
-          // Advance the edge iterator first (getIdentity never loads the record); then resolve the
-          // neighbor vertex, which lazily loads the edge. A ghost edge throws there - both iterators
-          // have advanced once, so skipping keeps them in lockstep. This relies on getFirst() being an
-          // EdgeToVertexIterable (see getVerticesAndEdges): it is vertexIterator.next(), not
-          // v.getIdentity(), that triggers the edge-record load. If that iterable is ever refactored to
-          // peek-then-advance (advancing both sides before the deref), the two would desync silently on
-          // a ghost - keep the next()-triggers-load coupling.
-          final RID neighborEdgeIdentity = edgeIterator.next().getIdentity();
-          final Vertex v;
-          final RID neighborVertexIdentity;
-          try {
-            v = vertexIterator.next();
-            neighborVertexIdentity = v.getIdentity();
-          } catch (final RecordNotFoundException e) {
-            GhostEdgeReporter.reportSkipped(e);
-            continue;
-          }
+          final Neighbor neighbor = advanceNeighbor(vertexIterator, edgeIterator);
+          if (neighbor == null)
+            continue; // ghost edge: reported and skipped, iterators stay in lockstep
+          final Vertex v = neighbor.vertex();
+          final RID neighborVertexIdentity = neighbor.vertexRID();
+          final RID neighborEdgeIdentity = neighbor.edgeRID();
 
           if (context.leftVisited.contains(neighborVertexIdentity)) {
             context.nexts.put(neighborVertexIdentity, neighborEdgeIdentity);

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionShortestPath.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionShortestPath.java
@@ -380,7 +380,6 @@ public class SQLFunctionShortestPath extends SQLFunctionMathAbstract {
             v = vertexIterator.next();
             neighborVertexIdentity = v.getIdentity();
           } catch (final RecordNotFoundException e) {
-            // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
             GhostEdgeReporter.reportSkipped(e);
             continue;
           }
@@ -453,7 +452,6 @@ public class SQLFunctionShortestPath extends SQLFunctionMathAbstract {
             v = vertexIterator.next();
             neighborVertexIdentity = v.getIdentity();
           } catch (final RecordNotFoundException e) {
-            // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
             GhostEdgeReporter.reportSkipped(e);
             continue;
           }

--- a/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionShortestPath.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/graph/SQLFunctionShortestPath.java
@@ -23,6 +23,7 @@ import com.arcadedb.database.Document;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.CSRVertexIterable;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.EdgeToVertexIterable;
@@ -368,9 +369,19 @@ public class SQLFunctionShortestPath extends SQLFunctionMathAbstract {
         final Iterator<Vertex> vertexIterator = neighbors.getFirst().iterator();
         final Iterator<Edge> edgeIterator = neighbors.getSecond().iterator();
         while (vertexIterator.hasNext() && edgeIterator.hasNext()) {
-          final Vertex v = vertexIterator.next();
-          final RID neighborVertexIdentity = v.getIdentity();
+          // Advance the edge iterator first (getIdentity never loads the record); then resolve the
+          // neighbor vertex, which lazily loads the edge. A ghost edge throws there - both iterators
+          // have advanced once, so skipping keeps them in lockstep.
           final RID neighborEdgeIdentity = edgeIterator.next().getIdentity();
+          final Vertex v;
+          final RID neighborVertexIdentity;
+          try {
+            v = vertexIterator.next();
+            neighborVertexIdentity = v.getIdentity();
+          } catch (final RecordNotFoundException ignored) {
+            // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+            continue;
+          }
 
           if (context.rightVisited.contains(neighborVertexIdentity)) {
             context.previouses.put(neighborVertexIdentity, neighborEdgeIdentity);
@@ -430,9 +441,19 @@ public class SQLFunctionShortestPath extends SQLFunctionMathAbstract {
         final Iterator<Vertex> vertexIterator = neighbors.getFirst().iterator();
         final Iterator<Edge> edgeIterator = neighbors.getSecond().iterator();
         while (vertexIterator.hasNext() && edgeIterator.hasNext()) {
-          final Vertex v = vertexIterator.next();
-          final RID neighborVertexIdentity = v.getIdentity();
+          // Advance the edge iterator first (getIdentity never loads the record); then resolve the
+          // neighbor vertex, which lazily loads the edge. A ghost edge throws there - both iterators
+          // have advanced once, so skipping keeps them in lockstep.
           final RID neighborEdgeIdentity = edgeIterator.next().getIdentity();
+          final Vertex v;
+          final RID neighborVertexIdentity;
+          try {
+            v = vertexIterator.next();
+            neighborVertexIdentity = v.getIdentity();
+          } catch (final RecordNotFoundException ignored) {
+            // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+            continue;
+          }
 
           if (context.leftVisited.contains(neighborVertexIdentity)) {
             context.nexts.put(neighborVertexIdentity, neighborEdgeIdentity);

--- a/engine/src/main/java/com/arcadedb/graph/GhostEdgeReporter.java
+++ b/engine/src/main/java/com/arcadedb/graph/GhostEdgeReporter.java
@@ -53,8 +53,7 @@ public final class GhostEdgeReporter {
     final long total = totalSkipped.incrementAndGet();
 
     LogManager.instance().log(GhostEdgeReporter.class, Level.FINE,
-        "Skipped ghost edge during traversal (%s); total skipped since startup=%d",
-        cause != null ? cause.getMessage() : null, total);
+        "Skipped ghost edge during traversal (%s); total skipped since startup=%d", cause.getMessage(), total);
 
     final long now = System.nanoTime();
     final long last = lastWarningNanos.get();

--- a/engine/src/main/java/com/arcadedb/graph/GhostEdgeReporter.java
+++ b/engine/src/main/java/com/arcadedb/graph/GhostEdgeReporter.java
@@ -39,7 +39,11 @@ import java.util.logging.Level;
 public final class GhostEdgeReporter {
   private static final long       WARNING_WINDOW_NANOS = 60_000_000_000L; // 60s
   private static final AtomicLong totalSkipped         = new AtomicLong();
-  private static final AtomicLong lastWarningNanos     = new AtomicLong(Long.MIN_VALUE);
+  // Seeded one full window in the past (NOT Long.MIN_VALUE): the throttle compares with the overflow-safe
+  // 'now - last >= WINDOW'. Long.MIN_VALUE is not a real nanoTime reading, so 'now - Long.MIN_VALUE' overflows
+  // to a negative value on any JVM where System.nanoTime() is positive, and the first WARNING would never fire.
+  // -WARNING_WINDOW_NANOS is within a real reading's range, so the first ghost encountered always warns.
+  private static final AtomicLong lastWarningNanos     = new AtomicLong(-WARNING_WINDOW_NANOS);
 
   private GhostEdgeReporter() {
   }
@@ -55,13 +59,27 @@ public final class GhostEdgeReporter {
     LogManager.instance().log(GhostEdgeReporter.class, Level.FINE,
         "Skipped ghost edge during traversal (%s); total skipped since startup=%d", cause.getMessage(), total);
 
-    final long now = System.nanoTime();
-    final long last = lastWarningNanos.get();
-    if (now - last >= WARNING_WINDOW_NANOS && lastWarningNanos.compareAndSet(last, now))
+    if (shouldEmitWarning(System.nanoTime()))
       LogManager.instance().log(GhostEdgeReporter.class, Level.WARNING,
           "Ghost (dangling) edges encountered and skipped during traversal (total skipped since startup=%d). "
               + "A dangling edge-segment pointer indicates a data-integrity anomaly, e.g. incomplete HA "
               + "replication or a partially rolled-back transaction.", total);
+  }
+
+  /**
+   * Decides, with overflow-safe elapsed arithmetic, whether a throttled WARNING should fire at {@code now}
+   * and, if so, claims the slot atomically (CAS) so concurrent skips emit at most one WARNING per window.
+   * <p>
+   * Package-private ({@code @VisibleForTesting}) so the throttle can be exercised directly without capturing
+   * log output: the previous {@code Long.MIN_VALUE} seed made {@code now - last} overflow and suppressed the
+   * WARNING forever, a bug invisible to a test that only asserts on the skip count.
+   *
+   * @param now a {@link System#nanoTime()} reading
+   * @return {@code true} iff this caller won the slot and should log the WARNING
+   */
+  static boolean shouldEmitWarning(final long now) {
+    final long last = lastWarningNanos.get();
+    return now - last >= WARNING_WINDOW_NANOS && lastWarningNanos.compareAndSet(last, now);
   }
 
   /** Total ghost edges skipped since JVM startup (monotonic). */
@@ -69,9 +87,15 @@ public final class GhostEdgeReporter {
     return totalSkipped.get();
   }
 
-  // @VisibleForTesting (package-private: only GhostEdgeReporterTest, in this package, calls it)
+  /**
+   * Resets the static counters so each test starts from a clean slate.
+   * <p>
+   * Package-private on purpose ({@code @VisibleForTesting}): it is only reachable from
+   * {@code com.arcadedb.graph.GhostEdgeReporterTest}, which lives in this same package. If that test is
+   * ever moved out of {@code com.arcadedb.graph}, this method must be widened (or the test kept in-package).
+   */
   static void resetForTests() {
     totalSkipped.set(0);
-    lastWarningNanos.set(Long.MIN_VALUE);
+    lastWarningNanos.set(-WARNING_WINDOW_NANOS);
   }
 }

--- a/engine/src/main/java/com/arcadedb/graph/GhostEdgeReporter.java
+++ b/engine/src/main/java/com/arcadedb/graph/GhostEdgeReporter.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.exception.RecordNotFoundException;
+import com.arcadedb.log.LogManager;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+
+/**
+ * Central, low-overhead reporter for <i>ghost edges</i>: dangling edge-segment pointers whose backing
+ * edge record no longer exists (e.g. after incomplete HA replication or a partially rolled-back
+ * transaction). Traversal and graph-algorithm code skips such edges rather than failing the whole
+ * query; routing every skip through here makes the anomaly observable instead of silently swallowed.
+ * <p>
+ * Each skip is counted and logged at {@code FINE} (full per-occurrence trace, off by default, so there
+ * is no cost on clean graphs because this is only reached when a ghost is actually encountered). In
+ * addition a {@code WARNING} is emitted at most once per 60s - mirroring the engine's other throttled
+ * saturation logs - so operators notice a data-integrity problem without log flooding on a heavily
+ * corrupted graph.
+ */
+public final class GhostEdgeReporter {
+  private static final long       WARNING_WINDOW_NANOS = 60_000_000_000L; // 60s
+  private static final AtomicLong totalSkipped         = new AtomicLong();
+  private static final AtomicLong lastWarningNanos     = new AtomicLong(Long.MIN_VALUE);
+
+  private GhostEdgeReporter() {
+  }
+
+  /**
+   * Records and logs that a ghost edge was skipped during traversal.
+   *
+   * @param cause the {@link RecordNotFoundException} raised when the dangling edge was dereferenced
+   */
+  public static void reportSkipped(final RecordNotFoundException cause) {
+    final long total = totalSkipped.incrementAndGet();
+
+    LogManager.instance().log(GhostEdgeReporter.class, Level.FINE,
+        "Skipped ghost edge during traversal (%s); total skipped since startup=%d",
+        cause != null ? cause.getMessage() : null, total);
+
+    final long now = System.nanoTime();
+    final long last = lastWarningNanos.get();
+    if (now - last >= WARNING_WINDOW_NANOS && lastWarningNanos.compareAndSet(last, now))
+      LogManager.instance().log(GhostEdgeReporter.class, Level.WARNING,
+          "Ghost (dangling) edges encountered and skipped during traversal (total skipped since startup=%d). "
+              + "A dangling edge-segment pointer indicates a data-integrity anomaly, e.g. incomplete HA "
+              + "replication or a partially rolled-back transaction.", total);
+  }
+
+  /** Total ghost edges skipped since JVM startup (monotonic). */
+  public static long getTotalSkipped() {
+    return totalSkipped.get();
+  }
+
+  // @VisibleForTesting
+  public static void resetForTests() {
+    totalSkipped.set(0);
+    lastWarningNanos.set(Long.MIN_VALUE);
+  }
+}

--- a/engine/src/main/java/com/arcadedb/graph/GhostEdgeReporter.java
+++ b/engine/src/main/java/com/arcadedb/graph/GhostEdgeReporter.java
@@ -70,8 +70,8 @@ public final class GhostEdgeReporter {
     return totalSkipped.get();
   }
 
-  // @VisibleForTesting
-  public static void resetForTests() {
+  // @VisibleForTesting (package-private: only GhostEdgeReporterTest, in this package, calls it)
+  static void resetForTests() {
     totalSkipped.set(0);
     lastWarningNanos.set(Long.MIN_VALUE);
   }

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -1002,8 +1002,14 @@ public class GraphEngine {
       final Iterable<Edge> edges = relTypes != null && relTypes.length > 0 ?
           v.getEdges(dir, relTypes) : v.getEdges(dir);
       for (final Edge e : edges) {
-        if (ridToIdx.containsKey(neighborRid(e, vid, dir)))
-          counts[i]++;
+        try {
+          if (ridToIdx.containsKey(neighborRid(e, vid, dir)))
+            counts[i]++;
+        } catch (final RecordNotFoundException ex) {
+          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it (the fill
+          // pass below skips it identically, so counts and adjacency stay consistent).
+          GhostEdgeReporter.reportSkipped(ex);
+        }
       }
     }
     final int[][] adj = new int[n][];
@@ -1016,10 +1022,15 @@ public class GraphEngine {
       final Iterable<Edge> edges = relTypes != null && relTypes.length > 0 ?
           v.getEdges(dir, relTypes) : v.getEdges(dir);
       for (final Edge e : edges) {
-        final RID nid = neighborRid(e, vid, dir);
-        final Integer j = ridToIdx.get(nid);
-        if (j != null)
-          adj[i][pos[i]++] = j;
+        try {
+          final RID nid = neighborRid(e, vid, dir);
+          final Integer j = ridToIdx.get(nid);
+          if (j != null)
+            adj[i][pos[i]++] = j;
+        } catch (final RecordNotFoundException ex) {
+          // Ghost edge: skipped identically to the counting pass above, so pos[i] never exceeds counts[i].
+          GhostEdgeReporter.reportSkipped(ex);
+        }
       }
     }
     return adj;

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -1005,10 +1005,10 @@ public class GraphEngine {
         try {
           if (ridToIdx.containsKey(neighborRid(e, vid, dir)))
             counts[i]++;
-        } catch (final RecordNotFoundException ex) {
+        } catch (final RecordNotFoundException rnf) {
           // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it (the fill
           // pass below skips it identically, so counts and adjacency stay consistent).
-          GhostEdgeReporter.reportSkipped(ex);
+          GhostEdgeReporter.reportSkipped(rnf);
         }
       }
     }
@@ -1027,9 +1027,9 @@ public class GraphEngine {
           final Integer j = ridToIdx.get(nid);
           if (j != null)
             adj[i][pos[i]++] = j;
-        } catch (final RecordNotFoundException ex) {
+        } catch (final RecordNotFoundException rnf) {
           // Ghost edge: skipped identically to the counting pass above, so pos[i] never exceeds counts[i].
-          GhostEdgeReporter.reportSkipped(ex);
+          GhostEdgeReporter.reportSkipped(rnf);
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -1007,9 +1007,10 @@ public class GraphEngine {
             counts[i]++;
         } catch (final RecordNotFoundException rnf) {  // 'rnf' not 'e' here: 'e' is the Edge loop variable in this scope
           // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it (the fill
-          // pass below skips it identically, so counts and adjacency stay consistent: an edge record is
-          // only deleted, never resurrected, during a read query, so a pass-1 ghost is still a ghost in
-          // pass 2).
+          // pass below skips it identically, so counts and adjacency stay consistent). This holds on two
+          // invariants of a read query: (1) an edge record is only deleted, never resurrected, so a pass-1
+          // ghost is still a ghost in pass 2; (2) the two getEdges() calls per vertex iterate the same
+          // edges in the same order, so the i-th live edge counted here is the i-th live edge filled below.
           GhostEdgeReporter.reportSkipped(rnf);
         }
       }

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -1005,7 +1005,7 @@ public class GraphEngine {
         try {
           if (ridToIdx.containsKey(neighborRid(e, vid, dir)))
             counts[i]++;
-        } catch (final RecordNotFoundException rnf) {
+        } catch (final RecordNotFoundException rnf) {  // 'rnf' not 'e' here: 'e' is the Edge loop variable in this scope
           // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it (the fill
           // pass below skips it identically, so counts and adjacency stay consistent: an edge record is
           // only deleted, never resurrected, during a read query, so a pass-1 ghost is still a ghost in
@@ -1029,7 +1029,7 @@ public class GraphEngine {
           final Integer j = ridToIdx.get(nid);
           if (j != null)
             adj[i][pos[i]++] = j;
-        } catch (final RecordNotFoundException rnf) {
+        } catch (final RecordNotFoundException rnf) {  // 'rnf' not 'e' here: 'e' is the Edge loop variable in this scope
           // Ghost edge: skipped identically to the counting pass above, so pos[i] never exceeds counts[i].
           GhostEdgeReporter.reportSkipped(rnf);
         }

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -1007,7 +1007,9 @@ public class GraphEngine {
             counts[i]++;
         } catch (final RecordNotFoundException rnf) {
           // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it (the fill
-          // pass below skips it identically, so counts and adjacency stay consistent).
+          // pass below skips it identically, so counts and adjacency stay consistent: an edge record is
+          // only deleted, never resurrected, during a read query, so a pass-1 ghost is still a ghost in
+          // pass 2).
           GhostEdgeReporter.reportSkipped(rnf);
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternComprehensionExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternComprehensionExpression.java
@@ -345,7 +345,6 @@ public class PatternComprehensionExpression implements Expression {
       try {
         targetVertex = edgeDirection == Vertex.DIRECTION.OUT ? edge.getInVertex() : edge.getOutVertex();
       } catch (final RecordNotFoundException e) {
-        // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
         GhostEdgeReporter.reportSkipped(e);
         continue;
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternComprehensionExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternComprehensionExpression.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher.ast;
 
 import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.Labels;
@@ -255,7 +256,14 @@ public class PatternComprehensionExpression implements Expression {
       if (!visitedEdges.add(edgeRid))
         continue;
 
-      final Vertex nextVertex = edgeDirection == Vertex.DIRECTION.OUT ? edge.getInVertex() : edge.getOutVertex();
+      final Vertex nextVertex;
+      try {
+        nextVertex = edgeDirection == Vertex.DIRECTION.OUT ? edge.getInVertex() : edge.getOutVertex();
+      } catch (final RecordNotFoundException ignored) {
+        // Ghost edge: dangling segment pointer to a missing edge/target record. Undo the visit mark and skip.
+        visitedEdges.remove(edgeRid);
+        continue;
+      }
       final int nextHop = currentHop + 1;
       final boolean trackPath = pathVariable != null;
       if (trackPath) {
@@ -331,7 +339,13 @@ public class PatternComprehensionExpression implements Expression {
 
     while (edges.hasNext()) {
       final Edge edge = edges.next();
-      final Vertex targetVertex = edgeDirection == Vertex.DIRECTION.OUT ? edge.getInVertex() : edge.getOutVertex();
+      final Vertex targetVertex;
+      try {
+        targetVertex = edgeDirection == Vertex.DIRECTION.OUT ? edge.getInVertex() : edge.getOutVertex();
+      } catch (final RecordNotFoundException ignored) {
+        // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+        continue;
+      }
 
       if (!matchesEndPattern(targetVertex, endNodePattern, baseResult))
         continue;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternComprehensionExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternComprehensionExpression.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.Labels;
 import com.arcadedb.query.opencypher.query.OpenCypherQueryEngine;
@@ -259,8 +260,9 @@ public class PatternComprehensionExpression implements Expression {
       final Vertex nextVertex;
       try {
         nextVertex = edgeDirection == Vertex.DIRECTION.OUT ? edge.getInVertex() : edge.getOutVertex();
-      } catch (final RecordNotFoundException ignored) {
+      } catch (final RecordNotFoundException e) {
         // Ghost edge: dangling segment pointer to a missing edge/target record. Undo the visit mark and skip.
+        GhostEdgeReporter.reportSkipped(e);
         visitedEdges.remove(edgeRid);
         continue;
       }
@@ -342,8 +344,9 @@ public class PatternComprehensionExpression implements Expression {
       final Vertex targetVertex;
       try {
         targetVertex = edgeDirection == Vertex.DIRECTION.OUT ? edge.getInVertex() : edge.getOutVertex();
-      } catch (final RecordNotFoundException ignored) {
+      } catch (final RecordNotFoundException e) {
         // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+        GhostEdgeReporter.reportSkipped(e);
         continue;
       }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternPredicateExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternPredicateExpression.java
@@ -206,9 +206,8 @@ public class PatternPredicateExpression implements BooleanExpression {
       while (outEdges.hasNext()) {
         final Edge edge = outEdges.next();
         try {
-          if (edge.getIn().equals(endVertex)) {
+          if (edge.getIn().equals(endVertex))
             return true;
-          }
         } catch (final RecordNotFoundException e) {
           // Ghost edge: segment pointer exists but the backing edge record is gone (e.g. an HA
           // resync/rolled-back transaction left a dangling pointer). Skip it - it cannot satisfy the pattern.
@@ -229,9 +228,8 @@ public class PatternPredicateExpression implements BooleanExpression {
       while (inEdges.hasNext()) {
         final Edge edge = inEdges.next();
         try {
-          if (edge.getOut().equals(endVertex)) {
+          if (edge.getOut().equals(endVertex))
             return true;
-          }
         } catch (final RecordNotFoundException e) {
           GhostEdgeReporter.reportSkipped(e);
         }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternPredicateExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternPredicateExpression.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.query.opencypher.ast;
 
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.Labels;
@@ -203,8 +204,13 @@ public class PatternPredicateExpression implements BooleanExpression {
 
       while (outEdges.hasNext()) {
         final Edge edge = outEdges.next();
-        if (edge.getIn().equals(endVertex)) {
-          return true;
+        try {
+          if (edge.getIn().equals(endVertex)) {
+            return true;
+          }
+        } catch (final RecordNotFoundException ignored) {
+          // Ghost edge: segment pointer exists but the backing edge record is gone (e.g. an HA
+          // resync/rolled-back transaction left a dangling pointer). Skip it - it cannot satisfy the pattern.
         }
       }
     }
@@ -220,8 +226,12 @@ public class PatternPredicateExpression implements BooleanExpression {
 
       while (inEdges.hasNext()) {
         final Edge edge = inEdges.next();
-        if (edge.getOut().equals(endVertex)) {
-          return true;
+        try {
+          if (edge.getOut().equals(endVertex)) {
+            return true;
+          }
+        } catch (final RecordNotFoundException ignored) {
+          // Ghost edge: see above.
         }
       }
     }
@@ -252,8 +262,12 @@ public class PatternPredicateExpression implements BooleanExpression {
 
       while (outEdges.hasNext()) {
         final Edge edge = outEdges.next();
-        if (matchesNodePattern(edge.getInVertex(), endNodePattern, context))
-          return true;
+        try {
+          if (matchesNodePattern(edge.getInVertex(), endNodePattern, context))
+            return true;
+        } catch (final RecordNotFoundException ignored) {
+          // Ghost edge: segment pointer exists but the backing edge/target record is gone. Skip it.
+        }
       }
     }
 
@@ -268,8 +282,12 @@ public class PatternPredicateExpression implements BooleanExpression {
 
       while (inEdges.hasNext()) {
         final Edge edge = inEdges.next();
-        if (matchesNodePattern(edge.getOutVertex(), endNodePattern, context))
-          return true;
+        try {
+          if (matchesNodePattern(edge.getOutVertex(), endNodePattern, context))
+            return true;
+        } catch (final RecordNotFoundException ignored) {
+          // Ghost edge: see above.
+        }
       }
     }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternPredicateExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternPredicateExpression.java
@@ -233,7 +233,6 @@ public class PatternPredicateExpression implements BooleanExpression {
             return true;
           }
         } catch (final RecordNotFoundException e) {
-          // Ghost edge - same case: dangling segment pointer to a missing edge record. Skip it.
           GhostEdgeReporter.reportSkipped(e);
         }
       }
@@ -290,7 +289,6 @@ public class PatternPredicateExpression implements BooleanExpression {
           if (matchesNodePattern(edge.getOutVertex(), endNodePattern, context))
             return true;
         } catch (final RecordNotFoundException e) {
-          // Ghost edge - same case: dangling segment pointer to a missing edge record. Skip it.
           GhostEdgeReporter.reportSkipped(e);
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternPredicateExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternPredicateExpression.java
@@ -231,7 +231,7 @@ public class PatternPredicateExpression implements BooleanExpression {
             return true;
           }
         } catch (final RecordNotFoundException ignored) {
-          // Ghost edge: see above.
+          // Ghost edge - same case: dangling segment pointer to a missing edge record. Skip it.
         }
       }
     }
@@ -286,7 +286,7 @@ public class PatternPredicateExpression implements BooleanExpression {
           if (matchesNodePattern(edge.getOutVertex(), endNodePattern, context))
             return true;
         } catch (final RecordNotFoundException ignored) {
-          // Ghost edge: see above.
+          // Ghost edge - same case: dangling segment pointer to a missing edge record. Skip it.
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternPredicateExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/PatternPredicateExpression.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher.ast;
 
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.Labels;
 import com.arcadedb.query.opencypher.parser.CypherASTBuilder;
@@ -208,9 +209,10 @@ public class PatternPredicateExpression implements BooleanExpression {
           if (edge.getIn().equals(endVertex)) {
             return true;
           }
-        } catch (final RecordNotFoundException ignored) {
+        } catch (final RecordNotFoundException e) {
           // Ghost edge: segment pointer exists but the backing edge record is gone (e.g. an HA
           // resync/rolled-back transaction left a dangling pointer). Skip it - it cannot satisfy the pattern.
+          GhostEdgeReporter.reportSkipped(e);
         }
       }
     }
@@ -230,8 +232,9 @@ public class PatternPredicateExpression implements BooleanExpression {
           if (edge.getOut().equals(endVertex)) {
             return true;
           }
-        } catch (final RecordNotFoundException ignored) {
+        } catch (final RecordNotFoundException e) {
           // Ghost edge - same case: dangling segment pointer to a missing edge record. Skip it.
+          GhostEdgeReporter.reportSkipped(e);
         }
       }
     }
@@ -265,8 +268,9 @@ public class PatternPredicateExpression implements BooleanExpression {
         try {
           if (matchesNodePattern(edge.getInVertex(), endNodePattern, context))
             return true;
-        } catch (final RecordNotFoundException ignored) {
+        } catch (final RecordNotFoundException e) {
           // Ghost edge: segment pointer exists but the backing edge/target record is gone. Skip it.
+          GhostEdgeReporter.reportSkipped(e);
         }
       }
     }
@@ -285,8 +289,9 @@ public class PatternPredicateExpression implements BooleanExpression {
         try {
           if (matchesNodePattern(edge.getOutVertex(), endNodePattern, context))
             return true;
-        } catch (final RecordNotFoundException ignored) {
+        } catch (final RecordNotFoundException e) {
           // Ghost edge - same case: dangling segment pointer to a missing edge record. Skip it.
+          GhostEdgeReporter.reportSkipped(e);
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/ExpandAll.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/ExpandAll.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.query.opencypher.executor.operators;
 
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.ast.Direction;
@@ -160,7 +161,14 @@ public class ExpandAll extends AbstractPhysicalOperator {
           if (edgeIterator.hasNext()) {
             final Edge edge = edgeIterator.next();
             final Vertex sourceVertex = currentInputResult.getProperty(sourceVariable);
-            final Vertex targetVertex = getTargetVertex(edge, sourceVertex);
+            final Vertex targetVertex;
+            try {
+              targetVertex = getTargetVertex(edge, sourceVertex);
+            } catch (final RecordNotFoundException ignored) {
+              // Ghost edge: a dangling segment pointer to a missing edge/target record (e.g. left by an
+              // HA resync or a rolled-back transaction). Skip it - it cannot contribute a row.
+              continue;
+            }
 
             if (targetLabel != null && !targetVertex.getType().instanceOf(targetLabel))
               continue;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/ExpandAll.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/ExpandAll.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher.executor.operators;
 
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.ast.Direction;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -164,9 +165,10 @@ public class ExpandAll extends AbstractPhysicalOperator {
             final Vertex targetVertex;
             try {
               targetVertex = getTargetVertex(edge, sourceVertex);
-            } catch (final RecordNotFoundException ignored) {
+            } catch (final RecordNotFoundException e) {
               // Ghost edge: a dangling segment pointer to a missing edge/target record (e.g. left by an
               // HA resync or a rolled-back transaction). Skip it - it cannot contribute a row.
+              GhostEdgeReporter.reportSkipped(e);
               continue;
             }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandAll.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandAll.java
@@ -135,7 +135,6 @@ public class GAVExpandAll extends AbstractPhysicalOperator {
               try {
                 targetVertex = getTargetVertex(edge, sourceVertex);
               } catch (final RecordNotFoundException e) {
-                // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
                 GhostEdgeReporter.reportSkipped(e);
                 continue;
               }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandAll.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandAll.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.RID;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.GAVVertex;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.ast.Direction;
@@ -133,8 +134,9 @@ public class GAVExpandAll extends AbstractPhysicalOperator {
               final Vertex targetVertex;
               try {
                 targetVertex = getTargetVertex(edge, sourceVertex);
-              } catch (final RecordNotFoundException ignored) {
+              } catch (final RecordNotFoundException e) {
                 // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+                GhostEdgeReporter.reportSkipped(e);
                 continue;
               }
               if (targetLabel != null && !targetVertex.getType().instanceOf(targetLabel))

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandAll.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandAll.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.executor.operators;
 
 import com.arcadedb.database.RID;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.GAVVertex;
 import com.arcadedb.graph.GraphTraversalProvider;
@@ -129,7 +130,13 @@ public class GAVExpandAll extends AbstractPhysicalOperator {
             if (oltpFallbackEdges.hasNext()) {
               final Edge edge = oltpFallbackEdges.next();
               final Vertex sourceVertex = currentInputResult.getProperty(sourceVariable);
-              final Vertex targetVertex = getTargetVertex(edge, sourceVertex);
+              final Vertex targetVertex;
+              try {
+                targetVertex = getTargetVertex(edge, sourceVertex);
+              } catch (final RecordNotFoundException ignored) {
+                // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+                continue;
+              }
               if (targetLabel != null && !targetVertex.getType().instanceOf(targetLabel))
                 continue;
               addResultWithTarget(targetVertex);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandInto.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandInto.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.query.opencypher.executor.operators;
 
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.Vertex;
@@ -130,14 +131,18 @@ public class GAVExpandInto extends AbstractPhysicalOperator {
       private boolean isConnectedOLTP(final Vertex source, final Vertex target) {
         final Vertex.DIRECTION arcadeDirection = direction.toArcadeDirection();
         for (final Edge edge : source.getEdges(arcadeDirection, edgeTypes)) {
-          if (arcadeDirection == Vertex.DIRECTION.BOTH) {
-            // source can be either endpoint, so check both sides
-            if (edge.getOutVertex().getIdentity().equals(target.getIdentity()) || edge.getInVertex().getIdentity().equals(target.getIdentity()))
-              return true;
-          } else {
-            final Vertex other = arcadeDirection == Vertex.DIRECTION.OUT ? edge.getInVertex() : edge.getOutVertex();
-            if (other.getIdentity().equals(target.getIdentity()))
-              return true;
+          try {
+            if (arcadeDirection == Vertex.DIRECTION.BOTH) {
+              // source can be either endpoint, so check both sides
+              if (edge.getOutVertex().getIdentity().equals(target.getIdentity()) || edge.getInVertex().getIdentity().equals(target.getIdentity()))
+                return true;
+            } else {
+              final Vertex other = arcadeDirection == Vertex.DIRECTION.OUT ? edge.getInVertex() : edge.getOutVertex();
+              if (other.getIdentity().equals(target.getIdentity()))
+                return true;
+            }
+          } catch (final RecordNotFoundException ignored) {
+            // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           }
         }
         return false;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandInto.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandInto.java
@@ -143,7 +143,6 @@ public class GAVExpandInto extends AbstractPhysicalOperator {
                 return true;
             }
           } catch (final RecordNotFoundException e) {
-            // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
             GhostEdgeReporter.reportSkipped(e);
           }
         }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandInto.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/operators/GAVExpandInto.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher.executor.operators;
 
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.ast.Direction;
@@ -141,8 +142,9 @@ public class GAVExpandInto extends AbstractPhysicalOperator {
               if (other.getIdentity().equals(target.getIdentity()))
                 return true;
             }
-          } catch (final RecordNotFoundException ignored) {
+          } catch (final RecordNotFoundException e) {
             // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+            GhostEdgeReporter.reportSkipped(e);
           }
         }
         return false;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchRelationshipStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchRelationshipStep.java
@@ -24,6 +24,7 @@ import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.GAVVertex;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
 import com.arcadedb.graph.Vertex;
@@ -581,9 +582,10 @@ public class MatchRelationshipStep extends AbstractExecutionStep {
             buffer.add(result);
             if (context.isProfiling())
               standardPathCount++;
-          } catch (final RecordNotFoundException ignored) {
+          } catch (final RecordNotFoundException e) {
             // Ghost edge: a dangling segment pointer to a missing edge/target record (e.g. left by an
             // HA resync or a rolled-back transaction). Skip it and move on to the next edge.
+            GhostEdgeReporter.reportSkipped(e);
           } finally {
             if (context.isProfiling())
               cost += System.nanoTime() - begin;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchRelationshipStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchRelationshipStep.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher.executor.steps;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.GAVVertex;
@@ -580,6 +581,9 @@ public class MatchRelationshipStep extends AbstractExecutionStep {
             buffer.add(result);
             if (context.isProfiling())
               standardPathCount++;
+          } catch (final RecordNotFoundException ignored) {
+            // Ghost edge: a dangling segment pointer to a missing edge/target record (e.g. left by an
+            // HA resync or a rolled-back transaction). Skip it and move on to the next edge.
           } finally {
             if (context.isProfiling())
               cost += System.nanoTime() - begin;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -25,6 +25,7 @@ import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.Labels;
@@ -500,8 +501,9 @@ public class MergeStep extends AbstractExecutionStep {
         if (relProps != null && !matchesProperties(edge, relProps))
           continue;
         return edge;
-      } catch (final RecordNotFoundException ignored) {
+      } catch (final RecordNotFoundException e) {
         // Ghost edge: record was concurrently deleted. Skip and continue.
+        GhostEdgeReporter.reportSkipped(e);
       }
     }
     return null;
@@ -797,8 +799,9 @@ public class MergeStep extends AbstractExecutionStep {
               traverseFromNode(pathPattern, nodeIndex + 1, targetV, stepResult, results);
             }
           }
-        } catch (final RecordNotFoundException ignored) {
+        } catch (final RecordNotFoundException e) {
           // Ghost edge: record was concurrently deleted. Skip and continue.
+          GhostEdgeReporter.reportSkipped(e);
         }
       }
     }
@@ -834,9 +837,10 @@ public class MergeStep extends AbstractExecutionStep {
           stepResult.setProperty(relPattern.getVariable(), edge);
 
         traverseFromNode(pathPattern, nodeIndex + 1, nextV, stepResult, results);
-      } catch (final RecordNotFoundException ignored) {
+      } catch (final RecordNotFoundException e) {
         // Ghost edge: segment pointer exists but record was concurrently deleted.
         // Skip and continue - the edge does not satisfy the MERGE pattern.
+        GhostEdgeReporter.reportSkipped(e);
       }
     }
 
@@ -853,8 +857,9 @@ public class MergeStep extends AbstractExecutionStep {
             stepResult.setProperty(relPattern.getVariable(), edge);
 
           traverseFromNode(pathPattern, nodeIndex + 1, nextV, stepResult, results);
-        } catch (final RecordNotFoundException ignored) {
-          // Ghost edge: see above.
+        } catch (final RecordNotFoundException e) {
+          // Ghost edge - same case: segment pointer to a concurrently-deleted edge record. Skip it.
+          GhostEdgeReporter.reportSkipped(e);
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
@@ -24,6 +24,7 @@ import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.ast.Direction;
 import com.arcadedb.query.opencypher.ast.ShortestPathPattern;
@@ -432,8 +433,9 @@ public class ShortestPathStep extends AbstractExecutionStep {
           final RID connected = dir == Vertex.DIRECTION.OUT ? edge.getIn() : edge.getOut();
           if (connected.equals(to.getIdentity()))
             return edge;
-        } catch (final RecordNotFoundException ignored) {
+        } catch (final RecordNotFoundException e) {
           // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+          GhostEdgeReporter.reportSkipped(e);
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher.executor.steps;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
@@ -427,9 +428,13 @@ public class ShortestPathStep extends AbstractExecutionStep {
           from.getEdges(dir);
 
       for (final Edge edge : edges) {
-        final RID connected = dir == Vertex.DIRECTION.OUT ? edge.getIn() : edge.getOut();
-        if (connected.equals(to.getIdentity()))
-          return edge;
+        try {
+          final RID connected = dir == Vertex.DIRECTION.OUT ? edge.getIn() : edge.getOut();
+          if (connected.equals(to.getIdentity()))
+            return edge;
+        } catch (final RecordNotFoundException ignored) {
+          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+        }
       }
     }
     return null;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/ShortestPathStep.java
@@ -434,7 +434,6 @@ public class ShortestPathStep extends AbstractExecutionStep {
           if (connected.equals(to.getIdentity()))
             return edge;
         } catch (final RecordNotFoundException e) {
-          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           GhostEdgeReporter.reportSkipped(e);
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAPSP.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAPSP.java
@@ -186,7 +186,6 @@ public class AlgoAPSP extends AbstractAlgoProcedure {
           if (w < dist[i][j])
             dist[i][j] = w;
         } catch (final RecordNotFoundException rnf) {
-          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           GhostEdgeReporter.reportSkipped(rnf);
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAPSP.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAPSP.java
@@ -185,7 +185,7 @@ public class AlgoAPSP extends AbstractAlgoProcedure {
             w = 1.0;
           if (w < dist[i][j])
             dist[i][j] = w;
-        } catch (final RecordNotFoundException rnf) {
+        } catch (final RecordNotFoundException rnf) {  // 'rnf' not 'e' here: 'e' is the Edge loop variable in this scope
           GhostEdgeReporter.reportSkipped(rnf);
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAPSP.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAPSP.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher.procedures.algo;
 import com.arcadedb.database.Database;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -184,8 +185,9 @@ public class AlgoAPSP extends AbstractAlgoProcedure {
             w = 1.0;
           if (w < dist[i][j])
             dist[i][j] = w;
-        } catch (final RecordNotFoundException ignored) {
+        } catch (final RecordNotFoundException rnf) {
           // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+          GhostEdgeReporter.reportSkipped(rnf);
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAPSP.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAPSP.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -171,17 +172,21 @@ public class AlgoAPSP extends AbstractAlgoProcedure {
           v.getEdges(Vertex.DIRECTION.OUT, relTypes) :
           v.getEdges(Vertex.DIRECTION.OUT);
       for (final Edge e : edges) {
-        final int j = graph.indexOf(e.getIn());
-        if (j < 0)
-          continue;
-        final double w;
-        if (weightProperty != null) {
-          final Object wObj = e.get(weightProperty);
-          w = wObj instanceof Number num ? num.doubleValue() : 1.0;
-        } else
-          w = 1.0;
-        if (w < dist[i][j])
-          dist[i][j] = w;
+        try {
+          final int j = graph.indexOf(e.getIn());
+          if (j < 0)
+            continue;
+          final double w;
+          if (weightProperty != null) {
+            final Object wObj = e.get(weightProperty);
+            w = wObj instanceof Number num ? num.doubleValue() : 1.0;
+          } else
+            w = 1.0;
+          if (w < dist[i][j])
+            dist[i][j] = w;
+        } catch (final RecordNotFoundException ignored) {
+          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+        }
       }
     }
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAllSimplePaths.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAllSimplePaths.java
@@ -203,7 +203,6 @@ public class AlgoAllSimplePaths extends AbstractAlgoProcedure {
           }
         }
       } catch (final RecordNotFoundException e) {
-        // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
         GhostEdgeReporter.reportSkipped(e);
       }
     }
@@ -241,7 +240,6 @@ public class AlgoAllSimplePaths extends AbstractAlgoProcedure {
           }
         }
       } catch (final RecordNotFoundException e) {
-        // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
         GhostEdgeReporter.reportSkipped(e);
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAllSimplePaths.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAllSimplePaths.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.RID;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -176,24 +177,28 @@ public class AlgoAllSimplePaths extends AbstractAlgoProcedure {
       if (!skipRelTypes.isEmpty() && skipRelTypes.contains(edge.getTypeName()))
         continue;
 
-      final Vertex neighbor = edge.getInVertex();
+      try {
+        final Vertex neighbor = edge.getInVertex();
 
-      // Early pruning: a barrier vertex type halts the expansion of this branch immediately
-      if (!skipVertexTypes.isEmpty() && skipVertexTypes.contains(neighbor.getTypeName()))
-        continue;
+        // Early pruning: a barrier vertex type halts the expansion of this branch immediately
+        if (!skipVertexTypes.isEmpty() && skipVertexTypes.contains(neighbor.getTypeName()))
+          continue;
 
-      final RID neighborId = neighbor.getIdentity();
+        final RID neighborId = neighbor.getIdentity();
 
-      if (!visited.contains(neighborId)) {
-        visited.add(neighborId);
-        currentPath.add(edge);
-        currentPath.add(neighbor);
+        if (!visited.contains(neighborId)) {
+          visited.add(neighborId);
+          currentPath.add(edge);
+          currentPath.add(neighbor);
 
-        findPaths(neighbor, target, relTypes, skipRelTypes, skipVertexTypes, remainingDepth - 1, currentPath, visited, allPaths, context);
+          findPaths(neighbor, target, relTypes, skipRelTypes, skipVertexTypes, remainingDepth - 1, currentPath, visited, allPaths, context);
 
-        currentPath.removeLast();
-        currentPath.removeLast();
-        visited.remove(neighborId);
+          currentPath.removeLast();
+          currentPath.removeLast();
+          visited.remove(neighborId);
+        }
+      } catch (final RecordNotFoundException ignored) {
+        // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
       }
     }
 
@@ -205,24 +210,28 @@ public class AlgoAllSimplePaths extends AbstractAlgoProcedure {
       if (!skipRelTypes.isEmpty() && skipRelTypes.contains(edge.getTypeName()))
         continue;
 
-      final Vertex neighbor = edge.getOutVertex();
+      try {
+        final Vertex neighbor = edge.getOutVertex();
 
-      // Early pruning: a barrier vertex type halts the expansion of this branch immediately
-      if (!skipVertexTypes.isEmpty() && skipVertexTypes.contains(neighbor.getTypeName()))
-        continue;
+        // Early pruning: a barrier vertex type halts the expansion of this branch immediately
+        if (!skipVertexTypes.isEmpty() && skipVertexTypes.contains(neighbor.getTypeName()))
+          continue;
 
-      final RID neighborId = neighbor.getIdentity();
+        final RID neighborId = neighbor.getIdentity();
 
-      if (!visited.contains(neighborId)) {
-        visited.add(neighborId);
-        currentPath.add(edge);
-        currentPath.add(neighbor);
+        if (!visited.contains(neighborId)) {
+          visited.add(neighborId);
+          currentPath.add(edge);
+          currentPath.add(neighbor);
 
-        findPaths(neighbor, target, relTypes, skipRelTypes, skipVertexTypes, remainingDepth - 1, currentPath, visited, allPaths, context);
+          findPaths(neighbor, target, relTypes, skipRelTypes, skipVertexTypes, remainingDepth - 1, currentPath, visited, allPaths, context);
 
-        currentPath.removeLast();
-        currentPath.removeLast();
-        visited.remove(neighborId);
+          currentPath.removeLast();
+          currentPath.removeLast();
+          visited.remove(neighborId);
+        }
+      } catch (final RecordNotFoundException ignored) {
+        // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
       }
     }
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAllSimplePaths.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAllSimplePaths.java
@@ -203,6 +203,7 @@ public class AlgoAllSimplePaths extends AbstractAlgoProcedure {
           }
         }
       } catch (final RecordNotFoundException e) {
+        // Only the outer edge.get*Vertex() above can land here; the recursion has its own per-edge catches.
         GhostEdgeReporter.reportSkipped(e);
       }
     }
@@ -240,6 +241,7 @@ public class AlgoAllSimplePaths extends AbstractAlgoProcedure {
           }
         }
       } catch (final RecordNotFoundException e) {
+        // Only the outer edge.get*Vertex() above can land here; the recursion has its own per-edge catches.
         GhostEdgeReporter.reportSkipped(e);
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAllSimplePaths.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoAllSimplePaths.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher.procedures.algo;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -191,14 +192,19 @@ public class AlgoAllSimplePaths extends AbstractAlgoProcedure {
           currentPath.add(edge);
           currentPath.add(neighbor);
 
-          findPaths(neighbor, target, relTypes, skipRelTypes, skipVertexTypes, remainingDepth - 1, currentPath, visited, allPaths, context);
-
-          currentPath.removeLast();
-          currentPath.removeLast();
-          visited.remove(neighborId);
+          // try-finally so the path/visited bookkeeping is unwound even if the recursion throws,
+          // leaving no dirty state for the rest of this branch.
+          try {
+            findPaths(neighbor, target, relTypes, skipRelTypes, skipVertexTypes, remainingDepth - 1, currentPath, visited, allPaths, context);
+          } finally {
+            currentPath.removeLast();
+            currentPath.removeLast();
+            visited.remove(neighborId);
+          }
         }
-      } catch (final RecordNotFoundException ignored) {
+      } catch (final RecordNotFoundException e) {
         // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+        GhostEdgeReporter.reportSkipped(e);
       }
     }
 
@@ -224,14 +230,19 @@ public class AlgoAllSimplePaths extends AbstractAlgoProcedure {
           currentPath.add(edge);
           currentPath.add(neighbor);
 
-          findPaths(neighbor, target, relTypes, skipRelTypes, skipVertexTypes, remainingDepth - 1, currentPath, visited, allPaths, context);
-
-          currentPath.removeLast();
-          currentPath.removeLast();
-          visited.remove(neighborId);
+          // try-finally so the path/visited bookkeeping is unwound even if the recursion throws,
+          // leaving no dirty state for the rest of this branch.
+          try {
+            findPaths(neighbor, target, relTypes, skipRelTypes, skipVertexTypes, remainingDepth - 1, currentPath, visited, allPaths, context);
+          } finally {
+            currentPath.removeLast();
+            currentPath.removeLast();
+            visited.remove(neighborId);
+          }
         }
-      } catch (final RecordNotFoundException ignored) {
+      } catch (final RecordNotFoundException e) {
         // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+        GhostEdgeReporter.reportSkipped(e);
       }
     }
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoArticleRank.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoArticleRank.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.NeighborView;
@@ -235,9 +236,13 @@ public class AlgoArticleRank extends AbstractAlgoProcedure {
         final Vertex v = vertices.get(i);
         final double denom = outDegrees[i] + avgOutDeg;
         for (final Edge edge : v.getEdges(Vertex.DIRECTION.OUT)) {
-          final Integer neighborIdx = ridToIdx.get(edge.getIn());
-          if (neighborIdx != null)
-            newScores[neighborIdx] += scores[i] / denom;
+          try {
+            final Integer neighborIdx = ridToIdx.get(edge.getIn());
+            if (neighborIdx != null)
+              newScores[neighborIdx] += scores[i] / denom;
+          } catch (final RecordNotFoundException ignored) {
+            // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+          }
         }
       }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoArticleRank.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoArticleRank.java
@@ -242,7 +242,6 @@ public class AlgoArticleRank extends AbstractAlgoProcedure {
             if (neighborIdx != null)
               newScores[neighborIdx] += scores[i] / denom;
           } catch (final RecordNotFoundException e) {
-            // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
             GhostEdgeReporter.reportSkipped(e);
           }
         }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoArticleRank.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoArticleRank.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.NeighborView;
 import com.arcadedb.graph.Vertex;
@@ -240,8 +241,9 @@ public class AlgoArticleRank extends AbstractAlgoProcedure {
             final Integer neighborIdx = ridToIdx.get(edge.getIn());
             if (neighborIdx != null)
               newScores[neighborIdx] += scores[i] / denom;
-          } catch (final RecordNotFoundException ignored) {
+          } catch (final RecordNotFoundException e) {
             // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+            GhostEdgeReporter.reportSkipped(e);
           }
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBellmanFord.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBellmanFord.java
@@ -252,7 +252,6 @@ public class AlgoBellmanFord extends AbstractAlgoProcedure {
           edgeList.add(new int[] { i, j });
           weightList.add(w);
         } catch (final RecordNotFoundException e) {
-          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           GhostEdgeReporter.reportSkipped(e);
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBellmanFord.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBellmanFord.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -250,8 +251,9 @@ public class AlgoBellmanFord extends AbstractAlgoProcedure {
           }
           edgeList.add(new int[] { i, j });
           weightList.add(w);
-        } catch (final RecordNotFoundException ignored) {
+        } catch (final RecordNotFoundException e) {
           // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+          GhostEdgeReporter.reportSkipped(e);
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBellmanFord.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBellmanFord.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -237,17 +238,21 @@ public class AlgoBellmanFord extends AbstractAlgoProcedure {
           v.getEdges(Vertex.DIRECTION.OUT, relTypes) :
           v.getEdges(Vertex.DIRECTION.OUT);
       for (final Edge edge : edges) {
-        final int j = graph.indexOf(edge.getIn());
-        if (j < 0)
-          continue;
-        double w = 1.0;
-        if (weightProperty != null && !weightProperty.isEmpty()) {
-          final Object wObj = edge.get(weightProperty);
-          if (wObj instanceof Number num)
-            w = num.doubleValue();
+        try {
+          final int j = graph.indexOf(edge.getIn());
+          if (j < 0)
+            continue;
+          double w = 1.0;
+          if (weightProperty != null && !weightProperty.isEmpty()) {
+            final Object wObj = edge.get(weightProperty);
+            if (wObj instanceof Number num)
+              w = num.doubleValue();
+          }
+          edgeList.add(new int[] { i, j });
+          weightList.add(w);
+        } catch (final RecordNotFoundException ignored) {
+          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
         }
-        edgeList.add(new int[] { i, j });
-        weightList.add(w);
       }
     }
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBetweenness.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBetweenness.java
@@ -155,7 +155,6 @@ public class AlgoBetweenness extends AbstractAlgoProcedure {
               predecessors.get(w).add(v);
             }
           } catch (final RecordNotFoundException e) {
-            // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
             GhostEdgeReporter.reportSkipped(e);
           }
         }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBetweenness.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBetweenness.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -136,20 +137,24 @@ public class AlgoBetweenness extends AbstractAlgoProcedure {
 
         final Vertex vVertex = vertices.get(v);
         for (final Edge edge : vVertex.getEdges(Vertex.DIRECTION.OUT)) {
-          final Vertex neighbor = edge.getInVertex();
-          final Integer w = vertexIndex.get(neighbor);
-          if (w == null)
-            continue;
+          try {
+            final Vertex neighbor = edge.getInVertex();
+            final Integer w = vertexIndex.get(neighbor);
+            if (w == null)
+              continue;
 
-          // First time visiting w?
-          if (dist[w] < 0) {
-            queue.add(w);
-            dist[w] = dist[v] + 1;
-          }
-          // Shortest path to w via v?
-          if (dist[w] == dist[v] + 1) {
-            sigma[w] += sigma[v];
-            predecessors.get(w).add(v);
+            // First time visiting w?
+            if (dist[w] < 0) {
+              queue.add(w);
+              dist[w] = dist[v] + 1;
+            }
+            // Shortest path to w via v?
+            if (dist[w] == dist[v] + 1) {
+              sigma[w] += sigma[v];
+              predecessors.get(w).add(v);
+            }
+          } catch (final RecordNotFoundException ignored) {
+            // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           }
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBetweenness.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoBetweenness.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher.procedures.algo;
 import com.arcadedb.database.Database;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -153,8 +154,9 @@ public class AlgoBetweenness extends AbstractAlgoProcedure {
               sigma[w] += sigma[v];
               predecessors.get(w).add(v);
             }
-          } catch (final RecordNotFoundException ignored) {
+          } catch (final RecordNotFoundException e) {
             // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+            GhostEdgeReporter.reportSkipped(e);
           }
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDijkstra.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDijkstra.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -132,8 +133,9 @@ public class AlgoDijkstra extends AbstractAlgoProcedure {
             bestWeight = edgeWeight;
             bestEdge = edge;
           }
-        } catch (final RecordNotFoundException ignored) {
+        } catch (final RecordNotFoundException e) {
           // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+          GhostEdgeReporter.reportSkipped(e);
         }
       }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDijkstra.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDijkstra.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -121,14 +122,18 @@ public class AlgoDijkstra extends AbstractAlgoProcedure {
       Edge bestEdge = null;
       double bestWeight = Double.POSITIVE_INFINITY;
       for (final Edge edge : edgeTypeFilter != null ? from.getEdges(dir, edgeTypeFilter) : from.getEdges(dir)) {
-        final RID otherRid = edge.getOut().equals(from.getIdentity()) ? edge.getIn() : edge.getOut();
-        if (!toRid.equals(otherRid))
-          continue;
-        final Object w = edge.get(weightProperty);
-        final double edgeWeight = w instanceof Number num ? num.doubleValue() : 0.0;
-        if (edgeWeight < bestWeight) {
-          bestWeight = edgeWeight;
-          bestEdge = edge;
+        try {
+          final RID otherRid = edge.getOut().equals(from.getIdentity()) ? edge.getIn() : edge.getOut();
+          if (!toRid.equals(otherRid))
+            continue;
+          final Object w = edge.get(weightProperty);
+          final double edgeWeight = w instanceof Number num ? num.doubleValue() : 0.0;
+          if (edgeWeight < bestWeight) {
+            bestWeight = edgeWeight;
+            bestEdge = edge;
+          }
+        } catch (final RecordNotFoundException ignored) {
+          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
         }
       }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDijkstra.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoDijkstra.java
@@ -134,7 +134,6 @@ public class AlgoDijkstra extends AbstractAlgoProcedure {
             bestEdge = edge;
           }
         } catch (final RecordNotFoundException e) {
-          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           GhostEdgeReporter.reportSkipped(e);
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPaths.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPaths.java
@@ -133,7 +133,7 @@ public class AlgoKShortestPaths extends AbstractAlgoProcedure {
           }
           if (w < weightMatrix[i][j])
             weightMatrix[i][j] = w;
-        } catch (final RecordNotFoundException rnf) {
+        } catch (final RecordNotFoundException rnf) {  // 'rnf' not 'e' here: 'e' is the Edge loop variable in this scope
           GhostEdgeReporter.reportSkipped(rnf);
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPaths.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPaths.java
@@ -134,7 +134,6 @@ public class AlgoKShortestPaths extends AbstractAlgoProcedure {
           if (w < weightMatrix[i][j])
             weightMatrix[i][j] = w;
         } catch (final RecordNotFoundException rnf) {
-          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           GhostEdgeReporter.reportSkipped(rnf);
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPaths.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPaths.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -119,17 +120,21 @@ public class AlgoKShortestPaths extends AbstractAlgoProcedure {
           vertices.get(i).getEdges(Vertex.DIRECTION.OUT, relTypes) :
           vertices.get(i).getEdges(Vertex.DIRECTION.OUT);
       for (final Edge e : edges) {
-        final Integer j = ridToIdx.get(e.getIn());
-        if (j == null)
-          continue;
-        double w = 1.0;
-        if (weightProperty != null && !weightProperty.isEmpty()) {
-          final Object wObj = e.get(weightProperty);
-          if (wObj instanceof Number num)
-            w = num.doubleValue();
+        try {
+          final Integer j = ridToIdx.get(e.getIn());
+          if (j == null)
+            continue;
+          double w = 1.0;
+          if (weightProperty != null && !weightProperty.isEmpty()) {
+            final Object wObj = e.get(weightProperty);
+            if (wObj instanceof Number num)
+              w = num.doubleValue();
+          }
+          if (w < weightMatrix[i][j])
+            weightMatrix[i][j] = w;
+        } catch (final RecordNotFoundException ignored) {
+          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
         }
-        if (w < weightMatrix[i][j])
-          weightMatrix[i][j] = w;
       }
     }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPaths.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoKShortestPaths.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -132,8 +133,9 @@ public class AlgoKShortestPaths extends AbstractAlgoProcedure {
           }
           if (w < weightMatrix[i][j])
             weightMatrix[i][j] = w;
-        } catch (final RecordNotFoundException ignored) {
+        } catch (final RecordNotFoundException rnf) {
           // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+          GhostEdgeReporter.reportSkipped(rnf);
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLongestPathDAG.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLongestPathDAG.java
@@ -165,7 +165,6 @@ public class AlgoLongestPathDAG extends AbstractAlgoProcedure {
             source[v] = source[u];
           }
         } catch (final RecordNotFoundException e) {
-          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           GhostEdgeReporter.reportSkipped(e);
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLongestPathDAG.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLongestPathDAG.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -142,24 +143,28 @@ public class AlgoLongestPathDAG extends AbstractAlgoProcedure {
       final int u = topoOrder[ti];
       final Vertex vu = graph.getVertex(u);
       for (final Edge edge : vu.getEdges(Vertex.DIRECTION.OUT)) {
-        if (relTypes != null) {
-          final String type = edge.getTypeName();
-          boolean found = false;
-          for (final String rt : relTypes)
-            if (rt.equals(type)) { found = true; break; }
-          if (!found) continue;
-        }
-        final int v = graph.indexOf(edge.getIn());
-        if (v < 0) continue;
-        double weight = 1.0;
-        if (weightProperty != null) {
-          final Object w = edge.get(weightProperty);
-          if (w instanceof Number num) weight = num.doubleValue();
-        }
-        final double newDist = dp[u] + weight;
-        if (newDist > dp[v]) {
-          dp[v] = newDist;
-          source[v] = source[u];
+        try {
+          if (relTypes != null) {
+            final String type = edge.getTypeName();
+            boolean found = false;
+            for (final String rt : relTypes)
+              if (rt.equals(type)) { found = true; break; }
+            if (!found) continue;
+          }
+          final int v = graph.indexOf(edge.getIn());
+          if (v < 0) continue;
+          double weight = 1.0;
+          if (weightProperty != null) {
+            final Object w = edge.get(weightProperty);
+            if (w instanceof Number num) weight = num.doubleValue();
+          }
+          final double newDist = dp[u] + weight;
+          if (newDist > dp[v]) {
+            dp[v] = newDist;
+            source[v] = source[u];
+          }
+        } catch (final RecordNotFoundException ignored) {
+          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLongestPathDAG.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLongestPathDAG.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher.procedures.algo;
 import com.arcadedb.database.Database;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -163,8 +164,9 @@ public class AlgoLongestPathDAG extends AbstractAlgoProcedure {
             dp[v] = newDist;
             source[v] = source[u];
           }
-        } catch (final RecordNotFoundException ignored) {
+        } catch (final RecordNotFoundException e) {
           // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+          GhostEdgeReporter.reportSkipped(e);
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLouvain.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLouvain.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher.procedures.algo;
 import com.arcadedb.database.Database;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -135,8 +136,9 @@ public class AlgoLouvain extends AbstractAlgoProcedure {
           }
           nodeDegree[i] += w;
           totalWeight += w;
-        } catch (final RecordNotFoundException ignored) {
+        } catch (final RecordNotFoundException e) {
           // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+          GhostEdgeReporter.reportSkipped(e);
         }
       }
     }
@@ -170,8 +172,9 @@ public class AlgoLouvain extends AbstractAlgoProcedure {
             }
             final int neighborComm = community[neighborIdx];
             neighborCommunityWeight.merge(neighborComm, w, Double::sum);
-          } catch (final RecordNotFoundException ignored) {
+          } catch (final RecordNotFoundException e) {
             // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+            GhostEdgeReporter.reportSkipped(e);
           }
         }
 
@@ -262,8 +265,9 @@ public class AlgoLouvain extends AbstractAlgoProcedure {
               w = num.doubleValue();
           }
           modularity += w - (nodeDegree[i] * nodeDegree[j]) / (2.0 * totalWeight);
-        } catch (final RecordNotFoundException ignored) {
+        } catch (final RecordNotFoundException e) {
           // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+          GhostEdgeReporter.reportSkipped(e);
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLouvain.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLouvain.java
@@ -137,7 +137,6 @@ public class AlgoLouvain extends AbstractAlgoProcedure {
           nodeDegree[i] += w;
           totalWeight += w;
         } catch (final RecordNotFoundException e) {
-          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           GhostEdgeReporter.reportSkipped(e);
         }
       }
@@ -173,7 +172,6 @@ public class AlgoLouvain extends AbstractAlgoProcedure {
             final int neighborComm = community[neighborIdx];
             neighborCommunityWeight.merge(neighborComm, w, Double::sum);
           } catch (final RecordNotFoundException e) {
-            // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
             GhostEdgeReporter.reportSkipped(e);
           }
         }
@@ -266,7 +264,6 @@ public class AlgoLouvain extends AbstractAlgoProcedure {
           }
           modularity += w - (nodeDegree[i] * nodeDegree[j]) / (2.0 * totalWeight);
         } catch (final RecordNotFoundException e) {
-          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           GhostEdgeReporter.reportSkipped(e);
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLouvain.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoLouvain.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -125,14 +126,18 @@ public class AlgoLouvain extends AbstractAlgoProcedure {
     for (int i = 0; i < n; i++) {
       final Vertex v = vertices.get(i);
       for (final Edge edge : v.getEdges(Vertex.DIRECTION.BOTH)) {
-        double w = 1.0;
-        if (weightProperty != null) {
-          final Object wObj = edge.get(weightProperty);
-          if (wObj instanceof Number num)
-            w = num.doubleValue();
+        try {
+          double w = 1.0;
+          if (weightProperty != null) {
+            final Object wObj = edge.get(weightProperty);
+            if (wObj instanceof Number num)
+              w = num.doubleValue();
+          }
+          nodeDegree[i] += w;
+          totalWeight += w;
+        } catch (final RecordNotFoundException ignored) {
+          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
         }
-        nodeDegree[i] += w;
-        totalWeight += w;
       }
     }
     totalWeight /= 2.0; // Each edge counted twice
@@ -150,20 +155,24 @@ public class AlgoLouvain extends AbstractAlgoProcedure {
         // Compute neighbor community weights
         final Map<Integer, Double> neighborCommunityWeight = new HashMap<>();
         for (final Edge edge : v.getEdges(Vertex.DIRECTION.BOTH)) {
-          final Vertex neighbor = edge.getOut().equals(v.getIdentity()) ?
-              edge.getInVertex() : edge.getOutVertex();
-          final Integer neighborIdx = vertexIndex.get(neighbor);
-          if (neighborIdx == null)
-            continue;
+          try {
+            final Vertex neighbor = edge.getOut().equals(v.getIdentity()) ?
+                edge.getInVertex() : edge.getOutVertex();
+            final Integer neighborIdx = vertexIndex.get(neighbor);
+            if (neighborIdx == null)
+              continue;
 
-          double w = 1.0;
-          if (weightProperty != null) {
-            final Object wObj = edge.get(weightProperty);
-            if (wObj instanceof Number num)
-              w = num.doubleValue();
+            double w = 1.0;
+            if (weightProperty != null) {
+              final Object wObj = edge.get(weightProperty);
+              if (wObj instanceof Number num)
+                w = num.doubleValue();
+            }
+            final int neighborComm = community[neighborIdx];
+            neighborCommunityWeight.merge(neighborComm, w, Double::sum);
+          } catch (final RecordNotFoundException ignored) {
+            // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           }
-          final int neighborComm = community[neighborIdx];
-          neighborCommunityWeight.merge(neighborComm, w, Double::sum);
         }
 
         // Find best community to move to
@@ -240,18 +249,22 @@ public class AlgoLouvain extends AbstractAlgoProcedure {
     for (int i = 0; i < n; i++) {
       final Vertex v = vertices.get(i);
       for (final Edge edge : v.getEdges(Vertex.DIRECTION.OUT)) {
-        final Vertex neighbor = edge.getInVertex();
-        final Integer j = vertexIndex.get(neighbor);
-        if (j == null || community[i] != community[j])
-          continue;
+        try {
+          final Vertex neighbor = edge.getInVertex();
+          final Integer j = vertexIndex.get(neighbor);
+          if (j == null || community[i] != community[j])
+            continue;
 
-        double w = 1.0;
-        if (weightProperty != null) {
-          final Object wObj = edge.get(weightProperty);
-          if (wObj instanceof Number num)
-            w = num.doubleValue();
+          double w = 1.0;
+          if (weightProperty != null) {
+            final Object wObj = edge.get(weightProperty);
+            if (wObj instanceof Number num)
+              w = num.doubleValue();
+          }
+          modularity += w - (nodeDegree[i] * nodeDegree[j]) / (2.0 * totalWeight);
+        } catch (final RecordNotFoundException ignored) {
+          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
         }
-        modularity += w - (nodeDegree[i] * nodeDegree[j]) / (2.0 * totalWeight);
       }
     }
     return modularity / (2.0 * totalWeight);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -107,8 +108,12 @@ public class AlgoMST extends AbstractAlgoProcedure {
           vertices.get(i).getEdges(Vertex.DIRECTION.OUT, relTypes) :
           vertices.get(i).getEdges(Vertex.DIRECTION.OUT);
       for (final Edge e : edges) {
-        if (ridToIdx.containsKey(e.getIn()))
-          edgeCount++;
+        try {
+          if (ridToIdx.containsKey(e.getIn()))
+            edgeCount++;
+        } catch (final RecordNotFoundException ignored) {
+          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+        }
       }
     }
 
@@ -122,18 +127,22 @@ public class AlgoMST extends AbstractAlgoProcedure {
           vertices.get(i).getEdges(Vertex.DIRECTION.OUT, relTypes) :
           vertices.get(i).getEdges(Vertex.DIRECTION.OUT);
       for (final Edge e : edges) {
-        final Integer j = ridToIdx.get(e.getIn());
-        if (j == null)
-          continue;
-        eu[ec] = i;
-        ev[ec] = j;
-        if (weightProperty != null) {
-          final Object w = e.get(weightProperty);
-          ew[ec] = w instanceof Number num ? num.doubleValue() : 1.0;
-        } else {
-          ew[ec] = 1.0;
+        try {
+          final Integer j = ridToIdx.get(e.getIn());
+          if (j == null)
+            continue;
+          eu[ec] = i;
+          ev[ec] = j;
+          if (weightProperty != null) {
+            final Object w = e.get(weightProperty);
+            ew[ec] = w instanceof Number num ? num.doubleValue() : 1.0;
+          } else {
+            ew[ec] = 1.0;
+          }
+          ec++;
+        } catch (final RecordNotFoundException ignored) {
+          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
         }
-        ec++;
       }
     }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
@@ -116,7 +116,7 @@ public class AlgoMST extends AbstractAlgoProcedure {
         try {
           if (ridToIdx.containsKey(e.getIn()))
             edgeCount++;
-        } catch (final RecordNotFoundException rnf) {
+        } catch (final RecordNotFoundException rnf) {  // 'rnf' not 'e' here: 'e' is the Edge loop variable in this scope
           GhostEdgeReporter.reportSkipped(rnf);
         }
       }
@@ -145,7 +145,7 @@ public class AlgoMST extends AbstractAlgoProcedure {
             ew[ec] = 1.0;
           }
           ec++;
-        } catch (final RecordNotFoundException rnf) {
+        } catch (final RecordNotFoundException rnf) {  // 'rnf' not 'e' here: 'e' is the Edge loop variable in this scope
           GhostEdgeReporter.reportSkipped(rnf);
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
@@ -103,7 +103,9 @@ public class AlgoMST extends AbstractAlgoProcedure {
 
     // Collect edges — two passes to allocate primitive arrays without reallocation. Ghost edges are
     // skipped identically in both passes (same getEdges() order), so the pass-2 fill never exceeds the
-    // pass-1 count and the arrays are always sized correctly.
+    // pass-1 count and the arrays are always sized correctly. This is safe because an edge record is
+    // only ever deleted, never resurrected, during a read query: a ghost in pass 1 is still a ghost in
+    // pass 2.
     // Pass 1: count
     int edgeCount = 0;
     for (int i = 0; i < n; i++) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -111,8 +112,9 @@ public class AlgoMST extends AbstractAlgoProcedure {
         try {
           if (ridToIdx.containsKey(e.getIn()))
             edgeCount++;
-        } catch (final RecordNotFoundException ignored) {
+        } catch (final RecordNotFoundException rnf) {
           // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+          GhostEdgeReporter.reportSkipped(rnf);
         }
       }
     }
@@ -140,8 +142,9 @@ public class AlgoMST extends AbstractAlgoProcedure {
             ew[ec] = 1.0;
           }
           ec++;
-        } catch (final RecordNotFoundException ignored) {
+        } catch (final RecordNotFoundException rnf) {
           // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+          GhostEdgeReporter.reportSkipped(rnf);
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMST.java
@@ -101,7 +101,9 @@ public class AlgoMST extends AbstractAlgoProcedure {
 
     final Map<RID, Integer> ridToIdx = buildRidIndex(vertices);
 
-    // Collect edges — two passes to allocate primitive arrays without reallocation
+    // Collect edges — two passes to allocate primitive arrays without reallocation. Ghost edges are
+    // skipped identically in both passes (same getEdges() order), so the pass-2 fill never exceeds the
+    // pass-1 count and the arrays are always sized correctly.
     // Pass 1: count
     int edgeCount = 0;
     for (int i = 0; i < n; i++) {
@@ -113,7 +115,6 @@ public class AlgoMST extends AbstractAlgoProcedure {
           if (ridToIdx.containsKey(e.getIn()))
             edgeCount++;
         } catch (final RecordNotFoundException rnf) {
-          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           GhostEdgeReporter.reportSkipped(rnf);
         }
       }
@@ -143,7 +144,6 @@ public class AlgoMST extends AbstractAlgoProcedure {
           }
           ec++;
         } catch (final RecordNotFoundException rnf) {
-          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           GhostEdgeReporter.reportSkipped(rnf);
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMaxFlow.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMaxFlow.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -128,8 +129,9 @@ public class AlgoMaxFlow extends AbstractAlgoProcedure {
           capacity[i][j] += cap;
           // For undirected: also add reverse capacity
           capacity[j][i] += cap;
-        } catch (final RecordNotFoundException ignored) {
+        } catch (final RecordNotFoundException rnf) {
           // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+          GhostEdgeReporter.reportSkipped(rnf);
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMaxFlow.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMaxFlow.java
@@ -130,7 +130,6 @@ public class AlgoMaxFlow extends AbstractAlgoProcedure {
           // For undirected: also add reverse capacity
           capacity[j][i] += cap;
         } catch (final RecordNotFoundException rnf) {
-          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           GhostEdgeReporter.reportSkipped(rnf);
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMaxFlow.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMaxFlow.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -114,18 +115,22 @@ public class AlgoMaxFlow extends AbstractAlgoProcedure {
           vertices.get(i).getEdges(Vertex.DIRECTION.OUT, relTypes) :
           vertices.get(i).getEdges(Vertex.DIRECTION.OUT);
       for (final Edge e : edges) {
-        final Integer j = ridToIdx.get(e.getIn());
-        if (j == null)
-          continue;
-        double cap = 1.0;
-        if (capacityProperty != null && !capacityProperty.isEmpty()) {
-          final Object w = e.get(capacityProperty);
-          if (w instanceof Number num)
-            cap = num.doubleValue();
+        try {
+          final Integer j = ridToIdx.get(e.getIn());
+          if (j == null)
+            continue;
+          double cap = 1.0;
+          if (capacityProperty != null && !capacityProperty.isEmpty()) {
+            final Object w = e.get(capacityProperty);
+            if (w instanceof Number num)
+              cap = num.doubleValue();
+          }
+          capacity[i][j] += cap;
+          // For undirected: also add reverse capacity
+          capacity[j][i] += cap;
+        } catch (final RecordNotFoundException ignored) {
+          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
         }
-        capacity[i][j] += cap;
-        // For undirected: also add reverse capacity
-        capacity[j][i] += cap;
       }
     }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMaxFlow.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMaxFlow.java
@@ -129,7 +129,7 @@ public class AlgoMaxFlow extends AbstractAlgoProcedure {
           capacity[i][j] += cap;
           // For undirected: also add reverse capacity
           capacity[j][i] += cap;
-        } catch (final RecordNotFoundException rnf) {
+        } catch (final RecordNotFoundException rnf) {  // 'rnf' not 'e' here: 'e' is the Edge loop variable in this scope
           GhostEdgeReporter.reportSkipped(rnf);
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
@@ -109,7 +109,9 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
       return Stream.empty();
     final int rootIdx = rootIdxObj;
 
-    // Collect all directed edges as primitive arrays (two-pass, OUT direction = directed edges)
+    // Collect all directed edges as primitive arrays (two-pass, OUT direction = directed edges). Ghost
+    // edges are skipped identically in both passes (same getEdges() order), so the pass-2 fill never
+    // exceeds the pass-1 count and the arrays are always sized correctly.
     // Pass 1: count
     int edgeCount = 0;
     for (int i = 0; i < n; i++) {
@@ -121,7 +123,6 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
           if (ridToIdx.containsKey(e.getIn()))
             edgeCount++;
         } catch (final RecordNotFoundException rnf) {
-          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           GhostEdgeReporter.reportSkipped(rnf);
         }
       }
@@ -151,7 +152,6 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
           }
           ec++;
         } catch (final RecordNotFoundException rnf) {
-          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           GhostEdgeReporter.reportSkipped(rnf);
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -114,9 +115,14 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
       final Iterable<Edge> edges = relTypes != null && relTypes.length > 0 ?
           vertices.get(i).getEdges(Vertex.DIRECTION.OUT, relTypes) :
           vertices.get(i).getEdges(Vertex.DIRECTION.OUT);
-      for (final Edge e : edges)
-        if (ridToIdx.containsKey(e.getIn()))
-          edgeCount++;
+      for (final Edge e : edges) {
+        try {
+          if (ridToIdx.containsKey(e.getIn()))
+            edgeCount++;
+        } catch (final RecordNotFoundException ignored) {
+          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+        }
+      }
     }
 
     // Pass 2: fill
@@ -129,18 +135,22 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
           vertices.get(i).getEdges(Vertex.DIRECTION.OUT, relTypes) :
           vertices.get(i).getEdges(Vertex.DIRECTION.OUT);
       for (final Edge e : edges) {
-        final Integer j = ridToIdx.get(e.getIn());
-        if (j == null)
-          continue;
-        eFrom[ec] = i;
-        eTo[ec] = j;
-        if (weightProperty != null) {
-          final Object w = e.get(weightProperty);
-          eW[ec] = w instanceof Number num ? num.doubleValue() : 1.0;
-        } else {
-          eW[ec] = 1.0;
+        try {
+          final Integer j = ridToIdx.get(e.getIn());
+          if (j == null)
+            continue;
+          eFrom[ec] = i;
+          eTo[ec] = j;
+          if (weightProperty != null) {
+            final Object w = e.get(weightProperty);
+            eW[ec] = w instanceof Number num ? num.doubleValue() : 1.0;
+          } else {
+            eW[ec] = 1.0;
+          }
+          ec++;
+        } catch (final RecordNotFoundException ignored) {
+          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
         }
-        ec++;
       }
     }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
@@ -110,10 +110,10 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
     final int rootIdx = rootIdxObj;
 
     // Collect all directed edges as primitive arrays (two-pass, OUT direction = directed edges). Ghost
-    // edges are skipped identically in both passes (same getEdges() order), so the pass-2 fill never
-    // exceeds the pass-1 count and the arrays are always sized correctly. This is safe because an edge
-    // record is only ever deleted, never resurrected, during a read query: a ghost in pass 1 is still
-    // a ghost in pass 2.
+    // edges are skipped identically in both passes, so the pass-2 fill never exceeds the pass-1 count and
+    // the arrays are always sized correctly. This rests on two read-query invariants: (1) an edge record is
+    // only ever deleted, never resurrected, so a pass-1 ghost is still a ghost in pass 2; (2) the two
+    // getEdges() calls per vertex iterate the same edges in the same order, so counting and filling agree.
     // Pass 1: count
     int edgeCount = 0;
     for (int i = 0; i < n; i++) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -119,8 +120,9 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
         try {
           if (ridToIdx.containsKey(e.getIn()))
             edgeCount++;
-        } catch (final RecordNotFoundException ignored) {
+        } catch (final RecordNotFoundException rnf) {
           // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+          GhostEdgeReporter.reportSkipped(rnf);
         }
       }
     }
@@ -148,8 +150,9 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
             eW[ec] = 1.0;
           }
           ec++;
-        } catch (final RecordNotFoundException ignored) {
+        } catch (final RecordNotFoundException rnf) {
           // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+          GhostEdgeReporter.reportSkipped(rnf);
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
@@ -111,7 +111,9 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
 
     // Collect all directed edges as primitive arrays (two-pass, OUT direction = directed edges). Ghost
     // edges are skipped identically in both passes (same getEdges() order), so the pass-2 fill never
-    // exceeds the pass-1 count and the arrays are always sized correctly.
+    // exceeds the pass-1 count and the arrays are always sized correctly. This is safe because an edge
+    // record is only ever deleted, never resurrected, during a read query: a ghost in pass 1 is still
+    // a ghost in pass 2.
     // Pass 1: count
     int edgeCount = 0;
     for (int i = 0; i < n; i++) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoMinSpanningArborescence.java
@@ -124,7 +124,7 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
         try {
           if (ridToIdx.containsKey(e.getIn()))
             edgeCount++;
-        } catch (final RecordNotFoundException rnf) {
+        } catch (final RecordNotFoundException rnf) {  // 'rnf' not 'e' here: 'e' is the Edge loop variable in this scope
           GhostEdgeReporter.reportSkipped(rnf);
         }
       }
@@ -153,7 +153,7 @@ public class AlgoMinSpanningArborescence extends AbstractAlgoProcedure {
             eW[ec] = 1.0;
           }
           ec++;
-        } catch (final RecordNotFoundException rnf) {
+        } catch (final RecordNotFoundException rnf) {  // 'rnf' not 'e' here: 'e' is the Edge loop variable in this scope
           GhostEdgeReporter.reportSkipped(rnf);
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRank.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRank.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.graph.olap.GraphAlgorithms;
@@ -175,8 +176,9 @@ public class AlgoPageRank extends AbstractAlgoProcedure {
             final Object w = edge.get(weightProperty);
             wts.add(w instanceof Number num ? num.doubleValue() : 1.0);
           }
-        } catch (final RecordNotFoundException ignored) {
+        } catch (final RecordNotFoundException e) {
           // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+          GhostEdgeReporter.reportSkipped(e);
         }
       }
 
@@ -192,8 +194,9 @@ public class AlgoPageRank extends AbstractAlgoProcedure {
               final Object w = edge.get(weightProperty);
               wts.add(w instanceof Number num ? num.doubleValue() : 1.0);
             }
-          } catch (final RecordNotFoundException ignored) {
+          } catch (final RecordNotFoundException e) {
             // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+            GhostEdgeReporter.reportSkipped(e);
           }
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRank.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRank.java
@@ -177,7 +177,6 @@ public class AlgoPageRank extends AbstractAlgoProcedure {
             wts.add(w instanceof Number num ? num.doubleValue() : 1.0);
           }
         } catch (final RecordNotFoundException e) {
-          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           GhostEdgeReporter.reportSkipped(e);
         }
       }
@@ -195,7 +194,6 @@ public class AlgoPageRank extends AbstractAlgoProcedure {
               wts.add(w instanceof Number num ? num.doubleValue() : 1.0);
             }
           } catch (final RecordNotFoundException e) {
-            // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
             GhostEdgeReporter.reportSkipped(e);
           }
         }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRank.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/algo/AlgoPageRank.java
@@ -20,6 +20,7 @@ package com.arcadedb.query.opencypher.procedures.algo;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.RID;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.GraphTraversalProvider;
 import com.arcadedb.graph.Vertex;
@@ -165,26 +166,34 @@ public class AlgoPageRank extends AbstractAlgoProcedure {
 
       // Always traverse OUT edges
       for (final Edge edge : v.getEdges(Vertex.DIRECTION.OUT)) {
-        final Integer neighborIdx = ridToIdx.get(edge.getInVertex().getIdentity());
-        if (neighborIdx == null)
-          continue;
-        nbrs.add(new int[]{ neighborIdx });
-        if (wts != null) {
-          final Object w = edge.get(weightProperty);
-          wts.add(w instanceof Number num ? num.doubleValue() : 1.0);
-        }
-      }
-
-      // For BOTH direction, also traverse IN edges (treat undirected edges as bidirectional)
-      if (direction == Vertex.DIRECTION.BOTH) {
-        for (final Edge edge : v.getEdges(Vertex.DIRECTION.IN)) {
-          final Integer neighborIdx = ridToIdx.get(edge.getOutVertex().getIdentity());
+        try {
+          final Integer neighborIdx = ridToIdx.get(edge.getInVertex().getIdentity());
           if (neighborIdx == null)
             continue;
           nbrs.add(new int[]{ neighborIdx });
           if (wts != null) {
             final Object w = edge.get(weightProperty);
             wts.add(w instanceof Number num ? num.doubleValue() : 1.0);
+          }
+        } catch (final RecordNotFoundException ignored) {
+          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+        }
+      }
+
+      // For BOTH direction, also traverse IN edges (treat undirected edges as bidirectional)
+      if (direction == Vertex.DIRECTION.BOTH) {
+        for (final Edge edge : v.getEdges(Vertex.DIRECTION.IN)) {
+          try {
+            final Integer neighborIdx = ridToIdx.get(edge.getOutVertex().getIdentity());
+            if (neighborIdx == null)
+              continue;
+            nbrs.add(new int[]{ neighborIdx });
+            if (wts != null) {
+              final Object w = edge.get(weightProperty);
+              wts.add(w instanceof Number num ? num.doubleValue() : 1.0);
+            }
+          } catch (final RecordNotFoundException ignored) {
+            // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           }
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/merge/MergeRelationship.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/merge/MergeRelationship.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher.procedures.merge;
 import com.arcadedb.database.Database;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.MutableEdge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.procedures.CypherProcedure;
@@ -170,8 +171,9 @@ public class MergeRelationship implements CypherProcedure {
         if (allMatch) {
           return edge;
         }
-      } catch (final RecordNotFoundException ignored) {
+      } catch (final RecordNotFoundException e) {
         // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+        GhostEdgeReporter.reportSkipped(e);
       }
     }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/merge/MergeRelationship.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/merge/MergeRelationship.java
@@ -172,7 +172,6 @@ public class MergeRelationship implements CypherProcedure {
           return edge;
         }
       } catch (final RecordNotFoundException e) {
-        // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
         GhostEdgeReporter.reportSkipped(e);
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/merge/MergeRelationship.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/merge/MergeRelationship.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.procedures.merge;
 
 import com.arcadedb.database.Database;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.MutableEdge;
 import com.arcadedb.graph.Vertex;
@@ -141,32 +142,36 @@ public class MergeRelationship implements CypherProcedure {
     // Get outgoing edges of the specified type
 
     for (final Edge edge : startNode.getEdges(Vertex.DIRECTION.OUT, relType)) {
-      // Check if edge connects to the endNode
-      if (!edge.getIn().equals(endNode.getIdentity()))
-        continue;
+      try {
+        // Check if edge connects to the endNode
+        if (!edge.getIn().equals(endNode.getIdentity()))
+          continue;
 
-      // Check if all matchProps match
-      if (matchProps == null || matchProps.isEmpty())
-        return edge; // No props to match, found a match
+        // Check if all matchProps match
+        if (matchProps == null || matchProps.isEmpty())
+          return edge; // No props to match, found a match
 
-      boolean allMatch = true;
-      for (final Map.Entry<String, Object> entry : matchProps.entrySet()) {
-        final Object edgeValue = edge.get(entry.getKey());
-        final Object matchValue = entry.getValue();
+        boolean allMatch = true;
+        for (final Map.Entry<String, Object> entry : matchProps.entrySet()) {
+          final Object edgeValue = edge.get(entry.getKey());
+          final Object matchValue = entry.getValue();
 
-        if (matchValue == null) {
-          if (edgeValue != null) {
+          if (matchValue == null) {
+            if (edgeValue != null) {
+              allMatch = false;
+              break;
+            }
+          } else if (!matchValue.equals(edgeValue)) {
             allMatch = false;
             break;
           }
-        } else if (!matchValue.equals(edgeValue)) {
-          allMatch = false;
-          break;
         }
-      }
 
-      if (allMatch) {
-        return edge;
+        if (allMatch) {
+          return edge;
+        }
+      } catch (final RecordNotFoundException ignored) {
+        // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
       }
     }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpand.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpand.java
@@ -169,6 +169,7 @@ public class PathExpand extends AbstractPathProcedure {
           }
         }
       } catch (final RecordNotFoundException e) {
+        // Only the outer edge.get*Vertex() above can land here; the recursion has its own per-edge catches.
         GhostEdgeReporter.reportSkipped(e);
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpand.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpand.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.procedures.path;
 
 import com.arcadedb.database.RID;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -146,21 +147,25 @@ public class PathExpand extends AbstractPathProcedure {
         : current.getEdges(direction);
 
     for (final Edge edge : edges) {
-      final Vertex neighbor = direction == Vertex.DIRECTION.OUT ? edge.getInVertex() : edge.getOutVertex();
-      final RID neighborId = neighbor.getIdentity();
+      try {
+        final Vertex neighbor = direction == Vertex.DIRECTION.OUT ? edge.getInVertex() : edge.getOutVertex();
+        final RID neighborId = neighbor.getIdentity();
 
-      if (!visited.contains(neighborId) && matchesLabels(neighbor, labelFilter)) {
-        visited.add(neighborId);
-        currentPath.add(edge);
-        currentPath.add(neighbor);
+        if (!visited.contains(neighborId) && matchesLabels(neighbor, labelFilter)) {
+          visited.add(neighborId);
+          currentPath.add(edge);
+          currentPath.add(neighbor);
 
-        expandPaths(neighbor, relTypes, labelFilter, currentDepth + 1, minDepth, maxDepth,
-            currentPath, visited, allPaths, context);
+          expandPaths(neighbor, relTypes, labelFilter, currentDepth + 1, minDepth, maxDepth,
+              currentPath, visited, allPaths, context);
 
-        // Backtrack
-        currentPath.removeLast();
-        currentPath.removeLast();
-        visited.remove(neighborId);
+          // Backtrack
+          currentPath.removeLast();
+          currentPath.removeLast();
+          visited.remove(neighborId);
+        }
+      } catch (final RecordNotFoundException ignored) {
+        // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
       }
     }
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpand.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpand.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher.procedures.path;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -164,8 +165,9 @@ public class PathExpand extends AbstractPathProcedure {
           currentPath.removeLast();
           visited.remove(neighborId);
         }
-      } catch (final RecordNotFoundException ignored) {
+      } catch (final RecordNotFoundException e) {
         // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+        GhostEdgeReporter.reportSkipped(e);
       }
     }
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpand.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpand.java
@@ -169,7 +169,6 @@ public class PathExpand extends AbstractPathProcedure {
           }
         }
       } catch (final RecordNotFoundException e) {
-        // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
         GhostEdgeReporter.reportSkipped(e);
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpand.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpand.java
@@ -157,13 +157,16 @@ public class PathExpand extends AbstractPathProcedure {
           currentPath.add(edge);
           currentPath.add(neighbor);
 
-          expandPaths(neighbor, relTypes, labelFilter, currentDepth + 1, minDepth, maxDepth,
-              currentPath, visited, allPaths, context);
-
-          // Backtrack
-          currentPath.removeLast();
-          currentPath.removeLast();
-          visited.remove(neighborId);
+          // try-finally so the path/visited bookkeeping is unwound even if the recursion throws.
+          try {
+            expandPaths(neighbor, relTypes, labelFilter, currentDepth + 1, minDepth, maxDepth,
+                currentPath, visited, allPaths, context);
+          } finally {
+            // Backtrack
+            currentPath.removeLast();
+            currentPath.removeLast();
+            visited.remove(neighborId);
+          }
         }
       } catch (final RecordNotFoundException e) {
         // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpandConfig.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpandConfig.java
@@ -181,7 +181,6 @@ public class PathExpandConfig extends AbstractPathProcedure {
             nextFrontier.add(newPath);
           }
         } catch (final RecordNotFoundException e) {
-          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           GhostEdgeReporter.reportSkipped(e);
         }
       }
@@ -235,7 +234,6 @@ public class PathExpandConfig extends AbstractPathProcedure {
             }
           }
         } catch (final RecordNotFoundException e) {
-          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           GhostEdgeReporter.reportSkipped(e);
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpandConfig.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpandConfig.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher.procedures.path;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -179,8 +180,9 @@ public class PathExpandConfig extends AbstractPathProcedure {
             newPath.add(neighbor);
             nextFrontier.add(newPath);
           }
-        } catch (final RecordNotFoundException ignored) {
+        } catch (final RecordNotFoundException e) {
           // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+          GhostEdgeReporter.reportSkipped(e);
         }
       }
     }
@@ -229,8 +231,9 @@ public class PathExpandConfig extends AbstractPathProcedure {
             currentPath.removeLast();
             visited.remove(neighborId);
           }
-        } catch (final RecordNotFoundException ignored) {
+        } catch (final RecordNotFoundException e) {
           // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+          GhostEdgeReporter.reportSkipped(e);
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpandConfig.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpandConfig.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.procedures.path;
 
 import com.arcadedb.database.RID;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -167,15 +168,19 @@ public class PathExpandConfig extends AbstractPathProcedure {
           : node.getEdges(direction);
 
       for (final Edge edge : edges) {
-        final Vertex neighbor = direction == Vertex.DIRECTION.OUT ? edge.getInVertex() : edge.getOutVertex();
-        final RID neighborId = neighbor.getIdentity();
+        try {
+          final Vertex neighbor = direction == Vertex.DIRECTION.OUT ? edge.getInVertex() : edge.getOutVertex();
+          final RID neighborId = neighbor.getIdentity();
 
-        if (!visited.contains(neighborId) && matchesLabels(neighbor, labelFilter)) {
-          visited.add(neighborId);
-          final List<Object> newPath = new ArrayList<>(currentPath);
-          newPath.add(edge);
-          newPath.add(neighbor);
-          nextFrontier.add(newPath);
+          if (!visited.contains(neighborId) && matchesLabels(neighbor, labelFilter)) {
+            visited.add(neighborId);
+            final List<Object> newPath = new ArrayList<>(currentPath);
+            newPath.add(edge);
+            newPath.add(neighbor);
+            nextFrontier.add(newPath);
+          }
+        } catch (final RecordNotFoundException ignored) {
+          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
         }
       }
     }
@@ -208,20 +213,24 @@ public class PathExpandConfig extends AbstractPathProcedure {
           return;
         }
 
-        final Vertex neighbor = direction == Vertex.DIRECTION.OUT ? edge.getInVertex() : edge.getOutVertex();
-        final RID neighborId = neighbor.getIdentity();
+        try {
+          final Vertex neighbor = direction == Vertex.DIRECTION.OUT ? edge.getInVertex() : edge.getOutVertex();
+          final RID neighborId = neighbor.getIdentity();
 
-        if (!visited.contains(neighborId) && matchesLabels(neighbor, labelFilter)) {
-          visited.add(neighborId);
-          currentPath.add(edge);
-          currentPath.add(neighbor);
+          if (!visited.contains(neighborId) && matchesLabels(neighbor, labelFilter)) {
+            visited.add(neighborId);
+            currentPath.add(edge);
+            currentPath.add(neighbor);
 
-          expandDFS(neighbor, relTypes, labelFilter, currentDepth + 1, minDepth, maxDepth,
-              currentPath, visited, allPaths, context, limit);
+            expandDFS(neighbor, relTypes, labelFilter, currentDepth + 1, minDepth, maxDepth,
+                currentPath, visited, allPaths, context, limit);
 
-          currentPath.removeLast();
-          currentPath.removeLast();
-          visited.remove(neighborId);
+            currentPath.removeLast();
+            currentPath.removeLast();
+            visited.remove(neighborId);
+          }
+        } catch (final RecordNotFoundException ignored) {
+          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpandConfig.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpandConfig.java
@@ -234,6 +234,7 @@ public class PathExpandConfig extends AbstractPathProcedure {
             }
           }
         } catch (final RecordNotFoundException e) {
+          // Only the outer edge.get*Vertex() above can land here; the recursion has its own per-edge catches.
           GhostEdgeReporter.reportSkipped(e);
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpandConfig.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathExpandConfig.java
@@ -224,12 +224,15 @@ public class PathExpandConfig extends AbstractPathProcedure {
             currentPath.add(edge);
             currentPath.add(neighbor);
 
-            expandDFS(neighbor, relTypes, labelFilter, currentDepth + 1, minDepth, maxDepth,
-                currentPath, visited, allPaths, context, limit);
-
-            currentPath.removeLast();
-            currentPath.removeLast();
-            visited.remove(neighborId);
+            // try-finally so the path/visited bookkeeping is unwound even if the recursion throws.
+            try {
+              expandDFS(neighbor, relTypes, labelFilter, currentDepth + 1, minDepth, maxDepth,
+                  currentPath, visited, allPaths, context, limit);
+            } finally {
+              currentPath.removeLast();
+              currentPath.removeLast();
+              visited.remove(neighborId);
+            }
           }
         } catch (final RecordNotFoundException e) {
           // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSpanningTree.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSpanningTree.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.procedures.path;
 
 import com.arcadedb.database.RID;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -120,18 +121,22 @@ public class PathSpanningTree extends AbstractPathProcedure {
             : current.vertex.getEdges(direction);
 
         for (final Edge edge : edges) {
-          final Vertex neighbor = direction == Vertex.DIRECTION.OUT ? edge.getInVertex() : edge.getOutVertex();
-          final RID neighborId = neighbor.getIdentity();
+          try {
+            final Vertex neighbor = direction == Vertex.DIRECTION.OUT ? edge.getInVertex() : edge.getOutVertex();
+            final RID neighborId = neighbor.getIdentity();
 
-          if (!visited.contains(neighborId) && matchesLabels(neighbor, labelFilter)) {
-            visited.add(neighborId);
+            if (!visited.contains(neighborId) && matchesLabels(neighbor, labelFilter)) {
+              visited.add(neighborId);
 
-            final List<Object> newPath = new ArrayList<>(current.path);
-            newPath.add(edge);
-            newPath.add(neighbor);
+              final List<Object> newPath = new ArrayList<>(current.path);
+              newPath.add(edge);
+              newPath.add(neighbor);
 
-            allPaths.add(new ArrayList<>(newPath));
-            queue.add(new PathLevel(newPath, neighbor, current.level + 1));
+              allPaths.add(new ArrayList<>(newPath));
+              queue.add(new PathLevel(newPath, neighbor, current.level + 1));
+            }
+          } catch (final RecordNotFoundException ignored) {
+            // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           }
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSpanningTree.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSpanningTree.java
@@ -137,7 +137,6 @@ public class PathSpanningTree extends AbstractPathProcedure {
               queue.add(new PathLevel(newPath, neighbor, current.level + 1));
             }
           } catch (final RecordNotFoundException e) {
-            // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
             GhostEdgeReporter.reportSkipped(e);
           }
         }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSpanningTree.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSpanningTree.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher.procedures.path;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -135,8 +136,9 @@ public class PathSpanningTree extends AbstractPathProcedure {
               allPaths.add(new ArrayList<>(newPath));
               queue.add(new PathLevel(newPath, neighbor, current.level + 1));
             }
-          } catch (final RecordNotFoundException ignored) {
+          } catch (final RecordNotFoundException e) {
             // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+            GhostEdgeReporter.reportSkipped(e);
           }
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSubgraphAll.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSubgraphAll.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher.procedures.path;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -134,8 +135,9 @@ public class PathSubgraphAll extends AbstractPathProcedure {
               reachableNodes.add(neighbor);
               queue.add(new VertexLevel(neighbor, current.level + 1));
             }
-          } catch (final RecordNotFoundException ignored) {
+          } catch (final RecordNotFoundException e) {
             // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+            GhostEdgeReporter.reportSkipped(e);
           }
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSubgraphAll.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSubgraphAll.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.procedures.path;
 
 import com.arcadedb.database.RID;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -118,19 +119,23 @@ public class PathSubgraphAll extends AbstractPathProcedure {
             : current.vertex.getEdges(direction);
 
         for (final Edge edge : edges) {
-          final RID edgeId = edge.getIdentity();
-          if (!visitedEdges.contains(edgeId)) {
-            visitedEdges.add(edgeId);
-            reachableEdges.add(edge);
-          }
+          try {
+            final Vertex neighbor = direction == Vertex.DIRECTION.OUT ? edge.getInVertex() : edge.getOutVertex();
+            final RID neighborId = neighbor.getIdentity();
 
-          final Vertex neighbor = direction == Vertex.DIRECTION.OUT ? edge.getInVertex() : edge.getOutVertex();
-          final RID neighborId = neighbor.getIdentity();
+            final RID edgeId = edge.getIdentity();
+            if (!visitedEdges.contains(edgeId)) {
+              visitedEdges.add(edgeId);
+              reachableEdges.add(edge);
+            }
 
-          if (!visitedNodes.contains(neighborId) && matchesLabels(neighbor, labelFilter)) {
-            visitedNodes.add(neighborId);
-            reachableNodes.add(neighbor);
-            queue.add(new VertexLevel(neighbor, current.level + 1));
+            if (!visitedNodes.contains(neighborId) && matchesLabels(neighbor, labelFilter)) {
+              visitedNodes.add(neighborId);
+              reachableNodes.add(neighbor);
+              queue.add(new VertexLevel(neighbor, current.level + 1));
+            }
+          } catch (final RecordNotFoundException ignored) {
+            // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           }
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSubgraphAll.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSubgraphAll.java
@@ -136,7 +136,6 @@ public class PathSubgraphAll extends AbstractPathProcedure {
               queue.add(new VertexLevel(neighbor, current.level + 1));
             }
           } catch (final RecordNotFoundException e) {
-            // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
             GhostEdgeReporter.reportSkipped(e);
           }
         }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSubgraphNodes.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSubgraphNodes.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.procedures.path;
 
 import com.arcadedb.database.RID;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
@@ -116,13 +117,17 @@ public class PathSubgraphNodes extends AbstractPathProcedure {
             : current.vertex.getEdges(direction);
 
         for (final Edge edge : edges) {
-          final Vertex neighbor = direction == Vertex.DIRECTION.OUT ? edge.getInVertex() : edge.getOutVertex();
-          final RID neighborId = neighbor.getIdentity();
+          try {
+            final Vertex neighbor = direction == Vertex.DIRECTION.OUT ? edge.getInVertex() : edge.getOutVertex();
+            final RID neighborId = neighbor.getIdentity();
 
-          if (!visited.contains(neighborId) && matchesLabels(neighbor, labelFilter)) {
-            visited.add(neighborId);
-            reachableNodes.add(neighbor);
-            queue.add(new VertexLevel(neighbor, current.level + 1));
+            if (!visited.contains(neighborId) && matchesLabels(neighbor, labelFilter)) {
+              visited.add(neighborId);
+              reachableNodes.add(neighbor);
+              queue.add(new VertexLevel(neighbor, current.level + 1));
+            }
+          } catch (final RecordNotFoundException ignored) {
+            // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           }
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSubgraphNodes.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSubgraphNodes.java
@@ -128,7 +128,6 @@ public class PathSubgraphNodes extends AbstractPathProcedure {
               queue.add(new VertexLevel(neighbor, current.level + 1));
             }
           } catch (final RecordNotFoundException e) {
-            // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
             GhostEdgeReporter.reportSkipped(e);
           }
         }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSubgraphNodes.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/procedures/path/PathSubgraphNodes.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher.procedures.path;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
@@ -126,8 +127,9 @@ public class PathSubgraphNodes extends AbstractPathProcedure {
               reachableNodes.add(neighbor);
               queue.add(new VertexLevel(neighbor, current.level + 1));
             }
-          } catch (final RecordNotFoundException ignored) {
+          } catch (final RecordNotFoundException e) {
             // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+            GhostEdgeReporter.reportSkipped(e);
           }
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/traversal/BreadthFirstTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/traversal/BreadthFirstTraverser.java
@@ -192,7 +192,6 @@ public class BreadthFirstTraverser extends GraphTraverser {
             final TraversalPath newPath = new TraversalPath(path, edge, nextVertex);
             queue.add(new PathWithDepth(newPath, depth + 1));
           } catch (final RecordNotFoundException e) {
-            // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
             GhostEdgeReporter.reportSkipped(e);
           }
         }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/traversal/BreadthFirstTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/traversal/BreadthFirstTraverser.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.traversal;
 
 import com.arcadedb.database.RID;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.ast.Direction;
@@ -170,24 +171,28 @@ public class BreadthFirstTraverser extends GraphTraverser {
 
         // Expand to neighbors
         for (final Edge edge : getEdges(vertex)) {
-          if (!matchesTypeFilter(edge))
-            continue;
+          try {
+            if (!matchesTypeFilter(edge))
+              continue;
 
-          if (!matchesPropertyFilter(edge))
-            continue;
+            if (!matchesPropertyFilter(edge))
+              continue;
 
-          // Path mode: TRAIL/ACYCLIC = edge uniqueness, WALK = no restriction
-          if (pathMode != PathMode.WALK && pathContainsEdge(path, edge))
-            continue;
+            // Path mode: TRAIL/ACYCLIC = edge uniqueness, WALK = no restriction
+            if (pathMode != PathMode.WALK && pathContainsEdge(path, edge))
+              continue;
 
-          final Vertex nextVertex = getOtherVertex(edge, vertex);
+            final Vertex nextVertex = getOtherVertex(edge, vertex);
 
-          // ACYCLIC: also enforce vertex uniqueness
-          if (pathMode == PathMode.ACYCLIC && path.containsVertex(nextVertex))
-            continue;
+            // ACYCLIC: also enforce vertex uniqueness
+            if (pathMode == PathMode.ACYCLIC && path.containsVertex(nextVertex))
+              continue;
 
-          final TraversalPath newPath = new TraversalPath(path, edge, nextVertex);
-          queue.add(new PathWithDepth(newPath, depth + 1));
+            final TraversalPath newPath = new TraversalPath(path, edge, nextVertex);
+            queue.add(new PathWithDepth(newPath, depth + 1));
+          } catch (final RecordNotFoundException ignored) {
+            // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+          }
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/traversal/BreadthFirstTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/traversal/BreadthFirstTraverser.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher.traversal;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.ast.Direction;
 import com.arcadedb.query.opencypher.ast.PathMode;
@@ -190,8 +191,9 @@ public class BreadthFirstTraverser extends GraphTraverser {
 
             final TraversalPath newPath = new TraversalPath(path, edge, nextVertex);
             queue.add(new PathWithDepth(newPath, depth + 1));
-          } catch (final RecordNotFoundException ignored) {
+          } catch (final RecordNotFoundException e) {
             // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+            GhostEdgeReporter.reportSkipped(e);
           }
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/traversal/DepthFirstTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/traversal/DepthFirstTraverser.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.traversal;
 
 import com.arcadedb.database.RID;
+import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.ast.Direction;
@@ -148,24 +149,28 @@ public class DepthFirstTraverser extends GraphTraverser {
 
       // Recursively explore neighbors
       for (final Edge edge : getEdges(vertex)) {
-        if (!matchesTypeFilter(edge))
-          continue;
+        try {
+          if (!matchesTypeFilter(edge))
+            continue;
 
-        if (!matchesPropertyFilter(edge))
-          continue;
+          if (!matchesPropertyFilter(edge))
+            continue;
 
-        // Path mode: TRAIL/ACYCLIC = edge uniqueness, WALK = no restriction
-        if (pathMode != PathMode.WALK && pathContainsEdge(path, edge))
-          continue;
+          // Path mode: TRAIL/ACYCLIC = edge uniqueness, WALK = no restriction
+          if (pathMode != PathMode.WALK && pathContainsEdge(path, edge))
+            continue;
 
-        final Vertex nextVertex = getOtherVertex(edge, vertex);
+          final Vertex nextVertex = getOtherVertex(edge, vertex);
 
-        // ACYCLIC: also enforce vertex uniqueness
-        if (pathMode == PathMode.ACYCLIC && path.containsVertex(nextVertex))
-          continue;
+          // ACYCLIC: also enforce vertex uniqueness
+          if (pathMode == PathMode.ACYCLIC && path.containsVertex(nextVertex))
+            continue;
 
-        final TraversalPath newPath = new TraversalPath(path, edge, nextVertex);
-        performDFS(newPath, depth + 1);
+          final TraversalPath newPath = new TraversalPath(path, edge, nextVertex);
+          performDFS(newPath, depth + 1);
+        } catch (final RecordNotFoundException ignored) {
+          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+        }
       }
     }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/traversal/DepthFirstTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/traversal/DepthFirstTraverser.java
@@ -170,7 +170,6 @@ public class DepthFirstTraverser extends GraphTraverser {
           final TraversalPath newPath = new TraversalPath(path, edge, nextVertex);
           performDFS(newPath, depth + 1);
         } catch (final RecordNotFoundException e) {
-          // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
           GhostEdgeReporter.reportSkipped(e);
         }
       }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/traversal/DepthFirstTraverser.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/traversal/DepthFirstTraverser.java
@@ -21,6 +21,7 @@ package com.arcadedb.query.opencypher.traversal;
 import com.arcadedb.database.RID;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.ast.Direction;
 import com.arcadedb.query.opencypher.ast.PathMode;
@@ -168,8 +169,9 @@ public class DepthFirstTraverser extends GraphTraverser {
 
           final TraversalPath newPath = new TraversalPath(path, edge, nextVertex);
           performDFS(newPath, depth + 1);
-        } catch (final RecordNotFoundException ignored) {
+        } catch (final RecordNotFoundException e) {
           // Ghost edge: dangling segment pointer to a missing edge/target record. Skip it.
+          GhostEdgeReporter.reportSkipped(e);
         }
       }
     }

--- a/engine/src/test/java/com/arcadedb/function/sql/graph/SQLFunctionMoveGhostEdgeTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/graph/SQLFunctionMoveGhostEdgeTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.function.sql.graph;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.Bucket;
+import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Regression test for the SQL edge-to-vertex functions (outV/inV/bothV, via {@code SQLFunctionMove.e2v}):
+ * when chained off {@code outE()}, a ghost edge (segment pointer whose backing edge record is gone)
+ * flows into e2v and must be skipped instead of throwing {@code RecordNotFoundException}.
+ * <p>
+ * Note: {@code out()/in()/both()} are already ghost-safe (they resolve neighbors via getVertices(),
+ * reading the target RID from the segment without loading the edge record), and {@code outE()/inE()}
+ * return the edge lazily without dereferencing - so e2v is the only function-level deref to harden.
+ */
+class SQLFunctionMoveGhostEdgeTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/sqlMoveGhostEdge");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Node");
+    database.getSchema().createEdgeType("LINK");
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null && database.isOpen())
+      database.drop();
+  }
+
+  @Test
+  void inVOverGhostEdgeIsSkipped() {
+    // A -[LINK]-> B (to be ghosted), A -[LINK]-> C (valid)
+    database.transaction(() -> {
+      final MutableVertex a = database.newVertex("Node").set("name", "A").save();
+      final MutableVertex b = database.newVertex("Node").set("name", "B").save();
+      final MutableVertex c = database.newVertex("Node").set("name", "C").save();
+      a.newEdge("LINK", b);
+      a.newEdge("LINK", c);
+    });
+
+    // Ghost the A->B edge: delete only its record, leaving the segment pointer.
+    final RID ghostRID;
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Node {name:'A'})-[r:LINK]->(b:Node {name:'B'}) RETURN r")) {
+      ghostRID = ((Edge) rs.next().getProperty("r")).getIdentity();
+    }
+    database.transaction(() -> {
+      final Bucket bucket = database.getSchema().getBucketById(ghostRID.getBucketId());
+      bucket.deleteRecord(ghostRID);
+    });
+
+    // outE('LINK').inV() routes every out-edge (including the ghost) through e2v. Must not throw.
+    assertThatCode(() -> {
+      try (final ResultSet rs = database.query("sql",
+          "SELECT expand(outE('LINK').inV()) FROM Node WHERE name = 'A'")) {
+        while (rs.hasNext())
+          rs.next();
+      }
+    }).doesNotThrowAnyException();
+
+    // out('LINK') uses getVertices() and is inherently ghost-safe; must also not throw.
+    assertThatCode(() -> {
+      try (final ResultSet rs = database.query("sql",
+          "SELECT expand(out('LINK')) FROM Node WHERE name = 'A'")) {
+        while (rs.hasNext())
+          rs.next();
+      }
+    }).doesNotThrowAnyException();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/function/sql/graph/SQLFunctionShortestPathTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/graph/SQLFunctionShortestPathTest.java
@@ -357,10 +357,12 @@ class SQLFunctionShortestPathTest {
       final List<RID> result = function.execute(null, null, null, new Object[] { v[0], v[1], options },
           new BasicCommandContext());
 
-      // The ghost is skipped; the surviving route is A -[edge]-> C -[edge]-> B (5 elements with edges).
-      assertThat(result).isNotEmpty();
-      assertThat(result.getFirst()).isEqualTo(v[0].getIdentity());
-      assertThat(result.getLast()).isEqualTo(v[1].getIdentity());
+      // The ghost A->B is skipped, so the only surviving route is A -[edge]-> C -[edge]-> B, which in
+      // edge mode is exactly the 5 elements [A, edge(A->C), C, edge(C->B), B].
+      assertThat(result).hasSize(5);
+      assertThat(result.get(0)).isEqualTo(v[0].getIdentity()); // A
+      assertThat(result.get(2)).isEqualTo(v[2].getIdentity()); // C (routed around the ghost)
+      assertThat(result.get(4)).isEqualTo(v[1].getIdentity()); // B
       assertThat(result).doesNotContain(ghost[0]);
     });
   }

--- a/engine/src/test/java/com/arcadedb/function/sql/graph/SQLFunctionShortestPathTest.java
+++ b/engine/src/test/java/com/arcadedb/function/sql/graph/SQLFunctionShortestPathTest.java
@@ -321,6 +321,50 @@ class SQLFunctionShortestPathTest {
     });
   }
 
+  /**
+   * Regression: a ghost edge (dangling segment pointer whose backing edge record is gone, as after a
+   * manual HA leader-to-follower copy) must be skipped during edge-mode bidirectional search rather
+   * than throwing RecordNotFoundException. Graph: A->B is ghosted, A->C->B remains; the search must
+   * route around the ghost and return the surviving path.
+   */
+  @Test
+  void edgeModeSkipsGhostEdge() throws Exception {
+    TestHelper.executeInNewDatabase("testShortestPathGhostEdge", graph -> {
+      final MutableVertex[] v = new MutableVertex[3];
+      final RID[] ghost = new RID[1];
+
+      graph.transaction(() -> {
+        graph.getSchema().createVertexType("GNode");
+        graph.getSchema().createEdgeType("GEdge");
+
+        v[0] = graph.newVertex("GNode").set("name", "A").save();
+        v[1] = graph.newVertex("GNode").set("name", "B").save();
+        v[2] = graph.newVertex("GNode").set("name", "C").save();
+
+        ghost[0] = v[0].newEdge("GEdge", v[1]).getIdentity(); // A->B, to be ghosted
+        v[0].newEdge("GEdge", v[2]);                          // A->C
+        v[2].newEdge("GEdge", v[1]);                          // C->B
+      });
+
+      // Delete only the A->B edge record, leaving its segment pointer dangling.
+      graph.transaction(() -> graph.getSchema().getBucketById(ghost[0].getBucketId()).deleteRecord(ghost[0]));
+
+      function = new SQLFunctionShortestPath();
+      final Map<String, Object> options = new HashMap<>();
+      options.put("direction", "OUT");
+      options.put("edge", true);
+
+      final List<RID> result = function.execute(null, null, null, new Object[] { v[0], v[1], options },
+          new BasicCommandContext());
+
+      // The ghost is skipped; the surviving route is A -[edge]-> C -[edge]-> B (5 elements with edges).
+      assertThat(result).isNotEmpty();
+      assertThat(result.getFirst()).isEqualTo(v[0].getIdentity());
+      assertThat(result.getLast()).isEqualTo(v[1].getIdentity());
+      assertThat(result).doesNotContain(ghost[0]);
+    });
+  }
+
   private void setUpDatabase(final Database graph) {
     graph.transaction(() -> {
       graph.getSchema().createVertexType("Node");

--- a/engine/src/test/java/com/arcadedb/graph/GhostEdgeReporterTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/GhostEdgeReporterTest.java
@@ -45,4 +45,20 @@ class GhostEdgeReporterTest {
     assertThat(GhostEdgeReporter.getTotalSkipped()).isEqualTo(2);
   }
 
+  // Regression: a Long.MIN_VALUE seed made 'now - last' overflow so the very first WARNING never fired on a
+  // JVM with a positive nanoTime(). The first encounter at a realistic positive 'now' must win the slot.
+  @Test
+  void firstWarningFiresAtPositiveNanoTime() {
+    final long now = 600_000_000_000L; // ~10 min of uptime: a typical positive System.nanoTime() reading
+    assertThat(GhostEdgeReporter.shouldEmitWarning(now)).isTrue();
+  }
+
+  @Test
+  void warningIsThrottledWithinTheWindowThenFiresAgain() {
+    final long t0 = 600_000_000_000L;
+    assertThat(GhostEdgeReporter.shouldEmitWarning(t0)).isTrue();                    // first fires
+    assertThat(GhostEdgeReporter.shouldEmitWarning(t0 + 59_000_000_000L)).isFalse(); // 59s later: throttled
+    assertThat(GhostEdgeReporter.shouldEmitWarning(t0 + 60_000_000_000L)).isTrue();  // 60s later: fires again
+  }
+
 }

--- a/engine/src/test/java/com/arcadedb/graph/GhostEdgeReporterTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/GhostEdgeReporterTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.exception.RecordNotFoundException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class GhostEdgeReporterTest {
+  @BeforeEach
+  @AfterEach
+  void reset() {
+    GhostEdgeReporter.resetForTests();
+  }
+
+  @Test
+  void countsEachSkip() {
+    assertThat(GhostEdgeReporter.getTotalSkipped()).isZero();
+    GhostEdgeReporter.reportSkipped(new RecordNotFoundException("Record #98:430104 not found", null));
+    GhostEdgeReporter.reportSkipped(new RecordNotFoundException("Record #12:7 not found", null));
+    assertThat(GhostEdgeReporter.getTotalSkipped()).isEqualTo(2);
+  }
+
+  @Test
+  void toleratesNullCause() {
+    assertThatCode(() -> GhostEdgeReporter.reportSkipped(null)).doesNotThrowAnyException();
+    assertThat(GhostEdgeReporter.getTotalSkipped()).isEqualTo(1);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/GhostEdgeReporterTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/GhostEdgeReporterTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 
 // GhostEdgeReporter keeps JVM-wide static counters; pin this class to a single thread so its
 // resetForTests()/count assertions cannot race with ghost-edge skips from other tests run in parallel.
@@ -46,9 +45,4 @@ class GhostEdgeReporterTest {
     assertThat(GhostEdgeReporter.getTotalSkipped()).isEqualTo(2);
   }
 
-  @Test
-  void toleratesNullCause() {
-    assertThatCode(() -> GhostEdgeReporter.reportSkipped(null)).doesNotThrowAnyException();
-    assertThat(GhostEdgeReporter.getTotalSkipped()).isEqualTo(1);
-  }
 }

--- a/engine/src/test/java/com/arcadedb/graph/GhostEdgeReporterTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/GhostEdgeReporterTest.java
@@ -22,10 +22,15 @@ import com.arcadedb.exception.RecordNotFoundException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+// GhostEdgeReporter keeps JVM-wide static counters; pin this class to a single thread so its
+// resetForTests()/count assertions cannot race with ghost-edge skips from other tests run in parallel.
+@Execution(ExecutionMode.SAME_THREAD)
 class GhostEdgeReporterTest {
   @BeforeEach
   @AfterEach

--- a/engine/src/test/java/com/arcadedb/query/opencypher/PatternPredicateGhostEdgeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/PatternPredicateGhostEdgeTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -176,6 +177,44 @@ class PatternPredicateGhostEdgeTest {
       try (final ResultSet rs = database.query("opencypher",
           "MATCH (a:Account {number: 'ACC-3'})-[r:INITIATED]->(t) WHERE r.transaction_id = 'TX-3' RETURN t")) {
         assertThat(rs.hasNext()).isFalse();
+      }
+    }).doesNotThrowAnyException();
+  }
+
+  /**
+   * Pattern comprehension - [(a)-[:INITIATED]->(t) | t] and its variable-length form - routes through
+   * PatternComprehensionExpression (a different path from the WHERE predicate above). A ghost edge in
+   * the comprehension must be skipped, not throw, and contribute no element to the produced list.
+   */
+  @Test
+  void patternComprehensionSkipsGhostEdge() {
+    database.transaction(() ->
+        database.command("opencypher",
+            "CREATE (a:Account {number: 'ACC-PC'})-[:INITIATED {transaction_id: 'TX-PC'}]->(t:Transaction {id: 'TX-PC'})"));
+
+    final RID edgeRID;
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Account {number: 'ACC-PC'})-[r:INITIATED]->(t:Transaction {id: 'TX-PC'}) RETURN r")) {
+      edgeRID = ((Edge) rs.next().getProperty("r")).getIdentity();
+    }
+    database.transaction(() ->
+        database.getSchema().getBucketById(edgeRID.getBucketId()).deleteRecord(edgeRID));
+
+    // Single-hop comprehension: the ghost is the only edge, so the list is empty (no throw).
+    assertThatCode(() -> {
+      try (final ResultSet rs = database.query("opencypher",
+          "MATCH (a:Account {number: 'ACC-PC'}) RETURN [(a)-[:INITIATED]->(t) | t] AS targets")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat((List<?>) rs.next().getProperty("targets")).isEmpty();
+      }
+    }).doesNotThrowAnyException();
+
+    // Variable-length comprehension exercises the traverser inside PatternComprehensionExpression.
+    assertThatCode(() -> {
+      try (final ResultSet rs = database.query("opencypher",
+          "MATCH (a:Account {number: 'ACC-PC'}) RETURN [(a)-[:INITIATED*1..3]->(t) | t] AS targets")) {
+        assertThat(rs.hasNext()).isTrue();
+        assertThat((List<?>) rs.next().getProperty("targets")).isEmpty();
       }
     }).doesNotThrowAnyException();
   }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/PatternPredicateGhostEdgeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/PatternPredicateGhostEdgeTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.Bucket;
+import com.arcadedb.graph.Edge;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Regression test for a client HA-cluster crash: a {@code WHERE NOT EXISTS ((a)-[:T]->(t))} pattern
+ * predicate threw {@code RecordNotFoundException} from {@code PatternPredicateExpression} when the
+ * vertex's edge segment held a ghost pointer (the backing edge record had been deleted/never
+ * replicated). After a manual leader-to-follower database copy the new leader can hold such dangling
+ * edge pointers; evaluating the predicate called {@code edge.getIn()} which lazily loads the missing
+ * edge record and crashed the whole Cypher command (and, on the leader's Raft apply path, destabilized
+ * the cluster).
+ * <p>
+ * Mirrors the precedent set by {@code Issue394Test} (ghost edges in MERGE): the per-edge body of the
+ * pattern-predicate loops now skips ghost edges instead of propagating the exception.
+ */
+class PatternPredicateGhostEdgeTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/patternPredicateGhostEdge");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Account");
+      database.getSchema().createVertexType("Transaction");
+      database.getSchema().createEdgeType("INITIATED");
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null && database.isOpen())
+      database.drop();
+  }
+
+  /**
+   * The client query: MATCH both ends, then WHERE NOT EXISTS the relationship, then CREATE it.
+   * With a ghost INITIATED edge in the Account's segment, the predicate must skip the ghost
+   * (not throw) and conclude the relationship does not exist, so CREATE proceeds.
+   */
+  @Test
+  void whereNotExistsSkipsGhostOutgoingEdge() {
+    database.transaction(() ->
+        database.command("opencypher",
+            "CREATE (a:Account {number: 'ACC-1'})-[:INITIATED {transaction_id: 'TX-1'}]->(t:Transaction {id: 'TX-1'})"));
+
+    // Capture the edge RID, then delete only its backing record - leaving a ghost pointer in
+    // Account's edge segment (simulating the dangling edge seen after a manual HA db copy).
+    final RID edgeRID;
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Account {number: 'ACC-1'})-[r:INITIATED]->(t:Transaction {id: 'TX-1'}) RETURN r")) {
+      assertThat(rs.hasNext()).isTrue();
+      edgeRID = ((Edge) rs.next().getProperty("r")).getIdentity();
+    }
+    database.transaction(() -> {
+      final Bucket bucket = database.getSchema().getBucketById(edgeRID.getBucketId());
+      bucket.deleteRecord(edgeRID);
+    });
+
+    // The client's command. Before the fix this threw RecordNotFoundException at
+    // PatternPredicateExpression.checkRelationshipExists -> edge.getIn().
+    assertThatCode(() -> database.transaction(() ->
+        database.command("opencypher",
+            "MATCH (a:Account {number: $accountNumber}), (t:Transaction {id: $id}) "
+                + "WHERE NOT EXISTS ((a)-[:INITIATED {transaction_id: $id}]->(t)) "
+                + "CREATE (a)-[:INITIATED {transaction_id: $id, channel: $channel}]->(t)",
+            Map.of("accountNumber", "ACC-1", "id", "TX-1", "channel", "web")))
+    ).doesNotThrowAnyException();
+
+    // The predicate skipped the ghost, so NOT EXISTS held and a fresh edge was created.
+    // Deleting only the edge record leaves the original segment pointer in place, so the segment
+    // now holds two entries: the lingering ghost pointer + the newly created real edge. A count of
+    // 2 (rather than 1) confirms CREATE fired - i.e. NOT EXISTS correctly treated the ghost as absent.
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Account {number: 'ACC-1'})-[r:INITIATED]->(t:Transaction {id: 'TX-1'}) RETURN count(r) AS c")) {
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(((Number) rs.next().getProperty("c")).intValue()).isEqualTo(2);
+    }
+  }
+
+  /**
+   * Same hardening for the open-ended form WHERE NOT EXISTS ((a)-[:INITIATED]->()) where the end
+   * node is not bound: checkAnyRelationshipExists must skip a ghost edge rather than throw.
+   */
+  @Test
+  void whereNotExistsSkipsGhostEdgeWithUnboundEnd() {
+    database.transaction(() ->
+        database.command("opencypher",
+            "CREATE (a:Account {number: 'ACC-2'})-[:INITIATED {transaction_id: 'TX-2'}]->(t:Transaction {id: 'TX-2'})"));
+
+    final RID edgeRID;
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Account {number: 'ACC-2'})-[r:INITIATED]->(t:Transaction {id: 'TX-2'}) RETURN r")) {
+      assertThat(rs.hasNext()).isTrue();
+      edgeRID = ((Edge) rs.next().getProperty("r")).getIdentity();
+    }
+    database.transaction(() ->
+        database.getSchema().getBucketById(edgeRID.getBucketId()).deleteRecord(edgeRID));
+
+    assertThatCode(() -> {
+      try (final ResultSet rs = database.query("opencypher",
+          "MATCH (a:Account {number: 'ACC-2'}) WHERE NOT EXISTS ((a)-[:INITIATED]->()) RETURN a")) {
+        // A ghost is the only edge: it is skipped, so the predicate holds and the row survives.
+        assertThat(rs.hasNext()).isTrue();
+      }
+    }).doesNotThrowAnyException();
+  }
+
+  /**
+   * The plain MATCH expand path (ExpandAll / MatchRelationshipStep) must also skip a ghost edge
+   * rather than throw. Returning the relationship (RETURN r) and filtering on an edge property both
+   * force the edge record to be materialized, which is exactly when a ghost pointer used to crash.
+   * The ghost must contribute no row.
+   */
+  @Test
+  void matchExpandSkipsGhostEdge() {
+    database.transaction(() ->
+        database.command("opencypher",
+            "CREATE (a:Account {number: 'ACC-3'})-[:INITIATED {transaction_id: 'TX-3'}]->(t:Transaction {id: 'TX-3'})"));
+
+    final RID edgeRID;
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Account {number: 'ACC-3'})-[r:INITIATED]->(t:Transaction {id: 'TX-3'}) RETURN r")) {
+      assertThat(rs.hasNext()).isTrue();
+      edgeRID = ((Edge) rs.next().getProperty("r")).getIdentity();
+    }
+    database.transaction(() ->
+        database.getSchema().getBucketById(edgeRID.getBucketId()).deleteRecord(edgeRID));
+
+    // Returning the edge forces it to be loaded; the ghost must be skipped, not crash, and yield no row.
+    assertThatCode(() -> {
+      try (final ResultSet rs = database.query("opencypher",
+          "MATCH (a:Account {number: 'ACC-3'})-[r:INITIATED]->(t) RETURN r")) {
+        assertThat(rs.hasNext()).isFalse();
+      }
+    }).doesNotThrowAnyException();
+
+    // Filtering on an edge property also forces a load and must skip the ghost without throwing.
+    assertThatCode(() -> {
+      try (final ResultSet rs = database.query("opencypher",
+          "MATCH (a:Account {number: 'ACC-3'})-[r:INITIATED]->(t) WHERE r.transaction_id = 'TX-3' RETURN t")) {
+        assertThat(rs.hasNext()).isFalse();
+      }
+    }).doesNotThrowAnyException();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/PatternPredicateGhostEdgeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/PatternPredicateGhostEdgeTest.java
@@ -102,14 +102,15 @@ class PatternPredicateGhostEdgeTest {
             Map.of("accountNumber", "ACC-1", "id", "TX-1", "channel", "web")))
     ).doesNotThrowAnyException();
 
-    // The predicate skipped the ghost, so NOT EXISTS held and a fresh edge was created.
-    // Deleting only the edge record leaves the original segment pointer in place, so the segment
-    // now holds two entries: the lingering ghost pointer + the newly created real edge. A count of
-    // 2 (rather than 1) confirms CREATE fired - i.e. NOT EXISTS correctly treated the ghost as absent.
+    // The predicate skipped the ghost, so NOT EXISTS held and a fresh edge (channel='web') was created.
+    // We assert on that created edge specifically rather than the total edge count: deleting the edge
+    // record frees its slot, which CREATE may reuse, so the total is an allocation artifact. That a
+    // genuinely-dangling ghost never surfaces as a result row is proven by matchExpandSkipsGhostEdge.
     try (final ResultSet rs = database.query("opencypher",
-        "MATCH (a:Account {number: 'ACC-1'})-[r:INITIATED]->(t:Transaction {id: 'TX-1'}) RETURN count(r) AS c")) {
+        "MATCH (a:Account {number: 'ACC-1'})-[r:INITIATED]->(t:Transaction {id: 'TX-1'}) "
+            + "WHERE r.channel = 'web' RETURN count(r) AS c")) {
       assertThat(rs.hasNext()).isTrue();
-      assertThat(((Number) rs.next().getProperty("c")).intValue()).isEqualTo(2);
+      assertThat(((Number) rs.next().getProperty("c")).intValue()).isGreaterThanOrEqualTo(1);
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoGhostEdgeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoGhostEdgeTest.java
@@ -130,8 +130,8 @@ class AlgoGhostEdgeTest {
   }
 
   /**
-   * Variable-length MATCH exercises the BFS/DFS path traversers; it must skip the ghost rather than
-   * throw while expanding.
+   * Variable-length MATCH ({@code -[:LINK*1..5]->}) drives the BreadthFirstTraverser /
+   * DepthFirstTraverser path traversers; encountering the ghost edge must be skipped, not throw.
    */
   @Test
   void variableLengthTraversalSkipsGhostEdge() {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoGhostEdgeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoGhostEdgeTest.java
@@ -155,6 +155,12 @@ class AlgoGhostEdgeTest {
     assertProcedureDoesNotThrow("CALL algo.mst('w') YIELD source, target, weight RETURN count(*) AS c");
     assertProcedureDoesNotThrow("CALL algo.longestPath() YIELD node RETURN count(*) AS c");
 
+    // algo.msa (directed minimum spanning arborescence, Chu-Liu/Edmonds) is rooted at A and reaches B only
+    // via A's ghost out-edge: distinct from algo.mst (undirected MST) above, so it needs its own smoke run.
+    assertProcedureDoesNotThrow(
+        "MATCH (a:Node {name:'A'}) "
+            + "CALL algo.msa(a, 'LINK', 'w') YIELD source, target, weight RETURN count(*) AS c");
+
     // Source/target path algorithms whose start node (A) reaches its neighbor only via the ghost edge.
     assertProcedureDoesNotThrow(
         "MATCH (a:Node {name:'A'}), (c:Node {name:'C'}) "

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoGhostEdgeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoGhostEdgeTest.java
@@ -127,4 +127,16 @@ class AlgoGhostEdgeTest {
     assertProcedureDoesNotThrow("CALL algo.louvain() YIELD node, communityId RETURN node, communityId");
     assertProcedureDoesNotThrow("CALL algo.betweenness() YIELD node, score RETURN node, score");
   }
+
+  /**
+   * Variable-length MATCH exercises the BFS/DFS path traversers; it must skip the ghost rather than
+   * throw while expanding.
+   */
+  @Test
+  void variableLengthTraversalSkipsGhostEdge() {
+    buildGraphWithGhostEdge();
+
+    assertProcedureDoesNotThrow(
+        "MATCH p = (a:Node {name:'A'})-[:LINK*1..5]->(c:Node) RETURN p");
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoGhostEdgeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoGhostEdgeTest.java
@@ -24,6 +24,7 @@ import com.arcadedb.database.RID;
 import com.arcadedb.engine.Bucket;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -138,5 +139,49 @@ class AlgoGhostEdgeTest {
 
     assertProcedureDoesNotThrow(
         "MATCH p = (a:Node {name:'A'})-[:LINK*1..5]->(c:Node) RETURN p");
+  }
+
+  /**
+   * Smoke coverage for the remaining hardened algorithms (the ghost-skip pattern is uniform, so one
+   * run per algorithm over the ghosted graph is enough to confirm none propagate the exception).
+   */
+  @Test
+  void remainingAlgorithmsSkipGhostEdge() {
+    buildGraphWithGhostEdge();
+
+    // Whole-graph algorithms iterate every vertex's edges, including A's ghost out-edge.
+    assertProcedureDoesNotThrow("CALL algo.apsp('w') YIELD source, target, distance RETURN count(*) AS c");
+    assertProcedureDoesNotThrow("CALL algo.articlerank() YIELD node, score RETURN count(*) AS c");
+    assertProcedureDoesNotThrow("CALL algo.mst('w') YIELD source, target, weight RETURN count(*) AS c");
+    assertProcedureDoesNotThrow("CALL algo.longestPath() YIELD node RETURN count(*) AS c");
+
+    // Source/target path algorithms whose start node (A) reaches its neighbor only via the ghost edge.
+    assertProcedureDoesNotThrow(
+        "MATCH (a:Node {name:'A'}), (c:Node {name:'C'}) "
+            + "CALL algo.kShortestPaths(a, c, 2, 'LINK', 'w') YIELD weight RETURN count(*) AS c");
+    assertProcedureDoesNotThrow(
+        "MATCH (s:Node {name:'A'}), (t:Node {name:'C'}) "
+            + "CALL algo.maxFlow(s, t, 'LINK', 'w') YIELD maxFlow RETURN maxFlow");
+
+    // SQL graph functions (bellmanFord, duanSSSP) iterate live edges via getEdges() too.
+    final RID a;
+    final RID c;
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Node {name:'A'}), (c:Node {name:'C'}) RETURN a, c")) {
+      final var row = rs.next();
+      a = ((Vertex) row.getProperty("a")).getIdentity();
+      c = ((Vertex) row.getProperty("c")).getIdentity();
+    }
+    assertSqlDoesNotThrow("SELECT bellmanFord(?, ?, 'w') AS p FROM (SELECT 1)", a, c);
+    assertSqlDoesNotThrow("SELECT duanSSSP(?, ?, 'w') AS p FROM (SELECT 1)", a, c);
+  }
+
+  private void assertSqlDoesNotThrow(final String sql, final Object... params) {
+    assertThatCode(() -> {
+      try (final ResultSet rs = database.query("sql", sql, params)) {
+        while (rs.hasNext())
+          rs.next();
+      }
+    }).doesNotThrowAnyException();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoGhostEdgeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoGhostEdgeTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.procedures.algo;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.Bucket;
+import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Regression test: graph-algorithm procedures must tolerate ghost edges (a dangling edge-segment
+ * pointer whose backing edge record is gone, as can occur after a manual HA leader-to-follower
+ * database copy or a rolled-back transaction) by skipping them, rather than throwing
+ * {@code RecordNotFoundException} and crashing the whole query.
+ * <p>
+ * Mirrors the ghost-edge fabrication used by {@code Issue394Test}: delete only the edge record from
+ * its bucket, leaving the segment pointer in place.
+ */
+class AlgoGhostEdgeTest {
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    final DatabaseFactory factory = new DatabaseFactory("./target/databases/algoGhostEdge");
+    if (factory.exists())
+      factory.open().drop();
+    database = factory.create();
+    database.getSchema().createVertexType("Node");
+    database.getSchema().createEdgeType("LINK");
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null && database.isOpen())
+      database.drop();
+  }
+
+  /**
+   * Build A -[LINK]-> B -[LINK]-> C, then ghost the A->B edge. Both allSimplePaths and dijkstra
+   * traverse live edges and must not throw when they encounter the ghost.
+   */
+  @Test
+  void algoProceduresSkipGhostEdge() {
+    database.transaction(() -> {
+      final MutableVertex a = database.newVertex("Node").set("name", "A").save();
+      final MutableVertex b = database.newVertex("Node").set("name", "B").save();
+      final MutableVertex c = database.newVertex("Node").set("name", "C").save();
+      a.newEdge("LINK", b).set("w", 1.0).save();
+      b.newEdge("LINK", c).set("w", 1.0).save();
+    });
+
+    // Ghost the A->B edge: delete its record, leaving the segment pointer dangling.
+    final RID ghostRID;
+    try (final ResultSet rs = database.query("opencypher",
+        "MATCH (a:Node {name:'A'})-[r:LINK]->(b:Node {name:'B'}) RETURN r")) {
+      ghostRID = ((Edge) rs.next().getProperty("r")).getIdentity();
+    }
+    database.transaction(() -> {
+      final Bucket bucket = database.getSchema().getBucketById(ghostRID.getBucketId());
+      bucket.deleteRecord(ghostRID);
+    });
+
+    // allSimplePaths must not throw while expanding across the ghost edge.
+    assertThatCode(() -> {
+      try (final ResultSet rs = database.query("opencypher",
+          "MATCH (a:Node {name:'A'}), (c:Node {name:'C'}) "
+              + "CALL algo.allSimplePaths(a, c, ['LINK'], 10) YIELD path RETURN path")) {
+        while (rs.hasNext())
+          rs.next();
+      }
+    }).doesNotThrowAnyException();
+
+    // dijkstra must not throw either (it iterates live edges to rebuild the path / read weights).
+    assertThatCode(() -> {
+      try (final ResultSet rs = database.query("opencypher",
+          "MATCH (a:Node {name:'A'}), (c:Node {name:'C'}) "
+              + "CALL algo.dijkstra(a, c, 'LINK', 'w') YIELD path, weight RETURN path, weight")) {
+        while (rs.hasNext())
+          rs.next();
+      }
+    }).doesNotThrowAnyException();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoGhostEdgeTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/procedures/algo/AlgoGhostEdgeTest.java
@@ -60,11 +60,10 @@ class AlgoGhostEdgeTest {
   }
 
   /**
-   * Build A -[LINK]-> B -[LINK]-> C, then ghost the A->B edge. Both allSimplePaths and dijkstra
-   * traverse live edges and must not throw when they encounter the ghost.
+   * Builds A -[LINK]-> B -[LINK]-> C and then ghosts the A->B edge (deletes only the edge record,
+   * leaving the segment pointer dangling). Returns after the ghost is in place.
    */
-  @Test
-  void algoProceduresSkipGhostEdge() {
+  private void buildGraphWithGhostEdge() {
     database.transaction(() -> {
       final MutableVertex a = database.newVertex("Node").set("name", "A").save();
       final MutableVertex b = database.newVertex("Node").set("name", "B").save();
@@ -73,7 +72,6 @@ class AlgoGhostEdgeTest {
       b.newEdge("LINK", c).set("w", 1.0).save();
     });
 
-    // Ghost the A->B edge: delete its record, leaving the segment pointer dangling.
     final RID ghostRID;
     try (final ResultSet rs = database.query("opencypher",
         "MATCH (a:Node {name:'A'})-[r:LINK]->(b:Node {name:'B'}) RETURN r")) {
@@ -83,25 +81,50 @@ class AlgoGhostEdgeTest {
       final Bucket bucket = database.getSchema().getBucketById(ghostRID.getBucketId());
       bucket.deleteRecord(ghostRID);
     });
+  }
 
-    // allSimplePaths must not throw while expanding across the ghost edge.
+  private void assertProcedureDoesNotThrow(final String cypher) {
     assertThatCode(() -> {
-      try (final ResultSet rs = database.query("opencypher",
-          "MATCH (a:Node {name:'A'}), (c:Node {name:'C'}) "
-              + "CALL algo.allSimplePaths(a, c, ['LINK'], 10) YIELD path RETURN path")) {
+      try (final ResultSet rs = database.query("opencypher", cypher)) {
         while (rs.hasNext())
           rs.next();
       }
     }).doesNotThrowAnyException();
+  }
 
-    // dijkstra must not throw either (it iterates live edges to rebuild the path / read weights).
-    assertThatCode(() -> {
-      try (final ResultSet rs = database.query("opencypher",
-          "MATCH (a:Node {name:'A'}), (c:Node {name:'C'}) "
-              + "CALL algo.dijkstra(a, c, 'LINK', 'w') YIELD path, weight RETURN path, weight")) {
-        while (rs.hasNext())
-          rs.next();
-      }
-    }).doesNotThrowAnyException();
+  /**
+   * Path-finding procedures that traverse live edges must skip the ghost rather than throw.
+   */
+  @Test
+  void pathFindingProceduresSkipGhostEdge() {
+    buildGraphWithGhostEdge();
+
+    // allSimplePaths expands live edges from A to C.
+    assertProcedureDoesNotThrow(
+        "MATCH (a:Node {name:'A'}), (c:Node {name:'C'}) "
+            + "CALL algo.allSimplePaths(a, c, ['LINK'], 10) YIELD path RETURN path");
+
+    // dijkstra iterates live edges to rebuild the path / read weights.
+    assertProcedureDoesNotThrow(
+        "MATCH (a:Node {name:'A'}), (c:Node {name:'C'}) "
+            + "CALL algo.dijkstra(a, c, 'LINK', 'w') YIELD path, weight RETURN path, weight");
+
+    // path.expand is an APOC-style traversal over live edges (procedures/path/PathExpand).
+    assertProcedureDoesNotThrow(
+        "MATCH (a:Node {name:'A'}) "
+            + "CALL path.expand(a, 'LINK', null, 1, 10) YIELD path RETURN path");
+  }
+
+  /**
+   * Whole-graph analytics with more complex inner loops (PageRank: 2 catch sites, Louvain: 3,
+   * Betweenness: 1) must also tolerate the ghost edge across their projection/relaxation passes.
+   */
+  @Test
+  void analyticsProceduresSkipGhostEdge() {
+    buildGraphWithGhostEdge();
+
+    assertProcedureDoesNotThrow("CALL algo.pagerank() YIELD node, score RETURN node, score");
+    assertProcedureDoesNotThrow("CALL algo.louvain() YIELD node, communityId RETURN node, communityId");
+    assertProcedureDoesNotThrow("CALL algo.betweenness() YIELD node, score RETURN node, score");
   }
 }

--- a/server/src/main/java/com/arcadedb/server/monitor/PoolMetrics.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/PoolMetrics.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.monitor;
 
+import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.index.sparsevector.SparseVectorScoringPool;
 import com.arcadedb.query.QueryEngineManager;
 
@@ -75,6 +76,14 @@ public final class PoolMetrics implements MeterBinder {
         () -> svsp.getPoolStats().queueCapacityRemaining(),
         () -> svsp.getPoolStats().completedTasks(),
         () -> svsp.getPoolStats().callerRunFallbacks());
+
+    // Not a pool, but a graph data-integrity signal surfaced the same way: cumulative ghost (dangling)
+    // edges skipped during traversal. Lets operators spot a corrupted graph from dashboards without
+    // parsing logs; complements the throttled WARNING already emitted by GhostEdgeReporter.
+    Gauge.builder("arcadedb.graph.ghost_edges_skipped", GhostEdgeReporter::getTotalSkipped)
+        .description("Cumulative ghost (dangling) edges skipped during graph traversal since startup. "
+            + "Sustained growth indicates a data-integrity anomaly, e.g. incomplete HA replication or a partially rolled-back transaction.")
+        .register(registry);
   }
 
   private static void bindPool(final MeterRegistry registry, final String poolTag, final String description,

--- a/server/src/main/java/com/arcadedb/server/monitor/PoolMetrics.java
+++ b/server/src/main/java/com/arcadedb/server/monitor/PoolMetrics.java
@@ -22,6 +22,7 @@ import com.arcadedb.graph.GhostEdgeReporter;
 import com.arcadedb.index.sparsevector.SparseVectorScoringPool;
 import com.arcadedb.query.QueryEngineManager;
 
+import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 
@@ -77,10 +78,11 @@ public final class PoolMetrics implements MeterBinder {
         () -> svsp.getPoolStats().completedTasks(),
         () -> svsp.getPoolStats().callerRunFallbacks());
 
-    // Not a pool, but a graph data-integrity signal surfaced the same way: cumulative ghost (dangling)
-    // edges skipped during traversal. Lets operators spot a corrupted graph from dashboards without
-    // parsing logs; complements the throttled WARNING already emitted by GhostEdgeReporter.
-    Gauge.builder("arcadedb.graph.ghost_edges_skipped", GhostEdgeReporter::getTotalSkipped)
+    // Not a pool, but a graph data-integrity signal surfaced the same way. A monotonic FunctionCounter
+    // (not a gauge) so dashboards can compute a rate() and alert on a sudden spike of corruption,
+    // complementing the throttled WARNING already emitted by GhostEdgeReporter.
+    FunctionCounter.builder("arcadedb.graph.ghost_edges_skipped", GhostEdgeReporter.class,
+            c -> GhostEdgeReporter.getTotalSkipped())
         .description("Cumulative ghost (dangling) edges skipped during graph traversal since startup. "
             + "Sustained growth indicates a data-integrity anomaly, e.g. incomplete HA replication or a partially rolled-back transaction.")
         .register(registry);


### PR DESCRIPTION
## What does this PR do?

Hardens OpenCypher queries, graph-algorithm procedures and the shared SQL graph functions against **ghost edges** - dangling edge-segment pointers whose backing edge record no longer exists (left by a rolled-back transaction under load, or an inconsistent manual leader-to-follower DB copy in HA). Dereferencing such an edge (`getIn`/`getOut`/`getInVertex`/`getOutVertex`/`getVertex`) triggers a lazy-load that throws `RecordNotFoundException` and aborts the whole command. Even `getIn()`/`getOut()`, which only return a RID, load the edge record and so throw too.

This is the same class as the MERGE fix in #4636 (`MergeStep`), extended to every remaining edge-traversal path. Each per-edge loop now catches `RecordNotFoundException`, routes it through the new `GhostEdgeReporter` (counter + FINE trace + throttled WARNING + Micrometer `FunctionCounter`), and skips the ghost instead of failing:

- `ast/PatternPredicateExpression` (the `WHERE [NOT] EXISTS` predicate - the reported crash), `ast/PatternComprehensionExpression`
- `executor/operators/ExpandAll`, `GAVExpandAll` (OLTP fallback), `GAVExpandInto`
- `executor/steps/MatchRelationshipStep`, `ShortestPathStep`, `MergeStep`
- `traversal/BreadthFirstTraverser`, `DepthFirstTraverser`
- `procedures/algo/*` (APSP, ArticleRank, BellmanFord, Betweenness, Dijkstra, KShortestPaths, LongestPathDAG, Louvain, MaxFlow, MST, MinSpanningArborescence, PageRank, AllSimplePaths)
- `procedures/path/*` (PathExpand, PathExpandConfig, PathSpanningTree, PathSubgraphAll, PathSubgraphNodes), `procedures/merge/MergeRelationship`
- `function/sql/graph/SQLFunctionAstar` (backs Cypher `algo.dijkstra`), `SQLFunctionBellmanFord`, `SQLFunctionDuanSSSP`, `SQLFunctionShortestPath`, `SQLFunctionMove` (outV/inV/bothV)
- `graph/GraphEngine.buildAdjacencyList` (shared two-pass projection builder behind several algorithms)

Paths that resolve neighbors via `getVertices()` (segment RID, no edge load) are already ghost-safe and unchanged. Recursive traversals (`AlgoAllSimplePaths`, `PathExpand`, `PathExpandConfig`) use `try/finally` so backtracking state unwinds even if the recursion throws; `PathSubgraphAll` resolves the neighbor before bookkeeping so a ghost is never recorded; `SQLFunctionShortestPath` advances the edge iterator before the vertex deref to keep the two iterators in lockstep when a ghost is skipped.

## Motivation

Reported by a client running an HA cluster: a Cypher `WHERE NOT EXISTS ((a)-[:INITIATED {...}]->(t))` failed with `RecordNotFoundException: Record #98:430104 not found` (the missing record is the edge itself, not the target vertex). Defense-in-depth so a dangling edge degrades gracefully instead of crashing the query; the underlying data inconsistency is addressed separately.

## Related issues

- #4657 (this issue)
- #4636 / arcadedb-operations#394 (the MERGE precedent this extends)

## Additional Notes

- `GhostEdgeReporter` centralises observability: a JVM-wide counter, a per-skip FINE log carrying the missing RID, a 60s-throttled WARNING, and the `arcadedb.graph.ghost_edges_skipped` Micrometer `FunctionCounter`.
- Catch variable is `e` throughout except the seven methods where `e` is already the `Edge`/`int` loop variable (compile error otherwise); those use `rnf` with an inline note.
- A per-database tag on the counter was considered but deferred (would require threading DB context through ~50 call sites; the FINE log already carries the RID for attribution).

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [x] My unit tests cover both failure and success scenarios
