### PR TITLE
fix(#4793): gRPC getDatabase rejects path-traversal names and enforces auth/authorization

### DIFF
--- a/docs/4793-grpc-getdatabase-auth-path-traversal.md
+++ b/docs/4793-grpc-getdatabase-auth-path-traversal.md
@@ -1,0 +1,71 @@
+# Issue #4793 - gRPC getDatabase: unauth DB create + path traversal
+
+## Summary
+
+`ArcadeDbGrpcService.getDatabase()` resolved a database from a request-supplied
+`databaseName` after only checking that a username was *resolvable*
+(`validateCredentials` never called `ServerSecurity.authenticate`). Two security
+problems:
+
+1. **Path traversal** - `databaseName` flowed unsanitized into
+   `new DatabaseFactory(databasePath + "/" + databaseName)` (fallback path) and
+   into `arcadeServer.getDatabase(databaseName)`. A name containing `..`, `/` or
+   `\` escapes the configured databases directory.
+2. **Weak authentication / missing authorization** - `validateCredentials` only
+   required a non-empty username. It never authenticated the password nor
+   authorized the user for the named database, so any path reaching the service
+   could open/create databases.
+
+## Root cause
+
+- `validateCredentials(DatabaseCredentials)` only resolved a username and threw
+  only when it was null. No call to `ServerSecurity.authenticate`, no
+  per-database authorization.
+- `getDatabase(String, DatabaseCredentials)` never validated the database name
+  before touching the filesystem.
+
+## Fix
+
+`grpcw/.../ArcadeDbGrpcService.java`:
+
+- New `validateDatabaseName(String)`: rejects null/blank names and any name
+  containing `/`, `\` or `..` (mirrors the established pattern in
+  `PostServerCommandHandler.resolveBackupFile` / `ServerQueryProfiler`). Called
+  at the top of `getDatabase` before any filesystem access.
+- `validateCredentials` now takes the database name and, when server security is
+  active (at least one user configured), enforces real authentication +
+  per-database authorization:
+  - If the auth interceptor already set the connection's context user, authorize
+    that user for the requested database.
+  - Otherwise authenticate the request-payload username/password and authorize
+    the requested database via `ServerSecurity.authenticate`.
+
+## Tests
+
+`grpcw/.../Issue4793GrpcGetDatabaseSecurityIT.java` (new):
+- path-traversal database name (`../`, nested `/`, backslash) is rejected and no
+  directory escapes the databases folder.
+- legitimate database access by an authorized user still works (positive
+  control / no regression).
+
+## Verification (results)
+
+- New IT `Issue4793GrpcGetDatabaseSecurityIT`: 3 of 5 tests FAIL before the fix
+  (traversal names produced "...does not exist" instead of being rejected); all
+  5 PASS after the fix.
+- `grpcw` surefire unit tests (104, incl. `ArcadeDbGrpcServiceExtendedTest`
+  authenticated happy path) and `GrpcAuthInterceptorTest` (8): pass.
+- `grpcw` failsafe ITs `GrpcServerIT` + `GrpcFollowerForwardingIT` (31, incl.
+  HA leader-forwarding using the interceptor context user): pass.
+- Pre-existing unrelated failure: `grpc-client` `Issue4562RollbackDeleteTest`
+  HTTP-path variants fail on `RemoteSchema.getType` for a gRPC-created type. Verified
+  this fails identically on the unmodified base code, so it is not caused by this
+  change (HTTP path is untouched).
+
+## Impact
+
+- Closes the path-traversal vector (request `databaseName` can no longer escape the
+  databases directory) for every gRPC entry point that resolves a database.
+- Enforces per-database authorization of the authenticated user and real
+  authentication of request-payload credentials when server security is active.
+- No behavioral change when security is disabled beyond the database-name sanitization.

--- a/docs/4793-grpc-getdatabase-auth-path-traversal.md
+++ b/docs/4793-grpc-getdatabase-auth-path-traversal.md
@@ -67,5 +67,35 @@ problems:
 - Closes the path-traversal vector (request `databaseName` can no longer escape the
   databases directory) for every gRPC entry point that resolves a database.
 - Enforces per-database authorization of the authenticated user and real
-  authentication of request-payload credentials when server security is active.
+  authentication of request-payload credentials when server security is active. This
+  also closes a cross-database authorization escape: the interceptor authenticates
+  against the `x-arcade-database` header while `getDatabase` resolves the request-body
+  database, so re-authorizing the resolved user against the actual `databaseName` is
+  required.
 - No behavioral change when security is disabled beyond the database-name sanitization.
+
+## Review cycles
+
+### Cycle 1 (gemini-code-assist, HIGH)
+
+- A bare `.` database name resolves to the databases directory itself and was not caught
+  by the separator/`..` checks. `validateDatabaseName` now also rejects `.`. Added
+  regression case `currentDirectoryDatabaseNameIsRejected`. (commit c425c28ce)
+
+### Cycle 2 (claude bot)
+
+- **Item 1 (status codes)** - addressed. `validateDatabaseName` now throws
+  `INVALID_ARGUMENT`; authn failures `UNAUTHENTICATED`; per-database authz failures
+  `PERMISSION_DENIED`. `executeQuery` preserves a `StatusRuntimeException` instead of
+  masking it as `INTERNAL`. Tests assert `Status.Code.INVALID_ARGUMENT` to pin the
+  contract.
+- **Item 2 (stale Javadoc)** - addressed. `resolvedUsername` Javadoc now links the
+  `(DatabaseCredentials, String)` signature.
+- **Item 3 (extract `authorizeDatabase` into `ServerSecurity`/`ServerSecurityUser`)** -
+  deferred. Optional cleanup that spans the `server` module; the duplicated check is the
+  two-line `ANY`/`contains` test. Tracked as a follow-up to keep this PR scoped to the
+  security boundary.
+- **Item 4 (auto-create database on a SELECT in the fallback path)** - deferred. The bot
+  itself flagged this as a pre-existing, separate follow-up; it is no longer a traversal
+  issue (confined to the databases directory) and gating creation behind an explicit
+  admin path is out of scope for this fix.

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -930,6 +930,12 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       final ExecuteQueryResponse response = executeQueryInternal(request, database);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
+    } catch (final StatusRuntimeException e) {
+      // Preserve the status code chosen by getDatabase (e.g. INVALID_ARGUMENT for a rejected
+      // database name, PERMISSION_DENIED/UNAUTHENTICATED for authz/authn failures) instead of
+      // masking it as INTERNAL.
+      LogManager.instance().log(this, Level.FINE, "Query rejected: %s", e, e.getMessage());
+      responseObserver.onError(e);
     } catch (Exception e) {
       LogManager.instance().log(this, Level.SEVERE, "Error executing query: %s", e, e.getMessage());
       responseObserver.onError(Status.INTERNAL.withDescription("Query execution failed: " + e.getMessage()).asException());
@@ -3157,7 +3163,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
    * Resolves the authenticated username for the current request. Prefers the interceptor-set
    * gRPC context (Bearer or basic auth flows) and falls back to the credentials carried by the
    * request payload. Single source of truth for username precedence; both
-   * {@link #validateCredentials(DatabaseCredentials)} and {@link #getDatabase(String, DatabaseCredentials)}
+   * {@link #validateCredentials(DatabaseCredentials, String)} and {@link #getDatabase(String, DatabaseCredentials)}
    * delegate here so the rule cannot drift between callers.
    */
   private String resolvedUsername(final DatabaseCredentials credentials) {
@@ -3181,11 +3187,11 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
    */
   private static void validateDatabaseName(final String databaseName) {
     if (databaseName == null || databaseName.isBlank())
-      throw new IllegalArgumentException("Invalid database name: name is required");
+      throw Status.INVALID_ARGUMENT.withDescription("Invalid database name: name is required").asRuntimeException();
     // A bare "." would resolve to the databases directory itself, so it is rejected alongside the
     // separator and parent-reference checks.
     if (databaseName.equals(".") || databaseName.contains("/") || databaseName.contains("\\") || databaseName.contains(".."))
-      throw new IllegalArgumentException("Invalid database name: " + databaseName);
+      throw Status.INVALID_ARGUMENT.withDescription("Invalid database name: " + databaseName).asRuntimeException();
   }
 
   /**
@@ -3205,7 +3211,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   private void validateCredentials(final DatabaseCredentials credentials, final String databaseName) {
     final String authenticatedUser = resolvedUsername(credentials);
     if (authenticatedUser == null)
-      throw new IllegalArgumentException("Invalid credentials");
+      throw Status.UNAUTHENTICATED.withDescription("Invalid credentials").asRuntimeException();
 
     final ServerSecurity security = arcadeServer != null ? arcadeServer.getSecurity() : null;
     if (security != null && security.getUsers() != null && !security.getUsers().isEmpty()) {
@@ -3215,17 +3221,22 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         // already-authenticated user for the specific database named in the request.
         final ServerSecurityUser user = security.getUser(contextUser);
         if (user == null)
-          throw new ServerSecurityException("User/Password not valid");
+          throw Status.UNAUTHENTICATED.withDescription("User/Password not valid").asRuntimeException();
         final Set<String> allowedDatabases = user.getAuthorizedDatabases();
         if (!allowedDatabases.contains(SecurityManager.ANY) && !allowedDatabases.contains(databaseName))
-          throw new ServerSecurityException("User has not access to database '" + databaseName + "'");
+          throw Status.PERMISSION_DENIED.withDescription("User has not access to database '" + databaseName + "'")
+              .asRuntimeException();
       } else {
         // No interceptor context (request-payload credentials only): authenticate the
         // username/password pair and authorize the requested database in one step.
         final String password = credentials != null ? credentials.getPassword() : null;
         if (password == null || password.isEmpty())
-          throw new ServerSecurityException("Authentication required");
-        security.authenticate(authenticatedUser, password, databaseName);
+          throw Status.UNAUTHENTICATED.withDescription("Authentication required").asRuntimeException();
+        try {
+          security.authenticate(authenticatedUser, password, databaseName);
+        } catch (final ServerSecurityException e) {
+          throw Status.PERMISSION_DENIED.withDescription(e.getMessage()).asRuntimeException();
+        }
       }
     }
 

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -3182,7 +3182,9 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   private static void validateDatabaseName(final String databaseName) {
     if (databaseName == null || databaseName.isBlank())
       throw new IllegalArgumentException("Invalid database name: name is required");
-    if (databaseName.contains("/") || databaseName.contains("\\") || databaseName.contains(".."))
+    // A bare "." would resolve to the databases directory itself, so it is rejected alongside the
+    // separator and parent-reference checks.
+    if (databaseName.equals(".") || databaseName.contains("/") || databaseName.contains("\\") || databaseName.contains(".."))
       throw new IllegalArgumentException("Invalid database name: " + databaseName);
   }
 

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -47,6 +47,7 @@ import com.arcadedb.schema.Property;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.VertexType;
 import com.arcadedb.security.SecurityDatabaseUser;
+import com.arcadedb.security.SecurityManager;
 import com.arcadedb.serializer.JsonSerializer;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.grpc.InsertOptions.ConflictMode;
@@ -54,6 +55,8 @@ import com.arcadedb.server.grpc.InsertOptions.TransactionMode;
 import com.arcadedb.server.grpc.ProjectionSettings.ProjectionEncoding;
 import com.arcadedb.server.monitor.QueryProfile;
 import com.arcadedb.server.monitor.ServerQueryProfiler;
+import com.arcadedb.server.security.ServerSecurity;
+import com.arcadedb.server.security.ServerSecurityException;
 import com.arcadedb.server.security.ServerSecurityUser;
 import io.micrometer.core.instrument.Metrics;
 import com.google.gson.JsonElement;
@@ -3059,8 +3062,12 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
   private Database getDatabase(String databaseName, DatabaseCredentials credentials) {
 
-    // Validate credentials
-    validateCredentials(credentials);
+    // Reject path-traversal / path-bearing database names before any filesystem access, so a
+    // request-supplied name can never escape the configured databases directory.
+    validateDatabaseName(databaseName);
+
+    // Authenticate the caller and authorize access to the requested database.
+    validateCredentials(credentials, databaseName);
 
     // Use the same approach as Postgres/Redis plugins
     if (arcadeServer != null) {
@@ -3165,10 +3172,60 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     return null;
   }
 
-  private void validateCredentials(DatabaseCredentials credentials) {
+  /**
+   * Rejects database names that could escape the configured databases directory. A request-supplied
+   * name containing a path separator ({@code /} or {@code \}) or a parent reference ({@code ..})
+   * would otherwise be concatenated straight onto the databases path and let a caller open or create
+   * databases anywhere on the filesystem (path traversal). Mirrors the validation already used by the
+   * HTTP server handlers (e.g. {@code PostServerCommandHandler}).
+   */
+  private static void validateDatabaseName(final String databaseName) {
+    if (databaseName == null || databaseName.isBlank())
+      throw new IllegalArgumentException("Invalid database name: name is required");
+    if (databaseName.contains("/") || databaseName.contains("\\") || databaseName.contains(".."))
+      throw new IllegalArgumentException("Invalid database name: " + databaseName);
+  }
+
+  /**
+   * Authenticates the caller and authorizes access to the named database.
+   * <p>
+   * A resolvable username alone is NOT proof of identity. When server security is active (at least
+   * one user is configured) this enforces real authentication and per-database authorization:
+   * <ul>
+   *   <li>if the auth interceptor already verified this connection's credentials (context user set),
+   *       the resolved user is authorized for the requested database;</li>
+   *   <li>otherwise the request-payload username/password are authenticated and the requested
+   *       database authorized in a single {@link ServerSecurity#authenticate} call.</li>
+   * </ul>
+   * When no users are configured the server is intentionally open (security disabled) and only the
+   * presence of a username is required, matching the auth interceptor's {@code securityEnabled} gate.
+   */
+  private void validateCredentials(final DatabaseCredentials credentials, final String databaseName) {
     final String authenticatedUser = resolvedUsername(credentials);
     if (authenticatedUser == null)
       throw new IllegalArgumentException("Invalid credentials");
+
+    final ServerSecurity security = arcadeServer != null ? arcadeServer.getSecurity() : null;
+    if (security != null && security.getUsers() != null && !security.getUsers().isEmpty()) {
+      final String contextUser = GrpcAuthInterceptor.USER_CONTEXT_KEY.get();
+      if (contextUser != null && !contextUser.isEmpty()) {
+        // The auth interceptor already verified the password for this connection; only authorize the
+        // already-authenticated user for the specific database named in the request.
+        final ServerSecurityUser user = security.getUser(contextUser);
+        if (user == null)
+          throw new ServerSecurityException("User/Password not valid");
+        final Set<String> allowedDatabases = user.getAuthorizedDatabases();
+        if (!allowedDatabases.contains(SecurityManager.ANY) && !allowedDatabases.contains(databaseName))
+          throw new ServerSecurityException("User has not access to database '" + databaseName + "'");
+      } else {
+        // No interceptor context (request-payload credentials only): authenticate the
+        // username/password pair and authorize the requested database in one step.
+        final String password = credentials != null ? credentials.getPassword() : null;
+        if (password == null || password.isEmpty())
+          throw new ServerSecurityException("Authentication required");
+        security.authenticate(authenticatedUser, password, databaseName);
+      }
+    }
 
     LogManager.instance().log(this, Level.FINE, "validateCredentials(): resolved user '%s'", authenticatedUser);
   }

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4793GrpcGetDatabaseSecurityIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4793GrpcGetDatabaseSecurityIT.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #4793.
+ * <p>
+ * {@code ArcadeDbGrpcService.getDatabase} previously accepted any request-supplied database name
+ * after merely checking that a username was resolvable. A name containing {@code ..}, {@code /} or
+ * {@code \} escaped the configured databases directory (path traversal), and the service could
+ * open/create arbitrary on-disk databases. These tests assert that path-traversal database names
+ * are rejected before any filesystem access while legitimate, authorized access keeps working.
+ */
+public class Issue4793GrpcGetDatabaseSecurityIT extends BaseGraphServerTest {
+
+  private static final int GRPC_PORT = 50051;
+
+  private static final Metadata.Key<String> USER_HEADER     =
+      Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER =
+      Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER =
+      Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  private ManagedChannel                                  channel;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub authenticatedStub;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+    GlobalConfiguration.QUERY_PARALLEL_SCAN.setValue(false);
+  }
+
+  @BeforeEach
+  void setupGrpcClient() {
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    final Channel authenticatedChannel = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+    authenticatedStub = ArcadeDbServiceGrpc.newBlockingStub(authenticatedChannel);
+  }
+
+  @AfterEach
+  void shutdownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private class AuthClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(final MethodDescriptor<ReqT, RespT> method,
+        final CallOptions callOptions, final Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata headers) {
+          headers.put(USER_HEADER, "root");
+          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
+          headers.put(DATABASE_HEADER, getDatabaseName());
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+
+  private DatabaseCredentials credentials() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  private ExecuteQueryRequest queryOn(final String databaseName) {
+    return ExecuteQueryRequest.newBuilder()
+        .setDatabase(databaseName)
+        .setCredentials(credentials())
+        .setQuery("SELECT FROM V1 LIMIT 1")
+        .build();
+  }
+
+  @Test
+  void parentDirectoryTraversalDatabaseNameIsRejected() {
+    final String traversalTarget = "escaped4793";
+    final ExecuteQueryRequest request = queryOn(".." + File.separator + traversalTarget);
+
+    assertThatThrownBy(() -> authenticatedStub.executeQuery(request))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("Invalid database name");
+
+    // The traversal must never have escaped the databases directory and created a database on disk.
+    final File databasesDir = new File(GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString());
+    final File escaped = new File(databasesDir.getParentFile(), traversalTarget);
+    assertThat(escaped).doesNotExist();
+  }
+
+  @Test
+  void forwardSlashDatabaseNameIsRejected() {
+    final ExecuteQueryRequest request = queryOn("sub/evil4793");
+
+    assertThatThrownBy(() -> authenticatedStub.executeQuery(request))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("Invalid database name");
+  }
+
+  @Test
+  void backslashDatabaseNameIsRejected() {
+    final ExecuteQueryRequest request = queryOn("sub\\evil4793");
+
+    assertThatThrownBy(() -> authenticatedStub.executeQuery(request))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("Invalid database name");
+  }
+
+  @Test
+  void blankDatabaseNameIsRejected() {
+    final ExecuteQueryRequest request = queryOn("   ");
+
+    assertThatThrownBy(() -> authenticatedStub.executeQuery(request))
+        .isInstanceOf(StatusRuntimeException.class);
+  }
+
+  @Test
+  void legitimateAuthorizedDatabaseAccessStillWorks() {
+    // Positive control: a plain, authorized database name must keep working after the hardening.
+    final ExecuteQueryResponse response = authenticatedStub.executeQuery(queryOn(getDatabaseName()));
+    assertThat(response).isNotNull();
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4793GrpcGetDatabaseSecurityIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4793GrpcGetDatabaseSecurityIT.java
@@ -148,6 +148,16 @@ public class Issue4793GrpcGetDatabaseSecurityIT extends BaseGraphServerTest {
   }
 
   @Test
+  void currentDirectoryDatabaseNameIsRejected() {
+    // A bare "." resolves to the databases directory itself; it must be rejected.
+    final ExecuteQueryRequest request = queryOn(".");
+
+    assertThatThrownBy(() -> authenticatedStub.executeQuery(request))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("Invalid database name");
+  }
+
+  @Test
   void blankDatabaseNameIsRejected() {
     final ExecuteQueryRequest request = queryOn("   ");
 

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4793GrpcGetDatabaseSecurityIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4793GrpcGetDatabaseSecurityIT.java
@@ -30,6 +30,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -114,14 +115,22 @@ public class Issue4793GrpcGetDatabaseSecurityIT extends BaseGraphServerTest {
         .build();
   }
 
+  /**
+   * Asserts the request is rejected with the INVALID_ARGUMENT status code and a message that names
+   * the offending database name, so the client-visible API contract is pinned (not masked as
+   * INTERNAL).
+   */
+  private void assertRejectedAsInvalidName(final ExecuteQueryRequest request) {
+    assertThatThrownBy(() -> authenticatedStub.executeQuery(request))
+        .isInstanceOfSatisfying(StatusRuntimeException.class,
+            e -> assertThat(e.getStatus().getCode()).isEqualTo(Status.Code.INVALID_ARGUMENT))
+        .hasMessageContaining("Invalid database name");
+  }
+
   @Test
   void parentDirectoryTraversalDatabaseNameIsRejected() {
     final String traversalTarget = "escaped4793";
-    final ExecuteQueryRequest request = queryOn(".." + File.separator + traversalTarget);
-
-    assertThatThrownBy(() -> authenticatedStub.executeQuery(request))
-        .isInstanceOf(StatusRuntimeException.class)
-        .hasMessageContaining("Invalid database name");
+    assertRejectedAsInvalidName(queryOn(".." + File.separator + traversalTarget));
 
     // The traversal must never have escaped the databases directory and created a database on disk.
     final File databasesDir = new File(GlobalConfiguration.SERVER_DATABASE_DIRECTORY.getValueAsString());
@@ -131,38 +140,23 @@ public class Issue4793GrpcGetDatabaseSecurityIT extends BaseGraphServerTest {
 
   @Test
   void forwardSlashDatabaseNameIsRejected() {
-    final ExecuteQueryRequest request = queryOn("sub/evil4793");
-
-    assertThatThrownBy(() -> authenticatedStub.executeQuery(request))
-        .isInstanceOf(StatusRuntimeException.class)
-        .hasMessageContaining("Invalid database name");
+    assertRejectedAsInvalidName(queryOn("sub/evil4793"));
   }
 
   @Test
   void backslashDatabaseNameIsRejected() {
-    final ExecuteQueryRequest request = queryOn("sub\\evil4793");
-
-    assertThatThrownBy(() -> authenticatedStub.executeQuery(request))
-        .isInstanceOf(StatusRuntimeException.class)
-        .hasMessageContaining("Invalid database name");
+    assertRejectedAsInvalidName(queryOn("sub\\evil4793"));
   }
 
   @Test
   void currentDirectoryDatabaseNameIsRejected() {
     // A bare "." resolves to the databases directory itself; it must be rejected.
-    final ExecuteQueryRequest request = queryOn(".");
-
-    assertThatThrownBy(() -> authenticatedStub.executeQuery(request))
-        .isInstanceOf(StatusRuntimeException.class)
-        .hasMessageContaining("Invalid database name");
+    assertRejectedAsInvalidName(queryOn("."));
   }
 
   @Test
   void blankDatabaseNameIsRejected() {
-    final ExecuteQueryRequest request = queryOn("   ");
-
-    assertThatThrownBy(() -> authenticatedStub.executeQuery(request))
-        .isInstanceOf(StatusRuntimeException.class);
+    assertRejectedAsInvalidName(queryOn("   "));
   }
 
   @Test


### PR DESCRIPTION
## Issue

Fixes #4793 (HIGH severity, security).

`ArcadeDbGrpcService.getDatabase` resolved a request-supplied `databaseName` after only checking that a username was *resolvable*. `validateCredentials` never called `ServerSecurity.authenticate`. Two problems:

1. **Path traversal** - `databaseName` flowed unsanitized into `new DatabaseFactory(databasePath + "/" + databaseName)` (fallback path) and into `arcadeServer.getDatabase(databaseName)`. A name containing `..`, `/` or `\` escapes the configured databases directory, letting a caller open/create databases anywhere on disk.
2. **Weak authentication / missing authorization** - validation accepted any non-empty username; the password was never authenticated and the user was never authorized for the named database.

## Fix

`grpcw/.../ArcadeDbGrpcService.java`:

- **`validateDatabaseName(String)`** (new): rejects null/blank names and any name containing `/`, `\` or `..`, before any filesystem access. Mirrors the established pattern in `PostServerCommandHandler.resolveBackupFile`. Called at the top of `getDatabase`.
- **`validateCredentials`** now takes the database name and, when server security is active (at least one user configured), enforces real authentication + per-database authorization:
  - if the auth interceptor already verified the connection (context user set), the resolved user is authorized for the requested database;
  - otherwise the request-payload username/password are authenticated and the requested database authorized via `ServerSecurity.authenticate`.
  - when no users are configured (security intentionally disabled) only username presence is required, matching the interceptor's `securityEnabled` gate.

## Tests

`grpcw/.../Issue4793GrpcGetDatabaseSecurityIT.java` (new): parent-dir `..`, embedded `/`, and `\` database names are rejected (and no directory escapes the databases folder); blank name rejected; a legitimate authorized access still works. 3 of the 5 cases fail before the fix, all pass after.

## Verification

- New IT: 3/5 fail pre-fix, 5/5 pass post-fix.
- `grpcw` unit tests (104, incl. `ArcadeDbGrpcServiceExtendedTest`) + `GrpcAuthInterceptorTest` (8): pass.
- `grpcw` ITs `GrpcServerIT` + `GrpcFollowerForwardingIT` (31, incl. HA leader-forwarding via the interceptor context user): pass.
- Pre-existing unrelated failure `grpc-client Issue4562RollbackDeleteTest` (HTTP-path schema-cache) verified to fail identically on the unmodified base - not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)