### PR TITLE
fix(#4802): reap abandoned gRPC transactions to stop executor/transaction leak

### DIFF
--- a/docs/4802-grpc-tx-executor-leak-reaper.md
+++ b/docs/4802-grpc-tx-executor-leak-reaper.md
@@ -58,3 +58,21 @@ so the test fails; after the fix it passes.
 
 Existing `GrpcServerIT` begin/commit/rollback tests confirm no regression to the
 normal transaction lifecycle.
+
+## Review cycles
+
+- Cycle 1 (claude + gemini): both flagged the synchronous `.get()` blocking the
+  reaper thread and the "throttled WARNING" wording not matching per-transaction
+  logging; claude additionally asked for max-age and disabled-reaper test
+  coverage and a TOCTOU note. Addressed in commit 66337b09b: async rollback via
+  cooperative `shutdown()`, one summary WARNING per sweep (per-tx at FINE),
+  TOCTOU comment, plus `ArcadeDbGrpcServiceReaperTest` and
+  `GrpcTransactionMaxAgeReaperIT`.
+- Cycle 2 (re-review): gemini approved ("ready to go"); claude verified every
+  prior item resolved ("ready to merge"), with a single explicitly non-blocking
+  observation about the broad catch in the busy-loop test.
+
+## Final state
+
+Clean approval from both reviewers after 2 cycles. No outstanding actionable
+feedback.

--- a/docs/4802-grpc-tx-executor-leak-reaper.md
+++ b/docs/4802-grpc-tx-executor-leak-reaper.md
@@ -32,8 +32,11 @@ transaction to liveness.
    `reapIdleTransactions()` on a fixed delay. A transaction is reaped when it has
    been idle longer than `maxIdleMs`, or (optionally) older than `maxAgeMs`.
    Reaping atomically removes it from `activeTransactions` (`remove(key, value)`,
-   so it never races a concurrent commit/rollback), rolls it back on its own
-   dedicated thread, and shuts the executor down. A throttled WARNING is logged.
+   so it never races a concurrent commit/rollback), submits a rollback on its own
+   dedicated thread without blocking the reaper (`shutdown()` lets that rollback
+   finish before the executor terminates), and releases the executor. Each reaped
+   transaction is logged at FINE; one summary WARNING per sweep reports the count
+   reclaimed, so a burst of abandoned transactions cannot flood the log.
 3. `close()` stops the reaper first, then performs the existing drain.
 4. The thresholds are configurable through `GrpcServerPlugin`:
    - `arcadedb.grpc.tx.maxIdleMs`     (default 300000 = 5 min)

--- a/docs/4802-grpc-tx-executor-leak-reaper.md
+++ b/docs/4802-grpc-tx-executor-leak-reaper.md
@@ -1,0 +1,57 @@
+# Issue #4802 - gRPC per-transaction executor + open transaction leak (no idle reaper)
+
+## Problem
+
+`ArcadeDbGrpcService.beginTransaction` creates, per call:
+- a dedicated single-thread daemon executor (`arcadedb-tx-<id>`),
+- an open ArcadeDB transaction (holding locks/WAL),
+- a `Database` reference,
+
+all registered in `activeTransactions`. These are released only on an explicit
+`commitTransaction` / `rollbackTransaction`, or on server shutdown (`close()`).
+
+There is no association with the gRPC call lifecycle and no idle reaper, so a
+client that calls `beginTransaction` and then disconnects (crash, network drop,
+forgotten handle) leaks the executor thread, the open transaction and the
+database reference indefinitely -> resource exhaustion + lock/WAL retention.
+
+## Root cause
+
+`TransactionContext` carries no notion of when it was created or last used, and
+the service never sweeps `activeTransactions`. Nothing ties a registered
+transaction to liveness.
+
+## Fix
+
+1. `TransactionContext` now records `createdAtMs` and a `volatile lastAccessMs`,
+   with a `touch()` that refreshes `lastAccessMs`. Every lookup of an active
+   transaction (`executeCommand`, insert, batch, etc.) goes through a single
+   `lookupActiveTransaction(txId)` helper that touches the context, so genuine
+   activity keeps a transaction alive.
+2. A single daemon `ScheduledExecutorService` ("arcadedb-grpc-tx-reaper") runs
+   `reapIdleTransactions()` on a fixed delay. A transaction is reaped when it has
+   been idle longer than `maxIdleMs`, or (optionally) older than `maxAgeMs`.
+   Reaping atomically removes it from `activeTransactions` (`remove(key, value)`,
+   so it never races a concurrent commit/rollback), rolls it back on its own
+   dedicated thread, and shuts the executor down. A throttled WARNING is logged.
+3. `close()` stops the reaper first, then performs the existing drain.
+4. The thresholds are configurable through `GrpcServerPlugin`:
+   - `arcadedb.grpc.tx.maxIdleMs`     (default 300000 = 5 min)
+   - `arcadedb.grpc.tx.maxAgeMs`      (default 0 = disabled)
+   - `arcadedb.grpc.tx.reaperPeriodMs` (default 30000 = 30 s)
+   Setting both idle and age to 0 disables the reaper entirely.
+
+## Verification
+
+New integration test `GrpcTransactionReaperIT` (grpcw module):
+- configures a short idle timeout + reaper period via system properties,
+- begins a transaction and writes inside it (does not commit, simulating an
+  abandoned client),
+- asserts the active-transaction count drops back to 0 once the reaper runs,
+- asserts a later commit on the reaped id reports `committed=false`.
+
+Before the fix the transaction is never reaped (count stays 1, commit succeeds),
+so the test fails; after the fix it passes.
+
+Existing `GrpcServerIT` begin/commit/rollback tests confirm no regression to the
+normal transaction lifecycle.

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -199,6 +199,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     this.txMaxAgeMs = txMaxAgeMs;
 
     // Start the reaper only when at least one expiry bound is active and a positive period is configured.
+    // A non-positive maxIdleMs/maxAgeMs disables that individual bound; non-positive for both (or a non-positive
+    // period) disables the reaper entirely.
     if ((txMaxIdleMs > 0 || txMaxAgeMs > 0) && txReaperPeriodMs > 0) {
       this.txReaper = Executors.newSingleThreadScheduledExecutor(r -> {
         final Thread t = new Thread(r, "arcadedb-grpc-tx-reaper");
@@ -217,6 +219,13 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
    */
   int getActiveTransactionCount() {
     return activeTransactions.size();
+  }
+
+  /**
+   * Returns whether the idle-transaction reaper is running. Exposed for testing the configuration wiring.
+   */
+  boolean isIdleReaperActive() {
+    return txReaper != null;
   }
 
   /**
@@ -240,6 +249,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   private void reapIdleTransactions() {
     try {
       final long now = System.currentTimeMillis();
+      int reaped = 0;
       for (final Map.Entry<String, TransactionContext> entry : activeTransactions.entrySet()) {
         final TransactionContext ctx = entry.getValue();
         final long idleMs = now - ctx.lastAccessMs;
@@ -250,13 +260,23 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           continue;
 
         // remove(key, value) ensures only one of the reaper / commit / rollback wins the cleanup.
+        // Residual TOCTOU note: a request could lookupActiveTransaction() (touch + submit work) in the instant
+        // between the staleness read above and this remove. That window only opens for an already-idle
+        // transaction; any command already submitted to the executor still runs to completion before the
+        // asynchronous shutdown() in reapTransaction() lets the thread terminate, so no in-flight work is lost.
         if (activeTransactions.remove(entry.getKey(), ctx)) {
-          LogManager.instance().log(this, Level.WARNING,
-              "Reaping abandoned gRPC transaction txId=%s (idleMs=%s ageMs=%s): rolling back and releasing resources",
-              entry.getKey(), idleMs, ageMs);
+          LogManager.instance().log(this, Level.FINE,
+              "Reaping abandoned gRPC transaction txId=%s (idleMs=%s ageMs=%s)", entry.getKey(), idleMs, ageMs);
           reapTransaction(ctx);
+          reaped++;
         }
       }
+      // A single summary line per sweep instead of one WARNING per transaction avoids flooding the log when a
+      // burst of abandoned transactions is reclaimed at once.
+      if (reaped > 0)
+        LogManager.instance().log(this, Level.WARNING,
+            "Reaped %s abandoned gRPC transaction(s): rolled back and released their executor/database resources",
+            reaped);
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.WARNING, "Error while reaping idle gRPC transactions", e);
     }
@@ -264,7 +284,9 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
   /**
    * Rolls back the abandoned transaction on its dedicated thread (where its DatabaseContext lives) and shuts the
-   * executor down.
+   * executor down. The rollback is submitted without blocking the single reaper thread: {@code shutdown()} (not
+   * {@code shutdownNow()}) lets the just-submitted rollback run to completion before the executor terminates, so a
+   * slow rollback never stalls reclamation of the remaining transactions in the same sweep.
    */
   private void reapTransaction(final TransactionContext txCtx) {
     try {
@@ -276,10 +298,11 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
             LogManager.instance().log(this, Level.WARNING, "Failed to rollback abandoned transaction %s during reaping",
                 e, txCtx.txId);
           }
-        }).get(10, TimeUnit.SECONDS);
+        });
       }
-    } catch (final Exception e) {
-      LogManager.instance().log(this, Level.WARNING, "Error reaping abandoned transaction %s", e, txCtx.txId);
+    } catch (final RejectedExecutionException e) {
+      LogManager.instance().log(this, Level.WARNING,
+          "Could not submit rollback for abandoned transaction %s; executor already shutting down", e, txCtx.txId);
     } finally {
       txCtx.shutdown();
     }

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -98,6 +98,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -132,16 +133,28 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     final Database        db;
     final ExecutorService executor;
     final String          txId;
+    final long            createdAtMs;
+    volatile long         lastAccessMs;
 
     TransactionContext(Database db, String txId) {
       this.db = db;
       this.txId = txId;
+      this.createdAtMs = System.currentTimeMillis();
+      this.lastAccessMs = this.createdAtMs;
       // Single-thread executor ensures all tx operations happen on the same thread
       this.executor = Executors.newSingleThreadExecutor(r -> {
         Thread t = new Thread(r, "arcadedb-tx-" + txId);
         t.setDaemon(true);
         return t;
       });
+    }
+
+    /**
+     * Records that the transaction has just been used so the idle reaper does not reclaim it while a client is
+     * actively working with it.
+     */
+    void touch() {
+      this.lastAccessMs = System.currentTimeMillis();
     }
 
     void shutdown() {
@@ -163,12 +176,120 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
   private static final int DEFAULT_MAX_COMMAND_ROWS = 1000;
 
+  // Idle reaper defaults (milliseconds). A registered transaction idle longer than maxIdle, or older than maxAge
+  // (when > 0), is rolled back and released so an abandoned client cannot leak its executor thread, open
+  // transaction and database reference forever.
+  static final long DEFAULT_TX_MAX_IDLE_MS      = 300_000L; // 5 minutes
+  static final long DEFAULT_TX_MAX_AGE_MS       = 0L;       // disabled by default
+  static final long DEFAULT_TX_REAPER_PERIOD_MS = 30_000L;  // 30 seconds
+
+  private final long                     txMaxIdleMs;
+  private final long                     txMaxAgeMs;
+  private final ScheduledExecutorService txReaper;
+
   public ArcadeDbGrpcService(String databasePath, ArcadeDBServer server) {
+    this(databasePath, server, DEFAULT_TX_MAX_IDLE_MS, DEFAULT_TX_MAX_AGE_MS, DEFAULT_TX_REAPER_PERIOD_MS);
+  }
+
+  public ArcadeDbGrpcService(String databasePath, ArcadeDBServer server, final long txMaxIdleMs, final long txMaxAgeMs,
+      final long txReaperPeriodMs) {
     this.databasePath = databasePath;
     this.arcadeServer = server;
+    this.txMaxIdleMs = txMaxIdleMs;
+    this.txMaxAgeMs = txMaxAgeMs;
+
+    // Start the reaper only when at least one expiry bound is active and a positive period is configured.
+    if ((txMaxIdleMs > 0 || txMaxAgeMs > 0) && txReaperPeriodMs > 0) {
+      this.txReaper = Executors.newSingleThreadScheduledExecutor(r -> {
+        final Thread t = new Thread(r, "arcadedb-grpc-tx-reaper");
+        t.setDaemon(true);
+        return t;
+      });
+      this.txReaper.scheduleWithFixedDelay(this::reapIdleTransactions, txReaperPeriodMs, txReaperPeriodMs,
+          TimeUnit.MILLISECONDS);
+    } else {
+      this.txReaper = null;
+    }
+  }
+
+  /**
+   * Returns the active transaction count, exposed for testing and monitoring.
+   */
+  int getActiveTransactionCount() {
+    return activeTransactions.size();
+  }
+
+  /**
+   * Looks up an active transaction and refreshes its last-access timestamp so that genuine activity keeps it alive.
+   * Returns {@code null} for a blank/unknown id, preserving the previous inline behaviour.
+   */
+  private TransactionContext lookupActiveTransaction(final String txId) {
+    if (txId == null || txId.isBlank())
+      return null;
+    final TransactionContext ctx = activeTransactions.get(txId);
+    if (ctx != null)
+      ctx.touch();
+    return ctx;
+  }
+
+  /**
+   * Scans the registered transactions and reclaims any that have been idle past {@code txMaxIdleMs}, or (when
+   * configured) older than {@code txMaxAgeMs}. Each reaped transaction is removed atomically so the sweep never
+   * races a concurrent commit/rollback, then rolled back on its own dedicated thread and its executor shut down.
+   */
+  private void reapIdleTransactions() {
+    try {
+      final long now = System.currentTimeMillis();
+      for (final Map.Entry<String, TransactionContext> entry : activeTransactions.entrySet()) {
+        final TransactionContext ctx = entry.getValue();
+        final long idleMs = now - ctx.lastAccessMs;
+        final long ageMs = now - ctx.createdAtMs;
+        final boolean idleExpired = txMaxIdleMs > 0 && idleMs >= txMaxIdleMs;
+        final boolean ageExpired = txMaxAgeMs > 0 && ageMs >= txMaxAgeMs;
+        if (!idleExpired && !ageExpired)
+          continue;
+
+        // remove(key, value) ensures only one of the reaper / commit / rollback wins the cleanup.
+        if (activeTransactions.remove(entry.getKey(), ctx)) {
+          LogManager.instance().log(this, Level.WARNING,
+              "Reaping abandoned gRPC transaction txId=%s (idleMs=%s ageMs=%s): rolling back and releasing resources",
+              entry.getKey(), idleMs, ageMs);
+          reapTransaction(ctx);
+        }
+      }
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.WARNING, "Error while reaping idle gRPC transactions", e);
+    }
+  }
+
+  /**
+   * Rolls back the abandoned transaction on its dedicated thread (where its DatabaseContext lives) and shuts the
+   * executor down.
+   */
+  private void reapTransaction(final TransactionContext txCtx) {
+    try {
+      if (txCtx.db != null && txCtx.db.isOpen()) {
+        txCtx.executor.submit(() -> {
+          try {
+            txCtx.db.rollback();
+          } catch (final Exception e) {
+            LogManager.instance().log(this, Level.WARNING, "Failed to rollback abandoned transaction %s during reaping",
+                e, txCtx.txId);
+          }
+        }).get(10, TimeUnit.SECONDS);
+      }
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.WARNING, "Error reaping abandoned transaction %s", e, txCtx.txId);
+    } finally {
+      txCtx.shutdown();
+    }
   }
 
   public void close() {
+    // Stop the idle reaper first so it does not race the shutdown drain below.
+    if (txReaper != null)
+      txReaper.shutdownNow();
+
     // Close all open databases
     for (Database db : databasePool.values()) {
       try {
@@ -214,8 +335,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       final boolean hasTx = req.hasTransaction();
       final var tx = hasTx ? req.getTransaction() : null;
       final String incomingTxId = hasTx && tx != null ? tx.getTransactionId() : null;
-      final TransactionContext txCtx = incomingTxId != null && !incomingTxId.isBlank()
-          ? activeTransactions.get(incomingTxId) : null;
+      final TransactionContext txCtx = lookupActiveTransaction(incomingTxId);
 
       if (txCtx != null) {
         // External transaction - execute command on the transaction's dedicated thread
@@ -483,8 +603,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   public void createRecord(CreateRecordRequest req, StreamObserver<CreateRecordResponse> resp) {
     // Check for external transaction
     final String incomingTxId = req.hasTransaction() ? req.getTransaction().getTransactionId() : null;
-    final TransactionContext txCtx = incomingTxId != null && !incomingTxId.isBlank()
-        ? activeTransactions.get(incomingTxId) : null;
+    final TransactionContext txCtx = lookupActiveTransaction(incomingTxId);
 
     if (txCtx != null) {
       // External transaction — execute on its dedicated thread to maintain thread-local state
@@ -605,8 +724,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     // record version is tracked in that transaction. Under REPEATABLE_READ this is what lets a later write detect a
     // concurrent modification on commit, mirroring the HTTP behavior (issue #4533).
     final String incomingTxId = req.hasTransaction() ? req.getTransaction().getTransactionId() : null;
-    final TransactionContext txCtx = incomingTxId != null && !incomingTxId.isBlank()
-        ? activeTransactions.get(incomingTxId) : null;
+    final TransactionContext txCtx = lookupActiveTransaction(incomingTxId);
 
     if (txCtx != null) {
       try {
@@ -648,8 +766,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   public void updateRecord(final UpdateRecordRequest req, final StreamObserver<UpdateRecordResponse> resp) {
     // Check for external transaction
     final String incomingTxId = req.hasTransaction() ? req.getTransaction().getTransactionId() : null;
-    final TransactionContext txCtx = incomingTxId != null && !incomingTxId.isBlank()
-        ? activeTransactions.get(incomingTxId) : null;
+    final TransactionContext txCtx = lookupActiveTransaction(incomingTxId);
 
     if (txCtx != null) {
       // External transaction — execute on its dedicated thread to maintain thread-local state
@@ -812,8 +929,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   public void deleteRecord(DeleteRecordRequest req, StreamObserver<DeleteRecordResponse> resp) {
     // Check for external transaction
     final String incomingTxId = req.hasTransaction() ? req.getTransaction().getTransactionId() : null;
-    final TransactionContext txCtx = incomingTxId != null && !incomingTxId.isBlank()
-        ? activeTransactions.get(incomingTxId) : null;
+    final TransactionContext txCtx = lookupActiveTransaction(incomingTxId);
 
     if (txCtx != null) {
       // External transaction — execute on its dedicated thread to maintain thread-local state
@@ -900,8 +1016,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       final String incomingTxId = request.getTransaction().getTransactionId();
       LogManager.instance().log(this, Level.FINE, "executeQuery(): has Tx %s", incomingTxId);
 
-      final TransactionContext txCtx = incomingTxId != null && !incomingTxId.isBlank()
-          ? activeTransactions.get(incomingTxId) : null;
+      final TransactionContext txCtx = lookupActiveTransaction(incomingTxId);
       if (txCtx == null) {
         responseObserver.onError(Status.INTERNAL
             .withDescription("Query execution failed: Invalid transaction ID").asException());

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcServerPlugin.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcServerPlugin.java
@@ -86,6 +86,9 @@ public class GrpcServerPlugin implements ServerPlugin {
   private static final String CONFIG_COMPRESSION_ENABLED = CONFIG_PREFIX + "compression.enabled";
   private static final String CONFIG_COMPRESSION_FORCE   = CONFIG_PREFIX + "compression.force";
   private static final String CONFIG_COMPRESSION_TYPE    = CONFIG_PREFIX + "compression.type";
+  private static final String CONFIG_TX_MAX_IDLE_MS      = CONFIG_PREFIX + "tx.maxIdleMs";
+  private static final String CONFIG_TX_MAX_AGE_MS       = CONFIG_PREFIX + "tx.maxAgeMs";
+  private static final String CONFIG_TX_REAPER_PERIOD_MS = CONFIG_PREFIX + "tx.reaperPeriodMs";
 
   @Override
   public void configure(ArcadeDBServer server, ContextConfiguration configuration) {
@@ -201,8 +204,15 @@ public class GrpcServerPlugin implements ServerPlugin {
     // Get database directory path
     String databasePath = arcadeServer.getRootPath() + File.separator + "databases";
 
+    // Idle-transaction reaper thresholds (issue #4802): reclaim abandoned transactions left open by clients that
+    // disconnected without committing or rolling back.
+    final long txMaxIdleMs = getConfigLong(config, CONFIG_TX_MAX_IDLE_MS, ArcadeDbGrpcService.DEFAULT_TX_MAX_IDLE_MS);
+    final long txMaxAgeMs = getConfigLong(config, CONFIG_TX_MAX_AGE_MS, ArcadeDbGrpcService.DEFAULT_TX_MAX_AGE_MS);
+    final long txReaperPeriodMs = getConfigLong(config, CONFIG_TX_REAPER_PERIOD_MS,
+        ArcadeDbGrpcService.DEFAULT_TX_REAPER_PERIOD_MS);
+
     // Create the main service and store reference for cleanup
-    this.grpcService = new ArcadeDbGrpcService(databasePath, arcadeServer);
+    this.grpcService = new ArcadeDbGrpcService(databasePath, arcadeServer, txMaxIdleMs, txMaxAgeMs, txReaperPeriodMs);
 
     // Add the main service
     serverBuilder.addService(grpcService);
@@ -383,6 +393,13 @@ public class GrpcServerPlugin implements ServerPlugin {
   }
 
   /**
+   * Returns the underlying gRPC service instance (used for monitoring and testing).
+   */
+  public ArcadeDbGrpcService getService() {
+    return grpcService;
+  }
+
+  /**
    * Get the status of the gRPC servers
    */
   public ServerStatus getStatus() {
@@ -408,6 +425,19 @@ public class GrpcServerPlugin implements ServerPlugin {
         return Integer.parseInt(value);
       } catch (NumberFormatException e) {
         LogManager.instance().log(this, Level.WARNING, "Invalid integer value for %s: %s", key, value);
+      }
+    }
+    return defaultValue;
+  }
+
+  private long getConfigLong(ContextConfiguration config, String key, long defaultValue) {
+
+    String value = getConfigString(config, key, null);
+    if (value != null) {
+      try {
+        return Long.parseLong(value.trim());
+      } catch (NumberFormatException e) {
+        LogManager.instance().log(this, Level.WARNING, "Invalid long value for %s: %s", key, value);
       }
     }
     return defaultValue;

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/ArcadeDbGrpcServiceReaperTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/ArcadeDbGrpcServiceReaperTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit test for the idle-transaction reaper configuration wiring of {@link ArcadeDbGrpcService} (issue #4802).
+ * No server is required: the constructor only decides whether to start the reaper thread based on the thresholds.
+ */
+public class ArcadeDbGrpcServiceReaperTest {
+
+  @Test
+  void reaperDisabledWhenBothBoundsNonPositive() {
+    final ArcadeDbGrpcService service = new ArcadeDbGrpcService("/tmp/notused", null, 0L, 0L, 30_000L);
+    try {
+      assertThat(service.isIdleReaperActive()).isFalse();
+      assertThat(service.getActiveTransactionCount()).isZero();
+    } finally {
+      service.close();
+    }
+  }
+
+  @Test
+  void reaperDisabledWhenPeriodNonPositive() {
+    final ArcadeDbGrpcService service = new ArcadeDbGrpcService("/tmp/notused", null, 1_000L, 1_000L, 0L);
+    try {
+      assertThat(service.isIdleReaperActive()).isFalse();
+    } finally {
+      service.close();
+    }
+  }
+
+  @Test
+  void reaperEnabledWithIdleBoundOnly() {
+    final ArcadeDbGrpcService service = new ArcadeDbGrpcService("/tmp/notused", null, 1_000L, 0L, 500L);
+    try {
+      assertThat(service.isIdleReaperActive()).isTrue();
+    } finally {
+      service.close();
+    }
+  }
+
+  @Test
+  void reaperEnabledWithAgeBoundOnly() {
+    final ArcadeDbGrpcService service = new ArcadeDbGrpcService("/tmp/notused", null, 0L, 1_000L, 500L);
+    try {
+      assertThat(service.isIdleReaperActive()).isTrue();
+    } finally {
+      service.close();
+    }
+  }
+
+  @Test
+  void defaultConstructorEnablesReaper() {
+    final ArcadeDbGrpcService service = new ArcadeDbGrpcService("/tmp/notused", null);
+    try {
+      assertThat(service.isIdleReaperActive()).isTrue();
+    } finally {
+      service.close();
+    }
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcTransactionMaxAgeReaperIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcTransactionMaxAgeReaperIT.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.ServerPlugin;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4802 covering the max-age expiry path: with the idle bound disabled, a transaction that
+ * is kept continuously busy must still be reaped once it exceeds the configured maximum age. This guarantees an
+ * upper bound on how long any single gRPC transaction can hold resources, independent of client activity.
+ */
+public class GrpcTransactionMaxAgeReaperIT extends BaseGraphServerTest {
+
+  private static final int GRPC_PORT = 50051;
+
+  private static final String MAX_AGE_MS       = "2000";
+  private static final String REAPER_PERIOD_MS = "300";
+
+  private static final Metadata.Key<String> USER_HEADER     =
+      Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER =
+      Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER =
+      Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  private ManagedChannel                                  channel;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub authenticatedStub;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+    // Disable the idle bound so only the max-age bound can trigger reaping; keep the period short and fast.
+    System.setProperty("arcadedb.grpc.tx.maxIdleMs", "0");
+    System.setProperty("arcadedb.grpc.tx.maxAgeMs", MAX_AGE_MS);
+    System.setProperty("arcadedb.grpc.tx.reaperPeriodMs", REAPER_PERIOD_MS);
+  }
+
+  @BeforeEach
+  void setupGrpcClient() {
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    final Channel authenticatedChannel = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+    authenticatedStub = ArcadeDbServiceGrpc.newBlockingStub(authenticatedChannel);
+  }
+
+  @AfterEach
+  void teardownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+    System.clearProperty("arcadedb.grpc.tx.maxIdleMs");
+    System.clearProperty("arcadedb.grpc.tx.maxAgeMs");
+    System.clearProperty("arcadedb.grpc.tx.reaperPeriodMs");
+  }
+
+  private class AuthClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(final MethodDescriptor<ReqT, RespT> method,
+        final CallOptions callOptions, final Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<>(next.newCall(method, callOptions)) {
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata headers) {
+          headers.put(USER_HEADER, "root");
+          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
+          headers.put(DATABASE_HEADER, getDatabaseName());
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+
+  private DatabaseCredentials credentials() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  private ArcadeDbGrpcService grpcService() {
+    for (final ServerPlugin plugin : getServer(0).getPlugins()) {
+      if (plugin instanceof GrpcServerPlugin grpcPlugin)
+        return grpcPlugin.getService();
+    }
+    throw new IllegalStateException("GrpcServerPlugin not found");
+  }
+
+  @Test
+  void busyTransactionIsReapedOnceItExceedsMaxAge() throws InterruptedException {
+    final ArcadeDbGrpcService service = grpcService();
+
+    final BeginTransactionResponse beginResponse = authenticatedStub.beginTransaction(BeginTransactionRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(credentials())
+        .build());
+    final String txId = beginResponse.getTransactionId();
+    assertThat(txId).isNotEmpty();
+    assertThat(service.getActiveTransactionCount()).isEqualTo(1);
+
+    // Keep the transaction continuously busy (touching lastAccess every iteration). Because the idle bound is
+    // disabled, only the max-age bound can reclaim it - which it must, despite the constant activity.
+    final TransactionContext txRef = TransactionContext.newBuilder().setTransactionId(txId).build();
+    final long deadline = System.currentTimeMillis() + 30_000L;
+    while (service.getActiveTransactionCount() > 0 && System.currentTimeMillis() < deadline) {
+      try {
+        authenticatedStub.executeCommand(ExecuteCommandRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setCommand("INSERT INTO Person SET name = 'Busy " + txId + "'")
+            .setTransaction(txRef)
+            .build());
+      } catch (final Exception ignore) {
+        // Once the transaction has been reaped, a command on its id is no longer part of that transaction; ignore.
+      }
+      Thread.sleep(150);
+    }
+
+    assertThat(service.getActiveTransactionCount())
+        .as("transaction must be reaped once it exceeds the configured max age, even while busy")
+        .isEqualTo(0);
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcTransactionReaperIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcTransactionReaperIT.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.ServerPlugin;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4802: an abandoned gRPC transaction (the client begins a transaction and then
+ * disconnects without committing or rolling back) must be reclaimed by the idle reaper, releasing the dedicated
+ * executor thread, the open ArcadeDB transaction and the database reference.
+ */
+public class GrpcTransactionReaperIT extends BaseGraphServerTest {
+
+  private static final int GRPC_PORT = 50051;
+
+  // Short reaper windows so the test stays fast and deterministic.
+  private static final String MAX_IDLE_MS      = "1500";
+  private static final String REAPER_PERIOD_MS = "300";
+
+  private static final Metadata.Key<String> USER_HEADER     =
+      Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER =
+      Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER =
+      Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  private ManagedChannel                                       channel;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub      authenticatedStub;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+    // The gRPC plugin reads these via ContextConfiguration, which falls back to system properties.
+    System.setProperty("arcadedb.grpc.tx.maxIdleMs", MAX_IDLE_MS);
+    System.setProperty("arcadedb.grpc.tx.reaperPeriodMs", REAPER_PERIOD_MS);
+  }
+
+  @BeforeEach
+  void setupGrpcClient() {
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    final Channel authenticatedChannel = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+    authenticatedStub = ArcadeDbServiceGrpc.newBlockingStub(authenticatedChannel);
+  }
+
+  @AfterEach
+  void teardownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+    System.clearProperty("arcadedb.grpc.tx.maxIdleMs");
+    System.clearProperty("arcadedb.grpc.tx.reaperPeriodMs");
+  }
+
+  private class AuthClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(final MethodDescriptor<ReqT, RespT> method,
+        final CallOptions callOptions, final Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<>(next.newCall(method, callOptions)) {
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata headers) {
+          headers.put(USER_HEADER, "root");
+          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
+          headers.put(DATABASE_HEADER, getDatabaseName());
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+
+  private DatabaseCredentials credentials() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  private ArcadeDbGrpcService grpcService() {
+    for (final ServerPlugin plugin : getServer(0).getPlugins()) {
+      if (plugin instanceof GrpcServerPlugin grpcPlugin)
+        return grpcPlugin.getService();
+    }
+    throw new IllegalStateException("GrpcServerPlugin not found");
+  }
+
+  @Test
+  void abandonedTransactionIsReaped() throws InterruptedException {
+    final ArcadeDbGrpcService service = grpcService();
+
+    // Begin a transaction the way a client would, then write inside it but never commit/rollback.
+    final BeginTransactionRequest beginRequest = BeginTransactionRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(credentials())
+        .build();
+
+    final BeginTransactionResponse beginResponse = authenticatedStub.beginTransaction(beginRequest);
+    final String txId = beginResponse.getTransactionId();
+    assertThat(txId).isNotEmpty();
+
+    final ExecuteCommandRequest insertRequest = ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(credentials())
+        .setCommand("INSERT INTO Person SET name = 'Abandoned " + txId + "'")
+        .setTransaction(TransactionContext.newBuilder().setTransactionId(txId).build())
+        .build();
+    authenticatedStub.executeCommand(insertRequest);
+
+    // The transaction is now registered and open.
+    assertThat(service.getActiveTransactionCount()).isEqualTo(1);
+
+    // Simulate an abandoned client: do not commit, do not rollback, do not touch the transaction again.
+    // The reaper must reclaim it once it has been idle past the configured threshold.
+    final long deadline = System.currentTimeMillis() + 30_000L;
+    while (service.getActiveTransactionCount() > 0 && System.currentTimeMillis() < deadline)
+      Thread.sleep(100);
+
+    assertThat(service.getActiveTransactionCount())
+        .as("abandoned transaction must be reaped by the idle reaper")
+        .isEqualTo(0);
+
+    // A late commit attempt on the reaped id must report it as already gone (idempotent no-op).
+    final CommitTransactionRequest commitRequest = CommitTransactionRequest.newBuilder()
+        .setCredentials(credentials())
+        .setTransaction(TransactionContext.newBuilder().setTransactionId(txId).setDatabase(getDatabaseName()).build())
+        .build();
+    final CommitTransactionResponse commitResponse = authenticatedStub.commitTransaction(commitRequest);
+    assertThat(commitResponse.getCommitted()).isFalse();
+
+    // The uncommitted write must not have been persisted.
+    final ExecuteQueryRequest queryRequest = ExecuteQueryRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(credentials())
+        .setQuery("SELECT FROM Person WHERE name = 'Abandoned " + txId + "'")
+        .build();
+    final ExecuteQueryResponse queryResponse = authenticatedStub.executeQuery(queryRequest);
+    assertThat(queryResponse.getResultsList().get(0).getRecordsList()).isEmpty();
+  }
+}


### PR DESCRIPTION
## Issue

Closes #4802

`ArcadeDbGrpcService.beginTransaction` creates, per call, a dedicated single-thread daemon executor, an open ArcadeDB transaction (holding locks/WAL) and a `Database` reference, all registered in `activeTransactions`. They are released only on an explicit `commitTransaction`/`rollbackTransaction` or on server shutdown. There is no tie to the gRPC call lifecycle and no idle reaper, so a client that begins a transaction and then disconnects leaks the thread, the open transaction and the database reference indefinitely -> resource exhaustion and lock/WAL retention.

## Fix

- `TransactionContext` now records `createdAtMs` and a `volatile lastAccessMs`, with a `touch()` that refreshes last-access. Every active-transaction lookup in the service goes through a single `lookupActiveTransaction(txId)` helper that touches the context, so genuine client activity keeps a transaction alive.
- A single daemon `ScheduledExecutorService` (`arcadedb-grpc-tx-reaper`) runs on a fixed delay and reclaims any transaction idle past `maxIdleMs`, or older than `maxAgeMs` when configured. Reaping removes the entry atomically with `remove(key, value)` (so it never races a concurrent commit/rollback), rolls the transaction back on its own dedicated thread, and shuts the executor down. A throttled WARNING is logged.
- `close()` stops the reaper before the existing drain.
- Thresholds are configurable through `GrpcServerPlugin`:
  - `arcadedb.grpc.tx.maxIdleMs` (default `300000` = 5 min)
  - `arcadedb.grpc.tx.maxAgeMs` (default `0` = disabled)
  - `arcadedb.grpc.tx.reaperPeriodMs` (default `30000` = 30 s)
  - setting both idle and age to `0` disables the reaper entirely.

## Tests

New `GrpcTransactionReaperIT` (grpcw): begins a transaction, writes inside it, then abandons it (no commit/rollback, no further touches) and asserts the active-transaction count returns to `0`, that a late commit on the reaped id reports `committed=false`, and that the uncommitted write was not persisted.

- Confirmed RED before the fix (count stays `1`).
- GREEN after the fix.
- No regression: `GrpcServerIT` (30) and `ArcadeDbGrpcServiceCoverageIT` (35) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)