### PR TITLE
fix(#4792): enforce gRPC admin auth centrally instead of blanket-skipping

### DIFF
--- a/docs/4792-grpc-admin-auth-interceptor.md
+++ b/docs/4792-grpc-admin-auth-interceptor.md
@@ -38,10 +38,13 @@ reachable, matching the behavior for all other gRPC methods.
 `GrpcAdminAuthInterceptorIT` (grpcw): mock-free unit test that drives
 `GrpcAuthInterceptor.interceptCall` for an admin method with a real `ServerSecurity`
 obtained from a running server and hand-written `ServerCall`/`ServerCallHandler`
-test doubles. Verifies:
+test doubles. Five cases:
 - invalid credentials: call closed UNAUTHENTICATED, request NOT delivered to handler
   (fails before the fix because the blanket skip delivered the message)
 - missing credentials: call closed UNAUTHENTICATED, request NOT delivered
+  (fails before the fix)
+- blank username: call closed UNAUTHENTICATED, request NOT delivered (fail closed)
+- security disabled: request passes through to the handler
 - valid credentials: request delivered to handler
 
 Existing `GrpcAdminServiceIT` end-to-end tests continue to pass (clients send body
@@ -49,8 +52,9 @@ credentials, which the central check accepts).
 
 ## Verification results
 
-- `GrpcAdminAuthInterceptorIT`: 3/3 pass after fix. Before the fix the two negative
-  tests failed (the request reached the handler), proving the regression is real.
+- `GrpcAdminAuthInterceptorIT`: 5/5 pass after fix. Before the fix the invalid- and
+  missing-credentials tests failed (the request reached the handler), proving the
+  regression is real.
 - `GrpcAdminServiceIT` (existing, 12 tests): pass, no regression on the real admin path.
 - `GrpcServerIT` (existing data-plane path, 30 tests): 29 pass; the single error was an
   environmental `Address already in use` on the fixed gRPC port 50051 caused by a

--- a/docs/4792-grpc-admin-auth-interceptor.md
+++ b/docs/4792-grpc-admin-auth-interceptor.md
@@ -61,5 +61,9 @@ credentials, which the central check accepts).
 - Admin RPCs are now authenticated at a single transport-level choke point. A future
   admin method that forgets its own `authenticate()` call can no longer be invoked
   unauthenticated.
+- Scope note: this enforces *authentication* (valid credentials), not admin-role
+  *authorization*. As today, any user that authenticates can pass the check; the
+  handlers do not require a server-root role. Adding an admin-role authorization gate
+  is a worthwhile follow-up but is out of scope for this fix (pre-existing behavior).
 - No behavior change for authenticated clients (valid body credentials still pass).
 - No data-plane change; only the admin-service branch of the interceptor was modified.

--- a/docs/4792-grpc-admin-auth-interceptor.md
+++ b/docs/4792-grpc-admin-auth-interceptor.md
@@ -1,0 +1,65 @@
+# Issue #4792 - gRPC auth interceptor blanket-skips the entire Admin service
+
+## Problem
+
+`GrpcAuthInterceptor.interceptCall` returned `next.startCall(...)` for any method
+whose name starts with `com.arcadedb.grpc.ArcadeDbAdminService/`, on the premise
+that each admin method "handles its own authentication via request body".
+
+Consequences:
+- No central choke point: authorization hinged on every admin RPC remembering to
+  call `authenticate(req.getCredentials())`.
+- The interceptor's `securityEnabled` gate never applied to admin methods at all.
+- Any admin method added in the future without a body-auth call would be silently,
+  fully open at the transport layer.
+
+## Root cause
+
+The blanket `startsWith("com.arcadedb.grpc.ArcadeDbAdminService/")` early-return in
+the interceptor bypassed all authentication for the whole admin service.
+
+## Fix
+
+Replace the blanket skip with central enforcement. When security is enabled, the
+interceptor now wraps the admin call listener and, on the inbound request message,
+extracts the `DatabaseCredentials` from the message's `credentials` field (present
+on every admin request, field #1) and validates it against `ServerSecurity` before
+the request is dispatched to the handler. A missing `credentials` field, missing or
+blank username, or failed validation closes the call with `UNAUTHENTICATED` and the
+request never reaches the handler (fail closed).
+
+This is defense-in-depth: the per-method `authenticate()` calls remain, but a
+forgotten call can no longer open a hole because the interceptor is now the central
+choke point. When security is disabled (no users configured), admin methods remain
+reachable, matching the behavior for all other gRPC methods.
+
+## Tests
+
+`GrpcAdminAuthInterceptorIT` (grpcw): mock-free unit test that drives
+`GrpcAuthInterceptor.interceptCall` for an admin method with a real `ServerSecurity`
+obtained from a running server and hand-written `ServerCall`/`ServerCallHandler`
+test doubles. Verifies:
+- invalid credentials: call closed UNAUTHENTICATED, request NOT delivered to handler
+  (fails before the fix because the blanket skip delivered the message)
+- missing credentials: call closed UNAUTHENTICATED, request NOT delivered
+- valid credentials: request delivered to handler
+
+Existing `GrpcAdminServiceIT` end-to-end tests continue to pass (clients send body
+credentials, which the central check accepts).
+
+## Verification results
+
+- `GrpcAdminAuthInterceptorIT`: 3/3 pass after fix. Before the fix the two negative
+  tests failed (the request reached the handler), proving the regression is real.
+- `GrpcAdminServiceIT` (existing, 12 tests): pass, no regression on the real admin path.
+- `GrpcServerIT` (existing data-plane path, 30 tests): 29 pass; the single error was an
+  environmental `Address already in use` on the fixed gRPC port 50051 caused by a
+  concurrent test run, not by this change.
+
+## Impact
+
+- Admin RPCs are now authenticated at a single transport-level choke point. A future
+  admin method that forgets its own `authenticate()` call can no longer be invoked
+  unauthenticated.
+- No behavior change for authenticated clients (valid body credentials still pass).
+- No data-plane change; only the admin-service branch of the interceptor was modified.

--- a/grpc/src/main/proto/arcadedb-server.proto
+++ b/grpc/src/main/proto/arcadedb-server.proto
@@ -567,7 +567,7 @@ service ArcadeDbAdminService {
 }
 
 message PingRequest {
-  DatabaseCredentials credentials = 1; // optional if you allow unauth ping
+  DatabaseCredentials credentials = 1; // required when server security is enabled (enforced centrally by the auth interceptor)
 }
 message PingResponse {
   bool ok = 1;

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
@@ -297,6 +297,10 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
   // Helpers
   // ------------------------------------------------------------------------------------
 
+  // Defense-in-depth: GrpcAuthInterceptor already authenticates these body credentials centrally
+  // before the call reaches this handler. This handler-side check is intentionally kept (do not
+  // remove it assuming the interceptor covers it) so the service stays safe even if the central
+  // gate is ever bypassed or reconfigured.
   private void authenticate(DatabaseCredentials creds) {
 
     if (creds == null)

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java
@@ -89,6 +89,8 @@ class GrpcAuthInterceptor implements ServerInterceptor {
       if (!securityEnabled)
         return next.startCall(call, headers);
 
+      // All admin RPCs are unary, so onMessage fires exactly once with the full request carrying the
+      // credentials. If a client-streaming admin RPC is ever added, revisit this per-message logic.
       return new ForwardingServerCallListener.SimpleForwardingServerCallListener<>(next.startCall(call, headers)) {
         private boolean halted = false;
 

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java
@@ -22,8 +22,11 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.server.http.HttpAuthSession;
 import com.arcadedb.server.http.HttpAuthSessionManager;
 import com.arcadedb.server.security.ServerSecurity;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.Message;
 import io.grpc.Context;
 import io.grpc.Contexts;
+import io.grpc.ForwardingServerCallListener;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
@@ -75,9 +78,35 @@ class GrpcAuthInterceptor implements ServerInterceptor {
       return next.startCall(call, headers);
     }
 
-    // Skip auth for admin service - it handles its own authentication via request body
+    // Admin service: enforce authentication centrally from the request-body credentials instead of
+    // trusting every RPC to authenticate itself. This is the central choke point: a missing,
+    // malformed or invalid credential closes the call before the request reaches the handler, so an
+    // admin method that forgets its own authenticate() call cannot expose a side effect.
     if (methodName.startsWith("com.arcadedb.grpc.ArcadeDbAdminService/")) {
-      return next.startCall(call, headers);
+      // If security is not enabled, allow all requests (consistent with the data-plane methods below)
+      if (!securityEnabled)
+        return next.startCall(call, headers);
+
+      return new ForwardingServerCallListener.SimpleForwardingServerCallListener<>(next.startCall(call, headers)) {
+        private boolean halted = false;
+
+        @Override
+        public void onMessage(final ReqT message) {
+          if (!authenticateAdminRequest(message)) {
+            halted = true;
+            call.close(Status.UNAUTHENTICATED.withDescription("Authentication required"), new Metadata());
+            return;
+          }
+          super.onMessage(message);
+        }
+
+        @Override
+        public void onHalfClose() {
+          if (halted)
+            return;
+          super.onHalfClose();
+        }
+      };
     }
 
     // If security is not enabled, allow all requests
@@ -134,6 +163,32 @@ class GrpcAuthInterceptor implements ServerInterceptor {
       return new ServerCall.Listener<ReqT>() {
       };
     }
+  }
+
+  /**
+   * Validates the credentials carried in the body of an admin request. Every admin request message
+   * declares an optional {@code DatabaseCredentials credentials = 1} field; the credential is
+   * resolved generically via the protobuf descriptor so new admin RPCs are covered automatically.
+   * Returns {@code true} only when valid credentials authenticate against server security. Fails
+   * closed: a non-protobuf message, a missing credentials field, a blank username or any
+   * authentication failure all return {@code false}.
+   */
+  private boolean authenticateAdminRequest(final Object message) {
+    if (!(message instanceof final Message protoMessage))
+      return false;
+
+    final FieldDescriptor credentialsField = protoMessage.getDescriptorForType().findFieldByName("credentials");
+    if (credentialsField == null || !protoMessage.hasField(credentialsField))
+      return false;
+
+    if (!(protoMessage.getField(credentialsField) instanceof final DatabaseCredentials credentials))
+      return false;
+
+    final String username = credentials.getUsername();
+    if (username == null || username.isBlank())
+      return false;
+
+    return validateCredentials(username, credentials.getPassword(), null);
   }
 
   private HttpAuthSession getValidSession(final String token, final String database) {

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java
@@ -98,7 +98,16 @@ class GrpcAuthInterceptor implements ServerInterceptor {
         public void onMessage(final ReqT message) {
           if (halted)
             return;
-          if (!authenticateAdminRequest(message)) {
+          boolean authenticated;
+          try {
+            authenticated = authenticateAdminRequest(message);
+          } catch (final Exception e) {
+            // Keep the fail-closed posture uniform with the rest of the interceptor: any unexpected
+            // error denies the call rather than surfacing as a generic UNKNOWN status.
+            LogManager.instance().log(this, Level.FINE, "Admin authentication error", e);
+            authenticated = false;
+          }
+          if (!authenticated) {
             halted = true;
             call.close(Status.UNAUTHENTICATED.withDescription("Authentication required"), new Metadata());
             return;

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java
@@ -92,6 +92,8 @@ class GrpcAuthInterceptor implements ServerInterceptor {
 
         @Override
         public void onMessage(final ReqT message) {
+          if (halted)
+            return;
           if (!authenticateAdminRequest(message)) {
             halted = true;
             call.close(Status.UNAUTHENTICATED.withDescription("Authentication required"), new Metadata());

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java
@@ -79,9 +79,11 @@ class GrpcAuthInterceptor implements ServerInterceptor {
     }
 
     // Admin service: enforce authentication centrally from the request-body credentials instead of
-    // trusting every RPC to authenticate itself. This is the central choke point: a missing,
-    // malformed or invalid credential closes the call before the request reaches the handler, so an
-    // admin method that forgets its own authenticate() call cannot expose a side effect.
+    // trusting every RPC to authenticate itself. This is the central authentication choke point: a
+    // missing, malformed or invalid credential closes the call before the request reaches the
+    // handler, so an admin method that forgets its own authenticate() call cannot expose a side
+    // effect. Note this enforces authentication only, not admin-role authorization (the handlers
+    // behave the same way today).
     if (methodName.startsWith("com.arcadedb.grpc.ArcadeDbAdminService/")) {
       // If security is not enabled, allow all requests (consistent with the data-plane methods below)
       if (!securityEnabled)
@@ -179,6 +181,9 @@ class GrpcAuthInterceptor implements ServerInterceptor {
     if (!(message instanceof final Message protoMessage))
       return false;
 
+    // 'credentials' is a message-typed field on every admin request, so hasField() reports explicit
+    // presence (proto3 tracks presence for message fields). This presence check is coupled to that
+    // field staying message-typed.
     final FieldDescriptor credentialsField = protoMessage.getDescriptorForType().findFieldByName("credentials");
     if (credentialsField == null || !protoMessage.hasField(credentialsField))
       return false;

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcAdminAuthInterceptorIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcAdminAuthInterceptorIT.java
@@ -85,6 +85,41 @@ public class GrpcAdminAuthInterceptorIT extends BaseGraphServerTest {
   }
 
   @Test
+  void adminCallWithBlankUsernameIsRejectedBeforeReachingHandler() {
+    final RecordingServerCall<CreateDatabaseRequest, CreateDatabaseResponse> call = new RecordingServerCall<>(
+        ArcadeDbAdminServiceGrpc.getCreateDatabaseMethod());
+    final AtomicBoolean delivered = new AtomicBoolean(false);
+    final ServerCallHandler<CreateDatabaseRequest, CreateDatabaseResponse> handler = recordingHandler(delivered);
+
+    final ServerCall.Listener<CreateDatabaseRequest> listener = interceptor().interceptCall(call, new Metadata(), handler);
+    // Credentials present but blank username must fail closed.
+    listener.onMessage(requestWithCredentials("   ", "irrelevant"));
+    listener.onHalfClose();
+
+    assertThat(delivered).as("request with a blank username must not reach the admin handler").isFalse();
+    assertThat(call.closeStatus).isNotNull();
+    assertThat(call.closeStatus.getCode()).isEqualTo(Status.Code.UNAUTHENTICATED);
+  }
+
+  @Test
+  void adminCallPassesThroughWhenSecurityDisabled() {
+    // securityEnabled is false when no ServerSecurity is configured; admin methods are then reachable,
+    // consistent with the data-plane methods.
+    final GrpcAuthInterceptor interceptor = new GrpcAuthInterceptor(null);
+    final RecordingServerCall<CreateDatabaseRequest, CreateDatabaseResponse> call = new RecordingServerCall<>(
+        ArcadeDbAdminServiceGrpc.getCreateDatabaseMethod());
+    final AtomicBoolean delivered = new AtomicBoolean(false);
+    final ServerCallHandler<CreateDatabaseRequest, CreateDatabaseResponse> handler = recordingHandler(delivered);
+
+    final ServerCall.Listener<CreateDatabaseRequest> listener = interceptor.interceptCall(call, new Metadata(), handler);
+    listener.onMessage(requestWithCredentials(null, null));
+    listener.onHalfClose();
+
+    assertThat(delivered).as("admin call must pass through when security is disabled").isTrue();
+    assertThat(call.closeStatus).isNull();
+  }
+
+  @Test
   void adminCallWithValidCredentialsReachesHandler() {
     final RecordingServerCall<CreateDatabaseRequest, CreateDatabaseResponse> call = new RecordingServerCall<>(
         ArcadeDbAdminServiceGrpc.getCreateDatabaseMethod());

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcAdminAuthInterceptorIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcAdminAuthInterceptorIT.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.security.ServerSecurity;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.Status;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4792: the gRPC auth interceptor must NOT blanket-skip the whole
+ * Admin service. Authentication is enforced centrally in the interceptor from the request-body
+ * credentials, so a missing/invalid credential closes the call with UNAUTHENTICATED and the request
+ * never reaches the service handler. Drives {@link GrpcAuthInterceptor#interceptCall} directly with
+ * a real {@link ServerSecurity} and hand-written gRPC test doubles (no mocking framework).
+ */
+public class GrpcAdminAuthInterceptorIT extends BaseGraphServerTest {
+
+  private GrpcAuthInterceptor interceptor() {
+    final ServerSecurity security = getServer(0).getSecurity();
+    return new GrpcAuthInterceptor(security);
+  }
+
+  private CreateDatabaseRequest requestWithCredentials(final String user, final String password) {
+    final CreateDatabaseRequest.Builder builder = CreateDatabaseRequest.newBuilder().setName("issue4792_db").setType("document");
+    if (user != null)
+      builder.setCredentials(DatabaseCredentials.newBuilder().setUsername(user).setPassword(password == null ? "" : password).build());
+    return builder.build();
+  }
+
+  @Test
+  void adminCallWithInvalidCredentialsIsRejectedBeforeReachingHandler() {
+    final RecordingServerCall<CreateDatabaseRequest, CreateDatabaseResponse> call = new RecordingServerCall<>(
+        ArcadeDbAdminServiceGrpc.getCreateDatabaseMethod());
+    final AtomicBoolean delivered = new AtomicBoolean(false);
+    final ServerCallHandler<CreateDatabaseRequest, CreateDatabaseResponse> handler = recordingHandler(delivered);
+
+    final ServerCall.Listener<CreateDatabaseRequest> listener = interceptor().interceptCall(call, new Metadata(), handler);
+    listener.onMessage(requestWithCredentials("root", "this_is_the_wrong_password"));
+    listener.onHalfClose();
+
+    assertThat(delivered).as("request must not reach the admin handler with invalid credentials").isFalse();
+    assertThat(call.closeStatus).as("call must be closed by the interceptor").isNotNull();
+    assertThat(call.closeStatus.getCode()).isEqualTo(Status.Code.UNAUTHENTICATED);
+  }
+
+  @Test
+  void adminCallWithoutCredentialsIsRejectedBeforeReachingHandler() {
+    final RecordingServerCall<CreateDatabaseRequest, CreateDatabaseResponse> call = new RecordingServerCall<>(
+        ArcadeDbAdminServiceGrpc.getCreateDatabaseMethod());
+    final AtomicBoolean delivered = new AtomicBoolean(false);
+    final ServerCallHandler<CreateDatabaseRequest, CreateDatabaseResponse> handler = recordingHandler(delivered);
+
+    final ServerCall.Listener<CreateDatabaseRequest> listener = interceptor().interceptCall(call, new Metadata(), handler);
+    listener.onMessage(requestWithCredentials(null, null));
+    listener.onHalfClose();
+
+    assertThat(delivered).as("request must not reach the admin handler without credentials").isFalse();
+    assertThat(call.closeStatus).as("call must be closed by the interceptor").isNotNull();
+    assertThat(call.closeStatus.getCode()).isEqualTo(Status.Code.UNAUTHENTICATED);
+  }
+
+  @Test
+  void adminCallWithValidCredentialsReachesHandler() {
+    final RecordingServerCall<CreateDatabaseRequest, CreateDatabaseResponse> call = new RecordingServerCall<>(
+        ArcadeDbAdminServiceGrpc.getCreateDatabaseMethod());
+    final AtomicBoolean delivered = new AtomicBoolean(false);
+    final ServerCallHandler<CreateDatabaseRequest, CreateDatabaseResponse> handler = recordingHandler(delivered);
+
+    final ServerCall.Listener<CreateDatabaseRequest> listener = interceptor().interceptCall(call, new Metadata(), handler);
+    listener.onMessage(requestWithCredentials("root", DEFAULT_PASSWORD_FOR_TESTS));
+    listener.onHalfClose();
+
+    assertThat(delivered).as("request with valid credentials must reach the admin handler").isTrue();
+    assertThat(call.closeStatus).as("interceptor must not reject a valid request").isNull();
+  }
+
+  private static <ReqT, RespT> ServerCallHandler<ReqT, RespT> recordingHandler(final AtomicBoolean delivered) {
+    return (call, headers) -> new ServerCall.Listener<>() {
+      @Override
+      public void onMessage(final ReqT message) {
+        delivered.set(true);
+      }
+    };
+  }
+
+  /**
+   * Minimal hand-written {@link ServerCall} test double that records the {@link Status} the
+   * interceptor closes the call with.
+   */
+  private static final class RecordingServerCall<ReqT, RespT> extends ServerCall<ReqT, RespT> {
+    private final MethodDescriptor<ReqT, RespT> methodDescriptor;
+    private       Status                        closeStatus;
+
+    private RecordingServerCall(final MethodDescriptor<ReqT, RespT> methodDescriptor) {
+      this.methodDescriptor = methodDescriptor;
+    }
+
+    @Override
+    public void request(final int numMessages) {
+    }
+
+    @Override
+    public void sendHeaders(final Metadata headers) {
+    }
+
+    @Override
+    public void sendMessage(final RespT message) {
+    }
+
+    @Override
+    public void close(final Status status, final Metadata trailers) {
+      this.closeStatus = status;
+    }
+
+    @Override
+    public boolean isCancelled() {
+      return false;
+    }
+
+    @Override
+    public MethodDescriptor<ReqT, RespT> getMethodDescriptor() {
+      return methodDescriptor;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #4792 (security, HIGH).

`GrpcAuthInterceptor.interceptCall` returned `next.startCall(...)` for any method whose name starts with `com.arcadedb.grpc.ArcadeDbAdminService/`, on the premise that each admin RPC "handles its own authentication via request body". This left authorization hinging on every admin method remembering to call `authenticate()`, and the interceptor's `securityEnabled` gate never applied to admin methods at all. Any admin method added without a body-auth call would be silently, fully open at the transport layer - there was no central choke point.

## Fix

Replace the blanket skip with central enforcement. When security is enabled, the interceptor now wraps the admin call listener and, on the inbound request message, extracts the `DatabaseCredentials` from the message's `credentials` field (present on every admin request as field #1, resolved generically via the protobuf field descriptor so new RPCs are covered automatically) and validates it against `ServerSecurity` before the request is dispatched to the handler.

- Missing `credentials` field, missing/blank username, malformed message, or failed validation -> call closed with `UNAUTHENTICATED`, request never reaches the handler (fail closed).
- When security is disabled (no users configured), admin methods remain reachable, consistent with the data-plane methods.
- Defense-in-depth: the per-method `authenticate()` calls remain, but a forgotten call can no longer open a hole.
- All admin RPCs are unary; the per-message listener documents that assumption.

Scope note: this enforces *authentication*, not admin-role *authorization* - any user that authenticates passes the gate, which is the pre-existing handler behavior. An admin-role gate is a worthwhile follow-up but is out of scope here. The data-plane (non-admin) interceptor path is unchanged.

## Tests

`GrpcAdminAuthInterceptorIT` (grpcw, mock-free): drives `GrpcAuthInterceptor.interceptCall` for an admin method with a real `ServerSecurity` and hand-written `ServerCall`/`ServerCallHandler` test doubles. 5 cases:

- invalid credentials -> closed `UNAUTHENTICATED`, request NOT delivered (fails before this fix)
- missing credentials -> closed `UNAUTHENTICATED`, request NOT delivered (fails before this fix)
- blank username -> closed `UNAUTHENTICATED`, request NOT delivered (fail closed)
- security disabled -> request passes through to the handler
- valid credentials -> request delivered to the handler

Verification:
- `GrpcAdminAuthInterceptorIT`: 5/5 pass (the invalid/missing negatives fail before the fix, proving the regression).
- `GrpcAdminServiceIT` (existing, 12 tests): pass, no regression.
- `GrpcServerIT` (existing data-plane, 30 tests): 29 pass; the one error was an environmental port-50051 bind conflict from a concurrent run, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)