### PR TITLE
fix(#4804): count in-band gRPC executeCommand failures as errors

### DIFF
--- a/docs/4804-grpc-executecommand-error-status.md
+++ b/docs/4804-grpc-executecommand-error-status.md
@@ -1,0 +1,63 @@
+# Issue #4804 - gRPC `executeCommand` failures counted as successes (status OK)
+
+## Summary
+
+`ArcadeDbGrpcService.executeCommand` reports execution failures *in-band* as
+`ExecuteCommandResponse{success=false}` and then closes the RPC with `onCompleted()`, so the
+gRPC status is `OK`. `GrpcMetricsInterceptor` keyed its error counter off `!status.isOk()`, so
+every command failure was counted as a success and error observability for the most-used RPC
+was broken.
+
+## Root cause
+
+Two layers report command failures in-band:
+- `ArcadeDbGrpcService.executeCommandInternal` catches every exception and returns a
+  `success=false` response (rolls back if needed).
+- `ArcadeDbGrpcService.executeCommand`'s outer catch likewise replies with `success=false` via
+  `onNext`/`onCompleted`.
+
+Both terminate the RPC with status `OK`, and `GrpcMetricsInterceptor.close` only incremented the
+error counter when `!status.isOk()`.
+
+## Why not the issue's suggested `onError` change
+
+The issue suggests surfacing failures via `resp.onError(Status.INTERNAL…)`. That would change the
+RPC contract from in-band `success=false` to a gRPC error status. Two existing tests pin the
+current in-band contract and would break:
+- `GrpcServerIT.executeCommandInvalidSqlReturnsError` - asserts invalid SQL returns
+  `success=false` (status OK).
+- `Issue4794GrpcPerDbAuthorizationIT.crossDatabaseCommandIsDenied` - asserts a denied
+  cross-database command returns `success=false` with an access-denied message.
+
+Repo policy is to never modify or delete existing tests. The fix therefore targets the locus of
+the reported impact (the metrics counter) and leaves the in-band response contract intact, so all
+existing tests stay green while the observability defect is corrected.
+
+## Fix
+
+`GrpcMetricsInterceptor`:
+- Override `sendMessage` on the wrapped `ServerCall` to detect an in-band command failure
+  (`ExecuteCommandResponse.success == false`).
+- In `close`, increment the error counter when `!status.isOk()` **or** an in-band failure was
+  observed.
+- Added package-private `getErrorCount()` / `getRequestCount()` test seams so error accounting can
+  be verified without reflection.
+
+## Tests
+
+`Issue4804GrpcCommandErrorMetricsTest` (new unit test):
+- `inBandCommandFailureWithStatusOkIsCountedAsError` - a `success=false` response followed by a
+  `Status.OK` close increments the error counter (fails before the fix, passes after).
+- `successfulCommandWithStatusOkIsNotCountedAsError` - a `success=true` response with `Status.OK`
+  is not counted as an error.
+- `nonOkStatusIsStillCountedAsError` - pre-existing non-OK accounting is preserved.
+
+## Affected components
+
+- `grpcw` module: `com.arcadedb.server.grpc.GrpcMetricsInterceptor`
+
+## Impact
+
+Restores error observability for the most-used gRPC RPC: command failures are now counted as
+errors by the metrics interceptor even though the response is still reported in-band as
+`success=false` (preserving the existing client-facing contract).

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcMetricsInterceptor.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcMetricsInterceptor.java
@@ -69,11 +69,25 @@ class GrpcMetricsInterceptor implements ServerInterceptor {
     requestCounter.increment();
 
     ServerCall<ReqT, RespT> wrappedCall = new ForwardingServerCall.SimpleForwardingServerCall<ReqT, RespT>(call) {
+      private boolean inBandFailure = false;
+
+      @Override
+      public void sendMessage(RespT message) {
+        // executeCommand reports execution failures in-band as ExecuteCommandResponse.success=false
+        // while still closing the RPC with status OK (unlike executeQuery/createRecord, which call
+        // onError). Without this check every command failure would be counted as a success. Detect
+        // the in-band failure here so it is reflected in the error counter at close() time.
+        if (message instanceof ExecuteCommandResponse response && !response.getSuccess())
+          inBandFailure = true;
+
+        super.sendMessage(message);
+      }
+
       @Override
       public void close(Status status, Metadata trailers) {
         sample.stop(requestTimer);
 
-        if (!status.isOk()) {
+        if (!status.isOk() || inBandFailure) {
           errorCounter.increment();
         }
 
@@ -86,5 +100,21 @@ class GrpcMetricsInterceptor implements ServerInterceptor {
     };
 
     return next.startCall(wrappedCall, headers);
+  }
+
+  /**
+   * Current value of the gRPC error counter. Exposed for testing so that error accounting
+   * (including in-band command failures reported as ExecuteCommandResponse.success=false) can be
+   * verified without reflection.
+   */
+  double getErrorCount() {
+    return errorCounter.count();
+  }
+
+  /**
+   * Current value of the gRPC request counter. Exposed for testing.
+   */
+  double getRequestCount() {
+    return requestCounter.count();
   }
 }

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcMetricsInterceptor.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcMetricsInterceptor.java
@@ -69,7 +69,9 @@ class GrpcMetricsInterceptor implements ServerInterceptor {
     requestCounter.increment();
 
     ServerCall<ReqT, RespT> wrappedCall = new ForwardingServerCall.SimpleForwardingServerCall<ReqT, RespT>(call) {
-      private boolean inBandFailure = false;
+      // gRPC may invoke sendMessage and close on different threads, so publish the flag with
+      // volatile to guarantee the value written in sendMessage is visible in close.
+      private volatile boolean inBandFailure = false;
 
       @Override
       public void sendMessage(RespT message) {

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4804GrpcCommandErrorMetricsTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4804GrpcCommandErrorMetricsTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.server.ArcadeDBServer;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.Status;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression test for issue #4804.
+ * <p>
+ * {@code ArcadeDbGrpcService.executeCommand} reports execution failures in-band as
+ * {@code ExecuteCommandResponse.success=false} while still closing the RPC with gRPC status
+ * {@code OK} (unlike {@code executeQuery}/{@code createRecord}, which call {@code onError}).
+ * {@code GrpcMetricsInterceptor} previously keyed its error counter solely off {@code !status.isOk()},
+ * so every command failure was counted as a success and error observability for the most-used RPC
+ * was broken.
+ * <p>
+ * These tests pin that the interceptor now counts an in-band command failure as an error even when
+ * the gRPC status is OK, while a successful command is not counted as an error.
+ */
+class Issue4804GrpcCommandErrorMetricsTest {
+
+  private GrpcMetricsInterceptor                interceptor;
+  private ServerCall<Object, Object>            mockCall;
+  private ServerCallHandler<Object, Object>     mockHandler;
+  private MethodDescriptor<Object, Object>      mockMethodDescriptor;
+  private Metadata                              headers;
+
+  @BeforeEach
+  @SuppressWarnings("unchecked")
+  void setUp() {
+    final ArcadeDBServer mockServer = mock(ArcadeDBServer.class);
+    interceptor = new GrpcMetricsInterceptor(mockServer);
+    mockCall = mock(ServerCall.class);
+    mockHandler = mock(ServerCallHandler.class);
+    mockMethodDescriptor = mock(MethodDescriptor.class);
+    headers = new Metadata();
+
+    when(mockCall.getMethodDescriptor()).thenReturn(mockMethodDescriptor);
+    when(mockMethodDescriptor.getFullMethodName())
+        .thenReturn("com.arcadedb.grpc.ArcadeDbService/ExecuteCommand");
+  }
+
+  @SuppressWarnings("unchecked")
+  private ServerCall<Object, Object> wrappedCall() {
+    final ArgumentCaptor<ServerCall<Object, Object>> callCaptor = ArgumentCaptor.forClass(ServerCall.class);
+    interceptor.interceptCall(mockCall, headers, mockHandler);
+    verify(mockHandler).startCall(callCaptor.capture(), any());
+    return callCaptor.getValue();
+  }
+
+  @Test
+  void inBandCommandFailureWithStatusOkIsCountedAsError() {
+    final ServerCall<Object, Object> wrapped = wrappedCall();
+
+    // executeCommand emits a success=false response and then closes the RPC with status OK.
+    final ExecuteCommandResponse failure = ExecuteCommandResponse.newBuilder()
+        .setSuccess(false)
+        .setMessage("SQL syntax error")
+        .build();
+    wrapped.sendMessage(failure);
+    wrapped.close(Status.OK, new Metadata());
+
+    // Even though the gRPC status is OK, the command failure must be counted as an error.
+    assertThat(interceptor.getErrorCount()).isEqualTo(1.0);
+  }
+
+  @Test
+  void successfulCommandWithStatusOkIsNotCountedAsError() {
+    final ServerCall<Object, Object> wrapped = wrappedCall();
+
+    final ExecuteCommandResponse success = ExecuteCommandResponse.newBuilder()
+        .setSuccess(true)
+        .setMessage("OK")
+        .build();
+    wrapped.sendMessage(success);
+    wrapped.close(Status.OK, new Metadata());
+
+    assertThat(interceptor.getErrorCount()).isEqualTo(0.0);
+  }
+
+  @Test
+  void nonOkStatusIsStillCountedAsError() {
+    final ServerCall<Object, Object> wrapped = wrappedCall();
+
+    // Pre-existing behaviour: a non-OK status (e.g. from executeQuery onError) is an error.
+    wrapped.close(Status.INTERNAL, new Metadata());
+
+    assertThat(interceptor.getErrorCount()).isEqualTo(1.0);
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4804GrpcCommandErrorMetricsTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4804GrpcCommandErrorMetricsTest.java
@@ -92,6 +92,8 @@ class Issue4804GrpcCommandErrorMetricsTest {
 
     // Even though the gRPC status is OK, the command failure must be counted as an error.
     assertThat(interceptor.getErrorCount()).isEqualTo(1.0);
+    // A failed command is still one request.
+    assertThat(interceptor.getRequestCount()).isEqualTo(1.0);
   }
 
   @Test


### PR DESCRIPTION
## Issue

Fixes #4804.

`ArcadeDbGrpcService.executeCommand` reports execution failures *in-band* as
`ExecuteCommandResponse{success=false}` and then closes the RPC with `onCompleted()`, so the gRPC
status is `OK`. `GrpcMetricsInterceptor` keyed its error counter off `!status.isOk()`, so every
command failure was counted as a success and error observability for the most-used RPC was broken.

## Approach

The issue suggests switching `executeCommand` to `resp.onError(Status.INTERNAL…)`. That would change
the contract from in-band `success=false` to a gRPC error status and **break two existing tests**
that pin the current contract:

- `GrpcServerIT.executeCommandInvalidSqlReturnsError` - asserts invalid SQL returns `success=false`
  (status OK).
- `Issue4794GrpcPerDbAuthorizationIT.crossDatabaseCommandIsDenied` - asserts a denied cross-database
  command returns `success=false` with an access-denied message.

Per repo policy (never modify or delete existing tests), the fix instead targets the locus of the
reported impact - the metrics counter - and leaves the in-band response contract intact. All
existing tests stay green while the observability defect is corrected.

## Fix

`GrpcMetricsInterceptor`:
- Override `sendMessage` on the wrapped `ServerCall` to detect an in-band command failure
  (`ExecuteCommandResponse.success == false`).
- In `close`, increment the error counter when `!status.isOk()` **or** an in-band failure was
  observed.
- Added package-private `getErrorCount()` / `getRequestCount()` test seams.

## Tests

New unit test `Issue4804GrpcCommandErrorMetricsTest`:
- `inBandCommandFailureWithStatusOkIsCountedAsError` - a `success=false` response then a `Status.OK`
  close increments the error counter (fails before the fix, passes after).
- `successfulCommandWithStatusOkIsNotCountedAsError` - a `success=true` response with `Status.OK` is
  not counted as an error.
- `nonOkStatusIsStillCountedAsError` - pre-existing non-OK accounting is preserved.

Verified green: new unit test + existing `GrpcMetricsInterceptorTest`, `GrpcQueryMetricsIT`,
`GrpcStreamMetricsIT`, `GrpcServerIT#executeCommandInvalidSqlReturnsError`, and
`Issue4794GrpcPerDbAuthorizationIT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)