### PR TITLE
test(#4794): gRPC cross-database authorization regression coverage

### DIFF
--- a/docs/4794-grpc-per-db-authorization-bypass.md
+++ b/docs/4794-grpc-per-db-authorization-bypass.md
@@ -1,0 +1,53 @@
+# Issue #4794 - gRPC per-DB authorization bypass
+
+URL: https://github.com/ArcadeData/arcadedb/issues/4794
+Type: bug (security, HIGH)
+
+## Summary
+
+`GrpcAuthInterceptor` authenticates the caller against the database named in the
+`x-arcade-database` metadata header (defaulting to `"default"` when absent), but the
+service methods resolve the database they actually operate on from the request body
+(`req.getDatabase()` -> `ArcadeDbGrpcService.getDatabase(...)`). The two are never
+reconciled, so an authenticated user can present a header naming a database they may
+access (or omit it entirely) and then read/write a *different* database named in the
+request body. This is a per-database access-control bypass.
+
+## Security boundary
+
+- Authentication (who are you + correct password): handled by `GrpcAuthInterceptor`
+  via `ServerSecurity.authenticate(user, pass, headerDb)`.
+- Authorization (may this user touch *this* database): must be enforced against the
+  database the operation actually uses, i.e. the request-body database resolved in
+  `ArcadeDbGrpcService.getDatabase(databaseName, credentials)`.
+
+The bug is that authorization was bound to the header database, not the body database.
+
+## Root cause
+
+`ArcadeDbGrpcService.getDatabase(databaseName, credentials)` opened/returned the body
+database and set the current security user without ever verifying the authenticated
+user is authorized for `databaseName`.
+
+## Fix
+
+The authorization gap is already closed by `validateCredentials(credentials, databaseName)`,
+which `getDatabase(...)` invokes as its first step (introduced by #4815). That method
+authorizes the resolved user against the request-body `databaseName`:
+
+- interceptor-context users are checked against `getAuthorizedDatabases()`;
+- request-payload credentials go through `ServerSecurity.authenticate(user, pass, databaseName)`,
+
+both throwing `PERMISSION_DENIED` ("User has not access to database '<db>'") when the user
+may not access the body database. Because this runs before any database work, the bypass is
+closed at the single chokepoint every RPC funnels through, regardless of what the header
+claimed. No additional gate is required; this issue contributes the cross-database
+regression coverage below.
+
+## Tests
+
+- `Issue4794GrpcPerDbAuthorizationIT` (grpcw): a user authorized only for a restricted
+  database authenticates with a header naming that allowed database, then issues a
+  query/command whose body targets a different database the user cannot access. Expect
+  `PERMISSION_DENIED`. A positive-control test confirms the same user can still operate
+  on the database it is authorized for.

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4794GrpcPerDbAuthorizationIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4794GrpcPerDbAuthorizationIT.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.security.ServerSecurity;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #4794.
+ * <p>
+ * The gRPC auth interceptor authenticates the caller against the database named in the
+ * {@code x-arcade-database} metadata header, but the service methods operate on the database named
+ * in the request body. Without per-database authorization at the body-database resolution point a
+ * caller can authenticate with a header naming a database it may access and then read/write a
+ * different database it is NOT authorized for.
+ * <p>
+ * This test creates a user authorized only for a dedicated database, then issues operations whose
+ * request body targets a different (forbidden) database while the header still names the allowed
+ * one. The forbidden operations must be rejected with {@code PERMISSION_DENIED}.
+ * <p>
+ * The read ({@code executeQuery}), command ({@code executeCommand}) and write ({@code createRecord})
+ * cases below are representative, not exhaustive: every database-touching RPC resolves its target
+ * database through the single {@code ArcadeDbGrpcService.getDatabase(...)} chokepoint, where
+ * {@code validateCredentials(...)} authorizes the request-body database. The untested RPCs
+ * (e.g. {@code lookupByRid}, {@code updateRecord}, {@code deleteRecord}, {@code bulkInsert}) are not
+ * intentionally excluded; they share that same gate and so are covered transitively.
+ */
+public class Issue4794GrpcPerDbAuthorizationIT extends BaseGraphServerTest {
+
+  private static final int    GRPC_PORT       = 50051;
+  private static final String ALLOWED_DB      = "allowed4794db";
+  private static final String LIMITED_USER    = "limited4794";
+  private static final String LIMITED_PASS    = "limited4794pass";
+
+  private static final Metadata.Key<String> USER_HEADER     =
+      Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER =
+      Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER =
+      Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  private ManagedChannel channel;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void setupRestrictedUserAndChannel() {
+    final ServerSecurity security = getServer(0).getSecurity();
+
+    // The database the limited user IS authorized for.
+    getServer(0).getOrCreateDatabase(ALLOWED_DB);
+
+    // Create a user authorized ONLY for ALLOWED_DB (no wildcard, no access to the default test db).
+    if (!security.existsUser(LIMITED_USER)) {
+      final JSONObject config = new JSONObject();
+      config.put("name", LIMITED_USER);
+      config.put("password", security.encodePassword(LIMITED_PASS));
+      config.put("databases", new JSONObject().put(ALLOWED_DB, new JSONArray().put("admin")));
+      security.createUser(config);
+    }
+
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+  }
+
+  @AfterEach
+  void teardown() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  /**
+   * Builds a stub whose metadata header names {@code headerDb} but that otherwise carries the
+   * limited user's basic-auth credentials.
+   */
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub stubWithHeaderDatabase(final String headerDb) {
+    final Channel authenticated = ClientInterceptors.intercept(channel, new ClientInterceptor() {
+      @Override
+      public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(final MethodDescriptor<ReqT, RespT> method,
+          final CallOptions callOptions, final Channel next) {
+        return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+          @Override
+          public void start(final Listener<RespT> responseListener, final Metadata headers) {
+            headers.put(USER_HEADER, LIMITED_USER);
+            headers.put(PASSWORD_HEADER, LIMITED_PASS);
+            headers.put(DATABASE_HEADER, headerDb);
+            super.start(responseListener, headers);
+          }
+        };
+      }
+    });
+    return ArcadeDbServiceGrpc.newBlockingStub(authenticated);
+  }
+
+  private DatabaseCredentials limitedCredentials() {
+    return DatabaseCredentials.newBuilder().setUsername(LIMITED_USER).setPassword(LIMITED_PASS).build();
+  }
+
+  @Test
+  void crossDatabaseQueryIsDenied() {
+    // Header names the database the user CAN access; request body targets the default test database
+    // (getDatabaseName()) which the limited user is NOT authorized for. The query RPC surfaces the
+    // failure as a gRPC error status, and the denial must come from the database-authorization gate
+    // (not, e.g., a leaked record-level error) so the bypass is closed for every operation.
+    final ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub stub = stubWithHeaderDatabase(ALLOWED_DB);
+
+    final ExecuteQueryRequest request = ExecuteQueryRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(limitedCredentials())
+        .setQuery("SELECT FROM V1")
+        .build();
+
+    assertThatThrownBy(() -> stub.executeQuery(request))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("has not access to database '" + getDatabaseName() + "'");
+  }
+
+  @Test
+  void crossDatabaseCommandIsDenied() {
+    // The command RPC reports execution errors via the response (success=false) rather than a gRPC
+    // error status. The denial must be raised by the per-database authorization gate before any work
+    // happens against the request-body database.
+    final ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub stub = stubWithHeaderDatabase(ALLOWED_DB);
+
+    final ExecuteCommandRequest request = ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(limitedCredentials())
+        .setCommand("INSERT INTO Person SET name = 'intruder'")
+        .build();
+
+    final ExecuteCommandResponse response = stub.executeCommand(request);
+
+    assertThat(response.getSuccess()).isFalse();
+    assertThat(response.getMessage()).contains("has not access to database '" + getDatabaseName() + "'");
+    assertThat(response.getAffectedRecords()).isZero();
+  }
+
+  @Test
+  void crossDatabaseCreateRecordIsDenied() {
+    // Write path: createRecord resolves its target database from the request body through the same
+    // getDatabase() authorization chokepoint. A header naming the allowed database must not grant a
+    // write into a different body database the user cannot access. createRecord surfaces failures via
+    // a gRPC error status (its catch block masks the PERMISSION_DENIED code as INTERNAL but preserves
+    // the authorization message), so the denial is asserted on the message.
+    final ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub stub = stubWithHeaderDatabase(ALLOWED_DB);
+
+    final CreateRecordRequest request = CreateRecordRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(limitedCredentials())
+        .setType("Person")
+        .setRecord(GrpcRecord.newBuilder()
+            .putProperties("name", GrpcValue.newBuilder().setStringValue("intruder").build())
+            .build())
+        .build();
+
+    assertThatThrownBy(() -> stub.createRecord(request))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("has not access to database '" + getDatabaseName() + "'");
+  }
+
+  @Test
+  void authorizedDatabaseAccessSucceeds() {
+    // Positive control: same user, body database == the database it is authorized for.
+    final ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub stub = stubWithHeaderDatabase(ALLOWED_DB);
+
+    final ExecuteCommandRequest createType = ExecuteCommandRequest.newBuilder()
+        .setDatabase(ALLOWED_DB)
+        .setCredentials(limitedCredentials())
+        .setCommand("CREATE DOCUMENT TYPE Doc4794 IF NOT EXISTS")
+        .build();
+
+    final ExecuteCommandResponse response = stub.executeCommand(createType);
+    assertThat(response.getSuccess()).isTrue();
+  }
+}


### PR DESCRIPTION
Closes #4794

## Summary

#4794 reported a per-database authorization bypass in the gRPC layer: `GrpcAuthInterceptor` authenticates the caller against the `x-arcade-database` metadata header (defaulting to `"default"` when absent), but every service method resolves the database it actually operates on from the request body via `ArcadeDbGrpcService.getDatabase(req.getDatabase(), ...)`. An authenticated user could name an accessible database in the header (or omit it) and then read/write a *different* database named in the request body.

**This bypass is already closed on `main`** by `validateCredentials(credentials, databaseName)`, which `getDatabase(...)` invokes as its first step (landed in #4815, commit `f4491e9`). That method authorizes the resolved user against the request-body database the operation actually targets:

- interceptor-context users are checked against `getAuthorizedDatabases()`;
- request-payload credentials go through `ServerSecurity.authenticate(user, pass, databaseName)`.

Both throw `PERMISSION_DENIED` (`"User has not access to database '<db>'"`) before any database work happens, at the single chokepoint every RPC funnels through - direct callers (`executeQuery`, `executeCommand`, `createRecord`, `lookupByRid`, `updateRecord`, `deleteRecord`, `streamQuery`, `graphBatchLoad`) and the `InsertContext` write paths (`bulkInsert`, `insertStream`, `insertBidirectional`) alike. `commitTransaction`/`rollbackTransaction` operate on transactions already bound through the same gate at begin time.

An earlier revision of this branch added a second `canAccessToDatabase()` gate in `getDatabase(...)`. Because `validateCredentials` runs first and checks the same condition on the same database name, that gate was unreachable dead code with a divergent message, so it was dropped (along with a duplicate import) on review.

**This PR therefore contributes regression coverage and documentation; the enforcement itself lives in #4815.**

## Test plan

- [x] `Issue4794GrpcPerDbAuthorizationIT` (grpcw): a user authorized only for a dedicated database authenticates with a header naming that allowed database, then targets a different (forbidden) database in the request body:
  - `crossDatabaseQueryIsDenied` - query RPC fails with `PERMISSION_DENIED` whose message contains `has not access to database '<db>'`.
  - `crossDatabaseCommandIsDenied` - command RPC returns `success=false`, `affectedRecords=0`, same authorization message (no record written).
  - `crossDatabaseCreateRecordIsDenied` - write path: `createRecord` is denied at `getDatabase(...)` before any record is created.
  - `authorizedDatabaseAccessSucceeds` - positive control: the same user can still operate on the database it is authorized for.
- [x] Full `grpcw` suite green (104 unit tests + integration tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
