### PR TITLE
fix(#4754): implement LifeCycle transitions so StateMachineUpdater.reload() proceeds after snapshot install

### DIFF
--- a/docs/4754-statemachineupdater-reload-after-snapshot.md
+++ b/docs/4754-statemachineupdater-reload-after-snapshot.md
@@ -1,0 +1,70 @@
+# Issue #4754 — HA: follower never rejoins after snapshot install
+
+## Root Cause
+
+`StateMachineUpdater.reload()` (Ratis 3.2.2, line 230) asserts:
+
+```java
+Preconditions.assertTrue(stateMachine.getLifeCycleState() == LifeCycle.State.PAUSED);
+```
+
+This throws `IllegalStateException` because `ArcadeStateMachine` never transitions its
+`LifeCycle` state — `BaseStateMachine.pause()` is a no-op, and `ArcadeStateMachine` neither
+calls `getLifeCycle().transition(STARTING)` in `initialize()` nor overrides `pause()` to
+transition to `PAUSED`. So `getLifeCycleState()` always returned `NEW`.
+
+After #4749 fixed the earlier crash in `notifyInstallSnapshotFromLeader`, the install now
+completes successfully and returns. Ratis then calls `pause()` (no-op, lifecycle stays `NEW`)
+and `state.reloadStateMachine()`, which signals the `StateMachineUpdater` to enter `RELOAD`
+mode. The updater calls `reload()`, which checks `getLifeCycleState() == PAUSED` — but the
+lifecycle is still `NEW` — and throws `IllegalStateException`. The `StateMachineUpdater` thread
+dies, the Raft division closes, and the follower permanently rejects `AppendEntries` as
+`ServerNotReadyException: current state is CLOSED`.
+
+Additionally, after the install `notifyInstallSnapshotFromLeader` returned `firstTermIndexInLog`
+(the first log entry AFTER the snapshot) instead of the snapshot's own TermIndex, and it never
+updated `SimpleStateMachineStorage` with the installed snapshot metadata. So after `reinitialize()`
+was called by `reload()`, `getLatestSnapshot()` would return null and cause a `NullPointerException`.
+
+## Changes
+
+### `ArcadeStateMachine.java`
+
+1. **`initialize()`**: transition lifecycle `NEW → STARTING → RUNNING` after `super.initialize()`.
+
+2. **`pause()` (new override)**: transition lifecycle `RUNNING → PAUSING → PAUSED` with
+   a guard so it is idempotent if called in an unexpected state.
+
+3. **`reinitialize()`**: after restoring `lastAppliedIndex` from storage, if lifecycle is
+   `PAUSED` transition `PAUSED → STARTING → RUNNING` so that after `reload()` calls
+   `reinitialize()`, the node is back to `RUNNING`.
+
+4. **`notifyInstallSnapshotFromLeader()`**:
+   - Compute the correct snapshot `TermIndex` as `(term, firstTermIndexInLog.getIndex()-1)`.
+   - Write an empty marker file in `SimpleStateMachineStorage`'s snapshot directory and call
+     `storage.updateLatestSnapshot(...)` so `getLatestSnapshot()` is non-null after
+     `reinitialize()`.
+   - Update `lastAppliedIndex`, `updateLastAppliedTermIndex`, `writePersistedAppliedIndex`.
+   - Return the correct `TermIndex` (not `firstTermIndexInLog`).
+
+### New test: `ArcadeStateMachineLifecycleTest.java`
+
+Unit test for the lifecycle contract that `StateMachineUpdater.reload()` relies on.
+
+### Updated test: `RaftFullSnapshotResyncIT.java`
+
+Now enabled - tests the full 3-node path: snapshot install completes → follower rejoins quorum.
+
+## Test Results
+
+| Test | Outcome |
+|------|---------|
+| `ArcadeStateMachineLifecycleTest` (3 tests) | PASS |
+| `ArcadeStateMachineTest` (12 tests) | PASS |
+| `ArcadeStateMachineApplyRetryTest` (12 tests) | PASS |
+| Full ha-raft unit suite (151 tests) | PASS |
+
+## Impact
+
+Followers now correctly rejoin the Raft quorum after a full snapshot resync. No behavior
+change for the normal (non-snapshot) replication path.

--- a/docs/4754-statemachineupdater-reload-after-snapshot.md
+++ b/docs/4754-statemachineupdater-reload-after-snapshot.md
@@ -51,18 +51,19 @@ was called by `reload()`, `getLatestSnapshot()` would return null and cause a `N
 
 Unit test for the lifecycle contract that `StateMachineUpdater.reload()` relies on.
 
-### Updated test: `RaftFullSnapshotResyncIT.java`
+### `RaftFullSnapshotResyncIT.java`
 
-Now enabled - tests the full 3-node path: snapshot install completes → follower rejoins quorum.
+Not modified in this PR. The test was not `@Disabled` before this PR and covers the same
+resync path; end-to-end coverage is provided by the IT suite.
 
 ## Test Results
 
 | Test | Outcome |
 |------|---------|
-| `ArcadeStateMachineLifecycleTest` (3 tests) | PASS |
+| `ArcadeStateMachineLifecycleTest` (4 tests) | PASS |
 | `ArcadeStateMachineTest` (12 tests) | PASS |
 | `ArcadeStateMachineApplyRetryTest` (12 tests) | PASS |
-| Full ha-raft unit suite (151 tests) | PASS |
+| Full ha-raft unit suite (153 tests) | PASS |
 
 ## Impact
 

--- a/docs/4754-statemachineupdater-reload-after-snapshot.md
+++ b/docs/4754-statemachineupdater-reload-after-snapshot.md
@@ -69,3 +69,16 @@ resync path; end-to-end coverage is provided by the IT suite.
 
 Followers now correctly rejoin the Raft quorum after a full snapshot resync. No behavior
 change for the normal (non-snapshot) replication path.
+
+## Review Cycles
+
+| Cycle | SHA | Summary | Bot outcome |
+|-------|-----|---------|-------------|
+| 1 | `250e30a4a` | Initial fix | Gemini: COMMENTED (null check, race). Claude: medium items (doc, test gap) |
+| 2 | `c84249bc9` | Fix doc, add initialize() test, concurrent download guard | Claude: critical CAS race; Gemini: no re-review |
+| 3 | `98611005c` | Fix CAS to be symmetric, document pause() invariant | Claude: verified fix, "solid well-reasoned fix"; Gemini: no re-review |
+| 4 | `e5822dbd0` | Em-dash cleanup, soften CAS comment, mkdirs logging | TIMEOUT - no review after 15 min |
+
+## Final State
+
+`timeout` (cycle 4 - no bot review within 15 minutes; prior cycles addressed all known issues)

--- a/docs/4754-statemachineupdater-reload-after-snapshot.md
+++ b/docs/4754-statemachineupdater-reload-after-snapshot.md
@@ -1,4 +1,4 @@
-# Issue #4754 — HA: follower never rejoins after snapshot install
+# Issue #4754 - HA: follower never rejoins after snapshot install
 
 ## Root Cause
 
@@ -9,15 +9,15 @@ Preconditions.assertTrue(stateMachine.getLifeCycleState() == LifeCycle.State.PAU
 ```
 
 This throws `IllegalStateException` because `ArcadeStateMachine` never transitions its
-`LifeCycle` state — `BaseStateMachine.pause()` is a no-op, and `ArcadeStateMachine` neither
+`LifeCycle` state - `BaseStateMachine.pause()` is a no-op, and `ArcadeStateMachine` neither
 calls `getLifeCycle().transition(STARTING)` in `initialize()` nor overrides `pause()` to
 transition to `PAUSED`. So `getLifeCycleState()` always returned `NEW`.
 
 After #4749 fixed the earlier crash in `notifyInstallSnapshotFromLeader`, the install now
 completes successfully and returns. Ratis then calls `pause()` (no-op, lifecycle stays `NEW`)
 and `state.reloadStateMachine()`, which signals the `StateMachineUpdater` to enter `RELOAD`
-mode. The updater calls `reload()`, which checks `getLifeCycleState() == PAUSED` — but the
-lifecycle is still `NEW` — and throws `IllegalStateException`. The `StateMachineUpdater` thread
+mode. The updater calls `reload()`, which checks `getLifeCycleState() == PAUSED` - but the
+lifecycle is still `NEW` - and throws `IllegalStateException`. The `StateMachineUpdater` thread
 dies, the Raft division closes, and the follower permanently rejects `AppendEntries` as
 `ServerNotReadyException: current state is CLOSED`.
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -238,6 +238,21 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * Idempotent: if the lifecycle is already PAUSED (e.g. a concurrent path already paused it),
    * the call is a no-op. If the lifecycle is in any unexpected state, a WARNING is logged and
    * the transition is skipped rather than crashing the caller.
+   * <p>
+   * <b>Invariant (verified against Ratis 3.2.2 source):</b> All three callers of
+   * {@code StateMachine.pause()} in Ratis 3.2.2 are paired with a subsequent
+   * {@link #reinitialize()} call that transitions the lifecycle back to RUNNING:
+   * <ul>
+   *   <li>{@code SnapshotInstallationHandler}: notification path (ArcadeDB's path) - pairs with
+   *       {@code state.reloadStateMachine()} which triggers {@code reload()} then
+   *       {@code reinitialize()}.</li>
+   *   <li>{@code ServerState.installSnapshot()}: chunk-based path (not used when
+   *       {@code HA_INSTALL_SNAPSHOT=false}) - same reload chain after last chunk.</li>
+   *   <li>{@code RaftServerImpl.pause()}: external server-pause API - pairs with
+   *       {@code RaftServerImpl.resume()} which calls {@code reinitialize()} directly.</li>
+   * </ul>
+   * If a future Ratis version introduces a {@code pause()} call without a matching
+   * {@code reinitialize()}, the state machine would be stuck in PAUSED permanently.
    */
   @Override
   public void pause() {
@@ -687,14 +702,16 @@ public class ArcadeStateMachine extends BaseStateMachine {
     return CompletableFuture.supplyAsync(() -> {
       // Participate in the same single-flight protocol as triggerSnapshotDownload() so that
       // isSnapshotDownloadPending() returns true during this install and the HealthMonitor's
-      // recoverFromPersistentLag() does not start a concurrent triggerSnapshotDownload().
-      // We use CAS (not unconditional set) so that:
-      //  - if triggerSnapshotDownload() is already running (flag=true), we do NOT set the flag
-      //    and we do NOT clear it in finally; the in-flight watchdog download continues uninterrupted
-      //    and will have installed current data before we call reconcileDatabasesFromLeader().
-      //  - if we won the CAS (flag=false->true), we own the flag and must clear it in finally.
-      // This avoids the asymmetric race where unconditional set + finally set(false) would clear
-      // a flag owned by a concurrently running triggerSnapshotDownload().
+      // recoverFromPersistentLag() does not initiate a new concurrent triggerSnapshotDownload().
+      // We use CAS (not unconditional set) to avoid clearing a flag owned by a concurrently
+      // running triggerSnapshotDownload():
+      //  - if we win (flag false->true): we own the flag and MUST clear it in finally.
+      //  - if we lose (flag already true, another download in progress): we skip the flag and let
+      //    the other download complete; we still proceed with reconcileDatabasesFromLeader() because
+      //    the two installs both pull from the same leader and SnapshotInstaller is crash-safe with
+      //    atomic directory swaps. NOTE: the two calls are not serialized by this flag; ordering
+      //    is only guaranteed when we win the CAS. Eliminating the residual race requires a mutex
+      //    or waiting on the in-flight download, which is deferred as a future improvement.
       final boolean acquiredSnapshotFlag = snapshotDownloadInProgress.compareAndSet(false, true);
       try {
         final RaftPeerId leaderId = RaftPeerId.valueOf(
@@ -728,14 +745,15 @@ public class ArcadeStateMachine extends BaseStateMachine {
 
         // Register the snapshot in SimpleStateMachineStorage. StateMachineUpdater.reload() calls
         // getLatestSnapshot() immediately after reinitialize() and requires a non-null result.
-        // We write an empty marker file — ArcadeDB's real snapshot is the database files on disk,
+        // We write an empty marker file - ArcadeDB's real snapshot is the database files on disk,
         // not a Ratis-managed chunk file. The null FileDigest passed to FileInfo is intentional and
         // safe: this path (file-less, notification-based snapshot install) does not use the Ratis
         // chunk-based verification flow that would check the digest.
         final File snapshotFile = storage.getSnapshotFile(snapshotTerm, snapshotIndex);
         final File parentDir = snapshotFile.getParentFile();
-        if (parentDir != null)
-          parentDir.mkdirs();
+        if (parentDir != null && !parentDir.exists() && !parentDir.mkdirs())
+          LogManager.instance().log(this, Level.WARNING,
+              "Could not create snapshot storage directory %s; snapshot registration may fail", parentDir);
         if (!snapshotFile.exists())
           snapshotFile.createNewFile();
         storage.updateLatestSnapshot(new SingleFileSnapshotInfo(
@@ -743,7 +761,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
         // The empty marker file will be re-discovered by SimpleStateMachineStorage.loadLatestSnapshot()
         // on restart (it scans for files matching "snapshot.term_index"). No .md5 file is written
         // alongside it, so MD5FileUtil.readStoredMd5ForFile() returns null and the SingleFileSnapshotInfo
-        // is constructed with a null digest — the same as when ArcadeDB boots fresh with no prior snapshot.
+        // is constructed with a null digest - the same as when ArcadeDB boots fresh with no prior snapshot.
         // ArcadeDB never validates snapshot file content via Ratis's chunk-verification path (it uses
         // the HTTP-based DatabaseReconciler instead), so the empty file is safe across restarts.
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -685,11 +685,17 @@ public class ArcadeStateMachine extends BaseStateMachine {
     // for the migration target; the cleanup item is to fork onto a dedicated executor (sized via
     // a future {@code arcadedb.haSnapshotInstallThreads} knob) once we add one.
     return CompletableFuture.supplyAsync(() -> {
-      // Set the in-progress flag so isSnapshotDownloadPending() returns true during this install,
-      // preventing the HealthMonitor's recoverFromPersistentLag() from starting a concurrent
-      // triggerSnapshotDownload() that would race with reconcileDatabasesFromLeader() on the same
-      // database files (both ultimately call SnapshotInstaller.install()).
-      snapshotDownloadInProgress.set(true);
+      // Participate in the same single-flight protocol as triggerSnapshotDownload() so that
+      // isSnapshotDownloadPending() returns true during this install and the HealthMonitor's
+      // recoverFromPersistentLag() does not start a concurrent triggerSnapshotDownload().
+      // We use CAS (not unconditional set) so that:
+      //  - if triggerSnapshotDownload() is already running (flag=true), we do NOT set the flag
+      //    and we do NOT clear it in finally; the in-flight watchdog download continues uninterrupted
+      //    and will have installed current data before we call reconcileDatabasesFromLeader().
+      //  - if we won the CAS (flag=false->true), we own the flag and must clear it in finally.
+      // This avoids the asymmetric race where unconditional set + finally set(false) would clear
+      // a flag owned by a concurrently running triggerSnapshotDownload().
+      final boolean acquiredSnapshotFlag = snapshotDownloadInProgress.compareAndSet(false, true);
       try {
         final RaftPeerId leaderId = RaftPeerId.valueOf(
             roleInfoProto.getFollowerInfo().getLeaderInfo().getId().getId());
@@ -734,6 +740,12 @@ public class ArcadeStateMachine extends BaseStateMachine {
           snapshotFile.createNewFile();
         storage.updateLatestSnapshot(new SingleFileSnapshotInfo(
             new FileInfo(snapshotFile.toPath(), null), snapshotTerm, snapshotIndex));
+        // The empty marker file will be re-discovered by SimpleStateMachineStorage.loadLatestSnapshot()
+        // on restart (it scans for files matching "snapshot.term_index"). No .md5 file is written
+        // alongside it, so MD5FileUtil.readStoredMd5ForFile() returns null and the SingleFileSnapshotInfo
+        // is constructed with a null digest — the same as when ArcadeDB boots fresh with no prior snapshot.
+        // ArcadeDB never validates snapshot file content via Ratis's chunk-verification path (it uses
+        // the HTTP-based DatabaseReconciler instead), so the empty file is safe across restarts.
 
         // Advance the local applied-index to the snapshot point so that the StateMachineUpdater
         // knows which log entries have been consumed by this install.
@@ -749,7 +761,8 @@ public class ArcadeStateMachine extends BaseStateMachine {
         LogManager.instance().log(this, Level.SEVERE, "Error during snapshot installation from leader", e);
         throw new RuntimeException("Error during Raft snapshot installation", e);
       } finally {
-        snapshotDownloadInProgress.set(false);
+        if (acquiredSnapshotFlag)
+          snapshotDownloadInProgress.set(false);
       }
     });
   }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -43,12 +43,15 @@ import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.server.raftlog.RaftLog;
+import org.apache.ratis.server.storage.FileInfo;
 import org.apache.ratis.server.storage.RaftStorage;
 import org.apache.ratis.statemachine.StateMachineStorage;
 import org.apache.ratis.statemachine.TransactionContext;
 import org.apache.ratis.statemachine.impl.BaseStateMachine;
 import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
+import org.apache.ratis.statemachine.impl.SingleFileSnapshotInfo;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.apache.ratis.util.LifeCycle;
 
 import java.io.File;
 import java.io.IOException;
@@ -208,6 +211,12 @@ public class ArcadeStateMachine extends BaseStateMachine {
   @Override
   public void initialize(final RaftServer raftServer, final RaftGroupId groupId, final RaftStorage raftStorage) throws IOException {
     super.initialize(raftServer, groupId, raftStorage);
+    // Start the LifeCycle so getLifeCycleState() returns RUNNING while the state machine is active.
+    // StateMachineUpdater.reload() asserts getLifeCycleState() == PAUSED (after pause() is called by
+    // SnapshotInstallationHandler) at Ratis StateMachineUpdater.java:230. Without this start-up the
+    // lifecycle stays in NEW and that precondition throws IllegalStateException (issue #4754).
+    getLifeCycle().transition(LifeCycle.State.STARTING);
+    getLifeCycle().transition(LifeCycle.State.RUNNING);
     storage.init(raftStorage);
     reinitialize();
     // Recover any snapshot installations that were interrupted by a crash
@@ -221,9 +230,35 @@ public class ArcadeStateMachine extends BaseStateMachine {
   }
 
   /**
+   * Transitions the state machine to {@link LifeCycle.State#PAUSED} so that
+   * {@code StateMachineUpdater.reload()} can proceed. Called by Ratis's
+   * {@code SnapshotInstallationHandler} after {@link #notifyInstallSnapshotFromLeader} completes,
+   * before signalling the updater to reload.
+   * <p>
+   * Idempotent: if the lifecycle is already PAUSED (e.g. a concurrent path already paused it),
+   * the call is a no-op. If the lifecycle is in any unexpected state, a WARNING is logged and
+   * the transition is skipped rather than crashing the caller.
+   */
+  @Override
+  public void pause() {
+    final LifeCycle.State current = getLifeCycleState();
+    if (current == LifeCycle.State.RUNNING) {
+      getLifeCycle().transition(LifeCycle.State.PAUSING);
+      getLifeCycle().transition(LifeCycle.State.PAUSED);
+    } else if (current != LifeCycle.State.PAUSED) {
+      LogManager.instance().log(this, Level.WARNING,
+          "pause() called in unexpected lifecycle state %s; skipping transition", current);
+    }
+  }
+
+  /**
    * Restores {@link #lastAppliedIndex} from the latest Ratis {@link SimpleStateMachineStorage}
    * snapshot metadata. Called during {@link #initialize} and again if the state machine storage
    * is reset (e.g., during Ratis recovery via {@link RaftHAServer#restartRatisIfNeeded}).
+   * <p>
+   * When called from {@code StateMachineUpdater.reload()} after a snapshot install, the lifecycle
+   * is in {@link LifeCycle.State#PAUSED} and this method transitions it back to
+   * {@link LifeCycle.State#RUNNING} so the updater can resume applying log entries.
    */
   public void reinitialize() throws IOException {
     final long persistedApplied = readPersistedAppliedIndex();
@@ -261,6 +296,15 @@ public class ArcadeStateMachine extends BaseStateMachine {
       updateLastAppliedTermIndex(snapshotInfo.getTerm(), snapshotIndex);
     } else
       lastAppliedIndex.set(-1);
+
+    // When called from StateMachineUpdater.reload() after a snapshot install, the lifecycle is
+    // PAUSED (pause() was called by SnapshotInstallationHandler). Transition back to RUNNING so
+    // the updater can resume applying log entries. This is a no-op during the normal startup path
+    // (lifecycle is already RUNNING when initialize() calls reinitialize()).
+    if (getLifeCycleState() == LifeCycle.State.PAUSED) {
+      getLifeCycle().transition(LifeCycle.State.STARTING);
+      getLifeCycle().transition(LifeCycle.State.RUNNING);
+    }
   }
 
   @Override
@@ -654,9 +698,38 @@ public class ArcadeStateMachine extends BaseStateMachine {
 
         reconciler.reconcileDatabasesFromLeader(leaderHttpAddr, leaderHttpsAddr, clusterToken);
 
-        LogManager.instance().log(this, Level.INFO, "Full resync from leader completed");
+        // Compute the installed snapshot TermIndex. firstTermIndexInLog is the first log entry
+        // AFTER the snapshot, so the snapshot covers all entries up to getIndex()-1.
+        // Returning firstTermIndexInLog itself (as the old code did) caused two bugs:
+        // 1. SnapshotInstallationHandler called state.reloadStateMachine(firstTermIndexInLog) which
+        //    purged log entries up to firstTermIndexInLog.getIndex() instead of firstTermIndexInLog.getIndex()-1.
+        // 2. StateMachineUpdater.reload() calls getLatestSnapshot().getIndex() and expects it to match
+        //    the TermIndex we return; returning firstTermIndexInLog while storage was never updated
+        //    caused NullPointerException (and before that, IllegalStateException from the PAUSED check).
+        final long snapshotIndex = Math.max(0L, firstTermIndexInLog.getIndex() - 1);
+        final long snapshotTerm = firstTermIndexInLog.getTerm();
+        final TermIndex installedTermIndex = TermIndex.valueOf(snapshotTerm, snapshotIndex);
+
+        // Register the snapshot in SimpleStateMachineStorage. StateMachineUpdater.reload() calls
+        // getLatestSnapshot() immediately after reinitialize() and requires a non-null result.
+        // We write an empty marker file (ArcadeDB's snapshot is the database files themselves,
+        // not a Ratis-managed snapshot file) and update the in-memory latestSnapshot reference.
+        final File snapshotFile = storage.getSnapshotFile(snapshotTerm, snapshotIndex);
+        snapshotFile.getParentFile().mkdirs();
+        if (!snapshotFile.exists())
+          snapshotFile.createNewFile();
+        storage.updateLatestSnapshot(new SingleFileSnapshotInfo(
+            new FileInfo(snapshotFile.toPath(), null), snapshotTerm, snapshotIndex));
+
+        // Advance the local applied-index to the snapshot point so that the StateMachineUpdater
+        // knows which log entries have been consumed by this install.
+        lastAppliedIndex.set(snapshotIndex);
+        updateLastAppliedTermIndex(snapshotTerm, snapshotIndex);
+        writePersistedAppliedIndex(snapshotIndex);
+
+        LogManager.instance().log(this, Level.INFO, "Full resync from leader completed (snapshotIndex=%d)", snapshotIndex);
         clearDivergedState();
-        return firstTermIndexInLog;
+        return installedTermIndex;
 
       } catch (final Exception e) {
         LogManager.instance().log(this, Level.SEVERE, "Error during snapshot installation from leader", e);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -685,6 +685,11 @@ public class ArcadeStateMachine extends BaseStateMachine {
     // for the migration target; the cleanup item is to fork onto a dedicated executor (sized via
     // a future {@code arcadedb.haSnapshotInstallThreads} knob) once we add one.
     return CompletableFuture.supplyAsync(() -> {
+      // Set the in-progress flag so isSnapshotDownloadPending() returns true during this install,
+      // preventing the HealthMonitor's recoverFromPersistentLag() from starting a concurrent
+      // triggerSnapshotDownload() that would race with reconcileDatabasesFromLeader() on the same
+      // database files (both ultimately call SnapshotInstaller.install()).
+      snapshotDownloadInProgress.set(true);
       try {
         final RaftPeerId leaderId = RaftPeerId.valueOf(
             roleInfoProto.getFollowerInfo().getLeaderInfo().getId().getId());
@@ -702,20 +707,29 @@ public class ArcadeStateMachine extends BaseStateMachine {
         // AFTER the snapshot, so the snapshot covers all entries up to getIndex()-1.
         // Returning firstTermIndexInLog itself (as the old code did) caused two bugs:
         // 1. SnapshotInstallationHandler called state.reloadStateMachine(firstTermIndexInLog) which
-        //    purged log entries up to firstTermIndexInLog.getIndex() instead of firstTermIndexInLog.getIndex()-1.
+        //    purged log entries up to firstTermIndexInLog.getIndex() instead of getIndex()-1.
         // 2. StateMachineUpdater.reload() calls getLatestSnapshot().getIndex() and expects it to match
         //    the TermIndex we return; returning firstTermIndexInLog while storage was never updated
         //    caused NullPointerException (and before that, IllegalStateException from the PAUSED check).
         final long snapshotIndex = Math.max(0L, firstTermIndexInLog.getIndex() - 1);
+        // Use firstTermIndexInLog.getTerm() as the snapshot term. The true last-entry term inside
+        // the snapshot is opaque to us (ArcadeDB ships database files, not Ratis snapshot chunks),
+        // so we use the term of the first available log entry as a safe upper bound. This value is
+        // only used to name the marker file (snapshot.term_index) and as metadata for Ratis's
+        // snapshotIndex tracking; it does not affect data correctness.
         final long snapshotTerm = firstTermIndexInLog.getTerm();
         final TermIndex installedTermIndex = TermIndex.valueOf(snapshotTerm, snapshotIndex);
 
         // Register the snapshot in SimpleStateMachineStorage. StateMachineUpdater.reload() calls
         // getLatestSnapshot() immediately after reinitialize() and requires a non-null result.
-        // We write an empty marker file (ArcadeDB's snapshot is the database files themselves,
-        // not a Ratis-managed snapshot file) and update the in-memory latestSnapshot reference.
+        // We write an empty marker file — ArcadeDB's real snapshot is the database files on disk,
+        // not a Ratis-managed chunk file. The null FileDigest passed to FileInfo is intentional and
+        // safe: this path (file-less, notification-based snapshot install) does not use the Ratis
+        // chunk-based verification flow that would check the digest.
         final File snapshotFile = storage.getSnapshotFile(snapshotTerm, snapshotIndex);
-        snapshotFile.getParentFile().mkdirs();
+        final File parentDir = snapshotFile.getParentFile();
+        if (parentDir != null)
+          parentDir.mkdirs();
         if (!snapshotFile.exists())
           snapshotFile.createNewFile();
         storage.updateLatestSnapshot(new SingleFileSnapshotInfo(
@@ -734,6 +748,8 @@ public class ArcadeStateMachine extends BaseStateMachine {
       } catch (final Exception e) {
         LogManager.instance().log(this, Level.SEVERE, "Error during snapshot installation from leader", e);
         throw new RuntimeException("Error during Raft snapshot installation", e);
+      } finally {
+        snapshotDownloadInProgress.set(false);
       }
     });
   }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineLifecycleTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineLifecycleTest.java
@@ -92,12 +92,12 @@ class ArcadeStateMachineLifecycleTest {
    * Simulates the sequence Ratis drives when it needs the state machine to reload
    * after a snapshot install:
    * <ol>
-   *   <li>{@link ArcadeStateMachine#pause()} — called by {@code SnapshotInstallationHandler}
+   *   <li>{@link ArcadeStateMachine#pause()} -called by {@code SnapshotInstallationHandler}
    *       before signalling {@code StateMachineUpdater} to enter RELOAD mode.</li>
    *   <li>{@code StateMachineUpdater.reload()} checks {@code getLifeCycleState() == PAUSED}
    *       at line 230. Before the fix this assertion failed with {@code IllegalStateException}
    *       because the lifecycle stayed in {@code NEW}.</li>
-   *   <li>{@link ArcadeStateMachine#reinitialize()} — called by {@code reload()} to restore
+   *   <li>{@link ArcadeStateMachine#reinitialize()} -called by {@code reload()} to restore
    *       the state machine from the installed snapshot. Must transition back to RUNNING.</li>
    * </ol>
    * The lifecycle is started manually rather than via {@code initialize()} to keep this test

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineLifecycleTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineLifecycleTest.java
@@ -18,10 +18,18 @@
  */
 package com.arcadedb.server.ha.raft;
 
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.server.RaftServer;
+import org.apache.ratis.server.storage.RaftStorage;
 import org.apache.ratis.util.LifeCycle;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.lang.reflect.Proxy;
+import java.nio.file.Path;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -37,6 +45,50 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ArcadeStateMachineLifecycleTest {
 
   /**
+   * Verifies that {@link ArcadeStateMachine#initialize} starts the {@link LifeCycle} so that
+   * subsequent {@link ArcadeStateMachine#pause()} calls can transition to {@code PAUSED}. This
+   * covers the regression path: if the lifecycle-start lines are removed from {@code initialize()},
+   * the lifecycle stays {@code NEW} and {@code pause()} silently skips the transition.
+   */
+  @Test
+  void initializeStartsLifecycleToRunning(@TempDir final Path tempDir) throws IOException {
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    assertThat(sm.getLifeCycleState())
+        .as("fresh state machine must start in NEW")
+        .isEqualTo(LifeCycle.State.NEW);
+
+    final RaftGroupId groupId = RaftGroupId.valueOf(UUID.randomUUID());
+    // RaftStorage.newBuilder requires an existing directory; FORMAT creates any missing subdirs.
+    final RaftStorage raftStorage = RaftStorage.newBuilder()
+        .setDirectory(tempDir.toFile())
+        .setOption(RaftStorage.StartupOption.FORMAT)
+        .build();
+    // Minimal RaftServer stub using a JDK dynamic proxy: BaseStateMachine.initialize() only
+    // calls server.complete(raftServer) and then toString() → getId() → server.join().getId(),
+    // so getId() must return non-null. All other method calls throw UnsupportedOperationException.
+    final RaftServer raftServer = (RaftServer) Proxy.newProxyInstance(
+        getClass().getClassLoader(),
+        new Class<?>[] { RaftServer.class },
+        (proxy, method, args) -> {
+          if ("getId".equals(method.getName()))
+            return RaftPeerId.valueOf("test-peer");
+          if ("close".equals(method.getName()) || "start".equals(method.getName()))
+            return null;
+          throw new UnsupportedOperationException("Stub: " + method.getName());
+        });
+    try {
+      sm.initialize(raftServer, groupId, raftStorage);
+
+      assertThat(sm.getLifeCycleState())
+          .as("initialize() must start the lifecycle so pause() can later transition to PAUSED")
+          .isEqualTo(LifeCycle.State.RUNNING);
+    } finally {
+      sm.close();
+      raftStorage.close();
+    }
+  }
+
+  /**
    * Simulates the sequence Ratis drives when it needs the state machine to reload
    * after a snapshot install:
    * <ol>
@@ -48,6 +100,9 @@ class ArcadeStateMachineLifecycleTest {
    *   <li>{@link ArcadeStateMachine#reinitialize()} — called by {@code reload()} to restore
    *       the state machine from the installed snapshot. Must transition back to RUNNING.</li>
    * </ol>
+   * The lifecycle is started manually rather than via {@code initialize()} to keep this test
+   * self-contained (no filesystem setup needed). {@link #initializeStartsLifecycleToRunning}
+   * separately verifies that {@code initialize()} itself performs this start.
    */
   @Test
   void pauseThenReinitializeFollowsLifecycleContractRequiredByReload() throws IOException {
@@ -85,7 +140,7 @@ class ArcadeStateMachineLifecycleTest {
     sm.pause();
     assertThat(sm.getLifeCycleState()).isEqualTo(LifeCycle.State.PAUSED);
 
-    // A second pause() call must not throw even though RUNNING->PAUSED is already done
+    // A second pause() call must not throw even though the lifecycle is already PAUSED
     sm.pause();
     assertThat(sm.getLifeCycleState()).isEqualTo(LifeCycle.State.PAUSED);
   }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineLifecycleTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineLifecycleTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.apache.ratis.util.LifeCycle;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #4754.
+ * <p>
+ * {@code StateMachineUpdater.reload()} (Ratis 3.2.2, line 230) asserts
+ * {@code getLifeCycleState() == PAUSED} before calling {@code reinitialize()},
+ * then asserts {@code getLatestSnapshot() != null} after. Before this fix,
+ * {@code BaseStateMachine.pause()} was a no-op so the lifecycle stayed in {@code NEW}
+ * and the precondition threw {@code IllegalStateException}.
+ */
+class ArcadeStateMachineLifecycleTest {
+
+  /**
+   * Simulates the sequence Ratis drives when it needs the state machine to reload
+   * after a snapshot install:
+   * <ol>
+   *   <li>{@link ArcadeStateMachine#pause()} — called by {@code SnapshotInstallationHandler}
+   *       before signalling {@code StateMachineUpdater} to enter RELOAD mode.</li>
+   *   <li>{@code StateMachineUpdater.reload()} checks {@code getLifeCycleState() == PAUSED}
+   *       at line 230. Before the fix this assertion failed with {@code IllegalStateException}
+   *       because the lifecycle stayed in {@code NEW}.</li>
+   *   <li>{@link ArcadeStateMachine#reinitialize()} — called by {@code reload()} to restore
+   *       the state machine from the installed snapshot. Must transition back to RUNNING.</li>
+   * </ol>
+   */
+  @Test
+  void pauseThenReinitializeFollowsLifecycleContractRequiredByReload() throws IOException {
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+
+    // Simulate initialize(): start the lifecycle (NEW -> STARTING -> RUNNING)
+    sm.getLifeCycle().transition(LifeCycle.State.STARTING);
+    sm.getLifeCycle().transition(LifeCycle.State.RUNNING);
+    assertThat(sm.getLifeCycleState()).isEqualTo(LifeCycle.State.RUNNING);
+
+    // Simulate SnapshotInstallationHandler calling pause() before reloadStateMachine()
+    sm.pause();
+
+    // This is the exact check at StateMachineUpdater.reload() line 230.
+    // Before the fix, this would be NEW (not PAUSED) and StateMachineUpdater.reload() would
+    // throw IllegalStateException, killing the updater thread and closing the Raft division.
+    assertThat(sm.getLifeCycleState())
+        .as("lifecycle must be PAUSED so StateMachineUpdater.reload() passes its precondition")
+        .isEqualTo(LifeCycle.State.PAUSED);
+
+    // Simulate StateMachineUpdater.reload() calling reinitialize()
+    sm.reinitialize();
+
+    assertThat(sm.getLifeCycleState())
+        .as("lifecycle must return to RUNNING after reinitialize() so the state machine can apply log entries again")
+        .isEqualTo(LifeCycle.State.RUNNING);
+  }
+
+  @Test
+  void pauseIsIdempotentAfterAlreadyPaused() throws IOException {
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    sm.getLifeCycle().transition(LifeCycle.State.STARTING);
+    sm.getLifeCycle().transition(LifeCycle.State.RUNNING);
+
+    sm.pause();
+    assertThat(sm.getLifeCycleState()).isEqualTo(LifeCycle.State.PAUSED);
+
+    // A second pause() call must not throw even though RUNNING->PAUSED is already done
+    sm.pause();
+    assertThat(sm.getLifeCycleState()).isEqualTo(LifeCycle.State.PAUSED);
+  }
+
+  @Test
+  void reinitializeWithoutSnapshotLeavesLifecycleRunning() throws IOException {
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    sm.getLifeCycle().transition(LifeCycle.State.STARTING);
+    sm.getLifeCycle().transition(LifeCycle.State.RUNNING);
+
+    sm.pause();
+    sm.reinitialize();
+
+    // Even with no snapshot in storage, the lifecycle must reach RUNNING after reinitialize()
+    assertThat(sm.getLifeCycleState()).isEqualTo(LifeCycle.State.RUNNING);
+  }
+}


### PR DESCRIPTION
## Summary

Closes #4754

After #4749 fixed the earlier crash in `notifyInstallSnapshotFromLeader`, the snapshot install now completes successfully - but then `StateMachineUpdater.reload()` (Ratis 3.2.2 line 230) immediately throws `IllegalStateException` because `getLifeCycleState() != PAUSED`. This kills the `StateMachineUpdater` thread, closes the Raft division, and the follower permanently rejects all `AppendEntries` as `CLOSED` - making it an unrecoverable zombie.

**Root cause**: `BaseStateMachine.pause()` is a no-op. The `LifeCycle` object in `BaseStateMachine` never transitions, so `getLifeCycleState()` always returned `NEW`. Ratis's `SnapshotInstallationHandler` calls `stateMachine.pause()` before signalling `RELOAD` mode, expecting the lifecycle to become `PAUSED` - but with a no-op `pause()`, the check at line 230 always fails.

**Three changes to `ArcadeStateMachine`:**

- `initialize()`: transition lifecycle `NEW→STARTING→RUNNING` after `super.initialize()` so the lifecycle is in a valid state before any snapshot install can be triggered.
- `pause()` (new override): transition `RUNNING→PAUSING→PAUSED`; idempotent if already `PAUSED`, logs a WARNING for unexpected states.
- `reinitialize()`: after restoring `lastAppliedIndex` from storage, if lifecycle is `PAUSED` (called from `StateMachineUpdater.reload()`), transition `PAUSED→STARTING→RUNNING` so the updater resumes log apply.

**Also fixes `notifyInstallSnapshotFromLeader`:**
- Was returning `firstTermIndexInLog` (the first log entry AFTER the snapshot) instead of the snapshot's own `TermIndex` (`getIndex()-1`).
- Never updated `SimpleStateMachineStorage` with the installed snapshot metadata. `StateMachineUpdater.reload()` calls `Objects.requireNonNull(getLatestSnapshot())` immediately after `reinitialize()`; without this update it would NPE after the lifecycle fix unblocked the PAUSED check.
- Now writes an empty marker file and calls `storage.updateLatestSnapshot(...)`, advances `lastAppliedIndex`/`updateLastAppliedTermIndex`/`writePersistedAppliedIndex` to the snapshot point, and returns the correct `TermIndex`.

## Test plan

- `ArcadeStateMachineLifecycleTest` (new, 3 tests): verifies the exact lifecycle contract that `StateMachineUpdater.reload()` relies on - `pause()` transitions to `PAUSED`, `reinitialize()` transitions back to `RUNNING`, idempotent `pause()`.
- Full ha-raft unit suite (151 tests): all pass, no regressions.
- `Issue4749SnapshotInstallClosesRegisteredDatabaseIT`: still passes (regression for the prior fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)