### PR TITLE
fix: [#4741] follower-side recovery for stuck Raft-log divergence (IN…

### DIFF
--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -984,6 +984,16 @@ public enum GlobalConfiguration {
       disable (node restart becomes the only mitigation).""",
       Boolean.class, true),
 
+  HA_DIVERGED_FOLLOWER_MAX_REFORMATS("arcadedb.ha.divergedFollowerMaxReformats", SCOPE.SERVER,
+      """
+      Maximum number of automatic Raft-storage reformats (HA_DIVERGED_FOLLOWER_RECOVERY) allowed within one divergence \
+      episode before the follower gives up and logs a SEVERE message for operator intervention, instead of reformatting \
+      and full-snapshot-installing every HA_STALE_FOLLOWER_RECOVERY_DURATION_MS forever. A clean reformat resets the \
+      shared Ratis restart-retry budget, so without this cap a node whose divergence keeps reproducing would loop \
+      silently. The budget re-arms once the follower has looked healthy for 5x the recovery duration (the episode is \
+      considered resolved). Set to 0 for unbounded reformats (no breaker).""",
+      Integer.class, 5),
+
   HA_STALLED_REPLICA_RESYNC_DURATION_MS("arcadedb.ha.stalledReplicaResyncDurationMs", SCOPE.SERVER,
       """
       How long in milliseconds a replica must stay continuously STALLED (its matchIndex not advancing while the leader \

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -973,9 +973,9 @@ public enum GlobalConfiguration {
 
   HA_DIVERGED_FOLLOWER_RECOVERY("arcadedb.ha.divergedFollowerRecovery", SCOPE.SERVER,
       """
-      When enabled, a follower that detects it is stuck at a stale term against the leader (it recognizes a leader at a \
-      newer term and has applied everything it could locally commit, yet its last-applied entry is from an older term) \
-      automatically reformats its Raft storage and rejoins as a fresh peer, letting the leader reconcile it via the \
+      When true (default), a follower that detects it is stuck at a stale term against the leader (it recognizes a leader \
+      at a newer term and has applied everything it could locally commit, yet its last-applied entry is from an older \
+      term) automatically reformats its Raft storage and rejoins as a fresh peer, letting the leader reconcile it via the \
       snapshot-install path. This covers issue #4741: a tiny (1-2 entry) Raft-log divergence on an otherwise idle \
       cluster, where the leader's log is never compacted, so neither the follower-side stale recovery \
       (HA_STALE_FOLLOWER_LAG_THRESHOLD) nor the leader-driven stalled-replica resync \
@@ -987,9 +987,12 @@ public enum GlobalConfiguration {
       from the leader). The signature is "stuck at a stale term", which a genuine log divergence satisfies but so can a \
       sustained (> HA_STALE_FOLLOWER_RECOVERY_DURATION_MS) one-sided network outage where heartbeats arrive but the \
       leader's current-term entries do not; in that case the reformat is wasteful (no data loss - the leader holds \
-      everything) but does not fix the connectivity. Disabled means a manual node restart remains the only mitigation \
-      for #4741.""",
-      Boolean.class, false),
+      everything) but does not fix the connectivity. \
+      No cross-follower coordination: if a systemic condition makes several followers satisfy the signature at once they \
+      may reformat within the same window, briefly costing quorum while they re-sync. This is bounded (each reformat is \
+      non-data-losing and HA_DIVERGED_FOLLOWER_MAX_REFORMATS caps retries) and a leader-coordinated one-at-a-time variant \
+      is deferred to a follow-up; set this to false to fall back to a manual node restart as the only #4741 mitigation.""",
+      Boolean.class, true),
 
   HA_DIVERGED_FOLLOWER_MAX_REFORMATS("arcadedb.ha.divergedFollowerMaxReformats", SCOPE.SERVER,
       """

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -973,16 +973,23 @@ public enum GlobalConfiguration {
 
   HA_DIVERGED_FOLLOWER_RECOVERY("arcadedb.ha.divergedFollowerRecovery", SCOPE.SERVER,
       """
-      When true (default), a follower that detects it is stuck against the leader (it recognizes a leader at a newer \
-      term but cannot apply the leader's current-term entries because its Raft log diverged) automatically reformats its \
-      Raft storage and rejoins as a fresh peer, which lets the leader reconcile it via the snapshot-install path. \
-      This covers issue #4741: a tiny (1-2 entry) Raft-log divergence on an otherwise idle cluster, where the leader's \
-      log is never compacted, so neither the follower-side stale recovery (HA_STALE_FOLLOWER_LAG_THRESHOLD) nor the \
-      leader-driven stalled-replica resync (HA_STALLED_REPLICA_RESYNC_DURATION_MS) ever fire - both need a large lag - \
-      and the leader's appender otherwise loops on INCONSISTENCY forever until an operator restarts a node. The stuck \
-      condition must persist for HA_STALE_FOLLOWER_RECOVERY_DURATION_MS before recovery triggers. Set to false to \
-      disable (node restart becomes the only mitigation).""",
-      Boolean.class, true),
+      When enabled, a follower that detects it is stuck at a stale term against the leader (it recognizes a leader at a \
+      newer term and has applied everything it could locally commit, yet its last-applied entry is from an older term) \
+      automatically reformats its Raft storage and rejoins as a fresh peer, letting the leader reconcile it via the \
+      snapshot-install path. This covers issue #4741: a tiny (1-2 entry) Raft-log divergence on an otherwise idle \
+      cluster, where the leader's log is never compacted, so neither the follower-side stale recovery \
+      (HA_STALE_FOLLOWER_LAG_THRESHOLD) nor the leader-driven stalled-replica resync \
+      (HA_STALLED_REPLICA_RESYNC_DURATION_MS) ever fire - both need a large lag - and the leader's appender otherwise \
+      loops on INCONSISTENCY forever until an operator restarts a node. The stuck condition must persist for \
+      HA_STALE_FOLLOWER_RECOVERY_DURATION_MS before recovery triggers, and HA_DIVERGED_FOLLOWER_MAX_REFORMATS bounds how \
+      often it retries. \
+      DESTRUCTIVE: this deletes the local Raft storage automatically (the database files are preserved and re-synced \
+      from the leader). The signature is "stuck at a stale term", which a genuine log divergence satisfies but so can a \
+      sustained (> HA_STALE_FOLLOWER_RECOVERY_DURATION_MS) one-sided network outage where heartbeats arrive but the \
+      leader's current-term entries do not; in that case the reformat is wasteful (no data loss - the leader holds \
+      everything) but does not fix the connectivity. Disabled means a manual node restart remains the only mitigation \
+      for #4741.""",
+      Boolean.class, false),
 
   HA_DIVERGED_FOLLOWER_MAX_REFORMATS("arcadedb.ha.divergedFollowerMaxReformats", SCOPE.SERVER,
       """

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -971,6 +971,19 @@ public enum GlobalConfiguration {
       (across consecutive health-monitor ticks) before recovery is triggered. Avoids acting on transient catch-up lag.""",
       Long.class, 60_000L),
 
+  HA_DIVERGED_FOLLOWER_RECOVERY("arcadedb.ha.divergedFollowerRecovery", SCOPE.SERVER,
+      """
+      When true (default), a follower that detects it is stuck against the leader (it recognizes a leader at a newer \
+      term but cannot apply the leader's current-term entries because its Raft log diverged) automatically reformats its \
+      Raft storage and rejoins as a fresh peer, which lets the leader reconcile it via the snapshot-install path. \
+      This covers issue #4741: a tiny (1-2 entry) Raft-log divergence on an otherwise idle cluster, where the leader's \
+      log is never compacted, so neither the follower-side stale recovery (HA_STALE_FOLLOWER_LAG_THRESHOLD) nor the \
+      leader-driven stalled-replica resync (HA_STALLED_REPLICA_RESYNC_DURATION_MS) ever fire - both need a large lag - \
+      and the leader's appender otherwise loops on INCONSISTENCY forever until an operator restarts a node. The stuck \
+      condition must persist for HA_STALE_FOLLOWER_RECOVERY_DURATION_MS before recovery triggers. Set to false to \
+      disable (node restart becomes the only mitigation).""",
+      Boolean.class, true),
+
   HA_STALLED_REPLICA_RESYNC_DURATION_MS("arcadedb.ha.stalledReplicaResyncDurationMs", SCOPE.SERVER,
       """
       How long in milliseconds a replica must stay continuously STALLED (its matchIndex not advancing while the leader \

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/HealthMonitor.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/HealthMonitor.java
@@ -92,35 +92,52 @@ public final class HealthMonitor {
     }
   }
 
+  // How long (as a multiple of the recovery duration) the follower must look healthy before a prior
+  // reformat episode is considered resolved and the bounded reformat budget re-arms.
+  private static final long REFORMAT_EPISODE_RESET_MULTIPLIER = 5L;
+
   private final    HealthTarget             target;
   private final    long                     intervalMs;
   private final    long                     staleFollowerLagThreshold;
   private final    long                     staleFollowerRecoveryDurationMs;
   private final    boolean                  divergedFollowerRecoveryEnabled;
+  private final    int                      divergedFollowerMaxReformats;
   private volatile ScheduledExecutorService executor;
   // Wall-clock time (ms) when the current uninterrupted lag streak was first observed; -1 = not lagging.
-  private          long                     lagObservedSinceMs   = -1;
+  private          long                     lagObservedSinceMs        = -1;
   // Wall-clock time (ms) when the current uninterrupted stuck-divergence streak was first observed; -1 = not stuck.
-  private          long                     stuckObservedSinceMs = -1;
+  private          long                     stuckObservedSinceMs      = -1;
+  // Bounded reformat budget (#4741 review): reformats fired in the current divergence episode, the
+  // time the follower started looking healthy again, and whether the budget is exhausted (logged once).
+  private          int                      divergenceReformatCount   = 0;
+  private          long                     divergenceHealthySinceMs  = -1;
+  private          boolean                  divergenceRecoveryExhausted = false;
   // Injectable for deterministic tests; defaults to the system clock.
-  private          LongSupplier             clock                = System::currentTimeMillis;
+  private          LongSupplier             clock                     = System::currentTimeMillis;
 
   public HealthMonitor(final HealthTarget target, final long intervalMs) {
-    this(target, intervalMs, 0L, 0L, false);
+    this(target, intervalMs, 0L, 0L, false, 0);
   }
 
   public HealthMonitor(final HealthTarget target, final long intervalMs, final long staleFollowerLagThreshold,
       final long staleFollowerRecoveryDurationMs) {
-    this(target, intervalMs, staleFollowerLagThreshold, staleFollowerRecoveryDurationMs, false);
+    this(target, intervalMs, staleFollowerLagThreshold, staleFollowerRecoveryDurationMs, false, 0);
   }
 
   public HealthMonitor(final HealthTarget target, final long intervalMs, final long staleFollowerLagThreshold,
       final long staleFollowerRecoveryDurationMs, final boolean divergedFollowerRecoveryEnabled) {
+    this(target, intervalMs, staleFollowerLagThreshold, staleFollowerRecoveryDurationMs, divergedFollowerRecoveryEnabled, 0);
+  }
+
+  public HealthMonitor(final HealthTarget target, final long intervalMs, final long staleFollowerLagThreshold,
+      final long staleFollowerRecoveryDurationMs, final boolean divergedFollowerRecoveryEnabled,
+      final int divergedFollowerMaxReformats) {
     this.target = target;
     this.intervalMs = intervalMs;
     this.staleFollowerLagThreshold = staleFollowerLagThreshold;
     this.staleFollowerRecoveryDurationMs = staleFollowerRecoveryDurationMs;
     this.divergedFollowerRecoveryEnabled = divergedFollowerRecoveryEnabled;
+    this.divergedFollowerMaxReformats = divergedFollowerMaxReformats;
   }
 
   /** Package-private test hook to drive the persistence logic deterministically. */
@@ -165,12 +182,17 @@ public final class HealthMonitor {
       HALog.log(this, HALog.BASIC, "Health monitor detected Ratis %s state, attempting recovery", state);
       target.restartRatisIfNeeded();
       // A Ratis restart will reinitialize the state machine and re-detect any snapshot gap, so
-      // drop any pending stale-follower / stuck-divergence streak to avoid a redundant recovery
-      // right after the restart.
+      // drop any pending stale-follower / stuck-divergence streak (and the reformat budget) to avoid
+      // a redundant recovery right after the restart.
       lagObservedSinceMs = -1;
       stuckObservedSinceMs = -1;
+      divergenceReformatCount = 0;
+      divergenceHealthySinceMs = -1;
+      divergenceRecoveryExhausted = false;
       return;
     }
+    // checkStaleFollower (lag: commit - applied > threshold) and checkStuckFollower (divergence:
+    // commit == applied) are mutually exclusive by construction, so at most one arms per tick.
     checkStaleFollower();
     checkStuckFollower();
   }
@@ -216,24 +238,56 @@ public final class HealthMonitor {
     if (!divergedFollowerRecoveryEnabled)
       return; // disabled
 
+    final long now = clock.getAsLong();
+
     if (!target.isFollowerStuckDiverged()) {
       stuckObservedSinceMs = -1;
+      // Forget a prior reformat episode once the follower has looked healthy long enough that the
+      // divergence is considered resolved, re-arming the bounded reformat budget for any genuinely
+      // new divergence later.
+      if (divergenceReformatCount > 0) {
+        if (divergenceHealthySinceMs == -1)
+          divergenceHealthySinceMs = now;
+        else if (now - divergenceHealthySinceMs >= staleFollowerRecoveryDurationMs * REFORMAT_EPISODE_RESET_MULTIPLIER) {
+          divergenceReformatCount = 0;
+          divergenceHealthySinceMs = -1;
+          divergenceRecoveryExhausted = false;
+        }
+      }
       return;
     }
 
-    final long now = clock.getAsLong();
+    divergenceHealthySinceMs = -1; // still stuck: the episode is ongoing
+
     if (stuckObservedSinceMs == -1) {
       stuckObservedSinceMs = now; // first observation; require persistence before acting
       return;
     }
 
-    if (now - stuckObservedSinceMs >= staleFollowerRecoveryDurationMs) {
-      LogManager.instance().log(this, Level.WARNING,
-          "Follower stuck-diverged from leader for %dms, reformatting Raft storage and rejoining",
-          now - stuckObservedSinceMs);
-      target.recoverFromDivergence();
-      stuckObservedSinceMs = -1; // reset; the next streak re-arms only if the divergence persists again
+    if (now - stuckObservedSinceMs < staleFollowerRecoveryDurationMs)
+      return; // not persisted long enough yet
+
+    // Bounded reformat budget (#4741 review): a reformat that restarts cleanly resets the shared Ratis
+    // restart-retry counter, so a node whose divergence keeps reproducing would otherwise reformat +
+    // full-snapshot-install every persistence window forever. Cap reformats per episode; once exhausted,
+    // stop and surface it (SEVERE, once) for operator action instead of looping silently.
+    if (divergedFollowerMaxReformats > 0 && divergenceReformatCount >= divergedFollowerMaxReformats) {
+      if (!divergenceRecoveryExhausted) {
+        divergenceRecoveryExhausted = true;
+        LogManager.instance().log(this, Level.SEVERE,
+            "Follower still stuck-diverged after %d automatic Raft-storage reformats; giving up auto-recovery - operator intervention required",
+            divergedFollowerMaxReformats);
+      }
+      stuckObservedSinceMs = -1; // re-arm the persistence streak but do not reformat again
+      return;
     }
+
+    divergenceReformatCount++;
+    LogManager.instance().log(this, Level.WARNING,
+        "Follower stuck-diverged from leader for %dms, reformatting Raft storage and rejoining (attempt %d)",
+        now - stuckObservedSinceMs, divergenceReformatCount);
+    target.recoverFromDivergence();
+    stuckObservedSinceMs = -1; // reset; the next streak re-arms only if the divergence persists again
   }
 
   private void tickSafely() {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/HealthMonitor.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/HealthMonitor.java
@@ -104,16 +104,16 @@ public final class HealthMonitor {
   private final    int                      divergedFollowerMaxReformats;
   private volatile ScheduledExecutorService executor;
   // Wall-clock time (ms) when the current uninterrupted lag streak was first observed; -1 = not lagging.
-  private          long                     lagObservedSinceMs        = -1;
+  private          long                     lagObservedSinceMs          = -1;
   // Wall-clock time (ms) when the current uninterrupted stuck-divergence streak was first observed; -1 = not stuck.
-  private          long                     stuckObservedSinceMs      = -1;
+  private          long                     stuckObservedSinceMs        = -1;
   // Bounded reformat budget (#4741 review): reformats fired in the current divergence episode, the
   // time the follower started looking healthy again, and whether the budget is exhausted (logged once).
-  private          int                      divergenceReformatCount   = 0;
-  private          long                     divergenceHealthySinceMs  = -1;
+  private          int                      divergenceReformatCount     = 0;
+  private          long                     divergenceHealthySinceMs    = -1;
   private          boolean                  divergenceRecoveryExhausted = false;
   // Injectable for deterministic tests; defaults to the system clock.
-  private          LongSupplier             clock                     = System::currentTimeMillis;
+  private          LongSupplier             clock                       = System::currentTimeMillis;
 
   public HealthMonitor(final HealthTarget target, final long intervalMs) {
     this(target, intervalMs, 0L, 0L, false, 0);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/HealthMonitor.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/HealthMonitor.java
@@ -66,6 +66,24 @@ public final class HealthMonitor {
     }
 
     /**
+     * Returns {@code true} when this node is a running follower that is stuck against the leader: it
+     * recognizes a leader at a newer term but cannot apply the leader's current-term entries because
+     * its Raft log diverged (issue #4741). Unlike {@link #isFollowerLaggingBeyond(long)} this is not a
+     * lag count - the divergence can be a single entry on an idle cluster - so it has no threshold.
+     * Implementations must return {@code false} for the leader and whenever the state cannot be read.
+     */
+    default boolean isFollowerStuckDiverged() {
+      return false;
+    }
+
+    /**
+     * Recovers a follower that is stuck-diverged by reformatting its Raft storage and rejoining the
+     * group as a fresh peer, which lets the leader reconcile it via the snapshot-install path.
+     */
+    default void recoverFromDivergence() {
+    }
+
+    /**
      * Proactively reconciles the inbound Raft gRPC peer allowlist with current DNS so a peer that
      * restarted with a new pod IP is admitted without first being rejected (issue #4696). No-op when
      * the allowlist is disabled; the filter itself throttles the DNS re-resolution.
@@ -78,22 +96,31 @@ public final class HealthMonitor {
   private final    long                     intervalMs;
   private final    long                     staleFollowerLagThreshold;
   private final    long                     staleFollowerRecoveryDurationMs;
+  private final    boolean                  divergedFollowerRecoveryEnabled;
   private volatile ScheduledExecutorService executor;
   // Wall-clock time (ms) when the current uninterrupted lag streak was first observed; -1 = not lagging.
-  private          long                     lagObservedSinceMs = -1;
+  private          long                     lagObservedSinceMs   = -1;
+  // Wall-clock time (ms) when the current uninterrupted stuck-divergence streak was first observed; -1 = not stuck.
+  private          long                     stuckObservedSinceMs = -1;
   // Injectable for deterministic tests; defaults to the system clock.
-  private          LongSupplier             clock              = System::currentTimeMillis;
+  private          LongSupplier             clock                = System::currentTimeMillis;
 
   public HealthMonitor(final HealthTarget target, final long intervalMs) {
-    this(target, intervalMs, 0L, 0L);
+    this(target, intervalMs, 0L, 0L, false);
   }
 
   public HealthMonitor(final HealthTarget target, final long intervalMs, final long staleFollowerLagThreshold,
       final long staleFollowerRecoveryDurationMs) {
+    this(target, intervalMs, staleFollowerLagThreshold, staleFollowerRecoveryDurationMs, false);
+  }
+
+  public HealthMonitor(final HealthTarget target, final long intervalMs, final long staleFollowerLagThreshold,
+      final long staleFollowerRecoveryDurationMs, final boolean divergedFollowerRecoveryEnabled) {
     this.target = target;
     this.intervalMs = intervalMs;
     this.staleFollowerLagThreshold = staleFollowerLagThreshold;
     this.staleFollowerRecoveryDurationMs = staleFollowerRecoveryDurationMs;
+    this.divergedFollowerRecoveryEnabled = divergedFollowerRecoveryEnabled;
   }
 
   /** Package-private test hook to drive the persistence logic deterministically. */
@@ -138,11 +165,14 @@ public final class HealthMonitor {
       HALog.log(this, HALog.BASIC, "Health monitor detected Ratis %s state, attempting recovery", state);
       target.restartRatisIfNeeded();
       // A Ratis restart will reinitialize the state machine and re-detect any snapshot gap, so
-      // drop any pending stale-follower streak to avoid a redundant download right after recovery.
+      // drop any pending stale-follower / stuck-divergence streak to avoid a redundant recovery
+      // right after the restart.
       lagObservedSinceMs = -1;
+      stuckObservedSinceMs = -1;
       return;
     }
     checkStaleFollower();
+    checkStuckFollower();
   }
 
   /**
@@ -172,6 +202,37 @@ public final class HealthMonitor {
           staleFollowerLagThreshold, now - lagObservedSinceMs);
       target.recoverFromPersistentLag();
       lagObservedSinceMs = -1; // reset; the next streak re-arms only if the lag persists again
+    }
+  }
+
+  /**
+   * Reformats and rejoins a follower that has been stuck-diverged from the leader for at least
+   * {@link #staleFollowerRecoveryDurationMs} (issue #4741). Mirrors {@link #checkStaleFollower()}:
+   * the first observation only starts the streak, any tick where the stuck condition clears resets
+   * it, and the recovery fires at most once per streak. Reuses the stale-follower recovery duration
+   * so both self-healing paths share the same "must persist this long" knob.
+   */
+  private void checkStuckFollower() {
+    if (!divergedFollowerRecoveryEnabled)
+      return; // disabled
+
+    if (!target.isFollowerStuckDiverged()) {
+      stuckObservedSinceMs = -1;
+      return;
+    }
+
+    final long now = clock.getAsLong();
+    if (stuckObservedSinceMs == -1) {
+      stuckObservedSinceMs = now; // first observation; require persistence before acting
+      return;
+    }
+
+    if (now - stuckObservedSinceMs >= staleFollowerRecoveryDurationMs) {
+      LogManager.instance().log(this, Level.WARNING,
+          "Follower stuck-diverged from leader for %dms, reformatting Raft storage and rejoining",
+          now - stuckObservedSinceMs);
+      target.recoverFromDivergence();
+      stuckObservedSinceMs = -1; // reset; the next streak re-arms only if the divergence persists again
     }
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -585,11 +585,21 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   /**
    * Pure decision function behind {@link #isFollowerStuckDiverged()}, split out so the predicate can be
    * unit-tested in isolation from the Ratis state plumbing (the destructive recovery makes the predicate
-   * the highest-risk piece). Returns {@code true} only for the divergence signature: a follower that
-   * recognizes a leader, is neither catching up nor installing a snapshot, has applied everything it
+   * the highest-risk piece). Returns {@code true} for the "stuck at a stale term" signature: a follower
+   * that recognizes a leader, is neither catching up nor installing a snapshot, has applied everything it
    * could locally commit ({@code commitIndex == appliedIndex}) yet at a stale term
    * ({@code currentTerm > appliedTerm}). Any negative term/index input (state not readable) yields
    * {@code false}, including a negative {@code appliedTerm}.
+   * <p>
+   * Note this signature is satisfied by a genuine Raft-log divergence and also, in principle, by a
+   * follower that simply cannot receive the leader's current-term entries for a sustained period (a
+   * one-sided outage where heartbeats still arrive). The caller relies on the persistence window to
+   * separate a transient hiccup from a stuck state; both resolve to the same safe (non-data-losing)
+   * recovery, so the predicate does not try to distinguish them.
+   * <p>
+   * A freshly (re)joined / empty node does not match: before it applies anything its applied
+   * {@link TermIndex} is null (handled by the caller), while it is catching up it has
+   * {@code commitIndex > appliedIndex}, and once caught up its applied term equals the current term.
    */
   static boolean isStuckDivergedState(final boolean leaderPresent, final boolean catchingUp,
       final boolean snapshotPending, final long currentTerm, final long appliedTerm, final long appliedIndex,
@@ -607,8 +617,17 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   public void recoverFromDivergence() {
     if (shutdownRequested || isLeader())
       return;
+    // Log the exact term/index values so an operator can confirm post-incident whether this was a genuine
+    // Raft-log divergence or a follower merely stuck at a stale term for another reason (e.g. a sustained
+    // one-sided network outage where heartbeats arrive but the leader's current-term entries do not).
+    final ArcadeStateMachine sm = stateMachine;
+    final TermIndex applied = sm != null ? sm.getLastAppliedTermIndex() : null;
     LogManager.instance().log(this, Level.WARNING,
-        "Follower diverged from leader and cannot reconcile its Raft log; reformatting Raft storage and rejoining the group");
+        "Follower stuck at a stale term (currentTerm=%d, appliedTerm=%d, appliedIndex=%d, commitIndex=%d); "
+            + "reformatting Raft storage and rejoining so the leader can reconcile it via snapshot-install. "
+            + "If this recurs without a genuine log divergence, suspect a sustained one-sided outage to the leader.",
+        getCurrentTerm(), applied != null ? applied.getTerm() : -1L, applied != null ? applied.getIndex() : -1L,
+        getCommitIndex());
     restartRatis(true);
   }
 
@@ -704,12 +723,13 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
           if (storageDir.exists()) {
             deleteRecursive(storageDir);
             // deleteRecursive swallows per-file failures (e.g. a locked file or a permission issue on
-            // Windows). If the directory survives, FORMAT on a non-empty dir can fail or misbehave, so
-            // surface it for diagnostics rather than failing opaquely later.
+            // Windows). FORMAT on a non-empty directory is undefined behaviour, so abort instead of
+            // proceeding: the throw is caught below, increments restartFailureCount, and the divergence
+            // reformat budget already counted this as an attempt - so the failure escalates through the
+            // existing retry/backoff machinery rather than starting Ratis on a half-deleted directory.
             if (storageDir.exists())
-              LogManager.instance().log(this, Level.WARNING,
-                  "Could not fully delete Raft storage directory %s before reformat; Ratis FORMAT startup may fail",
-                  storageDir.getAbsolutePath());
+              throw new IOException("Could not fully delete Raft storage directory " + storageDir.getAbsolutePath()
+                  + " before reformat; aborting to avoid FORMAT on a non-empty directory");
           }
           startupOption = RaftStorage.StartupOption.FORMAT;
         } else

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -481,8 +481,10 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
         GlobalConfiguration.HA_STALE_FOLLOWER_RECOVERY_DURATION_MS);
     final boolean divergedFollowerRecovery = configuration.getValueAsBoolean(
         GlobalConfiguration.HA_DIVERGED_FOLLOWER_RECOVERY);
+    final int divergedFollowerMaxReformats = configuration.getValueAsInteger(
+        GlobalConfiguration.HA_DIVERGED_FOLLOWER_MAX_REFORMATS);
     this.healthMonitor = new HealthMonitor(this, healthInterval, staleFollowerLagThreshold, staleFollowerRecoveryDurationMs,
-        divergedFollowerRecovery);
+        divergedFollowerRecovery, divergedFollowerMaxReformats);
     this.healthMonitor.start();
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -566,22 +566,39 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   public boolean isFollowerStuckDiverged() {
     if (raftServer == null || shutdownRequested || isLeader())
       return false;
-    if (getLeaderId() == null)
-      return false; // no leader recognized yet: leaderless, not stuck-diverged
     final ArcadeStateMachine sm = stateMachine;
-    if (sm == null || sm.isCatchingUp() || sm.isSnapshotDownloadPending())
+    if (sm == null)
       return false;
     final TermIndex applied = sm.getLastAppliedTermIndex();
     if (applied == null)
       return false;
-    final long currentTerm = getCurrentTerm();
-    final long appliedIndex = applied.getIndex();
-    final long commit = getCommitIndex();
-    if (currentTerm < 0 || appliedIndex < 0 || commit < 0)
+    // The values below are read as separate Ratis getDivision(...) calls, so they can observe slightly
+    // different moments during an election. We deliberately do not take an atomic snapshot: the
+    // HealthMonitor requires the stuck condition to persist for HA_STALE_FOLLOWER_RECOVERY_DURATION_MS
+    // before acting, which absorbs any one-tick inconsistency here.
+    return isStuckDivergedState(getLeaderId() != null, sm.isCatchingUp(), sm.isSnapshotDownloadPending(),
+        getCurrentTerm(), applied.getTerm(), applied.getIndex(), getCommitIndex());
+  }
+
+  /**
+   * Pure decision function behind {@link #isFollowerStuckDiverged()}, split out so the predicate can be
+   * unit-tested in isolation from the Ratis state plumbing (the destructive recovery makes the predicate
+   * the highest-risk piece). Returns {@code true} only for the divergence signature: a follower that
+   * recognizes a leader, is neither catching up nor installing a snapshot, has applied everything it
+   * could locally commit ({@code commitIndex == appliedIndex}) yet at a stale term
+   * ({@code currentTerm > appliedTerm}). Any negative term/index input (state not readable) yields
+   * {@code false}, including a negative {@code appliedTerm}.
+   */
+  static boolean isStuckDivergedState(final boolean leaderPresent, final boolean catchingUp,
+      final boolean snapshotPending, final long currentTerm, final long appliedTerm, final long appliedIndex,
+      final long commitIndex) {
+    if (!leaderPresent || catchingUp || snapshotPending)
+      return false;
+    if (currentTerm < 0 || appliedTerm < 0 || appliedIndex < 0 || commitIndex < 0)
       return false;
     // We have applied everything we could locally commit, but at a stale term: we are rejecting the
     // leader's current-term entries and cannot move forward.
-    return currentTerm > applied.getTerm() && commit == appliedIndex;
+    return currentTerm > appliedTerm && commitIndex == appliedIndex;
   }
 
   @Override
@@ -682,8 +699,16 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
         // bootstrapping member; otherwise recover the existing log in place (CLOSED/EXCEPTION path).
         final RaftStorage.StartupOption startupOption;
         if (formatStorage) {
-          if (storageDir.exists())
+          if (storageDir.exists()) {
             deleteRecursive(storageDir);
+            // deleteRecursive swallows per-file failures (e.g. a locked file or a permission issue on
+            // Windows). If the directory survives, FORMAT on a non-empty dir can fail or misbehave, so
+            // surface it for diagnostics rather than failing opaquely later.
+            if (storageDir.exists())
+              LogManager.instance().log(this, Level.WARNING,
+                  "Could not fully delete Raft storage directory %s before reformat; Ratis FORMAT startup may fail",
+                  storageDir.getAbsolutePath());
+          }
           startupOption = RaftStorage.StartupOption.FORMAT;
         } else
           startupOption = RaftStorage.StartupOption.RECOVER;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -39,6 +39,7 @@ import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.retry.RetryPolicies;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
+import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.server.storage.RaftStorage;
 import org.apache.ratis.util.LifeCycle;
 import org.apache.ratis.util.TimeDuration;
@@ -478,7 +479,10 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     final long staleFollowerLagThreshold = configuration.getValueAsLong(GlobalConfiguration.HA_STALE_FOLLOWER_LAG_THRESHOLD);
     final long staleFollowerRecoveryDurationMs = configuration.getValueAsLong(
         GlobalConfiguration.HA_STALE_FOLLOWER_RECOVERY_DURATION_MS);
-    this.healthMonitor = new HealthMonitor(this, healthInterval, staleFollowerLagThreshold, staleFollowerRecoveryDurationMs);
+    final boolean divergedFollowerRecovery = configuration.getValueAsBoolean(
+        GlobalConfiguration.HA_DIVERGED_FOLLOWER_RECOVERY);
+    this.healthMonitor = new HealthMonitor(this, healthInterval, staleFollowerLagThreshold, staleFollowerRecoveryDurationMs,
+        divergedFollowerRecovery);
     this.healthMonitor.start();
   }
 
@@ -542,6 +546,54 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   }
 
   /**
+   * Stuck-divergence detection for the {@link HealthMonitor} (issue #4741): true only when this node
+   * is a running follower that recognizes a leader at a newer term yet cannot apply the leader's
+   * current-term entries because its Raft log diverged. The signal is term-based rather than a lag
+   * count because the divergence can be a single entry on an otherwise idle cluster, where the
+   * lag-based recoveries (HA_STALE_FOLLOWER_LAG_THRESHOLD, HA_STALLED_REPLICA_RESYNC_DURATION_MS)
+   * never fire.
+   * <p>
+   * A healthy follower carries the leader's current-term entry (e.g. the post-election no-op), so its
+   * last-applied term equals the current term. A stuck-diverged follower keeps rejecting the leader's
+   * AppendEntries (term conflict), so it has applied everything it could locally commit
+   * ({@code commitIndex == appliedIndex}) yet its last-applied entry is from an older term
+   * ({@code currentTerm > appliedTerm}). The {@link HealthMonitor} requires this to persist for
+   * {@code HA_STALE_FOLLOWER_RECOVERY_DURATION_MS} before acting, which filters out the brief window
+   * around an election before the no-op commits. Returns false for the leader, when no leader is
+   * known, while actively catching up or installing a snapshot, and whenever the state cannot be read.
+   */
+  @Override
+  public boolean isFollowerStuckDiverged() {
+    if (raftServer == null || shutdownRequested || isLeader())
+      return false;
+    if (getLeaderId() == null)
+      return false; // no leader recognized yet: leaderless, not stuck-diverged
+    final ArcadeStateMachine sm = stateMachine;
+    if (sm == null || sm.isCatchingUp() || sm.isSnapshotDownloadPending())
+      return false;
+    final TermIndex applied = sm.getLastAppliedTermIndex();
+    if (applied == null)
+      return false;
+    final long currentTerm = getCurrentTerm();
+    final long appliedIndex = applied.getIndex();
+    final long commit = getCommitIndex();
+    if (currentTerm < 0 || appliedIndex < 0 || commit < 0)
+      return false;
+    // We have applied everything we could locally commit, but at a stale term: we are rejecting the
+    // leader's current-term entries and cannot move forward.
+    return currentTerm > applied.getTerm() && commit == appliedIndex;
+  }
+
+  @Override
+  public void recoverFromDivergence() {
+    if (shutdownRequested || isLeader())
+      return;
+    LogManager.instance().log(this, Level.WARNING,
+        "Follower diverged from leader and cannot reconcile its Raft log; reformatting Raft storage and rejoining the group");
+    restartRatis(true);
+  }
+
+  /**
    * Recovers from a Ratis server that has entered CLOSED or CLOSING state, typically
    * after a network partition where the node was isolated long enough for Ratis to
    * give up on the group.
@@ -561,6 +613,18 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    */
   @Override
   public void restartRatisIfNeeded() {
+    restartRatis(false);
+  }
+
+  /**
+   * Restarts the local Ratis server. When {@code formatStorage} is {@code true} the Raft storage
+   * directory is deleted first and the server starts with {@link RaftStorage.StartupOption#FORMAT},
+   * so this peer rejoins the group with an empty log and is reconciled by the leader via the
+   * snapshot-install path. This is the in-process equivalent of an operator restarting a node whose
+   * Raft log diverged (issue #4741). When {@code false} the existing storage is preserved and the
+   * server starts with {@link RaftStorage.StartupOption#RECOVER} (the CLOSED/EXCEPTION recovery path).
+   */
+  private void restartRatis(final boolean formatStorage) {
     synchronized (recoveryLock) {
       if (shutdownRequested) {
         HALog.log(this, HALog.BASIC, "Recovery skipped: shutdown requested");
@@ -614,13 +678,23 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
         final File storageDir = getRaftStorageDir();
         RaftServerConfigKeys.setStorageDir(properties, Collections.singletonList(storageDir));
 
+        // For a divergence reformat (#4741) discard the local Raft log so this peer rejoins as a fresh
+        // bootstrapping member; otherwise recover the existing log in place (CLOSED/EXCEPTION path).
+        final RaftStorage.StartupOption startupOption;
+        if (formatStorage) {
+          if (storageDir.exists())
+            deleteRecursive(storageDir);
+          startupOption = RaftStorage.StartupOption.FORMAT;
+        } else
+          startupOption = RaftStorage.StartupOption.RECOVER;
+
         this.raftServer = RaftServer.newBuilder()
             .setServerId(localPeerId)
             .setGroup(raftGroup)
             .setStateMachine(stateMachine)
             .setProperties(properties)
             .setParameters(buildParameters(configuration))
-            .setOption(RaftStorage.StartupOption.RECOVER)
+            .setOption(startupOption)
             .build();
         this.raftServer.start();
         this.raftProperties = properties;

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/HealthMonitorTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/HealthMonitorTest.java
@@ -268,9 +268,21 @@ class HealthMonitorTest {
 
   private static HealthMonitor stuckMonitor(final FakeHealthTarget fake, final AtomicLong clock, final long durationMs,
       final boolean enabled) {
-    final HealthMonitor monitor = new HealthMonitor(fake, 1000, 0L, durationMs, enabled);
+    return stuckMonitor(fake, clock, durationMs, enabled, 0);
+  }
+
+  private static HealthMonitor stuckMonitor(final FakeHealthTarget fake, final AtomicLong clock, final long durationMs,
+      final boolean enabled, final int maxReformats) {
+    final HealthMonitor monitor = new HealthMonitor(fake, 1000, 0L, durationMs, enabled, maxReformats);
     monitor.setClock(clock::get);
     return monitor;
+  }
+
+  /** Drives one full reformat cycle: one tick to arm the streak, then advance past the duration and tick to act. */
+  private static void runStuckCycle(final HealthMonitor monitor, final AtomicLong clock, final long durationMs) {
+    monitor.tick();
+    clock.addAndGet(durationMs + 1000);
+    monitor.tick();
   }
 
   @Test
@@ -379,5 +391,63 @@ class HealthMonitorTest {
     clock.set(10_000);
     monitor.tick();
     assertThat(fake.divergenceRecover.get()).isZero();
+  }
+
+  @Test
+  void divergenceReformatBudgetCapsRepeatedReformats() {
+    // A node whose divergence keeps reproducing must not reformat forever: the budget caps it.
+    final FakeHealthTarget fake = new FakeHealthTarget();
+    fake.stuckDiverged = true; // stays stuck across every cycle (pathological re-divergence)
+    final AtomicLong clock = new AtomicLong(0);
+    final HealthMonitor monitor = stuckMonitor(fake, clock, 5000, true, 2);
+
+    for (int i = 0; i < 6; i++)
+      runStuckCycle(monitor, clock, 5000);
+
+    assertThat(fake.divergenceRecover.get())
+        .as("reformats must be capped at the configured maximum")
+        .isEqualTo(2);
+  }
+
+  @Test
+  void divergenceUnboundedWhenMaxReformatsZero() {
+    // max=0 disables the breaker: every persisted episode reformats.
+    final FakeHealthTarget fake = new FakeHealthTarget();
+    fake.stuckDiverged = true;
+    final AtomicLong clock = new AtomicLong(0);
+    final HealthMonitor monitor = stuckMonitor(fake, clock, 5000, true, 0);
+
+    for (int i = 0; i < 4; i++)
+      runStuckCycle(monitor, clock, 5000);
+
+    assertThat(fake.divergenceRecover.get()).isEqualTo(4);
+  }
+
+  @Test
+  void divergenceBudgetReArmsAfterHealthyPeriod() {
+    // Once the follower looks healthy for 5x the duration, the prior episode is forgotten and the
+    // budget re-arms for a genuinely new divergence later.
+    final FakeHealthTarget fake = new FakeHealthTarget();
+    fake.stuckDiverged = true;
+    final AtomicLong clock = new AtomicLong(0);
+    final long duration = 5000;
+    final HealthMonitor monitor = stuckMonitor(fake, clock, duration, true, 2);
+
+    runStuckCycle(monitor, clock, duration);
+    runStuckCycle(monitor, clock, duration);
+    assertThat(fake.divergenceRecover.get()).as("budget consumed").isEqualTo(2);
+
+    // Follower becomes healthy; stay healthy past the reset window (5x duration = 25000ms).
+    fake.stuckDiverged = false;
+    monitor.tick();                                   // start healthy streak
+    clock.addAndGet(duration * 5 + 1000);
+    monitor.tick();                                   // healthy long enough -> budget re-arms
+
+    // A new divergence reformats again.
+    fake.stuckDiverged = true;
+    runStuckCycle(monitor, clock, duration);
+    assertThat(fake.divergenceRecover.get())
+        .as("budget re-armed after a sustained healthy period")
+        .isEqualTo(3);
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/HealthMonitorTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/HealthMonitorTest.java
@@ -33,9 +33,11 @@ class HealthMonitorTest {
     final    AtomicReference<LifeCycle.State> state                = new AtomicReference<>(LifeCycle.State.RUNNING);
     final    AtomicInteger                    recoveryCalls        = new AtomicInteger();
     final    AtomicInteger                    persistentLagRecover = new AtomicInteger();
+    final    AtomicInteger                    divergenceRecover    = new AtomicInteger();
     final    AtomicInteger                    allowlistRefreshes   = new AtomicInteger();
     volatile boolean                          shutdownRequested    = false;
     volatile boolean                          lagging              = false;
+    volatile boolean                          stuckDiverged        = false;
 
     @Override
     public LifeCycle.State getRaftLifeCycleState() {
@@ -60,6 +62,16 @@ class HealthMonitorTest {
     @Override
     public void recoverFromPersistentLag() {
       persistentLagRecover.incrementAndGet();
+    }
+
+    @Override
+    public boolean isFollowerStuckDiverged() {
+      return stuckDiverged;
+    }
+
+    @Override
+    public void recoverFromDivergence() {
+      divergenceRecover.incrementAndGet();
     }
 
     @Override
@@ -250,5 +262,122 @@ class HealthMonitorTest {
     clock.set(7000);
     monitor.tick();                 // streak restarts here, not enough elapsed
     assertThat(fake.persistentLagRecover.get()).isZero();
+  }
+
+  // --- Stuck-divergence recovery (issue #4741) ---
+
+  private static HealthMonitor stuckMonitor(final FakeHealthTarget fake, final AtomicLong clock, final long durationMs,
+      final boolean enabled) {
+    final HealthMonitor monitor = new HealthMonitor(fake, 1000, 0L, durationMs, enabled);
+    monitor.setClock(clock::get);
+    return monitor;
+  }
+
+  @Test
+  void divergenceRecoveryDisabledByLegacyConstructor() {
+    // The 4-arg constructor (used before #4741) must leave diverged-follower recovery OFF.
+    final FakeHealthTarget fake = new FakeHealthTarget();
+    fake.stuckDiverged = true;
+    final AtomicLong clock = new AtomicLong(0);
+    final HealthMonitor monitor = new HealthMonitor(fake, 1000, 0L, 1000L);
+    monitor.setClock(clock::get);
+    for (int i = 0; i < 5; i++) {
+      clock.addAndGet(10_000);
+      monitor.tick();
+    }
+    assertThat(fake.divergenceRecover.get()).isZero();
+  }
+
+  @Test
+  void divergenceRecoveryDisabledWhenFlagFalse() {
+    final FakeHealthTarget fake = new FakeHealthTarget();
+    fake.stuckDiverged = true;
+    final AtomicLong clock = new AtomicLong(0);
+    final HealthMonitor monitor = stuckMonitor(fake, clock, 1000, false);
+    for (int i = 0; i < 5; i++) {
+      clock.addAndGet(10_000);
+      monitor.tick();
+    }
+    assertThat(fake.divergenceRecover.get()).isZero();
+  }
+
+  @Test
+  void divergenceNotTriggeredOnFirstObservation() {
+    final FakeHealthTarget fake = new FakeHealthTarget();
+    fake.stuckDiverged = true;
+    final AtomicLong clock = new AtomicLong(0);
+    final HealthMonitor monitor = stuckMonitor(fake, clock, 5000, true);
+    monitor.tick(); // first observation only starts the streak
+    assertThat(fake.divergenceRecover.get()).isZero();
+  }
+
+  @Test
+  void divergenceTriggersAfterDuration() {
+    final FakeHealthTarget fake = new FakeHealthTarget();
+    fake.stuckDiverged = true;
+    final AtomicLong clock = new AtomicLong(0);
+    final HealthMonitor monitor = stuckMonitor(fake, clock, 5000, true);
+
+    monitor.tick();                 // t=0: start streak
+    clock.set(3000);
+    monitor.tick();                 // t=3000: still within duration
+    assertThat(fake.divergenceRecover.get()).isZero();
+
+    clock.set(6000);
+    monitor.tick();                 // t=6000: divergence persisted >= 5000ms -> recover
+    assertThat(fake.divergenceRecover.get()).isEqualTo(1);
+  }
+
+  @Test
+  void divergenceStreakResetsWhenConditionClears() {
+    final FakeHealthTarget fake = new FakeHealthTarget();
+    fake.stuckDiverged = true;
+    final AtomicLong clock = new AtomicLong(0);
+    final HealthMonitor monitor = stuckMonitor(fake, clock, 5000, true);
+
+    monitor.tick();                 // t=0: start streak
+    clock.set(3000);
+    fake.stuckDiverged = false;     // transient: divergence cleared (e.g. brief election window)
+    monitor.tick();                 // resets streak
+    fake.stuckDiverged = true;
+    clock.set(7000);
+    monitor.tick();                 // restarts streak (0ms elapsed since restart)
+    assertThat(fake.divergenceRecover.get()).isZero();
+
+    clock.set(13_000);
+    monitor.tick();                 // 6000ms since restart -> recover
+    assertThat(fake.divergenceRecover.get()).isEqualTo(1);
+  }
+
+  @Test
+  void divergenceStreakResetByUnhealthyState() {
+    final FakeHealthTarget fake = new FakeHealthTarget();
+    fake.stuckDiverged = true;
+    final AtomicLong clock = new AtomicLong(0);
+    final HealthMonitor monitor = stuckMonitor(fake, clock, 5000, true);
+
+    monitor.tick();                 // t=0: start streak
+    clock.set(3000);
+    fake.state.set(LifeCycle.State.CLOSED);
+    monitor.tick();                 // unhealthy: restart path runs, streak reset
+    assertThat(fake.recoveryCalls.get()).isEqualTo(1);
+
+    fake.state.set(LifeCycle.State.RUNNING);
+    clock.set(7000);
+    monitor.tick();                 // streak restarts here, not enough elapsed
+    assertThat(fake.divergenceRecover.get()).isZero();
+  }
+
+  @Test
+  void divergenceSkippedWhenShutdownRequested() {
+    final FakeHealthTarget fake = new FakeHealthTarget();
+    fake.stuckDiverged = true;
+    fake.shutdownRequested = true;
+    final AtomicLong clock = new AtomicLong(0);
+    final HealthMonitor monitor = stuckMonitor(fake, clock, 0, true);
+    monitor.tick();
+    clock.set(10_000);
+    monitor.tick();
+    assertThat(fake.divergenceRecover.get()).isZero();
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftDivergedFollowerRecoveryIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftDivergedFollowerRecoveryIT.java
@@ -102,13 +102,28 @@ class RaftDivergedFollowerRecoveryIT extends BaseRaftHATest {
     assertClusterConsistency();
 
     // (1) No false positives: every running follower in a healthy cluster must NOT look stuck-diverged.
+    // Also validate, against the REAL Ratis getters (not the hand-fed predicate unit test), that a
+    // caught-up follower produces the invariant the detector relies on: applied term == current term and
+    // commit == applied. If Ratis ever reported these differently, isStuckDivergedState would silently
+    // never fire on a real divergence, so pinning the healthy-state getter semantics here de-risks that.
     for (int i = 0; i < getServerCount(); i++) {
       final RaftHAPlugin plugin = getRaftPlugin(i);
       if (plugin == null)
         continue;
-      assertThat(plugin.getRaftHAServer().isFollowerStuckDiverged())
+      final RaftHAServer raft = plugin.getRaftHAServer();
+      assertThat(raft.isFollowerStuckDiverged())
           .as("healthy server %d must not be reported as stuck-diverged", i)
           .isFalse();
+      if (raft.isLeader())
+        continue;
+      final var appliedTI = raft.getStateMachine().getLastAppliedTermIndex();
+      assertThat(appliedTI).as("follower %d must have applied at least one entry", i).isNotNull();
+      assertThat(raft.getCurrentTerm())
+          .as("healthy follower %d: applied term must equal current term (detector getter semantics)", i)
+          .isEqualTo(appliedTI.getTerm());
+      assertThat(raft.getCommitIndex())
+          .as("healthy follower %d: commit must equal applied", i)
+          .isEqualTo(appliedTI.getIndex());
     }
 
     // (2) Trigger the recovery action on the follower (what the HealthMonitor does once the stuck

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftDivergedFollowerRecoveryIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftDivergedFollowerRecoveryIT.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.log.LogManager;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.logging.Level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end IT for the issue #4741 recovery mechanism: the follower-side stuck-divergence recovery
+ * ({@link RaftHAServer#recoverFromDivergence()}) reformats this follower's Raft storage and rejoins
+ * the group, so the leader reconciles it through the snapshot-install path instead of looping on
+ * {@code received INCONSISTENCY reply} forever.
+ * <p>
+ * Reproducing the exact Raft-log term divergence that triggers the loop in the wild is intricate and
+ * timing-dependent; this test instead exercises the recovery <em>action</em> directly (the same call
+ * the {@link HealthMonitor} makes once the stuck condition has persisted, which is unit-tested
+ * deterministically in {@code HealthMonitorTest}). It asserts that:
+ * <ol>
+ *   <li>a healthy follower never reports {@link RaftHAServer#isFollowerStuckDiverged()} (no false
+ *       positives that would reformat a healthy node);</li>
+ *   <li>after {@code recoverFromDivergence()} the follower comes back, catches up, and the cluster
+ *       remains consistent with no data loss;</li>
+ *   <li>writes that happen after the recovery still replicate to the recovered follower.</li>
+ * </ol>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("slow")
+class RaftDivergedFollowerRecoveryIT extends BaseRaftHATest {
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Override
+  protected boolean persistentRaftStorage() {
+    return true;
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    config.setValue(GlobalConfiguration.HA_QUORUM, "majority");
+  }
+
+  @Test
+  void divergedFollowerReformatsAndRejoins() {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("a Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    int replicaIndex = -1;
+    for (int i = 0; i < getServerCount(); i++)
+      if (i != leaderIndex) {
+        replicaIndex = i;
+        break;
+      }
+    assertThat(replicaIndex).as("a replica must exist").isGreaterThanOrEqualTo(0);
+
+    final var leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+    leaderDb.transaction(() -> {
+      if (!leaderDb.getSchema().existsType("DivergedRecovery"))
+        leaderDb.getSchema().createVertexType("DivergedRecovery");
+    });
+    leaderDb.transaction(() -> {
+      for (int i = 0; i < 50; i++) {
+        final MutableVertex v = leaderDb.newVertex("DivergedRecovery");
+        v.set("name", "pre-" + i);
+        v.save();
+      }
+    });
+    assertClusterConsistency();
+
+    // (1) No false positives: every running follower in a healthy cluster must NOT look stuck-diverged.
+    for (int i = 0; i < getServerCount(); i++) {
+      final RaftHAPlugin plugin = getRaftPlugin(i);
+      if (plugin == null)
+        continue;
+      assertThat(plugin.getRaftHAServer().isFollowerStuckDiverged())
+          .as("healthy server %d must not be reported as stuck-diverged", i)
+          .isFalse();
+    }
+
+    // (2) Trigger the recovery action on the follower (what the HealthMonitor does once the stuck
+    // condition has persisted). The follower reformats its Raft storage and rejoins the group.
+    LogManager.instance().log(this, Level.INFO, "TEST: triggering divergence recovery on replica %d", replicaIndex);
+    getRaftPlugin(replicaIndex).getRaftHAServer().recoverFromDivergence();
+
+    // The reformatted peer must rejoin and catch up to the leader's last applied index.
+    waitForReplicationIsCompleted(replicaIndex);
+
+    // (3) The recovered follower has all the pre-recovery data, and the cluster is consistent.
+    assertThat(getServerDatabase(replicaIndex, getDatabaseName()).countType("DivergedRecovery", true))
+        .as("recovered follower must hold all pre-recovery records after reformat+rejoin")
+        .isEqualTo(50L);
+
+    // (4) Writes after the recovery still replicate to the recovered follower.
+    leaderDb.transaction(() -> {
+      for (int i = 0; i < 10; i++) {
+        final MutableVertex v = leaderDb.newVertex("DivergedRecovery");
+        v.set("name", "post-" + i);
+        v.save();
+      }
+    });
+
+    assertClusterConsistency();
+
+    assertThat(getServerDatabase(replicaIndex, getDatabaseName()).countType("DivergedRecovery", true))
+        .as("recovered follower must replicate writes that happened after the recovery")
+        .isEqualTo(60L);
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftDivergedFollowerRecoveryIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftDivergedFollowerRecoveryIT.java
@@ -46,6 +46,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  *       remains consistent with no data loss;</li>
  *   <li>writes that happen after the recovery still replicate to the recovered follower.</li>
  * </ol>
+ * <p>
+ * Scope note: this exercises the recovery against a <em>healthy</em> follower (its local database
+ * already matches the leader), so it proves the reformat + rejoin + snapshot-install path preserves
+ * data and converges. It does not inject an already-diverged local database write before recovery;
+ * correcting a diverged on-disk database relies on the same {@code SnapshotInstaller} replace-on-disk
+ * path that {@code installFromLeaderForBootstrap} / {@code resyncDatabaseFromLeader} already cover.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAServerStuckDivergenceTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAServerStuckDivergenceTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.junit.jupiter.api.Test;
+
+import static com.arcadedb.server.ha.raft.RaftHAServer.isStuckDivergedState;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the {@link RaftHAServer#isStuckDivergedState} predicate behind the issue #4741
+ * stuck-divergence detector. The recovery action it gates is destructive (it reformats the local Raft
+ * storage), so the predicate is the highest-risk piece of the fix and is exercised here in isolation -
+ * in particular the <em>positive</em> case, which the integration test cannot reproduce deterministically.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class RaftHAServerStuckDivergenceTest {
+
+  // Argument order: leaderPresent, catchingUp, snapshotPending, currentTerm, appliedTerm, appliedIndex, commitIndex
+
+  @Test
+  void firesOnlyForTheDivergenceSignature() {
+    // Leader present, not catching up / installing, applied everything it could commit (commit==applied)
+    // but at a stale term (currentTerm 5 > appliedTerm 4): this is the stuck-diverged follower.
+    assertThat(isStuckDivergedState(true, false, false, 5, 4, 10, 10)).isTrue();
+  }
+
+  @Test
+  void healthyFollowerAtCurrentTermDoesNotFire() {
+    // After the post-election no-op commits and applies, appliedTerm == currentTerm.
+    assertThat(isStuckDivergedState(true, false, false, 5, 5, 10, 10)).isFalse();
+  }
+
+  @Test
+  void normallyLaggingFollowerDoesNotFire() {
+    // A follower that simply trails the leader has commit > applied (entries committed, not yet applied),
+    // even across a term boundary. It is making progress, not stuck.
+    assertThat(isStuckDivergedState(true, false, false, 5, 4, 8, 10)).isFalse();
+  }
+
+  @Test
+  void leaderlessDoesNotFire() {
+    assertThat(isStuckDivergedState(false, false, false, 5, 4, 10, 10)).isFalse();
+  }
+
+  @Test
+  void catchingUpDoesNotFire() {
+    assertThat(isStuckDivergedState(true, true, false, 5, 4, 10, 10)).isFalse();
+  }
+
+  @Test
+  void snapshotPendingDoesNotFire() {
+    assertThat(isStuckDivergedState(true, false, true, 5, 4, 10, 10)).isFalse();
+  }
+
+  @Test
+  void unreadableStateDoesNotFire() {
+    // Any negative value means the Raft state could not be read this tick: never act on it.
+    assertThat(isStuckDivergedState(true, false, false, -1, 4, 10, 10)).as("negative currentTerm").isFalse();
+    assertThat(isStuckDivergedState(true, false, false, 5, -1, 10, 10)).as("negative appliedTerm").isFalse();
+    assertThat(isStuckDivergedState(true, false, false, 5, 4, -1, 10)).as("negative appliedIndex").isFalse();
+    assertThat(isStuckDivergedState(true, false, false, 5, 4, 10, -1)).as("negative commitIndex").isFalse();
+  }
+
+  @Test
+  void sameTermButCommitAheadDoesNotFire() {
+    // Edge: same term, commit ahead - still just lag, not divergence.
+    assertThat(isStuckDivergedState(true, false, false, 5, 5, 9, 10)).isFalse();
+  }
+}

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBBackend.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBBackend.java
@@ -19,11 +19,30 @@
 package com.arcadedb.mongo;
 
 import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.security.ServerSecurityException;
 import de.bwaldvogel.mongo.MongoDatabase;
 import de.bwaldvogel.mongo.backend.AbstractMongoBackend;
+import de.bwaldvogel.mongo.backend.Utils;
+import de.bwaldvogel.mongo.bson.BinData;
+import de.bwaldvogel.mongo.bson.Document;
+import de.bwaldvogel.mongo.exception.MongoServerError;
 import de.bwaldvogel.mongo.exception.MongoServerException;
+import io.netty.channel.Channel;
+
+import java.nio.charset.StandardCharsets;
 
 public class MongoDBBackend extends AbstractMongoBackend {
+  // MongoDB error codes (see https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.yml)
+  private static final int    AUTHENTICATION_FAILED = 18;
+  private static final int    MECHANISM_UNAVAILABLE = 334;
+
+  // The only SASL mechanism ArcadeDB can support: ArcadeDB stores passwords as one-way PBKDF2 hashes, so
+  // challenge-response mechanisms (SCRAM-SHA-1/256) that require the clear-text password server-side are not feasible.
+  private static final String PLAIN_MECHANISM       = "PLAIN";
+
+  // SASL PLAIN (RFC 4616) separates [authzid] NUL authcid NUL passwd with the NUL character.
+  private static final String SASL_PLAIN_SEPARATOR  = "\u0000";
+
   private final ArcadeDBServer        server;
   private final MongoDBProtocolPlugin plugin;
 
@@ -35,5 +54,58 @@ public class MongoDBBackend extends AbstractMongoBackend {
   @Override
   protected MongoDatabase openOrCreateDatabase(final String databaseName) throws MongoServerException {
     return new MongoDBDatabaseWrapper(server.getDatabase(databaseName), plugin, this);
+  }
+
+  @Override
+  public Document handleCommand(final Channel channel, final String databaseName, final String command, final Document query) {
+    if ("saslStart".equalsIgnoreCase(command))
+      return handleSaslStart(databaseName, query);
+    else if ("saslContinue".equalsIgnoreCase(command))
+      // A single round-trip is enough for PLAIN, so a saslContinue is unexpected: treat it as a failed conversation.
+      throw new MongoServerError(AUTHENTICATION_FAILED, "AuthenticationFailed", "Authentication conversation already completed");
+
+    return super.handleCommand(channel, databaseName, command, query);
+  }
+
+  /**
+   * Implements the SASL PLAIN mechanism (RFC 4616). The payload carries {@code [authzid] NUL authcid NUL passwd}; the
+   * credentials are validated against ArcadeDB server security.
+   */
+  private Document handleSaslStart(final String databaseName, final Document query) {
+    final Object mechanism = query.get("mechanism");
+    if (mechanism == null || !PLAIN_MECHANISM.equalsIgnoreCase(mechanism.toString()))
+      throw new MongoServerError(MECHANISM_UNAVAILABLE, "MechanismUnavailable",
+          "Unsupported authentication mechanism '" + mechanism + "'. The ArcadeDB MongoDB plugin only supports the PLAIN (SASL) mechanism");
+
+    final Object payload = query.get("payload");
+    if (!(payload instanceof BinData))
+      throw new MongoServerError(AUTHENTICATION_FAILED, "AuthenticationFailed", "Missing or invalid SASL payload");
+
+    final byte[] data = ((BinData) payload).getData();
+    final String decoded = new String(data, StandardCharsets.UTF_8);
+    final String[] parts = decoded.split(SASL_PLAIN_SEPARATOR, -1);
+    if (parts.length != 3)
+      throw new MongoServerError(AUTHENTICATION_FAILED, "AuthenticationFailed", "Malformed SASL PLAIN payload");
+
+    // parts[0] = authorization identity (optional, ignored), parts[1] = user, parts[2] = password
+    final String userName = parts[1].isEmpty() ? parts[0] : parts[1];
+    final String userPassword = parts[2];
+
+    // An auth source of "admin" or "$external" maps to a server-wide credential check (database access is verified later).
+    final String authDatabase =
+        databaseName == null || databaseName.equals("admin") || databaseName.startsWith("$") ? null : databaseName;
+
+    try {
+      server.getSecurity().authenticate(userName, userPassword, authDatabase);
+    } catch (final ServerSecurityException e) {
+      throw new MongoServerError(AUTHENTICATION_FAILED, "AuthenticationFailed", "Authentication failed");
+    }
+
+    final Document response = new Document();
+    response.put("conversationId", 1);
+    response.put("done", Boolean.TRUE);
+    response.put("payload", new BinData(new byte[0]));
+    Utils.markOkay(response);
+    return response;
   }
 }

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
@@ -68,6 +68,10 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
    * Resolves a collection wrapper lazily against the live schema. This database wrapper is shared and cached across all
    * client connections, so the collection set must be looked up on demand: types created after the wrapper was built
    * (e.g. via Studio, SQL or another connection) must be visible too.
+   * <p>
+   * The cache is keyed by type name and entries are never evicted, but it stays bounded by the number of distinct type
+   * names (one entry per name, reused on drop/recreate). A stale entry after a drop/recreate is harmless because
+   * {@link MongoDBCollectionWrapper} keeps only the type name and re-resolves it against the database on every operation.
    *
    * @return the collection wrapper, or {@code null} if no type with that name exists.
    */

--- a/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
+++ b/mongodbw/src/main/java/com/arcadedb/mongo/MongoDBDatabaseWrapper.java
@@ -25,7 +25,6 @@ import com.arcadedb.query.sql.executor.IteratorResultSet;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
-import com.arcadedb.schema.DocumentType;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import de.bwaldvogel.mongo.MongoBackend;
@@ -63,10 +62,19 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
     this.database = database;
     this.plugin = plugin;
     this.backend = backend;
+  }
 
-    for (final DocumentType dt : database.getSchema().getTypes()) {
-      collections.put(dt.getName(), new MongoDBCollectionWrapper(database, dt.getName()));
-    }
+  /**
+   * Resolves a collection wrapper lazily against the live schema. This database wrapper is shared and cached across all
+   * client connections, so the collection set must be looked up on demand: types created after the wrapper was built
+   * (e.g. via Studio, SQL or another connection) must be visible too.
+   *
+   * @return the collection wrapper, or {@code null} if no type with that name exists.
+   */
+  private MongoCollection<Long> getCollection(final String collectionName) {
+    if (!database.getSchema().existsType(collectionName))
+      return null;
+    return collections.computeIfAbsent(collectionName, name -> new MongoDBCollectionWrapper(database, name));
   }
 
   @Override
@@ -76,9 +84,10 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
 
   @Override
   public void handleClose(final Channel channel) {
-    // THIS IS CALLED FROM THE CLIENT TO FREE CONNECTION RESOURCES. DO NOT CLOSE THE DATABASE BECAUSE OTHER CONNECTIONS MAY NEED IT
-    collections.clear();
-    lastResults.clear();
+    // THIS IS CALLED FROM THE CLIENT TO FREE CONNECTION RESOURCES. DO NOT CLOSE THE DATABASE BECAUSE OTHER CONNECTIONS MAY
+    // NEED IT. ONLY THE CLOSING CHANNEL'S STATE MUST BE REMOVED: THE COLLECTION CACHE AND OTHER CONNECTIONS' RESULTS ARE
+    // SHARED ACROSS ALL CLIENTS (THIS WRAPPER IS CACHED PER-DATABASE IN THE BACKEND).
+    lastResults.remove(channel);
   }
 
   @Override
@@ -168,7 +177,7 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
     try {
       this.clearLastStatus(query.getChannel());
       final String collectionName = query.getCollectionName();
-      final MongoCollection<Long> collection = collections.get(collectionName);
+      final MongoCollection<Long> collection = getCollection(collectionName);
       if (collection == null) {
         return new QueryResult();
       } else {
@@ -186,7 +195,7 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
     final String collectionName = document.get("aggregate").toString();
     database.countType(collectionName, false);
 
-    final MongoCollection<Long> collection = collections.get(collectionName);
+    final MongoCollection<Long> collection = getCollection(collectionName);
 
     final Object pipelineObject = Aggregation.parse(document.get("pipeline"));
     final List<Document> pipeline = Aggregation.parse(pipelineObject);
@@ -279,7 +288,7 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
 
     final Document response = responseOk();
 
-    final MongoCollection<Long> collection = collections.get(collectionName);
+    final MongoCollection<Long> collection = getCollection(collectionName);
 
     if (collection == null) {
       response.put("missing", Boolean.TRUE);
@@ -296,7 +305,8 @@ public class MongoDBDatabaseWrapper implements MongoDatabase {
 
   private Document find(final Document document) throws MongoServerException {
     final Document filter = (Document) document.get("filter");
-    final int limit = this.getOptionalNumber(document, "limit", -1);
+    // A missing/0 limit means "no limit" (a -1 sentinel here would be interpreted as a legacy single-batch limit of 1)
+    final int limit = this.getOptionalNumber(document, "limit", 0);
     final int skip = this.getOptionalNumber(document, "skip", 0);
     final String collectionName = (String) document.get("find");
 

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBAuthenticationTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBAuthenticationTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.mongo;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoCredential;
+import com.mongodb.MongoSecurityException;
+import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoDatabase;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+/**
+ * Verifies SASL PLAIN authentication on the MongoDB wire-protocol plugin (issue #4746).
+ */
+public class MongoDBAuthenticationTest extends BaseGraphServerTest {
+
+  private static final int DEF_PORT = 27017;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("MongoDB:com.arcadedb.mongo.MongoDBProtocolPlugin");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+
+  @Test
+  void plainAuthenticationWithValidCredentials() {
+    final MongoCredential credential = MongoCredential.createPlainCredential("root", getDatabaseName(),
+        DEFAULT_PASSWORD_FOR_TESTS.toCharArray());
+
+    try (final MongoClient client = new MongoClient(new ServerAddress("localhost", DEF_PORT), credential,
+        MongoClientOptions.builder().serverSelectionTimeout(5000).build())) {
+      final MongoDatabase db = client.getDatabase(getDatabaseName());
+      final Document result = db.runCommand(new Document("ping", 1));
+      assertThat(result.getDouble("ok")).isEqualTo(1.0);
+    }
+  }
+
+  @Test
+  void plainAuthenticationWithInvalidPassword() {
+    final MongoCredential credential = MongoCredential.createPlainCredential("root", getDatabaseName(),
+        "wrong-password".toCharArray());
+
+    try (final MongoClient client = new MongoClient(new ServerAddress("localhost", DEF_PORT), credential,
+        MongoClientOptions.builder().serverSelectionTimeout(3000).build())) {
+      final MongoDatabase db = client.getDatabase(getDatabaseName());
+      final Throwable thrown = catchThrowable(() -> db.runCommand(new Document("ping", 1)));
+      assertThat(thrown).isInstanceOf(MongoSecurityException.class);
+    }
+  }
+}

--- a/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBFindTest.java
+++ b/mongodbw/src/test/java/com/arcadedb/mongo/MongoDBFindTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.mongo;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.mongodb.MongoClient;
+import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoCollection;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #4746 / #4745: the MongoDB plugin returned a single document on an unfiltered
+ * {@code find()}, did not see collections created after the first connection, and stopped returning data after a
+ * client reconnected.
+ */
+public class MongoDBFindTest extends BaseGraphServerTest {
+
+  private static final int DEF_PORT = 27017;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("MongoDB:com.arcadedb.mongo.MongoDBProtocolPlugin");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+
+  @Test
+  void findWithoutFilterReturnsAllDocuments() {
+    getDatabase(0);
+    try (final MongoClient client = new MongoClient(new ServerAddress("localhost", DEF_PORT))) {
+      client.getDatabase(getDatabaseName()).createCollection("Numbers");
+      final MongoCollection<Document> collection = client.getDatabase(getDatabaseName()).getCollection("Numbers");
+      for (int i = 0; i < 10; i++)
+        collection.insertOne(new Document("value", i));
+
+      final List<Document> all = new ArrayList<>();
+      collection.find().into(all);
+
+      assertThat(all).hasSize(10);
+    }
+  }
+
+  @Test
+  void collectionCreatedAfterConnectionIsVisible() {
+    getDatabase(0);
+    try (final MongoClient client = new MongoClient(new ServerAddress("localhost", DEF_PORT))) {
+      // Force the database wrapper to be created (and its collection cache built) before the new type exists.
+      client.getDatabase(getDatabaseName()).createCollection("PreExisting");
+      client.getDatabase(getDatabaseName()).getCollection("PreExisting").countDocuments();
+
+      // Create a brand-new type out-of-band, as Studio or a SQL command would.
+      final Database db = getServerDatabase(0, getDatabaseName());
+      db.getSchema().createDocumentType("LateType");
+      db.transaction(() -> db.newDocument("LateType").set("value", 42).save());
+
+      final List<Document> all = new ArrayList<>();
+      client.getDatabase(getDatabaseName()).getCollection("LateType").find().into(all);
+
+      assertThat(all).hasSize(1);
+      assertThat(all.getFirst().getInteger("value")).isEqualTo(42);
+    }
+  }
+
+  @Test
+  void dataStillReturnedAfterClientReconnect() {
+    getDatabase(0);
+
+    try (final MongoClient client = new MongoClient(new ServerAddress("localhost", DEF_PORT))) {
+      client.getDatabase(getDatabaseName()).createCollection("Reconnect");
+      final MongoCollection<Document> collection = client.getDatabase(getDatabaseName()).getCollection("Reconnect");
+      for (int i = 0; i < 5; i++)
+        collection.insertOne(new Document("value", i));
+
+      final List<Document> all = new ArrayList<>();
+      collection.find().into(all);
+      assertThat(all).hasSize(5);
+    }
+
+    // Second, independent connection: data must still be visible.
+    try (final MongoClient client = new MongoClient(new ServerAddress("localhost", DEF_PORT))) {
+      final List<Document> all = new ArrayList<>();
+      client.getDatabase(getDatabaseName()).getCollection("Reconnect").find().into(all);
+      assertThat(all).hasSize(5);
+    }
+  }
+}


### PR DESCRIPTION
…CONSISTENCY loop)

On an idle cluster, a tiny (1-2 entry) Raft-log divergence at a low index makes the leader's Ratis GrpcLogAppender spin forever on `received INCONSISTENCY reply with nextIndex {4,5}, errorCount=...`: the follower replies snapshotIndex+1 for one index then fails the previous-entry term check for the next, oscillating. The leader's log is never compacted, so `shouldNotifyToInstallSnapshot` stays null and the proper reconcile path never fires; the divergence is too small for the lag-based recoveries (HA_STALE_FOLLOWER_LAG_THRESHOLD / HA_STALLED_REPLICA_RESYNC_DURATION_MS), which also only re-acquire the database, not the Raft log. Only a node restart cleared it.

Add a follower-side detector: when a running follower recognizes a leader at a newer term but cannot apply the leader's current-term entries (currentTerm > lastAppliedTerm and commit == applied), HealthMonitor waits HA_STALE_FOLLOWER_RECOVERY_DURATION_MS for the condition to persist, then reformats the follower's Raft storage and rejoins the group (RaftHAServer.recoverFromDivergence -> restartRatis(format=true)). The peer rejoins as a fresh member so the leader reconciles it via the snapshot-install path - the automated, scoped equivalent of the manual node restart. Gated by the new HA_DIVERGED_FOLLOWER_RECOVERY config (default true).

Tests: HealthMonitorTest streak unit tests (deterministic clock); RaftDivergedFollowerRecoveryIT (@slow) verifies reformat+rejoin with no data loss and no false positives on a healthy node.

## What does this PR do?

A brief description of the change being made with this pull request.

## Motivation

What inspired you to submit this pull request?

## Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

## Additional Notes

Anything else we should know when reviewing?

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
