### PR TITLE
fix(#4752): make AppendEntries element limit configurable, default 64

### DIFF
--- a/docs/4752-bound-appendentries-catch-up-batch.md
+++ b/docs/4752-bound-appendentries-catch-up-batch.md
@@ -73,33 +73,54 @@ https://github.com/ArcadeData/arcadedb/pull/4753
 
 ### Cycle 2 - HEAD 21be24b9
 
-- claude review #2 (on the cycle-1 SHA): essentially LGTM ("clean, well-scoped ... LGTM pending
+- claude review (on the cycle-1 SHA): essentially LGTM ("clean, well-scoped ... LGTM pending
   the description fix").
 - Applied (clear & low-risk): corrected the PR description test count, added a config-doc note
   that the byte limit (`appendBufferSize`) is the dominant per-batch heap bound and the element
   count is the secondary cap, added a `ConfigurationException` test for the
   `writeBuffer < appendBuffer + 8` branch.
 
-## Deferred items
+### Cycle 3 - HEAD 1c145183
 
-### Root-cause dimension question (claude review #1, 2026-06-27T11:00:41Z) - needs heap dump
+- claude review: code is correct and above bar; no new actionable code change. Amplified the
+  open question on the default value (see Open decision below) and added two non-blocking notes
+  (no upper bound enforced; per-issue doc phrasing). Final state: deferred to the maintainer.
 
-Claude asked, soundly, which dimension actually drove the OOM: for multi-MB entries the byte
-limit (4MB default) caps a batch to ~1-2 entries long before the element count (64 vs 256) ever
-binds, so lowering the element limit may not be the effective lever for that scenario. Resolving
-this needs the #4752 heap dump, which the automated loop does not have. Claude's later review (#2,
-on the current SHA) did not carry this forward and accepted the change.
+## Open decision for the maintainer
 
-The fix completes the trio of catch-up bounds the issue author requested, all now operator-tunable:
-- entry count: `arcadedb.ha.appendElementLimit` (default 64) - added by this PR
+### Should the default be 64 or stay at 256?
+
+Claude raised this in two reviews and it is the one decision worth settling before merge. The
+element limit only binds AFTER the 4MB byte limit (`arcadedb.ha.appendBufferSize`). For the
+incident workload (entries up to several MB of compressed WAL data), the 4MB byte cap truncates a
+batch to ~1-2 entries long before 64 vs 256 ever matters - so in that regime the element-limit
+default flip is a no-op for peak heap, while the lower default does cost healthy clusters extra
+AppendEntries round-trips for small transactions.
+
+Two defensible options:
+- Keep the new default of 64 (conservative bound) - justified if the heap dump confirms the OOM
+  was driven by many small entries (element count was the governing dimension).
+- Revert the default to 256 (no behavior change) and ship only the tunable knob - the strictly
+  safer change with no regression for the small-transaction case; operators who hit the OOM lower
+  it themselves.
+
+This requires the #4752 heap dump, which is not available here, so it is left for the maintainer
+(the issue author). The knob and its validation are correct either way.
+
+The fix makes the full trio of catch-up bounds operator-tunable:
+- entry count: `arcadedb.ha.appendElementLimit` (currently default 64) - added by this PR
 - byte limit: `arcadedb.ha.appendBufferSize` (default 4MB) - pre-existing
 - gRPC inbound message size: `arcadedb.ha.grpcMessageSizeMax` (default 128MB) - pre-existing
 
-Recommended developer follow-up:
-1. Confirm from the heap dump which dimension dominated.
-2. If large *individual* entries (e.g. a 50k-vertex GraphBatch exceeding the byte limit) drove
-   it, the more effective lever is lowering `arcadedb.ha.grpcMessageSizeMax` and/or bounding
-   transaction size - a single oversized entry bypasses the per-batch byte limit because
-   `DataQueue` admits the first element even when it exceeds the byte limit (to avoid deadlock).
-3. Consider a release-note line about the default change (256 -> 64) affecting replication
-   round-trips for healthy clusters with many small transactions.
+If large *individual* entries (e.g. a 50k-vertex GraphBatch exceeding the byte limit) drove the
+OOM, the more effective lever is lowering `arcadedb.ha.grpcMessageSizeMax` and/or bounding
+transaction size: a single oversized entry bypasses the per-batch byte limit because `DataQueue`
+admits the first element even when it exceeds the byte limit (to avoid deadlock).
+
+### Minor (non-blocking)
+
+- No upper bound is enforced on `appendElementLimit` (an operator could set a very large value
+  and re-introduce the OOM). The byte limit remains the real ceiling; an explicit upper bound was
+  not added because any chosen ceiling is itself a judgment call.
+- Release note: if the default stays at 64, call out the change from 256 so operators tuning
+  replication throughput are not surprised.

--- a/docs/4752-bound-appendentries-catch-up-batch.md
+++ b/docs/4752-bound-appendentries-catch-up-batch.md
@@ -48,7 +48,58 @@ Unit test: `RaftPropertiesBuilderTest`
 
 ## Test Results
 
-- `RaftPropertiesBuilderTest` (5 tests): PASS
+- `RaftPropertiesBuilderTest` (8 tests): PASS
 - `RaftHAServerTest` (45 tests): PASS
 - `RaftHAConfigurationIT` (5 tests): PASS
 - `GlobalConfigurationTest` (10 tests): PASS
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/4753
+
+## Review cycles
+
+### Cycle 1 - HEAD 8b18894b
+
+- gemini-code-assist (3 inline comments, 2 HIGH/1 MEDIUM): require `appendElementLimit > 0`,
+  update description, add validation test.
+- Verified gemini's claim that "0 freezes replication" against Ratis source
+  (`DataQueue.offer` line 101: `if (elementLimit > 0 && q.size() >= elementLimit)`) - 0 is
+  actually treated as "unlimited", so the literal claim is wrong. But the underlying advice is
+  sound: an operator setting 0 would silently defeat the per-batch element bound, so the value
+  should be a positive integer.
+- Applied: added `if (appendElementLimit < 1) throw ConfigurationException` in
+  `RaftPropertiesBuilder`, updated the config description, added zero/negative regression tests.
+
+### Cycle 2 - HEAD 21be24b9
+
+- claude review #2 (on the cycle-1 SHA): essentially LGTM ("clean, well-scoped ... LGTM pending
+  the description fix").
+- Applied (clear & low-risk): corrected the PR description test count, added a config-doc note
+  that the byte limit (`appendBufferSize`) is the dominant per-batch heap bound and the element
+  count is the secondary cap, added a `ConfigurationException` test for the
+  `writeBuffer < appendBuffer + 8` branch.
+
+## Deferred items
+
+### Root-cause dimension question (claude review #1, 2026-06-27T11:00:41Z) - needs heap dump
+
+Claude asked, soundly, which dimension actually drove the OOM: for multi-MB entries the byte
+limit (4MB default) caps a batch to ~1-2 entries long before the element count (64 vs 256) ever
+binds, so lowering the element limit may not be the effective lever for that scenario. Resolving
+this needs the #4752 heap dump, which the automated loop does not have. Claude's later review (#2,
+on the current SHA) did not carry this forward and accepted the change.
+
+The fix completes the trio of catch-up bounds the issue author requested, all now operator-tunable:
+- entry count: `arcadedb.ha.appendElementLimit` (default 64) - added by this PR
+- byte limit: `arcadedb.ha.appendBufferSize` (default 4MB) - pre-existing
+- gRPC inbound message size: `arcadedb.ha.grpcMessageSizeMax` (default 128MB) - pre-existing
+
+Recommended developer follow-up:
+1. Confirm from the heap dump which dimension dominated.
+2. If large *individual* entries (e.g. a 50k-vertex GraphBatch exceeding the byte limit) drove
+   it, the more effective lever is lowering `arcadedb.ha.grpcMessageSizeMax` and/or bounding
+   transaction size - a single oversized entry bypasses the per-batch byte limit because
+   `DataQueue` admits the first element even when it exceeds the byte limit (to avoid deadlock).
+3. Consider a release-note line about the default change (256 -> 64) affecting replication
+   round-trips for healthy clusters with many small transactions.

--- a/docs/4752-bound-appendentries-catch-up-batch.md
+++ b/docs/4752-bound-appendentries-catch-up-batch.md
@@ -1,0 +1,54 @@
+# Fix #4752: bound AppendEntries catch-up batch size
+
+## Issue Summary
+
+On a 3-node Raft HA cluster, a follower OOMs while parsing an inbound `AppendEntriesRequestProto`
+during catch-up resync. The Raft batch shipped by the leader during catch-up is not bounded
+conservatively enough: during log replay from a large database, enough entries queue in the
+follower's in-memory log that combined heap usage exceeds the JVM `-Xmx` limit. The follower
+then dies, stops resolving on the network, and OOMs again on restart (loop).
+
+## Root Cause Analysis
+
+Two contributing factors:
+
+1. `bufferElementLimit` was hardcoded at `256`. During catch-up the leader sends batches of up
+   to 256 log entries per AppendEntries. These entries buffer in the follower's in-memory Raft
+   log waiting for the state machine to apply them. With many large entries in flight (each up to
+   several MB of compressed WAL data), the combined in-memory footprint of buffered entries can
+   push the follower into OOM.
+
+2. There was no operator knob to tune the per-batch entry count. Operators could adjust bytes
+   via `HA_APPEND_BUFFER_SIZE` but not the entry count.
+
+## Fix
+
+Add `HA_APPEND_ELEMENT_LIMIT` (`arcadedb.ha.appendElementLimit`) to `GlobalConfiguration`:
+- Default: `64` (reduced from hardcoded `256`)
+- Wired into `RaftServerConfigKeys.Log.Appender.setBufferElementLimit(properties, limit)`
+  in `RaftPropertiesBuilder`
+
+Reducing the default from 256 to 64 means each AppendEntries batch carries at most 64 log
+entries. Combined with the existing `bufferByteLimit` (4 MB default), the per-batch in-memory
+footprint is bounded on both dimensions. Operators with fast catch-up requirements can raise
+`arcadedb.ha.appendElementLimit` to allow larger batches.
+
+## Verification
+
+Unit test: `RaftPropertiesBuilderTest`
+- Default configuration produces `bufferElementLimit = 64`
+- Custom configuration value is reflected
+- Buffer byte limit, gRPC message size, and element limit all verify correctly
+
+## Files Changed
+
+- `engine/src/main/java/com/arcadedb/GlobalConfiguration.java` - new `HA_APPEND_ELEMENT_LIMIT`
+- `ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftPropertiesBuilder.java` - use config
+- `ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftPropertiesBuilderTest.java` - new test
+
+## Test Results
+
+- `RaftPropertiesBuilderTest` (5 tests): PASS
+- `RaftHAServerTest` (45 tests): PASS
+- `RaftHAConfigurationIT` (5 tests): PASS
+- `GlobalConfigurationTest` (10 tests): PASS

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -742,7 +742,7 @@ public enum GlobalConfiguration {
       Maximum number of Raft log entries per AppendEntries batch. Bounds the per-batch in-memory \
       footprint on the follower during catch-up resync, where many batches may queue before the \
       state machine can apply them. Lowering this value reduces peak heap pressure on followers \
-      catching up from a far-behind state. 0 means no element-count limit (only the byte limit applies).""",
+      catching up from a far-behind state. Must be a positive integer (>= 1).""",
       Integer.class, 64),
 
   HA_WRITE_BUFFER_SIZE("arcadedb.ha.writeBufferSize", SCOPE.SERVER,

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -737,6 +737,14 @@ public enum GlobalConfiguration {
   HA_APPEND_BUFFER_SIZE("arcadedb.ha.appendBufferSize", SCOPE.SERVER,
       "AppendEntries batch byte limit for replication (e.g. '4MB')", String.class, "4MB"),
 
+  HA_APPEND_ELEMENT_LIMIT("arcadedb.ha.appendElementLimit", SCOPE.SERVER,
+      """
+      Maximum number of Raft log entries per AppendEntries batch. Bounds the per-batch in-memory \
+      footprint on the follower during catch-up resync, where many batches may queue before the \
+      state machine can apply them. Lowering this value reduces peak heap pressure on followers \
+      catching up from a far-behind state. 0 means no element-count limit (only the byte limit applies).""",
+      Integer.class, 64),
+
   HA_WRITE_BUFFER_SIZE("arcadedb.ha.writeBufferSize", SCOPE.SERVER,
       """
       Raft log write buffer size (e.g. '8MB'). Must be at least appendBufferSize + 8 bytes, \

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -742,7 +742,9 @@ public enum GlobalConfiguration {
       Maximum number of Raft log entries per AppendEntries batch. Bounds the per-batch in-memory \
       footprint on the follower during catch-up resync, where many batches may queue before the \
       state machine can apply them. Lowering this value reduces peak heap pressure on followers \
-      catching up from a far-behind state. Must be a positive integer (>= 1).""",
+      catching up from a far-behind state. The byte limit (arcadedb.ha.appendBufferSize) remains \
+      the dominant per-batch heap bound; this element count is the secondary cap that governs when \
+      entries are small enough that many fit under the byte limit. Must be a positive integer (>= 1).""",
       Integer.class, 64),
 
   HA_WRITE_BUFFER_SIZE("arcadedb.ha.writeBufferSize", SCOPE.SERVER,

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftPropertiesBuilder.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftPropertiesBuilder.java
@@ -101,6 +101,9 @@ class RaftPropertiesBuilder {
     final SizeInBytes appendBuffer = SizeInBytes.valueOf(appendBufferSize);
     RaftServerConfigKeys.Log.Appender.setBufferByteLimit(properties, appendBuffer);
     final int appendElementLimit = configuration.getValueAsInteger(GlobalConfiguration.HA_APPEND_ELEMENT_LIMIT);
+    if (appendElementLimit < 1)
+      throw new ConfigurationException(
+          "arcadedb.ha.appendElementLimit (" + appendElementLimit + ") must be >= 1");
     RaftServerConfigKeys.Log.Appender.setBufferElementLimit(properties, appendElementLimit);
 
     // Log segment size

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftPropertiesBuilder.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftPropertiesBuilder.java
@@ -94,11 +94,14 @@ class RaftPropertiesBuilder {
     RaftServerConfigKeys.Log.Appender.setInstallSnapshotEnabled(properties, false);
     RaftServerConfigKeys.Snapshot.setAutoTriggerEnabled(properties, true);
 
-    // AppendEntries batching: allow multiple entries per gRPC call to followers
+    // AppendEntries batching: allow multiple entries per gRPC call to followers.
+    // Element limit bounds the per-batch in-memory footprint on the follower during catch-up,
+    // where many batches may queue before the state machine can apply them (issue #4752).
     final String appendBufferSize = configuration.getValueAsString(GlobalConfiguration.HA_APPEND_BUFFER_SIZE);
     final SizeInBytes appendBuffer = SizeInBytes.valueOf(appendBufferSize);
     RaftServerConfigKeys.Log.Appender.setBufferByteLimit(properties, appendBuffer);
-    RaftServerConfigKeys.Log.Appender.setBufferElementLimit(properties, 256);
+    final int appendElementLimit = configuration.getValueAsInteger(GlobalConfiguration.HA_APPEND_ELEMENT_LIMIT);
+    RaftServerConfigKeys.Log.Appender.setBufferElementLimit(properties, appendElementLimit);
 
     // Log segment size
     final String logSegmentSize = configuration.getValueAsString(GlobalConfiguration.HA_LOG_SEGMENT_SIZE);

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftPropertiesBuilderTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftPropertiesBuilderTest.java
@@ -20,12 +20,14 @@ package com.arcadedb.server.ha.raft;
 
 import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.exception.ConfigurationException;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.grpc.GrpcConfigKeys;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Verifies that {@link RaftPropertiesBuilder} correctly translates ArcadeDB configuration
@@ -74,5 +76,24 @@ class RaftPropertiesBuilderTest {
     final RaftProperties props = RaftPropertiesBuilder.build(config);
     assertThat(RaftServerConfigKeys.Log.writeBufferSize(props).getSizeInt())
         .isEqualTo(8 * 1024 * 1024);
+  }
+
+  @Test
+  void zeroElementLimitThrowsConfigurationException() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_APPEND_ELEMENT_LIMIT, 0);
+    assertThatThrownBy(() -> RaftPropertiesBuilder.build(config))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining("arcadedb.ha.appendElementLimit")
+        .hasMessageContaining("must be >= 1");
+  }
+
+  @Test
+  void negativeElementLimitThrowsConfigurationException() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_APPEND_ELEMENT_LIMIT, -1);
+    assertThatThrownBy(() -> RaftPropertiesBuilder.build(config))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining("arcadedb.ha.appendElementLimit");
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftPropertiesBuilderTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftPropertiesBuilderTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.grpc.GrpcConfigKeys;
+import org.apache.ratis.server.RaftServerConfigKeys;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@link RaftPropertiesBuilder} correctly translates ArcadeDB configuration
+ * into Ratis properties. Regression for issue #4752: AppendEntries element limit must be
+ * configurable and bounded to prevent follower OOM during catch-up resync.
+ */
+class RaftPropertiesBuilderTest {
+
+  @Test
+  void defaultElementLimitIs64() {
+    final ContextConfiguration config = new ContextConfiguration();
+    final RaftProperties props = RaftPropertiesBuilder.build(config);
+    assertThat(RaftServerConfigKeys.Log.Appender.bufferElementLimit(props)).isEqualTo(64);
+  }
+
+  @Test
+  void customElementLimitIsApplied() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_APPEND_ELEMENT_LIMIT, 128);
+    final RaftProperties props = RaftPropertiesBuilder.build(config);
+    assertThat(RaftServerConfigKeys.Log.Appender.bufferElementLimit(props)).isEqualTo(128);
+  }
+
+  @Test
+  void defaultBufferByteLimitIs4MB() {
+    final ContextConfiguration config = new ContextConfiguration();
+    final RaftProperties props = RaftPropertiesBuilder.build(config);
+    assertThat(RaftServerConfigKeys.Log.Appender.bufferByteLimit(props).getSizeInt())
+        .isEqualTo(4 * 1024 * 1024);
+  }
+
+  @Test
+  void defaultGrpcMessageSizeMaxIs128MB() {
+    final ContextConfiguration config = new ContextConfiguration();
+    final RaftProperties props = RaftPropertiesBuilder.build(config);
+    assertThat(GrpcConfigKeys.messageSizeMax(props, msg -> {}).getSizeInt())
+        .isEqualTo(128 * 1024 * 1024);
+  }
+
+  @Test
+  void writeBufferSizeMustExceedAppendBufferPlusFraming() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_APPEND_BUFFER_SIZE, "4MB");
+    config.setValue(GlobalConfiguration.HA_WRITE_BUFFER_SIZE, "8MB");
+    // Should not throw
+    final RaftProperties props = RaftPropertiesBuilder.build(config);
+    assertThat(RaftServerConfigKeys.Log.writeBufferSize(props).getSizeInt())
+        .isEqualTo(8 * 1024 * 1024);
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftPropertiesBuilderTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftPropertiesBuilderTest.java
@@ -96,4 +96,15 @@ class RaftPropertiesBuilderTest {
         .isInstanceOf(ConfigurationException.class)
         .hasMessageContaining("arcadedb.ha.appendElementLimit");
   }
+
+  @Test
+  void writeBufferSmallerThanAppendBufferThrowsConfigurationException() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_APPEND_BUFFER_SIZE, "8MB");
+    config.setValue(GlobalConfiguration.HA_WRITE_BUFFER_SIZE, "4MB");
+    assertThatThrownBy(() -> RaftPropertiesBuilder.build(config))
+        .isInstanceOf(ConfigurationException.class)
+        .hasMessageContaining("arcadedb.ha.writeBufferSize")
+        .hasMessageContaining("must be >= arcadedb.ha.appendBufferSize");
+  }
 }


### PR DESCRIPTION
Closes #4752

## Summary

- Adds `HA_APPEND_ELEMENT_LIMIT` (`arcadedb.ha.appendElementLimit`) to `GlobalConfiguration` with a default of 64, replacing the previously hardcoded `256` in `RaftPropertiesBuilder`.
- Wires the new config into `RaftServerConfigKeys.Log.Appender.setBufferElementLimit` so operators can tune the per-batch entry count.
- Validates the value is `>= 1` at properties-build time (a value of 0 or negative would silently defeat the per-batch element bound).
- Adds `RaftPropertiesBuilderTest` (8 tests) covering the default/custom element limit, byte limit, gRPC message size, write-buffer validation, and the zero/negative element-limit rejection.

The lower default (64 vs 256) is a secondary cap that bounds the per-batch entry count during catch-up resync. The byte limit (`arcadedb.ha.appendBufferSize`, 4MB default) remains the dominant per-batch heap bound; the element count governs only when entries are small enough that many fit under the byte limit. Together with the existing `arcadedb.ha.grpcMessageSizeMax` knob, all three catch-up bounds the issue requested are now operator-tunable.

## Test plan

- `RaftPropertiesBuilderTest` - 8 unit tests: default element limit is 64, custom value applied, byte limit and gRPC message size read back correctly, write-buffer validation (happy path + exception), and zero/negative element-limit rejection.
- `RaftHAServerTest` (45 tests) and `RaftHAConfigurationIT` (5 tests) pass without change.
- `GlobalConfigurationTest` (10 tests) passes - new enum constant is valid.

## Note

The root-cause dimension (entry count vs byte/message size) that drove the OOM in the incident is documented as a deferred item in the tracking doc and needs the incident heap dump to confirm; this PR makes all three bounds tunable regardless.