### PR TITLE
fix(#4791): require root for cluster-management HTTP endpoints

### DIFF
--- a/docs/4791-cluster-mgmt-endpoints-require-root.md
+++ b/docs/4791-cluster-mgmt-endpoints-require-root.md
@@ -1,0 +1,52 @@
+# Issue #4791 — Cluster-management HTTP endpoints require root, not just any authenticated user
+
+## Problem
+
+The five Raft cluster-management HTTP handlers authenticate the caller but only via
+the base class, which guarantees *some* authenticated user, not root:
+
+- `PostAddPeerHandler`  — `POST /api/v1/cluster/peer`
+- `DeletePeerHandler`   — `DELETE /api/v1/cluster/peer/<id>`
+- `PostTransferLeaderHandler` — `POST /api/v1/cluster/leader`
+- `PostStepDownHandler` — `POST /api/v1/cluster/stepdown`
+- `PostLeaveHandler`    — `POST /api/v1/cluster/leave`
+
+None of them call `checkRootUser(user)`. Every other admin handler does
+(`PutUserHandler`, `DeleteGroupHandler`, `PostServerCommandHandler`, and the
+sibling raft handlers `PostResyncDatabaseHandler` / `PostVerifyDatabaseHandler`).
+
+### Impact (privilege escalation)
+
+Any authenticated, non-root tenant user (or any cluster-token holder on the
+forwarded-auth path) can remove peers until quorum is lost, force permanent
+election churn via repeated step-down, transfer leadership, or evict a node from
+the cluster.
+
+## Security boundary
+
+`AbstractServerHttpHandler.checkRootUser(user)` throws `ServerSecurityException`
+when `user.getName()` is not `"root"`. That exception is mapped to HTTP **403**
+by the base handler. The fix is to invoke `checkRootUser(user)` as the **first**
+statement of each handler's `execute(...)` so the root check runs before any
+side effect (and before the `raftHAServer == null` short-circuit).
+
+## Fix
+
+Add `checkRootUser(user);` as the first line of `execute(...)` in all five
+handlers. The resync/verify handlers already enforce it and are unchanged.
+
+## Tests
+
+`ClusterManagementAuthorizationIT` (ha-raft):
+- A non-root (but otherwise admin) tenant user receives **403** on all five
+  cluster-management endpoints. Because `checkRootUser` runs first, no cluster
+  mutation occurs.
+- The root user passes the root check (a malformed add-peer request returns
+  **400 validation**, not 403), proving the fix does not over-block root.
+
+The non-root assertions fail before the fix (the operation would otherwise run)
+and pass after it.
+
+## Verification
+
+- `mvn -q -pl ha-raft -am test -Dtest=ClusterManagementAuthorizationIT`

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/DeletePeerHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/DeletePeerHandler.java
@@ -40,6 +40,8 @@ public class DeletePeerHandler extends AbstractServerHttpHandler {
   @Override
   public ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user,
       final JSONObject payload) {
+    checkRootUser(user);
+
     final RaftHAServer raftHAServer = plugin.getRaftHAServer();
     if (raftHAServer == null)
       return new ExecutionResponse(400, new JSONObject().put("error", "Raft HA is not enabled").toString());

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostAddPeerHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostAddPeerHandler.java
@@ -45,6 +45,8 @@ public class PostAddPeerHandler extends AbstractServerHttpHandler {
   @Override
   public ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user,
       final JSONObject payload) {
+    checkRootUser(user);
+
     final RaftHAServer raftHAServer = plugin.getRaftHAServer();
     if (raftHAServer == null)
       return new ExecutionResponse(400, new JSONObject().put("error", "Raft HA is not enabled").toString());

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostLeaveHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostLeaveHandler.java
@@ -40,6 +40,8 @@ public class PostLeaveHandler extends AbstractServerHttpHandler {
   @Override
   public ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user,
       final JSONObject payload) {
+    checkRootUser(user);
+
     final RaftHAServer raftHAServer = plugin.getRaftHAServer();
     if (raftHAServer == null)
       return new ExecutionResponse(400, new JSONObject().put("error", "Raft HA is not enabled").toString());

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostStepDownHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostStepDownHandler.java
@@ -37,6 +37,8 @@ public class PostStepDownHandler extends AbstractServerHttpHandler {
   @Override
   public ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user,
       final JSONObject payload) {
+    checkRootUser(user);
+
     final RaftHAServer raftHAServer = plugin.getRaftHAServer();
     if (raftHAServer == null)
       return new ExecutionResponse(400, new JSONObject().put("error", "Raft HA is not enabled").toString());

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostTransferLeaderHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/PostTransferLeaderHandler.java
@@ -42,6 +42,8 @@ public class PostTransferLeaderHandler extends AbstractServerHttpHandler {
   @Override
   public ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user,
       final JSONObject payload) {
+    checkRootUser(user);
+
     final RaftHAServer raftHAServer = plugin.getRaftHAServer();
     if (raftHAServer == null)
       return new ExecutionResponse(400, new JSONObject().put("error", "Raft HA is not enabled").toString());

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ClusterManagementAuthorizationIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ClusterManagementAuthorizationIT.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4791: the five cluster-management HTTP endpoints must require the
+ * root user, not merely some authenticated user. A non-root tenant user must be rejected with
+ * HTTP 403 before any cluster mutation can take place, otherwise a tenant could remove peers,
+ * force election churn, transfer leadership, or evict a node.
+ */
+class ClusterManagementAuthorizationIT extends BaseRaftHATest {
+
+  private static final String TENANT_USER     = "tenant4791";
+  private static final String TENANT_PASSWORD = "tenantpw1234";
+
+  @Override
+  protected int getServerCount() {
+    return 2;
+  }
+
+  @Test
+  void nonRootRejectedOnAllClusterManagementEndpoints() throws Exception {
+    // A non-root user that is otherwise a database admin: this is the privilege-escalation scenario.
+    getServer(0).getSecurity().createUser(TENANT_USER, TENANT_PASSWORD);
+
+    // Every cluster-management endpoint must reject the non-root tenant with 403. Because the root
+    // check runs first, none of these calls mutates the cluster, so the order here is irrelevant.
+    assertThat(call(0, "POST", "/api/v1/cluster/peer",
+        new JSONObject().put("peerId", "localhost_9999").put("address", "localhost:9999"),
+        TENANT_USER, TENANT_PASSWORD))
+        .as("POST add-peer as non-root").isEqualTo(403);
+
+    assertThat(call(0, "DELETE", "/api/v1/cluster/peer/" + peerIdForIndex(1), null,
+        TENANT_USER, TENANT_PASSWORD))
+        .as("DELETE peer as non-root").isEqualTo(403);
+
+    assertThat(call(0, "POST", "/api/v1/cluster/leader", new JSONObject(), TENANT_USER, TENANT_PASSWORD))
+        .as("POST transfer-leader as non-root").isEqualTo(403);
+
+    assertThat(call(0, "POST", "/api/v1/cluster/stepdown", new JSONObject(), TENANT_USER, TENANT_PASSWORD))
+        .as("POST stepdown as non-root").isEqualTo(403);
+
+    assertThat(call(0, "POST", "/api/v1/cluster/leave", new JSONObject(), TENANT_USER, TENANT_PASSWORD))
+        .as("POST leave as non-root").isEqualTo(403);
+  }
+
+  @Test
+  void rootPassesRootCheck() throws Exception {
+    // The root user must pass the root check: a malformed add-peer request reaches validation and
+    // returns 400 (missing required fields) rather than 403. This proves the fix does not over-block
+    // root, and that the failure for non-root above is the authorization gate, not generic rejection.
+    final int status = call(0, "POST", "/api/v1/cluster/peer", new JSONObject(), "root",
+        BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS);
+    assertThat(status).as("root add-peer with empty body must pass the root check (400, not 403)")
+        .isEqualTo(400);
+  }
+
+  private int call(final int serverIndex, final String method, final String path, final JSONObject body,
+      final String user, final String password) throws Exception {
+    final int port = getServer(serverIndex).getHttpServer().getPort();
+    final HttpURLConnection conn = (HttpURLConnection) new URI(
+        "http://localhost:" + port + path).toURL().openConnection();
+    conn.setRequestMethod(method);
+    conn.setRequestProperty("Authorization",
+        "Basic " + Base64.getEncoder().encodeToString((user + ":" + password).getBytes(StandardCharsets.UTF_8)));
+    try {
+      if (body != null) {
+        conn.setDoOutput(true);
+        conn.setRequestProperty("Content-Type", "application/json");
+        final byte[] payload = body.toString().getBytes(StandardCharsets.UTF_8);
+        conn.getOutputStream().write(payload);
+      }
+      conn.connect();
+      return conn.getResponseCode();
+    } finally {
+      conn.disconnect();
+    }
+  }
+}


### PR DESCRIPTION
Closes #4791

## Summary

The five Raft cluster-management HTTP handlers - `PostAddPeerHandler`,
`DeletePeerHandler`, `PostTransferLeaderHandler`, `PostStepDownHandler`,
`PostLeaveHandler` - authenticated the caller through the base handler but never
verified that the caller is **root**. The base class only guarantees *some*
authenticated user, so any authenticated non-root tenant user (or, on the
forwarded-auth path, any cluster-token holder) could:

- `DELETE /api/v1/cluster/peer/<id>` to remove peers until quorum is lost
- `POST /api/v1/cluster/stepdown` repeatedly to cause permanent election churn
- `POST /api/v1/cluster/leave` to evict a node
- `POST /api/v1/cluster/leader` to transfer leadership
- `POST /api/v1/cluster/peer` to add arbitrary peers

This is a privilege-escalation hole. Every other admin handler
(`PutUserHandler`, `DeleteGroupHandler`, `PostServerCommandHandler`, and the
sibling raft handlers `PostResyncDatabaseHandler` / `PostVerifyDatabaseHandler`)
already calls `checkRootUser(user)`.

## Fix

Add `checkRootUser(user)` as the **first** statement of each handler's
`execute(...)`, so the root check runs before any cluster mutation (and before
the `raftHAServer == null` short-circuit). `checkRootUser` throws
`ServerSecurityException`, which the base handler maps to **HTTP 403**.

## Test plan

New regression IT `ClusterManagementAuthorizationIT` (ha-raft, 2-node cluster):

- [x] A non-root (but otherwise admin) tenant user receives **403** on all five
      cluster-management endpoints. Verified RED before the fix (the add-peer
      call reached the mutation logic and returned 500 instead of 403) and GREEN
      after.
- [x] The root user passes the root check: a malformed add-peer request returns
      **400** (validation), not 403 - proving the fix does not over-block root.
- [x] `ha-raft` production sources compile.

> Note for reviewers: at the current `main` HEAD the unrelated
> `ClusterMonitorTest` does not compile (three stale 2-arg
> `updateReplicaMatchIndex` call sites at lines 96/102/109, left over from the
> recent heartbeat-lag metrics work that changed the signature to 3 args). That
> pre-existing breakage is outside the scope of this issue and was not modified
> here. The new IT was executed by temporarily relocating that file out of the
> build; it is committed unchanged. The three call sites need a `, 0L` third
> argument (matching every other call site in that file) for the ha-raft test
> module to compile in CI.
