### PR TITLE
fix(#4801): serialize gRPC streaming terminal calls on a thread-safe StreamObserver

### DIFF
--- a/docs/4801-grpc-streamobserver-thread-safety.md
+++ b/docs/4801-grpc-streamobserver-thread-safety.md
@@ -71,3 +71,20 @@ Regression: `GrpcServerIT#graphBatchLoadVerticesAndEdges` still passes end-to-en
   one terminal reaches the delegate on the no-cancel path.
 - Verified: `Issue4801SynchronizedStreamObserverTest` 6/6, plus `GrpcServerIT#graphBatchLoadVerticesAndEdges`
   and `Issue4198InsertStreamCommitErrorIT` pass end-to-end.
+
+### Cycle 2 (claude - "looks good to merge")
+
+- Clarity-only: documented why `markTerminated()` is lock-free (cancel handler must not block behind
+  an in-flight `onNext`) and why `graphBatchLoad`'s `errorSent` flag is retained.
+- executeQuery / streamMaterialized-Cursor-Paged path left out of scope (single producer thread, already
+  self-heals via `safeOnNext` catching `StatusRuntimeException`); flagged as a dedicated follow-up.
+
+### Cycle 3 (claude)
+
+- Acted on the one pre-merge item: `onNext` now best-effort delivers `onError` when a write throws, so a
+  still-live call that rejects a single message (e.g. `RESOURCE_EXHAUSTED`) does not leave the client
+  hanging without a terminal. `compareAndSet` skips it if a concurrent `markTerminated` already fired; an
+  already-closed call swallows the no-op `onError`.
+- Added `failedWriteOnLiveCallDeliversTerminalSoClientDoesNotHang`. Unit suite now 7/7.
+- `insertBidirectional` half-close-without-COMMIT delivering no terminal is pre-existing and left as a
+  documented follow-up.

--- a/docs/4801-grpc-streamobserver-thread-safety.md
+++ b/docs/4801-grpc-streamobserver-thread-safety.md
@@ -1,0 +1,58 @@
+# Issue #4801 - gRPC streaming terminal calls on a non-thread-safe StreamObserver
+
+## Problem
+
+gRPC `StreamObserver` is not thread-safe. In `ArcadeDbGrpcService`:
+
+- `graphBatchLoad` made terminal/write calls (`onNext`/`onError`/`onCompleted`) directly on the
+  raw observer, guarded only by a TOCTOU `if (!cancelled.get())` check. A cancellation racing the
+  final terminal call could deliver a write/terminal on an already-closed call.
+- `insertBidirectional` dispatched database work to a single-threaded executor and called terminal
+  methods from those executor tasks, while the cancel handler ran on the transport thread. A
+  duplicate terminal (e.g. a COMMIT followed by a stray message hitting the defensive catch) or a
+  cancellation could interleave terminal calls.
+
+Symptoms: `IllegalStateException` ("call already closed"), dropped responses, or client hangs.
+
+## Fix
+
+Added `SynchronizedStreamObserver<T>` (grpcw, package `com.arcadedb.server.grpc`): a thread-safe
+wrapper that:
+
+- serializes every call through a single monitor;
+- uses an `AtomicBoolean completed` CAS so at most one terminal call (`onError`/`onCompleted`) is
+  delegated and any `onNext` after a terminal call is dropped;
+- exposes `markTerminated()` for the call's cancel handler to flip the flag without delegating
+  (the transport already closed the call);
+- swallows the `IllegalStateException` the delegate throws if the call was concurrently
+  closed/cancelled, marking itself terminated so nothing further is attempted.
+
+Both `graphBatchLoad` and `insertBidirectional` now wrap their response observer in
+`SynchronizedStreamObserver` and route all write/terminal calls through it. Their cancel handlers
+(and the bidirectional `onError`/cleanup path) call `markTerminated()`.
+
+The original `ServerCallStreamObserver` reference (`call`) is kept for flow-control
+(`disableAutoInboundFlowControl`, `setOnCancelHandler`, `request`).
+
+## Tests
+
+`Issue4801SynchronizedStreamObserverTest` (unit, mock-free) drives the wrapper against a delegate
+that emulates gRPC's real contract (throws `IllegalStateException` on a second terminal or on a
+write after close):
+
+- `onNextAfterCompletedIsDropped`
+- `duplicateTerminalCallsAreCollapsedToOne`
+- `markTerminatedDropsSubsequentCallsWithoutDelegating`
+- `delegateThrowingOnConcurrentCloseIsSwallowedAndTerminates`
+- `concurrentTerminalAndWriteCallsNeverInterleave` (200 iterations x 32 threads racing
+  onNext/onCompleted/onError/markTerminated)
+
+Red/green verified: with a naive pass-through wrapper the suite fails with the exact
+`IllegalStateException: call already closed` from the issue; with the fix all 5 pass.
+
+Regression: `GrpcServerIT#graphBatchLoadVerticesAndEdges` still passes end-to-end.
+
+## Impact
+
+- Scope limited to grpcw streaming handlers. Unary RPCs were already single-threaded and untouched.
+- No new dependencies. Negligible overhead (one monitor + one AtomicBoolean per stream).

--- a/docs/4801-grpc-streamobserver-thread-safety.md
+++ b/docs/4801-grpc-streamobserver-thread-safety.md
@@ -56,3 +56,18 @@ Regression: `GrpcServerIT#graphBatchLoadVerticesAndEdges` still passes end-to-en
 
 - Scope limited to grpcw streaming handlers. Unary RPCs were already single-threaded and untouched.
 - No new dependencies. Negligible overhead (one monitor + one AtomicBoolean per stream).
+
+## Review cycles
+
+### Cycle 1 (gemini-code-assist + claude)
+
+- gemini: also catch `io.grpc.StatusRuntimeException` (not only `IllegalStateException`) in all
+  three guarded delegate calls, since gRPC can throw a `StatusRuntimeException` (e.g. CANCELLED)
+  when the transport closes the call. Applied via multi-catch with an explicit import.
+- claude: `insertStream` (`ArcadeDbGrpcService.java:1646`) has the identical TOCTOU
+  cancel-vs-terminal race and was left untouched. Applied the same `SynchronizedStreamObserver`
+  wrapper to `insertStream` for consistency (cancel handler + onError + onCompleted paths).
+- claude (test suggestion): added `happyPathDeliversExactlyOneTerminalToDelegate` asserting exactly
+  one terminal reaches the delegate on the no-cancel path.
+- Verified: `Issue4801SynchronizedStreamObserverTest` 6/6, plus `GrpcServerIT#graphBatchLoadVerticesAndEdges`
+  and `Issue4198InsertStreamCommitErrorIT` pass end-to-end.

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -1648,6 +1648,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
     call.disableAutoInboundFlowControl();
 
+    // gRPC StreamObserver is not thread-safe. Route every write/terminal call through a single
+    // serialization point so a cancellation racing a terminal call cannot interleave terminal calls.
+    final SynchronizedStreamObserver<InsertSummary> out = new SynchronizedStreamObserver<>(resp);
+
     final long startedAt = System.currentTimeMillis();
 
     final AtomicBoolean cancelled = new AtomicBoolean(false);
@@ -1658,7 +1662,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     // cache the first-chunk effective options to validate consistency
     final AtomicReference<InsertOptions> firstOptsRef = new AtomicReference<>();
 
-    call.setOnCancelHandler(() -> cancelled.set(true));
+    call.setOnCancelHandler(() -> {
+      cancelled.set(true);
+      out.markTerminated();
+    });
 
     // Pull the very first inbound message
     call.request(1);
@@ -1737,6 +1744,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
       @Override
       public void onError(Throwable t) {
+        out.markTerminated();
         InsertContext ctx = ctxRef.get();
         if (ctx != null)
           ctx.closeQuietly();
@@ -1751,10 +1759,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
           if (ctx == null) {
             // Client closed without sending a first chunk → nothing to do
-            resp.onNext(InsertSummary.newBuilder().setReceived(0).setInserted(0).setUpdated(0).setIgnored(0).setFailed(0)
+            out.onNext(InsertSummary.newBuilder().setReceived(0).setInserted(0).setUpdated(0).setIgnored(0).setFailed(0)
                 .setExecutionTimeMs(System.currentTimeMillis() - startedAt).build());
 
-            resp.onCompleted();
+            out.onCompleted();
             return;
           }
 
@@ -1772,11 +1780,11 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           }
 
           if (!cancelled.get()) {
-            resp.onNext(ctx.summary(totals, startedAt));
-            resp.onCompleted();
+            out.onNext(ctx.summary(totals, startedAt));
+            out.onCompleted();
           }
         } catch (Exception e) {
-          resp.onError(Status.INTERNAL.withDescription("insertStream: " + e.getMessage()).asException());
+          out.onError(Status.INTERNAL.withDescription("insertStream: " + e.getMessage()).asException());
         } finally {
           InsertContext ctx = ctxRef.get();
           if (ctx != null)

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -1816,6 +1816,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     final ServerCallStreamObserver<GraphBatchResult> call = (ServerCallStreamObserver<GraphBatchResult>) resp;
     call.disableAutoInboundFlowControl();
 
+    // gRPC StreamObserver is not thread-safe. Route every write/terminal call through a single
+    // serialization point so a cancellation racing a terminal call cannot interleave terminal calls.
+    final SynchronizedStreamObserver<GraphBatchResult> out = new SynchronizedStreamObserver<>(resp);
+
     final long startedAt = System.currentTimeMillis();
     final AtomicBoolean cancelled = new AtomicBoolean(false);
     final boolean[] errorSent = { false };
@@ -1830,7 +1834,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     final long[] counts = new long[2]; // [0]=vertices, [1]=edges
     final boolean[] inEdgePhase = { false };
 
-    call.setOnCancelHandler(() -> cancelled.set(true));
+    call.setOnCancelHandler(() -> {
+      cancelled.set(true);
+      out.markTerminated();
+    });
     call.request(1);
 
     return new StreamObserver<>() {
@@ -1887,7 +1894,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           // Null batchRef so onCompleted skips processing; skip closeQuietly to avoid blocking the
           // gRPC thread via async.waitCompletion() (buffered edges have no open transaction).
           batchRef.set(null);
-          resp.onError(Status.INTERNAL.withDescription("graphBatchLoad: " + e.getMessage()).asException());
+          out.onError(Status.INTERNAL.withDescription("graphBatchLoad: " + e.getMessage()).asException());
           return;
         } finally {
           if (!cancelled.get() && !errorSent[0])
@@ -1897,6 +1904,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
       @Override
       public void onError(final Throwable t) {
+        out.markTerminated();
         closeQuietly(batchRef.getAndSet(null));
       }
 
@@ -1907,8 +1915,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         try {
           final GraphBatch batch = batchRef.get();
           if (batch == null) {
-            resp.onNext(GraphBatchResult.newBuilder().build());
-            resp.onCompleted();
+            out.onNext(GraphBatchResult.newBuilder().build());
+            out.onCompleted();
             return;
           }
 
@@ -1928,11 +1936,11 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
             result.putIdMapping(entry.getKey(), entry.getValue().toString());
 
           if (!cancelled.get()) {
-            resp.onNext(result.build());
-            resp.onCompleted();
+            out.onNext(result.build());
+            out.onCompleted();
           }
         } catch (final Exception e) {
-          resp.onError(Status.INTERNAL.withDescription("graphBatchLoad: " + e.getMessage()).asException());
+          out.onError(Status.INTERNAL.withDescription("graphBatchLoad: " + e.getMessage()).asException());
           closeQuietly(batchRef.get());
         }
       }
@@ -2047,6 +2055,11 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     final ServerCallStreamObserver<InsertResponse> call = (ServerCallStreamObserver<InsertResponse>) resp;
     call.disableAutoInboundFlowControl();
 
+    // gRPC StreamObserver is not thread-safe and the single-threaded executor below dispatches
+    // database work off the gRPC inbound thread. Funnel every write/terminal call through one
+    // serialization point so a cancellation or duplicate terminal can never interleave on the call.
+    final SynchronizedStreamObserver<InsertResponse> out = new SynchronizedStreamObserver<>(resp);
+
     final AtomicReference<InsertContext> ref = new AtomicReference<>();
     final AtomicBoolean cancelled = new AtomicBoolean(false);
     final AtomicBoolean started = new AtomicBoolean(false);
@@ -2063,11 +2076,12 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     // Send responses directly - gRPC handles backpressure internally for server-side.
     // Using a queue with isReady() check doesn't work well when sending from a non-gRPC thread
     // because isReady() may return false, causing responses to be stuck.
-    final Consumer<InsertResponse> sendResponse = resp::onNext;
+    final Consumer<InsertResponse> sendResponse = out::onNext;
 
     // Cleanup helper that can be called multiple times safely
     final Runnable cleanupAndShutdown = () -> {
       cancelled.set(true);
+      out.markTerminated();
       try {
         streamExecutor.submit(() -> {
           final InsertContext ctx = ref.getAndSet(null);
@@ -2103,7 +2117,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
               case START -> {
                 if (!started.compareAndSet(false, true)) {
-                  resp.onError(
+                  out.onError(
                       Status.FAILED_PRECONDITION.withDescription("insertBidirectional: START already received").asException());
                   return;
                 }
@@ -2132,7 +2146,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
                 if (c.getChunkSeq() <= hi) {
 
-                  resp.onNext(InsertResponse.newBuilder().setBatchAck(BatchAck.newBuilder().setSessionId(ctx.sessionId)
+                  out.onNext(InsertResponse.newBuilder().setBatchAck(BatchAck.newBuilder().setSessionId(ctx.sessionId)
                       .setChunkSeq(c.getChunkSeq()).setInserted(0).setUpdated(0).setIgnored(0).setFailed(0).build()).build());
 
                   call.request(1);
@@ -2180,10 +2194,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
                 try {
                   ctx.flushCommit(true); // commit unless validate_only in your InsertContext logic
                   final InsertSummary sum = ctx.summary(ctx.totals, ctx.startedAt);
-                  resp.onNext(InsertResponse.newBuilder().setCommitted(Committed.newBuilder().setSummary(sum).build()).build());
-                  resp.onCompleted();
+                  out.onNext(InsertResponse.newBuilder().setCommitted(Committed.newBuilder().setSummary(sum).build()).build());
+                  out.onCompleted();
                 } catch (Exception e) {
-                  resp.onError(Status.INTERNAL.withDescription("commit: " + e.getMessage()).asException());
+                  out.onError(Status.INTERNAL.withDescription("commit: " + e.getMessage()).asException());
                 } finally {
                   sessionWatermark.remove(ctx.sessionId);
                   ctx.closeQuietly();
@@ -2198,7 +2212,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
             }
           } catch (Exception unexpected) {
             // defensive: fail fast on unexpected exceptions
-            resp.onError(Status.INTERNAL.withDescription("insertBidirectional: " + unexpected.getMessage()).asException());
+            out.onError(Status.INTERNAL.withDescription("insertBidirectional: " + unexpected.getMessage()).asException());
             final InsertContext ctx = ref.getAndSet(null);
             if (ctx != null) {
               sessionWatermark.remove(ctx.sessionId);

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -1830,6 +1830,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
     final long startedAt = System.currentTimeMillis();
     final AtomicBoolean cancelled = new AtomicBoolean(false);
+    // errorSent gates the onCompleted flush and the call.request(1) flow-control pull; the
+    // SynchronizedStreamObserver above independently guarantees terminal-call safety.
     final boolean[] errorSent = { false };
     final AtomicReference<GraphBatch> batchRef = new AtomicReference<>();
     final AtomicReference<Database> dbRef = new AtomicReference<>();

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/SynchronizedStreamObserver.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/SynchronizedStreamObserver.java
@@ -94,6 +94,11 @@ final class SynchronizedStreamObserver<T> implements StreamObserver<T> {
    * Flags the stream as terminated without delegating any call. Intended for the gRPC call's cancel
    * handler: once the transport has cancelled the call, no further {@code onNext}/{@code onError}/
    * {@code onCompleted} may be delivered, so subsequent calls become no-ops.
+   *
+   * <p>This is deliberately lock-free (a plain flag flip, not guarded by {@code lock}) so the
+   * transport cancel handler never blocks behind an in-flight {@code delegate.onNext()}. A call
+   * already past the {@code completed} gate races at worst into {@code delegate.onNext} after close,
+   * which throws and is caught.
    */
   void markTerminated() {
     completed.set(true);

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/SynchronizedStreamObserver.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/SynchronizedStreamObserver.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import io.grpc.stub.StreamObserver;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Thread-safe wrapper around a gRPC {@link StreamObserver} that serializes every outbound call and
+ * enforces the StreamObserver contract: at most one terminal call ({@code onError} or
+ * {@code onCompleted}) is delegated, and no {@code onNext} is delegated after a terminal call.
+ *
+ * <p>gRPC observers are not thread-safe. A streaming RPC handler that dispatches work to executor
+ * threads, or that lets a terminal call race the call's cancellation handler, can otherwise
+ * interleave terminal calls on the same observer. That produces {@code IllegalStateException}
+ * ("call already closed"), duplicate/dropped responses, or a client hang.
+ *
+ * <p>All calls funnel through a single monitor. Calls that arrive after the stream is already
+ * terminated are dropped instead of delegated, so a late or duplicate terminal call is a no-op. If
+ * the underlying call was concurrently cancelled or closed by the transport, the
+ * {@code IllegalStateException} thrown by the delegate is caught and the wrapper marks itself
+ * terminated so no further calls are attempted.
+ */
+final class SynchronizedStreamObserver<T> implements StreamObserver<T> {
+  private final StreamObserver<T> delegate;
+  private final AtomicBoolean     completed = new AtomicBoolean(false);
+  private final Object            lock      = new Object();
+
+  SynchronizedStreamObserver(final StreamObserver<T> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void onNext(final T value) {
+    synchronized (lock) {
+      if (completed.get())
+        return;
+      try {
+        delegate.onNext(value);
+      } catch (final IllegalStateException closed) {
+        // The underlying call was concurrently cancelled/closed by the transport: stop sending.
+        completed.set(true);
+      }
+    }
+  }
+
+  @Override
+  public void onError(final Throwable t) {
+    synchronized (lock) {
+      if (!completed.compareAndSet(false, true))
+        return;
+      try {
+        delegate.onError(t);
+      } catch (final IllegalStateException ignore) {
+        // Call already closed: nothing more to deliver.
+      }
+    }
+  }
+
+  @Override
+  public void onCompleted() {
+    synchronized (lock) {
+      if (!completed.compareAndSet(false, true))
+        return;
+      try {
+        delegate.onCompleted();
+      } catch (final IllegalStateException ignore) {
+        // Call already closed: nothing more to deliver.
+      }
+    }
+  }
+
+  /**
+   * Flags the stream as terminated without delegating any call. Intended for the gRPC call's cancel
+   * handler: once the transport has cancelled the call, no further {@code onNext}/{@code onError}/
+   * {@code onCompleted} may be delivered, so subsequent calls become no-ops.
+   */
+  void markTerminated() {
+    completed.set(true);
+  }
+
+  boolean isTerminated() {
+    return completed.get();
+  }
+}

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/SynchronizedStreamObserver.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/SynchronizedStreamObserver.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.grpc;
 
+import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -54,8 +55,10 @@ final class SynchronizedStreamObserver<T> implements StreamObserver<T> {
         return;
       try {
         delegate.onNext(value);
-      } catch (final IllegalStateException closed) {
-        // The underlying call was concurrently cancelled/closed by the transport: stop sending.
+      } catch (final IllegalStateException | StatusRuntimeException closed) {
+        // The underlying call was concurrently cancelled/closed by the transport: mark terminated
+        // and stop sending. No terminal call is delegated in this path, by design - the transport
+        // has already closed the call.
         completed.set(true);
       }
     }
@@ -68,8 +71,8 @@ final class SynchronizedStreamObserver<T> implements StreamObserver<T> {
         return;
       try {
         delegate.onError(t);
-      } catch (final IllegalStateException ignore) {
-        // Call already closed: nothing more to deliver.
+      } catch (final IllegalStateException | StatusRuntimeException ignore) {
+        // Call already closed/cancelled by the transport: nothing more to deliver.
       }
     }
   }
@@ -81,8 +84,8 @@ final class SynchronizedStreamObserver<T> implements StreamObserver<T> {
         return;
       try {
         delegate.onCompleted();
-      } catch (final IllegalStateException ignore) {
-        // Call already closed: nothing more to deliver.
+      } catch (final IllegalStateException | StatusRuntimeException ignore) {
+        // Call already closed/cancelled by the transport: nothing more to deliver.
       }
     }
   }

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/SynchronizedStreamObserver.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/SynchronizedStreamObserver.java
@@ -55,11 +55,19 @@ final class SynchronizedStreamObserver<T> implements StreamObserver<T> {
         return;
       try {
         delegate.onNext(value);
-      } catch (final IllegalStateException | StatusRuntimeException closed) {
-        // The underlying call was concurrently cancelled/closed by the transport: mark terminated
-        // and stop sending. No terminal call is delegated in this path, by design - the transport
-        // has already closed the call.
-        completed.set(true);
+      } catch (final IllegalStateException | StatusRuntimeException failed) {
+        // The write failed: usually the transport already cancelled/closed the call. Best-effort
+        // terminate the stream so a still-live call that rejected this one message (e.g. a
+        // RESOURCE_EXHAUSTED) does not leave the client hanging without a terminal. compareAndSet
+        // skips the terminal if a concurrent markTerminated (cancel handler) already flipped the
+        // flag; if the call is already closed, the onError itself is a no-op and is swallowed.
+        if (completed.compareAndSet(false, true)) {
+          try {
+            delegate.onError(failed);
+          } catch (final IllegalStateException | StatusRuntimeException ignore) {
+            // Call already closed: nothing more to deliver.
+          }
+        }
       }
     }
   }

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4801SynchronizedStreamObserverTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4801SynchronizedStreamObserverTest.java
@@ -178,6 +178,42 @@ class Issue4801SynchronizedStreamObserverTest {
   }
 
   @Test
+  void failedWriteOnLiveCallDeliversTerminalSoClientDoesNotHang() {
+    // Delegate whose onNext rejects this one message but is otherwise live (records onError).
+    final AtomicInteger onNextAttempts = new AtomicInteger();
+    final AtomicReference<Throwable> deliveredError = new AtomicReference<>();
+    final StreamObserver<String> liveButRejecting = new StreamObserver<>() {
+      @Override
+      public void onNext(final String value) {
+        onNextAttempts.incrementAndGet();
+        throw new IllegalStateException("message rejected");
+      }
+
+      @Override
+      public void onError(final Throwable t) {
+        deliveredError.compareAndSet(null, t);
+      }
+
+      @Override
+      public void onCompleted() {
+      }
+    };
+
+    final SynchronizedStreamObserver<String> obs = new SynchronizedStreamObserver<>(liveButRejecting);
+
+    obs.onNext("x");
+
+    // A terminal must have been delivered so the client is not left hanging.
+    assertThat(obs.isTerminated()).isTrue();
+    assertThat(deliveredError.get()).isInstanceOf(IllegalStateException.class);
+
+    // The stream is terminal now: further calls are dropped.
+    obs.onNext("y");
+    obs.onCompleted();
+    assertThat(onNextAttempts.get()).isEqualTo(1);
+  }
+
+  @Test
   void concurrentTerminalAndWriteCallsNeverInterleave() throws Exception {
     final int threads = 32;
     final ExecutorService pool = Executors.newFixedThreadPool(threads);

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4801SynchronizedStreamObserverTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4801SynchronizedStreamObserverTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4801: gRPC {@code insertBidirectional} / {@code graphBatchLoad} called
+ * terminal {@code onNext}/{@code onError}/{@code onCompleted} on a non-thread-safe StreamObserver
+ * from multiple threads, which could interleave terminal calls and throw IllegalStateException
+ * ("call already closed"), drop responses, or hang the client.
+ *
+ * <p>The fix funnels every write/terminal call through {@link SynchronizedStreamObserver}, which
+ * serializes calls and guarantees at most one delegated terminal call with no {@code onNext} after
+ * it. These tests exercise that contract against a delegate that mimics gRPC's real behaviour of
+ * throwing once the call is closed.
+ */
+class Issue4801SynchronizedStreamObserverTest {
+
+  /**
+   * Delegate that emulates the gRPC ServerCallStreamObserver contract: any call after a terminal
+   * one (onError/onCompleted) throws IllegalStateException, and onNext after terminal also throws.
+   * It also records how many terminal calls and post-terminal calls actually reached it.
+   */
+  private static final class ContractEnforcingObserver implements StreamObserver<String> {
+    final AtomicInteger        onNextCount   = new AtomicInteger();
+    final AtomicInteger        terminalCount = new AtomicInteger();
+    final AtomicInteger        violations    = new AtomicInteger();
+    private final AtomicBoolean closed        = new AtomicBoolean(false);
+
+    @Override
+    public void onNext(final String value) {
+      if (closed.get()) {
+        violations.incrementAndGet();
+        throw new IllegalStateException("call already closed");
+      }
+      onNextCount.incrementAndGet();
+    }
+
+    @Override
+    public void onError(final Throwable t) {
+      if (!closed.compareAndSet(false, true)) {
+        violations.incrementAndGet();
+        throw new IllegalStateException("call already closed");
+      }
+      terminalCount.incrementAndGet();
+    }
+
+    @Override
+    public void onCompleted() {
+      if (!closed.compareAndSet(false, true)) {
+        violations.incrementAndGet();
+        throw new IllegalStateException("call already closed");
+      }
+      terminalCount.incrementAndGet();
+    }
+  }
+
+  @Test
+  void onNextAfterCompletedIsDropped() {
+    final ContractEnforcingObserver delegate = new ContractEnforcingObserver();
+    final SynchronizedStreamObserver<String> obs = new SynchronizedStreamObserver<>(delegate);
+
+    obs.onNext("a");
+    obs.onCompleted();
+    // Late writes/terminals must be silently dropped, never delegated.
+    obs.onNext("b");
+    obs.onCompleted();
+    obs.onError(new RuntimeException("late"));
+
+    assertThat(delegate.onNextCount.get()).isEqualTo(1);
+    assertThat(delegate.terminalCount.get()).isEqualTo(1);
+    assertThat(delegate.violations.get()).isZero();
+    assertThat(obs.isTerminated()).isTrue();
+  }
+
+  @Test
+  void duplicateTerminalCallsAreCollapsedToOne() {
+    final ContractEnforcingObserver delegate = new ContractEnforcingObserver();
+    final SynchronizedStreamObserver<String> obs = new SynchronizedStreamObserver<>(delegate);
+
+    obs.onError(new RuntimeException("first"));
+    obs.onError(new RuntimeException("second"));
+    obs.onCompleted();
+
+    assertThat(delegate.terminalCount.get()).isEqualTo(1);
+    assertThat(delegate.violations.get()).isZero();
+  }
+
+  @Test
+  void markTerminatedDropsSubsequentCallsWithoutDelegating() {
+    final ContractEnforcingObserver delegate = new ContractEnforcingObserver();
+    final SynchronizedStreamObserver<String> obs = new SynchronizedStreamObserver<>(delegate);
+
+    // Simulates the gRPC cancel handler firing: the transport already closed the call.
+    obs.markTerminated();
+
+    obs.onNext("late");
+    obs.onCompleted();
+    obs.onError(new RuntimeException("late"));
+
+    assertThat(delegate.onNextCount.get()).isZero();
+    assertThat(delegate.terminalCount.get()).isZero();
+    assertThat(delegate.violations.get()).isZero();
+  }
+
+  @Test
+  void delegateThrowingOnConcurrentCloseIsSwallowedAndTerminates() {
+    // Delegate that throws as if the call was concurrently closed by the transport mid-onNext.
+    final AtomicInteger attempts = new AtomicInteger();
+    final StreamObserver<String> closing = new StreamObserver<>() {
+      @Override
+      public void onNext(final String value) {
+        attempts.incrementAndGet();
+        throw new IllegalStateException("call already closed");
+      }
+
+      @Override
+      public void onError(final Throwable t) {
+      }
+
+      @Override
+      public void onCompleted() {
+      }
+    };
+
+    final SynchronizedStreamObserver<String> obs = new SynchronizedStreamObserver<>(closing);
+
+    // Must not propagate the IllegalStateException to the engine/executor caller.
+    obs.onNext("x");
+    assertThat(obs.isTerminated()).isTrue();
+
+    // Subsequent calls are no-ops; the delegate is not touched again.
+    obs.onNext("y");
+    obs.onCompleted();
+    assertThat(attempts.get()).isEqualTo(1);
+  }
+
+  @Test
+  void concurrentTerminalAndWriteCallsNeverInterleave() throws Exception {
+    final int threads = 32;
+    final ExecutorService pool = Executors.newFixedThreadPool(threads);
+    try {
+      for (int iter = 0; iter < 200; iter++) {
+        final ContractEnforcingObserver delegate = new ContractEnforcingObserver();
+        final SynchronizedStreamObserver<String> obs = new SynchronizedStreamObserver<>(delegate);
+
+        final CountDownLatch start = new CountDownLatch(1);
+        final CountDownLatch done = new CountDownLatch(threads);
+        final AtomicReference<Throwable> escaped = new AtomicReference<>();
+
+        for (int t = 0; t < threads; t++) {
+          final int idx = t;
+          pool.submit(() -> {
+            try {
+              start.await();
+              // Mix of writes, terminals and a simulated cancel, racing on the same observer.
+              switch (idx % 4) {
+              case 0 -> obs.onNext("v" + idx);
+              case 1 -> obs.onCompleted();
+              case 2 -> obs.onError(new RuntimeException("boom"));
+              default -> obs.markTerminated();
+              }
+            } catch (final Throwable th) {
+              escaped.compareAndSet(null, th);
+            } finally {
+              done.countDown();
+            }
+          });
+        }
+
+        start.countDown();
+        assertThat(done.await(10, TimeUnit.SECONDS)).isTrue();
+
+        // No exception may escape to the caller, and the delegate must never see a contract
+        // violation (a second terminal or a write after close).
+        assertThat(escaped.get()).isNull();
+        assertThat(delegate.terminalCount.get()).isLessThanOrEqualTo(1);
+        assertThat(delegate.violations.get()).isZero();
+      }
+    } finally {
+      pool.shutdownNow();
+      assertThat(pool.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+    }
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4801SynchronizedStreamObserverTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4801SynchronizedStreamObserverTest.java
@@ -102,6 +102,20 @@ class Issue4801SynchronizedStreamObserverTest {
   }
 
   @Test
+  void happyPathDeliversExactlyOneTerminalToDelegate() {
+    final ContractEnforcingObserver delegate = new ContractEnforcingObserver();
+    final SynchronizedStreamObserver<String> obs = new SynchronizedStreamObserver<>(delegate);
+
+    obs.onNext("a");
+    obs.onNext("b");
+    obs.onCompleted();
+
+    assertThat(delegate.onNextCount.get()).isEqualTo(2);
+    assertThat(delegate.terminalCount.get()).isEqualTo(1);
+    assertThat(delegate.violations.get()).isZero();
+  }
+
+  @Test
   void duplicateTerminalCallsAreCollapsedToOne() {
     final ContractEnforcingObserver delegate = new ContractEnforcingObserver();
     final SynchronizedStreamObserver<String> obs = new SynchronizedStreamObserver<>(delegate);


### PR DESCRIPTION
## Summary

Fixes #4801. gRPC `StreamObserver` is not thread-safe, but `ArcadeDbGrpcService.graphBatchLoad` and `insertBidirectional` issued terminal/write calls (`onNext`/`onError`/`onCompleted`) directly on the raw observer:

- `graphBatchLoad` relied on a TOCTOU `if (!cancelled.get())` check, so a cancellation racing the final terminal call could deliver a write/terminal on an already-closed call.
- `insertBidirectional` dispatched DB work to a single-threaded executor and called terminal methods from those tasks while the cancel handler ran on the transport thread; a duplicate terminal (e.g. COMMIT then a stray message hitting the defensive catch) or a cancellation could interleave terminal calls.

Symptoms: `IllegalStateException` ("call already closed"), dropped responses, or client hangs.

## Fix

New `SynchronizedStreamObserver<T>` (grpcw) wraps the response observer and:

- serializes every call through a single monitor;
- enforces at most one delegated terminal via an `AtomicBoolean completed` CAS, and drops any `onNext` after a terminal call;
- exposes `markTerminated()` for the call's cancel handler to flip the flag without delegating (the transport already closed the call);
- swallows the `IllegalStateException` the delegate throws on a concurrent close, marking itself terminated.

Both streaming handlers now route all write/terminal calls through it; the original `ServerCallStreamObserver` reference is kept only for flow control.

## Tests

`Issue4801SynchronizedStreamObserverTest` (unit, mock-free) drives the wrapper against a delegate that emulates gRPC's contract (throws on a second terminal / write-after-close):

- drop `onNext` after `onCompleted`
- collapse duplicate terminals to one
- `markTerminated` drops subsequent calls without delegating
- delegate `IllegalStateException` on concurrent close is swallowed
- 200 iterations x 32 threads racing `onNext`/`onCompleted`/`onError`/`markTerminated` - no exception escapes, never more than one terminal, no contract violation

Red/green verified: a naive pass-through wrapper fails with the exact `IllegalStateException: call already closed` from the issue; the fix makes all 5 pass. `GrpcServerIT#graphBatchLoadVerticesAndEdges` still passes end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)