### PR TITLE
fix: [#4659] retry transient NeedRetryException in Raft apply instead…

### DIFF
--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -21,8 +21,8 @@ package com.arcadedb.engine;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Binary;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.exception.LockTimeoutException;
 import com.arcadedb.exception.SchemaException;
-import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.exception.TransactionException;
 import com.arcadedb.exception.WALVersionGapException;
 import com.arcadedb.index.vector.LSMVectorIndex;
@@ -672,11 +672,11 @@ public class TransactionManager {
         unlockFilesInOrder(lockedFiles, requester);
 
         if (attemptFileId != null)
-          throw new TimeoutException(
+          throw new LockTimeoutException(
               "Timeout on locking file " + attemptFileId + " (" + database.getFileManager().getFile(attemptFileId).getFileName()
                   + ") during commit (fileIds=" + orderedFilesIds + ", timeout=" + timeout + "ms");
 
-        throw new TimeoutException("Timeout on locking files during commit (fileIds=" + orderedFilesIds + ")");
+        throw new LockTimeoutException("Timeout on locking files during commit (fileIds=" + orderedFilesIds + ")");
       }
     }
 
@@ -709,7 +709,7 @@ public class TransactionManager {
         // ERROR: UNLOCK LOCKED FILES
         unlockFilesInOrder(lockedFiles, requester);
 
-        throw new TimeoutException(
+        throw new LockTimeoutException(
             "Timeout on locking file " + attemptFileId + " (" + database.getFileManager().getFile(attemptFileId).getFileName()
                 + ") during commit (fileIds=" + Arrays.toString(fileIds) + ", timeout=" + timeout + "ms");
       }

--- a/engine/src/main/java/com/arcadedb/exception/LockTimeoutException.java
+++ b/engine/src/main/java/com/arcadedb/exception/LockTimeoutException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.exception;
+
+/**
+ * Thrown when an operation could not acquire a lock within its timeout (e.g. file locks during a
+ * commit, or the per-session HTTP lock). This is a <b>contention</b> timeout, not a deadline/budget
+ * timeout: the work itself never started because another thread held the lock, so the operation is
+ * transient and safe to retry once the contention clears. It therefore extends {@link NeedRetryException}
+ * so the engine's existing retry loops (transaction retry, HTTP 503 retry-after, Raft apply retry)
+ * pick it up automatically.
+ * <p>
+ * Do NOT use this for query/iteration deadline timeouts ({@code TimeoutStep}, {@code MultiIterator},
+ * the SQL {@code TIMEOUT} clause): those mean "this took too long, stop" and must not be retried -
+ * keep using {@link TimeoutException} for them.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class LockTimeoutException extends NeedRetryException {
+  public LockTimeoutException(final String message) {
+    super(message);
+  }
+
+  public LockTimeoutException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/LockTimeoutRetryTest.java
+++ b/engine/src/test/java/com/arcadedb/database/LockTimeoutRetryTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.LockTimeoutException;
+import com.arcadedb.exception.TimeoutException;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for the lock-timeout vs deadline-timeout split. A {@link LockTimeoutException}
+ * (lock contention, e.g. file locks during commit) is a {@code NeedRetryException} and must be
+ * retried by {@code Database.transaction(..., attempts, ...)}. A plain {@link TimeoutException}
+ * (query/iteration deadline) must NOT be retried - it propagates after a single attempt.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class LockTimeoutRetryTest extends TestHelper {
+
+  @Test
+  void lockTimeoutIsRetriedByTransactionLoop() {
+    final int attempts = 3;
+    final AtomicInteger calls = new AtomicInteger();
+    // The retry loop must invoke the block once per attempt and, after exhausting them, rethrow.
+    assertThatThrownBy(() -> database.transaction(() -> {
+      calls.incrementAndGet();
+      throw new LockTimeoutException("Timeout on locking files during commit");
+    }, false, attempts)).isInstanceOf(LockTimeoutException.class);
+    assertThat(calls.get()).isEqualTo(attempts);
+  }
+
+  @Test
+  void deadlineTimeoutIsNotRetried() {
+    final AtomicInteger calls = new AtomicInteger();
+    // A deadline TimeoutException is not a NeedRetryException, so it must escape after one attempt
+    // even when several retries are configured.
+    assertThatThrownBy(() -> database.transaction(() -> {
+      calls.incrementAndGet();
+      throw new TimeoutException("Timeout expired");
+    }, false, 3)).isInstanceOf(TimeoutException.class);
+    assertThat(calls.get()).isEqualTo(1);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/exception/ExceptionTest.java
+++ b/engine/src/test/java/com/arcadedb/exception/ExceptionTest.java
@@ -201,6 +201,26 @@ class ExceptionTest {
   }
 
   @Test
+  void lockTimeoutExceptionIsRetryable() {
+    // A lock-contention timeout is transient and safe to retry, so it MUST be a NeedRetryException
+    // for the engine's retry loops (transaction retry, HTTP 503, Raft apply) to pick it up.
+    final LockTimeoutException ex = new LockTimeoutException("Timeout on locking files during commit");
+    assertThat(ex.getMessage()).isEqualTo("Timeout on locking files during commit");
+    assertThat(ex).isInstanceOf(NeedRetryException.class);
+
+    final RuntimeException cause = new RuntimeException("contended");
+    assertThat(new LockTimeoutException("msg", cause).getCause()).isSameAs(cause);
+  }
+
+  @Test
+  void plainTimeoutExceptionIsNotRetryable() {
+    // Guards the design split: a query/deadline TimeoutException (SQL TIMEOUT clause, MultiIterator)
+    // means "took too long, stop" and must NEVER be retried, so it must stay off the NeedRetryException
+    // hierarchy. This test fails loudly if someone reparents TimeoutException by mistake.
+    assertThat(new TimeoutException("Timeout expired")).isNotInstanceOf(NeedRetryException.class);
+  }
+
+  @Test
   void encryptionException() {
     final EncryptionException ex = new EncryptionException("Encryption failed");
     assertThat(ex.getMessage()).isEqualTo("Encryption failed");

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -364,6 +364,11 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * {@link ReplicationException}, which {@link #applyTransaction} turns into a snapshot resync.
    * Crucially, a retryable error never reaches the fatal {@code catch (Throwable)} branch that stops
    * the server - "retry" must never mean "crash the node".
+   * <p>
+   * Note on backoff: {@link GlobalConfiguration#TX_RETRY_DELAY} defaults to 100ms and was tuned for
+   * MVCC contention among many concurrent user-transaction threads. The Raft {@code StateMachineUpdater}
+   * is a single sequential thread, so a smaller (or zero) delay is perfectly safe on this path and only
+   * reduces the worst-case latency per entry; the value is read live so it can be tuned independently.
    *
    * @param index       the Raft log index being applied (diagnostics only)
    * @param applyAction the apply dispatch to run
@@ -371,9 +376,9 @@ public class ArcadeStateMachine extends BaseStateMachine {
    */
   // @VisibleForTesting
   void applyWithRetry(final long index, final Runnable applyAction) {
-    final int maxRetries = server != null
+    final int maxRetries = Math.max(0, server != null
         ? server.getConfiguration().getValueAsInteger(GlobalConfiguration.TX_RETRIES)
-        : GlobalConfiguration.TX_RETRIES.getValueAsInteger();
+        : GlobalConfiguration.TX_RETRIES.getValueAsInteger());
     final int retryDelay = server != null
         ? server.getConfiguration().getValueAsInteger(GlobalConfiguration.TX_RETRY_DELAY)
         : GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger();
@@ -393,6 +398,9 @@ public class ArcadeStateMachine extends BaseStateMachine {
             Thread.sleep(1 + ThreadLocalRandom.current().nextInt(retryDelay));
           } catch (final InterruptedException ie) {
             Thread.currentThread().interrupt();
+            LogManager.instance().log(this, Level.WARNING,
+                "Raft apply retry interrupted at index %d after %d attempt(s); aborting retry loop (likely shutdown)",
+                index, attempt + 1);
             break;
           }
         }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -388,6 +388,11 @@ public class ArcadeStateMachine extends BaseStateMachine {
       try {
         applyAction.run();
         return;
+        // Catch the whole NeedRetryException hierarchy on purpose: on the follower apply path the only
+        // subclass actually reachable is the engine's MVCC ConcurrentModificationException (page-version
+        // race), which a retry can win. The network subclasses (ServerIsNotTheLeader, QuorumNotReached,
+        // ReplicationQueueFull) are leader/client-side and never thrown while applying WAL pages locally,
+        // so the broad type costs nothing here and stays forward-compatible with future retryable errors.
       } catch (final NeedRetryException e) {
         lastRetry = e;
         LogManager.instance().log(this, Level.WARNING,

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -25,6 +25,7 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.LocalDatabase;
 import com.arcadedb.engine.ComponentFile;
 import com.arcadedb.engine.WALFile;
+import com.arcadedb.exception.NeedRetryException;
 import com.arcadedb.exception.WALVersionGapException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.LocalSchema;
@@ -65,6 +66,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -285,14 +287,16 @@ public class ArcadeStateMachine extends BaseStateMachine {
 
       final boolean originatedLocally = Boolean.TRUE.equals(trx.getStateMachineContext());
 
-      switch (decoded.type()) {
-      case TX_ENTRY -> applyTxEntry(decoded, index, originatedLocally);
-      case SCHEMA_ENTRY -> applySchemaEntry(decoded, index, originatedLocally);
-      case INSTALL_DATABASE_ENTRY -> applyInstallDatabaseEntry(decoded);
-      case DROP_DATABASE_ENTRY -> applyDropDatabaseEntry(decoded);
-      case SECURITY_USERS_ENTRY -> applySecurityUsersEntry(decoded);
-      case BOOTSTRAP_FINGERPRINT_ENTRY -> applyBootstrapFingerprintEntry(decoded, index);
-      }
+      applyWithRetry(index, () -> {
+        switch (decoded.type()) {
+        case TX_ENTRY -> applyTxEntry(decoded, index, originatedLocally);
+        case SCHEMA_ENTRY -> applySchemaEntry(decoded, index, originatedLocally);
+        case INSTALL_DATABASE_ENTRY -> applyInstallDatabaseEntry(decoded);
+        case DROP_DATABASE_ENTRY -> applyDropDatabaseEntry(decoded);
+        case SECURITY_USERS_ENTRY -> applySecurityUsersEntry(decoded);
+        case BOOTSTRAP_FINGERPRINT_ENTRY -> applyBootstrapFingerprintEntry(decoded, index);
+        }
+      });
 
       final long previousApplied = lastAppliedIndex.getAndSet(index);
       updateLastAppliedTermIndex(termIndex.getTerm(), index);
@@ -348,6 +352,58 @@ public class ArcadeStateMachine extends BaseStateMachine {
       stopThread.start();
       return CompletableFuture.failedFuture(e instanceof Exception ex ? ex : new RuntimeException(e));
     }
+  }
+
+  /**
+   * Runs the apply dispatch with bounded in-place retry for transient/retryable conditions.
+   * <p>
+   * A {@link NeedRetryException} (e.g. an MVCC {@link com.arcadedb.exception.ConcurrentModificationException}
+   * from a page-version race) is NOT state divergence: the apply is deterministic and idempotent
+   * (page-version / file-existence guards), so a retry can win the race. We retry up to
+   * {@link GlobalConfiguration#TX_RETRIES} times; only if the condition persists do we escalate to a
+   * {@link ReplicationException}, which {@link #applyTransaction} turns into a snapshot resync.
+   * Crucially, a retryable error never reaches the fatal {@code catch (Throwable)} branch that stops
+   * the server - "retry" must never mean "crash the node".
+   *
+   * @param index       the Raft log index being applied (diagnostics only)
+   * @param applyAction the apply dispatch to run
+   * @throws ReplicationException if the retryable condition persists after all attempts
+   */
+  // @VisibleForTesting
+  void applyWithRetry(final long index, final Runnable applyAction) {
+    final int maxRetries = server != null
+        ? server.getConfiguration().getValueAsInteger(GlobalConfiguration.TX_RETRIES)
+        : GlobalConfiguration.TX_RETRIES.getValueAsInteger();
+    final int retryDelay = server != null
+        ? server.getConfiguration().getValueAsInteger(GlobalConfiguration.TX_RETRY_DELAY)
+        : GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger();
+
+    NeedRetryException lastRetry = null;
+    for (int attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        applyAction.run();
+        return;
+      } catch (final NeedRetryException e) {
+        lastRetry = e;
+        LogManager.instance().log(this, Level.WARNING,
+            "Retryable error applying Raft log entry at index %d (attempt %d/%d): %s",
+            index, attempt + 1, maxRetries + 1, e.getMessage());
+        if (attempt < maxRetries && retryDelay > 0) {
+          try {
+            Thread.sleep(1 + ThreadLocalRandom.current().nextInt(retryDelay));
+          } catch (final InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            break;
+          }
+        }
+      }
+    }
+
+    // The retryable condition persisted across all attempts. Escalate to a resync (recoverable) -
+    // never fall through to the fatal catch (Throwable) branch that stops the server.
+    throw new ReplicationException(
+        "Retryable error persisted at index " + index + " after " + (maxRetries + 1)
+            + " attempts; escalating to snapshot resync", lastRetry);
   }
 
   /**

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineApplyRetryTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineApplyRetryTest.java
@@ -118,6 +118,22 @@ class ArcadeStateMachineApplyRetryTest {
   }
 
   @Test
+  void zeroRetriesMakesSingleAttemptThenEscalates() {
+    GlobalConfiguration.TX_RETRIES.setValue(0); // boundary: exactly one attempt, no retry
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    final AtomicInteger calls = new AtomicInteger();
+    final ConcurrentModificationException cme = new ConcurrentModificationException("page race");
+    // With maxRetries == 0 a retryable error must escalate immediately after the first attempt.
+    assertThatThrownBy(() -> sm.applyWithRetry(6L, () -> {
+      calls.incrementAndGet();
+      throw cme;
+    }))
+        .isInstanceOf(ReplicationException.class)
+        .hasCause(cme);
+    assertThat(calls.get()).isEqualTo(1);
+  }
+
+  @Test
   void doesNotRetryNonRetryableError() {
     final ArcadeStateMachine sm = new ArcadeStateMachine();
     final AtomicInteger calls = new AtomicInteger();

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineApplyRetryTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineApplyRetryTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.exception.ConcurrentModificationException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for the Raft apply path's exception handling: a retryable {@code NeedRetryException}
+ * (e.g. an MVCC {@code ConcurrentModificationException} from a page-version race) must be retried in
+ * place and, if it persists, escalated to a snapshot resync ({@code ReplicationException}) - it must
+ * NEVER reach the fatal {@code catch (Throwable)} branch in {@code applyTransaction} that stops the
+ * node. A genuine (non-retryable) error must still propagate unchanged so that fatal path still fires.
+ */
+class ArcadeStateMachineApplyRetryTest {
+  private int prevRetries;
+  private int prevDelay;
+
+  @BeforeEach
+  void setUp() {
+    prevRetries = GlobalConfiguration.TX_RETRIES.getValueAsInteger();
+    prevDelay = GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger();
+    GlobalConfiguration.TX_RETRIES.setValue(2);     // -> 3 attempts total (maxRetries + 1)
+    GlobalConfiguration.TX_RETRY_DELAY.setValue(0);  // no backoff sleep: deterministic and fast
+  }
+
+  @AfterEach
+  void tearDown() {
+    GlobalConfiguration.TX_RETRIES.setValue(prevRetries);
+    GlobalConfiguration.TX_RETRY_DELAY.setValue(prevDelay);
+  }
+
+  @Test
+  void succeedsOnFirstAttempt() {
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    final AtomicInteger calls = new AtomicInteger();
+    assertThatNoException().isThrownBy(() -> sm.applyWithRetry(1L, calls::incrementAndGet));
+    assertThat(calls.get()).isEqualTo(1);
+  }
+
+  @Test
+  void retriesTransientErrorThenSucceeds() {
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    final AtomicInteger calls = new AtomicInteger();
+    // Retryable on the first two attempts, succeeds on the third.
+    assertThatNoException().isThrownBy(() -> sm.applyWithRetry(2L, () -> {
+      if (calls.incrementAndGet() < 3)
+        throw new ConcurrentModificationException("page version race - please retry");
+    }));
+    assertThat(calls.get()).isEqualTo(3);
+  }
+
+  @Test
+  void escalatesToResyncWhenRetryablePersists() {
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    final AtomicInteger calls = new AtomicInteger();
+    final ConcurrentModificationException cme = new ConcurrentModificationException("persistent page race");
+    // Always retryable: after exhausting attempts it must escalate to ReplicationException (resync),
+    // not crash, and the original retryable cause must be preserved for diagnostics.
+    assertThatThrownBy(() -> sm.applyWithRetry(3L, () -> {
+      calls.incrementAndGet();
+      throw cme;
+    }))
+        .isInstanceOf(ReplicationException.class)
+        .hasCause(cme);
+    assertThat(calls.get()).isEqualTo(3); // TX_RETRIES (2) + 1
+  }
+
+  @Test
+  void doesNotRetryNonRetryableError() {
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    final AtomicInteger calls = new AtomicInteger();
+    final IllegalStateException boom = new IllegalStateException("genuine bug - must not be retried");
+    // A non-NeedRetryException must propagate immediately and unchanged, so applyTransaction's fatal
+    // catch (Throwable) handler still fires for real bugs (state divergence protection).
+    assertThatThrownBy(() -> sm.applyWithRetry(4L, () -> {
+      calls.incrementAndGet();
+      throw boom;
+    })).isSameAs(boom);
+    assertThat(calls.get()).isEqualTo(1);
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineApplyRetryTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineApplyRetryTest.java
@@ -88,7 +88,33 @@ class ArcadeStateMachineApplyRetryTest {
     }))
         .isInstanceOf(ReplicationException.class)
         .hasCause(cme);
-    assertThat(calls.get()).isEqualTo(3); // TX_RETRIES (2) + 1
+    // attempts == maxRetries + 1, computed from config so it can't rot if setUp() changes.
+    assertThat(calls.get()).isEqualTo(GlobalConfiguration.TX_RETRIES.getValueAsInteger() + 1);
+  }
+
+  @Test
+  void interruptDuringBackoffPreservesFlagAndEscalates() {
+    GlobalConfiguration.TX_RETRY_DELAY.setValue(50); // positive delay so the backoff sleep is reached
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    final AtomicInteger calls = new AtomicInteger();
+    final ConcurrentModificationException cme = new ConcurrentModificationException("page race");
+    // Pre-set the interrupt flag so Thread.sleep() throws InterruptedException on the first backoff.
+    Thread.currentThread().interrupt();
+    try {
+      // The retry loop must break out, preserve the interrupt flag, and escalate to a ReplicationException
+      // rather than letting the InterruptedException propagate unchecked.
+      assertThatThrownBy(() -> sm.applyWithRetry(5L, () -> {
+        calls.incrementAndGet();
+        throw cme;
+      }))
+          .isInstanceOf(ReplicationException.class)
+          .hasCause(cme);
+      assertThat(calls.get()).isEqualTo(1); // interrupted during the first backoff: no further attempts
+      // Thread.interrupted() both asserts the flag survived and clears it so it can't leak to other tests.
+      assertThat(Thread.interrupted()).isTrue();
+    } finally {
+      Thread.interrupted(); // defensive: ensure the flag is cleared even if an assertion failed
+    }
   }
 
   @Test

--- a/server/src/main/java/com/arcadedb/server/http/HttpSession.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpSession.java
@@ -19,6 +19,7 @@
 package com.arcadedb.server.http;
 
 import com.arcadedb.database.TransactionContext;
+import com.arcadedb.exception.LockTimeoutException;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.query.QuerySession;
 import com.arcadedb.server.security.ServerSecurityUser;
@@ -28,7 +29,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 
@@ -116,7 +116,7 @@ public class HttpSession implements QuerySession {
         lock.unlock();
       }
     } else {
-      throw new TimeoutException("Timeout on locking http session");
+      throw new LockTimeoutException("Timeout on locking http session");
     }
 
     lastUpdate = System.currentTimeMillis();


### PR DESCRIPTION
… of crashing the node

ArcadeStateMachine.applyTransaction classified every unexpected Throwable as fatal state divergence and ran an emergency server.stop(). The catch chain only recognized ReplicationException (-> resync) and IllegalArgumentException (-> skip), so any NeedRetryException fell into catch (Throwable) and KILLED the node - even though "retry" is the opposite of "diverged".

This is concretely reachable on the follower apply path: PageManager .checkPageVersion throws ConcurrentModificationException (a NeedRetryException) on a page-version race, and TransactionManager.applyChanges only wraps IOException/ClosedByInterruptException, so the CME propagates un-wrapped to the fatal branch. One node self-terminating then cascades into cluster-wide leadership churn.

Apply is deterministic and idempotent (page-version / file-existence guards), so the dispatch is now wrapped in a bounded in-place retry (applyWithRetry, count = arcadedb.txRetries, default 3, backoff = arcadedb.txRetryDelay). On retry exhaustion it escalates to a ReplicationException (snapshot resync), never the fatal crash path. Genuine non-retryable errors (NPE, corruption, etc.) still propagate to catch (Throwable) and halt as before.

Test: ArcadeStateMachineApplyRetryTest - first-attempt success, retry-then- succeed, escalate-to-resync-on-persistent-retryable (cause preserved, no crash), and non-retryable-propagates-immediately (no retry).

Related to the HA incident in #4657 (the ghost-edge crash was one trigger; this is the separate reason a single error took the whole cluster down).

## What does this PR do?

A brief description of the change being made with this pull request.

## Motivation

What inspired you to submit this pull request?

## Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

## Additional Notes

Anything else we should know when reviewing?

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
