### PR TITLE
docs: document test suites in README and align e2e test naming

### DIFF
--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -328,7 +328,7 @@ jobs:
         run: docker load < /tmp/arcadedb-image.tar
 
       - name: E2E Tests
-        run: ./mvnw verify -pl e2e
+        run: ./mvnw verify -Pintegration -pl e2e
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARCADEDB_DOCKER_IMAGE: ${{ needs.build-and-package.outputs.image-tag }}

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -338,7 +338,7 @@ jobs:
         if: success() || failure()
         with:
           name: Java E2E Tests Report
-          path: "e2e/target/surefire-reports/TEST*.xml"
+          path: "e2e/target/failsafe-reports/TEST*.xml"
           list-suites: "failed"
           list-tests: "failed"
           reporter: java-junit

--- a/README.md
+++ b/README.md
@@ -297,6 +297,9 @@ The codebase is covered by several complementary test suites, each with a distin
 | **End-to-end (`e2e`)** | `mvn verify -Pintegration -pl e2e` | Black-box tests against a real ArcadeDB server in a Docker container (Testcontainers), exercising it the way external clients do: JDBC/Postgres queries, the remote Java API, server-side JavaScript functions, and the Bolt and gRPC drivers. |
 | **Load tests (`load-tests`)** | `mvn verify -Pintegration -pl load-tests` | Throughput and stability under sustained concurrent workloads against single-server and three-node clusters in containers, including high-volume document and time-series ingestion. Verifies no data loss or corruption under contention. |
 | **HA end-to-end (`e2e-ha`)** | `mvn verify -Pintegration -pl e2e-ha` | Resilience and correctness of the high-availability (Raft) cluster under failure: leader failover, rolling restarts, split-brain, network partitions/delay/packet loss, replication convergence, and cluster-wide operations (backup/restore, import, drop database, user management). Uses Testcontainers and fault injection (Toxiproxy). |
+| **Python client (`e2e-python`)** | `cd e2e-python && pytest tests/` | Verifies the Postgres wire protocol against real Python clients (`psycopg2`, `asyncpg`) and the SQLAlchemy ORM, running against a server in a Docker container (Testcontainers). |
+| **JavaScript client (`e2e-js`)** | `cd e2e-js && npm install && npm test` | Verifies Node.js client compatibility over the Bolt (`neo4j-driver`) and Postgres (`pg`) protocols, running against a server in a Docker container (Jest + Testcontainers). |
+| **C# client (`e2e-csharp`)** | `cd e2e-csharp/ArcadeDB.E2ETests && dotnet test` | Verifies the Postgres wire protocol against a .NET client (`Npgsql`), running against a server in a Docker container (xUnit + Testcontainers). |
 
 
 ### Community

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ imported `OpenBeer` database to find your favorite beer.
 
 ![ArcadeDB Studio](https://arcadedb.com/assets/images/openbeer-demo-graph.png)
 
-ArcadeDB is cloud-ready with [Docker](https://docs.arcadedb.com/#docker) and [Kubernetes](https://docs.arcadedb.com/#kubernetes)
+ArcadeDB is cloud-ready with [Docker](https://docs.arcadedb.com/arcadedb/how-to/operations/install-docker) and [Kubernetes](https://docs.arcadedb.com/arcadedb/how-to/operations/kubernetes)
 support.
 
 You can also [download the latest release](https://github.com/ArcadeData/arcadedb/releases), unpack it on your local hard drive and
@@ -233,7 +233,15 @@ Build the entire project (skipping tests):
 mvn clean install -DskipTests
 ```
 
-Run the full test suite:
+Build the Docker image (skipping tests):
+
+```bash
+mvn clean install -DskipTests -Pdocker
+```
+
+#### Running Unit Tests:
+
+Run the full unit test suite:
 
 ```bash
 mvn test
@@ -255,6 +263,41 @@ To run only a specific tag (e.g. benchmark tests in isolation):
 ```bash
 mvn test -Dgroups="benchmark"
 ```
+
+#### Running Integration Tests:
+
+Run all the integration tests (requires Docker):
+
+```bash
+mvn verify -Pintegration
+```
+
+Run integration tests excluding the end-to-end, load, and HA tests:
+
+```bash
+mvn verify -Pintegration -pl !e2e,!load-tests,!e2e-ha
+```
+
+#### Running End-to-End Tests:
+
+All end-to-end tests (requires Docker):
+
+```bash
+mvn verify -Pintegration -pl e2e,load-tests,e2e-ha
+```
+
+#### Test Suites at a Glance
+
+The codebase is covered by several complementary test suites, each with a distinct scope:
+
+| Suite | How it runs | Scope |
+|-------|-------------|-------|
+| **Unit tests** | `mvn test` (`*Test`) | Fast, in-process tests of a single component in isolation: engine internals (storage, pages, WAL, indexes, serialization), query parsing and execution (SQL, Cypher, Gremlin, GraphQL), schema, graph traversals, and security. The bulk of coverage; no external services required. Tagged `slow`/`benchmark` tests can be excluded. |
+| **Integration tests** | `mvn verify -Pintegration` (`*IT`) | Tests spanning multiple components or a running server within the same JVM/module: HTTP/REST API, wire protocols (Postgres, MongoDB, Redis, Bolt, gRPC), cross-module behavior, and embedded multi-server clustering. Some require Docker. |
+| **End-to-end (`e2e`)** | `mvn verify -Pintegration -pl e2e` | Black-box tests against a real ArcadeDB server in a Docker container (Testcontainers), exercising it the way external clients do: JDBC/Postgres queries, the remote Java API, server-side JavaScript functions, and the Bolt and gRPC drivers. |
+| **Load tests (`load-tests`)** | `mvn verify -Pintegration -pl load-tests` | Throughput and stability under sustained concurrent workloads against single-server and three-node clusters in containers, including high-volume document and time-series ingestion. Verifies no data loss or corruption under contention. |
+| **HA end-to-end (`e2e-ha`)** | `mvn verify -Pintegration -pl e2e-ha` | Resilience and correctness of the high-availability (Raft) cluster under failure: leader failover, rolling restarts, split-brain, network partitions/delay/packet loss, replication convergence, and cluster-wide operations (backup/restore, import, drop database, user management). Uses Testcontainers and fault injection (Toxiproxy). |
+
 
 ### Community
 

--- a/e2e/src/test/java/com/arcadedb/e2e/JdbcQueriesIT.java
+++ b/e2e/src/test/java/com/arcadedb/e2e/JdbcQueriesIT.java
@@ -39,7 +39,7 @@ import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class JdbcQueriesTest extends ArcadeContainerTemplate {
+class JdbcQueriesIT extends ArcadeContainerTemplate {
 
   private Connection conn;
 

--- a/e2e/src/test/java/com/arcadedb/e2e/JsFunctionsIT.java
+++ b/e2e/src/test/java/com/arcadedb/e2e/JsFunctionsIT.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class JsFunctionsTest extends ArcadeContainerTemplate {
+class JsFunctionsIT extends ArcadeContainerTemplate {
   private RemoteDatabase database;
 
   @BeforeEach

--- a/e2e/src/test/java/com/arcadedb/e2e/RemoteBoltDatabaseIT.java
+++ b/e2e/src/test/java/com/arcadedb/e2e/RemoteBoltDatabaseIT.java
@@ -34,7 +34,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class RemoteBoltDatabaseTest extends ArcadeContainerTemplate {
+class RemoteBoltDatabaseIT extends ArcadeContainerTemplate {
 
   private Driver driver;
 

--- a/e2e/src/test/java/com/arcadedb/e2e/RemoteDatabaseJavaApiIT.java
+++ b/e2e/src/test/java/com/arcadedb/e2e/RemoteDatabaseJavaApiIT.java
@@ -38,7 +38,7 @@ import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class RemoteDatabaseJavaApiTest extends ArcadeContainerTemplate {
+class RemoteDatabaseJavaApiIT extends ArcadeContainerTemplate {
   private RemoteDatabase database;
 
   @BeforeEach

--- a/e2e/src/test/java/com/arcadedb/e2e/RemoteDatabaseQueriesIT.java
+++ b/e2e/src/test/java/com/arcadedb/e2e/RemoteDatabaseQueriesIT.java
@@ -19,26 +19,20 @@
 package com.arcadedb.e2e;
 
 import com.arcadedb.query.sql.executor.ResultSet;
-import com.arcadedb.remote.grpc.RemoteGrpcDatabase;
-import com.arcadedb.remote.grpc.RemoteGrpcServer;
+import com.arcadedb.remote.RemoteDatabase;
 import com.arcadedb.utility.CollectionUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-class RemoteGrpcDatabaseTest extends ArcadeContainerTemplate {
-
-  private RemoteGrpcDatabase database;
+class RemoteDatabaseQueriesIT extends ArcadeContainerTemplate {
+  private RemoteDatabase database;
 
   @BeforeEach
   void setUp() {
-
-    RemoteGrpcServer server = new RemoteGrpcServer(host, grpcPort, "root", "playwithdata", true, List.of());
-    database = new RemoteGrpcDatabase(server, host, grpcPort, httpPort, "beer", "root", "playwithdata");
+    database = new RemoteDatabase(host, httpPort, "beer", "root", "playwithdata");
     // ENLARGE THE TIMEOUT TO PASS THESE TESTS ON CI (GITHUB ACTIONS)
     database.setTimeout(60_000);
   }
@@ -51,20 +45,26 @@ class RemoteGrpcDatabaseTest extends ArcadeContainerTemplate {
 
   @Test
   void simpleSQLQuery() {
-    final ResultSet result = database.query("SQL", "select * from Beer limit 10");
-    assertThat(CollectionUtils.countEntries(result)).isEqualTo(10);
+    database.transaction(() -> {
+      final ResultSet result = database.query("SQL", "select * from Beer limit 10");
+      assertThat(CollectionUtils.countEntries(result)).isEqualTo(10);
+    }, true, 10);
   }
 
   @Test
   void simpleGremlinQuery() {
-    final ResultSet result = database.query("gremlin", "g.V().limit(10)");
-    assertThat(CollectionUtils.countEntries(result)).isEqualTo(10);
+    database.transaction(() -> {
+      final ResultSet result = database.query("gremlin", "g.V().limit(10)");
+      assertThat(CollectionUtils.countEntries(result)).isEqualTo(10);
+    }, false, 10);
   }
 
   @Test
   void simpleCypherQuery() {
-    final ResultSet result = database.query("cypher", "MATCH(p:Beer) RETURN * LIMIT 10");
-    assertThat(CollectionUtils.countEntries(result)).isEqualTo(10);
+    database.transaction(() -> {
+      final ResultSet result = database.query("cypher", "MATCH(p:Beer) RETURN * LIMIT 10");
+      assertThat(CollectionUtils.countEntries(result)).isEqualTo(10);
+    }, false, 10);
   }
 
   @Test
@@ -74,17 +74,4 @@ class RemoteGrpcDatabaseTest extends ArcadeContainerTemplate {
       assertThat(CollectionUtils.countEntries(result)).isEqualTo(10);
     }, false, 10);
   }
-
-  @Test
-  void streamQueryWithSQL() {
-    final ResultSet result = database.queryStream("sql", "select * from Beer limit 10");
-    assertThat(CollectionUtils.countEntries(result)).isEqualTo(10);
-  }
-
-  @Test
-  void streamQueryWithOpenCypher() {
-    final ResultSet result = database.queryStream("opencypher", "MATCH(p:Beer) RETURN p LIMIT 10");
-    assertThat(CollectionUtils.countEntries(result)).isEqualTo(10);
-  }
-
 }

--- a/e2e/src/test/java/com/arcadedb/e2e/RemoteGrpcDatabaseIT.java
+++ b/e2e/src/test/java/com/arcadedb/e2e/RemoteGrpcDatabaseIT.java
@@ -19,20 +19,26 @@
 package com.arcadedb.e2e;
 
 import com.arcadedb.query.sql.executor.ResultSet;
-import com.arcadedb.remote.RemoteDatabase;
+import com.arcadedb.remote.grpc.RemoteGrpcDatabase;
+import com.arcadedb.remote.grpc.RemoteGrpcServer;
 import com.arcadedb.utility.CollectionUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
-class RemoteDatabaseQueriesTest extends ArcadeContainerTemplate {
-  private RemoteDatabase database;
+class RemoteGrpcDatabaseIT extends ArcadeContainerTemplate {
+
+  private RemoteGrpcDatabase database;
 
   @BeforeEach
   void setUp() {
-    database = new RemoteDatabase(host, httpPort, "beer", "root", "playwithdata");
+
+    RemoteGrpcServer server = new RemoteGrpcServer(host, grpcPort, "root", "playwithdata", true, List.of());
+    database = new RemoteGrpcDatabase(server, host, grpcPort, httpPort, "beer", "root", "playwithdata");
     // ENLARGE THE TIMEOUT TO PASS THESE TESTS ON CI (GITHUB ACTIONS)
     database.setTimeout(60_000);
   }
@@ -45,26 +51,20 @@ class RemoteDatabaseQueriesTest extends ArcadeContainerTemplate {
 
   @Test
   void simpleSQLQuery() {
-    database.transaction(() -> {
-      final ResultSet result = database.query("SQL", "select * from Beer limit 10");
-      assertThat(CollectionUtils.countEntries(result)).isEqualTo(10);
-    }, true, 10);
+    final ResultSet result = database.query("SQL", "select * from Beer limit 10");
+    assertThat(CollectionUtils.countEntries(result)).isEqualTo(10);
   }
 
   @Test
   void simpleGremlinQuery() {
-    database.transaction(() -> {
-      final ResultSet result = database.query("gremlin", "g.V().limit(10)");
-      assertThat(CollectionUtils.countEntries(result)).isEqualTo(10);
-    }, false, 10);
+    final ResultSet result = database.query("gremlin", "g.V().limit(10)");
+    assertThat(CollectionUtils.countEntries(result)).isEqualTo(10);
   }
 
   @Test
   void simpleCypherQuery() {
-    database.transaction(() -> {
-      final ResultSet result = database.query("cypher", "MATCH(p:Beer) RETURN * LIMIT 10");
-      assertThat(CollectionUtils.countEntries(result)).isEqualTo(10);
-    }, false, 10);
+    final ResultSet result = database.query("cypher", "MATCH(p:Beer) RETURN * LIMIT 10");
+    assertThat(CollectionUtils.countEntries(result)).isEqualTo(10);
   }
 
   @Test
@@ -74,4 +74,17 @@ class RemoteDatabaseQueriesTest extends ArcadeContainerTemplate {
       assertThat(CollectionUtils.countEntries(result)).isEqualTo(10);
     }, false, 10);
   }
+
+  @Test
+  void streamQueryWithSQL() {
+    final ResultSet result = database.queryStream("sql", "select * from Beer limit 10");
+    assertThat(CollectionUtils.countEntries(result)).isEqualTo(10);
+  }
+
+  @Test
+  void streamQueryWithOpenCypher() {
+    final ResultSet result = database.queryStream("opencypher", "MATCH(p:Beer) RETURN p LIMIT 10");
+    assertThat(CollectionUtils.countEntries(result)).isEqualTo(10);
+  }
+
 }


### PR DESCRIPTION
## Summary

- Adds a **Test Suites at a Glance** table to the README, describing the scope of each test suite (unit, integration, e2e, load, HA end-to-end) and how to run it.
- Renames the e2e `*Test` classes to `*IT` so they execute under the integration profile (Failsafe) rather than the unit-test phase (Surefire), matching the project's `IT`-suffix convention for integration/e2e tests.
- Adjusts the `mvn-test` workflow accordingly.

## Test suites documented

| Suite | Scope |
|-------|-------|
| Unit | Fast in-process component tests (engine, query engines, schema, graph, security) |
| Integration | Multi-component / running-server tests within a module (HTTP API, wire protocols, embedded clustering) |
| e2e | Black-box Testcontainers tests via external drivers (JDBC, remote Java API, JS functions, Bolt, gRPC) |
| load-tests | Throughput/stability under concurrent load on single-server and three-node clusters, incl. time-series |
| e2e-ha | Raft HA resilience under failure (failover, rolling restart, split-brain, partitions, packet loss, backup/restore) |

## Notes

Documentation and test-renaming only; no production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)