### PR TITLE
fix(#4803): bound gRPC result materialization and worker busy-wait (DoS)

### DIFF
--- a/docs/4803-grpc-unbounded-result-materialization.md
+++ b/docs/4803-grpc-unbounded-result-materialization.md
@@ -149,3 +149,39 @@ after upgrade. **This must be surfaced in the release notes / upgrade guide, not
 ### Verification (post-cycle-2)
 - `Issue4803GrpcResultBoundingIT` 5/5 (adds the disabled-cap opt-out test).
 - `Issue4803WaitUntilReadyTimeoutTest` 3/3.
+
+## Review cycle 3 (claude + gemini-code-assist)
+
+Claude re-surfaced the write-timeout client-status gap and asked for it to be resolved before merge
+(escalated from a deferred follow-up). Acted on it this cycle.
+
+### Applied
+- **Explicit `DEADLINE_EXCEEDED` on a server-induced write timeout (claude #1, previously deferred).**
+  A server timeout previously set the shared `cancelled` flag and the stream loop returned with no
+  terminal status, leaving a healthy-but-slow client blocked until its own deadline - the exact "stream
+  silently stops" symptom a DoS feature should not create. Introduced a per-call `serverTimedOut`
+  `AtomicBoolean`, threaded from `streamQuery` through `streamCursor`/`streamMaterialized`/`streamPaged`
+  into `waitUntilReady`, which now sets it (alongside `cancelled`) only on the deadline path - never on a
+  genuine client cancel. `streamQuery`'s cancelled branch surfaces `Status.DEADLINE_EXCEEDED` (before the
+  best-effort rollback, so the client is signaled even if rollback throws) when `serverTimedOut` is set,
+  and stays silent for a real client cancel (transport already tearing down). Single terminal preserved:
+  the catch block only emits when `!cancelled.get()`, so there is no double-terminal.
+
+### Not actioned (with rationale)
+- **gemini line-1690 `currentTimeMillis` (3rd identical post).** Still stale - the method has used a
+  monotonic `nanoTime` deadline since cycle 1; gemini re-posts its whole original review each push.
+- **`MATERIALIZE_ALL` 1M default may still spike heap (claude #2).** Deliberate tradeoff, "no change
+  strictly required"; the default is the operator's tuning call and is documented with its rationale.
+- **Boundary-semantics one-row asymmetry, poll granularity, test-config/port nits (claude).** All
+  confirmed harmless / convention-matching; not worth a behavior change.
+
+### Known test gap
+The `DEADLINE_EXCEEDED` emission is not covered by an end-to-end IT: deterministically forcing
+`ServerCallStreamObserver.isReady()` to stay false against a real client transport is not feasible in
+this harness (the same reason the original PR unit-tested only the `awaitTransportReady` helper). The
+threading and the helper's deadline logic are covered by `Issue4803WaitUntilReadyTimeoutTest` (3/3) plus
+the full stream-path regression (no regressions).
+
+### Verification (post-cycle-3)
+- `Issue4803GrpcResultBoundingIT` 5/5, `Issue4803WaitUntilReadyTimeoutTest` 3/3.
+- Regression: `GrpcStreamMetricsIT` 1/1, `Issue4197GrpcExecuteQueryResultSetLeakIT` 1/1 - no regressions.

--- a/docs/4803-grpc-unbounded-result-materialization.md
+++ b/docs/4803-grpc-unbounded-result-materialization.md
@@ -69,3 +69,47 @@ pre-existing `ha-raft` `ClusterMonitorTest` test-compile error on main HEAD.
   cap (`RESOURCE_EXHAUSTED`), `streamQuery` catch preserves explicit gRPC status,
   `waitUntilReady` bounded by deadline via new `awaitTransportReady` helper.
 - `grpcw/.../Issue4803GrpcResultBoundingIT.java` (new), `grpcw/.../Issue4803WaitUntilReadyTimeoutTest.java` (new).
+
+## Review cycle 1 (claude + gemini-code-assist)
+
+Both bots reviewed the initial PR head. Applied the gating items; deferred lower-priority notes.
+
+### Applied
+- **Unary cap is now a hard ceiling that fails loudly (gemini security-medium #1 + claude #1).**
+  The unary `executeQuery` previously let an explicit oversized `limit` bypass the cap, and when no
+  limit was given it *silently* truncated at the cap with no signal to the client (inconsistent with
+  the `MATERIALIZE_ALL` path and a backward-incompatible silent data loss). It now honors an explicit
+  limit only when it is at or below the configured cap, and a result that would exceed the cap fails
+  with `RESOURCE_EXHAUSTED` (same status, message style, and "use a LIMIT / CURSOR / PAGED" guidance as
+  the stream path). The `RESOURCE_EXHAUSTED` is thrown before any response emission, so no partial
+  batch or `ResultSet` leak. The transaction-path catch in `executeQuery` now also preserves an
+  explicit `StatusRuntimeException` instead of masking it as `INTERNAL`.
+- **Monotonic deadline in `awaitTransportReady` (gemini #2).** Switched from
+  `System.currentTimeMillis() + timeoutMs` to a `System.nanoTime()` elapsed-since-start comparison:
+  immune to wall-clock adjustments and free of the addition overflow for large timeouts.
+- **`0` documented as a second "unlimited" value (claude #3).** Both row-cap config descriptions now
+  say "Set to -1 or 0 for unlimited"; the unary description also states the hard-ceiling /
+  `RESOURCE_EXHAUSTED` semantics.
+- **New tests (claude test gap + gemini #1).** `Issue4803GrpcResultBoundingIT` now asserts that a
+  limitless query over a too-large result fails with `RESOURCE_EXHAUSTED`, and adds
+  `unaryExecuteQueryWithExplicitLimitLargerThanCapFailsWithResourceExhausted` locking in that an
+  oversized explicit limit cannot bypass the ceiling. The smaller-than-cap honored-limit test is kept.
+
+### Deferred / not actioned (with rationale)
+- **Explicit client status on the write-timeout path (claude #4).** On deadline expiry
+  `waitUntilReady` sets the shared `cancelled` flag, so a server-side timeout and a real client cancel
+  are indistinguishable to the stream loop and the client gets no explicit `DEADLINE_EXCEEDED`. Surfacing
+  a distinct status requires separating the two signals and is a larger, separable change; deferred as a
+  follow-up. The per-sweep WARNING log already gives operators visibility.
+- **Off-by-one between the two caps (claude #2).** No longer applies on the unary side - the new unary
+  path never materializes beyond the ceiling before failing (it checks `count >= configuredMax &&
+  resultSet.hasNext()`). The `MATERIALIZE_ALL` path keeps its existing "max + 1 buffered then throw"
+  behavior; both are safe and a one-row buffer difference is not worth a behavior change to the stream path.
+- **1 ms poll granularity in `awaitTransportReady` (claude #5).** Unchanged - only the total wait is now
+  bounded; the poll cadence matches prior behavior and was flagged for completeness, not as a defect.
+
+### Verification (post-review)
+- `Issue4803GrpcResultBoundingIT` 4/4 (includes the two new cap-failure tests; server log shows the
+  `RESOURCE_EXHAUSTED` unary cap-breach).
+- `Issue4803WaitUntilReadyTimeoutTest` 3/3 (monotonic-deadline change).
+- Regression: `GrpcStreamMetricsIT` 1/1, `Issue4197GrpcExecuteQueryResultSetLeakIT` 1/1 - no regressions.

--- a/docs/4803-grpc-unbounded-result-materialization.md
+++ b/docs/4803-grpc-unbounded-result-materialization.md
@@ -185,3 +185,39 @@ the full stream-path regression (no regressions).
 ### Verification (post-cycle-3)
 - `Issue4803GrpcResultBoundingIT` 5/5, `Issue4803WaitUntilReadyTimeoutTest` 3/3.
 - Regression: `GrpcStreamMetricsIT` 1/1, `Issue4197GrpcExecuteQueryResultSetLeakIT` 1/1 - no regressions.
+
+## Review cycle 4 (claude + gemini-code-assist) - final
+
+Claude's re-review verified correctness across the board (unary cap boundary, ResultSet lifecycle,
+single-terminal, status propagation) and concluded "**Nothing here is blocking**". This is the last cycle
+in the `--max-cycles=4` budget.
+
+### Applied
+- **Bail out immediately after a write-timeout (claude #2).** `waitUntilReady` flags
+  `cancelled`/`serverTimedOut` but does not itself return, so `streamCursor`/`streamPaged`/`streamMaterialized`
+  would convert and (no-op) emit one more row/batch before the loop-top `cancelled` check caught it. Added an
+  explicit `if (cancelled.get()) return;` right after each `waitUntilReady` call so an aborted stream stops
+  promptly without the wasted work - the right posture for a DoS-protection path.
+
+### Not actioned (with rationale)
+- **gemini line-1710 `currentTimeMillis` (4th identical post).** Stale - `awaitTransportReady` has used a
+  monotonic `nanoTime` deadline since cycle 1; gemini re-posts its entire original review on every push.
+- **Hoist `getValueAsLong()` out of the per-row `waitUntilReady` call (claude #4, optional).** It is a cached
+  field read (negligible per claude); hoisting would thread `timeoutMs` through three helper signatures for no
+  measurable gain. Skipped deliberately.
+- **Unit test for the `serverTimedOut` flag wiring via a stub `ServerCallStreamObserver` (claude #3, optional).**
+  The deterministic deadline logic already lives in the unit-tested `awaitTransportReady`; the flag flip in
+  `waitUntilReady` is a two-line glue. A full stub observer (many abstract methods) is disproportionate to that
+  glue. Left as the acknowledged e2e gap.
+- **100k unary default / release notes (claude #1).** Default tuning and release-note placement are the
+  maintainer's call; the breaking change is documented in the "BREAKING CHANGE" section above.
+
+### Verification (post-cycle-4)
+- `Issue4803GrpcResultBoundingIT` 5/5, `Issue4803WaitUntilReadyTimeoutTest` 3/3.
+- Regression: `GrpcStreamMetricsIT` 1/1, `Issue4197GrpcExecuteQueryResultSetLeakIT` 1/1 - no regressions.
+
+## Final state
+
+`max-cycles-reached` (4/4) with a clean approval from claude on the final commit and no outstanding blocking
+feedback. Remaining gemini item is stale; remaining claude items are optional/deferred with rationale above.
+Merge remains the developer's responsibility.

--- a/docs/4803-grpc-unbounded-result-materialization.md
+++ b/docs/4803-grpc-unbounded-result-materialization.md
@@ -113,3 +113,39 @@ Both bots reviewed the initial PR head. Applied the gating items; deferred lower
   `RESOURCE_EXHAUSTED` unary cap-breach).
 - `Issue4803WaitUntilReadyTimeoutTest` 3/3 (monotonic-deadline change).
 - Regression: `GrpcStreamMetricsIT` 1/1, `Issue4197GrpcExecuteQueryResultSetLeakIT` 1/1 - no regressions.
+
+## Review cycle 2 (claude + gemini-code-assist)
+
+Claude's re-review was an approval with nits ("clean, well-tested DoS hardening"); gemini re-posted
+its cycle-1 review verbatim.
+
+### Applied
+- **Config rationale for the 100k vs 1M asymmetry (claude).** The unary cap description now explains it
+  is lower than `grpcStreamMaxMaterializedRows` because the unary response is a single gRPC message
+  (also bounded by the max message size), whereas StreamQuery emits incrementally.
+- **Disabled-path regression test (claude).** Added `unaryExecuteQueryWithCapDisabledReturnsAllRows`:
+  sets the cap to `-1` and asserts the limitless query returns the full result (well past the former
+  ceiling) without `RESOURCE_EXHAUSTED`, locking in that the opt-out does not silently regress.
+
+### Not actioned (with rationale)
+- **gemini line-1690 `System.currentTimeMillis()` re-flag.** Stale: `awaitTransportReady` was already
+  converted to a monotonic `System.nanoTime()` deadline in cycle 1, and gemini's suggested replacement
+  is functionally identical to the current code. The only `currentTimeMillis` token left in that method
+  is inside an explanatory comment. No change.
+- **`count >= configuredMax && resultSet.hasNext()` double-evaluates `hasNext()` (claude minor).**
+  Idempotent for `ResultSet`; harmless, not worth restructuring.
+- **Write-timeout path conflates server deadline with client cancel (claude).** Confirmed conscious gap,
+  already deferred in cycle 1; the per-sweep WARNING gives operators visibility.
+- **Timing-based / hardcoded-port test notes (claude).** Bounds are generous and the port matches the
+  existing gRPC IT convention; no change.
+
+### BREAKING CHANGE - for release/upgrade notes
+The unary `ExecuteQuery` change is **backward-incompatible by design**: a limitless query whose result
+exceeds `arcadedb.server.grpcQueryMaxResultRows` (default 100000) now fails with `RESOURCE_EXHAUSTED`
+instead of returning everything. This is the correct DoS posture (loud failure over silent truncation)
+and is opt-out via `-1`/`0`, but clients running large limitless unary gRPC queries will get hard errors
+after upgrade. **This must be surfaced in the release notes / upgrade guide, not only in this doc.**
+
+### Verification (post-cycle-2)
+- `Issue4803GrpcResultBoundingIT` 5/5 (adds the disabled-cap opt-out test).
+- `Issue4803WaitUntilReadyTimeoutTest` 3/3.

--- a/docs/4803-grpc-unbounded-result-materialization.md
+++ b/docs/4803-grpc-unbounded-result-materialization.md
@@ -1,0 +1,71 @@
+# Issue #4803 - gRPC unbounded result materialization + busy-wait on the worker thread (DoS)
+
+URL: https://github.com/ArcadeData/arcadedb/issues/4803
+Type: bug (`fix`)
+
+## Problem
+
+`ArcadeDbGrpcService` has three unbounded paths that let slow or limitless gRPC
+clients pin worker threads / exhaust heap (DoS):
+
+1. **`waitUntilReady`** spins `Thread.sleep(1)` with no deadline while the client
+   transport stays not-ready. A slow/abandoned stream pins the gRPC worker thread
+   (and the open `ResultSet`/transaction) forever.
+2. **`streamMaterialized`** (retrieval mode `MATERIALIZE_ALL`) buffers the entire
+   result set into an `ArrayList<GrpcRecord>` before emitting anything - unbounded heap.
+3. **Unary `executeQuery`** builds the full result into one response unless
+   `request.getLimit() > 0` - unbounded heap.
+
+## Root cause
+
+No upper bound on busy-wait duration, materialized buffer size, or unary result
+row count.
+
+## Fix
+
+Three server-scoped `GlobalConfiguration` knobs (each with a DoS-protection
+default; `-1` opts back into the legacy unbounded behaviour):
+
+- `arcadedb.server.grpcQueryMaxResultRows` (Integer, default 100000) - caps unary
+  `ExecuteQuery` when the request gives no positive `limit`.
+- `arcadedb.server.grpcStreamMaxMaterializedRows` (Integer, default 1000000) - caps
+  `MATERIALIZE_ALL` buffering; exceeding fails the call with `RESOURCE_EXHAUSTED`
+  so the client falls back to `CURSOR`/`PAGED` streaming.
+- `arcadedb.server.grpcStreamWriteTimeoutMs` (Long, default 60000) - bounds how long
+  `waitUntilReady` blocks for transport readiness before aborting the stream
+  (sets the cancelled flag so the surrounding loop rolls back and releases the
+  `ResultSet`/transaction).
+
+The busy-wait logic is extracted into a package-private static helper
+`awaitTransportReady(BooleanSupplier, AtomicBoolean, long)` so the deadline is
+unit-testable without a real stalled transport.
+
+## Tests
+
+- `grpcw` `Issue4803GrpcResultBoundingIT` (extends `BaseGraphServerTest`):
+  - unary `ExecuteQuery` with no limit is capped at the configured max rows
+  - `MATERIALIZE_ALL` stream over a too-large result fails with `RESOURCE_EXHAUSTED`
+- `grpcw` `Issue4803WaitUntilReadyTimeoutTest` (plain unit test):
+  - `awaitTransportReady` returns `false` after the deadline when never ready
+  - returns `true` immediately when ready
+  - returns `false` promptly when already cancelled
+
+## Verification
+
+- `Issue4803WaitUntilReadyTimeoutTest`: 3/3 pass.
+- `Issue4803GrpcResultBoundingIT`: 3/3 pass (server log confirms the
+  `RESOURCE_EXHAUSTED` cap-breach for `MATERIALIZE_ALL`).
+- Regression check on the affected existing gRPC paths - no failures:
+  - `GrpcStreamMetricsIT` 1/1, `Issue4197GrpcExecuteQueryResultSetLeakIT` 1/1,
+    `ArcadeDbGrpcServiceExtendedTest` 26/26.
+
+Build scoped to `engine` (install) + `grpcw` (test) to avoid the unrelated
+pre-existing `ha-raft` `ClusterMonitorTest` test-compile error on main HEAD.
+
+## Files changed
+
+- `engine/.../GlobalConfiguration.java` - three new SERVER-scoped gRPC knobs.
+- `grpcw/.../ArcadeDbGrpcService.java` - unary `executeQuery` cap, `streamMaterialized`
+  cap (`RESOURCE_EXHAUSTED`), `streamQuery` catch preserves explicit gRPC status,
+  `waitUntilReady` bounded by deadline via new `awaitTransportReady` helper.
+- `grpcw/.../Issue4803GrpcResultBoundingIT.java` (new), `grpcw/.../Issue4803WaitUntilReadyTimeoutTest.java` (new).

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -655,8 +655,10 @@ public enum GlobalConfiguration {
       Hard ceiling on the number of rows the gRPC unary ExecuteQuery materializes. A request limit at or below \
       this cap is honored; a result that would exceed it fails the call with RESOURCE_EXHAUSTED (consistent with \
       the StreamQuery MATERIALIZE_ALL path) rather than silently truncating, and a client cannot bypass it with a \
-      larger limit. Bounds heap usage and protects against limitless-query DoS. Set to -1 or 0 for unlimited \
-      (WARNING: removes DoS protection). Default is 100000.""",
+      larger limit. Bounds heap usage and protects against limitless-query DoS. The default is lower than \
+      grpcStreamMaxMaterializedRows because the unary response is built and returned as a single gRPC message \
+      (also bounded by the max inbound/outbound message size), whereas StreamQuery emits incrementally. \
+      Set to -1 or 0 for unlimited (WARNING: removes DoS protection). Default is 100000.""",
       Integer.class, 100_000),
 
   SERVER_GRPC_STREAM_MAX_MATERIALIZED_ROWS("arcadedb.server.grpcStreamMaxMaterializedRows", SCOPE.SERVER,

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -652,16 +652,18 @@ public enum GlobalConfiguration {
   // SERVER gRPC
   SERVER_GRPC_QUERY_MAX_RESULT_ROWS("arcadedb.server.grpcQueryMaxResultRows", SCOPE.SERVER,
       """
-      Maximum number of rows the gRPC unary ExecuteQuery returns when the request specifies no positive limit. \
-      Bounds heap usage and protects against limitless-query DoS by capping the materialized response. \
-      Set to -1 for unlimited (WARNING: removes DoS protection). Default is 100000.""",
+      Hard ceiling on the number of rows the gRPC unary ExecuteQuery materializes. A request limit at or below \
+      this cap is honored; a result that would exceed it fails the call with RESOURCE_EXHAUSTED (consistent with \
+      the StreamQuery MATERIALIZE_ALL path) rather than silently truncating, and a client cannot bypass it with a \
+      larger limit. Bounds heap usage and protects against limitless-query DoS. Set to -1 or 0 for unlimited \
+      (WARNING: removes DoS protection). Default is 100000.""",
       Integer.class, 100_000),
 
   SERVER_GRPC_STREAM_MAX_MATERIALIZED_ROWS("arcadedb.server.grpcStreamMaxMaterializedRows", SCOPE.SERVER,
       """
       Maximum number of rows the gRPC StreamQuery MATERIALIZE_ALL retrieval mode buffers in memory before \
       emitting. Exceeding the cap fails the call with RESOURCE_EXHAUSTED so clients fall back to CURSOR/PAGED \
-      streaming instead of running the server out of memory. Set to -1 for unlimited (WARNING: removes DoS \
+      streaming instead of running the server out of memory. Set to -1 or 0 for unlimited (WARNING: removes DoS \
       protection). Default is 1000000.""",
       Integer.class, 1_000_000),
 

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -649,6 +649,30 @@ public enum GlobalConfiguration {
       "Maximum size in bytes for HTTP request body content. Set to -1 for unlimited size (WARNING: removes DoS protection). Default is 100MB",
       Long.class, 100L * 1024 * 1024), // 100MB DEFAULT
 
+  // SERVER gRPC
+  SERVER_GRPC_QUERY_MAX_RESULT_ROWS("arcadedb.server.grpcQueryMaxResultRows", SCOPE.SERVER,
+      """
+      Maximum number of rows the gRPC unary ExecuteQuery returns when the request specifies no positive limit. \
+      Bounds heap usage and protects against limitless-query DoS by capping the materialized response. \
+      Set to -1 for unlimited (WARNING: removes DoS protection). Default is 100000.""",
+      Integer.class, 100_000),
+
+  SERVER_GRPC_STREAM_MAX_MATERIALIZED_ROWS("arcadedb.server.grpcStreamMaxMaterializedRows", SCOPE.SERVER,
+      """
+      Maximum number of rows the gRPC StreamQuery MATERIALIZE_ALL retrieval mode buffers in memory before \
+      emitting. Exceeding the cap fails the call with RESOURCE_EXHAUSTED so clients fall back to CURSOR/PAGED \
+      streaming instead of running the server out of memory. Set to -1 for unlimited (WARNING: removes DoS \
+      protection). Default is 1000000.""",
+      Integer.class, 1_000_000),
+
+  SERVER_GRPC_STREAM_WRITE_TIMEOUT_MS("arcadedb.server.grpcStreamWriteTimeoutMs", SCOPE.SERVER,
+      """
+      Maximum time in milliseconds a gRPC StreamQuery worker waits for the client transport to become ready to \
+      accept the next batch before aborting the stream. Prevents a slow or abandoned client from pinning the \
+      worker thread (and the open ResultSet/transaction) indefinitely. Set to -1 to wait forever (WARNING: \
+      removes DoS protection). Default is 60000 (60s).""",
+      Long.class, 60_000L),
+
   // SERVER WS
   SERVER_WS_EVENT_BUS_QUEUE_SIZE("arcadedb.server.eventBusQueueSize", SCOPE.SERVER,
       "Size of the queue used as a buffer for unserviced database change events.", Integer.class, 1000),

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server.grpc;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.ProtocolContext;
 import com.arcadedb.database.DatabaseContext;
@@ -102,6 +103,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 
@@ -981,6 +983,12 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         // Process results
         int count = 0;
 
+        // Bound the materialized response. An explicit positive limit always wins; otherwise fall back to
+        // the configured cap so a limitless query cannot build an unbounded response and exhaust heap (DoS).
+        final int requestedLimit = request.getLimit();
+        final int configuredMax = GlobalConfiguration.SERVER_GRPC_QUERY_MAX_RESULT_ROWS.getValueAsInteger();
+        final int effectiveLimit = requestedLimit > 0 ? requestedLimit : configuredMax; // <= 0 means unlimited
+
         LogManager.instance().log(this, Level.FINE, "executeQuery(): resultSet.size = %s",
             resultSet.getExactSizeIfKnown());
 
@@ -1001,8 +1009,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
           count++;
 
-          // Apply limit if specified
-          if (request.getLimit() > 0 && count >= request.getLimit()) {
+          // Apply the effective limit (explicit request limit, or the configured DoS-protection cap).
+          if (effectiveLimit > 0 && count >= effectiveLimit) {
             break;
           }
         }
@@ -1348,7 +1356,12 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       }
 
       if (!cancelled.get()) {
-        responseObserver.onError(Status.INTERNAL.withDescription("Stream query failed: " + e.getMessage()).asException());
+        // Preserve an explicit gRPC status (e.g. RESOURCE_EXHAUSTED from the MATERIALIZE_ALL cap) instead of
+        // masking it as INTERNAL; only genuinely unexpected failures are reported as INTERNAL.
+        if (e instanceof StatusRuntimeException sre)
+          responseObserver.onError(sre);
+        else
+          responseObserver.onError(Status.INTERNAL.withDescription("Stream query failed: " + e.getMessage()).asException());
       }
     } finally {
       // Stream endpoints mix engine iteration and row serialization throughout; expose the
@@ -1442,6 +1455,11 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
     final List<GrpcRecord> all = new ArrayList<>();
 
+    // MATERIALIZE_ALL buffers the whole result before emitting, so bound it: a limitless query in this mode
+    // would otherwise build an unbounded list and exhaust heap (DoS). Exceeding the cap fails the call with
+    // RESOURCE_EXHAUSTED so the client can fall back to CURSOR/PAGED streaming.
+    final int maxMaterializedRows = GlobalConfiguration.SERVER_GRPC_STREAM_MAX_MATERIALIZED_ROWS.getValueAsInteger();
+
     try (ResultSet rs = db.query(language, request.getQuery(),
         GrpcTypeConverter.convertParameters(request.getParametersMap()))) {
 
@@ -1463,6 +1481,13 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
           }
 
           all.add(rb.build());
+        }
+
+        if (maxMaterializedRows > 0 && all.size() > maxMaterializedRows) {
+          throw Status.RESOURCE_EXHAUSTED
+              .withDescription("MATERIALIZE_ALL result exceeds the maximum of " + maxMaterializedRows
+                  + " buffered rows (arcadedb.server.grpcStreamMaxMaterializedRows); use CURSOR or PAGED retrieval mode for large results")
+              .asRuntimeException();
         }
       }
     }
@@ -1599,21 +1624,46 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   }
 
   private void waitUntilReady(ServerCallStreamObserver<?> scso, AtomicBoolean cancelled) {
-    // Skip if you're okay with best-effort pushes; otherwise honor transport
-    // readiness
-    if (scso.isReady())
-      return;
-    while (!scso.isReady()) {
+    // Honor transport readiness, but bound the wait: a slow or abandoned client must not pin this worker
+    // thread (and the open ResultSet/transaction) indefinitely.
+    final long timeoutMs = GlobalConfiguration.SERVER_GRPC_STREAM_WRITE_TIMEOUT_MS.getValueAsLong();
+    if (!awaitTransportReady(scso::isReady, cancelled, timeoutMs)) {
+      // Not ready: either the caller already cancelled, or we hit the deadline / were interrupted. In the
+      // latter case mark the stream cancelled so the surrounding loop stops, rolls back, and releases the
+      // ResultSet/transaction instead of busy-waiting forever.
+      if (!cancelled.get()) {
+        cancelled.set(true);
+        LogManager.instance().log(this, Level.WARNING,
+            "gRPC stream aborted: client transport not ready within %d ms (slow or abandoned consumer)", timeoutMs);
+      }
+    }
+  }
+
+  /**
+   * Waits for {@code ready} to report {@code true}, bounded by {@code timeoutMs}. Returns {@code true} only if
+   * the transport became ready; returns {@code false} if {@code cancelled} is set, the deadline elapses, or the
+   * thread is interrupted. A non-positive {@code timeoutMs} means wait indefinitely (legacy behavior).
+   *
+   * <p>Extracted from {@link #waitUntilReady} so the deadline can be unit-tested without a live gRPC transport.
+   */
+  static boolean awaitTransportReady(final BooleanSupplier ready, final AtomicBoolean cancelled, final long timeoutMs) {
+    if (ready.getAsBoolean())
+      return true;
+    final long deadline = timeoutMs > 0 ? System.currentTimeMillis() + timeoutMs : Long.MAX_VALUE;
+    while (!ready.getAsBoolean()) {
       if (cancelled.get())
-        return;
+        return false;
+      if (System.currentTimeMillis() >= deadline)
+        return false;
       // avoid burning CPU:
       try {
         Thread.sleep(1);
-      } catch (InterruptedException ie) {
+      } catch (final InterruptedException ie) {
         Thread.currentThread().interrupt();
-        return;
+        return false;
       }
     }
+    return true;
   }
 
   // --- 1) Unary bulk ---

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -918,9 +918,16 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         responseObserver.onCompleted();
       } catch (Exception e) {
         final Throwable cause = e instanceof ExecutionException && e.getCause() != null ? e.getCause() : e;
-        LogManager.instance().log(this, Level.SEVERE, "Error executing query: %s", cause, cause.getMessage());
-        responseObserver.onError(Status.INTERNAL
-            .withDescription("Query execution failed: " + cause.getMessage()).asException());
+        if (cause instanceof StatusRuntimeException sre) {
+          // Preserve an explicit gRPC status (e.g. RESOURCE_EXHAUSTED from the result cap, or the
+          // authz/authn status from getDatabase) instead of masking it as INTERNAL.
+          LogManager.instance().log(this, Level.FINE, "Query rejected: %s", sre, sre.getMessage());
+          responseObserver.onError(sre);
+        } else {
+          LogManager.instance().log(this, Level.SEVERE, "Error executing query: %s", cause, cause.getMessage());
+          responseObserver.onError(Status.INTERNAL
+              .withDescription("Query execution failed: " + cause.getMessage()).asException());
+        }
       }
       return;
     }
@@ -983,11 +990,16 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         // Process results
         int count = 0;
 
-        // Bound the materialized response. An explicit positive limit always wins; otherwise fall back to
-        // the configured cap so a limitless query cannot build an unbounded response and exhaust heap (DoS).
+        // Bound the materialized response. An explicit positive limit at or below the configured cap is the
+        // client's own bound and is honored silently. The configured cap (when > 0) is otherwise a HARD ceiling:
+        // a client cannot bypass DoS protection by requesting a larger limit, and a result that exceeds the cap
+        // fails loudly with RESOURCE_EXHAUSTED - consistent with the MATERIALIZE_ALL stream path - instead of
+        // silently truncating and dropping data without telling the caller.
         final int requestedLimit = request.getLimit();
         final int configuredMax = GlobalConfiguration.SERVER_GRPC_QUERY_MAX_RESULT_ROWS.getValueAsInteger();
-        final int effectiveLimit = requestedLimit > 0 ? requestedLimit : configuredMax; // <= 0 means unlimited
+        final boolean capEnabled = configuredMax > 0;
+        // The client's explicit limit applies as its own bound only when it does not exceed the hard ceiling.
+        final boolean clientLimitWithinCap = requestedLimit > 0 && (!capEnabled || requestedLimit <= configuredMax);
 
         LogManager.instance().log(this, Level.FINE, "executeQuery(): resultSet.size = %s",
             resultSet.getExactSizeIfKnown());
@@ -1009,10 +1021,17 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
           count++;
 
-          // Apply the effective limit (explicit request limit, or the configured DoS-protection cap).
-          if (effectiveLimit > 0 && count >= effectiveLimit) {
+          // Honor the client's explicit limit (guaranteed not to exceed the hard ceiling).
+          if (clientLimitWithinCap && count >= requestedLimit)
             break;
-          }
+
+          // Hard ceiling reached with more rows still available: fail loudly so the caller is never silently
+          // truncated and cannot bypass the cap with an oversized limit.
+          if (capEnabled && count >= configuredMax && resultSet.hasNext())
+            throw Status.RESOURCE_EXHAUSTED
+                .withDescription("ExecuteQuery result exceeds the maximum of " + configuredMax
+                    + " rows (arcadedb.server.grpcQueryMaxResultRows); add a LIMIT or use StreamQuery with CURSOR/PAGED retrieval mode for large results")
+                .asRuntimeException();
         }
         profile.addEngineNanos(System.nanoTime() - engineStart - serializationAccum);
 
@@ -1649,11 +1668,15 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   static boolean awaitTransportReady(final BooleanSupplier ready, final AtomicBoolean cancelled, final long timeoutMs) {
     if (ready.getAsBoolean())
       return true;
-    final long deadline = timeoutMs > 0 ? System.currentTimeMillis() + timeoutMs : Long.MAX_VALUE;
+    // Use a monotonic clock for the deadline: System.nanoTime() is immune to wall-clock adjustments (NTP/manual)
+    // and the elapsed-since-start comparison avoids the overflow a large System.currentTimeMillis()+timeoutMs sum
+    // could otherwise produce.
+    final long startNanos = System.nanoTime();
+    final long timeoutNanos = timeoutMs > 0 ? TimeUnit.MILLISECONDS.toNanos(timeoutMs) : Long.MAX_VALUE;
     while (!ready.getAsBoolean()) {
       if (cancelled.get())
         return false;
-      if (System.currentTimeMillis() >= deadline)
+      if (timeoutMs > 0 && (System.nanoTime() - startNanos) >= timeoutNanos)
         return false;
       // avoid burning CPU:
       try {

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -1432,6 +1432,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
         if (cancelled.get())
           return;
         waitUntilReady(scso, cancelled, serverTimedOut);
+        // The wait may have just flagged a server timeout (or observed a client cancel); bail out before
+        // converting/emitting another row against an aborted stream.
+        if (cancelled.get())
+          return;
 
         Result r = rs.next();
 
@@ -1534,6 +1538,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       if (cancelled.get())
         return;
       waitUntilReady(scso, cancelled, serverTimedOut);
+      // The wait may have just flagged a server timeout (or observed a client cancel); bail out before
+      // building/emitting another batch against an aborted stream.
+      if (cancelled.get())
+        return;
 
       int end = Math.min(i + batchSize, all.size());
       QueryResult.Builder b = QueryResult.newBuilder();
@@ -1563,6 +1571,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       if (cancelled.get())
         return;
       waitUntilReady(scso, cancelled, serverTimedOut);
+      // The wait may have just flagged a server timeout (or observed a client cancel); bail out before
+      // running/emitting another page against an aborted stream.
+      if (cancelled.get())
+        return;
 
       Map<String, Object> params = new HashMap<>(GrpcTypeConverter.convertParameters(request.getParametersMap()));
       params.put("_skip", offset);

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -1288,6 +1288,9 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     QueryProfile.pushCurrent(profile);
     final long engineStart = System.nanoTime();
     final AtomicBoolean cancelled = new AtomicBoolean(false);
+    // Distinguishes a server-induced write timeout (we gave up on a healthy-but-slow client) from a genuine
+    // client cancel: only the former should surface an explicit DEADLINE_EXCEEDED terminal to the client.
+    final AtomicBoolean serverTimedOut = new AtomicBoolean(false);
 
     Database db = null;
     boolean beganHere = false;
@@ -1317,20 +1320,35 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       // --- Dispatch on mode (helpers do NOT manage transactions) ---
       // PAGED mode uses SQL-specific SKIP/LIMIT wrapping, so fall back to CURSOR for non-SQL languages
       switch (request.getRetrievalMode()) {
-        case MATERIALIZE_ALL -> streamMaterialized(db, request, batchSize, scso, cancelled, projectionConfig, language);
+        case MATERIALIZE_ALL -> streamMaterialized(db, request, batchSize, scso, cancelled, serverTimedOut, projectionConfig, language);
         case PAGED -> {
           if (!"sql".equalsIgnoreCase(language))
-            streamCursor(db, request, batchSize, scso, cancelled, projectionConfig, language);
+            streamCursor(db, request, batchSize, scso, cancelled, serverTimedOut, projectionConfig, language);
           else
-            streamPaged(db, request, batchSize, scso, cancelled, projectionConfig, language);
+            streamPaged(db, request, batchSize, scso, cancelled, serverTimedOut, projectionConfig, language);
         }
-        case CURSOR -> streamCursor(db, request, batchSize, scso, cancelled, projectionConfig, language);
-        default -> streamCursor(db, request, batchSize, scso, cancelled, projectionConfig, language);
+        case CURSOR -> streamCursor(db, request, batchSize, scso, cancelled, serverTimedOut, projectionConfig, language);
+        default -> streamCursor(db, request, batchSize, scso, cancelled, serverTimedOut, projectionConfig, language);
       }
 
       // If the client cancelled mid-stream, choose rollback unless caller explicitly
       // asked to commit/rollback.
       if (cancelled.get()) {
+        // A server-induced write timeout is not a client cancel: the client transport is healthy, we gave up
+        // on it. Surface an explicit DEADLINE_EXCEEDED first (before the best-effort rollback, so the client is
+        // always signaled even if rollback fails) so it fails fast instead of blocking on its own deadline. A
+        // genuine client cancel needs no terminal - its transport is already tearing down.
+        if (serverTimedOut.get()) {
+          final long timeoutMs = GlobalConfiguration.SERVER_GRPC_STREAM_WRITE_TIMEOUT_MS.getValueAsLong();
+          try {
+            scso.onError(Status.DEADLINE_EXCEEDED
+                .withDescription("gRPC stream aborted: client transport not ready within " + timeoutMs
+                    + " ms (arcadedb.server.grpcStreamWriteTimeoutMs); slow or abandoned consumer")
+                .asRuntimeException());
+          } catch (final StatusRuntimeException ignore) {
+            // transport may have closed concurrently; the terminal is already moot
+          }
+        }
         if (hasTx) {
           if (tx.getRollback()) {
             db.rollback();
@@ -1340,7 +1358,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
             db.rollback(); // safe default on cancellation
           }
         }
-        return; // don't call onCompleted()
+        return; // terminal already sent (DEADLINE_EXCEEDED) or intentionally omitted (client cancel)
       }
 
       // --- TX end (normal path) — precedence: rollback > commit > begin-only ⇒
@@ -1399,7 +1417,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
    */
   private void streamCursor(Database db, StreamQueryRequest request, int batchSize,
                             ServerCallStreamObserver<QueryResult> scso,
-                            AtomicBoolean cancelled, ProjectionConfig projectionConfig, String language) {
+                            AtomicBoolean cancelled, AtomicBoolean serverTimedOut, ProjectionConfig projectionConfig, String language) {
 
     long running = 0L;
 
@@ -1413,7 +1431,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
         if (cancelled.get())
           return;
-        waitUntilReady(scso, cancelled);
+        waitUntilReady(scso, cancelled, serverTimedOut);
 
         Result r = rs.next();
 
@@ -1470,7 +1488,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
    */
   private void streamMaterialized(Database db, StreamQueryRequest request, int batchSize,
                                   ServerCallStreamObserver<QueryResult> scso,
-                                  AtomicBoolean cancelled, ProjectionConfig projectionConfig, String language) {
+                                  AtomicBoolean cancelled, AtomicBoolean serverTimedOut, ProjectionConfig projectionConfig, String language) {
 
     final List<GrpcRecord> all = new ArrayList<>();
 
@@ -1515,7 +1533,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     for (int i = 0; i < all.size(); i += batchSize) {
       if (cancelled.get())
         return;
-      waitUntilReady(scso, cancelled);
+      waitUntilReady(scso, cancelled, serverTimedOut);
 
       int end = Math.min(i + batchSize, all.size());
       QueryResult.Builder b = QueryResult.newBuilder();
@@ -1535,7 +1553,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
    */
   private void streamPaged(Database db, StreamQueryRequest request, int batchSize,
                            ServerCallStreamObserver<QueryResult> scso,
-                           AtomicBoolean cancelled, ProjectionConfig projectionConfig, String language) {
+                           AtomicBoolean cancelled, AtomicBoolean serverTimedOut, ProjectionConfig projectionConfig, String language) {
 
     final String pagedSql = wrapWithSkipLimit(request.getQuery()); // see helper below
     int offset = 0;
@@ -1544,7 +1562,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     while (true) {
       if (cancelled.get())
         return;
-      waitUntilReady(scso, cancelled);
+      waitUntilReady(scso, cancelled, serverTimedOut);
 
       Map<String, Object> params = new HashMap<>(GrpcTypeConverter.convertParameters(request.getParametersMap()));
       params.put("_skip", offset);
@@ -1642,15 +1660,17 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     }
   }
 
-  private void waitUntilReady(ServerCallStreamObserver<?> scso, AtomicBoolean cancelled) {
+  private void waitUntilReady(ServerCallStreamObserver<?> scso, AtomicBoolean cancelled, AtomicBoolean serverTimedOut) {
     // Honor transport readiness, but bound the wait: a slow or abandoned client must not pin this worker
     // thread (and the open ResultSet/transaction) indefinitely.
     final long timeoutMs = GlobalConfiguration.SERVER_GRPC_STREAM_WRITE_TIMEOUT_MS.getValueAsLong();
     if (!awaitTransportReady(scso::isReady, cancelled, timeoutMs)) {
       // Not ready: either the caller already cancelled, or we hit the deadline / were interrupted. In the
       // latter case mark the stream cancelled so the surrounding loop stops, rolls back, and releases the
-      // ResultSet/transaction instead of busy-waiting forever.
+      // ResultSet/transaction instead of busy-waiting forever, and flag it as a server-induced timeout so the
+      // caller surfaces an explicit DEADLINE_EXCEEDED to the client rather than silently dropping the stream.
       if (!cancelled.get()) {
+        serverTimedOut.set(true);
         cancelled.set(true);
         LogManager.instance().log(this, Level.WARNING,
             "gRPC stream aborted: client transport not ready within %d ms (slow or abandoned consumer)", timeoutMs);

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4803GrpcResultBoundingIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4803GrpcResultBoundingIT.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+/**
+ * Regression test for issue #4803: gRPC unbounded result materialization. The unary {@code ExecuteQuery}
+ * used to build the full result into one response when the request gave no positive {@code limit}, and the
+ * {@code StreamQuery} {@code MATERIALIZE_ALL} retrieval mode buffered the entire result set into memory before
+ * emitting anything. A limitless query against a large type could exhaust heap (DoS).
+ *
+ * <p>The fix bounds both paths with server-scoped configuration:
+ * <ul>
+ *   <li>{@code arcadedb.server.grpcQueryMaxResultRows} caps the unary {@code ExecuteQuery} when no positive
+ *       limit is given;</li>
+ *   <li>{@code arcadedb.server.grpcStreamMaxMaterializedRows} caps {@code MATERIALIZE_ALL} buffering and fails
+ *       the call with {@code RESOURCE_EXHAUSTED} when exceeded.</li>
+ * </ul>
+ */
+public class Issue4803GrpcResultBoundingIT extends BaseGraphServerTest {
+
+  private static final int GRPC_PORT = 50051;
+
+  private static final int MAX_QUERY_ROWS       = 5;
+  private static final int MAX_MATERIALIZED_ROWS = 5;
+  private static final int ROWS_INSERTED         = 40;
+
+  private static final Metadata.Key<String> USER_HEADER     = Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER = Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER = Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  private ManagedChannel                                 channel;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub authenticatedStub;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+    // Tight caps so the bound is reached with a small, fast dataset.
+    GlobalConfiguration.SERVER_GRPC_QUERY_MAX_RESULT_ROWS.setValue(MAX_QUERY_ROWS);
+    GlobalConfiguration.SERVER_GRPC_STREAM_MAX_MATERIALIZED_ROWS.setValue(MAX_MATERIALIZED_ROWS);
+  }
+
+  @BeforeEach
+  void setupGrpcClient() {
+    // Seed enough rows to exceed both caps.
+    final Database db = getServerDatabase(0, getDatabaseName());
+    db.transaction(() -> {
+      for (int i = 0; i < ROWS_INSERTED; i++)
+        db.newVertex(VERTEX1_TYPE_NAME).set("id", 1000L + i).save();
+    });
+
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    final Channel authenticatedChannel = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+    authenticatedStub = ArcadeDbServiceGrpc.newBlockingStub(authenticatedChannel);
+  }
+
+  @AfterEach
+  void shutdownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+    GlobalConfiguration.SERVER_GRPC_QUERY_MAX_RESULT_ROWS.reset();
+    GlobalConfiguration.SERVER_GRPC_STREAM_MAX_MATERIALIZED_ROWS.reset();
+  }
+
+  private class AuthClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        final MethodDescriptor<ReqT, RespT> method, final CallOptions callOptions, final Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata headers) {
+          headers.put(USER_HEADER, "root");
+          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
+          headers.put(DATABASE_HEADER, getDatabaseName());
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+
+  private DatabaseCredentials credentials() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  @Test
+  void unaryExecuteQueryWithoutLimitIsCapped() {
+    final ExecuteQueryResponse response = authenticatedStub.executeQuery(
+        ExecuteQueryRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setQuery("SELECT FROM " + VERTEX1_TYPE_NAME) // deliberately no LIMIT
+            .build());
+
+    assertThat(response.getResultsList()).isNotEmpty();
+    final int returned = response.getResults(0).getRecordsCount();
+
+    // The dataset is larger than the cap, so a limitless query must be bounded to the configured max.
+    assertThat(returned)
+        .as("limitless gRPC executeQuery must be capped at grpcQueryMaxResultRows (issue #4803)")
+        .isEqualTo(MAX_QUERY_ROWS);
+  }
+
+  @Test
+  void unaryExecuteQueryHonorsExplicitSmallerLimit() {
+    final int explicitLimit = 3;
+    final ExecuteQueryResponse response = authenticatedStub.executeQuery(
+        ExecuteQueryRequest.newBuilder()
+            .setDatabase(getDatabaseName())
+            .setCredentials(credentials())
+            .setQuery("SELECT FROM " + VERTEX1_TYPE_NAME)
+            .setLimit(explicitLimit)
+            .build());
+
+    assertThat(response.getResults(0).getRecordsCount())
+        .as("an explicit limit smaller than the cap must still be honored")
+        .isEqualTo(explicitLimit);
+  }
+
+  @Test
+  void materializeAllStreamExceedingCapFailsWithResourceExhausted() {
+    final StreamQueryRequest request = StreamQueryRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(credentials())
+        .setQuery("SELECT FROM " + VERTEX1_TYPE_NAME)
+        .setBatchSize(10)
+        .setRetrievalMode(StreamQueryRequest.RetrievalMode.MATERIALIZE_ALL)
+        .build();
+
+    final StatusRuntimeException ex = catchThrowableOfType(StatusRuntimeException.class, () -> {
+      final Iterator<QueryResult> results = authenticatedStub.streamQuery(request);
+      while (results.hasNext())
+        results.next();
+    });
+
+    assertThat(ex)
+        .as("MATERIALIZE_ALL over a result larger than the cap must fail, not buffer everything (issue #4803)")
+        .isNotNull();
+    assertThat(ex.getStatus().getCode())
+        .as("the cap breach must surface as RESOURCE_EXHAUSTED so clients can fall back to CURSOR/PAGED")
+        .isEqualTo(Status.Code.RESOURCE_EXHAUSTED);
+  }
+}

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4803GrpcResultBoundingIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4803GrpcResultBoundingIT.java
@@ -168,6 +168,30 @@ public class Issue4803GrpcResultBoundingIT extends BaseGraphServerTest {
   }
 
   @Test
+  void unaryExecuteQueryWithCapDisabledReturnsAllRows() {
+    // The -1 opt-out must restore the legacy unlimited behavior so disabling DoS protection does not
+    // silently keep capping (or now, failing) large results.
+    GlobalConfiguration.SERVER_GRPC_QUERY_MAX_RESULT_ROWS.setValue(-1);
+    try {
+      final ExecuteQueryResponse response = authenticatedStub.executeQuery(
+          ExecuteQueryRequest.newBuilder()
+              .setDatabase(getDatabaseName())
+              .setCredentials(credentials())
+              .setQuery("SELECT FROM " + VERTEX1_TYPE_NAME) // no limit, cap disabled
+              .build());
+
+      // The seeded rows alone exceed the (now disabled) cap, so the opt-out is proven by the call returning
+      // the full result without a RESOURCE_EXHAUSTED failure and without truncating at the former ceiling.
+      assertThat(response.getResults(0).getRecordsCount())
+          .as("a disabled cap (-1) must opt back into unlimited and return the full result, not cap at the ceiling")
+          .isGreaterThanOrEqualTo(ROWS_INSERTED)
+          .isGreaterThan(MAX_QUERY_ROWS);
+    } finally {
+      GlobalConfiguration.SERVER_GRPC_QUERY_MAX_RESULT_ROWS.setValue(MAX_QUERY_ROWS);
+    }
+  }
+
+  @Test
   void unaryExecuteQueryHonorsExplicitSmallerLimit() {
     final int explicitLimit = 3;
     final ExecuteQueryResponse response = authenticatedStub.executeQuery(

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4803GrpcResultBoundingIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4803GrpcResultBoundingIT.java
@@ -51,8 +51,9 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
  *
  * <p>The fix bounds both paths with server-scoped configuration:
  * <ul>
- *   <li>{@code arcadedb.server.grpcQueryMaxResultRows} caps the unary {@code ExecuteQuery} when no positive
- *       limit is given;</li>
+ *   <li>{@code arcadedb.server.grpcQueryMaxResultRows} is a hard ceiling on the unary {@code ExecuteQuery}:
+ *       a result that would exceed it fails with {@code RESOURCE_EXHAUSTED} instead of silently truncating,
+ *       and a client cannot bypass it with an oversized explicit limit;</li>
  *   <li>{@code arcadedb.server.grpcStreamMaxMaterializedRows} caps {@code MATERIALIZE_ALL} buffering and fails
  *       the call with {@code RESOURCE_EXHAUSTED} when exceeded.</li>
  * </ul>
@@ -126,21 +127,44 @@ public class Issue4803GrpcResultBoundingIT extends BaseGraphServerTest {
   }
 
   @Test
-  void unaryExecuteQueryWithoutLimitIsCapped() {
-    final ExecuteQueryResponse response = authenticatedStub.executeQuery(
-        ExecuteQueryRequest.newBuilder()
-            .setDatabase(getDatabaseName())
-            .setCredentials(credentials())
-            .setQuery("SELECT FROM " + VERTEX1_TYPE_NAME) // deliberately no LIMIT
-            .build());
+  void unaryExecuteQueryWithoutLimitExceedingCapFailsWithResourceExhausted() {
+    final StatusRuntimeException ex = catchThrowableOfType(StatusRuntimeException.class,
+        () -> authenticatedStub.executeQuery(
+            ExecuteQueryRequest.newBuilder()
+                .setDatabase(getDatabaseName())
+                .setCredentials(credentials())
+                .setQuery("SELECT FROM " + VERTEX1_TYPE_NAME) // deliberately no LIMIT
+                .build()));
 
-    assertThat(response.getResultsList()).isNotEmpty();
-    final int returned = response.getResults(0).getRecordsCount();
+    // The dataset is larger than the cap. A limitless query must fail loudly rather than silently truncating
+    // and dropping data without telling the caller (issue #4803).
+    assertThat(ex)
+        .as("limitless gRPC executeQuery over a result larger than the cap must fail, not silently truncate")
+        .isNotNull();
+    assertThat(ex.getStatus().getCode())
+        .as("the cap breach must surface as RESOURCE_EXHAUSTED so the client knows the result was not complete")
+        .isEqualTo(Status.Code.RESOURCE_EXHAUSTED);
+  }
 
-    // The dataset is larger than the cap, so a limitless query must be bounded to the configured max.
-    assertThat(returned)
-        .as("limitless gRPC executeQuery must be capped at grpcQueryMaxResultRows (issue #4803)")
-        .isEqualTo(MAX_QUERY_ROWS);
+  @Test
+  void unaryExecuteQueryWithExplicitLimitLargerThanCapFailsWithResourceExhausted() {
+    // A client must not be able to bypass the DoS-protection ceiling by requesting an oversized explicit limit:
+    // the configured cap is a hard ceiling, so a larger limit over a larger result still fails loudly.
+    final StatusRuntimeException ex = catchThrowableOfType(StatusRuntimeException.class,
+        () -> authenticatedStub.executeQuery(
+            ExecuteQueryRequest.newBuilder()
+                .setDatabase(getDatabaseName())
+                .setCredentials(credentials())
+                .setQuery("SELECT FROM " + VERTEX1_TYPE_NAME)
+                .setLimit(MAX_QUERY_ROWS + 10)
+                .build()));
+
+    assertThat(ex)
+        .as("an explicit limit larger than the cap must not bypass the hard ceiling")
+        .isNotNull();
+    assertThat(ex.getStatus().getCode())
+        .as("exceeding the hard ceiling must surface as RESOURCE_EXHAUSTED")
+        .isEqualTo(Status.Code.RESOURCE_EXHAUSTED);
   }
 
   @Test

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4803WaitUntilReadyTimeoutTest.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue4803WaitUntilReadyTimeoutTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4803 (busy-wait portion): {@code ArcadeDbGrpcService.waitUntilReady}
+ * used to spin {@code Thread.sleep(1)} with no deadline while the client transport stayed not-ready,
+ * pinning the gRPC worker thread (and the open ResultSet/transaction) for a slow or abandoned stream.
+ *
+ * <p>The fix bounds the wait by a configurable deadline. This test exercises the extracted, transport-free
+ * helper {@link ArcadeDbGrpcService#awaitTransportReady} directly so the deadline behaviour is deterministic
+ * without needing a real stalled gRPC channel.
+ */
+public class Issue4803WaitUntilReadyTimeoutTest {
+
+  @Test
+  void abortsAfterDeadlineWhenNeverReady() {
+    final AtomicBoolean cancelled = new AtomicBoolean(false);
+    final long timeoutMs = 150;
+
+    final long start = System.currentTimeMillis();
+    final boolean ready = ArcadeDbGrpcService.awaitTransportReady(() -> false, cancelled, timeoutMs);
+    final long elapsed = System.currentTimeMillis() - start;
+
+    // The wait must give up (return not-ready) instead of spinning forever.
+    assertThat(ready).as("never-ready transport must time out, not block forever").isFalse();
+    // It must have waited at least the configured deadline ...
+    assertThat(elapsed).as("must honor the configured deadline").isGreaterThanOrEqualTo(timeoutMs);
+    // ... but not run away well past it (generous upper bound to stay CI-stable).
+    assertThat(elapsed).as("must not spin indefinitely past the deadline").isLessThan(timeoutMs + 5_000L);
+  }
+
+  @Test
+  void returnsImmediatelyWhenReady() {
+    final AtomicBoolean cancelled = new AtomicBoolean(false);
+
+    final long start = System.currentTimeMillis();
+    final boolean ready = ArcadeDbGrpcService.awaitTransportReady(() -> true, cancelled, 60_000L);
+    final long elapsed = System.currentTimeMillis() - start;
+
+    assertThat(ready).as("an already-ready transport must return ready").isTrue();
+    assertThat(elapsed).as("must not wait when already ready").isLessThan(1_000L);
+  }
+
+  @Test
+  void returnsPromptlyWhenAlreadyCancelled() {
+    final AtomicBoolean cancelled = new AtomicBoolean(true);
+
+    final long start = System.currentTimeMillis();
+    final boolean ready = ArcadeDbGrpcService.awaitTransportReady(() -> false, cancelled, 60_000L);
+    final long elapsed = System.currentTimeMillis() - start;
+
+    assertThat(ready).as("a cancelled stream must not report ready").isFalse();
+    assertThat(elapsed).as("a cancelled stream must abort promptly, not wait for the deadline").isLessThan(1_000L);
+  }
+}


### PR DESCRIPTION
Closes #4803

## Summary

`ArcadeDbGrpcService` had three unbounded paths that let slow or limitless gRPC clients pin worker threads or exhaust heap (a medium-severity DoS):

- **`waitUntilReady`** spun `Thread.sleep(1)` with no deadline while the client transport stayed not-ready, pinning the gRPC worker thread (and the open `ResultSet`/transaction) indefinitely for a slow or abandoned stream.
- **`streamMaterialized`** (retrieval mode `MATERIALIZE_ALL`) buffered the entire result set into an `ArrayList` before emitting anything.
- **Unary `executeQuery`** built the full result into a single response unless `request.getLimit() > 0`.

The fix adds three SERVER-scoped `GlobalConfiguration` knobs, each defaulting to a DoS-protection bound (set `-1` to opt back into the legacy unbounded behaviour):

- `arcadedb.server.grpcQueryMaxResultRows` (default 100000) - caps unary `ExecuteQuery` when no positive `limit` is given.
- `arcadedb.server.grpcStreamMaxMaterializedRows` (default 1000000) - caps `MATERIALIZE_ALL` buffering; exceeding it fails the call with `RESOURCE_EXHAUSTED` so clients fall back to `CURSOR`/`PAGED` streaming.
- `arcadedb.server.grpcStreamWriteTimeoutMs` (default 60000) - bounds how long `waitUntilReady` blocks for transport readiness before aborting the stream (sets the cancelled flag so the surrounding loop rolls back and releases the `ResultSet`/transaction).

The busy-wait logic is extracted into a package-private, transport-free static helper `awaitTransportReady(BooleanSupplier, AtomicBoolean, long)` so the deadline is unit-testable. `streamQuery`'s catch block now preserves an explicit gRPC status instead of masking it as `INTERNAL`.

## Test plan

- [x] `Issue4803WaitUntilReadyTimeoutTest` (unit): `awaitTransportReady` times out when never ready, returns immediately when ready, aborts promptly when already cancelled - 3/3.
- [x] `Issue4803GrpcResultBoundingIT`: limitless unary `ExecuteQuery` capped at the configured max; explicit smaller limit still honored; `MATERIALIZE_ALL` over a too-large result fails with `RESOURCE_EXHAUSTED` - 3/3.
- [x] Regression: `GrpcStreamMetricsIT`, `Issue4197GrpcExecuteQueryResultSetLeakIT`, `ArcadeDbGrpcServiceExtendedTest` (26) - no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)