### PR TITLE
fix(#4825): propagate truncated embedded WAL section in SCHEMA_ENTRY decode

### DIFF
--- a/docs/4825-schema-entry-wal-truncation.md
+++ b/docs/4825-schema-entry-wal-truncation.md
@@ -71,3 +71,30 @@ https://github.com/ArcadeData/arcadedb/pull/4845
     added the length-prefix boundary test. **Applied.**
   - Result: both WAL and sealed-blob sections now use the `available() > 0` presence check; the
     `EOFException` import was removed (no longer referenced).
+- Cycle 2 (`caa0457`): claude approved (LGTM, only cosmetic/optional items); gemini-code-assist did
+  not re-review within the 15-minute per-iteration window (it reviewed cycle 1, and all of its
+  feedback was already applied). No code changes were required in this cycle.
+  - Verified claude's non-blocking consideration about a "poison" (now-throwing) committed entry:
+    `RaftLogEntryCodec.decode()` is called in `ArcadeStateMachine.applyTransaction` *before*
+    `applyWithRetry`, so a decode `IllegalStateException` is not retried. It falls into the final
+    `catch (Throwable)`, which logs SEVERE, triggers the critical halt + server stop (snapshot
+    recovery on restart), and leaves `lastAppliedIndex` untouched. No infinite apply-retry loop is
+    introduced; this matches the existing fail-loud handling for unknown entry types (#4798).
+  - Addressed the stale test name in the PR description (the committed tests are
+    `decodeSchemaEntryWithTruncatedWalPayloadThrows` and `decodeSchemaEntryTruncatedInWalLengthPrefixThrows`).
+
+## Known limitation (accepted trade-off)
+
+The fix narrows but cannot fully eliminate silent truncation: a stream cut *exactly* at a section
+boundary (e.g. the whole sealed-blob section lost after a fully-intact WAL section) is
+indistinguishable from "an older node never wrote that section", so it still decodes as absent. This
+is inherent to the length-prefix-free, self-describing trailing-section format and is the accepted
+cost of backward compatibility. A per-entry total-length prefix or whole-entry CRC would be required
+to close it if stronger integrity is ever wanted.
+
+## Final state
+
+timeout (cycle 2): claude approved; gemini-code-assist did not re-review cycle 2 within 15 minutes.
+All actionable review feedback (gemini cycle 1 + claude main point) was applied in cycle 1; the only
+remaining items were cosmetic (PR-body test name, handled) and an optional documentation note (added
+above). No outstanding actionable code feedback.

--- a/docs/4825-schema-entry-wal-truncation.md
+++ b/docs/4825-schema-entry-wal-truncation.md
@@ -1,0 +1,50 @@
+# Issue #4825 — `RaftLogEntryCodec.decodeSchemaEntry` swallows truncated/corrupt WAL section as "old version"
+
+## Problem
+
+`decodeSchemaEntry` wraps the entire embedded-WAL section in `catch (IOException ignored) {}`
+("treat as empty"). This means a SCHEMA_ENTRY whose WAL section is present but truncated or
+misaligned silently decodes with `walEntries = emptyList()` (or a partial list), with no error
+surfaced. The follower then applies a schema change with missing index/WAL pages, producing the
+"Cannot find indexes ..." class of failures.
+
+The original intent of the catch was backward compatibility: log entries produced by nodes that
+predate the embedded-WAL section end the stream cleanly right after the `filesToRemove` map, so the
+first read of the section (the WAL count) hits EOF. That single case is legitimate. But the broad
+`IOException` catch also swallows EOF/IO failures that occur *after* the WAL count has been read,
+i.e. real truncation/corruption of a present section.
+
+The sibling TimeSeries sealed-blob section (issue #4382) already catches only `EOFException`.
+
+## Root cause
+
+`RaftLogEntryCodec.decodeSchemaEntry` (ha-raft module):
+- The whole WAL read loop is inside one `try { ... } catch (final IOException ignored) {}` block.
+  Any failure mid-section is treated identically to an absent section.
+
+## Fix
+
+Scope the backward-compatibility tolerance to the **absence** of the section only:
+- Read the WAL count in its own `try`; an `EOFException` there (and only there) means the section is
+  absent (older entry) and is decoded as empty.
+- Once the WAL count has been read, the section is present: the per-entry reads run outside any
+  swallowing catch, so a truncated/misaligned section propagates as an `IOException`, which
+  `decode()` wraps into an `IllegalStateException` ("Failed to decode Raft log entry").
+
+The forward/backward-compatible trailing sealed-blob section is unchanged (still `EOFException`-only).
+The `decode()` trailing-byte check remains disabled for SCHEMA_ENTRY because that type legitimately
+carries optional self-describing trailing sections that newer nodes may append.
+
+## Tests (TDD)
+
+Added to `RaftLogEntryCodecTest`:
+- `decodeSchemaEntryWithTruncatedWalSectionThrows` — encodes a SCHEMA_ENTRY with an embedded WAL
+  entry, truncates the bytes mid-WAL-section, asserts `decode()` throws (fails before the fix:
+  silently returns empty WAL entries).
+- `decodeLegacySchemaEntryWithoutWalSectionDecodesEmpty` — hand-crafts a legacy SCHEMA_ENTRY that
+  ends right after `filesToRemove` (no WAL section); asserts it still decodes with empty WAL/blob
+  lists (backward compatibility preserved).
+
+## Verification
+
+- `mvn -q -pl ha-raft -am test -Dtest=RaftLogEntryCodecTest`

--- a/docs/4825-schema-entry-wal-truncation.md
+++ b/docs/4825-schema-entry-wal-truncation.md
@@ -38,13 +38,36 @@ carries optional self-describing trailing sections that newer nodes may append.
 ## Tests (TDD)
 
 Added to `RaftLogEntryCodecTest`:
-- `decodeSchemaEntryWithTruncatedWalSectionThrows` — encodes a SCHEMA_ENTRY with an embedded WAL
-  entry, truncates the bytes mid-WAL-section, asserts `decode()` throws (fails before the fix:
-  silently returns empty WAL entries).
+- `decodeSchemaEntryWithTruncatedWalPayloadThrows` — encodes a SCHEMA_ENTRY with an embedded WAL
+  entry, truncates the bytes a few bytes into the compressed WAL payload (count + length prefixes
+  fully read), asserts `decode()` throws (fails before the fix: silently returns empty WAL entries).
+- `decodeSchemaEntryTruncatedInWalLengthPrefixThrows` — truncates 2 bytes into the first WAL entry's
+  length prefix to lock the boundary semantics (count read, then truncation propagates).
 - `decodeLegacySchemaEntryWithoutWalSectionDecodesEmpty` — hand-crafts a legacy SCHEMA_ENTRY that
   ends right after `filesToRemove` (no WAL section); asserts it still decodes with empty WAL/blob
   lists (backward compatibility preserved).
 
+Truncation offsets are computed explicitly from the wire format (not as a fraction of the entry
+size) so they stay anchored if the encoder or compression ratio changes.
+
 ## Verification
 
-- `mvn -q -pl ha-raft -am test -Dtest=RaftLogEntryCodecTest`
+- `mvn -pl ha-raft test -Dtest=RaftLogEntryCodecTest` — 33/33 pass.
+- `mvn -pl ha-raft test -Dtest='ArcadeStateMachine*Test,RaftLogEntry*Test'` — 74/74 pass.
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/4845
+
+## Review cycles
+
+- Cycle 1 (`a8f149f`): initial fix (WAL section only, boundary-only `try`/`EOFException`).
+  - gemini-code-assist (high): use `dis.available() > 0` to detect the optional WAL section instead
+    of a `try`/catch on the count, matching `decodeInstallDatabaseEntry`; also fixes a mid-`walCount`
+    truncation hole (1-3 bytes left) that the catch would have swallowed. **Applied.**
+  - claude (main): the sibling TimeSeries sealed-blob section has the identical latent bug (reads
+    `blobCount` inside the same swallowing `catch (EOFException)`). **Applied** the analogous
+    `available() > 0` guard there too. Minor: made the truncation-test offsets deterministic and
+    added the length-prefix boundary test. **Applied.**
+  - Result: both WAL and sealed-blob sections now use the `available() > 0` presence check; the
+    `EOFException` import was removed (no longer referenced).

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
@@ -361,8 +361,9 @@ public final class RaftLogEntryCodec {
       };
 
       // Trailing-byte validation: detect truncated or corrupted entries.
-      // SCHEMA_ENTRY is excluded because older entries may lack the embedded WAL section
-      // and the decoder already handles that gracefully via IOException catch.
+      // SCHEMA_ENTRY is excluded because it carries optional, self-describing trailing sections
+      // (the embedded WAL section and the TimeSeries sealed-blob section) that newer nodes may
+      // append and older decoders stop before; a clean EOF at a section boundary is normal here.
       if (type != RaftLogEntryType.SCHEMA_ENTRY && dis.available() > 0)
         throw new IllegalStateException(
             "Corrupted Raft log entry: " + dis.available() + " trailing bytes after " + type + " decode");
@@ -404,11 +405,23 @@ public final class RaftLogEntryCodec {
     final Map<Integer, String> filesToAdd = readFileMap(dis);
     final Map<Integer, String> filesToRemove = readFileMap(dis);
 
-    // Read embedded WAL entries; older entries without this section are handled gracefully
+    // Read embedded WAL entries. The section is optional: log entries produced by nodes that predate
+    // it end the stream cleanly right here, so the very first read (the WAL count) hits EOF. That
+    // single case is the only legitimate one and is decoded as an absent (empty) section. Once the
+    // WAL count has been read the section IS present, so any subsequent truncation or misalignment is
+    // corruption and must propagate rather than silently yield empty/partial WAL pages (which would
+    // apply a schema change with missing index/WAL pages on followers).
     List<byte[]> walEntries = Collections.emptyList();
     List<Map<Integer, Integer>> bucketDeltas = Collections.emptyList();
+    boolean walSectionPresent = true;
+    int walCount = 0;
     try {
-      final int walCount = dis.readInt();
+      walCount = dis.readInt();
+    } catch (final EOFException ignored) {
+      // Older log entry without the embedded WAL section - treat as absent.
+      walSectionPresent = false;
+    }
+    if (walSectionPresent) {
       checkCollectionSize(walCount, "SCHEMA_ENTRY WAL entries");
       if (walCount > 0) {
         walEntries = new ArrayList<>(walCount);
@@ -431,8 +444,6 @@ public final class RaftLogEntryCodec {
           bucketDeltas.add(delta);
         }
       }
-    } catch (final IOException ignored) {
-      // Older log entries without embedded WAL section - treat as empty
     }
 
     // TimeSeries sealed-store blob section (issue #4382). Trailing section: a missing one (older

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftLogEntryCodec.java
@@ -24,7 +24,6 @@ import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -406,22 +405,15 @@ public final class RaftLogEntryCodec {
     final Map<Integer, String> filesToRemove = readFileMap(dis);
 
     // Read embedded WAL entries. The section is optional: log entries produced by nodes that predate
-    // it end the stream cleanly right here, so the very first read (the WAL count) hits EOF. That
-    // single case is the only legitimate one and is decoded as an absent (empty) section. Once the
-    // WAL count has been read the section IS present, so any subsequent truncation or misalignment is
-    // corruption and must propagate rather than silently yield empty/partial WAL pages (which would
-    // apply a schema change with missing index/WAL pages on followers).
+    // it end the stream cleanly right after the file maps. A clean section boundary leaves no bytes
+    // (available()==0) and is decoded as an absent (empty) section, mirroring decodeInstallDatabaseEntry.
+    // Once any bytes remain the section IS present, so a truncated/misaligned section makes the reads
+    // below hit EOF and propagate as corruption rather than silently yielding empty/partial WAL pages
+    // (which would apply a schema change with missing index/WAL pages on followers).
     List<byte[]> walEntries = Collections.emptyList();
     List<Map<Integer, Integer>> bucketDeltas = Collections.emptyList();
-    boolean walSectionPresent = true;
-    int walCount = 0;
-    try {
-      walCount = dis.readInt();
-    } catch (final EOFException ignored) {
-      // Older log entry without the embedded WAL section - treat as absent.
-      walSectionPresent = false;
-    }
-    if (walSectionPresent) {
+    if (dis.available() > 0) {
+      final int walCount = dis.readInt();
       checkCollectionSize(walCount, "SCHEMA_ENTRY WAL entries");
       if (walCount > 0) {
         walEntries = new ArrayList<>(walCount);
@@ -446,10 +438,13 @@ public final class RaftLogEntryCodec {
       }
     }
 
-    // TimeSeries sealed-store blob section (issue #4382). Trailing section: a missing one (older
-    // entry) ends the stream and is treated as empty; a CRC mismatch is a hard failure.
+    // TimeSeries sealed-store blob section (issue #4382). Trailing, self-describing section with the
+    // same presence rule as the WAL section above: no remaining bytes (available()==0) means the
+    // section is absent (older entry) and is decoded as empty. Once any bytes remain the section IS
+    // present, so a truncated/misaligned blob makes the reads below hit EOF and propagate rather than
+    // being silently dropped; a CRC mismatch on a fully-read blob is likewise a hard failure.
     List<TsSealedBlob> sealedFileBlobs = Collections.emptyList();
-    try {
+    if (dis.available() > 0) {
       final int blobCount = dis.readInt();
       checkCollectionSize(blobCount, "SCHEMA_ENTRY sealed blobs");
       if (blobCount > 0) {
@@ -474,8 +469,6 @@ public final class RaftLogEntryCodec {
           sealedFileBlobs.add(new TsSealedBlob(typeName, shardIndex, fileName, raw));
         }
       }
-    } catch (final EOFException ignored) {
-      // Older log entry without the sealed-blob section - treat as empty
     }
 
     return new DecodedEntry(RaftLogEntryType.SCHEMA_ENTRY, databaseName, null, null,

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftLogEntryCodecTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftLogEntryCodecTest.java
@@ -486,10 +486,18 @@ class RaftLogEntryCodecTest {
 
   // --- Embedded WAL section truncation/backward-compatibility (issue #4825) ---
 
+  // Wire-format offsets of an encoded SCHEMA_ENTRY with dbName "testdb", schema "{}", empty file maps,
+  // and a single embedded WAL entry. Computed explicitly (rather than via a fraction of the entry size)
+  // so the truncation points stay anchored to the format if the encoder or compression ratio changes.
+  // Layout: type(1) + writeUTF("testdb")=2+6 + schemaLen(4)+"{}"(2) + filesToAdd count(4)
+  //         + filesToRemove count(4) + walCount(4) + walUncompressedLen(4) + walCompressedLen(4) ...
+  private static final int SCHEMA_WAL_COUNT_END     = 1 + (2 + 6) + (4 + 2) + 4 + 4 + 4; // = 27
+  private static final int SCHEMA_WAL_PAYLOAD_START = SCHEMA_WAL_COUNT_END + 4 + 4;       // = 35
+
   @Test
-  void decodeSchemaEntryWithTruncatedWalSectionThrows() {
-    // A SCHEMA_ENTRY whose embedded WAL section is present but truncated mid-section must surface as
-    // a decode failure, not silently decode with empty/partial WAL entries. A silently emptied WAL
+  void decodeSchemaEntryWithTruncatedWalPayloadThrows() {
+    // A SCHEMA_ENTRY whose embedded WAL section is present but truncated mid-payload must surface as a
+    // decode failure, not silently decode with empty/partial WAL entries. A silently emptied WAL
     // section makes a follower apply the schema change with missing index/WAL pages (the
     // "Cannot find indexes ..." class of failure) with no error surfaced.
     final byte[] walData = new byte[4096];
@@ -500,9 +508,30 @@ class RaftLogEntryCodecTest {
     final ByteString encoded = RaftLogEntryCodec.encodeSchemaEntry("testdb", "{}",
         Map.of(), Map.of(), List.of(walData), List.of(delta));
 
-    // Keep the entry header + WAL count + length prefixes, but cut off the WAL payload mid-stream.
-    // Half the entry lands inside the compressed WAL bytes, after the count has been read.
-    final ByteString truncated = encoded.substring(0, encoded.size() / 2);
+    // Cut a few bytes into the compressed WAL payload: the WAL count and both length prefixes are read
+    // in full, then readFully hits EOF inside the payload.
+    final int cut = SCHEMA_WAL_PAYLOAD_START + 4;
+    assertThat(cut).isLessThan(encoded.size());
+    final ByteString truncated = encoded.substring(0, cut);
+
+    Assertions.assertThatThrownBy(() -> RaftLogEntryCodec.decode(truncated))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void decodeSchemaEntryTruncatedInWalLengthPrefixThrows() {
+    // Boundary semantics: once the WAL count has been read, a truncation a couple of bytes into the
+    // first entry's length prefix (before any payload) must still propagate rather than being treated
+    // as an absent section.
+    final byte[] walData = new byte[64];
+    Arrays.fill(walData, (byte) 7);
+
+    final ByteString encoded = RaftLogEntryCodec.encodeSchemaEntry("testdb", "{}",
+        Map.of(), Map.of(), List.of(walData), List.of(Map.of(1, 5)));
+
+    final int cut = SCHEMA_WAL_COUNT_END + 2; // 2 of the 4 bytes of walUncompressedLen present
+    assertThat(cut).isLessThan(encoded.size());
+    final ByteString truncated = encoded.substring(0, cut);
 
     Assertions.assertThatThrownBy(() -> RaftLogEntryCodec.decode(truncated))
         .isInstanceOf(IllegalStateException.class);

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftLogEntryCodecTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftLogEntryCodecTest.java
@@ -483,4 +483,55 @@ class RaftLogEntryCodecTest {
             () -> RaftLogEntryCodec.decode(ByteString.copyFrom(corrupted)))
         .isInstanceOf(IllegalStateException.class);
   }
+
+  // --- Embedded WAL section truncation/backward-compatibility (issue #4825) ---
+
+  @Test
+  void decodeSchemaEntryWithTruncatedWalSectionThrows() {
+    // A SCHEMA_ENTRY whose embedded WAL section is present but truncated mid-section must surface as
+    // a decode failure, not silently decode with empty/partial WAL entries. A silently emptied WAL
+    // section makes a follower apply the schema change with missing index/WAL pages (the
+    // "Cannot find indexes ..." class of failure) with no error surfaced.
+    final byte[] walData = new byte[4096];
+    for (int i = 0; i < walData.length; i++)
+      walData[i] = (byte) ((i * 31 + 7) ^ (i >>> 3));
+    final Map<Integer, Integer> delta = Map.of(1, 5);
+
+    final ByteString encoded = RaftLogEntryCodec.encodeSchemaEntry("testdb", "{}",
+        Map.of(), Map.of(), List.of(walData), List.of(delta));
+
+    // Keep the entry header + WAL count + length prefixes, but cut off the WAL payload mid-stream.
+    // Half the entry lands inside the compressed WAL bytes, after the count has been read.
+    final ByteString truncated = encoded.substring(0, encoded.size() / 2);
+
+    Assertions.assertThatThrownBy(() -> RaftLogEntryCodec.decode(truncated))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void decodeLegacySchemaEntryWithoutWalSectionDecodesEmpty() throws Exception {
+    // Hand-crafted byte layout matching a pre-embedded-WAL SCHEMA_ENTRY: the stream ends right after
+    // the filesToRemove map, so the WAL-count read hits a clean EOF at the section boundary. This is
+    // the one legitimate "absent section" case and must still decode as an empty WAL section.
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (final DataOutputStream dos = new DataOutputStream(baos)) {
+      dos.writeByte(RaftLogEntryType.SCHEMA_ENTRY.getId());
+      dos.writeUTF("legacydb");
+      final byte[] schemaBytes = "{}".getBytes(StandardCharsets.UTF_8);
+      dos.writeInt(schemaBytes.length);
+      dos.write(schemaBytes);
+      dos.writeInt(0); // filesToAdd: empty
+      dos.writeInt(0); // filesToRemove: empty
+      // no WAL section, no sealed-blob section
+    }
+    final ByteString legacy = ByteString.copyFrom(baos.toByteArray());
+
+    final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(legacy);
+
+    assertThat(decoded.type()).isEqualTo(RaftLogEntryType.SCHEMA_ENTRY);
+    assertThat(decoded.databaseName()).isEqualTo("legacydb");
+    assertThat(decoded.walEntries()).isEmpty();
+    assertThat(decoded.bucketDeltas()).isEmpty();
+    assertThat(decoded.sealedFileBlobs()).isEmpty();
+  }
 }


### PR DESCRIPTION
Closes #4825

## Summary

`RaftLogEntryCodec.decodeSchemaEntry` wrapped the entire embedded-WAL read loop in a broad `catch (IOException ignored)` ("treat as empty"). A SCHEMA_ENTRY whose WAL section was present but truncated or misaligned therefore decoded silently with `walEntries = emptyList()` (or a partial list), with no error surfaced. The follower then applied the schema change with missing index/WAL pages, producing the "Cannot find indexes ..." class of failures.

The fix replaces the swallowing `try`/catch with a `dis.available() > 0` presence check (matching `decodeInstallDatabaseEntry` and the `decode()` trailing-byte check): no remaining bytes at the section boundary means the section is absent (an older entry) and decodes as empty, while any remaining bytes mean the section is present, so a truncated/misaligned read hits EOF and propagates as an `IllegalStateException`. This also closes a mid-`walCount` truncation hole (1-3 leftover bytes) that the old catch would have swallowed.

The identical latent bug in the sibling TimeSeries sealed-blob section (issue #4382) - `blobCount` read inside the same swallowing `catch (EOFException)` - is fixed the same way, for parity. The decode failure is safe at the consumer: `ArcadeStateMachine.applyTransaction` decodes *before* `applyWithRetry`, so a thrown decode exception is not retried; it triggers the existing critical-halt + snapshot-recovery path with `lastAppliedIndex` left untouched (no infinite apply-retry loop).

## Test plan

- [x] `decodeSchemaEntryWithTruncatedWalPayloadThrows` - encodes a SCHEMA_ENTRY with an embedded WAL entry, truncates a few bytes into the compressed WAL payload (count + length prefixes fully read), asserts `decode()` throws (fails before the fix: silently returns empty WAL entries; passes after).
- [x] `decodeSchemaEntryTruncatedInWalLengthPrefixThrows` - truncates 2 bytes into the first WAL entry's length prefix to lock the boundary semantics (count read, then truncation propagates).
- [x] `decodeLegacySchemaEntryWithoutWalSectionDecodesEmpty` - hand-crafts a legacy SCHEMA_ENTRY ending right after `filesToRemove` (no WAL section), asserts it still decodes with empty WAL/blob lists (backward compatibility preserved).
- [x] Truncation offsets are computed explicitly from the wire format (not a fraction of the entry size) so they stay anchored if the encoder/compression ratio changes.
- [x] `mvn -pl ha-raft test -Dtest=RaftLogEntryCodecTest` - 33/33 pass.
- [x] `mvn -pl ha-raft test -Dtest='ArcadeStateMachine*Test,RaftLogEntry*Test'` - 74/74 pass, BUILD SUCCESS (codec consumers unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)