### PR TITLE
test(#4689): regression tests for MATCH (u:User) RETURN u NoSuchElementException

### DIFF
--- a/docs/4689-cypher-match-return-vertex.md
+++ b/docs/4689-cypher-match-return-vertex.md
@@ -75,9 +75,31 @@ a real remote driver uses, which is the most faithful reproduction of the report
 - SQL `SELECT name FROM SqlRemoteFields` over RemoteDatabase
 - Vertices with edges over RemoteDatabase
 
+### Customer follow-up (2026-06-23)
+
+Reporter clarified: the error happens **only in Studio** (direct HTTP and Bolt work fine), and only
+in 2 specific collections. Studio uses the `serializer=studio` path, which is the only serializer
+that builds the full graph (vertices + edges + records) and runs the "FILTER OUT NOT CONNECTED EDGES"
+loop iterating `getEdges()` on every returned vertex (`AbstractQueryHandler.serializeResultSet` case
+"studio", lines 98-179). This is studio-only behavior that HTTP record/default and Bolt never hit.
+
+Added `Issue4689StudioSerializerIT` to stress the studio graph-building path with the structures
+most likely behind the customer's "2 collections":
+- edges between two returned vertices (filter loop surfaces the edge)
+- edges to vertices OUTSIDE the result set (filter loop must exclude them)
+- self-loop edges
+- a hub vertex with 25 edges (per-vertex getEdges iteration)
+- SQL whole-record SELECT over studio with connected vertices
+- bidirectional edges (exercises both OUT and IN edge loops)
+
+All 6 studio tests pass - the bug still cannot be reproduced over the exact serializer Studio uses.
+The customer's case is likely data-specific (e.g. ghost/dangling edges in those 2 collections, or
+a property type that trips serialization); more reproduction detail is still needed from the reporter.
+
 ## Location
 
 `server/src/test/java/com/arcadedb/server/http/handler/Issue4689MatchReturnVertexIT.java`
+`server/src/test/java/com/arcadedb/server/http/handler/Issue4689StudioSerializerIT.java`
 `server/src/test/java/com/arcadedb/remote/Issue4689MatchReturnVertexRemoteIT.java`
 
 ---

--- a/docs/4689-cypher-match-return-vertex.md
+++ b/docs/4689-cypher-match-return-vertex.md
@@ -96,6 +96,51 @@ All 6 studio tests pass - the bug still cannot be reproduced over the exact seri
 The customer's case is likely data-specific (e.g. ghost/dangling edges in those 2 collections, or
 a property type that trips serialization); more reproduction detail is still needed from the reporter.
 
+### Root cause found and fixed (2026-06-25)
+
+After the reporter supplied the 2-record dataset (comment 4794871273), reproduction attempts with
+that exact data shape (UUID `id` + nanosecond `updatedAt` LocalDateTime, schemaful and schemaless,
+custom and default datetime formats, SQL and Cypher) all serialized cleanly. The data alone is not
+the trigger - the "ghost/dangling edges" hypothesis was correct.
+
+**Root cause:** the untyped `EdgeIterator` (returned by `getEdges(DIRECTION)` with no edge-type
+filter - exactly what the studio "FILTER OUT NOT CONNECTED EDGES" loop calls) violated the
+`Iterator` contract. `hasNext()` only checked the segment position, while `next()` lazily loaded the
+edge record. When a vertex has a **dangling edge pointer** (the edge record was removed but the link
+survives in the vertex's edge segment) AND the content is force-loaded, `next()` caught the
+`RecordNotFoundException`, skipped the entry, then threw `NoSuchElementException` once the segment
+ended - even though `hasNext()` had just returned `true`. A standard for-each loop propagated the NSE.
+
+The forced load (which turns the dangling pointer into a `RecordNotFoundException` inside `next()`)
+happens via `LocalDatabase.lookupByRID(rid, loadContent=false)` when either:
+- the transaction isolation is `REPEATABLE_READ` (forces content load to pin multi-page records), or
+- the edge's bucket/type no longer resolves (`type == null`).
+
+This is why only Studio failed (it is the only serializer that *iterates and loads* each vertex's
+edges; HTTP record/default and Bolt only *count* edges), why only some collections failed (only those
+with a dangling edge pointer), and why `RETURN u`/`SELECT FROM` failed while `RETURN u{.*}`/
+`SELECT field` worked (scalar projections are not vertices, so they never enter the edge-iterating
+filter loop). The sibling typed `EdgeIteratorFilter` was already robust (it validates the RID inside
+`hasNext()` and self-heals via `handleCorruption`); only the untyped `EdgeIterator` was affected.
+
+**Fix:** `EdgeIterator` now validates the (non-lightweight) edge RID inside `hasNext()` and skips
+dangling pointers there (mirroring `IteratorFilterBase`), so `hasNext()` and `next()` stay consistent
+and a dangling edge is simply skipped during iteration instead of throwing. `reset()` clears the new
+prefetch state; `remove()` semantics are preserved (its only production caller, `GraphDatabaseChecker`,
+uses the `entryIterator()`/`EdgeVertexIterator` path, not `EdgeIterator`).
+
+**Regression tests:**
+- `engine` `DanglingEdgeIteratorTest` - creates a dangling edge pointer (bucket-level record delete),
+  iterates `getEdges(OUT)` under REPEATABLE_READ; fails with NSE before the fix, skips cleanly after.
+- `server` `Issue4689StudioSerializerIT.matchReturnVertexWithDanglingEdgeDoesNotReturn500` - the exact
+  customer path: `MATCH (u) RETURN u` over the studio serializer with a dangling edge under
+  REPEATABLE_READ returns HTTP 200 (was 500) and filters the dangling edge out.
+
+**Files changed:**
+- `engine/src/main/java/com/arcadedb/graph/EdgeIterator.java` (fix)
+- `engine/src/test/java/com/arcadedb/graph/DanglingEdgeIteratorTest.java` (new)
+- `server/src/test/java/com/arcadedb/server/http/handler/Issue4689StudioSerializerIT.java` (new test)
+
 ## Location
 
 `server/src/test/java/com/arcadedb/server/http/handler/Issue4689MatchReturnVertexIT.java`

--- a/docs/4689-cypher-match-return-vertex.md
+++ b/docs/4689-cypher-match-return-vertex.md
@@ -1,0 +1,91 @@
+# Issue #4689 - Cypher MATCH ... RETURN vertex throws NoSuchElementException
+
+## Summary
+
+`MATCH (u:User) RETURN u` throws `java.util.NoSuchElementException` / PostCommandHandler error,
+while `MATCH (u:User) RETURN u{.*} as user` works. Same issue with SQL (`SELECT FROM User` fails,
+`SELECT field FROM User` works).
+
+Reported in `arcadedata/arcadedb:26.7.1-SNAPSHOT`.
+
+## Analysis
+
+### What the error means
+
+The error path is:
+1. NSE thrown inside `PostCommandHandler.execute()` (specifically during result serialization)
+2. Caught by `database.transaction()` lambda → wrapped as `TransactionException("Error on executing command", NSE)`
+3. `AbstractServerHttpHandler.handleHttp()` catches TransactionException
+4. Logs: `"Error on transaction execution (PostCommandHandler): Error on executing command"`
+5. Sends HTTP 500 with `"exception": "java.util.NoSuchElementException"` in response body
+
+### Differences between failing and working queries
+
+- `RETURN u` (fails): creates `ResultInternal` with `element=vertex, content={"u":vertex}, _projectionName="u"`
+  - Uses element-based serialization path: `setMetadata(vertex)` + early-return via `document.toMap()`
+- `RETURN u{.*} as user` (works): creates `ResultInternal` with `content={"user": map}`, no element
+  - Uses projection-based serialization path: iterates content properties
+
+### Exhaustive investigation
+
+Investigated the following code paths for NSE sources:
+
+1. **FinalProjectionStep.filterResult()** - no NSE possible; logic creates dual element+content result
+2. **FinalProjectionStep.fetchMore()** - safe; uses hasNext() before next()
+3. **NodeByLabelScan.execute()** - safe buffer/iterator pattern
+4. **MatchNodeStep.fetchMore()** - safe; uses hasNext() before next()
+5. **JsonSerializer.serializeResult()** - uses early-return path for _projectionName; no NSE
+6. **AbstractQueryHandler.serializeResultSet()** - safe; stream uses tryAdvance()
+7. **EdgeIterator/EdgeLinkedList** - safe; uses hasNext() before next()
+8. **MultiIterator** - safe; hasNextInternal() guards limit
+9. **GraphEngine.countEdges()** - no NSE
+10. **FetchFromTypeExecutionStep.syncPullSequential()** - known double-syncPull inefficiency but no NSE for normal scenarios
+11. **FetchFromTypeExecutionStep.syncPullParallel()** - safe; parallelScan=false when transaction active
+
+### Structural inconsistency in FinalProjectionStep
+
+When `RETURN u` returns a single Document, `FinalProjectionStep.filterResult()` sets BOTH:
+- `content = {"u": vertex}` (via setProperty)
+- `element = vertex` (via setElement)
+
+This dual state creates `getPropertyNames()` vs `getProperty()` inconsistency:
+- `getPropertyNames()` = element's own properties (name, age) UNION content keys (u)
+- `getProperty("name")` returns null (content has "u", not "name")
+
+The serialization works because `serializeResult` uses the `_projectionName` early-return path that calls `document.toMap()` directly, bypassing the inconsistency.
+
+### Reproduction
+
+Extensive testing with the following scenarios - ALL PASS:
+- Simple vertices (name + age properties)
+- 110 vertices (tests >100 batch pagination)
+- Vertices with connected edges
+- Default (non-studio) serializer
+- Studio serializer
+- SQL SELECT FROM type
+
+### Conclusion
+
+The NSE cannot be reproduced with the current codebase. The issue may be:
+1. Environment/data-specific (certain property types or database state)
+2. Fixed by a recent commit before the investigation
+3. Related to a specific client configuration not covered by tests
+
+## Changes Made
+
+Added regression test `Issue4689MatchReturnVertexIT` covering:
+- `MATCH (u:IssueUser) RETURN u` - exact failing query from issue
+- `MATCH (u:IssueUser) RETURN u{.*} as user` - working workaround
+- SQL `SELECT FROM V1` - equivalent SQL case
+- SQL `SELECT name FROM V1` - SQL field selection
+- 110-vertex test (pagination boundary)
+- Vertices with edges
+- Default (non-studio) HTTP serializer path
+
+## Test Results
+
+All 7 regression tests pass.
+
+## Location
+
+`server/src/test/java/com/arcadedb/server/http/handler/Issue4689MatchReturnVertexIT.java`

--- a/docs/4689-cypher-match-return-vertex.md
+++ b/docs/4689-cypher-match-return-vertex.md
@@ -14,7 +14,7 @@ Reported in `arcadedata/arcadedb:26.7.1-SNAPSHOT`.
 
 The error path is:
 1. NSE thrown inside `PostCommandHandler.execute()` (specifically during result serialization)
-2. Caught by `database.transaction()` lambda → wrapped as `TransactionException("Error on executing command", NSE)`
+2. Caught by `database.transaction()` lambda wrapped as `TransactionException("Error on executing command", NSE)`
 3. `AbstractServerHttpHandler.handleHttp()` catches TransactionException
 4. Logs: `"Error on transaction execution (PostCommandHandler): Error on executing command"`
 5. Sends HTTP 500 with `"exception": "java.util.NoSuchElementException"` in response body
@@ -26,22 +26,6 @@ The error path is:
 - `RETURN u{.*} as user` (works): creates `ResultInternal` with `content={"user": map}`, no element
   - Uses projection-based serialization path: iterates content properties
 
-### Exhaustive investigation
-
-Investigated the following code paths for NSE sources:
-
-1. **FinalProjectionStep.filterResult()** - no NSE possible; logic creates dual element+content result
-2. **FinalProjectionStep.fetchMore()** - safe; uses hasNext() before next()
-3. **NodeByLabelScan.execute()** - safe buffer/iterator pattern
-4. **MatchNodeStep.fetchMore()** - safe; uses hasNext() before next()
-5. **JsonSerializer.serializeResult()** - uses early-return path for _projectionName; no NSE
-6. **AbstractQueryHandler.serializeResultSet()** - safe; stream uses tryAdvance()
-7. **EdgeIterator/EdgeLinkedList** - safe; uses hasNext() before next()
-8. **MultiIterator** - safe; hasNextInternal() guards limit
-9. **GraphEngine.countEdges()** - no NSE
-10. **FetchFromTypeExecutionStep.syncPullSequential()** - known double-syncPull inefficiency but no NSE for normal scenarios
-11. **FetchFromTypeExecutionStep.syncPullParallel()** - safe; parallelScan=false when transaction active
-
 ### Structural inconsistency in FinalProjectionStep
 
 When `RETURN u` returns a single Document, `FinalProjectionStep.filterResult()` sets BOTH:
@@ -52,17 +36,13 @@ This dual state creates `getPropertyNames()` vs `getProperty()` inconsistency:
 - `getPropertyNames()` = element's own properties (name, age) UNION content keys (u)
 - `getProperty("name")` returns null (content has "u", not "name")
 
-The serialization works because `serializeResult` uses the `_projectionName` early-return path that calls `document.toMap()` directly, bypassing the inconsistency.
+The serialization works because `serializeResult` uses the `_projectionName` early-return path that calls `document.toMap()` directly, bypassing the inconsistency. This is a latent fragility worth tracking as a follow-up.
 
-### Reproduction
+### Exhaustive investigation
 
-Extensive testing with the following scenarios - ALL PASS:
-- Simple vertices (name + age properties)
-- 110 vertices (tests >100 batch pagination)
-- Vertices with connected edges
-- Default (non-studio) serializer
-- Studio serializer
-- SQL SELECT FROM type
+Investigated through FinalProjectionStep, NodeByLabelScan, MatchNodeStep, JsonSerializer, HTTP
+serialization layer, EdgeIterator, MultiIterator, GraphEngine.countEdges, and
+FetchFromTypeExecutionStep. All code paths appear correct and all regression tests pass.
 
 ### Conclusion
 
@@ -75,11 +55,11 @@ The NSE cannot be reproduced with the current codebase. The issue may be:
 
 Added regression test `Issue4689MatchReturnVertexIT` covering:
 - `MATCH (u:IssueUser) RETURN u` - exact failing query from issue
-- `MATCH (u:IssueUser) RETURN u{.*} as user` - working workaround
-- SQL `SELECT FROM V1` - equivalent SQL case
-- SQL `SELECT name FROM V1` - SQL field selection
-- 110-vertex test (pagination boundary)
-- Vertices with edges
+- `MATCH (u:IssueUserProj) RETURN u{.*} as user` - working workaround
+- SQL `SELECT FROM SqlSelectAll` - equivalent SQL case (self-contained with own type)
+- SQL `SELECT name FROM SqlSelectFields` - SQL field selection (self-contained)
+- 110-vertex UNWIND test (pagination boundary)
+- Vertices with edges (edge-count validation via setMetadata)
 - Default (non-studio) HTTP serializer path
 
 ## Test Results
@@ -89,3 +69,49 @@ All 7 regression tests pass.
 ## Location
 
 `server/src/test/java/com/arcadedb/server/http/handler/Issue4689MatchReturnVertexIT.java`
+
+---
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/4690
+
+## Review Cycles
+
+### Cycle 1 - HEAD d3ed3e307
+
+**Changes applied from review:**
+- Gemini (HIGH x2): Made `sqlSelectFromTypeShouldNotThrow` and `sqlSelectFieldsShouldWork` self-contained with own vertex types (SqlSelectAll, SqlSelectFields)
+- Gemini (MEDIUM): Updated URL to use `getDatabaseName()` instead of hardcoded "graph"
+- Claude (CORRECTNESS): `cypherMatchReturnVertexProjectionWorkaround` now uses own isolated type (IssueUserProj)
+- Claude (CORRECTNESS): Added record count assertions where data is explicitly created
+- Claude (STYLE): Replaced FQN imports with proper import statements
+- Claude (PERFORMANCE): Added `@Tag("slow")` to 110-vertex test
+- PR title updated from `fix(#4689)` to `test(#4689)`
+
+**Deferred items:**
+- Claude: Remove tracking doc from repo (contradicts established convention; docs/4274-*, docs/4275-*, docs/4278-* are all committed tracking docs)
+- Claude: File follow-up issue for FinalProjectionStep dual element+content state (out of scope for this PR; documented in PR description and this tracking doc)
+
+### Cycle 2 - HEAD 7afd23064
+
+**Changes applied from review:**
+- Claude (CRITICAL): `cypherMatchReturnManyVerticesShouldWork` now uses UNWIND for single-command bulk create and asserts count=110
+- Claude (CORRECTNESS): `cypherMatchReturnVertexWithEdgesShouldWork` validates edge counts in @out/@in
+- Claude (MINOR): Trimmed class-level Javadoc to single line
+- Removed `@Tag("slow")` since UNWIND replaced the slow loop
+- Gemini carried forward same stale comments (already addressed, replied)
+
+**Deferred items:**
+- Claude: Remove tracking doc (same as cycle 1, same rationale)
+
+### Cycle 3 - HEAD 64e6805a2
+
+No new actionable items. Claude had no new review on this SHA. Gemini had only the same carried-forward stale comments about V1 (already addressed and replied). Working tree clean.
+
+## Final State
+
+`clean-approval` after 3 cycles.
+
+**Deferred items (for developer follow-up):**
+1. File follow-up issue for `FinalProjectionStep.filterResult()` dual element+content state - latent fragility documented above.

--- a/docs/4689-cypher-match-return-vertex.md
+++ b/docs/4689-cypher-match-return-vertex.md
@@ -66,9 +66,19 @@ Added regression test `Issue4689MatchReturnVertexIT` covering:
 
 All 7 regression tests pass.
 
+Added `Issue4689MatchReturnVertexRemoteIT` exercising the same scenarios through the
+`RemoteDatabase` client (HTTP "record" serializer parsed via json2Result/json2Record) - the path
+a real remote driver uses, which is the most faithful reproduction of the reporter's setup:
+- `MATCH (u:IssueUser) RETURN u` over RemoteDatabase (asserts isVertex + name)
+- `MATCH (u:IssueUserProj) RETURN u{.*} as user` over RemoteDatabase
+- SQL `SELECT FROM SqlRemoteAll` over RemoteDatabase
+- SQL `SELECT name FROM SqlRemoteFields` over RemoteDatabase
+- Vertices with edges over RemoteDatabase
+
 ## Location
 
 `server/src/test/java/com/arcadedb/server/http/handler/Issue4689MatchReturnVertexIT.java`
+`server/src/test/java/com/arcadedb/remote/Issue4689MatchReturnVertexRemoteIT.java`
 
 ---
 

--- a/engine/src/main/java/com/arcadedb/graph/EdgeIterator.java
+++ b/engine/src/main/java/com/arcadedb/graph/EdgeIterator.java
@@ -33,6 +33,7 @@ public class EdgeIterator extends ResettableIteratorBase<Edge> {
   private       int              lastElementPosition = currentPosition.get();
   private       RID              nextEdgeRID;
   private       RID              nextVertexRID;
+  private       boolean          pending             = false;
 
   public EdgeIterator(final EdgeSegment current, final RID vertex, final Vertex.DIRECTION direction) {
     super(null, current);
@@ -42,12 +43,37 @@ public class EdgeIterator extends ResettableIteratorBase<Edge> {
 
   @Override
   public boolean hasNext() {
+    if (pending)
+      return true;
+
     if (currentContainer == null)
       return false;
 
     while (true) {
-      if (currentPosition.get() < currentContainer.getUsed())
+      if (currentPosition.get() < currentContainer.getUsed()) {
+        lastElementPosition = currentPosition.get();
+
+        nextEdgeRID = currentContainer.getRID(currentPosition);
+        nextVertexRID = currentContainer.getRID(currentPosition);
+
+        // VALIDATE A NON-LIGHTWEIGHT EDGE HERE SO A DANGLING POINTER (edge record removed but the link still in
+        // the segment) IS SKIPPED WHILE PEEKING, KEEPING hasNext()/next() CONSISTENT WITH THE Iterator CONTRACT.
+        // OTHERWISE next() WOULD SKIP THE RECORD AND THROW NoSuchElementException WHEN THE SEGMENT ENDS - WHICH
+        // ONLY SURFACES WHEN THE CONTENT IS ACTUALLY LOADED, e.g. UNDER REPEATABLE_READ ISOLATION.
+        if (nextEdgeRID.getPosition() > -1) {
+          try {
+            currentContainer.getDatabase().lookupByRID(nextEdgeRID, false);
+          } catch (final RecordNotFoundException e) {
+            // SKIP DANGLING EDGE
+            nextEdgeRID = null;
+            nextVertexRID = null;
+            continue;
+          }
+        }
+
+        pending = true;
         return true;
+      }
 
       currentContainer = currentContainer.getPrevious();
       if (currentContainer == null)
@@ -61,34 +87,34 @@ public class EdgeIterator extends ResettableIteratorBase<Edge> {
 
   @Override
   public Edge next() {
-    while (true) {
-      if (!hasNext())
-        throw new NoSuchElementException();
+    if (!hasNext())
+      throw new NoSuchElementException();
 
-      lastElementPosition = currentPosition.get();
+    pending = false;
 
-      nextEdgeRID = currentContainer.getRID(currentPosition);
-      nextVertexRID = currentContainer.getRID(currentPosition);
+    if (nextEdgeRID.getPosition() < 0) {
+      // CREATE LIGHTWEIGHT EDGE
+      final DocumentType edgeType = currentContainer.getDatabase().getSchema().getTypeByBucketId(nextEdgeRID.getBucketId());
 
-      if (nextEdgeRID.getPosition() < 0) {
-        // CREATE LIGHTWEIGHT EDGE
-        final DocumentType edgeType = currentContainer.getDatabase().getSchema().getTypeByBucketId(nextEdgeRID.getBucketId());
-
-        if (direction == Vertex.DIRECTION.OUT)
-          return new ImmutableLightEdge(currentContainer.getDatabase(), edgeType, nextEdgeRID, vertex, nextVertexRID);
-        else
-          return new ImmutableLightEdge(currentContainer.getDatabase(), edgeType, nextEdgeRID, nextVertexRID, vertex);
-      }
-
-      ++browsed;
-
-      try {
-        // LAZY LOAD THE CONTENT TO IMPROVE PERFORMANCE WITH TRAVERSAL. NOTE: THE RECORD NOT FOUND WILL NEVER BE TRIGGERED HERE ANYMORE
-        return (Edge) currentContainer.getDatabase().lookupByRID(nextEdgeRID, false);
-      } catch (final RecordNotFoundException e) {
-        // SKIP
-      }
+      if (direction == Vertex.DIRECTION.OUT)
+        return new ImmutableLightEdge(currentContainer.getDatabase(), edgeType, nextEdgeRID, vertex, nextVertexRID);
+      else
+        return new ImmutableLightEdge(currentContainer.getDatabase(), edgeType, nextEdgeRID, nextVertexRID, vertex);
     }
+
+    ++browsed;
+
+    // ALREADY VALIDATED IN hasNext(); LAZY LOAD THE CONTENT TO IMPROVE PERFORMANCE WITH TRAVERSAL.
+    return (Edge) currentContainer.getDatabase().lookupByRID(nextEdgeRID, false);
+  }
+
+  @Override
+  public void reset() {
+    super.reset();
+    pending = false;
+    nextEdgeRID = null;
+    nextVertexRID = null;
+    lastElementPosition = currentPosition.get();
   }
 
   @Override

--- a/engine/src/test/java/com/arcadedb/graph/DanglingEdgeIteratorTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/DanglingEdgeIteratorTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+/**
+ * Regression test for issue #4689: iterating the edges of a vertex that has a dangling edge pointer
+ * (the edge record was removed but the link still lives in the vertex's edge segment) must not throw
+ * {@link java.util.NoSuchElementException}.
+ * <p>
+ * The untyped {@link EdgeIterator} (used by {@code getEdges(DIRECTION)} with no edge-type filter)
+ * loads the edge record lazily. When the content is forced to load - under REPEATABLE_READ isolation,
+ * or when the edge's bucket/type no longer resolves - a dangling pointer raised a RecordNotFoundException
+ * that {@code next()} silently skipped, then threw NoSuchElementException once the segment ended, even
+ * though {@code hasNext()} had returned {@code true}. A standard for-each loop (e.g. the Studio graph
+ * serializer's "filter out not connected edges" pass) propagated that as an unhandled exception.
+ */
+class DanglingEdgeIteratorTest {
+  private static final String DB_PATH = "./target/databases/danglingEdgeIterator";
+
+  private Database database;
+
+  @BeforeEach
+  void setUp() {
+    database = new DatabaseFactory(DB_PATH).create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (database != null && database.isOpen())
+      database.drop();
+  }
+
+  @Test
+  void iteratingDanglingEdgeDoesNotThrowNoSuchElement() {
+    final RID[] sourceVertex = new RID[1];
+    final RID[] edgeRid = new RID[1];
+
+    database.transaction(() -> {
+      database.getSchema().createVertexType("User");
+      database.getSchema().createEdgeType("Knows");
+      final MutableVertex a = database.newVertex("User").set("name", "A").save();
+      final MutableVertex b = database.newVertex("User").set("name", "B").save();
+      final Edge e = a.newEdge("Knows", b);
+      sourceVertex[0] = a.getIdentity();
+      edgeRid[0] = e.getIdentity();
+    });
+
+    // Create a dangling edge pointer: remove the edge RECORD at bucket level, bypassing graph cleanup,
+    // so the link survives in vertex A's edge segment while the edge record is gone.
+    database.transaction(() ->
+        database.getSchema().getBucketById(edgeRid[0].getBucketId()).deleteRecord(edgeRid[0]));
+
+    // REPEATABLE_READ forces the edge content to load during iteration, exposing the dangling pointer.
+    database.setTransactionIsolationLevel(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
+
+    database.transaction(() -> {
+      final Vertex a = database.lookupByRID(sourceVertex[0], true).asVertex();
+
+      final Throwable thrown = catchThrowable(() -> {
+        int count = 0;
+        for (final Edge ignored : a.getEdges(Vertex.DIRECTION.OUT))
+          count++;
+        assertThat(count).as("the dangling edge must be skipped during iteration").isZero();
+      });
+
+      assertThat(thrown).as("iterating a dangling edge must not throw NoSuchElementException").isNull();
+    });
+  }
+}

--- a/server/src/test/java/com/arcadedb/remote/Issue4689MatchReturnVertexRemoteIT.java
+++ b/server/src/test/java/com/arcadedb/remote/Issue4689MatchReturnVertexRemoteIT.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.remote;
+
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4689 via the RemoteDatabase client (HTTP "record" serializer path,
+ * parsed through json2Result/json2Record) - the path a remote driver actually uses.
+ */
+class Issue4689MatchReturnVertexRemoteIT extends BaseGraphServerTest {
+
+  @Override
+  protected String getDatabaseName() {
+    return "issue4689";
+  }
+
+  @Test
+  void cypherMatchReturnWholeVertexOverRemote() {
+    final RemoteDatabase database = new RemoteDatabase("127.0.0.1", 2480, getDatabaseName(), "root",
+        BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
+
+    database.command("opencypher", "CREATE (u:IssueUser {name: 'Alice', age: 30})");
+    database.command("opencypher", "CREATE (u:IssueUser {name: 'Bob', age: 25})");
+
+    // The reported failing query: returning the whole vertex
+    final ResultSet rs = database.query("opencypher", "MATCH (u:IssueUser) RETURN u");
+
+    int count = 0;
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      assertThat(row.isVertex()).as("RETURN u should produce a vertex element over RemoteDatabase").isTrue();
+      final Vertex v = row.getVertex().get();
+      assertThat(v.getString("name")).isNotNull();
+      count++;
+    }
+    assertThat(count).as("Should return 2 User vertices over RemoteDatabase").isEqualTo(2);
+  }
+
+  @Test
+  void cypherMatchReturnVertexProjectionOverRemote() {
+    final RemoteDatabase database = new RemoteDatabase("127.0.0.1", 2480, getDatabaseName(), "root",
+        BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
+
+    database.command("opencypher", "CREATE (u:IssueUserProj {name: 'Charlie', age: 35})");
+
+    // The workaround the reporter says works
+    final ResultSet rs = database.query("opencypher", "MATCH (u:IssueUserProj) RETURN u{.*} as user");
+
+    assertThat(rs.hasNext()).isTrue();
+    final Result row = rs.next();
+    assertThat(row.<Object>getProperty("user")).as("Projection should expose the 'user' property").isNotNull();
+  }
+
+  @Test
+  void sqlSelectWholeRecordOverRemote() {
+    final RemoteDatabase database = new RemoteDatabase("127.0.0.1", 2480, getDatabaseName(), "root",
+        BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
+
+    database.command("sql", "CREATE VERTEX TYPE SqlRemoteAll");
+    database.command("sql", "INSERT INTO SqlRemoteAll SET name = 'Alice', age = 30");
+    database.command("sql", "INSERT INTO SqlRemoteAll SET name = 'Bob', age = 25");
+
+    // SQL: returning the whole record (same class of issue as Cypher)
+    final ResultSet rs = database.query("sql", "SELECT FROM SqlRemoteAll");
+
+    int count = 0;
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      assertThat(row.isVertex()).as("SELECT FROM should produce a vertex element over RemoteDatabase").isTrue();
+      count++;
+    }
+    assertThat(count).as("Should return 2 records over RemoteDatabase").isEqualTo(2);
+  }
+
+  @Test
+  void sqlSelectFieldOverRemote() {
+    final RemoteDatabase database = new RemoteDatabase("127.0.0.1", 2480, getDatabaseName(), "root",
+        BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
+
+    database.command("sql", "CREATE VERTEX TYPE SqlRemoteFields");
+    database.command("sql", "INSERT INTO SqlRemoteFields SET name = 'Dave', age = 40");
+
+    // SQL workaround: selecting an individual field
+    final ResultSet rs = database.query("sql", "SELECT name FROM SqlRemoteFields");
+
+    assertThat(rs.hasNext()).isTrue();
+    final Result row = rs.next();
+    assertThat(row.<String>getProperty("name")).isEqualTo("Dave");
+  }
+
+  @Test
+  void cypherMatchReturnVertexWithEdgesOverRemote() {
+    final RemoteDatabase database = new RemoteDatabase("127.0.0.1", 2480, getDatabaseName(), "root",
+        BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
+
+    database.command("opencypher", "CREATE (u:UserEdgeRemote {name: 'Src', role: 'admin'})");
+    database.command("opencypher", "CREATE (u:UserEdgeRemote {name: 'Dst', role: 'user'})");
+    database.command("sql",
+        "CREATE EDGE E1 FROM (SELECT FROM UserEdgeRemote WHERE name = 'Src') TO (SELECT FROM UserEdgeRemote WHERE name = 'Dst')");
+
+    // Vertices with edges - exercises the vertex serialization with edge metadata over the wire
+    final ResultSet rs = database.query("opencypher", "MATCH (u:UserEdgeRemote) RETURN u");
+
+    int count = 0;
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      assertThat(row.isVertex()).isTrue();
+      count++;
+    }
+    assertThat(count).as("Should return 2 vertices with edges over RemoteDatabase").isEqualTo(2);
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue4689MatchReturnVertexIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue4689MatchReturnVertexIT.java
@@ -21,7 +21,6 @@ package com.arcadedb.server.http.handler;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.BaseGraphServerTest;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
@@ -31,12 +30,7 @@ import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * Regression test for GitHub issue #4689:
- * MATCH (u:User) RETURN u throws NoSuchElementException via HTTP,
- * while MATCH (u:User) RETURN u{.*} as user works.
- * Same issue affects SQL: SELECT FROM type fails, SELECT field FROM type works.
- */
+/** Regression test for issue #4689: MATCH (u:IssueUser) RETURN u must not throw NSE via HTTP. */
 class Issue4689MatchReturnVertexIT extends BaseGraphServerTest {
 
   @Test
@@ -44,7 +38,6 @@ class Issue4689MatchReturnVertexIT extends BaseGraphServerTest {
     executeCommand(0, "opencypher", "CREATE (u:IssueUser {name: 'Alice', age: 30})");
     executeCommand(0, "opencypher", "CREATE (u:IssueUser {name: 'Bob', age: 25})");
 
-    // This is the query that the reporter says fails (issue #4689)
     final JSONObject response = executeCommand(0, "opencypher", "MATCH (u:IssueUser) RETURN u");
 
     assertThat(response).isNotNull();
@@ -55,10 +48,8 @@ class Issue4689MatchReturnVertexIT extends BaseGraphServerTest {
 
   @Test
   void cypherMatchReturnVertexProjectionWorkaround() throws Exception {
-    // Each test creates its own isolated type to avoid ordering dependencies
     executeCommand(0, "opencypher", "CREATE (u:IssueUserProj {name: 'Charlie', age: 35})");
 
-    // Workaround the reporter says works
     final JSONObject response = executeCommand(0, "opencypher", "MATCH (u:IssueUserProj) RETURN u{.*} as user");
 
     assertThat(response).isNotNull();
@@ -69,12 +60,10 @@ class Issue4689MatchReturnVertexIT extends BaseGraphServerTest {
 
   @Test
   void sqlSelectFromTypeShouldNotThrow() throws Exception {
-    // Self-contained: creates its own type and data
     executeCommand(0, "sql", "CREATE VERTEX TYPE SqlSelectAll");
     executeCommand(0, "sql", "INSERT INTO SqlSelectAll SET name = 'Alice', age = 30");
     executeCommand(0, "sql", "INSERT INTO SqlSelectAll SET name = 'Bob', age = 25");
 
-    // SQL: returning whole record should work (same issue with SQL as with Cypher)
     final JSONObject response = executeCommand(0, "sql", "SELECT FROM SqlSelectAll");
 
     assertThat(response).isNotNull();
@@ -85,11 +74,9 @@ class Issue4689MatchReturnVertexIT extends BaseGraphServerTest {
 
   @Test
   void sqlSelectFieldsShouldWork() throws Exception {
-    // Self-contained: creates its own type and data
     executeCommand(0, "sql", "CREATE VERTEX TYPE SqlSelectFields");
     executeCommand(0, "sql", "INSERT INTO SqlSelectFields SET name = 'Dave', age = 40");
 
-    // Selecting individual fields should work (workaround for SQL)
     final JSONObject response = executeCommand(0, "sql", "SELECT name FROM SqlSelectFields");
 
     assertThat(response).isNotNull();
@@ -98,22 +85,24 @@ class Issue4689MatchReturnVertexIT extends BaseGraphServerTest {
     assertThat(result.getJSONArray("records").length()).as("Should return 1 record").isEqualTo(1);
   }
 
-  @Tag("slow")
   @Test
   void cypherMatchReturnManyVerticesShouldWork() throws Exception {
-    // Create more than 100 vertices to test multi-batch pagination
-    for (int i = 0; i < 110; i++)
-      executeCommand(0, "opencypher", "CREATE (u:ManyUsers {idx: " + i + ", name: 'User" + i + "'})");
+    // Create 110 vertices in a single command to test multi-batch pagination (>100 default batch)
+    executeCommand(0, "opencypher",
+        "UNWIND range(0, 109) AS i CREATE (:ManyUsers {idx: i, name: 'User' + toString(i)})");
 
     final JSONObject response = executeCommand(0, "opencypher", "MATCH (u:ManyUsers) RETURN u");
 
     assertThat(response).isNotNull();
     assertThat(response.has("result")).isTrue();
+    final JSONObject result = response.getJSONObject("result");
+    assertThat(result.getJSONArray("records").length())
+        .as("Should return all 110 vertices across pagination batches")
+        .isEqualTo(110);
   }
 
   @Test
   void cypherMatchReturnVertexWithEdgesShouldWork() throws Exception {
-    // Vertices connected by edges - edge counting runs in setMetadata()
     executeCommand(0, "opencypher", "CREATE (u:UserEdgeTest {name: 'Src', role: 'admin'})");
     executeCommand(0, "opencypher", "CREATE (u:UserEdgeTest {name: 'Dst', role: 'user'})");
     executeCommand(0, "sql",
@@ -124,12 +113,22 @@ class Issue4689MatchReturnVertexIT extends BaseGraphServerTest {
     assertThat(response).isNotNull();
     assertThat(response.has("result")).isTrue();
     final JSONObject result = response.getJSONObject("result");
-    assertThat(result.getJSONArray("records").length()).as("Should return 2 vertices with edges").isEqualTo(2);
+    final JSONArray records = result.getJSONArray("records");
+    assertThat(records.length()).as("Should return 2 vertices").isEqualTo(2);
+    // Verify edge counts are populated via setMetadata() - at least one vertex must have edges
+    boolean hasEdgeCounts = false;
+    for (int i = 0; i < records.length(); i++) {
+      final JSONObject rec = records.getJSONObject(i);
+      if (rec.getInt("@out", 0) > 0 || rec.getInt("@in", 0) > 0) {
+        hasEdgeCounts = true;
+        break;
+      }
+    }
+    assertThat(hasEdgeCounts).as("At least one vertex should have non-zero edge count in @out or @in").isTrue();
   }
 
   @Test
   void cypherMatchReturnVertexWithDefaultSerializer() throws Exception {
-    // Test using the default (non-studio) serializer via a direct HTTP call
     executeCommand(0, "opencypher", "CREATE (u:DefaultSerTest {name: 'Alice2', age: 30})");
     executeCommand(0, "opencypher", "CREATE (u:DefaultSerTest {name: 'Bob2', age: 25})");
 
@@ -139,7 +138,6 @@ class Issue4689MatchReturnVertexIT extends BaseGraphServerTest {
       connection.setRequestMethod("POST");
       connection.setRequestProperty("Authorization",
           "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
-      // Sending without serializer uses the default (non-studio) code path
       formatPayload(connection, "opencypher", "MATCH (u:DefaultSerTest) RETURN u", null, Collections.emptyMap());
       connection.connect();
 

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue4689MatchReturnVertexIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue4689MatchReturnVertexIT.java
@@ -18,9 +18,16 @@
  */
 package com.arcadedb.server.http.handler;
 
+import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Base64;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,7 +41,6 @@ class Issue4689MatchReturnVertexIT extends BaseGraphServerTest {
 
   @Test
   void cypherMatchReturnWholeVertexShouldNotThrow() throws Exception {
-    // Set up User type with vertices
     executeCommand(0, "opencypher", "CREATE (u:IssueUser {name: 'Alice', age: 30})");
     executeCommand(0, "opencypher", "CREATE (u:IssueUser {name: 'Bob', age: 25})");
 
@@ -43,37 +49,56 @@ class Issue4689MatchReturnVertexIT extends BaseGraphServerTest {
 
     assertThat(response).isNotNull();
     assertThat(response.has("result")).as("Response should have 'result' key - query must not throw").isTrue();
+    final JSONObject result = response.getJSONObject("result");
+    assertThat(result.getJSONArray("records").length()).as("Should return 2 User vertices").isEqualTo(2);
   }
 
   @Test
   void cypherMatchReturnVertexProjectionWorkaround() throws Exception {
-    executeCommand(0, "opencypher", "CREATE (u:IssueUser {name: 'Charlie', age: 35})");
+    // Each test creates its own isolated type to avoid ordering dependencies
+    executeCommand(0, "opencypher", "CREATE (u:IssueUserProj {name: 'Charlie', age: 35})");
 
     // Workaround the reporter says works
-    final JSONObject response = executeCommand(0, "opencypher", "MATCH (u:IssueUser) RETURN u{.*} as user");
+    final JSONObject response = executeCommand(0, "opencypher", "MATCH (u:IssueUserProj) RETURN u{.*} as user");
 
     assertThat(response).isNotNull();
     assertThat(response.has("result")).isTrue();
+    final JSONObject result = response.getJSONObject("result");
+    assertThat(result.getJSONArray("records").length()).as("Projection workaround should return 1 vertex").isEqualTo(1);
   }
 
   @Test
   void sqlSelectFromTypeShouldNotThrow() throws Exception {
+    // Self-contained: creates its own type and data
+    executeCommand(0, "sql", "CREATE VERTEX TYPE SqlSelectAll");
+    executeCommand(0, "sql", "INSERT INTO SqlSelectAll SET name = 'Alice', age = 30");
+    executeCommand(0, "sql", "INSERT INTO SqlSelectAll SET name = 'Bob', age = 25");
+
     // SQL: returning whole record should work (same issue with SQL as with Cypher)
-    final JSONObject response = executeCommand(0, "sql", "SELECT FROM V1");
+    final JSONObject response = executeCommand(0, "sql", "SELECT FROM SqlSelectAll");
 
     assertThat(response).isNotNull();
     assertThat(response.has("result")).as("SELECT FROM should not throw NoSuchElementException").isTrue();
+    final JSONObject result = response.getJSONObject("result");
+    assertThat(result.getJSONArray("records").length()).as("Should return 2 records").isEqualTo(2);
   }
 
   @Test
   void sqlSelectFieldsShouldWork() throws Exception {
+    // Self-contained: creates its own type and data
+    executeCommand(0, "sql", "CREATE VERTEX TYPE SqlSelectFields");
+    executeCommand(0, "sql", "INSERT INTO SqlSelectFields SET name = 'Dave', age = 40");
+
     // Selecting individual fields should work (workaround for SQL)
-    final JSONObject response = executeCommand(0, "sql", "SELECT name FROM V1");
+    final JSONObject response = executeCommand(0, "sql", "SELECT name FROM SqlSelectFields");
 
     assertThat(response).isNotNull();
     assertThat(response.has("result")).isTrue();
+    final JSONObject result = response.getJSONObject("result");
+    assertThat(result.getJSONArray("records").length()).as("Should return 1 record").isEqualTo(1);
   }
 
+  @Tag("slow")
   @Test
   void cypherMatchReturnManyVerticesShouldWork() throws Exception {
     // Create more than 100 vertices to test multi-batch pagination
@@ -98,6 +123,8 @@ class Issue4689MatchReturnVertexIT extends BaseGraphServerTest {
 
     assertThat(response).isNotNull();
     assertThat(response.has("result")).isTrue();
+    final JSONObject result = response.getJSONObject("result");
+    assertThat(result.getJSONArray("records").length()).as("Should return 2 vertices with edges").isEqualTo(2);
   }
 
   @Test
@@ -106,17 +133,24 @@ class Issue4689MatchReturnVertexIT extends BaseGraphServerTest {
     executeCommand(0, "opencypher", "CREATE (u:DefaultSerTest {name: 'Alice2', age: 30})");
     executeCommand(0, "opencypher", "CREATE (u:DefaultSerTest {name: 'Bob2', age: 25})");
 
-    final java.net.HttpURLConnection connection = (java.net.HttpURLConnection) new java.net.URI(
-        "http://127.0.0.1:2480/api/v1/command/graph").toURL().openConnection();
+    final HttpURLConnection connection = (HttpURLConnection) new URL(
+        "http://127.0.0.1:2480/api/v1/command/" + getDatabaseName()).openConnection();
     try {
       connection.setRequestMethod("POST");
       connection.setRequestProperty("Authorization",
-          "Basic " + java.util.Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+          "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
       // Sending without serializer uses the default (non-studio) code path
-      formatPayload(connection, "opencypher", "MATCH (u:DefaultSerTest) RETURN u", null, java.util.Collections.emptyMap());
+      formatPayload(connection, "opencypher", "MATCH (u:DefaultSerTest) RETURN u", null, Collections.emptyMap());
       connection.connect();
 
-      assertThat(connection.getResponseCode()).as("MATCH RETURN u with default serializer should return HTTP 200, not 500").isEqualTo(200);
+      assertThat(connection.getResponseCode())
+          .as("MATCH RETURN u with default serializer should return HTTP 200, not 500").isEqualTo(200);
+
+      final String responseBody = readResponse(connection);
+      final JSONObject response = new JSONObject(responseBody);
+      assertThat(response.has("result")).isTrue();
+      final JSONArray result = response.getJSONArray("result");
+      assertThat(result.length()).as("Should return 2 vertices").isEqualTo(2);
     } finally {
       connection.disconnect();
     }

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue4689MatchReturnVertexIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue4689MatchReturnVertexIT.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for GitHub issue #4689:
+ * MATCH (u:User) RETURN u throws NoSuchElementException via HTTP,
+ * while MATCH (u:User) RETURN u{.*} as user works.
+ * Same issue affects SQL: SELECT FROM type fails, SELECT field FROM type works.
+ */
+class Issue4689MatchReturnVertexIT extends BaseGraphServerTest {
+
+  @Test
+  void cypherMatchReturnWholeVertexShouldNotThrow() throws Exception {
+    // Set up User type with vertices
+    executeCommand(0, "opencypher", "CREATE (u:IssueUser {name: 'Alice', age: 30})");
+    executeCommand(0, "opencypher", "CREATE (u:IssueUser {name: 'Bob', age: 25})");
+
+    // This is the query that the reporter says fails (issue #4689)
+    final JSONObject response = executeCommand(0, "opencypher", "MATCH (u:IssueUser) RETURN u");
+
+    assertThat(response).isNotNull();
+    assertThat(response.has("result")).as("Response should have 'result' key - query must not throw").isTrue();
+  }
+
+  @Test
+  void cypherMatchReturnVertexProjectionWorkaround() throws Exception {
+    executeCommand(0, "opencypher", "CREATE (u:IssueUser {name: 'Charlie', age: 35})");
+
+    // Workaround the reporter says works
+    final JSONObject response = executeCommand(0, "opencypher", "MATCH (u:IssueUser) RETURN u{.*} as user");
+
+    assertThat(response).isNotNull();
+    assertThat(response.has("result")).isTrue();
+  }
+
+  @Test
+  void sqlSelectFromTypeShouldNotThrow() throws Exception {
+    // SQL: returning whole record should work (same issue with SQL as with Cypher)
+    final JSONObject response = executeCommand(0, "sql", "SELECT FROM V1");
+
+    assertThat(response).isNotNull();
+    assertThat(response.has("result")).as("SELECT FROM should not throw NoSuchElementException").isTrue();
+  }
+
+  @Test
+  void sqlSelectFieldsShouldWork() throws Exception {
+    // Selecting individual fields should work (workaround for SQL)
+    final JSONObject response = executeCommand(0, "sql", "SELECT name FROM V1");
+
+    assertThat(response).isNotNull();
+    assertThat(response.has("result")).isTrue();
+  }
+
+  @Test
+  void cypherMatchReturnManyVerticesShouldWork() throws Exception {
+    // Create more than 100 vertices to test multi-batch pagination
+    for (int i = 0; i < 110; i++)
+      executeCommand(0, "opencypher", "CREATE (u:ManyUsers {idx: " + i + ", name: 'User" + i + "'})");
+
+    final JSONObject response = executeCommand(0, "opencypher", "MATCH (u:ManyUsers) RETURN u");
+
+    assertThat(response).isNotNull();
+    assertThat(response.has("result")).isTrue();
+  }
+
+  @Test
+  void cypherMatchReturnVertexWithEdgesShouldWork() throws Exception {
+    // Vertices connected by edges - edge counting runs in setMetadata()
+    executeCommand(0, "opencypher", "CREATE (u:UserEdgeTest {name: 'Src', role: 'admin'})");
+    executeCommand(0, "opencypher", "CREATE (u:UserEdgeTest {name: 'Dst', role: 'user'})");
+    executeCommand(0, "sql",
+        "CREATE EDGE E1 FROM (SELECT FROM UserEdgeTest WHERE name = 'Src') TO (SELECT FROM UserEdgeTest WHERE name = 'Dst')");
+
+    final JSONObject response = executeCommand(0, "opencypher", "MATCH (u:UserEdgeTest) RETURN u");
+
+    assertThat(response).isNotNull();
+    assertThat(response.has("result")).isTrue();
+  }
+
+  @Test
+  void cypherMatchReturnVertexWithDefaultSerializer() throws Exception {
+    // Test using the default (non-studio) serializer via a direct HTTP call
+    executeCommand(0, "opencypher", "CREATE (u:DefaultSerTest {name: 'Alice2', age: 30})");
+    executeCommand(0, "opencypher", "CREATE (u:DefaultSerTest {name: 'Bob2', age: 25})");
+
+    final java.net.HttpURLConnection connection = (java.net.HttpURLConnection) new java.net.URI(
+        "http://127.0.0.1:2480/api/v1/command/graph").toURL().openConnection();
+    try {
+      connection.setRequestMethod("POST");
+      connection.setRequestProperty("Authorization",
+          "Basic " + java.util.Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+      // Sending without serializer uses the default (non-studio) code path
+      formatPayload(connection, "opencypher", "MATCH (u:DefaultSerTest) RETURN u", null, java.util.Collections.emptyMap());
+      connection.connect();
+
+      assertThat(connection.getResponseCode()).as("MATCH RETURN u with default serializer should return HTTP 200, not 500").isEqualTo(200);
+    } finally {
+      connection.disconnect();
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue4689StudioSerializerIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue4689StudioSerializerIT.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4689 over the Studio serializer (serializer=studio), which builds the
+ * full graph (vertices + edges + records) and runs the "filter out not connected edges" loop that
+ * iterates getEdges() on every returned vertex - the studio-only path HTTP/Bolt clients never hit.
+ */
+class Issue4689StudioSerializerIT extends BaseGraphServerTest {
+
+  /**
+   * Helper that always sends serializer=studio (what {@link #executeCommand(int, String, String)}
+   * already does) and returns the {@code result} object containing vertices/edges/records.
+   */
+  private JSONObject studioResult(final String language, final String command) throws Exception {
+    final JSONObject response = executeCommand(0, language, command);
+    assertThat(response).as("Studio query '%s' must not throw (no HTTP 500)", command).isNotNull();
+    assertThat(response.has("result")).isTrue();
+    return response.getJSONObject("result");
+  }
+
+  @Test
+  void matchReturnVertexWithEdgesBetweenReturnedVertices() throws Exception {
+    // Two returned vertices connected to each other - exercises the FILTER OUT NOT CONNECTED EDGES loop
+    executeCommand(0, "opencypher", "CREATE (u:StudioUser {name: 'Alice'})");
+    executeCommand(0, "opencypher", "CREATE (u:StudioUser {name: 'Bob'})");
+    executeCommand(0, "sql", "CREATE EDGE TYPE Knows");
+    executeCommand(0, "sql",
+        "CREATE EDGE Knows FROM (SELECT FROM StudioUser WHERE name = 'Alice') TO (SELECT FROM StudioUser WHERE name = 'Bob')");
+
+    final JSONObject result = studioResult("opencypher", "MATCH (u:StudioUser) RETURN u");
+
+    assertThat(result.getJSONArray("records").length()).as("Should return 2 vertices").isEqualTo(2);
+    assertThat(result.getJSONArray("vertices").length()).as("Both vertices should be in the graph").isEqualTo(2);
+    assertThat(result.getJSONArray("edges").length())
+        .as("The connecting edge should be surfaced by the studio filter loop").isEqualTo(1);
+  }
+
+  @Test
+  void matchReturnVertexWithEdgesToVerticesOutsideResult() throws Exception {
+    // The returned vertex has an edge to a vertex NOT matched by the query - the filter loop
+    // must iterate the edge and exclude it (the target is not in includedVertices)
+    executeCommand(0, "opencypher", "CREATE (u:StudioHub {name: 'Hub'})");
+    executeCommand(0, "opencypher", "CREATE (u:StudioLeaf {name: 'Leaf'})");
+    executeCommand(0, "sql", "CREATE EDGE TYPE Points");
+    executeCommand(0, "sql",
+        "CREATE EDGE Points FROM (SELECT FROM StudioHub WHERE name = 'Hub') TO (SELECT FROM StudioLeaf WHERE name = 'Leaf')");
+
+    // Only match the hub; its edge points outside the result set
+    final JSONObject result = studioResult("opencypher", "MATCH (u:StudioHub) RETURN u");
+
+    assertThat(result.getJSONArray("records").length()).as("Should return the hub vertex").isEqualTo(1);
+    assertThat(result.getJSONArray("vertices").length()).as("Only the hub is in the graph").isEqualTo(1);
+    assertThat(result.getJSONArray("edges").length())
+        .as("Edge to an unmatched vertex must be filtered out").isEqualTo(0);
+  }
+
+  @Test
+  void matchReturnVertexWithSelfLoopEdge() throws Exception {
+    // Self-referencing edge - both endpoints are the same returned vertex
+    executeCommand(0, "opencypher", "CREATE (u:StudioSelf {name: 'Solo'})");
+    executeCommand(0, "sql", "CREATE EDGE TYPE SelfRef");
+    executeCommand(0, "sql",
+        "CREATE EDGE SelfRef FROM (SELECT FROM StudioSelf WHERE name = 'Solo') TO (SELECT FROM StudioSelf WHERE name = 'Solo')");
+
+    final JSONObject result = studioResult("opencypher", "MATCH (u:StudioSelf) RETURN u");
+
+    assertThat(result.getJSONArray("records").length()).as("Should return the vertex").isEqualTo(1);
+    assertThat(result.getJSONArray("vertices").length()).isEqualTo(1);
+    assertThat(result.getJSONArray("edges").length()).as("Self-loop edge should be surfaced").isEqualTo(1);
+  }
+
+  @Test
+  void matchReturnHubVertexWithManyEdges() throws Exception {
+    // A hub vertex with many outgoing edges - stresses the per-vertex getEdges() iteration
+    executeCommand(0, "opencypher", "CREATE (u:StudioBigHub {name: 'Center'})");
+    for (int i = 0; i < 25; i++)
+      executeCommand(0, "opencypher", "CREATE (u:StudioSpoke {idx: " + i + "})");
+    executeCommand(0, "sql", "CREATE EDGE TYPE Spoke");
+    executeCommand(0, "sql",
+        "CREATE EDGE Spoke FROM (SELECT FROM StudioBigHub WHERE name = 'Center') TO (SELECT FROM StudioSpoke)");
+
+    // Match the whole connected component so every spoke edge connects two included vertices
+    final JSONObject result = studioResult("opencypher", "MATCH (u) WHERE u:StudioBigHub OR u:StudioSpoke RETURN u");
+
+    assertThat(result.getJSONArray("records").length()).as("Hub + 25 spokes").isEqualTo(26);
+    assertThat(result.getJSONArray("vertices").length()).isEqualTo(26);
+    assertThat(result.getJSONArray("edges").length()).as("All 25 spoke edges should be surfaced").isEqualTo(25);
+  }
+
+  @Test
+  void sqlSelectWholeRecordOverStudio() throws Exception {
+    // SQL whole-record SELECT over the studio serializer with connected vertices
+    executeCommand(0, "sql", "CREATE VERTEX TYPE StudioSqlV");
+    executeCommand(0, "sql", "INSERT INTO StudioSqlV SET name = 'A'");
+    executeCommand(0, "sql", "INSERT INTO StudioSqlV SET name = 'B'");
+    executeCommand(0, "sql", "CREATE EDGE TYPE StudioSqlE");
+    executeCommand(0, "sql",
+        "CREATE EDGE StudioSqlE FROM (SELECT FROM StudioSqlV WHERE name = 'A') TO (SELECT FROM StudioSqlV WHERE name = 'B')");
+
+    final JSONObject result = studioResult("sql", "SELECT FROM StudioSqlV");
+
+    assertThat(result.getJSONArray("records").length()).as("Should return 2 records").isEqualTo(2);
+    assertThat(result.getJSONArray("vertices").length()).isEqualTo(2);
+    assertThat(result.getJSONArray("edges").length()).as("Connecting edge surfaced").isEqualTo(1);
+  }
+
+  @Test
+  void matchReturnVertexWithBidirectionalEdges() throws Exception {
+    // Two vertices with edges in BOTH directions - exercises both the OUT and IN edge loops
+    executeCommand(0, "opencypher", "CREATE (u:StudioBidir {name: 'X'})");
+    executeCommand(0, "opencypher", "CREATE (u:StudioBidir {name: 'Y'})");
+    executeCommand(0, "sql", "CREATE EDGE TYPE Fwd");
+    executeCommand(0, "sql", "CREATE EDGE TYPE Bwd");
+    executeCommand(0, "sql",
+        "CREATE EDGE Fwd FROM (SELECT FROM StudioBidir WHERE name = 'X') TO (SELECT FROM StudioBidir WHERE name = 'Y')");
+    executeCommand(0, "sql",
+        "CREATE EDGE Bwd FROM (SELECT FROM StudioBidir WHERE name = 'Y') TO (SELECT FROM StudioBidir WHERE name = 'X')");
+
+    final JSONObject result = studioResult("opencypher", "MATCH (u:StudioBidir) RETURN u");
+
+    assertThat(result.getJSONArray("records").length()).isEqualTo(2);
+    assertThat(result.getJSONArray("vertices").length()).isEqualTo(2);
+    assertThat(result.getJSONArray("edges").length()).as("Both directed edges should be surfaced").isEqualTo(2);
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue4689StudioSerializerIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue4689StudioSerializerIT.java
@@ -18,6 +18,10 @@
  */
 package com.arcadedb.server.http.handler;
 
+import com.arcadedb.database.Database;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.Edge;
+import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.BaseGraphServerTest;
 import org.junit.jupiter.api.Test;
@@ -126,6 +130,43 @@ class Issue4689StudioSerializerIT extends BaseGraphServerTest {
     assertThat(result.getJSONArray("records").length()).as("Should return 2 records").isEqualTo(2);
     assertThat(result.getJSONArray("vertices").length()).isEqualTo(2);
     assertThat(result.getJSONArray("edges").length()).as("Connecting edge surfaced").isEqualTo(1);
+  }
+
+  @Test
+  void matchReturnVertexWithDanglingEdgeDoesNotReturn500() throws Exception {
+    // Reproduces the customer's exact failure: a vertex whose edge segment still references an edge
+    // record that no longer exists (dangling pointer). The studio serializer's "filter out not connected
+    // edges" pass iterates every returned vertex's edges; loading the dangling edge under REPEATABLE_READ
+    // isolation used to skip it and then throw NoSuchElementException, surfacing as an HTTP 500. Whole-record
+    // queries (RETURN u / SELECT FROM) hit this; scalar projections (RETURN u{.*}) do not. See issue #4689.
+    final Database db = getServerDatabase(0, getDatabaseName());
+
+    final RID[] danglingEdge = new RID[1];
+    db.transaction(() -> {
+      db.command("sql", "CREATE VERTEX TYPE DanglingUser");
+      db.command("sql", "CREATE EDGE TYPE DanglingKnows");
+      final MutableVertex a = db.newVertex("DanglingUser").set("name", "A").save();
+      final MutableVertex b = db.newVertex("DanglingUser").set("name", "B").save();
+      final Edge e = a.newEdge("DanglingKnows", b);
+      danglingEdge[0] = e.getIdentity();
+    });
+
+    // Create the dangling pointer: remove the edge RECORD at bucket level, bypassing graph cleanup.
+    db.transaction(() ->
+        db.getSchema().getBucketById(danglingEdge[0].getBucketId()).deleteRecord(danglingEdge[0]));
+
+    final Database.TRANSACTION_ISOLATION_LEVEL previous = db.getTransactionIsolationLevel();
+    db.setTransactionIsolationLevel(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
+    try {
+      final JSONObject result = studioResult("opencypher", "MATCH (u:DanglingUser) RETURN u");
+
+      assertThat(result.getJSONArray("records").length()).as("Both vertices should be returned").isEqualTo(2);
+      assertThat(result.getJSONArray("vertices").length()).isEqualTo(2);
+      assertThat(result.getJSONArray("edges").length())
+          .as("The dangling edge must be filtered out, not surfaced, and must not cause an error").isZero();
+    } finally {
+      db.setTransactionIsolationLevel(previous);
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Adds regression test `Issue4689MatchReturnVertexIT` for issue #4689, which reports `MATCH (u:User) RETURN u` throwing `java.util.NoSuchElementException` via HTTP, while `MATCH (u:User) RETURN u{.*} as user` works
- Covers 7 scenarios: whole-vertex return, projection workaround, SQL SELECT FROM, SQL field selection, >100 vertices (pagination boundary), vertices with edges, and the default (non-studio) HTTP serializer path
- Extensive investigation traced the error path through FinalProjectionStep, NodeByLabelScan, JsonSerializer, and the HTTP serialization layer; all code paths appear correct and all 7 tests pass on the current codebase

Closes #4689

The investigation found a structural inconsistency in `FinalProjectionStep.filterResult()`: when a single Document property is returned, the result has both `element=vertex` AND `content={"u":vertex}` set simultaneously. This creates `getPropertyNames()` vs `getProperty()` inconsistency but does not cause NSE in the current serialization path (which uses the `_projectionName` early-return that calls `document.toMap()` directly). The regression tests provide coverage so any future regression is caught immediately.

## Test plan

- [ ] Run `mvn test -pl server -Dtest=Issue4689MatchReturnVertexIT` - should show 7 tests passing
- [ ] Verify `MATCH (u:User) RETURN u` returns correct vertex data via HTTP
- [ ] Verify `SELECT FROM <type>` returns correct records via HTTP
- [ ] Verify the default (non-studio) serializer path returns HTTP 200 for vertex queries