### PR TITLE
fix: [#4728] follow-ups - wait for leader on forward + bound snapshot…

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -326,6 +326,16 @@ public enum GlobalConfiguration {
 
   PAGE_FLUSH_QUEUE("arcadedb.pageFlushQueue", SCOPE.DATABASE, "Size of the asynchronous page flush queue", Integer.class, 512),
 
+  FLUSH_SUSPEND_MAX_DEFERRED_RAM("arcadedb.flushSuspendMaxDeferredRAM", SCOPE.DATABASE,
+      """
+      Maximum amount of RAM (in MB) of dirty pages the page-flush thread may defer in memory while flushing \
+      is suspended (during an HA snapshot ship or a full backup, when the on-disk files must stay stable). \
+      Once the deferred backlog crosses this cap the flush thread stops draining its bounded queue, so \
+      committing threads are throttled instead of the deferred backlog growing without limit and exhausting \
+      the heap (issue #4728: a busy leader shipping a multi-GB snapshot OOM'd). Set to 0 to disable the cap \
+      (unbounded, pre-4728 behavior).""",
+      Long.class, 512),
+
   EXPLICIT_LOCK_TIMEOUT("arcadedb.explicitLockTimeout", SCOPE.DATABASE, "Timeout in ms to lock resources on explicit lock",
       Long.class, 5000),
 
@@ -892,6 +902,16 @@ public enum GlobalConfiguration {
   HA_CLIENT_ELECTION_RETRY_DELAY_MS("arcadedb.ha.clientElectionRetryDelayMs", SCOPE.SERVER,
       "Delay in milliseconds between RemoteDatabase election retries.",
       Long.class, 2000L),
+
+  HA_FORWARD_LEADER_WAIT_TIMEOUT_MS("arcadedb.ha.forwardLeaderWaitTimeoutMs", SCOPE.SERVER,
+      """
+      Maximum time in milliseconds a follower waits for a leader to be (re)elected before failing a write \
+      command it has to forward to the leader. During cluster startup or a leader change there is a window \
+      with no elected leader; without this wait a forwarded write fails immediately with "leader HTTP address \
+      is not available" and the caller's transaction is lost (issue #4728 follow-up). The follower polls for \
+      the leader and forwards as soon as one appears. Set to 0 to restore the previous fail-fast behavior. \
+      Default 20000 comfortably covers a first-election window (which can exceed 10s on cluster startup).""",
+      Long.class, 20000L),
 
   HA_RATIS_RESTART_MAX_RETRIES("arcadedb.ha.ratisRestartMaxRetries", SCOPE.SERVER,
       """

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -174,7 +174,9 @@ public class PageManagerFlushThread extends Thread {
     // shipping a multi-GB snapshot this exhausted the heap. Once the deferred backlog crosses the cap, stop
     // draining the bounded queue: it fills up and scheduleFlushOfPages() throttles the committing threads, so
     // the dirty pages stay in the (separately bounded) page cache instead of growing the deferred map forever.
-    if (maxDeferredRAM > 0 && deferredRAMBytes.get() >= maxDeferredRAM) {
+    // Gate on `running`: during shutdown the queue must still be drained to reach the SHUTDOWN_THREAD marker,
+    // otherwise a database left suspended with a full backlog would spin the run loop forever and block join().
+    if (running && maxDeferredRAM > 0 && deferredRAMBytes.get() >= maxDeferredRAM) {
       Thread.sleep(timeout);
       return;
     }
@@ -358,8 +360,13 @@ public class PageManagerFlushThread extends Thread {
   private static long batchRAM(final PagesToFlush batch) {
     long bytes = 0;
     if (batch.pages != null)
-      for (final MutablePage page : batch.pages)
-        bytes += page.getPhysicalSize();
+      // Synchronize on the same monitor used by removePagesOfFileFromBatch / removeAllPagesOfDatabase, which
+      // can concurrently mutate this list (it.remove() / clear()), to avoid a ConcurrentModificationException
+      // and miscounting while a dropped file or database is being purged.
+      synchronized (batch.pages) {
+        for (final MutablePage page : batch.pages)
+          bytes += page.getPhysicalSize();
+      }
     return bytes;
   }
 

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 
@@ -62,6 +63,19 @@ public class PageManagerFlushThread extends Thread {
    */
   final                ConcurrentHashMap<PageId, MutablePage> pageIndex = new ConcurrentHashMap<>();
 
+  /**
+   * Maximum bytes of dirty pages that may sit deferred (in {@link #deferredByDatabase}) while flushing is
+   * suspended, before the flush thread stops draining its bounded queue and lets {@code scheduleFlushOfPages}
+   * throttle the committing threads. {@code 0} disables the cap (unbounded, pre-#4728 behavior).
+   */
+  private final        long                                   maxDeferredRAM;
+
+  /**
+   * Running total of bytes currently deferred across all suspended databases. Package-private so the white-box
+   * regression test for issue #4728 can assert the backlog stays bounded.
+   */
+  final                AtomicLong                             deferredRAMBytes = new AtomicLong();
+
   public static class PagesToFlush {
     public final BasicDatabase     database;
     public final List<MutablePage> pages;
@@ -78,6 +92,8 @@ public class PageManagerFlushThread extends Thread {
     this.pageManager = pageManager;
     this.logContext = LogManager.instance().getContext();
     this.queue = new ArrayBlockingQueue<>(configuration.getValueAsInteger(GlobalConfiguration.PAGE_FLUSH_QUEUE));
+    final long maxDeferredMB = configuration.getValueAsLong(GlobalConfiguration.FLUSH_SUSPEND_MAX_DEFERRED_RAM);
+    this.maxDeferredRAM = maxDeferredMB > 0 ? maxDeferredMB * 1024 * 1024 : 0;
   }
 
   public void scheduleFlushOfPages(final List<MutablePage> pages) throws InterruptedException {
@@ -153,6 +169,16 @@ public class PageManagerFlushThread extends Thread {
   }
 
   protected void flushPagesFromQueueToDisk(final Database database, final long timeout) throws InterruptedException, IOException {
+    // Backpressure (issue #4728): while a database is suspended (HA snapshot ship / full backup) its dirty
+    // pages cannot be written to disk and pile up in the unbounded deferredByDatabase map. On a busy leader
+    // shipping a multi-GB snapshot this exhausted the heap. Once the deferred backlog crosses the cap, stop
+    // draining the bounded queue: it fills up and scheduleFlushOfPages() throttles the committing threads, so
+    // the dirty pages stay in the (separately bounded) page cache instead of growing the deferred map forever.
+    if (maxDeferredRAM > 0 && deferredRAMBytes.get() >= maxDeferredRAM) {
+      Thread.sleep(timeout);
+      return;
+    }
+
     final PagesToFlush pagesToFlush = queue.poll(timeout, TimeUnit.MILLISECONDS);
 
     if (pagesToFlush != null) {
@@ -176,6 +202,7 @@ public class PageManagerFlushThread extends Thread {
               synchronized (suspendLock(db)) {
                 if (isSuspended(db)) {
                   deferredByDatabase.computeIfAbsent(db, k -> new ConcurrentLinkedQueue<>()).offer(pagesToFlush);
+                  deferredRAMBytes.addAndGet(batchRAM(pagesToFlush));
                   return;
                 }
               }
@@ -245,6 +272,8 @@ public class PageManagerFlushThread extends Thread {
             } catch (final IOException e) {
               LogManager.instance().log(this, Level.WARNING, "Error on flushing deferred page '%s' to disk", e, page);
             } finally {
+              // The page leaves the deferred backlog (flushed to disk), so release its reserved RAM (issue #4728).
+              deferredRAMBytes.addAndGet(-page.getPhysicalSize());
               removeFromFlushIndex(page);
             }
           }
@@ -271,6 +300,8 @@ public class PageManagerFlushThread extends Thread {
     // the same per-database lock to make progress, so holding it across the offer would deadlock.
     if (newDeferred != null) {
       for (final PagesToFlush batch : newDeferred) {
+        // The batch moves back to the main queue and leaves the deferred backlog accounting (issue #4728).
+        deferredRAMBytes.addAndGet(-batchRAM(batch));
         while (running) {
           try {
             if (queue.offer(batch, 1, TimeUnit.SECONDS))
@@ -284,6 +315,11 @@ public class PageManagerFlushThread extends Thread {
         }
       }
     }
+
+    // Safety net: once nothing is deferred for any database the backlog is provably empty, so reset the counter
+    // to absorb any drift from edge cases above (a batch skipped because its database closed mid-unsuspend).
+    if (deferredByDatabase.isEmpty())
+      deferredRAMBytes.set(0);
 
     return true;
   }
@@ -318,6 +354,15 @@ public class PageManagerFlushThread extends Thread {
     pageIndex.computeIfPresent(page.getPageId(), (id, indexed) -> indexed == page ? null : indexed);
   }
 
+  /** Sum of the in-RAM size of every page in a deferred batch, used to bound the deferred backlog (issue #4728). */
+  private static long batchRAM(final PagesToFlush batch) {
+    long bytes = 0;
+    if (batch.pages != null)
+      for (final MutablePage page : batch.pages)
+        bytes += page.getPhysicalSize();
+    return bytes;
+  }
+
   public CachedPage getCachedPageFromMutablePageInQueue(final PageId pageId) {
     final MutablePage page = pageIndex.get(pageId);
     if (page != null)
@@ -341,7 +386,13 @@ public class PageManagerFlushThread extends Thread {
     // pins) can be garbage collected instead of being retained for the flush thread's lifetime as a map key.
     suspendLocks.remove(database);
     suspended.remove(database);
-    deferredByDatabase.remove(database);
+    final ConcurrentLinkedQueue<PagesToFlush> droppedDeferred = deferredByDatabase.remove(database);
+    if (droppedDeferred != null) {
+      for (final PagesToFlush batch : droppedDeferred)
+        deferredRAMBytes.addAndGet(-batchRAM(batch));
+      if (deferredByDatabase.isEmpty())
+        deferredRAMBytes.set(0);
+    }
   }
 
   /** Drops every pending {@link MutablePage} of a single dropped file from the queue, the deferred batches and the index. */
@@ -354,26 +405,31 @@ public class PageManagerFlushThread extends Thread {
     final ConcurrentLinkedQueue<PagesToFlush> deferred = deferredByDatabase.get(database);
     if (deferred != null)
       for (final PagesToFlush pagesToFlush : deferred)
-        removePagesOfFileFromBatch(pagesToFlush, database, fileId);
+        // These pages leave the deferred backlog, so release their reserved RAM accounting (issue #4728).
+        deferredRAMBytes.addAndGet(-removePagesOfFileFromBatch(pagesToFlush, database, fileId));
 
     // Finally clean any index entry for a page currently being flushed.
     pageIndex.entrySet()
         .removeIf(e -> database.equals(e.getKey().getDatabase()) && e.getKey().getFileId() == fileId);
   }
 
-  private void removePagesOfFileFromBatch(final PagesToFlush pagesToFlush, final Database database, final int fileId) {
+  /** Removes the dropped file's pages from a batch and returns the sum of their in-RAM size (issue #4728). */
+  private long removePagesOfFileFromBatch(final PagesToFlush pagesToFlush, final Database database, final int fileId) {
     // pages is null for the SHUTDOWN_THREAD marker.
     if (pagesToFlush.pages == null || !database.equals(pagesToFlush.database))
-      return;
+      return 0;
 
+    long removedBytes = 0;
     synchronized (pagesToFlush.pages) {
       for (final Iterator<MutablePage> it = pagesToFlush.pages.iterator(); it.hasNext(); ) {
         final MutablePage page = it.next();
         if (page.getPageId().getFileId() == fileId) {
           pageIndex.remove(page.getPageId());
           it.remove();
+          removedBytes += page.getPhysicalSize();
         }
       }
     }
+    return removedBytes;
   }
 }

--- a/engine/src/test/java/com/arcadedb/engine/PageManagerFlushSuspendBackpressureTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageManagerFlushSuspendBackpressureTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Database;
+import com.arcadedb.engine.PageManagerFlushThread.PagesToFlush;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4728: a busy leader shipping a multi-GB HA snapshot OOM'd because dirty pages
+ * accumulated without bound in {@link PageManagerFlushThread}'s deferred map while page flushing was suspended.
+ * <p>
+ * The fix caps the deferred backlog ({@code arcadedb.flushSuspendMaxDeferredRAM}). Once the cap is reached the
+ * flush thread stops draining its bounded queue, which then fills and backpressures the committing threads
+ * instead of letting the deferred map grow until the heap is exhausted.
+ */
+class PageManagerFlushSuspendBackpressureTest extends TestHelper {
+
+  private static final int PAGE_SIZE = 256 * 1024;          // 256 KB per page
+  private static final int CAP_MB    = 1;                   // 1 MB deferred cap -> 4 pages fit exactly
+
+  @Test
+  void deferredBacklogStaysBoundedWhileSuspended() throws Exception {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.setValue(GlobalConfiguration.FLUSH_SUSPEND_MAX_DEFERRED_RAM, (long) CAP_MB);
+
+    // Constructing the flush thread directly does NOT start the background thread; flushPagesFromQueueToDisk is
+    // driven explicitly below so the test is deterministic.
+    final PageManagerFlushThread flush = new PageManagerFlushThread(PageManager.INSTANCE, cfg);
+
+    final Database db = (Database) database;
+    flush.setSuspended(db, true);
+
+    // Enqueue 6 single-page batches: 4 fit under the 1 MB cap, the remaining 2 must stay in the queue.
+    final int batches = 6;
+    for (int i = 0; i < batches; i++) {
+      final PageId pageId = new PageId(database, 9, i);
+      final MutablePage page = new MutablePage(pageId, PAGE_SIZE, new byte[PAGE_SIZE], 0, 0);
+      flush.pageIndex.put(pageId, page);
+      flush.queue.offer(new PagesToFlush(List.of(page)));
+    }
+
+    // Drive the flush thread by hand. Each call either defers one batch (under cap) or, once the cap is hit,
+    // returns without polling. A short timeout keeps the over-cap sleeps fast.
+    for (int i = 0; i < batches + 4; i++)
+      flush.flushPagesFromQueueToDisk(null, 20L);
+
+    final long capBytes = (long) CAP_MB * 1024 * 1024;
+    // The deferred backlog never exceeds the cap...
+    assertThat(flush.deferredRAMBytes.get()).isLessThanOrEqualTo(capBytes);
+    // ...and exactly the 4 pages that fit were deferred.
+    assertThat(flush.deferredRAMBytes.get()).isEqualTo(4L * PAGE_SIZE);
+    // ...leaving the remaining 2 batches stuck in the queue (this is the writer backpressure signal).
+    assertThat(flush.queue).hasSize(2);
+  }
+
+  @Test
+  void disabledCapKeepsDrainingTheQueue() throws Exception {
+    final ContextConfiguration cfg = new ContextConfiguration();
+    cfg.setValue(GlobalConfiguration.FLUSH_SUSPEND_MAX_DEFERRED_RAM, 0L); // 0 = unbounded (pre-#4728 behavior)
+
+    final PageManagerFlushThread flush = new PageManagerFlushThread(PageManager.INSTANCE, cfg);
+
+    final Database db = (Database) database;
+    flush.setSuspended(db, true);
+
+    final int batches = 6;
+    for (int i = 0; i < batches; i++) {
+      final PageId pageId = new PageId(database, 9, i);
+      final MutablePage page = new MutablePage(pageId, PAGE_SIZE, new byte[PAGE_SIZE], 0, 0);
+      flush.pageIndex.put(pageId, page);
+      flush.queue.offer(new PagesToFlush(List.of(page)));
+    }
+
+    for (int i = 0; i < batches; i++)
+      flush.flushPagesFromQueueToDisk(null, 20L);
+
+    // With the cap disabled the whole queue drains into the deferred map regardless of size.
+    assertThat(flush.queue).isEmpty();
+    assertThat(flush.deferredRAMBytes.get()).isEqualTo((long) batches * PAGE_SIZE);
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -99,6 +99,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 
 /**
@@ -137,6 +138,9 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       ThreadLocal.withInitial(ArrayList::new);
 
   private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+
+  /** Poll cadence while waiting for a leader to be (re)elected before forwarding a write (issue #4728 follow-up). */
+  private static final long LEADER_WAIT_POLL_INTERVAL_MS = 100;
 
   /**
    * Emits the "no security context, forwarding as root" notice only once per JVM so embedded
@@ -1503,9 +1507,15 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
   private ResultSet forwardCommandToLeaderViaRaft(final String language, final String query,
       final Map<String, Object> mapArgs, final Object[] positionalArgs) {
     final RaftHAServer raft = requireRaftServer();
-    final String leaderHttpAddress = raft.getLeaderHttpAddress();
+    // During cluster startup or a leader change there is a window with no elected leader. Rather than failing
+    // the forwarded write immediately (which loses the caller's transaction - issue #4728 follow-up), wait a
+    // bounded time for a leader to appear and forward as soon as one does. If this node becomes the leader
+    // while waiting, getLeaderHttpAddress() returns its own address and the POST to self executes locally.
+    final long leaderWaitMs = server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_FORWARD_LEADER_WAIT_TIMEOUT_MS);
+    final String leaderHttpAddress = awaitLeaderAddress(raft::getLeaderHttpAddress, leaderWaitMs, LEADER_WAIT_POLL_INTERVAL_MS);
     if (leaderHttpAddress == null)
-      throw new TransactionException("Cannot forward command to leader: leader HTTP address is not available");
+      throw new TransactionException("Cannot forward command to leader: leader HTTP address is not available "
+          + "(no leader elected within " + leaderWaitMs + "ms; tune " + GlobalConfiguration.HA_FORWARD_LEADER_WAIT_TIMEOUT_MS.getKey() + ")");
 
     final JSONObject body = new JSONObject();
     body.put("language", language);
@@ -1567,6 +1577,36 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     } catch (final Exception e) {
       throw new TransactionException("Error forwarding command to leader at " + leaderHttpAddress, e);
     }
+  }
+
+  /**
+   * Resolves the Raft leader address, polling for up to {@code timeoutMs} when none is known yet so a write
+   * forwarded during a startup/leader-change election window is delayed rather than lost (issue #4728 follow-up).
+   *
+   * @param leaderAddressProbe supplier of the current leader address, or {@code null} when no leader is known
+   * @param timeoutMs          maximum time to wait for a leader; {@code <= 0} disables waiting (fail-fast)
+   * @param pollIntervalMs     poll cadence while waiting
+   * @return the leader address, or {@code null} if none appeared within the timeout
+   */
+  static String awaitLeaderAddress(final Supplier<String> leaderAddressProbe, final long timeoutMs, final long pollIntervalMs) {
+    String addr = leaderAddressProbe.get();
+    if (addr != null || timeoutMs <= 0)
+      return addr;
+
+    final long deadline = System.currentTimeMillis() + timeoutMs;
+    while (addr == null) {
+      final long remaining = deadline - System.currentTimeMillis();
+      if (remaining <= 0)
+        break;
+      try {
+        Thread.sleep(Math.min(pollIntervalMs, remaining));
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        break;
+      }
+      addr = leaderAddressProbe.get();
+    }
+    return addr;
   }
 
   /**

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabaseLeaderWaitTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabaseLeaderWaitTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit test for {@link RaftReplicatedDatabase#awaitLeaderAddress} (issue #4728 follow-up).
+ * <p>
+ * During cluster startup or a leader change there is a window with no elected leader. Before this fix a write
+ * forwarded by a follower failed immediately with "leader HTTP address is not available" and the caller's
+ * transaction was lost. The follower now waits a bounded time for a leader to appear and forwards as soon as
+ * one does.
+ */
+class RaftReplicatedDatabaseLeaderWaitTest {
+
+  @Test
+  void returnsImmediatelyWhenLeaderAlreadyKnown() {
+    final AtomicInteger probes = new AtomicInteger();
+    final String addr = RaftReplicatedDatabase.awaitLeaderAddress(() -> {
+      probes.incrementAndGet();
+      return "leader:2480";
+    }, 10_000L, 100L);
+
+    assertThat(addr).isEqualTo("leader:2480");
+    assertThat(probes.get()).isEqualTo(1); // no waiting/polling when a leader is already available
+  }
+
+  @Test
+  void waitsThenReturnsLeaderElectedDuringTheWindow() {
+    // Leader is unknown for the first 3 probes (election in progress), then becomes available.
+    final AtomicInteger probes = new AtomicInteger();
+    final String addr = RaftReplicatedDatabase.awaitLeaderAddress(
+        () -> probes.incrementAndGet() > 3 ? "leader:2480" : null, 10_000L, 20L);
+
+    assertThat(addr).isEqualTo("leader:2480");
+    assertThat(probes.get()).isGreaterThanOrEqualTo(4);
+  }
+
+  @Test
+  void returnsNullAfterTimeoutWhenNoLeaderAppears() {
+    final long timeoutMs = 300L;
+    final long start = System.currentTimeMillis();
+    final String addr = RaftReplicatedDatabase.awaitLeaderAddress(() -> null, timeoutMs, 20L);
+    final long elapsed = System.currentTimeMillis() - start;
+
+    assertThat(addr).isNull();
+    // It actually waited (roughly) the configured timeout before giving up.
+    assertThat(elapsed).isGreaterThanOrEqualTo(timeoutMs - 50L);
+  }
+
+  @Test
+  void failsFastWhenTimeoutDisabled() {
+    final AtomicInteger probes = new AtomicInteger();
+    final long start = System.currentTimeMillis();
+    final String addr = RaftReplicatedDatabase.awaitLeaderAddress(() -> {
+      probes.incrementAndGet();
+      return null;
+    }, 0L, 100L);
+    final long elapsed = System.currentTimeMillis() - start;
+
+    assertThat(addr).isNull();
+    assertThat(probes.get()).isEqualTo(1); // probed once, no waiting
+    assertThat(elapsed).isLessThan(100L);
+  }
+}


### PR DESCRIPTION
… deferred-page RAM

Two HA follow-ups to #4728, both surfaced by a client cluster restart:

1. Lost writes during the no-leader startup window. A follower forwarding a write threw "leader HTTP address is not available" the instant no leader was known, losing the caller's transaction. forwardCommandToLeaderViaRaft now waits up to arcadedb.ha.forwardLeaderWaitTimeoutMs (default 20000, 0=fail-fast) for a leader to be (re)elected and forwards as soon as one appears. Wait logic extracted to the static, unit-tested awaitLeaderAddress(...) helper.

2. Leader OOM while shipping a full snapshot. SnapshotHttpHandler streams the whole DB inside suspendFlushAndExecute, and while flushing is suspended the bounded page-flush queue drains into the UNBOUNDED deferredByDatabase map, so committing threads never backpressure and a multi-GB ship exhausts the heap. PageManagerFlushThread now caps the deferred backlog (arcadedb.flushSuspendMaxDeferredRAM, MB, default 512, 0=unbounded): once the cap is reached the flush thread stops draining its queue, which fills and throttles the committers via scheduleFlushOfPages instead of OOMing.

Tests: RaftReplicatedDatabaseLeaderWaitTest, PageManagerFlushSuspendBackpressureTest.

## What does this PR do?

A brief description of the change being made with this pull request.

## Motivation

What inspired you to submit this pull request?

## Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

## Additional Notes

Anything else we should know when reviewing?

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
