### PR TITLE
feat: [#4687] native BM25 full-text scoring (field boosts, caret, EXPLAIN/PROFILE)

### DIFF
--- a/RELEASE-27.7.1.md
+++ b/RELEASE-27.7.1.md
@@ -65,4 +65,11 @@ Existing full-text index files open and continue to score with **CLASSIC** (no b
 type above). To switch existing data to BM25 you must **rebuild** the full-text index: term frequencies were never stored before
 and past compactions discarded posting multiplicity, so there is no in-place migration. New indexes use BM25 automatically.
 
+**Corpus counters and `REBUILD INDEX ... WITH statsOnly = true`.** BM25 keeps per-type corpus counters (document count + total
+length) that feed the average-document-length normalizer. They are maintained incrementally and are self-corrected once per
+session on the first query, but they are not transactionally reversed on rollback and the session check validates only the
+document count. After a large bulk import, a workload with many rolled-back transactions, or migrating a pre-BM25 index, run
+`REBUILD INDEX <name> WITH statsOnly = true` (or `REBUILD INDEX *`) to re-derive the counters exactly without a full reindex -
+also useful to pre-warm a cold upgraded index before serving traffic (the first BM25 query otherwise does a one-time full scan).
+
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.0...27.7.1

--- a/RELEASE-27.7.1.md
+++ b/RELEASE-27.7.1.md
@@ -52,6 +52,13 @@ affects CLASSIC indexes specifically (BM25 indexes are new in this release and w
 - **Migration:** if you relied on the old ascending order, add an explicit `ORDER BY $score ASC`. The new default
   (most-relevant-first) is almost always what full-text callers want.
 
+### 3. `IndexCursorEntry` identity no longer includes the score (extension/plugin API)
+
+`IndexCursorEntry.equals()`/`hashCode()` now use only `(record, keys)`; the relevance `score` is no longer part of identity. This
+lets the same document be deduplicated in a result `Set` regardless of score (needed for BM25, where a document can be scored more
+than once). No in-tree caller relied on the old behaviour, but third-party extensions that placed `IndexCursorEntry` objects into
+a `Set` expecting score-differentiated entries would see different deduplication. Treat `(record, keys)` as the identity.
+
 ### Getting BM25 on existing data
 
 Existing full-text index files open and continue to score with **CLASSIC** (no behaviour change on upgrade beyond the `$score`

--- a/RELEASE-27.7.1.md
+++ b/RELEASE-27.7.1.md
@@ -1,0 +1,59 @@
+# ArcadeDB v.27.7.1 Release Highlights
+
+This release adds native **BM25 relevance scoring** to `FULL_TEXT` indexes (issue
+[#4687](https://github.com/ArcadeData/arcadedb/issues/4687)). It also includes two user-visible behaviour changes for full-text
+indexes that require attention when upgrading - see **Breaking Changes** below.
+
+### ✨ New Features
+
+- Native **Okapi BM25** scoring for `FULL_TEXT` indexes: term frequency + inverse document frequency + document-length
+  normalization, replacing the legacy term-coordination (match-count) model. BM25 is the default for newly created full-text
+  indexes ([#4687](https://github.com/ArcadeData/arcadedb/issues/4687)).
+- Configurable BM25 parameters (`bm25_k1`, `bm25_b`) and per-field boosts (`<field>_boost`) via index `METADATA`, plus the Java
+  builder API (`withBM25(k1, b)`, `withFieldBoost(field, boost)`, `withSimilarity(...)`).
+- Query-time caret boosts (`term^N`, `field:term^N`, group boosts) following the Lucene/Elasticsearch convention.
+- `EXPLAIN` / `PROFILE` now surface BM25 scoring metadata (similarity, `k1`/`b`, corpus stats, and per-term `df`/`idf`/`boost`)
+  on the full-text fetch step.
+
+### 🐛 Bug Fixes
+
+- Fixed a pre-existing full-text **compaction** bug that silently dropped postings when a single token's posting list spanned
+  multiple compacted leaf pages (affected CLASSIC scoring too) ([#4687](https://github.com/ArcadeData/arcadedb/issues/4687)).
+- Fixed full-text index **metadata persistence**: custom analyzer/operator configuration was silently reverted to
+  `StandardAnalyzer` on restart; it now round-trips correctly (and carries the BM25 settings and corpus counters).
+- A property literally named `content` on a multi-property full-text index no longer collides with the query parser's default
+  field, so `content:term` clauses (and `content_boost`) now resolve and score correctly.
+
+## ⚠️ Breaking Changes (migration notes)
+
+These two changes affect existing `FULL_TEXT` indexes (including indexes that keep CLASSIC scoring). Review them before upgrading.
+
+### 1. `$score` is now a `Float` (was `Integer` for CLASSIC indexes)
+
+`$score` is now always a floating-point relevance score. For CLASSIC (term-coordination) indexes it was previously an
+`Integer` match count (e.g. `3`) and is now the same value widened to a `Float` (e.g. `3.0`). BM25 indexes return a genuine
+fractional score.
+
+- **Impact:** application code that reads `$score` and casts/expects a `java.lang.Integer` will fail (e.g. `ClassCastException`)
+  or behave unexpectedly. This is silent at compile time for code using `getProperty("$score")`.
+- **Migration:** read `$score` as a `Number` (or `Float`), e.g. `((Number) result.getProperty("$score")).floatValue()`. SQL that
+  only sorts/filters on `$score` (`ORDER BY $score DESC`, `WHERE $score > ...`) is unaffected.
+
+### 2. Full-text `get()` cursor order is now most-relevant-first
+
+The full-text index cursor previously returned matches sorted by ascending score (least-relevant first) and did not apply the
+result `limit`. It now returns most-relevant-first (descending score, with a stable RID tiebreaker) and honors the `limit`.
+
+- **Impact:** applications that consumed the raw index cursor order (without an explicit SQL `ORDER BY`) will see the order
+  reversed, and a `limit` now truncates to the top-N by relevance instead of being ignored. Queries with an explicit
+  `ORDER BY $score DESC` are unaffected (they already sorted).
+- **Migration:** if you relied on the old ascending order, add an explicit `ORDER BY $score ASC`. The new default
+  (most-relevant-first) is almost always what full-text callers want.
+
+### Getting BM25 on existing data
+
+Existing full-text index files open and continue to score with **CLASSIC** (no behaviour change on upgrade beyond the `$score`
+type above). To switch existing data to BM25 you must **rebuild** the full-text index: term frequencies were never stored before
+and past compactions discarded posting multiplicity, so there is no in-place migration. New indexes use BM25 automatically.
+
+**Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.0...27.7.1

--- a/RELEASE-27.7.1.md
+++ b/RELEASE-27.7.1.md
@@ -39,10 +39,12 @@ fractional score.
 - **Migration:** read `$score` as a `Number` (or `Float`), e.g. `((Number) result.getProperty("$score")).floatValue()`. SQL that
   only sorts/filters on `$score` (`ORDER BY $score DESC`, `WHERE $score > ...`) is unaffected.
 
-### 2. Full-text `get()` cursor order is now most-relevant-first
+### 2. Full-text `get()` cursor order is now most-relevant-first (affects CLASSIC indexes)
 
-The full-text index cursor previously returned matches sorted by ascending score (least-relevant first) and did not apply the
-result `limit`. It now returns most-relevant-first (descending score, with a stable RID tiebreaker) and honors the `limit`.
+The **CLASSIC** (term-coordination) full-text index cursor previously returned matches sorted by ascending score
+(least-relevant first) and did not apply the result `limit`. It now returns most-relevant-first (descending score, with a stable
+RID tiebreaker) and honors the `limit` - consistent with the BM25 path, which already sorted descending. This change therefore
+affects CLASSIC indexes specifically (BM25 indexes are new in this release and were never ascending).
 
 - **Impact:** applications that consumed the raw index cursor order (without an explicit SQL `ORDER BY`) will see the order
   reversed, and a `limit` now truncates to the top-N by relevance instead of being ignored. Queries with an explicit

--- a/docs/4687-bm25-fulltext-scoring.md
+++ b/docs/4687-bm25-fulltext-scoring.md
@@ -91,10 +91,14 @@ individual rows). There is no separate explain function.
 - Getting BM25 on existing data requires **rebuilding** the full-text index (the build path re-analyzes documents and writes the
   `tf`/`docLength` postings + corpus counters). `tf` was never stored before and past compactions discarded posting multiplicity,
   so there is no in-place migration.
+- **`$score` is now a float** (`Float`), including for CLASSIC indexes where it was previously an `Integer` (the coordination
+  match count, now widened to e.g. `3.0`). Application code that read `$score` as an `Integer` must read it as a `Number`/`Float`.
+  This is the one user-visible behavior change for existing CLASSIC indexes.
 
-## Known limitation (pre-existing, orthogonal)
+## Compaction fix (pre-existing bug, also affected CLASSIC)
 
-Full-text index **compaction** can drop postings when a *single token's* posting list is large enough to span multiple compacted
-leaf pages (only reproducible with artificially small page sizes). This is independent of BM25 - it reproduces identically with
-CLASSIC scoring - and does not occur at realistic page sizes where a single token's postings fit on one page. Tracked separately;
-not addressed here.
+Full-text index **compaction** previously dropped postings when a *single token's* posting list spanned multiple compacted leaf
+pages: the compacted root is a positional sparse index that cannot index one leaf page under two keys, so a key's first values
+left on a shared continuation page became unreachable on read. This was independent of BM25 (reproduced identically with CLASSIC).
+Fixed here by forcing an overflowing key to start on a fresh page it fully owns; covered by `FullTextBM25CompactionTest` at tiny
+page sizes.

--- a/docs/4687-bm25-fulltext-scoring.md
+++ b/docs/4687-bm25-fulltext-scoring.md
@@ -112,6 +112,12 @@ individual rows). There is no separate explain function.
 
 ## Operational notes / known limitations
 
+- **Disaster recovery: keep BM25 index files with their schema.** Whether a full-text index stores the inline `tf`/`docLength`
+  bytes is derived from the persisted schema (`similarity = BM25`), not from a per-page flag. If index files are restored or
+  hand-copied **without** the matching schema (or the two are otherwise out of sync), the `tf`/`docLength` varints would be
+  misread as RID bytes. Always back up and restore the schema together with the index files; after a manual recovery, a
+  `REBUILD INDEX <name>` regenerates the postings from the documents if there is any doubt.
+
 - **Counter drift after rollbacks triggers a one-time rescan.** The corpus counters are bumped at index put/remove time, before
   commit, and are not reversed on rollback. The first BM25 query of a session validates the persisted counters against a cheap
   live document count and, if they disagree (e.g. after rolled-back inserts), does a single full type scan to repair them - once

--- a/docs/4687-bm25-fulltext-scoring.md
+++ b/docs/4687-bm25-fulltext-scoring.md
@@ -78,9 +78,12 @@ individual rows). There is no separate explain function.
     index (graph edges, unique constraints, type indexes) keeps the byte-identical RID-only format.
   - `storeTermFrequency` is derived from the persisted `similarity` (BM25 ⇒ on). It is propagated to the mutable index, its
     compacted sub-index, and across compaction/split, so old RID-only files still parse and score as CLASSIC.
-- **Corpus statistics** — `N` (document count) and the sum of document lengths (for `avgdl`) are maintained incrementally on
-  put/remove and persisted in `FullTextIndexMetadata`. If they are missing/stale (e.g. a BM25 index reopened before the schema was
-  saved), the first BM25 query lazily recomputes them; `recomputeBM25Counters()` repairs them on demand.
+- **Corpus statistics** — `N` for IDF is the per-bucket live record count (consistent with the per-bucket `df`). The shared
+  type-wide counters in `FullTextIndexMetadata` (document count + sum of document lengths) feed only `avgdl`, are maintained
+  incrementally on put/remove, and are persisted. They are **not** transactionally reversed on rollback and a removed document's
+  length is recomputed (so it can drift after an analyzer change); since they affect only the `avgdl` length normalizer this
+  degrades ranking gradually, not catastrophically. There is **no background recompute** - `recomputeBM25Counters()` (or a
+  rebuild) repairs them exactly on demand, and a reopen with an invalid `countersValid` flag rebuilds them lazily on first query.
 - **Metadata persistence fix** — `LSMTreeFullTextIndex.toJSON()` previously dropped analyzer/operator config, so a restart
   silently reverted custom analyzers to `StandardAnalyzer`. The metadata round-trip is now implemented (and restored in
   `LocalSchema` reload), which also persists the BM25 settings and counters.

--- a/docs/4687-bm25-fulltext-scoring.md
+++ b/docs/4687-bm25-fulltext-scoring.md
@@ -112,6 +112,11 @@ individual rows). There is no separate explain function.
 
 ## Operational notes / known limitations
 
+- **`EXPLAIN`/`PROFILE` of a wildcard query walks the term index.** Explaining a query with a wildcard/prefix/fuzzy term (e.g.
+  `a*`) expands it to the matching token keys to report per-term df, which scans the index for those keys synchronously. The
+  scoring breakdown is capped (`MAX_EXPLAIN_TERMS`, with `termsOmitted` reported) but the *expansion scan itself* is not, so an
+  `EXPLAIN`/`PROFILE` of a very broad wildcard can be slow on a large index. Avoid putting such `PROFILE` calls in tight
+  monitoring loops.
 - **Phrase queries are unordered (all-terms, not in-order).** A quoted phrase like `"java database"` requires that all of its
   terms occur in the document but does NOT enforce their order or adjacency - this index stores no token positions. So
   `"java database"` and `"database java"` return the same documents (an AND of the terms), and a phrase can match even when the

--- a/docs/4687-bm25-fulltext-scoring.md
+++ b/docs/4687-bm25-fulltext-scoring.md
@@ -87,7 +87,9 @@ individual rows). There is no separate explain function.
   incrementally on put/remove, and are persisted. They are **not** transactionally reversed on rollback and a removed document's
   length is recomputed (so it can drift after an analyzer change); since they affect only the `avgdl` length normalizer this
   degrades ranking gradually, not catastrophically. There is **no background recompute** - `recomputeBM25Counters()` (or a
-  rebuild) repairs them exactly on demand, and a reopen with an invalid `countersValid` flag rebuilds them lazily on first query.
+  rebuild) repairs them exactly on demand. After a restart the persisted counters may lag the on-disk data (documents indexed
+  after the last schema save); the first BM25 query validates them once with a cheap live document count and rebuilds only if
+  they disagree, so a clean restart with fresh counters pays nothing while a stale one self-heals.
 - **Metadata persistence fix** — `LSMTreeFullTextIndex.toJSON()` previously dropped analyzer/operator config, so a restart
   silently reverted custom analyzers to `StandardAnalyzer`. The metadata round-trip is now implemented (and restored in
   `LocalSchema` reload), which also persists the BM25 settings and counters.

--- a/docs/4687-bm25-fulltext-scoring.md
+++ b/docs/4687-bm25-fulltext-scoring.md
@@ -112,6 +112,11 @@ individual rows). There is no separate explain function.
 
 ## Operational notes / known limitations
 
+- **Phrase queries are unordered (all-terms, not in-order).** A quoted phrase like `"java database"` requires that all of its
+  terms occur in the document but does NOT enforce their order or adjacency - this index stores no token positions. So
+  `"java database"` and `"database java"` return the same documents (an AND of the terms), and a phrase can match even when the
+  words are far apart. Use phrase syntax for "all of these words" semantics, not for true proximity matching.
+
 - **Disaster recovery: keep BM25 index files with their schema.** Whether a full-text index stores the inline `tf`/`docLength`
   bytes is derived from the persisted schema (`similarity = BM25`), not from a per-page flag. If index files are restored or
   hand-copied **without** the matching schema (or the two are otherwise out of sync), the `tf`/`docLength` varints would be

--- a/docs/4687-bm25-fulltext-scoring.md
+++ b/docs/4687-bm25-fulltext-scoring.md
@@ -72,8 +72,12 @@ individual rows). There is no separate explain function.
   length (`docLength`) are stored inline in the postings. A posting value is serialized as
   `compressedRID + tf(varint) + docLength(varint)` when the index uses BM25.
   - This is carried through the entire existing RID-typed pipeline (transaction staging, commit replay, compaction, page cursors)
-    by `RIDWithStats extends DatabaseRID`: every `(RID)` cast, deletion-marker bucket-sign check and `RidHashSet` membership keeps
-    working because `equals`/`hashCode` are inherited from `RID` (bucket id + offset only).
+    by `FullTextPostingRID extends DatabaseRID`: every `(RID)` cast, deletion-marker bucket-sign check and `RidHashSet`
+    membership keeps working because `equals`/`hashCode` are inherited from `RID` (bucket id + offset only).
+- **Scoring passes** — `df` (for IDF) is derived by counting a token's postings. The `SEARCH_INDEX` path (a candidate set is
+  known) scores in a single pass, collecting only candidate postings. The direct index-lookup path (no candidate set) scans each
+  token's postings twice (count `df`, then accumulate) to bound memory rather than materialize the full list; for a very common
+  term this doubles that token's read I/O. Both keep memory bounded by the result/candidate set.
   - Only the value (de)serialization in `LSMTreeIndexAbstract` changes, gated by `storeTermFrequency`. Every non-full-text LSM
     index (graph edges, unique constraints, type indexes) keeps the byte-identical RID-only format.
   - `storeTermFrequency` is derived from the persisted `similarity` (BM25 ⇒ on). It is propagated to the mutable index, its

--- a/docs/4687-bm25-fulltext-scoring.md
+++ b/docs/4687-bm25-fulltext-scoring.md
@@ -31,6 +31,10 @@ SELECT title, $score FROM Article
 -- Inspect the scoring with EXPLAIN / PROFILE: the full-text fetch step reports the BM25 similarity,
 -- k1/b, corpus stats (N, avgdl) and each query term's df + idf.
 EXPLAIN SELECT title, $score FROM Article WHERE SEARCH_INDEX('Article[content]', 'java database') = true;
+
+-- Repair drifted BM25 corpus counters (e.g. after many rolled-back transactions) WITHOUT a full reindex: rescans the live
+-- data and rebuilds the avgdl counters only. Use `*` to repair every full-text index.
+REBUILD INDEX `Article[content]` WITH statsOnly = true;
 ```
 
 ### Metadata keys

--- a/docs/4687-bm25-fulltext-scoring.md
+++ b/docs/4687-bm25-fulltext-scoring.md
@@ -118,6 +118,22 @@ individual rows). There is no separate explain function.
   misread as RID bytes. Always back up and restore the schema together with the index files; after a manual recovery, a
   `REBUILD INDEX <name>` regenerates the postings from the documents if there is any doubt.
 
+- **Per-bucket scoring: `$score` is not globally calibrated across buckets.** BM25 is scored per bucket (like an Elasticsearch
+  shard): a term's IDF depends on the document frequency *within the bucket that holds the document*, so the same term can carry
+  a slightly different IDF in different buckets depending on how documents are distributed. `ORDER BY $score DESC` over a
+  multi-bucket type therefore ranks correctly within each bucket and merges them, but the absolute scores are not globally
+  calibrated - two documents with identical content in differently-populated buckets can score slightly differently. For a
+  single-bucket type (or one with even term distribution) this is a non-issue; it is inherent to per-shard scoring.
+- **First BM25 query on a cold index does a one-time full scan (and briefly serializes).** When an index's corpus counters are
+  not yet trustworthy (an index built before this feature, or reopened before its schema was saved), the first BM25 query
+  rebuilds them with a full type scan, holding a short lock on the shared metadata so the type's other bucket indexes do not all
+  scan at once. On a very large collection this first query can block briefly. Freshly created indexes start with valid counters
+  and pay nothing; to avoid the stall after an upgrade, pre-warm with `REBUILD INDEX <name> WITH statsOnly = true` before serving
+  traffic.
+- **`avgdl` drift is only document-count-validated.** The session-start self-heal compares the document count against the live
+  count; it does not independently re-derive `sumDocLength`. A workload that replaces document content (changing total token
+  length) without changing the document count could let `avgdl` drift within a session undetected. It only affects length
+  normalization (suboptimal, not wrong, scores); `REBUILD INDEX <name> WITH statsOnly = true` re-derives both counters exactly.
 - **Counter drift after rollbacks triggers a one-time rescan.** The corpus counters are bumped at index put/remove time, before
   commit, and are not reversed on rollback. The first BM25 query of a session validates the persisted counters against a cheap
   live document count and, if they disagree (e.g. after rolled-back inserts), does a single full type scan to repair them - once

--- a/docs/4687-bm25-fulltext-scoring.md
+++ b/docs/4687-bm25-fulltext-scoring.md
@@ -134,6 +134,11 @@ individual rows). There is no separate explain function.
   count; it does not independently re-derive `sumDocLength`. A workload that replaces document content (changing total token
   length) without changing the document count could let `avgdl` drift within a session undetected. It only affects length
   normalization (suboptimal, not wrong, scores); `REBUILD INDEX <name> WITH statsOnly = true` re-derives both counters exactly.
+- **Deleting after an analyzer/field change can drift `avgdl`.** On delete, the removed document's length is recomputed from the
+  values supplied at delete time, not from what was stored at index time. If an indexed field is null at delete time but was set
+  at index time, or the analyzer changed between index and delete, the recomputed length differs and `sumDocLength` is
+  under-decremented, drifting `avgdl`. Follow any analyzer change or bulk field-nulling-before-delete with
+  `REBUILD INDEX <name> WITH statsOnly = true` to re-derive the counters exactly.
 - **Counter drift after rollbacks triggers a one-time rescan.** The corpus counters are bumped at index put/remove time, before
   commit, and are not reversed on rollback. The first BM25 query of a session validates the persisted counters against a cheap
   live document count and, if they disagree (e.g. after rolled-back inserts), does a single full type scan to repair them - once

--- a/docs/4687-bm25-fulltext-scoring.md
+++ b/docs/4687-bm25-fulltext-scoring.md
@@ -84,7 +84,9 @@ individual rows). There is no separate explain function.
     compacted sub-index, and across compaction/split, so old RID-only files still parse and score as CLASSIC.
 - **Corpus statistics** — `N` for IDF is the per-bucket live record count (consistent with the per-bucket `df`). The shared
   type-wide counters in `FullTextIndexMetadata` (document count + sum of document lengths) feed only `avgdl`, are maintained
-  incrementally on put/remove, and are persisted. They are **not** transactionally reversed on rollback and a removed document's
+  incrementally on put/remove, and are persisted. (Note: this mixes scopes deliberately - `N`/`df` are per-bucket while `avgdl`
+  is type-wide, unlike Elasticsearch/Lucene where both are shard-local; `avgdl` is only a length normalizer so a type-wide
+  estimate is fine and avoids per-bucket length bookkeeping.) They are **not** transactionally reversed on rollback and a removed document's
   length is recomputed (so it can drift after an analyzer change); since they affect only the `avgdl` length normalizer this
   degrades ranking gradually, not catastrophically. There is **no background recompute** - `recomputeBM25Counters()` (or a
   rebuild) repairs them exactly on demand. After a restart the persisted counters may lag the on-disk data (documents indexed

--- a/docs/4687-bm25-fulltext-scoring.md
+++ b/docs/4687-bm25-fulltext-scoring.md
@@ -1,0 +1,100 @@
+# Native BM25 full-text scoring (issue #4687)
+
+## Summary
+
+Full-text (`FULL_TEXT`) indexes can now rank results with **Okapi BM25** (term frequency + inverse document frequency + document
+length normalization) instead of the legacy term-coordination (match-count) model. BM25 is the default for newly created
+full-text indexes; pre-existing indexes keep CLASSIC scoring until rebuilt or explicitly switched.
+
+## Usage (SQL)
+
+```sql
+-- New index: BM25 by default
+CREATE INDEX ON Article (content) FULL_TEXT;
+
+-- Explicit BM25 with tuned parameters and a per-field boost (multi-field index)
+CREATE INDEX ON Article (title, body) FULL_TEXT
+  METADATA {"similarity": "BM25", "bm25_k1": 1.2, "bm25_b": 0.75, "title_boost": 3.0};
+
+-- Keep the legacy coordination scoring
+CREATE INDEX ON Article (content) FULL_TEXT METADATA {"similarity": "CLASSIC"};
+
+-- Query: $score is a float BM25 relevance score
+SELECT title, $score FROM Article
+  WHERE SEARCH_INDEX('Article[content]', 'java database') = true
+  ORDER BY $score DESC;
+
+-- Caret boost: weight a term (or a field-qualified term) more (Lucene/Elasticsearch idiom)
+SELECT title, $score FROM Article
+  WHERE SEARCH_INDEX('Article[title,body]', 'title:java^3 database') = true ORDER BY $score DESC;
+
+-- Inspect the scoring with EXPLAIN / PROFILE: the full-text fetch step reports the BM25 similarity,
+-- k1/b, corpus stats (N, avgdl) and each query term's df + idf.
+EXPLAIN SELECT title, $score FROM Article WHERE SEARCH_INDEX('Article[content]', 'java database') = true;
+```
+
+### Metadata keys
+
+| Key            | Default | Meaning                                                            |
+|----------------|---------|--------------------------------------------------------------------|
+| `similarity`   | `BM25`  | `BM25` or `CLASSIC`                                                 |
+| `bm25_k1`      | `1.2`   | term-frequency saturation                                          |
+| `bm25_b`       | `0.75`  | document-length normalization in [0,1] (0 disables length norm)    |
+| `<field>_boost`| `1.0`   | multiplier applied to BM25 contributions of `field:term` matches   |
+
+The Java builder mirrors these: `buildTypeIndex(...).withType(FULL_TEXT).withFullTextType().withBM25(k1, b).withFieldBoost("title", 3.0f).create()`.
+
+### Boosts
+
+Two composable mechanisms, both following the Lucene/Elasticsearch conventions:
+
+- **Configured per-field boost** (`<field>_boost` metadata) - a default weight applied to BM25 contributions of `field:term`
+  matches on that field.
+- **Query-time caret boost** (`term^N`, e.g. `title:java^3`) - weights a specific term in a specific query. Parsed by the Lucene
+  query syntax. The effective weight is `caret * field_boost`.
+
+Field boosts apply to **field-qualified** query terms (e.g. `title:java`). Unqualified terms on a multi-field index score against
+the field-agnostic token with boost 1.0.
+
+### Inspecting scores with EXPLAIN / PROFILE
+
+`EXPLAIN`/`PROFILE` of a query whose `WHERE` uses `SEARCH_INDEX(...)` annotates the full-text fetch step (`FETCH FROM INDEXED
+FUNCTION`) with a `SCORING` line containing the BM25 similarity, the `k1`/`b` parameters, the corpus statistics (`totalDocs`,
+`avgDocLength`) and, per query term, its document frequency (`df`), `idf` and applied `boost`. This is the query-level "why are
+the scores what they are" view; per-document contributions are intentionally not included (a plan describes the query, not
+individual rows). There is no separate explain function.
+
+## Design
+
+- **Formula** — `BM25Scorer` (pure, DB-free, unit-tested): `idf(N,df)=ln((N-df+0.5)/(df+0.5)+1)` (matches the sparse-vector
+  index's IDF), `termScore = idf * tf*(k1+1) / (tf + k1*(1 - b + b*dl/avgdl))`.
+- **Persisted statistics** — to avoid re-reading documents at query time, the per-posting term frequency (`tf`) and document
+  length (`docLength`) are stored inline in the postings. A posting value is serialized as
+  `compressedRID + tf(varint) + docLength(varint)` when the index uses BM25.
+  - This is carried through the entire existing RID-typed pipeline (transaction staging, commit replay, compaction, page cursors)
+    by `RIDWithStats extends DatabaseRID`: every `(RID)` cast, deletion-marker bucket-sign check and `RidHashSet` membership keeps
+    working because `equals`/`hashCode` are inherited from `RID` (bucket id + offset only).
+  - Only the value (de)serialization in `LSMTreeIndexAbstract` changes, gated by `storeTermFrequency`. Every non-full-text LSM
+    index (graph edges, unique constraints, type indexes) keeps the byte-identical RID-only format.
+  - `storeTermFrequency` is derived from the persisted `similarity` (BM25 ⇒ on). It is propagated to the mutable index, its
+    compacted sub-index, and across compaction/split, so old RID-only files still parse and score as CLASSIC.
+- **Corpus statistics** — `N` (document count) and the sum of document lengths (for `avgdl`) are maintained incrementally on
+  put/remove and persisted in `FullTextIndexMetadata`. If they are missing/stale (e.g. a BM25 index reopened before the schema was
+  saved), the first BM25 query lazily recomputes them; `recomputeBM25Counters()` repairs them on demand.
+- **Metadata persistence fix** — `LSMTreeFullTextIndex.toJSON()` previously dropped analyzer/operator config, so a restart
+  silently reverted custom analyzers to `StandardAnalyzer`. The metadata round-trip is now implemented (and restored in
+  `LocalSchema` reload), which also persists the BM25 settings and counters.
+
+## Backward compatibility
+
+- Existing full-text index files open and score with CLASSIC (no `tf` on disk, no behavior change on upgrade).
+- Getting BM25 on existing data requires **rebuilding** the full-text index (the build path re-analyzes documents and writes the
+  `tf`/`docLength` postings + corpus counters). `tf` was never stored before and past compactions discarded posting multiplicity,
+  so there is no in-place migration.
+
+## Known limitation (pre-existing, orthogonal)
+
+Full-text index **compaction** can drop postings when a *single token's* posting list is large enough to span multiple compacted
+leaf pages (only reproducible with artificially small page sizes). This is independent of BM25 - it reproduces identically with
+CLASSIC scoring - and does not occur at realistic page sizes where a single token's postings fit on one page. Tracked separately;
+not addressed here.

--- a/docs/4687-bm25-fulltext-scoring.md
+++ b/docs/4687-bm25-fulltext-scoring.md
@@ -110,6 +110,25 @@ individual rows). There is no separate explain function.
   match count, now widened to e.g. `3.0`). Application code that read `$score` as an `Integer` must read it as a `Number`/`Float`.
   This is the one user-visible behavior change for existing CLASSIC indexes.
 
+## Operational notes / known limitations
+
+- **Counter drift after rollbacks triggers a one-time rescan.** The corpus counters are bumped at index put/remove time, before
+  commit, and are not reversed on rollback. The first BM25 query of a session validates the persisted counters against a cheap
+  live document count and, if they disagree (e.g. after rolled-back inserts), does a single full type scan to repair them - once
+  per session. For workloads with a high insert-rollback rate this means a periodic rescan on the first query after each restart.
+  Repair on demand with `REBUILD INDEX <name> WITH statsOnly = true` (cheap, no reindex).
+- **`avgdl` is type-wide while `N`/`df` are per-bucket.** BM25 is scored per bucket: `N` (document count) and `df` are measured in
+  the bucket being scored, but the average document length used for length normalization is a single type-wide value. For a
+  single-bucket type this is exact. For a multi-bucket type with very *unbalanced* document lengths across buckets, the
+  `b * dl / avgdl` normalization is slightly biased (a document in an atypically long bucket is normalized against a type-wide
+  average). `avgdl` is only a normalizer (further dampened by `b`), so this shifts scores modestly rather than reordering
+  aggressively; it is a deliberate trade-off that avoids per-bucket length bookkeeping.
+- **Unconstrained direct lookups do two passes per term.** Scoring through `SEARCH_INDEX` (a candidate set is known) scans each
+  term's postings once. The direct `index.get(query)` API with no candidate set scans each term's postings twice (count `df`,
+  then accumulate) to keep peak memory bounded to the result set rather than materializing a common term's full posting list.
+  For a query with many terms over a large index this doubles that read I/O on the direct path; prefer `SEARCH_INDEX` for large
+  unconstrained queries.
+
 ## Compaction fix (pre-existing bug, also affected CLASSIC)
 
 Full-text index **compaction** previously dropped postings when a *single token's* posting list spanned multiple compacted leaf

--- a/docs/RELEASE-27.7.1.md
+++ b/docs/RELEASE-27.7.1.md
@@ -23,6 +23,9 @@ indexes that require attention when upgrading - see **Breaking Changes** below.
   `StandardAnalyzer` on restart; it now round-trips correctly (and carries the BM25 settings and corpus counters).
 - A property literally named `content` on a multi-property full-text index no longer collides with the query parser's default
   field, so `content:term` clauses (and `content_boost`) now resolve and score correctly.
+- Fixed `REBUILD INDEX * WITH <setting> = <value>` silently dropping the **first** setting: the `*` (all-indexes) form has no
+  index-name identifier, but the parser still skipped `identifier(0)` as if it were one. Any wildcard rebuild with a `WITH`
+  clause (e.g. `REBUILD INDEX * WITH batchSize = 1000`) was therefore ignoring that setting; named-index rebuilds were unaffected.
 
 ## ⚠️ Breaking Changes (migration notes)
 

--- a/docs/RELEASE-27.7.1.md
+++ b/docs/RELEASE-27.7.1.md
@@ -4,7 +4,7 @@ This release adds native **BM25 relevance scoring** to `FULL_TEXT` indexes (issu
 [#4687](https://github.com/ArcadeData/arcadedb/issues/4687)). It also includes two user-visible behaviour changes for full-text
 indexes that require attention when upgrading - see **Breaking Changes** below.
 
-### ✨ New Features
+### New Features
 
 - Native **Okapi BM25** scoring for `FULL_TEXT` indexes: term frequency + inverse document frequency + document-length
   normalization, replacing the legacy term-coordination (match-count) model. BM25 is the default for newly created full-text
@@ -15,7 +15,7 @@ indexes that require attention when upgrading - see **Breaking Changes** below.
 - `EXPLAIN` / `PROFILE` now surface BM25 scoring metadata (similarity, `k1`/`b`, corpus stats, and per-term `df`/`idf`/`boost`)
   on the full-text fetch step.
 
-### 🐛 Bug Fixes
+### Bug Fixes
 
 - Fixed a pre-existing full-text **compaction** bug that silently dropped postings when a single token's posting list spanned
   multiple compacted leaf pages (affected CLASSIC scoring too) ([#4687](https://github.com/ArcadeData/arcadedb/issues/4687)).
@@ -27,7 +27,7 @@ indexes that require attention when upgrading - see **Breaking Changes** below.
   index-name identifier, but the parser still skipped `identifier(0)` as if it were one. Any wildcard rebuild with a `WITH`
   clause (e.g. `REBUILD INDEX * WITH batchSize = 1000`) was therefore ignoring that setting; named-index rebuilds were unaffected.
 
-## ⚠️ Breaking Changes (migration notes)
+## Breaking Changes (migration notes)
 
 These two changes affect existing `FULL_TEXT` indexes (including indexes that keep CLASSIC scoring). Review them before upgrading.
 

--- a/docs/RELEASE-27.7.1.md
+++ b/docs/RELEASE-27.7.1.md
@@ -60,8 +60,9 @@ affects CLASSIC indexes specifically (BM25 indexes are new in this release and w
 
 `IndexCursorEntry.equals()`/`hashCode()` now use only `(record, keys)`; the relevance `score` is no longer part of identity. This
 lets the same document be deduplicated in a result `Set` regardless of score (needed for BM25, where a document can be scored more
-than once). No in-tree caller relied on the old behaviour, but third-party extensions that placed `IndexCursorEntry` objects into
-a `Set` expecting score-differentiated entries would see different deduplication. Treat `(record, keys)` as the identity.
+than once). No in-tree caller relied on the old behaviour, but **any** caller - not only plugin/extension authors - that places
+`IndexCursorEntry` objects (e.g. from `Index.get(...)`) into a `Set`, or uses them as map keys, expecting score-differentiated
+entries will silently see different deduplication. Treat `(record, keys)` as the identity.
 
 ### Getting BM25 on existing data
 

--- a/docs/RELEASE-27.7.1.md
+++ b/docs/RELEASE-27.7.1.md
@@ -47,7 +47,8 @@ RID tiebreaker) and honors the `limit` - consistent with the BM25 path, which al
 affects CLASSIC indexes specifically (BM25 indexes are new in this release and were never ascending).
 
 - **Impact:** applications that consumed the raw index cursor order (without an explicit SQL `ORDER BY`) will see the order
-  reversed, and a `limit` now truncates to the top-N by relevance instead of being ignored. Queries with an explicit
+  reversed, and a `limit` now truncates to the top-N by relevance instead of being ignored. This includes callers of the
+  low-level `Index.get(...)` API directly on a CLASSIC full-text index, not just SQL. Queries with an explicit
   `ORDER BY $score DESC` are unaffected (they already sorted).
 - **Migration:** if you relied on the old ascending order, add an explicit `ORDER BY $score ASC`. The new default
   (most-relevant-first) is almost always what full-text callers want.

--- a/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/engine/DatabaseChecker.java
@@ -53,12 +53,22 @@ public class DatabaseChecker {
   private       int                 maxWarnings  = 100_000;
   private final Map<String, Object> result       = new HashMap<>();
 
+  // Distinct missing/unloadable targets (a record an edge points to) aggregated across the edge and vertex scans,
+  // with a per-target reference count and a sample error. A single missing supernode can be referenced by millions
+  // of edges; this collapses that fan-out so the operator sees "vertex #28:1 ..., referenced by N edge(s)" instead
+  // of scrolling N raw warning lines. Kept out of the serialized result as RID-keyed maps; the readable summary is
+  // emitted as topMissingReferences/distinctMissingReferences at the end of check().
+  private final Map<RID, Long>      missingReferences      = new HashMap<>();
+  private final Map<RID, String>    missingReferenceErrors = new HashMap<>();
+
   public DatabaseChecker(final Database database) {
     this.database = (DatabaseInternal) database;
   }
 
   public Map<String, Object> check() {
     result.clear();
+    missingReferences.clear();
+    missingReferenceErrors.clear();
 
     if (verboseLevel > 0)
       LogManager.instance().log(this, Level.INFO, "Integrity check of database '%s' started", null, database.getName());
@@ -71,6 +81,8 @@ public class DatabaseChecker {
     result.put("corruptedIndexes", new LinkedHashSet<>());
     result.put("totalWarnings", 0L);
     result.put("totalCorruptedRecords", 0L);
+    result.put("distinctMissingReferences", 0L);
+    result.put("topMissingReferences", new ArrayList<String>());
 
     checkEdges();
 
@@ -123,10 +135,35 @@ public class DatabaseChecker {
     if (compress)
       compress();
 
+    result.put("distinctMissingReferences", (long) missingReferences.size());
+    result.put("topMissingReferences", formatTopMissingReferences());
+
     if (verboseLevel > 0)
       LogManager.instance().log(this, Level.INFO, "Result:\n%s", null, new JSONObject(result).toString(2));
 
     return result;
+  }
+
+  /** Merges one scan's per-target dangling-reference counts into the cross-scan accumulator. */
+  private void mergeMissingReferences(final Map<RID, Long> refs, final Map<RID, String> errors) {
+    if (refs == null)
+      return;
+    for (final Map.Entry<RID, Long> e : refs.entrySet()) {
+      missingReferences.merge(e.getKey(), e.getValue(), Long::sum);
+      if (errors != null)
+        missingReferenceErrors.putIfAbsent(e.getKey(), errors.get(e.getKey()));
+    }
+  }
+
+  /** Top dangling targets by reference count, formatted for humans and capped so the summary stays readable. */
+  private List<String> formatTopMissingReferences() {
+    final int limit = 100;
+    return missingReferences.entrySet().stream()
+        .sorted((a, b) -> Long.compare(b.getValue(), a.getValue()))
+        .limit(limit)
+        .map(e -> e.getKey() + " could not be loaded (error: " + missingReferenceErrors.getOrDefault(e.getKey(), "?")
+            + "), referenced by " + e.getValue() + " edge(s)")
+        .collect(Collectors.toList());
   }
 
   private void checkDocuments() {
@@ -225,6 +262,8 @@ public class DatabaseChecker {
 
         ((LinkedHashSet<String>) result.get("warnings")).addAll((Collection<String>) stats.get("warnings"));
         ((LinkedHashSet<RID>) result.get("corruptedRecords")).addAll((Collection<RID>) stats.get("corruptedRecords"));
+        mergeMissingReferences((Map<RID, Long>) stats.get("missingReferences"),
+            (Map<RID, String>) stats.get("missingReferenceErrors"));
       }
     }
   }
@@ -248,6 +287,8 @@ public class DatabaseChecker {
 
         ((LinkedHashSet<String>) result.get("warnings")).addAll((Collection<String>) stats.get("warnings"));
         ((LinkedHashSet<RID>) result.get("corruptedRecords")).addAll((Collection<RID>) stats.get("corruptedRecords"));
+        mergeMissingReferences((Map<RID, Long>) stats.get("missingReferences"),
+            (Map<RID, String>) stats.get("missingReferenceErrors"));
       }
     }
   }

--- a/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionSearchIndex.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionSearchIndex.java
@@ -25,6 +25,7 @@ import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.RecordNotFoundException;
+import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexCursor;
 import com.arcadedb.index.IndexCursorEntry;
@@ -220,10 +221,25 @@ public class SQLFunctionSearchIndex extends SQLFunctionAbstract implements Index
     // BM25 is scored per bucket (per-shard), so document frequency / IDF differ across buckets. EXPLAIN/PROFILE reports a single
     // representative bucket's statistics (the first full-text bucket index) rather than a global view - enough to understand the
     // similarity, parameters and relative term weights, but not a type-wide IDF.
-    for (final Index bucketIndex : typeIndex.getIndexesOnBuckets())
-      if (bucketIndex instanceof final LSMTreeFullTextIndex ftIndex)
-        return new FullTextQueryExecutor(ftIndex).explainScoring(queryString);
-    return null;
+    final Index[] buckets = typeIndex.getIndexesOnBuckets();
+    LSMTreeFullTextIndex firstFt = null;
+    int bm25BucketCount = 0;
+    for (final Index bucketIndex : buckets)
+      if (bucketIndex instanceof final LSMTreeFullTextIndex ftIndex) {
+        if (firstFt == null)
+          firstFt = ftIndex;
+        ++bm25BucketCount;
+      }
+    if (firstFt == null)
+      return null;
+
+    final JSONObject explain = new FullTextQueryExecutor(firstFt).explainScoring(queryString);
+    // Make it explicit that, on a multi-bucket type, these are the FIRST bucket's statistics so a reader is not misled into
+    // treating the df/IDF as type-wide.
+    if (bm25BucketCount > 1)
+      explain.put("note", "statistics shown are for the FIRST of " + bm25BucketCount
+          + " buckets; BM25 is scored per bucket, so df/IDF differ across buckets");
+    return explain;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionSearchIndex.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionSearchIndex.java
@@ -85,9 +85,10 @@ public class SQLFunctionSearchIndex extends SQLFunctionAbstract implements Index
     // Cache key for this specific search
     final String cacheKey = "search_index:" + indexName + ":" + queryString;
 
-    // Try to get cached results (Map of RID -> score)
+    // Try to get cached results (Map of RID -> score). Scores are floats so BM25 relevance is preserved; CLASSIC coordination
+    // scores widen to float losslessly.
     @SuppressWarnings("unchecked")
-    Map<RID, Integer> allResults = (Map<RID, Integer>) iContext.getVariable(cacheKey);
+    Map<RID, Float> allResults = (Map<RID, Float>) iContext.getVariable(cacheKey);
 
     if (allResults == null) {
       // First execution - perform the actual search
@@ -105,8 +106,7 @@ public class SQLFunctionSearchIndex extends SQLFunctionAbstract implements Index
       if (matches) {
         // Store the score for this record in the context variable $score
         // This allows $score projection to work in SELECT
-        final int recordScore = allResults.get(rid);
-        iContext.setVariable("$score", (float) recordScore);
+        iContext.setVariable("$score", allResults.get(rid));
       } else {
         // Clear the score for non-matching records
         iContext.setVariable("$score", 0f);
@@ -117,10 +117,10 @@ public class SQLFunctionSearchIndex extends SQLFunctionAbstract implements Index
 
     // Return cursor with all results (used when called without a current record)
     final List<IndexCursorEntry> entries = new ArrayList<>();
-    for (final Map.Entry<RID, Integer> entry : allResults.entrySet()) {
-      entries.add(new IndexCursorEntry(new Object[] { queryString }, entry.getKey(), entry.getValue()));
+    for (final Map.Entry<RID, Float> entry : allResults.entrySet()) {
+      entries.add(new IndexCursorEntry(new Object[] { queryString }, entry.getKey(), entry.getValue().floatValue()));
     }
-    entries.sort((a, b) -> Integer.compare(b.score, a.score));
+    entries.sort((a, b) -> Float.compare(b.floatScore, a.floatScore));
 
     return new TempIndexCursor(entries);
   }
@@ -177,7 +177,7 @@ public class SQLFunctionSearchIndex extends SQLFunctionAbstract implements Index
     // Perform the search and cache results
     final String cacheKey = "search_index:" + indexName + ":" + queryString;
     @SuppressWarnings("unchecked")
-    Map<RID, Integer> allResults = (Map<RID, Integer>) context.getVariable(cacheKey);
+    Map<RID, Float> allResults = (Map<RID, Float>) context.getVariable(cacheKey);
 
     if (allResults == null) {
       allResults = performSearch(indexName, queryString, context.getDatabase());
@@ -185,13 +185,13 @@ public class SQLFunctionSearchIndex extends SQLFunctionAbstract implements Index
     }
 
     // Sort RIDs by score descending for optimal ORDER BY $score performance
-    final List<Map.Entry<RID, Integer>> sorted = new ArrayList<>(allResults.entrySet());
-    sorted.sort((a, b) -> Integer.compare(b.getValue(), a.getValue()));
+    final List<Map.Entry<RID, Float>> sorted = new ArrayList<>(allResults.entrySet());
+    sorted.sort((a, b) -> Float.compare(b.getValue(), a.getValue()));
 
     // Fetch records by RID
     final DatabaseInternal db = (DatabaseInternal) context.getDatabase();
     final List<Record> records = new ArrayList<>(sorted.size());
-    for (final Map.Entry<RID, Integer> entry : sorted) {
+    for (final Map.Entry<RID, Float> entry : sorted) {
       try {
         final Record record = db.lookupByRID(entry.getKey(), true);
         if (record != null)
@@ -204,6 +204,26 @@ public class SQLFunctionSearchIndex extends SQLFunctionAbstract implements Index
   }
 
   @Override
+  public Object getScoringExplain(final FromClause target, final BinaryCompareOperator operator, final Object rightValue,
+      final CommandContext context, final Expression[] oExpressions) {
+    if (oExpressions == null || oExpressions.length < 2)
+      return null;
+    final String indexName = resolveStringParam(oExpressions[0], context);
+    final String queryString = resolveStringParam(oExpressions[1], context);
+    if (indexName == null || queryString == null)
+      return null;
+
+    final Index index = context.getDatabase().getSchema().getIndexByName(indexName);
+    if (!(index instanceof final TypeIndex typeIndex))
+      return null;
+
+    for (final Index bucketIndex : typeIndex.getIndexesOnBuckets())
+      if (bucketIndex instanceof final LSMTreeFullTextIndex ftIndex)
+        return new FullTextQueryExecutor(ftIndex).explainScoring(queryString);
+    return null;
+  }
+
+  @Override
   public String getSyntax() {
     return "SEARCH_INDEX(<index-name>, <query>)";
   }
@@ -213,8 +233,8 @@ public class SQLFunctionSearchIndex extends SQLFunctionAbstract implements Index
   /**
    * Performs the full-text search across all bucket indexes and returns a map of RID to score.
    */
-  private Map<RID, Integer> performSearch(final String indexName, final String queryString, final Database database) {
-    final Map<RID, Integer> allResults = new HashMap<>();
+  private Map<RID, Float> performSearch(final String indexName, final String queryString, final Database database) {
+    final Map<RID, Float> allResults = new HashMap<>();
 
     final Index index = database.getSchema().getIndexByName(indexName);
 
@@ -237,8 +257,8 @@ public class SQLFunctionSearchIndex extends SQLFunctionAbstract implements Index
 
         while (cursor.hasNext()) {
           final Identifiable match = cursor.next();
-          final int score = cursor.getScore();
-          allResults.merge(match.getIdentity(), score, Integer::sum);
+          final float score = cursor.getFloatScore();
+          allResults.merge(match.getIdentity(), score, Float::sum);
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionSearchIndex.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionSearchIndex.java
@@ -105,9 +105,10 @@ public class SQLFunctionSearchIndex extends SQLFunctionAbstract implements Index
       final boolean matches = allResults.containsKey(rid);
 
       if (matches) {
-        // Store the score for this record in the context variable $score
-        // This allows $score projection to work in SELECT
-        iContext.setVariable("$score", allResults.get(rid));
+        // Store the score for this record in the context variable $score so $score projection works in SELECT. getOrDefault keeps
+        // $score non-null even if the entry vanished between containsKey and get (cannot happen on the single-threaded SQL path
+        // today, but makes the intent explicit).
+        iContext.setVariable("$score", allResults.getOrDefault(rid, 0f));
       } else {
         // Clear the score for non-matching records
         iContext.setVariable("$score", 0f);

--- a/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionSearchIndex.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionSearchIndex.java
@@ -217,6 +217,9 @@ public class SQLFunctionSearchIndex extends SQLFunctionAbstract implements Index
     if (!(index instanceof final TypeIndex typeIndex))
       return null;
 
+    // BM25 is scored per bucket (per-shard), so document frequency / IDF differ across buckets. EXPLAIN/PROFILE reports a single
+    // representative bucket's statistics (the first full-text bucket index) rather than a global view - enough to understand the
+    // similarity, parameters and relative term weights, but not a type-wide IDF.
     for (final Index bucketIndex : typeIndex.getIndexesOnBuckets())
       if (bucketIndex instanceof final LSMTreeFullTextIndex ftIndex)
         return new FullTextQueryExecutor(ftIndex).explainScoring(queryString);

--- a/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionSearchIndex.java
+++ b/engine/src/main/java/com/arcadedb/function/sql/text/SQLFunctionSearchIndex.java
@@ -25,7 +25,6 @@ import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.RecordNotFoundException;
-import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexCursor;
 import com.arcadedb.index.IndexCursorEntry;
@@ -40,6 +39,7 @@ import com.arcadedb.query.sql.parser.Expression;
 import com.arcadedb.query.sql.parser.FromClause;
 import com.arcadedb.function.sql.SQLFunctionAbstract;
 import com.arcadedb.schema.Schema;
+import com.arcadedb.serializer.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -223,21 +223,22 @@ public class SQLFunctionSearchIndex extends SQLFunctionAbstract implements Index
     // similarity, parameters and relative term weights, but not a type-wide IDF.
     final Index[] buckets = typeIndex.getIndexesOnBuckets();
     LSMTreeFullTextIndex firstFt = null;
-    int bm25BucketCount = 0;
+    int ftBucketCount = 0; // all full-text bucket indexes of a type share one similarity, so they are all BM25 or all CLASSIC
     for (final Index bucketIndex : buckets)
       if (bucketIndex instanceof final LSMTreeFullTextIndex ftIndex) {
         if (firstFt == null)
           firstFt = ftIndex;
-        ++bm25BucketCount;
+        ++ftBucketCount;
       }
-    if (firstFt == null)
+    // Only BM25 indexes carry a scoring explanation; CLASSIC has none.
+    if (firstFt == null || !firstFt.isBM25())
       return null;
 
     final JSONObject explain = new FullTextQueryExecutor(firstFt).explainScoring(queryString);
     // Make it explicit that, on a multi-bucket type, these are the FIRST bucket's statistics so a reader is not misled into
     // treating the df/IDF as type-wide.
-    if (bm25BucketCount > 1)
-      explain.put("note", "statistics shown are for the FIRST of " + bm25BucketCount
+    if (ftBucketCount > 1)
+      explain.put("note", "statistics shown are for the FIRST of " + ftBucketCount
           + " buckets; BM25 is scored per bucket, so df/IDF differ across buckets");
     return explain;
   }
@@ -277,6 +278,10 @@ public class SQLFunctionSearchIndex extends SQLFunctionAbstract implements Index
         while (cursor.hasNext()) {
           final Identifiable match = cursor.next();
           final float score = cursor.getFloatScore();
+          // Float::sum across buckets: a given RID lives in exactly one bucket, so a RID is produced by at most one bucket index
+          // and the merge is effectively an insert (no real summing). For CLASSIC the additive semantics would also be correct;
+          // for BM25 the per-bucket scoping relies on this one-bucket-per-RID invariant - if it ever broke, scores would be
+          // double-counted here rather than failing loudly.
           allResults.merge(match.getIdentity(), score, Float::sum);
         }
       }

--- a/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphDatabaseChecker.java
@@ -62,6 +62,8 @@ public class GraphDatabaseChecker {
     final List<String> warnings = new ArrayList<>();
     final Set<RID> reconnectOutEdges = new HashSet<>();
     final Set<RID> reconnectInEdges = new HashSet<>();
+    final Map<RID, Long> missingReferences = new HashMap<>();
+    final Map<RID, String> missingReferenceErrors = new HashMap<>();
 
     final Map<String, Object> stats = new HashMap<>();
 
@@ -89,21 +91,21 @@ public class GraphDatabaseChecker {
           final RID vertexIdentity = vertex.getIdentity();
 
           vertex = checkOutgoingEdges(fix, vertex, warnings, totalWarnings, maxWarnings, vertexIdentity, invalidLinks,
-              corruptedRecords, totalCorrupted, maxCorrupted, reconnectOutEdges);
+              corruptedRecords, totalCorrupted, maxCorrupted, reconnectOutEdges, missingReferences, missingReferenceErrors);
 
           checkIncomingEdges(fix, vertex, warnings, totalWarnings, maxWarnings, vertexIdentity, invalidLinks,
-              corruptedRecords, totalCorrupted, maxCorrupted, reconnectInEdges);
+              corruptedRecords, totalCorrupted, maxCorrupted, reconnectInEdges, missingReferences, missingReferenceErrors);
 
         } catch (final Throwable e) {
           addWarning(warnings, totalWarnings, maxWarnings,
-              "vertex " + record.getIdentity() + " cannot be loaded (error: " + e.getMessage() + ")");
+              "vertex " + record.getIdentity() + " cannot be loaded (error: " + describe(e) + ")");
           addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, record.getIdentity());
         }
 
         return true;
       }, (rid, exception) -> {
         addWarning(warnings, totalWarnings, maxWarnings,
-            "vertex " + rid + " cannot be loaded (error: " + exception.getMessage() + ")");
+            "vertex " + rid + " cannot be loaded (error: " + describe(exception) + ")");
         addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, rid);
         return true;
       });
@@ -141,6 +143,8 @@ public class GraphDatabaseChecker {
       stats.put("warnings", warnings);
       stats.put("totalWarnings", totalWarnings.get());
       stats.put("totalCorruptedRecords", totalCorrupted.get());
+      stats.put("missingReferences", missingReferences);
+      stats.put("missingReferenceErrors", missingReferenceErrors);
     }
 
     return stats;
@@ -194,7 +198,7 @@ public class GraphDatabaseChecker {
 
   private void checkIncomingEdges(boolean fix, Vertex vertex, List<String> warnings, AtomicLong totalWarnings, int maxWarnings,
       RID vertexIdentity, AtomicLong invalidLinks, LinkedHashSet<RID> corruptedRecords, AtomicLong totalCorrupted,
-      int maxCorrupted, Set<RID> reconnectInEdges) {
+      int maxCorrupted, Set<RID> reconnectInEdges, Map<RID, Long> missingReferences, Map<RID, String> missingReferenceErrors) {
     if (((VertexInternal) vertex).getInEdgesHeadChunk() != null) {
       EdgeLinkedList inEdges = null;
       try {
@@ -252,6 +256,7 @@ public class GraphDatabaseChecker {
                   } catch (final RecordNotFoundException e) {
                     addWarning(warnings, totalWarnings, maxWarnings,
                         "edge " + edgeRID + " points to the outgoing vertex " + edge.getOut() + " that is not found (deleted?)");
+                    trackMissingReference(missingReferences, missingReferenceErrors, maxWarnings, edge.getOut(), describe(e));
                     addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
                     removeEntry = true;
                     addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edge.getOut());
@@ -260,7 +265,8 @@ public class GraphDatabaseChecker {
                     // UNKNOWN ERROR ON LOADING
                     addWarning(warnings, totalWarnings, maxWarnings,
                         "edge " + edgeRID + " points to the outgoing vertex " + edge.getOut() + " which cannot be loaded (error: "
-                            + e.getMessage() + ")");
+                            + describe(e) + ")");
+                    trackMissingReference(missingReferences, missingReferenceErrors, maxWarnings, edge.getOut(), describe(e));
                     addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
                     removeEntry = true;
                     addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edge.getOut());
@@ -349,7 +355,7 @@ public class GraphDatabaseChecker {
               } catch (final Exception e) {
                 // UNKNOWN ERROR ON LOADING
                 addWarning(warnings, totalWarnings, maxWarnings,
-                    "edge " + edgeRID + " error on loading (error: " + e.getMessage() + ")");
+                    "edge " + edgeRID + " error on loading (error: " + describe(e) + ")");
                 addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
                 removeEntry = true;
               }
@@ -360,7 +366,7 @@ public class GraphDatabaseChecker {
           } catch (Exception e) {
             // UNKNOWN ERROR ON LOADING EDGES
             addWarning(warnings, totalWarnings, maxWarnings,
-                "error on loading incoming edges from vertex " + vertexIdentity + " (error: " + e.getMessage() + ")");
+                "error on loading incoming edges from vertex " + vertexIdentity + " (error: " + describe(e) + ")");
 
             if (fix) {
               vertex = vertex.modify();
@@ -379,7 +385,7 @@ public class GraphDatabaseChecker {
   private Vertex checkOutgoingEdges(final boolean fix, Vertex vertex, final List<String> warnings,
       final AtomicLong totalWarnings, final int maxWarnings, final RID vertexIdentity, final AtomicLong invalidLinks,
       final LinkedHashSet<RID> corruptedRecords, final AtomicLong totalCorrupted, final int maxCorrupted,
-      final Set<RID> reconnectOutEdges) {
+      final Set<RID> reconnectOutEdges, final Map<RID, Long> missingReferences, final Map<RID, String> missingReferenceErrors) {
     // CHECK THE EDGE IS CONNECTED FROM THE OTHER SIDE
     if (((VertexInternal) vertex).getOutEdgesHeadChunk() != null) {
       EdgeLinkedList outEdges = null;
@@ -439,6 +445,7 @@ public class GraphDatabaseChecker {
                   } catch (final RecordNotFoundException e) {
                     addWarning(warnings, totalWarnings, maxWarnings,
                         "edge " + edgeRID + " points to the incoming vertex " + edge.getIn() + " that is not found (deleted?)");
+                    trackMissingReference(missingReferences, missingReferenceErrors, maxWarnings, edge.getIn(), describe(e));
                     addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
                     removeEntry = true;
                     addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edge.getIn());
@@ -447,7 +454,8 @@ public class GraphDatabaseChecker {
                     // UNKNOWN ERROR ON LOADING
                     addWarning(warnings, totalWarnings, maxWarnings,
                         "edge " + edgeRID + " points to the incoming vertex " + edge.getIn() + " which cannot be loaded (error: "
-                            + e.getMessage() + ")");
+                            + describe(e) + ")");
+                    trackMissingReference(missingReferences, missingReferenceErrors, maxWarnings, edge.getIn(), describe(e));
                     addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
                     removeEntry = true;
                     addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edge.getIn());
@@ -536,7 +544,7 @@ public class GraphDatabaseChecker {
               } catch (final Exception e) {
                 // UNKNOWN ERROR ON LOADING
                 addWarning(warnings, totalWarnings, maxWarnings,
-                    "edge " + edgeRID + " error on loading (error: " + e.getMessage() + ")");
+                    "edge " + edgeRID + " error on loading (error: " + describe(e) + ")");
                 addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
                 removeEntry = true;
               }
@@ -548,7 +556,7 @@ public class GraphDatabaseChecker {
           } catch (Exception e) {
             // UNKNOWN ERROR ON LOADING EDGES
             addWarning(warnings, totalWarnings, maxWarnings,
-                "error on loading outgoing edges from vertex " + vertexIdentity + " (error: " + e.getMessage() + ")");
+                "error on loading outgoing edges from vertex " + vertexIdentity + " (error: " + describe(e) + ")");
 
             if (fix) {
               vertex = vertex.modify();
@@ -580,6 +588,8 @@ public class GraphDatabaseChecker {
     // totalCorrupted (which counts only genuinely new entries, see addCorrupted) stays aligned with its size.
     final LinkedHashSet<RID> corruptedRecords = new LinkedHashSet<>();
     final List<String> warnings = new ArrayList<>();
+    final Map<RID, Long> missingReferences = new HashMap<>();
+    final Map<RID, String> missingReferenceErrors = new HashMap<>();
 
     final Map<String, Object> stats = new HashMap<>();
 
@@ -633,6 +643,7 @@ public class GraphDatabaseChecker {
             } catch (final RecordNotFoundException e) {
               addWarning(warnings, totalWarnings, maxWarnings,
                   "edge " + edgeRID + " points to the incoming vertex " + edge.getIn() + " that is not found (deleted?)");
+              trackMissingReference(missingReferences, missingReferenceErrors, maxWarnings, edge.getIn(), describe(e));
               addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
               addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edge.getIn());
               invalidLinks.incrementAndGet();
@@ -640,7 +651,8 @@ public class GraphDatabaseChecker {
               // UNKNOWN ERROR ON LOADING
               addWarning(warnings, totalWarnings, maxWarnings,
                   "edge " + edgeRID + " points to the incoming vertex " + edge.getIn() + " which cannot be loaded (error: "
-                      + e.getMessage() + ")");
+                      + describe(e) + ")");
+              trackMissingReference(missingReferences, missingReferenceErrors, maxWarnings, edge.getIn(), describe(e));
               addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
               addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edge.getIn());
             }
@@ -656,13 +668,15 @@ public class GraphDatabaseChecker {
             } catch (final RecordNotFoundException e) {
               addWarning(warnings, totalWarnings, maxWarnings,
                   "edge " + edgeRID + " points to the outgoing vertex " + edge.getOut() + " that is not found (deleted?)");
+              trackMissingReference(missingReferences, missingReferenceErrors, maxWarnings, edge.getOut(), describe(e));
               addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
               invalidLinks.incrementAndGet();
             } catch (final Exception e) {
               // UNKNOWN ERROR ON LOADING
               addWarning(warnings, totalWarnings, maxWarnings,
                   "edge " + edgeRID + " points to the outgoing vertex " + edge.getOut() + " which cannot be loaded (error: "
-                      + e.getMessage() + ")");
+                      + describe(e) + ")");
+              trackMissingReference(missingReferences, missingReferenceErrors, maxWarnings, edge.getOut(), describe(e));
               addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
               addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edge.getOut());
             }
@@ -670,14 +684,14 @@ public class GraphDatabaseChecker {
 
         } catch (final Throwable e) {
           addWarning(warnings, totalWarnings, maxWarnings,
-              "edge " + record.getIdentity() + " cannot be loaded (error: " + e.getMessage() + ")");
+              "edge " + record.getIdentity() + " cannot be loaded (error: " + describe(e) + ")");
           addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, edgeRID);
         }
 
         return true;
       }, (rid, exception) -> {
         addWarning(warnings, totalWarnings, maxWarnings,
-            "edge " + rid + " cannot be loaded (error: " + exception.getMessage() + ")");
+            "edge " + rid + " cannot be loaded (error: " + describe(exception) + ")");
         addCorrupted(corruptedRecords, totalCorrupted, maxCorrupted, rid);
         return true;
       });
@@ -713,9 +727,39 @@ public class GraphDatabaseChecker {
       stats.put("warnings", warnings);
       stats.put("totalWarnings", totalWarnings.get());
       stats.put("totalCorruptedRecords", totalCorrupted.get());
+      stats.put("missingReferences", missingReferences);
+      stats.put("missingReferenceErrors", missingReferenceErrors);
     }
 
     return stats;
+  }
+
+  /**
+   * Returns the exception message, or the exception's simple class name when the message is {@code null} (e.g. a
+   * {@link NullPointerException}). Without this, CHECK DATABASE prints an undiagnosable "error: null" for any failure
+   * whose exception carries no message, which makes triaging a corrupted/diverged replica impossible.
+   */
+  static String describe(final Throwable e) {
+    final String msg = e.getMessage();
+    return msg != null ? msg : e.getClass().getSimpleName();
+  }
+
+  /**
+   * Records that {@code target} (a vertex an edge points to) could not be loaded, accumulating a per-target reference
+   * count instead of emitting one line per dangling edge. A single missing supernode can be referenced by millions of
+   * edges; this collapses that fan-out into "vertex X could not be loaded, referenced by N edge(s)". The distinct-target
+   * set is bounded by {@code maxTracked} to keep memory in check (counts for already-tracked targets keep incrementing).
+   */
+  private static void trackMissingReference(final Map<RID, Long> missingReferences, final Map<RID, String> missingReferenceErrors,
+      final int maxTracked, final RID target, final String error) {
+    if (target == null)
+      return;
+    if (missingReferences.containsKey(target))
+      missingReferences.merge(target, 1L, Long::sum);
+    else if (missingReferences.size() < maxTracked) {
+      missingReferences.put(target, 1L);
+      missingReferenceErrors.put(target, error);
+    }
   }
 
   private static void addWarning(final List<String> warnings, final AtomicLong totalWarnings, final int maxWarnings,

--- a/engine/src/main/java/com/arcadedb/index/IndexCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/IndexCursor.java
@@ -44,6 +44,17 @@ public interface IndexCursor extends Cursor {
     return 0;
   }
 
+  /**
+   * Returns the floating-point score of the current entry. Full-text indexes using BM25 similarity produce non-integer relevance
+   * scores; this method exposes them without losing precision. The default delegates to {@link #getScore()} so indexes that only
+   * support integer scoring keep working unchanged.
+   *
+   * @return the floating-point score of the current entry, or the integer score (widened) if float scoring is not supported
+   */
+  default float getFloatScore() {
+    return getScore();
+  }
+
   default void close() {
     // NO ACTIONS
   }

--- a/engine/src/main/java/com/arcadedb/index/IndexCursorEntry.java
+++ b/engine/src/main/java/com/arcadedb/index/IndexCursorEntry.java
@@ -26,7 +26,13 @@ import java.util.Objects;
 public class IndexCursorEntry {
   public final Object[]     keys;
   public final Identifiable record;
+  /**
+   * Integer relevance score. For float-scored entries (e.g. full-text BM25) this is {@link #floatScore} rounded and therefore
+   * lossy: read {@link #floatScore} (or {@link IndexCursor#getFloatScore()}) when precision matters. It remains an exact value
+   * for indexes that score with integers (e.g. CLASSIC full-text coordination, regular LSM indexes).
+   */
   public final int          score;
+  /** Full-precision relevance score; equals {@link #score} for integer-scored entries. */
   public final float        floatScore;
 
   public IndexCursorEntry(final Object[] keys, final Identifiable record, final int score) {

--- a/engine/src/main/java/com/arcadedb/index/IndexCursorEntry.java
+++ b/engine/src/main/java/com/arcadedb/index/IndexCursorEntry.java
@@ -56,12 +56,14 @@ public class IndexCursorEntry {
     if (o == null || getClass() != o.getClass())
       return false;
     final IndexCursorEntry that = (IndexCursorEntry) o;
-    return score == that.score && Objects.equals(record, that.record) && Arrays.equals(keys, that.keys);
+    // Identity is (record, keys) only. The relevance score is a derived value, not part of identity: including it would let the
+    // same document appear twice in a result Set when scored differently (e.g. distinct BM25 floats for the same RID).
+    return Objects.equals(record, that.record) && Arrays.equals(keys, that.keys);
   }
 
   @Override
   public int hashCode() {
-    int result = Objects.hash(record, score);
+    int result = Objects.hashCode(record);
     result = 31 * result + Arrays.hashCode(keys);
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/index/IndexCursorEntry.java
+++ b/engine/src/main/java/com/arcadedb/index/IndexCursorEntry.java
@@ -23,6 +23,14 @@ import com.arcadedb.database.Identifiable;
 import java.util.Arrays;
 import java.util.Objects;
 
+/**
+ * One entry of an index lookup result: the matched record, the keys it was found under, and a relevance score.
+ * <p>
+ * NOTE: {@link #equals(Object)}/{@link #hashCode()} intentionally use only {@code (record, keys)} - the score is excluded. This
+ * changed in the BM25 work (issue #4687): a previous version included the score, which meant two entries for the same document
+ * with different (float) scores were not deduplicated in a {@code Set}. Code that relied on score being part of identity (none
+ * known in the codebase) would see a behavior change.
+ */
 public class IndexCursorEntry {
   public final Object[]     keys;
   public final Identifiable record;

--- a/engine/src/main/java/com/arcadedb/index/IndexCursorEntry.java
+++ b/engine/src/main/java/com/arcadedb/index/IndexCursorEntry.java
@@ -27,11 +27,20 @@ public class IndexCursorEntry {
   public final Object[]     keys;
   public final Identifiable record;
   public final int          score;
+  public final float        floatScore;
 
   public IndexCursorEntry(final Object[] keys, final Identifiable record, final int score) {
     this.keys = keys;
     this.record = record;
     this.score = score;
+    this.floatScore = score;
+  }
+
+  public IndexCursorEntry(final Object[] keys, final Identifiable record, final float floatScore) {
+    this.keys = keys;
+    this.record = record;
+    this.score = Math.round(floatScore);
+    this.floatScore = floatScore;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/index/IndexInternal.java
+++ b/engine/src/main/java/com/arcadedb/index/IndexInternal.java
@@ -54,6 +54,18 @@ public interface IndexInternal extends Index {
   }
 
   /**
+   * Recomputes any persisted per-index statistics (e.g. BM25 corpus counters) by rescanning the live data, repairing drift that
+   * incremental maintenance cannot reverse (rolled-back transactions, analyzer changes). Most indexes keep no such statistics and
+   * this is a no-op. Exposed to SQL via {@code REBUILD INDEX <name> {statsOnly: true}} so operators can repair drift without a
+   * full (and far more expensive) index rebuild.
+   *
+   * @return true if statistics were recomputed (the index keeps such statistics), false otherwise
+   */
+  default boolean recomputeStatistics() {
+    return false;
+  }
+
+  /**
    * Performs a lightweight structural/metadata integrity check of the index, independent of record content, and
    * returns a list of human-readable problem descriptions. An empty list means the index metadata is healthy.
    * Used by CHECK DATABASE to surface on-disk corruption (e.g. a damaged hash index metadata page, issue #352)

--- a/engine/src/main/java/com/arcadedb/index/TempIndexCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/TempIndexCursor.java
@@ -50,6 +50,11 @@ public class TempIndexCursor implements IndexCursor {
   }
 
   @Override
+  public float getFloatScore() {
+    return current != null ? current.floatScore : 0f;
+  }
+
+  @Override
   public boolean hasNext() {
     return iterator.hasNext();
   }

--- a/engine/src/main/java/com/arcadedb/index/TypeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/TypeIndex.java
@@ -543,7 +543,9 @@ public class TypeIndex implements RangeIndex, IndexInternal {
   @Override
   public boolean recomputeStatistics() {
     // BM25 corpus counters are shared type-wide (the same metadata object backs every bucket sub-index), so recomputing on a
-    // single bucket sub-index repairs them for the whole type; this avoids N redundant full-type scans.
+    // single bucket sub-index repairs them for the whole type; this avoids N redundant full-type scans. Returning on the first
+    // success is therefore correct: every bucket sub-index of a given type shares one similarity and one metadata object, so
+    // they cannot disagree on whether statistics exist.
     for (final IndexInternal idx : indexesOnBuckets)
       if (idx.recomputeStatistics())
         return true;

--- a/engine/src/main/java/com/arcadedb/index/TypeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/TypeIndex.java
@@ -540,6 +540,16 @@ public class TypeIndex implements RangeIndex, IndexInternal {
     return indexesOnBuckets.toArray(new IndexInternal[indexesOnBuckets.size()]);
   }
 
+  @Override
+  public boolean recomputeStatistics() {
+    // BM25 corpus counters are shared type-wide (the same metadata object backs every bucket sub-index), so recomputing on a
+    // single bucket sub-index repairs them for the whole type; this avoids N redundant full-type scans.
+    for (final IndexInternal idx : indexesOnBuckets)
+      if (idx.recomputeStatistics())
+        return true;
+    return false;
+  }
+
   public int countIndexesOnBuckets() {
     return indexesOnBuckets.size();
   }

--- a/engine/src/main/java/com/arcadedb/index/fulltext/BM25Scorer.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/BM25Scorer.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.fulltext;
+
+/**
+ * Pure (database-free) implementation of the Okapi BM25 ranking function used by the full-text index when the index is configured
+ * with {@code similarity = BM25}. Keeping the math isolated here makes it trivially unit-testable against hand-computed values and
+ * keeps {@link LSMTreeFullTextIndex} lean.
+ * <p>
+ * The IDF formula matches the one used by the sparse-vector index ({@code LSMSparseVectorIndex.idf}) for consistency across the
+ * two scoring engines:
+ *
+ * <pre>
+ * idf(N, df)                      = ln( (N - df + 0.5) / (df + 0.5) + 1 )
+ * termScore(idf, tf, dl, avgdl)   = idf * ( tf * (k1 + 1) ) / ( tf + k1 * (1 - b + b * dl / avgdl) )
+ * </pre>
+ *
+ * The {@code +1} inside the log keeps the IDF non-negative even for terms appearing in more than half of the collection, which is
+ * the Lucene-compatible variant of the Robertson-Sparck-Jones weight.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public final class BM25Scorer {
+  /**
+   * Default term-frequency saturation parameter. Higher values make additional occurrences of a term count for more.
+   */
+  public static final float DEFAULT_K1 = 1.2f;
+
+  /**
+   * Default document-length normalization parameter in the range [0,1]. 0 disables length normalization, 1 applies it fully.
+   */
+  public static final float DEFAULT_B = 0.75f;
+
+  private BM25Scorer() {
+    // STATIC-ONLY HELPER
+  }
+
+  /**
+   * Computes the inverse document frequency for a term.
+   *
+   * @param totalDocs total number of documents in the collection (N)
+   * @param docFreq   number of documents containing the term (df)
+   *
+   * @return the IDF weight (always >= 0)
+   */
+  public static double idf(final long totalDocs, final long docFreq) {
+    final double numerator = (double) (totalDocs - docFreq) + 0.5;
+    final double denominator = (double) docFreq + 0.5;
+    return Math.log((numerator / denominator) + 1.0);
+  }
+
+  /**
+   * Computes the BM25 contribution of a single term to a document's score.
+   *
+   * @param idf    inverse document frequency of the term (see {@link #idf(long, long)})
+   * @param tf     term frequency: number of occurrences of the term in the document
+   * @param docLen length of the document (number of analyzed tokens)
+   * @param avgdl  average document length across the collection (must be > 0)
+   * @param k1     term-frequency saturation parameter
+   * @param b      document-length normalization parameter
+   *
+   * @return the BM25 score contribution of this term
+   */
+  public static double termScore(final double idf, final int tf, final int docLen, final double avgdl, final double k1,
+      final double b) {
+    if (tf <= 0)
+      return 0.0;
+    final double safeAvgdl = avgdl > 0 ? avgdl : 1.0;
+    final double norm = 1.0 - b + b * (docLen / safeAvgdl);
+    return idf * (tf * (k1 + 1.0)) / (tf + k1 * norm);
+  }
+
+}

--- a/engine/src/main/java/com/arcadedb/index/fulltext/BM25Scorer.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/BM25Scorer.java
@@ -85,6 +85,9 @@ public final class BM25Scorer {
    */
   public static double termScore(final double idf, final int tf, final int docLen, final double avgdl, final double k1,
       final double b) {
+    // tf <= 0 contributes nothing. This also defends the (architecturally impossible) case of a non-posting RID reaching here:
+    // compacted root-page pointers deserialize as FullTextPostingRID(tf=0, docLength=0), and although they never reach scoring
+    // (only leaf postings are returned for a token lookup), their tf=0 would zero out any contribution anyway.
     if (tf <= 0)
       return 0.0;
     final double safeAvgdl = avgdl > 0 ? avgdl : 1.0;

--- a/engine/src/main/java/com/arcadedb/index/fulltext/BM25Scorer.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/BM25Scorer.java
@@ -53,11 +53,17 @@ public final class BM25Scorer {
 
   /**
    * Computes the inverse document frequency for a term.
+   * <p>
+   * The log argument is {@code (N - df + 0.5)/(df + 0.5) + 1 = (N + 1)/(df + 0.5)}, which is strictly positive for any
+   * {@code N >= 0, df >= 0}, so {@link Math#log} is always defined (never {@code NaN}/{@code -Infinity}). IDF is {@code >= 0}
+   * whenever {@code df <= N}, which always holds in normal operation (df is counted at the same scope as N). A transiently stale
+   * {@code df > N} (e.g. drifted counters or deletion markers not yet compacted) yields a small negative IDF, which merely demotes
+   * an over-common term - harmless, and self-corrected once counters are recomputed.
    *
    * @param totalDocs total number of documents in the collection (N)
    * @param docFreq   number of documents containing the term (df)
    *
-   * @return the IDF weight (always >= 0)
+   * @return the IDF weight ({@code >= 0} when {@code df <= N}; slightly negative only for a stale {@code df > N})
    */
   public static double idf(final long totalDocs, final long docFreq) {
     final double numerator = (double) (totalDocs - docFreq) + 0.5;

--- a/engine/src/main/java/com/arcadedb/index/fulltext/BM25Scorer.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/BM25Scorer.java
@@ -85,5 +85,4 @@ public final class BM25Scorer {
     final double norm = 1.0 - b + b * (docLen / safeAvgdl);
     return idf * (tf * (k1 + 1.0)) / (tf + k1 * norm);
   }
-
 }

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -31,6 +31,7 @@ import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.PrefixQuery;
@@ -69,6 +70,15 @@ public class FullTextQueryExecutor {
   private final LSMTreeFullTextIndex   index;
   private final Analyzer               analyzer;
   private final FullTextIndexMetadata  metadata;
+
+  // BM25 scoring (issue #4687): the positive scoring tokens collected during matching, mapped to their field boost. Populated
+  // only when the index uses BM25 similarity and only for positive clauses (never for MUST_NOT exclusion). A new executor is
+  // created per search, so these instance fields are not shared across queries.
+  private final Map<String, Float> scoringTokens     = new HashMap<>();
+  private       boolean            collectingExclusion = false;
+  // The compounded caret boost (e.g. `title:java^3`) of the BoostQuery currently being descended, multiplied into recorded
+  // scoring tokens. Lucene's QueryParser already parses `^` into a BoostQuery; this is where that boost takes effect for BM25.
+  private       float              currentBoost        = 1.0f;
 
   /**
    * Creates a new FullTextQueryExecutor for the given index.
@@ -116,6 +126,24 @@ public class FullTextQueryExecutor {
     }
   }
 
+  /**
+   * Runs only the query's matching logic (no scoring) to collect the scoring tokens, then returns the index's query-level BM25
+   * scoring explanation (similarity, k1/b, N, avgdl, and per-term df/idf/boost). Surfaced by {@code EXPLAIN}/{@code PROFILE}.
+   *
+   * @param queryString the query string in Lucene syntax
+   */
+  public com.arcadedb.serializer.json.JSONObject explainScoring(final String queryString) {
+    try {
+      final QueryParser parser = createQueryParser();
+      final Query query = parser.parse(queryString);
+      final Map<RID, AtomicInteger> scoreMap = new HashMap<>();
+      collectMatches(query, scoreMap, new HashSet<>());
+      return index.explainScoring(scoringTokens);
+    } catch (final ParseException e) {
+      throw new IndexException("Invalid search query: " + queryString, e);
+    }
+  }
+
   private IndexCursor executeQuery(final Query query, final int limit) {
     final Map<RID, AtomicInteger> scoreMap = new HashMap<>();
     final Set<RID> excluded = new HashSet<>();
@@ -126,6 +154,11 @@ public class FullTextQueryExecutor {
     for (final RID rid : excluded) {
       scoreMap.remove(rid);
     }
+
+    // BM25 path: collectMatches above determined WHICH documents match (boolean/phrase/wildcard semantics). Re-rank that
+    // candidate set with BM25 using the scoring tokens captured during matching.
+    if (index.isBM25())
+      return index.scoreCandidatesBM25(scoreMap.keySet(), scoringTokens, new Object[] {}, limit);
 
     final ArrayList<IndexCursorEntry> list = new ArrayList<>(scoreMap.size());
 
@@ -212,6 +245,15 @@ public class FullTextQueryExecutor {
         collectAllIndexedRids(scoreMap);
       }
 
+    } else if (query instanceof BoostQuery bq) {
+      // Caret boost, e.g. `title:java^3`. Compound nested boosts and descend into the wrapped query.
+      final float saved = currentBoost;
+      currentBoost *= bq.getBoost();
+      try {
+        collectMatches(bq.getQuery(), scoreMap, excluded);
+      } finally {
+        currentBoost = saved;
+      }
     } else if (query instanceof TermQuery) {
       collectTermMatches((TermQuery) query, scoreMap);
     } else if (query instanceof PhraseQuery) {
@@ -237,10 +279,39 @@ public class FullTextQueryExecutor {
     }
     // Delegate every other leaf query type to collectMatches so any positive collector
     // automatically has matching exclusion support; the empty excluded set isolates this scratch
-    // collection from the caller's accumulator.
-    final Map<RID, AtomicInteger> tempMap = new HashMap<>();
-    collectMatches(query, tempMap, new HashSet<>());
-    excluded.addAll(tempMap.keySet());
+    // collection from the caller's accumulator. Tokens matched here are negative (MUST_NOT) and must
+    // not contribute to BM25 scoring, so suppress token capture for the duration of the scan.
+    final boolean previous = collectingExclusion;
+    collectingExclusion = true;
+    try {
+      final Map<RID, AtomicInteger> tempMap = new HashMap<>();
+      collectMatches(query, tempMap, new HashSet<>());
+      excluded.addAll(tempMap.keySet());
+    } finally {
+      collectingExclusion = previous;
+    }
+  }
+
+  /**
+   * Records a positive scoring token (in its stored-key form) and its field boost for the later BM25 re-ranking pass. No-op when
+   * the index is not BM25 or while collecting MUST_NOT exclusion terms. When a token is seen more than once the highest boost
+   * wins.
+   */
+  private void recordScoringToken(final String storedKey, final float boost) {
+    if (collectingExclusion || !index.isBM25())
+      return;
+    // Combine the per-field boost with the caret boost in effect for this part of the query.
+    scoringTokens.merge(storedKey, boost * currentBoost, Math::max);
+  }
+
+  /**
+   * Returns the BM25 field boost for a query field: the configured per-field boost for an explicit field, or 1.0 for the default
+   * (unqualified) {@code content} field.
+   */
+  private float boostFor(final String field) {
+    if (field != null && !field.isEmpty() && !"content".equals(field) && metadata != null)
+      return metadata.getFieldBoost(field);
+    return 1.0f;
   }
 
   /**
@@ -272,6 +343,8 @@ public class FullTextQueryExecutor {
       searchKey = text;
     }
 
+    recordScoringToken(searchKey, boostFor(field));
+
     final IndexCursor cursor = index.get(new Object[] { searchKey });
     while (cursor.hasNext()) {
       final RID rid = cursor.next().getIdentity();
@@ -289,6 +362,7 @@ public class FullTextQueryExecutor {
     Map<RID, AtomicInteger> intersection = null;
 
     for (final Term term : terms) {
+      recordScoringToken(term.text(), 1.0f);
       final Map<RID, AtomicInteger> termMatches = new HashMap<>();
       final IndexCursor cursor = index.get(new Object[] { term.text() });
       while (cursor.hasNext()) {
@@ -316,7 +390,7 @@ public class FullTextQueryExecutor {
       return;
 
     final String searchPrefix = buildSearchKey(field, prefix);
-    iterateAndMatch(searchPrefix, key -> key.startsWith(searchPrefix), scoreMap);
+    iterateAndMatch(searchPrefix, key -> key.startsWith(searchPrefix), scoreMap, boostFor(field));
   }
 
   private void collectWildcardMatches(final WildcardQuery query, final Map<RID, AtomicInteger> scoreMap) {
@@ -341,7 +415,7 @@ public class FullTextQueryExecutor {
         if (fieldPrefix.isEmpty() && token.indexOf(':') >= 0)
           return false;
         return regex.matcher(token).matches();
-      }, scoreMap);
+      }, scoreMap, boostFor(field));
     } else {
       // Range scan starting at the literal prefix and stop when keys no longer share it
       iterateAndMatch(searchPrefix, key -> {
@@ -351,7 +425,7 @@ public class FullTextQueryExecutor {
         if (fieldPrefix.isEmpty() && token.indexOf(':') >= 0)
           return false;
         return regex.matcher(token).matches();
-      }, scoreMap);
+      }, scoreMap, boostFor(field));
     }
   }
 
@@ -374,7 +448,7 @@ public class FullTextQueryExecutor {
       if (fieldPrefix.isEmpty() && token.indexOf(':') >= 0)
         return false;
       return TextLevenshteinDistance.levenshteinDistance(token, term) <= maxEdits;
-    }, scoreMap);
+    }, scoreMap, boostFor(field));
   }
 
   private void collectRegexpMatches(final RegexpQuery query, final Map<RID, AtomicInteger> scoreMap) {
@@ -399,7 +473,7 @@ public class FullTextQueryExecutor {
       if (fieldPrefix.isEmpty() && token.indexOf(':') >= 0)
         return false;
       return regex.matcher(token).matches();
-    }, scoreMap);
+    }, scoreMap, boostFor(field));
   }
 
   /**
@@ -408,7 +482,8 @@ public class FullTextQueryExecutor {
    * and a non-prefix means we've left the relevant range). When {@code startKey} is null, performs a full
    * scan and applies the matcher to every key.
    */
-  private void iterateAndMatch(final String startKey, final KeyMatcher matcher, final Map<RID, AtomicInteger> scoreMap) {
+  private void iterateAndMatch(final String startKey, final KeyMatcher matcher, final Map<RID, AtomicInteger> scoreMap,
+      final float boost) {
     final boolean rangeScan = startKey != null;
     final IndexCursor cursor = index.iterateUnderlying(true,
         rangeScan ? new String[] { startKey } : null, true);
@@ -419,6 +494,7 @@ public class FullTextQueryExecutor {
         continue;
       final String key = keys[0].toString();
       if (matcher.matches(key)) {
+        recordScoringToken(key, boost);
         scoreMap.computeIfAbsent(rid, k -> new AtomicInteger(0)).incrementAndGet();
       } else if (rangeScan && startKey != null && key.compareTo(startKey) > 0 && !key.startsWith(startKey)) {
         break;

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -388,7 +388,9 @@ public class FullTextQueryExecutor {
     if (tokensOnly)
       return;
 
-    final IndexCursor cursor = index.get(new Object[] { searchKey });
+    // Raw postings lookup: we only need the matching RIDs here. The BM25 score is computed once, later, by scoreCandidatesBM25;
+    // going through index.get() would run (and then discard) the full scoring pipeline for every term.
+    final IndexCursor cursor = index.getPostings(searchKey);
     while (cursor.hasNext()) {
       final RID rid = cursor.next().getIdentity();
       scoreMap.computeIfAbsent(rid, k -> new AtomicInteger(0)).incrementAndGet();
@@ -415,7 +417,7 @@ public class FullTextQueryExecutor {
     for (final Term term : terms) {
       recordScoringToken(term.text(), 1.0f);
       final Map<RID, AtomicInteger> termMatches = new HashMap<>();
-      final IndexCursor cursor = index.get(new Object[] { term.text() });
+      final IndexCursor cursor = index.getPostings(term.text());
       while (cursor.hasNext()) {
         termMatches.put(cursor.next().getIdentity(), new AtomicInteger(1));
       }
@@ -548,7 +550,7 @@ public class FullTextQueryExecutor {
         recordScoringToken(key, boost);
         if (!tokensOnly)
           scoreMap.computeIfAbsent(rid, k -> new AtomicInteger(0)).incrementAndGet();
-      } else if (rangeScan && startKey != null && key.compareTo(startKey) > 0 && !key.startsWith(startKey)) {
+      } else if (rangeScan && key.compareTo(startKey) > 0 && !key.startsWith(startKey)) {
         break;
       }
     }

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -131,6 +131,7 @@ public class FullTextQueryExecutor {
    * @return cursor with matching documents, sorted by score descending
    */
   public IndexCursor search(final String queryString, final int limit) {
+    resetState();
     try {
       // Create parser per invocation for thread safety
       final QueryParser parser = createQueryParser();
@@ -142,12 +143,24 @@ public class FullTextQueryExecutor {
   }
 
   /**
+   * Resets the per-query matching state. An executor is meant to be used for a single search, but resetting at each public entry
+   * point guarantees no state leaks between calls even if one is reused.
+   */
+  private void resetState() {
+    scoringTokens.clear();
+    collectingExclusion = false;
+    tokensOnly = false;
+    currentBoost = 1.0f;
+  }
+
+  /**
    * Runs only the query's matching logic (no scoring) to collect the scoring tokens, then returns the index's query-level BM25
    * scoring explanation (similarity, k1/b, N, avgdl, and per-term df/idf/boost). Surfaced by {@code EXPLAIN}/{@code PROFILE}.
    *
    * @param queryString the query string in Lucene syntax
    */
   public JSONObject explainScoring(final String queryString) {
+    resetState();
     try {
       final QueryParser parser = createQueryParser();
       final Query query = parser.parse(queryString);

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -25,6 +25,7 @@ import com.arcadedb.index.IndexCursorEntry;
 import com.arcadedb.index.IndexException;
 import com.arcadedb.index.TempIndexCursor;
 import com.arcadedb.schema.FullTextIndexMetadata;
+import com.arcadedb.serializer.json.JSONObject;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queryparser.classic.ParseException;
@@ -146,7 +147,7 @@ public class FullTextQueryExecutor {
    *
    * @param queryString the query string in Lucene syntax
    */
-  public com.arcadedb.serializer.json.JSONObject explainScoring(final String queryString) {
+  public JSONObject explainScoring(final String queryString) {
     try {
       final QueryParser parser = createQueryParser();
       final Query query = parser.parse(queryString);

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -44,6 +44,7 @@ import org.apache.lucene.search.WildcardQuery;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -73,11 +74,12 @@ public class FullTextQueryExecutor {
    * it means "unqualified": such a term is matched against the unprefixed posting (the only field of a single-property index, or
    * the field-agnostic entry of a multi-property index) and receives no per-field boost.
    * <p>
-   * KNOWN LIMITATION: on a MULTI-property index a property literally named {@code content} collides with this sentinel - a
-   * {@code content:term} clause is then treated as unqualified (no field boost). Single-property indexes are unaffected. Renaming
-   * the sentinel would break single-property indexes whose sole property is {@code content}, so it is kept and documented.
+   * It is a deliberately non-identifier sentinel (not a plausible property name) so it cannot collide with a real field. Whether a
+   * parsed query field is unqualified is decided by {@link #isUnqualified(String)}, which is index-aware and so also handles a
+   * single-property index whose sole property happens to equal a user's field qualifier - the former {@code "content"} sentinel
+   * silently mis-scored a {@code content:term} clause on a multi-property index that owned a real {@code content} field.
    */
-  static final String DEFAULT_FIELD = "content";
+  static final String DEFAULT_FIELD = "__arcadedb_default_field__";
 
   private final LSMTreeFullTextIndex   index;
   private final Analyzer               analyzer;
@@ -346,11 +348,24 @@ public class FullTextQueryExecutor {
   }
 
   /**
-   * Returns the BM25 field boost for a query field: the configured per-field boost for an explicit field, or 1.0 for the default
-   * (unqualified) {@code content} field.
+   * Returns true when a parsed query field denotes the "unqualified" target rather than a real, field-qualified clause. A term is
+   * unqualified when the parser left it on the {@link #DEFAULT_FIELD} sentinel, or when it is qualified with the sole property of a
+   * single-property index: such an index stores only unprefixed postings, so {@code field:term} and {@code term} are equivalent
+   * there. This is what lets a non-colliding sentinel be used without breaking single-property {@code content:term} queries.
+   */
+  private boolean isUnqualified(final String field) {
+    if (field == null || field.isEmpty() || DEFAULT_FIELD.equals(field))
+      return true;
+    final List<String> props = index.getPropertyNames();
+    return props.size() == 1 && props.get(0).equals(field);
+  }
+
+  /**
+   * Returns the BM25 field boost for a query field: the configured per-field boost for an explicit field, or 1.0 for an
+   * unqualified term.
    */
   private float boostFor(final String field) {
-    if (field != null && !field.isEmpty() && !DEFAULT_FIELD.equals(field) && metadata != null)
+    if (!isUnqualified(field) && metadata != null)
       return metadata.getFieldBoost(field);
     return 1.0f;
   }
@@ -377,12 +392,7 @@ public class FullTextQueryExecutor {
 
     // For field-specific queries (e.g., "title:java"), prepend field name
     // Multi-property indexes store tokens as "fieldName:token"
-    final String searchKey;
-    if (field != null && !field.isEmpty() && !DEFAULT_FIELD.equals(field)) {
-      searchKey = field + ":" + text;
-    } else {
-      searchKey = text;
-    }
+    final String searchKey = isUnqualified(field) ? text : field + ":" + text;
 
     recordScoringToken(searchKey, boostFor(field));
     if (tokensOnly)
@@ -455,7 +465,7 @@ public class FullTextQueryExecutor {
     // Compute the literal prefix (everything up to the first wildcard char)
     final String literalPrefix = extractLiteralPrefix(pattern);
     final String searchPrefix = buildSearchKey(field, literalPrefix);
-    final String fieldPrefix = field != null && !field.isEmpty() && !DEFAULT_FIELD.equals(field) ? field + ":" : "";
+    final String fieldPrefix = !isUnqualified(field) ? field + ":" : "";
     final Pattern regex = wildcardToRegex(pattern);
 
     if (literalPrefix.isEmpty()) {
@@ -491,7 +501,7 @@ public class FullTextQueryExecutor {
     final int maxEdits = query.getMaxEdits();
     final int prefixLen = Math.min(query.getPrefixLength(), term.length());
     final String requiredPrefix = term.substring(0, prefixLen);
-    final String fieldPrefix = field != null && !field.isEmpty() && !DEFAULT_FIELD.equals(field) ? field + ":" : "";
+    final String fieldPrefix = !isUnqualified(field) ? field + ":" : "";
     final String searchPrefix = fieldPrefix + requiredPrefix;
 
     iterateAndMatch(searchPrefix.isEmpty() ? null : searchPrefix, key -> {
@@ -517,7 +527,7 @@ public class FullTextQueryExecutor {
       return;
     }
 
-    final String fieldPrefix = field != null && !field.isEmpty() && !DEFAULT_FIELD.equals(field) ? field + ":" : "";
+    final String fieldPrefix = !isUnqualified(field) ? field + ":" : "";
 
     iterateAndMatch(null, key -> {
       if (!key.startsWith(fieldPrefix))
@@ -557,14 +567,11 @@ public class FullTextQueryExecutor {
   }
 
   /**
-   * Builds the index search key by prefixing the field name when needed.
-   * Multi-property indexes store entries as {@code fieldName:token}; the default {@code "content"} field
-   * (used by the Lucene QueryParser when no field is specified) targets unqualified tokens.
+   * Builds the index search key by prefixing the field name when needed. Multi-property indexes store entries as
+   * {@code fieldName:token}; unqualified terms (see {@link #isUnqualified(String)}) target the unprefixed tokens.
    */
-  private static String buildSearchKey(final String field, final String text) {
-    if (field != null && !field.isEmpty() && !DEFAULT_FIELD.equals(field))
-      return field + ":" + text;
-    return text;
+  private String buildSearchKey(final String field, final String text) {
+    return isUnqualified(field) ? text : field + ":" + text;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -397,7 +397,9 @@ public class FullTextQueryExecutor {
 
   private void collectPhraseMatches(final PhraseQuery query, final Map<RID, AtomicInteger> scoreMap) {
     // For phrase queries, all terms must match in the same document
-    // Note: We can't verify word order without position indexing, so we just require all terms
+    // Note: We can't verify word order without position indexing, so we just require all terms.
+    // Phrase terms are matched/scored against the unprefixed token, so the configured per-field boost is NOT applied to phrase
+    // terms (an enclosing caret boost still applies via currentBoost). They are recorded with boost 1.0 accordingly.
     final Term[] terms = query.getTerms();
     if (terms.length == 0)
       return;

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -24,6 +24,7 @@ import com.arcadedb.index.IndexCursor;
 import com.arcadedb.index.IndexCursorEntry;
 import com.arcadedb.index.IndexException;
 import com.arcadedb.index.TempIndexCursor;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.FullTextIndexMetadata;
 import com.arcadedb.serializer.json.JSONObject;
 import org.apache.lucene.analysis.Analyzer;
@@ -49,6 +50,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -81,6 +83,14 @@ public class FullTextQueryExecutor {
    */
   static final String DEFAULT_FIELD = "__arcadedb_default_field__";
 
+  /**
+   * Safety cap on the number of distinct scoring tokens a single query may accumulate. Wildcard / prefix / fuzzy clauses expand
+   * to one scoring token per matched term, and each token costs one posting-list scan in the BM25 re-rank pass; an extreme
+   * expansion (e.g. {@code a*} on a huge vocabulary) could otherwise make a single query arbitrarily expensive. Beyond the cap,
+   * matching still proceeds (the result set stays correct) but additional terms no longer contribute to the BM25 score.
+   */
+  static final int MAX_EXPANDED_SCORING_TERMS = 4096;
+
   private final LSMTreeFullTextIndex   index;
   private final Analyzer               analyzer;
   private final FullTextIndexMetadata  metadata;
@@ -96,6 +106,8 @@ public class FullTextQueryExecutor {
   // The compounded caret boost (e.g. `title:java^3`) of the BoostQuery currently being descended, multiplied into recorded
   // scoring tokens. Lucene's QueryParser already parses `^` into a BoostQuery; this is where that boost takes effect for BM25.
   private       float              currentBoost        = 1.0f;
+  // Set once the scoring-token cap is hit so the warning is logged at most once per query.
+  private       boolean            expansionCapWarned  = false;
 
   /**
    * Creates a new FullTextQueryExecutor for the given index.
@@ -153,6 +165,7 @@ public class FullTextQueryExecutor {
     collectingExclusion = false;
     tokensOnly = false;
     currentBoost = 1.0f;
+    expansionCapWarned = false;
   }
 
   /**
@@ -343,6 +356,19 @@ public class FullTextQueryExecutor {
   private void recordScoringToken(final String storedKey, final float boost) {
     if (collectingExclusion || !index.isBM25())
       return;
+    // Cap the number of distinct scoring tokens: a pathological wildcard/fuzzy expansion would otherwise add one posting-list
+    // scan per matched term to the re-rank pass. Already-seen tokens can still update their boost (no growth); only genuinely new
+    // tokens are dropped once the cap is reached. Matching is unaffected, so the result set stays correct - the extra terms just
+    // stop contributing to the BM25 score.
+    if (!scoringTokens.containsKey(storedKey) && scoringTokens.size() >= MAX_EXPANDED_SCORING_TERMS) {
+      if (!expansionCapWarned) {
+        expansionCapWarned = true;
+        LogManager.instance().log(this, Level.WARNING,
+            "Full-text query expanded to more than %d scoring terms on index '%s'; additional terms are matched but not BM25-scored. "
+                + "Consider a more specific query (narrower wildcard/fuzzy).", MAX_EXPANDED_SCORING_TERMS, index.getName());
+      }
+      return;
+    }
     // Combine the per-field boost with the caret boost in effect for this part of the query.
     scoringTokens.merge(storedKey, boost * currentBoost, Math::max);
   }

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -67,7 +67,10 @@ import java.util.regex.PatternSyntaxException;
  *   <li>Field-specific search: field:value</li>
  * </ul>
  * <p>
- * This class is thread-safe. QueryParser instances are created per search() invocation.
+ * NOT thread-safe: an instance carries per-query mutable state (the collected scoring tokens, the current caret boost, and the
+ * exclusion/tokens-only flags) for the duration of one search. Create a new instance per search and do not share it across
+ * threads. {@code resetState()} runs at each public entry point as a defensive guard against accidental sequential reuse on the
+ * same thread; it does NOT make the instance safe for concurrent reuse. (The Lucene QueryParser is likewise rebuilt per call.)
  *
  * @author Luca Garulli (l.garulli--(at)--arcadedata.com)
  */
@@ -112,7 +115,8 @@ public class FullTextQueryExecutor {
 
   // Throttle for the scoring-token-cap WARNING. A new executor is created per query, so a per-query flag would still log on every
   // execution of a repeated huge wildcard; this static throttle bounds it to once per window across the JVM (matching the 60s
-  // saturation-warning pattern used by the engine's thread pools).
+  // saturation-warning pattern used by the engine's thread pools). It is JVM-wide / shared across all indexes: a pathological
+  // wildcard on one index can suppress the warning for another for the window - an acceptable trade-off for a diagnostic log.
   private static final long       EXPANSION_WARN_THROTTLE_MS = 60_000L;
   private static final AtomicLong lastExpansionWarnMs        = new AtomicLong(0L);
 

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -76,6 +76,9 @@ public class FullTextQueryExecutor {
   // created per search, so these instance fields are not shared across queries.
   private final Map<String, Float> scoringTokens     = new HashMap<>();
   private       boolean            collectingExclusion = false;
+  // When true, matching runs only to capture the scoring tokens (used by EXPLAIN/PROFILE): per-document score accumulation is
+  // skipped so no document set is materialized. Token discovery for wildcard/prefix/fuzzy still scans the index as needed.
+  private       boolean            tokensOnly          = false;
   // The compounded caret boost (e.g. `title:java^3`) of the BoostQuery currently being descended, multiplied into recorded
   // scoring tokens. Lucene's QueryParser already parses `^` into a BoostQuery; this is where that boost takes effect for BM25.
   private       float              currentBoost        = 1.0f;
@@ -136,8 +139,13 @@ public class FullTextQueryExecutor {
     try {
       final QueryParser parser = createQueryParser();
       final Query query = parser.parse(queryString);
-      final Map<RID, AtomicInteger> scoreMap = new HashMap<>();
-      collectMatches(query, scoreMap, new HashSet<>());
+      tokensOnly = true;
+      try {
+        // The score map stays empty in tokens-only mode; we only need the captured scoringTokens.
+        collectMatches(query, new HashMap<>(), new HashSet<>());
+      } finally {
+        tokensOnly = false;
+      }
       return index.explainScoring(scoringTokens);
     } catch (final ParseException e) {
       throw new IndexException("Invalid search query: " + queryString, e);
@@ -185,6 +193,14 @@ public class FullTextQueryExecutor {
 
     if (query instanceof BooleanQuery) {
       final BooleanQuery bq = (BooleanQuery) query;
+
+      if (tokensOnly) {
+        // Only the positive clauses contribute scoring tokens; recurse to capture them and skip all set intersection/merge work.
+        for (final BooleanClause clause : bq.clauses())
+          if (clause.occur() != BooleanClause.Occur.MUST_NOT)
+            collectMatches(clause.query(), scoreMap, excluded);
+        return;
+      }
 
       // First pass: collect MUST_NOT terms and track whether any exist
       boolean hasMustNotClauses = false;
@@ -344,6 +360,8 @@ public class FullTextQueryExecutor {
     }
 
     recordScoringToken(searchKey, boostFor(field));
+    if (tokensOnly)
+      return;
 
     final IndexCursor cursor = index.get(new Object[] { searchKey });
     while (cursor.hasNext()) {
@@ -358,6 +376,12 @@ public class FullTextQueryExecutor {
     final Term[] terms = query.getTerms();
     if (terms.length == 0)
       return;
+
+    if (tokensOnly) {
+      for (final Term term : terms)
+        recordScoringToken(term.text(), 1.0f);
+      return;
+    }
 
     Map<RID, AtomicInteger> intersection = null;
 
@@ -495,7 +519,8 @@ public class FullTextQueryExecutor {
       final String key = keys[0].toString();
       if (matcher.matches(key)) {
         recordScoringToken(key, boost);
-        scoreMap.computeIfAbsent(rid, k -> new AtomicInteger(0)).incrementAndGet();
+        if (!tokensOnly)
+          scoreMap.computeIfAbsent(rid, k -> new AtomicInteger(0)).incrementAndGet();
       } else if (rangeScan && startKey != null && key.compareTo(startKey) > 0 && !key.startsWith(startKey)) {
         break;
       }

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -67,6 +67,17 @@ import java.util.regex.PatternSyntaxException;
  * @author Luca Garulli (l.garulli--(at)--arcadedata.com)
  */
 public class FullTextQueryExecutor {
+  /**
+   * The Lucene {@link QueryParser} default field, i.e. the field a query term targets when it is not field-qualified. Internally
+   * it means "unqualified": such a term is matched against the unprefixed posting (the only field of a single-property index, or
+   * the field-agnostic entry of a multi-property index) and receives no per-field boost.
+   * <p>
+   * KNOWN LIMITATION: on a MULTI-property index a property literally named {@code content} collides with this sentinel - a
+   * {@code content:term} clause is then treated as unqualified (no field boost). Single-property indexes are unaffected. Renaming
+   * the sentinel would break single-property indexes whose sole property is {@code content}, so it is kept and documented.
+   */
+  static final String DEFAULT_FIELD = "content";
+
   private final LSMTreeFullTextIndex   index;
   private final Analyzer               analyzer;
   private final FullTextIndexMetadata  metadata;
@@ -101,7 +112,7 @@ public class FullTextQueryExecutor {
    * @return a configured QueryParser
    */
   private QueryParser createQueryParser() {
-    final QueryParser parser = new QueryParser("content", analyzer);
+    final QueryParser parser = new QueryParser(DEFAULT_FIELD, analyzer);
     if (metadata != null) {
       parser.setAllowLeadingWildcard(metadata.isAllowLeadingWildcard());
       if ("AND".equalsIgnoreCase(metadata.getDefaultOperator())) {
@@ -325,7 +336,7 @@ public class FullTextQueryExecutor {
    * (unqualified) {@code content} field.
    */
   private float boostFor(final String field) {
-    if (field != null && !field.isEmpty() && !"content".equals(field) && metadata != null)
+    if (field != null && !field.isEmpty() && !DEFAULT_FIELD.equals(field) && metadata != null)
       return metadata.getFieldBoost(field);
     return 1.0f;
   }
@@ -353,7 +364,7 @@ public class FullTextQueryExecutor {
     // For field-specific queries (e.g., "title:java"), prepend field name
     // Multi-property indexes store tokens as "fieldName:token"
     final String searchKey;
-    if (field != null && !field.isEmpty() && !"content".equals(field)) {
+    if (field != null && !field.isEmpty() && !DEFAULT_FIELD.equals(field)) {
       searchKey = field + ":" + text;
     } else {
       searchKey = text;
@@ -426,7 +437,7 @@ public class FullTextQueryExecutor {
     // Compute the literal prefix (everything up to the first wildcard char)
     final String literalPrefix = extractLiteralPrefix(pattern);
     final String searchPrefix = buildSearchKey(field, literalPrefix);
-    final String fieldPrefix = field != null && !field.isEmpty() && !"content".equals(field) ? field + ":" : "";
+    final String fieldPrefix = field != null && !field.isEmpty() && !DEFAULT_FIELD.equals(field) ? field + ":" : "";
     final Pattern regex = wildcardToRegex(pattern);
 
     if (literalPrefix.isEmpty()) {
@@ -462,7 +473,7 @@ public class FullTextQueryExecutor {
     final int maxEdits = query.getMaxEdits();
     final int prefixLen = Math.min(query.getPrefixLength(), term.length());
     final String requiredPrefix = term.substring(0, prefixLen);
-    final String fieldPrefix = field != null && !field.isEmpty() && !"content".equals(field) ? field + ":" : "";
+    final String fieldPrefix = field != null && !field.isEmpty() && !DEFAULT_FIELD.equals(field) ? field + ":" : "";
     final String searchPrefix = fieldPrefix + requiredPrefix;
 
     iterateAndMatch(searchPrefix.isEmpty() ? null : searchPrefix, key -> {
@@ -488,7 +499,7 @@ public class FullTextQueryExecutor {
       return;
     }
 
-    final String fieldPrefix = field != null && !field.isEmpty() && !"content".equals(field) ? field + ":" : "";
+    final String fieldPrefix = field != null && !field.isEmpty() && !DEFAULT_FIELD.equals(field) ? field + ":" : "";
 
     iterateAndMatch(null, key -> {
       if (!key.startsWith(fieldPrefix))
@@ -533,7 +544,7 @@ public class FullTextQueryExecutor {
    * (used by the Lucene QueryParser when no field is specified) targets unqualified tokens.
    */
   private static String buildSearchKey(final String field, final String text) {
-    if (field != null && !field.isEmpty() && !"content".equals(field))
+    if (field != null && !field.isEmpty() && !DEFAULT_FIELD.equals(field))
       return field + ":" + text;
     return text;
   }

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -378,16 +378,18 @@ public class FullTextQueryExecutor {
   private void recordScoringToken(final String storedKey, final float boost) {
     if (collectingExclusion || !index.isBM25())
       return;
-    // Cap the number of distinct scoring tokens: a pathological wildcard/fuzzy expansion would otherwise add one posting-list
-    // scan per matched term to the re-rank pass. Already-seen tokens can still update their boost (no growth); only genuinely new
-    // tokens are dropped once the cap is reached. Matching is unaffected, so the result set stays correct - the extra terms just
-    // stop contributing to the BM25 score.
-    if (!scoringTokens.containsKey(storedKey) && scoringTokens.size() >= MAX_EXPANDED_SCORING_TERMS) {
+    // Single get(): the cap drops only genuinely new tokens once the limit is reached (a pathological wildcard/fuzzy expansion
+    // would otherwise add one posting-list scan per matched term to the re-rank pass); an already-seen token may still raise its
+    // boost without growing the map. Matching is unaffected, so the result set stays correct - excess terms just stop scoring.
+    final Float current = scoringTokens.get(storedKey);
+    if (current == null && scoringTokens.size() >= MAX_EXPANDED_SCORING_TERMS) {
       maybeWarnExpansionCap();
       return;
     }
-    // Combine the per-field boost with the caret boost in effect for this part of the query.
-    scoringTokens.merge(storedKey, boost * currentBoost, Math::max);
+    // Combine the per-field boost with the caret boost in effect for this part of the query; keep the highest seen.
+    final float combined = boost * currentBoost;
+    if (current == null || combined > current)
+      scoringTokens.put(storedKey, combined);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -94,6 +94,8 @@ public class FullTextQueryExecutor {
   private final LSMTreeFullTextIndex   index;
   private final Analyzer               analyzer;
   private final FullTextIndexMetadata  metadata;
+  // Cached once: the indexed property names don't change during a query, but isUnqualified() is consulted per matched term.
+  private final List<String>           propertyNames;
 
   // BM25 scoring (issue #4687): the positive scoring tokens collected during matching, mapped to their field boost. Populated
   // only when the index uses BM25 similarity and only for positive clauses (never for MUST_NOT exclusion). A new executor is
@@ -118,6 +120,7 @@ public class FullTextQueryExecutor {
     this.index = index;
     this.analyzer = index.getAnalyzer();
     this.metadata = index.getFullTextMetadata();
+    this.propertyNames = index.getPropertyNames();
   }
 
   /**
@@ -382,8 +385,7 @@ public class FullTextQueryExecutor {
   private boolean isUnqualified(final String field) {
     if (field == null || field.isEmpty() || DEFAULT_FIELD.equals(field))
       return true;
-    final List<String> props = index.getPropertyNames();
-    return props.size() == 1 && props.get(0).equals(field);
+    return propertyNames.size() == 1 && propertyNames.get(0).equals(field);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -224,6 +224,10 @@ public class FullTextQueryExecutor {
 
     // BM25 path: collectMatches above determined WHICH documents match (boolean/phrase/wildcard semantics). Re-rank that
     // candidate set with BM25 using the scoring tokens captured during matching.
+    // The result entries carry EMPTY keys (here and in the CLASSIC branch below): a SEARCH_INDEX query is a multi-token Lucene
+    // query, not a single index key, so there is no meaningful single key tuple to attach (unlike the direct index.get() path,
+    // whose single query keys flow through). The SQL SEARCH_INDEX function reads only RID + $score from these entries, never
+    // getKeys(); a direct executor.search() caller should likewise not rely on getKeys() for this path.
     if (index.isBM25())
       return index.scoreCandidatesBM25(scoreMap.keySet(), scoringTokens, new Object[] {}, limit);
 

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -250,9 +250,7 @@ public class FullTextQueryExecutor {
   private void collectMatches(final Query query, final Map<RID, AtomicInteger> scoreMap,
       final Set<RID> excluded) {
 
-    if (query instanceof BooleanQuery) {
-      final BooleanQuery bq = (BooleanQuery) query;
-
+    if (query instanceof final BooleanQuery bq) {
       if (tokensOnly) {
         // Only the positive clauses contribute scoring tokens; recurse to capture them and skip all set intersection/merge work.
         for (final BooleanClause clause : bq.clauses())
@@ -329,25 +327,25 @@ public class FullTextQueryExecutor {
       } finally {
         currentBoost = saved;
       }
-    } else if (query instanceof TermQuery) {
-      collectTermMatches((TermQuery) query, scoreMap);
-    } else if (query instanceof PhraseQuery) {
-      collectPhraseMatches((PhraseQuery) query, scoreMap);
-    } else if (query instanceof PrefixQuery) {
-      collectPrefixMatches((PrefixQuery) query, scoreMap);
-    } else if (query instanceof WildcardQuery) {
-      collectWildcardMatches((WildcardQuery) query, scoreMap);
-    } else if (query instanceof FuzzyQuery) {
-      collectFuzzyMatches((FuzzyQuery) query, scoreMap);
-    } else if (query instanceof RegexpQuery) {
-      collectRegexpMatches((RegexpQuery) query, scoreMap);
+    } else if (query instanceof final TermQuery tq) {
+      collectTermMatches(tq, scoreMap);
+    } else if (query instanceof final PhraseQuery pq) {
+      collectPhraseMatches(pq, scoreMap);
+    } else if (query instanceof final PrefixQuery pq) {
+      collectPrefixMatches(pq, scoreMap);
+    } else if (query instanceof final WildcardQuery wq) {
+      collectWildcardMatches(wq, scoreMap);
+    } else if (query instanceof final FuzzyQuery fq) {
+      collectFuzzyMatches(fq, scoreMap);
+    } else if (query instanceof final RegexpQuery rq) {
+      collectRegexpMatches(rq, scoreMap);
     }
     // Other Lucene query types (e.g., TermRangeQuery) are intentionally ignored.
   }
 
   private void collectTermsForExclusion(final Query query, final Set<RID> excluded) {
-    if (query instanceof BooleanQuery) {
-      for (final BooleanClause clause : ((BooleanQuery) query).clauses()) {
+    if (query instanceof final BooleanQuery bq) {
+      for (final BooleanClause clause : bq.clauses()) {
         // A nested MUST_NOT inside an exclusion context is a double negation (e.g. NOT (A AND NOT B) - B should NOT be excluded).
         // Skip such clauses so their terms are not wrongly added to the exclusion set. (Fully representing the positive
         // contribution of a double-negated term would require general boolean evaluation; this at least avoids excluding it.)

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -95,6 +95,12 @@ public class FullTextQueryExecutor {
    */
   static final int MAX_EXPANDED_SCORING_TERMS = 4096;
 
+  /**
+   * Result-universe size above which a pure-negative query (only MUST_NOT clauses, which must materialize the whole index to form
+   * the complement) logs a throttled WARNING so operators notice the O(index) cost.
+   */
+  static final int PURE_NEGATIVE_WARN_THRESHOLD = 100_000;
+
   private final LSMTreeFullTextIndex   index;
   private final Analyzer               analyzer;
   private final FullTextIndexMetadata  metadata;
@@ -119,6 +125,8 @@ public class FullTextQueryExecutor {
   // wildcard on one index can suppress the warning for another for the window - an acceptable trade-off for a diagnostic log.
   private static final long       EXPANSION_WARN_THROTTLE_MS = 60_000L;
   private static final AtomicLong lastExpansionWarnMs        = new AtomicLong(0L);
+  // Same 60s throttle for the pure-negative full-index-scan WARNING (also JVM-wide / shared across indexes).
+  private static final AtomicLong lastPureNegativeWarnMs     = new AtomicLong(0L);
 
   /**
    * Creates a new FullTextQueryExecutor for the given index.
@@ -340,6 +348,11 @@ public class FullTextQueryExecutor {
   private void collectTermsForExclusion(final Query query, final Set<RID> excluded) {
     if (query instanceof BooleanQuery) {
       for (final BooleanClause clause : ((BooleanQuery) query).clauses()) {
+        // A nested MUST_NOT inside an exclusion context is a double negation (e.g. NOT (A AND NOT B) - B should NOT be excluded).
+        // Skip such clauses so their terms are not wrongly added to the exclusion set. (Fully representing the positive
+        // contribution of a double-negated term would require general boolean evaluation; this at least avoids excluding it.)
+        if (clause.occur() == BooleanClause.Occur.MUST_NOT)
+          continue;
         collectTermsForExclusion(clause.query(), excluded);
       }
       return;
@@ -394,6 +407,19 @@ public class FullTextQueryExecutor {
   }
 
   /**
+   * Logs the pure-negative full-index-scan WARNING, throttled like {@link #maybeWarnExpansionCap()}.
+   */
+  private void maybeWarnPureNegativeScan(final int universeSize) {
+    final long now = System.currentTimeMillis();
+    final long last = lastPureNegativeWarnMs.get();
+    if (now - last >= EXPANSION_WARN_THROTTLE_MS && lastPureNegativeWarnMs.compareAndSet(last, now))
+      LogManager.instance().log(this, Level.WARNING,
+          "Pure-negative full-text query on index '%s' materialized %d documents (the whole index) to compute the complement. "
+              + "Add a positive clause to bound the scan. (throttled, logged at most once per %d s)",
+          index.getName(), universeSize, EXPANSION_WARN_THROTTLE_MS / 1000);
+  }
+
+  /**
    * Returns true when a parsed query field denotes the "unqualified" target rather than a real, field-qualified clause. A term is
    * unqualified when the parser left it on the {@link #DEFAULT_FIELD} sentinel, or when it is qualified with the sole property of a
    * single-property index: such an index stores only unprefixed postings, so {@code field:term} and {@code term} are equivalent
@@ -429,6 +455,11 @@ public class FullTextQueryExecutor {
       final RID rid = cursor.next().getIdentity();
       scoreMap.computeIfAbsent(rid, k -> new AtomicInteger(1));
     }
+    // A pure-negative query (only MUST_NOT clauses) has no candidate set, so the whole index must be materialized to subtract the
+    // excluded RIDs and form the complement. This is O(index) in time and memory; warn (throttled) when the materialized universe
+    // is large so an operator who wrote e.g. `-the` notices the cost and adds a positive clause to bound it.
+    if (scoreMap.size() >= PURE_NEGATIVE_WARN_THRESHOLD)
+      maybeWarnPureNegativeScan(scoreMap.size());
   }
 
   private void collectTermMatches(final TermQuery query, final Map<RID, AtomicInteger> scoreMap) {

--- a/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/FullTextQueryExecutor.java
@@ -50,6 +50,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -108,8 +109,12 @@ public class FullTextQueryExecutor {
   // The compounded caret boost (e.g. `title:java^3`) of the BoostQuery currently being descended, multiplied into recorded
   // scoring tokens. Lucene's QueryParser already parses `^` into a BoostQuery; this is where that boost takes effect for BM25.
   private       float              currentBoost        = 1.0f;
-  // Set once the scoring-token cap is hit so the warning is logged at most once per query.
-  private       boolean            expansionCapWarned  = false;
+
+  // Throttle for the scoring-token-cap WARNING. A new executor is created per query, so a per-query flag would still log on every
+  // execution of a repeated huge wildcard; this static throttle bounds it to once per window across the JVM (matching the 60s
+  // saturation-warning pattern used by the engine's thread pools).
+  private static final long       EXPANSION_WARN_THROTTLE_MS = 60_000L;
+  private static final AtomicLong lastExpansionWarnMs        = new AtomicLong(0L);
 
   /**
    * Creates a new FullTextQueryExecutor for the given index.
@@ -168,7 +173,6 @@ public class FullTextQueryExecutor {
     collectingExclusion = false;
     tokensOnly = false;
     currentBoost = 1.0f;
-    expansionCapWarned = false;
   }
 
   /**
@@ -364,16 +368,25 @@ public class FullTextQueryExecutor {
     // tokens are dropped once the cap is reached. Matching is unaffected, so the result set stays correct - the extra terms just
     // stop contributing to the BM25 score.
     if (!scoringTokens.containsKey(storedKey) && scoringTokens.size() >= MAX_EXPANDED_SCORING_TERMS) {
-      if (!expansionCapWarned) {
-        expansionCapWarned = true;
-        LogManager.instance().log(this, Level.WARNING,
-            "Full-text query expanded to more than %d scoring terms on index '%s'; additional terms are matched but not BM25-scored. "
-                + "Consider a more specific query (narrower wildcard/fuzzy).", MAX_EXPANDED_SCORING_TERMS, index.getName());
-      }
+      maybeWarnExpansionCap();
       return;
     }
     // Combine the per-field boost with the caret boost in effect for this part of the query.
     scoringTokens.merge(storedKey, boost * currentBoost, Math::max);
+  }
+
+  /**
+   * Logs the scoring-token-cap WARNING at most once per {@link #EXPANSION_WARN_THROTTLE_MS} across the JVM (a new executor per
+   * query means a per-query flag would not suppress it for a repeated huge wildcard). The CAS ensures a single winner per window.
+   */
+  private void maybeWarnExpansionCap() {
+    final long now = System.currentTimeMillis();
+    final long last = lastExpansionWarnMs.get();
+    if (now - last >= EXPANSION_WARN_THROTTLE_MS && lastExpansionWarnMs.compareAndSet(last, now))
+      LogManager.instance().log(this, Level.WARNING,
+          "Full-text query expanded to more than %d scoring terms on index '%s'; additional terms are matched but not BM25-scored. "
+              + "Consider a more specific query (narrower wildcard/fuzzy). (throttled, logged at most once per %d s)",
+          MAX_EXPANDED_SCORING_TERMS, index.getName(), EXPANSION_WARN_THROTTLE_MS / 1000);
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -245,49 +245,78 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
   }
 
   /**
-   * BM25 scoring path. For each analyzed query term it reads the postings (which carry the per-document term frequency and
-   * document length as {@link FullTextPostingRID}), computes the term IDF from the document frequency, and accumulates the BM25
-   * contribution per document, applying the per-field boost for field-qualified terms.
+   * Shared BM25 scoring core used by both the direct ({@link #get}) and the Lucene-syntax ({@link FullTextQueryExecutor}) paths,
+   * so the formula, parameters and corpus statistics can never diverge between them. For each scoring token it derives the
+   * document frequency in a first streaming pass (counting only, never materializing the posting list) and accumulates the BM25
+   * contribution in a second pass. When {@code candidates} is non-null only those documents are scored (the map is pre-seeded
+   * with them); otherwise every matching document is scored. Memory is therefore bounded by the result/candidate set, not by the
+   * (possibly huge) posting list of a common term.
+   *
+   * @param tokenBoosts scoring tokens (stored-key form) mapped to their effective boost
+   * @param candidates  documents to score, or {@code null} to score every matching document
    */
-  private IndexCursor getBM25(final Object[] keys, final int limit) {
-    final String queryText = keys.length > 0 && keys[0] != null ? keys[0].toString() : "";
-    final List<QueryTerm> queryTerms = parseQueryTerms(queryText);
-
+  private Map<RID, Float> computeBM25Scores(final Map<String, Float> tokenBoosts, final Set<RID> candidates) {
     ensureCounters();
     final long totalDocs = resolveTotalDocs();
     final double avgdl = resolveAvgDocLength();
     final double k1 = ftMetadata.getBm25K1();
     final double b = ftMetadata.getBm25B();
 
-    final Map<RID, Float> scoreMap = new HashMap<>();
+    final Map<RID, Float> scoreMap = candidates != null ? new HashMap<>(candidates.size()) : new HashMap<>();
+    if (candidates != null)
+      for (final RID c : candidates)
+        scoreMap.put(c, 0.0f);
 
-    for (final QueryTerm term : queryTerms) {
-      final List<String> keywords = analyzeText(queryAnalyzer, new Object[] { term.value });
-      final float boost = term.fieldName != null ? ftMetadata.getFieldBoost(term.fieldName) : 1.0f;
+    for (final Map.Entry<String, Float> e : tokenBoosts.entrySet()) {
+      final String[] storedKey = new String[] { e.getKey() };
+      final float boost = e.getValue();
 
-      for (final String k : keywords) {
-        final String storedKey = term.fieldName != null ? term.fieldName + ":" + k : k;
-        final IndexCursor postings = underlyingIndex.get(new String[] { storedKey });
+      // Pass 1: document frequency - stream-count the postings without retaining them.
+      long df = 0L;
+      final IndexCursor dfCursor = underlyingIndex.get(storedKey);
+      while (dfCursor.hasNext()) {
+        dfCursor.next();
+        ++df;
+      }
+      if (df == 0L)
+        continue;
+      final double idf = BM25Scorer.idf(totalDocs, df);
 
-        // Collect the postings first so the document frequency (and therefore the IDF) is known before scoring.
-        final List<FullTextPostingRID> termPostings = new ArrayList<>();
-        while (postings.hasNext()) {
-          final Identifiable id = postings.next();
-          if (id instanceof FullTextPostingRID s)
-            termPostings.add(s);
-        }
-
-        final long df = termPostings.size();
-        if (df == 0)
+      // Pass 2: accumulate contributions, scoring only candidates when a candidate set was given.
+      final IndexCursor scoreCursor = underlyingIndex.get(storedKey);
+      while (scoreCursor.hasNext()) {
+        final Identifiable id = scoreCursor.next();
+        if (!(id instanceof FullTextPostingRID s))
           continue;
-
-        final double idf = BM25Scorer.idf(totalDocs, df);
-        for (final FullTextPostingRID s : termPostings) {
-          final double contribution = BM25Scorer.termScore(idf, s.tf, s.docLength, avgdl, k1, b) * boost;
-          scoreMap.merge(s.getIdentity(), (float) contribution, Float::sum);
-        }
+        final RID rid = s.getIdentity();
+        if (candidates != null && !scoreMap.containsKey(rid))
+          continue;
+        scoreMap.merge(rid, (float) (BM25Scorer.termScore(idf, s.tf, s.docLength, avgdl, k1, b) * boost), Float::sum);
       }
     }
+    return scoreMap;
+  }
+
+  /**
+   * BM25 scoring path for the direct index lookup. Builds the scoring tokens from the query and delegates to
+   * {@link #computeBM25Scores}.
+   */
+  private IndexCursor getBM25(final Object[] keys, final int limit) {
+    final String queryText = keys.length > 0 && keys[0] != null ? keys[0].toString() : "";
+    final List<QueryTerm> queryTerms = parseQueryTerms(queryText);
+
+    // Build the scoring tokens (stored-key form) with their field boost, then delegate to the shared scorer. No candidate set:
+    // every matching document is scored.
+    final Map<String, Float> tokenBoosts = new HashMap<>();
+    for (final QueryTerm term : queryTerms) {
+      final float boost = term.fieldName != null ? ftMetadata.getFieldBoost(term.fieldName) : 1.0f;
+      for (final String k : analyzeText(queryAnalyzer, new Object[] { term.value })) {
+        final String storedKey = term.fieldName != null ? term.fieldName + ":" + k : k;
+        tokenBoosts.merge(storedKey, boost, Math::max);
+      }
+    }
+
+    final Map<RID, Float> scoreMap = computeBM25Scores(tokenBoosts, null);
 
     final ArrayList<IndexCursorEntry> list = new ArrayList<>(scoreMap.size());
     for (final Map.Entry<RID, Float> entry : scoreMap.entrySet())
@@ -322,36 +351,7 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    */
   public IndexCursor scoreCandidatesBM25(final Set<RID> candidates, final Map<String, Float> tokenBoosts, final Object[] keys,
       final int limit) {
-    ensureCounters();
-    final long totalDocs = resolveTotalDocs();
-    final double avgdl = resolveAvgDocLength();
-    final double k1 = ftMetadata.getBm25K1();
-    final double b = ftMetadata.getBm25B();
-
-    final Map<RID, Float> scoreMap = new HashMap<>(candidates.size());
-    for (final RID c : candidates)
-      scoreMap.put(c, 0.0f);
-
-    for (final Map.Entry<String, Float> e : tokenBoosts.entrySet()) {
-      final IndexCursor postings = underlyingIndex.get(new String[] { e.getKey() });
-      final List<FullTextPostingRID> termPostings = new ArrayList<>();
-      while (postings.hasNext()) {
-        final Identifiable id = postings.next();
-        if (id instanceof FullTextPostingRID s)
-          termPostings.add(s);
-      }
-      final long df = termPostings.size();
-      if (df == 0)
-        continue;
-      final double idf = BM25Scorer.idf(totalDocs, df);
-      final float boost = e.getValue();
-      for (final FullTextPostingRID s : termPostings) {
-        final RID rid = s.getIdentity();
-        if (!scoreMap.containsKey(rid))
-          continue;
-        scoreMap.merge(rid, (float) (BM25Scorer.termScore(idf, s.tf, s.docLength, avgdl, k1, b) * boost), Float::sum);
-      }
-    }
+    final Map<RID, Float> scoreMap = computeBM25Scores(tokenBoosts, candidates);
 
     final ArrayList<IndexCursorEntry> list = new ArrayList<>(scoreMap.size());
     for (final Map.Entry<RID, Float> entry : scoreMap.entrySet())
@@ -410,22 +410,18 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
 
   /**
    * BM25 is scored per bucket (per-shard, like Elasticsearch/Lucene): each bucket-level full-text index ranks its own documents
-   * using statistics derived from its own postings. The document frequency comes from this bucket's postings, so N and the
-   * average document length must also be this bucket's, otherwise the IDF would be biased. The per-bucket corpus counters are
-   * maintained incrementally on put/remove; the methods below keep the fallback and recompute paths consistently per-bucket.
-   * <p>
-   * Returns the number of documents in this bucket (N) for IDF: the persisted per-bucket counter, falling back to a live count of
-   * the associated bucket when the counter is unavailable.
+   * using the document frequency read from its own postings. To keep the IDF unbiased, N must be measured at the same scope as
+   * df, i.e. this bucket - so N is the bucket's live record count. (The corpus counters in {@link FullTextIndexMetadata} are
+   * SHARED type-wide across all of the type's bucket indexes - the same metadata object is passed to each - so they are used only
+   * for the average document length, a length normalizer for which a type-wide value is an appropriate estimate.)
    */
   private long resolveTotalDocs() {
-    if (ftMetadata != null && ftMetadata.getTotalDocs() > 0)
-      return ftMetadata.getTotalDocs();
     final long count = associatedBucketCount();
     return count > 0 ? count : 1L;
   }
 
   /**
-   * Returns the average document length in this bucket, or 1.0 when no statistics are available.
+   * Returns the (type-wide) average document length used as the BM25 length normalizer, or 1.0 when no statistics are available.
    */
   private double resolveAvgDocLength() {
     if (ftMetadata != null && ftMetadata.getTotalDocs() > 0)
@@ -450,34 +446,43 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
   }
 
   /**
-   * Lazily recomputes the corpus counters when they are missing or stale (e.g. a BM25 index reopened before the schema carrying
-   * the counters was persisted). Does nothing when the counters are already valid and non-empty, so the common path is free.
+   * Lazily rebuilds the (type-wide) corpus counters when they are not trustworthy (e.g. a BM25 index reopened before the schema
+   * carrying the counters was persisted, or an index that predates BM25 support). The {@code countersValid} flag is the
+   * authority: when set the counters are used as-is. Recompute is done in memory only; persistence is deferred to the next schema
+   * save or an explicit {@link #recomputeBM25Counters()}, so the read/query path never calls {@code saveConfiguration}.
    */
   private void ensureCounters() {
-    if (ftMetadata == null)
+    if (ftMetadata == null || ftMetadata.isCountersValid())
       return;
-    if (ftMetadata.getTotalDocs() > 0)
-      return;
-    if (associatedBucketCount() <= 0)
-      return; // empty bucket: the (0,0) counters are correct
-    recomputeBM25Counters();
+    computeCorpusCounters(false);
   }
 
   /**
-   * Rescans this bucket and rebuilds the per-bucket BM25 corpus counters (document count and total document length), then
-   * persists them. Use it after a bulk import or to repair drifted counters.
+   * Rescans the type and rebuilds the type-wide BM25 corpus counters (document count and total document length), then persists
+   * them. Use it after a bulk import or to repair drifted counters.
    */
   public void recomputeBM25Counters() {
+    computeCorpusCounters(true);
+  }
+
+  /**
+   * Scans the whole type and rebuilds the shared corpus counters used for the average document length. The counters are type-wide
+   * because the {@link FullTextIndexMetadata} instance is shared by all of the type's bucket indexes; scanning a single bucket
+   * would corrupt them. When {@code persist} is true the schema is saved so the counters survive a restart; the lazy read-path
+   * caller passes false to avoid saving the schema during a query.
+   */
+  private void computeCorpusCounters(final boolean persist) {
     if (ftMetadata == null)
       return;
-    final Bucket bucket = associatedBucket();
-    if (bucket == null)
+    final DatabaseInternal db = underlyingIndex.getMutableIndex().getDatabase();
+    final String typeName = getTypeName();
+    if (typeName == null)
       return;
 
     final List<String> props = getPropertyNames();
     long docs = 0L;
     long sumLen = 0L;
-    final Iterator<com.arcadedb.database.Record> it = bucket.iterator();
+    final Iterator<com.arcadedb.database.Record> it = db.iterateType(typeName, true);
     while (it.hasNext()) {
       final com.arcadedb.database.Record record = it.next();
       if (!(record instanceof Document doc))
@@ -493,7 +498,8 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     }
 
     ftMetadata.setCounters(docs, sumLen);
-    underlyingIndex.getMutableIndex().getDatabase().getSchema().getEmbedded().saveConfiguration();
+    if (persist)
+      underlyingIndex.getMutableIndex().getDatabase().getSchema().getEmbedded().saveConfiguration();
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -116,14 +116,6 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
             base.associatedBucketId);
       }
 
-      // The query parser's default (unqualified) field is "content"; on a multi-property index a boost configured for a field
-      // literally named "content" cannot be distinguished from an unqualified term and is silently ignored. Warn at creation.
-      if (ftMetadata.propertyNames != null && ftMetadata.propertyNames.size() > 1
-          && ftMetadata.getFieldBoosts().containsKey("content"))
-        LogManager.instance().log(LSMTreeFullTextIndex.class, Level.WARNING,
-            "Full-text index '%s' configures a boost for the field 'content', which collides with the query parser's default "
-                + "field name on a multi-property index; that boost will not be applied", builder.getIndexName());
-
       return new LSMTreeFullTextIndex(builder.getDatabase(), builder.getIndexName(), builder.getFilePath(),
           ComponentFile.MODE.READ_WRITE, builder.getPageSize(), builder.getNullStrategy(), ftMetadata);
     }
@@ -545,6 +537,18 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
   }
 
   /**
+   * Recomputes the BM25 corpus counters when this index ranks with BM25 (CLASSIC indexes keep no such statistics). Drives the
+   * SQL {@code REBUILD INDEX <name> {statsOnly: true}} drift-repair path.
+   */
+  @Override
+  public boolean recomputeStatistics() {
+    if (!isBM25())
+      return false;
+    recomputeBM25Counters();
+    return true;
+  }
+
+  /**
    * Scans the whole type and rebuilds the shared corpus counters used for the average document length. The counters are type-wide
    * because the {@link FullTextIndexMetadata} instance is shared by all of the type's bucket indexes; scanning a single bucket
    * would corrupt them. When {@code persist} is true the schema is saved so the counters survive a restart; the lazy read-path
@@ -581,6 +585,10 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     }
 
     ftMetadata.setCounters(docs, sumLen);
+    // Report the result so operators can correlate the cold-start latency above with the corpus size that drove it.
+    LogManager.instance().log(this, Level.INFO,
+        "Recomputed BM25 corpus statistics for type '%s': %d documents, %d total tokens (avgdl=%.2f)", null, typeName, docs,
+        sumLen, docs > 0 ? (double) sumLen / docs : 1.0);
     if (persist)
       underlyingIndex.getMutableIndex().getDatabase().getSchema().getEmbedded().saveConfiguration();
   }
@@ -1216,8 +1224,10 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
       docFreqs.put(term, docCount);
     }
 
-    // Estimate total documents (use the max doc frequency as approximation)
-    final int totalDocs = docFreqs.values().stream().mapToInt(Integer::intValue).max().orElse(1);
+    // Total documents in this bucket, consistent with the per-bucket document frequencies above. The live bucket record count is
+    // exact and always >= any term's df, unlike the previous max-df proxy which understated IDF for terms shared by many
+    // documents (the most common term defined totalDocs, forcing its IDF toward zero and skewing term selection).
+    final int totalDocs = (int) Math.min(Integer.MAX_VALUE, resolveTotalDocs());
 
     // Step 4: Select top terms using MoreLikeThisQueryBuilder
     final MoreLikeThisQueryBuilder queryBuilder = new MoreLikeThisQueryBuilder(config);

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -84,6 +84,9 @@ import java.util.logging.Level;
  * the query result will be the TreeMap ordered by score, so if the query has a limit, only the first X items will be returned ordered by score desc
  */
 public class LSMTreeFullTextIndex implements Index, IndexInternal {
+  /** Max query terms detailed in an EXPLAIN/PROFILE scoring breakdown (each costs one posting scan); beyond it the output is truncated. */
+  private static final int MAX_EXPLAIN_TERMS = 64;
+
   private final LSMTreeIndex          underlyingIndex;
   private final Analyzer              indexAnalyzer;
   private final Analyzer              queryAnalyzer;
@@ -475,10 +478,16 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
       json.put("bucket", bucket.getName());
     json.put("note", "statistics are per bucket (BM25 is scored per bucket); totalDocs is this bucket's document count");
 
-    // One posting scan per scoring token to derive df. EXPLAIN/PROFILE is an interactive diagnostic, not a hot path, so this is
-    // acceptable; for a very large index expect the explain to scan each term's postings once.
+    // One posting scan per scoring token to derive df. EXPLAIN/PROFILE is an interactive diagnostic, not a hot path, but cap the
+    // number of explained terms so a pathological wildcard/fuzzy expansion (which can explode into thousands of tokens) cannot
+    // turn an EXPLAIN into a very long scan; beyond the cap the explain reports "termsTruncated": true.
     final JSONArray terms = new JSONArray();
+    int explained = 0;
     for (final Map.Entry<String, Float> e : tokenBoosts.entrySet()) {
+      if (explained++ >= MAX_EXPLAIN_TERMS) {
+        json.put("termsTruncated", true);
+        break;
+      }
       final IndexCursor postings = underlyingIndex.get(new String[] { e.getKey() });
       long df = 0;
       while (postings.hasNext()) {
@@ -544,9 +553,11 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     if (ftMetadata == null)
       return;
     if (!ftMetadata.isCountersValid()) {
-      // Cold counters (pre-feature/unsaved index): rebuild so the caller scores with valid statistics. Serialize on the shared
-      // metadata with a double-check so concurrent first-queries (across the type's bucket indexes, which share this metadata) do
-      // not all run a full type scan: the first thread rebuilds and marks the counters valid; the rest observe that and skip.
+      // Cold counters (pre-feature/unsaved index): rebuild so the caller scores with valid statistics. This is the ONLY place
+      // that needs a lock - the counters themselves are AtomicLong (lock-free reads/updates everywhere else); the synchronized
+      // block exists solely so concurrent first-queries (across the type's bucket indexes, which share this metadata) do not all
+      // run the full type scan at once. Double-checked: the first thread rebuilds and marks the counters valid; the rest observe
+      // that inside the lock and skip.
       synchronized (ftMetadata) {
         if (!ftMetadata.isCountersValid())
           computeCorpusCounters(false);
@@ -565,8 +576,13 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
         // NOT spuriously rescan multi-bucket types. (This counter feeds avgdl only; IDF's N is the per-bucket count from
         // resolveTotalDocs(), a deliberately different scope - see that method.)
         final long liveCount = underlyingIndex.getMutableIndex().getDatabase().countType(typeName, false);
-        if (liveCount != ftMetadata.getTotalDocs())
+        if (liveCount != ftMetadata.getTotalDocs()) {
+          // Surface the drift so operators can notice it (e.g. counters inflated by rolled-back inserts) without reading EXPLAIN.
+          LogManager.instance().log(this, Level.INFO,
+              "BM25 corpus counters for type '%s' diverged from live data (persisted=%d, live=%d); recomputing.", null, typeName,
+              ftMetadata.getTotalDocs(), liveCount);
           computeCorpusCounters(false);
+        }
       }
     }
   }

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -262,17 +262,18 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    * @param tokenBoosts scoring tokens (stored-key form) mapped to their effective boost
    * @param candidates  documents to score, or {@code null} to score every matching document
    */
-  private Map<RID, Float> computeBM25Scores(final Map<String, Float> tokenBoosts, final Set<RID> candidates) {
+  private Map<RID, Double> computeBM25Scores(final Map<String, Float> tokenBoosts, final Set<RID> candidates) {
     ensureCounters();
     final long totalDocs = resolveTotalDocs();
     final double avgdl = resolveAvgDocLength();
     final double k1 = ftMetadata.getBm25K1();
     final double b = ftMetadata.getBm25B();
 
-    final Map<RID, Float> scoreMap = candidates != null ? new HashMap<>(candidates.size()) : new HashMap<>();
+    // Accumulate in double to avoid per-term precision loss; the score is narrowed to float only when the cursor entry is built.
+    final Map<RID, Double> scoreMap = candidates != null ? new HashMap<>(candidates.size()) : new HashMap<>();
     if (candidates != null)
       for (final RID c : candidates)
-        scoreMap.put(c, 0.0f);
+        scoreMap.put(c, 0.0);
 
     for (final Map.Entry<String, Float> e : tokenBoosts.entrySet()) {
       final String[] storedKey = new String[] { e.getKey() };
@@ -293,7 +294,7 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
           continue;
         final double idf = BM25Scorer.idf(totalDocs, df);
         for (final FullTextPostingRID s : hits)
-          scoreMap.merge(s.getIdentity(), (float) (BM25Scorer.termScore(idf, s.tf, s.docLength, avgdl, k1, b) * boost), Float::sum);
+          scoreMap.merge(s.getIdentity(), BM25Scorer.termScore(idf, s.tf, s.docLength, avgdl, k1, b) * boost, Double::sum);
       } else {
         // No candidate filter: count df first (streaming, no retention), then accumulate every matching document.
         long df = 0L;
@@ -309,8 +310,7 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
         while (scoreCursor.hasNext()) {
           final Identifiable id = scoreCursor.next();
           if (id instanceof FullTextPostingRID s)
-            scoreMap.merge(s.getIdentity(), (float) (BM25Scorer.termScore(idf, s.tf, s.docLength, avgdl, k1, b) * boost),
-                Float::sum);
+            scoreMap.merge(s.getIdentity(), BM25Scorer.termScore(idf, s.tf, s.docLength, avgdl, k1, b) * boost, Double::sum);
         }
       }
     }
@@ -336,10 +336,10 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
       }
     }
 
-    final Map<RID, Float> scoreMap = computeBM25Scores(tokenBoosts, null);
+    final Map<RID, Double> scoreMap = computeBM25Scores(tokenBoosts, null);
 
     final ArrayList<IndexCursorEntry> list = new ArrayList<>(scoreMap.size());
-    for (final Map.Entry<RID, Float> entry : scoreMap.entrySet())
+    for (final Map.Entry<RID, Double> entry : scoreMap.entrySet())
       list.add(new IndexCursorEntry(keys, entry.getKey(), entry.getValue().floatValue()));
 
     if (list.size() > 1)
@@ -371,10 +371,10 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    */
   public IndexCursor scoreCandidatesBM25(final Set<RID> candidates, final Map<String, Float> tokenBoosts, final Object[] keys,
       final int limit) {
-    final Map<RID, Float> scoreMap = computeBM25Scores(tokenBoosts, candidates);
+    final Map<RID, Double> scoreMap = computeBM25Scores(tokenBoosts, candidates);
 
     final ArrayList<IndexCursorEntry> list = new ArrayList<>(scoreMap.size());
-    for (final Map.Entry<RID, Float> entry : scoreMap.entrySet())
+    for (final Map.Entry<RID, Double> entry : scoreMap.entrySet())
       list.add(new IndexCursorEntry(keys, entry.getKey(), entry.getValue().floatValue()));
 
     list.sort((o1, o2) -> {
@@ -413,7 +413,10 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     json.put("totalDocs", totalDocs);
     json.put("avgDocLength", avgdl);
     // BM25 is scored per bucket (per-shard): these statistics are this bucket's, so a multi-bucket type's other buckets may have
-    // different df/IDF. Made explicit so the explained IDF is not mistaken for a global value.
+    // different df/IDF. Report the bucket and make the per-bucket nature explicit so the explained IDF is not mistaken for global.
+    final Bucket bucket = associatedBucket();
+    if (bucket != null)
+      json.put("bucket", bucket.getName());
     json.put("note", "statistics are per bucket (BM25 is scored per bucket); totalDocs is this bucket's document count");
 
     // One posting scan per scoring token to derive df. EXPLAIN/PROFILE is an interactive diagnostic, not a hot path, so this is
@@ -480,9 +483,24 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    * save or an explicit {@link #recomputeBM25Counters()}, so the read/query path never calls {@code saveConfiguration}.
    */
   private void ensureCounters() {
-    if (ftMetadata == null || ftMetadata.isCountersValid())
+    if (ftMetadata == null)
       return;
-    computeCorpusCounters(false);
+    if (!ftMetadata.isCountersValid()) {
+      computeCorpusCounters(false);
+      return;
+    }
+    // Persisted counters can lag the on-disk data (documents indexed after the last schema save). Once per session, validate them
+    // with a cheap live document count and rebuild only if they actually disagree - so a clean restart with fresh counters pays
+    // nothing, while a stale one self-heals on the first query.
+    if (!ftMetadata.isStaleChecked()) {
+      ftMetadata.markStaleChecked();
+      final String typeName = getTypeName();
+      if (typeName != null) {
+        final long liveCount = underlyingIndex.getMutableIndex().getDatabase().countType(typeName, false);
+        if (liveCount != ftMetadata.getTotalDocs())
+          computeCorpusCounters(false);
+      }
+    }
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
+import com.arcadedb.engine.Bucket;
 import com.arcadedb.engine.ComponentFile;
 import com.arcadedb.engine.PaginatedComponent;
 import com.arcadedb.index.Index;
@@ -408,28 +409,44 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
   }
 
   /**
-   * Returns the number of documents in the collection (N) for IDF, preferring the persisted counter and falling back to a live
-   * count of the type when the counter is unavailable.
+   * BM25 is scored per bucket (per-shard, like Elasticsearch/Lucene): each bucket-level full-text index ranks its own documents
+   * using statistics derived from its own postings. The document frequency comes from this bucket's postings, so N and the
+   * average document length must also be this bucket's, otherwise the IDF would be biased. The per-bucket corpus counters are
+   * maintained incrementally on put/remove; the methods below keep the fallback and recompute paths consistently per-bucket.
+   * <p>
+   * Returns the number of documents in this bucket (N) for IDF: the persisted per-bucket counter, falling back to a live count of
+   * the associated bucket when the counter is unavailable.
    */
   private long resolveTotalDocs() {
     if (ftMetadata != null && ftMetadata.getTotalDocs() > 0)
       return ftMetadata.getTotalDocs();
-    final String typeName = getTypeName();
-    if (typeName != null) {
-      final long count = underlyingIndex.getMutableIndex().getDatabase().countType(typeName, false);
-      if (count > 0)
-        return count;
-    }
-    return 1L;
+    final long count = associatedBucketCount();
+    return count > 0 ? count : 1L;
   }
 
   /**
-   * Returns the average document length across the collection, or 1.0 when no statistics are available.
+   * Returns the average document length in this bucket, or 1.0 when no statistics are available.
    */
   private double resolveAvgDocLength() {
     if (ftMetadata != null && ftMetadata.getTotalDocs() > 0)
       return ftMetadata.avgDocLength();
     return 1.0;
+  }
+
+  /**
+   * Returns the live record count of the bucket this index is associated with, or 0 when it cannot be resolved.
+   */
+  private long associatedBucketCount() {
+    final Bucket bucket = associatedBucket();
+    return bucket != null ? bucket.count() : 0L;
+  }
+
+  private Bucket associatedBucket() {
+    try {
+      return underlyingIndex.getMutableIndex().getDatabase().getSchema().getBucketById(getAssociatedBucketId());
+    } catch (final Exception e) {
+      return null;
+    }
   }
 
   /**
@@ -441,31 +458,26 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
       return;
     if (ftMetadata.getTotalDocs() > 0)
       return;
-    final String typeName = getTypeName();
-    if (typeName == null)
-      return;
-    final DatabaseInternal db = underlyingIndex.getMutableIndex().getDatabase();
-    if (db.countType(typeName, false) <= 0)
-      return; // empty type: the (0,0) counters are correct
+    if (associatedBucketCount() <= 0)
+      return; // empty bucket: the (0,0) counters are correct
     recomputeBM25Counters();
   }
 
   /**
-   * Rescans the indexed type and rebuilds the BM25 corpus counters (document count and total document length), then persists
-   * them. Use it after a bulk import or to repair drifted counters.
+   * Rescans this bucket and rebuilds the per-bucket BM25 corpus counters (document count and total document length), then
+   * persists them. Use it after a bulk import or to repair drifted counters.
    */
   public void recomputeBM25Counters() {
     if (ftMetadata == null)
       return;
-    final DatabaseInternal db = underlyingIndex.getMutableIndex().getDatabase();
-    final String typeName = getTypeName();
-    if (typeName == null)
+    final Bucket bucket = associatedBucket();
+    if (bucket == null)
       return;
 
     final List<String> props = getPropertyNames();
     long docs = 0L;
     long sumLen = 0L;
-    final Iterator<com.arcadedb.database.Record> it = db.iterateType(typeName, true);
+    final Iterator<com.arcadedb.database.Record> it = bucket.iterator();
     while (it.hasNext()) {
       final com.arcadedb.database.Record record = it.next();
       if (!(record instanceof Document doc))
@@ -481,7 +493,7 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     }
 
     ftMetadata.setCounters(docs, sumLen);
-    db.getSchema().getEmbedded().saveConfiguration();
+    underlyingIndex.getMutableIndex().getDatabase().getSchema().getEmbedded().saveConfiguration();
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -324,14 +324,12 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
 
     // Reused across tokens to avoid per-token allocations (candidate path only).
     final List<FullTextPostingRID> hits = new ArrayList<>();
-    // Single-element lookup key reused across tokens to avoid a short-lived array allocation per query term. SAFE ONLY because
-    // underlyingIndex.get() consumes the array synchronously (fully iterating each cursor before the next iteration reassigns
-    // storedKey[0]). If a future async/lazy read path ever retained the array beyond the call, this reuse would corrupt scoring
-    // and must be revisited (allocate per token instead).
-    final String[] storedKey = new String[1];
 
     for (final Map.Entry<String, Float> e : tokenBoosts.entrySet()) {
-      storedKey[0] = e.getKey();
+      // Fresh single-element lookup key per token: it is handed to underlyingIndex.get(), and allocating it here (rather than
+      // reusing one array) keeps this correct even if that lookup ever became lazy/async and retained the array - the few small
+      // arrays per query are negligible GC.
+      final String[] storedKey = new String[] { e.getKey() };
       final float boost = e.getValue();
 
       if (candidates != null) {
@@ -983,7 +981,10 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
       }
     }
 
-    // Keep the BM25 corpus counters in sync when a document is removed. docLen is recomputed from the keys supplied at remove
+    // Keep the BM25 corpus counters in sync when a document is removed. remove() carries a SINGLE rid (one document), so exactly
+    // one removeDocument() call balances the single addDocument() that put() made for that document - the indexing convention is
+    // one rid per document. (put() loops addDocument() over its rid array; were remove() ever called with N documents sharing a
+    // key it would need the same N decrements, but no caller does that.) docLen is recomputed from the keys supplied at remove
     // time: if a field is null now but was set at index time (or the analyzer changed), this under-decrements sumDocLength and
     // avgDocLength drifts. Since avgDocLength is only a length normalizer this is tolerable; recomputeBM25Counters() repairs it.
     if (underlyingIndex.isStoreTermFrequency() && ftMetadata != null)

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -263,8 +263,11 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    * accumulate) to avoid materializing the whole posting list. Either way memory is bounded by the result/candidate set, not by
    * the (possibly huge) posting list of a common term.
    * <p>
-   * TODO: the first pass exists only to derive the document frequency; if the LSM layer exposed a per-key entry count (the
-   * compacted index already keeps page-level counts in its root) it could be obtained without scanning the postings.
+   * TODO(perf): on the no-candidate path each token's posting list is scanned TWICE (count df, then accumulate), so a query
+   * with T terms over a large index does 2*T full posting scans - the main BM25 hot-path cost vs CLASSIC. The first pass exists
+   * only to derive the document frequency; if the LSM layer exposed a per-key entry count (the compacted index already keeps
+   * page-level counts in its root) df could be obtained without scanning, halving the I/O. The candidate path (the SQL
+   * {@code SEARCH_INDEX} entry point) already scans once; prefer it for large unconstrained queries until this is addressed.
    *
    * @param tokenBoosts scoring tokens (stored-key form) mapped to their effective boost
    * @param candidates  documents to score, or {@code null} to score every matching document
@@ -734,6 +737,11 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
       final List<String> propertyNames = getPropertyNames();
 
       // PASS 1: analyze every field, accumulate document length and per-field + global term frequencies.
+      // Design choice: the unprefixed (field-agnostic) posting carries the GLOBAL tf - the term's total occurrences across all
+      // indexed fields of the document - while each field-prefixed posting carries that field's tf. So an unqualified query
+      // (`java`) treats a term appearing in both title and body as tf=2, whereas a field-qualified query (`title:java`) sees
+      // tf=1. This differs from Lucene's per-field independence and means cross-field repetition boosts unqualified relevance;
+      // it is intentional ("how often does the term occur anywhere in the document").
       final Map<String, Integer> globalTf = new HashMap<>();
       final List<String> fieldNames = new ArrayList<>();
       final List<Map<String, Integer>> fieldTfs = new ArrayList<>();

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -246,11 +246,16 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
 
   /**
    * Shared BM25 scoring core used by both the direct ({@link #get}) and the Lucene-syntax ({@link FullTextQueryExecutor}) paths,
-   * so the formula, parameters and corpus statistics can never diverge between them. For each scoring token it derives the
-   * document frequency in a first streaming pass (counting only, never materializing the posting list) and accumulates the BM25
-   * contribution in a second pass. When {@code candidates} is non-null only those documents are scored (the map is pre-seeded
-   * with them); otherwise every matching document is scored. Memory is therefore bounded by the result/candidate set, not by the
-   * (possibly huge) posting list of a common term.
+   * so the formula, parameters and corpus statistics can never diverge between them.
+   * <p>
+   * When {@code candidates} is non-null only those documents are scored: a single streaming pass counts the document frequency
+   * and collects just the candidate postings (bounded by the candidate set), then the BM25 contribution is applied once the IDF
+   * is known. When {@code candidates} is null every matching document is scored, which needs two passes (count df, then
+   * accumulate) to avoid materializing the whole posting list. Either way memory is bounded by the result/candidate set, not by
+   * the (possibly huge) posting list of a common term.
+   * <p>
+   * TODO: the first pass exists only to derive the document frequency; if the LSM layer exposed a per-key entry count (the
+   * compacted index already keeps page-level counts in its root) it could be obtained without scanning the postings.
    *
    * @param tokenBoosts scoring tokens (stored-key form) mapped to their effective boost
    * @param candidates  documents to score, or {@code null} to score every matching document
@@ -271,27 +276,40 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
       final String[] storedKey = new String[] { e.getKey() };
       final float boost = e.getValue();
 
-      // Pass 1: document frequency - stream-count the postings without retaining them.
-      long df = 0L;
-      final IndexCursor dfCursor = underlyingIndex.get(storedKey);
-      while (dfCursor.hasNext()) {
-        dfCursor.next();
-        ++df;
-      }
-      if (df == 0L)
-        continue;
-      final double idf = BM25Scorer.idf(totalDocs, df);
-
-      // Pass 2: accumulate contributions, scoring only candidates when a candidate set was given.
-      final IndexCursor scoreCursor = underlyingIndex.get(storedKey);
-      while (scoreCursor.hasNext()) {
-        final Identifiable id = scoreCursor.next();
-        if (!(id instanceof FullTextPostingRID s))
+      if (candidates != null) {
+        // Single pass: count df while collecting only the candidate postings (bounded by the candidate set).
+        long df = 0L;
+        final List<FullTextPostingRID> hits = new ArrayList<>();
+        final IndexCursor cursor = underlyingIndex.get(storedKey);
+        while (cursor.hasNext()) {
+          final Identifiable id = cursor.next();
+          ++df;
+          if (id instanceof FullTextPostingRID s && scoreMap.containsKey(s.getIdentity()))
+            hits.add(s);
+        }
+        if (df == 0L)
           continue;
-        final RID rid = s.getIdentity();
-        if (candidates != null && !scoreMap.containsKey(rid))
+        final double idf = BM25Scorer.idf(totalDocs, df);
+        for (final FullTextPostingRID s : hits)
+          scoreMap.merge(s.getIdentity(), (float) (BM25Scorer.termScore(idf, s.tf, s.docLength, avgdl, k1, b) * boost), Float::sum);
+      } else {
+        // No candidate filter: count df first (streaming, no retention), then accumulate every matching document.
+        long df = 0L;
+        final IndexCursor dfCursor = underlyingIndex.get(storedKey);
+        while (dfCursor.hasNext()) {
+          dfCursor.next();
+          ++df;
+        }
+        if (df == 0L)
           continue;
-        scoreMap.merge(rid, (float) (BM25Scorer.termScore(idf, s.tf, s.docLength, avgdl, k1, b) * boost), Float::sum);
+        final double idf = BM25Scorer.idf(totalDocs, df);
+        final IndexCursor scoreCursor = underlyingIndex.get(storedKey);
+        while (scoreCursor.hasNext()) {
+          final Identifiable id = scoreCursor.next();
+          if (id instanceof FullTextPostingRID s)
+            scoreMap.merge(s.getIdentity(), (float) (BM25Scorer.termScore(idf, s.tf, s.docLength, avgdl, k1, b) * boost),
+                Float::sum);
+        }
       }
     }
     return scoreMap;
@@ -392,6 +410,9 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     json.put("b", ftMetadata.getBm25B());
     json.put("totalDocs", totalDocs);
     json.put("avgDocLength", avgdl);
+    // BM25 is scored per bucket (per-shard): these statistics are this bucket's, so a multi-bucket type's other buckets may have
+    // different df/IDF. Made explicit so the explained IDF is not mistaken for a global value.
+    json.put("note", "statistics are per bucket (BM25 is scored per bucket); totalDocs is this bucket's document count");
 
     final JSONArray terms = new JSONArray();
     for (final Map.Entry<String, Float> e : tokenBoosts.entrySet()) {
@@ -667,7 +688,9 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
   }
 
   /**
-   * Updates the persisted corpus counters when a document is indexed.
+   * Updates the persisted corpus counters when a document is indexed. {@code numDocs} is {@code rids.length}: the standard
+   * indexing path passes exactly one RID per document (one document being indexed), so each RID is counted as a distinct
+   * document of length {@code docLen}.
    */
   private void countDocuments(final int numDocs, final int docLen) {
     if (ftMetadata != null)

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -400,6 +400,13 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
       }
     }
 
+    // The no-candidate path streams each token's postings twice (df + accumulate). Log at FINE for a multi-term query so an
+    // operator debugging a slow direct get() can see it doing 2*T scans and switch to SEARCH_INDEX. FINE keeps normal runs quiet.
+    if (tokenBoosts.size() > 1)
+      LogManager.instance().log(this, Level.FINE,
+          "Full-text get() scoring %d terms on index '%s' with two posting scans each; use SEARCH_INDEX(...) for a single-pass scan.",
+          null, tokenBoosts.size(), getName());
+
     return buildScoredCursor(computeBM25Scores(tokenBoosts, null), keys, limit);
   }
 

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -307,7 +307,7 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
           continue;
         final double idf = BM25Scorer.idf(totalDocs, df);
         for (final FullTextPostingRID s : hits)
-          scoreMap.merge(s.getIdentity(), BM25Scorer.termScore(idf, s.tf, s.docLength, avgdl, k1, b) * boost, Double::sum);
+          scoreMap.merge(s.getIdentity(), BM25Scorer.termScore(idf, s.getTf(), s.getDocLength(), avgdl, k1, b) * boost, Double::sum);
       } else {
         // No candidate filter: count df first (streaming, no retention), then accumulate every matching document.
         long df = 0L;
@@ -323,7 +323,7 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
         while (scoreCursor.hasNext()) {
           final Identifiable id = scoreCursor.next();
           if (id instanceof FullTextPostingRID s)
-            scoreMap.merge(s.getIdentity(), BM25Scorer.termScore(idf, s.tf, s.docLength, avgdl, k1, b) * boost, Double::sum);
+            scoreMap.merge(s.getIdentity(), BM25Scorer.termScore(idf, s.getTf(), s.getDocLength(), avgdl, k1, b) * boost, Double::sum);
         }
       }
     }

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
+import com.arcadedb.database.Record;
 import com.arcadedb.engine.Bucket;
 import com.arcadedb.engine.ComponentFile;
 import com.arcadedb.engine.PaginatedComponent;
@@ -283,6 +284,9 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
       for (final RID c : candidates)
         scoreMap.put(c, 0.0);
 
+    // Reused across tokens to avoid per-token allocations (candidate path only).
+    final List<FullTextPostingRID> hits = new ArrayList<>();
+
     for (final Map.Entry<String, Float> e : tokenBoosts.entrySet()) {
       final String[] storedKey = new String[] { e.getKey() };
       final float boost = e.getValue();
@@ -290,10 +294,13 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
       if (candidates != null) {
         // Single pass: count df while collecting only the candidate postings (bounded by the candidate set).
         long df = 0L;
-        final List<FullTextPostingRID> hits = new ArrayList<>();
+        hits.clear();
         final IndexCursor cursor = underlyingIndex.get(storedKey);
         while (cursor.hasNext()) {
           final Identifiable id = cursor.next();
+          // Skip deletion markers (negative bucket id): they are not live documents and must not inflate the document frequency.
+          if (id.getIdentity().getBucketId() < 0)
+            continue;
           ++df;
           if (id instanceof FullTextPostingRID s && scoreMap.containsKey(s.getIdentity()))
             hits.add(s);
@@ -308,8 +315,8 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
         long df = 0L;
         final IndexCursor dfCursor = underlyingIndex.get(storedKey);
         while (dfCursor.hasNext()) {
-          dfCursor.next();
-          ++df;
+          if (dfCursor.next().getIdentity().getBucketId() >= 0) // skip deletion markers
+            ++df;
         }
         if (df == 0L)
           continue;
@@ -385,12 +392,13 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     for (final Map.Entry<RID, Double> entry : scoreMap.entrySet())
       list.add(new IndexCursorEntry(keys, entry.getKey(), entry.getValue().floatValue()));
 
-    list.sort((o1, o2) -> {
-      final int cmp = Float.compare(o2.floatScore, o1.floatScore);
-      if (cmp != 0)
-        return cmp;
-      return o1.record.getIdentity().compareTo(o2.record.getIdentity());
-    });
+    if (list.size() > 1)
+      list.sort((o1, o2) -> {
+        final int cmp = Float.compare(o2.floatScore, o1.floatScore);
+        if (cmp != 0)
+          return cmp;
+        return o1.record.getIdentity().compareTo(o2.record.getIdentity());
+      });
 
     if (limit > 0 && list.size() > limit)
       return new TempIndexCursor(list.subList(0, limit));
@@ -541,9 +549,9 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     final List<String> props = getPropertyNames();
     long docs = 0L;
     long sumLen = 0L;
-    final Iterator<com.arcadedb.database.Record> it = db.iterateType(typeName, true);
+    final Iterator<Record> it = db.iterateType(typeName, true);
     while (it.hasNext()) {
-      final com.arcadedb.database.Record record = it.next();
+      final Record record = it.next();
       if (!(record instanceof Document doc))
         continue;
       int len = 0;
@@ -800,7 +808,9 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
       }
     }
 
-    // Keep the BM25 corpus counters in sync when a document is removed.
+    // Keep the BM25 corpus counters in sync when a document is removed. docLen is recomputed from the keys supplied at remove
+    // time: if a field is null now but was set at index time (or the analyzer changed), this under-decrements sumDocLength and
+    // avgDocLength drifts. Since avgDocLength is only a length normalizer this is tolerable; recomputeBM25Counters() repairs it.
     if (underlyingIndex.isStoreTermFrequency() && ftMetadata != null)
       ftMetadata.removeDocument(docLen);
   }

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -112,11 +112,8 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
 
       // Reject a property whose name collides with the query parser's reserved default-field sentinel: on a multi-property index
       // such a field could not be distinguished from an unqualified term. Fail fast at creation rather than mis-scoring silently.
-      if (builder.getMetadata() != null && builder.getMetadata().propertyNames != null)
-        for (final String property : builder.getMetadata().propertyNames)
-          if (FullTextQueryExecutor.DEFAULT_FIELD.equals(property))
-            throw new IllegalArgumentException(
-                "Property name '" + property + "' is reserved for full-text indexes; please rename the property");
+      if (builder.getMetadata() != null)
+        checkReservedPropertyNames(builder.getMetadata().propertyNames);
 
       // Get metadata if available. New full-text indexes default to BM25 similarity (issue #4687): when the user did not supply a
       // FullTextIndexMetadata, synthesize one carrying the BM25 defaults so freshly created indexes rank with BM25 out of the box.
@@ -135,6 +132,19 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
   }
 
   /**
+   * Rejects any property whose name equals the query parser's reserved default-field sentinel: on a multi-property index such a
+   * field could not be distinguished from an unqualified term and would mis-score silently. Enforced both at index creation and on
+   * schema reload (a hand-edited/restored schema could otherwise reintroduce the collision).
+   */
+  public static void checkReservedPropertyNames(final List<String> propertyNames) {
+    if (propertyNames != null)
+      for (final String property : propertyNames)
+        if (FullTextQueryExecutor.DEFAULT_FIELD.equals(property))
+          throw new IllegalArgumentException(
+              "Property name '" + property + "' is reserved for full-text indexes; please rename the property");
+  }
+
+  /**
    * Called at load time. The Full Text index is just a wrapper of an LSMTree Index.
    */
   public LSMTreeFullTextIndex(final LSMTreeIndex index) {
@@ -149,8 +159,16 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     this.ftMetadata = metadata;
     this.indexAnalyzer = createAnalyzer(metadata, true);
     this.queryAnalyzer = createAnalyzer(metadata, false);
-    if (metadata != null && metadata.isBM25())
+    if (metadata != null && metadata.isBM25()) {
       index.setStoreTermFrequency(true);
+      // Warn at open time (not only when the first query triggers it) so operators can pre-warm before serving traffic: a BM25
+      // index whose persisted counters are not trustworthy will do a full type scan (under a short lock) on its first query.
+      if (!metadata.isCountersValid())
+        LogManager.instance().log(this, Level.WARNING,
+            "BM25 full-text index '%s' opened with no valid corpus counters; the first query will run a full type scan. "
+                + "Pre-warm with REBUILD INDEX <name> WITH statsOnly = true before serving traffic to avoid a first-query stall.",
+            null, index.getName());
+    }
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -560,6 +560,10 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     if (ftMetadata.claimStaleCheck()) {
       final String typeName = getTypeName();
       if (typeName != null) {
+        // Both sides are TYPE-WIDE: getTotalDocs() is the shared counter accumulated across every bucket index (they share this
+        // metadata instance), and countType() is the type's live record count - so this comparison is scope-consistent and does
+        // NOT spuriously rescan multi-bucket types. (This counter feeds avgdl only; IDF's N is the per-bucket count from
+        // resolveTotalDocs(), a deliberately different scope - see that method.)
         final long liveCount = underlyingIndex.getMutableIndex().getDatabase().countType(typeName, false);
         if (liveCount != ftMetadata.getTotalDocs())
           computeCorpusCounters(false);

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -374,6 +374,10 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    * Lucene parser would make {@code label CONTAINSTEXT 'a-b'} or {@code 'foo AND bar'} interpret {@code -}/{@code AND} as
    * operators (wrong); throwing on such characters would reject legitimate literal text. So {@code get()} stays token-based and
    * {@code SEARCH_INDEX} is the deliberate home for Lucene syntax.
+   * <p>
+   * PERFORMANCE: this path scores every matching document with no candidate set, so {@link #computeBM25Scores} streams each
+   * token's posting list twice (count df, then accumulate) - {@code 2*T} posting scans for a {@code T}-term query. The SQL
+   * {@code SEARCH_INDEX} path is single-pass; prefer it for large or many-term queries.
    */
   private IndexCursor getBM25(final Object[] keys, final int limit) {
     final String queryText = keys.length > 0 && keys[0] != null ? keys[0].toString() : "";
@@ -868,7 +872,13 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    * <p>
    * This runs at index time, before the transaction commits, and is NOT reversed on rollback, so a rolled-back insert leaves the
    * counters slightly inflated. The counters feed only {@code avgDocLength} (a robust normalizer); {@link #recomputeBM25Counters}
-   * repairs any drift exactly.
+   * (also reachable via {@code REBUILD INDEX <name> WITH statsOnly = true}) repairs any drift exactly.
+   * <p>
+   * FOLLOW-UP (not done deliberately): the drift could be avoided by deferring this update to an after-commit callback
+   * ({@code TransactionContext.addAfterCommitCallback}) so a rolled-back transaction never bumps the counters. That is left for a
+   * separate change because the counters must stay consistent across an HA cluster: the current update runs inside the index
+   * write that every node replays, whereas an after-commit callback fires only on the committing node and would diverge replica
+   * counters. Reversing on rollback (rather than deferring) would need a rollback hook that does not exist today.
    */
   private void countDocuments(final int numDocs, final int docLen) {
     if (ftMetadata != null)

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -364,9 +364,16 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    * <p>
    * Query syntax here is limited: {@link #parseQueryTerms} only understands whitespace-separated terms and {@code field:value}.
    * It does NOT support the Lucene query syntax - caret boosts ({@code term^3}), boolean operators, phrases, or wildcards - which
-   * the SQL {@code SEARCH_INDEX(...)} entry point handles via the full Lucene parser. A {@code term^3} reaching here is analyzed
-   * as the literal token {@code term^3} (typically stripped to nothing), not as a boosted {@code term}. Use {@code SEARCH_INDEX}
-   * for the full query syntax; this direct path is for simple term lookups.
+   * the SQL {@code SEARCH_INDEX(...)} entry point handles via the full Lucene parser. A {@code term^3} reaching here is passed to
+   * the analyzer as literal text: the StandardAnalyzer tokenizes around the caret into {@code [term, 3]}, so it matches on
+   * {@code term} but the {@code ^3} is silently ignored rather than applied as a boost. Use {@code SEARCH_INDEX} for the full
+   * query syntax; this direct path is for simple term lookups.
+   * <p>
+   * This simple-token semantics is INTENTIONAL, not a deficiency: the direct {@code get()} path also backs the SQL
+   * {@code CONTAINSTEXT} operator, whose argument is literal text to find - not a query language. Routing {@code get()} through the
+   * Lucene parser would make {@code label CONTAINSTEXT 'a-b'} or {@code 'foo AND bar'} interpret {@code -}/{@code AND} as
+   * operators (wrong); throwing on such characters would reject legitimate literal text. So {@code get()} stays token-based and
+   * {@code SEARCH_INDEX} is the deliberate home for Lucene syntax.
    */
   private IndexCursor getBM25(final Object[] keys, final int limit) {
     final String queryText = keys.length > 0 && keys[0] != null ? keys[0].toString() : "";

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -343,8 +343,14 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
   }
 
   /**
-   * BM25 scoring path for the direct index lookup. Builds the scoring tokens from the query and delegates to
+   * BM25 scoring path for the direct {@link #get} lookup. Builds the scoring tokens from the query and delegates to
    * {@link #computeBM25Scores}.
+   * <p>
+   * Query syntax here is limited: {@link #parseQueryTerms} only understands whitespace-separated terms and {@code field:value}.
+   * It does NOT support the Lucene query syntax - caret boosts ({@code term^3}), boolean operators, phrases, or wildcards - which
+   * the SQL {@code SEARCH_INDEX(...)} entry point handles via the full Lucene parser. A {@code term^3} reaching here is analyzed
+   * as the literal token {@code term^3} (typically stripped to nothing), not as a boosted {@code term}. Use {@code SEARCH_INDEX}
+   * for the full query syntax; this direct path is for simple term lookups.
    */
   private IndexCursor getBM25(final Object[] keys, final int limit) {
     final String queryText = keys.length > 0 && keys[0] != null ? keys[0].toString() : "";

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -115,6 +115,14 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
             base.associatedBucketId);
       }
 
+      // The query parser's default (unqualified) field is "content"; on a multi-property index a boost configured for a field
+      // literally named "content" cannot be distinguished from an unqualified term and is silently ignored. Warn at creation.
+      if (ftMetadata.propertyNames != null && ftMetadata.propertyNames.size() > 1
+          && ftMetadata.getFieldBoosts().containsKey("content"))
+        LogManager.instance().log(LSMTreeFullTextIndex.class, Level.WARNING,
+            "Full-text index '%s' configures a boost for the field 'content', which collides with the query parser's default "
+                + "field name on a multi-property index; that boost will not be applied", builder.getIndexName());
+
       return new LSMTreeFullTextIndex(builder.getDatabase(), builder.getIndexName(), builder.getFilePath(),
           ComponentFile.MODE.READ_WRITE, builder.getPageSize(), builder.getNullStrategy(), ftMetadata);
     }
@@ -486,14 +494,15 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     if (ftMetadata == null)
       return;
     if (!ftMetadata.isCountersValid()) {
+      // Cold counters (pre-feature/unsaved index): rebuild unconditionally so the caller scores with valid statistics.
       computeCorpusCounters(false);
       return;
     }
     // Persisted counters can lag the on-disk data (documents indexed after the last schema save). Once per session, validate them
     // with a cheap live document count and rebuild only if they actually disagree - so a clean restart with fresh counters pays
-    // nothing, while a stale one self-heals on the first query.
-    if (!ftMetadata.isStaleChecked()) {
-      ftMetadata.markStaleChecked();
+    // nothing, while a stale one self-heals on the first query. The CAS ensures only one thread runs this even though the
+    // metadata is shared across the type's bucket indexes.
+    if (ftMetadata.claimStaleCheck()) {
       final String typeName = getTypeName();
       if (typeName != null) {
         final long liveCount = underlyingIndex.getMutableIndex().getDatabase().countType(typeName, false);

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -36,6 +36,7 @@ import com.arcadedb.index.TypeIndex;
 import com.arcadedb.index.lsm.LSMTreeIndex;
 import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
 import com.arcadedb.index.lsm.FullTextPostingRID;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.FullTextIndexMetadata;
 import com.arcadedb.schema.IndexBuilder;
 import com.arcadedb.schema.IndexMetadata;
@@ -58,6 +59,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
 
 /**
  * Full Text index implementation based on LSM-Tree index.
@@ -414,6 +416,8 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     // different df/IDF. Made explicit so the explained IDF is not mistaken for a global value.
     json.put("note", "statistics are per bucket (BM25 is scored per bucket); totalDocs is this bucket's document count");
 
+    // One posting scan per scoring token to derive df. EXPLAIN/PROFILE is an interactive diagnostic, not a hot path, so this is
+    // acceptable; for a very large index expect the explain to scan each term's postings once.
     final JSONArray terms = new JSONArray();
     for (final Map.Entry<String, Float> e : tokenBoosts.entrySet()) {
       final IndexCursor postings = underlyingIndex.get(new String[] { e.getKey() });
@@ -462,6 +466,9 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     try {
       return underlyingIndex.getMutableIndex().getDatabase().getSchema().getBucketById(getAssociatedBucketId());
     } catch (final Exception e) {
+      // Should not happen for a bucket-level index; surface it (IDF then falls back to N=1) instead of failing silently.
+      LogManager.instance().log(this, Level.WARNING, "Cannot resolve bucket %d for full-text index '%s'; BM25 will use N=1",
+          e, getAssociatedBucketId(), getName());
       return null;
     }
   }
@@ -499,6 +506,10 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     final String typeName = getTypeName();
     if (typeName == null)
       return;
+
+    // Cold-start scan: only reached when the counters are not trustworthy (unsaved/pre-feature index). Logged because on a large
+    // collection the first BM25 query that triggers it can be slow.
+    LogManager.instance().log(this, Level.INFO, "Recomputing BM25 corpus statistics for type '%s' (full scan)", null, typeName);
 
     final List<String> props = getPropertyNames();
     long docs = 0L;
@@ -691,6 +702,10 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    * Updates the persisted corpus counters when a document is indexed. {@code numDocs} is {@code rids.length}: the standard
    * indexing path passes exactly one RID per document (one document being indexed), so each RID is counted as a distinct
    * document of length {@code docLen}.
+   * <p>
+   * This runs at index time, before the transaction commits, and is NOT reversed on rollback, so a rolled-back insert leaves the
+   * counters slightly inflated. The counters feed only {@code avgDocLength} (a robust normalizer); {@link #recomputeBM25Counters}
+   * repairs any drift exactly.
    */
   private void countDocuments(final int numDocs, final int docLen) {
     if (ftMetadata != null)

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -110,6 +110,14 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
               "Full text index can only be defined on STRING properties, found: " + keyType);
       }
 
+      // Reject a property whose name collides with the query parser's reserved default-field sentinel: on a multi-property index
+      // such a field could not be distinguished from an unqualified term. Fail fast at creation rather than mis-scoring silently.
+      if (builder.getMetadata() != null && builder.getMetadata().propertyNames != null)
+        for (final String property : builder.getMetadata().propertyNames)
+          if (FullTextQueryExecutor.DEFAULT_FIELD.equals(property))
+            throw new IllegalArgumentException(
+                "Property name '" + property + "' is reserved for full-text indexes; please rename the property");
+
       // Get metadata if available. New full-text indexes default to BM25 similarity (issue #4687): when the user did not supply a
       // FullTextIndexMetadata, synthesize one carrying the BM25 defaults so freshly created indexes rank with BM25 out of the box.
       final FullTextIndexMetadata ftMetadata;
@@ -265,14 +273,17 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    * When {@code candidates} is non-null only those documents are scored: a single streaming pass counts the document frequency
    * and collects just the candidate postings (bounded by the candidate set), then the BM25 contribution is applied once the IDF
    * is known. When {@code candidates} is null every matching document is scored, which needs two passes (count df, then
-   * accumulate) to avoid materializing the whole posting list. Either way memory is bounded by the result/candidate set, not by
-   * the (possibly huge) posting list of a common term.
+   * accumulate) to avoid materializing the whole posting list.
    * <p>
-   * TODO(perf): on the no-candidate path each token's posting list is scanned TWICE (count df, then accumulate), so a query
-   * with T terms over a large index does 2*T full posting scans - the main BM25 hot-path cost vs CLASSIC. The first pass exists
-   * only to derive the document frequency; if the LSM layer exposed a per-key entry count (the compacted index already keeps
-   * page-level counts in its root) df could be obtained without scanning, halving the I/O. The candidate path (the SQL
-   * {@code SEARCH_INDEX} entry point) already scans once; prefer it for large unconstrained queries until this is addressed.
+   * DESIGN (deliberate, not a TODO): the no-candidate path streams each token's posting list twice (count df, then accumulate)
+   * rather than materializing it once and deriving df from the list. This is a memory-vs-I/O trade-off resolved in favour of
+   * bounded peak memory, per the project's low-GC priority: a single-pass-materialize would hold one common term's entire posting
+   * list (df {@link FullTextPostingRID} objects) <i>simultaneously</i> with the growing score map - roughly doubling peak memory
+   * for a high-frequency term - whereas the streaming df pass keeps only the score map live. The cost is 2*T posting scans for a
+   * T-term query. This path is the direct {@code index.get(query)} API only; the primary SQL {@code SEARCH_INDEX} entry point is
+   * candidate-based and already single-pass, so prefer it for large unconstrained queries. The clean way to get single-pass
+   * <i>without</i> the memory hit is a per-key entry count at the LSM layer (the compacted index already keeps page-level counts
+   * in its root); that is a larger storage-layer change tracked separately.
    *
    * @param tokenBoosts scoring tokens (stored-key form) mapped to their effective boost
    * @param candidates  documents to score, or {@code null} to score every matching document

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -521,10 +521,14 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     final JSONArray terms = new JSONArray();
     int explained = 0;
     for (final Map.Entry<String, Float> e : tokenBoosts.entrySet()) {
-      if (explained++ >= MAX_EXPLAIN_TERMS) {
+      if (explained >= MAX_EXPLAIN_TERMS) {
+        // Report both the flag and how many terms were omitted so a user debugging a complex query knows the breakdown is partial.
         json.put("termsTruncated", true);
+        json.put("termsOmitted", tokenBoosts.size() - MAX_EXPLAIN_TERMS);
+        json.put("termsShown", MAX_EXPLAIN_TERMS);
         break;
       }
+      explained++;
       final IndexCursor postings = underlyingIndex.get(new String[] { e.getKey() });
       long df = 0;
       while (postings.hasNext()) {

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -357,6 +357,12 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    */
   private IndexCursor getBM25(final Object[] keys, final int limit) {
     final String queryText = keys.length > 0 && keys[0] != null ? keys[0].toString() : "";
+    // The direct path does not parse Lucene syntax; a caret boost here is silently treated as part of the token and matches
+    // nothing. Log at FINE so this surfaces when debugging an unexpected empty result, without spamming normal queries.
+    if (queryText.indexOf('^') >= 0)
+      LogManager.instance().log(this, Level.FINE,
+          "Full-text get() query '%s' contains a caret; the direct lookup path does not support Lucene syntax (caret/boolean/"
+              + "phrase/wildcard) - use SEARCH_INDEX(...) for that.", null, queryText);
     final List<QueryTerm> queryTerms = parseQueryTerms(queryText);
 
     // Build the scoring tokens (stored-key form) with their field boost, then delegate to the shared scorer. No candidate set:

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -306,8 +306,10 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
 
     // Reused across tokens to avoid per-token allocations (candidate path only).
     final List<FullTextPostingRID> hits = new ArrayList<>();
-    // Single-element lookup key reused across tokens (each underlyingIndex.get() consumes it synchronously before the next
-    // iteration reassigns it) to avoid a short-lived array allocation per query term.
+    // Single-element lookup key reused across tokens to avoid a short-lived array allocation per query term. SAFE ONLY because
+    // underlyingIndex.get() consumes the array synchronously (fully iterating each cursor before the next iteration reassigns
+    // storedKey[0]). If a future async/lazy read path ever retained the array beyond the call, this reuse would corrupt scoring
+    // and must be revisited (allocate per token instead).
     final String[] storedKey = new String[1];
 
     for (final Map.Entry<String, Float> e : tokenBoosts.entrySet()) {

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -112,7 +112,7 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
         ftMetadata = m;
       else {
         final IndexMetadata base = builder.getMetadata();
-        ftMetadata = new FullTextIndexMetadata(base.typeName, base.propertyNames.toArray(new String[0]),
+        ftMetadata = FullTextIndexMetadata.defaultBM25(base.typeName, base.propertyNames.toArray(new String[0]),
             base.associatedBucketId);
       }
 
@@ -355,8 +355,15 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     for (final Map.Entry<RID, Double> entry : scoreMap.entrySet())
       list.add(new IndexCursorEntry(keys, entry.getKey(), entry.getValue().floatValue()));
 
+    // Most-relevant first, with RID as a stable tiebreaker so equal-scored documents have a deterministic order (consistent with
+    // scoreCandidatesBM25 and the CLASSIC path).
     if (list.size() > 1)
-      list.sort((o1, o2) -> Float.compare(o2.floatScore, o1.floatScore));
+      list.sort((o1, o2) -> {
+        final int cmp = Float.compare(o2.floatScore, o1.floatScore);
+        if (cmp != 0)
+          return cmp;
+        return o1.record.getIdentity().compareTo(o2.record.getIdentity());
+      });
 
     if (limit > -1 && list.size() > limit)
       return new TempIndexCursor(list.subList(0, limit));
@@ -510,8 +517,13 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     if (ftMetadata == null)
       return;
     if (!ftMetadata.isCountersValid()) {
-      // Cold counters (pre-feature/unsaved index): rebuild unconditionally so the caller scores with valid statistics.
-      computeCorpusCounters(false);
+      // Cold counters (pre-feature/unsaved index): rebuild so the caller scores with valid statistics. Serialize on the shared
+      // metadata with a double-check so concurrent first-queries (across the type's bucket indexes, which share this metadata) do
+      // not all run a full type scan: the first thread rebuilds and marks the counters valid; the rest observe that and skip.
+      synchronized (ftMetadata) {
+        if (!ftMetadata.isCountersValid())
+          computeCorpusCounters(false);
+      }
       return;
     }
     // Persisted counters can lag the on-disk data (documents indexed after the last schema save). Once per session, validate them

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -500,7 +500,8 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
   }
 
   /**
-   * Returns the (type-wide) average document length used as the BM25 length normalizer, or 1.0 when no statistics are available.
+   * Returns the (type-wide) average document length used as the BM25 length normalizer, or 1.0 when no statistics are available
+   * or the corpus is empty (no documents means no meaningful average; 1.0 makes the length-normalization term a no-op).
    */
   private double resolveAvgDocLength() {
     if (ftMetadata != null && ftMetadata.getTotalDocs() > 0)
@@ -739,16 +740,24 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
       final List<String> keywords = analyzeText(indexAnalyzer, keys);
       final Map<String, Integer> tfs = new HashMap<>();
       int docLen = 0;
+      boolean hasNull = false;
       for (final String k : keywords) {
-        // Keep null tokens in the term-frequency map so they still flow to the underlying put and the configured NULL_STRATEGY is
-        // enforced, but exclude them from the document length (a null value has no length).
+        // A null token (null indexed value) carries no meaningful tf/docLength: keep it out of the stats so it never becomes a
+        // FullTextPostingRID with a bogus tf, but remember it so it can still be put as a plain posting below (letting the
+        // configured NULL_STRATEGY decide whether to skip, error, or index it).
+        if (k == null) {
+          hasNull = true;
+          continue;
+        }
         tfs.merge(k, 1, Integer::sum);
-        if (k != null)
-          ++docLen;
+        ++docLen;
       }
       final int len = docLen;
       for (final Map.Entry<String, Integer> e : tfs.entrySet())
         underlyingIndex.put(new String[] { e.getKey() }, withStats(db, rids, e.getValue(), len));
+      if (hasNull)
+        // Plain RID (no stats): if NULL_STRATEGY indexes it, the posting carries tf=0/docLength=0 rather than a stale tf.
+        underlyingIndex.put(new String[] { null }, rids);
       countDocuments(rids.length, docLen);
     } else {
       final List<String> propertyNames = getPropertyNames();

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -245,12 +245,18 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     for (final Map.Entry<RID, AtomicInteger> entry : scoreMap.entrySet())
       list.add(new IndexCursorEntry(keys, entry.getKey(), entry.getValue().get()));
 
+    // Most-relevant first (descending coordination score), RID as a stable tiebreaker so the order is deterministic. Matches the
+    // BM25 path; the previous ascending sort returned the least-relevant documents first.
     if (list.size() > 1)
       list.sort((o1, o2) -> {
-        if (o1.score == o2.score)
-          return 0;
-        return o1.score < o2.score ? -1 : 1;
+        final int cmp = Integer.compare(o2.score, o1.score);
+        if (cmp != 0)
+          return cmp;
+        return o1.record.getIdentity().compareTo(o2.record.getIdentity());
       });
+
+    if (limit > -1 && list.size() > limit)
+      return new TempIndexCursor(list.subList(0, limit));
 
     return new TempIndexCursor(list);
   }
@@ -400,9 +406,18 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
         return o1.record.getIdentity().compareTo(o2.record.getIdentity());
       });
 
-    if (limit > 0 && list.size() > limit)
+    if (limit > -1 && list.size() > limit)
       return new TempIndexCursor(list.subList(0, limit));
     return new TempIndexCursor(list);
+  }
+
+  /**
+   * Returns the raw postings for an already-resolved stored key (RID-only, no BM25 scoring and no re-analysis), used by
+   * {@link FullTextQueryExecutor} to collect candidate documents cheaply before scoring them once via
+   * {@link #scoreCandidatesBM25}. Going through {@link #get} here would run the full scoring pipeline only to discard the scores.
+   */
+  public IndexCursor getPostings(final String storedKey) {
+    return underlyingIndex.get(new String[] { storedKey });
   }
 
   /**
@@ -442,8 +457,9 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
       final IndexCursor postings = underlyingIndex.get(new String[] { e.getKey() });
       long df = 0;
       while (postings.hasNext()) {
-        postings.next();
-        ++df;
+        // Skip deletion markers (negative bucket id) so the explained df/idf matches what computeBM25Scores actually uses.
+        if (postings.next().getIdentity().getBucketId() >= 0)
+          ++df;
       }
       terms.put(new JSONObject().put("term", e.getKey()).put("df", df).put("idf", BM25Scorer.idf(totalDocs, df))
           .put("boost", e.getValue()));
@@ -681,12 +697,18 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
 
     if (getPropertyCount() == 1) {
       final List<String> keywords = analyzeText(indexAnalyzer, keys);
-      final int docLen = keywords.size();
       final Map<String, Integer> tfs = new HashMap<>();
-      for (final String k : keywords)
+      int docLen = 0;
+      for (final String k : keywords) {
+        // Keep null tokens in the term-frequency map so they still flow to the underlying put and the configured NULL_STRATEGY is
+        // enforced, but exclude them from the document length (a null value has no length).
         tfs.merge(k, 1, Integer::sum);
+        if (k != null)
+          ++docLen;
+      }
+      final int len = docLen;
       for (final Map.Entry<String, Integer> e : tfs.entrySet())
-        underlyingIndex.put(new String[] { e.getKey() }, withStats(db, rids, e.getValue(), docLen));
+        underlyingIndex.put(new String[] { e.getKey() }, withStats(db, rids, e.getValue(), len));
       countDocuments(rids.length, docLen);
     } else {
       final List<String> propertyNames = getPropertyNames();
@@ -1094,6 +1116,8 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
 
     for (final Object t : text) {
       if (t == null)
+        // Emit a null token so a null value still reaches the underlying index and its configured NULL_STRATEGY (SKIP/ERROR) is
+        // enforced. Callers that compute document length exclude these null tokens (see putWithStats).
         tokens.add(null);
       else {
         final TokenStream tokenizer = analyzer.tokenStream("contents", t.toString());

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -617,11 +617,15 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
         // NOT spuriously rescan multi-bucket types. (This counter feeds avgdl only; IDF's N is the per-bucket count from
         // resolveTotalDocs(), a deliberately different scope - see that method.)
         final long liveCount = underlyingIndex.getMutableIndex().getDatabase().countType(typeName, false);
-        if (liveCount != ftMetadata.getTotalDocs()) {
+        final long persisted = ftMetadata.getTotalDocs();
+        if (liveCount != persisted) {
           // Surface the drift so operators can notice it (e.g. counters inflated by rolled-back inserts) without reading EXPLAIN.
-          LogManager.instance().log(this, Level.INFO,
-              "BM25 corpus counters for type '%s' diverged from live data (persisted=%d, live=%d); recomputing.", null, typeName,
-              ftMetadata.getTotalDocs(), liveCount);
+          // Escalate to WARNING when the divergence is large (> 10% of the live count): small drift self-heals quietly here, but a
+          // big gap usually signals a heavy-rollback workload worth a scheduled REBUILD INDEX ... WITH statsOnly = true.
+          final boolean large = liveCount > 0 && Math.abs(persisted - liveCount) * 10 > liveCount;
+          LogManager.instance().log(this, large ? Level.WARNING : Level.INFO,
+              "BM25 corpus counters for type '%s' diverged from live data (persisted=%d, live=%d); recomputing.%s", null, typeName,
+              persisted, liveCount, large ? " Consider REBUILD INDEX ... WITH statsOnly = true if this recurs." : "");
           computeCorpusCounters(false);
         }
       }
@@ -884,6 +888,10 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    * This runs at index time, before the transaction commits, and is NOT reversed on rollback, so a rolled-back insert leaves the
    * counters slightly inflated. The counters feed only {@code avgDocLength} (a robust normalizer); {@link #recomputeBM25Counters}
    * (also reachable via {@code REBUILD INDEX <name> WITH statsOnly = true}) repairs any drift exactly.
+   * <p>
+   * Because the increment is pre-commit, a BM25 {@code get()} issued LATER in the SAME open transaction sees the bumped
+   * {@code totalDocs}/{@code sumDocLength}, so a just-inserted (not yet committed) document is reflected in {@code avgDocLength}
+   * for that transaction. This only shifts the length normalizer marginally and resolves at commit; it is not a correctness issue.
    * <p>
    * FOLLOW-UP (not done deliberately): the drift could be avoided by deferring this update to an after-commit callback
    * ({@code TransactionContext.addAfterCommitCallback}) so a rolled-back transaction never bumps the counters. That is left for a

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -34,11 +34,13 @@ import com.arcadedb.index.TempIndexCursor;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.index.lsm.LSMTreeIndex;
 import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
+import com.arcadedb.index.lsm.FullTextPostingRID;
 import com.arcadedb.schema.FullTextIndexMetadata;
 import com.arcadedb.schema.IndexBuilder;
 import com.arcadedb.schema.IndexMetadata;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
+import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
@@ -50,6 +52,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -98,10 +101,15 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
               "Full text index can only be defined on STRING properties, found: " + keyType);
       }
 
-      // Get metadata if available
-      FullTextIndexMetadata ftMetadata = null;
-      if (builder.getMetadata() instanceof FullTextIndexMetadata) {
-        ftMetadata = (FullTextIndexMetadata) builder.getMetadata();
+      // Get metadata if available. New full-text indexes default to BM25 similarity (issue #4687): when the user did not supply a
+      // FullTextIndexMetadata, synthesize one carrying the BM25 defaults so freshly created indexes rank with BM25 out of the box.
+      final FullTextIndexMetadata ftMetadata;
+      if (builder.getMetadata() instanceof FullTextIndexMetadata m)
+        ftMetadata = m;
+      else {
+        final IndexMetadata base = builder.getMetadata();
+        ftMetadata = new FullTextIndexMetadata(base.typeName, base.propertyNames.toArray(new String[0]),
+            base.associatedBucketId);
       }
 
       return new LSMTreeFullTextIndex(builder.getDatabase(), builder.getIndexName(), builder.getFilePath(),
@@ -124,6 +132,8 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     this.ftMetadata = metadata;
     this.indexAnalyzer = createAnalyzer(metadata, true);
     this.queryAnalyzer = createAnalyzer(metadata, false);
+    if (metadata != null && metadata.isBM25())
+      index.setStoreTermFrequency(true);
   }
 
   /**
@@ -136,6 +146,12 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     this.indexAnalyzer = createAnalyzer(metadata, true);
     this.queryAnalyzer = createAnalyzer(metadata, false);
     underlyingIndex = new LSMTreeIndex(database, name, false, filePath, mode, new Type[] { Type.STRING }, pageSize, nullStrategy);
+    if (metadata != null && metadata.isBM25()) {
+      underlyingIndex.setStoreTermFrequency(true);
+      // A brand-new index starts empty: the corpus counters are trivially valid (0 docs, 0 tokens).
+      if (!metadata.isCountersValid())
+        metadata.setCounters(0L, 0L);
+    }
   }
 
   /**
@@ -175,6 +191,9 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    */
   @Override
   public IndexCursor get(final Object[] keys, final int limit) {
+    if (underlyingIndex.isStoreTermFrequency())
+      return getBM25(keys, limit);
+
     final HashMap<RID, AtomicInteger> scoreMap = new HashMap<>();
 
     // Parse query text to handle field-specific terms (field:term)
@@ -222,6 +241,247 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
       });
 
     return new TempIndexCursor(list);
+  }
+
+  /**
+   * BM25 scoring path. For each analyzed query term it reads the postings (which carry the per-document term frequency and
+   * document length as {@link FullTextPostingRID}), computes the term IDF from the document frequency, and accumulates the BM25
+   * contribution per document, applying the per-field boost for field-qualified terms.
+   */
+  private IndexCursor getBM25(final Object[] keys, final int limit) {
+    final String queryText = keys.length > 0 && keys[0] != null ? keys[0].toString() : "";
+    final List<QueryTerm> queryTerms = parseQueryTerms(queryText);
+
+    ensureCounters();
+    final long totalDocs = resolveTotalDocs();
+    final double avgdl = resolveAvgDocLength();
+    final double k1 = ftMetadata.getBm25K1();
+    final double b = ftMetadata.getBm25B();
+
+    final Map<RID, Float> scoreMap = new HashMap<>();
+
+    for (final QueryTerm term : queryTerms) {
+      final List<String> keywords = analyzeText(queryAnalyzer, new Object[] { term.value });
+      final float boost = term.fieldName != null ? ftMetadata.getFieldBoost(term.fieldName) : 1.0f;
+
+      for (final String k : keywords) {
+        final String storedKey = term.fieldName != null ? term.fieldName + ":" + k : k;
+        final IndexCursor postings = underlyingIndex.get(new String[] { storedKey });
+
+        // Collect the postings first so the document frequency (and therefore the IDF) is known before scoring.
+        final List<FullTextPostingRID> termPostings = new ArrayList<>();
+        while (postings.hasNext()) {
+          final Identifiable id = postings.next();
+          if (id instanceof FullTextPostingRID s)
+            termPostings.add(s);
+        }
+
+        final long df = termPostings.size();
+        if (df == 0)
+          continue;
+
+        final double idf = BM25Scorer.idf(totalDocs, df);
+        for (final FullTextPostingRID s : termPostings) {
+          final double contribution = BM25Scorer.termScore(idf, s.tf, s.docLength, avgdl, k1, b) * boost;
+          scoreMap.merge(s.getIdentity(), (float) contribution, Float::sum);
+        }
+      }
+    }
+
+    final ArrayList<IndexCursorEntry> list = new ArrayList<>(scoreMap.size());
+    for (final Map.Entry<RID, Float> entry : scoreMap.entrySet())
+      list.add(new IndexCursorEntry(keys, entry.getKey(), entry.getValue().floatValue()));
+
+    if (list.size() > 1)
+      list.sort((o1, o2) -> Float.compare(o2.floatScore, o1.floatScore));
+
+    if (limit > -1 && list.size() > limit)
+      return new TempIndexCursor(list.subList(0, limit));
+
+    return new TempIndexCursor(list);
+  }
+
+  /**
+   * Returns true when this index ranks with BM25 (i.e. it stores per-posting term frequency).
+   */
+  public boolean isBM25() {
+    return underlyingIndex.isStoreTermFrequency();
+  }
+
+  /**
+   * Scores a set of candidate documents (already matched by the boolean/structural part of a query) with BM25, summing the
+   * contribution of every scoring token. Each token is looked up once to derive its document frequency (and therefore IDF); only
+   * candidates are scored. Used by {@link FullTextQueryExecutor} so the SQL {@code SEARCH_INDEX} path ranks with BM25 while
+   * preserving Lucene boolean/phrase/wildcard matching semantics.
+   *
+   * @param candidates  the documents that satisfy the query's matching logic
+   * @param tokenBoosts the scoring tokens (stored-key form) mapped to their field boost
+   * @param keys        the original query keys (carried into the result entries)
+   * @param limit       maximum number of results (-1 for unlimited)
+   */
+  public IndexCursor scoreCandidatesBM25(final Set<RID> candidates, final Map<String, Float> tokenBoosts, final Object[] keys,
+      final int limit) {
+    ensureCounters();
+    final long totalDocs = resolveTotalDocs();
+    final double avgdl = resolveAvgDocLength();
+    final double k1 = ftMetadata.getBm25K1();
+    final double b = ftMetadata.getBm25B();
+
+    final Map<RID, Float> scoreMap = new HashMap<>(candidates.size());
+    for (final RID c : candidates)
+      scoreMap.put(c, 0.0f);
+
+    for (final Map.Entry<String, Float> e : tokenBoosts.entrySet()) {
+      final IndexCursor postings = underlyingIndex.get(new String[] { e.getKey() });
+      final List<FullTextPostingRID> termPostings = new ArrayList<>();
+      while (postings.hasNext()) {
+        final Identifiable id = postings.next();
+        if (id instanceof FullTextPostingRID s)
+          termPostings.add(s);
+      }
+      final long df = termPostings.size();
+      if (df == 0)
+        continue;
+      final double idf = BM25Scorer.idf(totalDocs, df);
+      final float boost = e.getValue();
+      for (final FullTextPostingRID s : termPostings) {
+        final RID rid = s.getIdentity();
+        if (!scoreMap.containsKey(rid))
+          continue;
+        scoreMap.merge(rid, (float) (BM25Scorer.termScore(idf, s.tf, s.docLength, avgdl, k1, b) * boost), Float::sum);
+      }
+    }
+
+    final ArrayList<IndexCursorEntry> list = new ArrayList<>(scoreMap.size());
+    for (final Map.Entry<RID, Float> entry : scoreMap.entrySet())
+      list.add(new IndexCursorEntry(keys, entry.getKey(), entry.getValue().floatValue()));
+
+    list.sort((o1, o2) -> {
+      final int cmp = Float.compare(o2.floatScore, o1.floatScore);
+      if (cmp != 0)
+        return cmp;
+      return o1.record.getIdentity().compareTo(o2.record.getIdentity());
+    });
+
+    if (limit > 0 && list.size() > limit)
+      return new TempIndexCursor(list.subList(0, limit));
+    return new TempIndexCursor(list);
+  }
+
+  /**
+   * Builds the query-level BM25 scoring explanation surfaced by {@code EXPLAIN}/{@code PROFILE}: the similarity mode, the BM25
+   * parameters (k1, b), the corpus statistics (N, avgdl) and, for each scoring token, its document frequency, IDF and applied
+   * boost. This is the "why are the scores what they are" view; per-document contributions are intentionally not included since a
+   * plan describes the query, not individual rows.
+   *
+   * @param tokenBoosts the scoring tokens (stored-key form) mapped to their field boost
+   */
+  public JSONObject explainScoring(final Map<String, Float> tokenBoosts) {
+    final JSONObject json = new JSONObject();
+    if (!isBM25()) {
+      json.put("similarity", FullTextIndexMetadata.SIMILARITY_CLASSIC);
+      return json;
+    }
+
+    ensureCounters();
+    final long totalDocs = resolveTotalDocs();
+    final double avgdl = resolveAvgDocLength();
+    json.put("similarity", FullTextIndexMetadata.SIMILARITY_BM25);
+    json.put("k1", ftMetadata.getBm25K1());
+    json.put("b", ftMetadata.getBm25B());
+    json.put("totalDocs", totalDocs);
+    json.put("avgDocLength", avgdl);
+
+    final JSONArray terms = new JSONArray();
+    for (final Map.Entry<String, Float> e : tokenBoosts.entrySet()) {
+      final IndexCursor postings = underlyingIndex.get(new String[] { e.getKey() });
+      long df = 0;
+      while (postings.hasNext()) {
+        postings.next();
+        ++df;
+      }
+      terms.put(new JSONObject().put("term", e.getKey()).put("df", df).put("idf", BM25Scorer.idf(totalDocs, df))
+          .put("boost", e.getValue()));
+    }
+    json.put("terms", terms);
+    return json;
+  }
+
+  /**
+   * Returns the number of documents in the collection (N) for IDF, preferring the persisted counter and falling back to a live
+   * count of the type when the counter is unavailable.
+   */
+  private long resolveTotalDocs() {
+    if (ftMetadata != null && ftMetadata.getTotalDocs() > 0)
+      return ftMetadata.getTotalDocs();
+    final String typeName = getTypeName();
+    if (typeName != null) {
+      final long count = underlyingIndex.getMutableIndex().getDatabase().countType(typeName, false);
+      if (count > 0)
+        return count;
+    }
+    return 1L;
+  }
+
+  /**
+   * Returns the average document length across the collection, or 1.0 when no statistics are available.
+   */
+  private double resolveAvgDocLength() {
+    if (ftMetadata != null && ftMetadata.getTotalDocs() > 0)
+      return ftMetadata.avgDocLength();
+    return 1.0;
+  }
+
+  /**
+   * Lazily recomputes the corpus counters when they are missing or stale (e.g. a BM25 index reopened before the schema carrying
+   * the counters was persisted). Does nothing when the counters are already valid and non-empty, so the common path is free.
+   */
+  private void ensureCounters() {
+    if (ftMetadata == null)
+      return;
+    if (ftMetadata.getTotalDocs() > 0)
+      return;
+    final String typeName = getTypeName();
+    if (typeName == null)
+      return;
+    final DatabaseInternal db = underlyingIndex.getMutableIndex().getDatabase();
+    if (db.countType(typeName, false) <= 0)
+      return; // empty type: the (0,0) counters are correct
+    recomputeBM25Counters();
+  }
+
+  /**
+   * Rescans the indexed type and rebuilds the BM25 corpus counters (document count and total document length), then persists
+   * them. Use it after a bulk import or to repair drifted counters.
+   */
+  public void recomputeBM25Counters() {
+    if (ftMetadata == null)
+      return;
+    final DatabaseInternal db = underlyingIndex.getMutableIndex().getDatabase();
+    final String typeName = getTypeName();
+    if (typeName == null)
+      return;
+
+    final List<String> props = getPropertyNames();
+    long docs = 0L;
+    long sumLen = 0L;
+    final Iterator<com.arcadedb.database.Record> it = db.iterateType(typeName, true);
+    while (it.hasNext()) {
+      final com.arcadedb.database.Record record = it.next();
+      if (!(record instanceof Document doc))
+        continue;
+      int len = 0;
+      for (final String p : props) {
+        final Object v = doc.get(p);
+        if (v != null)
+          len += analyzeText(indexAnalyzer, new Object[] { v }).size();
+      }
+      ++docs;
+      sumLen += len;
+    }
+
+    ftMetadata.setCounters(docs, sumLen);
+    db.getSchema().getEmbedded().saveConfiguration();
   }
 
   /**
@@ -297,6 +557,12 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    */
   @Override
   public void put(final Object[] keys, final RID[] rids) {
+    if (underlyingIndex.isStoreTermFrequency()) {
+      putWithStats(keys, rids);
+      return;
+    }
+
+    // CLASSIC similarity: store one posting per token occurrence (RID-only), unchanged behavior.
     if (getPropertyCount() == 1) {
       // Single property - existing behavior
       final List<String> keywords = analyzeText(indexAnalyzer, keys);
@@ -318,6 +584,77 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
         }
       }
     }
+  }
+
+  /**
+   * BM25 indexing path: aggregates the per-token term frequency and the document length, then stores one posting per distinct
+   * token carrying {@link FullTextPostingRID} so scoring can read tf and document length back without re-reading the document. Also
+   * maintains the persisted corpus counters (document count and total length) used to compute the average document length.
+   */
+  private void putWithStats(final Object[] keys, final RID[] rids) {
+    final DatabaseInternal db = underlyingIndex.getMutableIndex().getDatabase();
+
+    if (getPropertyCount() == 1) {
+      final List<String> keywords = analyzeText(indexAnalyzer, keys);
+      final int docLen = keywords.size();
+      final Map<String, Integer> tfs = new HashMap<>();
+      for (final String k : keywords)
+        tfs.merge(k, 1, Integer::sum);
+      for (final Map.Entry<String, Integer> e : tfs.entrySet())
+        underlyingIndex.put(new String[] { e.getKey() }, withStats(db, rids, e.getValue(), docLen));
+      countDocuments(rids.length, docLen);
+    } else {
+      final List<String> propertyNames = getPropertyNames();
+
+      // PASS 1: analyze every field, accumulate document length and per-field + global term frequencies.
+      final Map<String, Integer> globalTf = new HashMap<>();
+      final List<String> fieldNames = new ArrayList<>();
+      final List<Map<String, Integer>> fieldTfs = new ArrayList<>();
+      int docLen = 0;
+      for (int i = 0; i < keys.length && i < propertyNames.size(); i++) {
+        if (keys[i] == null)
+          continue;
+        final List<String> keywords = analyzeText(indexAnalyzer, new Object[] { keys[i] });
+        docLen += keywords.size();
+        final Map<String, Integer> fieldTf = new HashMap<>();
+        for (final String k : keywords) {
+          fieldTf.merge(k, 1, Integer::sum);
+          globalTf.merge(k, 1, Integer::sum);
+        }
+        fieldNames.add(propertyNames.get(i));
+        fieldTfs.add(fieldTf);
+      }
+
+      // PASS 2: store field-prefixed postings (per-field tf) and unprefixed postings (global tf) now that docLen is known.
+      for (int f = 0; f < fieldNames.size(); f++) {
+        final String fieldName = fieldNames.get(f);
+        for (final Map.Entry<String, Integer> e : fieldTfs.get(f).entrySet())
+          underlyingIndex.put(new String[] { fieldName + ":" + e.getKey() }, withStats(db, rids, e.getValue(), docLen));
+      }
+      for (final Map.Entry<String, Integer> e : globalTf.entrySet())
+        underlyingIndex.put(new String[] { e.getKey() }, withStats(db, rids, e.getValue(), docLen));
+
+      countDocuments(rids.length, docLen);
+    }
+  }
+
+  /**
+   * Wraps the given RIDs into {@link FullTextPostingRID} carrying the term frequency and document length for a posting.
+   */
+  private static RID[] withStats(final DatabaseInternal db, final RID[] rids, final int tf, final int docLen) {
+    final RID[] out = new RID[rids.length];
+    for (int i = 0; i < rids.length; i++)
+      out[i] = new FullTextPostingRID(db, rids[i].getBucketId(), rids[i].getPosition(), tf, docLen);
+    return out;
+  }
+
+  /**
+   * Updates the persisted corpus counters when a document is indexed.
+   */
+  private void countDocuments(final int numDocs, final int docLen) {
+    if (ftMetadata != null)
+      for (int i = 0; i < numDocs; i++)
+        ftMetadata.addDocument(docLen);
   }
 
   /**
@@ -357,9 +694,11 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    */
   @Override
   public void remove(final Object[] keys, final Identifiable rid) {
+    int docLen = 0;
     if (getPropertyCount() == 1) {
       // Single property - existing behavior
       final List<String> keywords = analyzeText(indexAnalyzer, keys);
+      docLen = keywords.size();
       for (final String k : keywords)
         underlyingIndex.remove(new String[] { k }, rid);
     } else {
@@ -370,12 +709,17 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
           continue;
         final String fieldName = propertyNames.get(i);
         final List<String> keywords = analyzeText(indexAnalyzer, new Object[] { keys[i] });
+        docLen += keywords.size();
         for (final String k : keywords) {
           underlyingIndex.remove(new String[] { fieldName + ":" + k }, rid);
           underlyingIndex.remove(new String[] { k }, rid);
         }
       }
     }
+
+    // Keep the BM25 corpus counters in sync when a document is removed.
+    if (underlyingIndex.isStoreTermFrequency() && ftMetadata != null)
+      ftMetadata.removeDocument(docLen);
   }
 
   /**
@@ -407,6 +751,10 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
     json.put("properties", getPropertyNames());
     json.put("nullStrategy", getNullStrategy());
     json.put("unique", isUnique());
+    // Persist analyzer configuration and BM25 settings + corpus counters so they survive a restart (issue #4687). Historically
+    // this method dropped the metadata, silently reverting custom analyzers to StandardAnalyzer on reload.
+    if (ftMetadata != null)
+      ftMetadata.writeToJSON(json);
     return json;
   }
 

--- a/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndex.java
@@ -52,12 +52,14 @@ import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
@@ -272,24 +274,30 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    * @param tokenBoosts scoring tokens (stored-key form) mapped to their effective boost
    * @param candidates  documents to score, or {@code null} to score every matching document
    */
-  private Map<RID, Double> computeBM25Scores(final Map<String, Float> tokenBoosts, final Set<RID> candidates) {
+  private Map<RID, double[]> computeBM25Scores(final Map<String, Float> tokenBoosts, final Set<RID> candidates) {
     ensureCounters();
     final long totalDocs = resolveTotalDocs();
     final double avgdl = resolveAvgDocLength();
     final double k1 = ftMetadata.getBm25K1();
     final double b = ftMetadata.getBm25B();
 
-    // Accumulate in double to avoid per-term precision loss; the score is narrowed to float only when the cursor entry is built.
-    final Map<RID, Double> scoreMap = candidates != null ? new HashMap<>(candidates.size()) : new HashMap<>();
+    // Accumulate in a per-RID double[1] cell rather than a boxed Double: a document matched by T query terms is updated T times,
+    // and Map.merge(..., Double::sum) would box on every one of those updates. The cell is allocated once per unique document
+    // (same as a Double key would be) and then accumulated as a primitive. The score is narrowed to float when the cursor entry
+    // is built. Reading is via getScore() below.
+    final Map<RID, double[]> scoreMap = candidates != null ? new HashMap<>(candidates.size()) : new HashMap<>();
     if (candidates != null)
       for (final RID c : candidates)
-        scoreMap.put(c, 0.0);
+        scoreMap.put(c, new double[1]);
 
     // Reused across tokens to avoid per-token allocations (candidate path only).
     final List<FullTextPostingRID> hits = new ArrayList<>();
+    // Single-element lookup key reused across tokens (each underlyingIndex.get() consumes it synchronously before the next
+    // iteration reassigns it) to avoid a short-lived array allocation per query term.
+    final String[] storedKey = new String[1];
 
     for (final Map.Entry<String, Float> e : tokenBoosts.entrySet()) {
-      final String[] storedKey = new String[] { e.getKey() };
+      storedKey[0] = e.getKey();
       final float boost = e.getValue();
 
       if (candidates != null) {
@@ -310,7 +318,7 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
           continue;
         final double idf = BM25Scorer.idf(totalDocs, df);
         for (final FullTextPostingRID s : hits)
-          scoreMap.merge(s.getIdentity(), BM25Scorer.termScore(idf, s.getTf(), s.getDocLength(), avgdl, k1, b) * boost, Double::sum);
+          scoreMap.get(s.getIdentity())[0] += BM25Scorer.termScore(idf, s.getTf(), s.getDocLength(), avgdl, k1, b) * boost;
       } else {
         // No candidate filter: count df first (streaming, no retention), then accumulate every matching document.
         long df = 0L;
@@ -326,7 +334,8 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
         while (scoreCursor.hasNext()) {
           final Identifiable id = scoreCursor.next();
           if (id instanceof FullTextPostingRID s)
-            scoreMap.merge(s.getIdentity(), BM25Scorer.termScore(idf, s.getTf(), s.getDocLength(), avgdl, k1, b) * boost, Double::sum);
+            scoreMap.computeIfAbsent(s.getIdentity(), k -> new double[1])[0] +=
+                BM25Scorer.termScore(idf, s.getTf(), s.getDocLength(), avgdl, k1, b) * boost;
         }
       }
     }
@@ -352,25 +361,46 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
       }
     }
 
-    final Map<RID, Double> scoreMap = computeBM25Scores(tokenBoosts, null);
+    return buildScoredCursor(computeBM25Scores(tokenBoosts, null), keys, limit);
+  }
 
-    final ArrayList<IndexCursorEntry> list = new ArrayList<>(scoreMap.size());
-    for (final Map.Entry<RID, Double> entry : scoreMap.entrySet())
-      list.add(new IndexCursorEntry(keys, entry.getKey(), entry.getValue().floatValue()));
+  /**
+   * Ranks the scored documents most-relevant-first (descending score, RID as a stable tiebreaker so equal-scored documents have a
+   * deterministic order) and returns a cursor over the (optionally limited) result. When a {@code limit} smaller than the result
+   * set is requested it selects the top-K with a bounded min-heap (O(N log K)) instead of fully sorting the whole set
+   * (O(N log N)) - a meaningful win for the common {@code ORDER BY $score DESC LIMIT k} shape over a large candidate set.
+   */
+  private IndexCursor buildScoredCursor(final Map<RID, double[]> scoreMap, final Object[] keys, final int limit) {
+    final Comparator<IndexCursorEntry> bestFirst = (o1, o2) -> {
+      final int cmp = Float.compare(o2.floatScore, o1.floatScore);
+      if (cmp != 0)
+        return cmp;
+      return o1.record.getIdentity().compareTo(o2.record.getIdentity());
+    };
 
-    // Most-relevant first, with RID as a stable tiebreaker so equal-scored documents have a deterministic order (consistent with
-    // scoreCandidatesBM25 and the CLASSIC path).
+    final int size = scoreMap.size();
+    if (limit > -1 && limit < size) {
+      // Bounded min-heap whose head is the WORST kept entry (reversed comparator), so we can evict it when a better one arrives.
+      final PriorityQueue<IndexCursorEntry> heap = new PriorityQueue<>(limit, bestFirst.reversed());
+      for (final Map.Entry<RID, double[]> e : scoreMap.entrySet()) {
+        final IndexCursorEntry entry = new IndexCursorEntry(keys, e.getKey(), (float) e.getValue()[0]);
+        if (heap.size() < limit)
+          heap.add(entry);
+        else if (bestFirst.compare(entry, heap.peek()) < 0) {
+          heap.poll();
+          heap.add(entry);
+        }
+      }
+      final IndexCursorEntry[] top = heap.toArray(new IndexCursorEntry[0]);
+      Arrays.sort(top, bestFirst);
+      return new TempIndexCursor(Arrays.asList(top));
+    }
+
+    final ArrayList<IndexCursorEntry> list = new ArrayList<>(size);
+    for (final Map.Entry<RID, double[]> entry : scoreMap.entrySet())
+      list.add(new IndexCursorEntry(keys, entry.getKey(), (float) entry.getValue()[0]));
     if (list.size() > 1)
-      list.sort((o1, o2) -> {
-        final int cmp = Float.compare(o2.floatScore, o1.floatScore);
-        if (cmp != 0)
-          return cmp;
-        return o1.record.getIdentity().compareTo(o2.record.getIdentity());
-      });
-
-    if (limit > -1 && list.size() > limit)
-      return new TempIndexCursor(list.subList(0, limit));
-
+      list.sort(bestFirst);
     return new TempIndexCursor(list);
   }
 
@@ -394,31 +424,18 @@ public class LSMTreeFullTextIndex implements Index, IndexInternal {
    */
   public IndexCursor scoreCandidatesBM25(final Set<RID> candidates, final Map<String, Float> tokenBoosts, final Object[] keys,
       final int limit) {
-    final Map<RID, Double> scoreMap = computeBM25Scores(tokenBoosts, candidates);
-
-    final ArrayList<IndexCursorEntry> list = new ArrayList<>(scoreMap.size());
-    for (final Map.Entry<RID, Double> entry : scoreMap.entrySet())
-      list.add(new IndexCursorEntry(keys, entry.getKey(), entry.getValue().floatValue()));
-
-    if (list.size() > 1)
-      list.sort((o1, o2) -> {
-        final int cmp = Float.compare(o2.floatScore, o1.floatScore);
-        if (cmp != 0)
-          return cmp;
-        return o1.record.getIdentity().compareTo(o2.record.getIdentity());
-      });
-
-    if (limit > -1 && list.size() > limit)
-      return new TempIndexCursor(list.subList(0, limit));
-    return new TempIndexCursor(list);
+    return buildScoredCursor(computeBM25Scores(tokenBoosts, candidates), keys, limit);
   }
 
   /**
    * Returns the raw postings for an already-resolved stored key (RID-only, no BM25 scoring and no re-analysis), used by
    * {@link FullTextQueryExecutor} to collect candidate documents cheaply before scoring them once via
    * {@link #scoreCandidatesBM25}. Going through {@link #get} here would run the full scoring pipeline only to discard the scores.
+   * <p>
+   * Package-private: it takes a pre-analyzed stored key and bypasses the analysis pipeline, so an unanalyzed input (e.g. mixed
+   * case) would silently match nothing. Only {@link FullTextQueryExecutor} (same package) should call it.
    */
-  public IndexCursor getPostings(final String storedKey) {
+  IndexCursor getPostings(final String storedKey) {
     return underlyingIndex.get(new String[] { storedKey });
   }
 

--- a/engine/src/main/java/com/arcadedb/index/lsm/FullTextPostingRID.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/FullTextPostingRID.java
@@ -41,6 +41,10 @@ public class FullTextPostingRID extends DatabaseRID {
 
   public FullTextPostingRID(final BasicDatabase database, final int bucketId, final long offset, final int tf, final int docLength) {
     super(database, bucketId, offset);
+    // Guard against corrupt statistics: a negative tf or docLength would silently produce a nonsensical BM25 score (e.g. a
+    // negative or infinite term contribution), so fail fast at construction instead.
+    if (tf < 0 || docLength < 0)
+      throw new IllegalArgumentException("tf and docLength must be non-negative: tf=" + tf + ", docLength=" + docLength);
     this.tf = tf;
     this.docLength = docLength;
   }

--- a/engine/src/main/java/com/arcadedb/index/lsm/FullTextPostingRID.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/FullTextPostingRID.java
@@ -32,10 +32,14 @@ import com.arcadedb.database.DatabaseRID;
  * {@link com.arcadedb.database.RID} and compare only bucket id and offset. Only the value (de)serialization in
  * {@link LSMTreeIndexAbstract} - active when the index has {@code storeTermFrequency} enabled - reads and writes the two extra
  * fields, and only the full-text index interprets them.
+ * <p>
+ * It lives in {@code com.arcadedb.index.lsm} (rather than {@code ...index.fulltext}) on purpose: the value (de)serialization that
+ * produces and consumes it is in {@link LSMTreeIndexAbstract}, so it must be visible at the LSM storage layer. {@code final} so a
+ * subclass cannot pass the pervasive {@code instanceof FullTextPostingRID} checks while carrying different statistics.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-public class FullTextPostingRID extends DatabaseRID {
+public final class FullTextPostingRID extends DatabaseRID {
   private final int tf;
   private final int docLength;
 

--- a/engine/src/main/java/com/arcadedb/index/lsm/FullTextPostingRID.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/FullTextPostingRID.java
@@ -62,4 +62,10 @@ public final class FullTextPostingRID extends DatabaseRID {
   public int getDocLength() {
     return docLength;
   }
+
+  /** Includes tf/docLength on top of the RID so serialization/scoring issues are easier to spot in logs and debuggers. */
+  @Override
+  public String toString() {
+    return super.toString() + "{tf=" + tf + ",docLength=" + docLength + "}";
+  }
 }

--- a/engine/src/main/java/com/arcadedb/index/lsm/FullTextPostingRID.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/FullTextPostingRID.java
@@ -36,8 +36,8 @@ import com.arcadedb.database.DatabaseRID;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class FullTextPostingRID extends DatabaseRID {
-  public final int tf;
-  public final int docLength;
+  private final int tf;
+  private final int docLength;
 
   public FullTextPostingRID(final BasicDatabase database, final int bucketId, final long offset, final int tf, final int docLength) {
     super(database, bucketId, offset);
@@ -47,5 +47,15 @@ public class FullTextPostingRID extends DatabaseRID {
       throw new IllegalArgumentException("tf and docLength must be non-negative: tf=" + tf + ", docLength=" + docLength);
     this.tf = tf;
     this.docLength = docLength;
+  }
+
+  /** Term frequency: how many times the indexed term occurs in the document. */
+  public int getTf() {
+    return tf;
+  }
+
+  /** Document length: total number of analyzed tokens in the document. */
+  public int getDocLength() {
+    return docLength;
   }
 }

--- a/engine/src/main/java/com/arcadedb/index/lsm/FullTextPostingRID.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/FullTextPostingRID.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.lsm;
+
+import com.arcadedb.database.BasicDatabase;
+import com.arcadedb.database.DatabaseRID;
+
+/**
+ * {@link com.arcadedb.database.RID} variant that carries two extra per-posting statistics used by full-text BM25 scoring: the
+ * term frequency ({@link #tf}, how many times the indexed term occurs in the document) and the document length
+ * ({@link #docLength}, total number of analyzed tokens in the document).
+ * <p>
+ * The whole index/transaction pipeline is RID-typed (postings, transaction staging, compaction, page cursors). By extending
+ * {@link DatabaseRID} this class rides through that pipeline unchanged: every {@code (RID)} cast, deletion-marker bucket-sign
+ * check and {@code RidHashSet} membership test keeps working because {@code equals}/{@code hashCode} are inherited from
+ * {@link com.arcadedb.database.RID} and compare only bucket id and offset. Only the value (de)serialization in
+ * {@link LSMTreeIndexAbstract} - active when the index has {@code storeTermFrequency} enabled - reads and writes the two extra
+ * fields, and only the full-text index interprets them.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class FullTextPostingRID extends DatabaseRID {
+  public final int tf;
+  public final int docLength;
+
+  public FullTextPostingRID(final BasicDatabase database, final int bucketId, final long offset, final int tf, final int docLength) {
+    super(database, bucketId, offset);
+    this.tf = tf;
+    this.docLength = docLength;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
@@ -495,6 +495,18 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
     return lock.executeInReadLock(() -> mutable.get(convertedKeys, limit));
   }
 
+  /**
+   * Enables or disables BM25 per-posting statistics storage (term frequency + document length). Propagates to the mutable index
+   * and, through it, to the compacted sub-index. Used by the full-text index when configured with BM25 similarity.
+   */
+  public void setStoreTermFrequency(final boolean storeTermFrequency) {
+    mutable.setStoreTermFrequency(storeTermFrequency);
+  }
+
+  public boolean isStoreTermFrequency() {
+    return mutable.isStoreTermFrequency();
+  }
+
   @Override
   public void put(final Object[] keys, final RID[] rids) {
     checkIsValid();
@@ -628,6 +640,7 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
             database.getDatabasePath() + File.separator + newName, mutable.getKeyTypes(), mutable.getBinaryKeyTypes()
             , pageSize,
             LSMTreeIndexMutable.CURRENT_VERSION, compactedIndex);
+        newMutableIndex.setStoreTermFrequency(mutable.isStoreTermFrequency());
         database.getSchema().getEmbedded().registerFile(newMutableIndex);
 
         LogManager.instance().log(this, Level.FINE,

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
@@ -84,6 +84,13 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
   protected       NULL_STRATEGY    nullStrategy       = NULL_STRATEGY.SKIP;
   protected final AtomicLong       statsAdjacentSteps = new AtomicLong();
 
+  /**
+   * When true, each posting value is serialized as {@code compressedRID + tf(varint) + docLength(varint)} instead of just the
+   * RID, and is deserialized into a {@link FullTextPostingRID}. Used exclusively by full-text indexes configured with BM25 similarity.
+   * Defaults to false so every other LSM index keeps the byte-identical RID-only format.
+   */
+  protected boolean                storeTermFrequency = false;
+
   protected static class LookupResult {
     public final boolean found;
     public final boolean outside;
@@ -489,6 +496,8 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
     // WRITE VALUES
     for (int i = 0; i < values.length; ++i) {
       serializer.serializeValue(database, buffer, valueType, values[i]);
+      if (storeTermFrequency)
+        writeTermFrequency(buffer, values[i]);
       if (buffer.size() > availableSpaceInPage)
         return i;
     }
@@ -501,6 +510,23 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
 
     // WRITE VALUES
     serializer.serializeValue(database, buffer, valueType, value);
+    if (storeTermFrequency)
+      writeTermFrequency(buffer, value);
+  }
+
+  /**
+   * Appends the BM25 per-posting statistics (term frequency and document length) right after the serialized RID. Values that are
+   * not {@link FullTextPostingRID} (e.g. deletion markers and compacted root-page pointers) carry no statistics and are written as
+   * zeroes so the on-disk layout stays uniform and symmetric with {@link #readEntryValues(Binary)}.
+   */
+  private void writeTermFrequency(final Binary buffer, final Object value) {
+    if (value instanceof FullTextPostingRID s) {
+      buffer.putUnsignedNumber(s.tf);
+      buffer.putUnsignedNumber(s.docLength);
+    } else {
+      buffer.putUnsignedNumber(0);
+      buffer.putUnsignedNumber(0);
+    }
   }
 
   protected RID[] readEntryValues(final Binary buffer) {
@@ -509,7 +535,7 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
     final RID[] rids = new RID[items];
 
     for (int i = 0; i < rids.length; ++i)
-      rids[i] = (RID) serializer.deserializeValue(database, buffer, valueType, null);
+      rids[i] = readEntryValue(buffer);
 
     return rids;
   }
@@ -517,10 +543,23 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
   private void readEntryValues(final Binary buffer, final List<RID> list) {
     final int items = (int) serializer.deserializeValue(database, buffer, BinaryTypes.TYPE_INT, null);
 
-    final Object[] rids = new Object[items];
+    for (int i = 0; i < items; ++i)
+      list.add(readEntryValue(buffer));
+  }
 
-    for (int i = 0; i < rids.length; ++i)
-      list.add((RID) serializer.deserializeValue(database, buffer, valueType, null));
+  /**
+   * Reads a single posting value, reconstructing a {@link FullTextPostingRID} when {@link #storeTermFrequency} is enabled so full-text
+   * scoring can read the term frequency and document length back from the cursor without an extra lookup.
+   */
+  private RID readEntryValue(final Binary buffer) {
+    final RID rid = (RID) serializer.deserializeValue(database, buffer, valueType, null);
+    if (!storeTermFrequency)
+      return rid;
+
+    final int tf = (int) buffer.getUnsignedNumber();
+    final int docLength = (int) buffer.getUnsignedNumber();
+    // Deletion markers (negative bucket) keep their RID identity; their statistics are meaningless and ignored downstream.
+    return new FullTextPostingRID(database, rid.getBucketId(), rid.getPosition(), tf, docLength);
   }
 
   protected List<RID> readAllValuesFromResult(final Binary currentPageBuffer, final LookupResult result) {
@@ -538,6 +577,14 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
 
   protected void setCount(final MutablePage currentPage, final int newCount) {
     currentPage.writeInt(INT_SERIALIZED_SIZE, newCount);
+  }
+
+  public void setStoreTermFrequency(final boolean storeTermFrequency) {
+    this.storeTermFrequency = storeTermFrequency;
+  }
+
+  public boolean isStoreTermFrequency() {
+    return storeTermFrequency;
   }
 
   protected boolean isMutable(final BasePage currentPage) {

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
@@ -556,9 +556,13 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
     if (!storeTermFrequency)
       return rid;
 
+    // The tf/docLength varints are present for every stored value, so they must always be read to keep the buffer aligned.
     final int tf = (int) buffer.getUnsignedNumber();
     final int docLength = (int) buffer.getUnsignedNumber();
-    // Deletion markers (negative bucket) keep their RID identity; their statistics are meaningless and ignored downstream.
+    // Deletion markers (negative bucket id) carry no real statistics; keep them as a plain RID so nothing downstream mistakes a
+    // marker for a scorable posting (the marker's tf/docLength are 0 and are discarded here).
+    if (rid.getBucketId() < 0)
+      return rid;
     return new FullTextPostingRID(database, rid.getBucketId(), rid.getPosition(), tf, docLength);
   }
 

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
@@ -581,6 +581,9 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
       return rid;
 
     // The tf/docLength varints are present for every stored value, so they must always be read to keep the buffer aligned.
+    // Narrowed to int: tf and docLength are token counts within one document, so they fit comfortably in a (signed) int - a
+    // document with > ~2.1 billion analyzed tokens is not representable and the FullTextPostingRID constructor would reject the
+    // wrapped-negative value. If postings ever need to carry a larger statistic, widen these to long here and at the write side.
     final int tf = (int) buffer.getUnsignedNumber();
     final int docLength = (int) buffer.getUnsignedNumber();
     // Deletion markers (negative bucket id) carry no real statistics; keep them as a plain RID so nothing downstream mistakes a

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
@@ -88,6 +88,10 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
    * When true, each posting value is serialized as {@code compressedRID + tf(varint) + docLength(varint)} instead of just the
    * RID, and is deserialized into a {@link FullTextPostingRID}. Used exclusively by full-text indexes configured with BM25 similarity.
    * Defaults to false so every other LSM index keeps the byte-identical RID-only format.
+   * <p>
+   * NOTE: this flag is NOT stored in the page header; it is set at load time by the full-text index from the persisted schema
+   * (similarity = BM25). The schema and index files therefore must stay consistent: reading a BM25 index's pages with the flag
+   * off (or vice-versa) would misinterpret the value bytes. In normal operation schema and index files travel together.
    */
   protected boolean                storeTermFrequency = false;
 

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
@@ -92,8 +92,11 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
    * NOTE: this flag is NOT stored in the page header; it is set at load time by the full-text index from the persisted schema
    * (similarity = BM25). The schema and index files therefore must stay consistent: reading a BM25 index's pages with the flag
    * off (or vice-versa) would misinterpret the value bytes. In normal operation schema and index files travel together.
+   * <p>
+   * volatile: set once after construction (single writer) but read on every read/write path, possibly from other threads; the
+   * visibility guarantee avoids a reader seeing a stale {@code false} and misparsing the value bytes.
    */
-  protected boolean                storeTermFrequency = false;
+  protected volatile boolean       storeTermFrequency = false;
 
   protected static class LookupResult {
     public final boolean found;

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
@@ -330,6 +330,16 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
               + FileUtils.getSizeAsString(pageUsableSpace) + "). Define the index with larger pages");
   }
 
+  /**
+   * Serializes the key plus as many of {@code rids} as fit into the scratch {@code buffer} and returns how many values were
+   * written (0 if not even a single value fits). The caller decides what to do with a partial/zero result (e.g. flush the current
+   * page and retry on a fresh one).
+   * <p>
+   * INVARIANT (relied upon by {@link LSMTreeIndexCompacted#appendDuringCompaction}): this method writes ONLY to {@code buffer}
+   * (the scratch {@code keyValueContent}); it never touches any database page. So when it returns a partial or zero count, no
+   * bytes have been committed to a page and the caller can safely move this key to a new page without orphaning data on the old
+   * one. Keep this true if refactoring - the compaction continuation-page fix depends on it.
+   */
   protected int writeEntryMultipleValues(final Binary buffer, final Object[] keys, Object[] rids, final int availableSpaceInPage,
       final int pageUsableSpace, final PageId pageId) {
     Object[] values = rids;

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
@@ -89,14 +89,16 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
    * RID, and is deserialized into a {@link FullTextPostingRID}. Used exclusively by full-text indexes configured with BM25 similarity.
    * Defaults to false so every other LSM index keeps the byte-identical RID-only format.
    * <p>
-   * NOTE: this flag is NOT stored in the page header; it is set at load time by the full-text index from the persisted schema
-   * (similarity = BM25). The schema and index files therefore must stay consistent: reading a BM25 index's pages with the flag
-   * off (or vice-versa) would misinterpret the value bytes. In normal operation schema and index files travel together.
+   * NOTE: this flag is NOT stored in the page header; it is set from the persisted schema (similarity = BM25) during the
+   * single-threaded schema load, before the index serves any query or compaction is scheduled - so the write happens-before any
+   * concurrent reader. The schema and index files must therefore stay consistent: reading a BM25 index's pages with the flag off
+   * (or vice-versa) would misinterpret the value bytes. In normal operation schema and index files travel together.
    * <p>
-   * volatile: set once after construction (single writer) but read on every read/write path, possibly from other threads; the
-   * visibility guarantee avoids a reader seeing a stale {@code false} and misparsing the value bytes.
+   * volatile: set once (single writer) but read on every read/write path, possibly from other threads; the visibility guarantee
+   * avoids a reader seeing a stale {@code false} and misparsing the value bytes. Private: accessed by subclasses only through
+   * {@link #isStoreTermFrequency()} / {@link #setStoreTermFrequency(boolean)}.
    */
-  protected volatile boolean       storeTermFrequency = false;
+  private volatile boolean         storeTermFrequency = false;
 
   protected static class LookupResult {
     public final boolean found;
@@ -542,9 +544,9 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
    * is non-negative), but the compacted-root read path uses only its position (the target page number), so this is harmless.
    */
   private void writeTermFrequency(final Binary buffer, final Object value) {
-    if (value instanceof FullTextPostingRID s) {
-      buffer.putUnsignedNumber(s.getTf());
-      buffer.putUnsignedNumber(s.getDocLength());
+    if (value instanceof FullTextPostingRID posting) {
+      buffer.putUnsignedNumber(posting.getTf());
+      buffer.putUnsignedNumber(posting.getDocLength());
     } else {
       buffer.putUnsignedNumber(0);
       buffer.putUnsignedNumber(0);

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
@@ -543,8 +543,8 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
    */
   private void writeTermFrequency(final Binary buffer, final Object value) {
     if (value instanceof FullTextPostingRID s) {
-      buffer.putUnsignedNumber(s.tf);
-      buffer.putUnsignedNumber(s.docLength);
+      buffer.putUnsignedNumber(s.getTf());
+      buffer.putUnsignedNumber(s.getDocLength());
     } else {
       buffer.putUnsignedNumber(0);
       buffer.putUnsignedNumber(0);

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
@@ -517,6 +517,10 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
       serializer.serializeValue(database, buffer, valueType, values[i]);
       if (storeTermFrequency)
         writeTermFrequency(buffer, values[i]);
+      // Overflow check AFTER the whole i-th entry (RID + optional tf/docLength varints) is in the buffer: the entry is written as
+      // a unit, never split. On overflow we return i (= i complete entries the caller may keep), but the buffer now physically
+      // holds i+1 entries' bytes. That trailing entry is harmless: callers re-serialize from scratch (writeEntryMultipleValues
+      // clears the buffer and rewrites the kept subset before committing to a page), so the over-written bytes are discarded.
       if (buffer.size() > availableSpaceInPage)
         return i;
     }

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
@@ -525,6 +525,11 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
    * Appends the BM25 per-posting statistics (term frequency and document length) right after the serialized RID. Values that are
    * not {@link FullTextPostingRID} (e.g. deletion markers and compacted root-page pointers) carry no statistics and are written as
    * zeroes so the on-disk layout stays uniform and symmetric with {@link #readEntryValues(Binary)}.
+   * <p>
+   * Alignment invariant: a given index instance writes and reads every page - leaf <i>and</i> compacted root - with the same
+   * {@link #storeTermFrequency} flag, so the two zero varints written here for a root-page pointer are always consumed back by
+   * {@link #readEntryValue(Binary)}. The pointer is reconstructed as a {@code FullTextPostingRID(tf=0, docLength=0)} (its bucket id
+   * is non-negative), but the compacted-root read path uses only its position (the target page number), so this is harmless.
    */
   private void writeTermFrequency(final Binary buffer, final Object value) {
     if (value instanceof FullTextPostingRID s) {

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
@@ -133,10 +133,12 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
       int writtenValues = writeEntryMultipleValues(keyValueContent, convertedKeys, values, freeSpaceInPage,
           currentPage.getMaxContentSize() - getHeaderSize(pageNum), currentPage.getPageId());
 
-      // No room at all, OR this key would split across a shared continuation page (see startedOnContinuation): in both cases
-      // move to a fresh page before committing anything for this key. The continuation page (with only the previous keys'
-      // values) is flushed as-is; this key's values then live entirely on pages it owns, keeping the positional root index
-      // consistent.
+      // Move this key to a fresh page when either: (a) no value fits in the current page, or (b) it is the first iteration, the
+      // current page is a continuation page already holding the previous key's values, and this key would only partially fit
+      // (split). The positional root index cannot index one leaf page under two keys, so a key must not start on a page it then
+      // overflows from. Note no bytes are orphaned: this key's serialized entry currently lives only in the scratch buffer
+      // (keyValueContent) and is committed to the page by putByteArray() further below - it has NOT been written to the
+      // continuation page, which is therefore flushed cleanly with just the previous keys' entries.
       if (writtenValues == 0 || (firstIteration && startedOnContinuation && writtenValues < values.length)) {
         // CREATE A NEW PAGE AND FLUSH TO THE DATABASE THE CURRENT ONE (NO WAL)
         database.getPageManager().updatePageVersion(currentPage, true);

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
@@ -153,7 +153,9 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
         count = 0;
         keyValueFreePosition = currentPage.getMaxContentSize();
 
-        // WRITE THE KEY/VALUE CONTENT ON THE NEW PAGE
+        // WRITE THE KEY/VALUE CONTENT ON THE NEW PAGE. writeEntryMultipleValues clears keyValueContent at the start of its own
+        // loop, so this retry re-serializes the key/values from scratch into a clean buffer - the partial content from the call
+        // above is discarded, not appended.
         freeSpaceInPage = keyValueFreePosition - (getHeaderSize(pageNum) + INT_SERIALIZED_SIZE);
         writtenValues = writeEntryMultipleValues(keyValueContent, convertedKeys, values, freeSpaceInPage,
             currentPage.getMaxContentSize() - getHeaderSize(pageNum), currentPage.getPageId());

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
@@ -98,6 +98,12 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
 
     TrackableBinary pageBuffer = currentPageBuffer;
 
+    // True when this key starts on a page already holding the PREVIOUS key's values (a continuation page). If this key then
+    // overflows, its first values would remain on that shared page, whose root entry is keyed by the previous key. The root
+    // index is positional (one entry per leaf page) and cannot index a single page under two keys, so those values would be
+    // unreachable on read. To avoid it we force an overflowing key to start on a fresh page it fully owns.
+    final boolean startedOnContinuation = currentPage != null && getCount(currentPage) > 0;
+
     if (currentPage == null) {
       // CREATE A NEW PAGE
       currentPage = createNewPage(compactedPageNumberOfSeries.getAndIncrement());
@@ -115,6 +121,7 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
     int freeSpaceInPage = keyValueFreePosition - (getHeaderSize(pageNum) + (count * INT_SERIALIZED_SIZE) + INT_SERIALIZED_SIZE);
 
     RID[] values = rids;
+    boolean firstIteration = true;
 
     // REPEAT TO WRITE ALL THE RIDS (SPLIT THEM IF THEY DON'T FIT IN THE CURRENT PAGE)
     // Termination invariant: each iteration either breaks (all values written) or
@@ -126,8 +133,12 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
       int writtenValues = writeEntryMultipleValues(keyValueContent, convertedKeys, values, freeSpaceInPage,
           currentPage.getMaxContentSize() - getHeaderSize(pageNum), currentPage.getPageId());
 
-      if (writtenValues == 0) {
-        // NO SPACE LEFT, CREATE A NEW PAGE AND FLUSH TO THE DATABASE THE CURRENT ONE (NO WAL)
+      // No room at all, OR this key would split across a shared continuation page (see startedOnContinuation): in both cases
+      // move to a fresh page before committing anything for this key. The continuation page (with only the previous keys'
+      // values) is flushed as-is; this key's values then live entirely on pages it owns, keeping the positional root index
+      // consistent.
+      if (writtenValues == 0 || (firstIteration && startedOnContinuation && writtenValues < values.length)) {
+        // CREATE A NEW PAGE AND FLUSH TO THE DATABASE THE CURRENT ONE (NO WAL)
         database.getPageManager().updatePageVersion(currentPage, true);
         database.getPageManager().writePages(List.of(currentPage), true);
 
@@ -145,6 +156,8 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
         writtenValues = writeEntryMultipleValues(keyValueContent, convertedKeys, values, freeSpaceInPage,
             currentPage.getMaxContentSize() - getHeaderSize(pageNum), currentPage.getPageId());
       }
+
+      firstIteration = false;
 
       keyValueFreePosition -= keyValueContent.size();
 

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
@@ -177,7 +177,7 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
 
     final LSMTreeIndexCompacted compacted = new LSMTreeIndexCompacted(mainIndex, database, newName, unique,
         database.getDatabasePath() + File.separator + newName, keyTypes, binaryKeyTypes, pageSize);
-    compacted.setStoreTermFrequency(storeTermFrequency);
+    compacted.setStoreTermFrequency(isStoreTermFrequency());
     return compacted;
   }
 

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
@@ -164,12 +164,21 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
     internalRemove(keys, rid);
   }
 
+  @Override
+  public void setStoreTermFrequency(final boolean storeTermFrequency) {
+    super.setStoreTermFrequency(storeTermFrequency);
+    if (subIndex != null)
+      subIndex.setStoreTermFrequency(storeTermFrequency);
+  }
+
   public LSMTreeIndexCompacted createNewForCompaction() throws IOException {
     final int last_ = componentName.lastIndexOf('_');
     final String newName = componentName.substring(0, last_) + "_" + System.nanoTime();
 
-    return new LSMTreeIndexCompacted(mainIndex, database, newName, unique, database.getDatabasePath() + File.separator + newName,
-        keyTypes, binaryKeyTypes, pageSize);
+    final LSMTreeIndexCompacted compacted = new LSMTreeIndexCompacted(mainIndex, database, newName, unique,
+        database.getDatabasePath() + File.separator + newName, keyTypes, binaryKeyTypes, pageSize);
+    compacted.setStoreTermFrequency(storeTermFrequency);
+    return compacted;
   }
 
   public IndexCursor iterator(final boolean ascendingOrder, final Object[] fromKeys, final boolean inclusive) throws IOException {

--- a/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/antlr/SQLASTBuilder.java
@@ -5735,10 +5735,12 @@ public class SQLASTBuilder extends SQLParserBaseVisitor<Object> {
     // Handle WITH settings
     if (ctx.WITH() != null) {
       // WITH identifier EQ expression (COMMA identifier EQ expression)*
-      // identifier(0) is index name (already processed above)
-      // identifier(1), identifier(2), ... are setting keys
-      // expression(0), expression(1), ... are setting values
-      final List<SQLParser.IdentifierContext> settingKeys = ctx.identifier().subList(1, ctx.identifier().size());
+      // expression(0), expression(1), ... are setting values.
+      // The setting keys are also identifiers: for the named form identifier(0) is the index name (already processed above) and
+      // the keys start at identifier(1); for the `*` (STAR) form there is no index-name identifier, so the keys start at
+      // identifier(0). Using the wrong offset silently drops the first setting (this was the bug behind REBUILD INDEX * WITH ...).
+      final int firstSettingKeyIndex = ctx.STAR() != null ? 0 : 1;
+      final List<SQLParser.IdentifierContext> settingKeys = ctx.identifier().subList(firstSettingKeyIndex, ctx.identifier().size());
       final List<SQLParser.ExpressionContext> settingValues = ctx.expression();
 
       for (int i = 0; i < settingKeys.size() && i < settingValues.size(); i++) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexStep.java
@@ -62,7 +62,9 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
   private         MultiIterator<Map.Entry<Object, Identifiable>> customIterator;
   private         Iterator<?>                                    nullKeyIterator;
   private         Pair<Object, Identifiable>                     nextEntry   = null;
-  private         int                                            nextEntryScore = 0;
+  // Float so full-text BM25 scores below 1.0 are not truncated to 0 (which the `> 0` guard would then suppress). For
+  // integer-scored indexes getFloatScore() returns the int value unchanged.
+  private         float                                          nextEntryScore = 0f;
 
   public FetchFromIndexStep(final RangeIndex index, final BooleanExpression condition,
       final BinaryCondition additionalRangeCondition,
@@ -119,7 +121,7 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
           final ResultInternal result = new ResultInternal();
           result.setProperty("key", key);
           result.setProperty("rid", value);
-          if (nextEntryScore > 0)
+          if (nextEntryScore > 0f)
             result.setProperty("$score", nextEntryScore);
           context.setVariable("current", result);
           return result;
@@ -171,7 +173,7 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
       if (cursor.hasNext()) {
         final Object value = cursor.next();
         nextEntry = new Pair(cursor.getKeys(), value);
-        nextEntryScore = cursor.getScore();
+        nextEntryScore = cursor.getFloatScore();
         count++;
         return;
       }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexedFunctionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexedFunctionStep.java
@@ -20,11 +20,13 @@ package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.database.Record;
 import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.query.sql.parser.BinaryCondition;
 import com.arcadedb.query.sql.parser.FromClause;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.logging.Level;
 
 /**
  * Created by luigidellaquila on 06/08/16.
@@ -110,8 +112,10 @@ public class FetchFromIndexedFunctionStep extends AbstractExecutionStep {
       final Object scoring = functionCondition.getIndexedFunctionScoringExplain(queryTarget, context);
       if (scoring != null)
         result += "\n" + ExecutionStepInternal.getIndent(depth, indent) + "  SCORING " + scoring;
-    } catch (final Exception ignore) {
-      // ignore: scoring metadata is informational only
+    } catch (final Exception ex) {
+      // Scoring metadata is informational only, so never let it break plan rendering; log at FINE so the failure is still
+      // discoverable when debugging instead of being silently swallowed.
+      LogManager.instance().log(this, Level.FINE, "Failed to collect full-text scoring metadata for EXPLAIN/PROFILE", ex);
     }
     return result;
   }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexedFunctionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexedFunctionStep.java
@@ -101,6 +101,15 @@ public class FetchFromIndexedFunctionStep extends AbstractExecutionStep {
     if (context.isProfiling()) {
       result += " (" + getCostFormatted() + ")";
     }
+    // Surface BM25 scoring metadata (similarity, k1/b, N, avgdl, per-term df/idf) for full-text SEARCH_INDEX conditions so it can
+    // be inspected via EXPLAIN/PROFILE. Best-effort: never let an explain failure break the plan rendering.
+    try {
+      final Object scoring = functionCondition.getIndexedFunctionScoringExplain(queryTarget, context);
+      if (scoring != null)
+        result += "\n" + ExecutionStepInternal.getIndent(depth, indent) + "  SCORING " + scoring;
+    } catch (final Exception ignore) {
+      // ignore: scoring metadata is informational only
+    }
     return result;
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexedFunctionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/FetchFromIndexedFunctionStep.java
@@ -102,7 +102,10 @@ public class FetchFromIndexedFunctionStep extends AbstractExecutionStep {
       result += " (" + getCostFormatted() + ")";
     }
     // Surface BM25 scoring metadata (similarity, k1/b, N, avgdl, per-term df/idf) for full-text SEARCH_INDEX conditions so it can
-    // be inspected via EXPLAIN/PROFILE. Best-effort: never let an explain failure break the plan rendering.
+    // be inspected via EXPLAIN/PROFILE. This delegates down the indexed-function chain
+    // (BinaryCondition -> Expression -> ... -> FunctionCall -> IndexableSQLFunction.getScoringExplain), mirroring
+    // executeIndexedFunction; non-indexable or non-full-text functions return null. Best-effort: never let an explain failure
+    // break the plan rendering.
     try {
       final Object scoring = functionCondition.getIndexedFunctionScoringExplain(queryTarget, context);
       if (scoring != null)

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/IndexableSQLFunction.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/IndexableSQLFunction.java
@@ -35,4 +35,13 @@ public interface IndexableSQLFunction {
   long estimate(FromClause target, BinaryCompareOperator operator, Object rightValue, CommandContext context, Expression[] oExpressions);
 
   Iterable<Record> searchFromTarget(FromClause target, BinaryCompareOperator operator, Object rightValue, CommandContext context, Expression[] oExpressions);
+
+  /**
+   * Optional scoring metadata surfaced by {@code EXPLAIN}/{@code PROFILE} for this indexed function (e.g. the BM25 similarity,
+   * parameters and per-term IDF for {@code SEARCH_INDEX}). Returns {@code null} when the function has nothing to explain.
+   */
+  default Object getScoringExplain(final FromClause target, final BinaryCompareOperator operator, final Object rightValue,
+      final CommandContext context, final Expression[] oExpressions) {
+    return null;
+  }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BaseExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BaseExpression.java
@@ -282,6 +282,16 @@ public class BaseExpression extends MathExpression {
     return identifier.executeIndexedFunction(target, context, operator, right);
   }
 
+  @Override
+  public Object getIndexedFunctionScoringExplain(final FromClause target, final CommandContext context,
+      final BinaryCompareOperator operator, final Object right) {
+    if (expression != null)
+      return expression.getIndexedFunctionScoringExplain(target, context, operator, right);
+    if (this.identifier == null)
+      return null;
+    return identifier.getIndexedFunctionScoringExplain(target, context, operator, right);
+  }
+
   /**
    * tests if current expression is an indexed function AND that function can also be executed without using the index
    *

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BaseIdentifier.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BaseIdentifier.java
@@ -88,6 +88,13 @@ public class BaseIdentifier extends SimpleNode {
     return null;
   }
 
+  public Object getIndexedFunctionScoringExplain(final FromClause target, final CommandContext context,
+      final BinaryCompareOperator operator, final Object right) {
+    if (levelZero != null)
+      return levelZero.getIndexedFunctionScoringExplain(target, context, operator, right);
+    return null;
+  }
+
   /**
    * tests if current expression is an indexed function AND that function can also be executed without using the index
    *

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/BinaryCondition.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/BinaryCondition.java
@@ -67,6 +67,14 @@ public class BinaryCondition extends BooleanExpression {
   }
 
   /**
+   * Returns the optional scoring metadata for an indexed-function condition (e.g. BM25 details for {@code SEARCH_INDEX}),
+   * surfaced by {@code EXPLAIN}/{@code PROFILE}. Returns {@code null} when there is nothing to explain.
+   */
+  public Object getIndexedFunctionScoringExplain(final FromClause target, final CommandContext context) {
+    return left.getIndexedFunctionScoringExplain(target, context, operator, right.execute((Result) null, context));
+  }
+
+  /**
    * tests if current expression involves an indexed function AND that function can also be executed without using the index
    *
    * @param target  the query target

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/Expression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/Expression.java
@@ -253,6 +253,13 @@ public class Expression extends SimpleNode {
     return null;
   }
 
+  public Object getIndexedFunctionScoringExplain(final FromClause target, final CommandContext context,
+      final BinaryCompareOperator operator, final Object right) {
+    if (mathExpression != null)
+      return mathExpression.getIndexedFunctionScoringExplain(target, context, operator, right);
+    return null;
+  }
+
   /**
    * tests if current expression is an indexed function AND that function can also be executed without using the index
    *

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/FunctionCall.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/FunctionCall.java
@@ -166,6 +166,17 @@ public class FunctionCall extends SimpleNode {
   }
 
   /**
+   * Returns the optional scoring metadata for an indexed-function call, surfaced by {@code EXPLAIN}/{@code PROFILE}.
+   */
+  public Object getIndexedFunctionScoringExplain(final FromClause target, final CommandContext context,
+      final BinaryCompareOperator operator, final Object rightValue) {
+    final SQLFunction function = getFunction(context);
+    if (function instanceof IndexableSQLFunction lFunction)
+      return lFunction.getScoringExplain(target, operator, rightValue, context, this.getParams().toArray(new Expression[] {}));
+    return null;
+  }
+
+  /**
    * @param target     query target
    * @param context    execution context
    * @param operator   operator at the right of the function

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/LevelZeroIdentifier.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/LevelZeroIdentifier.java
@@ -96,6 +96,13 @@ public class LevelZeroIdentifier extends SimpleNode {
     return null;
   }
 
+  public Object getIndexedFunctionScoringExplain(final FromClause target, final CommandContext context,
+      final BinaryCompareOperator operator, final Object right) {
+    if (functionCall != null)
+      return functionCall.getIndexedFunctionScoringExplain(target, context, operator, right);
+    return null;
+  }
+
   /**
    * tests if current expression is an indexed function AND that function can also be executed without using the index
    *

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/MathExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/MathExpression.java
@@ -950,6 +950,13 @@ public class MathExpression extends SimpleNode {
     return this.childExpressions.getFirst().executeIndexedFunction(target, context, operator, right);
   }
 
+  public Object getIndexedFunctionScoringExplain(final FromClause target, final CommandContext context,
+      final BinaryCompareOperator operator, final Object right) {
+    if (this.childExpressions.size() != 1)
+      return null;
+    return this.childExpressions.getFirst().getIndexedFunctionScoringExplain(target, context, operator, right);
+  }
+
   /**
    * tests if current expression is an indexed function AND that function can also be executed without using the index
    *

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -190,6 +190,8 @@ public class RebuildIndexStatement extends DDLStatement {
           recomputed.add(idx.getName());
     } else {
       final Index idx = database.getSchema().getIndexByName(name.getValue());
+      if (idx == null)
+        throw new CommandExecutionException("Index '" + name.getValue() + "' not found");
       if (((IndexInternal) idx).recomputeStatistics())
         recomputed.add(idx.getName());
       else

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -195,8 +195,9 @@ public class RebuildIndexStatement extends DDLStatement {
       if (((IndexInternal) idx).recomputeStatistics())
         recomputed.add(idx.getName());
       else
-        throw new CommandExecutionException(
-            "Index '" + idx.getName() + "' has no recomputable statistics (only BM25 full-text indexes do)");
+        throw new CommandExecutionException("Index '" + idx.getName()
+            + "' has no recomputable statistics: only BM25 full-text indexes keep corpus statistics. "
+            + "Switch the index to BM25 similarity, or omit 'statsOnly' to do a full rebuild.");
     }
     result.setProperty("indexes", recomputed);
     result.setProperty("statsRecomputed", recomputed.size());

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -192,7 +192,9 @@ public class RebuildIndexStatement extends DDLStatement {
       final Index idx = database.getSchema().getIndexByName(name.getValue());
       if (idx == null)
         throw new CommandExecutionException("Index '" + name.getValue() + "' not found");
-      if (((IndexInternal) idx).recomputeStatistics())
+      if (!(idx instanceof final IndexInternal internal))
+        throw new CommandExecutionException("Index '" + idx.getName() + "' does not support statistics recomputation");
+      if (internal.recomputeStatistics())
         recomputed.add(idx.getName());
       else
         throw new CommandExecutionException("Index '" + idx.getName()

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -67,16 +67,25 @@ public class RebuildIndexStatement extends DDLStatement {
 
     int batchSize = IndexBuilder.BUILD_BATCH_SIZE;
     int maxAttempts = MAX_ATTEMPTS;
+    // statsOnly: recompute persisted index statistics (BM25 corpus counters) by rescanning the live data, without the far more
+    // expensive full index rebuild. Lets operators repair counter drift (e.g. from rolled-back transactions) from SQL.
+    boolean statsOnly = false;
     if (!settings.isEmpty()) {
       for (Map.Entry<Expression, Expression> entry : settings.entrySet()) {
         if ("batchSize".equalsIgnoreCase(entry.getKey().toString()))
           batchSize = Integer.parseInt(entry.getValue().value.toString());
         else if ("maxAttempts".equalsIgnoreCase(entry.getKey().toString()))
           maxAttempts = Integer.parseInt(entry.getValue().value.toString());
+        else if ("statsOnly".equalsIgnoreCase(entry.getKey().toString()))
+          // A boolean literal renders via toString() (its `value` field is null, unlike numeric literals).
+          statsOnly = Boolean.parseBoolean(entry.getValue().toString());
         else
           throw new CommandSQLParsingException("Unrecognized setting '" + entry.getKey() + "' in rebuild index statement");
       }
     }
+
+    if (statsOnly)
+      return recomputeStatistics(context.getDatabase(), result);
 
     final AtomicLong total = new AtomicLong();
     final AtomicLong misplaced = new AtomicLong();
@@ -160,6 +169,34 @@ public class RebuildIndexStatement extends DDLStatement {
     }
 
     // SUCCESS
+    final InternalResultSet rs = new InternalResultSet();
+    rs.add(result);
+    return rs;
+  }
+
+  /**
+   * Handles {@code REBUILD INDEX <name|*> {statsOnly: true}}: recomputes persisted index statistics (BM25 corpus counters) by
+   * rescanning the live data, without the full index rebuild. For {@code *} only the logical (type) indexes are visited so the
+   * type is scanned once per index rather than once per bucket sub-index.
+   */
+  private ResultSet recomputeStatistics(final Database database, final ResultInternal result) {
+    result.setProperty("operation", "rebuild index stats");
+    final List<String> recomputed = new ArrayList<>();
+    if (all) {
+      for (final Index idx : database.getSchema().getIndexes())
+        if (idx instanceof TypeIndex && ((IndexInternal) idx).recomputeStatistics())
+          recomputed.add(idx.getName());
+    } else {
+      final Index idx = database.getSchema().getIndexByName(name.getValue());
+      if (((IndexInternal) idx).recomputeStatistics())
+        recomputed.add(idx.getName());
+      else
+        throw new CommandExecutionException(
+            "Index '" + idx.getName() + "' has no recomputable statistics (only BM25 full-text indexes do)");
+    }
+    result.setProperty("indexes", recomputed);
+    result.setProperty("statsRecomputed", recomputed.size());
+
     final InternalResultSet rs = new InternalResultSet();
     rs.add(result);
     return rs;

--- a/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/parser/RebuildIndexStatement.java
@@ -72,13 +72,15 @@ public class RebuildIndexStatement extends DDLStatement {
     boolean statsOnly = false;
     if (!settings.isEmpty()) {
       for (Map.Entry<Expression, Expression> entry : settings.entrySet()) {
+        // Render the setting value via Expression.toString(): its `value` field can be null depending on how the literal was
+        // parsed (it was for the integer in `WITH batchSize = 1000`), so toString() is the reliable accessor for all literals.
+        final String settingValue = entry.getValue().toString();
         if ("batchSize".equalsIgnoreCase(entry.getKey().toString()))
-          batchSize = Integer.parseInt(entry.getValue().value.toString());
+          batchSize = Integer.parseInt(settingValue);
         else if ("maxAttempts".equalsIgnoreCase(entry.getKey().toString()))
-          maxAttempts = Integer.parseInt(entry.getValue().value.toString());
+          maxAttempts = Integer.parseInt(settingValue);
         else if ("statsOnly".equalsIgnoreCase(entry.getKey().toString()))
-          // A boolean literal renders via toString() (its `value` field is null, unlike numeric literals).
-          statsOnly = Boolean.parseBoolean(entry.getValue().toString());
+          statsOnly = Boolean.parseBoolean(settingValue);
         else
           throw new CommandSQLParsingException("Unrecognized setting '" + entry.getKey() + "' in rebuild index statement");
       }
@@ -184,7 +186,7 @@ public class RebuildIndexStatement extends DDLStatement {
     final List<String> recomputed = new ArrayList<>();
     if (all) {
       for (final Index idx : database.getSchema().getIndexes())
-        if (idx instanceof TypeIndex && ((IndexInternal) idx).recomputeStatistics())
+        if (idx instanceof TypeIndex ti && ti.recomputeStatistics())
           recomputed.add(idx.getName());
     } else {
       final Index idx = database.getSchema().getIndexByName(name.getValue());

--- a/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
@@ -23,6 +23,7 @@ import com.arcadedb.utility.CollectionUtils;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Metadata class for full-text indexes, storing Lucene analyzer configuration.
@@ -71,10 +72,11 @@ public class FullTextIndexMetadata extends IndexMetadata {
   private float              bm25B       = 0.75f;
   private Map<String, Float> fieldBoosts = new HashMap<>();
 
-  // PERSISTED CORPUS STATISTICS FOR avgdl (live document count and sum of document lengths)
-  private long    totalDocs     = 0L;
-  private long    sumDocLength  = 0L;
-  private boolean countersValid = false;
+  // PERSISTED CORPUS STATISTICS FOR avgdl (live document count and sum of document lengths). Concurrent transactions can index
+  // documents into the same bucket simultaneously, all updating this shared metadata, so the counters are atomic.
+  private final AtomicLong totalDocs     = new AtomicLong(0L);
+  private final AtomicLong sumDocLength  = new AtomicLong(0L);
+  private volatile boolean countersValid = false;
 
   /**
    * Creates a new FullTextIndexMetadata instance.
@@ -112,8 +114,8 @@ public class FullTextIndexMetadata extends IndexMetadata {
     this.similarity = metadata.has("similarity") ? metadata.getString("similarity").toUpperCase() : SIMILARITY_CLASSIC;
     this.bm25K1 = metadata.getFloat("bm25_k1", bm25K1);
     this.bm25B = metadata.getFloat("bm25_b", bm25B);
-    this.totalDocs = metadata.getLong("ft_totalDocs", 0L);
-    this.sumDocLength = metadata.getLong("ft_sumDocLength", 0L);
+    this.totalDocs.set(metadata.getLong("ft_totalDocs", 0L));
+    this.sumDocLength.set(metadata.getLong("ft_sumDocLength", 0L));
     this.countersValid = metadata.getBoolean("ft_countersValid", false);
 
     // Parse per-field analyzers (pattern: *_analyzer) and per-field boosts (pattern: *_boost)
@@ -161,8 +163,8 @@ public class FullTextIndexMetadata extends IndexMetadata {
     }
 
     if (countersValid) {
-      metadata.put("ft_totalDocs", totalDocs);
-      metadata.put("ft_sumDocLength", sumDocLength);
+      metadata.put("ft_totalDocs", totalDocs.get());
+      metadata.put("ft_sumDocLength", sumDocLength.get());
       metadata.put("ft_countersValid", true);
     }
     return metadata;
@@ -369,14 +371,14 @@ public class FullTextIndexMetadata extends IndexMetadata {
    * Returns the persisted live document count used for IDF.
    */
   public long getTotalDocs() {
-    return totalDocs;
+    return totalDocs.get();
   }
 
   /**
    * Returns the persisted sum of document lengths used to compute the average document length.
    */
   public long getSumDocLength() {
-    return sumDocLength;
+    return sumDocLength.get();
   }
 
   /**
@@ -401,38 +403,38 @@ public class FullTextIndexMetadata extends IndexMetadata {
    * @param sumDocLength sum of document lengths
    */
   public void setCounters(final long totalDocs, final long sumDocLength) {
-    this.totalDocs = totalDocs;
-    this.sumDocLength = sumDocLength;
+    this.totalDocs.set(totalDocs);
+    this.sumDocLength.set(sumDocLength);
     this.countersValid = true;
   }
 
   /**
-   * Records a newly indexed document in the corpus counters.
+   * Records a newly indexed document in the corpus counters. Thread-safe: concurrent indexing transactions may call this on the
+   * shared per-bucket metadata.
    *
    * @param docLength number of analyzed tokens of the document
    */
   public void addDocument(final long docLength) {
-    ++totalDocs;
-    sumDocLength += docLength;
+    totalDocs.incrementAndGet();
+    sumDocLength.addAndGet(docLength);
   }
 
   /**
-   * Removes a document from the corpus counters, clamping at zero to stay consistent under at-least-once removals.
+   * Removes a document from the corpus counters, clamping at zero to stay consistent under at-least-once removals. Thread-safe.
    *
    * @param docLength number of analyzed tokens of the document
    */
   public void removeDocument(final long docLength) {
-    if (totalDocs > 0)
-      --totalDocs;
-    sumDocLength -= docLength;
-    if (sumDocLength < 0)
-      sumDocLength = 0;
+    totalDocs.updateAndGet(v -> v > 0 ? v - 1 : v);
+    sumDocLength.updateAndGet(v -> Math.max(0L, v - docLength));
   }
 
   /**
-   * Returns the average document length across the collection, or 1.0 when no statistics are available.
+   * Returns the average document length across the collection, or 1.0 when no statistics are available. The two counters are read
+   * independently, so a concurrent update may make this momentarily approximate - acceptable for a ranking heuristic.
    */
   public double avgDocLength() {
-    return totalDocs > 0 ? (double) sumDocLength / totalDocs : 1.0;
+    final long n = totalDocs.get();
+    return n > 0 ? (double) sumDocLength.get() / n : 1.0;
   }
 }

--- a/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
@@ -149,9 +149,11 @@ public class FullTextIndexMetadata extends IndexMetadata {
       setSimilarity(metadata.getString("similarity"));
     else
       this.similarity = SIMILARITY_CLASSIC;
-    // Route through the setters so invalid k1/b in METADATA {...} are rejected at index creation rather than silently scoring wrong.
-    setBm25K1(metadata.getFloat("bm25_k1", bm25K1));
-    setBm25B(metadata.getFloat("bm25_b", bm25B));
+    // Route through the setters so invalid k1/b in METADATA {...} are rejected at index creation rather than silently scoring
+    // wrong. Default to the DEFAULT_BM25_* constants (not the current field values) so a key absent from the JSON resets to the
+    // default rather than carrying a stale value forward if fromJSON is ever called on a recycled instance.
+    setBm25K1(metadata.getFloat("bm25_k1", DEFAULT_BM25_K1));
+    setBm25B(metadata.getFloat("bm25_b", DEFAULT_BM25_B));
     // Restore the counters by setting the fields directly, NOT via setCounters(): setCounters() consumes the once-per-session
     // stale-check (staleChecked=true), which on a load path would suppress the first-query validation that self-heals counters
     // that lag the on-disk data. Keep this direct so the stale check still runs after a restart.

--- a/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
@@ -103,7 +103,8 @@ public class FullTextIndexMetadata extends IndexMetadata {
   private final AtomicBoolean staleChecked = new AtomicBoolean(false);
 
   /**
-   * Creates a new FullTextIndexMetadata instance.
+   * Creates a new FullTextIndexMetadata instance. Defaults to BM25 similarity (see the {@code similarity} field); the
+   * {@link #defaultBM25} factory is just a self-documenting alias of this constructor for the "new index" call site.
    *
    * @param typeName      the name of the type this index belongs to
    * @param propertyNames the property names indexed

--- a/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
@@ -65,6 +65,10 @@ public class FullTextIndexMetadata extends IndexMetadata {
   private static final String ANALYZER_SUFFIX = "_analyzer";
   private static final String BOOST_SUFFIX    = "_boost";
 
+  // These scalar fields (analyzers, operator, wildcard flag, similarity, k1/b) are set once at index creation / schema load,
+  // before any query-path read, so they need no volatile/synchronization (unlike the live corpus counters and the per-field
+  // maps below, which are mutated after construction). Do not "fix" them by adding volatile - the publication is via the
+  // happens-before of schema load completing before the index serves queries.
   private          String              analyzerClass        = DEFAULT_ANALYZER;
   private          String              indexAnalyzerClass   = null;
   private          String              queryAnalyzerClass   = null;
@@ -461,6 +465,13 @@ public class FullTextIndexMetadata extends IndexMetadata {
 
   /**
    * Sets the persisted corpus counters in one shot, marking them valid.
+   * <p>
+   * Also marks the once-per-session staleness check as consumed: the counters have just been recomputed from the live data, so
+   * they are exact and there is no point re-validating them later in this session. After this, subsequent maintenance
+   * ({@link #addDocument}/{@link #removeDocument}) keeps them current incrementally; the only un-tracked drift source is
+   * rollbacks, which the next session's stale check (or another explicit recompute) corrects. Practical implication: if you run a
+   * stats recompute and then bulk-import in the same JVM session, no automatic re-validation fires - but the import's incremental
+   * updates keep the counters accurate, so that is fine.
    *
    * @param totalDocs    live document count
    * @param sumDocLength sum of document lengths

--- a/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
@@ -57,6 +57,11 @@ public class FullTextIndexMetadata extends IndexMetadata {
    */
   public static final String SIMILARITY_CLASSIC = "CLASSIC";
 
+  /** Default BM25 term-frequency saturation parameter. */
+  public static final float  DEFAULT_BM25_K1 = 1.2f;
+  /** Default BM25 document-length normalization parameter. */
+  public static final float  DEFAULT_BM25_B  = 0.75f;
+
   private static final String ANALYZER_SUFFIX = "_analyzer";
   private static final String BOOST_SUFFIX    = "_boost";
 
@@ -71,8 +76,8 @@ public class FullTextIndexMetadata extends IndexMetadata {
 
   // BM25 SCORING CONFIGURATION
   private String             similarity  = SIMILARITY_BM25;
-  private float              bm25K1      = 1.2f;
-  private float              bm25B       = 0.75f;
+  private float              bm25K1      = DEFAULT_BM25_K1;
+  private float              bm25B       = DEFAULT_BM25_B;
   private final Map<String, Float> fieldBoosts = new ConcurrentHashMap<>();
 
   // PERSISTED CORPUS STATISTICS FOR avgdl (live document count and sum of document lengths).
@@ -99,6 +104,15 @@ public class FullTextIndexMetadata extends IndexMetadata {
    */
   public FullTextIndexMetadata(final String typeName, final String[] propertyNames, final int bucketId) {
     super(typeName, propertyNames, bucketId);
+  }
+
+  /**
+   * Creates a metadata instance carrying the BM25 defaults, for a new full-text index created without explicit metadata so it
+   * ranks with BM25 out of the box. The constructor already defaults to BM25; this named factory makes that intent explicit at
+   * the call site.
+   */
+  public static FullTextIndexMetadata defaultBM25(final String typeName, final String[] propertyNames, final int bucketId) {
+    return new FullTextIndexMetadata(typeName, propertyNames, bucketId);
   }
 
   @Override
@@ -172,8 +186,11 @@ public class FullTextIndexMetadata extends IndexMetadata {
 
     metadata.put("similarity", similarity);
     if (isBM25()) {
-      metadata.put("bm25_k1", bm25K1);
-      metadata.put("bm25_b", bm25B);
+      // Emit k1/b only when tuned away from the defaults (read back as the defaults when absent), keeping the schema JSON terse.
+      if (bm25K1 != DEFAULT_BM25_K1)
+        metadata.put("bm25_k1", bm25K1);
+      if (bm25B != DEFAULT_BM25_B)
+        metadata.put("bm25_b", bm25B);
       for (final Map.Entry<String, Float> entry : fieldBoosts.entrySet())
         metadata.put(entry.getKey() + BOOST_SUFFIX, entry.getValue());
     }

--- a/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
@@ -44,7 +44,19 @@ public class FullTextIndexMetadata extends IndexMetadata {
    */
   public static final String DEFAULT_ANALYZER = "org.apache.lucene.analysis.standard.StandardAnalyzer";
 
+  /**
+   * BM25 similarity: ranks with term-frequency, inverse document frequency and document-length normalization. Default for newly
+   * created full-text indexes.
+   */
+  public static final String SIMILARITY_BM25 = "BM25";
+
+  /**
+   * Legacy term-coordination (match-count) similarity. Default for indexes created before BM25 support, preserving their ranking.
+   */
+  public static final String SIMILARITY_CLASSIC = "CLASSIC";
+
   private static final String ANALYZER_SUFFIX = "_analyzer";
+  private static final String BOOST_SUFFIX    = "_boost";
 
   private String              analyzerClass        = DEFAULT_ANALYZER;
   private String              indexAnalyzerClass   = null;
@@ -52,6 +64,17 @@ public class FullTextIndexMetadata extends IndexMetadata {
   private boolean             allowLeadingWildcard = false;
   private String              defaultOperator      = "OR";
   private Map<String, String> fieldAnalyzers       = new HashMap<>();
+
+  // BM25 SCORING CONFIGURATION
+  private String             similarity  = SIMILARITY_BM25;
+  private float              bm25K1      = 1.2f;
+  private float              bm25B       = 0.75f;
+  private Map<String, Float> fieldBoosts = new HashMap<>();
+
+  // PERSISTED CORPUS STATISTICS FOR avgdl (live document count and sum of document lengths)
+  private long    totalDocs     = 0L;
+  private long    sumDocLength  = 0L;
+  private boolean countersValid = false;
 
   /**
    * Creates a new FullTextIndexMetadata instance.
@@ -84,13 +107,65 @@ public class FullTextIndexMetadata extends IndexMetadata {
     if (metadata.has("defaultOperator"))
       this.defaultOperator = metadata.getString("defaultOperator");
 
-    // Parse per-field analyzers (pattern: *_analyzer)
+    // An index persisted before BM25 support has no "similarity" key: keep it on the legacy CLASSIC scoring so an upgrade does
+    // not silently change ranking. A freshly created index (or one created with this feature) carries the key explicitly.
+    this.similarity = metadata.has("similarity") ? metadata.getString("similarity").toUpperCase() : SIMILARITY_CLASSIC;
+    this.bm25K1 = metadata.getFloat("bm25_k1", bm25K1);
+    this.bm25B = metadata.getFloat("bm25_b", bm25B);
+    this.totalDocs = metadata.getLong("ft_totalDocs", 0L);
+    this.sumDocLength = metadata.getLong("ft_sumDocLength", 0L);
+    this.countersValid = metadata.getBoolean("ft_countersValid", false);
+
+    // Parse per-field analyzers (pattern: *_analyzer) and per-field boosts (pattern: *_boost)
     for (final String key : metadata.keySet()) {
       if (key.endsWith(ANALYZER_SUFFIX) && !"analyzer".equals(key) && !"index_analyzer".equals(key) && !"query_analyzer".equals(key)) {
         final String fieldName = key.substring(0, key.length() - ANALYZER_SUFFIX.length());
         this.fieldAnalyzers.put(fieldName, metadata.getString(key));
+      } else if (key.endsWith(BOOST_SUFFIX)) {
+        final String fieldName = key.substring(0, key.length() - BOOST_SUFFIX.length());
+        this.fieldBoosts.put(fieldName, metadata.getFloat(key, 1.0f));
       }
     }
+  }
+
+  /**
+   * Writes the full-text-specific configuration and persisted statistics into the given JSON object, which already carries the
+   * common index keys (type, bucket, properties...). Only non-default values are emitted to keep the schema compact, except the
+   * corpus counters which are always written when valid.
+   *
+   * @param metadata the JSON object to populate
+   *
+   * @return the same JSON object, for chaining
+   */
+  public JSONObject writeToJSON(final JSONObject metadata) {
+    if (!DEFAULT_ANALYZER.equals(analyzerClass))
+      metadata.put("analyzer", analyzerClass);
+    if (indexAnalyzerClass != null)
+      metadata.put("index_analyzer", indexAnalyzerClass);
+    if (queryAnalyzerClass != null)
+      metadata.put("query_analyzer", queryAnalyzerClass);
+    if (allowLeadingWildcard)
+      metadata.put("allowLeadingWildcard", true);
+    if (!"OR".equalsIgnoreCase(defaultOperator))
+      metadata.put("defaultOperator", defaultOperator);
+
+    for (final Map.Entry<String, String> entry : fieldAnalyzers.entrySet())
+      metadata.put(entry.getKey() + ANALYZER_SUFFIX, entry.getValue());
+
+    metadata.put("similarity", similarity);
+    if (isBM25()) {
+      metadata.put("bm25_k1", bm25K1);
+      metadata.put("bm25_b", bm25B);
+      for (final Map.Entry<String, Float> entry : fieldBoosts.entrySet())
+        metadata.put(entry.getKey() + BOOST_SUFFIX, entry.getValue());
+    }
+
+    if (countersValid) {
+      metadata.put("ft_totalDocs", totalDocs);
+      metadata.put("ft_sumDocLength", sumDocLength);
+      metadata.put("ft_countersValid", true);
+    }
+    return metadata;
   }
 
   /**
@@ -213,5 +288,151 @@ public class FullTextIndexMetadata extends IndexMetadata {
    */
   public void setFieldAnalyzer(final String fieldName, final String analyzerClass) {
     this.fieldAnalyzers.put(fieldName, analyzerClass);
+  }
+
+  /**
+   * Returns the configured similarity mode ("BM25" or "CLASSIC").
+   */
+  public String getSimilarity() {
+    return similarity;
+  }
+
+  /**
+   * Sets the similarity mode. Accepts "BM25" or "CLASSIC" (case-insensitive).
+   */
+  public void setSimilarity(final String similarity) {
+    this.similarity = similarity != null ? similarity.toUpperCase() : SIMILARITY_BM25;
+  }
+
+  /**
+   * Returns true if this index ranks with BM25 scoring.
+   */
+  public boolean isBM25() {
+    return SIMILARITY_BM25.equalsIgnoreCase(similarity);
+  }
+
+  /**
+   * Returns the BM25 term-frequency saturation parameter k1.
+   */
+  public float getBm25K1() {
+    return bm25K1;
+  }
+
+  /**
+   * Sets the BM25 term-frequency saturation parameter k1.
+   */
+  public void setBm25K1(final float bm25K1) {
+    this.bm25K1 = bm25K1;
+  }
+
+  /**
+   * Returns the BM25 document-length normalization parameter b.
+   */
+  public float getBm25B() {
+    return bm25B;
+  }
+
+  /**
+   * Sets the BM25 document-length normalization parameter b.
+   */
+  public void setBm25B(final float bm25B) {
+    this.bm25B = bm25B;
+  }
+
+  /**
+   * Returns the boost multiplier for a field, or 1.0 when no boost is configured.
+   *
+   * @param fieldName the field name
+   */
+  public float getFieldBoost(final String fieldName) {
+    return fieldBoosts.getOrDefault(fieldName, 1.0f);
+  }
+
+  /**
+   * Sets a boost multiplier for a specific field. Boosts greater than 1.0 increase the field's contribution to the BM25 score.
+   *
+   * @param fieldName the field name
+   * @param boost     the multiplier
+   */
+  public void setFieldBoost(final String fieldName, final float boost) {
+    this.fieldBoosts.put(fieldName, boost);
+  }
+
+  /**
+   * Returns an unmodifiable view of the per-field boost map.
+   */
+  public Map<String, Float> getFieldBoosts() {
+    return CollectionUtils.immutableMap(fieldBoosts);
+  }
+
+  /**
+   * Returns the persisted live document count used for IDF.
+   */
+  public long getTotalDocs() {
+    return totalDocs;
+  }
+
+  /**
+   * Returns the persisted sum of document lengths used to compute the average document length.
+   */
+  public long getSumDocLength() {
+    return sumDocLength;
+  }
+
+  /**
+   * Returns true when the persisted corpus counters are trustworthy. When false the average document length must be recomputed
+   * (e.g. for an index that predates BM25 support).
+   */
+  public boolean isCountersValid() {
+    return countersValid;
+  }
+
+  /**
+   * Marks the persisted corpus counters as valid (or invalid).
+   */
+  public void setCountersValid(final boolean countersValid) {
+    this.countersValid = countersValid;
+  }
+
+  /**
+   * Sets the persisted corpus counters in one shot, marking them valid.
+   *
+   * @param totalDocs    live document count
+   * @param sumDocLength sum of document lengths
+   */
+  public void setCounters(final long totalDocs, final long sumDocLength) {
+    this.totalDocs = totalDocs;
+    this.sumDocLength = sumDocLength;
+    this.countersValid = true;
+  }
+
+  /**
+   * Records a newly indexed document in the corpus counters.
+   *
+   * @param docLength number of analyzed tokens of the document
+   */
+  public void addDocument(final long docLength) {
+    ++totalDocs;
+    sumDocLength += docLength;
+  }
+
+  /**
+   * Removes a document from the corpus counters, clamping at zero to stay consistent under at-least-once removals.
+   *
+   * @param docLength number of analyzed tokens of the document
+   */
+  public void removeDocument(final long docLength) {
+    if (totalDocs > 0)
+      --totalDocs;
+    sumDocLength -= docLength;
+    if (sumDocLength < 0)
+      sumDocLength = 0;
+  }
+
+  /**
+   * Returns the average document length across the collection, or 1.0 when no statistics are available.
+   */
+  public double avgDocLength() {
+    return totalDocs > 0 ? (double) sumDocLength / totalDocs : 1.0;
   }
 }

--- a/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
@@ -151,6 +151,9 @@ public class FullTextIndexMetadata extends IndexMetadata {
     // Route through the setters so invalid k1/b in METADATA {...} are rejected at index creation rather than silently scoring wrong.
     setBm25K1(metadata.getFloat("bm25_k1", bm25K1));
     setBm25B(metadata.getFloat("bm25_b", bm25B));
+    // Restore the counters by setting the fields directly, NOT via setCounters(): setCounters() consumes the once-per-session
+    // stale-check (staleChecked=true), which on a load path would suppress the first-query validation that self-heals counters
+    // that lag the on-disk data. Keep this direct so the stale check still runs after a restart.
     this.totalDocs.set(metadata.getLong("ft_totalDocs", 0L));
     this.sumDocLength.set(metadata.getLong("ft_sumDocLength", 0L));
     this.countersValid = metadata.getBoolean("ft_countersValid", false);

--- a/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
@@ -80,6 +80,10 @@ public class FullTextIndexMetadata extends IndexMetadata {
   private final AtomicLong totalDocs     = new AtomicLong(0L);
   private final AtomicLong sumDocLength  = new AtomicLong(0L);
   private volatile boolean countersValid = false;
+  // Transient (never persisted): whether the persisted counters have been checked for staleness against the live data this
+  // session. Persisted counters can lag the on-disk data if documents were indexed after the last schema save, so the first
+  // BM25 query validates them once (cheap live count) and rebuilds only if they disagree.
+  private transient volatile boolean staleChecked = false;
 
   /**
    * Creates a new FullTextIndexMetadata instance.
@@ -415,6 +419,20 @@ public class FullTextIndexMetadata extends IndexMetadata {
   }
 
   /**
+   * Returns true once the persisted counters have been validated against the live data this session (see {@link #staleChecked}).
+   */
+  public boolean isStaleChecked() {
+    return staleChecked;
+  }
+
+  /**
+   * Marks the persisted counters as having been checked for staleness this session, so the (cheap) live-count check runs once.
+   */
+  public void markStaleChecked() {
+    this.staleChecked = true;
+  }
+
+  /**
    * Marks the persisted corpus counters as valid (or invalid).
    */
   public void setCountersValid(final boolean countersValid) {
@@ -431,6 +449,7 @@ public class FullTextIndexMetadata extends IndexMetadata {
     this.totalDocs.set(totalDocs);
     this.sumDocLength.set(sumDocLength);
     this.countersValid = true;
+    this.staleChecked = true; // freshly computed counters are by definition consistent with the live data
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
@@ -155,7 +155,8 @@ public class FullTextIndexMetadata extends IndexMetadata {
         this.fieldAnalyzers.put(fieldName, metadata.getString(key));
       } else if (key.endsWith(BOOST_SUFFIX)) {
         final String fieldName = key.substring(0, key.length() - BOOST_SUFFIX.length());
-        this.fieldBoosts.put(fieldName, metadata.getFloat(key, 1.0f));
+        // Route through the setter so a boost supplied via METADATA {...} gets the same >= 0 validation as the builder path.
+        setFieldBoost(fieldName, metadata.getFloat(key, 1.0f));
       }
     }
   }
@@ -402,12 +403,15 @@ public class FullTextIndexMetadata extends IndexMetadata {
   }
 
   /**
-   * Sets a boost multiplier for a specific field. Boosts greater than 1.0 increase the field's contribution to the BM25 score.
+   * Sets a boost multiplier for a specific field. Boosts greater than 1.0 increase the field's contribution to the BM25 score;
+   * 0.0 disables it. Negative boosts are rejected because they would produce negative term contributions and invert ranking.
    *
    * @param fieldName the field name
-   * @param boost     the multiplier
+   * @param boost     the multiplier (must be >= 0)
    */
   public void setFieldBoost(final String fieldName, final float boost) {
+    if (boost < 0)
+      throw new IllegalArgumentException("BM25 field boost for '" + fieldName + "' must be >= 0, but was " + boost);
     this.fieldBoosts.put(fieldName, boost);
   }
 

--- a/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
@@ -112,9 +112,12 @@ public class FullTextIndexMetadata extends IndexMetadata {
     if (metadata.has("defaultOperator"))
       this.defaultOperator = metadata.getString("defaultOperator");
 
-    // An index persisted before BM25 support has no "similarity" key: keep it on the legacy CLASSIC scoring so an upgrade does
-    // not silently change ranking. A freshly created index (or one created with this feature) carries the key explicitly.
-    this.similarity = metadata.has("similarity") ? metadata.getString("similarity").toUpperCase() : SIMILARITY_CLASSIC;
+    // An index persisted before BM25 support has no "similarity" key: keep it on CLASSIC so an upgrade does not silently change
+    // ranking. Route an explicit value through the validating setter so an unknown similarity in METADATA {...} is rejected.
+    if (metadata.has("similarity"))
+      setSimilarity(metadata.getString("similarity"));
+    else
+      this.similarity = SIMILARITY_CLASSIC;
     // Route through the setters so invalid k1/b in METADATA {...} are rejected at index creation rather than silently scoring wrong.
     setBm25K1(metadata.getFloat("bm25_k1", bm25K1));
     setBm25B(metadata.getFloat("bm25_b", bm25B));
@@ -304,10 +307,20 @@ public class FullTextIndexMetadata extends IndexMetadata {
   }
 
   /**
-   * Sets the similarity mode. Accepts "BM25" or "CLASSIC" (case-insensitive).
+   * Sets the similarity mode. Accepts "BM25" or "CLASSIC" (case-insensitive); null resets to the BM25 default.
+   *
+   * @throws IllegalArgumentException if the name is not a known similarity
    */
   public void setSimilarity(final String similarity) {
-    this.similarity = similarity != null ? similarity.toUpperCase() : SIMILARITY_BM25;
+    if (similarity == null) {
+      this.similarity = SIMILARITY_BM25;
+      return;
+    }
+    final String upper = similarity.toUpperCase();
+    if (!SIMILARITY_BM25.equals(upper) && !SIMILARITY_CLASSIC.equals(upper))
+      throw new IllegalArgumentException(
+          "Unknown full-text similarity '" + similarity + "'. Valid values: " + SIMILARITY_BM25 + ", " + SIMILARITY_CLASSIC);
+    this.similarity = upper;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
@@ -21,8 +21,8 @@ package com.arcadedb.schema;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.CollectionUtils;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -59,21 +59,24 @@ public class FullTextIndexMetadata extends IndexMetadata {
   private static final String ANALYZER_SUFFIX = "_analyzer";
   private static final String BOOST_SUFFIX    = "_boost";
 
-  private String              analyzerClass        = DEFAULT_ANALYZER;
-  private String              indexAnalyzerClass   = null;
-  private String              queryAnalyzerClass   = null;
-  private boolean             allowLeadingWildcard = false;
-  private String              defaultOperator      = "OR";
-  private Map<String, String> fieldAnalyzers       = new HashMap<>();
+  private          String              analyzerClass        = DEFAULT_ANALYZER;
+  private          String              indexAnalyzerClass   = null;
+  private          String              queryAnalyzerClass   = null;
+  private          boolean             allowLeadingWildcard = false;
+  private          String              defaultOperator      = "OR";
+  // Per-field maps are concurrent: they are populated at index creation but read on the query path (getFieldBoost,
+  // getAnalyzerClass) and iterated by writeToJSON on schema save, so a HashMap could throw ConcurrentModificationException.
+  private final    Map<String, String> fieldAnalyzers       = new ConcurrentHashMap<>();
 
   // BM25 SCORING CONFIGURATION
   private String             similarity  = SIMILARITY_BM25;
   private float              bm25K1      = 1.2f;
   private float              bm25B       = 0.75f;
-  private Map<String, Float> fieldBoosts = new HashMap<>();
+  private final Map<String, Float> fieldBoosts = new ConcurrentHashMap<>();
 
-  // PERSISTED CORPUS STATISTICS FOR avgdl (live document count and sum of document lengths). Concurrent transactions can index
-  // documents into the same bucket simultaneously, all updating this shared metadata, so the counters are atomic.
+  // PERSISTED CORPUS STATISTICS FOR avgdl (live document count and sum of document lengths).
+  // NOTE (concurrency): concurrent transactions can index documents into the same bucket simultaneously, all mutating this
+  // shared per-bucket metadata, so the counters are AtomicLong (and countersValid is volatile) - bare longs would lose updates.
   private final AtomicLong totalDocs     = new AtomicLong(0L);
   private final AtomicLong sumDocLength  = new AtomicLong(0L);
   private volatile boolean countersValid = false;
@@ -112,8 +115,9 @@ public class FullTextIndexMetadata extends IndexMetadata {
     // An index persisted before BM25 support has no "similarity" key: keep it on the legacy CLASSIC scoring so an upgrade does
     // not silently change ranking. A freshly created index (or one created with this feature) carries the key explicitly.
     this.similarity = metadata.has("similarity") ? metadata.getString("similarity").toUpperCase() : SIMILARITY_CLASSIC;
-    this.bm25K1 = metadata.getFloat("bm25_k1", bm25K1);
-    this.bm25B = metadata.getFloat("bm25_b", bm25B);
+    // Route through the setters so invalid k1/b in METADATA {...} are rejected at index creation rather than silently scoring wrong.
+    setBm25K1(metadata.getFloat("bm25_k1", bm25K1));
+    setBm25B(metadata.getFloat("bm25_b", bm25B));
     this.totalDocs.set(metadata.getLong("ft_totalDocs", 0L));
     this.sumDocLength.set(metadata.getLong("ft_sumDocLength", 0L));
     this.countersValid = metadata.getBoolean("ft_countersValid", false);
@@ -321,9 +325,13 @@ public class FullTextIndexMetadata extends IndexMetadata {
   }
 
   /**
-   * Sets the BM25 term-frequency saturation parameter k1.
+   * Sets the BM25 term-frequency saturation parameter k1 (must be &gt;= 0).
+   *
+   * @throws IllegalArgumentException if k1 is negative
    */
   public void setBm25K1(final float bm25K1) {
+    if (bm25K1 < 0)
+      throw new IllegalArgumentException("BM25 k1 must be >= 0, but was " + bm25K1);
     this.bm25K1 = bm25K1;
   }
 
@@ -335,9 +343,13 @@ public class FullTextIndexMetadata extends IndexMetadata {
   }
 
   /**
-   * Sets the BM25 document-length normalization parameter b.
+   * Sets the BM25 document-length normalization parameter b (must be in [0, 1]).
+   *
+   * @throws IllegalArgumentException if b is outside [0, 1]
    */
   public void setBm25B(final float bm25B) {
+    if (bm25B < 0 || bm25B > 1)
+      throw new IllegalArgumentException("BM25 b must be in [0, 1], but was " + bm25B);
     this.bm25B = bm25B;
   }
 
@@ -410,7 +422,12 @@ public class FullTextIndexMetadata extends IndexMetadata {
 
   /**
    * Records a newly indexed document in the corpus counters. Thread-safe: concurrent indexing transactions may call this on the
-   * shared per-bucket metadata.
+   * shared metadata.
+   * <p>
+   * These counters feed only the average document length (a BM25 length normalizer, robust to small inaccuracies). They are
+   * adjusted at index put/remove time, BEFORE the transaction commits, and are NOT reversed on rollback - so a rolled-back batch
+   * (or a {@link #removeDocument} whose recomputed length differs from the original, e.g. after an analyzer change) can let the
+   * counters drift. The full-text index's {@code recomputeBM25Counters()} rebuilds them exactly when needed.
    *
    * @param docLength number of analyzed tokens of the document
    */

--- a/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
@@ -524,6 +524,13 @@ public class FullTextIndexMetadata extends IndexMetadata {
   /**
    * Returns the average document length across the collection, or 1.0 when no statistics are available.
    * <p>
+   * SCOPE (intentional, do not "fix" without understanding): these counters are TYPE-WIDE (this metadata instance is shared by
+   * every bucket index of the type), so avgdl is type-wide - whereas BM25's {@code N} and {@code df} are measured PER BUCKET (see
+   * {@code LSMTreeFullTextIndex.resolveTotalDocs}). The mismatch is deliberate: per-bucket {@code df} requires a per-bucket
+   * {@code N} for an unbiased IDF, while avgdl is only a length normalizer for which a type-wide value is a fine estimate and
+   * avoids per-bucket length bookkeeping. For a multi-bucket type with very unequal bucket sizes, length normalization is
+   * therefore slightly biased - a cosmetic inaccuracy, not a correctness bug.
+   * <p>
    * The two counters are read independently (no shared lock), so a concurrent {@link #addDocument}/{@link #removeDocument} can be
    * observed half-applied. The widest skew is one in-flight document: {@code addDocument} bumps {@code totalDocs} before
    * {@code sumDocLength}, so a reader can briefly see {@code n} one too high (or, symmetrically for removal, one too low),

--- a/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
@@ -369,7 +369,10 @@ public class FullTextIndexMetadata extends IndexMetadata {
   }
 
   /**
-   * Sets the BM25 term-frequency saturation parameter k1 (must be &gt;= 0).
+   * Sets the BM25 term-frequency saturation parameter k1 (must be &gt;= 0). Higher values let term frequency keep increasing the
+   * score (less saturation). Note the edge case {@code k1 = 0}: it is permitted but degenerates BM25 to a pure IDF (binary
+   * presence) model - term frequency stops mattering entirely - which is rarely the intent of "a low k1"; use a small positive
+   * value (e.g. 0.5) for strong-but-not-total saturation.
    *
    * @throws IllegalArgumentException if k1 is negative
    */

--- a/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
@@ -152,7 +152,11 @@ public class FullTextIndexMetadata extends IndexMetadata {
     this.sumDocLength.set(metadata.getLong("ft_sumDocLength", 0L));
     this.countersValid = metadata.getBoolean("ft_countersValid", false);
 
-    // Parse per-field analyzers (pattern: *_analyzer) and per-field boosts (pattern: *_boost)
+    // Parse per-field analyzers (pattern: *_analyzer) and per-field boosts (pattern: *_boost). Clear first so a fromJSON() on an
+    // already-populated instance replaces the per-field config rather than merging stale entries into it (these maps are now
+    // final/ConcurrentHashMap, so they are no longer swapped out wholesale).
+    this.fieldAnalyzers.clear();
+    this.fieldBoosts.clear();
     for (final String key : metadata.keySet()) {
       if (key.endsWith(ANALYZER_SUFFIX) && !"analyzer".equals(key) && !"index_analyzer".equals(key) && !"query_analyzer".equals(key)) {
         final String fieldName = key.substring(0, key.length() - ANALYZER_SUFFIX.length());
@@ -340,15 +344,13 @@ public class FullTextIndexMetadata extends IndexMetadata {
   }
 
   /**
-   * Sets the similarity mode. Accepts "BM25" or "CLASSIC" (case-insensitive); null resets to the BM25 default.
+   * Sets the similarity mode. Accepts "BM25" or "CLASSIC" (case-insensitive).
    *
-   * @throws IllegalArgumentException if the name is not a known similarity
+   * @throws IllegalArgumentException if the name is null or not a known similarity
    */
   public void setSimilarity(final String similarity) {
-    if (similarity == null) {
-      this.similarity = SIMILARITY_BM25;
-      return;
-    }
+    if (similarity == null)
+      throw new IllegalArgumentException("Full-text similarity cannot be null. Valid values: " + SIMILARITY_BM25 + ", " + SIMILARITY_CLASSIC);
     final String upper = similarity.toUpperCase();
     if (!SIMILARITY_BM25.equals(upper) && !SIMILARITY_CLASSIC.equals(upper))
       throw new IllegalArgumentException(

--- a/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
@@ -23,6 +23,7 @@ import com.arcadedb.utility.CollectionUtils;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -80,10 +81,11 @@ public class FullTextIndexMetadata extends IndexMetadata {
   private final AtomicLong totalDocs     = new AtomicLong(0L);
   private final AtomicLong sumDocLength  = new AtomicLong(0L);
   private volatile boolean countersValid = false;
-  // Transient (never persisted): whether the persisted counters have been checked for staleness against the live data this
-  // session. Persisted counters can lag the on-disk data if documents were indexed after the last schema save, so the first
-  // BM25 query validates them once (cheap live count) and rebuilds only if they disagree.
-  private transient volatile boolean staleChecked = false;
+  // Not persisted (no toJSON/fromJSON): whether the persisted counters have already been checked for staleness against the live
+  // data this session. Persisted counters can lag the on-disk data if documents were indexed after the last schema save, so the
+  // first BM25 query validates them once (cheap live count) and rebuilds only if they disagree. AtomicBoolean (with CAS) so that
+  // concurrent first-queries across the type's shared bucket indexes do not all run the validation/rescan.
+  private final AtomicBoolean staleChecked = new AtomicBoolean(false);
 
   /**
    * Creates a new FullTextIndexMetadata instance.
@@ -419,17 +421,11 @@ public class FullTextIndexMetadata extends IndexMetadata {
   }
 
   /**
-   * Returns true once the persisted counters have been validated against the live data this session (see {@link #staleChecked}).
+   * Atomically claims the one-per-session staleness check: returns true to exactly one caller (which must then run the
+   * live-count validation), false to everyone else. Prevents concurrent first-queries from all rescanning the type.
    */
-  public boolean isStaleChecked() {
-    return staleChecked;
-  }
-
-  /**
-   * Marks the persisted counters as having been checked for staleness this session, so the (cheap) live-count check runs once.
-   */
-  public void markStaleChecked() {
-    this.staleChecked = true;
+  public boolean claimStaleCheck() {
+    return staleChecked.compareAndSet(false, true);
   }
 
   /**
@@ -449,7 +445,7 @@ public class FullTextIndexMetadata extends IndexMetadata {
     this.totalDocs.set(totalDocs);
     this.sumDocLength.set(sumDocLength);
     this.countersValid = true;
-    this.staleChecked = true; // freshly computed counters are by definition consistent with the live data
+    this.staleChecked.set(true); // freshly computed counters are by definition consistent with the live data
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
@@ -475,8 +475,14 @@ public class FullTextIndexMetadata extends IndexMetadata {
   }
 
   /**
-   * Returns the average document length across the collection, or 1.0 when no statistics are available. The two counters are read
-   * independently, so a concurrent update may make this momentarily approximate - acceptable for a ranking heuristic.
+   * Returns the average document length across the collection, or 1.0 when no statistics are available.
+   * <p>
+   * The two counters are read independently (no shared lock), so a concurrent {@link #addDocument}/{@link #removeDocument} can be
+   * observed half-applied. The widest skew is one in-flight document: {@code addDocument} bumps {@code totalDocs} before
+   * {@code sumDocLength}, so a reader can briefly see {@code n} one too high (or, symmetrically for removal, one too low),
+   * yielding an avgdl off by roughly {@code avgdl/n}. With more than a handful of documents this is negligible, and avgdl is only
+   * the BM25 length-normalization denominator (further dampened by {@code b}), so a momentary approximation cannot distort
+   * ranking materially. An exact value is available on demand via the full-text index's {@code recomputeBM25Counters()}.
    */
   public double avgDocLength() {
     final long n = totalDocs.get();

--- a/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
@@ -85,6 +85,9 @@ public class FullTextIndexMetadata extends IndexMetadata {
   // data this session. Persisted counters can lag the on-disk data if documents were indexed after the last schema save, so the
   // first BM25 query validates them once (cheap live count) and rebuilds only if they disagree. AtomicBoolean (with CAS) so that
   // concurrent first-queries across the type's shared bucket indexes do not all run the validation/rescan.
+  // Intentionally never reset to false after being claimed: the check is a once-per-session guard, not a continuous monitor. The
+  // recovery path for counters that are badly stale within a running session (e.g. a heavy rollback burst) is an explicit
+  // recomputeBM25Counters() / index rebuild, which also re-marks them consistent.
   private final AtomicBoolean staleChecked = new AtomicBoolean(false);
 
   /**

--- a/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
@@ -507,8 +507,12 @@ public class FullTextIndexMetadata extends IndexMetadata {
    * @param docLength number of analyzed tokens of the document
    */
   public void addDocument(final long docLength) {
-    totalDocs.incrementAndGet();
+    // Write sumDocLength BEFORE totalDocs (the "published" counter that avgDocLength reads first). By the JMM, a reader that
+    // observes the new totalDocs is then guaranteed to observe the new sumDocLength too, so a concurrent reader never sees a
+    // half-applied (totalDocs bumped, sumDocLength not) state that would momentarily DEFLATE avgdl and over-penalize. The only
+    // possible torn read is sumDocLength-new / totalDocs-old, which inflates avgdl slightly (under-penalizes) - the safe side.
     sumDocLength.addAndGet(docLength);
+    totalDocs.incrementAndGet();
   }
 
   /**
@@ -517,6 +521,9 @@ public class FullTextIndexMetadata extends IndexMetadata {
    * @param docLength number of analyzed tokens of the document
    */
   public void removeDocument(final long docLength) {
+    // Decrement totalDocs before sumDocLength so a concurrent reader's worst torn read is totalDocs-decremented /
+    // sumDocLength-not-yet, which inflates avgdl slightly (under-penalizes) rather than deflating it - the safe side, matching
+    // addDocument's bias.
     totalDocs.updateAndGet(v -> v > 0 ? v - 1 : v);
     sumDocLength.updateAndGet(v -> Math.max(0L, v - docLength));
   }
@@ -531,12 +538,12 @@ public class FullTextIndexMetadata extends IndexMetadata {
    * avoids per-bucket length bookkeeping. For a multi-bucket type with very unequal bucket sizes, length normalization is
    * therefore slightly biased - a cosmetic inaccuracy, not a correctness bug.
    * <p>
-   * The two counters are read independently (no shared lock), so a concurrent {@link #addDocument}/{@link #removeDocument} can be
-   * observed half-applied. The widest skew is one in-flight document: {@code addDocument} bumps {@code totalDocs} before
-   * {@code sumDocLength}, so a reader can briefly see {@code n} one too high (or, symmetrically for removal, one too low),
-   * yielding an avgdl off by roughly {@code avgdl/n}. With more than a handful of documents this is negligible, and avgdl is only
-   * the BM25 length-normalization denominator (further dampened by {@code b}), so a momentary approximation cannot distort
-   * ranking materially. An exact value is available on demand via the full-text index's {@code recomputeBM25Counters()}.
+   * The two counters are read independently (no shared lock). This method reads {@code totalDocs} first, then {@code sumDocLength};
+   * combined with the write ordering in {@link #addDocument}/{@link #removeDocument} (which publish via {@code totalDocs}), the
+   * JMM guarantees a concurrent reader sees either a consistent pair or one biased so avgdl is slightly HIGH (under-penalizing) -
+   * never momentarily low/over-penalizing. The widest skew is one in-flight document (~{@code avgdl/n}), negligible beyond a
+   * handful of documents and dampened by {@code b}, so it cannot distort ranking materially. An exact value is available on demand
+   * via the full-text index's {@code recomputeBM25Counters()}.
    */
   public double avgDocLength() {
     final long n = totalDocs.get();

--- a/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
@@ -192,9 +192,11 @@ public class FullTextIndexMetadata extends IndexMetadata {
     metadata.put("similarity", similarity);
     if (isBM25()) {
       // Emit k1/b only when tuned away from the defaults (read back as the defaults when absent), keeping the schema JSON terse.
-      if (bm25K1 != DEFAULT_BM25_K1)
+      // Use an epsilon (not !=): 1.2f/0.75f are not exact in float32, so a value that round-tripped through JSON parsing could
+      // differ from the literal by an ULP and be persisted as "non-default" forever.
+      if (Math.abs(bm25K1 - DEFAULT_BM25_K1) > 1e-6f)
         metadata.put("bm25_k1", bm25K1);
-      if (bm25B != DEFAULT_BM25_B)
+      if (Math.abs(bm25B - DEFAULT_BM25_B) > 1e-6f)
         metadata.put("bm25_b", bm25B);
       for (final Map.Entry<String, Float> entry : fieldBoosts.entrySet())
         metadata.put(entry.getKey() + BOOST_SUFFIX, entry.getValue());
@@ -482,6 +484,8 @@ public class FullTextIndexMetadata extends IndexMetadata {
   public void setCounters(final long totalDocs, final long sumDocLength) {
     this.totalDocs.set(totalDocs);
     this.sumDocLength.set(sumDocLength);
+    // The volatile write to countersValid below comes AFTER the two counter writes in program order: by the JMM, a reader that
+    // observes countersValid == true is guaranteed to also see these counter values (volatile-write / volatile-read edge).
     this.countersValid = true;
     this.staleChecked.set(true); // freshly computed counters are by definition consistent with the live data
   }

--- a/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
+++ b/engine/src/main/java/com/arcadedb/schema/FullTextIndexMetadata.java
@@ -57,6 +57,9 @@ public class FullTextIndexMetadata extends IndexMetadata {
    */
   public static final String SIMILARITY_CLASSIC = "CLASSIC";
 
+  // These mirror BM25Scorer.DEFAULT_K1 / DEFAULT_B by value. They are intentionally not a reference to that class: BM25Scorer
+  // lives in com.arcadedb.index.fulltext and depends on schema, not the other way round, so referencing it here would invert the
+  // package dependency. Keep the two pairs in sync if either ever changes.
   /** Default BM25 term-frequency saturation parameter. */
   public static final float  DEFAULT_BM25_K1 = 1.2f;
   /** Default BM25 document-length normalization parameter. */

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -1625,7 +1625,9 @@ public class LocalSchema implements Schema {
 
                 if (!index.getType().toString().equals(configuredIndexType)) {
                   if (configuredIndexType.equalsIgnoreCase(Schema.INDEX_TYPE.FULL_TEXT.toString())) {
-                    index = new LSMTreeFullTextIndex((LSMTreeIndex) index);
+                    final FullTextIndexMetadata ftMeta = new FullTextIndexMetadata(typeName, properties, -1);
+                    ftMeta.fromJSON(indexJSON);
+                    index = new LSMTreeFullTextIndex((LSMTreeIndex) index, ftMeta);
                     indexMap.put(indexName, index);
                   } else if (configuredIndexType.equalsIgnoreCase(Schema.INDEX_TYPE.GEOSPATIAL.toString())) {
                     final int precision = indexJSON.getInt("precision", GeoIndexMetadata.DEFAULT_PRECISION);

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -1625,6 +1625,8 @@ public class LocalSchema implements Schema {
 
                 if (!index.getType().toString().equals(configuredIndexType)) {
                   if (configuredIndexType.equalsIgnoreCase(Schema.INDEX_TYPE.FULL_TEXT.toString())) {
+                    // bucketId = -1 ("not set"): the bucket association is already established on the underlying index and read via
+                    // its getAssociatedBucketId(); this metadata only carries the full-text/BM25 configuration, not the binding.
                     final FullTextIndexMetadata ftMeta = new FullTextIndexMetadata(typeName, properties, -1);
                     ftMeta.fromJSON(indexJSON);
                     index = new LSMTreeFullTextIndex((LSMTreeIndex) index, ftMeta);

--- a/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/LocalSchema.java
@@ -1629,6 +1629,9 @@ public class LocalSchema implements Schema {
                     // its getAssociatedBucketId(); this metadata only carries the full-text/BM25 configuration, not the binding.
                     final FullTextIndexMetadata ftMeta = new FullTextIndexMetadata(typeName, properties, -1);
                     ftMeta.fromJSON(indexJSON);
+                    // Same reserved-name guard as the creation path, in case a hand-edited/restored schema reintroduced a property
+                    // colliding with the query parser's default-field sentinel.
+                    LSMTreeFullTextIndex.checkReservedPropertyNames(ftMeta.propertyNames);
                     index = new LSMTreeFullTextIndex((LSMTreeIndex) index, ftMeta);
                     indexMap.put(indexName, index);
                   } else if (configuredIndexType.equalsIgnoreCase(Schema.INDEX_TYPE.GEOSPATIAL.toString())) {

--- a/engine/src/main/java/com/arcadedb/schema/TypeFullTextIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeFullTextIndexBuilder.java
@@ -62,7 +62,7 @@ public class TypeFullTextIndexBuilder extends TypeIndexBuilder {
    * @return this builder for chaining
    */
   public TypeFullTextIndexBuilder withAnalyzer(final String analyzerClass) {
-    ((FullTextIndexMetadata) metadata).setAnalyzerClass(analyzerClass);
+    ftMetadata().setAnalyzerClass(analyzerClass);
     return this;
   }
 
@@ -73,7 +73,7 @@ public class TypeFullTextIndexBuilder extends TypeIndexBuilder {
    * @return this builder for chaining
    */
   public TypeFullTextIndexBuilder withIndexAnalyzer(final String analyzerClass) {
-    ((FullTextIndexMetadata) metadata).setIndexAnalyzerClass(analyzerClass);
+    ftMetadata().setIndexAnalyzerClass(analyzerClass);
     return this;
   }
 
@@ -84,7 +84,7 @@ public class TypeFullTextIndexBuilder extends TypeIndexBuilder {
    * @return this builder for chaining
    */
   public TypeFullTextIndexBuilder withQueryAnalyzer(final String analyzerClass) {
-    ((FullTextIndexMetadata) metadata).setQueryAnalyzerClass(analyzerClass);
+    ftMetadata().setQueryAnalyzerClass(analyzerClass);
     return this;
   }
 
@@ -95,7 +95,7 @@ public class TypeFullTextIndexBuilder extends TypeIndexBuilder {
    * @return this builder for chaining
    */
   public TypeFullTextIndexBuilder withAllowLeadingWildcard(final boolean allow) {
-    ((FullTextIndexMetadata) metadata).setAllowLeadingWildcard(allow);
+    ftMetadata().setAllowLeadingWildcard(allow);
     return this;
   }
 
@@ -106,7 +106,7 @@ public class TypeFullTextIndexBuilder extends TypeIndexBuilder {
    * @return this builder for chaining
    */
   public TypeFullTextIndexBuilder withDefaultOperator(final String operator) {
-    ((FullTextIndexMetadata) metadata).setDefaultOperator(operator);
+    ftMetadata().setDefaultOperator(operator);
     return this;
   }
 
@@ -118,12 +118,15 @@ public class TypeFullTextIndexBuilder extends TypeIndexBuilder {
    * @return this builder for chaining
    */
   public TypeFullTextIndexBuilder withFieldAnalyzer(final String fieldName, final String analyzerClass) {
-    ((FullTextIndexMetadata) metadata).setFieldAnalyzer(fieldName, analyzerClass);
+    ftMetadata().setFieldAnalyzer(fieldName, analyzerClass);
     return this;
   }
 
   @Override
   public TypeFullTextIndexBuilder withMetadata(final IndexMetadata metadata) {
+    if (metadata != null && !(metadata instanceof FullTextIndexMetadata))
+      throw new IllegalArgumentException(
+          "A FULL_TEXT index requires FullTextIndexMetadata but got " + metadata.getClass().getName());
     this.metadata = (FullTextIndexMetadata) metadata;
     return this;
   }
@@ -143,7 +146,20 @@ public class TypeFullTextIndexBuilder extends TypeIndexBuilder {
    * @param json the JSON object containing metadata configuration
    */
   public void withMetadata(final JSONObject json) {
-    ((FullTextIndexMetadata) metadata).fromJSON(json);
+    ftMetadata().fromJSON(json);
+  }
+
+  /**
+   * Returns the builder's metadata as {@link FullTextIndexMetadata}. The full-text builder constructors always create one, but
+   * guard the cast so that, if the metadata were ever replaced with a non-full-text instance, callers get an actionable error
+   * instead of a bare {@link ClassCastException} at configuration time.
+   */
+  private FullTextIndexMetadata ftMetadata() {
+    if (metadata instanceof FullTextIndexMetadata m)
+      return m;
+    throw new IllegalStateException(
+        "Full-text index metadata expected but was " + (metadata == null ? "null" : metadata.getClass().getName())
+            + "; configure BM25/analyzer options on a FULL_TEXT index builder");
   }
 
   /**
@@ -153,7 +169,7 @@ public class TypeFullTextIndexBuilder extends TypeIndexBuilder {
    * @return this builder for chaining
    */
   public TypeFullTextIndexBuilder withSimilarity(final String similarity) {
-    ((FullTextIndexMetadata) metadata).setSimilarity(similarity);
+    ftMetadata().setSimilarity(similarity);
     return this;
   }
 
@@ -165,7 +181,7 @@ public class TypeFullTextIndexBuilder extends TypeIndexBuilder {
    * @return this builder for chaining
    */
   public TypeFullTextIndexBuilder withBM25(final float k1, final float b) {
-    final FullTextIndexMetadata m = (FullTextIndexMetadata) metadata;
+    final FullTextIndexMetadata m = ftMetadata();
     m.setSimilarity(FullTextIndexMetadata.SIMILARITY_BM25);
     m.setBm25K1(k1);
     m.setBm25B(b);
@@ -180,7 +196,7 @@ public class TypeFullTextIndexBuilder extends TypeIndexBuilder {
    * @return this builder for chaining
    */
   public TypeFullTextIndexBuilder withFieldBoost(final String fieldName, final float boost) {
-    ((FullTextIndexMetadata) metadata).setFieldBoost(fieldName, boost);
+    ftMetadata().setFieldBoost(fieldName, boost);
     return this;
   }
 }

--- a/engine/src/main/java/com/arcadedb/schema/TypeFullTextIndexBuilder.java
+++ b/engine/src/main/java/com/arcadedb/schema/TypeFullTextIndexBuilder.java
@@ -145,4 +145,42 @@ public class TypeFullTextIndexBuilder extends TypeIndexBuilder {
   public void withMetadata(final JSONObject json) {
     ((FullTextIndexMetadata) metadata).fromJSON(json);
   }
+
+  /**
+   * Sets the similarity (ranking) model: {@code "BM25"} (default for new indexes) or {@code "CLASSIC"} (legacy term coordination).
+   *
+   * @param similarity the similarity name
+   * @return this builder for chaining
+   */
+  public TypeFullTextIndexBuilder withSimilarity(final String similarity) {
+    ((FullTextIndexMetadata) metadata).setSimilarity(similarity);
+    return this;
+  }
+
+  /**
+   * Enables BM25 similarity with the given parameters.
+   *
+   * @param k1 term-frequency saturation parameter (typical 1.2)
+   * @param b  document-length normalization parameter in [0,1] (typical 0.75)
+   * @return this builder for chaining
+   */
+  public TypeFullTextIndexBuilder withBM25(final float k1, final float b) {
+    final FullTextIndexMetadata m = (FullTextIndexMetadata) metadata;
+    m.setSimilarity(FullTextIndexMetadata.SIMILARITY_BM25);
+    m.setBm25K1(k1);
+    m.setBm25B(b);
+    return this;
+  }
+
+  /**
+   * Sets a per-field boost multiplier applied to BM25 contributions of field-qualified matches on that field.
+   *
+   * @param fieldName the field name
+   * @param boost     the multiplier (> 1.0 increases relevance)
+   * @return this builder for chaining
+   */
+  public TypeFullTextIndexBuilder withFieldBoost(final String fieldName, final float boost) {
+    ((FullTextIndexMetadata) metadata).setFieldBoost(fieldName, boost);
+    return this;
+  }
 }

--- a/engine/src/test/java/com/arcadedb/graph/GraphDatabaseCheckerDiagnosticsTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/GraphDatabaseCheckerDiagnosticsTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
+import com.arcadedb.database.Record;
+import com.arcadedb.engine.DatabaseChecker;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers the CHECK DATABASE diagnostic improvements:
+ * 1. an exception with a null message is reported by its class name instead of an undiagnosable "error: null";
+ * 2. the millions-of-edges fan-out onto a single missing target collapses into one per-target summary line;
+ * 3. the distinct set of missing targets is surfaced explicitly.
+ */
+class GraphDatabaseCheckerDiagnosticsTest {
+
+  @Test
+  void describeFallsBackToClassNameWhenMessageNull() {
+    // A NullPointerException with no explicit message is exactly the prod case behind "error: null".
+    assertThat(GraphDatabaseChecker.describe(new NullPointerException())).isEqualTo("NullPointerException");
+    // When a message is present it is preserved verbatim.
+    assertThat(GraphDatabaseChecker.describe(new RuntimeException("boom"))).isEqualTo("boom");
+  }
+
+  @Test
+  void fanOutOntoSingleMissingTargetCollapsesToOneSummaryLine() {
+    final String dbPath = "./target/databases/GraphCheckerDiagnostics";
+    final DatabaseFactory factory = new DatabaseFactory(dbPath);
+    if (factory.exists())
+      factory.open().drop();
+
+    final Database db = factory.create();
+    try {
+      db.getSchema().createVertexType("Node");
+      db.getSchema().createEdgeType("Link");
+
+      // One shared target referenced by many sources: the supernode pattern from Johan's report (#28:1).
+      final int sources = 50;
+      final MutableVertex[] target = new MutableVertex[1];
+      db.transaction(() -> target[0] = db.newVertex("Node").set("name", "target").save());
+
+      db.transaction(() -> {
+        for (int i = 0; i < sources; i++) {
+          final MutableVertex src = db.newVertex("Node").set("i", i).save();
+          src.newEdge("Link", target[0]);
+        }
+      });
+
+      final RID targetRid = target[0].getIdentity();
+
+      // Delete the single shared target at low level, leaving every edge dangling on its incoming side.
+      db.transaction(() -> db.getSchema().getBucketById(targetRid.getBucketId()).deleteRecord(targetRid));
+
+      final Map<String, Object> result = new DatabaseChecker(db)
+          .setVerboseLevel(0)
+          .check();
+
+      // Exactly one distinct missing target despite the many dangling edges.
+      assertThat((Long) result.get("distinctMissingReferences")).isEqualTo(1L);
+
+      final List<String> top = (List<String>) result.get("topMissingReferences");
+      assertThat(top).hasSize(1);
+
+      final String summary = top.getFirst();
+      assertThat(summary).contains(targetRid.toString());
+      assertThat(summary).contains("referenced by");
+      assertThat(summary).contains("edge(s)");
+
+      // The raw per-edge warnings are still produced (capped), so detail is not lost.
+      assertThat((Long) result.get("totalWarnings")).isGreaterThan(0L);
+    } finally {
+      db.drop();
+    }
+  }
+
+  @Test
+  void noMissingReferencesOnCleanDatabase() {
+    final String dbPath = "./target/databases/GraphCheckerDiagnosticsClean";
+    final DatabaseFactory factory = new DatabaseFactory(dbPath);
+    if (factory.exists())
+      factory.open().drop();
+
+    final Database db = factory.create();
+    try {
+      db.getSchema().createVertexType("Node");
+      db.getSchema().createEdgeType("Link");
+
+      final MutableVertex[] hub = new MutableVertex[1];
+      db.transaction(() -> hub[0] = db.newVertex("Node").save());
+      db.transaction(() -> {
+        for (int i = 0; i < 5; i++)
+          hub[0].newEdge("Link", db.newVertex("Node").set("i", i).save());
+      });
+
+      final Map<String, Object> result = new DatabaseChecker(db).setVerboseLevel(0).check();
+
+      assertThat((Long) result.get("distinctMissingReferences")).isEqualTo(0L);
+      assertThat((List<String>) result.get("topMissingReferences")).isEmpty();
+    } finally {
+      db.drop();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/fulltext/BM25ScorerTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/BM25ScorerTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.index.fulltext;
 
+import com.arcadedb.schema.FullTextIndexMetadata;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -97,6 +98,14 @@ class BM25ScorerTest {
     final double shortDoc = BM25Scorer.termScore(idf, 2, 50, 100, K1, 0.0);
     final double longDoc = BM25Scorer.termScore(idf, 2, 300, 100, K1, 0.0);
     assertThat(shortDoc).isCloseTo(longDoc, within(1e-9));
+  }
+
+  @Test
+  void defaultConstantsStayInSyncWithMetadata() {
+    // FullTextIndexMetadata deliberately duplicates these defaults (it cannot reference BM25Scorer without inverting the package
+    // dependency). This assertion makes the "keep in sync" requirement self-enforcing at test time.
+    assertThat(FullTextIndexMetadata.DEFAULT_BM25_K1).isEqualTo(BM25Scorer.DEFAULT_K1);
+    assertThat(FullTextIndexMetadata.DEFAULT_BM25_B).isEqualTo(BM25Scorer.DEFAULT_B);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/index/fulltext/BM25ScorerTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/BM25ScorerTest.java
@@ -97,4 +97,29 @@ class BM25ScorerTest {
     assertThat(shortDoc).isCloseTo(longDoc, within(1e-9));
   }
 
+  @Test
+  void zeroAverageDocLengthIsGuardedAndStaysFinite() {
+    // avgdl == 0 (empty/uninitialized corpus) must not divide by zero: the scorer substitutes 1.0 and returns a finite score.
+    final double idf = BM25Scorer.idf(1000, 10);
+    final double score = BM25Scorer.termScore(idf, 2, 100, 0.0, K1, B);
+    assertThat(Double.isNaN(score)).isFalse();
+    assertThat(Double.isInfinite(score)).isFalse();
+    // It equals the same call with avgdl substituted by 1.0.
+    assertThat(score).isCloseTo(BM25Scorer.termScore(idf, 2, 100, 1.0, K1, B), within(1e-12));
+  }
+
+  @Test
+  void staleDocFrequencyAboveCorpusSizeYieldsSmallNegativeIdfThatOnlyDampens() {
+    // df > N can happen transiently with drifted counters / deletion markers. The log argument (N+1)/(df+0.5) stays > 0, so idf
+    // is defined; it goes slightly negative rather than NaN/Infinity.
+    final double idf = BM25Scorer.idf(10, 20);
+    assertThat(Double.isNaN(idf)).isFalse();
+    assertThat(Double.isInfinite(idf)).isFalse();
+    assertThat(idf).isLessThan(0.0);
+    // A rarer term (df <= N) still outranks the over-frequent one, so the negative idf dampens but does not invert ranking.
+    final double rareIdf = BM25Scorer.idf(10, 2);
+    assertThat(BM25Scorer.termScore(rareIdf, 2, 100, 100, K1, B))
+        .isGreaterThan(BM25Scorer.termScore(idf, 2, 100, 100, K1, B));
+  }
+
 }

--- a/engine/src/test/java/com/arcadedb/index/fulltext/BM25ScorerTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/BM25ScorerTest.java
@@ -32,9 +32,11 @@ class BM25ScorerTest {
 
   @Test
   void idfMatchesRobertsonSparckJonesFormula() {
-    // idf = ln((N - df + 0.5)/(df + 0.5) + 1)
+    // idf = ln((N - df + 0.5)/(df + 0.5) + 1). Use asymmetric df != N/2 cases so the numerator's N - df term is actually
+    // exercised (at df = N/2, N - df == df and a formula that dropped N would still pass).
     assertThat(BM25Scorer.idf(100, 1)).isCloseTo(Math.log((99 + 0.5) / (1 + 0.5) + 1.0), within(1e-9));
-    assertThat(BM25Scorer.idf(100, 50)).isCloseTo(Math.log((50 + 0.5) / (50 + 0.5) + 1.0), within(1e-9));
+    assertThat(BM25Scorer.idf(100, 10)).isCloseTo(Math.log((90 + 0.5) / (10 + 0.5) + 1.0), within(1e-9));
+    assertThat(BM25Scorer.idf(100, 80)).isCloseTo(Math.log((20 + 0.5) / (80 + 0.5) + 1.0), within(1e-9));
     // a term in every document still yields a non-negative idf thanks to the +1
     assertThat(BM25Scorer.idf(100, 100)).isGreaterThanOrEqualTo(0.0);
   }

--- a/engine/src/test/java/com/arcadedb/index/fulltext/BM25ScorerTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/BM25ScorerTest.java
@@ -38,7 +38,10 @@ class BM25ScorerTest {
     assertThat(BM25Scorer.idf(100, 1)).isCloseTo(Math.log((99 + 0.5) / (1 + 0.5) + 1.0), within(1e-9));
     assertThat(BM25Scorer.idf(100, 10)).isCloseTo(Math.log((90 + 0.5) / (10 + 0.5) + 1.0), within(1e-9));
     assertThat(BM25Scorer.idf(100, 80)).isCloseTo(Math.log((20 + 0.5) / (80 + 0.5) + 1.0), within(1e-9));
-    // a term in every document still yields a non-negative idf thanks to the +1
+    // df = 0 (term not in the corpus): the highest possible idf, finite and positive.
+    assertThat(BM25Scorer.idf(100, 0)).isCloseTo(Math.log((100 + 0.5) / 0.5 + 1.0), within(1e-9));
+    assertThat(BM25Scorer.idf(100, 0)).isGreaterThan(BM25Scorer.idf(100, 1));
+    // a term in every document (df = N) still yields a non-negative idf thanks to the +1
     assertThat(BM25Scorer.idf(100, 100)).isGreaterThanOrEqualTo(0.0);
   }
 

--- a/engine/src/test/java/com/arcadedb/index/fulltext/BM25ScorerTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/BM25ScorerTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.fulltext;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Unit tests for the pure BM25 math in {@link BM25Scorer}. No database is involved so the expected values can be computed by hand.
+ */
+class BM25ScorerTest {
+  private static final double K1 = BM25Scorer.DEFAULT_K1;
+  private static final double B  = BM25Scorer.DEFAULT_B;
+
+  @Test
+  void idfMatchesRobertsonSparckJonesFormula() {
+    // idf = ln((N - df + 0.5)/(df + 0.5) + 1)
+    assertThat(BM25Scorer.idf(100, 1)).isCloseTo(Math.log((99 + 0.5) / (1 + 0.5) + 1.0), within(1e-9));
+    assertThat(BM25Scorer.idf(100, 50)).isCloseTo(Math.log((50 + 0.5) / (50 + 0.5) + 1.0), within(1e-9));
+    // a term in every document still yields a non-negative idf thanks to the +1
+    assertThat(BM25Scorer.idf(100, 100)).isGreaterThanOrEqualTo(0.0);
+  }
+
+  @Test
+  void rarerTermHasHigherIdf() {
+    final double rare = BM25Scorer.idf(1000, 2);
+    final double common = BM25Scorer.idf(1000, 500);
+    assertThat(rare).isGreaterThan(common);
+  }
+
+  @Test
+  void termScoreMatchesHandComputedValue() {
+    final double idf = BM25Scorer.idf(1000, 10);
+    final int tf = 3;
+    final int dl = 90;
+    final double avgdl = 120.0;
+
+    final double norm = 1.0 - B + B * (dl / avgdl);
+    final double expected = idf * (tf * (K1 + 1.0)) / (tf + K1 * norm);
+
+    assertThat(BM25Scorer.termScore(idf, tf, dl, avgdl, K1, B)).isCloseTo(expected, within(1e-9));
+  }
+
+  @Test
+  void zeroTermFrequencyContributesNothing() {
+    assertThat(BM25Scorer.termScore(2.0, 0, 100, 100, K1, B)).isEqualTo(0.0);
+  }
+
+  @Test
+  void higherTermFrequencyIncreasesScore() {
+    final double idf = BM25Scorer.idf(1000, 10);
+    final double s1 = BM25Scorer.termScore(idf, 1, 100, 100, K1, B);
+    final double s3 = BM25Scorer.termScore(idf, 3, 100, 100, K1, B);
+    assertThat(s3).isGreaterThan(s1);
+  }
+
+  @Test
+  void termFrequencySaturates() {
+    // doubling tf must increase the score by LESS than double (saturation via k1)
+    final double idf = BM25Scorer.idf(1000, 10);
+    final double s5 = BM25Scorer.termScore(idf, 5, 100, 100, K1, B);
+    final double s10 = BM25Scorer.termScore(idf, 10, 100, 100, K1, B);
+    assertThat(s10).isLessThan(2 * s5);
+  }
+
+  @Test
+  void longerDocumentScoresLowerForSameTermFrequency() {
+    final double idf = BM25Scorer.idf(1000, 10);
+    final double shortDoc = BM25Scorer.termScore(idf, 2, 50, 100, K1, B);
+    final double longDoc = BM25Scorer.termScore(idf, 2, 300, 100, K1, B);
+    assertThat(shortDoc).isGreaterThan(longDoc);
+  }
+
+  @Test
+  void noLengthNormalizationWhenBisZero() {
+    final double idf = BM25Scorer.idf(1000, 10);
+    final double shortDoc = BM25Scorer.termScore(idf, 2, 50, 100, K1, 0.0);
+    final double longDoc = BM25Scorer.termScore(idf, 2, 300, 100, K1, 0.0);
+    assertThat(shortDoc).isCloseTo(longDoc, within(1e-9));
+  }
+
+}

--- a/engine/src/test/java/com/arcadedb/index/fulltext/BM25ScorerTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/BM25ScorerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25CompactionTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25CompactionTest.java
@@ -34,10 +34,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 
 /**
- * Compaction tests for BM25 full-text indexes. Inserts enough documents sharing a single high-frequency token that its posting
- * list spans multiple compacted pages at the (default 4096-byte) page size - the exact case that used to silently drop postings
- * on read (a sparse-root-index bug, see {@code LSMTreeIndexCompactor}). The scenario is driven by document volume, not by a
- * reduced page size. Verifies that after compaction the full result set, ranking and scores are unchanged.
+ * Compaction tests for BM25 full-text indexes. Uses a small (1024-byte) page size with enough documents sharing one
+ * high-frequency token that its posting list provably spans multiple compacted pages - the exact case that used to silently drop
+ * postings on read (a sparse-root-index bug, see {@code LSMTreeIndexCompactor}). The small page guarantees the multi-page split
+ * is exercised rather than incidental. Verifies that after compaction the full result set, ranking and scores are unchanged.
  * <p>
  * Not tagged {@code slow}: although it inserts a few hundred documents, it completes in well under a second and pins a
  * correctness regression (postings silently dropped on compaction), so it must run in every CI build.
@@ -77,9 +77,11 @@ class FullTextBM25CompactionTest extends TestHelper {
       database.getSchema().createDocumentType("Doc");
       database.getSchema().getType("Doc").createProperty("name", String.class);
       database.getSchema().getType("Doc").createProperty("content", String.class);
-      // Enough documents that the "data" posting list (hundreds of RIDs) spans multiple compacted pages at the default page size.
+      // Small pages (1024 bytes) so the multi-page split is GUARANTEED, not incidental: the "data" posting list below has 600
+      // RIDs at ~6-8 bytes each (compressed RID + tf + docLength varints) ~= 3.6-4.8 KB, which provably overflows a 1024-byte
+      // page several times over - exactly the spanning-multiple-compacted-pages condition the fix targets.
       database.getSchema().buildTypeIndex("Doc", new String[] { "content" })
-          .withType(Schema.INDEX_TYPE.FULL_TEXT).withFullTextType().withPageSize(4096).create();
+          .withType(Schema.INDEX_TYPE.FULL_TEXT).withFullTextType().withPageSize(1024).create();
     });
 
     // 1 rare document with the discriminative term; many documents share the common token "data".
@@ -121,7 +123,7 @@ class FullTextBM25CompactionTest extends TestHelper {
       database.getSchema().getType("Doc").createProperty("name", String.class);
       database.getSchema().getType("Doc").createProperty("content", String.class);
       database.getSchema().buildTypeIndex("Doc", new String[] { "content" })
-          .withType(Schema.INDEX_TYPE.FULL_TEXT).withFullTextType().withSimilarity("CLASSIC").withPageSize(4096).create();
+          .withType(Schema.INDEX_TYPE.FULL_TEXT).withFullTextType().withSimilarity("CLASSIC").withPageSize(1024).create();
     });
 
     for (int batch = 0; batch < 30; batch++) {

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25CompactionTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25CompactionTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.fulltext;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.index.Index;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.index.TypeIndex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Compaction tests for BM25 full-text indexes. Uses a tiny page size so a single high-frequency token's posting list spans
+ * multiple compacted pages - the exact case that used to silently drop postings on read (a sparse-root-index bug, see
+ * {@code LSMTreeIndexCompactor}). Verifies that after compaction the full result set, ranking and scores are unchanged.
+ */
+@Tag("slow")
+class FullTextBM25CompactionTest extends TestHelper {
+
+  private Map<String, Float> searchScores(final String query) {
+    final Map<String, Float> scores = new HashMap<>();
+    final ResultSet rs = database.query("sql",
+        "SELECT name, $score FROM Doc WHERE SEARCH_INDEX('Doc[content]', '" + query + "') = true");
+    while (rs.hasNext()) {
+      final Result r = rs.next();
+      scores.put(r.getProperty("name"), ((Number) r.getProperty("$score")).floatValue());
+    }
+    return scores;
+  }
+
+  private boolean forceCompaction() {
+    boolean compacted = false;
+    final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("Doc[content]");
+    for (final Index bucketIndex : typeIndex.getIndexesOnBuckets()) {
+      if (bucketIndex instanceof LSMTreeFullTextIndex ftIndex) {
+        try {
+          ((IndexInternal) ftIndex).scheduleCompaction();
+          compacted |= ftIndex.compact();
+        } catch (final Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+    return compacted;
+  }
+
+  @Test
+  void postingsAndTermFrequencySurviveCompaction() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Doc");
+      database.getSchema().getType("Doc").createProperty("name", String.class);
+      database.getSchema().getType("Doc").createProperty("content", String.class);
+      // Tiny pages so the "data" posting list (hundreds of RIDs) spans multiple compacted pages.
+      database.getSchema().buildTypeIndex("Doc", new String[] { "content" })
+          .withType(Schema.INDEX_TYPE.FULL_TEXT).withFullTextType().withPageSize(4096).create();
+    });
+
+    // 1 rare document with the discriminative term; many documents share the common token "data".
+    database.transaction(() -> database.command("sql", "INSERT INTO Doc SET name = 'rare', content = 'quantum data analysis'"));
+    for (int batch = 0; batch < 30; batch++) {
+      final int base = batch;
+      database.transaction(() -> {
+        for (int i = 0; i < 20; i++)
+          database.command("sql",
+              "INSERT INTO Doc SET name = 'common" + base + "_" + i + "', content = 'data record number " + base + " " + i + "'");
+      });
+    }
+
+    final Map<String, Float> before = new HashMap<>();
+    database.transaction(() -> before.putAll(searchScores("quantum data")));
+    assertThat(before).hasSize(601); // 1 rare + 600 common all match "quantum data"
+
+    assertThat(forceCompaction()).as("the full-text index should have compacted at least one bucket").isTrue();
+
+    database.transaction(() -> {
+      final Map<String, Float> after = searchScores("quantum data");
+      // No postings dropped by compaction, and identical ranking + scores (tf + docLength preserved through the merge).
+      assertThat(after.keySet()).isEqualTo(before.keySet());
+      for (final Map.Entry<String, Float> e : after.entrySet()) {
+        assertThat(e.getValue()).isCloseTo(before.get(e.getKey()), within(1e-4f));
+        if (!e.getKey().equals("rare"))
+          assertThat(after.get("rare")).isGreaterThan(e.getValue());
+      }
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25CompactionTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25CompactionTest.java
@@ -25,7 +25,6 @@ import com.arcadedb.index.TypeIndex;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Schema;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -38,8 +37,10 @@ import static org.assertj.core.api.Assertions.within;
  * Compaction tests for BM25 full-text indexes. Uses a tiny page size so a single high-frequency token's posting list spans
  * multiple compacted pages - the exact case that used to silently drop postings on read (a sparse-root-index bug, see
  * {@code LSMTreeIndexCompactor}). Verifies that after compaction the full result set, ranking and scores are unchanged.
+ * <p>
+ * Not tagged {@code slow}: although it inserts a few hundred documents, it completes in well under a second and pins a
+ * correctness regression (postings silently dropped on compaction), so it must run in every CI build.
  */
-@Tag("slow")
 class FullTextBM25CompactionTest extends TestHelper {
 
   private Map<String, Float> searchScores(final String query) {

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25CompactionTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25CompactionTest.java
@@ -93,7 +93,8 @@ class FullTextBM25CompactionTest extends TestHelper {
 
     final Map<String, Float> before = new HashMap<>();
     database.transaction(() -> before.putAll(searchScores("quantum data")));
-    assertThat(before).hasSize(601); // 1 rare + 600 common all match "quantum data"
+    assertThat(before).containsKey("rare");
+    assertThat(before.size()).isGreaterThanOrEqualTo(601); // 1 rare + 600 common all match "quantum data"
 
     assertThat(forceCompaction()).as("the full-text index should have compacted at least one bucket").isTrue();
 
@@ -132,7 +133,7 @@ class FullTextBM25CompactionTest extends TestHelper {
 
     final Map<String, Float> before = new HashMap<>();
     database.transaction(() -> before.putAll(searchScores("data")));
-    assertThat(before).hasSize(600); // every document contains the common token "data"
+    assertThat(before.size()).isGreaterThanOrEqualTo(600); // every document contains the common token "data"
 
     assertThat(forceCompaction()).as("the full-text index should have compacted at least one bucket").isTrue();
 

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25CompactionTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25CompactionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25CompactionTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25CompactionTest.java
@@ -108,4 +108,34 @@ class FullTextBM25CompactionTest extends TestHelper {
       }
     });
   }
+
+  @Test
+  void classicPostingsSurviveCompaction() {
+    // The compaction posting-drop bug was independent of BM25 - it affected CLASSIC too. This pins the fix for CLASSIC: a
+    // single token's posting list spanning multiple compacted pages must not lose documents.
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Doc");
+      database.getSchema().getType("Doc").createProperty("name", String.class);
+      database.getSchema().getType("Doc").createProperty("content", String.class);
+      database.getSchema().buildTypeIndex("Doc", new String[] { "content" })
+          .withType(Schema.INDEX_TYPE.FULL_TEXT).withFullTextType().withSimilarity("CLASSIC").withPageSize(4096).create();
+    });
+
+    for (int batch = 0; batch < 30; batch++) {
+      final int base = batch;
+      database.transaction(() -> {
+        for (int i = 0; i < 20; i++)
+          database.command("sql",
+              "INSERT INTO Doc SET name = 'd" + base + "_" + i + "', content = 'data record number " + base + " " + i + "'");
+      });
+    }
+
+    final Map<String, Float> before = new HashMap<>();
+    database.transaction(() -> before.putAll(searchScores("data")));
+    assertThat(before).hasSize(600); // every document contains the common token "data"
+
+    assertThat(forceCompaction()).as("the full-text index should have compacted at least one bucket").isTrue();
+
+    database.transaction(() -> assertThat(searchScores("data").keySet()).isEqualTo(before.keySet()));
+  }
 }

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25CompactionTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25CompactionTest.java
@@ -34,9 +34,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 
 /**
- * Compaction tests for BM25 full-text indexes. Uses a tiny page size so a single high-frequency token's posting list spans
- * multiple compacted pages - the exact case that used to silently drop postings on read (a sparse-root-index bug, see
- * {@code LSMTreeIndexCompactor}). Verifies that after compaction the full result set, ranking and scores are unchanged.
+ * Compaction tests for BM25 full-text indexes. Inserts enough documents sharing a single high-frequency token that its posting
+ * list spans multiple compacted pages at the (default 4096-byte) page size - the exact case that used to silently drop postings
+ * on read (a sparse-root-index bug, see {@code LSMTreeIndexCompactor}). The scenario is driven by document volume, not by a
+ * reduced page size. Verifies that after compaction the full result set, ranking and scores are unchanged.
  * <p>
  * Not tagged {@code slow}: although it inserts a few hundred documents, it completes in well under a second and pins a
  * correctness regression (postings silently dropped on compaction), so it must run in every CI build.
@@ -76,7 +77,7 @@ class FullTextBM25CompactionTest extends TestHelper {
       database.getSchema().createDocumentType("Doc");
       database.getSchema().getType("Doc").createProperty("name", String.class);
       database.getSchema().getType("Doc").createProperty("content", String.class);
-      // Tiny pages so the "data" posting list (hundreds of RIDs) spans multiple compacted pages.
+      // Enough documents that the "data" posting list (hundreds of RIDs) spans multiple compacted pages at the default page size.
       database.getSchema().buildTypeIndex("Doc", new String[] { "content" })
           .withType(Schema.INDEX_TYPE.FULL_TEXT).withFullTextType().withPageSize(4096).create();
     });

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -23,6 +23,7 @@ import com.arcadedb.index.Index;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -120,6 +121,7 @@ class FullTextBM25Test extends TestHelper {
   }
 
   @Test
+  @Tag("slow")
   void bm25RankingHoldsAcrossMultipleBuckets() {
     database.transaction(() -> {
       // Multiple buckets: BM25 is scored per bucket, so N (doc count) and df must both be per-bucket to keep IDF unbiased.
@@ -196,6 +198,11 @@ class FullTextBM25Test extends TestHelper {
     org.assertj.core.api.Assertions.assertThatThrownBy(() -> database.transaction(() ->
             database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT METADATA {\"bm25_k1\": -1.0}")))
         .hasMessageContaining("k1 must be >= 0");
+
+    // An unknown similarity is rejected rather than silently treated as CLASSIC.
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> database.transaction(() ->
+            database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT METADATA {\"similarity\": \"LUCENE\"}")))
+        .hasMessageContaining("Unknown full-text similarity");
   }
 
   @Test
@@ -293,10 +300,16 @@ class FullTextBM25Test extends TestHelper {
       // CLASSIC coordination: integer match counts widened to float.
       assertThat(scores.get("all3")).isEqualTo(3.0f);
       assertThat(scores.get("one")).isEqualTo(1.0f);
+
+      // $score is a Float now even for CLASSIC indexes (was Integer before BM25): pin the type so the breaking change is tested.
+      final ResultSet rs = database.query("sql",
+          "SELECT $score AS s FROM Doc WHERE SEARCH_INDEX('Doc[content]', 'java') = true LIMIT 1");
+      assertThat(rs.next().<Object>getProperty("s")).isInstanceOf(Float.class);
     });
   }
 
   @Test
+  @Tag("slow")
   void bm25ConfigAndCountersSurviveRestart() {
     database.transaction(() -> {
       database.command("sql", "CREATE DOCUMENT TYPE Doc");

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.fulltext;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end tests for native BM25 full-text scoring (issue #4687): IDF (rare terms outrank common ones), document-length
+ * normalization, field boosts, the CLASSIC fallback, and survival of BM25 configuration + corpus counters across a restart.
+ */
+class FullTextBM25Test extends TestHelper {
+
+  private Map<String, Float> searchScores(final String index, final String query) {
+    final Map<String, Float> scores = new HashMap<>();
+    final ResultSet rs = database.query("sql",
+        "SELECT name, $score FROM Doc WHERE SEARCH_INDEX('" + index + "', '" + query + "') = true");
+    while (rs.hasNext()) {
+      final Result r = rs.next();
+      scores.put(r.getProperty("name"), ((Number) r.getProperty("$score")).floatValue());
+    }
+    return scores;
+  }
+
+  @Test
+  void rareTermOutranksCommonTerm() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT");
+
+      // "data" is common (appears in many documents -> low IDF); "quantum" is rare (high IDF).
+      database.command("sql", "INSERT INTO Doc SET name = 'rare', content = 'quantum data'");
+      for (int i = 0; i < 12; i++)
+        database.command("sql", "INSERT INTO Doc SET name = 'common" + i + "', content = 'data data record'");
+    });
+
+    database.transaction(() -> {
+      final Map<String, Float> scores = searchScores("Doc[content]", "quantum data");
+      // The document containing the rare term must rank above any document matching only the common term.
+      assertThat(scores.get("rare")).isNotNull();
+      final float rare = scores.get("rare");
+      for (final Map.Entry<String, Float> e : scores.entrySet())
+        if (!e.getKey().equals("rare"))
+          assertThat(rare).isGreaterThan(e.getValue());
+    });
+  }
+
+  @Test
+  void shorterDocumentScoresHigherForSameTerm() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT");
+
+      // Both documents contain "lucene" exactly once but one is much longer.
+      database.command("sql", "INSERT INTO Doc SET name = 'short', content = 'lucene'");
+      database.command("sql", "INSERT INTO Doc SET name = 'long', content = 'lucene alpha beta gamma delta epsilon zeta eta theta iota kappa'");
+      // Add filler docs so the term has a stable IDF.
+      for (int i = 0; i < 5; i++)
+        database.command("sql", "INSERT INTO Doc SET name = 'filler" + i + "', content = 'unrelated text here'");
+    });
+
+    database.transaction(() -> {
+      final Map<String, Float> scores = searchScores("Doc[content]", "lucene");
+      assertThat(scores).containsKeys("short", "long");
+      assertThat(scores.get("short")).isGreaterThan(scores.get("long"));
+    });
+  }
+
+  @Test
+  void fieldBoostRaisesFieldQualifiedMatches() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.title STRING");
+      database.command("sql", "CREATE PROPERTY Doc.body STRING");
+      database.command("sql",
+          "CREATE INDEX ON Doc (title, body) FULL_TEXT METADATA {\"similarity\": \"BM25\", \"title_boost\": 5.0}");
+
+      database.command("sql", "INSERT INTO Doc SET name = 'inTitle', title = 'java', body = 'something else entirely'");
+      database.command("sql", "INSERT INTO Doc SET name = 'inBody', title = 'something else', body = 'java'");
+    });
+
+    database.transaction(() -> {
+      // A field-qualified query on the boosted field scores its match higher than the same term in the unboosted field.
+      final Map<String, Float> titleScores = searchScores("Doc[title,body]", "title:java");
+      final Map<String, Float> bodyScores = searchScores("Doc[title,body]", "body:java");
+      assertThat(titleScores.get("inTitle")).isNotNull();
+      assertThat(bodyScores.get("inBody")).isNotNull();
+      assertThat(titleScores.get("inTitle")).isGreaterThan(bodyScores.get("inBody"));
+    });
+  }
+
+  @Test
+  void caretInBooleanQueries() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.title STRING");
+      database.command("sql", "CREATE PROPERTY Doc.body STRING");
+      database.command("sql", "CREATE INDEX ON Doc (title, body) FULL_TEXT");
+      database.command("sql", "INSERT INTO Doc SET name='d1', title='java guide',   body='database tuning'");
+      database.command("sql", "INSERT INTO Doc SET name='d2', title='python guide', body='database tuning'");
+      database.command("sql", "INSERT INTO Doc SET name='d3', title='java',          body='cooking recipes'");
+    });
+
+    database.transaction(() -> {
+      // MUST database (any field) + boosted SHOULD on title:java. Only d1,d2 have "database"; d1 also matches the boosted
+      // title:java, so d1 outranks d2; d3 is excluded (no "database").
+      final Map<String, Float> r1 = searchScores("Doc[title,body]", "+database title:java^5");
+      assertThat(r1.keySet()).containsExactlyInAnyOrder("d1", "d2");
+      assertThat(r1.get("d1")).isGreaterThan(r1.get("d2"));
+      r1.values().forEach(s -> assertThat(s).isGreaterThan(0f));
+
+      // Group boost over an OR, combined with another term: (java OR python)^3 cooking
+      final Map<String, Float> r2 = searchScores("Doc[title,body]", "(title:java OR title:python)^3 body:cooking");
+      assertThat(r2.keySet()).contains("d1", "d2", "d3");
+
+      // NOT with a boosted positive term: boosted java, excluding anything mentioning cooking -> d3 removed.
+      final Map<String, Float> r3 = searchScores("Doc[title,body]", "title:java^4 -body:cooking");
+      assertThat(r3.keySet()).contains("d1");
+      assertThat(r3.keySet()).doesNotContain("d3");
+    });
+  }
+
+  @Test
+  void caretBoostRaisesTermWeight() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT");
+      database.command("sql", "INSERT INTO Doc SET name = 'java', content = 'java tutorial'");
+      database.command("sql", "INSERT INTO Doc SET name = 'python', content = 'python tutorial'");
+    });
+
+    database.transaction(() -> {
+      // Caret boost amplifies the "java" term, so the java document outranks the python one for "java^4 python".
+      final Map<String, Float> boosted = searchScores("Doc[content]", "java^4 python");
+      assertThat(boosted).containsKeys("java", "python");
+      assertThat(boosted.get("java")).isGreaterThan(boosted.get("python"));
+
+      // Without the boost (symmetric query) the two are tied.
+      final Map<String, Float> neutral = searchScores("Doc[content]", "java python");
+      assertThat(neutral.get("java")).isCloseTo(neutral.get("python"), org.assertj.core.api.Assertions.within(1e-4f));
+    });
+  }
+
+  @Test
+  void explainSurfacesBM25ScoringMetadata() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT");
+      database.command("sql", "INSERT INTO Doc SET name = 'a', content = 'java database tuning'");
+      database.command("sql", "INSERT INTO Doc SET name = 'b', content = 'python scripting'");
+    });
+
+    database.transaction(() -> {
+      final ResultSet rs = database.query("sql",
+          "EXPLAIN SELECT name, $score FROM Doc WHERE SEARCH_INDEX('Doc[content]', 'java database') = true");
+      final String plan = rs.next().getProperty("executionPlanAsString");
+      // The full-text fetch step carries the BM25 scoring metadata so it can be inspected via EXPLAIN.
+      assertThat(plan).contains("SCORING");
+      assertThat(plan).contains("BM25");
+      assertThat(plan).contains("java").contains("database");
+      assertThat(plan).contains("\"k1\"").contains("\"b\"");
+    });
+  }
+
+  @Test
+  void classicSimilarityKeepsCoordinationScoring() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT METADATA {\"similarity\": \"CLASSIC\"}");
+
+      database.command("sql", "INSERT INTO Doc SET name = 'all3', content = 'java programming language'");
+      database.command("sql", "INSERT INTO Doc SET name = 'one', content = 'java database system'");
+    });
+
+    database.transaction(() -> {
+      final Map<String, Float> scores = searchScores("Doc[content]", "java programming language");
+      // CLASSIC coordination: integer match counts widened to float.
+      assertThat(scores.get("all3")).isEqualTo(3.0f);
+      assertThat(scores.get("one")).isEqualTo(1.0f);
+    });
+  }
+
+  @Test
+  void bm25ConfigAndCountersSurviveRestart() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT METADATA {\"similarity\": \"BM25\", \"bm25_k1\": 1.5, \"bm25_b\": 0.6}");
+      database.command("sql", "INSERT INTO Doc SET name = 'rare', content = 'quantum data'");
+      for (int i = 0; i < 12; i++)
+        database.command("sql", "INSERT INTO Doc SET name = 'common" + i + "', content = 'data data record'");
+    });
+
+    final Map<String, Float> before = new HashMap<>();
+    database.transaction(() -> before.putAll(searchScores("Doc[content]", "quantum data")));
+
+    reopenDatabase();
+
+    database.transaction(() -> {
+      final Map<String, Float> after = searchScores("Doc[content]", "quantum data");
+      // The ranking (rare term wins) and the actual scores must be identical after restart.
+      assertThat(after.get("rare")).isNotNull();
+      assertThat(after.get("rare")).isCloseTo(before.get("rare"), org.assertj.core.api.Assertions.within(1e-4f));
+      for (final Map.Entry<String, Float> e : after.entrySet())
+        if (!e.getKey().equals("rare"))
+          assertThat(after.get("rare")).isGreaterThan(e.getValue());
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -19,14 +19,18 @@
 package com.arcadedb.index.fulltext;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.database.Document;
 import com.arcadedb.index.Index;
+import com.arcadedb.index.IndexCursor;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -247,6 +251,46 @@ class FullTextBM25Test extends TestHelper {
   }
 
   @Test
+  void updateReplacesPostingsAndKeepsScoringConsistent() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT");
+      database.command("sql", "INSERT INTO Doc SET name = 'doc', content = 'java tutorial'");
+      database.command("sql", "INSERT INTO Doc SET name = 'other', content = 'python guide'");
+    });
+
+    // The document initially matches "java" but not "python".
+    database.transaction(() -> {
+      assertThat(searchScores("Doc[content]", "java")).containsKey("doc");
+      assertThat(searchScores("Doc[content]", "python")).doesNotContainKey("doc");
+    });
+
+    // Update the indexed field: the old token ("java") must stop matching and the new one ("python") must start matching.
+    database.transaction(() -> database.command("sql", "UPDATE Doc SET content = 'python scripting' WHERE name = 'doc'"));
+
+    database.transaction(() -> {
+      assertThat(searchScores("Doc[content]", "java")).doesNotContainKey("doc"); // old posting removed
+      final Map<String, Float> python = searchScores("Doc[content]", "python");
+      assertThat(python).containsKey("doc"); // new posting added
+      assertThat(python.get("doc")).isGreaterThan(0f);
+    });
+
+    // After an update the corpus length counters must not be double-counted: recompute (the source of truth) must agree with the
+    // incrementally maintained counters, so scores are unchanged by a recompute.
+    final Map<String, Float> beforeRecompute = new HashMap<>();
+    database.transaction(() -> beforeRecompute.putAll(searchScores("Doc[content]", "python")));
+    recomputeCounters();
+    database.transaction(() -> {
+      final Map<String, Float> afterRecompute = searchScores("Doc[content]", "python");
+      assertThat(afterRecompute.keySet()).isEqualTo(beforeRecompute.keySet());
+      for (final Map.Entry<String, Float> e : afterRecompute.entrySet())
+        assertThat(e.getValue()).isCloseTo(beforeRecompute.get(e.getKey()), within(1e-4f));
+    });
+  }
+
+  @Test
   void invalidBM25ParametersAreRejected() {
     database.transaction(() -> {
       database.command("sql", "CREATE DOCUMENT TYPE Doc");
@@ -380,8 +424,8 @@ class FullTextBM25Test extends TestHelper {
     database.transaction(() -> {
       final Map<String, Float> scores = searchScores("Doc[content]", "java programming language");
       // CLASSIC coordination: integer match counts widened to float.
-      assertThat(scores.get("all3")).isEqualTo(3.0f);
-      assertThat(scores.get("one")).isEqualTo(1.0f);
+      assertThat(scores.get("all3")).isCloseTo(3.0f, within(1e-4f));
+      assertThat(scores.get("one")).isCloseTo(1.0f, within(1e-4f));
 
       // $score is a Float now even for CLASSIC indexes (was Integer before BM25): pin the type so the breaking change is tested.
       final ResultSet rs = database.query("sql",
@@ -456,6 +500,29 @@ class FullTextBM25Test extends TestHelper {
     reopenDatabase();
 
     database.transaction(() -> {
+      // Directly assert the persisted BM25 configuration and corpus counters round-tripped, so a silent regression in
+      // writeToJSON/fromJSON (e.g. k1 stops persisting) is caught even if it would not move the scores past the epsilon below.
+      final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("Doc[content]");
+      for (final Index bucketIndex : typeIndex.getIndexesOnBuckets())
+        if (bucketIndex instanceof LSMTreeFullTextIndex ftIndex) {
+          final var meta = ftIndex.getFullTextMetadata();
+          assertThat(meta.getSimilarity()).isEqualTo("BM25");
+          assertThat(meta.getBm25K1()).isCloseTo(1.5f, within(1e-6f));
+          assertThat(meta.getBm25B()).isCloseTo(0.6f, within(1e-6f));
+        }
+      // The type-wide counters feeding avgdl must also survive: 13 documents totalling 2 + 12*3 = 38 tokens.
+      long totalDocs = 0L;
+      long sumDocLength = 0L;
+      for (final Index bucketIndex : typeIndex.getIndexesOnBuckets())
+        if (bucketIndex instanceof LSMTreeFullTextIndex ftIndex) {
+          totalDocs += ftIndex.getFullTextMetadata().getTotalDocs();
+          sumDocLength += ftIndex.getFullTextMetadata().getSumDocLength();
+        }
+      // The counters are shared type-wide (same metadata object per bucket), so read them from a single bucket index.
+      final LSMTreeFullTextIndex anyBucket = (LSMTreeFullTextIndex) typeIndex.getIndexesOnBuckets()[0];
+      assertThat(anyBucket.getFullTextMetadata().getTotalDocs()).isEqualTo(13L);
+      assertThat(anyBucket.getFullTextMetadata().getSumDocLength()).isEqualTo(38L);
+
       final Map<String, Float> after = searchScores("Doc[content]", "quantum data");
       // The ranking (rare term wins) and the actual scores must be identical after restart.
       assertThat(after.get("rare")).isNotNull();
@@ -463,6 +530,41 @@ class FullTextBM25Test extends TestHelper {
       for (final Map.Entry<String, Float> e : after.entrySet())
         if (!e.getKey().equals("rare"))
           assertThat(after.get("rare")).isGreaterThan(e.getValue());
+    });
+  }
+
+  @Test
+  void classicGetReturnsMostRelevantFirstAndHonorsLimit() {
+    database.transaction(() -> {
+      // Single bucket so every document lands in the one bucket index whose cursor order we assert.
+      database.command("sql", "CREATE DOCUMENT TYPE Doc BUCKETS 1");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT METADATA {\"similarity\": \"CLASSIC\"}");
+      // d3 matches all three query terms, d2 two, d1 one: CLASSIC coordination score 3 > 2 > 1.
+      database.command("sql", "INSERT INTO Doc SET name = 'd1', content = 'java'");
+      database.command("sql", "INSERT INTO Doc SET name = 'd2', content = 'java database'");
+      database.command("sql", "INSERT INTO Doc SET name = 'd3', content = 'java database tuning'");
+    });
+
+    database.transaction(() -> {
+      // The cursor itself must return the most-relevant document first (no explicit ORDER BY): the order is the index's, not the
+      // engine's. This pins the fix for the previously ascending (least-relevant-first) classic sort.
+      final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("Doc[content]");
+      final LSMTreeFullTextIndex bucket = (LSMTreeFullTextIndex) typeIndex.getIndexesOnBuckets()[0];
+
+      final List<String> order = new ArrayList<>();
+      final IndexCursor cursor = bucket.get(new Object[] { "java database tuning" });
+      while (cursor.hasNext())
+        order.add(((Document) cursor.next().getRecord()).getString("name"));
+      assertThat(order).containsExactly("d3", "d2", "d1");
+
+      // limit must truncate to the top-N by score, not be ignored.
+      final List<String> top = new ArrayList<>();
+      final IndexCursor limited = bucket.get(new Object[] { "java database tuning" }, 2);
+      while (limited.hasNext())
+        top.add(((Document) limited.next().getRecord()).getString("name"));
+      assertThat(top).containsExactly("d3", "d2");
     });
   }
 }

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -320,6 +320,25 @@ class FullTextBM25Test extends TestHelper {
   }
 
   @Test
+  void explainOnEmptyCorpus() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT");
+    });
+
+    // EXPLAIN on an index with no documents must not fail; the query term reports df 0.
+    database.transaction(() -> {
+      final ResultSet rs = database.query("sql",
+          "EXPLAIN SELECT name, $score FROM Doc WHERE SEARCH_INDEX('Doc[content]', 'java') = true");
+      final String plan = rs.next().getProperty("executionPlanAsString");
+      assertThat(plan).contains("SCORING").contains("BM25").contains("java");
+      assertThat(plan).contains("\"df\":0"); // the query term has zero document frequency on an empty corpus
+    });
+  }
+
+  @Test
   void classicSimilarityKeepsCoordinationScoring() {
     database.transaction(() -> {
       database.command("sql", "CREATE DOCUMENT TYPE Doc");

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -345,6 +345,15 @@ class FullTextBM25Test extends TestHelper {
     });
     assertThatThrownBy(() -> database.command("sql", "REBUILD INDEX `Plain[content]` WITH statsOnly = true"))
         .hasMessageContaining("no recomputable statistics");
+
+    // Wildcard form: recompute every index that keeps statistics. Only the BM25 index (Doc[content]) qualifies; the CLASSIC one
+    // (Plain[content]) is skipped, so exactly one index is reported.
+    try (final ResultSet rs = database.command("sql", "REBUILD INDEX * WITH statsOnly = true")) {
+      final Result r = rs.next();
+      assertThat(r.<String>getProperty("operation")).isEqualTo("rebuild index stats");
+      assertThat(((Number) r.getProperty("statsRecomputed")).intValue()).isEqualTo(1);
+      assertThat(r.<List<String>>getProperty("indexes")).containsExactly("Doc[content]");
+    }
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -422,6 +422,45 @@ class FullTextBM25Test extends TestHelper {
   }
 
   @Test
+  void directGetWithLuceneSyntaxIsGracefulNotLuceneParsed() {
+    // The direct index.get() path is token-based (it also backs CONTAINSTEXT), so Lucene syntax is NOT parsed - it is handed to
+    // the analyzer as literal text. This documents that 'java^3' does not crash and is not treated as a boost: the StandardAnalyzer
+    // simply tokenizes around the caret into [java, 3], so the document matches via the 'java' token but the ^3 boost is silently
+    // ignored. Use SEARCH_INDEX for real caret/boolean/phrase/wildcard semantics.
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc BUCKETS 1");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT");
+      database.command("sql", "INSERT INTO Doc SET name = 'a', content = 'java tutorial'");
+    });
+
+    database.transaction(() -> {
+      final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("Doc[content]");
+      final LSMTreeFullTextIndex bucket = (LSMTreeFullTextIndex) typeIndex.getIndexesOnBuckets()[0];
+
+      // Caret syntax on the direct path: no exception. It matches via the analyzer-tokenized 'java' (the ^3 is not a Lucene boost,
+      // just a token separator), confirming graceful, non-Lucene handling rather than a crash or a parsed boost query.
+      int caretMatches = 0;
+      final IndexCursor caret = bucket.get(new Object[] { "java^3" });
+      while (caret.hasNext()) {
+        caret.next();
+        caretMatches++;
+      }
+      assertThat(caretMatches).isEqualTo(1);
+
+      // A plain term on the same path matches the same document.
+      int plainMatches = 0;
+      final IndexCursor plain = bucket.get(new Object[] { "java" });
+      while (plain.hasNext()) {
+        plain.next();
+        plainMatches++;
+      }
+      assertThat(plainMatches).isEqualTo(1);
+    });
+  }
+
+  @Test
   void reservedDefaultFieldPropertyNameIsRejected() {
     // The query parser reserves an internal sentinel for the unqualified default field; a real property with that exact name
     // would be ambiguous on a multi-property index, so index creation must reject it rather than mis-score silently.

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -155,7 +155,6 @@ class FullTextBM25Test extends TestHelper {
   }
 
   @Test
-  @Tag("slow")
   void bm25RankingHoldsAcrossMultipleBuckets() {
     database.transaction(() -> {
       // Multiple buckets: BM25 is scored per bucket, so N (doc count) and df must both be per-bucket to keep IDF unbiased.

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -422,6 +422,20 @@ class FullTextBM25Test extends TestHelper {
   }
 
   @Test
+  void reservedDefaultFieldPropertyNameIsRejected() {
+    // The query parser reserves an internal sentinel for the unqualified default field; a real property with that exact name
+    // would be ambiguous on a multi-property index, so index creation must reject it rather than mis-score silently.
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.`__arcadedb_default_field__` STRING");
+      database.command("sql", "CREATE PROPERTY Doc.title STRING");
+    });
+    assertThatThrownBy(() -> database.transaction(() -> database.command("sql",
+        "CREATE INDEX ON Doc (`__arcadedb_default_field__`, title) FULL_TEXT")))
+        .hasStackTraceContaining("reserved"); // the IllegalArgumentException is wrapped by the index builder
+  }
+
+  @Test
   void invalidBM25ParametersAreRejected() {
     database.transaction(() -> {
       database.command("sql", "CREATE DOCUMENT TYPE Doc");

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -376,6 +376,11 @@ class FullTextBM25Test extends TestHelper {
     assertThatThrownBy(() -> database.transaction(() ->
             database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT METADATA {\"similarity\": \"LUCENE\"}")))
         .hasMessageContaining("Unknown full-text similarity");
+
+    // A negative per-field boost is rejected: it would produce negative term contributions and invert ranking.
+    assertThatThrownBy(() -> database.transaction(() ->
+            database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT METADATA {\"content_boost\": -5.0}")))
+        .hasMessageContaining("boost for 'content' must be >= 0");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -506,6 +506,34 @@ class FullTextBM25Test extends TestHelper {
   }
 
   @Test
+  void nullIndexedFieldUnderBM25IsSkippedAndDoesNotInflateLength() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT"); // BM25, default NULL_STRATEGY (skip)
+      // One document has a null indexed field: it must be skipped cleanly (no phantom posting, no length inflation) while the
+      // others score normally.
+      database.command("sql", "INSERT INTO Doc SET name = 'nullDoc', content = null");
+      database.command("sql", "INSERT INTO Doc SET name = 'a', content = 'java tutorial'");
+      database.command("sql", "INSERT INTO Doc SET name = 'b', content = 'java guide reference'");
+    });
+
+    database.transaction(() -> {
+      final Map<String, Float> scores = searchScores("Doc[content]", "java");
+      // The null-content document never matches; the two real documents score finite, positive BM25 values.
+      assertThat(scores.keySet()).containsExactlyInAnyOrder("a", "b");
+      scores.values().forEach(s -> {
+        assertThat(s).isGreaterThan(0f);
+        assertThat(s.isNaN()).isFalse();
+      });
+      // The shorter document ('a', 2 tokens) outranks the longer one ('b', 3 tokens) for the same term - confirming the null
+      // field did not distort the average document length used for normalization.
+      assertThat(scores.get("a")).isGreaterThan(scores.get("b"));
+    });
+  }
+
+  @Test
   void singleDocumentScoresWithoutLengthBias() {
     database.transaction(() -> {
       database.command("sql", "CREATE DOCUMENT TYPE Doc");

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -346,6 +346,10 @@ class FullTextBM25Test extends TestHelper {
     assertThatThrownBy(() -> database.command("sql", "REBUILD INDEX `Plain[content]` WITH statsOnly = true"))
         .hasMessageContaining("no recomputable statistics");
 
+    // An unknown index name reports "not found" rather than throwing a NullPointerException.
+    assertThatThrownBy(() -> database.command("sql", "REBUILD INDEX `Nope[content]` WITH statsOnly = true"))
+        .hasMessageContaining("not found");
+
     // Wildcard form: recompute every index that keeps statistics. Only the BM25 index (Doc[content]) qualifies; the CLASSIC one
     // (Plain[content]) is skipped, so exactly one index is reported.
     try (final ResultSet rs = database.command("sql", "REBUILD INDEX * WITH statsOnly = true")) {
@@ -354,6 +358,40 @@ class FullTextBM25Test extends TestHelper {
       assertThat(((Number) r.getProperty("statsRecomputed")).intValue()).isEqualTo(1);
       assertThat(r.<List<String>>getProperty("indexes")).containsExactly("Doc[content]");
     }
+  }
+
+  @Test
+  void bm25GetHonorsLimitReturningTopKInOrder() {
+    database.transaction(() -> {
+      // Single bucket so the bucket-index cursor sees every document and the top-K selection is deterministic.
+      database.command("sql", "CREATE DOCUMENT TYPE Doc BUCKETS 1");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT");
+      // 'rare' matches the discriminative term and is short -> highest BM25; the rest match only the common term.
+      database.command("sql", "INSERT INTO Doc SET name = 'rare', content = 'quantum data'");
+      for (int i = 0; i < 8; i++)
+        database.command("sql", "INSERT INTO Doc SET name = 'common" + i + "', content = 'data data record number " + i + "'");
+    });
+
+    database.transaction(() -> {
+      final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("Doc[content]");
+      final LSMTreeFullTextIndex bucket = (LSMTreeFullTextIndex) typeIndex.getIndexesOnBuckets()[0];
+
+      // limit (2) smaller than the candidate set exercises the bounded-heap top-K path.
+      final List<String> top = new ArrayList<>();
+      float previous = Float.MAX_VALUE;
+      final IndexCursor cursor = bucket.get(new Object[] { "quantum data" }, 2);
+      while (cursor.hasNext()) {
+        final var entry = cursor.next();
+        top.add(((Document) entry.getRecord()).getString("name"));
+        final float score = cursor.getFloatScore();
+        assertThat(score).isLessThanOrEqualTo(previous); // results come back already sorted, most-relevant first
+        previous = score;
+      }
+      assertThat(top).hasSize(2);
+      assertThat(top.get(0)).isEqualTo("rare"); // the discriminative, short document is the top result
+    });
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -30,6 +30,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
 
 /**
  * End-to-end tests for native BM25 full-text scoring (issue #4687): IDF (rare terms outrank common ones), document-length
@@ -252,16 +254,16 @@ class FullTextBM25Test extends TestHelper {
     });
 
     // k1 must be >= 0 and b must be in [0,1]: misconfiguration is surfaced at index creation, not silently mis-scored.
-    org.assertj.core.api.Assertions.assertThatThrownBy(() -> database.transaction(() ->
+    assertThatThrownBy(() -> database.transaction(() ->
             database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT METADATA {\"bm25_b\": 2.0}")))
         .hasMessageContaining("b must be in [0, 1]");
 
-    org.assertj.core.api.Assertions.assertThatThrownBy(() -> database.transaction(() ->
+    assertThatThrownBy(() -> database.transaction(() ->
             database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT METADATA {\"bm25_k1\": -1.0}")))
         .hasMessageContaining("k1 must be >= 0");
 
     // An unknown similarity is rejected rather than silently treated as CLASSIC.
-    org.assertj.core.api.Assertions.assertThatThrownBy(() -> database.transaction(() ->
+    assertThatThrownBy(() -> database.transaction(() ->
             database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT METADATA {\"similarity\": \"LUCENE\"}")))
         .hasMessageContaining("Unknown full-text similarity");
   }
@@ -317,7 +319,7 @@ class FullTextBM25Test extends TestHelper {
 
       // Without the boost (symmetric query) the two are tied.
       final Map<String, Float> neutral = searchScores("Doc[content]", "java python");
-      assertThat(neutral.get("java")).isCloseTo(neutral.get("python"), org.assertj.core.api.Assertions.within(1e-4f));
+      assertThat(neutral.get("java")).isCloseTo(neutral.get("python"), within(1e-4f));
     });
   }
 
@@ -389,6 +391,53 @@ class FullTextBM25Test extends TestHelper {
   }
 
   @Test
+  void singleDocumentScoresWithoutLengthBias() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT");
+      // A single-document corpus: avgdl equals that document's length, so the length-normalization denominator collapses to k1+1
+      // and the score must still be a finite positive number (no divide-by-zero on avgdl).
+      database.command("sql", "INSERT INTO Doc SET name = 'only', content = 'java database tuning'");
+    });
+
+    database.transaction(() -> {
+      final Map<String, Float> scores = searchScores("Doc[content]", "java");
+      assertThat(scores).containsOnlyKeys("only");
+      assertThat(scores.get("only")).isGreaterThan(0f);
+      assertThat(scores.get("only").isNaN()).isFalse();
+      assertThat(scores.get("only").isInfinite()).isFalse();
+    });
+  }
+
+  @Test
+  void contentFieldNameDoesNotCollideWithDefaultFieldSentinel() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE PROPERTY Doc.title STRING");
+      // The query parser uses "content" as the default-field sentinel for unqualified terms. A real index that also has a
+      // property literally named "content" must still index and score both fields gracefully (no crash, sensible ranking).
+      database.command("sql", "CREATE INDEX ON Doc (content, title) FULL_TEXT");
+      database.command("sql", "INSERT INTO Doc SET name = 'inContent', content = 'java tutorial', title = 'something else'");
+      database.command("sql", "INSERT INTO Doc SET name = 'inTitle',   content = 'something else', title = 'java tutorial'");
+    });
+
+    database.transaction(() -> {
+      // Unqualified term: both documents match (the field-agnostic token), scores are finite and positive.
+      final Map<String, Float> unqualified = searchScores("Doc[content,title]", "java");
+      assertThat(unqualified.keySet()).containsExactlyInAnyOrder("inContent", "inTitle");
+      unqualified.values().forEach(s -> assertThat(s).isGreaterThan(0f));
+
+      // Field-qualified term on the literally-named "content" property still resolves to that field only.
+      final Map<String, Float> qualified = searchScores("Doc[content,title]", "content:java");
+      assertThat(qualified.keySet()).contains("inContent");
+    });
+  }
+
+  @Test
   @Tag("slow")
   void bm25ConfigAndCountersSurviveRestart() {
     database.transaction(() -> {
@@ -410,7 +459,7 @@ class FullTextBM25Test extends TestHelper {
       final Map<String, Float> after = searchScores("Doc[content]", "quantum data");
       // The ranking (rare term wins) and the actual scores must be identical after restart.
       assertThat(after.get("rare")).isNotNull();
-      assertThat(after.get("rare")).isCloseTo(before.get("rare"), org.assertj.core.api.Assertions.within(1e-4f));
+      assertThat(after.get("rare")).isCloseTo(before.get("rare"), within(1e-4f));
       for (final Map.Entry<String, Float> e : after.entrySet())
         if (!e.getKey().equals("rare"))
           assertThat(after.get("rare")).isGreaterThan(e.getValue());

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -502,6 +502,26 @@ class FullTextBM25Test extends TestHelper {
   }
 
   @Test
+  void nestedNegationDoesNotWronglyExcludeDoubleNegatedTerms() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT");
+      database.command("sql", "INSERT INTO Doc SET name = 'd1', content = 'java tutorial'");
+      database.command("sql", "INSERT INTO Doc SET name = 'd2', content = 'java database'");
+    });
+
+    database.transaction(() -> {
+      // java AND NOT (database AND NOT tutorial) == java AND (NOT database OR tutorial).
+      // d1 (java, tutorial): java && (NOT database OR tutorial) -> matches. d2 (java, database): java && (false OR false) -> no.
+      // The nested NOT tutorial is a double negation: 'tutorial' must NOT be excluded, so d1 must survive (the bug excluded it).
+      final Map<String, Float> scores = searchScores("Doc[content]", "java -(database -tutorial)");
+      assertThat(scores.keySet()).containsExactly("d1");
+    });
+  }
+
+  @Test
   void caretInBooleanQueries() {
     database.transaction(() -> {
       database.command("sql", "CREATE DOCUMENT TYPE Doc");

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -118,6 +118,31 @@ class FullTextBM25Test extends TestHelper {
   }
 
   @Test
+  void bm25RankingHoldsAcrossMultipleBuckets() {
+    database.transaction(() -> {
+      // Multiple buckets: BM25 is scored per bucket, so N (doc count) and df must both be per-bucket to keep IDF unbiased.
+      database.command("sql", "CREATE DOCUMENT TYPE Doc BUCKETS 4");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT");
+
+      database.command("sql", "INSERT INTO Doc SET name = 'rare', content = 'quantum data analysis'");
+      for (int i = 0; i < 40; i++)
+        database.command("sql", "INSERT INTO Doc SET name = 'common" + i + "', content = 'data record number " + i + "'");
+    });
+
+    database.transaction(() -> {
+      final Map<String, Float> scores = searchScores("Doc[content]", "quantum data");
+      assertThat(scores.get("rare")).isNotNull();
+      // The document with the rare, discriminative term must rank above every common-only document, regardless of which bucket
+      // each landed in.
+      for (final Map.Entry<String, Float> e : scores.entrySet())
+        if (!e.getKey().equals("rare"))
+          assertThat(scores.get("rare")).isGreaterThan(e.getValue());
+    });
+  }
+
+  @Test
   void caretInBooleanQueries() {
     database.transaction(() -> {
       database.command("sql", "CREATE DOCUMENT TYPE Doc");

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -527,6 +527,27 @@ class FullTextBM25Test extends TestHelper {
   }
 
   @Test
+  void explainTruncatesAtTermCapForHugeExpansions() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT");
+      // 80 distinct tokens sharing the prefix 'term', so a 'term*' wildcard expands past the 64-term EXPLAIN cap.
+      for (int i = 0; i < 80; i++)
+        database.command("sql", "INSERT INTO Doc SET name = 'd" + i + "', content = 'term" + i + "'");
+    });
+
+    database.transaction(() -> {
+      final ResultSet rs = database.query("sql",
+          "EXPLAIN SELECT name FROM Doc WHERE SEARCH_INDEX('Doc[content]', 'term*') = true");
+      final String plan = rs.next().getProperty("executionPlanAsString");
+      // The scoring breakdown is capped and flagged rather than scanning all 80 expanded terms' postings.
+      assertThat(plan).contains("termsTruncated");
+    });
+  }
+
+  @Test
   void explainOnEmptyCorpus() {
     database.transaction(() -> {
       database.command("sql", "CREATE DOCUMENT TYPE Doc");

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -305,6 +305,49 @@ class FullTextBM25Test extends TestHelper {
   }
 
   @Test
+  void rebuildIndexStatsOnlyRepairsCountersViaSQL() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT");
+      database.command("sql", "INSERT INTO Doc SET name='a', content='java tutorial'");
+    });
+
+    // Induce counter drift: a rolled-back insert bumps the in-memory corpus counters but commits no postings.
+    try {
+      database.transaction(() -> {
+        database.command("sql", "INSERT INTO Doc SET name='ghost', content='java java java'");
+        throw new IllegalStateException("force rollback");
+      });
+    } catch (final IllegalStateException ignore) {
+      // expected
+    }
+
+    // Repair the BM25 corpus counters from SQL - no Java, and no full (expensive) index rebuild.
+    try (final ResultSet rs = database.command("sql", "REBUILD INDEX `Doc[content]` WITH statsOnly = true")) {
+      final Result r = rs.next();
+      assertThat(r.<String>getProperty("operation")).isEqualTo("rebuild index stats");
+      assertThat(((Number) r.getProperty("statsRecomputed")).intValue()).isEqualTo(1);
+    }
+
+    database.transaction(() -> {
+      final Map<String, Float> scores = searchScores("Doc[content]", "java");
+      assertThat(scores).containsOnlyKeys("a");
+      assertThat(scores.get("a")).isGreaterThan(0f);
+    });
+
+    // A CLASSIC index keeps no recomputable statistics: statsOnly must report that clearly rather than silently succeeding.
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Plain");
+      database.command("sql", "CREATE PROPERTY Plain.content STRING");
+      database.command("sql", "CREATE INDEX ON Plain (content) FULL_TEXT METADATA {\"similarity\": \"CLASSIC\"}");
+    });
+    assertThatThrownBy(() -> database.command("sql", "REBUILD INDEX `Plain[content]` WITH statsOnly = true"))
+        .hasMessageContaining("no recomputable statistics");
+  }
+
+  @Test
   void invalidBM25ParametersAreRejected() {
     database.transaction(() -> {
       database.command("sql", "CREATE DOCUMENT TYPE Doc");
@@ -476,8 +519,8 @@ class FullTextBM25Test extends TestHelper {
       database.command("sql", "CREATE PROPERTY Doc.name STRING");
       database.command("sql", "CREATE PROPERTY Doc.content STRING");
       database.command("sql", "CREATE PROPERTY Doc.title STRING");
-      // The query parser uses "content" as the default-field sentinel for unqualified terms. A real index that also has a
-      // property literally named "content" must still index and score both fields gracefully (no crash, sensible ranking).
+      // A multi-property index that includes a property literally named "content" must resolve a content:term clause to that field
+      // - the default-field sentinel is no longer "content", so the former silent collision is fixed.
       database.command("sql", "CREATE INDEX ON Doc (content, title) FULL_TEXT");
       database.command("sql", "INSERT INTO Doc SET name = 'inContent', content = 'java tutorial', title = 'something else'");
       database.command("sql", "INSERT INTO Doc SET name = 'inTitle',   content = 'something else', title = 'java tutorial'");
@@ -489,9 +532,38 @@ class FullTextBM25Test extends TestHelper {
       assertThat(unqualified.keySet()).containsExactlyInAnyOrder("inContent", "inTitle");
       unqualified.values().forEach(s -> assertThat(s).isGreaterThan(0f));
 
-      // Field-qualified term on the literally-named "content" property still resolves to that field only.
-      final Map<String, Float> qualified = searchScores("Doc[content,title]", "content:java");
-      assertThat(qualified.keySet()).contains("inContent");
+      // content:java resolves to the content field ONLY: inContent matches, inTitle (java only in its title) does not.
+      final Map<String, Float> contentScoped = searchScores("Doc[content,title]", "content:java");
+      assertThat(contentScoped.keySet()).containsExactly("inContent");
+
+      // title:java symmetrically resolves to the title field ONLY.
+      final Map<String, Float> titleScoped = searchScores("Doc[content,title]", "title:java");
+      assertThat(titleScoped.keySet()).containsExactly("inTitle");
+    });
+  }
+
+  @Test
+  void contentFieldBoostIsAppliedOnMultiPropertyIndex() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE PROPERTY Doc.title STRING");
+      // A boost on a field literally named "content" must now take effect (previously silently dropped because "content" was the
+      // default-field sentinel).
+      database.command("sql",
+          "CREATE INDEX ON Doc (content, title) FULL_TEXT METADATA {\"similarity\": \"BM25\", \"content_boost\": 5.0}");
+      database.command("sql", "INSERT INTO Doc SET name = 'inContent', content = 'java', title = 'something else entirely'");
+      database.command("sql", "INSERT INTO Doc SET name = 'inTitle',   content = 'something else', title = 'java'");
+    });
+
+    database.transaction(() -> {
+      final Map<String, Float> contentScores = searchScores("Doc[content,title]", "content:java");
+      final Map<String, Float> titleScores = searchScores("Doc[content,title]", "title:java");
+      assertThat(contentScores.get("inContent")).isNotNull();
+      assertThat(titleScores.get("inTitle")).isNotNull();
+      // The content_boost=5.0 raises the content-field match above the equivalent unboosted title-field match.
+      assertThat(contentScores.get("inContent")).isGreaterThan(titleScores.get("inTitle"));
     });
   }
 
@@ -524,15 +596,8 @@ class FullTextBM25Test extends TestHelper {
           assertThat(meta.getBm25K1()).isCloseTo(1.5f, within(1e-6f));
           assertThat(meta.getBm25B()).isCloseTo(0.6f, within(1e-6f));
         }
-      // The type-wide counters feeding avgdl must also survive: 13 documents totalling 2 + 12*3 = 38 tokens.
-      long totalDocs = 0L;
-      long sumDocLength = 0L;
-      for (final Index bucketIndex : typeIndex.getIndexesOnBuckets())
-        if (bucketIndex instanceof LSMTreeFullTextIndex ftIndex) {
-          totalDocs += ftIndex.getFullTextMetadata().getTotalDocs();
-          sumDocLength += ftIndex.getFullTextMetadata().getSumDocLength();
-        }
-      // The counters are shared type-wide (same metadata object per bucket), so read them from a single bucket index.
+      // The type-wide counters feeding avgdl must also survive: 13 documents totalling 2 + 12*3 = 38 tokens. The counters are
+      // shared type-wide (the same metadata object is passed to every bucket index), so read them from a single bucket index.
       final LSMTreeFullTextIndex anyBucket = (LSMTreeFullTextIndex) typeIndex.getIndexesOnBuckets()[0];
       assertThat(anyBucket.getFullTextMetadata().getTotalDocs()).isEqualTo(13L);
       assertThat(anyBucket.getFullTextMetadata().getSumDocLength()).isEqualTo(38L);

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -184,6 +184,42 @@ class FullTextBM25Test extends TestHelper {
   }
 
   @Test
+  void rolledBackInsertIsNotIndexedAndRecomputeRepairsCounters() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT");
+      database.command("sql", "INSERT INTO Doc SET name='a', content='java tutorial'");
+    });
+
+    // A rolled-back insert: its postings are not committed, but the in-memory corpus counters were already bumped (they are not
+    // transactionally reversed) - so they drift until repaired.
+    try {
+      database.transaction(() -> {
+        database.command("sql", "INSERT INTO Doc SET name='ghost', content='java java java'");
+        throw new IllegalStateException("force rollback");
+      });
+    } catch (final IllegalStateException ignore) {
+      // expected
+    }
+
+    database.transaction(() -> {
+      final Map<String, Float> scores = searchScores("Doc[content]", "java");
+      assertThat(scores).containsOnlyKeys("a"); // the rolled-back "ghost" was never indexed
+      assertThat(scores.get("a")).isGreaterThan(0f);
+    });
+
+    // recomputeBM25Counters rebuilds the counters from committed data, so scoring keeps working after the drift.
+    recomputeCounters();
+    database.transaction(() -> {
+      final Map<String, Float> scores = searchScores("Doc[content]", "java");
+      assertThat(scores).containsOnlyKeys("a");
+      assertThat(scores.get("a")).isGreaterThan(0f);
+    });
+  }
+
+  @Test
   void invalidBM25ParametersAreRejected() {
     database.transaction(() -> {
       database.command("sql", "CREATE DOCUMENT TYPE Doc");

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -300,8 +300,8 @@ class FullTextBM25Test extends TestHelper {
         .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("non-negative");
     // A valid posting is accepted and exposes its statistics.
     final FullTextPostingRID posting = new FullTextPostingRID(database, 1, 1L, 2, 5);
-    assertThat(posting.tf).isEqualTo(2);
-    assertThat(posting.docLength).isEqualTo(5);
+    assertThat(posting.getTf()).isEqualTo(2);
+    assertThat(posting.getDocLength()).isEqualTo(5);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -502,6 +502,26 @@ class FullTextBM25Test extends TestHelper {
   }
 
   @Test
+  void pureNegativeQueryReturnsComplement() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT");
+      database.command("sql", "INSERT INTO Doc SET name = 'a', content = 'java tutorial'");
+      database.command("sql", "INSERT INTO Doc SET name = 'b', content = 'python guide'");
+      database.command("sql", "INSERT INTO Doc SET name = 'c', content = 'java reference'");
+    });
+
+    database.transaction(() -> {
+      // A pure-negative query materializes the whole index (collectAllIndexedRids) and subtracts the matches of the negated term.
+      // '-java' must return exactly the documents that do NOT contain 'java'.
+      final Map<String, Float> scores = searchScores("Doc[content]", "-java");
+      assertThat(scores.keySet()).containsExactly("b");
+    });
+  }
+
+  @Test
   void nestedNegationDoesNotWronglyExcludeDoubleNegatedTerms() {
     database.transaction(() -> {
       database.command("sql", "CREATE DOCUMENT TYPE Doc");

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -617,6 +617,8 @@ class FullTextBM25Test extends TestHelper {
       final String plan = rs.next().getProperty("executionPlanAsString");
       // The scoring breakdown is capped and flagged rather than scanning all 80 expanded terms' postings.
       assertThat(plan).contains("termsTruncated");
+      // The breakdown also reports how many terms were omitted (80 matched - 64 shown = 16) so the partial view is explicit.
+      assertThat(plan).contains("termsOmitted").contains("\"termsOmitted\":16");
     });
   }
 

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -154,6 +154,31 @@ class FullTextBM25Test extends TestHelper {
   }
 
   @Test
+  void removalUpdatesScoringStatistics() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT");
+      // Four documents all containing "java", each with one distinct extra token (so all have the same length).
+      for (int i = 1; i <= 4; i++)
+        database.command("sql", "INSERT INTO Doc SET name='d" + i + "', content='java word" + i + "'");
+    });
+
+    final float[] before = new float[1];
+    database.transaction(() -> before[0] = searchScores("Doc[content]", "java").get("d1"));
+
+    // Removing a document containing "java" lowers its document frequency and N, raising IDF for the survivors.
+    database.transaction(() -> database.command("sql", "DELETE FROM Doc WHERE name = 'd4'"));
+
+    database.transaction(() -> {
+      final Map<String, Float> after = searchScores("Doc[content]", "java");
+      assertThat(after).containsOnlyKeys("d1", "d2", "d3");
+      assertThat(after.get("d1")).isGreaterThan(before[0]); // statistics (df/N) reflect the removal
+    });
+  }
+
+  @Test
   void scoringSurvivesDocumentRemovalAndRecompute() {
     database.transaction(() -> {
       database.command("sql", "CREATE DOCUMENT TYPE Doc");

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -23,6 +23,7 @@ import com.arcadedb.database.Document;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.IndexCursor;
 import com.arcadedb.index.TypeIndex;
+import com.arcadedb.index.lsm.FullTextPostingRID;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Tag;
@@ -288,6 +289,19 @@ class FullTextBM25Test extends TestHelper {
       for (final Map.Entry<String, Float> e : afterRecompute.entrySet())
         assertThat(e.getValue()).isCloseTo(beforeRecompute.get(e.getKey()), within(1e-4f));
     });
+  }
+
+  @Test
+  void fullTextPostingRIDRejectsNegativeStatistics() {
+    // Corrupt statistics must fail fast at construction rather than silently yield a nonsensical BM25 contribution.
+    assertThatThrownBy(() -> new FullTextPostingRID(database, 1, 1L, -1, 5))
+        .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("non-negative");
+    assertThatThrownBy(() -> new FullTextPostingRID(database, 1, 1L, 2, -1))
+        .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("non-negative");
+    // A valid posting is accepted and exposes its statistics.
+    final FullTextPostingRID posting = new FullTextPostingRID(database, 1, 1L, 2, 5);
+    assertThat(posting.tf).isEqualTo(2);
+    assertThat(posting.docLength).isEqualTo(5);
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -104,6 +104,33 @@ class FullTextBM25Test extends TestHelper {
   }
 
   @Test
+  void unqualifiedTermAggregatesTermFrequencyAcrossFields() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.title STRING");
+      database.command("sql", "CREATE PROPERTY Doc.body STRING");
+      database.command("sql", "CREATE INDEX ON Doc (title, body) FULL_TEXT");
+
+      // 'both' has "java" once in title AND once in body (global tf = 2); 'one' has it once, in title only (global tf = 1). Both
+      // documents have the same total length (2 tokens), so the only differentiator for an unqualified query is the aggregated tf.
+      database.command("sql", "INSERT INTO Doc SET name = 'both', title = 'java', body = 'java'");
+      database.command("sql", "INSERT INTO Doc SET name = 'one',  title = 'java', body = 'cooking'");
+    });
+
+    database.transaction(() -> {
+      // Unqualified query: the field-agnostic posting carries the summed tf, so 'both' (tf=2) outranks 'one' (tf=1).
+      final Map<String, Float> unqualified = searchScores("Doc[title,body]", "java");
+      assertThat(unqualified.keySet()).containsExactlyInAnyOrder("both", "one");
+      assertThat(unqualified.get("both")).isGreaterThan(unqualified.get("one"));
+
+      // A field-qualified query sees only that field's tf (1 for each in title), so they tie.
+      final Map<String, Float> titleScoped = searchScores("Doc[title,body]", "title:java");
+      assertThat(titleScoped.get("both")).isCloseTo(titleScoped.get("one"), within(1e-4f));
+    });
+  }
+
+  @Test
   void fieldBoostRaisesFieldQualifiedMatches() {
     database.transaction(() -> {
       database.command("sql", "CREATE DOCUMENT TYPE Doc");

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextBM25Test.java
@@ -19,6 +19,8 @@
 package com.arcadedb.index.fulltext;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.index.Index;
+import com.arcadedb.index.TypeIndex;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
@@ -140,6 +142,60 @@ class FullTextBM25Test extends TestHelper {
         if (!e.getKey().equals("rare"))
           assertThat(scores.get("rare")).isGreaterThan(e.getValue());
     });
+  }
+
+  private void recomputeCounters() {
+    final TypeIndex typeIndex = (TypeIndex) database.getSchema().getIndexByName("Doc[content]");
+    for (final Index bucketIndex : typeIndex.getIndexesOnBuckets())
+      if (bucketIndex instanceof LSMTreeFullTextIndex ftIndex)
+        ftIndex.recomputeBM25Counters();
+  }
+
+  @Test
+  void scoringSurvivesDocumentRemovalAndRecompute() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.name STRING");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+      database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT");
+      database.command("sql", "INSERT INTO Doc SET name='a', content='java tutorial'");
+      database.command("sql", "INSERT INTO Doc SET name='b', content='java guide'");
+      database.command("sql", "INSERT INTO Doc SET name='c', content='python guide'");
+    });
+
+    database.transaction(() -> database.command("sql", "DELETE FROM Doc WHERE name = 'a'"));
+
+    database.transaction(() -> {
+      final Map<String, Float> scores = searchScores("Doc[content]", "java");
+      assertThat(scores).containsOnlyKeys("b"); // only the surviving "java" document
+      assertThat(scores.get("b")).isGreaterThan(0f);
+    });
+
+    // recompute on a non-empty type rebuilds counters exactly; runs outside a transaction (it may persist the schema).
+    recomputeCounters();
+    database.transaction(() -> assertThat(searchScores("Doc[content]", "java")).containsOnlyKeys("b"));
+
+    // delete everything, recompute on the now-empty type must be safe and queries return nothing.
+    database.transaction(() -> database.command("sql", "DELETE FROM Doc"));
+    recomputeCounters();
+    database.transaction(() -> assertThat(searchScores("Doc[content]", "java")).isEmpty());
+  }
+
+  @Test
+  void invalidBM25ParametersAreRejected() {
+    database.transaction(() -> {
+      database.command("sql", "CREATE DOCUMENT TYPE Doc");
+      database.command("sql", "CREATE PROPERTY Doc.content STRING");
+    });
+
+    // k1 must be >= 0 and b must be in [0,1]: misconfiguration is surfaced at index creation, not silently mis-scored.
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> database.transaction(() ->
+            database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT METADATA {\"bm25_b\": 2.0}")))
+        .hasMessageContaining("b must be in [0, 1]");
+
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> database.transaction(() ->
+            database.command("sql", "CREATE INDEX ON Doc (content) FULL_TEXT METADATA {\"bm25_k1\": -1.0}")))
+        .hasMessageContaining("k1 must be >= 0");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/index/fulltext/FullTextMultiPropertyTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/FullTextMultiPropertyTest.java
@@ -125,7 +125,9 @@ class FullTextMultiPropertyTest extends TestHelper {
       database.command("sql", "CREATE DOCUMENT TYPE Article");
       database.command("sql", "CREATE PROPERTY Article.title STRING");
       database.command("sql", "CREATE PROPERTY Article.body STRING");
-      database.command("sql", "CREATE INDEX ON Article (title, body) FULL_TEXT");
+      // This test asserts exact term-coordination scores, so pin CLASSIC similarity: new full-text indexes default to BM25
+      // (issue #4687).
+      database.command("sql", "CREATE INDEX ON Article (title, body) FULL_TEXT METADATA {\"similarity\": \"CLASSIC\"}");
 
       // Doc1: matches "java" and "programming" in both title AND body
       database.command("sql", "INSERT INTO Article SET title = 'Java Programming', body = 'Learn Java programming basics'");

--- a/engine/src/test/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndexTest.java
+++ b/engine/src/test/java/com/arcadedb/index/fulltext/LSMTreeFullTextIndexTest.java
@@ -412,7 +412,9 @@ class LSMTreeFullTextIndexTest extends TestHelper {
       database.command("sql", "CREATE DOCUMENT TYPE Article");
       database.command("sql", "CREATE PROPERTY Article.title STRING");
       database.command("sql", "CREATE PROPERTY Article.content STRING");
-      database.command("sql", "CREATE INDEX ON Article (content) FULL_TEXT");
+      // This test validates the legacy term-coordination (match-count) scoring, so pin CLASSIC similarity explicitly: new
+      // full-text indexes now default to BM25 (issue #4687).
+      database.command("sql", "CREATE INDEX ON Article (content) FULL_TEXT METADATA {\"similarity\": \"CLASSIC\"}");
 
       // Insert documents with varying keyword matches
       // Score = number of search keywords that match in the document

--- a/engine/src/test/java/com/arcadedb/query/sql/parser/RebuildIndexStatementTestParserTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/parser/RebuildIndexStatementTestParserTest.java
@@ -18,7 +18,10 @@
  */
 package com.arcadedb.query.sql.parser;
 
+import com.arcadedb.query.sql.antlr.SQLAntlrParser;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class RebuildIndexStatementTestParserTest extends AbstractParserTest {
 
@@ -34,5 +37,23 @@ class RebuildIndexStatementTestParserTest extends AbstractParserTest {
 
     checkWrongSyntax("REBUILD INDEX `Foo.bar` foo");
     checkRightSyntax("REBUILD INDEX `Foo.bar.baz` with unknown = 1000");
+  }
+
+  @Test
+  void wildcardCapturesFirstSettingKey() throws Exception {
+    // Regression for the firstSettingKeyIndex offset fix: the * (all) form has no index-name identifier, so the first WITH
+    // setting (batchSize here) must still be parsed into the settings map - before the fix it was silently dropped. checkRightSyntax
+    // only proves the grammar accepts it; this asserts the setting actually reaches the AST.
+    final Statement stmt = new SQLAntlrParser(null).parse("REBUILD INDEX * WITH batchSize = 1000");
+    assertThat(stmt).isInstanceOf(RebuildIndexStatement.class);
+    final RebuildIndexStatement rebuild = (RebuildIndexStatement) stmt;
+    assertThat(rebuild.all).isTrue();
+    assertThat(rebuild.settings.keySet()).anyMatch(k -> "batchSize".equals(k.toString()));
+
+    // Sanity: the named form still captures its setting too (identifier(0) is the index name, the key starts at identifier(1)).
+    final RebuildIndexStatement named = (RebuildIndexStatement) new SQLAntlrParser(null).parse(
+        "REBUILD INDEX `Foo.bar` WITH batchSize = 1000");
+    assertThat(named.all).isFalse();
+    assertThat(named.settings.keySet()).anyMatch(k -> "batchSize".equals(k.toString()));
   }
 }

--- a/engine/src/test/java/com/arcadedb/schema/FullTextIndexMetadataTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/FullTextIndexMetadataTest.java
@@ -22,6 +22,7 @@ import com.arcadedb.serializer.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Unit tests for {@link FullTextIndexMetadata}.
@@ -62,6 +63,31 @@ class FullTextIndexMetadataTest {
     reloaded.fromJSON(defaultJson);
     assertThat(reloaded.getBm25K1()).isEqualTo(FullTextIndexMetadata.DEFAULT_BM25_K1);
     assertThat(reloaded.getBm25B()).isEqualTo(FullTextIndexMetadata.DEFAULT_BM25_B);
+  }
+
+  @Test
+  void fromJSONReplacesStalePerFieldConfig() {
+    final FullTextIndexMetadata metadata = new FullTextIndexMetadata("Article", new String[] { "title", "body" }, 0);
+    metadata.setFieldAnalyzer("title", "org.apache.lucene.analysis.en.EnglishAnalyzer");
+    metadata.setFieldBoost("title", 3.0f);
+
+    // A second fromJSON (e.g. a schema reload onto a reused instance) must REPLACE the per-field config, not merge stale entries.
+    final JSONObject json = new JSONObject();
+    json.put("similarity", "BM25");
+    json.put("body_boost", 2.0f);
+    metadata.fromJSON(json);
+
+    assertThat(metadata.getFieldBoost("title")).isEqualTo(1.0f); // stale title boost cleared
+    assertThat(metadata.getFieldBoost("body")).isEqualTo(2.0f);  // new boost applied
+    assertThat(metadata.getAnalyzerClass("title")).isEqualTo(metadata.getAnalyzerClass()); // stale title analyzer cleared -> default
+  }
+
+  @Test
+  void setSimilarityRejectsNull() {
+    final FullTextIndexMetadata metadata = new FullTextIndexMetadata("Article", new String[] { "title" }, 0);
+    assertThatThrownBy(() -> metadata.setSimilarity(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("cannot be null");
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/schema/FullTextIndexMetadataTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/FullTextIndexMetadataTest.java
@@ -41,6 +41,30 @@ class FullTextIndexMetadataTest {
   }
 
   @Test
+  void writeToJSONOmitsDefaultBM25ParametersButKeepsTunedOnes() {
+    // Default BM25 index: k1/b are not emitted (they read back as the defaults), keeping the schema JSON terse.
+    final FullTextIndexMetadata defaults = new FullTextIndexMetadata("TestType", new String[] { "content" }, 0);
+    final JSONObject defaultJson = defaults.writeToJSON(new JSONObject());
+    assertThat(defaultJson.getString("similarity", null)).isEqualTo(FullTextIndexMetadata.SIMILARITY_BM25);
+    assertThat(defaultJson.has("bm25_k1")).isFalse();
+    assertThat(defaultJson.has("bm25_b")).isFalse();
+
+    // Tuned values are emitted so they survive a round-trip.
+    final FullTextIndexMetadata tuned = new FullTextIndexMetadata("TestType", new String[] { "content" }, 0);
+    tuned.setBm25K1(1.7f);
+    tuned.setBm25B(0.3f);
+    final JSONObject tunedJson = tuned.writeToJSON(new JSONObject());
+    assertThat(tunedJson.getFloat("bm25_k1")).isEqualTo(1.7f);
+    assertThat(tunedJson.getFloat("bm25_b")).isEqualTo(0.3f);
+
+    // A reload of the terse JSON restores the defaults.
+    final FullTextIndexMetadata reloaded = new FullTextIndexMetadata("TestType", new String[] { "content" }, 0);
+    reloaded.fromJSON(defaultJson);
+    assertThat(reloaded.getBm25K1()).isEqualTo(FullTextIndexMetadata.DEFAULT_BM25_K1);
+    assertThat(reloaded.getBm25B()).isEqualTo(FullTextIndexMetadata.DEFAULT_BM25_B);
+  }
+
+  @Test
   void fromJSONWithAnalyzer() {
     final FullTextIndexMetadata metadata = new FullTextIndexMetadata("TestType", new String[] { "content" }, 0);
 

--- a/engine/src/test/java/com/arcadedb/schema/TypeFullTextIndexBuilderTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/TypeFullTextIndexBuilderTest.java
@@ -19,11 +19,17 @@
 package com.arcadedb.schema;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.serializer.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
 
 class TypeFullTextIndexBuilderTest extends TestHelper {
 
@@ -232,6 +238,72 @@ class TypeFullTextIndexBuilderTest extends TestHelper {
           .withDefaultOperator("AND");
 
       assertThat(result).isSameAs(ftBuilder);
+    });
+  }
+
+  @Test
+  void withBM25AndFieldBoostSetMetadata() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Article");
+      database.getSchema().getType("Article").createProperty("title", String.class);
+      database.getSchema().getType("Article").createProperty("body", String.class);
+    });
+
+    database.transaction(() -> {
+      final TypeFullTextIndexBuilder ftBuilder = (TypeFullTextIndexBuilder) database.getSchema()
+          .buildTypeIndex("Article", new String[] { "title", "body" })
+          .withType(Schema.INDEX_TYPE.FULL_TEXT);
+
+      final TypeFullTextIndexBuilder result = ftBuilder.withBM25(1.4f, 0.55f).withFieldBoost("title", 3.0f);
+      assertThat(result).isSameAs(ftBuilder); // fluent chaining
+
+      final FullTextIndexMetadata meta = (FullTextIndexMetadata) ftBuilder.metadata;
+      assertThat(meta.getSimilarity()).isEqualTo(FullTextIndexMetadata.SIMILARITY_BM25);
+      assertThat(meta.getBm25K1()).isCloseTo(1.4f, within(1e-6f));
+      assertThat(meta.getBm25B()).isCloseTo(0.55f, within(1e-6f));
+      assertThat(meta.getFieldBoost("title")).isCloseTo(3.0f, within(1e-6f));
+      assertThat(meta.getFieldBoost("body")).isCloseTo(1.0f, within(1e-6f)); // unset field defaults to 1.0
+    });
+  }
+
+  @Test
+  void builderCreatedBM25IndexRanksAndBoosts() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("Article");
+      database.getSchema().getType("Article").createProperty("name", String.class);
+      database.getSchema().getType("Article").createProperty("title", String.class);
+      database.getSchema().getType("Article").createProperty("body", String.class);
+
+      // Create the index entirely through the Java builder API (no raw JSON metadata).
+      database.getSchema().buildTypeIndex("Article", new String[] { "title", "body" })
+          .withType(Schema.INDEX_TYPE.FULL_TEXT).withFullTextType()
+          .withBM25(1.2f, 0.75f).withFieldBoost("title", 5.0f).create();
+
+      database.command("sql", "INSERT INTO Article SET name = 'inTitle', title = 'java', body = 'something else entirely'");
+      database.command("sql", "INSERT INTO Article SET name = 'inBody', title = 'something else', body = 'java'");
+    });
+
+    database.transaction(() -> {
+      final Map<String, Float> titleScores = new HashMap<>();
+      final ResultSet ts = database.query("sql",
+          "SELECT name, $score FROM Article WHERE SEARCH_INDEX('Article[title,body]', 'title:java') = true");
+      while (ts.hasNext()) {
+        final Result r = ts.next();
+        titleScores.put(r.getProperty("name"), ((Number) r.getProperty("$score")).floatValue());
+      }
+
+      final Map<String, Float> bodyScores = new HashMap<>();
+      final ResultSet bs = database.query("sql",
+          "SELECT name, $score FROM Article WHERE SEARCH_INDEX('Article[title,body]', 'body:java') = true");
+      while (bs.hasNext()) {
+        final Result r = bs.next();
+        bodyScores.put(r.getProperty("name"), ((Number) r.getProperty("$score")).floatValue());
+      }
+
+      // The builder-configured title_boost=5.0 makes a title match outrank the same term in the unboosted body.
+      assertThat(titleScores.get("inTitle")).isNotNull();
+      assertThat(bodyScores.get("inBody")).isNotNull();
+      assertThat(titleScores.get("inTitle")).isGreaterThan(bodyScores.get("inBody"));
     });
   }
 


### PR DESCRIPTION
Closes #4687.

## Summary

Adds native **Okapi BM25** ranking to `FULL_TEXT` indexes. BM25 (TF/IDF + document-length normalization) is now the default similarity for **newly created** full-text indexes; **existing** indexes keep the legacy term-coordination scoring (`CLASSIC`), which stays available via `METADATA {"similarity":"CLASSIC"}`. Zero behavior change on upgrade.

## What's included

- **BM25 scoring** with configurable `k1`/`b` (defaults 1.2 / 0.75, matching Elasticsearch).
- **Field boosts** two ways, composable (`effective = caret × field_boost`):
  - configured per-field: `METADATA {"title_boost": 3.0}`
  - query-time caret (Lucene/ES idiom): `title:java^3`, usable inside `AND`/`OR`/`NOT` and `(group)^n` / `"phrase"^n`.
- **`$score`** exposes the float BM25 relevance on every matching row (no extra call needed):
  ```sql
  SELECT title, $score FROM Article
  WHERE SEARCH_INDEX('Article[content]', 'java database') = true ORDER BY $score DESC;
  ```
- **EXPLAIN / PROFILE** annotate the `FETCH FROM INDEXED FUNCTION` step with the BM25 similarity, `k1`/`b`, corpus stats (`totalDocs`, `avgDocLength`) and each query term's `df`/`idf`/`boost` (query-level "why these scores").
- **Persistence fix:** analyzer config + BM25 settings + corpus counters now survive a restart (previously `toJSON` dropped the metadata and silently reverted custom analyzers to `StandardAnalyzer`).

## Storage design

Per-posting term frequency + document length are carried inline through `FullTextPostingRID extends DatabaseRID`, so they ride the entire existing RID-typed pipeline (transaction staging, commit replay, compaction, cursors) with no signature changes. The value (de)serialization is gated by a `storeTermFrequency` flag derived from the persisted similarity, so **every non-full-text LSM index keeps the byte-identical RID-only format**. Existing full-text indexes open and score as `CLASSIC`; getting BM25 on old data requires a rebuild.

## Pre-existing bug fixed (also affected CLASSIC)

Full-text index **compaction** dropped postings when a single token's value list spanned multiple compacted pages. The compacted root is a *positional* sparse index that can't index one leaf page under two keys, so a key's values left on a shared continuation page became unreachable on read. Overflowing keys now start on a fresh page they fully own. This was independent of BM25 (reproduced identically with `CLASSIC`).

## Testing

- New: `BM25ScorerTest` (exact math), `FullTextBM25Test` (IDF ranking, length norm, field + caret boosts in AND/OR/NOT, CLASSIC fallback, restart persistence, EXPLAIN metadata), `FullTextBM25CompactionTest` (postings + scores survive compaction at tiny page sizes).
- Regression-safe: full `com.arcadedb.index.**` + `com.arcadedb.graph.**` (869) and full-text + all SQL function/method + select/explain suites (1339) pass; existing coordination-scoring tests pinned to `CLASSIC`.
