### PR TITLE
fix(#4691): strip backticks from quoted identifier in SELECT projection alias

### DIFF
--- a/docs/4691-backtick-projection-alias.md
+++ b/docs/4691-backtick-projection-alias.md
@@ -1,0 +1,52 @@
+# Issue #4691 - Backtick-quoted identifier in SELECT projection not resolved as column reference
+
+## Summary
+
+Backtick-quoting an identifier in a SELECT projection position caused the output column key to retain the literal backticks instead of stripping them, and caused GROUP BY values to resolve to `null`.
+
+## Root Cause
+
+`ProjectionItem.getProjectionAlias()` built the default alias for an unaliased projection item as:
+
+```java
+result = new Identifier(expression.toString());
+```
+
+For a quoted column reference like `` `col1` ``, `expression.toString()` renders the backtick-quoted text. The `Identifier(String)` constructor calls `setStringValue()` which backslash-escapes any backticks in the string - so the stored value became `\`col1\`` (with escape sequences). This became the output key, causing symptom 1 (wrong key) and symptom 2 (GROUP BY null, because the backtick-bearing key didn't match the property `col1`).
+
+The same issue propagated to explicit quoted aliases (`AS \`alias1\``) when the aggregate planner reconstructed projection items for the GROUP BY split, calling `new Expression(item.getProjectionAlias())` and then querying `aggItem.getProjectionAlias()` on the new item - which again used `new Identifier(expression.toString())` and re-injected backticks from the identifier's `toString()` (which adds backticks for `quoted=true` identifiers).
+
+## Fix
+
+Changed the one buggy line in `ProjectionItem.getProjectionAlias()`:
+
+```java
+// Before (buggy):
+result = new Identifier(expression.toString());
+
+// After:
+return expression.getDefaultAlias();
+```
+
+`Expression.getDefaultAlias()` already existed and correctly handled this: for a base identifier it navigates to the underlying `Identifier` and calls `getStringValue()` (which returns the bare value without backticks), rather than `toString()` (which adds backticks for quoted identifiers). For non-base-identifier expressions (function calls, multi-hop access, etc.) it falls back to `new Identifier(this.toString())` - identical to the old behavior.
+
+The method also simplified from 7 lines to 4.
+
+## Affected Files
+
+- `engine/src/main/java/com/arcadedb/query/sql/parser/ProjectionItem.java` - one-line fix in `getProjectionAlias()`
+
+## Tests
+
+New regression test class: `engine/src/test/java/com/arcadedb/query/sql/BacktickProjectionAliasTest.java`
+
+Four test cases:
+1. `backtickProjectionKeyIsStripped` - `SELECT \`col1\` FROM T` produces key `col1` (not `` `col1` ``)
+2. `backtickProjectionGroupByValueIsNotNull` - `SELECT \`col1\`, count(*) AS n ... GROUP BY \`col1\`` produces correct key and non-null values
+3. `quotedAliasOnQuotedColumnIsStripped` - `SELECT \`col1\` AS \`alias1\` ... GROUP BY \`col1\`` produces key `alias1` with correct value
+4. `unquotedProjectionStillWorks` - regression guard: unquoted `SELECT col1 ... GROUP BY col1` still works
+
+## Test Results
+
+- All 4 new tests: PASS
+- 224 related SQL/query tests: PASS (GroupByMixedNumericTypesTest, QueryTest, DDLTest, ProjectionTest, etc.)

--- a/docs/4691-backtick-projection-alias.md
+++ b/docs/4691-backtick-projection-alias.md
@@ -50,3 +50,21 @@ Four test cases:
 
 - All 4 new tests: PASS
 - 224 related SQL/query tests: PASS (GroupByMixedNumericTypesTest, QueryTest, DDLTest, ProjectionTest, etc.)
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/4694
+
+## Review Cycles
+
+### Cycle 1 - HEAD `0589714`
+
+**Gemini (COMMENTED):** Suggested adding `expression != null` null check before calling `expression.getDefaultAlias()`. Assessment: the original code had the same NPE risk (`expression.toString()` also NPEs for null expression); the suggested fix returns `null` which just pushes the NPE into `getProjectionAliasAsString()` without resolving it. Pre-existing issue, out of scope, incomplete fix. **Skipped (nitpick/disagree).**
+
+**Claude (APPROVED):** "The fix is correct, well-motivated, and minimal." Noted a pre-existing edge case (backtick + method modifier) as a follow-up suggestion, not a blocker. "No blocking issues." **No changes needed.**
+
+No changes applied this cycle.
+
+## Final State
+
+`clean-approval` - both bots reviewed cycle 1; Claude approved, Gemini's only comment was a pre-existing nitpick. No further cycles needed.

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/ProjectionItem.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/ProjectionItem.java
@@ -154,16 +154,11 @@ public class ProjectionItem extends SimpleNode {
   }
 
   public Identifier getProjectionAlias() {
-    if (alias != null) {
+    if (alias != null)
       return alias;
-    }
-    final Identifier result;
-    if (all) {
-      result = new Identifier("*");
-    } else {
-      result = new Identifier(expression.toString());
-    }
-    return result;
+    if (all)
+      return new Identifier("*");
+    return expression.getDefaultAlias();
   }
 
   public boolean isExpand() {

--- a/engine/src/test/java/com/arcadedb/query/sql/BacktickProjectionAliasTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/BacktickProjectionAliasTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #4691: backtick-quoted identifiers in SELECT projection were not
+ * resolved as column references - the output key kept the literal backticks and GROUP BY values
+ * resolved to null.
+ */
+class BacktickProjectionAliasTest extends TestHelper {
+
+  @Test
+  void backtickProjectionKeyIsStripped() {
+    database.transaction(() -> {
+      database.command("SQL", "CREATE DOCUMENT TYPE Tbl4691a");
+      database.command("SQL", "CREATE PROPERTY Tbl4691a.col1 INTEGER");
+      database.command("SQL", "INSERT INTO Tbl4691a SET col1 = 42");
+
+      final ResultSet rs = database.query("SQL", "SELECT `col1` FROM Tbl4691a");
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+
+      // The output key must be "col1" without surrounding backticks.
+      assertThat(row.getPropertyNames()).containsExactly("col1");
+      assertThat(row.<Integer>getProperty("col1")).isEqualTo(42);
+    });
+  }
+
+  @Test
+  void backtickProjectionGroupByValueIsNotNull() {
+    database.transaction(() -> {
+      database.command("SQL", "CREATE DOCUMENT TYPE Tbl4691b");
+      database.command("SQL", "CREATE PROPERTY Tbl4691b.col1 INTEGER");
+      database.command("SQL", "INSERT INTO Tbl4691b SET col1 = 1");
+      database.command("SQL", "INSERT INTO Tbl4691b SET col1 = 1");
+      database.command("SQL", "INSERT INTO Tbl4691b SET col1 = 2");
+
+      final ResultSet rs = database.query("SQL",
+          "SELECT `col1`, count(*) AS n FROM Tbl4691b GROUP BY `col1` ORDER BY `col1`");
+
+      final List<Result> rows = new ArrayList<>();
+      while (rs.hasNext())
+        rows.add(rs.next());
+
+      assertThat(rows).hasSize(2);
+
+      // The grouped column must be keyed "col1" (no backticks) and must not be null.
+      final Result first = rows.get(0);
+      assertThat(first.getPropertyNames()).contains("col1");
+      assertThat(first.<Integer>getProperty("col1")).isNotNull().isEqualTo(1);
+      assertThat(first.<Number>getProperty("n").longValue()).isEqualTo(2L);
+
+      final Result second = rows.get(1);
+      assertThat(second.<Integer>getProperty("col1")).isNotNull().isEqualTo(2);
+      assertThat(second.<Number>getProperty("n").longValue()).isEqualTo(1L);
+    });
+  }
+
+  @Test
+  void quotedAliasOnQuotedColumnIsStripped() {
+    database.transaction(() -> {
+      database.command("SQL", "CREATE DOCUMENT TYPE Tbl4691c");
+      database.command("SQL", "CREATE PROPERTY Tbl4691c.col1 INTEGER");
+      database.command("SQL", "INSERT INTO Tbl4691c SET col1 = 7");
+      database.command("SQL", "INSERT INTO Tbl4691c SET col1 = 7");
+
+      // `col1` AS `alias1` → key should be "alias1" and value should be correct.
+      final ResultSet rs = database.query("SQL",
+          "SELECT `col1` AS `alias1`, count(*) AS n FROM Tbl4691c GROUP BY `col1`");
+      assertThat(rs.hasNext()).isTrue();
+      final Result row = rs.next();
+      assertThat(row.getPropertyNames()).contains("alias1");
+      assertThat(row.<Integer>getProperty("alias1")).isNotNull().isEqualTo(7);
+      assertThat(row.<Number>getProperty("n").longValue()).isEqualTo(2L);
+    });
+  }
+
+  @Test
+  void unquotedProjectionStillWorks() {
+    database.transaction(() -> {
+      database.command("SQL", "CREATE DOCUMENT TYPE Tbl4691d");
+      database.command("SQL", "CREATE PROPERTY Tbl4691d.col1 INTEGER");
+      database.command("SQL", "INSERT INTO Tbl4691d SET col1 = 3");
+      database.command("SQL", "INSERT INTO Tbl4691d SET col1 = 3");
+      database.command("SQL", "INSERT INTO Tbl4691d SET col1 = 5");
+
+      final ResultSet rs = database.query("SQL",
+          "SELECT col1, count(*) AS n FROM Tbl4691d GROUP BY col1 ORDER BY col1");
+      final List<Result> rows = new ArrayList<>();
+      while (rs.hasNext())
+        rows.add(rs.next());
+
+      assertThat(rows).hasSize(2);
+      assertThat(rows.get(0).<Integer>getProperty("col1")).isEqualTo(3);
+      assertThat(rows.get(0).<Number>getProperty("n").longValue()).isEqualTo(2L);
+      assertThat(rows.get(1).<Integer>getProperty("col1")).isEqualTo(5);
+      assertThat(rows.get(1).<Number>getProperty("n").longValue()).isEqualTo(1L);
+    });
+  }
+}


### PR DESCRIPTION
Closes #4691

## Summary

Backtick-quoted identifiers in SELECT projection position were not resolved as column references: the output key retained the literal backticks (e.g. `` `col1` `` instead of `col1`), and under GROUP BY the value resolved to `null`.

The root cause was a one-liner in `ProjectionItem.getProjectionAlias()`: the default alias was built as `new Identifier(expression.toString())`. For a quoted column reference, `expression.toString()` renders the backtick-wrapped text, and `Identifier(String)` stores that with backslash-escaped backticks - the wrong output key. This also broke GROUP BY resolution because the backtick-bearing key did not match the bare property name.

The fix delegates to `expression.getDefaultAlias()`, which already existed and correctly navigates to the underlying `Identifier.getStringValue()` (bare value, no backticks) for base identifier expressions. Non-base expressions (function calls, multi-hop property access) fall back to `toString()` as before.

## Test plan

- [x] `BacktickProjectionAliasTest.backtickProjectionKeyIsStripped` - `SELECT \`col1\` FROM T` returns key `col1` (no backticks)
- [x] `BacktickProjectionAliasTest.backtickProjectionGroupByValueIsNotNull` - `SELECT \`col1\`, count(*) AS n ... GROUP BY \`col1\`` returns correct key and non-null grouped value
- [x] `BacktickProjectionAliasTest.quotedAliasOnQuotedColumnIsStripped` - `SELECT \`col1\` AS \`alias1\` ... GROUP BY \`col1\`` returns key `alias1` with correct value
- [x] `BacktickProjectionAliasTest.unquotedProjectionStillWorks` - unquoted `SELECT col1 ... GROUP BY col1` still works (regression guard)
- [x] 224 existing SQL/query tests pass with no regressions