### PR TITLE
fix(#4805): preserve DATETIME_MICROS/DATETIME_NANOS precision on gRPC write path

### DIFF
--- a/docs/4805-grpc-datetime-micros-nanos-truncation.md
+++ b/docs/4805-grpc-datetime-micros-nanos-truncation.md
@@ -1,0 +1,65 @@
+# Issue #4805 - gRPC write path truncates DATETIME_MICROS/DATETIME_NANOS to milliseconds
+
+- Issue: https://github.com/ArcadeData/arcadedb/issues/4805
+- Type: bug
+- Branch: fix/4805-grpc-datetime-micros-nanos-truncation
+
+## Summary
+
+The gRPC record write path (`createRecord` / `updateRecord`) routes property
+conversion through `ArcadeDbGrpcService.convertWithSchemaType`. For columns typed
+`DATETIME_SECOND` / `DATETIME_MICROS` / `DATETIME_NANOS`, the `TIMESTAMP_VALUE`
+branch converted the inbound proto `Timestamp` via
+`new Date(GrpcTypeConverter.tsToMillis(...))`, collapsing the value to
+millisecond precision before the engine ever saw it. Sub-millisecond precision
+(micros / nanos) that the column is declared to keep was silently discarded.
+
+The parameter-binding path (`fromGrpcValue`, fixed in #4149) already keeps full
+precision by returning `Instant.ofEpochSecond(sec, nanos)` and letting
+`Type.convert()` truncate to the column's declared precision via
+`DateUtils.getPrecisionFromType(...)`. The write path disagreed with the
+parameter path.
+
+## Root cause
+
+`ArcadeDbGrpcService.convertWithSchemaType`, `DATETIME_SECOND/MICROS/NANOS`
+branch, `TIMESTAMP_VALUE` case:
+
+```java
+case TIMESTAMP_VALUE -> new Date(GrpcTypeConverter.tsToMillis(v.getTimestampValue()));
+```
+
+`java.util.Date` is millisecond-resolution, so micro/nano digits are lost up
+front. The fix is to hand the engine an `Instant` carrying the full nanosecond
+precision and let `Type.convert()` truncate to the declared column precision -
+exactly mirroring `fromGrpcValue`.
+
+## Expected vs actual
+
+- Write a `DATETIME_NANOS` column with proto Timestamp nanos=123_456_789.
+- Actual (before fix): stored value truncated to .123 (milliseconds).
+- Expected: stored value keeps .123456789 (nanoseconds).
+
+## Fix
+
+1. Add a static helper `GrpcTypeConverter.tsToInstant(Timestamp)` mirroring the
+   existing `tsToMillis`, returning `Instant.ofEpochSecond(sec, nanos)`.
+2. In `ArcadeDbGrpcService.convertWithSchemaType`, the
+   `DATETIME_SECOND/MICROS/NANOS` `TIMESTAMP_VALUE` case now returns
+   `GrpcTypeConverter.tsToInstant(...)` instead of `new Date(tsToMillis(...))`.
+
+The millisecond-precision `DATE`/`DATETIME` branch is intentionally left
+unchanged: `DATETIME` is millisecond precision and `DATE` is date precision, so
+`new Date(tsToMillis(...))` loses nothing there.
+
+## Tests
+
+- New unit test in `GrpcTypeConverterTest` for `tsToInstant` precision.
+- New IT `Issue4805GrpcDatetimePrecisionIT` exercising the `createRecord` write
+  path end-to-end for DATETIME_NANOS and DATETIME_MICROS columns, reading the
+  value back and asserting the preserved precision.
+
+## Verification
+
+- `mvn -pl grpcw -am test -Dtest=...` (scoped to grpcw; ha-raft has an unrelated
+  pre-existing test-compile error on main HEAD).

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -3743,9 +3743,12 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       case DATETIME_SECOND:
       case DATETIME_MICROS:
       case DATETIME_NANOS: {
-        // Same handling as DATETIME
+        // Keep full nanosecond precision from the proto Timestamp (matching the parameter-binding
+        // path fromGrpcValue). Type.convert() truncates the Instant to the column's declared
+        // precision via DateUtils.getPrecisionFromType(...); a java.util.Date would collapse the
+        // value to milliseconds up front, discarding the sub-millisecond digits these types keep.
         return switch (v.getKindCase()) {
-          case TIMESTAMP_VALUE -> new Date(GrpcTypeConverter.tsToMillis(v.getTimestampValue()));
+          case TIMESTAMP_VALUE -> GrpcTypeConverter.tsToInstant(v.getTimestampValue());
           case INT64_VALUE -> new Date(v.getInt64Value()); // epoch ms expected
           case STRING_VALUE -> new Date(Long.parseLong(v.getStringValue()));
           default -> null;

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcTypeConverter.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcTypeConverter.java
@@ -55,6 +55,15 @@ class GrpcTypeConverter {
   }
 
   /**
+   * Convert a protobuf Timestamp to an {@link Instant}, preserving full nanosecond precision.
+   * Used on write paths for DATETIME_MICROS / DATETIME_NANOS columns so the engine can truncate
+   * to the column's declared precision instead of losing sub-millisecond digits up front.
+   */
+  static Instant tsToInstant(final Timestamp ts) {
+    return Instant.ofEpochSecond(ts.getSeconds(), ts.getNanos());
+  }
+
+  /**
    * Convert milliseconds since epoch to a protobuf Timestamp.
    */
   static Timestamp msToTimestamp(final long ms) {

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcTypeConverter.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcTypeConverter.java
@@ -60,6 +60,8 @@ class GrpcTypeConverter {
    * to the column's declared precision instead of losing sub-millisecond digits up front.
    */
   static Instant tsToInstant(final Timestamp ts) {
+    if (ts == null)
+      return null;
     return Instant.ofEpochSecond(ts.getSeconds(), ts.getNanos());
   }
 

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcTypeConverterTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcTypeConverterTest.java
@@ -47,6 +47,21 @@ class GrpcTypeConverterTest {
   }
 
   @Test
+  void tsToInstantPreservesNanos() {
+    // Issue #4805: the write path must keep full nanosecond precision (not collapse to millis)
+    // so DATETIME_MICROS / DATETIME_NANOS columns receive the precision the proto Timestamp carries.
+    final Timestamp ts = Timestamp.newBuilder()
+        .setSeconds(1000)
+        .setNanos(123_456_789)
+        .build();
+
+    final Instant instant = GrpcTypeConverter.tsToInstant(ts);
+
+    assertThat(instant.getEpochSecond()).isEqualTo(1000L);
+    assertThat(instant.getNano()).isEqualTo(123_456_789);
+  }
+
+  @Test
   void msToTimestampConvertsCorrectly() {
     long millis = 1000_500L;
 

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4805GrpcDatetimePrecisionIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4805GrpcDatetimePrecisionIT.java
@@ -194,4 +194,41 @@ public class Issue4805GrpcDatetimePrecisionIT extends BaseGraphServerTest {
     // Before the fix the write path collapsed to millis (123_000_000).
     assertThat(readBackNanos("MicrosTest4805")).isEqualTo(123_456_000);
   }
+
+  @Test
+  void updateRecordPreservesNanosForDatetimeNanos() {
+    executeCommand("CREATE DOCUMENT TYPE NanosUpdate4805 IF NOT EXISTS");
+    executeCommand("CREATE PROPERTY NanosUpdate4805.t IF NOT EXISTS DATETIME_NANOS");
+
+    // Create with a placeholder timestamp, then update through the updateRecord path
+    // (which also routes through convertWithSchemaType).
+    final Timestamp placeholder = Timestamp.newBuilder().setSeconds(TEST_SECONDS).setNanos(0).build();
+    final String rid = authenticatedStub.createRecord(
+        CreateRecordRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setType("NanosUpdate4805")
+            .setRecord(GrpcRecord.newBuilder()
+                .setType("NanosUpdate4805")
+                .putProperties("t", GrpcValue.newBuilder().setTimestampValue(placeholder).build())
+                .build())
+            .build())
+        .getRid();
+    assertThat(rid).isNotEmpty();
+
+    final Timestamp ts = Timestamp.newBuilder().setSeconds(TEST_SECONDS).setNanos(TEST_NANOS).build();
+    final UpdateRecordResponse updateResp = authenticatedStub.updateRecord(
+        UpdateRecordRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setRid(rid)
+            .setRecord(GrpcRecord.newBuilder()
+                .setType("NanosUpdate4805")
+                .putProperties("t", GrpcValue.newBuilder().setTimestampValue(ts).build())
+                .build())
+            .build());
+    assertThat(updateResp.getSuccess()).isTrue();
+
+    assertThat(readBackNanos("NanosUpdate4805")).isEqualTo(TEST_NANOS);
+  }
 }

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4805GrpcDatetimePrecisionIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4805GrpcDatetimePrecisionIT.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.google.protobuf.Timestamp;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4805: writing a DATETIME_MICROS / DATETIME_NANOS column through the
+ * gRPC record write path ({@code createRecord} -> {@code convertWithSchemaType}) truncated the
+ * proto Timestamp to millisecond precision via {@code new Date(tsToMillis(...))}, discarding the
+ * sub-millisecond precision the column type is declared to keep.
+ * <p>
+ * The fix converts the inbound proto Timestamp to {@link java.time.Instant} (carrying full
+ * nanosecond precision) and lets {@code Type.convert()} truncate to the column's declared
+ * precision, matching the parameter-binding path ({@code fromGrpcValue}, issue #4149).
+ */
+public class Issue4805GrpcDatetimePrecisionIT extends BaseGraphServerTest {
+
+  private static final int GRPC_PORT = 50051;
+
+  private static final Metadata.Key<String> USER_HEADER =
+      Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER =
+      Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER =
+      Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  // 2026-05-09T12:34:56.123456789Z - carries distinct millis, micros and nanos digits
+  private static final LocalDateTime TEST_TIME = LocalDateTime.of(2026, 5, 9, 12, 34, 56, 123_456_789);
+  private static final long          TEST_SECONDS = TEST_TIME.toEpochSecond(ZoneOffset.UTC);
+  private static final int           TEST_NANOS = 123_456_789;
+
+  private ManagedChannel channel;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub authenticatedStub;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+    GlobalConfiguration.QUERY_PARALLEL_SCAN.setValue(false);
+  }
+
+  @BeforeEach
+  void setupGrpcClient() {
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    final Channel authenticatedChannel = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+    authenticatedStub = ArcadeDbServiceGrpc.newBlockingStub(authenticatedChannel);
+  }
+
+  @AfterEach
+  void shutdownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private class AuthClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        final MethodDescriptor<ReqT, RespT> method, final CallOptions callOptions, final Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata headers) {
+          headers.put(USER_HEADER, "root");
+          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
+          headers.put(DATABASE_HEADER, getDatabaseName());
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+
+  private DatabaseCredentials credentials() {
+    return DatabaseCredentials.newBuilder()
+        .setUsername("root")
+        .setPassword(DEFAULT_PASSWORD_FOR_TESTS)
+        .build();
+  }
+
+  private void executeCommand(final String command) {
+    authenticatedStub.executeCommand(
+        ExecuteCommandRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setCommand(command)
+            .build());
+  }
+
+  private int readBackNanos(final String type) {
+    final ExecuteQueryResponse response = authenticatedStub.executeQuery(
+        ExecuteQueryRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setQuery("SELECT t FROM " + type)
+            .build());
+
+    assertThat(response.getResultsList()).as("query must return at least one result group").isNotEmpty();
+    assertThat(response.getResultsList().get(0).getRecordsList()).as("result group must contain records").isNotEmpty();
+
+    final GrpcRecord record = response.getResultsList().get(0).getRecordsList().get(0);
+    assertThat(record.getPropertiesMap()).as("'t' property must be present").containsKey("t");
+    final GrpcValue tValue = record.getPropertiesMap().get("t");
+    assertThat(tValue.hasTimestampValue()).as("datetime property must come back as a Timestamp").isTrue();
+    assertThat(tValue.getTimestampValue().getSeconds()).isEqualTo(TEST_SECONDS);
+    return tValue.getTimestampValue().getNanos();
+  }
+
+  @Test
+  void createRecordPreservesNanosForDatetimeNanos() {
+    executeCommand("CREATE DOCUMENT TYPE NanosTest4805 IF NOT EXISTS");
+    executeCommand("CREATE PROPERTY NanosTest4805.t IF NOT EXISTS DATETIME_NANOS");
+
+    final Timestamp ts = Timestamp.newBuilder().setSeconds(TEST_SECONDS).setNanos(TEST_NANOS).build();
+
+    final GrpcRecord record = GrpcRecord.newBuilder()
+        .setType("NanosTest4805")
+        .putProperties("t", GrpcValue.newBuilder().setTimestampValue(ts).build())
+        .build();
+
+    // Write through the createRecord path (convertWithSchemaType), the path with the bug.
+    final CreateRecordResponse createResp = authenticatedStub.createRecord(
+        CreateRecordRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setType("NanosTest4805")
+            .setRecord(record)
+            .build());
+    assertThat(createResp.getRid()).isNotEmpty();
+
+    // Before the fix the write path collapsed to millis (123_000_000); DATETIME_NANOS keeps full nanos.
+    assertThat(readBackNanos("NanosTest4805")).isEqualTo(TEST_NANOS);
+  }
+
+  @Test
+  void createRecordPreservesMicrosForDatetimeMicros() {
+    executeCommand("CREATE DOCUMENT TYPE MicrosTest4805 IF NOT EXISTS");
+    executeCommand("CREATE PROPERTY MicrosTest4805.t IF NOT EXISTS DATETIME_MICROS");
+
+    final Timestamp ts = Timestamp.newBuilder().setSeconds(TEST_SECONDS).setNanos(TEST_NANOS).build();
+
+    final GrpcRecord record = GrpcRecord.newBuilder()
+        .setType("MicrosTest4805")
+        .putProperties("t", GrpcValue.newBuilder().setTimestampValue(ts).build())
+        .build();
+
+    final CreateRecordResponse createResp = authenticatedStub.createRecord(
+        CreateRecordRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setType("MicrosTest4805")
+            .setRecord(record)
+            .build());
+    assertThat(createResp.getRid()).isNotEmpty();
+
+    // DATETIME_MICROS truncates to microsecond precision: 123_456_789 -> 123_456_000.
+    // Before the fix the write path collapsed to millis (123_000_000).
+    assertThat(readBackNanos("MicrosTest4805")).isEqualTo(123_456_000);
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #4805. The gRPC record write path (`createRecord` / `updateRecord` -> `ArcadeDbGrpcService.convertWithSchemaType`) converted an inbound proto `Timestamp` for `DATETIME_SECOND` / `DATETIME_MICROS` / `DATETIME_NANOS` columns via `new Date(GrpcTypeConverter.tsToMillis(...))`. `java.util.Date` is millisecond-resolution, so the sub-millisecond precision these column types are declared to keep was silently truncated before the engine ever saw the value.

The parameter-binding path (`fromGrpcValue`, fixed in #4149) already preserves full precision by returning `Instant.ofEpochSecond(sec, nanos)` and letting `Type.convert()` truncate to the column's declared precision via `DateUtils.getPrecisionFromType(...)`. The write path disagreed with the parameter path.

## Change

- Add `GrpcTypeConverter.tsToInstant(Timestamp)` (mirrors the existing `tsToMillis`), returning `Instant.ofEpochSecond(sec, nanos)`.
- `convertWithSchemaType`'s `DATETIME_SECOND/MICROS/NANOS` `TIMESTAMP_VALUE` case now returns that `Instant` instead of a millisecond-collapsed `Date`, so the engine truncates to the column's declared precision.
- The millisecond `DATE` / `DATETIME` branch is intentionally left unchanged (no precision is lost there).

## Behavior

- Write a `DATETIME_NANOS` column with proto Timestamp nanos `123_456_789`: before, stored as `123_000_000` (millis); after, `123_456_789`.
- `DATETIME_MICROS`: before `123_000_000`; after `123_456_000` (microsecond precision).

## Tests

- Unit test `GrpcTypeConverterTest.tsToInstantPreservesNanos`.
- New IT `Issue4805GrpcDatetimePrecisionIT` exercising the `createRecord` write path end-to-end for `DATETIME_NANOS` and `DATETIME_MICROS` columns, reading the value back and asserting the preserved precision. Confirmed failing before the fix (`123000000`) and passing after.

Connected suites green: `GrpcTypeConverterTest` (39), `Issue4149GrpcTypeConverterTest` (5), `ArcadeDbGrpcServiceExtendedTest` (26, createRecord coverage), `Issue4181GrpcDateCorruptionIT` (2), `Issue4805GrpcDatetimePrecisionIT` (2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)