### PR TITLE
fix(#4740): prevent node self-halt after leader phase-2 commit failure / WAL version gap divergence

### DIFF
--- a/docs/4740-ha-leader-phase2-commit-divergence.md
+++ b/docs/4740-ha-leader-phase2-commit-divergence.md
@@ -17,23 +17,24 @@ Under concurrent write load on a 3-node Raft HA cluster, two bugs compound to ta
 ## Changes
 
 ### `ArcadeStateMachine.java`
-- Add `stateDivergedSinceWalGap` AtomicBoolean field
-- In `applyTxEntry` WAL gap handler: set flag + schedule immediate `triggerSnapshotDownload`
-- In `applyWithRetry`: catch `Throwable` when diverged → wrap as `ReplicationException`
-- Reset flag in `triggerSnapshotDownload` and `notifyInstallSnapshotFromLeader` success paths
+- Replace the diverged flag with a per-database `divergedDatabases` set (scoped so a gap in one DB never masks a bug while applying another, healthy DB - review item)
+- In `applyTxEntry` WAL gap handler: add DB to the set + schedule immediate `triggerSnapshotDownload`
+- In `applyWithRetry` (now takes a `databaseName` arg; old 2-arg form kept as a delegating overload): rethrow JVM `Error` and `ReplicationException` unchanged; wrap other Throwables as `ReplicationException` only when the DB is diverged; bounded-escalation counter so a node that can never resync eventually re-halts loudly
+- `clearDivergedState()` resets the set + counter from `triggerSnapshotDownload` and `notifyInstallSnapshotFromLeader` success paths
 
 ### `RaftReplicatedDatabase.java`
-- In `commit()` phase-2 failure catch: call `applyChanges` to reconcile pages before step-down
-- Same in `applyLocallyAfterMajorityCommit` failure path
-- Add `TEST_PHASE2_FAILURE_HOOK` for IT test
+- `reconcileLeaderPagesAfterPhase2Failure()` replays the committed WAL on the leader before step-down (idempotent via page-version guards)
+- Called from both `commit()` and `applyLocallyAfterMajorityCommit` phase-2 failure paths
+- Added `TEST_PHASE2_COMMIT_FAULT` hook for the regression IT
 
 ### Tests
-- `ArcadeStateMachineApplyRetryTest`: two new unit tests for diverged-state wrapping
+- `ArcadeStateMachineApplyRetryTest`: 4 new unit tests (diverged-DB wrap, healthy-DB rethrow, JVM Error rethrow, ReplicationException no-double-wrap)
+- `Issue4740Phase2ReconcileIT`: 3-node IT injecting a phase-2 fault, asserting no WAL gap and cluster convergence (Fix 1 coverage)
 
 ## Test Results
 
-- `ArcadeStateMachineApplyRetryTest`: 8/8 PASS (6 existing + 2 new regression guards)
-- All ha-raft unit tests (48 total): 48/48 PASS
+- `ArcadeStateMachineApplyRetryTest`: 10/10 PASS (6 existing + 4 new regression guards)
+- All ha-raft unit tests: PASS
 - Full project build (`mvn clean install -DskipTests`): SUCCESS
 
 ## Files Changed
@@ -41,4 +42,22 @@ Under concurrent write load on a 3-node Raft HA cluster, two bugs compound to ta
 - `ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java`
 - `ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java`
 - `ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineApplyRetryTest.java`
+- `ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4740Phase2ReconcileIT.java`
 - `docs/4740-ha-leader-phase2-commit-divergence.md` (this file)
+
+## Review cycles
+
+### Cycle 1 - HEAD 51c69fff
+
+**Gemini** (3 items, all applied):
+1. Rethrow JVM `Error` instead of wrapping as recoverable
+2. Pass `ree` not `null` to the logger
+3. Add regression test for Error rethrow
+
+**Claude** (6 items):
+1. `stateDivergedSinceWalGap` server-global → scoped per-database (applied)
+2. Flag sticky if resync never succeeds → bounded escalation counter that re-halts a stuck node (applied)
+3. Javadoc note that reconcile runs under the read lock (applied)
+4. Fix 1 had no automated test → added `Issue4740Phase2ReconcileIT` (applied)
+5. Doc/code mismatch on the test hook name → reconciled; hook is `TEST_PHASE2_COMMIT_FAULT` (applied)
+6. Minor test comment about default-retries fallback (applied)

--- a/docs/4740-ha-leader-phase2-commit-divergence.md
+++ b/docs/4740-ha-leader-phase2-commit-divergence.md
@@ -61,3 +61,15 @@ Under concurrent write load on a 3-node Raft HA cluster, two bugs compound to ta
 4. Fix 1 had no automated test → added `Issue4740Phase2ReconcileIT` (applied)
 5. Doc/code mismatch on the test hook name → reconciled; hook is `TEST_PHASE2_COMMIT_FAULT` (applied)
 6. Minor test comment about default-retries fallback (applied)
+
+### Cycle 2 - HEAD 654f43d5c
+
+Gemini did not re-review (its cycle-1 items were already resolved). Claude re-reviewed, confirmed cycle-1 items addressed, and raised 6 follow-ups (all applied):
+1. Detailed javadoc was attached to the 2-arg overload (referenced a non-existent `databaseName` param) → moved onto the 3-arg method; short doc on the overload
+2. `markStateDiverged`/`clearDivergedState` were interleaved in the field block → moved to the private-method group near `triggerSnapshotDownload`
+3. Comment said "compareAndSet" for a `Set.add()` → reworded
+4. Escalation counter is JVM-wide while the diverged set is per-DB → added a comment noting the global scope is deliberate
+5. Best-effort reconcile used `ignoreErrors=false` → switched to `true` so it applies every page it can; gapped pages resync via Fix 2
+6. Untested Fix-2 internals → added `boundedEscalationRePropagatesAfterThresholdExceeded` and `clearDivergedStateResetsSetAndCounter` (with `isDatabaseDiverged`/`divergedSwallowedErrorCount` test accessors)
+
+`ArcadeStateMachineApplyRetryTest` now 12/12; ha-raft unit suite 102/102; `Issue4740Phase2ReconcileIT` green; full build SUCCESS.

--- a/docs/4740-ha-leader-phase2-commit-divergence.md
+++ b/docs/4740-ha-leader-phase2-commit-divergence.md
@@ -1,0 +1,44 @@
+# Issue #4740 - HA: leader phase-2 commit failure → follower-ahead divergence, non-converging snapshot resync, node self-halt
+
+## Problem
+
+Under concurrent write load on a 3-node Raft HA cluster, two bugs compound to take a node fully offline:
+
+1. **Leader phase-2 commit failure leaves pages behind**: When the leader's local `commit2ndPhase` throws after Raft has already committed the entry (followers applied it), the leader steps down but its pages stay at version N. When it becomes a follower and replays the log, it hits `WALVersionGapException` (version N+1 expected, page at N) on every subsequent entry.
+
+2. **Diverged-state unexpected errors trigger fatal halt**: After WAL gaps leave the state inconsistent, subsequent `applyTransaction` calls throw unexpected exceptions (NPE, ClassCastException, etc.) from operating on corrupted in-memory state. These reach the `catch (Throwable)` branch in `applyTransaction`, set `haltedAfterCriticalError`, and shut the server down. The node cannot auto-recover — manual data-dir wipe required.
+
+## Root Cause
+
+**Fix 1 - Leader self-reconciliation** (`RaftReplicatedDatabase`): After `commit2ndPhase` fails, call `applyChanges` with the existing WAL payload to bring leader pages from version N to N+1 before stepping down. Page-version guards make this idempotent — already-applied pages are skipped, un-applied ones are written. When the ex-leader replays as a follower, there is no version gap.
+
+**Fix 2 - Diverged-state safety** (`ArcadeStateMachine`): Add `stateDivergedSinceWalGap` flag. When a `WALVersionGapException` is detected (state known-diverged), wrap unexpected `Throwable`s in `applyWithRetry` as `ReplicationException` (recoverable resync) instead of letting them reach the fatal halt path. Also trigger an immediate snapshot download on first WAL gap detection instead of waiting for the HealthMonitor's periodic check.
+
+## Changes
+
+### `ArcadeStateMachine.java`
+- Add `stateDivergedSinceWalGap` AtomicBoolean field
+- In `applyTxEntry` WAL gap handler: set flag + schedule immediate `triggerSnapshotDownload`
+- In `applyWithRetry`: catch `Throwable` when diverged → wrap as `ReplicationException`
+- Reset flag in `triggerSnapshotDownload` and `notifyInstallSnapshotFromLeader` success paths
+
+### `RaftReplicatedDatabase.java`
+- In `commit()` phase-2 failure catch: call `applyChanges` to reconcile pages before step-down
+- Same in `applyLocallyAfterMajorityCommit` failure path
+- Add `TEST_PHASE2_FAILURE_HOOK` for IT test
+
+### Tests
+- `ArcadeStateMachineApplyRetryTest`: two new unit tests for diverged-state wrapping
+
+## Test Results
+
+- `ArcadeStateMachineApplyRetryTest`: 8/8 PASS (6 existing + 2 new regression guards)
+- All ha-raft unit tests (48 total): 48/48 PASS
+- Full project build (`mvn clean install -DskipTests`): SUCCESS
+
+## Files Changed
+
+- `ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java`
+- `ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java`
+- `ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineApplyRetryTest.java`
+- `docs/4740-ha-leader-phase2-commit-divergence.md` (this file)

--- a/docs/4740-ha-leader-phase2-commit-divergence.md
+++ b/docs/4740-ha-leader-phase2-commit-divergence.md
@@ -73,3 +73,9 @@ Gemini did not re-review (its cycle-1 items were already resolved). Claude re-re
 6. Untested Fix-2 internals → added `boundedEscalationRePropagatesAfterThresholdExceeded` and `clearDivergedStateResetsSetAndCounter` (with `isDatabaseDiverged`/`divergedSwallowedErrorCount` test accessors)
 
 `ArcadeStateMachineApplyRetryTest` now 12/12; ha-raft unit suite 102/102; `Issue4740Phase2ReconcileIT` green; full build SUCCESS.
+
+### Cycle 3 - HEAD b0cd5b21a
+
+Claude re-reviewed and posted no further items (clean). Gemini did not re-review. CI green (build-and-package, claude-review, CodeQL all pass; the Meterian failure is a pre-existing dependency vuln unrelated to this change).
+
+Remaining signal: Codacy reported a persistent high-severity ErrorProne finding (the broad `catch (Throwable)` in `applyWithRetry`). Resolved by narrowing to `catch (RuntimeException)`: a `Runnable` can only throw `RuntimeException` or `Error`, so JVM `Error`s now propagate to the fatal halt path by simply not being caught - identical semantics, no broad catch, and the explicit `instanceof Error` rethrow is no longer needed. All tests still pass (the OOM-rethrow guard now verifies the Error propagates uncaught).

--- a/docs/4740-ha-leader-phase2-commit-divergence.md
+++ b/docs/4740-ha-leader-phase2-commit-divergence.md
@@ -79,3 +79,16 @@ Gemini did not re-review (its cycle-1 items were already resolved). Claude re-re
 Claude re-reviewed and posted no further items (clean). Gemini did not re-review. CI green (build-and-package, claude-review, CodeQL all pass; the Meterian failure is a pre-existing dependency vuln unrelated to this change).
 
 Remaining signal: Codacy reported a persistent high-severity ErrorProne finding (the broad `catch (Throwable)` in `applyWithRetry`). Resolved by narrowing to `catch (RuntimeException)`: a `Runnable` can only throw `RuntimeException` or `Error`, so JVM `Error`s now propagate to the fatal halt path by simply not being caught - identical semantics, no broad catch, and the explicit `instanceof Error` rethrow is no longer needed. All tests still pass (the OOM-rethrow guard now verifies the Error propagates uncaught).
+
+## Final state
+
+`clean-approval` (HEAD `9a9b74239`).
+
+- Claude re-reviewed each push; the final two cycles returned no further items.
+- Gemini's only review was cycle 0; all of its items were addressed in cycle 1 and it did not re-review.
+- Codacy: `success` (the high-severity ErrorProne finding and the earlier CodeStyle minors are all cleared).
+- CI: `build-and-package`, `claude-review`, `CodeQL`, all language analyzers and e2e suites green. The `Meterian client scan` failure is a pre-existing dependency vulnerability on the default branch, unrelated to this change.
+
+PR: https://github.com/ArcadeData/arcadedb/pull/4742
+
+Merge remains the developer's decision; this workflow does not merge.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -108,22 +108,6 @@ public class ArcadeStateMachine extends BaseStateMachine {
    */
   public static volatile AtomicInteger TEST_WAL_GAP_COUNTER = null;
 
-  // @VisibleForTesting
-  void markStateDiverged(final String dbName) {
-    divergedDatabases.add(dbName);
-  }
-
-  /**
-   * Clears the diverged-database set and the bounded-escalation counter after a snapshot resync has
-   * restored consistent state across all databases. A resync always reinstalls every database from
-   * the leader, so clearing the whole set (rather than a single database) matches what the resync
-   * actually did.
-   */
-  private void clearDivergedState() {
-    divergedDatabases.clear();
-    divergedSwallowedErrors.set(0);
-  }
-
   private final    SimpleStateMachineStorage storage          = new SimpleStateMachineStorage();
   private final    AtomicLong                lastAppliedIndex = new AtomicLong(-1);
   private final    AtomicLong                electionCount    = new AtomicLong(0);
@@ -188,6 +172,9 @@ public class ArcadeStateMachine extends BaseStateMachine {
   // swallowed on a diverged database increments this; once it exceeds the threshold the next
   // unexpected error is allowed to propagate to the fatal halt path so a truly stuck node surfaces
   // loudly rather than quietly. Reset to 0 whenever a snapshot resync clears the diverged set.
+  // Deliberately JVM-wide (not per-database): the threshold is a coarse "this node is stuck, halt
+  // loudly" backstop, so a shared budget across all diverged databases is the intended behaviour -
+  // one very noisy diverged database crossing the threshold should still halt the node.
   private final        AtomicInteger divergedSwallowedErrors      = new AtomicInteger(0);
   private static final int           MAX_DIVERGED_SWALLOWED_ERRORS = 100;
 
@@ -390,6 +377,16 @@ public class ArcadeStateMachine extends BaseStateMachine {
   }
 
   /**
+   * Convenience overload that runs the dispatch without scoping the diverged-state guard to a
+   * specific database (equivalent to {@code applyWithRetry(index, null, applyAction)}). Used where
+   * the entry has no single target database.
+   */
+  // @VisibleForTesting
+  void applyWithRetry(final long index, final Runnable applyAction) {
+    applyWithRetry(index, null, applyAction);
+  }
+
+  /**
    * Runs the apply dispatch with bounded in-place retry for transient/retryable conditions.
    * <p>
    * A {@link NeedRetryException} (e.g. an MVCC {@link com.arcadedb.exception.ConcurrentModificationException}
@@ -411,16 +408,6 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * @param applyAction  the apply dispatch to run
    * @throws ReplicationException if the retryable condition persists after all attempts
    */
-  /**
-   * Convenience overload that runs the dispatch without scoping the diverged-state guard to a
-   * specific database (equivalent to {@code applyWithRetry(index, null, applyAction)}). Used where
-   * the entry has no single target database.
-   */
-  // @VisibleForTesting
-  void applyWithRetry(final long index, final Runnable applyAction) {
-    applyWithRetry(index, null, applyAction);
-  }
-
   // @VisibleForTesting
   void applyWithRetry(final long index, final String databaseName, final Runnable applyAction) {
     final int maxRetries = Math.max(0, server != null
@@ -747,8 +734,9 @@ public class ArcadeStateMachine extends BaseStateMachine {
           decoded.databaseName(), walTx.txId, e.getMessage());
       // Mark this database as diverged so subsequent unexpected errors don't trigger fatal halt
       // (issue #4740). Trigger an immediate snapshot download instead of waiting for the
-      // HealthMonitor's periodic check. compareAndSet on the add (newly diverged) keeps the
-      // immediate-download trigger to once per database until a resync clears it.
+      // HealthMonitor's periodic check. Set.add() returns true only when the database was not
+      // already in the set, so the immediate-download trigger fires at most once per database
+      // until a resync clears it.
       if (divergedDatabases.add(decoded.databaseName())) {
         try {
           lifecycleExecutor.submit(this::triggerSnapshotDownload);
@@ -1367,6 +1355,38 @@ public class ArcadeStateMachine extends BaseStateMachine {
     } finally {
       snapshotDownloadInProgress.set(false);
     }
+  }
+
+  /**
+   * Marks {@code dbName} as diverged from the committed Raft log (issue #4740). While a database is
+   * diverged, unexpected Throwables raised while applying its entries are treated as recoverable
+   * resync conditions in {@link #applyWithRetry} rather than fatal halts.
+   */
+  // @VisibleForTesting
+  void markStateDiverged(final String dbName) {
+    divergedDatabases.add(dbName);
+  }
+
+  /**
+   * Clears the diverged-database set and the bounded-escalation counter after a snapshot resync has
+   * restored consistent state across all databases. A resync always reinstalls every database from
+   * the leader, so clearing the whole set (rather than a single database) matches what the resync
+   * actually did.
+   */
+  // @VisibleForTesting
+  void clearDivergedState() {
+    divergedDatabases.clear();
+    divergedSwallowedErrors.set(0);
+  }
+
+  // @VisibleForTesting
+  boolean isDatabaseDiverged(final String dbName) {
+    return divergedDatabases.contains(dbName);
+  }
+
+  // @VisibleForTesting
+  int divergedSwallowedErrorCount() {
+    return divergedSwallowedErrors.get();
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -108,6 +108,11 @@ public class ArcadeStateMachine extends BaseStateMachine {
    */
   public static volatile AtomicInteger TEST_WAL_GAP_COUNTER = null;
 
+  // @VisibleForTesting
+  void markStateDiverged() {
+    stateDivergedSinceWalGap.set(true);
+  }
+
   private final    SimpleStateMachineStorage storage          = new SimpleStateMachineStorage();
   private final    AtomicLong                lastAppliedIndex = new AtomicLong(-1);
   private final    AtomicLong                electionCount    = new AtomicLong(0);
@@ -155,6 +160,15 @@ public class ArcadeStateMachine extends BaseStateMachine {
   // database state and the recovery path is the asynchronous server shutdown plus a snapshot
   // resync on the next start.
   private final AtomicBoolean haltedAfterCriticalError = new AtomicBoolean(false);
+
+  // Set to true when a WALVersionGapException is detected on this follower (state has diverged
+  // from the committed Raft log). While set, unexpected Throwables in applyWithRetry are wrapped
+  // as ReplicationException (recoverable resync) instead of propagating to the fatal server-halt
+  // path (issue #4740): operating on inconsistent page state after a WAL gap often throws NPE,
+  // ClassCastException, or similar errors that would otherwise trigger the server-halt path even
+  // though the node is merely waiting for a snapshot resync to restore consistent state. Cleared
+  // when a snapshot resync completes and the database is restored to a consistent state.
+  private final AtomicBoolean stateDivergedSinceWalGap = new AtomicBoolean(false);
 
 
   public void setServer(final ArcadeDBServer server) {
@@ -409,6 +423,21 @@ public class ArcadeStateMachine extends BaseStateMachine {
             break;
           }
         }
+      } catch (final Throwable t) {
+        // When state has already diverged (WAL gap detected earlier), an unexpected error most likely
+        // stems from the engine operating on the inconsistent in-memory state left by the gap - e.g.
+        // NPE on a page that wasn't refreshed, ClassCastException on a stale object. Treat it as a
+        // recoverable resync condition (issue #4740) instead of propagating to applyTransaction's
+        // fatal catch (Throwable) path that would halt the server. The ongoing snapshot download
+        // will restore consistent state once a stable leader is available.
+        if (stateDivergedSinceWalGap.get()) {
+          LogManager.instance().log(this, Level.SEVERE,
+              "Unexpected error at index %d while state is diverged (WAL gap detected earlier); treating as resync condition: %s",
+              index, t.getMessage());
+          throw new ReplicationException(
+              "Apply error on diverged state at index " + index + "; snapshot resync in progress", t);
+        }
+        throw t;
       }
     }
 
@@ -578,6 +607,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
         }
 
         LogManager.instance().log(this, Level.INFO, "Full resync from leader completed");
+        stateDivergedSinceWalGap.set(false);
         return firstTermIndexInLog;
 
       } catch (final Exception e) {
@@ -663,6 +693,16 @@ public class ArcadeStateMachine extends BaseStateMachine {
       LogManager.instance().log(this, Level.SEVERE,
           "WAL version gap on follower - state divergence detected, triggering snapshot resync (db=%s, txId=%d): %s",
           decoded.databaseName(), walTx.txId, e.getMessage());
+      // Mark state as diverged so subsequent unexpected errors don't trigger fatal halt (issue #4740).
+      // Trigger an immediate snapshot download instead of waiting for the HealthMonitor's periodic check.
+      if (stateDivergedSinceWalGap.compareAndSet(false, true)) {
+        try {
+          lifecycleExecutor.submit(this::triggerSnapshotDownload);
+        } catch (final RejectedExecutionException ree) {
+          LogManager.instance().log(this, Level.WARNING,
+              "Cannot schedule immediate snapshot download after WAL gap (db=%s): executor is shut down", null, decoded.databaseName());
+        }
+      }
       throw new ReplicationException(
           "WAL version gap detected - snapshot resync required (db=" + decoded.databaseName() + ")", e);
     }
@@ -1266,6 +1306,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
               leaderHttpAddr, leaderHttpsAddr, clusterToken, server);
       }
       LogManager.instance().log(this, Level.INFO, "Snapshot download triggered by watchdog completed");
+      stateDivergedSinceWalGap.set(false);
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.SEVERE, "Snapshot download triggered by watchdog failed", e);
     } finally {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -109,8 +109,19 @@ public class ArcadeStateMachine extends BaseStateMachine {
   public static volatile AtomicInteger TEST_WAL_GAP_COUNTER = null;
 
   // @VisibleForTesting
-  void markStateDiverged() {
-    stateDivergedSinceWalGap.set(true);
+  void markStateDiverged(final String dbName) {
+    divergedDatabases.add(dbName);
+  }
+
+  /**
+   * Clears the diverged-database set and the bounded-escalation counter after a snapshot resync has
+   * restored consistent state across all databases. A resync always reinstalls every database from
+   * the leader, so clearing the whole set (rather than a single database) matches what the resync
+   * actually did.
+   */
+  private void clearDivergedState() {
+    divergedDatabases.clear();
+    divergedSwallowedErrors.set(0);
   }
 
   private final    SimpleStateMachineStorage storage          = new SimpleStateMachineStorage();
@@ -161,14 +172,24 @@ public class ArcadeStateMachine extends BaseStateMachine {
   // resync on the next start.
   private final AtomicBoolean haltedAfterCriticalError = new AtomicBoolean(false);
 
-  // Set to true when a WALVersionGapException is detected on this follower (state has diverged
-  // from the committed Raft log). While set, unexpected Throwables in applyWithRetry are wrapped
-  // as ReplicationException (recoverable resync) instead of propagating to the fatal server-halt
-  // path (issue #4740): operating on inconsistent page state after a WAL gap often throws NPE,
-  // ClassCastException, or similar errors that would otherwise trigger the server-halt path even
-  // though the node is merely waiting for a snapshot resync to restore consistent state. Cleared
-  // when a snapshot resync completes and the database is restored to a consistent state.
-  private final AtomicBoolean stateDivergedSinceWalGap = new AtomicBoolean(false);
+  // Database names whose state has diverged from the committed Raft log (a WALVersionGapException
+  // was detected while applying an entry for them). While a database is in this set, unexpected
+  // Throwables in applyWithRetry for THAT database are wrapped as ReplicationException (recoverable
+  // resync) instead of propagating to the fatal server-halt path (issue #4740): operating on
+  // inconsistent page state after a WAL gap often throws NPE, ClassCastException, or similar errors
+  // that would otherwise halt the server even though the node is merely waiting for a snapshot
+  // resync. Scoped per-database so a gap in one database never masks a genuine bug raised while
+  // applying an entry for an unrelated, healthy database. Cleared when a snapshot resync completes
+  // (it resyncs all databases) and restores consistent state.
+  private final Set<String> divergedDatabases = ConcurrentHashMap.newKeySet();
+
+  // Bounded escalation (issue #4740): a node that can never resync (no stable leader reachable)
+  // must not stay in "swallow unexpected errors" mode forever, silently degrading. Each error
+  // swallowed on a diverged database increments this; once it exceeds the threshold the next
+  // unexpected error is allowed to propagate to the fatal halt path so a truly stuck node surfaces
+  // loudly rather than quietly. Reset to 0 whenever a snapshot resync clears the diverged set.
+  private final        AtomicInteger divergedSwallowedErrors      = new AtomicInteger(0);
+  private static final int           MAX_DIVERGED_SWALLOWED_ERRORS = 100;
 
 
   public void setServer(final ArcadeDBServer server) {
@@ -301,7 +322,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
 
       final boolean originatedLocally = Boolean.TRUE.equals(trx.getStateMachineContext());
 
-      applyWithRetry(index, () -> {
+      applyWithRetry(index, decoded.databaseName(), () -> {
         switch (decoded.type()) {
         case TX_ENTRY -> applyTxEntry(decoded, index, originatedLocally);
         case SCHEMA_ENTRY -> applySchemaEntry(decoded, index, originatedLocally);
@@ -384,12 +405,24 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * is a single sequential thread, so a smaller (or zero) delay is perfectly safe on this path and only
    * reduces the worst-case latency per entry; the value is read live so it can be tuned independently.
    *
-   * @param index       the Raft log index being applied (diagnostics only)
-   * @param applyAction the apply dispatch to run
+   * @param index        the Raft log index being applied (diagnostics only)
+   * @param databaseName the database the entry targets, used to scope the diverged-state guard
+   *                     (may be {@code null} for entry types without a single target database)
+   * @param applyAction  the apply dispatch to run
    * @throws ReplicationException if the retryable condition persists after all attempts
+   */
+  /**
+   * Convenience overload that runs the dispatch without scoping the diverged-state guard to a
+   * specific database (equivalent to {@code applyWithRetry(index, null, applyAction)}). Used where
+   * the entry has no single target database.
    */
   // @VisibleForTesting
   void applyWithRetry(final long index, final Runnable applyAction) {
+    applyWithRetry(index, null, applyAction);
+  }
+
+  // @VisibleForTesting
+  void applyWithRetry(final long index, final String databaseName, final Runnable applyAction) {
     final int maxRetries = Math.max(0, server != null
         ? server.getConfiguration().getValueAsInteger(GlobalConfiguration.TX_RETRIES)
         : GlobalConfiguration.TX_RETRIES.getValueAsInteger());
@@ -423,17 +456,36 @@ public class ArcadeStateMachine extends BaseStateMachine {
             break;
           }
         }
+      } catch (final ReplicationException re) {
+        // Already a resync signal (e.g. the WAL-gap escalation from applyTxEntry); propagate it
+        // unchanged so it reaches applyTransaction's catch (ReplicationException) handler without
+        // being re-wrapped or counted against the bounded-escalation budget below.
+        throw re;
       } catch (final Throwable t) {
-        // When state has already diverged (WAL gap detected earlier), an unexpected error most likely
-        // stems from the engine operating on the inconsistent in-memory state left by the gap - e.g.
-        // NPE on a page that wasn't refreshed, ClassCastException on a stale object. Treat it as a
-        // recoverable resync condition (issue #4740) instead of propagating to applyTransaction's
-        // fatal catch (Throwable) path that would halt the server. The ongoing snapshot download
-        // will restore consistent state once a stable leader is available.
-        if (stateDivergedSinceWalGap.get()) {
+        // JVM Errors (OutOfMemoryError, StackOverflowError, ...) mean the JVM itself is unstable;
+        // they must never be swallowed as a recoverable resync condition - let them reach the fatal
+        // halt path unchanged so the node stops loudly rather than masking a corrupt runtime.
+        if (t instanceof Error)
+          throw t;
+        // When this database has already diverged (WAL gap detected earlier), an unexpected error
+        // most likely stems from the engine operating on the inconsistent in-memory state left by
+        // the gap - e.g. NPE on a page that wasn't refreshed, ClassCastException on a stale object.
+        // Treat it as a recoverable resync condition (issue #4740) instead of propagating to
+        // applyTransaction's fatal catch (Throwable) path that would halt the server. The ongoing
+        // snapshot download will restore consistent state once a stable leader is available.
+        if (databaseName != null && divergedDatabases.contains(databaseName)) {
+          // Bounded escalation: a node that can never resync (no stable leader) must not swallow
+          // errors forever and degrade silently. Once the swallow count exceeds the threshold, let
+          // the error propagate to the fatal halt path so a truly stuck node surfaces loudly.
+          if (divergedSwallowedErrors.incrementAndGet() > MAX_DIVERGED_SWALLOWED_ERRORS) {
+            LogManager.instance().log(this, Level.SEVERE,
+                "Diverged database '%s' swallowed over %d unexpected errors without resyncing (index %d); escalating to fatal halt: %s",
+                databaseName, MAX_DIVERGED_SWALLOWED_ERRORS, index, t.getMessage());
+            throw t;
+          }
           LogManager.instance().log(this, Level.SEVERE,
-              "Unexpected error at index %d while state is diverged (WAL gap detected earlier); treating as resync condition: %s",
-              index, t.getMessage());
+              "Unexpected error at index %d while database '%s' is diverged (WAL gap detected earlier); treating as resync condition: %s",
+              index, databaseName, t.getMessage());
           throw new ReplicationException(
               "Apply error on diverged state at index " + index + "; snapshot resync in progress", t);
         }
@@ -607,7 +659,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
         }
 
         LogManager.instance().log(this, Level.INFO, "Full resync from leader completed");
-        stateDivergedSinceWalGap.set(false);
+        clearDivergedState();
         return firstTermIndexInLog;
 
       } catch (final Exception e) {
@@ -693,14 +745,17 @@ public class ArcadeStateMachine extends BaseStateMachine {
       LogManager.instance().log(this, Level.SEVERE,
           "WAL version gap on follower - state divergence detected, triggering snapshot resync (db=%s, txId=%d): %s",
           decoded.databaseName(), walTx.txId, e.getMessage());
-      // Mark state as diverged so subsequent unexpected errors don't trigger fatal halt (issue #4740).
-      // Trigger an immediate snapshot download instead of waiting for the HealthMonitor's periodic check.
-      if (stateDivergedSinceWalGap.compareAndSet(false, true)) {
+      // Mark this database as diverged so subsequent unexpected errors don't trigger fatal halt
+      // (issue #4740). Trigger an immediate snapshot download instead of waiting for the
+      // HealthMonitor's periodic check. compareAndSet on the add (newly diverged) keeps the
+      // immediate-download trigger to once per database until a resync clears it.
+      if (divergedDatabases.add(decoded.databaseName())) {
         try {
           lifecycleExecutor.submit(this::triggerSnapshotDownload);
         } catch (final RejectedExecutionException ree) {
           LogManager.instance().log(this, Level.WARNING,
-              "Cannot schedule immediate snapshot download after WAL gap (db=%s): executor is shut down", null, decoded.databaseName());
+              "Cannot schedule immediate snapshot download after WAL gap (db=%s): executor is shut down",
+              ree, decoded.databaseName());
         }
       }
       throw new ReplicationException(
@@ -1306,7 +1361,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
               leaderHttpAddr, leaderHttpsAddr, clusterToken, server);
       }
       LogManager.instance().log(this, Level.INFO, "Snapshot download triggered by watchdog completed");
-      stateDivergedSinceWalGap.set(false);
+      clearDivergedState();
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.SEVERE, "Snapshot download triggered by watchdog failed", e);
     } finally {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -448,12 +448,13 @@ public class ArcadeStateMachine extends BaseStateMachine {
         // unchanged so it reaches applyTransaction's catch (ReplicationException) handler without
         // being re-wrapped or counted against the bounded-escalation budget below.
         throw re;
-      } catch (final Throwable t) {
-        // JVM Errors (OutOfMemoryError, StackOverflowError, ...) mean the JVM itself is unstable;
-        // they must never be swallowed as a recoverable resync condition - let them reach the fatal
-        // halt path unchanged so the node stops loudly rather than masking a corrupt runtime.
-        if (t instanceof Error)
-          throw t;
+      } catch (final RuntimeException t) {
+        // Catch RuntimeException (not Throwable) on purpose: applyAction is a Runnable, so the only
+        // things it can throw are RuntimeException or Error. JVM Errors (OutOfMemoryError,
+        // StackOverflowError, ...) mean the JVM itself is unstable and must never be swallowed as a
+        // recoverable resync condition - leaving them uncaught lets them propagate unchanged to
+        // applyTransaction's fatal halt path so the node stops loudly rather than masking a corrupt
+        // runtime.
         // When this database has already diverged (WAL gap detected earlier), an unexpected error
         // most likely stems from the engine operating on the inconsistent in-memory state left by
         // the gap - e.g. NPE on a page that wasn't refreshed, ClassCastException on a stale object.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -155,6 +155,14 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    */
   static volatile Consumer<String> TEST_POST_REPLICATION_HOOK = null;
 
+  /**
+   * Test-only fault-injection hook. Fires inside phase-2 on the leader, just before
+   * {@code commit2ndPhase} runs, after Raft has already committed the entry. Throw from the
+   * consumer to simulate a leader-side phase-2 commit failure while the followers are already
+   * ahead (issue #4740). Always null in production.
+   */
+  static volatile Consumer<String> TEST_PHASE2_COMMIT_FAULT = null;
+
   public record ReadConsistencyContext(Database.READ_CONSISTENCY consistency, long readAfterIndex) {
   }
 
@@ -358,6 +366,11 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     proxied.executeInReadLock(() -> {
       final DatabaseContext.DatabaseContextTL current = DatabaseContext.INSTANCE.getContext(proxied.getDatabasePath());
       try {
+        // Test-only fault injection: simulate a phase-2 commit failure while followers are ahead.
+        final Consumer<String> phase2Fault = TEST_PHASE2_COMMIT_FAULT;
+        if (phase2Fault != null)
+          phase2Fault.accept(getName());
+
         payload.tx().commit2ndPhase(payload.phase1());
 
         if (getSchema().getEmbedded().isDirty())
@@ -426,6 +439,11 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * ones are written. After this call the leader's page versions match what the followers
    * applied, so when this node steps down and replays the log as a follower it will not
    * encounter a {@link com.arcadedb.exception.WALVersionGapException} for this entry.
+   * <p>
+   * Called by the phase-2 failure handlers while they still hold the read lock that the failed
+   * {@code commit2ndPhase} ran under. {@code applyChanges} mutates pages under the per-page I/O
+   * lock, so running it under the same read lock keeps the page-write coordination identical to
+   * the normal phase-2 path and avoids racing a concurrent phase-1 snapshot.
    */
   private void reconcileLeaderPagesAfterPhase2Failure(final ReplicationPayload payload) {
     try {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -378,6 +378,7 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
               Followers have applied this transaction but the leader has not. \
               Stepping down to prevent stale reads. Error: %s""",
               getName(), payload.tx(), e.getMessage());
+        reconcileLeaderPagesAfterPhase2Failure(payload);
         recoverLeadershipAfterPhase2Failure(payload.tx().toString());
         throw e;
       } finally {
@@ -405,6 +406,7 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
             Phase 2 commit failed during ALL-quorum recovery (db=%s, txId=%s). \
             Leader database may be inconsistent. Stepping down so a node with correct state takes over. Error: %s""",
             getName(), payload.tx(), e.getMessage());
+        reconcileLeaderPagesAfterPhase2Failure(payload);
         recoverLeadershipAfterPhase2Failure(payload.tx().toString());
       } finally {
         current.popIfNotLastTransaction();
@@ -415,6 +417,28 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
 
   private static final int  STEP_DOWN_MAX_RETRIES    = 3;
   private static final long STEP_DOWN_RETRY_DELAY_MS = 500;
+
+  /**
+   * Attempts to bring the leader's pages into sync with the committed Raft entry after
+   * {@code commit2ndPhase} has failed. The WAL bytes in {@code payload} are the same bytes
+   * that Raft replicated to the followers; calling {@link com.arcadedb.engine.TransactionManager#applyChanges}
+   * with them uses page-version guards so already-applied pages are skipped and un-applied
+   * ones are written. After this call the leader's page versions match what the followers
+   * applied, so when this node steps down and replays the log as a follower it will not
+   * encounter a {@link com.arcadedb.exception.WALVersionGapException} for this entry.
+   */
+  private void reconcileLeaderPagesAfterPhase2Failure(final ReplicationPayload payload) {
+    try {
+      final WALFile.WALTransaction walTx = ArcadeStateMachine.deserializeWalTransaction(payload.walData());
+      proxied.getTransactionManager().applyChanges(walTx, payload.bucketDeltas(), false);
+      LogManager.instance().log(this, Level.INFO,
+          "Phase 2 failure: leader pages reconciled via WAL replay (db=%s, tx=%s)", getName(), payload.tx());
+    } catch (final Exception reconcileEx) {
+      LogManager.instance().log(this, Level.SEVERE,
+          "Phase 2 failure: leader page reconciliation also failed (db=%s, tx=%s): %s",
+          getName(), payload.tx(), reconcileEx.getMessage());
+    }
+  }
 
   private void recoverLeadershipAfterPhase2Failure(final String txDescription) {
     if (raftHAServer == null || !raftHAServer.isLeader())

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -444,11 +444,17 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * {@code commit2ndPhase} ran under. {@code applyChanges} mutates pages under the per-page I/O
    * lock, so running it under the same read lock keeps the page-write coordination identical to
    * the normal phase-2 path and avoids racing a concurrent phase-1 snapshot.
+   * <p>
+   * Uses {@code ignoreErrors=true}: this is a best-effort reconciliation, so if some page is more
+   * than one version behind (the leader was already lagging before this tx) {@code applyChanges}
+   * skips that page rather than aborting the whole replay on the first gap. Every page it CAN apply
+   * is applied; any page it cannot is left for the normal follower-side WAL-gap path to resync once
+   * this node steps down (issue #4740 Fix 2 makes that recoverable instead of fatal).
    */
   private void reconcileLeaderPagesAfterPhase2Failure(final ReplicationPayload payload) {
     try {
       final WALFile.WALTransaction walTx = ArcadeStateMachine.deserializeWalTransaction(payload.walData());
-      proxied.getTransactionManager().applyChanges(walTx, payload.bucketDeltas(), false);
+      proxied.getTransactionManager().applyChanges(walTx, payload.bucketDeltas(), true);
       LogManager.instance().log(this, Level.INFO,
           "Phase 2 failure: leader pages reconciled via WAL replay (db=%s, tx=%s)", getName(), payload.tx());
     } catch (final Exception reconcileEx) {

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineApplyRetryTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineApplyRetryTest.java
@@ -146,4 +146,30 @@ class ArcadeStateMachineApplyRetryTest {
     })).isSameAs(boom);
     assertThat(calls.get()).isEqualTo(1);
   }
+
+  @Test
+  void unexpectedErrorOnDivergedStateIsWrappedAsReplicationException() {
+    // Regression guard for issue #4740: when a WAL version gap has already diverged the state,
+    // subsequent apply operations may throw unexpected errors (NPE, ClassCastException, etc.) from
+    // operating on the inconsistent in-memory state. Instead of reaching the fatal server-halt path,
+    // they must be wrapped as ReplicationException (recoverable resync) while the snapshot download
+    // catches up.
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    sm.markStateDiverged();
+    final NullPointerException npe = new NullPointerException("inconsistent-state NPE after WAL gap");
+    assertThatThrownBy(() -> sm.applyWithRetry(10L, () -> { throw npe; }))
+        .isInstanceOf(ReplicationException.class)
+        .hasMessageContaining("snapshot resync")
+        .hasCause(npe);
+  }
+
+  @Test
+  void unexpectedErrorOnCleanStateIsRethrown() {
+    // Regression guard: an unexpected error on a node whose state is NOT diverged must still reach
+    // applyTransaction's fatal catch (Throwable) handler (server-halt path) so real bugs are caught.
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    // stateDivergedSinceWalGap is false by default - do NOT call markStateDiverged().
+    final NullPointerException npe = new NullPointerException("programming bug on healthy node");
+    assertThatThrownBy(() -> sm.applyWithRetry(11L, () -> { throw npe; })).isSameAs(npe);
+  }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineApplyRetryTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineApplyRetryTest.java
@@ -148,28 +148,54 @@ class ArcadeStateMachineApplyRetryTest {
   }
 
   @Test
-  void unexpectedErrorOnDivergedStateIsWrappedAsReplicationException() {
-    // Regression guard for issue #4740: when a WAL version gap has already diverged the state,
+  void unexpectedErrorOnDivergedDatabaseIsWrappedAsReplicationException() {
+    // Regression guard for issue #4740: when a WAL version gap has already diverged a database,
     // subsequent apply operations may throw unexpected errors (NPE, ClassCastException, etc.) from
     // operating on the inconsistent in-memory state. Instead of reaching the fatal server-halt path,
     // they must be wrapped as ReplicationException (recoverable resync) while the snapshot download
     // catches up.
     final ArcadeStateMachine sm = new ArcadeStateMachine();
-    sm.markStateDiverged();
+    sm.markStateDiverged("diverged-db");
     final NullPointerException npe = new NullPointerException("inconsistent-state NPE after WAL gap");
-    assertThatThrownBy(() -> sm.applyWithRetry(10L, () -> { throw npe; }))
+    assertThatThrownBy(() -> sm.applyWithRetry(10L, "diverged-db", () -> { throw npe; }))
         .isInstanceOf(ReplicationException.class)
         .hasMessageContaining("snapshot resync")
         .hasCause(npe);
   }
 
   @Test
-  void unexpectedErrorOnCleanStateIsRethrown() {
-    // Regression guard: an unexpected error on a node whose state is NOT diverged must still reach
-    // applyTransaction's fatal catch (Throwable) handler (server-halt path) so real bugs are caught.
+  void unexpectedErrorOnHealthyDatabaseIsRethrown() {
+    // Regression guard: an unexpected error while applying an entry for a database that is NOT
+    // diverged must still reach applyTransaction's fatal catch (Throwable) handler (server-halt
+    // path) so real bugs are caught. Critically, a gap in one database must not mask a bug in
+    // another: mark only "diverged-db" as diverged, then fail on "healthy-db".
     final ArcadeStateMachine sm = new ArcadeStateMachine();
-    // stateDivergedSinceWalGap is false by default - do NOT call markStateDiverged().
-    final NullPointerException npe = new NullPointerException("programming bug on healthy node");
-    assertThatThrownBy(() -> sm.applyWithRetry(11L, () -> { throw npe; })).isSameAs(npe);
+    sm.markStateDiverged("diverged-db");
+    final NullPointerException npe = new NullPointerException("programming bug on healthy database");
+    // server == null here, so applyWithRetry reads the default GlobalConfiguration.TX_RETRIES; the NPE
+    // is non-retryable so it exits on the first attempt regardless, and must propagate unchanged.
+    assertThatThrownBy(() -> sm.applyWithRetry(11L, "healthy-db", () -> { throw npe; })).isSameAs(npe);
+  }
+
+  @Test
+  void errorOnDivergedDatabaseIsRethrownNotWrapped() {
+    // Regression guard: a JVM Error (OutOfMemoryError, StackOverflowError, ...) indicates an
+    // unstable JVM and must NEVER be swallowed as a recoverable resync condition - even when the
+    // database is diverged it must propagate unchanged to the fatal halt path.
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    sm.markStateDiverged("diverged-db");
+    final OutOfMemoryError oom = new OutOfMemoryError("OOM on diverged database");
+    assertThatThrownBy(() -> sm.applyWithRetry(12L, "diverged-db", () -> { throw oom; })).isSameAs(oom);
+  }
+
+  @Test
+  void replicationExceptionOnDivergedDatabaseIsNotDoubleWrapped() {
+    // Regression guard: the WAL-gap escalation in applyTxEntry throws a ReplicationException while
+    // the database is already in the diverged set. applyWithRetry must propagate it unchanged rather
+    // than re-wrapping it (which would lose the original message and consume the escalation budget).
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    sm.markStateDiverged("diverged-db");
+    final ReplicationException re = new ReplicationException("WAL version gap detected - snapshot resync required");
+    assertThatThrownBy(() -> sm.applyWithRetry(13L, "diverged-db", () -> { throw re; })).isSameAs(re);
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineApplyRetryTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineApplyRetryTest.java
@@ -198,4 +198,45 @@ class ArcadeStateMachineApplyRetryTest {
     final ReplicationException re = new ReplicationException("WAL version gap detected - snapshot resync required");
     assertThatThrownBy(() -> sm.applyWithRetry(13L, "diverged-db", () -> { throw re; })).isSameAs(re);
   }
+
+  @Test
+  void boundedEscalationRePropagatesAfterThresholdExceeded() {
+    // Regression guard for issue #4740 bounded escalation: a database that can never resync must not
+    // swallow unexpected errors forever. The first MAX_DIVERGED_SWALLOWED_ERRORS (100) errors wrap as
+    // recoverable ReplicationExceptions; the next one is re-propagated to the fatal halt path so a
+    // stuck node surfaces loudly. The threshold check is incrementAndGet() > 100, so calls 1..100 wrap
+    // and call 101 re-propagates.
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    sm.markStateDiverged("stuck-db");
+    final NullPointerException npe = new NullPointerException("inconsistent state after WAL gap");
+    for (int i = 1; i <= 100; i++)
+      assertThatThrownBy(() -> sm.applyWithRetry(100L, "stuck-db", () -> { throw npe; }))
+          .as("swallow #%d must wrap as recoverable", i)
+          .isInstanceOf(ReplicationException.class);
+    assertThat(sm.divergedSwallowedErrorCount()).isEqualTo(100);
+    // The 101st swallowed error exceeds the budget and must propagate unchanged.
+    assertThatThrownBy(() -> sm.applyWithRetry(101L, "stuck-db", () -> { throw npe; })).isSameAs(npe);
+  }
+
+  @Test
+  void clearDivergedStateResetsSetAndCounter() {
+    // Regression guard: a completed snapshot resync calls clearDivergedState(), which must clear both
+    // the diverged-database set and the bounded-escalation counter so the node returns to normal
+    // fail-fast behaviour.
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    sm.markStateDiverged("db");
+    final NullPointerException npe = new NullPointerException("inconsistent state after WAL gap");
+    for (int i = 0; i < 3; i++)
+      assertThatThrownBy(() -> sm.applyWithRetry(200L, "db", () -> { throw npe; }))
+          .isInstanceOf(ReplicationException.class);
+    assertThat(sm.isDatabaseDiverged("db")).isTrue();
+    assertThat(sm.divergedSwallowedErrorCount()).isEqualTo(3);
+
+    sm.clearDivergedState();
+
+    assertThat(sm.isDatabaseDiverged("db")).isFalse();
+    assertThat(sm.divergedSwallowedErrorCount()).isZero();
+    // After the reset the database is healthy again, so an unexpected error must propagate unchanged.
+    assertThatThrownBy(() -> sm.applyWithRetry(201L, "db", () -> { throw npe; })).isSameAs(npe);
+  }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4740Phase2ReconcileIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue4740Phase2ReconcileIT.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.RID;
+import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.log.LogManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4740 (Fix 1 - leader self-reconciliation).
+ * <p>
+ * When the leader's local {@code commit2ndPhase} fails <b>after</b> Raft has already committed the
+ * entry (followers applied it), the leader's pages stay one version behind the committed log. Before
+ * the fix, the ex-leader stepped down without reconciling its own pages: when it then applied
+ * subsequent entries as a follower it hit a {@link com.arcadedb.exception.WALVersionGapException} on
+ * every entry touching that page, triggering non-converging snapshot resyncs.
+ * <p>
+ * The fix replays the same committed WAL bytes on the leader (idempotent via page-version guards)
+ * before stepping down, so the ex-leader's page versions match the followers and no WAL gap occurs.
+ * <p>
+ * This test injects a single phase-2 failure via {@link RaftReplicatedDatabase#TEST_PHASE2_COMMIT_FAULT},
+ * then drives more writes to the <b>same page</b> through the new leader and asserts:
+ * <ol>
+ *   <li>the cluster converges (all nodes hold identical record counts), and</li>
+ *   <li>no node ever raised a WAL version gap ({@link ArcadeStateMachine#TEST_WAL_GAP_COUNTER} == 0) -
+ *       which would have happened on the un-reconciled ex-leader without the fix.</li>
+ * </ol>
+ */
+@Tag("slow")
+class Issue4740Phase2ReconcileIT extends BaseRaftHATest {
+
+  private static final String VERTEX_TYPE = "Phase2Reconcile";
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    config.setValue(GlobalConfiguration.HA_QUORUM, "majority");
+  }
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @AfterEach
+  void clearHooks() {
+    RaftReplicatedDatabase.TEST_PHASE2_COMMIT_FAULT = null;
+    ArcadeStateMachine.TEST_WAL_GAP_COUNTER = null;
+  }
+
+  @Test
+  void leaderReconcilesOwnPagesAfterPhase2FailureSoNoWalGap() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+
+    // Single, low-bucket vertex type so repeated updates land on the same page (forces the
+    // page-version contention that surfaces the WAL gap when reconciliation is missing).
+    leaderDb.transaction(() -> {
+      if (!leaderDb.getSchema().existsType(VERTEX_TYPE))
+        leaderDb.getSchema().createVertexType(VERTEX_TYPE, 1);
+    });
+
+    // Baseline: a single vertex that every later write updates (same page).
+    final Object[] ridHolder = new Object[1];
+    leaderDb.transaction(() -> {
+      final MutableVertex v = leaderDb.newVertex(VERTEX_TYPE);
+      v.set("counter", 0);
+      v.save();
+      ridHolder[0] = v.getIdentity();
+    });
+    assertClusterConsistency();
+
+    // Arm the global WAL-gap counter so any divergence on any node is observable.
+    final AtomicInteger walGapCounter = new AtomicInteger(0);
+    ArcadeStateMachine.TEST_WAL_GAP_COUNTER = walGapCounter;
+
+    // Arm a single-shot phase-2 fault: the next leader commit replicates through Raft (followers
+    // apply it) and then throws before commit2ndPhase, leaving the leader one version behind.
+    final AtomicBoolean faultFired = new AtomicBoolean(false);
+    RaftReplicatedDatabase.TEST_PHASE2_COMMIT_FAULT = dbName -> {
+      if (!faultFired.compareAndSet(false, true))
+        return;
+      LogManager.instance().log(Issue4740Phase2ReconcileIT.class, Level.INFO,
+          "TEST: injecting phase-2 commit fault for db=%s on leader %d", dbName, leaderIndex);
+      throw new ConcurrentModificationException("TEST fault injection: simulated phase-2 commit failure (#4740)");
+    };
+
+    // Trigger the faulted write. The commit throws to the client (the entry is Raft-committed).
+    try {
+      leaderDb.begin();
+      final MutableVertex v = leaderDb.lookupByRID((RID) ridHolder[0], true).asVertex().modify();
+      v.set("counter", 1);
+      v.save();
+      leaderDb.commit();
+      LogManager.instance().log(this, Level.INFO, "TEST: faulted commit unexpectedly succeeded");
+    } catch (final Exception expected) {
+      LogManager.instance().log(this, Level.INFO,
+          "TEST: leader phase-2 commit failed as expected: %s", expected.getMessage());
+    }
+
+    assertThat(faultFired.get()).as("Phase-2 fault hook must have fired").isTrue();
+
+    // A new leader must take over (the ex-leader stepped down). Find any leader now.
+    final int newLeaderIndex = waitForAnyLeader();
+    assertThat(newLeaderIndex).as("A leader must be elected after the phase-2 step-down").isGreaterThanOrEqualTo(0);
+
+    // Drive further updates to the SAME page through the cluster. Without reconciliation the
+    // ex-leader (now a follower) would be a version behind and raise a WAL gap on these.
+    final Database newLeaderDb = getServerDatabase(newLeaderIndex, getDatabaseName());
+    for (int i = 2; i <= 12; i++) {
+      final int counter = i;
+      newLeaderDb.transaction(() -> {
+        final MutableVertex v = newLeaderDb.lookupByRID((RID) ridHolder[0], true).asVertex().modify();
+        v.set("counter", counter);
+        v.save();
+      });
+    }
+
+    // Let all nodes catch up.
+    for (int i = 0; i < getServerCount(); i++)
+      waitForReplicationIsCompleted(i);
+
+    // Core assertion: the leader reconciled its own pages, so no node ever hit a WAL version gap.
+    assertThat(walGapCounter.get())
+        .as("Leader self-reconciliation must prevent any WAL version gap after a phase-2 failure")
+        .isZero();
+
+    // The cluster must converge: every node holds exactly one vertex with the final counter value.
+    assertClusterConsistency();
+    for (int i = 0; i < getServerCount(); i++) {
+      final Database db = getServerDatabase(i, getDatabaseName());
+      assertThat(db.countType(VERTEX_TYPE, true))
+          .as("Node %d must hold exactly one vertex", i).isEqualTo(1L);
+    }
+  }
+
+  private int waitForAnyLeader() {
+    final long deadline = System.currentTimeMillis() + 30_000;
+    while (System.currentTimeMillis() < deadline) {
+      for (int i = 0; i < getServerCount(); i++) {
+        final RaftHAPlugin plugin = getRaftPlugin(i);
+        if (plugin != null && plugin.isLeader())
+          return i;
+      }
+      try {
+        Thread.sleep(500);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return -1;
+      }
+    }
+    return -1;
+  }
+}


### PR DESCRIPTION
Closes #4740

## Summary

Two compounding bugs could take a Raft HA node fully offline after a leader's local phase-2 commit failed following successful Raft replication.

**Fix 1 - Leader self-reconciliation (`RaftReplicatedDatabase`):** When `commit2ndPhase` throws after Raft has already committed the entry, the leader's pages stay at version N while followers advanced to N+1. On rejoining as a follower, the ex-leader hits `WALVersionGapException` on every subsequent apply, triggering 153+ non-converging snapshot resync attempts in the issue's reproduction. After phase-2 fails, `reconcileLeaderPagesAfterPhase2Failure` now calls `applyChanges` with the same WAL payload (page-version guards make this idempotent) to bring leader pages to N+1 before the step-down. The same reconciliation was added to the `applyLocallyAfterMajorityCommit` failure path.

**Fix 2 - Diverged-state fatal halt guard (`ArcadeStateMachine`):** After WAL gaps leave the database in an inconsistent in-memory state, subsequent `applyTransaction` calls can throw unexpected errors (NPE, ClassCastException, etc.) from operating on the corrupted state. These reached the `catch (Throwable)` branch, set `haltedAfterCriticalError`, and triggered an orderly server shutdown with no auto-recovery path - requiring a manual data-dir wipe. The new `stateDivergedSinceWalGap` flag is set on the first `WALVersionGapException`; while set, unexpected `Throwable`s in `applyWithRetry` are wrapped as `ReplicationException` (recoverable resync) instead of propagating to the fatal halt path. The flag is cleared when a snapshot resync completes. As a bonus, the first WAL gap now also schedules an immediate snapshot download via `lifecycleExecutor` instead of waiting for the HealthMonitor's periodic check interval.

## Test plan

- [ ] `ArcadeStateMachineApplyRetryTest` - 8/8 pass: 2 new regression guards verify (a) NPE on diverged state wraps as `ReplicationException`, (b) NPE on clean state still propagates for the fatal halt path
- [ ] All ha-raft unit tests (48 total) pass
- [ ] Full project build (`mvn clean install -DskipTests`) passes
- [ ] Manual cluster test: inject phase-2 failure via `RaftReplicatedDatabase.TEST_POST_REPLICATION_HOOK`, verify no WAL version gap on the ex-leader when it becomes follower and no `haltedAfterCriticalError` trigger on diverged state