### PR TITLE
fix: [#4656] gRPC InsertStream CONFLICT_UPDATE upsert - merge non-key…

### DIFF
--- a/grpc/src/main/proto/arcadedb-server.proto
+++ b/grpc/src/main/proto/arcadedb-server.proto
@@ -385,6 +385,10 @@ message InsertOptions {
 
   ConflictMode conflict_mode = 3;
 
+  // Columns to overwrite when CONFLICT_UPDATE matches an existing row. Empty = merge all non-key
+  // columns present on the incoming record. A column absent from the incoming record is skipped
+  // (left unchanged), so a property cannot be set to null through this path. For edge targets the
+  // out/in endpoints are always ignored here (endpoints cannot be re-pointed by an upsert).
   repeated string update_columns_on_conflict = 4;
 
   enum TransactionMode {

--- a/grpc/src/main/proto/arcadedb-server.proto
+++ b/grpc/src/main/proto/arcadedb-server.proto
@@ -386,9 +386,10 @@ message InsertOptions {
   ConflictMode conflict_mode = 3;
 
   // Columns to overwrite when CONFLICT_UPDATE matches an existing row. Empty = merge all non-key
-  // columns present on the incoming record. A column absent from the incoming record is skipped
-  // (left unchanged), so a property cannot be set to null through this path. For edge targets the
-  // out/in endpoints are always ignored here (endpoints cannot be re-pointed by an upsert).
+  // columns present on the incoming record. A column whose incoming value is absent or a proto
+  // NullValue is skipped (left unchanged, not rejected), so a property cannot be set to null through
+  // this path. For edge targets the out/in endpoints are always ignored here (endpoints cannot be
+  // re-pointed by an upsert).
   repeated string update_columns_on_conflict = 4;
 
   enum TransactionMode {

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -2228,87 +2228,72 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     };
   }
 
-  private boolean tryUpsertVertex(final InsertContext ctx, final MutableVertex incoming) {
+  /**
+   * Issue #4656: resolves which columns to write when a {@code CONFLICT_UPDATE} matches an existing
+   * row. When the client supplied an explicit {@code update_columns_on_conflict} list it is honored
+   * verbatim. When that list is empty, every non-key property present on the incoming record is
+   * merged (true upsert/merge), matching SQL {@code UPDATE ... UPSERT} semantics, instead of
+   * silently leaving the row unchanged while still reporting it as {@code updated}. System fields
+   * ({@code @}-prefixed) and, for edges, the {@code out}/{@code in} endpoints are never merged.
+   */
+  private List<String> conflictUpdateColumns(final InsertContext ctx, final Iterable<String> incomingProps,
+      final boolean isEdge) {
+    if (!ctx.updateCols.isEmpty())
+      return ctx.updateCols;
 
-    var keys = ctx.keyCols;
+    final List<String> cols = new ArrayList<>();
+    for (final String name : incomingProps) {
+      if (name.startsWith("@") || ctx.keyCols.contains(name))
+        continue;
+      if (isEdge && ("out".equals(name) || "in".equals(name)))
+        continue;
+      cols.add(name);
+    }
+    return cols;
+  }
 
+  private Object recordValue(final GrpcRecord r, final String col) {
+    final GrpcValue v = r.getPropertiesMap().get(col);
+    return v == null ? null : fromGrpcValue(v);
+  }
+
+  /**
+   * Issue #4656: matches an existing record by the configured key columns and, when found, merges
+   * the incoming values onto it. Works uniformly for documents, vertices and edges (the latter two
+   * are {@link MutableDocument} subclasses for query/update purposes). Returns {@code true} when an
+   * existing row was updated, {@code false} when no match was found (the caller then inserts).
+   */
+  private boolean tryUpsertByRecord(final InsertContext ctx, final GrpcRecord r, final boolean isEdge) {
+    final List<String> keys = ctx.keyCols;
     if (keys.isEmpty())
       return false;
 
-    // Read incoming values via the (read-only) document view
-    var inDoc = incoming.asDocument();
+    final String where = String.join(" AND ", keys.stream().map(k -> k + " = ?").toList());
+    final Object[] params = keys.stream().map(k -> recordValue(r, k)).toArray();
 
-    String where = String.join(" AND ", keys.stream().map(k -> k + " = ?").toList());
-    Object[] params = keys.stream().map(inDoc::get).toArray();
-
-    // Prefer selecting the element so we can get a mutable vertex directly
-    final String sql = "SELECT FROM " + ctx.opts.getTargetClass() + " WHERE " + where;
-
-    try (var rs = ctx.db.query("sql", sql, params)) {
+    try (final ResultSet rs = ctx.db.query("sql", "SELECT FROM " + ctx.opts.getTargetClass() + " WHERE " + where, params)) {
       if (!rs.hasNext())
         return false;
 
-      var res = rs.next();
+      final Result res = rs.next();
       if (!res.isElement())
         return false;
 
-      Vertex v = res.getElement().get().asVertex();
+      final MutableDocument existing = res.getElement().get().asDocument().modify();
 
-      MutableVertex existingV = v.modify();
-
-      // Apply the updates
-
-      for (String col : ctx.updateCols) {
-        existingV.set(col, inDoc.get(col));
-      }
-
-      existingV.save();
-
-      return true;
-    }
-  }
-
-  private boolean tryUpsertDocument(InsertContext ctx, MutableDocument incoming) {
-
-    var keys = ctx.keyCols;
-
-    if (keys.isEmpty())
-      return false;
-
-    String where = String.join(" AND ", keys.stream().map(k -> k + " = ?").toList());
-    Object[] params = keys.stream().map(incoming::get).toArray();
-
-    try (ResultSet rs = ctx.db.query("sql", "SELECT FROM " + ctx.opts.getTargetClass() + " WHERE " + where, params)) {
-
-      if (!rs.hasNext()) {
-        return false;
-      }
-
-      var res = rs.next();
-      if (!res.isElement())
-        return false;
-
-      Document d = res.getElement().get().asDocument();
-
-      var existing = d.modify();
-
-      // Apply the updates
-
-      for (String col : ctx.updateCols) {
-        existing.set(col, incoming.get(col));
-      }
+      for (final String col : conflictUpdateColumns(ctx, r.getPropertiesMap().keySet(), isEdge))
+        existing.set(col, recordValue(r, col));
 
       existing.save();
-
       return true;
     }
   }
 
-  private boolean keyExists(final InsertContext ctx, final MutableDocument incoming) {
+  private boolean keyExistsByRecord(final InsertContext ctx, final GrpcRecord r) {
     if (ctx.keyCols.isEmpty())
       return false;
     final String where = String.join(" AND ", ctx.keyCols.stream().map(k -> k + " = ?").toList());
-    final Object[] params = ctx.keyCols.stream().map(incoming::get).toArray();
+    final Object[] params = ctx.keyCols.stream().map(k -> recordValue(r, k)).toArray();
     try (final ResultSet rs = ctx.db.query("sql", "SELECT FROM " + ctx.opts.getTargetClass() + " WHERE " + where, params)) {
       return rs.hasNext();
     }
@@ -2359,45 +2344,55 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         if (ctx.opts.getValidateOnly())
           continue;
 
+        final ConflictMode mode = ctx.opts.getConflictMode();
+
         if (isVertex) {
-          MutableVertex v = ctx.db.newVertex(ctx.opts.getTargetClass());
-          applyGrpcRecord(v, r);
-          if (ctx.opts.getConflictMode() == ConflictMode.CONFLICT_UPDATE && tryUpsertVertex(ctx, v)) {
+          if (mode == ConflictMode.CONFLICT_UPDATE && tryUpsertByRecord(ctx, r, false)) {
             c.updated++;
-          } else if (ctx.opts.getConflictMode() == ConflictMode.CONFLICT_IGNORE && keyExists(ctx, v)) {
+          } else if (mode == ConflictMode.CONFLICT_IGNORE && keyExistsByRecord(ctx, r)) {
             c.ignored++;
           } else {
+            final MutableVertex v = ctx.db.newVertex(ctx.opts.getTargetClass());
+            applyGrpcRecord(v, r);
             v.save();
             c.inserted++;
           }
         } else if (isEdge) {
-
-          String outRid = getStringProp(r, "out"); // lookup helper you already have
-          String inRid = getStringProp(r, "in");
-
-          if (outRid == null || inRid == null) {
-
-            c.failed++;
-
-            c.errors.add(InsertError.newBuilder().setRowIndex(ctx.received - 1).setCode("MISSING_ENDPOINTS")
-                .setMessage("Edge requires 'out' and 'in'").build());
-          } else {
-            var outV = ctx.db.lookupByRID(new RID(outRid), false).asVertex(false);
-
-            // Create edge from the OUT vertex. The `in` RID is stored in the edge record; use DatabaseRID so edge.getIn() resolves across threads.
-            MutableEdge e = outV.newEdge(ctx.opts.getTargetClass(), ctx.db.newRID(inRid));
-            applyGrpcRecord(e, r); // sets edge properties
-            e.save();
-            c.inserted++;
-          }
-        } else {
-          MutableDocument d = ctx.db.newDocument(ctx.opts.getTargetClass());
-          applyGrpcRecord(d, r);
-          if (ctx.opts.getConflictMode() == ConflictMode.CONFLICT_UPDATE && tryUpsertDocument(ctx, d)) {
+          // Issue #4656 (3): edges must honor conflict_mode / key_columns like documents and
+          // vertices. newEdge() persists and links the edge immediately, so the upsert/ignore check
+          // has to run before the edge is created, otherwise a match would leave a dangling edge.
+          if (mode == ConflictMode.CONFLICT_UPDATE && tryUpsertByRecord(ctx, r, true)) {
             c.updated++;
-          } else if (ctx.opts.getConflictMode() == ConflictMode.CONFLICT_IGNORE && keyExists(ctx, d)) {
+          } else if (mode == ConflictMode.CONFLICT_IGNORE && keyExistsByRecord(ctx, r)) {
             c.ignored++;
           } else {
+            final String outRid = getStringProp(r, "out"); // lookup helper you already have
+            final String inRid = getStringProp(r, "in");
+
+            if (outRid == null || inRid == null) {
+
+              c.failed++;
+
+              c.errors.add(InsertError.newBuilder().setRowIndex(ctx.received - 1).setCode("MISSING_ENDPOINTS")
+                  .setMessage("Edge requires 'out' and 'in'").build());
+            } else {
+              final var outV = ctx.db.lookupByRID(new RID(outRid), false).asVertex(false);
+
+              // Create edge from the OUT vertex. The `in` RID is stored in the edge record; use DatabaseRID so edge.getIn() resolves across threads.
+              final MutableEdge e = outV.newEdge(ctx.opts.getTargetClass(), ctx.db.newRID(inRid));
+              applyGrpcRecord(e, r); // sets edge properties
+              e.save();
+              c.inserted++;
+            }
+          }
+        } else {
+          if (mode == ConflictMode.CONFLICT_UPDATE && tryUpsertByRecord(ctx, r, false)) {
+            c.updated++;
+          } else if (mode == ConflictMode.CONFLICT_IGNORE && keyExistsByRecord(ctx, r)) {
+            c.ignored++;
+          } else {
+            final MutableDocument d = ctx.db.newDocument(ctx.opts.getTargetClass());
+            applyGrpcRecord(d, r);
             d.save();
             c.inserted++;
           }
@@ -2407,7 +2402,15 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         switch (ctx.opts.getConflictMode()) {
           case CONFLICT_IGNORE -> c.ignored++;
           case CONFLICT_ABORT, UNRECOGNIZED -> c.err(ctx.received - 1, "CONFLICT", dup.getMessage(), "");
-          case CONFLICT_UPDATE -> c.err(ctx.received - 1, "CONFLICT", dup.getMessage(), "");
+          // Issue #4656 (1): a concurrent stream may have inserted the same key between our existence
+          // check and save(). The unique index now guarantees the row exists, so retry the match path
+          // as an update rather than losing the row to a CONFLICT error.
+          case CONFLICT_UPDATE -> {
+            if (tryUpsertByRecord(ctx, r, isEdge))
+              c.updated++;
+            else
+              c.err(ctx.received - 1, "CONFLICT", dup.getMessage(), "");
+          }
           case CONFLICT_ERROR -> c.err(ctx.received - 1, "CONFLICT", dup.getMessage(), "");
         }
       } catch (Exception e) {

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -2228,14 +2228,12 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     };
   }
 
-  /**
-   * Issue #4656: resolves which columns to write when a {@code CONFLICT_UPDATE} matches an existing
-   * row. When the client supplied an explicit {@code update_columns_on_conflict} list it is honored
-   * verbatim. When that list is empty, every non-key property present on the incoming record is
-   * merged (true upsert/merge), matching SQL {@code UPDATE ... UPSERT} semantics, instead of
-   * silently leaving the row unchanged while still reporting it as {@code updated}. System fields
-   * ({@code @}-prefixed) and, for edges, the {@code out}/{@code in} endpoints are never merged.
-   */
+  // Resolves which columns to write when a CONFLICT_UPDATE matches an existing row. When the client
+  // supplied an explicit update_columns_on_conflict list it is honored verbatim. When that list is
+  // empty, every non-key property present on the incoming record is merged (true upsert/merge),
+  // matching SQL UPDATE ... UPSERT semantics, instead of silently leaving the row unchanged while
+  // still reporting it as updated. System fields (@-prefixed) and, for edges, the out/in endpoints
+  // are never merged.
   private List<String> conflictUpdateColumns(final InsertContext ctx, final Iterable<String> incomingProps,
       final boolean isEdge) {
     if (!ctx.updateCols.isEmpty())
@@ -2257,12 +2255,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     return v == null ? null : fromGrpcValue(v);
   }
 
-  /**
-   * Issue #4656: matches an existing record by the configured key columns and, when found, merges
-   * the incoming values onto it. Works uniformly for documents, vertices and edges (the latter two
-   * are {@link MutableDocument} subclasses for query/update purposes). Returns {@code true} when an
-   * existing row was updated, {@code false} when no match was found (the caller then inserts).
-   */
+  // Matches an existing record by the configured key columns and, when found, merges the incoming
+  // values onto it. Works uniformly for documents, vertices and edges (the latter two are
+  // MutableDocument subclasses for query/update purposes). Returns true when an existing row was
+  // updated, false when no match was found (the caller then inserts).
   private boolean tryUpsertByRecord(final InsertContext ctx, final GrpcRecord r, final boolean isEdge) {
     final List<String> keys = ctx.keyCols;
     if (keys.isEmpty())
@@ -2358,15 +2354,15 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
             c.inserted++;
           }
         } else if (isEdge) {
-          // Issue #4656 (3): edges must honor conflict_mode / key_columns like documents and
-          // vertices. newEdge() persists and links the edge immediately, so the upsert/ignore check
-          // has to run before the edge is created, otherwise a match would leave a dangling edge.
+          // Edges must honor conflict_mode / key_columns like documents and vertices. newEdge()
+          // persists and links the edge immediately, so the upsert/ignore check has to run before the
+          // edge is created, otherwise a match would leave a dangling edge.
           if (mode == ConflictMode.CONFLICT_UPDATE && tryUpsertByRecord(ctx, r, true)) {
             c.updated++;
           } else if (mode == ConflictMode.CONFLICT_IGNORE && keyExistsByRecord(ctx, r)) {
             c.ignored++;
           } else {
-            final String outRid = getStringProp(r, "out"); // lookup helper you already have
+            final String outRid = getStringProp(r, "out");
             final String inRid = getStringProp(r, "in");
 
             if (outRid == null || inRid == null) {
@@ -2402,9 +2398,9 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         switch (ctx.opts.getConflictMode()) {
           case CONFLICT_IGNORE -> c.ignored++;
           case CONFLICT_ABORT, UNRECOGNIZED -> c.err(ctx.received - 1, "CONFLICT", dup.getMessage(), "");
-          // Issue #4656 (1): a concurrent stream may have inserted the same key between our existence
-          // check and save(). The unique index now guarantees the row exists, so retry the match path
-          // as an update rather than losing the row to a CONFLICT error.
+          // A concurrent stream may have inserted the same key between our existence check and save().
+          // The unique index now guarantees the row exists, so retry the match path as an update
+          // rather than losing the row to a CONFLICT error.
           case CONFLICT_UPDATE -> {
             if (tryUpsertByRecord(ctx, r, isEdge))
               c.updated++;

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -2229,31 +2229,35 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     };
   }
 
-  // An empty update list means "merge every non-key property" (true upsert), not a silent no-op.
-  private List<String> conflictUpdateColumns(final InsertContext ctx, final Iterable<String> incomingProps,
-      final boolean excludeEdgeEndpoints) {
-    if (!ctx.updateCols.isEmpty())
-      return ctx.updateCols;
-
-    final List<String> cols = new ArrayList<>();
-    for (final String name : incomingProps) {
-      if (name.startsWith("@") || ctx.keyColsSet.contains(name))
-        continue;
-      if (excludeEdgeEndpoints && ("out".equals(name) || "in".equals(name)))
-        continue;
-      cols.add(name);
-    }
-    return cols;
-  }
-
   private Object recordValue(final GrpcRecord r, final String col) {
     final GrpcValue v = r.getPropertiesMap().get(col);
     return v == null ? null : fromGrpcValue(v);
   }
 
+  // Merges the incoming values onto a matched record. With an explicit update_columns_on_conflict
+  // list only those columns are written; with an empty list every non-key property is merged (true
+  // upsert, not a silent no-op). For edges the out/in endpoints are skipped in BOTH cases: they
+  // address the graph topology, and setting them through the MutableDocument view would write plain
+  // properties while bypassing the vertex edge-list bookkeeping the graph engine maintains.
+  private void applyConflictUpdates(final InsertContext ctx, final GrpcRecord r, final boolean isEdge,
+      final MutableDocument existing) {
+    if (!ctx.updateCols.isEmpty()) {
+      for (final String col : ctx.updateCols)
+        if (!(isEdge && ("out".equals(col) || "in".equals(col))))
+          existing.set(col, recordValue(r, col));
+    } else {
+      for (final String name : r.getPropertiesMap().keySet()) {
+        if (name.startsWith("@") || ctx.keyColsSet.contains(name))
+          continue;
+        if (isEdge && ("out".equals(name) || "in".equals(name)))
+          continue;
+        existing.set(name, recordValue(r, name));
+      }
+    }
+  }
+
   // Returns true when an existing row was matched by key and merged; false when none matched (the
-  // caller then inserts). For an existing edge the out/in endpoints are left intact - the key
-  // columns identify the edge, endpoints are not re-pointed by an upsert.
+  // caller then inserts).
   private boolean tryUpsertByRecord(final InsertContext ctx, final GrpcRecord r, final boolean isEdge) {
     final List<String> keys = ctx.keyCols;
     if (keys.isEmpty())
@@ -2271,10 +2275,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         return false;
 
       final MutableDocument existing = res.getElement().get().asDocument().modify();
-
-      for (final String col : conflictUpdateColumns(ctx, r.getPropertiesMap().keySet(), isEdge))
-        existing.set(col, recordValue(r, col));
-
+      applyConflictUpdates(ctx, r, isEdge, existing);
       existing.save();
       return true;
     }
@@ -2881,8 +2882,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     final Database db;
 
     final List<String> keyCols;
-    final Set<String>  keyColsSet;
     final List<String> updateCols;
+    final Set<String> keyColsSet;
 
     long startedAt;
 

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -2239,7 +2239,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   // upsert, not a silent no-op). System fields (@-prefixed) are never written. For edges the out/in
   // endpoints are skipped too: they address the graph topology, and setting them through the
   // MutableDocument view would write plain properties while bypassing the vertex edge-list
-  // bookkeeping the graph engine maintains.
+  // bookkeeping the graph engine maintains. Columns absent from the incoming record are skipped
+  // (merge semantics): an explicit update column the row does not carry is left untouched, not nulled.
   private void applyConflictUpdates(final InsertContext ctx, final GrpcRecord r, final boolean isEdge,
       final MutableDocument existing) {
     final Iterable<String> cols = ctx.updateCols.isEmpty() ? r.getPropertiesMap().keySet() : ctx.updateCols;
@@ -2251,7 +2252,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         continue;
       if (isEdge && ("out".equals(col) || "in".equals(col)))
         continue;
-      existing.set(col, recordValue(r, col));
+      final Object value = recordValue(r, col);
+      if (value == null)
+        continue;
+      existing.set(col, value);
     }
   }
 

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -2236,23 +2236,22 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
   // Merges the incoming values onto a matched record. With an explicit update_columns_on_conflict
   // list only those columns are written; with an empty list every non-key property is merged (true
-  // upsert, not a silent no-op). For edges the out/in endpoints are skipped in BOTH cases: they
-  // address the graph topology, and setting them through the MutableDocument view would write plain
-  // properties while bypassing the vertex edge-list bookkeeping the graph engine maintains.
+  // upsert, not a silent no-op). System fields (@-prefixed) are never written. For edges the out/in
+  // endpoints are skipped too: they address the graph topology, and setting them through the
+  // MutableDocument view would write plain properties while bypassing the vertex edge-list
+  // bookkeeping the graph engine maintains.
   private void applyConflictUpdates(final InsertContext ctx, final GrpcRecord r, final boolean isEdge,
       final MutableDocument existing) {
-    if (!ctx.updateCols.isEmpty()) {
-      for (final String col : ctx.updateCols)
-        if (!(isEdge && ("out".equals(col) || "in".equals(col))))
-          existing.set(col, recordValue(r, col));
-    } else {
-      for (final String name : r.getPropertiesMap().keySet()) {
-        if (name.startsWith("@") || ctx.keyColsSet.contains(name))
-          continue;
-        if (isEdge && ("out".equals(name) || "in".equals(name)))
-          continue;
-        existing.set(name, recordValue(r, name));
-      }
+    final Iterable<String> cols = ctx.updateCols.isEmpty() ? r.getPropertiesMap().keySet() : ctx.updateCols;
+    final boolean mergeAll = ctx.updateCols.isEmpty();
+    for (final String col : cols) {
+      if (col.startsWith("@"))
+        continue;
+      if (mergeAll && ctx.keyColsSet.contains(col))
+        continue;
+      if (isEdge && ("out".equals(col) || "in".equals(col)))
+        continue;
+      existing.set(col, recordValue(r, col));
     }
   }
 
@@ -2398,12 +2397,18 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           // The unique index now guarantees the row exists, so retry the match path as an update
           // rather than losing the row to a CONFLICT error.
           case CONFLICT_UPDATE -> {
-            if (tryUpsertByRecord(ctx, r, isEdge))
-              c.updated++;
-            else
-              // The match vanished between the conflict and the retry (transient MVCC window): report
-              // it as a retriable CONFLICT rather than guessing.
-              c.err(ctx.received - 1, "CONFLICT", dup.getMessage(), "");
+            try {
+              if (tryUpsertByRecord(ctx, r, isEdge))
+                c.updated++;
+              else
+                // The match vanished between the conflict and the retry (transient MVCC window): report
+                // it as a retriable CONFLICT rather than guessing.
+                c.err(ctx.received - 1, "CONFLICT", dup.getMessage(), "");
+            } catch (Exception retryEx) {
+              // A third writer can race the retry too; keep it a predictable CONFLICT instead of
+              // letting it surface as an unexpected DB_ERROR.
+              c.err(ctx.received - 1, "CONFLICT", retryEx.getMessage(), "");
+            }
           }
           case CONFLICT_ERROR -> c.err(ctx.received - 1, "CONFLICT", dup.getMessage(), "");
         }

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -2228,14 +2228,9 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     };
   }
 
-  // Resolves which columns to write when a CONFLICT_UPDATE matches an existing row. When the client
-  // supplied an explicit update_columns_on_conflict list it is honored verbatim. When that list is
-  // empty, every non-key property present on the incoming record is merged (true upsert/merge),
-  // matching SQL UPDATE ... UPSERT semantics, instead of silently leaving the row unchanged while
-  // still reporting it as updated. System fields (@-prefixed) and, for edges, the out/in endpoints
-  // are never merged.
+  // An empty update list means "merge every non-key property" (true upsert), not a silent no-op.
   private List<String> conflictUpdateColumns(final InsertContext ctx, final Iterable<String> incomingProps,
-      final boolean isEdge) {
+      final boolean excludeEdgeEndpoints) {
     if (!ctx.updateCols.isEmpty())
       return ctx.updateCols;
 
@@ -2243,7 +2238,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     for (final String name : incomingProps) {
       if (name.startsWith("@") || ctx.keyCols.contains(name))
         continue;
-      if (isEdge && ("out".equals(name) || "in".equals(name)))
+      if (excludeEdgeEndpoints && ("out".equals(name) || "in".equals(name)))
         continue;
       cols.add(name);
     }
@@ -2255,10 +2250,9 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     return v == null ? null : fromGrpcValue(v);
   }
 
-  // Matches an existing record by the configured key columns and, when found, merges the incoming
-  // values onto it. Works uniformly for documents, vertices and edges (the latter two are
-  // MutableDocument subclasses for query/update purposes). Returns true when an existing row was
-  // updated, false when no match was found (the caller then inserts).
+  // Returns true when an existing row was matched by key and merged; false when none matched (the
+  // caller then inserts). For an existing edge the out/in endpoints are left intact - the key
+  // columns identify the edge, endpoints are not re-pointed by an upsert.
   private boolean tryUpsertByRecord(final InsertContext ctx, final GrpcRecord r, final boolean isEdge) {
     final List<String> keys = ctx.keyCols;
     if (keys.isEmpty())
@@ -2405,6 +2399,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
             if (tryUpsertByRecord(ctx, r, isEdge))
               c.updated++;
             else
+              // The match vanished between the conflict and the retry (transient MVCC window): report
+              // it as a retriable CONFLICT rather than guessing.
               c.err(ctx.received - 1, "CONFLICT", dup.getMessage(), "");
           }
           case CONFLICT_ERROR -> c.err(ctx.received - 1, "CONFLICT", dup.getMessage(), "");

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -2234,13 +2234,9 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     return v == null ? null : fromGrpcValue(v);
   }
 
-  // Merges the incoming values onto a matched record. With an explicit update_columns_on_conflict
-  // list only those columns are written; with an empty list every non-key property is merged (true
-  // upsert, not a silent no-op). System fields (@-prefixed) are never written. For edges the out/in
-  // endpoints are skipped too: they address the graph topology, and setting them through the
-  // MutableDocument view would write plain properties while bypassing the vertex edge-list
-  // bookkeeping the graph engine maintains. Columns absent from the incoming record are skipped
-  // (merge semantics): an explicit update column the row does not carry is left untouched, not nulled.
+  // Merge incoming values onto the matched record (explicit update_columns, else all non-key props).
+  // Skips @-fields and absent/null columns (so a field cannot be nulled here), and edge out/in -
+  // writing those via set() would bypass the graph engine's vertex edge-list bookkeeping.
   private void applyConflictUpdates(final InsertContext ctx, final GrpcRecord r, final boolean isEdge,
       final MutableDocument existing) {
     final Iterable<String> cols = ctx.updateCols.isEmpty() ? r.getPropertiesMap().keySet() : ctx.updateCols;
@@ -2259,8 +2255,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     }
   }
 
-  // Returns true when an existing row was matched by key and merged; false when none matched (the
-  // caller then inserts).
+  // Match an existing row by key and merge onto it; false when none matched (caller then inserts).
+  // asDocument().modify() yields a MutableVertex/MutableEdge at runtime, so save() persists correctly.
   private boolean tryUpsertByRecord(final InsertContext ctx, final GrpcRecord r, final boolean isEdge) {
     final List<String> keys = ctx.keyCols;
     if (keys.isEmpty())
@@ -2397,9 +2393,9 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         switch (ctx.opts.getConflictMode()) {
           case CONFLICT_IGNORE -> c.ignored++;
           case CONFLICT_ABORT, UNRECOGNIZED -> c.err(ctx.received - 1, "CONFLICT", dup.getMessage(), "");
-          // A concurrent stream may have inserted the same key between our existence check and save().
-          // The unique index now guarantees the row exists, so retry the match path as an update
-          // rather than losing the row to a CONFLICT error.
+          // A concurrent stream inserted this key after our check; the unique index proves it exists
+          // now, so retry as an update instead of losing the row. The cross-stream race itself is not
+          // single-threaded reproducible (see Issue4656InsertStreamConflictUpdateIT).
           case CONFLICT_UPDATE -> {
             try {
               if (tryUpsertByRecord(ctx, r, isEdge))

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -2255,6 +2255,12 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     }
   }
 
+  // Backtick-quote a client-supplied identifier (target class / key column) so it cannot inject SQL;
+  // values stay parameterized via '?'. Embedded backticks are escaped per the SQL grammar.
+  private static String quoteName(final String name) {
+    return "`" + name.replace("`", "\\`") + "`";
+  }
+
   // Match an existing row by key and merge onto it; false when none matched (caller then inserts).
   // asDocument().modify() yields a MutableVertex/MutableEdge at runtime, so save() persists correctly.
   private boolean tryUpsertByRecord(final InsertContext ctx, final GrpcRecord r, final boolean isEdge) {
@@ -2262,10 +2268,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     if (keys.isEmpty())
       return false;
 
-    final String where = String.join(" AND ", keys.stream().map(k -> k + " = ?").toList());
+    final String where = String.join(" AND ", keys.stream().map(k -> quoteName(k) + " = ?").toList());
     final Object[] params = keys.stream().map(k -> recordValue(r, k)).toArray();
 
-    try (final ResultSet rs = ctx.db.query("sql", "SELECT FROM " + ctx.opts.getTargetClass() + " WHERE " + where, params)) {
+    try (final ResultSet rs = ctx.db.query("sql", "SELECT FROM " + quoteName(ctx.opts.getTargetClass()) + " WHERE " + where, params)) {
       if (!rs.hasNext())
         return false;
 
@@ -2283,9 +2289,9 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   private boolean keyExistsByRecord(final InsertContext ctx, final GrpcRecord r) {
     if (ctx.keyCols.isEmpty())
       return false;
-    final String where = String.join(" AND ", ctx.keyCols.stream().map(k -> k + " = ?").toList());
+    final String where = String.join(" AND ", ctx.keyCols.stream().map(k -> quoteName(k) + " = ?").toList());
     final Object[] params = ctx.keyCols.stream().map(k -> recordValue(r, k)).toArray();
-    try (final ResultSet rs = ctx.db.query("sql", "SELECT FROM " + ctx.opts.getTargetClass() + " WHERE " + where, params)) {
+    try (final ResultSet rs = ctx.db.query("sql", "SELECT FROM " + quoteName(ctx.opts.getTargetClass()) + " WHERE " + where, params)) {
       return rs.hasNext();
     }
   }
@@ -2321,8 +2327,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
     Schema schema = ctx.db.getSchema();
     DocumentType dt = schema.getType(ctx.opts.getTargetClass());
-    boolean isVertex = dt instanceof VertexType;
-    boolean isEdge = dt instanceof EdgeType;
+    final boolean isVertex = dt instanceof VertexType;
+    final boolean isEdge = dt instanceof EdgeType;
 
     // Tell callers their out/in update columns are being ignored, rather than dropping them silently.
     if (isEdge && !ctx.warnedEdgeEndpointUpdateCols && (ctx.updateCols.contains("out") || ctx.updateCols.contains("in"))) {
@@ -2412,10 +2418,12 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
                 // The match vanished between the conflict and the retry (transient MVCC window): report
                 // it as a retriable CONFLICT rather than guessing.
                 c.err(ctx.received - 1, "CONFLICT", dup.getMessage(), "");
+            } catch (DuplicatedKeyException retryDup) {
+              // A third writer can race the retry too: still a retriable conflict.
+              c.err(ctx.received - 1, "CONFLICT", retryDup.getMessage(), "");
             } catch (Exception retryEx) {
-              // A third writer can race the retry too; keep it a predictable CONFLICT instead of
-              // letting it surface as an unexpected DB_ERROR.
-              c.err(ctx.received - 1, "CONFLICT", retryEx.getMessage(), "");
+              // Anything else (IO error, etc.) is a real failure - do not mask it as a CONFLICT.
+              c.err(ctx.received - 1, "DB_ERROR", retryEx.getMessage(), "");
             }
           }
           case CONFLICT_ERROR -> c.err(ctx.received - 1, "CONFLICT", dup.getMessage(), "");

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -2256,13 +2256,17 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   }
 
   // Backtick-quote a client-supplied identifier (target class / key column) so it cannot inject SQL;
-  // values stay parameterized via '?'. Embedded backticks are escaped per the SQL grammar.
+  // values stay parameterized via '?'. Embedded backticks are escaped per the SQL grammar, which
+  // also requires at least one character between the backticks.
   private static String quoteName(final String name) {
+    if (name == null || name.isEmpty())
+      throw new IllegalArgumentException("SQL identifier must not be empty");
     return "`" + name.replace("`", "\\`") + "`";
   }
 
   // Match an existing row by key and merge onto it; false when none matched (caller then inserts).
-  // asDocument().modify() yields a MutableVertex/MutableEdge at runtime, so save() persists correctly.
+  // MutableVertex and MutableEdge both extend MutableDocument, so asDocument().modify() returns the
+  // record's real mutable subtype; save() therefore persists a vertex/edge through its own path.
   private boolean tryUpsertByRecord(final InsertContext ctx, final GrpcRecord r, final boolean isEdge) {
     final List<String> keys = ctx.keyCols;
     if (keys.isEmpty())
@@ -2408,8 +2412,9 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           case CONFLICT_IGNORE -> c.ignored++;
           case CONFLICT_ABORT, UNRECOGNIZED -> c.err(ctx.received - 1, "CONFLICT", dup.getMessage(), "");
           // A concurrent stream inserted this key after our check; the unique index proves it exists
-          // now, so retry as an update instead of losing the row. The cross-stream race itself is not
-          // single-threaded reproducible (see Issue4656InsertStreamConflictUpdateIT).
+          // now, so retry as an update instead of losing the row. Not exercised by
+          // Issue4656InsertStreamConflictUpdateIT: the race needs two concurrent streams hitting the
+          // same new key, which is not deterministically reproducible single-threaded.
           case CONFLICT_UPDATE -> {
             try {
               if (tryUpsertByRecord(ctx, r, isEdge))
@@ -2906,7 +2911,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     final List<String> updateCols;
     final Set<String> keyColsSet;
 
-    // Issue #4656: latch so the "out/in in update_columns ignored for edges" warning fires once per stream.
+    // Mutable latch (single-stream, no concurrent access): set once after the "out/in in
+    // update_columns ignored for edges" warning fires so it is logged at most once per stream.
     boolean warnedEdgeEndpointUpdateCols;
 
     long startedAt;

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -2239,8 +2239,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   // writing those via set() would bypass the graph engine's vertex edge-list bookkeeping.
   private void applyConflictUpdates(final InsertContext ctx, final GrpcRecord r, final boolean isEdge,
       final MutableDocument existing) {
-    final Iterable<String> cols = ctx.updateCols.isEmpty() ? r.getPropertiesMap().keySet() : ctx.updateCols;
     final boolean mergeAll = ctx.updateCols.isEmpty();
+    final Iterable<String> cols = mergeAll ? r.getPropertiesMap().keySet() : ctx.updateCols;
     for (final String col : cols) {
       if (col.startsWith("@"))
         continue;
@@ -2341,6 +2341,14 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           "InsertStream upsert on edge type '%s': 'out'/'in' in update_columns_on_conflict are ignored (edge endpoints cannot be re-pointed via upsert)",
           ctx.opts.getTargetClass());
     }
+
+    // Reject blank key columns with a clear client-visible error instead of letting the per-row
+    // identifier quoting throw a generic DB_ERROR for every record.
+    for (final String kc : ctx.keyCols)
+      if (kc == null || kc.isBlank()) {
+        c.err(-1, "INVALID_KEY_COLUMN", "key_columns must not contain empty names", "");
+        return c;
+      }
 
     while (it.hasNext()) {
 

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -2324,6 +2324,14 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     boolean isVertex = dt instanceof VertexType;
     boolean isEdge = dt instanceof EdgeType;
 
+    // Tell callers their out/in update columns are being ignored, rather than dropping them silently.
+    if (isEdge && !ctx.warnedEdgeEndpointUpdateCols && (ctx.updateCols.contains("out") || ctx.updateCols.contains("in"))) {
+      ctx.warnedEdgeEndpointUpdateCols = true;
+      LogManager.instance().log(this, Level.WARNING,
+          "InsertStream upsert on edge type '%s': 'out'/'in' in update_columns_on_conflict are ignored (edge endpoints cannot be re-pointed via upsert)",
+          ctx.opts.getTargetClass());
+    }
+
     while (it.hasNext()) {
 
       GrpcRecord r = it.next();
@@ -2889,6 +2897,9 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     final List<String> keyCols;
     final List<String> updateCols;
     final Set<String> keyColsSet;
+
+    // Issue #4656: latch so the "out/in in update_columns ignored for edges" warning fires once per stream.
+    boolean warnedEdgeEndpointUpdateCols;
 
     long startedAt;
 

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -87,6 +87,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -2236,7 +2237,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
     final List<String> cols = new ArrayList<>();
     for (final String name : incomingProps) {
-      if (name.startsWith("@") || ctx.keyCols.contains(name))
+      if (name.startsWith("@") || ctx.keyColsSet.contains(name))
         continue;
       if (excludeEdgeEndpoints && ("out".equals(name) || "in".equals(name)))
         continue;
@@ -2880,6 +2881,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     final Database db;
 
     final List<String> keyCols;
+    final Set<String>  keyColsSet;
     final List<String> updateCols;
 
     long startedAt;
@@ -2903,6 +2905,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       this.db = getDatabase(opts.getDatabase(), opts.getCredentials());
 
       this.keyCols = opts.getKeyColumnsList();
+      this.keyColsSet = Set.copyOf(this.keyCols);
 
       this.updateCols = opts.getUpdateColumnsOnConflictList();
 

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4656InsertStreamConflictUpdateIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4656InsertStreamConflictUpdateIT.java
@@ -277,6 +277,50 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
   }
 
   @Test
+  void conflictUpdateWithBlankKeyColumnReportsInvalidKeyColumn() throws Exception {
+    final String typeName = "Issue4656BlankKey_" + System.currentTimeMillis();
+    cmd("CREATE DOCUMENT TYPE " + typeName);
+    cmd("CREATE PROPERTY " + typeName + ".v STRING");
+    try {
+      final GrpcRecord row = GrpcRecord.newBuilder().setType(typeName).putProperties("v", stringValue("x")).build();
+
+      // A blank key column must yield a clean INVALID_KEY_COLUMN error, not a generic DB_ERROR.
+      final InsertSummary summary = runStream(typeName, InsertOptions.ConflictMode.CONFLICT_UPDATE, List.of(""), List.of(), row);
+
+      assertThat(summary.getErrorsList()).anyMatch(e -> "INVALID_KEY_COLUMN".equals(e.getCode()));
+      assertThat(summary.getInserted()).isEqualTo(0);
+      assertThat(summary.getUpdated()).isEqualTo(0);
+    } finally {
+      cmd("DROP TYPE " + typeName + " IF EXISTS UNSAFE");
+    }
+  }
+
+  @Test
+  void conflictUpdateWithQuotedKeyColumnName() throws Exception {
+    // A key column whose name needs SQL quoting (here a space) must round-trip through the
+    // backtick-quoted upsert query - proves quoteName() neutralizes special identifier characters.
+    final String typeName = "Issue4656QuotedKey_" + System.currentTimeMillis();
+    cmd("CREATE DOCUMENT TYPE " + typeName);
+    cmd("CREATE PROPERTY " + typeName + ".`my key` STRING");
+    cmd("CREATE PROPERTY " + typeName + ".v STRING");
+    cmd("CREATE INDEX ON " + typeName + "(`my key`) UNIQUE");
+    cmd("INSERT INTO " + typeName + " SET `my key` = 'a', v = 'orig'");
+    try {
+      final GrpcRecord row = GrpcRecord.newBuilder().setType(typeName)
+          .putProperties("my key", stringValue("a")).putProperties("v", stringValue("changed")).build();
+
+      final InsertSummary summary = runStream(typeName, InsertOptions.ConflictMode.CONFLICT_UPDATE, List.of("my key"), List.of(), row);
+
+      assertThat(summary.getUpdated()).isEqualTo(1);
+      assertThat(summary.getFailed()).isEqualTo(0);
+      assertThat(firstString("SELECT v FROM " + typeName + " WHERE `my key` = 'a'", "v")).isEqualTo("changed");
+      assertThat(firstLong("SELECT count(*) AS cnt FROM " + typeName, "cnt")).isEqualTo(1);
+    } finally {
+      cmd("DROP TYPE " + typeName + " IF EXISTS UNSAFE");
+    }
+  }
+
+  @Test
   void conflictUpdateWithExplicitUpdateColumnsMerges() throws Exception {
     final String typeName = "Issue4656WithCols_" + System.currentTimeMillis();
     cmd("CREATE DOCUMENT TYPE " + typeName);
@@ -588,6 +632,43 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
           .putProperties("k", stringValue("e1")).putProperties("v", stringValue("changed")).build();
 
       final InsertSummary summary = runStream(eType, InsertOptions.ConflictMode.CONFLICT_ERROR, List.of("k"), List.of(), row);
+
+      assertThat(summary.getUpdated()).isEqualTo(0);
+      assertThat(summary.getFailed()).isGreaterThanOrEqualTo(1);
+      assertThat(summary.getErrorsList()).anyMatch(e -> "CONFLICT".equals(e.getCode()));
+      assertThat(firstString("SELECT v FROM " + eType + " WHERE k = 'e1'", "v")).isEqualTo("orig");
+      assertThat(firstLong("SELECT count(*) AS cnt FROM " + eType, "cnt")).isEqualTo(1);
+    } finally {
+      cmd("DROP TYPE " + eType + " IF EXISTS UNSAFE");
+      cmd("DROP TYPE " + vType + " IF EXISTS UNSAFE");
+    }
+  }
+
+  @Test
+  void edgeConflictAbortReportsDuplicateKeyAsFailed() throws Exception {
+    // CONFLICT_ABORT on an edge behaves like CONFLICT_ERROR: the duplicate is a failed row and the
+    // pre-existing edge is left intact.
+    final long suffix = System.currentTimeMillis();
+    final String vType = "Issue4656NodeAbrt_" + suffix;
+    final String eType = "Issue4656EdgeAbrt_" + suffix;
+    cmd("CREATE VERTEX TYPE " + vType);
+    cmd("CREATE PROPERTY " + vType + ".name STRING");
+    cmd("CREATE VERTEX " + vType + " SET name = 'A'");
+    cmd("CREATE VERTEX " + vType + " SET name = 'B'");
+    cmd("CREATE EDGE TYPE " + eType);
+    cmd("CREATE PROPERTY " + eType + ".k STRING");
+    cmd("CREATE PROPERTY " + eType + ".v STRING");
+    cmd("CREATE INDEX ON " + eType + "(k) UNIQUE");
+
+    final String ridA = firstRid("SELECT FROM " + vType + " WHERE name = 'A'");
+    final String ridB = firstRid("SELECT FROM " + vType + " WHERE name = 'B'");
+    cmd("CREATE EDGE " + eType + " FROM " + ridA + " TO " + ridB + " SET k = 'e1', v = 'orig'");
+    try {
+      final GrpcRecord row = GrpcRecord.newBuilder().setType(eType)
+          .putProperties("out", stringValue(ridA)).putProperties("in", stringValue(ridB))
+          .putProperties("k", stringValue("e1")).putProperties("v", stringValue("changed")).build();
+
+      final InsertSummary summary = runStream(eType, InsertOptions.ConflictMode.CONFLICT_ABORT, List.of("k"), List.of(), row);
 
       assertThat(summary.getUpdated()).isEqualTo(0);
       assertThat(summary.getFailed()).isGreaterThanOrEqualTo(1);

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4656InsertStreamConflictUpdateIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4656InsertStreamConflictUpdateIT.java
@@ -50,6 +50,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  *   <li>(3) edge targets used to ignore {@code conflict_mode}/{@code key_columns} entirely; they must
  *   now honour {@code CONFLICT_UPDATE} and {@code CONFLICT_IGNORE} like documents and vertices.</li>
  * </ul>
+ * <p>
+ * Coverage gap: fix (1) - retrying a {@code DuplicatedKeyException} as an update - resolves the race
+ * between two <i>concurrent</i> streams inserting the same new key. That race surfaces the conflict
+ * at commit time and is not deterministically reproducible single-threaded, so the retry branch in
+ * the {@code DuplicatedKeyException} handler is not directly exercised here; the tests cover the
+ * reachable same-stream (read-your-own-writes) and same-key edge paths instead.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
@@ -421,6 +427,48 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
       assertThat(firstLong("SELECT count(*) AS cnt FROM (SELECT expand(out('" + eType + "')) FROM " + ridA + ") WHERE name = 'C'", "cnt"))
           .isEqualTo(0);
       assertThat(firstLong("SELECT count(*) AS cnt FROM " + eType, "cnt")).isEqualTo(1);
+    } finally {
+      cmd("DROP TYPE " + eType + " IF EXISTS UNSAFE");
+      cmd("DROP TYPE " + vType + " IF EXISTS UNSAFE");
+    }
+  }
+
+  @Test
+  void edgeConflictUpdateSameKeyTwiceInOneStreamCreatesNoGhostEdge() throws Exception {
+    // The same new edge key appearing twice in one CONFLICT_UPDATE stream must yield exactly one
+    // edge wired into the vertex edge-lists - no orphan/ghost edge record and no dangling endpoint.
+    final long suffix = System.currentTimeMillis();
+    final String vType = "Issue4656NodeGhost_" + suffix;
+    final String eType = "Issue4656EdgeGhost_" + suffix;
+    cmd("CREATE VERTEX TYPE " + vType);
+    cmd("CREATE PROPERTY " + vType + ".name STRING");
+    cmd("CREATE VERTEX " + vType + " SET name = 'A'");
+    cmd("CREATE VERTEX " + vType + " SET name = 'B'");
+    cmd("CREATE EDGE TYPE " + eType);
+    cmd("CREATE PROPERTY " + eType + ".k STRING");
+    cmd("CREATE PROPERTY " + eType + ".v STRING");
+    cmd("CREATE INDEX ON " + eType + "(k) UNIQUE");
+
+    final String ridA = firstRid("SELECT FROM " + vType + " WHERE name = 'A'");
+    final String ridB = firstRid("SELECT FROM " + vType + " WHERE name = 'B'");
+    try {
+      final GrpcRecord first = GrpcRecord.newBuilder().setType(eType)
+          .putProperties("out", stringValue(ridA)).putProperties("in", stringValue(ridB))
+          .putProperties("k", stringValue("e1")).putProperties("v", stringValue("first")).build();
+      final GrpcRecord second = GrpcRecord.newBuilder().setType(eType)
+          .putProperties("out", stringValue(ridA)).putProperties("in", stringValue(ridB))
+          .putProperties("k", stringValue("e1")).putProperties("v", stringValue("second")).build();
+
+      final InsertSummary summary = runStream(eType, InsertOptions.ConflictMode.CONFLICT_UPDATE, List.of("k"), List.of(), first, second);
+
+      assertThat(summary.getFailed()).isEqualTo(0);
+      assertThat(summary.getInserted() + summary.getUpdated()).isEqualTo(2);
+      // Exactly one edge record (no orphan), merged to the last value.
+      assertThat(firstLong("SELECT count(*) AS cnt FROM " + eType, "cnt")).isEqualTo(1);
+      assertThat(firstString("SELECT v FROM " + eType + " WHERE k = 'e1'", "v")).isEqualTo("second");
+      // A is wired to exactly one neighbour (the edge-list has no dangling/duplicate entry).
+      assertThat(firstLong("SELECT count(*) AS cnt FROM (SELECT expand(out('" + eType + "')) FROM " + ridA + ")", "cnt"))
+          .isEqualTo(1);
     } finally {
       cmd("DROP TYPE " + eType + " IF EXISTS UNSAFE");
       cmd("DROP TYPE " + vType + " IF EXISTS UNSAFE");

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4656InsertStreamConflictUpdateIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4656InsertStreamConflictUpdateIT.java
@@ -112,8 +112,9 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
   }
 
   private void cmd(final String sql) {
-    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+    final ExecuteCommandResponse resp = authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
         .setDatabase(getDatabaseName()).setCredentials(credentials()).setCommand(sql).build());
+    assertThat(resp.getSuccess()).as("setup command failed: %s -> %s", sql, resp.getMessage()).isTrue();
   }
 
   private GrpcRecord firstRecord(final String query) {
@@ -226,6 +227,53 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
       assertThat(summary.getInserted() + summary.getUpdated()).isEqualTo(2);
       assertThat(firstLong("SELECT count(*) AS cnt FROM " + typeName, "cnt")).isEqualTo(1);
       assertThat(firstString("SELECT v FROM " + typeName + " WHERE k = 'a'", "v")).isEqualTo("second");
+    } finally {
+      cmd("DROP TYPE " + typeName + " IF EXISTS UNSAFE");
+    }
+  }
+
+  @Test
+  void conflictUpdateWithNoKeyColumnsCannotMatchAndReportsConflict() throws Exception {
+    // Documents current behavior: CONFLICT_UPDATE without key_columns cannot resolve a match
+    // (tryUpsertByRecord/keyExistsByRecord short-circuit on empty keys), so a unique-index duplicate
+    // is reported as a failed row rather than merged. Guards against a silent behavior change.
+    final String typeName = "Issue4656NoKeys_" + System.currentTimeMillis();
+    cmd("CREATE DOCUMENT TYPE " + typeName);
+    cmd("CREATE PROPERTY " + typeName + ".v STRING");
+    cmd("CREATE INDEX ON " + typeName + "(v) UNIQUE");
+    cmd("INSERT INTO " + typeName + " SET v = 'dup'");
+    try {
+      final CountDownLatch done = new CountDownLatch(1);
+      final AtomicReference<InsertSummary> summaryRef = new AtomicReference<>();
+      final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+      final StreamObserver<InsertChunk> req = asyncAuthenticatedStub.insertStream(new StreamObserver<>() {
+        @Override public void onNext(final InsertSummary s) { summaryRef.set(s); }
+        @Override public void onError(final Throwable t) { errorRef.set(t); done.countDown(); }
+        @Override public void onCompleted() { done.countDown(); }
+      });
+
+      // No addKeyColumns(...) on purpose.
+      req.onNext(InsertChunk.newBuilder()
+          .setSessionId("issue-4656-no-keys").setChunkSeq(0).setLast(true)
+          .setOptions(InsertOptions.newBuilder()
+              .setDatabase(getDatabaseName()).setCredentials(credentials()).setTargetClass(typeName)
+              .setConflictMode(InsertOptions.ConflictMode.CONFLICT_UPDATE)
+              .setTransactionMode(InsertOptions.TransactionMode.PER_STREAM).build())
+          .addRows(GrpcRecord.newBuilder().setType(typeName).putProperties("v", stringValue("dup")).build())
+          .build());
+      req.onCompleted();
+
+      assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+      assertThat(errorRef.get()).isNull();
+      assertThat(summaryRef.get()).isNotNull();
+
+      final InsertSummary summary = summaryRef.get();
+      assertThat(summary.getUpdated()).isEqualTo(0);
+      assertThat(summary.getFailed()).isEqualTo(1);
+      assertThat(summary.getErrorsList()).anyMatch(e -> "CONFLICT".equals(e.getCode()));
+      // The duplicate was not stored: still exactly the pre-existing row.
+      assertThat(firstLong("SELECT count(*) AS cnt FROM " + typeName, "cnt")).isEqualTo(1);
     } finally {
       cmd("DROP TYPE " + typeName + " IF EXISTS UNSAFE");
     }

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4656InsertStreamConflictUpdateIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4656InsertStreamConflictUpdateIT.java
@@ -209,6 +209,12 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
   void conflictUpdateWithSameKeyTwiceInOneStreamDoesNotLoseTheRow() throws Exception {
     // The same (new) key appearing twice in a single CONFLICT_UPDATE stream must resolve to one
     // stored row (insert then update/merge), never a lost-row CONFLICT error.
+    //
+    // Coverage note: within one transaction the second row's upsert SELECT sees the first row's
+    // pending index entry (read-your-own-writes), so this resolves via the normal upsert path. The
+    // DuplicatedKeyException retry (fix 1) targets two *concurrent* streams racing the same new key;
+    // that cross-stream race surfaces the conflict at commit time and is not deterministically
+    // reproducible in a single-threaded test, so it is not directly exercised here.
     final String typeName = "Issue4656DupInStream_" + System.currentTimeMillis();
     cmd("CREATE DOCUMENT TYPE " + typeName);
     cmd("CREATE PROPERTY " + typeName + ".k STRING");

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4656InsertStreamConflictUpdateIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4656InsertStreamConflictUpdateIT.java
@@ -440,6 +440,52 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
   }
 
   @Test
+  void edgeConflictUpdateIgnoresEndpointColumnsListedExplicitly() throws Exception {
+    // Even when a caller explicitly lists 'in' in update_columns_on_conflict, the endpoint must not
+    // be re-pointed or written as a plain property; only the other listed columns are merged.
+    final long suffix = System.currentTimeMillis();
+    final String vType = "Issue4656NodeExpl_" + suffix;
+    final String eType = "Issue4656EdgeExpl_" + suffix;
+    cmd("CREATE VERTEX TYPE " + vType);
+    cmd("CREATE PROPERTY " + vType + ".name STRING");
+    cmd("CREATE VERTEX " + vType + " SET name = 'A'");
+    cmd("CREATE VERTEX " + vType + " SET name = 'B'");
+    cmd("CREATE VERTEX " + vType + " SET name = 'C'");
+    cmd("CREATE EDGE TYPE " + eType);
+    cmd("CREATE PROPERTY " + eType + ".k STRING");
+    cmd("CREATE PROPERTY " + eType + ".v STRING");
+    cmd("CREATE INDEX ON " + eType + "(k) UNIQUE");
+
+    final String ridA = firstRid("SELECT FROM " + vType + " WHERE name = 'A'");
+    final String ridB = firstRid("SELECT FROM " + vType + " WHERE name = 'B'");
+    final String ridC = firstRid("SELECT FROM " + vType + " WHERE name = 'C'");
+    cmd("CREATE EDGE " + eType + " FROM " + ridA + " TO " + ridB + " SET k = 'e1', v = 'orig'");
+    try {
+      final GrpcRecord row = GrpcRecord.newBuilder().setType(eType)
+          .putProperties("out", stringValue(ridA)).putProperties("in", stringValue(ridC))
+          .putProperties("k", stringValue("e1")).putProperties("v", stringValue("changed")).build();
+
+      // 'in' is listed explicitly but must still be ignored.
+      final InsertSummary summary = runStream(eType, InsertOptions.ConflictMode.CONFLICT_UPDATE, List.of("k"), List.of("v", "in"), row);
+
+      assertThat(summary.getUpdated()).isEqualTo(1);
+      assertThat(summary.getFailed()).isEqualTo(0);
+
+      final GrpcRecord edge = firstRecord("SELECT FROM " + eType + " WHERE k = 'e1'");
+      assertThat(edge.getPropertiesMap().get("v").getStringValue()).isEqualTo("changed");
+      assertThat(edge.getPropertiesMap()).doesNotContainKey("in");
+      // Endpoint untouched: still A -> B, not A -> C.
+      assertThat(firstLong("SELECT count(*) AS cnt FROM (SELECT expand(out('" + eType + "')) FROM " + ridA + ") WHERE name = 'B'", "cnt"))
+          .isEqualTo(1);
+      assertThat(firstLong("SELECT count(*) AS cnt FROM (SELECT expand(out('" + eType + "')) FROM " + ridA + ") WHERE name = 'C'", "cnt"))
+          .isEqualTo(0);
+    } finally {
+      cmd("DROP TYPE " + eType + " IF EXISTS UNSAFE");
+      cmd("DROP TYPE " + vType + " IF EXISTS UNSAFE");
+    }
+  }
+
+  @Test
   void edgeConflictUpdateSameKeyTwiceInOneStreamCreatesNoGhostEdge() throws Exception {
     // The same new edge key appearing twice in one CONFLICT_UPDATE stream must yield exactly one
     // edge wired into the vertex edge-lists - no orphan/ghost edge record and no dangling endpoint.

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4656InsertStreamConflictUpdateIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4656InsertStreamConflictUpdateIT.java
@@ -562,4 +562,41 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
       cmd("DROP TYPE " + vType + " IF EXISTS UNSAFE");
     }
   }
+
+  @Test
+  void edgeConflictErrorReportsDuplicateKeyAsFailed() throws Exception {
+    // CONFLICT_ERROR (the default) on an edge: a duplicate key is reported as a failed row and the
+    // pre-existing edge is left intact (no second edge, no ghost).
+    final long suffix = System.currentTimeMillis();
+    final String vType = "Issue4656NodeErr_" + suffix;
+    final String eType = "Issue4656EdgeErr_" + suffix;
+    cmd("CREATE VERTEX TYPE " + vType);
+    cmd("CREATE PROPERTY " + vType + ".name STRING");
+    cmd("CREATE VERTEX " + vType + " SET name = 'A'");
+    cmd("CREATE VERTEX " + vType + " SET name = 'B'");
+    cmd("CREATE EDGE TYPE " + eType);
+    cmd("CREATE PROPERTY " + eType + ".k STRING");
+    cmd("CREATE PROPERTY " + eType + ".v STRING");
+    cmd("CREATE INDEX ON " + eType + "(k) UNIQUE");
+
+    final String ridA = firstRid("SELECT FROM " + vType + " WHERE name = 'A'");
+    final String ridB = firstRid("SELECT FROM " + vType + " WHERE name = 'B'");
+    cmd("CREATE EDGE " + eType + " FROM " + ridA + " TO " + ridB + " SET k = 'e1', v = 'orig'");
+    try {
+      final GrpcRecord row = GrpcRecord.newBuilder().setType(eType)
+          .putProperties("out", stringValue(ridA)).putProperties("in", stringValue(ridB))
+          .putProperties("k", stringValue("e1")).putProperties("v", stringValue("changed")).build();
+
+      final InsertSummary summary = runStream(eType, InsertOptions.ConflictMode.CONFLICT_ERROR, List.of("k"), List.of(), row);
+
+      assertThat(summary.getUpdated()).isEqualTo(0);
+      assertThat(summary.getFailed()).isGreaterThanOrEqualTo(1);
+      assertThat(summary.getErrorsList()).anyMatch(e -> "CONFLICT".equals(e.getCode()));
+      assertThat(firstString("SELECT v FROM " + eType + " WHERE k = 'e1'", "v")).isEqualTo("orig");
+      assertThat(firstLong("SELECT count(*) AS cnt FROM " + eType, "cnt")).isEqualTo(1);
+    } finally {
+      cmd("DROP TYPE " + eType + " IF EXISTS UNSAFE");
+      cmd("DROP TYPE " + vType + " IF EXISTS UNSAFE");
+    }
+  }
 }

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4656InsertStreamConflictUpdateIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4656InsertStreamConflictUpdateIT.java
@@ -137,9 +137,9 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
     return firstRecord(query).getPropertiesMap().get(prop).getInt64Value();
   }
 
-  /** Runs a single-chunk {@code InsertStream} keyed on column "k" in PER_STREAM mode and returns the summary. */
+  /** Runs a single-chunk {@code InsertStream} in PER_STREAM mode and returns the summary. */
   private InsertSummary runStream(final String typeName, final InsertOptions.ConflictMode mode,
-      final List<String> updateColumns, final GrpcRecord... rows) throws Exception {
+      final List<String> keyColumns, final List<String> updateColumns, final GrpcRecord... rows) throws Exception {
     final CountDownLatch done = new CountDownLatch(1);
     final AtomicReference<InsertSummary> summaryRef = new AtomicReference<>();
     final AtomicReference<Throwable> errorRef = new AtomicReference<>();
@@ -153,7 +153,7 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
     final InsertOptions.Builder opts = InsertOptions.newBuilder()
         .setDatabase(getDatabaseName()).setCredentials(credentials()).setTargetClass(typeName)
         .setConflictMode(mode)
-        .addKeyColumns("k")
+        .addAllKeyColumns(keyColumns)
         .setTransactionMode(InsertOptions.TransactionMode.PER_STREAM);
     opts.addAllUpdateColumnsOnConflict(updateColumns);
 
@@ -171,10 +171,10 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
     return summaryRef.get();
   }
 
-  /** Sends a single-row {@code CONFLICT_UPDATE} {@code InsertStream} and returns the resulting summary. */
+  /** Sends a single-row {@code CONFLICT_UPDATE} {@code InsertStream} keyed on "k" and returns the summary. */
   private InsertSummary upsert(final String typeName, final GrpcRecord row, final List<String> updateColumns)
       throws Exception {
-    return runStream(typeName, InsertOptions.ConflictMode.CONFLICT_UPDATE, updateColumns, row);
+    return runStream(typeName, InsertOptions.ConflictMode.CONFLICT_UPDATE, List.of("k"), updateColumns, row);
   }
 
   // ---------------------------------------------------------------------------------------------
@@ -220,7 +220,7 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
       final GrpcRecord second = GrpcRecord.newBuilder().setType(typeName)
           .putProperties("k", stringValue("a")).putProperties("v", stringValue("second")).build();
 
-      final InsertSummary summary = runStream(typeName, InsertOptions.ConflictMode.CONFLICT_UPDATE, List.of(), first, second);
+      final InsertSummary summary = runStream(typeName, InsertOptions.ConflictMode.CONFLICT_UPDATE, List.of("k"), List.of(), first, second);
 
       // Exactly one row stored, the second occurrence merged on top of the first, no lost-row error.
       assertThat(summary.getFailed()).isEqualTo(0);
@@ -243,32 +243,11 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
     cmd("CREATE INDEX ON " + typeName + "(v) UNIQUE");
     cmd("INSERT INTO " + typeName + " SET v = 'dup'");
     try {
-      final CountDownLatch done = new CountDownLatch(1);
-      final AtomicReference<InsertSummary> summaryRef = new AtomicReference<>();
-      final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+      final GrpcRecord row = GrpcRecord.newBuilder().setType(typeName).putProperties("v", stringValue("dup")).build();
 
-      final StreamObserver<InsertChunk> req = asyncAuthenticatedStub.insertStream(new StreamObserver<>() {
-        @Override public void onNext(final InsertSummary s) { summaryRef.set(s); }
-        @Override public void onError(final Throwable t) { errorRef.set(t); done.countDown(); }
-        @Override public void onCompleted() { done.countDown(); }
-      });
+      // Empty key_columns on purpose.
+      final InsertSummary summary = runStream(typeName, InsertOptions.ConflictMode.CONFLICT_UPDATE, List.of(), List.of(), row);
 
-      // No addKeyColumns(...) on purpose.
-      req.onNext(InsertChunk.newBuilder()
-          .setSessionId("issue-4656-no-keys").setChunkSeq(0).setLast(true)
-          .setOptions(InsertOptions.newBuilder()
-              .setDatabase(getDatabaseName()).setCredentials(credentials()).setTargetClass(typeName)
-              .setConflictMode(InsertOptions.ConflictMode.CONFLICT_UPDATE)
-              .setTransactionMode(InsertOptions.TransactionMode.PER_STREAM).build())
-          .addRows(GrpcRecord.newBuilder().setType(typeName).putProperties("v", stringValue("dup")).build())
-          .build());
-      req.onCompleted();
-
-      assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
-      assertThat(errorRef.get()).isNull();
-      assertThat(summaryRef.get()).isNotNull();
-
-      final InsertSummary summary = summaryRef.get();
       assertThat(summary.getUpdated()).isEqualTo(0);
       assertThat(summary.getFailed()).isEqualTo(1);
       assertThat(summary.getErrorsList()).anyMatch(e -> "CONFLICT".equals(e.getCode()));
@@ -337,7 +316,7 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
       final GrpcRecord row = GrpcRecord.newBuilder().setType(typeName)
           .putProperties("k", stringValue("a")).putProperties("v", stringValue("changed")).build();
 
-      final InsertSummary summary = runStream(typeName, InsertOptions.ConflictMode.CONFLICT_IGNORE, List.of(), row);
+      final InsertSummary summary = runStream(typeName, InsertOptions.ConflictMode.CONFLICT_IGNORE, List.of("k"), List.of(), row);
 
       assertThat(summary.getIgnored()).isEqualTo(1);
       assertThat(summary.getInserted()).isEqualTo(0);
@@ -391,6 +370,58 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
   }
 
   @Test
+  void edgeConflictUpdateWithEmptyUpdateColumnsMergesWithoutTouchingEndpoints() throws Exception {
+    // Merge-all path on an edge: every non-key property is merged, but out/in must NOT be written
+    // (neither as topology nor as shadowing plain properties), even though the incoming record
+    // carries a mismatched endpoint.
+    final long suffix = System.currentTimeMillis();
+    final String vType = "Issue4656NodeMrg_" + suffix;
+    final String eType = "Issue4656EdgeMrg_" + suffix;
+    cmd("CREATE VERTEX TYPE " + vType);
+    cmd("CREATE PROPERTY " + vType + ".name STRING");
+    cmd("CREATE VERTEX " + vType + " SET name = 'A'");
+    cmd("CREATE VERTEX " + vType + " SET name = 'B'");
+    cmd("CREATE VERTEX " + vType + " SET name = 'C'");
+    cmd("CREATE EDGE TYPE " + eType);
+    cmd("CREATE PROPERTY " + eType + ".k STRING");
+    cmd("CREATE PROPERTY " + eType + ".v STRING");
+    cmd("CREATE INDEX ON " + eType + "(k) UNIQUE");
+
+    final String ridA = firstRid("SELECT FROM " + vType + " WHERE name = 'A'");
+    final String ridB = firstRid("SELECT FROM " + vType + " WHERE name = 'B'");
+    final String ridC = firstRid("SELECT FROM " + vType + " WHERE name = 'C'");
+    cmd("CREATE EDGE " + eType + " FROM " + ridA + " TO " + ridB + " SET k = 'e1', v = 'orig'");
+    try {
+      // Empty update columns, and a deliberately mismatched 'in' endpoint (C instead of B).
+      final GrpcRecord row = GrpcRecord.newBuilder().setType(eType)
+          .putProperties("out", stringValue(ridA)).putProperties("in", stringValue(ridC))
+          .putProperties("k", stringValue("e1")).putProperties("v", stringValue("changed"))
+          .putProperties("w", stringValue("extra")).build();
+
+      final InsertSummary summary = runStream(eType, InsertOptions.ConflictMode.CONFLICT_UPDATE, List.of("k"), List.of(), row);
+
+      assertThat(summary.getUpdated()).isEqualTo(1);
+      assertThat(summary.getFailed()).isEqualTo(0);
+
+      // Non-key, non-endpoint properties were merged.
+      final GrpcRecord edge = firstRecord("SELECT FROM " + eType + " WHERE k = 'e1'");
+      assertThat(edge.getPropertiesMap().get("v").getStringValue()).isEqualTo("changed");
+      assertThat(edge.getPropertiesMap().get("w").getStringValue()).isEqualTo("extra");
+      // out/in were not written as plain properties.
+      assertThat(edge.getPropertiesMap()).doesNotContainKey("out").doesNotContainKey("in");
+      // Topology was not re-pointed: the edge still connects A -> B, not A -> C.
+      assertThat(firstLong("SELECT count(*) AS cnt FROM (SELECT expand(out('" + eType + "')) FROM " + ridA + ") WHERE name = 'B'", "cnt"))
+          .isEqualTo(1);
+      assertThat(firstLong("SELECT count(*) AS cnt FROM (SELECT expand(out('" + eType + "')) FROM " + ridA + ") WHERE name = 'C'", "cnt"))
+          .isEqualTo(0);
+      assertThat(firstLong("SELECT count(*) AS cnt FROM " + eType, "cnt")).isEqualTo(1);
+    } finally {
+      cmd("DROP TYPE " + eType + " IF EXISTS UNSAFE");
+      cmd("DROP TYPE " + vType + " IF EXISTS UNSAFE");
+    }
+  }
+
+  @Test
   void edgeConflictIgnoreSkipsExistingEdge() throws Exception {
     final long suffix = System.currentTimeMillis();
     final String vType = "Issue4656NodeIgn_" + suffix;
@@ -412,7 +443,7 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
           .putProperties("out", stringValue(ridA)).putProperties("in", stringValue(ridB))
           .putProperties("k", stringValue("e1")).putProperties("v", stringValue("changed")).build();
 
-      final InsertSummary summary = runStream(eType, InsertOptions.ConflictMode.CONFLICT_IGNORE, List.of(), row);
+      final InsertSummary summary = runStream(eType, InsertOptions.ConflictMode.CONFLICT_IGNORE, List.of("k"), List.of(), row);
 
       assertThat(summary.getIgnored()).isEqualTo(1);
       assertThat(summary.getInserted()).isEqualTo(0);

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4656InsertStreamConflictUpdateIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4656InsertStreamConflictUpdateIT.java
@@ -1,0 +1,388 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4656: gRPC {@code InsertStream} {@code CONFLICT_UPDATE} upsert gaps.
+ * <ul>
+ *   <li>(2) an empty {@code update_columns_on_conflict} used to be reported as {@code updated} while
+ *   leaving the record unchanged; it must now merge all non-key columns of the incoming record.</li>
+ *   <li>(3) edge targets used to ignore {@code conflict_mode}/{@code key_columns} entirely; they must
+ *   now honour {@code CONFLICT_UPDATE} and {@code CONFLICT_IGNORE} like documents and vertices.</li>
+ * </ul>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
+
+  private static final int GRPC_PORT = 50051;
+
+  private static final Metadata.Key<String> USER_HEADER     = Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER = Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER = Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  private ManagedChannel                                  channel;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub authenticatedStub;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceStub         asyncAuthenticatedStub;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void setupGrpcClient() {
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    final Channel authenticatedChannel = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+    authenticatedStub = ArcadeDbServiceGrpc.newBlockingStub(authenticatedChannel);
+    asyncAuthenticatedStub = ArcadeDbServiceGrpc.newStub(authenticatedChannel);
+  }
+
+  @AfterEach
+  void shutdownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private class AuthClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        final MethodDescriptor<ReqT, RespT> method, final CallOptions callOptions, final Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata headers) {
+          headers.put(USER_HEADER, "root");
+          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
+          headers.put(DATABASE_HEADER, getDatabaseName());
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+
+  private DatabaseCredentials credentials() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  private GrpcValue stringValue(final String s) {
+    return GrpcValue.newBuilder().setStringValue(s).build();
+  }
+
+  private void cmd(final String sql) {
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials()).setCommand(sql).build());
+  }
+
+  private String firstString(final String query, final String prop) {
+    final ExecuteQueryResponse resp = authenticatedStub.executeQuery(ExecuteQueryRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials()).setQuery(query).build());
+    return resp.getResultsList().get(0).getRecordsList().get(0).getPropertiesMap().get(prop).getStringValue();
+  }
+
+  private String firstRid(final String query) {
+    final ExecuteQueryResponse resp = authenticatedStub.executeQuery(ExecuteQueryRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials()).setQuery(query).build());
+    return resp.getResultsList().get(0).getRecordsList().get(0).getRid();
+  }
+
+  private long firstLong(final String query, final String prop) {
+    final ExecuteQueryResponse resp = authenticatedStub.executeQuery(ExecuteQueryRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials()).setQuery(query).build());
+    return resp.getResultsList().get(0).getRecordsList().get(0).getPropertiesMap().get(prop).getInt64Value();
+  }
+
+  /** Sends a single-row {@code CONFLICT_UPDATE} {@code InsertStream} and returns the resulting summary. */
+  private InsertSummary upsert(final String typeName, final GrpcRecord row, final java.util.List<String> updateColumns)
+      throws Exception {
+    final CountDownLatch done = new CountDownLatch(1);
+    final AtomicReference<InsertSummary> summaryRef = new AtomicReference<>();
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+    final StreamObserver<InsertChunk> req = asyncAuthenticatedStub.insertStream(new StreamObserver<>() {
+      @Override public void onNext(final InsertSummary s) { summaryRef.set(s); }
+      @Override public void onError(final Throwable t) { errorRef.set(t); done.countDown(); }
+      @Override public void onCompleted() { done.countDown(); }
+    });
+
+    final InsertOptions.Builder opts = InsertOptions.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials()).setTargetClass(typeName)
+        .setConflictMode(InsertOptions.ConflictMode.CONFLICT_UPDATE)
+        .addKeyColumns("k")
+        .setTransactionMode(InsertOptions.TransactionMode.PER_STREAM);
+    opts.addAllUpdateColumnsOnConflict(updateColumns);
+
+    req.onNext(InsertChunk.newBuilder()
+        .setSessionId("issue-4656").setChunkSeq(0).setLast(true)
+        .setOptions(opts.build())
+        .addRows(row)
+        .build());
+    req.onCompleted();
+
+    assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+    assertThat(errorRef.get()).isNull();
+    assertThat(summaryRef.get()).isNotNull();
+    return summaryRef.get();
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // (2) Empty update_columns_on_conflict
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void conflictUpdateWithEmptyUpdateColumnsMergesAllNonKeyColumns() throws Exception {
+    final String typeName = "Issue4656EmptyCols_" + System.currentTimeMillis();
+    cmd("CREATE DOCUMENT TYPE " + typeName);
+    cmd("CREATE PROPERTY " + typeName + ".k STRING");
+    cmd("CREATE PROPERTY " + typeName + ".v STRING");
+    cmd("CREATE INDEX ON " + typeName + "(k) UNIQUE");
+    cmd("INSERT INTO " + typeName + " SET k = 'a', v = 'orig'");
+    try {
+      final GrpcRecord row = GrpcRecord.newBuilder().setType(typeName)
+          .putProperties("k", stringValue("a")).putProperties("v", stringValue("changed")).build();
+
+      final InsertSummary summary = upsert(typeName, row, java.util.List.of()); // empty update columns
+
+      assertThat(summary.getUpdated()).isEqualTo(1);
+      assertThat(summary.getFailed()).isEqualTo(0);
+      // Issue #4656 (2): the row must actually be merged, not silently left unchanged.
+      assertThat(firstString("SELECT v FROM " + typeName + " WHERE k = 'a'", "v")).isEqualTo("changed");
+      assertThat(firstLong("SELECT count(*) AS cnt FROM " + typeName, "cnt")).isEqualTo(1);
+    } finally {
+      cmd("DROP TYPE " + typeName + " IF EXISTS UNSAFE");
+    }
+  }
+
+  @Test
+  void conflictUpdateWithSameKeyTwiceInOneStreamDoesNotLoseTheRow() throws Exception {
+    // Issue #4656 (1): the same (new) key appearing twice in a single CONFLICT_UPDATE stream must
+    // resolve to one stored row (insert then update/merge), never a lost-row CONFLICT error.
+    final String typeName = "Issue4656DupInStream_" + System.currentTimeMillis();
+    cmd("CREATE DOCUMENT TYPE " + typeName);
+    cmd("CREATE PROPERTY " + typeName + ".k STRING");
+    cmd("CREATE PROPERTY " + typeName + ".v STRING");
+    cmd("CREATE INDEX ON " + typeName + "(k) UNIQUE");
+    try {
+      final CountDownLatch done = new CountDownLatch(1);
+      final AtomicReference<InsertSummary> summaryRef = new AtomicReference<>();
+      final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+      final StreamObserver<InsertChunk> req = asyncAuthenticatedStub.insertStream(new StreamObserver<>() {
+        @Override public void onNext(final InsertSummary s) { summaryRef.set(s); }
+        @Override public void onError(final Throwable t) { errorRef.set(t); done.countDown(); }
+        @Override public void onCompleted() { done.countDown(); }
+      });
+
+      req.onNext(InsertChunk.newBuilder()
+          .setSessionId("issue-4656-dup-in-stream").setChunkSeq(0).setLast(true)
+          .setOptions(InsertOptions.newBuilder()
+              .setDatabase(getDatabaseName()).setCredentials(credentials()).setTargetClass(typeName)
+              .setConflictMode(InsertOptions.ConflictMode.CONFLICT_UPDATE)
+              .addKeyColumns("k")
+              .setTransactionMode(InsertOptions.TransactionMode.PER_STREAM).build())
+          .addRows(GrpcRecord.newBuilder().setType(typeName)
+              .putProperties("k", stringValue("a")).putProperties("v", stringValue("first")).build())
+          .addRows(GrpcRecord.newBuilder().setType(typeName)
+              .putProperties("k", stringValue("a")).putProperties("v", stringValue("second")).build())
+          .build());
+      req.onCompleted();
+
+      assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+      assertThat(errorRef.get()).isNull();
+      assertThat(summaryRef.get()).isNotNull();
+
+      final InsertSummary summary = summaryRef.get();
+      // Exactly one row stored, the second occurrence merged on top of the first, no lost-row error.
+      assertThat(summary.getFailed()).isEqualTo(0);
+      assertThat(summary.getInserted() + summary.getUpdated()).isEqualTo(2);
+      assertThat(firstLong("SELECT count(*) AS cnt FROM " + typeName, "cnt")).isEqualTo(1);
+      assertThat(firstString("SELECT v FROM " + typeName + " WHERE k = 'a'", "v")).isEqualTo("second");
+    } finally {
+      cmd("DROP TYPE " + typeName + " IF EXISTS UNSAFE");
+    }
+  }
+
+  @Test
+  void conflictUpdateWithExplicitUpdateColumnsMerges() throws Exception {
+    final String typeName = "Issue4656WithCols_" + System.currentTimeMillis();
+    cmd("CREATE DOCUMENT TYPE " + typeName);
+    cmd("CREATE PROPERTY " + typeName + ".k STRING");
+    cmd("CREATE PROPERTY " + typeName + ".v STRING");
+    cmd("CREATE INDEX ON " + typeName + "(k) UNIQUE");
+    cmd("INSERT INTO " + typeName + " SET k = 'a', v = 'orig'");
+    try {
+      final GrpcRecord row = GrpcRecord.newBuilder().setType(typeName)
+          .putProperties("k", stringValue("a")).putProperties("v", stringValue("changed")).build();
+
+      final InsertSummary summary = upsert(typeName, row, java.util.List.of("v"));
+
+      assertThat(summary.getUpdated()).isEqualTo(1);
+      assertThat(summary.getFailed()).isEqualTo(0);
+      assertThat(firstString("SELECT v FROM " + typeName + " WHERE k = 'a'", "v")).isEqualTo("changed");
+    } finally {
+      cmd("DROP TYPE " + typeName + " IF EXISTS UNSAFE");
+    }
+  }
+
+  @Test
+  void conflictUpdateMergesAllNonKeyColumnsForVertex() throws Exception {
+    final String typeName = "Issue4656Vertex_" + System.currentTimeMillis();
+    cmd("CREATE VERTEX TYPE " + typeName);
+    cmd("CREATE PROPERTY " + typeName + ".k STRING");
+    cmd("CREATE PROPERTY " + typeName + ".v STRING");
+    cmd("CREATE INDEX ON " + typeName + "(k) UNIQUE");
+    cmd("CREATE VERTEX " + typeName + " SET k = 'a', v = 'orig'");
+    try {
+      final GrpcRecord row = GrpcRecord.newBuilder().setType(typeName)
+          .putProperties("k", stringValue("a")).putProperties("v", stringValue("changed")).build();
+
+      final InsertSummary summary = upsert(typeName, row, java.util.List.of()); // empty update columns
+
+      assertThat(summary.getUpdated()).isEqualTo(1);
+      assertThat(summary.getFailed()).isEqualTo(0);
+      assertThat(firstString("SELECT v FROM " + typeName + " WHERE k = 'a'", "v")).isEqualTo("changed");
+      assertThat(firstLong("SELECT count(*) AS cnt FROM " + typeName, "cnt")).isEqualTo(1);
+    } finally {
+      cmd("DROP TYPE " + typeName + " IF EXISTS UNSAFE");
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // (3) Edges honour conflict_mode
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  void edgeConflictUpdateUpdatesExistingEdgeInsteadOfFailing() throws Exception {
+    final long suffix = System.currentTimeMillis();
+    final String vType = "Issue4656Node_" + suffix;
+    final String eType = "Issue4656Edge_" + suffix;
+    cmd("CREATE VERTEX TYPE " + vType);
+    cmd("CREATE PROPERTY " + vType + ".name STRING");
+    cmd("CREATE VERTEX " + vType + " SET name = 'A'");
+    cmd("CREATE VERTEX " + vType + " SET name = 'B'");
+    cmd("CREATE EDGE TYPE " + eType);
+    cmd("CREATE PROPERTY " + eType + ".k STRING");
+    cmd("CREATE PROPERTY " + eType + ".v STRING");
+    cmd("CREATE INDEX ON " + eType + "(k) UNIQUE");
+
+    final String ridA = firstRid("SELECT FROM " + vType + " WHERE name = 'A'");
+    final String ridB = firstRid("SELECT FROM " + vType + " WHERE name = 'B'");
+    cmd("CREATE EDGE " + eType + " FROM " + ridA + " TO " + ridB + " SET k = 'e1', v = 'orig'");
+    try {
+      final GrpcRecord row = GrpcRecord.newBuilder().setType(eType)
+          .putProperties("out", stringValue(ridA)).putProperties("in", stringValue(ridB))
+          .putProperties("k", stringValue("e1")).putProperties("v", stringValue("changed")).build();
+
+      final InsertSummary summary = upsert(eType, row, java.util.List.of("v"));
+
+      // Issue #4656 (3): the edge must be updated, not inserted, and not failed.
+      assertThat(summary.getUpdated()).isEqualTo(1);
+      assertThat(summary.getInserted()).isEqualTo(0);
+      assertThat(summary.getFailed()).isEqualTo(0);
+      assertThat(firstString("SELECT v FROM " + eType + " WHERE k = 'e1'", "v")).isEqualTo("changed");
+      assertThat(firstLong("SELECT count(*) AS cnt FROM " + eType, "cnt")).isEqualTo(1);
+    } finally {
+      cmd("DROP TYPE " + eType + " IF EXISTS UNSAFE");
+      cmd("DROP TYPE " + vType + " IF EXISTS UNSAFE");
+    }
+  }
+
+  @Test
+  void edgeConflictIgnoreSkipsExistingEdge() throws Exception {
+    final long suffix = System.currentTimeMillis();
+    final String vType = "Issue4656NodeIgn_" + suffix;
+    final String eType = "Issue4656EdgeIgn_" + suffix;
+    cmd("CREATE VERTEX TYPE " + vType);
+    cmd("CREATE PROPERTY " + vType + ".name STRING");
+    cmd("CREATE VERTEX " + vType + " SET name = 'A'");
+    cmd("CREATE VERTEX " + vType + " SET name = 'B'");
+    cmd("CREATE EDGE TYPE " + eType);
+    cmd("CREATE PROPERTY " + eType + ".k STRING");
+    cmd("CREATE PROPERTY " + eType + ".v STRING");
+    cmd("CREATE INDEX ON " + eType + "(k) UNIQUE");
+
+    final String ridA = firstRid("SELECT FROM " + vType + " WHERE name = 'A'");
+    final String ridB = firstRid("SELECT FROM " + vType + " WHERE name = 'B'");
+    cmd("CREATE EDGE " + eType + " FROM " + ridA + " TO " + ridB + " SET k = 'e1', v = 'orig'");
+    try {
+      final CountDownLatch done = new CountDownLatch(1);
+      final AtomicReference<InsertSummary> summaryRef = new AtomicReference<>();
+      final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+      final StreamObserver<InsertChunk> req = asyncAuthenticatedStub.insertStream(new StreamObserver<>() {
+        @Override public void onNext(final InsertSummary s) { summaryRef.set(s); }
+        @Override public void onError(final Throwable t) { errorRef.set(t); done.countDown(); }
+        @Override public void onCompleted() { done.countDown(); }
+      });
+
+      req.onNext(InsertChunk.newBuilder()
+          .setSessionId("issue-4656-edge-ignore").setChunkSeq(0).setLast(true)
+          .setOptions(InsertOptions.newBuilder()
+              .setDatabase(getDatabaseName()).setCredentials(credentials()).setTargetClass(eType)
+              .setConflictMode(InsertOptions.ConflictMode.CONFLICT_IGNORE)
+              .addKeyColumns("k")
+              .setTransactionMode(InsertOptions.TransactionMode.PER_STREAM).build())
+          .addRows(GrpcRecord.newBuilder().setType(eType)
+              .putProperties("out", stringValue(ridA)).putProperties("in", stringValue(ridB))
+              .putProperties("k", stringValue("e1")).putProperties("v", stringValue("changed")).build())
+          .build());
+      req.onCompleted();
+
+      assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+      assertThat(errorRef.get()).isNull();
+      assertThat(summaryRef.get()).isNotNull();
+
+      final InsertSummary summary = summaryRef.get();
+      assertThat(summary.getIgnored()).isEqualTo(1);
+      assertThat(summary.getInserted()).isEqualTo(0);
+      assertThat(summary.getFailed()).isEqualTo(0);
+      // The pre-existing edge must be left untouched.
+      assertThat(firstString("SELECT v FROM " + eType + " WHERE k = 'e1'", "v")).isEqualTo("orig");
+      assertThat(firstLong("SELECT count(*) AS cnt FROM " + eType, "cnt")).isEqualTo(1);
+    } finally {
+      cmd("DROP TYPE " + eType + " IF EXISTS UNSAFE");
+      cmd("DROP TYPE " + vType + " IF EXISTS UNSAFE");
+    }
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4656InsertStreamConflictUpdateIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4656InsertStreamConflictUpdateIT.java
@@ -33,6 +33,7 @@ import io.grpc.MethodDescriptor;
 import io.grpc.stub.StreamObserver;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -59,6 +60,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
+@Tag("slow")
 public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
 
   private static final int GRPC_PORT = 50051;
@@ -132,7 +134,9 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
   }
 
   private String firstString(final String query, final String prop) {
-    return firstRecord(query).getPropertiesMap().get(prop).getStringValue();
+    final GrpcRecord rec = firstRecord(query);
+    assertThat(rec.getPropertiesMap()).as("missing property '%s' in: %s", prop, query).containsKey(prop);
+    return rec.getPropertiesMap().get(prop).getStringValue();
   }
 
   private String firstRid(final String query) {
@@ -140,7 +144,9 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
   }
 
   private long firstLong(final String query, final String prop) {
-    return firstRecord(query).getPropertiesMap().get(prop).getInt64Value();
+    final GrpcRecord rec = firstRecord(query);
+    assertThat(rec.getPropertiesMap()).as("missing property '%s' in: %s", prop, query).containsKey(prop);
+    return rec.getPropertiesMap().get(prop).getInt64Value();
   }
 
   /** Runs a single-chunk {@code InsertStream} in PER_STREAM mode and returns the summary. */

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4656InsertStreamConflictUpdateIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4656InsertStreamConflictUpdateIT.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -134,7 +135,7 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
   }
 
   /** Sends a single-row {@code CONFLICT_UPDATE} {@code InsertStream} and returns the resulting summary. */
-  private InsertSummary upsert(final String typeName, final GrpcRecord row, final java.util.List<String> updateColumns)
+  private InsertSummary upsert(final String typeName, final GrpcRecord row, final List<String> updateColumns)
       throws Exception {
     final CountDownLatch done = new CountDownLatch(1);
     final AtomicReference<InsertSummary> summaryRef = new AtomicReference<>();
@@ -182,7 +183,7 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
       final GrpcRecord row = GrpcRecord.newBuilder().setType(typeName)
           .putProperties("k", stringValue("a")).putProperties("v", stringValue("changed")).build();
 
-      final InsertSummary summary = upsert(typeName, row, java.util.List.of()); // empty update columns
+      final InsertSummary summary = upsert(typeName, row, List.of()); // empty update columns
 
       assertThat(summary.getUpdated()).isEqualTo(1);
       assertThat(summary.getFailed()).isEqualTo(0);
@@ -255,11 +256,12 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
       final GrpcRecord row = GrpcRecord.newBuilder().setType(typeName)
           .putProperties("k", stringValue("a")).putProperties("v", stringValue("changed")).build();
 
-      final InsertSummary summary = upsert(typeName, row, java.util.List.of("v"));
+      final InsertSummary summary = upsert(typeName, row, List.of("v"));
 
       assertThat(summary.getUpdated()).isEqualTo(1);
       assertThat(summary.getFailed()).isEqualTo(0);
       assertThat(firstString("SELECT v FROM " + typeName + " WHERE k = 'a'", "v")).isEqualTo("changed");
+      assertThat(firstLong("SELECT count(*) AS cnt FROM " + typeName, "cnt")).isEqualTo(1);
     } finally {
       cmd("DROP TYPE " + typeName + " IF EXISTS UNSAFE");
     }
@@ -277,7 +279,7 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
       final GrpcRecord row = GrpcRecord.newBuilder().setType(typeName)
           .putProperties("k", stringValue("a")).putProperties("v", stringValue("changed")).build();
 
-      final InsertSummary summary = upsert(typeName, row, java.util.List.of()); // empty update columns
+      final InsertSummary summary = upsert(typeName, row, List.of()); // empty update columns
 
       assertThat(summary.getUpdated()).isEqualTo(1);
       assertThat(summary.getFailed()).isEqualTo(0);
@@ -314,7 +316,7 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
           .putProperties("out", stringValue(ridA)).putProperties("in", stringValue(ridB))
           .putProperties("k", stringValue("e1")).putProperties("v", stringValue("changed")).build();
 
-      final InsertSummary summary = upsert(eType, row, java.util.List.of("v"));
+      final InsertSummary summary = upsert(eType, row, List.of("v"));
 
       // Issue #4656 (3): the edge must be updated, not inserted, and not failed.
       assertThat(summary.getUpdated()).isEqualTo(1);

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4656InsertStreamConflictUpdateIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4656InsertStreamConflictUpdateIT.java
@@ -116,22 +116,24 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
         .setDatabase(getDatabaseName()).setCredentials(credentials()).setCommand(sql).build());
   }
 
-  private String firstString(final String query, final String prop) {
+  private GrpcRecord firstRecord(final String query) {
     final ExecuteQueryResponse resp = authenticatedStub.executeQuery(ExecuteQueryRequest.newBuilder()
         .setDatabase(getDatabaseName()).setCredentials(credentials()).setQuery(query).build());
-    return resp.getResultsList().get(0).getRecordsList().get(0).getPropertiesMap().get(prop).getStringValue();
+    assertThat(resp.getResultsList()).as("query returned no result set: %s", query).isNotEmpty();
+    assertThat(resp.getResultsList().get(0).getRecordsList()).as("query returned no records: %s", query).isNotEmpty();
+    return resp.getResultsList().get(0).getRecordsList().get(0);
+  }
+
+  private String firstString(final String query, final String prop) {
+    return firstRecord(query).getPropertiesMap().get(prop).getStringValue();
   }
 
   private String firstRid(final String query) {
-    final ExecuteQueryResponse resp = authenticatedStub.executeQuery(ExecuteQueryRequest.newBuilder()
-        .setDatabase(getDatabaseName()).setCredentials(credentials()).setQuery(query).build());
-    return resp.getResultsList().get(0).getRecordsList().get(0).getRid();
+    return firstRecord(query).getRid();
   }
 
   private long firstLong(final String query, final String prop) {
-    final ExecuteQueryResponse resp = authenticatedStub.executeQuery(ExecuteQueryRequest.newBuilder()
-        .setDatabase(getDatabaseName()).setCredentials(credentials()).setQuery(query).build());
-    return resp.getResultsList().get(0).getRecordsList().get(0).getPropertiesMap().get(prop).getInt64Value();
+    return firstRecord(query).getPropertiesMap().get(prop).getInt64Value();
   }
 
   /** Sends a single-row {@code CONFLICT_UPDATE} {@code InsertStream} and returns the resulting summary. */

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4656InsertStreamConflictUpdateIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4656InsertStreamConflictUpdateIT.java
@@ -136,9 +136,9 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
     return firstRecord(query).getPropertiesMap().get(prop).getInt64Value();
   }
 
-  /** Sends a single-row {@code CONFLICT_UPDATE} {@code InsertStream} and returns the resulting summary. */
-  private InsertSummary upsert(final String typeName, final GrpcRecord row, final List<String> updateColumns)
-      throws Exception {
+  /** Runs a single-chunk {@code InsertStream} keyed on column "k" in PER_STREAM mode and returns the summary. */
+  private InsertSummary runStream(final String typeName, final InsertOptions.ConflictMode mode,
+      final List<String> updateColumns, final GrpcRecord... rows) throws Exception {
     final CountDownLatch done = new CountDownLatch(1);
     final AtomicReference<InsertSummary> summaryRef = new AtomicReference<>();
     final AtomicReference<Throwable> errorRef = new AtomicReference<>();
@@ -151,22 +151,29 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
 
     final InsertOptions.Builder opts = InsertOptions.newBuilder()
         .setDatabase(getDatabaseName()).setCredentials(credentials()).setTargetClass(typeName)
-        .setConflictMode(InsertOptions.ConflictMode.CONFLICT_UPDATE)
+        .setConflictMode(mode)
         .addKeyColumns("k")
         .setTransactionMode(InsertOptions.TransactionMode.PER_STREAM);
     opts.addAllUpdateColumnsOnConflict(updateColumns);
 
-    req.onNext(InsertChunk.newBuilder()
+    final InsertChunk.Builder chunk = InsertChunk.newBuilder()
         .setSessionId("issue-4656").setChunkSeq(0).setLast(true)
-        .setOptions(opts.build())
-        .addRows(row)
-        .build());
+        .setOptions(opts.build());
+    for (final GrpcRecord row : rows)
+      chunk.addRows(row);
+    req.onNext(chunk.build());
     req.onCompleted();
 
     assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
     assertThat(errorRef.get()).isNull();
     assertThat(summaryRef.get()).isNotNull();
     return summaryRef.get();
+  }
+
+  /** Sends a single-row {@code CONFLICT_UPDATE} {@code InsertStream} and returns the resulting summary. */
+  private InsertSummary upsert(final String typeName, final GrpcRecord row, final List<String> updateColumns)
+      throws Exception {
+    return runStream(typeName, InsertOptions.ConflictMode.CONFLICT_UPDATE, updateColumns, row);
   }
 
   // ---------------------------------------------------------------------------------------------
@@ -189,7 +196,7 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
 
       assertThat(summary.getUpdated()).isEqualTo(1);
       assertThat(summary.getFailed()).isEqualTo(0);
-      // Issue #4656 (2): the row must actually be merged, not silently left unchanged.
+      // The row must actually be merged, not silently left unchanged.
       assertThat(firstString("SELECT v FROM " + typeName + " WHERE k = 'a'", "v")).isEqualTo("changed");
       assertThat(firstLong("SELECT count(*) AS cnt FROM " + typeName, "cnt")).isEqualTo(1);
     } finally {
@@ -199,43 +206,21 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
 
   @Test
   void conflictUpdateWithSameKeyTwiceInOneStreamDoesNotLoseTheRow() throws Exception {
-    // Issue #4656 (1): the same (new) key appearing twice in a single CONFLICT_UPDATE stream must
-    // resolve to one stored row (insert then update/merge), never a lost-row CONFLICT error.
+    // The same (new) key appearing twice in a single CONFLICT_UPDATE stream must resolve to one
+    // stored row (insert then update/merge), never a lost-row CONFLICT error.
     final String typeName = "Issue4656DupInStream_" + System.currentTimeMillis();
     cmd("CREATE DOCUMENT TYPE " + typeName);
     cmd("CREATE PROPERTY " + typeName + ".k STRING");
     cmd("CREATE PROPERTY " + typeName + ".v STRING");
     cmd("CREATE INDEX ON " + typeName + "(k) UNIQUE");
     try {
-      final CountDownLatch done = new CountDownLatch(1);
-      final AtomicReference<InsertSummary> summaryRef = new AtomicReference<>();
-      final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+      final GrpcRecord first = GrpcRecord.newBuilder().setType(typeName)
+          .putProperties("k", stringValue("a")).putProperties("v", stringValue("first")).build();
+      final GrpcRecord second = GrpcRecord.newBuilder().setType(typeName)
+          .putProperties("k", stringValue("a")).putProperties("v", stringValue("second")).build();
 
-      final StreamObserver<InsertChunk> req = asyncAuthenticatedStub.insertStream(new StreamObserver<>() {
-        @Override public void onNext(final InsertSummary s) { summaryRef.set(s); }
-        @Override public void onError(final Throwable t) { errorRef.set(t); done.countDown(); }
-        @Override public void onCompleted() { done.countDown(); }
-      });
+      final InsertSummary summary = runStream(typeName, InsertOptions.ConflictMode.CONFLICT_UPDATE, List.of(), first, second);
 
-      req.onNext(InsertChunk.newBuilder()
-          .setSessionId("issue-4656-dup-in-stream").setChunkSeq(0).setLast(true)
-          .setOptions(InsertOptions.newBuilder()
-              .setDatabase(getDatabaseName()).setCredentials(credentials()).setTargetClass(typeName)
-              .setConflictMode(InsertOptions.ConflictMode.CONFLICT_UPDATE)
-              .addKeyColumns("k")
-              .setTransactionMode(InsertOptions.TransactionMode.PER_STREAM).build())
-          .addRows(GrpcRecord.newBuilder().setType(typeName)
-              .putProperties("k", stringValue("a")).putProperties("v", stringValue("first")).build())
-          .addRows(GrpcRecord.newBuilder().setType(typeName)
-              .putProperties("k", stringValue("a")).putProperties("v", stringValue("second")).build())
-          .build());
-      req.onCompleted();
-
-      assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
-      assertThat(errorRef.get()).isNull();
-      assertThat(summaryRef.get()).isNotNull();
-
-      final InsertSummary summary = summaryRef.get();
       // Exactly one row stored, the second occurrence merged on top of the first, no lost-row error.
       assertThat(summary.getFailed()).isEqualTo(0);
       assertThat(summary.getInserted() + summary.getUpdated()).isEqualTo(2);
@@ -292,6 +277,31 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
     }
   }
 
+  @Test
+  void conflictIgnoreSkipsExistingVertex() throws Exception {
+    final String typeName = "Issue4656VertexIgn_" + System.currentTimeMillis();
+    cmd("CREATE VERTEX TYPE " + typeName);
+    cmd("CREATE PROPERTY " + typeName + ".k STRING");
+    cmd("CREATE PROPERTY " + typeName + ".v STRING");
+    cmd("CREATE INDEX ON " + typeName + "(k) UNIQUE");
+    cmd("CREATE VERTEX " + typeName + " SET k = 'a', v = 'orig'");
+    try {
+      final GrpcRecord row = GrpcRecord.newBuilder().setType(typeName)
+          .putProperties("k", stringValue("a")).putProperties("v", stringValue("changed")).build();
+
+      final InsertSummary summary = runStream(typeName, InsertOptions.ConflictMode.CONFLICT_IGNORE, List.of(), row);
+
+      assertThat(summary.getIgnored()).isEqualTo(1);
+      assertThat(summary.getInserted()).isEqualTo(0);
+      assertThat(summary.getFailed()).isEqualTo(0);
+      // The pre-existing vertex must be left untouched.
+      assertThat(firstString("SELECT v FROM " + typeName + " WHERE k = 'a'", "v")).isEqualTo("orig");
+      assertThat(firstLong("SELECT count(*) AS cnt FROM " + typeName, "cnt")).isEqualTo(1);
+    } finally {
+      cmd("DROP TYPE " + typeName + " IF EXISTS UNSAFE");
+    }
+  }
+
   // ---------------------------------------------------------------------------------------------
   // (3) Edges honour conflict_mode
   // ---------------------------------------------------------------------------------------------
@@ -320,7 +330,7 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
 
       final InsertSummary summary = upsert(eType, row, List.of("v"));
 
-      // Issue #4656 (3): the edge must be updated, not inserted, and not failed.
+      // The edge must be updated, not inserted, and not failed.
       assertThat(summary.getUpdated()).isEqualTo(1);
       assertThat(summary.getInserted()).isEqualTo(0);
       assertThat(summary.getFailed()).isEqualTo(0);
@@ -350,34 +360,12 @@ public class Issue4656InsertStreamConflictUpdateIT extends BaseGraphServerTest {
     final String ridB = firstRid("SELECT FROM " + vType + " WHERE name = 'B'");
     cmd("CREATE EDGE " + eType + " FROM " + ridA + " TO " + ridB + " SET k = 'e1', v = 'orig'");
     try {
-      final CountDownLatch done = new CountDownLatch(1);
-      final AtomicReference<InsertSummary> summaryRef = new AtomicReference<>();
-      final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+      final GrpcRecord row = GrpcRecord.newBuilder().setType(eType)
+          .putProperties("out", stringValue(ridA)).putProperties("in", stringValue(ridB))
+          .putProperties("k", stringValue("e1")).putProperties("v", stringValue("changed")).build();
 
-      final StreamObserver<InsertChunk> req = asyncAuthenticatedStub.insertStream(new StreamObserver<>() {
-        @Override public void onNext(final InsertSummary s) { summaryRef.set(s); }
-        @Override public void onError(final Throwable t) { errorRef.set(t); done.countDown(); }
-        @Override public void onCompleted() { done.countDown(); }
-      });
+      final InsertSummary summary = runStream(eType, InsertOptions.ConflictMode.CONFLICT_IGNORE, List.of(), row);
 
-      req.onNext(InsertChunk.newBuilder()
-          .setSessionId("issue-4656-edge-ignore").setChunkSeq(0).setLast(true)
-          .setOptions(InsertOptions.newBuilder()
-              .setDatabase(getDatabaseName()).setCredentials(credentials()).setTargetClass(eType)
-              .setConflictMode(InsertOptions.ConflictMode.CONFLICT_IGNORE)
-              .addKeyColumns("k")
-              .setTransactionMode(InsertOptions.TransactionMode.PER_STREAM).build())
-          .addRows(GrpcRecord.newBuilder().setType(eType)
-              .putProperties("out", stringValue(ridA)).putProperties("in", stringValue(ridB))
-              .putProperties("k", stringValue("e1")).putProperties("v", stringValue("changed")).build())
-          .build());
-      req.onCompleted();
-
-      assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
-      assertThat(errorRef.get()).isNull();
-      assertThat(summaryRef.get()).isNotNull();
-
-      final InsertSummary summary = summaryRef.get();
       assertThat(summary.getIgnored()).isEqualTo(1);
       assertThat(summary.getInserted()).isEqualTo(0);
       assertThat(summary.getFailed()).isEqualTo(0);


### PR DESCRIPTION
… columns when update list empty, honor conflict_mode on edges, retry on duplicate key

- (2) empty update_columns_on_conflict now merges all non-key columns of the incoming record (true upsert) instead of silently no-oping while reporting updated
- (3) edge targets now honor conflict_mode/key_columns like documents and vertices; the upsert/ignore check runs before newEdge() so a match never leaves a dangling edge
- (1) CONFLICT_UPDATE retries the match path on DuplicatedKeyException instead of losing the row to a CONFLICT error (optimistic-concurrency, caller-retriable residual)
- unified the per-type upsert helpers into tryUpsertByRecord/keyExistsByRecord

Adds regression test Issue4656InsertStreamConflictUpdateIT (15 tests).

**Known limitation:** under CONFLICT_UPDATE a column whose incoming value is absent or a proto NullValue is skipped (left unchanged), so there is currently no way to clear (null-out) a field via upsert.

## What does this PR do?

A brief description of the change being made with this pull request.

## Motivation

What inspired you to submit this pull request?

## Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

## Additional Notes

Anything else we should know when reviewing?

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios