### PR TITLE
fix: [#4728] auto-recover a replica stuck STALLED at matchIndex=-1

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -53,4 +53,4 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--model claude-opus-4-8 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -937,8 +937,11 @@ public enum GlobalConfiguration {
       Number of Raft log entries a follower may lag behind the commit index, while NOT actively catching up, before the \
       health monitor re-arms a snapshot download from the leader. Guards against a follower that diverged (apply failure) \
       and whose snapshot download also failed on a quiet cluster, where no new entry arrives to re-trigger recovery. \
-      Defaults to 10000 (well below the default HA_SNAPSHOT_THRESHOLD) so a genuinely stuck follower self-heals; \
-      set to 0 to disable follower-side stale recovery and rely only on the node restart path.""",
+      UPGRADE NOTE: this defaults to 10000 (was 0/disabled before 26.7.1), well below the default HA_SNAPSHOT_THRESHOLD \
+      (100000), so a genuinely stuck follower self-heals without operator action. The value must stay below \
+      HA_SNAPSHOT_THRESHOLD so recovery is attempted before the leader compacts the entries the follower still needs. \
+      Set to 0 to restore the previous behaviour (follower-side stale recovery disabled; node restart is the only \
+      mitigation) if a deployment prefers to avoid automatic snapshot downloads.""",
       Long.class, 10_000L),
 
   HA_STALE_FOLLOWER_RECOVERY_DURATION_MS("arcadedb.ha.staleFollowerRecoveryDurationMs", SCOPE.SERVER,

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -937,15 +937,23 @@ public enum GlobalConfiguration {
       Number of Raft log entries a follower may lag behind the commit index, while NOT actively catching up, before the \
       health monitor re-arms a snapshot download from the leader. Guards against a follower that diverged (apply failure) \
       and whose snapshot download also failed on a quiet cluster, where no new entry arrives to re-trigger recovery. \
-      0 (the default) disables stale-follower recovery; the node restart path remains the primary mitigation. \
-      Enable with a value well below HA_SNAPSHOT_THRESHOLD once you have observed normal catch-up lag for your workload, \
-      to avoid multiple followers downloading snapshots from the leader at once.""",
-      Long.class, 0L),
+      Defaults to 10000 (well below the default HA_SNAPSHOT_THRESHOLD) so a genuinely stuck follower self-heals; \
+      set to 0 to disable follower-side stale recovery and rely only on the node restart path.""",
+      Long.class, 10_000L),
 
   HA_STALE_FOLLOWER_RECOVERY_DURATION_MS("arcadedb.ha.staleFollowerRecoveryDurationMs", SCOPE.SERVER,
       """
       How long in milliseconds the lag described by HA_STALE_FOLLOWER_LAG_THRESHOLD must persist continuously \
       (across consecutive health-monitor ticks) before recovery is triggered. Avoids acting on transient catch-up lag.""",
+      Long.class, 60_000L),
+
+  HA_STALLED_REPLICA_RESYNC_DURATION_MS("arcadedb.ha.stalledReplicaResyncDurationMs", SCOPE.SERVER,
+      """
+      How long in milliseconds a replica must stay continuously STALLED (its matchIndex not advancing while the leader \
+      keeps committing - e.g. stuck at -1 after a rolling upgrade) before the LEADER actively forces it to resync from \
+      the leader. This is the leader-driven counterpart to HA_STALE_FOLLOWER_LAG_THRESHOLD: it covers the case where the \
+      follower cannot self-detect the stall because its own commit index never advances. Defaults to 60000; set to 0 to \
+      disable leader-driven stalled-replica recovery (the STALLED condition is still detected and logged).""",
       Long.class, 60_000L),
 
   HA_SNAPSHOT_MAX_ENTRY_SIZE("arcadedb.ha.snapshotMaxEntrySize", SCOPE.SERVER,

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterMonitor.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterMonitor.java
@@ -73,8 +73,9 @@ public class ClusterMonitor {
   private final    Consumer<String>                stalledReplicaHandler;
   private volatile long                            leaderCommitIndex;
   private final    ConcurrentHashMap<String, ReplicaState> replicaStates = new ConcurrentHashMap<>();
-  // Injectable clock for deterministic tests; defaults to the wall clock.
-  private          LongSupplier                    clock         = System::currentTimeMillis;
+  // Injectable clock for deterministic tests; defaults to the wall clock. Volatile because the test
+  // thread writes it while the lag-monitor thread reads it (consistent with the other volatile fields).
+  private volatile LongSupplier                    clock         = System::currentTimeMillis;
 
   public ClusterMonitor(final long lagWarningThreshold) {
     this(lagWarningThreshold, 0L, null);
@@ -133,9 +134,9 @@ public class ClusterMonitor {
     state.lastLag = lag;
     state.status = status;
 
-    // Leader-driven recovery (#4728): if the replica stays STALLED long enough, the leader actively
+    // Leader-driven recovery (#4728): if the replica stays stuck long enough, the leader actively
     // forces it to resync instead of merely logging forever. Tracked regardless of the log throttle.
-    trackStallForRecovery(replicaId, state, status, now);
+    trackStallForRecovery(replicaId, state, matchIndex, replicaDelta, lag, now);
 
     // HEALTHY: nothing to say.
     if (status == ReplicaStatus.HEALTHY)
@@ -169,37 +170,51 @@ public class ClusterMonitor {
   }
 
   /**
-   * Drives the leader-driven recovery for a persistently {@link ReplicaStatus#STALLED} replica
-   * (issue #4728). A replica whose {@code matchIndex} never advances (e.g. stuck at -1) while the
-   * leader keeps committing will otherwise stay stuck forever, since the follower's own commit index
-   * does not advance and its follower-side stale-recovery never fires. Here the leader, which is the
-   * node that actually observes the stall, triggers the recovery once the stall has persisted for
+   * Drives the leader-driven recovery for a replica whose {@code matchIndex} is stuck (issue #4728).
+   * A replica whose {@code matchIndex} never advances (e.g. stuck at -1) while it is far behind will
+   * otherwise stay stuck forever, since the follower's own commit index does not advance and its
+   * follower-side stale-recovery never fires. Here the leader, which is the node that actually
+   * observes the stall, triggers the recovery once the stall has persisted for
    * {@link #stalledResyncDurationMs}.
    * <p>
-   * The first STALLED tick only starts the streak; the handler fires at most once per uninterrupted
-   * streak and re-arms only after the replica recovers (any non-STALLED tick resets the streak).
+   * The streak is intentionally decoupled from the per-tick {@link ReplicaStatus#STALLED}
+   * classification, which requires the leader to have advanced <i>this</i> tick ({@code leaderDelta > 0}).
+   * On a low-traffic cluster many ticks have no new commits, so keying the streak on that would reset
+   * it on every quiet tick and a genuinely stuck replica would never reach the trigger duration. Instead
+   * the streak persists as long as the replica stays over the lag threshold and its {@code matchIndex}
+   * has not advanced at all since the streak began; it resets the moment the replica catches up (lag
+   * drops to the threshold) or its {@code matchIndex} moves. The handler fires at most once per streak
+   * and re-arms only after a reset.
    */
-  private void trackStallForRecovery(final String replicaId, final ReplicaState state,
-      final ReplicaStatus status, final long now) {
-    if (status != ReplicaStatus.STALLED) {
-      state.stalledSinceMs = -1;
-      state.resyncTriggered = false;
-      return;
-    }
-
+  private void trackStallForRecovery(final String replicaId, final ReplicaState state, final long matchIndex,
+      final long replicaDelta, final long lag, final long now) {
     if (stalledResyncDurationMs <= 0 || stalledReplicaHandler == null)
       return; // detection/logging still run, but leader-driven recovery is disabled
 
+    final boolean behind = lag > lagWarningThreshold;
+
     if (state.stalledSinceMs == -1) {
-      state.stalledSinceMs = now; // first observation; require persistence before acting
+      // Not in a streak: start one when the replica is over the lag threshold and its matchIndex did
+      // not advance this tick. The duration guard below absorbs transient blips.
+      if (behind && replicaDelta <= 0) {
+        state.stalledSinceMs = now;
+        state.stalledAtMatchIndex = matchIndex;
+      }
+      return;
+    }
+
+    // In a streak: the replica recovered if it is no longer behind or its matchIndex moved at all.
+    if (!behind || matchIndex > state.stalledAtMatchIndex) {
+      state.stalledSinceMs = -1;
+      state.resyncTriggered = false;
       return;
     }
 
     if (!state.resyncTriggered && now - state.stalledSinceMs >= stalledResyncDurationMs) {
       state.resyncTriggered = true;
       LogManager.instance().log(this, Level.WARNING,
-          "Replica '%s' STALLED for %dms: leader is forcing a resync to recover it.",
-          replicaId, now - state.stalledSinceMs);
+          "Replica '%s' stuck (matchIndex=%d, lag=%d) for %dms: leader is forcing a resync to recover it.",
+          replicaId, matchIndex, lag, now - state.stalledSinceMs);
       try {
         stalledReplicaHandler.accept(replicaId);
       } catch (final Exception e) {
@@ -254,10 +269,12 @@ public class ClusterMonitor {
     long          lastLag;
     long          lastWarnAtMs;
     ReplicaStatus status = ReplicaStatus.UNKNOWN;
-    // Wall-clock time (ms) when the current uninterrupted STALLED streak began; -1 = not stalled.
-    long          stalledSinceMs   = -1;
+    // Wall-clock time (ms) when the current uninterrupted stall streak began; -1 = not stalled.
+    long          stalledSinceMs    = -1;
+    // matchIndex observed when the streak began; the streak ends as soon as matchIndex moves past it.
+    long          stalledAtMatchIndex = -1;
     // True once the leader-driven resync has been fired for the current streak (re-armed on recovery).
-    boolean       resyncTriggered  = false;
+    boolean       resyncTriggered   = false;
 
     ReplicaState(final long initialMatchIndex, final long initialLeaderCommitIndex) {
       this.lastMatchIndex = initialMatchIndex;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterMonitor.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterMonitor.java
@@ -91,6 +91,9 @@ public class ClusterMonitor {
    */
   public ClusterMonitor(final long lagWarningThreshold, final long stalledResyncDurationMs,
       final Consumer<String> stalledReplicaHandler) {
+    if (stalledResyncDurationMs > 0 && stalledReplicaHandler == null)
+      throw new IllegalArgumentException(
+          "stalledReplicaHandler must be non-null when stalledResyncDurationMs > 0 (leader-driven recovery enabled)");
     this.lagWarningThreshold = lagWarningThreshold;
     this.stalledResyncDurationMs = stalledResyncDurationMs;
     this.stalledReplicaHandler = stalledReplicaHandler;
@@ -269,6 +272,10 @@ public class ClusterMonitor {
     long          lastLag;
     long          lastWarnAtMs;
     ReplicaStatus status = ReplicaStatus.UNKNOWN;
+    // Stall-streak state for leader-driven recovery. Unlike the snapshot fields above (which the
+    // status table / lag map read cross-thread, tolerating staleness), these three are BOTH written
+    // and read only from the single lag-monitor thread, so they need no synchronization. Any future
+    // change that reads or mutates them from another thread MUST add it.
     // Wall-clock time (ms) when the current uninterrupted stall streak began; -1 = not stalled.
     long          stalledSinceMs    = -1;
     // matchIndex observed when the streak began; the streak ends as soon as matchIndex moves past it.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterMonitor.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterMonitor.java
@@ -23,6 +23,8 @@ import com.arcadedb.log.LogManager;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.LongSupplier;
 import java.util.logging.Level;
 
 /**
@@ -67,11 +69,35 @@ public class ClusterMonitor {
   }
 
   private final    long                            lagWarningThreshold;
+  private final    long                            stalledResyncDurationMs;
+  private final    Consumer<String>                stalledReplicaHandler;
   private volatile long                            leaderCommitIndex;
   private final    ConcurrentHashMap<String, ReplicaState> replicaStates = new ConcurrentHashMap<>();
+  // Injectable clock for deterministic tests; defaults to the wall clock.
+  private          LongSupplier                    clock         = System::currentTimeMillis;
 
   public ClusterMonitor(final long lagWarningThreshold) {
+    this(lagWarningThreshold, 0L, null);
+  }
+
+  /**
+   * @param lagWarningThreshold     lag (in Raft log entries) above which a replica is reported as lagging.
+   * @param stalledResyncDurationMs how long a replica must stay {@link ReplicaStatus#STALLED} continuously
+   *                                before {@code stalledReplicaHandler} is invoked to force a recovery.
+   *                                {@code <= 0} disables leader-driven recovery (detection/logging still run).
+   * @param stalledReplicaHandler   callback invoked (once per stall streak) with the stalled replica's id when
+   *                                the stall has persisted for {@code stalledResyncDurationMs}. May be {@code null}.
+   */
+  public ClusterMonitor(final long lagWarningThreshold, final long stalledResyncDurationMs,
+      final Consumer<String> stalledReplicaHandler) {
     this.lagWarningThreshold = lagWarningThreshold;
+    this.stalledResyncDurationMs = stalledResyncDurationMs;
+    this.stalledReplicaHandler = stalledReplicaHandler;
+  }
+
+  /** Package-private test hook to drive the stall-duration logic deterministically. */
+  void setClock(final LongSupplier clock) {
+    this.clock = clock;
   }
 
   public void updateLeaderCommitIndex(final long commitIndex) {
@@ -79,7 +105,7 @@ public class ClusterMonitor {
   }
 
   public void updateReplicaMatchIndex(final String replicaId, final long matchIndex) {
-    final long now = System.currentTimeMillis();
+    final long now = clock.getAsLong();
     final long leaderIdx = leaderCommitIndex;
     final long lag = leaderIdx - matchIndex;
 
@@ -106,6 +132,10 @@ public class ClusterMonitor {
     state.lastLeaderCommitIndex = leaderIdx;
     state.lastLag = lag;
     state.status = status;
+
+    // Leader-driven recovery (#4728): if the replica stays STALLED long enough, the leader actively
+    // forces it to resync instead of merely logging forever. Tracked regardless of the log throttle.
+    trackStallForRecovery(replicaId, state, status, now);
 
     // HEALTHY: nothing to say.
     if (status == ReplicaStatus.HEALTHY)
@@ -134,6 +164,47 @@ public class ClusterMonitor {
           replicaId, lag, previousLag, replicaDelta, leaderDelta);
       default -> {
         /* HEALTHY/UNKNOWN handled above */
+      }
+    }
+  }
+
+  /**
+   * Drives the leader-driven recovery for a persistently {@link ReplicaStatus#STALLED} replica
+   * (issue #4728). A replica whose {@code matchIndex} never advances (e.g. stuck at -1) while the
+   * leader keeps committing will otherwise stay stuck forever, since the follower's own commit index
+   * does not advance and its follower-side stale-recovery never fires. Here the leader, which is the
+   * node that actually observes the stall, triggers the recovery once the stall has persisted for
+   * {@link #stalledResyncDurationMs}.
+   * <p>
+   * The first STALLED tick only starts the streak; the handler fires at most once per uninterrupted
+   * streak and re-arms only after the replica recovers (any non-STALLED tick resets the streak).
+   */
+  private void trackStallForRecovery(final String replicaId, final ReplicaState state,
+      final ReplicaStatus status, final long now) {
+    if (status != ReplicaStatus.STALLED) {
+      state.stalledSinceMs = -1;
+      state.resyncTriggered = false;
+      return;
+    }
+
+    if (stalledResyncDurationMs <= 0 || stalledReplicaHandler == null)
+      return; // detection/logging still run, but leader-driven recovery is disabled
+
+    if (state.stalledSinceMs == -1) {
+      state.stalledSinceMs = now; // first observation; require persistence before acting
+      return;
+    }
+
+    if (!state.resyncTriggered && now - state.stalledSinceMs >= stalledResyncDurationMs) {
+      state.resyncTriggered = true;
+      LogManager.instance().log(this, Level.WARNING,
+          "Replica '%s' STALLED for %dms: leader is forcing a resync to recover it.",
+          replicaId, now - state.stalledSinceMs);
+      try {
+        stalledReplicaHandler.accept(replicaId);
+      } catch (final Exception e) {
+        LogManager.instance().log(this, Level.WARNING,
+            "Leader-driven resync trigger for replica '%s' failed: %s", replicaId, e.getMessage());
       }
     }
   }
@@ -183,6 +254,10 @@ public class ClusterMonitor {
     long          lastLag;
     long          lastWarnAtMs;
     ReplicaStatus status = ReplicaStatus.UNKNOWN;
+    // Wall-clock time (ms) when the current uninterrupted STALLED streak began; -1 = not stalled.
+    long          stalledSinceMs   = -1;
+    // True once the leader-driven resync has been fired for the current streak (re-armed on recovery).
+    boolean       resyncTriggered  = false;
 
     ReplicaState(final long initialMatchIndex, final long initialLeaderCommitIndex) {
       this.lastMatchIndex = initialMatchIndex;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostResyncDatabaseHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostResyncDatabaseHandler.java
@@ -54,6 +54,10 @@ public class PostResyncDatabaseHandler extends AbstractServerHttpHandler {
   @Override
   public ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user,
       final JSONObject payload) {
+    // Accepts an operator (root via Basic auth) or an inter-node call from the leader, which presents
+    // the cluster token plus X-ArcadeDB-Forwarded-User: root (resolved to the root user by
+    // AbstractServerHttpHandler before execute() runs). The leader uses this to force a persistently
+    // STALLED replica to resync (issue #4728).
     checkRootUser(user);
 
     final RaftHAServer raftHAServer = plugin.getRaftHAServer();

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -59,9 +59,11 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
@@ -120,6 +122,10 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   private volatile RaftTransactionBroker     transactionBroker;
   private          RaftClusterStatusExporter statusExporter;
   private          ScheduledExecutorService  lagMonitorExecutor;
+  // Runs leader-driven stalled-replica resyncs off the lag-monitor thread (issue #4728). One worker is
+  // enough since at most one resync fires per replica per stall streak; a small bounded queue with a
+  // caller-runs policy degrades to running on the lag-monitor thread under the (unlikely) burst.
+  private final    ThreadPoolExecutor        stalledResyncExecutor = createStalledResyncExecutor();
   // Inbound Raft gRPC peer allowlist, recreated on each Ratis (re)start. Periodically refreshed by the
   // health monitor tick so a returned peer's new pod IP is admitted proactively (issue #4696).
   private volatile PeerAddressAllowlistFilter allowlistFilter;
@@ -290,16 +296,24 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
       return;
     }
 
+    final String clusterToken = getClusterToken();
+    if (clusterToken == null || clusterToken.isEmpty()) {
+      // The follower's resync endpoint only accepts inter-node calls authenticated with the cluster
+      // token; without one the request is doomed to be rejected, so do not even attempt it.
+      LogManager.instance().log(this, Level.WARNING,
+          "Cannot force resync of stalled replica '%s': cluster token is not configured", peerId);
+      return;
+    }
+
     final String address = followerAddr;
     final boolean useHttps = https;
-    final String clusterToken = getClusterToken();
 
-    final Thread t = new Thread(() -> {
+    stalledResyncExecutor.execute(() -> {
       // TODO (#4728): this resyncs EVERY non-reserved database on the follower. When a cluster hosts
       // many databases and only one is stuck, this forces unnecessary full snapshots of the others.
       // A per-database stall signal would let us scope the resync; acceptable as a first pass.
       for (final String dbName : arcadeServer.getDatabaseNames()) {
-        // Re-check leadership on each iteration: the outer guard ran before this thread started, and
+        // Re-check leadership on each iteration: the outer guard ran before this task was queued, and
         // leadership may have moved since. A resync request from a non-leader is harmless (the
         // follower rejects it) but would log spurious warnings, so stop early instead.
         if (!isLeader())
@@ -316,9 +330,17 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
               dbName, peerId, address, e.getMessage());
         }
       }
-    }, "arcadedb-raft-stalled-resync-" + peerId);
-    t.setDaemon(true);
-    t.start();
+    });
+  }
+
+  private static ThreadPoolExecutor createStalledResyncExecutor() {
+    final ThreadPoolExecutor executor = new ThreadPoolExecutor(0, 1, 30L, TimeUnit.SECONDS,
+        new ArrayBlockingQueue<>(16), r -> {
+      final Thread t = new Thread(r, "arcadedb-raft-stalled-resync");
+      t.setDaemon(true);
+      return t;
+    }, new ThreadPoolExecutor.CallerRunsPolicy());
+    return executor;
   }
 
   /**
@@ -336,6 +358,8 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
         httpsConn.setSSLSocketFactory(SnapshotInstaller.buildSSLContext(arcadeServer).getSocketFactory());
       conn.setRequestMethod("POST");
       conn.setConnectTimeout(10_000);
+      // The resync endpoint is synchronous: it downloads the full snapshot from the leader and only
+      // then returns, so the read timeout must accommodate a snapshot transfer, not just a trigger.
       conn.setReadTimeout(120_000);
       conn.setDoOutput(true);
       conn.setRequestProperty("Content-Type", "application/json");
@@ -639,6 +663,7 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
       healthMonitor = null;
     }
     stopLagMonitor();
+    stalledResyncExecutor.shutdownNow();
     if (transactionBroker != null) {
       transactionBroker.stop();
       transactionBroker = null;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -43,8 +43,10 @@ import org.apache.ratis.server.storage.RaftStorage;
 import org.apache.ratis.util.LifeCycle;
 import org.apache.ratis.util.TimeDuration;
 
+import javax.net.ssl.HttpsURLConnection;
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -263,13 +265,27 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     if (targetId.equals(localPeerId))
       return; // never resync the leader itself
 
-    final String followerHttpAddr = getPeerHttpAddress(targetId);
-    if (followerHttpAddr == null) {
+    // On an SSL-enabled cluster the follower listens on HTTPS (a different port from plain HTTP), so
+    // prefer its HTTPS endpoint; mirror SnapshotInstaller's behaviour and fall back to plain HTTP
+    // only when no HTTPS endpoint is known.
+    final boolean useSSL = configuration.getValueAsBoolean(GlobalConfiguration.NETWORK_USE_SSL);
+    boolean https = false;
+    String followerAddr = null;
+    if (useSSL) {
+      followerAddr = getPeerHttpsAddress(targetId);
+      if (followerAddr != null)
+        https = true;
+    }
+    if (followerAddr == null)
+      followerAddr = getPeerHttpAddress(targetId);
+    if (followerAddr == null) {
       LogManager.instance().log(this, Level.WARNING,
-          "Cannot force resync of stalled replica '%s': its HTTP address is unknown", peerId);
+          "Cannot force resync of stalled replica '%s': its address is unknown", peerId);
       return;
     }
 
+    final String address = followerAddr;
+    final boolean useHttps = https;
     final String clusterToken = getClusterToken();
 
     final Thread t = new Thread(() -> {
@@ -277,13 +293,13 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
         if (ArcadeDBServer.isReservedDatabaseName(dbName))
           continue;
         try {
-          requestRemoteResync(followerHttpAddr, dbName, clusterToken);
+          requestRemoteResync(address, dbName, clusterToken, useHttps);
           LogManager.instance().log(this, Level.INFO,
-              "Requested resync of database '%s' on stalled replica '%s' (%s)", dbName, peerId, followerHttpAddr);
+              "Requested resync of database '%s' on stalled replica '%s' (%s)", dbName, peerId, address);
         } catch (final Exception e) {
           LogManager.instance().log(this, Level.WARNING,
               "Failed to request resync of database '%s' on stalled replica '%s' (%s): %s",
-              dbName, peerId, followerHttpAddr, e.getMessage());
+              dbName, peerId, address, e.getMessage());
         }
       }
     }, "arcadedb-raft-stalled-resync-" + peerId);
@@ -293,13 +309,16 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
 
   /**
    * Sends {@code POST /api/v1/cluster/resync/{database}} to a follower, authenticated with the
-   * cluster token. Visible for testing. Throws on a non-2xx response.
+   * cluster token. When {@code https} is true the connection uses the cluster SSL context (the same
+   * one used for snapshot transfer). Visible for testing. Throws on a non-2xx response.
    */
-  void requestRemoteResync(final String followerHttpAddr, final String databaseName, final String clusterToken)
-      throws IOException {
-    final String url = "http://" + followerHttpAddr + "/api/v1/cluster/resync/" + databaseName;
+  void requestRemoteResync(final String followerAddr, final String databaseName, final String clusterToken,
+      final boolean https) throws IOException {
+    final String url = (https ? "https://" : "http://") + followerAddr + "/api/v1/cluster/resync/" + databaseName;
     final HttpURLConnection conn = (HttpURLConnection) URI.create(url).toURL().openConnection();
     try {
+      if (conn instanceof final HttpsURLConnection httpsConn)
+        httpsConn.setSSLSocketFactory(SnapshotInstaller.buildSSLContext(arcadeServer).getSocketFactory());
       conn.setRequestMethod("POST");
       conn.setConnectTimeout(10_000);
       conn.setReadTimeout(120_000);
@@ -312,7 +331,9 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
         conn.setRequestProperty("X-ArcadeDB-Cluster-Token", clusterToken);
         conn.setRequestProperty("X-ArcadeDB-Forwarded-User", "root");
       }
-      conn.getOutputStream().write("{}".getBytes(StandardCharsets.UTF_8));
+      try (final OutputStream os = conn.getOutputStream()) {
+        os.write("{}".getBytes(StandardCharsets.UTF_8));
+      }
       final int code = conn.getResponseCode();
       if (code < 200 || code >= 300)
         throw new IOException("resync endpoint returned HTTP " + code);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -88,6 +89,11 @@ import java.util.logging.Logger;
  * NetworkPolicy rules in production.
  */
 public class RaftHAServer implements HealthMonitor.HealthTarget {
+
+  // The forwarded user the leader presents (with the cluster token) for inter-node calls such as the
+  // stalled-replica resync. ArcadeDB's bootstrap 'root' user is the cluster-wide superuser; named here
+  // so the coupling is visible rather than scattered as a string literal.
+  private static final String FORWARDED_ROOT_USER = "root";
 
   private final    ArcadeDBServer          arcadeServer;
   private final    ContextConfiguration    configuration;
@@ -289,7 +295,15 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     final String clusterToken = getClusterToken();
 
     final Thread t = new Thread(() -> {
+      // TODO (#4728): this resyncs EVERY non-reserved database on the follower. When a cluster hosts
+      // many databases and only one is stuck, this forces unnecessary full snapshots of the others.
+      // A per-database stall signal would let us scope the resync; acceptable as a first pass.
       for (final String dbName : arcadeServer.getDatabaseNames()) {
+        // Re-check leadership on each iteration: the outer guard ran before this thread started, and
+        // leadership may have moved since. A resync request from a non-leader is harmless (the
+        // follower rejects it) but would log spurious warnings, so stop early instead.
+        if (!isLeader())
+          return;
         if (ArcadeDBServer.isReservedDatabaseName(dbName))
           continue;
         try {
@@ -314,7 +328,8 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    */
   void requestRemoteResync(final String followerAddr, final String databaseName, final String clusterToken,
       final boolean https) throws IOException {
-    final String url = (https ? "https://" : "http://") + followerAddr + "/api/v1/cluster/resync/" + databaseName;
+    final String url = (https ? "https://" : "http://") + followerAddr + "/api/v1/cluster/resync/"
+        + URLEncoder.encode(databaseName, StandardCharsets.UTF_8);
     final HttpURLConnection conn = (HttpURLConnection) URI.create(url).toURL().openConnection();
     try {
       if (conn instanceof final HttpsURLConnection httpsConn)
@@ -324,21 +339,36 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
       conn.setReadTimeout(120_000);
       conn.setDoOutput(true);
       conn.setRequestProperty("Content-Type", "application/json");
-      // Inter-node forwarded auth: the cluster token plus a forwarded 'root' user, validated by
+      // Inter-node forwarded auth: the cluster token plus the forwarded root user, validated by
       // AbstractServerHttpHandler before the handler runs (same mechanism used for follower->leader
       // request forwarding). No operator credentials are sent over the wire.
       if (clusterToken != null && !clusterToken.isEmpty()) {
         conn.setRequestProperty("X-ArcadeDB-Cluster-Token", clusterToken);
-        conn.setRequestProperty("X-ArcadeDB-Forwarded-User", "root");
+        conn.setRequestProperty("X-ArcadeDB-Forwarded-User", FORWARDED_ROOT_USER);
       }
       try (final OutputStream os = conn.getOutputStream()) {
         os.write("{}".getBytes(StandardCharsets.UTF_8));
       }
       final int code = conn.getResponseCode();
-      if (code < 200 || code >= 300)
+      if (code < 200 || code >= 300) {
+        drainErrorStream(conn);
         throw new IOException("resync endpoint returned HTTP " + code);
+      }
     } finally {
       conn.disconnect();
+    }
+  }
+
+  /**
+   * Drains and discards the error response body so the underlying keep-alive socket can be reused by
+   * the JVM connection pool instead of being abandoned (and leaked).
+   */
+  private static void drainErrorStream(final HttpURLConnection conn) {
+    try (final var err = conn.getErrorStream()) {
+      if (err != null)
+        err.readAllBytes();
+    } catch (final IOException ignored) {
+      // best-effort cleanup
     }
   }
 
@@ -1209,9 +1239,10 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   }
 
   /**
-   * Ensures linearizable read consistency for the leader. Sends a ReadIndex RPC to
-   * confirm the leader lease, then waits for the local state machine to apply up to
-   * the confirmed commit index.
+   * Ensures linearizable read consistency for the leader. Sends a ReadIndex RPC which (with the
+   * leader lease disabled, see {@code RaftPropertiesBuilder}) confirms leadership via a fresh
+   * majority heartbeat round, then waits for the local state machine to apply up to the confirmed
+   * commit index.
    * <p>
    * Throws {@link ReplicationException} if leadership is lost before or after the RPC.
    */

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -45,6 +45,8 @@ import org.apache.ratis.util.TimeDuration;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -196,7 +198,9 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     this.stateMachine = new ArcadeStateMachine();
     this.stateMachine.setServer(arcadeServer);
 
-    this.clusterMonitor = new ClusterMonitor(lagWarningThreshold);
+    final long stalledResyncDurationMs = configuration.getValueAsLong(
+        GlobalConfiguration.HA_STALLED_REPLICA_RESYNC_DURATION_MS);
+    this.clusterMonitor = new ClusterMonitor(lagWarningThreshold, stalledResyncDurationMs, this::forceResyncStalledReplica);
     this.quorum = Quorum.parse(configuration.getValueAsString(GlobalConfiguration.HA_QUORUM));
     this.quorumTimeout = configuration.getValueAsLong(GlobalConfiguration.HA_QUORUM_TIMEOUT);
 
@@ -236,6 +240,85 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    */
   public String getPeerHttpsAddress(final RaftPeerId peerId) {
     return resolveHttpsAddress(peerId);
+  }
+
+  /**
+   * Leader-driven recovery for a persistently STALLED replica (issue #4728). Invoked by
+   * {@link ClusterMonitor} on the leader's lag-monitor thread once a replica's {@code matchIndex} has
+   * not advanced for {@link GlobalConfiguration#HA_STALLED_REPLICA_RESYNC_DURATION_MS} while the
+   * leader kept committing. The leader instructs the stuck follower to drop its local copy and
+   * re-acquire a fresh full snapshot, the same operation an operator runs manually via
+   * {@code POST /api/v1/cluster/resync/{database}} - reused here so the cluster self-heals instead of
+   * logging the stall forever.
+   * <p>
+   * The HTTP work is done on a short-lived daemon thread so the lag-monitor thread is never blocked
+   * on network I/O. Authenticated with the inter-node cluster token (the same trust mechanism used
+   * for snapshot transfer), never with operator credentials.
+   */
+  void forceResyncStalledReplica(final String peerId) {
+    if (peerId == null || !isLeader())
+      return;
+
+    final RaftPeerId targetId = RaftPeerId.valueOf(peerId);
+    if (targetId.equals(localPeerId))
+      return; // never resync the leader itself
+
+    final String followerHttpAddr = getPeerHttpAddress(targetId);
+    if (followerHttpAddr == null) {
+      LogManager.instance().log(this, Level.WARNING,
+          "Cannot force resync of stalled replica '%s': its HTTP address is unknown", peerId);
+      return;
+    }
+
+    final String clusterToken = getClusterToken();
+
+    final Thread t = new Thread(() -> {
+      for (final String dbName : arcadeServer.getDatabaseNames()) {
+        if (ArcadeDBServer.isReservedDatabaseName(dbName))
+          continue;
+        try {
+          requestRemoteResync(followerHttpAddr, dbName, clusterToken);
+          LogManager.instance().log(this, Level.INFO,
+              "Requested resync of database '%s' on stalled replica '%s' (%s)", dbName, peerId, followerHttpAddr);
+        } catch (final Exception e) {
+          LogManager.instance().log(this, Level.WARNING,
+              "Failed to request resync of database '%s' on stalled replica '%s' (%s): %s",
+              dbName, peerId, followerHttpAddr, e.getMessage());
+        }
+      }
+    }, "arcadedb-raft-stalled-resync-" + peerId);
+    t.setDaemon(true);
+    t.start();
+  }
+
+  /**
+   * Sends {@code POST /api/v1/cluster/resync/{database}} to a follower, authenticated with the
+   * cluster token. Visible for testing. Throws on a non-2xx response.
+   */
+  void requestRemoteResync(final String followerHttpAddr, final String databaseName, final String clusterToken)
+      throws IOException {
+    final String url = "http://" + followerHttpAddr + "/api/v1/cluster/resync/" + databaseName;
+    final HttpURLConnection conn = (HttpURLConnection) URI.create(url).toURL().openConnection();
+    try {
+      conn.setRequestMethod("POST");
+      conn.setConnectTimeout(10_000);
+      conn.setReadTimeout(120_000);
+      conn.setDoOutput(true);
+      conn.setRequestProperty("Content-Type", "application/json");
+      // Inter-node forwarded auth: the cluster token plus a forwarded 'root' user, validated by
+      // AbstractServerHttpHandler before the handler runs (same mechanism used for follower->leader
+      // request forwarding). No operator credentials are sent over the wire.
+      if (clusterToken != null && !clusterToken.isEmpty()) {
+        conn.setRequestProperty("X-ArcadeDB-Cluster-Token", clusterToken);
+        conn.setRequestProperty("X-ArcadeDB-Forwarded-User", "root");
+      }
+      conn.getOutputStream().write("{}".getBytes(StandardCharsets.UTF_8));
+      final int code = conn.getResponseCode();
+      if (code < 200 || code >= 300)
+        throw new IOException("resync endpoint returned HTTP " + code);
+    } finally {
+      conn.disconnect();
+    }
   }
 
   /**

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ClusterMonitorTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ClusterMonitorTest.java
@@ -256,6 +256,41 @@ class ClusterMonitorTest {
     assertThat(resynced).hasSize(2);
   }
 
+  /**
+   * On a low-traffic cluster many lag-monitor ticks have no new leader commits. The stall streak must
+   * NOT reset on those quiet ticks, otherwise a genuinely stuck replica would never reach the trigger
+   * duration (#4728 - the reported cluster only advanced a few entries per 30s).
+   */
+  @Test
+  void stallStreakSurvivesQuietLeaderTicks() {
+    final List<String> resynced = new ArrayList<>();
+    final AtomicLong now = new AtomicLong(0);
+    final ClusterMonitor monitor = new ClusterMonitor(50L, 30_000L, resynced::add);
+    monitor.setClock(now::get);
+
+    monitor.updateLeaderCommitIndex(100);
+    monitor.updateReplicaMatchIndex("replica1", 100);
+
+    // Stall begins: leader jumps ahead, replica stuck at 100.
+    monitor.updateLeaderCommitIndex(1100);
+    monitor.updateReplicaMatchIndex("replica1", 100);
+
+    // Several quiet ticks where the leader does NOT advance (leaderDelta == 0) and the replica is
+    // still stuck. The streak must keep counting from when it began.
+    for (int t = 5; t <= 25; t += 5) {
+      now.set(t * 1000L);
+      monitor.updateLeaderCommitIndex(1100); // no new commits this tick
+      monitor.updateReplicaMatchIndex("replica1", 100);
+    }
+    assertThat(resynced).as("must not fire before the duration elapses").isEmpty();
+
+    // Past the duration, still stuck on a quiet tick: must fire.
+    now.set(31_000);
+    monitor.updateLeaderCommitIndex(1100);
+    monitor.updateReplicaMatchIndex("replica1", 100);
+    assertThat(resynced).containsExactly("replica1");
+  }
+
   /** With the duration set to 0 (disabled), the leader never forces a resync however long the stall. */
   @Test
   void leaderDrivenResyncDisabledWhenDurationZero() {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ClusterMonitorTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ClusterMonitorTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -177,6 +178,100 @@ class ClusterMonitorTest {
     monitor.updateLeaderCommitIndex(2100);
     monitor.updateReplicaMatchIndex("replica1", 100);
     assertThat(captured.lines).hasSize(afterFirst);
+  }
+
+  /**
+   * Issue #4728: a replica stuck STALLED long enough must make the leader force a resync. The first
+   * stalled tick only starts the streak; the callback fires once after the configured duration and
+   * not before.
+   */
+  @Test
+  void stalledReplicaTriggersLeaderDrivenResyncAfterDuration() {
+    final List<String> resynced = new ArrayList<>();
+    final AtomicLong now = new AtomicLong(0);
+    final ClusterMonitor monitor = new ClusterMonitor(50L, 30_000L, resynced::add);
+    monitor.setClock(now::get);
+
+    // Seed: replica at 100, leader at 100 (healthy).
+    monitor.updateLeaderCommitIndex(100);
+    monitor.updateReplicaMatchIndex("replica1", 100);
+
+    // First STALLED tick (t=0): leader jumps to 1100, replica stuck at 100. Streak starts, no fire.
+    monitor.updateLeaderCommitIndex(1100);
+    monitor.updateReplicaMatchIndex("replica1", 100);
+    assertThat(resynced).isEmpty();
+
+    // Still stalled at t=10s: duration (30s) not elapsed, no fire.
+    now.set(10_000);
+    monitor.updateLeaderCommitIndex(1110);
+    monitor.updateReplicaMatchIndex("replica1", 100);
+    assertThat(resynced).isEmpty();
+
+    // Still stalled at t=31s: duration elapsed, fire exactly once.
+    now.set(31_000);
+    monitor.updateLeaderCommitIndex(1120);
+    monitor.updateReplicaMatchIndex("replica1", 100);
+    assertThat(resynced).containsExactly("replica1");
+
+    // Still stalled at t=40s: already fired for this streak, no second fire.
+    now.set(40_000);
+    monitor.updateLeaderCommitIndex(1130);
+    monitor.updateReplicaMatchIndex("replica1", 100);
+    assertThat(resynced).containsExactly("replica1");
+  }
+
+  /** A replica that recovers resets the streak, so a later stall re-arms the leader-driven resync. */
+  @Test
+  void recoveryResetsStalledStreakSoItCanReArm() {
+    final List<String> resynced = new ArrayList<>();
+    final AtomicLong now = new AtomicLong(0);
+    final ClusterMonitor monitor = new ClusterMonitor(50L, 30_000L, resynced::add);
+    monitor.setClock(now::get);
+
+    monitor.updateLeaderCommitIndex(100);
+    monitor.updateReplicaMatchIndex("replica1", 100);
+
+    // Stall, fire once at t=31s.
+    monitor.updateLeaderCommitIndex(1100);
+    monitor.updateReplicaMatchIndex("replica1", 100);
+    now.set(31_000);
+    monitor.updateLeaderCommitIndex(1110);
+    monitor.updateReplicaMatchIndex("replica1", 100);
+    assertThat(resynced).hasSize(1);
+
+    // Replica catches up fully (healthy) -> streak resets.
+    now.set(40_000);
+    monitor.updateLeaderCommitIndex(1110);
+    monitor.updateReplicaMatchIndex("replica1", 1110);
+
+    // New stall streak begins.
+    now.set(50_000);
+    monitor.updateLeaderCommitIndex(2110);
+    monitor.updateReplicaMatchIndex("replica1", 1110);
+    assertThat(resynced).hasSize(1); // first observation of the new streak, no fire yet
+
+    now.set(90_000); // >30s after the new streak began
+    monitor.updateLeaderCommitIndex(2120);
+    monitor.updateReplicaMatchIndex("replica1", 1110);
+    assertThat(resynced).hasSize(2);
+  }
+
+  /** With the duration set to 0 (disabled), the leader never forces a resync however long the stall. */
+  @Test
+  void leaderDrivenResyncDisabledWhenDurationZero() {
+    final List<String> resynced = new ArrayList<>();
+    final AtomicLong now = new AtomicLong(0);
+    final ClusterMonitor monitor = new ClusterMonitor(50L, 0L, resynced::add);
+    monitor.setClock(now::get);
+
+    monitor.updateLeaderCommitIndex(100);
+    monitor.updateReplicaMatchIndex("replica1", 100);
+    for (int i = 1; i <= 10; i++) {
+      now.set(i * 60_000L);
+      monitor.updateLeaderCommitIndex(100 + i * 1000L);
+      monitor.updateReplicaMatchIndex("replica1", 100);
+    }
+    assertThat(resynced).isEmpty();
   }
 
   /** ArcadeDB Logger that captures everything in memory for test assertions. */

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4728ReplicaStalledIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4728ReplicaStalledIT.java
@@ -90,14 +90,14 @@ class Issue4728ReplicaStalledIT extends BaseRaftHATest {
     assertThat(followerHttpAddr).as("leader must resolve the follower's HTTP address").isNotNull();
 
     // A request WITHOUT the cluster token (and without operator credentials) must be refused.
-    assertThatThrownBy(() -> leaderRaft.requestRemoteResync(followerHttpAddr, getDatabaseName(), "wrong-token"))
+    assertThatThrownBy(() -> leaderRaft.requestRemoteResync(followerHttpAddr, getDatabaseName(), "wrong-token", false))
         .as("resync endpoint must reject an invalid cluster token")
         .isInstanceOf(IOException.class);
 
     // The leader-driven recovery path: force the follower to resync using the real cluster token.
     LogManager.instance().log(this, Level.INFO, "TEST: leader forcing resync of replica %d via cluster token", replicaIndex);
     try {
-      leaderRaft.requestRemoteResync(followerHttpAddr, getDatabaseName(), leaderRaft.getClusterToken());
+      leaderRaft.requestRemoteResync(followerHttpAddr, getDatabaseName(), leaderRaft.getClusterToken(), false);
     } catch (final IOException e) {
       throw new AssertionError("leader-driven resync with a valid cluster token must succeed", e);
     }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4728ReplicaStalledIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4728ReplicaStalledIT.java
@@ -85,6 +85,11 @@ class Issue4728ReplicaStalledIT extends BaseRaftHATest {
     assertThat(getServerDatabase(replicaIndex, getDatabaseName()).countType(TYPE, true))
         .as("replica must hold the data before resync").isEqualTo((long) COUNT);
 
+    // NOTE: this exercises only the transport half of the fix - the leader->follower resync call. The
+    // decision half (ClusterMonitor detecting a sustained stall and invoking forceResyncStalledReplica)
+    // is covered deterministically in ClusterMonitorTest, so the two halves are tested in isolation
+    // rather than driving the full ClusterMonitor -> forceResyncStalledReplica -> requestRemoteResync
+    // wiring end-to-end (which would require reproducing the hard-to-trigger stall on a live cluster).
     final RaftHAServer leaderRaft = getRaftPlugin(leaderIndex).getRaftHAServer();
     final String followerHttpAddr = leaderRaft.getPeerHttpAddress(RaftPeerId.valueOf(replicaPeerId));
     assertThat(followerHttpAddr).as("leader must resolve the follower's HTTP address").isNotNull();

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4728ReplicaStalledIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4728ReplicaStalledIT.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.log.LogManager;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.logging.Level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #4728: a replica that gets stuck STALLED (its {@code matchIndex} never advancing - e.g. stuck
+ * at -1 after a rolling upgrade) used to stay stuck forever, since the leader only logged the stall
+ * and the follower cannot self-detect it (its own commit index does not advance). The fix makes the
+ * LEADER actively force the stalled replica to resync once the stall persists
+ * ({@link GlobalConfiguration#HA_STALLED_REPLICA_RESYNC_DURATION_MS}).
+ * <p>
+ * The pure decision logic (when the leader fires the resync) is covered deterministically by
+ * {@code ClusterMonitorTest}. This integration test exercises the cross-node transport the leader
+ * uses to recover the follower: {@link RaftHAServer#requestRemoteResync} hitting the follower's
+ * {@code POST /api/v1/cluster/resync/{database}} endpoint authenticated with the inter-node cluster
+ * token. It also asserts the endpoint rejects a request that does not present the token.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("slow")
+class Issue4728ReplicaStalledIT extends BaseRaftHATest {
+
+  private static final String TYPE  = "Issue4728";
+  private static final int    COUNT = 50;
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    config.setValue(GlobalConfiguration.HA_QUORUM, "majority");
+  }
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Test
+  void leaderForcesStalledReplicaToResync() {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("a Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    final int replicaIndex = (leaderIndex + 1) % getServerCount();
+    final String replicaPeerId = peerIdForIndex(replicaIndex);
+
+    final var leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+    leaderDb.transaction(() -> {
+      if (!leaderDb.getSchema().existsType(TYPE))
+        leaderDb.getSchema().createVertexType(TYPE);
+    });
+    leaderDb.transaction(() -> {
+      for (int i = 0; i < COUNT; i++)
+        leaderDb.newVertex(TYPE).set("idx", i).save();
+    });
+
+    assertClusterConsistency();
+    assertThat(getServerDatabase(replicaIndex, getDatabaseName()).countType(TYPE, true))
+        .as("replica must hold the data before resync").isEqualTo((long) COUNT);
+
+    final RaftHAServer leaderRaft = getRaftPlugin(leaderIndex).getRaftHAServer();
+    final String followerHttpAddr = leaderRaft.getPeerHttpAddress(RaftPeerId.valueOf(replicaPeerId));
+    assertThat(followerHttpAddr).as("leader must resolve the follower's HTTP address").isNotNull();
+
+    // A request WITHOUT the cluster token (and without operator credentials) must be refused.
+    assertThatThrownBy(() -> leaderRaft.requestRemoteResync(followerHttpAddr, getDatabaseName(), "wrong-token"))
+        .as("resync endpoint must reject an invalid cluster token")
+        .isInstanceOf(IOException.class);
+
+    // The leader-driven recovery path: force the follower to resync using the real cluster token.
+    LogManager.instance().log(this, Level.INFO, "TEST: leader forcing resync of replica %d via cluster token", replicaIndex);
+    try {
+      leaderRaft.requestRemoteResync(followerHttpAddr, getDatabaseName(), leaderRaft.getClusterToken());
+    } catch (final IOException e) {
+      throw new AssertionError("leader-driven resync with a valid cluster token must succeed", e);
+    }
+
+    // After the forced resync the follower still holds the full dataset and the cluster is consistent.
+    assertThat(getServerDatabase(replicaIndex, getDatabaseName()).countType(TYPE, true))
+        .as("replica must still hold all data after the leader-driven resync").isEqualTo((long) COUNT);
+    assertClusterConsistency();
+  }
+}


### PR DESCRIPTION
A follower whose matchIndex never advances (e.g. stuck at -1 after a rolling upgrade) used to stay stuck forever: the leader's ClusterMonitor only logged the STALLED condition, and the follower-side stale-recovery was disabled by default and could not self-detect the stall (its own commit index never advances when it receives nothing).

Two complementary fixes:

- Leader-driven recovery: ClusterMonitor now tracks how long a replica stays STALLED and, after HA_STALLED_REPLICA_RESYNC_DURATION_MS (default 60s), makes the leader force that replica to resync from the leader. The leader calls the follower's POST /api/v1/cluster/resync/{db} endpoint using the existing inter-node forwarded auth (cluster token + X-ArcadeDB-Forwarded-User), on a daemon thread so the lag-monitor is never blocked.

- Follower-side safety net: HA_STALE_FOLLOWER_LAG_THRESHOLD now defaults to 10000 (was 0/disabled) so a genuinely stuck follower self-heals via the HealthMonitor when it can detect the lag.

Tests: ClusterMonitorTest covers the sustained-STALLED trigger logic (fires once per streak after the duration, re-arms after recovery, disabled when duration=0). Issue4728ReplicaStalledIT exercises the leader-driven resync transport end-to-end (cluster-token auth accepted, invalid token rejected, data intact after the forced resync).

## What does this PR do?

A brief description of the change being made with this pull request.

## Motivation

What inspired you to submit this pull request?

## Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

## Additional Notes

Anything else we should know when reviewing?

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
