### PR TITLE
fix(grpc): time-series INSERT over gRPC threw on empty @type/@rid

### DIFF
--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
@@ -1898,11 +1898,9 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     // Convert properties
     grpcRecord.getPropertiesMap().forEach((k, v) -> map.put(k, grpcValueToObject(v)));
 
-    // Add metadata. Proto3 scalar fields default to "" (never null), so an absent rid/type arrives
-    // as an empty string. Treat empty as absent - mirroring the HTTP/JSON contract where the metadata
-    // key is simply missing - otherwise non-addressable rows (e.g. time-series points, which have no
-    // @rid) make RemoteImmutableDocument call newRID("")/getType(""), throwing on every such row even
-    // though the server already committed.
+    // Proto3 scalars default to "" (never null), so an absent rid/type arrives empty. Treat empty as
+    // absent, mirroring the HTTP/JSON contract (missing key), so non-addressable rows (time-series
+    // points have no @rid) do not make RemoteImmutableDocument call newRID("")/getType("").
     if (!grpcRecord.getRid().isEmpty())
       map.put("@rid", grpcRecord.getRid());
     if (!grpcRecord.getType().isEmpty())

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
@@ -1898,9 +1898,7 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     // Convert properties
     grpcRecord.getPropertiesMap().forEach((k, v) -> map.put(k, grpcValueToObject(v)));
 
-    // Proto3 scalars default to "" (never null), so an absent rid/type arrives empty. Treat empty as
-    // absent, mirroring the HTTP/JSON contract (missing key), so non-addressable rows (time-series
-    // points have no @rid) do not make RemoteImmutableDocument call newRID("")/getType("").
+    // Proto3 empty == absent: non-addressable rows (e.g. time-series points) have no @rid/@type.
     if (!grpcRecord.getRid().isEmpty())
       map.put("@rid", grpcRecord.getRid());
     if (!grpcRecord.getType().isEmpty())

--- a/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
+++ b/grpc-client/src/main/java/com/arcadedb/remote/grpc/RemoteGrpcDatabase.java
@@ -1898,9 +1898,15 @@ public class RemoteGrpcDatabase extends RemoteDatabase {
     // Convert properties
     grpcRecord.getPropertiesMap().forEach((k, v) -> map.put(k, grpcValueToObject(v)));
 
-    // Add metadata
-    map.put("@rid", grpcRecord.getRid());
-    map.put("@type", grpcRecord.getType());
+    // Add metadata. Proto3 scalar fields default to "" (never null), so an absent rid/type arrives
+    // as an empty string. Treat empty as absent - mirroring the HTTP/JSON contract where the metadata
+    // key is simply missing - otherwise non-addressable rows (e.g. time-series points, which have no
+    // @rid) make RemoteImmutableDocument call newRID("")/getType(""), throwing on every such row even
+    // though the server already committed.
+    if (!grpcRecord.getRid().isEmpty())
+      map.put("@rid", grpcRecord.getRid());
+    if (!grpcRecord.getType().isEmpty())
+      map.put("@type", grpcRecord.getType());
 
     GrpcValue catFromGrpcRecord = grpcRecord.getPropertiesMap().get("@cat");
 

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/TimeSeriesGrpcInsertMaterializationIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/TimeSeriesGrpcInsertMaterializationIT.java
@@ -49,7 +49,7 @@ class TimeSeriesGrpcInsertMaterializationIT extends BaseGraphServerTest {
   @Override
   public void setTestConfiguration() {
     super.setTestConfiguration();
-    GlobalConfiguration.SERVER_PLUGINS.setValue("GRPC:com.arcadedb.server.grpc.GrpcServerPlugin");
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
   }
 
   @AfterEach

--- a/grpc-client/src/test/java/com/arcadedb/remote/grpc/TimeSeriesGrpcInsertMaterializationIT.java
+++ b/grpc-client/src/test/java/com/arcadedb/remote/grpc/TimeSeriesGrpcInsertMaterializationIT.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Regression: a single-row SQL {@code INSERT} into a TIME SERIES type, executed through the gRPC
+ * client, must materialise its response without throwing. Time-series points are non-addressable
+ * (no @rid), so the server returns the inserted row with an empty proto rid field. The client copied
+ * that empty string into the metadata map, and {@code RemoteImmutableDocument} then called
+ * {@code newRID("")}, throwing "The RID '' is not valid" on every TS insert even though the point was
+ * already committed. Proto3 scalars cannot be null, so the gRPC client must treat an empty proto
+ * rid/type as absent (matching the HTTP/JSON contract where the metadata key is simply missing).
+ */
+class TimeSeriesGrpcInsertMaterializationIT extends BaseGraphServerTest {
+
+  private static final int    GRPC_PORT = 50051;
+  private static final String TYPE_NAME = "sensor";
+
+  private RemoteGrpcServer   grpcServer;
+  private RemoteGrpcDatabase db;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GRPC:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    if (db != null) {
+      db.close();
+      db = null;
+    }
+    if (grpcServer != null) {
+      grpcServer.close();
+      grpcServer = null;
+    }
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+
+  @Test
+  void tsInsertOverGrpcClientMaterialisesWithoutThrowing() {
+    grpcServer = new RemoteGrpcServer("localhost", GRPC_PORT, "root", DEFAULT_PASSWORD_FOR_TESTS, true, List.of());
+    db = new RemoteGrpcDatabase(grpcServer, "localhost", GRPC_PORT, 2480, getDatabaseName(), "root", DEFAULT_PASSWORD_FOR_TESTS);
+
+    db.command("sql", "CREATE TIMESERIES TYPE " + TYPE_NAME
+        + " TIMESTAMP ts TAGS (sensor_id STRING, region STRING) FIELDS (temperature DOUBLE, humidity DOUBLE)");
+
+    // Before the fix this threw "The RID '' is not valid" while materialising the inserted row.
+    assertThatCode(() -> {
+      try (final ResultSet rs = db.command("sql",
+          "INSERT INTO " + TYPE_NAME + " SET ts = ?, sensor_id = ?, region = ?, temperature = ?, humidity = ?",
+          1_000L, "sensor-0", "region-0", 15.0, 40.0)) {
+        // Materialise the row: this is where the empty @rid was rejected.
+        while (rs.hasNext())
+          rs.next();
+      }
+    }).doesNotThrowAnyException();
+
+    final ResultSet count = db.query("sql", "SELECT count(*) AS cnt FROM " + TYPE_NAME);
+    assertThat(((Number) count.next().getProperty("cnt")).longValue()).isEqualTo(1L);
+  }
+}

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -3198,8 +3198,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       }
     }
 
-    // HA leader-forwarding rebuilds each row as a non-element projection that carries the type only as
-    // the @type property, so the isElement() branch above did not populate the type field. Recover it.
+    // HA-forwarded rows are non-element projections; recover the type from the @type property.
     if (builder.getType().isEmpty()) {
       final Object typeProperty = result.getProperty(Property.TYPE_PROPERTY);
       if (typeProperty instanceof String typeName && !typeName.isEmpty())

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -3198,6 +3198,17 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       }
     }
 
+    // HA leader-forwarding returns each row as a plain projection (the follower rebuilds it from the
+    // leader's JSON as a non-element ResultInternal that carries the type name as the @type property),
+    // so the isElement() branch above never populated the type field. Recover it from @type, otherwise
+    // the client materialises the row with an empty type and RemoteImmutableDocument throws
+    // "Type with name '' was not found" - even though the leader already committed the record.
+    if (builder.getType().isEmpty()) {
+      final Object typeProperty = result.getProperty(Property.TYPE_PROPERTY);
+      if (typeProperty instanceof String typeName && !typeName.isEmpty())
+        builder.setType(typeName);
+    }
+
     // Iterate over ALL properties from the Result, including aliases
     for (String propertyName : result.getPropertyNames()) {
       Object value = result.getProperty(propertyName);

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -3198,11 +3198,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       }
     }
 
-    // HA leader-forwarding returns each row as a plain projection (the follower rebuilds it from the
-    // leader's JSON as a non-element ResultInternal that carries the type name as the @type property),
-    // so the isElement() branch above never populated the type field. Recover it from @type, otherwise
-    // the client materialises the row with an empty type and RemoteImmutableDocument throws
-    // "Type with name '' was not found" - even though the leader already committed the record.
+    // HA leader-forwarding rebuilds each row as a non-element projection that carries the type only as
+    // the @type property, so the isElement() branch above did not populate the type field. Recover it.
     if (builder.getType().isEmpty()) {
       final Object typeProperty = result.getProperty(Property.TYPE_PROPERTY);
       if (typeProperty instanceof String typeName && !typeName.isEmpty())

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcTestAuthInterceptor.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcTestAuthInterceptor.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+
+/**
+ * Test client interceptor that injects the ArcadeDB gRPC auth headers (user, password, database) on
+ * every call. Shared by the gRPC server integration tests that authenticate via header metadata.
+ */
+final class GrpcTestAuthInterceptor implements ClientInterceptor {
+  private static final Metadata.Key<String> USER_HEADER     =
+      Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER =
+      Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER =
+      Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  private final String user;
+  private final String password;
+  private final String database;
+
+  GrpcTestAuthInterceptor(final String user, final String password, final String database) {
+    this.user = user;
+    this.password = password;
+    this.database = database;
+  }
+
+  @Override
+  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(final MethodDescriptor<ReqT, RespT> method,
+      final CallOptions callOptions, final Channel next) {
+    return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+      @Override
+      public void start(final Listener<RespT> responseListener, final Metadata headers) {
+        headers.put(USER_HEADER, user);
+        headers.put(PASSWORD_HEADER, password);
+        headers.put(DATABASE_HEADER, database);
+        super.start(responseListener, headers);
+      }
+    };
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/TimeSeriesGrpcForwardedInsertTypeIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/TimeSeriesGrpcForwardedInsertTypeIT.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.server.ha.raft.BaseRaftHATest;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test: a single-row time-series {@code INSERT} sent over gRPC to a FOLLOWER (so the
+ * command is forwarded to the Raft leader) must return a result row that carries the type name.
+ * <p>
+ * The leader returns each forwarded row as a plain projection (the follower rebuilds it from the
+ * leader's JSON as a non-element {@code ResultInternal} with {@code @type} as a property). The gRPC
+ * row converter only set the record type field for element results, so the forwarded TS-insert row
+ * was emitted with an empty type. The client {@code RemoteImmutableDocument} then threw
+ * "Type with name '' was not found" on every TS insert while materialising the response, even though
+ * the leader had already committed the point.
+ */
+@Tag("slow")
+class TimeSeriesGrpcForwardedInsertTypeIT extends BaseRaftHATest {
+
+  private static final int    BASE_GRPC_PORT = 51091;
+  private static final String TYPE_NAME      = "sensor";
+
+  private static final Metadata.Key<String> USER_HEADER     =
+      Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER =
+      Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER =
+      Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  private ManagedChannel channel;
+
+  private final class AuthClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(final MethodDescriptor<ReqT, RespT> method,
+        final CallOptions callOptions, final Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata headers) {
+          headers.put(USER_HEADER, "root");
+          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
+          headers.put(DATABASE_HEADER, getDatabaseName());
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    final String serverName = config.getValueAsString(GlobalConfiguration.SERVER_NAME);
+    final int index = Integer.parseInt(serverName.substring(serverName.lastIndexOf('_') + 1));
+    config.setValue("arcadedb.grpc.enabled", "true");
+    config.setValue("arcadedb.grpc.port", String.valueOf(BASE_GRPC_PORT + index));
+    config.setValue("arcadedb.grpc.host", "localhost");
+    config.setValue("arcadedb.grpc.reflection.enabled", "false");
+    config.setValue("arcadedb.grpc.health.enabled", "false");
+
+    final String existingPlugins = config.getValueAsString(GlobalConfiguration.SERVER_PLUGINS);
+    final String pluginEntry = "GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin";
+    if (existingPlugins == null || existingPlugins.isEmpty())
+      config.setValue(GlobalConfiguration.SERVER_PLUGINS, pluginEntry);
+    else if (!existingPlugins.contains(pluginEntry))
+      config.setValue(GlobalConfiguration.SERVER_PLUGINS, existingPlugins + "," + pluginEntry);
+  }
+
+  @Override
+  protected int getServerCount() {
+    return 2;
+  }
+
+  @AfterEach
+  void teardownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+      channel = null;
+    }
+  }
+
+  @Test
+  void forwardedTsInsertReturnsTypeName() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+    leaderDb.command("sql",
+        "CREATE TIMESERIES TYPE " + TYPE_NAME
+            + " TIMESTAMP ts TAGS (sensor_id STRING, region STRING) FIELDS (temperature DOUBLE, humidity DOUBLE)");
+
+    waitForAllServers();
+
+    // Connect to a FOLLOWER so the INSERT is forwarded to the leader (the path that lost the type).
+    final int followerIndex = (leaderIndex + 1) % getServerCount();
+
+    channel = ManagedChannelBuilder
+        .forAddress("localhost", BASE_GRPC_PORT + followerIndex)
+        .usePlaintext()
+        .maxInboundMessageSize(64 * 1024 * 1024)
+        .build();
+    final Channel authenticated = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+    final ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub stub = ArcadeDbServiceGrpc.newBlockingStub(authenticated);
+
+    final DatabaseCredentials credentials = DatabaseCredentials.newBuilder()
+        .setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+
+    final ExecuteCommandResponse resp = stub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCommand("INSERT INTO " + TYPE_NAME + " SET ts = ?, sensor_id = ?, region = ?, temperature = ?, humidity = ?")
+        .setLanguage("sql")
+        .setReturnRows(true)
+        .setCredentials(credentials)
+        .putParameters("0", GrpcValue.newBuilder().setInt64Value(1_000L).build())
+        .putParameters("1", GrpcValue.newBuilder().setStringValue("sensor-0").build())
+        .putParameters("2", GrpcValue.newBuilder().setStringValue("region-0").build())
+        .putParameters("3", GrpcValue.newBuilder().setDoubleValue(15.0).build())
+        .putParameters("4", GrpcValue.newBuilder().setDoubleValue(40.0).build())
+        .build());
+
+    assertThat(resp.getSuccess()).as("leader must commit the forwarded TS insert").isTrue();
+    assertThat(resp.getRecordsList()).as("forwarded INSERT with returnRows must return the inserted row").isNotEmpty();
+
+    final GrpcRecord record = resp.getRecords(0);
+    final String dump = "type='" + record.getType() + "' rid='" + record.getRid() + "' props=" + record.getPropertiesMap();
+
+    assertThat(record.getType())
+        .as("forwarded TS insert result row must carry the type name, not empty. Server emitted: %s", dump)
+        .isEqualTo(TYPE_NAME);
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/TimeSeriesGrpcForwardedInsertTypeIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/TimeSeriesGrpcForwardedInsertTypeIT.java
@@ -22,16 +22,10 @@ import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.server.ha.raft.BaseRaftHATest;
-import io.grpc.CallOptions;
 import io.grpc.Channel;
-import io.grpc.ClientCall;
-import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
-import io.grpc.ForwardingClientCall;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import io.grpc.Metadata;
-import io.grpc.MethodDescriptor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -57,30 +51,7 @@ class TimeSeriesGrpcForwardedInsertTypeIT extends BaseRaftHATest {
   private static final int    BASE_GRPC_PORT = 51091;
   private static final String TYPE_NAME      = "sensor";
 
-  private static final Metadata.Key<String> USER_HEADER     =
-      Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
-  private static final Metadata.Key<String> PASSWORD_HEADER =
-      Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
-  private static final Metadata.Key<String> DATABASE_HEADER =
-      Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
-
   private ManagedChannel channel;
-
-  private final class AuthClientInterceptor implements ClientInterceptor {
-    @Override
-    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(final MethodDescriptor<ReqT, RespT> method,
-        final CallOptions callOptions, final Channel next) {
-      return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
-        @Override
-        public void start(final Listener<RespT> responseListener, final Metadata headers) {
-          headers.put(USER_HEADER, "root");
-          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
-          headers.put(DATABASE_HEADER, getDatabaseName());
-          super.start(responseListener, headers);
-        }
-      };
-    }
-  }
 
   @Override
   protected void onServerConfiguration(final ContextConfiguration config) {
@@ -135,7 +106,8 @@ class TimeSeriesGrpcForwardedInsertTypeIT extends BaseRaftHATest {
         .usePlaintext()
         .maxInboundMessageSize(64 * 1024 * 1024)
         .build();
-    final Channel authenticated = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+    final Channel authenticated = ClientInterceptors.intercept(channel,
+        new GrpcTestAuthInterceptor("root", DEFAULT_PASSWORD_FOR_TESTS, getDatabaseName()));
     final ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub stub = ArcadeDbServiceGrpc.newBlockingStub(authenticated);
 
     final DatabaseCredentials credentials = DatabaseCredentials.newBuilder()

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/TimeSeriesGrpcInsertResultTypeIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/TimeSeriesGrpcInsertResultTypeIT.java
@@ -79,6 +79,7 @@ public class TimeSeriesGrpcInsertResultTypeIT extends BaseGraphServerTest {
       channel.shutdown();
       channel.awaitTermination(5, TimeUnit.SECONDS);
     }
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
   }
 
   private final class AuthClientInterceptor implements ClientInterceptor {
@@ -133,8 +134,6 @@ public class TimeSeriesGrpcInsertResultTypeIT extends BaseGraphServerTest {
     assertThat(resp.getRecordsList()).as("INSERT with returnRows must return the inserted row").isNotEmpty();
 
     final GrpcRecord record = resp.getRecords(0);
-
-    // DIAGNOSTIC dump (visible on failure) - shows exactly what the server emits.
     final String dump = "type='" + record.getType() + "' rid='" + record.getRid() + "' props=" + record.getPropertiesMap();
 
     assertThat(record.getType())

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/TimeSeriesGrpcInsertResultTypeIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/TimeSeriesGrpcInsertResultTypeIT.java
@@ -81,7 +81,7 @@ public class TimeSeriesGrpcInsertResultTypeIT extends BaseGraphServerTest {
     }
   }
 
-  private class AuthClientInterceptor implements ClientInterceptor {
+  private final class AuthClientInterceptor implements ClientInterceptor {
     @Override
     public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
         final MethodDescriptor<ReqT, RespT> method, final CallOptions callOptions, final Channel next) {

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/TimeSeriesGrpcInsertResultTypeIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/TimeSeriesGrpcInsertResultTypeIT.java
@@ -20,16 +20,10 @@ package com.arcadedb.server.grpc;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.server.BaseGraphServerTest;
-import io.grpc.CallOptions;
 import io.grpc.Channel;
-import io.grpc.ClientCall;
-import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
-import io.grpc.ForwardingClientCall;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import io.grpc.Metadata;
-import io.grpc.MethodDescriptor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,17 +39,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * "Type with name '' was not found" on every TS insert while materialising the response, even though
  * the server had already committed the point.
  */
-public class TimeSeriesGrpcInsertResultTypeIT extends BaseGraphServerTest {
+class TimeSeriesGrpcInsertResultTypeIT extends BaseGraphServerTest {
 
   private static final int    GRPC_PORT = 50051;
   private static final String TYPE_NAME = "sensor";
-
-  private static final Metadata.Key<String> USER_HEADER     =
-      Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
-  private static final Metadata.Key<String> PASSWORD_HEADER =
-      Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
-  private static final Metadata.Key<String> DATABASE_HEADER =
-      Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
 
   private ManagedChannel                                  channel;
   private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub authenticatedStub;
@@ -69,32 +56,20 @@ public class TimeSeriesGrpcInsertResultTypeIT extends BaseGraphServerTest {
   @BeforeEach
   void setupGrpcClient() {
     channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
-    final Channel authenticatedChannel = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+    final Channel authenticatedChannel = ClientInterceptors.intercept(channel,
+        new GrpcTestAuthInterceptor("root", DEFAULT_PASSWORD_FOR_TESTS, getDatabaseName()));
     authenticatedStub = ArcadeDbServiceGrpc.newBlockingStub(authenticatedChannel);
   }
 
   @AfterEach
   void shutdownGrpcClient() throws InterruptedException {
-    if (channel != null) {
-      channel.shutdown();
-      channel.awaitTermination(5, TimeUnit.SECONDS);
-    }
-    GlobalConfiguration.SERVER_PLUGINS.setValue("");
-  }
-
-  private final class AuthClientInterceptor implements ClientInterceptor {
-    @Override
-    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
-        final MethodDescriptor<ReqT, RespT> method, final CallOptions callOptions, final Channel next) {
-      return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
-        @Override
-        public void start(final Listener<RespT> responseListener, final Metadata headers) {
-          headers.put(USER_HEADER, "root");
-          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
-          headers.put(DATABASE_HEADER, getDatabaseName());
-          super.start(responseListener, headers);
-        }
-      };
+    try {
+      if (channel != null) {
+        channel.shutdown();
+        channel.awaitTermination(5, TimeUnit.SECONDS);
+      }
+    } finally {
+      GlobalConfiguration.SERVER_PLUGINS.setValue("");
     }
   }
 

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/TimeSeriesGrpcInsertResultTypeIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/TimeSeriesGrpcInsertResultTypeIT.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test: a single-row SQL {@code INSERT} into a TIME SERIES type, executed over gRPC with
+ * {@code returnRows=true}, must return a result record carrying the type name. Previously the
+ * server emitted an empty type field, so the client (RemoteImmutableDocument) threw
+ * "Type with name '' was not found" on every TS insert while materialising the response, even though
+ * the server had already committed the point.
+ */
+public class TimeSeriesGrpcInsertResultTypeIT extends BaseGraphServerTest {
+
+  private static final int    GRPC_PORT = 50051;
+  private static final String TYPE_NAME = "sensor";
+
+  private static final Metadata.Key<String> USER_HEADER     =
+      Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER =
+      Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER =
+      Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  private ManagedChannel                                  channel;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub authenticatedStub;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void setupGrpcClient() {
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    final Channel authenticatedChannel = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+    authenticatedStub = ArcadeDbServiceGrpc.newBlockingStub(authenticatedChannel);
+  }
+
+  @AfterEach
+  void shutdownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private class AuthClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        final MethodDescriptor<ReqT, RespT> method, final CallOptions callOptions, final Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata headers) {
+          headers.put(USER_HEADER, "root");
+          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
+          headers.put(DATABASE_HEADER, getDatabaseName());
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+
+  private DatabaseCredentials credentials() {
+    return DatabaseCredentials.newBuilder()
+        .setUsername("root")
+        .setPassword(DEFAULT_PASSWORD_FOR_TESTS)
+        .build();
+  }
+
+  @Test
+  void tsInsertOverGrpcReturnsTypeName() {
+    authenticatedStub.executeCommand(
+        ExecuteCommandRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setCommand("CREATE TIMESERIES TYPE " + TYPE_NAME
+                + " TIMESTAMP ts TAGS (sensor_id STRING, region STRING) FIELDS (temperature DOUBLE, humidity DOUBLE)")
+            .build());
+
+    final ExecuteCommandResponse resp = authenticatedStub.executeCommand(
+        ExecuteCommandRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setCommand("INSERT INTO " + TYPE_NAME
+                + " SET ts = ?, sensor_id = ?, region = ?, temperature = ?, humidity = ?")
+            .setLanguage("sql")
+            .setReturnRows(true)
+            .putParameters("0", GrpcValue.newBuilder().setInt64Value(1_000L).build())
+            .putParameters("1", GrpcValue.newBuilder().setStringValue("sensor-0").build())
+            .putParameters("2", GrpcValue.newBuilder().setStringValue("region-0").build())
+            .putParameters("3", GrpcValue.newBuilder().setDoubleValue(15.0).build())
+            .putParameters("4", GrpcValue.newBuilder().setDoubleValue(40.0).build())
+            .build());
+
+    assertThat(resp.getSuccess()).as("server must commit the TS insert").isTrue();
+    assertThat(resp.getRecordsList()).as("INSERT with returnRows must return the inserted row").isNotEmpty();
+
+    final GrpcRecord record = resp.getRecords(0);
+
+    // DIAGNOSTIC dump (visible on failure) - shows exactly what the server emits.
+    final String dump = "type='" + record.getType() + "' rid='" + record.getRid() + "' props=" + record.getPropertiesMap();
+
+    assertThat(record.getType())
+        .as("TS insert result row must carry the type name, not empty. Server emitted: %s", dump)
+        .isEqualTo(TYPE_NAME);
+  }
+}


### PR DESCRIPTION
## Summary

A single-row SQL `INSERT` into a TIME SERIES type executed over gRPC failed **on the client while materialising the response - on every insert** - even though the server had already committed the point (so data converged, but the call threw). Two empty-field rejections surfaced in sequence:

1. **`Type with name '' was not found`** - when the client targets a Raft **follower**, the command is forwarded to the leader and the row is rebuilt as a non-element `ResultInternal` (`RaftReplicatedDatabase.parseResultSetFromJson`) that carries the type only as the `@type` property. `ArcadeDbGrpcService.convertResultToGrpcRecord` set the `GrpcRecord` type field only for element results, so the forwarded row shipped with an empty type and `RemoteImmutableDocument`'s constructor then called `getType("")`.
2. **`The RID '' is not valid`** - time-series points are non-addressable, so the server never sets a RID. Proto3 scalars cannot be null, so `GrpcRecord.getRid()` defaults to `""`. The client copied that empty string into the metadata map and `RemoteImmutableDocument` called `newRID("")`.

HTTP never hit either, because an absent metadata key is simply missing from the JSON map (vs. proto3's empty-string default).

## Fixes

- **Server** (`ArcadeDbGrpcService.convertResultToGrpcRecord`): recover the type field from the `@type` property for non-element (forwarded) rows, so the wire record is correct for any consumer.
- **Client** (`RemoteGrpcDatabase.grpcRecordToDBRecord`): treat an empty proto `@rid`/`@type` as **absent** (proto3 empty == absent), mirroring the HTTP/JSON contract. This is the only way to handle the empty `@rid`, since the server has no RID to send for a time-series point.

## Tests

- `grpcw` **`TimeSeriesGrpcForwardedInsertTypeIT`** (`@slow`, 2-node HA, insert against the follower; asserts the forwarded row carries the type) - red before the server fix.
- `grpcw` **`TimeSeriesGrpcInsertResultTypeIT`** (single-server element path).
- `grpc-client` **`TimeSeriesGrpcInsertMaterializationIT`** (drives the real `RemoteGrpcDatabase`; asserts a TS insert materialises without throwing and `count == 1`) - red at `newRID("")` before the client fix.

Full `grpcw` (16 ITs) and `grpc-client` (22 classes) suites pass.

## Notes

- Discovered via `ThreeNodesTimeSeriesLoadTestIT` with `SQL_GRPC` ingestion (every insert logged an error yet all data converged). The separate `LINE_PROTOCOL` point loss in that test is an unrelated concurrent-append issue and is **not** addressed here.
- The load test pulls `arcadedata/arcadedb:latest`, so a Docker image rebuild is required before the container e2e reflects these fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)