### PR TITLE
fix(#4806): stop gRPC insertStream after a mid-stream commit failure and stop mis-indexing the error

### DIFF
--- a/docs/4806-grpc-insertstream-commit-failure.md
+++ b/docs/4806-grpc-insertstream-commit-failure.md
@@ -59,8 +59,41 @@ not processed against the broken transaction.
 - **Cycle 2 - claude**: (1) counted the failing chunk's rows as `received` so the summary can no
   longer report `failed > received`; (2/3) documented the intentional all-or-nothing stance and the
   asymmetry with `recordCommitException`; (4) extracted `commitErrorCode()`/`exceptionMessage()`
-  helpers shared by both failure paths; (5) the contract-change test covers the `COMMIT_FAILED` branch.
+  helpers shared by both failure paths; (5) the contract-change test asserts the `CONTRACT_VIOLATION`
+  branch (a pre-insert contract rejection is not a commit failure).
+- **Cycle 3 - claude** (post-rebase onto `main`, which now includes #4801's thread-safe `out` observer):
+  - **(#1, medium) Fixed summary over-reporting `inserted`/`updated` after a mid-stream rollback.** In
+    `PER_STREAM`/`PER_REQUEST` (and `PER_BATCH` when the batch is larger than the chunk) earlier rows stay
+    uncommitted; `abortTransaction()` rolls them back but they were already counted. `abortTransaction()`
+    now returns whether it actually rolled back an active transaction; when it did, the `onNext` catch
+    reclassifies the still-uncommitted `inserted`/`updated` as `failed` (symmetric to
+    `recordCommitException`). When nothing was rolled back (`PER_BATCH`/`PER_ROW` whose earlier batches
+    already committed) the counts stand. The contract-change test now asserts `inserted == 0`,
+    `received == 2`, `failed == 2` (counts balance).
+  - **(#5, edge) Closed a transaction leak in the `InsertContext` constructor.** If construction threw
+    after `db.begin()` but before the context reached `ctxRef`, the mid-stream catch could not roll the
+    begun transaction back (it saw `ctxRef.get() == null`). The constructor now rolls back its own
+    just-begun transaction on failure before propagating.
+  - **(#2, minor) Not changed:** `commitErrorCode()` keeps `COMMIT_FAILED` as the catch-all even for a
+    pre-loop structural failure (e.g. a missing target type from `schema.getType`). The `InsertError.code`
+    values are a client-visible contract; renaming the default is itself a compatibility change for a
+    cosmetic mislabel, so the dominant-case label stands.
+  - **(#3, minor) Error-code set documented** (below).
+
+## InsertError.code values (client-facing contract)
+
+`InsertError.code` is a free-form string; clients may switch on it. The full set currently emitted by the
+insert paths:
+
+- `CONFLICT` - a unique-key/`DuplicatedKeyException` violation.
+- `CONTRACT_VIOLATION` - a stream contract rejection (`IllegalArgumentException`, e.g. "options changed
+  mid-stream"); not a commit failure.
+- `COMMIT_FAILED` - any other transaction-level failure escaping `insertRows` (catch-all).
+- `DB_ERROR` - a per-row insert/update error caught inside `insertRows`.
+- `MISSING_ENDPOINTS` - an edge row missing its required `from`/`to` endpoints.
+- `INVALID_KEY_COLUMN` - a key-column reference that does not resolve on the row.
 
 ## Final state
 
 Fix complete. 2 new ITs + 21 existing insertStream ITs (#4198/#4214/#4644/#4656) pass; no regressions.
+Rebased onto `main` (resolves the #4801 thread-safe-observer overlap in `ArcadeDbGrpcService`).

--- a/docs/4806-grpc-insertstream-commit-failure.md
+++ b/docs/4806-grpc-insertstream-commit-failure.md
@@ -47,3 +47,20 @@ not processed against the broken transaction.
 - [x] Test (fails before fix)
 - [x] Fix
 - [x] Verify
+
+## Review cycles
+
+- **Cycle 1 - gemini-code-assist** (transaction leak): a transaction-level failure that is not a
+  commit failure (e.g. "options changed mid-stream") leaves the transaction active and bound to the
+  pooled gRPC thread. Added `InsertContext.abortTransaction()` (rolls back only if still active on the
+  calling thread, then drops the captured handle; never re-binds a dead transaction). Called from the
+  `onNext` catch and defensively from `onCompleted` when `streamFailed`. Added the contract-change
+  regression test.
+- **Cycle 2 - claude**: (1) counted the failing chunk's rows as `received` so the summary can no
+  longer report `failed > received`; (2/3) documented the intentional all-or-nothing stance and the
+  asymmetry with `recordCommitException`; (4) extracted `commitErrorCode()`/`exceptionMessage()`
+  helpers shared by both failure paths; (5) the contract-change test covers the `COMMIT_FAILED` branch.
+
+## Final state
+
+Fix complete. 2 new ITs + 21 existing insertStream ITs (#4198/#4214/#4644/#4656) pass; no regressions.

--- a/docs/4806-grpc-insertstream-commit-failure.md
+++ b/docs/4806-grpc-insertstream-commit-failure.md
@@ -1,0 +1,49 @@
+# Issue #4806 - gRPC insertStream keeps processing after a commit failure and mis-indexes the error
+
+## Problem
+
+`ArcadeDbGrpcService.insertStream` (`onNext`): when a chunk insert throws (e.g. a
+`PER_BATCH`/`PER_ROW` mid-stream `flushCommit` failure, such as a deferred unique-index
+violation surfacing at `db.commit()`), two defects occur:
+
+1. **Mis-indexed error.** The `catch` records the failure against a single context-wide row
+   index (`ctx.received - 1`) with a generic `DB_ERROR` code, even though a transaction-level
+   commit failure is not attributable to one specific row.
+2. **Keeps processing on a broken transaction.** The `flushCommit` that failed has already
+   rolled the transaction back (the post-commit `db.begin()` never ran), but the `finally`
+   keeps pulling more chunks (`call.request(1)`) and `onNext` re-binds and inserts into the now
+   rolled-back transaction, producing further spurious `DB_ERROR`s and losing rows.
+
+## Root cause
+
+Per-row errors are caught row-by-row inside `insertRows`. Any exception that *escapes*
+`insertRows` is therefore a transaction-level/structural failure (mid-stream commit). The
+`onNext` handler treated it like a recoverable per-row error: it recorded it at `ctx.received-1`
+and let the stream continue against the dead transaction.
+
+## Fix
+
+In `insertStream.onNext`, on an exception escaping `insertRows`:
+- mark the stream failed (`AtomicBoolean streamFailed`),
+- record the failure at the transaction level (`rowIndex = -1`) with code `CONFLICT`
+  (for `DuplicatedKeyException`) or `COMMIT_FAILED` otherwise, instead of `ctx.received-1`/`DB_ERROR`,
+- short-circuit subsequent `onNext` chunks (drain inbound to reach `onCompleted` but skip
+  inserting), so subsequent rows never touch the rolled-back transaction.
+
+In `onCompleted`, skip the deferred `flushCommit` when the stream already failed mid-stream (the
+transaction is gone) and still deliver a structured `InsertSummary` (consistent with #4198/#4214,
+which prefer a structured summary over `Status.INTERNAL`).
+
+## Test
+
+`Issue4806InsertStreamMidStreamCommitFailureIT` - PER_BATCH, `server_batch_size = 1`, UNIQUE index,
+duplicate row triggers a mid-stream commit failure followed by a would-be-valid row. Asserts a
+single transaction-level error (`rowIndex == -1`, code `CONFLICT`) and that the subsequent row is
+not processed against the broken transaction.
+
+## Status
+
+- [x] Analysis
+- [x] Test (fails before fix)
+- [x] Fix
+- [x] Verify

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -2002,9 +2002,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           streamFailed.set(true);
           // insertRows discards its partial Counts when it throws, so the failing chunk's rows never
           // reach totals via totals.add(cts). Count them as received (the client did send them) so the
-          // summary cannot report failed > received. Unlike recordCommitException (used for the whole
-          // -stream deferred commit), do NOT reclassify previously counted inserted/updated as failed:
-          // in PER_BATCH/PER_ROW the earlier batches already committed and persisted.
+          // summary cannot report failed > received.
           //
           // Known limitation (out of scope for #4806): when server_batch_size is smaller than a single
           // chunk, insertRows may have already committed earlier mini-batches of this chunk before a
@@ -2018,8 +2016,18 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           // where it is bound) so its locks are released immediately and it is not leaked into a later
           // request that reuses the thread.
           final InsertContext failedCtx = ctxRef.get();
-          if (failedCtx != null)
-            failedCtx.abortTransaction();
+          final boolean rolledBack = failedCtx != null && failedCtx.abortTransaction();
+          // If that rollback actually discarded uncommitted rows - PER_STREAM/PER_REQUEST never commit
+          // before onCompleted, and PER_BATCH with a batch larger than the chunk leaves rows buffered -
+          // then rows already folded into totals.inserted/updated are no longer in the database, so
+          // reclassify them as failed (symmetric to recordCommitException; the -1 error is already
+          // recorded above). When nothing was rolled back (rolledBack == false) the earlier batches had
+          // already committed and persisted, so their counts stand.
+          if (rolledBack) {
+            totals.failed += totals.inserted + totals.updated;
+            totals.inserted = 0;
+            totals.updated = 0;
+          }
         } finally {
           if (!cancelled.get())
             call.request(1);
@@ -3309,7 +3317,16 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         }
       }
 
-      captureTransaction();
+      // Issue #4806: if anything after db.begin() throws, the caller never receives this context (it is
+      // not yet stored in ctxRef), so its mid-stream failure path cannot roll the just-begun transaction
+      // back - it would leak, bound to this pooled gRPC thread. Clean up our own transaction before
+      // propagating the failure.
+      try {
+        captureTransaction();
+      } catch (final RuntimeException e) {
+        abortTransaction();
+        throw e;
+      }
     }
 
     /**
@@ -3353,13 +3370,21 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
      * re-bound onto a pooled gRPC thread. Idempotent and best-effort: a mid-stream commit failure has
      * usually already terminated the transaction (isTransactionActive() == false), in which case this
      * only clears the handle. Must be called on the thread whose context holds the transaction.
+     *
+     * @return {@code true} if an active transaction was actually rolled back (its uncommitted rows are
+     *         no longer in the database); {@code false} if there was nothing to roll back (the
+     *         transaction had already been terminated by a failed commit, so earlier batches persisted).
      */
-    void abortTransaction() {
+    boolean abortTransaction() {
       try {
-        if (db.isTransactionActive())
+        if (db.isTransactionActive()) {
           db.rollback();
+          return true;
+        }
+        return false;
       } catch (final Exception ignore) {
         // best-effort: the engine may have already rolled the transaction back on the failed commit
+        return false;
       } finally {
         tx = null;
       }

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -1931,7 +1931,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         // back. Do not insert further rows into the broken transaction; just keep draining the
         // remaining inbound chunks so the stream still reaches onCompleted and delivers the summary.
         if (streamFailed.get()) {
-          call.request(1);
+          if (!cancelled.get())
+            call.request(1);
           return;
         }
 
@@ -2004,6 +2005,12 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           // summary cannot report failed > received. Unlike recordCommitException (used for the whole
           // -stream deferred commit), do NOT reclassify previously counted inserted/updated as failed:
           // in PER_BATCH/PER_ROW the earlier batches already committed and persisted.
+          //
+          // Known limitation (out of scope for #4806): when server_batch_size is smaller than a single
+          // chunk, insertRows may have already committed earlier mini-batches of this chunk before a
+          // later mini-batch's commit failed. Those rows are durable but their inserted/updated counts
+          // were in the discarded Counts, so the summary under-reports inserted for this chunk. The
+          // tests use single-row chunks; a precise per-chunk reconciliation is a separate follow-up.
           totals.received += c.getRowsCount();
           totals.err(-1, commitErrorCode(e), exceptionMessage(e), "");
           // A structural failure (e.g. "options changed mid-stream") leaves the transaction still
@@ -2065,12 +2072,11 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
             } catch (Exception commitEx) {
               recordCommitException(totals, commitEx);
             }
-          } else {
-            // Issue #4806: the mid-stream failure already aborted the transaction in onNext. Defensively
-            // ensure nothing is left active and bound to this (pooled) thread before the summary is sent.
-            // Do not re-bind here: the captured handle points at a dead transaction.
-            ctx.abortTransaction();
           }
+          // Issue #4806: when streamFailed is set the onNext catch already aborted the transaction on
+          // the thread it was bound to and cleared the handle, so there is nothing to clean up here.
+          // Deliberately do NOT call abortTransaction()/rollback() on this (possibly different, pooled)
+          // thread: it could roll back an unrelated transaction that another request left bound to it.
 
           if (!cancelled.get()) {
             out.onNext(ctx.summary(totals, startedAt));
@@ -2110,13 +2116,19 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   }
 
   /**
-   * Classifies a commit/transaction-level exception into the structured {@link InsertError} code:
-   * {@code CONFLICT} for a {@link DuplicatedKeyException}, {@code COMMIT_FAILED} otherwise. Shared by
-   * the mid-stream onNext failure path (Issue #4806) and the deferred whole-stream commit path
-   * (Issue #4198) so the two stay in sync.
+   * Classifies a transaction-level exception into the structured {@link InsertError} code:
+   * {@code CONFLICT} for a {@link DuplicatedKeyException}, {@code CONTRACT_VIOLATION} for a stream
+   * contract rejection ({@link IllegalArgumentException}, e.g. "options changed mid-stream", which is
+   * not a commit failure at all), and {@code COMMIT_FAILED} otherwise. Shared by the mid-stream onNext
+   * failure path (Issue #4806) and the deferred whole-stream commit path (Issue #4198) so the two stay
+   * in sync.
    */
   private static String commitErrorCode(final Exception e) {
-    return e instanceof DuplicatedKeyException ? "CONFLICT" : "COMMIT_FAILED";
+    if (e instanceof DuplicatedKeyException)
+      return "CONFLICT";
+    if (e instanceof IllegalArgumentException)
+      return "CONTRACT_VIOLATION";
+    return "COMMIT_FAILED";
   }
 
   /**

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -1900,6 +1900,11 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     final AtomicBoolean cancelled = new AtomicBoolean(false);
     final AtomicReference<InsertContext> ctxRef = new AtomicReference<>();
 
+    // Issue #4806: set when a chunk fails at the transaction level (e.g. a mid-stream commit that
+    // rolled the transaction back). Once set, no further rows are inserted: the stream just drains
+    // the remaining inbound chunks and delivers the summary in onCompleted.
+    final AtomicBoolean streamFailed = new AtomicBoolean(false);
+
     final Counts totals = new Counts();
 
     // cache the first-chunk effective options to validate consistency
@@ -1919,6 +1924,14 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       public void onNext(InsertChunk c) {
 
         if (cancelled.get()) {
+          return;
+        }
+
+        // Issue #4806: a previous chunk failed at the transaction level and rolled the transaction
+        // back. Do not insert further rows into the broken transaction; just keep draining the
+        // remaining inbound chunks so the stream still reaches onCompleted and delivers the summary.
+        if (streamFailed.get()) {
+          call.request(1);
           return;
         }
 
@@ -1975,10 +1988,15 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           Counts cts = insertRows(ctxRef.get(), c.getRowsList().iterator());
           totals.add(cts);
         } catch (Exception e) {
-          // Register as an error on totals; keep stream alive unless you prefer to fail
-          // the call
-          totals.err(Math.max(0, (ctxRef.get() != null ? ctxRef.get().received : 0) - 1), "DB_ERROR", e.getMessage(),
-              "");
+          // Issue #4806: per-row errors are handled row-by-row inside insertRows, so an exception
+          // reaching here is a transaction-level failure (typically a mid-stream PER_BATCH/PER_ROW
+          // commit that has already rolled the transaction back). Record it once at the transaction
+          // level (rowIndex -1) instead of mis-attributing it to a single row, and mark the stream
+          // failed so subsequent chunks are not inserted into the broken transaction. onCompleted
+          // delivers the summary.
+          streamFailed.set(true);
+          final String code = e instanceof DuplicatedKeyException ? "CONFLICT" : "COMMIT_FAILED";
+          totals.err(-1, code, e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName(), "");
         } finally {
           if (!cancelled.get())
             call.request(1);
@@ -2001,8 +2019,13 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           InsertContext ctx = ctxRef.get();
 
           if (ctx == null) {
-            // Client closed without sending a first chunk → nothing to do
-            out.onNext(InsertSummary.newBuilder().setReceived(0).setInserted(0).setUpdated(0).setIgnored(0).setFailed(0)
+            // Client closed without sending a first chunk, or the first chunk failed before a context
+            // could be built (Issue #4806). Deliver whatever was recorded: zeros when truly empty, or
+            // the recorded error when first-chunk setup failed. Route through the thread-safe observer
+            // (Issue #4801).
+            out.onNext(InsertSummary.newBuilder()
+                .setReceived(totals.received).setInserted(totals.inserted).setUpdated(totals.updated)
+                .setIgnored(totals.ignored).setFailed(totals.failed).addAllErrors(totals.errors)
                 .setExecutionTimeMs(System.currentTimeMillis() - startedAt).build());
 
             out.onCompleted();
@@ -2013,13 +2036,19 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           // violation (e.g. DuplicatedKeyException) used to bubble up to the outer catch and become
           // Status.INTERNAL, leaving the client without an InsertSummary. Instead, surface those as
           // structured errors in totals.errors and still deliver the summary.
-          try {
-            // Issue #4644: onCompleted may run on a different pool thread than the onNext that began
-            // the transaction; re-bind it to this thread so the deferred commit finds it.
-            ctx.bindToCurrentThread();
-            ctx.flushCommit(true); // commit if not validate-only
-          } catch (Exception commitEx) {
-            recordCommitException(totals, commitEx);
+          //
+          // Issue #4806: when a chunk already failed at the transaction level mid-stream the
+          // transaction was rolled back, so there is nothing left to commit - attempting the deferred
+          // commit would just re-raise "Transaction not begun". Skip it and deliver the summary as-is.
+          if (!streamFailed.get()) {
+            try {
+              // Issue #4644: onCompleted may run on a different pool thread than the onNext that began
+              // the transaction; re-bind it to this thread so the deferred commit finds it.
+              ctx.bindToCurrentThread();
+              ctx.flushCommit(true); // commit if not validate-only
+            } catch (Exception commitEx) {
+              recordCommitException(totals, commitEx);
+            }
           }
 
           if (!cancelled.get()) {

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -1997,6 +1997,13 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           streamFailed.set(true);
           final String code = e instanceof DuplicatedKeyException ? "CONFLICT" : "COMMIT_FAILED";
           totals.err(-1, code, e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName(), "");
+          // Not every transaction-level failure is a commit failure: an "options changed mid-stream"
+          // rejection or a schema error leaves the transaction still active and bound to this pooled
+          // gRPC thread. Roll it back here (on the failing thread, where it is bound) so its locks are
+          // released immediately and it is not leaked into a later request that reuses the thread.
+          final InsertContext failedCtx = ctxRef.get();
+          if (failedCtx != null)
+            failedCtx.abortTransaction();
         } finally {
           if (!cancelled.get())
             call.request(1);
@@ -2049,6 +2056,11 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
             } catch (Exception commitEx) {
               recordCommitException(totals, commitEx);
             }
+          } else {
+            // Issue #4806: the mid-stream failure already aborted the transaction in onNext. Defensively
+            // ensure nothing is left active and bound to this (pooled) thread before the summary is sent.
+            // Do not re-bind here: the captured handle points at a dead transaction.
+            ctx.abortTransaction();
           }
 
           if (!cancelled.get()) {
@@ -3294,6 +3306,25 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       } else {
         tx = null;
         txUser = null;
+      }
+    }
+
+    /**
+     * Issue #4806: abort the in-flight transaction after a transaction-level failure. Rolls back the
+     * transaction if it is still active on the calling thread - which releases its locks and clears
+     * this thread's binding - and drops the captured handle so the (now dead) transaction is never
+     * re-bound onto a pooled gRPC thread. Idempotent and best-effort: a mid-stream commit failure has
+     * usually already terminated the transaction (isTransactionActive() == false), in which case this
+     * only clears the handle. Must be called on the thread whose context holds the transaction.
+     */
+    void abortTransaction() {
+      try {
+        if (db.isTransactionActive())
+          db.rollback();
+      } catch (final Exception ignore) {
+        // best-effort: the engine may have already rolled the transaction back on the failed commit
+      } finally {
+        tx = null;
       }
     }
 

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -1990,17 +1990,26 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         } catch (Exception e) {
           // Issue #4806: per-row errors are handled row-by-row inside insertRows, so an exception
           // reaching here is a transaction-level failure (typically a mid-stream PER_BATCH/PER_ROW
-          // commit that has already rolled the transaction back). Record it once at the transaction
+          // commit that has already rolled the transaction back, or a structural error such as an
+          // "options changed mid-stream" rejection in any mode). Record it once at the transaction
           // level (rowIndex -1) instead of mis-attributing it to a single row, and mark the stream
           // failed so subsequent chunks are not inserted into the broken transaction. onCompleted
-          // delivers the summary.
+          // delivers the summary. This is deliberately all-or-nothing for the failed chunk and
+          // (for PER_STREAM / PER_REQUEST) for the whole stream: a structural failure is not a
+          // recoverable per-row error, so the deferred commit is skipped rather than persisting a
+          // partial stream the client did not intend.
           streamFailed.set(true);
-          final String code = e instanceof DuplicatedKeyException ? "CONFLICT" : "COMMIT_FAILED";
-          totals.err(-1, code, e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName(), "");
-          // Not every transaction-level failure is a commit failure: an "options changed mid-stream"
-          // rejection or a schema error leaves the transaction still active and bound to this pooled
-          // gRPC thread. Roll it back here (on the failing thread, where it is bound) so its locks are
-          // released immediately and it is not leaked into a later request that reuses the thread.
+          // insertRows discards its partial Counts when it throws, so the failing chunk's rows never
+          // reach totals via totals.add(cts). Count them as received (the client did send them) so the
+          // summary cannot report failed > received. Unlike recordCommitException (used for the whole
+          // -stream deferred commit), do NOT reclassify previously counted inserted/updated as failed:
+          // in PER_BATCH/PER_ROW the earlier batches already committed and persisted.
+          totals.received += c.getRowsCount();
+          totals.err(-1, commitErrorCode(e), exceptionMessage(e), "");
+          // A structural failure (e.g. "options changed mid-stream") leaves the transaction still
+          // active and bound to this pooled gRPC thread. Roll it back here (on the failing thread,
+          // where it is bound) so its locks are released immediately and it is not leaked into a later
+          // request that reuses the thread.
           final InsertContext failedCtx = ctxRef.get();
           if (failedCtx != null)
             failedCtx.abortTransaction();
@@ -2092,14 +2101,30 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     if (rolledBack == 0)
       totals.failed++;
 
-    final String code = e instanceof DuplicatedKeyException ? "CONFLICT" : "COMMIT_FAILED";
-    final String message = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
     totals.errors.add(InsertError.newBuilder()
         .setRowIndex(-1)
-        .setCode(code)
-        .setMessage(message)
+        .setCode(commitErrorCode(e))
+        .setMessage(exceptionMessage(e))
         .setField("")
         .build());
+  }
+
+  /**
+   * Classifies a commit/transaction-level exception into the structured {@link InsertError} code:
+   * {@code CONFLICT} for a {@link DuplicatedKeyException}, {@code COMMIT_FAILED} otherwise. Shared by
+   * the mid-stream onNext failure path (Issue #4806) and the deferred whole-stream commit path
+   * (Issue #4198) so the two stay in sync.
+   */
+  private static String commitErrorCode(final Exception e) {
+    return e instanceof DuplicatedKeyException ? "CONFLICT" : "COMMIT_FAILED";
+  }
+
+  /**
+   * Returns a non-null human-readable message for an exception, falling back to the simple class name
+   * when {@link Exception#getMessage()} is null.
+   */
+  private static String exceptionMessage(final Exception e) {
+    return e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
   }
 
   // --- 3) Client-streaming graph batch load ---

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4806InsertStreamMidStreamCommitFailureIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4806InsertStreamMidStreamCommitFailureIT.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4806: a mid-stream commit failure in {@code InsertStream} must stop
+ * the stream and record the failure at the transaction level, instead of mis-attributing it to a
+ * single row and then continuing to insert subsequent rows into the already rolled-back
+ * transaction.
+ *
+ * <p>In {@code PER_BATCH} mode with a small server batch size, the deferred unique-index check
+ * fires at the mid-stream {@code db.commit()} inside {@code insertRows(...)}. That exception
+ * escapes {@code insertRows} (per-row errors are caught row-by-row) and the engine has already
+ * rolled the transaction back. The old code recorded the error at {@code ctx.received - 1} with a
+ * generic {@code DB_ERROR} code and then kept pulling chunks against the broken transaction,
+ * producing further spurious {@code DB_ERROR}s.
+ */
+public class Issue4806InsertStreamMidStreamCommitFailureIT extends BaseGraphServerTest {
+
+  private static final int GRPC_PORT = 50051;
+
+  private static final Metadata.Key<String> USER_HEADER     = Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER = Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER = Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  private ManagedChannel                          channel;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub authenticatedStub;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceStub         asyncAuthenticatedStub;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void setupGrpcClient() {
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    final Channel authenticatedChannel = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+    authenticatedStub = ArcadeDbServiceGrpc.newBlockingStub(authenticatedChannel);
+    asyncAuthenticatedStub = ArcadeDbServiceGrpc.newStub(authenticatedChannel);
+  }
+
+  @AfterEach
+  void shutdownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private class AuthClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        final MethodDescriptor<ReqT, RespT> method, final CallOptions callOptions, final Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata headers) {
+          headers.put(USER_HEADER, "root");
+          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
+          headers.put(DATABASE_HEADER, getDatabaseName());
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+
+  private DatabaseCredentials credentials() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  private GrpcValue stringValue(final String s) {
+    return GrpcValue.newBuilder().setStringValue(s).build();
+  }
+
+  @Test
+  void midStreamCommitFailureStopsStreamAndRecordsTransactionLevelError() throws Exception {
+    final String typeName = "Issue4806PerBatch_" + System.currentTimeMillis();
+
+    // Schema + unique index + one pre-existing row the streamed duplicate will collide with at commit.
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials())
+        .setCommand("CREATE DOCUMENT TYPE " + typeName).build());
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials())
+        .setCommand("CREATE PROPERTY " + typeName + ".name STRING").build());
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials())
+        .setCommand("CREATE INDEX ON " + typeName + "(name) UNIQUE").build());
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials())
+        .setCommand("INSERT INTO " + typeName + " SET name = 'Alice'").build());
+
+    try {
+      final CountDownLatch done = new CountDownLatch(1);
+      final AtomicReference<InsertSummary> summaryRef = new AtomicReference<>();
+      final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+      final StreamObserver<InsertChunk> req = asyncAuthenticatedStub.insertStream(new StreamObserver<>() {
+        @Override public void onNext(final InsertSummary s) { summaryRef.set(s); }
+        @Override public void onError(final Throwable t) { errorRef.set(t); done.countDown(); }
+        @Override public void onCompleted() { done.countDown(); }
+      });
+
+      // PER_BATCH with server_batch_size=1 forces a commit after every row, so the duplicate 'Alice'
+      // triggers a mid-stream commit failure inside insertRows. CONFLICT_ERROR (no key_columns) means
+      // the duplicate is not pre-checked away; it surfaces only at the deferred commit.
+      final InsertOptions options = InsertOptions.newBuilder()
+          .setDatabase(getDatabaseName())
+          .setCredentials(credentials())
+          .setTargetClass(typeName)
+          .setConflictMode(InsertOptions.ConflictMode.CONFLICT_ERROR)
+          .setTransactionMode(InsertOptions.TransactionMode.PER_BATCH)
+          .setServerBatchSize(1)
+          .build();
+
+      // Chunk 0: the duplicate that fails to commit mid-stream.
+      req.onNext(InsertChunk.newBuilder()
+          .setSessionId("issue-4806")
+          .setChunkSeq(0)
+          .setOptions(options)
+          .addRows(GrpcRecord.newBuilder().setType(typeName).putProperties("name", stringValue("Alice")).build())
+          .build());
+
+      // Chunk 1: a row that would succeed against a healthy transaction. It must NOT be processed
+      // against the rolled-back transaction.
+      req.onNext(InsertChunk.newBuilder()
+          .setSessionId("issue-4806")
+          .setChunkSeq(1)
+          .setLast(true)
+          .addRows(GrpcRecord.newBuilder().setType(typeName).putProperties("name", stringValue("Charlie")).build())
+          .build());
+
+      req.onCompleted();
+
+      assertThat(done.await(30, TimeUnit.SECONDS)).as("InsertStream should terminate within 30s").isTrue();
+
+      assertThat(summaryRef.get()).as("client must receive an InsertSummary").isNotNull();
+      final InsertSummary summary = summaryRef.get();
+
+      // Exactly one transaction-level error: the mid-stream commit failure. The old code produced a
+      // second spurious DB_ERROR by continuing to insert 'Charlie' into the rolled-back transaction.
+      assertThat(summary.getErrorsList())
+          .as("a mid-stream commit failure must be reported as a single transaction-level error")
+          .hasSize(1);
+
+      final InsertError error = summary.getErrors(0);
+      // The failure is not attributable to a single row: it must be reported at the transaction
+      // level (rowIndex -1), not mis-indexed at ctx.received-1.
+      assertThat(error.getRowIndex())
+          .as("a commit failure must be reported at the transaction level (-1), not mis-indexed to a row")
+          .isEqualTo(-1);
+      assertThat(error.getCode()).isEqualTo("CONFLICT");
+      assertThat(error.getMessage()).contains("Alice");
+
+      // 'Charlie' must never have been inserted: the duplicate rolled the transaction back and the
+      // stream stopped processing further rows.
+      final ExecuteQueryResponse queryResp = authenticatedStub.executeQuery(ExecuteQueryRequest.newBuilder()
+          .setDatabase(getDatabaseName())
+          .setCredentials(credentials())
+          .setQuery("SELECT name FROM " + typeName + " WHERE name = 'Charlie'")
+          .build());
+      final boolean charlieExists = !queryResp.getResultsList().isEmpty()
+          && !queryResp.getResultsList().get(0).getRecordsList().isEmpty();
+      assertThat(charlieExists)
+          .as("rows after a mid-stream commit failure must not be inserted into the broken transaction")
+          .isFalse();
+    } finally {
+      authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+          .setDatabase(getDatabaseName()).setCredentials(credentials())
+          .setCommand("DROP TYPE " + typeName + " IF EXISTS UNSAFE").build());
+    }
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4806InsertStreamMidStreamCommitFailureIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4806InsertStreamMidStreamCommitFailureIT.java
@@ -282,7 +282,8 @@ public class Issue4806InsertStreamMidStreamCommitFailureIT extends BaseGraphServ
           .hasSize(1);
       final InsertError error = summary.getErrors(0);
       assertThat(error.getRowIndex()).isEqualTo(-1);
-      assertThat(error.getCode()).isEqualTo("COMMIT_FAILED");
+      // A pre-insert contract rejection is not a commit failure: it is reported as CONTRACT_VIOLATION.
+      assertThat(error.getCode()).isEqualTo("CONTRACT_VIOLATION");
 
       // The buffered row must have been rolled back with the aborted transaction, not committed by the
       // deferred onCompleted commit running against a leaked active transaction.

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4806InsertStreamMidStreamCommitFailureIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4806InsertStreamMidStreamCommitFailureIT.java
@@ -285,6 +285,20 @@ public class Issue4806InsertStreamMidStreamCommitFailureIT extends BaseGraphServ
       // A pre-insert contract rejection is not a commit failure: it is reported as CONTRACT_VIOLATION.
       assertThat(error.getCode()).isEqualTo("CONTRACT_VIOLATION");
 
+      // The buffered row was counted as inserted before the transaction was aborted. Once abortTransaction()
+      // rolls it back it is no longer in the database, so the summary must not still report it as inserted -
+      // it must be reclassified as failed so the counts match the durable state.
+      assertThat(summary.getInserted())
+          .as("rows rolled back by the mid-stream abort must not be reported as inserted")
+          .isEqualTo(0);
+      assertThat(summary.getUpdated()).isEqualTo(0);
+      // Both rows end up not persisted: the rolled-back "Buffered" row (reclassified) and the rejected
+      // "Never" row (the structural failure). The summary balances: received == inserted + updated + failed.
+      assertThat(summary.getReceived()).isEqualTo(2);
+      assertThat(summary.getFailed())
+          .as("the rolled-back buffered row and the rejected row must both be counted as failed")
+          .isEqualTo(2);
+
       // The buffered row must have been rolled back with the aborted transaction, not committed by the
       // deferred onCompleted commit running against a leaked active transaction.
       final ExecuteQueryResponse queryResp = authenticatedStub.executeQuery(ExecuteQueryRequest.newBuilder()

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4806InsertStreamMidStreamCommitFailureIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4806InsertStreamMidStreamCommitFailureIT.java
@@ -210,4 +210,96 @@ public class Issue4806InsertStreamMidStreamCommitFailureIT extends BaseGraphServ
           .setCommand("DROP TYPE " + typeName + " IF EXISTS UNSAFE").build());
     }
   }
+
+  /**
+   * A transaction-level failure that is NOT a commit failure (here: an "options changed mid-stream"
+   * rejection) leaves the PER_BATCH transaction still active and bound to the pooled gRPC thread. It
+   * must be rolled back (not silently abandoned active), so the rows buffered in the failed
+   * transaction are not committed and the failure is reported once at the transaction level.
+   */
+  @Test
+  void midStreamContractChangeAbortsActiveTransactionAndReportsSingleError() throws Exception {
+    final String typeName = "Issue4806ContractChange_" + System.currentTimeMillis();
+
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials())
+        .setCommand("CREATE DOCUMENT TYPE " + typeName).build());
+    authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName()).setCredentials(credentials())
+        .setCommand("CREATE PROPERTY " + typeName + ".name STRING").build());
+
+    try {
+      final CountDownLatch done = new CountDownLatch(1);
+      final AtomicReference<InsertSummary> summaryRef = new AtomicReference<>();
+      final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+      final StreamObserver<InsertChunk> req = asyncAuthenticatedStub.insertStream(new StreamObserver<>() {
+        @Override public void onNext(final InsertSummary s) { summaryRef.set(s); }
+        @Override public void onError(final Throwable t) { errorRef.set(t); done.countDown(); }
+        @Override public void onCompleted() { done.countDown(); }
+      });
+
+      // PER_BATCH with the default (large) batch size keeps the first chunk's row buffered in an
+      // active, uncommitted transaction.
+      req.onNext(InsertChunk.newBuilder()
+          .setSessionId("issue-4806-contract")
+          .setChunkSeq(0)
+          .setOptions(InsertOptions.newBuilder()
+              .setDatabase(getDatabaseName())
+              .setCredentials(credentials())
+              .setTargetClass(typeName)
+              .setConflictMode(InsertOptions.ConflictMode.CONFLICT_ERROR)
+              .setTransactionMode(InsertOptions.TransactionMode.PER_BATCH)
+              .build())
+          .addRows(GrpcRecord.newBuilder().setType(typeName).putProperties("name", stringValue("Buffered")).build())
+          .build());
+
+      // Second chunk changes the target class -> contract violation -> transaction-level failure while
+      // the transaction from chunk 0 is still active.
+      req.onNext(InsertChunk.newBuilder()
+          .setSessionId("issue-4806-contract")
+          .setChunkSeq(1)
+          .setLast(true)
+          .setOptions(InsertOptions.newBuilder()
+              .setDatabase(getDatabaseName())
+              .setCredentials(credentials())
+              .setTargetClass(typeName + "_other")
+              .setConflictMode(InsertOptions.ConflictMode.CONFLICT_ERROR)
+              .setTransactionMode(InsertOptions.TransactionMode.PER_BATCH)
+              .build())
+          .addRows(GrpcRecord.newBuilder().setType(typeName).putProperties("name", stringValue("Never")).build())
+          .build());
+
+      req.onCompleted();
+
+      assertThat(done.await(30, TimeUnit.SECONDS)).as("InsertStream should terminate within 30s").isTrue();
+
+      assertThat(summaryRef.get()).as("client must receive an InsertSummary").isNotNull();
+      final InsertSummary summary = summaryRef.get();
+
+      assertThat(summary.getErrorsList())
+          .as("a mid-stream contract violation must be reported as a single transaction-level error")
+          .hasSize(1);
+      final InsertError error = summary.getErrors(0);
+      assertThat(error.getRowIndex()).isEqualTo(-1);
+      assertThat(error.getCode()).isEqualTo("COMMIT_FAILED");
+
+      // The buffered row must have been rolled back with the aborted transaction, not committed by the
+      // deferred onCompleted commit running against a leaked active transaction.
+      final ExecuteQueryResponse queryResp = authenticatedStub.executeQuery(ExecuteQueryRequest.newBuilder()
+          .setDatabase(getDatabaseName())
+          .setCredentials(credentials())
+          .setQuery("SELECT count(*) as cnt FROM " + typeName)
+          .build());
+      final long count = queryResp.getResultsList().get(0).getRecordsList().get(0)
+          .getPropertiesMap().get("cnt").getInt64Value();
+      assertThat(count)
+          .as("rows buffered in a transaction aborted mid-stream must not be committed")
+          .isEqualTo(0);
+    } finally {
+      authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+          .setDatabase(getDatabaseName()).setCredentials(credentials())
+          .setCommand("DROP TYPE " + typeName + " IF EXISTS UNSAFE").build());
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #4806. A mid-stream commit failure in `ArcadeDbGrpcService.insertStream` (e.g. a deferred unique-index violation surfacing at `db.commit()` in `PER_BATCH`/`PER_ROW` mode) was mishandled:

- The exception (which escapes `insertRows`, since per-row errors are caught row-by-row inside it) was recorded against a single context-wide row index (`ctx.received - 1`) with a generic `DB_ERROR` code, **mis-attributing a transaction-level failure to one row**.
- The `finally` kept pulling more chunks (`call.request(1)`) against the **already rolled-back transaction** (the post-commit `db.begin()` never ran). Subsequent rows then ran on the broken transaction, producing spurious `"Transaction not begun"` errors, and `onCompleted` re-raised the same on its deferred commit.

## Fix

In `insertStream`:
- Add a `streamFailed` flag, set when an exception escapes `insertRows` (a transaction-level failure).
- Record the failure **once at the transaction level** (`rowIndex = -1`, code `CONFLICT` for `DuplicatedKeyException` else `COMMIT_FAILED`) instead of mis-indexing it to a row.
- Short-circuit subsequent `onNext` chunks (drain inbound to reach `onCompleted`, but do not insert into the broken transaction).
- Skip the deferred `flushCommit` in `onCompleted` when the stream already failed (nothing left to commit), still delivering a structured `InsertSummary` (consistent with #4198 / #4214).

## Test

`Issue4806InsertStreamMidStreamCommitFailureIT` - `PER_BATCH`, `server_batch_size = 1`, UNIQUE index. A duplicate row triggers a mid-stream commit failure followed by a would-be-valid row.

Before the fix the summary contained **3** errors (mis-indexed `DB_ERROR`, a `"Transaction not begun"` `DB_ERROR` from processing the next row on the dead transaction, and a `COMMIT_FAILED` from `onCompleted`). After the fix it contains exactly **1** transaction-level error (`rowIndex == -1`, code `CONFLICT`) and the subsequent row is not inserted.

## Verification

- New IT passes; the 4 existing insertStream ITs (`Issue4198`, `Issue4214`, `Issue4644`, `Issue4656` - 21 tests) pass with no regressions.
- `grpcw` module compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)