### PR TITLE
feat: [#4727] HA auto-acquire of databases a joining node has never seen

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -867,6 +867,16 @@ public enum GlobalConfiguration {
       knows which peer was unreachable.""",
       Long.class, 120_000L),
 
+  HA_AUTO_ACQUIRE_DATABASES("arcadedb.ha.autoAcquireDatabases", SCOPE.SERVER,
+      """
+      When true (the default), a node that joins the cluster reconciles its local database set against the leader's \
+      and auto-pulls (full snapshot install) any database it has never seen on disk - so an empty/new node \
+      (e.g. a StatefulSet scaled up) becomes a full replica with zero manual steps. When false, the node only \
+      refreshes databases already present locally (the legacy behavior) and never acquires unseen ones. This is a \
+      per-node local policy, re-read on every boot and not stored in Raft; acquisition is additive and never drops \
+      a database the leader is missing, so a mixed cluster is safe.""",
+      Boolean.class, true),
+
   HA_SNAPSHOT_MAX_CONCURRENT("arcadedb.ha.snapshotMaxConcurrent", SCOPE.SERVER,
       "Maximum number of concurrent snapshot downloads served by the leader. Requests over this limit receive HTTP 503.",
       Integer.class, 2),

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -873,8 +873,8 @@ public enum GlobalConfiguration {
       and auto-pulls (full snapshot install) any database it has never seen on disk - so an empty/new node \
       (e.g. a StatefulSet scaled up) becomes a full replica with zero manual steps. When false, the node only \
       refreshes databases already present locally (the legacy behavior) and never acquires unseen ones. This is a \
-      per-node local policy, re-read on every boot and not stored in Raft; acquisition is additive and never drops \
-      a database the leader is missing, so a mixed cluster is safe.""",
+      per-node local policy, read live on each reconcile (not stored in Raft); acquisition is additive and never \
+      drops a database the leader is missing, so a mixed cluster is safe.""",
       Boolean.class, true),
 
   HA_SNAPSHOT_MAX_CONCURRENT("arcadedb.ha.snapshotMaxConcurrent", SCOPE.SERVER,

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -874,7 +874,10 @@ public enum GlobalConfiguration {
       (e.g. a StatefulSet scaled up) becomes a full replica with zero manual steps. When false, the node only \
       refreshes databases already present locally (the legacy behavior) and never acquires unseen ones. This is a \
       per-node local policy, read live on each reconcile (not stored in Raft); acquisition is additive and never \
-      drops a database the leader is missing, so a mixed cluster is safe.""",
+      drops a database the leader is missing, so a mixed cluster is safe. Note: a database whose snapshot \
+      persistently fails to install is retried up to a small bounded number of times, and because a failed install \
+      makes Ratis re-trigger the whole InstallSnapshot, each retry re-downloads the other databases on this node \
+      too; the retry count is capped so this cannot loop indefinitely.""",
       Boolean.class, true),
 
   HA_SNAPSHOT_MAX_CONCURRENT("arcadedb.ha.snapshotMaxConcurrent", SCOPE.SERVER,

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -608,11 +608,12 @@ public class ArcadeStateMachine extends BaseStateMachine {
       raftHAServer.startLagMonitor();
       raftHAServer.printClusterConfiguration();
 
-      // A LEADER_MISSING flag means "the leader lacks a database this node holds" - meaningless once this node
-      // IS the leader. Clear those stale entries so the leader-missing alert does not linger on the new leader
-      // (issue #4727); they would otherwise survive because the leader never runs the follower reconcile path.
-      // Also drop the parallel acquire failure counters, which are likewise a follower-side reconcile concern.
-      acquireStatuses.values().removeIf(s -> s.state() == AcquireState.LEADER_MISSING);
+      // LEADER_MISSING ("the leader lacks a database this node holds") and FAILED ("could not acquire from the
+      // leader") are both follower-side reconcile states, meaningless once this node IS the leader. Clear them and
+      // the parallel failure counters so their cluster alerts do not linger on the new leader (issue #4727); they
+      // would otherwise survive because the leader never runs the follower reconcile path. ACQUIRED is harmless
+      // history and is kept.
+      acquireStatuses.values().removeIf(s -> s.state() == AcquireState.LEADER_MISSING || s.state() == AcquireState.FAILED);
       acquireFailureCounts.clear();
 
       // Issue #4147: drive offline cluster bootstrap if conditions match (commit index still 0,

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -783,6 +783,25 @@ public class ArcadeStateMachine extends BaseStateMachine {
               leaderHttpAddr, leaderHttpsAddr, clusterToken, server);
         });
 
+    // Apply the status-map / failure-counter bookkeeping and decide whether to fail the overall install so Ratis
+    // re-triggers it. Extracted to a package-private method so these transitions are unit-testable without a live
+    // cluster (the InstallSnapshot path is not deterministically reachable in-process - see SnapshotAcquireNewDatabaseIT).
+    if (applyReconcileOutcome(plan, outcome))
+      throw new IOException("Reconcile from leader had transient database failure(s); will retry: "
+          + outcome.acquireFailures() + outcome.refreshFailures());
+  }
+
+  /**
+   * Applies the outcome of a reconcile pass to {@link #acquireStatuses} and {@link #acquireFailureCounts}, and
+   * returns whether the overall install should be failed so Ratis re-triggers it. Package-private and free of
+   * leader/network I/O so the FAILED/ACQUIRED/LEADER_MISSING transitions and the give-up decision are directly
+   * unit-testable.
+   *
+   * @return {@code true} if at least one failed database is still within its retry budget
+   *         ({@link #ACQUIRE_GIVE_UP_AFTER}); {@code false} when there were no failures, or every failure has
+   *         exhausted its budget (so a persistently bad database no longer forces the whole install to re-run).
+   */
+  boolean applyReconcileOutcome(final ReconcilePlan plan, final ReconcileOutcome outcome) {
     // acquireStatuses records only genuine acquisitions, so operators can tell a true pull from a routine refresh.
     // A success also resets the consecutive-failure counter for that database.
     for (final String dbName : outcome.acquired()) {
@@ -810,19 +829,17 @@ public class ArcadeStateMachine extends BaseStateMachine {
           dbName, dbName);
     }
 
-    // Decide whether to fail the overall install (so Ratis re-triggers it). A failure is "still worth retrying"
-    // only until it has failed ACQUIRE_GIVE_UP_AFTER times in a row: past that, a persistently bad database stops
-    // forcing the retry, so it no longer re-downloads every healthy database on this follower in a tight loop. It
-    // is left FAILED (surfaced to operators) and retried on the next natural InstallSnapshot.
+    // A failure is "still worth retrying" only until it has failed ACQUIRE_GIVE_UP_AFTER times in a row. Past that
+    // a persistently bad database stops forcing the retry, so it no longer makes Ratis re-trigger InstallSnapshot
+    // in a tight loop (which would re-download every healthy database on this follower each pass). It is left
+    // FAILED and is still attempted on the next *natural* InstallSnapshot - which already re-downloads every
+    // database anyway - so it can still recover if the leader's copy is later fixed; it just no longer hot-loops.
     boolean retryWorthwhile = false;
     for (final String dbName : outcome.acquireFailures().keySet())
       retryWorthwhile |= bumpFailureAndShouldRetry(dbName);
     for (final String dbName : outcome.refreshFailures().keySet())
       retryWorthwhile |= bumpFailureAndShouldRetry(dbName);
-
-    if (retryWorthwhile)
-      throw new IOException("Reconcile from leader had transient database failure(s); will retry: "
-          + outcome.acquireFailures() + outcome.refreshFailures());
+    return retryWorthwhile;
   }
 
   /**
@@ -850,6 +867,10 @@ public class ArcadeStateMachine extends BaseStateMachine {
   private void refreshExistingDatabases(final String leaderHttpAddr, final String leaderHttpsAddr,
       final String clusterToken) throws IOException {
     for (final String dbName : server.getDatabaseNames()) {
+      // Skip reserved internal databases (e.g. the Raft control directory '.raft'): the leader does not serve them
+      // as snapshots, so an install attempt would only fail. Mirrors the filter on the auto-acquire path.
+      if (dbName.startsWith(ArcadeDBServer.RESERVED_DATABASE_PREFIX))
+        continue;
       if (server.existsDatabase(dbName)) {
         LogManager.instance().log(this, Level.INFO,
             "Installing snapshot for database '%s' from leader %s...", dbName, leaderHttpAddr);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -59,6 +59,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -196,6 +197,51 @@ public class ArcadeStateMachine extends BaseStateMachine {
     Collections.sort(toRefresh);
     Collections.sort(leaderMissing);
     return new ReconcilePlan(toAcquire, toRefresh, leaderMissing);
+  }
+
+  /** A per-database install operation that may fail with {@link IOException}. */
+  @FunctionalInterface
+  interface DbInstallOp {
+    void run(String databaseName) throws IOException;
+  }
+
+  /** Result of running a {@link ReconcilePlan}: which databases were acquired/refreshed and which failed. */
+  public record ReconcileOutcome(List<String> acquired, Map<String, String> acquireFailures,
+      List<String> refreshed, Map<String, String> refreshFailures) {
+  }
+
+  /**
+   * Runs a {@link ReconcilePlan}: acquires the never-seen databases and refreshes the existing ones, isolating
+   * per-database failures so one bad database never starves the others. A failing acquire (e.g. a persistently
+   * corrupt snapshot that fails validation every pass) must not abort the whole reconcile - otherwise the healthy,
+   * already-replicated databases on this follower would never get refreshed. Each failure is collected and the
+   * caller fails the overall install at the end so Ratis re-triggers (installs are idempotent). Package-private
+   * and operation-injected so the no-starvation behavior is unit-testable without a Raft cluster.
+   */
+  static ReconcileOutcome executeReconcilePlan(final ReconcilePlan plan, final DbInstallOp acquireOp,
+      final DbInstallOp refreshOp) {
+    final List<String> acquired = new ArrayList<>();
+    final Map<String, String> acquireFailures = new LinkedHashMap<>();
+    final List<String> refreshed = new ArrayList<>();
+    final Map<String, String> refreshFailures = new LinkedHashMap<>();
+
+    for (final String db : plan.toAcquire()) {
+      try {
+        acquireOp.run(db);
+        acquired.add(db);
+      } catch (final IOException e) {
+        acquireFailures.put(db, e.getMessage());
+      }
+    }
+    for (final String db : plan.toRefresh()) {
+      try {
+        refreshOp.run(db);
+        refreshed.add(db);
+      } catch (final IOException e) {
+        refreshFailures.put(db, e.getMessage());
+      }
+    }
+    return new ReconcileOutcome(acquired, acquireFailures, refreshed, refreshFailures);
   }
 
   private final AtomicBoolean needsSnapshotDownload      = new AtomicBoolean(false);
@@ -685,9 +731,18 @@ public class ArcadeStateMachine extends BaseStateMachine {
       return;
     }
 
+    // Build the leader's database set. Skip entries the leader reported it could not open (lastTxId < 0): such a
+    // database is not a usable snapshot source, so trying to acquire it would only fail validation every pass.
     final Set<String> leaderDbNames = new HashSet<>();
-    for (final LeaderDatabaseQuery.DatabaseInfo info : leaderDbs)
+    for (final LeaderDatabaseQuery.DatabaseInfo info : leaderDbs) {
+      if (info.lastTxId() < 0) {
+        LogManager.instance().log(this, Level.WARNING,
+            "Leader reported database '%s' as unreadable (no usable snapshot source); skipping it this reconcile.",
+            info.name());
+        continue;
+      }
       leaderDbNames.add(info.name());
+    }
 
     final Set<String> localDbNames = new HashSet<>();
     for (final String name : server.getDatabaseNames())
@@ -701,31 +756,34 @@ public class ArcadeStateMachine extends BaseStateMachine {
 
     final ReconcilePlan plan = classifyReconcile(leaderDbNames, localDbNames);
 
-    // Acquire databases this node has never seen. acquireStatuses records only genuine acquisitions so operators
-    // can tell a true pull from a routine refresh.
-    for (final String dbName : plan.toAcquire()) {
-      acquireStatuses.put(dbName, new AcquireStatus(AcquireState.ACQUIRING, System.currentTimeMillis(), null));
-      LogManager.instance().log(this, Level.INFO, "Acquiring database '%s' from leader %s...", dbName, leaderHttpAddr);
-      try {
-        SnapshotInstaller.acquireNewDatabase(dbName, () -> leaderHttpAddr, () -> leaderHttpsAddr, clusterToken, server);
-        acquireStatuses.put(dbName, new AcquireStatus(AcquireState.ACQUIRED, System.currentTimeMillis(), null));
-      } catch (final IOException e) {
-        acquireStatuses.put(dbName, new AcquireStatus(AcquireState.FAILED, System.currentTimeMillis(), e.getMessage()));
-        throw e;
-      }
-    }
+    // Execute the plan with per-database failure isolation so one bad acquire never starves the refresh of the
+    // healthy, already-replicated databases (and vice-versa). Statuses are applied from the outcome below, and
+    // any failure fails the overall install at the end so Ratis re-triggers (installs are idempotent).
+    final ReconcileOutcome outcome = executeReconcilePlan(plan,
+        dbName -> {
+          acquireStatuses.put(dbName, new AcquireStatus(AcquireState.ACQUIRING, System.currentTimeMillis(), null));
+          LogManager.instance().log(this, Level.INFO, "Acquiring database '%s' from leader %s...", dbName, leaderHttpAddr);
+          SnapshotInstaller.acquireNewDatabase(dbName, () -> leaderHttpAddr, () -> leaderHttpsAddr, clusterToken, server);
+        },
+        dbName -> {
+          LogManager.instance().log(this, Level.INFO, "Refreshing database '%s' from leader %s...", dbName, leaderHttpAddr);
+          // install() downloads with the database still open and only closes + swaps once a complete copy is on
+          // disk, rolling back on failure, so a failed download never leaves the database closed.
+          SnapshotInstaller.install(dbName, SnapshotInstaller.resolveDatabasePath(server, dbName),
+              leaderHttpAddr, leaderHttpsAddr, clusterToken, server);
+        });
 
-    // Refresh databases we already have. The leader holds them, so clear any stale LEADER_MISSING/FAILED status
-    // left from a prior pass (the resync / leadership-transfer recovery flow this PR documents): the alert must
-    // clear once the leader regains the database.
-    for (final String dbName : plan.toRefresh()) {
-      LogManager.instance().log(this, Level.INFO, "Refreshing database '%s' from leader %s...", dbName, leaderHttpAddr);
-      // install() downloads the snapshot with the database still open and only closes + swaps it once a complete
-      // copy is on disk, rolling back on failure, so a failed download never leaves the database closed.
-      SnapshotInstaller.install(dbName, SnapshotInstaller.resolveDatabasePath(server, dbName),
-          leaderHttpAddr, leaderHttpsAddr, clusterToken, server);
+    // acquireStatuses records only genuine acquisitions, so operators can tell a true pull from a routine refresh.
+    for (final String dbName : outcome.acquired())
+      acquireStatuses.put(dbName, new AcquireStatus(AcquireState.ACQUIRED, System.currentTimeMillis(), null));
+    // A refreshed database is one the leader holds, so clear any stale LEADER_MISSING/FAILED status left from a
+    // prior pass (the resync / leadership-transfer recovery flow this PR documents).
+    for (final String dbName : outcome.refreshed())
       acquireStatuses.remove(dbName);
-    }
+    for (final Map.Entry<String, String> e : outcome.acquireFailures().entrySet())
+      acquireStatuses.put(e.getKey(), new AcquireStatus(AcquireState.FAILED, System.currentTimeMillis(), e.getValue()));
+    for (final Map.Entry<String, String> e : outcome.refreshFailures().entrySet())
+      acquireStatuses.put(e.getKey(), new AcquireStatus(AcquireState.FAILED, System.currentTimeMillis(), e.getValue()));
 
     // Additive-only guard: a database we hold that the leader does not must NOT be dropped here. Flag it so the
     // cluster status / Studio surfaces it; a genuine DROP still arrives via DROP_DATABASE_ENTRY replay.
@@ -736,6 +794,13 @@ public class ArcadeStateMachine extends BaseStateMachine {
               + "If this node is an authoritative source, transfer leadership to a node that holds '%s' and resync.",
           dbName, dbName);
     }
+
+    // Fail the overall install if any database failed, so Ratis re-triggers it; the healthy databases were still
+    // refreshed/acquired above and are not blocked by the failing one.
+    final int failed = outcome.acquireFailures().size() + outcome.refreshFailures().size();
+    if (failed > 0)
+      throw new IOException("Reconcile from leader completed with " + failed + " failed database(s): "
+          + outcome.acquireFailures() + outcome.refreshFailures());
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -56,6 +56,7 @@ import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -142,6 +143,28 @@ public class ArcadeStateMachine extends BaseStateMachine {
 
   /** Per-database bootstrap baseline as it appears in the committed Raft log entry. */
   public record BootstrapBaseline(String fingerprint, long lastTxId) {
+  }
+
+  /**
+   * Per-database auto-acquisition status (issue #4727), surfaced in the cluster status endpoint and the
+   * Studio HA panel. Updated by {@link #notifyInstallSnapshotFromLeader} as a joining node reconciles its
+   * local database set against the leader's.
+   */
+  private final ConcurrentHashMap<String, AcquireStatus> acquireStatuses = new ConcurrentHashMap<>();
+
+  public enum AcquireState {
+    /** A full-snapshot pull of this database is in progress. */
+    ACQUIRING,
+    /** This database was successfully pulled from the leader. */
+    ACQUIRED,
+    /** This node holds this database but the leader does not - kept (not dropped); needs operator attention. */
+    LEADER_MISSING,
+    /** The last acquisition attempt failed; it will be retried on the next reconcile. */
+    FAILED
+  }
+
+  /** Snapshot of a database's acquisition state for status export. */
+  public record AcquireStatus(AcquireState state, long timestamp, String error) {
   }
 
   private final AtomicBoolean needsSnapshotDownload      = new AtomicBoolean(false);
@@ -565,17 +588,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
 
         final String clusterToken = raftHAServer.getClusterToken();
 
-        for (final String dbName : server.getDatabaseNames()) {
-          LogManager.instance().log(this, Level.INFO,
-              "Installing snapshot for database '%s' from leader %s...", dbName, leaderHttpAddr);
-
-          // install() downloads the snapshot with the database still open and only closes + swaps it
-          // once a complete copy is on disk, rolling back on failure, so a failed download never
-          // leaves this database closed (DatabaseIsClosedException).
-          if (server.existsDatabase(dbName))
-            SnapshotInstaller.install(dbName, SnapshotInstaller.resolveDatabasePath(server, dbName),
-                leaderHttpAddr, leaderHttpsAddr, clusterToken, server);
-        }
+        reconcileDatabasesFromLeader(leaderHttpAddr, leaderHttpsAddr, clusterToken);
 
         LogManager.instance().log(this, Level.INFO, "Full resync from leader completed");
         return firstTermIndexInLog;
@@ -585,6 +598,120 @@ public class ArcadeStateMachine extends BaseStateMachine {
         throw new RuntimeException("Error during Raft snapshot installation", e);
       }
     });
+  }
+
+  /**
+   * Reconciles this node's local database set against the leader's and installs every database the leader holds -
+   * refreshing the ones already present and acquiring the ones this node has never seen (issue #4727).
+   * <p>
+   * Gated on {@link GlobalConfiguration#HA_AUTO_ACQUIRE_DATABASES}: when disabled, falls back to the legacy
+   * behavior of refreshing only databases already present on disk. When the leader's database list cannot be
+   * fetched (leader momentarily unreachable), it also falls back to the legacy refresh so the install never
+   * regresses; the missing databases are retried on the next install-snapshot / leader change.
+   * <p>
+   * <b>Additive only:</b> a database present locally but absent on the leader is never dropped (that keeps a real
+   * {@code DROP_DATABASE_ENTRY} distinguishable from "the leader never had it"); it is flagged
+   * {@link AcquireState#LEADER_MISSING} for operator attention.
+   *
+   * @throws IOException if a database install fails (so the caller leaves the Ratis snapshot install incomplete
+   *                     and Ratis re-triggers it; installs are idempotent).
+   */
+  private void reconcileDatabasesFromLeader(final String leaderHttpAddr, final String leaderHttpsAddr,
+      final String clusterToken) throws IOException {
+
+    final boolean autoAcquire = server.getConfiguration().getValueAsBoolean(
+        GlobalConfiguration.HA_AUTO_ACQUIRE_DATABASES);
+
+    if (!autoAcquire) {
+      refreshExistingDatabases(leaderHttpAddr, leaderHttpsAddr, clusterToken);
+      return;
+    }
+
+    // Enumerate the leader's databases via the existing bootstrap-state RPC. On failure, degrade to the legacy
+    // refresh-existing-only path rather than failing the whole install.
+    final List<LeaderDatabaseQuery.DatabaseInfo> leaderDbs;
+    try {
+      final long timeoutMs = server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_BOOTSTRAP_TIMEOUT_MS);
+      leaderDbs = LeaderDatabaseQuery.fetch(leaderHttpAddr, clusterToken, timeoutMs);
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.WARNING,
+          "Could not list the leader's databases for auto-acquire (%s); refreshing only the databases already "
+              + "present locally. Missing databases will be retried on the next reconcile.", e.getMessage());
+      refreshExistingDatabases(leaderHttpAddr, leaderHttpsAddr, clusterToken);
+      return;
+    }
+
+    final Set<String> leaderDbNames = new HashSet<>();
+    for (final LeaderDatabaseQuery.DatabaseInfo info : leaderDbs)
+      leaderDbNames.add(info.name());
+
+    // Install every database the leader holds: refresh the ones we already have, acquire the rest.
+    for (final String dbName : leaderDbNames) {
+      final boolean isNew = !server.existsDatabase(dbName);
+      acquireStatuses.put(dbName, new AcquireStatus(AcquireState.ACQUIRING, System.currentTimeMillis(), null));
+      LogManager.instance().log(this, Level.INFO, "%s database '%s' from leader %s...",
+          isNew ? "Acquiring" : "Refreshing", dbName, leaderHttpAddr);
+      try {
+        if (isNew)
+          SnapshotInstaller.acquireNewDatabase(dbName, () -> leaderHttpAddr, () -> leaderHttpsAddr, clusterToken, server);
+        else
+          // install() downloads the snapshot with the database still open and only closes + swaps it once a
+          // complete copy is on disk, rolling back on failure, so a failed download never leaves the database
+          // closed (DatabaseIsClosedException).
+          SnapshotInstaller.install(dbName, SnapshotInstaller.resolveDatabasePath(server, dbName),
+              leaderHttpAddr, leaderHttpsAddr, clusterToken, server);
+        acquireStatuses.put(dbName, new AcquireStatus(AcquireState.ACQUIRED, System.currentTimeMillis(), null));
+      } catch (final IOException e) {
+        acquireStatuses.put(dbName, new AcquireStatus(AcquireState.FAILED, System.currentTimeMillis(), e.getMessage()));
+        throw e;
+      }
+    }
+
+    // Additive-only guard: a database we hold that the leader does not must NOT be dropped here. Flag it so the
+    // cluster status / Studio surfaces it; a genuine DROP still arrives via DROP_DATABASE_ENTRY replay.
+    for (final String localDb : server.getDatabaseNames()) {
+      if (localDb.startsWith(ArcadeDBServer.RESERVED_DATABASE_PREFIX))
+        continue;
+      if (!leaderDbNames.contains(localDb)) {
+        acquireStatuses.put(localDb, new AcquireStatus(AcquireState.LEADER_MISSING, System.currentTimeMillis(), null));
+        LogManager.instance().log(this, Level.WARNING,
+            "Database '%s' is present locally but the leader does not hold it; keeping the local copy (not dropping). "
+                + "If this node is an authoritative source, transfer leadership to a node that holds '%s' and resync.",
+            localDb, localDb);
+      }
+    }
+  }
+
+  /**
+   * Legacy behavior: refresh only the databases already present on this node from the leader. Used when
+   * {@link GlobalConfiguration#HA_AUTO_ACQUIRE_DATABASES} is disabled or the leader's database list is
+   * unavailable.
+   */
+  private void refreshExistingDatabases(final String leaderHttpAddr, final String leaderHttpsAddr,
+      final String clusterToken) throws IOException {
+    for (final String dbName : server.getDatabaseNames()) {
+      if (server.existsDatabase(dbName)) {
+        LogManager.instance().log(this, Level.INFO,
+            "Installing snapshot for database '%s' from leader %s...", dbName, leaderHttpAddr);
+        SnapshotInstaller.install(dbName, SnapshotInstaller.resolveDatabasePath(server, dbName),
+            leaderHttpAddr, leaderHttpsAddr, clusterToken, server);
+      }
+    }
+  }
+
+  /** Snapshot of the per-database auto-acquisition status, for the cluster status endpoint (issue #4727). */
+  public AcquireStatus getAcquireStatus(final String dbName) {
+    return acquireStatuses.get(dbName);
+  }
+
+  /** Database names currently in the given auto-acquisition state (issue #4727), e.g. for cluster alerts. */
+  public List<String> getDatabasesWithAcquireState(final AcquireState state) {
+    final List<String> out = new ArrayList<>();
+    for (final Map.Entry<String, AcquireStatus> e : acquireStatuses.entrySet())
+      if (e.getValue().state() == state)
+        out.add(e.getKey());
+    Collections.sort(out);
+    return out;
   }
 
   public long getElectionCount() {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -167,6 +167,37 @@ public class ArcadeStateMachine extends BaseStateMachine {
   public record AcquireStatus(AcquireState state, long timestamp, String error) {
   }
 
+  /**
+   * The classification of a reconcile pass (issue #4727): which leader databases this node must acquire (never
+   * seen), which it already has and merely refreshes, and which it holds that the leader does not (kept, flagged
+   * {@link AcquireState#LEADER_MISSING}). Pure and package-private so the set logic is unit-testable.
+   */
+  public record ReconcilePlan(List<String> toAcquire, List<String> toRefresh, List<String> leaderMissing) {
+  }
+
+  /**
+   * Computes the {@link ReconcilePlan} from the leader's database set and this node's local (non-reserved) set.
+   * Lists are sorted for deterministic output. Pure - no side effects.
+   */
+  static ReconcilePlan classifyReconcile(final Set<String> leaderDbs, final Set<String> localDbs) {
+    final List<String> toAcquire = new ArrayList<>();
+    final List<String> toRefresh = new ArrayList<>();
+    final List<String> leaderMissing = new ArrayList<>();
+    for (final String db : leaderDbs) {
+      if (localDbs.contains(db))
+        toRefresh.add(db);
+      else
+        toAcquire.add(db);
+    }
+    for (final String db : localDbs)
+      if (!leaderDbs.contains(db))
+        leaderMissing.add(db);
+    Collections.sort(toAcquire);
+    Collections.sort(toRefresh);
+    Collections.sort(leaderMissing);
+    return new ReconcilePlan(toAcquire, toRefresh, leaderMissing);
+  }
+
   private final AtomicBoolean needsSnapshotDownload      = new AtomicBoolean(false);
   private final AtomicBoolean snapshotDownloadInProgress = new AtomicBoolean(false);
   private final AtomicBoolean catchingUp                 = new AtomicBoolean(false);
@@ -519,6 +550,11 @@ public class ArcadeStateMachine extends BaseStateMachine {
       raftHAServer.startLagMonitor();
       raftHAServer.printClusterConfiguration();
 
+      // A LEADER_MISSING flag means "the leader lacks a database this node holds" - meaningless once this node
+      // IS the leader. Clear those stale entries so the leader-missing alert does not linger on the new leader
+      // (issue #4727); they would otherwise survive because the leader never runs the follower reconcile path.
+      acquireStatuses.values().removeIf(s -> s.state() == AcquireState.LEADER_MISSING);
+
       // Issue #4147: drive offline cluster bootstrap if conditions match (commit index still 0,
       // arcadedb.ha.bootstrapFromLocalDatabase=true). Runs on a background thread to keep the
       // notifyLeaderChanged callback non-blocking; a slow peer or a bootstrap-state RPC timeout
@@ -653,51 +689,52 @@ public class ArcadeStateMachine extends BaseStateMachine {
     for (final LeaderDatabaseQuery.DatabaseInfo info : leaderDbs)
       leaderDbNames.add(info.name());
 
-    // Prune stale acquisition statuses for databases that are no longer on this node (e.g. a previously
-    // LEADER_MISSING database that was later dropped via DROP_DATABASE_ENTRY, or one redistributed after a
-    // leadership transfer). Otherwise the leader-missing cluster alert would stay raised for a database that
-    // no longer exists locally.
-    acquireStatuses.keySet().removeIf(name -> !server.existsDatabase(name) && !leaderDbNames.contains(name));
+    final Set<String> localDbNames = new HashSet<>();
+    for (final String name : server.getDatabaseNames())
+      if (!name.startsWith(ArcadeDBServer.RESERVED_DATABASE_PREFIX))
+        localDbNames.add(name);
 
-    // Install every database the leader holds: refresh the ones we already have, acquire the rest. The
-    // acquireStatuses map records only genuine acquisitions (isNew); a routine snapshot refresh of an
-    // already-present database is not reported as ACQUIRED so operators can tell a true pull from a refresh.
-    for (final String dbName : leaderDbNames) {
-      final boolean isNew = !server.existsDatabase(dbName);
-      if (isNew)
-        acquireStatuses.put(dbName, new AcquireStatus(AcquireState.ACQUIRING, System.currentTimeMillis(), null));
-      LogManager.instance().log(this, Level.INFO, "%s database '%s' from leader %s...",
-          isNew ? "Acquiring" : "Refreshing", dbName, leaderHttpAddr);
+    // Prune acquisition statuses for databases that are neither local nor on the leader (e.g. a previously
+    // LEADER_MISSING database later dropped via DROP_DATABASE_ENTRY). Otherwise the leader-missing alert would
+    // stay raised for a database that no longer exists anywhere this node knows about.
+    acquireStatuses.keySet().removeIf(name -> !localDbNames.contains(name) && !leaderDbNames.contains(name));
+
+    final ReconcilePlan plan = classifyReconcile(leaderDbNames, localDbNames);
+
+    // Acquire databases this node has never seen. acquireStatuses records only genuine acquisitions so operators
+    // can tell a true pull from a routine refresh.
+    for (final String dbName : plan.toAcquire()) {
+      acquireStatuses.put(dbName, new AcquireStatus(AcquireState.ACQUIRING, System.currentTimeMillis(), null));
+      LogManager.instance().log(this, Level.INFO, "Acquiring database '%s' from leader %s...", dbName, leaderHttpAddr);
       try {
-        if (isNew)
-          SnapshotInstaller.acquireNewDatabase(dbName, () -> leaderHttpAddr, () -> leaderHttpsAddr, clusterToken, server);
-        else
-          // install() downloads the snapshot with the database still open and only closes + swaps it once a
-          // complete copy is on disk, rolling back on failure, so a failed download never leaves the database
-          // closed (DatabaseIsClosedException).
-          SnapshotInstaller.install(dbName, SnapshotInstaller.resolveDatabasePath(server, dbName),
-              leaderHttpAddr, leaderHttpsAddr, clusterToken, server);
-        if (isNew)
-          acquireStatuses.put(dbName, new AcquireStatus(AcquireState.ACQUIRED, System.currentTimeMillis(), null));
+        SnapshotInstaller.acquireNewDatabase(dbName, () -> leaderHttpAddr, () -> leaderHttpsAddr, clusterToken, server);
+        acquireStatuses.put(dbName, new AcquireStatus(AcquireState.ACQUIRED, System.currentTimeMillis(), null));
       } catch (final IOException e) {
-        if (isNew)
-          acquireStatuses.put(dbName, new AcquireStatus(AcquireState.FAILED, System.currentTimeMillis(), e.getMessage()));
+        acquireStatuses.put(dbName, new AcquireStatus(AcquireState.FAILED, System.currentTimeMillis(), e.getMessage()));
         throw e;
       }
     }
 
+    // Refresh databases we already have. The leader holds them, so clear any stale LEADER_MISSING/FAILED status
+    // left from a prior pass (the resync / leadership-transfer recovery flow this PR documents): the alert must
+    // clear once the leader regains the database.
+    for (final String dbName : plan.toRefresh()) {
+      LogManager.instance().log(this, Level.INFO, "Refreshing database '%s' from leader %s...", dbName, leaderHttpAddr);
+      // install() downloads the snapshot with the database still open and only closes + swaps it once a complete
+      // copy is on disk, rolling back on failure, so a failed download never leaves the database closed.
+      SnapshotInstaller.install(dbName, SnapshotInstaller.resolveDatabasePath(server, dbName),
+          leaderHttpAddr, leaderHttpsAddr, clusterToken, server);
+      acquireStatuses.remove(dbName);
+    }
+
     // Additive-only guard: a database we hold that the leader does not must NOT be dropped here. Flag it so the
     // cluster status / Studio surfaces it; a genuine DROP still arrives via DROP_DATABASE_ENTRY replay.
-    for (final String localDb : server.getDatabaseNames()) {
-      if (localDb.startsWith(ArcadeDBServer.RESERVED_DATABASE_PREFIX))
-        continue;
-      if (!leaderDbNames.contains(localDb)) {
-        acquireStatuses.put(localDb, new AcquireStatus(AcquireState.LEADER_MISSING, System.currentTimeMillis(), null));
-        LogManager.instance().log(this, Level.WARNING,
-            "Database '%s' is present locally but the leader does not hold it; keeping the local copy (not dropping). "
-                + "If this node is an authoritative source, transfer leadership to a node that holds '%s' and resync.",
-            localDb, localDb);
-      }
+    for (final String dbName : plan.leaderMissing()) {
+      acquireStatuses.put(dbName, new AcquireStatus(AcquireState.LEADER_MISSING, System.currentTimeMillis(), null));
+      LogManager.instance().log(this, Level.WARNING,
+          "Database '%s' is present locally but the leader does not hold it; keeping the local copy (not dropping). "
+              + "If this node is an authoritative source, transfer leadership to a node that holds '%s' and resync.",
+          dbName, dbName);
     }
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -632,7 +632,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
     final List<LeaderDatabaseQuery.DatabaseInfo> leaderDbs;
     try {
       final long timeoutMs = server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_BOOTSTRAP_TIMEOUT_MS);
-      leaderDbs = LeaderDatabaseQuery.fetch(leaderHttpAddr, clusterToken, timeoutMs);
+      leaderDbs = LeaderDatabaseQuery.fetch(leaderHttpAddr, leaderHttpsAddr, clusterToken, timeoutMs, server);
     } catch (final InterruptedException e) {
       // Preserve the interrupt so the pool/executor can observe it and shut down cleanly.
       Thread.currentThread().interrupt();
@@ -659,10 +659,13 @@ public class ArcadeStateMachine extends BaseStateMachine {
     // no longer exists locally.
     acquireStatuses.keySet().removeIf(name -> !server.existsDatabase(name) && !leaderDbNames.contains(name));
 
-    // Install every database the leader holds: refresh the ones we already have, acquire the rest.
+    // Install every database the leader holds: refresh the ones we already have, acquire the rest. The
+    // acquireStatuses map records only genuine acquisitions (isNew); a routine snapshot refresh of an
+    // already-present database is not reported as ACQUIRED so operators can tell a true pull from a refresh.
     for (final String dbName : leaderDbNames) {
       final boolean isNew = !server.existsDatabase(dbName);
-      acquireStatuses.put(dbName, new AcquireStatus(AcquireState.ACQUIRING, System.currentTimeMillis(), null));
+      if (isNew)
+        acquireStatuses.put(dbName, new AcquireStatus(AcquireState.ACQUIRING, System.currentTimeMillis(), null));
       LogManager.instance().log(this, Level.INFO, "%s database '%s' from leader %s...",
           isNew ? "Acquiring" : "Refreshing", dbName, leaderHttpAddr);
       try {
@@ -674,9 +677,11 @@ public class ArcadeStateMachine extends BaseStateMachine {
           // closed (DatabaseIsClosedException).
           SnapshotInstaller.install(dbName, SnapshotInstaller.resolveDatabasePath(server, dbName),
               leaderHttpAddr, leaderHttpsAddr, clusterToken, server);
-        acquireStatuses.put(dbName, new AcquireStatus(AcquireState.ACQUIRED, System.currentTimeMillis(), null));
+        if (isNew)
+          acquireStatuses.put(dbName, new AcquireStatus(AcquireState.ACQUIRED, System.currentTimeMillis(), null));
       } catch (final IOException e) {
-        acquireStatuses.put(dbName, new AcquireStatus(AcquireState.FAILED, System.currentTimeMillis(), e.getMessage()));
+        if (isNew)
+          acquireStatuses.put(dbName, new AcquireStatus(AcquireState.FAILED, System.currentTimeMillis(), e.getMessage()));
         throw e;
       }
     }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -153,6 +153,15 @@ public class ArcadeStateMachine extends BaseStateMachine {
    */
   private final ConcurrentHashMap<String, AcquireStatus> acquireStatuses = new ConcurrentHashMap<>();
 
+  // Consecutive acquire/refresh failures per database (issue #4727). After ACQUIRE_GIVE_UP_AFTER consecutive
+  // failures, that database stops failing the overall install so Ratis no longer re-triggers InstallSnapshot in a
+  // tight loop - which would otherwise re-download every healthy database on this follower each pass just because
+  // one database's snapshot opens on the leader but persistently fails validation here. The database is left
+  // FAILED (surfaced in cluster status) and retried on the next natural InstallSnapshot; the counter resets on
+  // any success.
+  private final ConcurrentHashMap<String, Integer> acquireFailureCounts = new ConcurrentHashMap<>();
+  private static final int                          ACQUIRE_GIVE_UP_AFTER = 3;
+
   public enum AcquireState {
     /** A full-snapshot pull of this database is in progress. */
     ACQUIRING,
@@ -753,6 +762,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
     // LEADER_MISSING database later dropped via DROP_DATABASE_ENTRY). Otherwise the leader-missing alert would
     // stay raised for a database that no longer exists anywhere this node knows about.
     acquireStatuses.keySet().removeIf(name -> !localDbNames.contains(name) && !leaderDbNames.contains(name));
+    acquireFailureCounts.keySet().removeIf(name -> !localDbNames.contains(name) && !leaderDbNames.contains(name));
 
     final ReconcilePlan plan = classifyReconcile(leaderDbNames, localDbNames);
 
@@ -774,12 +784,17 @@ public class ArcadeStateMachine extends BaseStateMachine {
         });
 
     // acquireStatuses records only genuine acquisitions, so operators can tell a true pull from a routine refresh.
-    for (final String dbName : outcome.acquired())
+    // A success also resets the consecutive-failure counter for that database.
+    for (final String dbName : outcome.acquired()) {
       acquireStatuses.put(dbName, new AcquireStatus(AcquireState.ACQUIRED, System.currentTimeMillis(), null));
+      acquireFailureCounts.remove(dbName);
+    }
     // A refreshed database is one the leader holds, so clear any stale LEADER_MISSING/FAILED status left from a
     // prior pass (the resync / leadership-transfer recovery flow this PR documents).
-    for (final String dbName : outcome.refreshed())
+    for (final String dbName : outcome.refreshed()) {
       acquireStatuses.remove(dbName);
+      acquireFailureCounts.remove(dbName);
+    }
     for (final Map.Entry<String, String> e : outcome.acquireFailures().entrySet())
       acquireStatuses.put(e.getKey(), new AcquireStatus(AcquireState.FAILED, System.currentTimeMillis(), e.getValue()));
     for (final Map.Entry<String, String> e : outcome.refreshFailures().entrySet())
@@ -795,12 +810,36 @@ public class ArcadeStateMachine extends BaseStateMachine {
           dbName, dbName);
     }
 
-    // Fail the overall install if any database failed, so Ratis re-triggers it; the healthy databases were still
-    // refreshed/acquired above and are not blocked by the failing one.
-    final int failed = outcome.acquireFailures().size() + outcome.refreshFailures().size();
-    if (failed > 0)
-      throw new IOException("Reconcile from leader completed with " + failed + " failed database(s): "
+    // Decide whether to fail the overall install (so Ratis re-triggers it). A failure is "still worth retrying"
+    // only until it has failed ACQUIRE_GIVE_UP_AFTER times in a row: past that, a persistently bad database stops
+    // forcing the retry, so it no longer re-downloads every healthy database on this follower in a tight loop. It
+    // is left FAILED (surfaced to operators) and retried on the next natural InstallSnapshot.
+    boolean retryWorthwhile = false;
+    for (final String dbName : outcome.acquireFailures().keySet())
+      retryWorthwhile |= bumpFailureAndShouldRetry(dbName);
+    for (final String dbName : outcome.refreshFailures().keySet())
+      retryWorthwhile |= bumpFailureAndShouldRetry(dbName);
+
+    if (retryWorthwhile)
+      throw new IOException("Reconcile from leader had transient database failure(s); will retry: "
           + outcome.acquireFailures() + outcome.refreshFailures());
+  }
+
+  /**
+   * Increments the consecutive-failure counter for a database and returns whether it is still within the retry
+   * budget ({@link #ACQUIRE_GIVE_UP_AFTER}). Once exceeded, logs once and returns false so the caller stops
+   * forcing Ratis to re-trigger the whole install for this one database.
+   */
+  private boolean bumpFailureAndShouldRetry(final String dbName) {
+    final int count = acquireFailureCounts.merge(dbName, 1, Integer::sum);
+    if (count < ACQUIRE_GIVE_UP_AFTER)
+      return true;
+    if (count == ACQUIRE_GIVE_UP_AFTER)
+      LogManager.instance().log(this, Level.SEVERE,
+          "Database '%s' failed to acquire/refresh %d times in a row; leaving it FAILED and no longer re-triggering "
+              + "the snapshot install for it (it will be retried on the next install). Check the leader's copy.",
+          dbName, count);
+    return false;
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -633,6 +633,14 @@ public class ArcadeStateMachine extends BaseStateMachine {
     try {
       final long timeoutMs = server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_BOOTSTRAP_TIMEOUT_MS);
       leaderDbs = LeaderDatabaseQuery.fetch(leaderHttpAddr, clusterToken, timeoutMs);
+    } catch (final InterruptedException e) {
+      // Preserve the interrupt so the pool/executor can observe it and shut down cleanly.
+      Thread.currentThread().interrupt();
+      LogManager.instance().log(this, Level.WARNING,
+          "Interrupted while listing the leader's databases for auto-acquire; refreshing only the databases "
+              + "already present locally.");
+      refreshExistingDatabases(leaderHttpAddr, leaderHttpsAddr, clusterToken);
+      return;
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.WARNING,
           "Could not list the leader's databases for auto-acquire (%s); refreshing only the databases already "
@@ -644,6 +652,12 @@ public class ArcadeStateMachine extends BaseStateMachine {
     final Set<String> leaderDbNames = new HashSet<>();
     for (final LeaderDatabaseQuery.DatabaseInfo info : leaderDbs)
       leaderDbNames.add(info.name());
+
+    // Prune stale acquisition statuses for databases that are no longer on this node (e.g. a previously
+    // LEADER_MISSING database that was later dropped via DROP_DATABASE_ENTRY, or one redistributed after a
+    // leadership transfer). Otherwise the leader-missing cluster alert would stay raised for a database that
+    // no longer exists locally.
+    acquireStatuses.keySet().removeIf(name -> !server.existsDatabase(name) && !leaderDbNames.contains(name));
 
     // Install every database the leader holds: refresh the ones we already have, acquire the rest.
     for (final String dbName : leaderDbNames) {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -234,20 +234,23 @@ public class ArcadeStateMachine extends BaseStateMachine {
     final List<String> refreshed = new ArrayList<>();
     final Map<String, String> refreshFailures = new LinkedHashMap<>();
 
+    // Catch Exception (not just the declared IOException): an unchecked failure escaping one database's
+    // acquire/refresh must be isolated too, otherwise it would abort the whole reconcile and defeat the
+    // no-starvation guarantee that is the entire point of this method.
     for (final String db : plan.toAcquire()) {
       try {
         acquireOp.run(db);
         acquired.add(db);
-      } catch (final IOException e) {
-        acquireFailures.put(db, e.getMessage());
+      } catch (final Exception e) {
+        acquireFailures.put(db, String.valueOf(e.getMessage()));
       }
     }
     for (final String db : plan.toRefresh()) {
       try {
         refreshOp.run(db);
         refreshed.add(db);
-      } catch (final IOException e) {
-        refreshFailures.put(db, e.getMessage());
+      } catch (final Exception e) {
+        refreshFailures.put(db, String.valueOf(e.getMessage()));
       }
     }
     return new ReconcileOutcome(acquired, acquireFailures, refreshed, refreshFailures);
@@ -703,6 +706,12 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * <b>Additive only:</b> a database present locally but absent on the leader is never dropped (that keeps a real
    * {@code DROP_DATABASE_ENTRY} distinguishable from "the leader never had it"); it is flagged
    * {@link AcquireState#LEADER_MISSING} for operator attention.
+   * <p>
+   * <b>Documented boundary:</b> auto-acquire runs only on the follower InstallSnapshot path, so a brand-new empty
+   * node that became leader without first receiving a snapshot would not acquire anything. Raft's up-to-date-log
+   * election rule prevents an empty-log node from winning over peers that hold committed data, and the
+   * {@link AcquireState#LEADER_MISSING} alert plus the leadership-transfer flow cover the #4522 redistribution
+   * edge, so this boundary is not reachable in normal operation.
    *
    * @throws IOException if a database install fails (so the caller leaves the Ratis snapshot install incomplete
    *                     and Ratis re-triggers it; installs are idempotent).
@@ -787,8 +796,8 @@ public class ArcadeStateMachine extends BaseStateMachine {
     // re-triggers it. Extracted to a package-private method so these transitions are unit-testable without a live
     // cluster (the InstallSnapshot path is not deterministically reachable in-process - see SnapshotAcquireNewDatabaseIT).
     if (applyReconcileOutcome(plan, outcome))
-      throw new IOException("Reconcile from leader had transient database failure(s); will retry: "
-          + outcome.acquireFailures() + outcome.refreshFailures());
+      throw new IOException(String.format("Reconcile from leader had database failure(s); will retry (acquire=%s, refresh=%s)",
+          outcome.acquireFailures(), outcome.refreshFailures()));
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -611,7 +611,9 @@ public class ArcadeStateMachine extends BaseStateMachine {
       // A LEADER_MISSING flag means "the leader lacks a database this node holds" - meaningless once this node
       // IS the leader. Clear those stale entries so the leader-missing alert does not linger on the new leader
       // (issue #4727); they would otherwise survive because the leader never runs the follower reconcile path.
+      // Also drop the parallel acquire failure counters, which are likewise a follower-side reconcile concern.
       acquireStatuses.values().removeIf(s -> s.state() == AcquireState.LEADER_MISSING);
+      acquireFailureCounts.clear();
 
       // Issue #4147: drive offline cluster bootstrap if conditions match (commit index still 0,
       // arcadedb.ha.bootstrapFromLocalDatabase=true). Runs on a background thread to keep the

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterAlerts.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterAlerts.java
@@ -92,8 +92,12 @@ public class ClusterAlerts {
    * leadership to a node that holds it (or resync) to redistribute it.
    */
   static void checkLeaderMissingDatabases(final ArcadeStateMachine stateMachine, final JSONArray alerts) {
-    final List<String> missing = stateMachine.getDatabasesWithAcquireState(ArcadeStateMachine.AcquireState.LEADER_MISSING);
-    if (missing.isEmpty())
+    addLeaderMissingAlert(stateMachine.getDatabasesWithAcquireState(ArcadeStateMachine.AcquireState.LEADER_MISSING), alerts);
+  }
+
+  /** Pure alert builder (package-private for unit testing): appends the leader-missing alert iff {@code missing} is non-empty. */
+  static void addLeaderMissingAlert(final List<String> missing, final JSONArray alerts) {
+    if (missing == null || missing.isEmpty())
       return;
 
     final JSONArray names = new JSONArray();

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterAlerts.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterAlerts.java
@@ -70,9 +70,46 @@ public class ClusterAlerts {
    * Databases that are not in memory are skipped: a status poll must never trigger a database open.
    */
   public static JSONArray scan(final ArcadeDBServer server) {
+    return scan(server, null);
+  }
+
+  /**
+   * Scan overload that also includes HA auto-acquisition alerts when a {@link ArcadeStateMachine} is available
+   * (issue #4727). Pass {@code null} for the non-HA / pre-start path.
+   */
+  public static JSONArray scan(final ArcadeDBServer server, final ArcadeStateMachine stateMachine) {
     final JSONArray alerts = new JSONArray();
     checkSingleBucketTypes(server, alerts);
+    if (stateMachine != null)
+      checkLeaderMissingDatabases(stateMachine, alerts);
     return alerts;
+  }
+
+  /**
+   * Flags databases this node holds that the leader does not (issue #4727). This is the aggravating factor from
+   * #4522: a node that lacks a database can be elected leader, leaving the only authoritative copies on followers
+   * where auto-acquire cannot reach them. The database is deliberately NOT dropped; the operator must transfer
+   * leadership to a node that holds it (or resync) to redistribute it.
+   */
+  static void checkLeaderMissingDatabases(final ArcadeStateMachine stateMachine, final JSONArray alerts) {
+    final List<String> missing = stateMachine.getDatabasesWithAcquireState(ArcadeStateMachine.AcquireState.LEADER_MISSING);
+    if (missing.isEmpty())
+      return;
+
+    final JSONArray names = new JSONArray();
+    for (final String name : missing)
+      names.put(name);
+
+    alerts.put(new JSONObject()
+        .put("id", "leader-missing-databases")
+        .put("severity", SEVERITY_WARNING)
+        .put("title", "This node holds database(s) the leader does not")
+        .put("message", "This node holds " + missing.size() + " database(s) that the current leader does not have. "
+            + "They were kept (never dropped), but the cluster cannot auto-replicate them to other nodes while the "
+            + "leader lacks them, so new/empty nodes will not receive them.")
+        .put("recommendation", "Transfer leadership to a node that holds these databases (POST /api/v1/cluster/leader), "
+            + "then resync the nodes that are missing them (POST /api/v1/cluster/resync/{database}).")
+        .put("details", new JSONObject().put("databases", names)));
   }
 
   static void checkSingleBucketTypes(final ArcadeDBServer server, final JSONArray alerts) {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterAlerts.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ClusterAlerts.java
@@ -80,8 +80,10 @@ public class ClusterAlerts {
   public static JSONArray scan(final ArcadeDBServer server, final ArcadeStateMachine stateMachine) {
     final JSONArray alerts = new JSONArray();
     checkSingleBucketTypes(server, alerts);
-    if (stateMachine != null)
+    if (stateMachine != null) {
       checkLeaderMissingDatabases(stateMachine, alerts);
+      checkFailedAcquireDatabases(stateMachine, alerts);
+    }
     return alerts;
   }
 
@@ -93,6 +95,37 @@ public class ClusterAlerts {
    */
   static void checkLeaderMissingDatabases(final ArcadeStateMachine stateMachine, final JSONArray alerts) {
     addLeaderMissingAlert(stateMachine.getDatabasesWithAcquireState(ArcadeStateMachine.AcquireState.LEADER_MISSING), alerts);
+  }
+
+  /**
+   * Flags databases left in the FAILED acquisition state (issue #4727). After the acquire give-up threshold a
+   * database stops forcing the snapshot install to re-run, so it is only retried on the next natural
+   * InstallSnapshot - which Ratis avoids in favor of log replay. Such a database can therefore stay absent
+   * indefinitely even after the leader's copy is fixed, so surface it for an explicit operator resync.
+   */
+  static void checkFailedAcquireDatabases(final ArcadeStateMachine stateMachine, final JSONArray alerts) {
+    addFailedAcquireAlert(stateMachine.getDatabasesWithAcquireState(ArcadeStateMachine.AcquireState.FAILED), alerts);
+  }
+
+  /** Pure alert builder (package-private for unit testing): appends the failed-acquire alert iff {@code failed} is non-empty. */
+  static void addFailedAcquireAlert(final List<String> failed, final JSONArray alerts) {
+    if (failed == null || failed.isEmpty())
+      return;
+
+    final JSONArray names = new JSONArray();
+    for (final String name : failed)
+      names.put(name);
+
+    alerts.put(new JSONObject()
+        .put("id", "failed-acquire-databases")
+        .put("severity", SEVERITY_WARNING)
+        .put("title", "Database(s) failed to acquire from the leader")
+        .put("message", failed.size() + " database(s) could not be acquired/refreshed from the leader after repeated "
+            + "attempts and are not present on this node. They will only be retried on the next snapshot install, so "
+            + "they may stay absent even after the leader's copy is healthy.")
+        .put("recommendation", "Once the leader's copy is healthy, force a fresh download on this node "
+            + "(POST /api/v1/cluster/resync/{database}). Check the logs for the underlying acquisition error.")
+        .put("details", new JSONObject().put("databases", names)));
   }
 
   /** Pure alert builder (package-private for unit testing): appends the leader-missing alert iff {@code missing} is non-empty. */

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/GetClusterHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/GetClusterHandler.java
@@ -152,9 +152,12 @@ public class GetClusterHandler extends AbstractServerHttpHandler {
    * missing:[...]}]}}. A peer that cannot be reached is reported in {@code unreachable} and omitted from the
    * present/missing accounting so a transient blip is not mistaken for a dropped database.
    * <p>
-   * The fan-out is sequential on the Undertow worker thread, so worst-case latency is
-   * {@code peers x HA_BOOTSTRAP_TIMEOUT_MS}. This is acceptable because it is opt-in ({@code ?presence=true}) and
-   * leader-only, not part of the cheap auto-poll; a parallel fan-out would bound it for very large clusters.
+   * The fan-out is sequential on the Undertow worker thread, with a short per-peer timeout
+   * ({@link #PRESENCE_QUERY_TIMEOUT_MS}), so worst-case latency is {@code peers x 5s}. This is acceptable because
+   * it is opt-in ({@code ?presence=true}) and leader-only, not part of the cheap auto-poll; a parallel fan-out
+   * would bound it for very large clusters. If parallelized later, honor the CLAUDE.md concurrency rule - do not
+   * use {@code ForkJoinPool.commonPool()} for server-internal work; use a dedicated bounded pool wired into
+   * {@code PoolMetrics}.
    * Note the queried peer's bootstrap-state handler may open a closed database to fingerprint it, so this path -
    * unlike the no-open cheap poll - can trigger a database load on the remote peer.
    */

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/GetClusterHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/GetClusterHandler.java
@@ -50,6 +50,9 @@ import java.util.logging.Level;
  */
 public class GetClusterHandler extends AbstractServerHttpHandler {
 
+  /** Per-peer timeout for the opt-in presence fan-out; kept short so a hung peer cannot block the worker thread. */
+  private static final long PRESENCE_QUERY_TIMEOUT_MS = 5_000L;
+
   private final RaftHAPlugin plugin;
 
   public GetClusterHandler(final HttpServer httpServer, final RaftHAPlugin plugin) {
@@ -158,7 +161,11 @@ public class GetClusterHandler extends AbstractServerHttpHandler {
   private JSONObject buildPresenceMatrix(final RaftHAServer raftHAServer, final RaftPeerId localPeerId) {
     final ArcadeDBServer server = httpServer.getServer();
     final String clusterToken = raftHAServer.getClusterToken();
-    final long timeoutMs = server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_BOOTSTRAP_TIMEOUT_MS);
+    // Use a short per-peer timeout (not HA_BOOTSTRAP_TIMEOUT_MS, which defaults to 120s): this fan-out runs on an
+    // Undertow worker thread, and a peer that accepts the connection but then hangs would otherwise tie up the
+    // worker for the full bootstrap budget per peer. A few seconds is plenty for a peer to list its databases; a
+    // slower peer is simply reported unreachable in the matrix.
+    final long timeoutMs = PRESENCE_QUERY_TIMEOUT_MS;
 
     // Preserve a stable node order; collect each reachable peer's database set.
     final Set<String> nodes = new LinkedHashSet<>();

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/GetClusterHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/GetClusterHandler.java
@@ -19,8 +19,10 @@
 package com.arcadedb.server.ha.raft;
 
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.http.handler.AbstractServerHttpHandler;
 import com.arcadedb.server.http.handler.ExecutionResponse;
@@ -28,6 +30,15 @@ import com.arcadedb.server.security.ServerSecurityUser;
 import io.undertow.server.HttpServerExchange;
 import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
+
+import java.util.Deque;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.logging.Level;
 
 /**
  * Returns Raft cluster status: local peer, leader, and peer list with roles.
@@ -100,14 +111,109 @@ public class GetClusterHandler extends AbstractServerHttpHandler {
         dbJson.put("bootstrapLastTxId", baseline.lastTxId());
         dbJson.put("bootstrapFingerprint", baseline.fingerprint());
       }
+      // Per-database auto-acquisition status (issue #4727), when this node has reconciled against a leader.
+      final ArcadeStateMachine.AcquireStatus acquire = stateMachine.getAcquireStatus(dbName);
+      if (acquire != null) {
+        dbJson.put("acquireStatus", acquire.state().name());
+        dbJson.put("acquireTimestamp", acquire.timestamp());
+        if (acquire.error() != null)
+          dbJson.put("acquireError", acquire.error());
+      }
       databases.put(dbJson);
     }
     response.put("databases", databases);
 
+    // Optional per-database x per-node presence matrix (issue #4727), gated behind ?presence=true so the
+    // cheap auto-poll never triggers the peer fan-out. Built on the leader; followers return only their own.
+    if (isLeader && isPresenceRequested(exchange))
+      response.put("databasePresence", buildPresenceMatrix(raftHAServer, localPeerId));
+
     // Cluster-level health alerts (e.g. single-bucket types that serialize concurrent writes on the
     // leader). Surfaced in Studio's HA panel so operators see actionable warnings without log-grepping.
-    response.put("alerts", ClusterAlerts.scan(httpServer.getServer()));
+    response.put("alerts", ClusterAlerts.scan(httpServer.getServer(), stateMachine));
 
     return new ExecutionResponse(200, response.toString());
+  }
+
+  private static boolean isPresenceRequested(final HttpServerExchange exchange) {
+    final Deque<String> values = exchange.getQueryParameters().get("presence");
+    if (values == null || values.isEmpty())
+      return false;
+    final String v = values.getFirst();
+    return v == null || v.isEmpty() || "true".equalsIgnoreCase(v) || "1".equals(v);
+  }
+
+  /**
+   * Builds a per-database x per-node presence matrix (issue #4727) by fanning out the bootstrap-state RPC to
+   * every peer. Returns {@code {nodes:[peerId...], unreachable:[peerId...], databases:[{name, present:[...],
+   * missing:[...]}]}}. A peer that cannot be reached is reported in {@code unreachable} and omitted from the
+   * present/missing accounting so a transient blip is not mistaken for a dropped database.
+   */
+  private JSONObject buildPresenceMatrix(final RaftHAServer raftHAServer, final RaftPeerId localPeerId) {
+    final ArcadeDBServer server = httpServer.getServer();
+    final String clusterToken = raftHAServer.getClusterToken();
+    final long timeoutMs = server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_BOOTSTRAP_TIMEOUT_MS);
+
+    // Preserve a stable node order; collect each reachable peer's database set.
+    final Set<String> nodes = new LinkedHashSet<>();
+    final Set<String> unreachable = new TreeSet<>();
+    final Map<String, Set<String>> dbsByNode = new TreeMap<>();
+    final Set<String> allDbs = new TreeSet<>();
+
+    for (final RaftPeer peer : raftHAServer.getRaftGroup().getPeers()) {
+      final RaftPeerId peerId = peer.getId();
+      final String peerIdStr = peerId.toString();
+      nodes.add(peerIdStr);
+
+      final Set<String> dbNames = new TreeSet<>();
+      if (peerId.equals(localPeerId)) {
+        for (final String dbName : server.getDatabaseNames())
+          if (!dbName.startsWith(ArcadeDBServer.RESERVED_DATABASE_PREFIX))
+            dbNames.add(dbName);
+      } else {
+        final String httpAddr = raftHAServer.getPeerHttpAddress(peerId);
+        if (httpAddr == null) {
+          unreachable.add(peerIdStr);
+          continue;
+        }
+        try {
+          final List<LeaderDatabaseQuery.DatabaseInfo> infos = LeaderDatabaseQuery.fetch(httpAddr, clusterToken, timeoutMs);
+          for (final LeaderDatabaseQuery.DatabaseInfo info : infos)
+            dbNames.add(info.name());
+        } catch (final Exception e) {
+          LogManager.instance().log(this, Level.WARNING,
+              "Presence matrix: could not query peer '%s' (%s)", peerIdStr, e.getMessage());
+          unreachable.add(peerIdStr);
+          continue;
+        }
+      }
+      dbsByNode.put(peerIdStr, dbNames);
+      allDbs.addAll(dbNames);
+    }
+
+    final JSONArray databases = new JSONArray();
+    for (final String dbName : allDbs) {
+      final JSONArray present = new JSONArray();
+      final JSONArray missing = new JSONArray();
+      for (final Map.Entry<String, Set<String>> e : dbsByNode.entrySet()) {
+        if (e.getValue().contains(dbName))
+          present.put(e.getKey());
+        else
+          missing.put(e.getKey());
+      }
+      databases.put(new JSONObject().put("name", dbName).put("present", present).put("missing", missing));
+    }
+
+    final JSONArray nodesArray = new JSONArray();
+    for (final String n : nodes)
+      nodesArray.put(n);
+    final JSONArray unreachableArray = new JSONArray();
+    for (final String n : unreachable)
+      unreachableArray.put(n);
+
+    return new JSONObject()
+        .put("nodes", nodesArray)
+        .put("unreachable", unreachableArray)
+        .put("databases", databases);
   }
 }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/GetClusterHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/GetClusterHandler.java
@@ -180,6 +180,12 @@ public class GetClusterHandler extends AbstractServerHttpHandler {
           final List<LeaderDatabaseQuery.DatabaseInfo> infos = LeaderDatabaseQuery.fetch(httpAddr, clusterToken, timeoutMs);
           for (final LeaderDatabaseQuery.DatabaseInfo info : infos)
             dbNames.add(info.name());
+        } catch (final InterruptedException e) {
+          // Preserve the interrupt so the worker thread can be shut down cleanly.
+          Thread.currentThread().interrupt();
+          LogManager.instance().log(this, Level.WARNING, "Presence matrix query interrupted for peer '%s'", peerIdStr);
+          unreachable.add(peerIdStr);
+          continue;
         } catch (final Exception e) {
           LogManager.instance().log(this, Level.WARNING,
               "Presence matrix: could not query peer '%s' (%s)", peerIdStr, e.getMessage());

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/GetClusterHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/GetClusterHandler.java
@@ -148,6 +148,12 @@ public class GetClusterHandler extends AbstractServerHttpHandler {
    * every peer. Returns {@code {nodes:[peerId...], unreachable:[peerId...], databases:[{name, present:[...],
    * missing:[...]}]}}. A peer that cannot be reached is reported in {@code unreachable} and omitted from the
    * present/missing accounting so a transient blip is not mistaken for a dropped database.
+   * <p>
+   * The fan-out is sequential on the Undertow worker thread, so worst-case latency is
+   * {@code peers x HA_BOOTSTRAP_TIMEOUT_MS}. This is acceptable because it is opt-in ({@code ?presence=true}) and
+   * leader-only, not part of the cheap auto-poll; a parallel fan-out would bound it for very large clusters.
+   * Note the queried peer's bootstrap-state handler may open a closed database to fingerprint it, so this path -
+   * unlike the no-open cheap poll - can trigger a database load on the remote peer.
    */
   private JSONObject buildPresenceMatrix(final RaftHAServer raftHAServer, final RaftPeerId localPeerId) {
     final ArcadeDBServer server = httpServer.getServer();
@@ -176,8 +182,10 @@ public class GetClusterHandler extends AbstractServerHttpHandler {
           unreachable.add(peerIdStr);
           continue;
         }
+        final String httpsAddr = raftHAServer.getPeerHttpsAddress(peerId);
         try {
-          final List<LeaderDatabaseQuery.DatabaseInfo> infos = LeaderDatabaseQuery.fetch(httpAddr, clusterToken, timeoutMs);
+          final List<LeaderDatabaseQuery.DatabaseInfo> infos =
+              LeaderDatabaseQuery.fetch(httpAddr, httpsAddr, clusterToken, timeoutMs, server);
           for (final LeaderDatabaseQuery.DatabaseInfo info : infos)
             dbNames.add(info.name());
         } catch (final InterruptedException e) {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/LeaderDatabaseQuery.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/LeaderDatabaseQuery.java
@@ -18,8 +18,11 @@
  */
 package com.arcadedb.server.ha.raft;
 
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
 
 import java.io.IOException;
 import java.net.URI;
@@ -29,12 +32,20 @@ import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
 
 /**
  * Lists the (user) databases a peer holds, by calling its {@code POST /api/v1/cluster/bootstrap-state} RPC
  * (issue #4727). Reuses the same cluster-token + forwarded-user authentication as every other peer-to-peer
  * cluster RPC (see {@link PostBootstrapStateHandler}). The handler already excludes reserved internal
  * databases (names starting with {@code .}), so the returned set is the operator-visible database list.
+ * <p>
+ * <b>Transport:</b> mirrors {@link SnapshotInstaller#downloadWithRetry} - when {@code arcadedb.ssl.enabled} is
+ * set it prefers the peer's HTTPS endpoint and trusts the cluster keystore via
+ * {@link SnapshotInstaller#buildSSLContext(ArcadeDBServer)}, falling back to plain HTTP (with a one-time warning)
+ * only when no HTTPS address is known. This keeps the feature working on SSL-only clusters, where the plain-HTTP
+ * listener is typically disabled - exactly the StatefulSet/empty-node deployments this feature targets (#4470).
  * <p>
  * Used by:
  * <ul>
@@ -50,38 +61,83 @@ public final class LeaderDatabaseQuery {
   public record DatabaseInfo(String name, long lastTxId) {
   }
 
+  /** The chosen endpoint and scheme for a query; package-private so scheme selection is unit-testable. */
+  record Endpoint(String url, boolean https) {
+  }
+
   private static final HttpClient HTTP = HttpClient.newBuilder()
       .connectTimeout(Duration.ofSeconds(5))
       .build();
+
+  /** One-time warning that SSL is enabled but the query fell back to plain HTTP for lack of an HTTPS address. */
+  private static final AtomicBoolean PLAIN_HTTP_FALLBACK_WARNED = new AtomicBoolean(false);
 
   private LeaderDatabaseQuery() {
   }
 
   /**
-   * Synchronously queries {@code httpAddr} for the list of databases it holds.
+   * Synchronously queries a peer for the list of databases it holds.
    *
-   * @param httpAddr     the peer HTTP address ({@code host:port}).
+   * @param httpAddr     the peer plain-HTTP address ({@code host:port}).
+   * @param httpsAddr    the peer HTTPS address ({@code host:port}), or {@code null} when none is known. Preferred
+   *                     when SSL is enabled.
    * @param clusterToken the inter-node cluster token, may be {@code null}/blank if not configured.
    * @param timeoutMs    per-request timeout in milliseconds.
+   * @param server       the local server, used to read {@code arcadedb.ssl.enabled} and build the trust context.
    * @return the databases reported by the peer (never {@code null}).
    * @throws IOException          on transport error or a non-200 response.
    * @throws InterruptedException if the calling thread is interrupted while waiting.
    */
-  public static List<DatabaseInfo> fetch(final String httpAddr, final String clusterToken, final long timeoutMs)
-      throws IOException, InterruptedException {
-    final String url = "http://" + httpAddr + "/api/v1/cluster/bootstrap-state";
+  public static List<DatabaseInfo> fetch(final String httpAddr, final String httpsAddr, final String clusterToken,
+      final long timeoutMs, final ArcadeDBServer server) throws IOException, InterruptedException {
+
+    final boolean useSSL = server != null && server.getConfiguration().getValueAsBoolean(GlobalConfiguration.NETWORK_USE_SSL);
+    final Endpoint endpoint = chooseEndpoint(httpAddr, httpsAddr, useSSL);
+    if (endpoint == null)
+      throw new IOException("no peer address available for bootstrap-state query");
+    if (useSSL && !endpoint.https() && PLAIN_HTTP_FALLBACK_WARNED.compareAndSet(false, true))
+      LogManager.instance().log(LeaderDatabaseQuery.class, Level.WARNING,
+          "SSL is enabled but no HTTPS address is known for a peer; querying its database list over plain HTTP.");
+
     final HttpRequest.Builder builder = HttpRequest.newBuilder()
-        .uri(URI.create(url))
+        .uri(URI.create(endpoint.url()))
         .timeout(Duration.ofMillis(timeoutMs))
         .header("Content-Type", "application/json")
         .POST(HttpRequest.BodyPublishers.ofString("{}"));
     if (clusterToken != null && !clusterToken.isBlank())
       builder.header("X-ArcadeDB-Cluster-Token", clusterToken);
     builder.header("X-ArcadeDB-Forwarded-User", RaftHAServer.FORWARDED_ROOT_USER);
+    final HttpRequest request = builder.build();
 
-    final HttpResponse<String> resp = HTTP.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+    if (endpoint.https()) {
+      // A dedicated client carrying the cluster trust context. HttpClient is AutoCloseable on Java 21, so the
+      // selector thread is released after the (rare, opt-in) query rather than leaked.
+      try (final HttpClient client = HttpClient.newBuilder()
+          .connectTimeout(Duration.ofSeconds(5))
+          .sslContext(SnapshotInstaller.buildSSLContext(server))
+          .build()) {
+        return parse(client.send(request, HttpResponse.BodyHandlers.ofString()), endpoint.url());
+      }
+    }
+    return parse(HTTP.send(request, HttpResponse.BodyHandlers.ofString()), endpoint.url());
+  }
+
+  /**
+   * Picks the endpoint URL and scheme. Prefers HTTPS when SSL is enabled and an HTTPS address is available;
+   * otherwise uses plain HTTP. Returns {@code null} when no usable address is provided. Package-private and pure
+   * for unit testing.
+   */
+  static Endpoint chooseEndpoint(final String httpAddr, final String httpsAddr, final boolean useSSL) {
+    if (useSSL && httpsAddr != null)
+      return new Endpoint("https://" + httpsAddr + "/api/v1/cluster/bootstrap-state", true);
+    if (httpAddr != null)
+      return new Endpoint("http://" + httpAddr + "/api/v1/cluster/bootstrap-state", false);
+    return null;
+  }
+
+  private static List<DatabaseInfo> parse(final HttpResponse<String> resp, final String url) throws IOException {
     if (resp.statusCode() != 200)
-      throw new IOException("bootstrap-state query to " + httpAddr + " returned HTTP " + resp.statusCode());
+      throw new IOException("bootstrap-state query to " + url + " returned HTTP " + resp.statusCode());
 
     final JSONObject json = new JSONObject(resp.body());
     final JSONArray dbs = json.getJSONArray("databases");

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/LeaderDatabaseQuery.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/LeaderDatabaseQuery.java
@@ -111,7 +111,9 @@ public final class LeaderDatabaseQuery {
 
     if (endpoint.https()) {
       // A dedicated client carrying the cluster trust context. HttpClient is AutoCloseable on Java 21, so the
-      // selector thread is released after the (rare, opt-in) query rather than leaked.
+      // selector thread is released after the (rare, opt-in) query rather than leaked. Building one per call is
+      // fine for these infrequent paths (reconcile / opt-in presence); if this ever moves onto a hot path, cache
+      // an SSL-configured client instead.
       try (final HttpClient client = HttpClient.newBuilder()
           .connectTimeout(Duration.ofSeconds(5))
           .sslContext(SnapshotInstaller.buildSSLContext(server))

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/LeaderDatabaseQuery.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/LeaderDatabaseQuery.java
@@ -77,7 +77,7 @@ public final class LeaderDatabaseQuery {
         .POST(HttpRequest.BodyPublishers.ofString("{}"));
     if (clusterToken != null && !clusterToken.isBlank())
       builder.header("X-ArcadeDB-Cluster-Token", clusterToken);
-    builder.header("X-ArcadeDB-Forwarded-User", "root");
+    builder.header("X-ArcadeDB-Forwarded-User", RaftHAServer.FORWARDED_ROOT_USER);
 
     final HttpResponse<String> resp = HTTP.send(builder.build(), HttpResponse.BodyHandlers.ofString());
     if (resp.statusCode() != 200)

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/LeaderDatabaseQuery.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/LeaderDatabaseQuery.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Lists the (user) databases a peer holds, by calling its {@code POST /api/v1/cluster/bootstrap-state} RPC
+ * (issue #4727). Reuses the same cluster-token + forwarded-user authentication as every other peer-to-peer
+ * cluster RPC (see {@link PostBootstrapStateHandler}). The handler already excludes reserved internal
+ * databases (names starting with {@code .}), so the returned set is the operator-visible database list.
+ * <p>
+ * Used by:
+ * <ul>
+ *   <li>the join-time reconcile in {@code ArcadeStateMachine.notifyInstallSnapshotFromLeader} to learn which
+ *       databases the leader holds and pull the ones this node is missing;</li>
+ *   <li>the optional presence fan-out in {@code GetClusterHandler} to build the Studio per-node/per-database
+ *       presence matrix.</li>
+ * </ul>
+ */
+public final class LeaderDatabaseQuery {
+
+  /** A single database entry reported by a peer. {@code lastTxId} is {@code -1} when unknown/unreadable. */
+  public record DatabaseInfo(String name, long lastTxId) {
+  }
+
+  private static final HttpClient HTTP = HttpClient.newBuilder()
+      .connectTimeout(Duration.ofSeconds(5))
+      .build();
+
+  private LeaderDatabaseQuery() {
+  }
+
+  /**
+   * Synchronously queries {@code httpAddr} for the list of databases it holds.
+   *
+   * @param httpAddr     the peer HTTP address ({@code host:port}).
+   * @param clusterToken the inter-node cluster token, may be {@code null}/blank if not configured.
+   * @param timeoutMs    per-request timeout in milliseconds.
+   * @return the databases reported by the peer (never {@code null}).
+   * @throws IOException          on transport error or a non-200 response.
+   * @throws InterruptedException if the calling thread is interrupted while waiting.
+   */
+  public static List<DatabaseInfo> fetch(final String httpAddr, final String clusterToken, final long timeoutMs)
+      throws IOException, InterruptedException {
+    final String url = "http://" + httpAddr + "/api/v1/cluster/bootstrap-state";
+    final HttpRequest.Builder builder = HttpRequest.newBuilder()
+        .uri(URI.create(url))
+        .timeout(Duration.ofMillis(timeoutMs))
+        .header("Content-Type", "application/json")
+        .POST(HttpRequest.BodyPublishers.ofString("{}"));
+    if (clusterToken != null && !clusterToken.isBlank())
+      builder.header("X-ArcadeDB-Cluster-Token", clusterToken);
+    builder.header("X-ArcadeDB-Forwarded-User", "root");
+
+    final HttpResponse<String> resp = HTTP.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+    if (resp.statusCode() != 200)
+      throw new IOException("bootstrap-state query to " + httpAddr + " returned HTTP " + resp.statusCode());
+
+    final JSONObject json = new JSONObject(resp.body());
+    final JSONArray dbs = json.getJSONArray("databases");
+    final List<DatabaseInfo> out = new ArrayList<>(dbs.length());
+    for (int i = 0; i < dbs.length(); i++) {
+      final JSONObject db = dbs.getJSONObject(i);
+      out.add(new DatabaseInfo(db.getString("name"), db.getLong("lastTxId", -1L)));
+    }
+    return out;
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -95,7 +95,9 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   // The forwarded user the leader presents (with the cluster token) for inter-node calls such as the
   // stalled-replica resync. ArcadeDB's bootstrap 'root' user is the cluster-wide superuser; named here
   // so the coupling is visible rather than scattered as a string literal.
-  private static final String FORWARDED_ROOT_USER = "root";
+  // Package-private so other cluster-internal RPC callers (e.g. LeaderDatabaseQuery) reuse the same constant
+  // instead of re-inlining the "root" literal.
+  static final String FORWARDED_ROOT_USER = "root";
 
   private final    ArcadeDBServer          arcadeServer;
   private final    ContextConfiguration    configuration;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
@@ -282,6 +282,11 @@ public final class SnapshotInstaller {
    * If the database materialises locally while we download (e.g. an {@code INSTALL_DATABASE_ENTRY} is replayed
    * concurrently), this falls back to the in-place {@link #install} refresh so the now-registered database still
    * receives the leader's snapshot.
+   * <p>
+   * The leader addresses are taken as {@link Supplier}s for symmetry with {@link #install}, whose retry loop
+   * re-resolves them per attempt. The reconcile caller passes constant suppliers on purpose: an InstallSnapshot is
+   * tied to one specific leader, and if leadership changes mid-download Ratis re-triggers the whole install from
+   * the new leader, so re-resolving within a single call would not help.
    */
   public static void acquireNewDatabase(final String databaseName,
       final Supplier<String> leaderHttpAddrSupplier, final Supplier<String> leaderHttpsAddrSupplier,
@@ -401,6 +406,10 @@ public final class SnapshotInstaller {
    * (not the raw open exception) so callers can treat a corrupt snapshot uniformly with a download failure.
    */
   private static void validateSnapshotOpens(final Path stagingPath) throws IOException {
+    // Safe to open under the reserved staging name and then publish: ArcadeDB derives the database name from the
+    // directory at open time (the staging name is not persisted into the files), and a READ_ONLY open performs no
+    // writes, so it leaves behind no lock/WAL artifact that the atomic rename would carry into the final directory.
+    // The end-to-end acquire IT (SnapshotAcquireNewDatabaseIT) confirms the published database opens cleanly.
     try (final DatabaseFactory factory = new DatabaseFactory(stagingPath.toString());
         final Database db = factory.open(ComponentFile.MODE.READ_ONLY)) {
       // Opening + closing is the validation: it confirms the configuration, schema and component files load.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
@@ -36,6 +36,7 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -74,6 +75,12 @@ public final class SnapshotInstaller {
   static final String SNAPSHOT_BACKUP_DIR    = ".snapshot-backup";
   static final String SNAPSHOT_PENDING_FILE  = ".snapshot-pending";
   static final String SNAPSHOT_COMPLETE_FILE = ".snapshot-complete";
+
+  // Reserved staging directory prefix for acquiring a database the node has NEVER seen (issue #4727).
+  // A new-database acquire downloads into databases/.acquire-<name>/ and publishes with a single atomic
+  // rename to databases/<name>/. The '.' prefix makes it a reserved name (ArcadeDBServer.isReservedDatabaseName),
+  // so the startup scan (ArcadeDBServer.loadDatabases) never tries to open a half-written acquisition.
+  static final String ACQUIRE_STAGING_PREFIX = ".acquire-";
 
   /**
    * Maximum tolerated uncompressed:compressed size ratio per ZIP entry.
@@ -257,6 +264,113 @@ public final class SnapshotInstaller {
   }
 
   /**
+   * Acquires a database the local node has <b>never seen</b> on disk, crash-safely (issue #4727).
+   * <p>
+   * Unlike {@link #install} - which refreshes an <i>existing</i> database in place and can roll back to a
+   * retained {@code .snapshot-backup} - a brand-new acquire has no previous copy. The hazard is the startup
+   * scan: {@code ArcadeDBServer.loadDatabases} opens every non-reserved {@code databases/<name>/} directory
+   * before HA crash recovery runs, so a half-written download left under the final name would be opened as a
+   * corrupt database. To avoid that, the download is staged under a <b>reserved</b> directory
+   * ({@code databases/.acquire-<name>/}, skipped by the boot scan) and published with a single
+   * {@link StandardCopyOption#ATOMIC_MOVE atomic rename}. A crash before the rename leaves only the reserved
+   * staging dir (cleaned on the next startup by {@link #recoverPendingSnapshotSwaps}); a crash after it leaves
+   * a complete, openable database. No partial non-reserved directory can ever exist.
+   * <p>
+   * If the database materialises locally while we download (e.g. an {@code INSTALL_DATABASE_ENTRY} is replayed
+   * concurrently), this falls back to the in-place {@link #install} refresh so the now-registered database still
+   * receives the leader's snapshot.
+   */
+  public static void acquireNewDatabase(final String databaseName,
+      final Supplier<String> leaderHttpAddrSupplier, final Supplier<String> leaderHttpsAddrSupplier,
+      final String clusterToken, final ArcadeDBServer server) throws IOException {
+
+    final Path databasesDir = Path.of(
+        server.getConfiguration().getValueAsString(GlobalConfiguration.SERVER_DATABASE_DIRECTORY))
+        .normalize().toAbsolutePath();
+    final Path dbPath = databasesDir.resolve(databaseName);
+    final Path staging = databasesDir.resolve(ACQUIRE_STAGING_PREFIX + databaseName);
+
+    // Raced: the database already exists locally (created/registered concurrently). Refresh in place instead
+    // of acquiring, so two creators never race on dbPath.
+    if (server.existsDatabase(databaseName)) {
+      install(databaseName, dbPath.toString(), leaderHttpAddrSupplier, leaderHttpsAddrSupplier, clusterToken, server);
+      return;
+    }
+
+    try {
+      // Clean any leftover staging from a previous failed attempt, then create a fresh reserved staging dir.
+      deleteDirectoryIfExists(staging);
+      Files.createDirectories(staging);
+
+      // PHASE 1 - DOWNLOAD into the reserved staging dir. A crash here cannot leave a half-written
+      // databases/<name>/ that the boot scan opens.
+      final int maxRetries = server.getConfiguration().getValueAsInteger(GlobalConfiguration.HA_SNAPSHOT_INSTALL_RETRIES);
+      final long retryBaseMs = server.getConfiguration().getValueAsLong(GlobalConfiguration.HA_SNAPSHOT_INSTALL_RETRY_BASE_MS);
+      try {
+        downloadWithRetry(databaseName, staging, leaderHttpAddrSupplier, leaderHttpsAddrSupplier, clusterToken,
+            maxRetries, retryBaseMs, server);
+      } catch (final IOException e) {
+        deleteDirectoryIfExists(staging);
+        throw e;
+      }
+
+      // Re-check right before publishing: the database may have been created concurrently while we downloaded.
+      if (server.existsDatabase(databaseName)) {
+        deleteDirectoryIfExists(staging);
+        install(databaseName, dbPath.toString(), leaderHttpAddrSupplier, leaderHttpsAddrSupplier, clusterToken, server);
+        return;
+      }
+
+      // A stale, unregistered databases/<name>/ (e.g. from a pre-upgrade crash) would block the rename. The
+      // leader's copy is authoritative for an unseen database, so clear it before publishing.
+      if (Files.exists(dbPath))
+        deleteDirectoryIfExists(dbPath);
+
+      // PHASE 2 - PUBLISH with a single atomic rename.
+      publishStaging(staging, dbPath);
+
+      try {
+        // Register + validate the freshly acquired snapshot by opening it.
+        server.getDatabase(databaseName);
+      } catch (final RuntimeException openEx) {
+        // No previous copy to roll back to: drop the directory and leave the database ABSENT (the safe state).
+        // The next reconcile re-acquires it.
+        LogManager.instance().log(SnapshotInstaller.class, Level.SEVERE,
+            "Acquired snapshot for new database '%s' failed to open; removing it and leaving the database absent "
+                + "(it will be re-acquired on the next reconcile)", openEx, databaseName);
+        try {
+          if (server.existsDatabase(databaseName))
+            ((DatabaseInternal) server.getDatabase(databaseName)).getEmbedded().close();
+        } catch (final Exception ignore) {
+          // best-effort close before removal
+        }
+        server.removeDatabase(databaseName);
+        deleteDirectoryIfExists(dbPath);
+        throw new IOException("Acquired snapshot for new database '" + databaseName + "' failed to open", openEx);
+      }
+
+      HALog.log(SnapshotInstaller.class, HALog.BASIC, "New database '%s' acquired from leader", databaseName);
+    } finally {
+      // Defensive: on success the staging dir was renamed away; on failure it was deleted. This is a no-op
+      // in both cases but guarantees no reserved staging dir is ever leaked.
+      deleteDirectoryIfExists(staging);
+    }
+  }
+
+  /**
+   * Publishes a fully-downloaded acquisition staging directory to its final database directory with a single
+   * atomic rename. Same-filesystem directory rename, so the swap is all-or-nothing. Falls back to a plain move
+   * only on the rare filesystem that does not support {@link StandardCopyOption#ATOMIC_MOVE}.
+   */
+  private static void publishStaging(final Path staging, final Path dbPath) throws IOException {
+    try {
+      Files.move(staging, dbPath, StandardCopyOption.ATOMIC_MOVE);
+    } catch (final AtomicMoveNotSupportedException e) {
+      Files.move(staging, dbPath);
+    }
+  }
+
+  /**
    * Resolves the on-disk path of a database, so callers no longer need to keep it open just to read its
    * path before an install. Two cases:
    * <ul>
@@ -377,8 +491,25 @@ public final class SnapshotInstaller {
 
     try (final DirectoryStream<Path> stream = Files.newDirectoryStream(databasesDir, Files::isDirectory)) {
       for (final Path dbDir : stream) {
-        // Skip internal snapshot directories themselves
         final String dirName = dbDir.getFileName().toString();
+
+        // Clean up an interrupted new-database acquisition staging dir (databases/.acquire-<name>, issue #4727).
+        // A completed acquire atomically renames the staging dir to its final database name, so any surviving
+        // .acquire-* dir is an interrupted download and is safe to delete; the node re-acquires it on the next
+        // reconcile. These are reserved ('.'-prefixed) so the boot scan never opened them.
+        if (dirName.startsWith(ACQUIRE_STAGING_PREFIX)) {
+          try {
+            LogManager.instance().log(SnapshotInstaller.class, Level.INFO,
+                "Cleaning up interrupted new-database acquisition staging dir: %s", null, dbDir);
+            deleteDirectoryIfExists(dbDir);
+          } catch (final IOException e) {
+            LogManager.instance().log(SnapshotInstaller.class, Level.WARNING,
+                "Could not delete acquisition staging dir %s: %s", e, dbDir, e.getMessage());
+          }
+          continue;
+        }
+
+        // Skip internal snapshot directories themselves
         if (dirName.startsWith("."))
           continue;
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
@@ -294,11 +294,20 @@ public final class SnapshotInstaller {
     final Path staging = databasesDir.resolve(ACQUIRE_STAGING_PREFIX + databaseName);
 
     // Raced: the database already exists locally (created/registered concurrently). Refresh in place instead
-    // of acquiring, so two creators never race on dbPath.
+    // of acquiring, so two creators never race on dbPath. install() manages its own in-flight guard.
     if (server.existsDatabase(databaseName)) {
       install(databaseName, dbPath.toString(), leaderHttpAddrSupplier, leaderHttpsAddrSupplier, clusterToken, server);
       return;
     }
+
+    // Same overlap guard install() uses: the lifecycle assumes acquisitions for a given database never overlap
+    // (Ratis serializes InstallSnapshot per follower). Keyed by the resolved final path so distinct logical
+    // servers in one JVM (tests) do not collide. A violation is logged loudly rather than silently double-staging.
+    final String inFlightKey = dbPath.toString();
+    if (!INSTALLS_IN_FLIGHT.add(inFlightKey))
+      LogManager.instance().log(SnapshotInstaller.class, Level.WARNING,
+          "Concurrent acquisition detected for '%s'; acquisitions for the same database are assumed never to overlap "
+              + "- this may indicate a coordination bug in the HA layer", null, databaseName);
 
     try {
       // Clean any leftover staging from a previous failed attempt, then create a fresh reserved staging dir.
@@ -320,6 +329,8 @@ public final class SnapshotInstaller {
       // Re-check right before publishing: the database may have been created concurrently while we downloaded.
       if (server.existsDatabase(databaseName)) {
         deleteDirectoryIfExists(staging);
+        // Release our guard before delegating so install()'s own guard does not see a spurious overlap.
+        INSTALLS_IN_FLIGHT.remove(inFlightKey);
         install(databaseName, dbPath.toString(), leaderHttpAddrSupplier, leaderHttpsAddrSupplier, clusterToken, server);
         return;
       }
@@ -363,6 +374,8 @@ public final class SnapshotInstaller {
 
       HALog.log(SnapshotInstaller.class, HALog.BASIC, "New database '%s' acquired from leader", databaseName);
     } finally {
+      // Idempotent: a no-op if we already released the key before delegating to install() above.
+      INSTALLS_IN_FLIGHT.remove(inFlightKey);
       // Defensive: on success the staging dir was renamed away; on failure it was deleted. This is a no-op
       // in both cases but guarantees no reserved staging dir is ever leaked.
       deleteDirectoryIfExists(staging);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
@@ -19,7 +19,10 @@
 package com.arcadedb.server.ha.raft;
 
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.ComponentFile;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.utility.FileUtils;
@@ -321,32 +324,41 @@ public final class SnapshotInstaller {
         return;
       }
 
+      // PHASE 2 - VALIDATE the downloaded snapshot while it is STILL under the reserved staging name, BEFORE
+      // publishing it. A corrupt/incompatible snapshot must never reach databases/<name>/, where the startup
+      // scan would try to open it and crash the server: there is no previous copy to roll back to for a
+      // never-seen database. Validating in staging means a bad download is simply discarded (the reserved dir
+      // is ignored by the boot scan), leaving the database absent - the safe state - to be re-acquired next
+      // reconcile. This is stronger than validating after the rename, which on Windows could leave an
+      // undeletable corrupt directory under the final name if the failed open leaked a file handle.
+      try {
+        validateSnapshotOpens(staging);
+      } catch (final IOException validationEx) {
+        LogManager.instance().log(SnapshotInstaller.class, Level.SEVERE,
+            "Acquired snapshot for new database '%s' failed validation; discarding it and leaving the database "
+                + "absent (it will be re-acquired on the next reconcile): %s", null, databaseName, validationEx.getMessage());
+        deleteDirectoryIfExists(staging);
+        throw validationEx;
+      }
+
       // A stale, unregistered databases/<name>/ (e.g. from a pre-upgrade crash) would block the rename. The
       // leader's copy is authoritative for an unseen database, so clear it before publishing.
       if (Files.exists(dbPath))
         deleteDirectoryIfExists(dbPath);
 
-      // PHASE 2 - PUBLISH with a single atomic rename.
+      // PHASE 3 - PUBLISH the validated snapshot with a single atomic rename, then register it. The open here
+      // re-opens files we just validated, so it is not expected to fail; if it somehow does, drop the directory
+      // (best effort) and leave the database absent rather than registered-but-broken.
       publishStaging(staging, dbPath);
-
       try {
-        // Register + validate the freshly acquired snapshot by opening it.
         server.getDatabase(databaseName);
       } catch (final RuntimeException openEx) {
-        // No previous copy to roll back to: drop the directory and leave the database ABSENT (the safe state).
-        // The next reconcile re-acquires it.
         LogManager.instance().log(SnapshotInstaller.class, Level.SEVERE,
-            "Acquired snapshot for new database '%s' failed to open; removing it and leaving the database absent "
-                + "(it will be re-acquired on the next reconcile)", openEx, databaseName);
-        try {
-          if (server.existsDatabase(databaseName))
-            ((DatabaseInternal) server.getDatabase(databaseName)).getEmbedded().close();
-        } catch (final Exception ignore) {
-          // best-effort close before removal
-        }
+            "Acquired snapshot for new database '%s' was validated but failed to open after publish; removing it "
+                + "and leaving the database absent", openEx, databaseName);
         server.removeDatabase(databaseName);
         deleteDirectoryIfExists(dbPath);
-        throw new IOException("Acquired snapshot for new database '" + databaseName + "' failed to open", openEx);
+        throw new IOException("Acquired snapshot for new database '" + databaseName + "' failed to open after publish", openEx);
       }
 
       HALog.log(SnapshotInstaller.class, HALog.BASIC, "New database '%s' acquired from leader", databaseName);
@@ -367,6 +379,21 @@ public final class SnapshotInstaller {
       Files.move(staging, dbPath, StandardCopyOption.ATOMIC_MOVE);
     } catch (final AtomicMoveNotSupportedException e) {
       Files.move(staging, dbPath);
+    }
+  }
+
+  /**
+   * Smoke-tests that a freshly-downloaded snapshot directory is a loadable ArcadeDB database, by opening it
+   * read-only and closing it again. Read-only avoids any writes to the staging files. Throws {@link IOException}
+   * (not the raw open exception) so callers can treat a corrupt snapshot uniformly with a download failure.
+   */
+  private static void validateSnapshotOpens(final Path stagingPath) throws IOException {
+    try (final Database db = new DatabaseFactory(stagingPath.toString()).open(ComponentFile.MODE.READ_ONLY)) {
+      // Opening + closing is the validation: it confirms the configuration, schema and component files load.
+      if (db == null)
+        throw new IOException("snapshot did not open");
+    } catch (final RuntimeException e) {
+      throw new IOException("downloaded snapshot failed to open: " + e.getMessage(), e);
     }
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
@@ -360,6 +360,9 @@ public final class SnapshotInstaller {
 
       // A stale, unregistered databases/<name>/ (e.g. from a pre-upgrade crash) would block the rename. The
       // leader's copy is authoritative for an unseen database, so clear it before publishing.
+      // Safety rests on Ratis applying the log single-threaded relative to this snapshot-install path: a
+      // concurrent INSTALL_DATABASE_ENTRY replay that creates databases/<name>/ cannot interleave between the
+      // re-check above and this delete+rename, so we never blow away a database being created by another path.
       if (Files.exists(dbPath))
         deleteDirectoryIfExists(dbPath);
 
@@ -408,8 +411,10 @@ public final class SnapshotInstaller {
    */
   private static void validateSnapshotOpens(final Path stagingPath, final ArcadeDBServer server) throws IOException {
     // Safe to open under the reserved staging name and then publish: ArcadeDB derives the database name from the
-    // directory at open time (the staging name is not persisted into the files), and a READ_ONLY open performs no
-    // writes, so it leaves behind no lock/WAL artifact that the atomic rename would carry into the final directory.
+    // directory basename at open time (LocalDatabase computes it from the path; it is not persisted into
+    // configuration.json / schema.json), so opening as ".acquire-<name>" and later as "<name>" yields the same DB.
+    // A READ_ONLY open performs no writes, so it leaves behind no lock/WAL artifact that the atomic rename would
+    // carry into the final directory.
     // The end-to-end acquire IT (SnapshotAcquireNewDatabaseIT) confirms the published database opens cleanly.
     // Use the server's security + auto-transaction so this validation open matches the settings of the eventual
     // live open in ArcadeDBServer.getDatabase, rather than opening under defaults that could diverge.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
@@ -401,7 +401,8 @@ public final class SnapshotInstaller {
    * (not the raw open exception) so callers can treat a corrupt snapshot uniformly with a download failure.
    */
   private static void validateSnapshotOpens(final Path stagingPath) throws IOException {
-    try (final Database db = new DatabaseFactory(stagingPath.toString()).open(ComponentFile.MODE.READ_ONLY)) {
+    try (final DatabaseFactory factory = new DatabaseFactory(stagingPath.toString());
+        final Database db = factory.open(ComponentFile.MODE.READ_ONLY)) {
       // Opening + closing is the validation: it confirms the configuration, schema and component files load.
       if (db == null)
         throw new IOException("snapshot did not open");

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotInstaller.java
@@ -305,14 +305,15 @@ public final class SnapshotInstaller {
       return;
     }
 
-    // Same overlap guard install() uses: the lifecycle assumes acquisitions for a given database never overlap
-    // (Ratis serializes InstallSnapshot per follower). Keyed by the resolved final path so distinct logical
-    // servers in one JVM (tests) do not collide. A violation is logged loudly rather than silently double-staging.
+    // Same overlap guard install() uses, but fail-fast: the lifecycle assumes acquisitions for a given database
+    // never overlap (Ratis serializes InstallSnapshot per follower). Keyed by the resolved final path so distinct
+    // logical servers in one JVM (tests) do not collide. If the invariant is ever violated, abort rather than let
+    // two acquisitions share one staging dir and race on the atomic rename; the caller treats this like any other
+    // failed install and Ratis re-triggers once the other acquisition has finished and released the key.
     final String inFlightKey = dbPath.toString();
     if (!INSTALLS_IN_FLIGHT.add(inFlightKey))
-      LogManager.instance().log(SnapshotInstaller.class, Level.WARNING,
-          "Concurrent acquisition detected for '%s'; acquisitions for the same database are assumed never to overlap "
-              + "- this may indicate a coordination bug in the HA layer", null, databaseName);
+      throw new IOException("Concurrent acquisition already in progress for '" + databaseName
+          + "'; acquisitions for the same database must not overlap (possible HA coordination bug)");
 
     try {
       // Clean any leftover staging from a previous failed attempt, then create a fresh reserved staging dir.
@@ -348,7 +349,7 @@ public final class SnapshotInstaller {
       // reconcile. This is stronger than validating after the rename, which on Windows could leave an
       // undeletable corrupt directory under the final name if the failed open leaked a file handle.
       try {
-        validateSnapshotOpens(staging);
+        validateSnapshotOpens(staging, server);
       } catch (final IOException validationEx) {
         LogManager.instance().log(SnapshotInstaller.class, Level.SEVERE,
             "Acquired snapshot for new database '%s' failed validation; discarding it and leaving the database "
@@ -405,12 +406,16 @@ public final class SnapshotInstaller {
    * read-only and closing it again. Read-only avoids any writes to the staging files. Throws {@link IOException}
    * (not the raw open exception) so callers can treat a corrupt snapshot uniformly with a download failure.
    */
-  private static void validateSnapshotOpens(final Path stagingPath) throws IOException {
+  private static void validateSnapshotOpens(final Path stagingPath, final ArcadeDBServer server) throws IOException {
     // Safe to open under the reserved staging name and then publish: ArcadeDB derives the database name from the
     // directory at open time (the staging name is not persisted into the files), and a READ_ONLY open performs no
     // writes, so it leaves behind no lock/WAL artifact that the atomic rename would carry into the final directory.
     // The end-to-end acquire IT (SnapshotAcquireNewDatabaseIT) confirms the published database opens cleanly.
-    try (final DatabaseFactory factory = new DatabaseFactory(stagingPath.toString());
+    // Use the server's security + auto-transaction so this validation open matches the settings of the eventual
+    // live open in ArcadeDBServer.getDatabase, rather than opening under defaults that could diverge.
+    try (final DatabaseFactory factory = new DatabaseFactory(stagingPath.toString())
+        .setAutoTransaction(true)
+        .setSecurity(server.getSecurity());
         final Database db = factory.open(ComponentFile.MODE.READ_ONLY)) {
       // Opening + closing is the validation: it confirms the configuration, schema and component files load.
       if (db == null)

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ClusterAlertsTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ClusterAlertsTest.java
@@ -20,6 +20,8 @@ package com.arcadedb.server.ha.raft;
 
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -93,5 +95,31 @@ class ClusterAlertsTest {
     final List<String> flagged = ClusterAlerts.findSingleBucketTypes(db);
 
     assertThat(flagged).isSorted();
+  }
+
+  // ---- leader-missing-databases alert (issue #4727) ----
+
+  @Test
+  void leaderMissingAlertIsRaisedWithTheDatabaseNames() {
+    final JSONArray alerts = new JSONArray();
+    ClusterAlerts.addLeaderMissingAlert(List.of("OpenBeer", "Catalog"), alerts);
+
+    assertThat(alerts.length()).isEqualTo(1);
+    final JSONObject alert = alerts.getJSONObject(0);
+    assertThat(alert.getString("id")).isEqualTo("leader-missing-databases");
+    assertThat(alert.getString("severity")).isEqualTo(ClusterAlerts.SEVERITY_WARNING);
+    final JSONArray names = alert.getJSONObject("details").getJSONArray("databases");
+    assertThat(names.toList()).containsExactlyInAnyOrder("OpenBeer", "Catalog");
+  }
+
+  @Test
+  void leaderMissingAlertIsAbsentWhenNothingIsMissing() {
+    final JSONArray empty = new JSONArray();
+    ClusterAlerts.addLeaderMissingAlert(List.of(), empty);
+    assertThat(empty.length()).isEqualTo(0);
+
+    final JSONArray nullCase = new JSONArray();
+    ClusterAlerts.addLeaderMissingAlert(null, nullCase);
+    assertThat(nullCase.length()).isEqualTo(0);
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ClusterAlertsTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ClusterAlertsTest.java
@@ -122,4 +122,26 @@ class ClusterAlertsTest {
     ClusterAlerts.addLeaderMissingAlert(null, nullCase);
     assertThat(nullCase.length()).isEqualTo(0);
   }
+
+  // ---- failed-acquire-databases alert (issue #4727) ----
+
+  @Test
+  void failedAcquireAlertIsRaisedWithTheDatabaseNames() {
+    final JSONArray alerts = new JSONArray();
+    ClusterAlerts.addFailedAcquireAlert(List.of("OpenBeer"), alerts);
+
+    assertThat(alerts.length()).isEqualTo(1);
+    final JSONObject alert = alerts.getJSONObject(0);
+    assertThat(alert.getString("id")).isEqualTo("failed-acquire-databases");
+    assertThat(alert.getString("severity")).isEqualTo(ClusterAlerts.SEVERITY_WARNING);
+    assertThat(alert.getJSONObject("details").getJSONArray("databases").toList()).containsExactly("OpenBeer");
+  }
+
+  @Test
+  void failedAcquireAlertIsAbsentWhenNothingFailed() {
+    final JSONArray empty = new JSONArray();
+    ClusterAlerts.addFailedAcquireAlert(List.of(), empty);
+    ClusterAlerts.addFailedAcquireAlert(null, empty);
+    assertThat(empty.length()).isEqualTo(0);
+  }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/LeaderDatabaseQueryTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/LeaderDatabaseQueryTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link LeaderDatabaseQuery} endpoint/scheme selection (issue #4727). Locks in the fix that the
+ * database-list RPC honors SSL: it must prefer the peer's HTTPS endpoint when SSL is enabled, so the feature is
+ * not silently disabled on SSL-only clusters (the StatefulSet/empty-node deployments it targets). No network is
+ * involved - this exercises the pure scheme-selection logic.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class LeaderDatabaseQueryTest {
+
+  @Test
+  void plainHttpWhenSslDisabled() {
+    final LeaderDatabaseQuery.Endpoint e = LeaderDatabaseQuery.chooseEndpoint("host:2480", "host:2490", false);
+    assertThat(e).isNotNull();
+    assertThat(e.https()).isFalse();
+    assertThat(e.url()).isEqualTo("http://host:2480/api/v1/cluster/bootstrap-state");
+  }
+
+  @Test
+  void prefersHttpsWhenSslEnabledAndHttpsAddressKnown() {
+    final LeaderDatabaseQuery.Endpoint e = LeaderDatabaseQuery.chooseEndpoint("host:2480", "host:2490", true);
+    assertThat(e).isNotNull();
+    assertThat(e.https()).isTrue();
+    assertThat(e.url()).isEqualTo("https://host:2490/api/v1/cluster/bootstrap-state");
+  }
+
+  @Test
+  void fallsBackToHttpWhenSslEnabledButNoHttpsAddress() {
+    final LeaderDatabaseQuery.Endpoint e = LeaderDatabaseQuery.chooseEndpoint("host:2480", null, true);
+    assertThat(e).isNotNull();
+    assertThat(e.https()).isFalse();
+    assertThat(e.url()).isEqualTo("http://host:2480/api/v1/cluster/bootstrap-state");
+  }
+
+  @Test
+  void nullWhenNoUsableAddress() {
+    assertThat(LeaderDatabaseQuery.chooseEndpoint(null, null, false)).isNull();
+    // SSL on but only a null https and null http -> still nothing usable.
+    assertThat(LeaderDatabaseQuery.chooseEndpoint(null, null, true)).isNull();
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ReconcilePlanTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ReconcilePlanTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link ArcadeStateMachine#classifyReconcile} (issue #4727): the pure set-reconciliation that
+ * decides which leader databases a joining node must acquire, refresh, or flag as leader-missing. Keeping this
+ * logic pure makes the union/difference behavior - and the LEADER_MISSING transitions behind the cluster alert -
+ * deterministically testable without a Raft cluster.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class ReconcilePlanTest {
+
+  @Test
+  void emptyNodeAcquiresEverythingTheLeaderHolds() {
+    final var plan = ArcadeStateMachine.classifyReconcile(Set.of("a", "b", "c"), Set.of());
+    assertThat(plan.toAcquire()).containsExactly("a", "b", "c");
+    assertThat(plan.toRefresh()).isEmpty();
+    assertThat(plan.leaderMissing()).isEmpty();
+  }
+
+  @Test
+  void fullyReplicatedNodeRefreshesEverythingAndAcquiresNothing() {
+    final var plan = ArcadeStateMachine.classifyReconcile(Set.of("a", "b"), Set.of("a", "b"));
+    assertThat(plan.toAcquire()).isEmpty();
+    assertThat(plan.toRefresh()).containsExactly("a", "b");
+    assertThat(plan.leaderMissing()).isEmpty();
+  }
+
+  @Test
+  void mixedSetSplitsIntoAcquireRefreshAndLeaderMissing() {
+    // leader: a, b, c ; local: b, c, d  -> acquire a ; refresh b, c ; leader-missing d
+    final var plan = ArcadeStateMachine.classifyReconcile(Set.of("a", "b", "c"), Set.of("b", "c", "d"));
+    assertThat(plan.toAcquire()).containsExactly("a");
+    assertThat(plan.toRefresh()).containsExactly("b", "c");
+    assertThat(plan.leaderMissing()).containsExactly("d");
+  }
+
+  @Test
+  void databaseOnlyOnThisNodeIsFlaggedLeaderMissing() {
+    final var plan = ArcadeStateMachine.classifyReconcile(Set.of(), Set.of("orphan"));
+    assertThat(plan.toAcquire()).isEmpty();
+    assertThat(plan.toRefresh()).isEmpty();
+    assertThat(plan.leaderMissing()).containsExactly("orphan");
+  }
+
+  @Test
+  void outputListsAreSortedForDeterminism() {
+    final var plan = ArcadeStateMachine.classifyReconcile(Set.of("zeta", "alpha", "mike"), Set.of("alpha"));
+    assertThat(plan.toAcquire()).containsExactly("mike", "zeta");
+    assertThat(plan.toRefresh()).containsExactly("alpha");
+    assertThat(plan.toAcquire()).isSorted();
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ReconcilePlanTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ReconcilePlanTest.java
@@ -115,4 +115,63 @@ class ReconcilePlanTest {
     assertThat(outcome.acquireFailures()).isEmpty();
     assertThat(outcome.refreshFailures()).isEmpty();
   }
+
+  // ---- bookkeeping: applyReconcileOutcome status transitions + give-up decision ----
+
+  private static ArcadeStateMachine.ReconcileOutcome outcome(final List<String> acquired, final List<String> acquireFailures,
+      final List<String> refreshed, final List<String> refreshFailures) {
+    final java.util.Map<String, String> af = new java.util.LinkedHashMap<>();
+    for (final String d : acquireFailures)
+      af.put(d, "boom");
+    final java.util.Map<String, String> rf = new java.util.LinkedHashMap<>();
+    for (final String d : refreshFailures)
+      rf.put(d, "boom");
+    return new ArcadeStateMachine.ReconcileOutcome(acquired, af, refreshed, rf);
+  }
+
+  @Test
+  void outcomeSetsAcquiredFailedAndLeaderMissingStatuses() {
+    final var sm = new ArcadeStateMachine();
+    final var plan = new ArcadeStateMachine.ReconcilePlan(List.of("newok", "newbad"), List.of(), List.of("orphan"));
+
+    final boolean retry = sm.applyReconcileOutcome(plan, outcome(List.of("newok"), List.of("newbad"), List.of(), List.of()));
+
+    assertThat(sm.getAcquireStatus("newok").state()).isEqualTo(ArcadeStateMachine.AcquireState.ACQUIRED);
+    assertThat(sm.getAcquireStatus("newbad").state()).isEqualTo(ArcadeStateMachine.AcquireState.FAILED);
+    assertThat(sm.getAcquireStatus("orphan").state()).isEqualTo(ArcadeStateMachine.AcquireState.LEADER_MISSING);
+    assertThat(retry).as("a fresh failure is still within the retry budget").isTrue();
+  }
+
+  @Test
+  void refreshClearsAStaleLeaderMissingStatus() {
+    final var sm = new ArcadeStateMachine();
+    // First pass: "db" is local-only, flagged LEADER_MISSING.
+    sm.applyReconcileOutcome(new ArcadeStateMachine.ReconcilePlan(List.of(), List.of(), List.of("db")),
+        outcome(List.of(), List.of(), List.of(), List.of()));
+    assertThat(sm.getAcquireStatus("db").state()).isEqualTo(ArcadeStateMachine.AcquireState.LEADER_MISSING);
+
+    // Second pass: the leader now holds it, so it is refreshed -> the stale status must clear.
+    sm.applyReconcileOutcome(new ArcadeStateMachine.ReconcilePlan(List.of(), List.of("db"), List.of()),
+        outcome(List.of(), List.of(), List.of("db"), List.of()));
+    assertThat(sm.getAcquireStatus("db")).isNull();
+  }
+
+  @Test
+  void persistentFailureStopsForcingRetryAfterGiveUpThreshold() {
+    final var sm = new ArcadeStateMachine();
+    final var plan = new ArcadeStateMachine.ReconcilePlan(List.of("bad"), List.of(), List.of());
+    final var failing = outcome(List.of(), List.of("bad"), List.of(), List.of());
+
+    // Within the budget the failure keeps forcing a retry; once the threshold is hit it stops.
+    assertThat(sm.applyReconcileOutcome(plan, failing)).isTrue();  // 1
+    assertThat(sm.applyReconcileOutcome(plan, failing)).isTrue();  // 2
+    assertThat(sm.applyReconcileOutcome(plan, failing)).isFalse(); // 3 -> give up
+    assertThat(sm.getAcquireStatus("bad").state()).isEqualTo(ArcadeStateMachine.AcquireState.FAILED);
+
+    // A later success resets the counter (and would let it retry again if it failed afresh).
+    sm.applyReconcileOutcome(new ArcadeStateMachine.ReconcilePlan(List.of("bad"), List.of(), List.of()),
+        outcome(List.of("bad"), List.of(), List.of(), List.of()));
+    assertThat(sm.getAcquireStatus("bad").state()).isEqualTo(ArcadeStateMachine.AcquireState.ACQUIRED);
+    assertThat(sm.applyReconcileOutcome(plan, failing)).as("counter reset after success").isTrue();
+  }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ReconcilePlanTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ReconcilePlanTest.java
@@ -105,6 +105,23 @@ class ReconcilePlanTest {
   }
 
   @Test
+  void runtimeExceptionFromOneDatabaseIsIsolatedToo() {
+    // An unchecked exception (not just IOException) from one acquire must not abort the others.
+    final var plan = new ArcadeStateMachine.ReconcilePlan(List.of("npe", "goodnew"), List.of("healthy"), List.of());
+    final List<String> refreshCalls = new ArrayList<>();
+    final var outcome = ArcadeStateMachine.executeReconcilePlan(plan,
+        db -> {
+          if (db.equals("npe"))
+            throw new RuntimeException("unexpected");
+        },
+        refreshCalls::add);
+    assertThat(outcome.acquired()).containsExactly("goodnew");
+    assertThat(outcome.acquireFailures()).containsKey("npe");
+    assertThat(refreshCalls).containsExactly("healthy");
+    assertThat(outcome.refreshed()).containsExactly("healthy");
+  }
+
+  @Test
   void allSucceedWhenNoOperationFails() {
     final var plan = new ArcadeStateMachine.ReconcilePlan(List.of("n1"), List.of("e1", "e2"), List.of("orphan"));
     final var outcome = ArcadeStateMachine.executeReconcilePlan(plan, db -> {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ReconcilePlanTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ReconcilePlanTest.java
@@ -20,6 +20,9 @@ package com.arcadedb.server.ha.raft;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -73,5 +76,43 @@ class ReconcilePlanTest {
     assertThat(plan.toAcquire()).containsExactly("mike", "zeta");
     assertThat(plan.toRefresh()).containsExactly("alpha");
     assertThat(plan.toAcquire()).isSorted();
+  }
+
+  // ---- execution: a failing acquire must not starve refresh of healthy databases ----
+
+  @Test
+  void oneFailingAcquireDoesNotStarveRefreshOfHealthyDatabases() {
+    // leader: acquire "bad" (fails validation) + "goodnew" ; refresh "healthy"
+    final var plan = new ArcadeStateMachine.ReconcilePlan(List.of("bad", "goodnew"), List.of("healthy"), List.of());
+    final List<String> acquireCalls = new ArrayList<>();
+    final List<String> refreshCalls = new ArrayList<>();
+
+    final var outcome = ArcadeStateMachine.executeReconcilePlan(plan,
+        db -> {
+          acquireCalls.add(db);
+          if (db.equals("bad"))
+            throw new IOException("corrupt snapshot");
+        },
+        refreshCalls::add);
+
+    // The bad acquire failed, but the healthy database was still refreshed and the good new one acquired.
+    assertThat(refreshCalls).containsExactly("healthy");
+    assertThat(acquireCalls).containsExactlyInAnyOrder("bad", "goodnew");
+    assertThat(outcome.refreshed()).containsExactly("healthy");
+    assertThat(outcome.acquired()).containsExactly("goodnew");
+    assertThat(outcome.acquireFailures()).containsKey("bad");
+    assertThat(outcome.refreshFailures()).isEmpty();
+  }
+
+  @Test
+  void allSucceedWhenNoOperationFails() {
+    final var plan = new ArcadeStateMachine.ReconcilePlan(List.of("n1"), List.of("e1", "e2"), List.of("orphan"));
+    final var outcome = ArcadeStateMachine.executeReconcilePlan(plan, db -> {
+    }, db -> {
+    });
+    assertThat(outcome.acquired()).containsExactly("n1");
+    assertThat(outcome.refreshed()).containsExactly("e1", "e2");
+    assertThat(outcome.acquireFailures()).isEmpty();
+    assertThat(outcome.refreshFailures()).isEmpty();
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotAcquireNewDatabaseIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotAcquireNewDatabaseIT.java
@@ -112,4 +112,43 @@ class SnapshotAcquireNewDatabaseIT extends BaseRaftHATest {
     assertThat(acquiredPath.resolve(SnapshotInstaller.SNAPSHOT_PENDING_FILE)).doesNotExist();
     assertThat(acquiredPath.resolve(SnapshotInstaller.SNAPSHOT_NEW_DIR)).doesNotExist();
   }
+
+  /**
+   * Covers the concurrent-create fallback branch: when the database already exists locally (e.g. it materialised
+   * via an INSTALL_DATABASE_ENTRY replay while a reconcile was deciding to acquire it), acquireNewDatabase must
+   * fall back to the in-place {@code install} refresh rather than acquiring, and the database must remain present
+   * with its data.
+   */
+  @Test
+  void acquireOnAnExistingDatabaseRefreshesInsteadOfAcquiring() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).isGreaterThanOrEqualTo(0);
+    final int followerIndex = (leaderIndex + 1) % getServerCount();
+
+    final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+    leaderDb.transaction(() -> {
+      if (!leaderDb.getSchema().existsType("Item"))
+        leaderDb.getSchema().createVertexType("Item");
+      for (int i = 0; i < 15; i++)
+        leaderDb.newVertex("Item").set("name", "v-" + i).save();
+    });
+    waitForReplicationIsCompleted(followerIndex);
+
+    // The follower already has the database; acquireNewDatabase must detect this and refresh in place.
+    assertThat(getServer(followerIndex).existsDatabase(getDatabaseName())).isTrue();
+
+    final String leaderHttp = "localhost:" + getServer(leaderIndex).getHttpServer().getPort();
+    final String token = getRaftPlugin(followerIndex).getRaftHAServer().getClusterToken();
+    SnapshotInstaller.acquireNewDatabase(getDatabaseName(), () -> leaderHttp, () -> null, token,
+        getServer(followerIndex));
+
+    assertThat(getServer(followerIndex).existsDatabase(getDatabaseName()))
+        .as("database must still be present after the refresh fallback").isTrue();
+    assertThat(getServerDatabase(followerIndex, getDatabaseName()).countType("Item", true))
+        .as("refreshed database should still contain all records").isEqualTo(leaderDb.countType("Item", true));
+
+    final Path dbDir = Path.of(getServerDatabase(followerIndex, getDatabaseName()).getDatabasePath());
+    assertThat(dbDir.getParent().resolve(SnapshotInstaller.ACQUIRE_STAGING_PREFIX + getDatabaseName()))
+        .as("no acquisition staging dir should be created on the refresh path").doesNotExist();
+  }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotAcquireNewDatabaseIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotAcquireNewDatabaseIT.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.logging.Level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end test for the never-seen database acquisition added in issue #4727. Exercises
+ * {@link SnapshotInstaller#acquireNewDatabase} directly: a follower that does NOT have a database pulls it from
+ * the leader over the real snapshot HTTP endpoint, stages it under the reserved {@code .acquire-<name>} directory,
+ * publishes it with an atomic rename, and registers it - with no leftover staging/marker files.
+ * <p>
+ * This drives the new code deterministically (a direct synchronous call) rather than depending on Ratis to
+ * trigger an InstallSnapshot, which is timing-dependent in-process.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class SnapshotAcquireNewDatabaseIT extends BaseRaftHATest {
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    config.setValue(GlobalConfiguration.HA_QUORUM, "majority");
+  }
+
+  @Override
+  protected void checkDatabasesAreIdentical() {
+    // Skip the cross-node page comparator: this test deletes and re-acquires a database on one node, so a
+    // page-level identity check at teardown is neither meaningful nor needed (logical equality is asserted).
+  }
+
+  @Test
+  void followerAcquiresNeverSeenDatabaseFromLeader() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("a Raft leader must be elected").isGreaterThanOrEqualTo(0);
+    final int followerIndex = (leaderIndex + 1) % getServerCount();
+
+    // Populate the database on the leader and let it replicate.
+    final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+    leaderDb.transaction(() -> {
+      if (!leaderDb.getSchema().existsType("Item"))
+        leaderDb.getSchema().createVertexType("Item");
+      for (int i = 0; i < 30; i++)
+        leaderDb.newVertex("Item").set("name", "v-" + i).save();
+    });
+    // Ensure the follower has fully replicated the database before we delete and re-acquire it.
+    waitForReplicationIsCompleted(followerIndex);
+
+    final long expected = leaderDb.countType("Item", true);
+    assertThat(expected).isEqualTo(30);
+
+    // Make the database never-seen on the follower: close + deregister + delete its on-disk copy.
+    final DatabaseInternal followerDb = (DatabaseInternal) getServerDatabase(followerIndex, getDatabaseName());
+    final String dbPath = followerDb.getDatabasePath();
+    followerDb.getEmbedded().close();
+    getServer(followerIndex).removeDatabase(getDatabaseName());
+    FileUtils.deleteRecursively(new File(dbPath));
+    assertThat(getServer(followerIndex).existsDatabase(getDatabaseName()))
+        .as("database must be absent on the follower before acquisition").isFalse();
+
+    // Acquire it from the leader via the new crash-safe path.
+    final String leaderHttp = "localhost:" + getServer(leaderIndex).getHttpServer().getPort();
+    final String token = getRaftPlugin(followerIndex).getRaftHAServer().getClusterToken();
+    LogManager.instance().log(this, Level.INFO, "TEST: Acquiring never-seen database '%s' from leader %s",
+        getDatabaseName(), leaderHttp);
+    SnapshotInstaller.acquireNewDatabase(getDatabaseName(), () -> leaderHttp, () -> null, token,
+        getServer(followerIndex));
+
+    // The follower now has the database with all records, and no staging/marker files are left behind.
+    assertThat(getServer(followerIndex).existsDatabase(getDatabaseName()))
+        .as("follower should have acquired the never-seen database").isTrue();
+    assertThat(getServerDatabase(followerIndex, getDatabaseName()).countType("Item", true))
+        .as("acquired database should contain all records").isEqualTo(expected);
+
+    final Path acquiredPath = Path.of(getServerDatabase(followerIndex, getDatabaseName()).getDatabasePath());
+    final Path databasesDir = acquiredPath.getParent();
+    assertThat(databasesDir.resolve(SnapshotInstaller.ACQUIRE_STAGING_PREFIX + getDatabaseName()))
+        .as("reserved acquisition staging dir must be gone").doesNotExist();
+    assertThat(acquiredPath.resolve(SnapshotInstaller.SNAPSHOT_PENDING_FILE)).doesNotExist();
+    assertThat(acquiredPath.resolve(SnapshotInstaller.SNAPSHOT_NEW_DIR)).doesNotExist();
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotAcquireNewDatabaseIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotAcquireNewDatabaseIT.java
@@ -111,6 +111,14 @@ class SnapshotAcquireNewDatabaseIT extends BaseRaftHATest {
         .as("reserved acquisition staging dir must be gone").doesNotExist();
     assertThat(acquiredPath.resolve(SnapshotInstaller.SNAPSHOT_PENDING_FILE)).doesNotExist();
     assertThat(acquiredPath.resolve(SnapshotInstaller.SNAPSHOT_NEW_DIR)).doesNotExist();
+
+    // The acquired copy must keep receiving replication: a subsequent write on the leader must reach the
+    // newly-registered follower copy (the part that matters operationally, beyond the one-time pull).
+    leaderDb.transaction(() -> leaderDb.newVertex("Item").set("name", "after-acquire").save());
+    final long afterWrite = leaderDb.countType("Item", true);
+    waitForReplicationIsCompleted(followerIndex);
+    assertThat(getServerDatabase(followerIndex, getDatabaseName()).countType("Item", true))
+        .as("a write after acquisition must replicate to the acquired follower copy").isEqualTo(afterWrite);
   }
 
   /**

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotAcquireStagingRecoveryTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotAcquireStagingRecoveryTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.server.ArcadeDBServer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests crash recovery of an interrupted <i>new-database acquisition</i> (issue #4727). When a node crashes
+ * while downloading a database it has never seen, the partial download lives under the reserved staging dir
+ * {@code databases/.acquire-<name>/}. On the next startup {@link SnapshotInstaller#recoverPendingSnapshotSwaps}
+ * must delete it without leaving a half-written non-reserved {@code databases/<name>/} that the boot scan would
+ * try to open. No HTTP downloads or Raft clusters are involved.
+ */
+class SnapshotAcquireStagingRecoveryTest {
+
+  @Test
+  void acquireStagingPrefixIsReserved() {
+    // The startup scan (ArcadeDBServer.loadDatabases) skips reserved ('.'-prefixed) directories, which is what
+    // keeps a half-written acquisition from being opened as a database. Guard that invariant.
+    assertThat(ArcadeDBServer.isReservedDatabaseName(SnapshotInstaller.ACQUIRE_STAGING_PREFIX + "mydb")).isTrue();
+  }
+
+  @Test
+  void recoveryDeletesInterruptedAcquireStaging(@TempDir final Path databasesDir) throws Exception {
+    // Simulate a crash mid-download of a never-seen database: only the reserved staging dir exists, with
+    // partial content. There is no final databases/mydb directory.
+    final Path staging = databasesDir.resolve(SnapshotInstaller.ACQUIRE_STAGING_PREFIX + "mydb");
+    Files.createDirectories(staging);
+    Files.writeString(staging.resolve("partial.bucket"), "incomplete-download");
+
+    SnapshotInstaller.recoverPendingSnapshotSwaps(databasesDir);
+
+    // The staging dir is cleaned up and no non-reserved database directory was published.
+    assertThat(staging).doesNotExist();
+    assertThat(databasesDir.resolve("mydb")).doesNotExist();
+  }
+
+  @Test
+  void recoveryLeavesCompletedDatabasesUntouched(@TempDir final Path databasesDir) throws Exception {
+    // A fully-acquired database (final name, no staging) sits next to a leftover staging dir from a different,
+    // interrupted acquisition. Recovery must clean only the staging dir.
+    final Path liveDb = databasesDir.resolve("livedb");
+    Files.createDirectories(liveDb);
+    Files.writeString(liveDb.resolve("data.dat"), "live-data");
+
+    final Path staging = databasesDir.resolve(SnapshotInstaller.ACQUIRE_STAGING_PREFIX + "otherdb");
+    Files.createDirectories(staging);
+    Files.writeString(staging.resolve("partial.bucket"), "incomplete");
+
+    SnapshotInstaller.recoverPendingSnapshotSwaps(databasesDir);
+
+    assertThat(staging).doesNotExist();
+    assertThat(liveDb.resolve("data.dat")).exists();
+    assertThat(Files.readString(liveDb.resolve("data.dat"))).isEqualTo("live-data");
+  }
+
+  @Test
+  void recoveryHandlesAcquireStagingAndPendingSwapTogether(@TempDir final Path databasesDir) throws Exception {
+    // An interrupted acquisition (reserved staging) and an interrupted in-place refresh (pending swap with a
+    // retained backup) coexist. Each must be recovered independently in a single pass.
+    final Path staging = databasesDir.resolve(SnapshotInstaller.ACQUIRE_STAGING_PREFIX + "newdb");
+    Files.createDirectories(staging);
+    Files.writeString(staging.resolve("partial.bucket"), "incomplete");
+
+    final Path refreshDb = databasesDir.resolve("refreshdb");
+    final Path snapshotNew = refreshDb.resolve(".snapshot-new");
+    final Path snapshotBackup = refreshDb.resolve(".snapshot-backup");
+    Files.createDirectories(snapshotNew);
+    Files.createDirectories(snapshotBackup);
+    Files.writeString(refreshDb.resolve(".snapshot-pending"), "");
+    Files.writeString(snapshotNew.resolve(".snapshot-complete"), "");
+    Files.writeString(snapshotNew.resolve("data.dat"), "new-data");
+    Files.writeString(snapshotBackup.resolve("data.dat"), "old-data");
+
+    SnapshotInstaller.recoverPendingSnapshotSwaps(databasesDir);
+
+    // Acquisition staging cleaned, no phantom newdb.
+    assertThat(staging).doesNotExist();
+    assertThat(databasesDir.resolve("newdb")).doesNotExist();
+    // In-place refresh swap completed.
+    assertThat(Files.readString(refreshDb.resolve("data.dat"))).isEqualTo("new-data");
+    assertThat(snapshotBackup).doesNotExist();
+    assertThat(refreshDb.resolve(".snapshot-pending")).doesNotExist();
+  }
+}

--- a/studio/src/main/resources/static/cluster.html
+++ b/studio/src/main/resources/static/cluster.html
@@ -72,6 +72,24 @@
         <!-- Dynamically populated by JS -->
       </div>
 
+      <!-- Per-database x per-node presence matrix (issue #4727). Built on the leader via a peer fan-out
+           (GET /api/v1/cluster?presence=true), so it is loaded on demand (button) rather than on every
+           auto-poll. Lets an operator see at a glance which databases are missing on which nodes. -->
+      <div class="row mb-4" id="clusterPresenceRow">
+        <div class="col-12">
+          <div class="d-flex align-items-center justify-content-between mb-2">
+            <h6 style="color: var(--text-secondary); font-weight: 600; margin: 0;">Database Presence</h6>
+            <button id="btnLoadPresence" class="btn btn-sm db-action-btn" onclick="loadPresenceMatrix()"
+                    title="Query every node for the databases it holds (leader only)">
+              <i class="fa fa-table"></i> Load presence matrix
+            </button>
+          </div>
+          <div id="clusterPresenceMatrix" style="font-size: 0.82rem;">
+            <!-- Dynamically populated by renderPresenceMatrix -->
+          </div>
+        </div>
+      </div>
+
     </div>
 
     <!-- ==================== METRICS TAB ==================== -->
@@ -171,6 +189,51 @@
               </p>
               <div id="clusterResyncList">
                 <!-- Dynamically populated by renderResyncRecovery -->
+              </div>
+            </div>
+          </div>
+
+          <!-- Leadership controls (issue #4727 Studio scope): transfer leadership to a chosen peer or step
+               down. Shown on the leader; followers see a hint. Toggled by renderLeadershipControls. -->
+          <div class="card mb-3" id="clusterLeadershipCard" style="border: 1px solid var(--border-light); border-radius: 10px;">
+            <div class="card-header py-2" style="background: var(--bg-hover); border-bottom: 1px solid var(--border-light); border-radius: 10px 10px 0 0;">
+              <i class="fas fa-crown" style="color: var(--color-brand);"></i>
+              <span style="font-weight: 600; font-size: 0.88rem; margin-left: 6px;">Leadership</span>
+            </div>
+            <div class="card-body py-3">
+              <div id="clusterLeadershipHint" class="mb-2" style="font-size:0.75rem; color:var(--text-secondary); display:none;">
+                <i class="fa fa-info-circle"></i> Leadership actions can only be performed on the leader node.
+              </div>
+              <div id="clusterLeadershipActions" style="display:none;">
+                <p style="font-size: 0.78rem; color: var(--text-secondary); margin-bottom: 10px;">
+                  Move leadership to a node that holds a database the current leader is missing, then resync the
+                  others (the #4522 recovery flow).
+                </p>
+                <button class="btn btn-sm db-action-btn me-2" onclick="transferLeadershipPrompt()"
+                        title="Transfer leadership to a specific peer">
+                  <i class="fa fa-exchange-alt"></i> Transfer leadership
+                </button>
+                <button class="btn btn-sm btn-outline-secondary" onclick="stepDownLeader()"
+                        title="Relinquish leadership; the cluster elects a new leader">
+                  <i class="fa fa-sign-out-alt"></i> Step down
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <!-- Database consistency verification (issue #4727 Studio scope): per-database checksum comparison
+               across all peers. Runs from the leader; toggled by renderVerifyConsistency. -->
+          <div class="card mb-3" id="clusterVerifyCard" style="display:none; border: 1px solid var(--border-light); border-radius: 10px;">
+            <div class="card-header py-2" style="background: var(--bg-hover); border-bottom: 1px solid var(--border-light); border-radius: 10px 10px 0 0;">
+              <i class="fas fa-check-double" style="color: var(--color-brand);"></i>
+              <span style="font-weight: 600; font-size: 0.88rem; margin-left: 6px;">Database Consistency</span>
+            </div>
+            <div class="card-body py-3">
+              <p style="font-size: 0.78rem; color: var(--text-secondary); margin-bottom: 10px;">
+                Compares per-file checksums of each database across every node and reports any mismatch.
+              </p>
+              <div id="clusterVerifyList">
+                <!-- Dynamically populated by renderVerifyConsistency -->
               </div>
             </div>
           </div>

--- a/studio/src/main/resources/static/cluster.html
+++ b/studio/src/main/resources/static/cluster.html
@@ -80,9 +80,12 @@
           <div class="d-flex align-items-center justify-content-between mb-2">
             <h6 style="color: var(--text-secondary); font-weight: 600; margin: 0;">Database Presence</h6>
             <button id="btnLoadPresence" class="btn btn-sm db-action-btn" onclick="loadPresenceMatrix()"
-                    title="Query every node for the databases it holds (leader only)">
+                    title="Query every node for the databases it holds (leader only). Each node briefly opens any closed database to read it, so use on demand rather than continuously.">
               <i class="fa fa-table"></i> Load presence matrix
             </button>
+          </div>
+          <div style="font-size: 0.72rem; color: var(--text-secondary); margin-bottom: 6px;">
+            Queries each node for its databases; a node may briefly open a closed database to report it. Run on demand.
           </div>
           <div id="clusterPresenceMatrix" style="font-size: 0.82rem;">
             <!-- Dynamically populated by renderPresenceMatrix -->

--- a/studio/src/main/resources/static/js/studio-cluster.js
+++ b/studio/src/main/resources/static/js/studio-cluster.js
@@ -1,4 +1,7 @@
 var clusterRefreshTimer = null;
+// Last cluster status payload, kept so on-demand actions (e.g. the leadership peer picker) can read the
+// current peer list without re-fetching.
+var clusterLastData = null;
 
 function updateCluster(callback) {
   jQuery.ajax({
@@ -17,6 +20,8 @@ function updateCluster(callback) {
 }
 
 function renderClusterData(data) {
+  clusterLastData = data;
+
   // Header
   $("#clusterNameLabel").text(data.clusterName || "");
 
@@ -62,6 +67,10 @@ function renderClusterData(data) {
   // Emergency recovery controls (resync a diverged database from the leader). Only shown on a
   // follower; the leader holds the authoritative copy and has nothing to resync.
   renderResyncRecovery(data);
+
+  // Leadership controls (transfer / step down) and per-database consistency verification (issue #4727).
+  renderLeadershipControls(data);
+  renderVerifyConsistency(data);
 
   // Update metrics summary
   updateMetricsSummary(data);
@@ -228,6 +237,205 @@ function resyncDatabase(databaseName) {
       })
       .fail(function(jqXHR) { globalNotifyError(jqXHR.responseText); });
     });
+}
+
+// ==================== LEADERSHIP CONTROLS (issue #4727) ====================
+
+// Shows the transfer-leadership / step-down actions on the leader; followers see a hint instead.
+function renderLeadershipControls(data) {
+  var card = $("#clusterLeadershipCard");
+  if (card.length === 0)
+    return; // Older cluster.html; degrade silently.
+  var isLeader = data.isLeader === true;
+  $("#clusterLeadershipActions").toggle(isLeader);
+  $("#clusterLeadershipHint").toggle(!isLeader);
+}
+
+// Opens a peer picker and transfers leadership to the chosen peer (POST /api/v1/cluster/leader).
+function transferLeadershipPrompt() {
+  var data = clusterLastData || {};
+  var peers = data.peers || [];
+  var localPeerId = data.localPeerId;
+  var options = "";
+  for (var i = 0; i < peers.length; i++) {
+    var id = peers[i].id;
+    if (id === localPeerId)
+      continue; // cannot transfer to self (the current leader)
+    options += '<option value="' + escapeHtml(id) + '">' + escapeHtml(id) + '</option>';
+  }
+  if (options === "") {
+    globalNotify("Transfer leadership", "No other peer is available to receive leadership", "warning");
+    return;
+  }
+  var html =
+    '<div class="mb-2">'
+    + '<label for="transferPeerId" class="form-label" style="font-size:0.85rem;">Target peer</label>'
+    + '<select class="form-select" id="transferPeerId">' + options + '</select>'
+    + '</div>';
+  globalPrompt("Transfer Leadership", html, "Transfer", function(values) {
+    var peerId = values["transferPeerId"];
+    if (!peerId) return;
+    globalNotify("Transfer leadership", "Transferring leadership to '" + peerId + "'...", "info");
+    jQuery.ajax({
+      type: "POST",
+      url: "api/v1/cluster/leader",
+      data: JSON.stringify({ peerId: peerId }),
+      contentType: "application/json",
+      beforeSend: function(xhr) { xhr.setRequestHeader("Authorization", globalCredentials); }
+    })
+    .done(function() {
+      globalNotify("Success", "Leadership transferred to '" + peerId + "'", "success");
+      setTimeout(function() { updateCluster(); }, 2000);
+    })
+    .fail(function(jqXHR) { globalNotifyError(jqXHR.responseText); });
+  });
+}
+
+// Steps the local leader down (POST /api/v1/cluster/stepdown); the cluster elects a new leader.
+function stepDownLeader() {
+  globalConfirm("Step Down",
+    "Relinquish leadership on this node? The cluster will elect a new leader.",
+    "warning",
+    function() {
+      jQuery.ajax({
+        type: "POST",
+        url: "api/v1/cluster/stepdown",
+        beforeSend: function(xhr) { xhr.setRequestHeader("Authorization", globalCredentials); }
+      })
+      .done(function() {
+        globalNotify("Success", "Leadership step-down initiated", "success");
+        setTimeout(function() { updateCluster(); }, 2000);
+      })
+      .fail(function(jqXHR) { globalNotifyError(jqXHR.responseText); });
+    });
+}
+
+// ==================== CONSISTENCY VERIFICATION (issue #4727) ====================
+
+// On the leader, lists every database with a "Verify" button that fans out a per-file checksum comparison.
+function renderVerifyConsistency(data) {
+  var card = $("#clusterVerifyCard");
+  var container = $("#clusterVerifyList");
+  if (card.length === 0)
+    return;
+  container.empty();
+
+  var isLeader = data.isLeader === true;
+  var dbs = data.databases || [];
+  if (!isLeader || dbs.length === 0) {
+    card.hide();
+    return;
+  }
+  card.show();
+
+  for (var i = 0; i < dbs.length; i++) {
+    var name = dbs[i].name;
+    var nameAttr = JSON.stringify(name).replace(/"/g, "&quot;");
+    container.append(
+      '<div class="d-flex align-items-center justify-content-between py-1 px-2 mb-1" '
+      + 'style="font-size:0.82rem; background:var(--bg-main); border-radius:6px; border:1px solid var(--border-light);">'
+      + '<div><i class="fa fa-database" style="color:var(--color-brand); margin-right:6px;"></i>'
+      + escapeHtml(name) + '</div>'
+      + '<div><button class="btn btn-sm btn-outline-secondary" style="font-size:0.7rem; padding:1px 8px;" '
+      + 'onclick="verifyDatabase(' + nameAttr + ')" title="Compare this database\'s checksums across all nodes">'
+      + '<i class="fa fa-check-double"></i> Verify</button></div>'
+      + '</div>'
+    );
+  }
+}
+
+// Runs POST /api/v1/cluster/verify/{db} and shows the per-peer result.
+function verifyDatabase(databaseName) {
+  globalNotify("Verify", "Verifying '" + databaseName + "' across the cluster...", "info");
+  jQuery.ajax({
+    type: "POST",
+    url: "api/v1/cluster/verify/" + encodeURIComponent(databaseName),
+    beforeSend: function(xhr) { xhr.setRequestHeader("Authorization", globalCredentials); }
+  })
+  .done(function(data) {
+    var result = (data && data.result) ? data.result : data;
+    var status = result.overallStatus || "UNKNOWN";
+    var ok = status === "ALL_CONSISTENT";
+    var html = '<div style="font-size:0.85rem;">'
+      + '<div class="mb-2"><b>Status:</b> <span class="badge ' + (ok ? "bg-success" : "bg-danger") + '">'
+      + escapeHtml(status) + '</span></div>';
+    var peers = result.peers || [];
+    if (peers.length > 0) {
+      html += '<table class="table table-sm" style="font-size:0.8rem;"><thead><tr><th>Peer</th><th>Status</th></tr></thead><tbody>';
+      for (var i = 0; i < peers.length; i++) {
+        var p = peers[i];
+        var pStatus = p.status || "-";
+        var badge = pStatus === "CONSISTENT" ? "bg-success" : (pStatus === "ERROR" ? "bg-secondary" : "bg-danger");
+        html += '<tr><td>' + escapeHtml(p.peerId || p.httpAddress || "-") + '</td>'
+          + '<td><span class="badge ' + badge + '">' + escapeHtml(pStatus) + '</span></td></tr>';
+      }
+      html += '</tbody></table>';
+    }
+    html += '</div>';
+    globalAlert("Consistency: " + escapeHtml(databaseName), html, ok ? "success" : "warning");
+  })
+  .fail(function(jqXHR) { globalNotifyError(jqXHR.responseText); });
+}
+
+// ==================== PRESENCE MATRIX (issue #4727) ====================
+
+// Loads the per-database x per-node presence matrix from the leader (on demand, not on the auto-poll).
+function loadPresenceMatrix() {
+  jQuery.ajax({
+    type: "GET",
+    url: "api/v1/cluster?presence=true",
+    beforeSend: function(xhr) { xhr.setRequestHeader("Authorization", globalCredentials); }
+  })
+  .done(function(data) { renderPresenceMatrix(data); })
+  .fail(function(jqXHR) { globalNotifyError(jqXHR.responseText); });
+}
+
+function renderPresenceMatrix(data) {
+  var container = $("#clusterPresenceMatrix");
+  if (container.length === 0)
+    return;
+  container.empty();
+
+  var presence = data.databasePresence;
+  if (!presence) {
+    container.append('<div style="font-size:0.8rem;color:var(--text-secondary);">'
+      + 'The presence matrix is computed on the leader. Open this page on the leader node and click '
+      + '"Load presence matrix".</div>');
+    return;
+  }
+
+  var nodes = presence.nodes || [];
+  var dbs = presence.databases || [];
+  var unreachable = presence.unreachable || [];
+
+  var html = '<div class="table-responsive"><table class="table table-sm table-bordered" style="font-size:0.8rem;">';
+  html += '<thead><tr><th>Database</th>';
+  for (var n = 0; n < nodes.length; n++) {
+    var isUnreachable = unreachable.indexOf(nodes[n]) >= 0;
+    html += '<th title="' + escapeHtml(nodes[n]) + '">' + escapeHtml(nodes[n])
+      + (isUnreachable ? ' <span class="badge bg-secondary">unreachable</span>' : '') + '</th>';
+  }
+  html += '</tr></thead><tbody>';
+
+  for (var d = 0; d < dbs.length; d++) {
+    var db = dbs[d];
+    var present = db.present || [];
+    html += '<tr><td><i class="fa fa-database" style="color:var(--color-brand); margin-right:6px;"></i>'
+      + escapeHtml(db.name) + '</td>';
+    for (var c = 0; c < nodes.length; c++) {
+      var has = present.indexOf(nodes[c]) >= 0;
+      var unreach = unreachable.indexOf(nodes[c]) >= 0;
+      if (unreach)
+        html += '<td class="text-center" style="color:var(--text-secondary);">?</td>';
+      else if (has)
+        html += '<td class="text-center" style="color:#16a34a;"><i class="fa fa-check"></i></td>';
+      else
+        html += '<td class="text-center" style="color:#dc2626;"><i class="fa fa-times"></i></td>';
+    }
+    html += '</tr>';
+  }
+  html += '</tbody></table></div>';
+  container.append(html);
 }
 
 function abbreviateFingerprint(fp) {

--- a/studio/src/main/resources/static/js/studio-cluster.js
+++ b/studio/src/main/resources/static/js/studio-cluster.js
@@ -273,7 +273,9 @@ function transferLeadershipPrompt() {
     + '<select class="form-select" id="transferPeerId">' + options + '</select>'
     + '</div>';
   globalPrompt("Transfer Leadership", html, "Transfer", function(values) {
-    var peerId = values["transferPeerId"];
+    // globalPrompt only captures input/textarea values, not <select>, so read the select directly (the
+    // convention used elsewhere in Studio, e.g. studio-database.js).
+    var peerId = $("#transferPeerId").val();
     if (!peerId) return;
     globalNotify("Transfer leadership", "Transferring leadership to '" + peerId + "'...", "info");
     jQuery.ajax({


### PR DESCRIPTION
## Summary

Fixes #4727. A node joining a Raft HA cluster with an **empty data directory** never acquired databases it had not previously seen on disk - it only refreshed databases already present, so runtime-created/imported databases were silently missing on new nodes (the #4522 StatefulSet scale-up case: new pods came up with only the `defaultDatabases` entry).

Now a joining node **reconciles its local database set against the leader's** and pulls (full snapshot install) any database it is missing.

## Root cause

`ArcadeStateMachine.notifyInstallSnapshotFromLeader` iterated `server.getDatabaseNames()` (local DBs only), so a brand-new node had nothing to install. There was no step that listed the leader's databases and pulled the missing ones.

## What changed

**Core (engine / ha-raft)**
- New global setting `arcadedb.ha.autoAcquireDatabases` (default **true**), per-node, re-read each boot. It gates the *join-time pull* only; the *create-time push* via `INSTALL_DATABASE_ENTRY` stays mandatory (core Raft consensus).
- `notifyInstallSnapshotFromLeader` now enumerates the leader's databases (reusing the existing `POST /api/v1/cluster/bootstrap-state` RPC via the new `LeaderDatabaseQuery`) and installs the **union** of leader + local DBs - refreshing existing ones, acquiring never-seen ones.
- **Additive-only guard:** a database present locally but absent on the leader is never dropped (keeps a real `DROP_DATABASE_ENTRY` distinguishable from "the leader never had it"); it is flagged `LEADER_MISSING`.
- `SnapshotInstaller.acquireNewDatabase`: **crash-safe** acquisition of a never-seen database. The download is staged under a reserved `databases/.acquire-<name>/` directory (skipped by the startup scan) and published with a single **atomic rename**, so a crash mid-download can never leave a half-written `databases/<name>/` that `loadDatabases` would try to open. Startup recovery cleans leftover `.acquire-*` staging dirs.

**Observability**
- Per-database `acquireStatus` (`ACQUIRING` / `ACQUIRED` / `LEADER_MISSING` / `FAILED`) in `GET /api/v1/cluster`.
- A `leader-missing-databases` cluster alert (the #4522 aggravating factor: a node lacking a DB is elected leader).
- Optional `GET /api/v1/cluster?presence=true` per-node x per-database presence fan-out (gated so the auto-poll stays cheap).

**Studio Cluster tab**
- Transfer leadership (peer picker), Step down, per-database Verify-consistency buttons, and a database presence matrix.

## Tests

- `SnapshotAcquireStagingRecoveryTest` (unit) - crash recovery of the reserved acquisition staging dir; verifies no phantom non-reserved database directory is left behind.
- `SnapshotAcquireNewDatabaseIT` - drives `acquireNewDatabase` end-to-end against a live leader (HTTP snapshot download → atomic publish → register), asserting the DB is acquired with all records and no leftover staging/marker files.
- Full `ha-raft` suite: **355 tests, 0 failures**.

> Note: full-cluster restart ITs were intentionally not used to assert this path - in-process Ratis catches a restarted node up via log **replay** rather than `InstallSnapshot`, so such a test would pass even without the fix. The direct `acquireNewDatabase` IT exercises the genuinely new code deterministically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)