### PR TITLE
fix(#4838): apply HA_K8S_DNS_SUFFIX to peer addresses, not only the self host

### DIFF
--- a/docs/4838-k8s-dns-suffix-peer-addresses.md
+++ b/docs/4838-k8s-dns-suffix-peer-addresses.md
@@ -1,0 +1,46 @@
+# Issue #4838 - HA_K8S_DNS_SUFFIX applied only to self host, not to peer addresses
+
+## Problem
+
+`ArcadeDBServer.assignHostAddress()` builds the self-advertised host as
+`HOSTNAME + HA_K8S_DNS_SUFFIX` when running inside Kubernetes (`HA_K8S=true`).
+However `RaftPeerAddressResolver.parsePeerList()` derives every peer's Raft/HTTP/HTTPS
+address straight from the raw `HA_SERVER_LIST` host strings and never applies the
+suffix. Result: when an operator writes short pod names (e.g. `arcadedb-0`) in
+`HA_SERVER_LIST` and configures `k8sSuffix`, the peers keep their short names, fail
+to resolve (NXDOMAIN) and the cluster silently never forms. The suffix is effectively
+a dead knob for peer resolution.
+
+The configuration description states the suffix is used "to reach the other servers",
+so applying it only to self is a defect.
+
+## Root cause
+
+`RaftPeerAddressResolver.parsePeerList(serverList, defaultPort)` has no knowledge of the
+K8s DNS suffix; it builds addresses verbatim from the parsed host component.
+
+## Fix
+
+- Add an overload `parsePeerList(serverList, defaultPort, k8sDnsSuffix)` that appends the
+  DNS suffix to each peer host (Raft, HTTP and HTTPS addresses), consistent with how the
+  self host is built in `assignHostAddress`.
+- The application is idempotent (skips a host already ending with the suffix) and skips
+  raw IP literals and `localhost`, which do not need DNS resolution.
+- The legacy 2-arg `parsePeerList` delegates with an empty suffix, so non-K8s behavior is
+  unchanged.
+- `RaftHAServer` reads `HA_K8S` / `HA_K8S_DNS_SUFFIX` and passes the suffix only when
+  running inside Kubernetes (default suffix is empty, so non-K8s deployments are unaffected).
+
+## Tests
+
+`RaftHAServerAddressParsingTest` (new methods):
+- suffix appended to short peer hosts (Raft + HTTP) and reflected in the peer ID
+- suffix appended in object form and to HTTPS address
+- idempotent when the host is already fully qualified
+- skipped for IPv4 literal and for localhost
+- empty/absent suffix leaves hosts unchanged (legacy 2-arg path)
+
+## Impact
+
+K8s-only behavior gated behind `HA_K8S` + non-empty `k8sSuffix`. No change for any
+existing deployment that already uses FQDNs or runs outside Kubernetes.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -164,7 +164,14 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     final long lagWarningThreshold = configuration.getValueAsLong(GlobalConfiguration.HA_REPLICATION_LAG_WARNING);
     final int raftPort = configuration.getValueAsInteger(GlobalConfiguration.HA_RAFT_PORT);
 
-    final RaftPeerAddressResolver.ParsedPeerList parsed = RaftPeerAddressResolver.parsePeerList(serverList, raftPort);
+    // Inside Kubernetes the DNS suffix must reach peers too, not only the self-advertised host built in
+    // ArcadeDBServer.assignHostAddress; otherwise short pod names in the server list never resolve.
+    final String k8sDnsSuffix = configuration.getValueAsBoolean(GlobalConfiguration.HA_K8S)
+        ? configuration.getValueAsString(GlobalConfiguration.HA_K8S_DNS_SUFFIX)
+        : "";
+
+    final RaftPeerAddressResolver.ParsedPeerList parsed = RaftPeerAddressResolver.parsePeerList(serverList, raftPort,
+        k8sDnsSuffix);
     List<RaftPeer> peers = parsed.peers();
     final Map<RaftPeerId, String> configuredPeerNames = parsed.peerNames();
     final String serverName = arcadeServer.getServerName();

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftPeerAddressResolver.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftPeerAddressResolver.java
@@ -88,6 +88,19 @@ final class RaftPeerAddressResolver {
    * This is a soft preference - if the preferred leader is unavailable, another node will take over.
    */
   static ParsedPeerList parsePeerList(final String serverList, final int defaultPort) {
+    return parsePeerList(serverList, defaultPort, "");
+  }
+
+  /**
+   * Same as {@link #parsePeerList(String, int)} but additionally appends a Kubernetes DNS suffix to
+   * every peer host so short pod names (e.g. {@code arcadedb-0}) written in the server list expand to
+   * the cluster-internal FQDN, consistent with the self-advertised host built in
+   * {@code ArcadeDBServer.assignHostAddress}. The suffix is applied to the Raft, HTTP and HTTPS host
+   * components. It is a no-op when {@code k8sDnsSuffix} is empty, when a host is already fully
+   * qualified with that suffix (idempotent), and for raw IP literals or {@code localhost}, which need
+   * no DNS resolution.
+   */
+  static ParsedPeerList parsePeerList(final String serverList, final int defaultPort, final String k8sDnsSuffix) {
     // Split on top-level commas only: the object form {raft:..,http:..} contains commas that must not
     // be treated as entry separators.
     final List<String> entries = splitEntries(serverList);
@@ -124,11 +137,12 @@ final class RaftPeerAddressResolver {
       if (braceIdx >= 0) {
         // Object form: host:{raft:2434,http:2480,https:2490,priority:10}
         final PeerSpec spec = parseObjectForm(entry, braceIdx, defaultPort);
-        raftAddress = spec.host + ":" + spec.raftPort;
+        final String host = applyDnsSuffix(spec.host, k8sDnsSuffix);
+        raftAddress = host + ":" + spec.raftPort;
         if (spec.httpPort != null)
-          httpAddress = spec.host + ":" + spec.httpPort;
+          httpAddress = host + ":" + spec.httpPort;
         if (spec.httpsPort != null)
-          httpsAddress = spec.host + ":" + spec.httpsPort;
+          httpsAddress = host + ":" + spec.httpsPort;
         priority = spec.priority;
       } else {
         final String[] parts = entry.split(":");
@@ -139,27 +153,29 @@ final class RaftPeerAddressResolver {
                   + "'. Expected [name@]host[:raftPort[:httpPort[:priority[:httpsPort]]]] "
                   + "or [name@]host:{raft:..,http:..,https:..,priority:..}");
 
+        final String host = applyDnsSuffix(parts[0], k8sDnsSuffix);
+
         if (parts.length == 5) {
           // host:raftPort:httpPort:priority:httpsPort
-          raftAddress = parts[0] + ":" + parts[1];
-          httpAddress = parts[0] + ":" + parts[2];
+          raftAddress = host + ":" + parts[1];
+          httpAddress = host + ":" + parts[2];
           priority = parseIntField(parts[3], "priority", entry);
-          httpsAddress = parts[0] + ":" + parts[4];
+          httpsAddress = host + ":" + parts[4];
         } else if (parts.length == 4) {
           // host:raftPort:httpPort:priority
-          raftAddress = parts[0] + ":" + parts[1];
-          httpAddress = parts[0] + ":" + parts[2];
+          raftAddress = host + ":" + parts[1];
+          httpAddress = host + ":" + parts[2];
           priority = parseIntField(parts[3], "priority", entry);
         } else if (parts.length == 3) {
           // host:raftPort:httpPort
-          raftAddress = parts[0] + ":" + parts[1];
-          httpAddress = parts[0] + ":" + parts[2];
+          raftAddress = host + ":" + parts[1];
+          httpAddress = host + ":" + parts[2];
         } else if (parts.length == 2) {
           // host:raftPort
-          raftAddress = entry;
+          raftAddress = host + ":" + parts[1];
         } else {
           // host only - use default Raft port
-          raftAddress = entry + ":" + defaultPort;
+          raftAddress = host + ":" + defaultPort;
         }
       }
 
@@ -267,6 +283,41 @@ final class RaftPeerAddressResolver {
       }
     }
     return new PeerSpec(host, raftPort, httpPort, httpsPort, priority);
+  }
+
+  /**
+   * Appends the Kubernetes DNS suffix to a peer host so short pod names in the server list resolve to
+   * the cluster-internal FQDN, consistent with the self-advertised host. Returns the host unchanged
+   * when the suffix is empty, when the host is already fully qualified with that suffix (idempotent),
+   * or when the host is a raw IP literal or {@code localhost} (which need no DNS resolution).
+   */
+  static String applyDnsSuffix(final String host, final String k8sDnsSuffix) {
+    if (k8sDnsSuffix == null || k8sDnsSuffix.isEmpty() || host == null || host.isEmpty())
+      return host;
+    if (host.endsWith(k8sDnsSuffix))
+      return host;
+    if ("localhost".equals(host) || isIpLiteral(host))
+      return host;
+    return host + k8sDnsSuffix;
+  }
+
+  /** Returns true when the host is an IPv4/IPv6 literal, which must never receive a DNS suffix. */
+  private static boolean isIpLiteral(final String host) {
+    // IPv6 literals contain ':' (or are written in bracketed form); they are never DNS names.
+    if (host.indexOf(':') >= 0 || host.charAt(0) == '[')
+      return true;
+    // IPv4 dotted-quad: exactly four numeric octets.
+    final String[] octets = host.split("\\.");
+    if (octets.length != 4)
+      return false;
+    for (final String octet : octets) {
+      if (octet.isEmpty())
+        return false;
+      for (int i = 0; i < octet.length(); i++)
+        if (!Character.isDigit(octet.charAt(i)))
+          return false;
+    }
+    return true;
   }
 
   /** Parses an integer field, throwing a descriptive {@link ServerException} on malformed input. */

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAServerAddressParsingTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAServerAddressParsingTest.java
@@ -276,4 +276,74 @@ class RaftHAServerAddressParsingTest {
     final var parsed = RaftPeerAddressResolver.parsePeerList("alpha@myhost:9999", 2434);
     assertThat(parsed.peers().get(0).getId().toString()).isEqualTo("myhost_9999");
   }
+
+  // --- Issue #4838: HA_K8S_DNS_SUFFIX must be applied to peer addresses, not only to the self host ---
+
+  @Test
+  void k8sSuffixAppendedToShortPeerHosts() {
+    // Short pod names with a K8s DNS suffix must be expanded to the cluster-internal FQDN so peers resolve.
+    final var parsed = RaftPeerAddressResolver.parsePeerList(
+        "arcadedb-0:2434:2480,arcadedb-1:2434:2480", 2434, ".arcadedb.default.svc.cluster.local");
+    final var peer0 = parsed.peers().get(0);
+    final var peer1 = parsed.peers().get(1);
+    assertThat(peer0.getAddress()).isEqualTo("arcadedb-0.arcadedb.default.svc.cluster.local:2434");
+    assertThat(peer1.getAddress()).isEqualTo("arcadedb-1.arcadedb.default.svc.cluster.local:2434");
+    assertThat(parsed.httpAddresses()).containsEntry(peer0.getId(), "arcadedb-0.arcadedb.default.svc.cluster.local:2480");
+    assertThat(parsed.httpAddresses()).containsEntry(peer1.getId(), "arcadedb-1.arcadedb.default.svc.cluster.local:2480");
+  }
+
+  @Test
+  void k8sSuffixReflectedInPeerId() {
+    // The peer ID is derived from the (now-qualified) Raft address.
+    final var parsed = RaftPeerAddressResolver.parsePeerList(
+        "arcadedb-0:2434:2480", 2434, ".arcadedb.default.svc.cluster.local");
+    assertThat(parsed.peers().get(0).getId().toString())
+        .isEqualTo("arcadedb-0.arcadedb.default.svc.cluster.local_2434");
+  }
+
+  @Test
+  void k8sSuffixAppendedInObjectFormAndToHttps() {
+    final var parsed = RaftPeerAddressResolver.parsePeerList(
+        "arcadedb-0:{raft:2434,http:2480,https:2490}", 2434, ".svc.local");
+    final var peer = parsed.peers().get(0);
+    assertThat(peer.getAddress()).isEqualTo("arcadedb-0.svc.local:2434");
+    assertThat(parsed.httpAddresses()).containsEntry(peer.getId(), "arcadedb-0.svc.local:2480");
+    assertThat(parsed.httpsAddresses()).containsEntry(peer.getId(), "arcadedb-0.svc.local:2490");
+  }
+
+  @Test
+  void k8sSuffixIsIdempotentWhenHostAlreadyQualified() {
+    // An operator who already wrote FQDNs must not get the suffix appended twice.
+    final var parsed = RaftPeerAddressResolver.parsePeerList(
+        "arcadedb-0.svc.local:2434:2480", 2434, ".svc.local");
+    assertThat(parsed.peers().get(0).getAddress()).isEqualTo("arcadedb-0.svc.local:2434");
+  }
+
+  @Test
+  void k8sSuffixSkippedForIpLiteral() {
+    final var parsed = RaftPeerAddressResolver.parsePeerList(
+        "10.0.0.5:2434:2480", 2434, ".svc.local");
+    assertThat(parsed.peers().get(0).getAddress()).isEqualTo("10.0.0.5:2434");
+  }
+
+  @Test
+  void k8sSuffixSkippedForLocalhost() {
+    final var parsed = RaftPeerAddressResolver.parsePeerList(
+        "localhost:2434:2480", 2434, ".svc.local");
+    assertThat(parsed.peers().get(0).getAddress()).isEqualTo("localhost:2434");
+  }
+
+  @Test
+  void emptyK8sSuffixLeavesHostsUnchanged() {
+    final var parsed = RaftPeerAddressResolver.parsePeerList(
+        "arcadedb-0:2434:2480", 2434, "");
+    assertThat(parsed.peers().get(0).getAddress()).isEqualTo("arcadedb-0:2434");
+  }
+
+  @Test
+  void legacyTwoArgParsePeerListLeavesHostsUnchanged() {
+    // The 2-arg overload must behave exactly as before (no suffix).
+    final var parsed = RaftPeerAddressResolver.parsePeerList("arcadedb-0:2434:2480", 2434);
+    assertThat(parsed.peers().get(0).getAddress()).isEqualTo("arcadedb-0:2434");
+  }
 }


### PR DESCRIPTION
## Issue

Closes #4838.

`ArcadeDBServer.assignHostAddress()` builds the self-advertised host as `HOSTNAME + HA_K8S_DNS_SUFFIX` when running inside Kubernetes, but `RaftPeerAddressResolver.parsePeerList()` derived every peer's Raft/HTTP/HTTPS address verbatim from `HA_SERVER_LIST` and never applied the suffix.

Consequence: an operator who writes short pod names (e.g. `arcadedb-0`) in `HA_SERVER_LIST` together with `k8sSuffix` gets peers that stay unqualified, fail to resolve (NXDOMAIN) and the cluster silently never forms. The knob was effectively dead for peer resolution, contradicting its documented purpose ("use this suffix to reach the other servers").

## Fix

- `RaftPeerAddressResolver.parsePeerList` gains an optional `k8sDnsSuffix` parameter and appends it to each peer host (Raft, HTTP and HTTPS components), consistent with how the self host is built.
- The suffix is applied **only when running inside Kubernetes** (`HA_K8S=true`). It is idempotent for hosts already ending with the suffix, and skipped for raw IP literals and `localhost`, which need no DNS resolution.
- The legacy 2-arg `parsePeerList` overload delegates with an empty suffix, so non-Kubernetes deployments (and any deployment already using FQDNs) are completely unaffected.
- `RaftHAServer` reads `HA_K8S` / `HA_K8S_DNS_SUFFIX` and passes the suffix through.

## Tests

New methods in `RaftHAServerAddressParsingTest`:
- suffix appended to short peer hosts (Raft + HTTP) and reflected in the peer ID
- suffix appended in object form and to the HTTPS address
- idempotent when the host is already fully qualified
- skipped for an IPv4 literal and for `localhost`
- empty/absent suffix and the legacy 2-arg path leave hosts unchanged

Verification: `mvn -pl ha-raft test -Dtest='RaftHAServerTest,RaftHAServerValidatePeerAddressTest,RaftHAServerAddressParsingTest'` -> 98 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)