### PR TITLE
fix(#4824): make Raft applied-index tracking per-database-aware

### DIFF
--- a/docs/4824-applied-index-per-database-skew.md
+++ b/docs/4824-applied-index-per-database-skew.md
@@ -55,3 +55,19 @@ Make applied-index tracking per-database-aware (suggested fix option 2):
   still skip its bootstrap verification (legitimate skip preserved).
 - `legacyPlainNumberFileReadAsGlobalNotPerDatabase` — a legacy plain-number file is honoured as
   the global value and yields no per-database evidence.
+- `perDatabaseValuesRoundTripAcrossRestart` — per-database and global values round-trip through the
+  file and recover in a fresh state machine.
+- `fullInstallRecordsSnapshotIndexForEveryPresentDatabase` — a full state-machine install records
+  the snapshot index for every present database (exercises the `getDatabaseNames()` path).
+
+## PR
+
+https://github.com/ArcadeData/arcadedb/pull/4847
+
+## Review cycles
+
+- cycle 1 (`5267f6b`): gemini + claude reviewed. Addressed: synchronise the persisted-index writers
+  on `appliedIndexFileLock` (in-memory + shared temp-file race; both bots); evict dropped databases
+  from the per-database map (claude); add a test for the full-install path and stub
+  `getDatabaseNames()` (claude); document that the hot-path JSON allocation is dominated by the
+  atomic-rename I/O that already ran every apply (claude); fix the doc test count (claude).

--- a/docs/4824-applied-index-per-database-skew.md
+++ b/docs/4824-applied-index-per-database-skew.md
@@ -102,3 +102,14 @@ https://github.com/ArcadeData/arcadedb/pull/4847
   so a later-available file is never masked; add a direct DROP-eviction test; note the graceful
   downgrade path; comment that `globalAppliedIndex` mirrors `lastAppliedIndex`; replace em dashes in
   this doc. The "Review cycles" section is retained per the resolve-issue-with-review Phase 6 convention.
+- cycle 4 (`5c3e016`): gemini re-posted the (already-applied) synchronisation suggestion - no-op.
+  Claude rated all remaining points non-blocking polish. Applied: soften the
+  `globalAppliedIndex`/`lastAppliedIndex` comment (they can briefly differ after `reinitialize()`);
+  note that the corrupt-file -> gap-detection suppression coupling is deliberate; add the upgrade-merge
+  test (`writePreservesOtherDatabasesEntriesOnDisk`) for the load-before-mutate property.
+
+## Final state
+
+max-cycles-reached (4 cycles). All actionable review feedback addressed; the final-cycle reviews are
+approval-level / non-blocking polish (gemini's recurring synchronisation note was already implemented
+in cycle 1). Merge remains the developer's responsibility.

--- a/docs/4824-applied-index-per-database-skew.md
+++ b/docs/4824-applied-index-per-database-skew.md
@@ -1,4 +1,4 @@
-# Issue #4824 — Single global `applied-index` file vs per-database snapshot installs
+# Issue #4824 - Single global `applied-index` file vs per-database snapshot installs
 
 ## Problem
 
@@ -22,7 +22,7 @@ if (persistedApplied >= index) {  // "this DB's baseline already applied" -> ski
 Here `index` is the Raft index of THIS database's `BOOTSTRAP_FINGERPRINT_ENTRY`, but
 `persistedApplied` is the GLOBAL applied index. If a co-located database advanced the global
 index past this entry's index, the bootstrap verification for a database that was never actually
-bootstrapped is silently skipped — the "value that mixes databases" defect described in the issue.
+bootstrapped is silently skipped - the "value that mixes databases" defect described in the issue.
 
 `reinitialize()`'s snapshot-gap decision (`snapshotIndex > persistedApplied + tolerance`) is
 legitimately global: the Ratis snapshot index it compares against is itself global, so it keeps
@@ -49,15 +49,15 @@ Make applied-index tracking per-database-aware (suggested fix option 2):
 ## Tests
 
 `ArcadeStateMachineAppliedIndexPerDatabaseTest`:
-- `bootstrapSkipNotTriggeredByAnotherDatabasesAppliedIndex` — regression: a co-located database's
+- `bootstrapSkipNotTriggeredByAnotherDatabasesAppliedIndex` - regression: a co-located database's
   high applied index must NOT skip another database's bootstrap verification (fails before fix).
-- `bootstrapSkipHonorsPerDatabaseAppliedIndex` — a database's OWN per-database applied index does
+- `bootstrapSkipHonorsPerDatabaseAppliedIndex` - a database's OWN per-database applied index does
   still skip its bootstrap verification (legitimate skip preserved).
-- `legacyPlainNumberFileReadAsGlobalNotPerDatabase` — a legacy plain-number file is honoured as
+- `legacyPlainNumberFileReadAsGlobalNotPerDatabase` - a legacy plain-number file is honoured as
   the global value and yields no per-database evidence.
-- `perDatabaseValuesRoundTripAcrossRestart` — per-database and global values round-trip through the
+- `perDatabaseValuesRoundTripAcrossRestart` - per-database and global values round-trip through the
   file and recover in a fresh state machine.
-- `fullInstallRecordsSnapshotIndexForEveryPresentDatabase` — a full state-machine install records
+- `fullInstallRecordsSnapshotIndexForEveryPresentDatabase` - a full state-machine install records
   the snapshot index for every present database (exercises the `getDatabaseNames()` path).
 
 ## Upgrade behavior (one-time)
@@ -76,6 +76,11 @@ the latest snapshot, mostly recently-formed/low-snapshot clusters) and safe:
 
 From the first post-upgrade apply onwards the per-database map is authoritative and the skew is fixed.
 
+A downgrade degrades gracefully too: an older binary reading the new JSON document fails to parse it
+as a plain number, logs at FINE, and treats the global value as -1, which re-runs the same idempotent
+verification. No external reader of `.raft/applied-index` exists in the tree, so the format change is
+self-contained.
+
 ## PR
 
 https://github.com/ArcadeData/arcadedb/pull/4847
@@ -92,3 +97,8 @@ https://github.com/ArcadeData/arcadedb/pull/4847
   write (`writePersistedAppliedIndexDroppingDatabase`) to remove the two-write crash window;
   document the one-time legacy-upgrade re-verification behavior (bounded and safe) in code and in the
   "Upgrade behavior" section above.
+- cycle 3 (`6422e01`): gemini re-posted the (already-applied) synchronisation suggestion - no-op.
+  Addressed claude: do not latch the load cache when the file path is unresolvable (server not wired)
+  so a later-available file is never masked; add a direct DROP-eviction test; note the graceful
+  downgrade path; comment that `globalAppliedIndex` mirrors `lastAppliedIndex`; replace em dashes in
+  this doc. The "Review cycles" section is retained per the resolve-issue-with-review Phase 6 convention.

--- a/docs/4824-applied-index-per-database-skew.md
+++ b/docs/4824-applied-index-per-database-skew.md
@@ -1,0 +1,57 @@
+# Issue #4824 — Single global `applied-index` file vs per-database snapshot installs
+
+## Problem
+
+`ArcadeStateMachine` multiplexes every database onto one Raft group, but persists a single
+global scalar at `<SERVER_DATABASE_DIRECTORY>/.raft/applied-index`. That scalar is advanced on
+every `applyTransaction` regardless of which database the entry targeted, so it represents the
+union of all databases' Raft-log progress. A per-database snapshot install fast-forwards one
+database's on-disk state without a matching meaning for the global counter, so the persisted
+value cannot be trusted to answer a per-database question.
+
+The one genuinely per-database decision that consumes the scalar is the replay-skip in
+`applyBootstrapFingerprintEntry`:
+
+```java
+final long persistedApplied = readPersistedAppliedIndex();
+if (persistedApplied >= index) {  // "this DB's baseline already applied" -> skip verification
+  return;
+}
+```
+
+Here `index` is the Raft index of THIS database's `BOOTSTRAP_FINGERPRINT_ENTRY`, but
+`persistedApplied` is the GLOBAL applied index. If a co-located database advanced the global
+index past this entry's index, the bootstrap verification for a database that was never actually
+bootstrapped is silently skipped — the "value that mixes databases" defect described in the issue.
+
+`reinitialize()`'s snapshot-gap decision (`snapshotIndex > persistedApplied + tolerance`) is
+legitimately global: the Ratis snapshot index it compares against is itself global, so it keeps
+using the global value (behaviour unchanged).
+
+## Fix
+
+Make applied-index tracking per-database-aware (suggested fix option 2):
+
+- The persisted file becomes a small JSON document: a `global` Raft-log position plus a `db` map
+  of `database name -> highest applied Raft index for that database`. A legacy plain-number file
+  is read as the `global` value with an empty per-database map (honest: no per-database evidence).
+- `applyTransaction` records the applied index against the database the entry targeted
+  (`decoded.databaseName()`) as well as the global position.
+- `applyBootstrapFingerprintEntry` now consults the PER-DATABASE applied index (strict, no global
+  fallback): verification is skipped only when there is positive per-database evidence that this
+  database was already advanced past the entry. Absent that evidence it re-verifies, which is
+  idempotent (a fingerprint match returns immediately).
+- The whole-state-machine Ratis install path records the snapshot index for every present
+  database, since after a full install every database is at that index.
+- An in-memory cache (volatile global + `ConcurrentHashMap`) keeps the hot apply path cheap: the
+  file is parsed once on first access; each apply updates memory and serialises the small map.
+
+## Tests
+
+`ArcadeStateMachineAppliedIndexPerDatabaseTest`:
+- `bootstrapSkipNotTriggeredByAnotherDatabasesAppliedIndex` — regression: a co-located database's
+  high applied index must NOT skip another database's bootstrap verification (fails before fix).
+- `bootstrapSkipHonorsPerDatabaseAppliedIndex` — a database's OWN per-database applied index does
+  still skip its bootstrap verification (legitimate skip preserved).
+- `legacyPlainNumberFileReadAsGlobalNotPerDatabase` — a legacy plain-number file is honoured as
+  the global value and yields no per-database evidence.

--- a/docs/4824-applied-index-per-database-skew.md
+++ b/docs/4824-applied-index-per-database-skew.md
@@ -60,6 +60,22 @@ Make applied-index tracking per-database-aware (suggested fix option 2):
 - `fullInstallRecordsSnapshotIndexForEveryPresentDatabase` — a full state-machine install records
   the snapshot index for every present database (exercises the `getDatabaseNames()` path).
 
+## Upgrade behavior (one-time)
+
+A legacy plain-number `.raft/applied-index` file written by an older version carries no per-database
+breakdown, so on the FIRST restart after upgrade every per-database read returns -1. Any
+`BOOTSTRAP_FINGERPRINT_ENTRY` still above the latest Ratis snapshot at that moment will re-run
+verification instead of being skipped. This is bounded (it only affects bootstrap entries still above
+the latest snapshot, mostly recently-formed/low-snapshot clusters) and safe:
+
+- matching local fingerprint -> returns immediately (no bytes moved);
+- locally-fresher copy (`local lastTxId > baseline`) -> hits the existing "refusing to overwrite
+  local data" guard: a SEVERE log line, but no data loss;
+- genuinely-behind copy (`local < baseline`) -> re-installs from the leader, the correct action
+  anyway (download-before-close keeps the database open on failure).
+
+From the first post-upgrade apply onwards the per-database map is authoritative and the skew is fixed.
+
 ## PR
 
 https://github.com/ArcadeData/arcadedb/pull/4847
@@ -71,3 +87,8 @@ https://github.com/ArcadeData/arcadedb/pull/4847
   from the per-database map (claude); add a test for the full-install path and stub
   `getDatabaseNames()` (claude); document that the hot-path JSON allocation is dominated by the
   atomic-rename I/O that already ran every apply (claude); fix the doc test count (claude).
+- cycle 2 (`851e3d5`): gemini re-posted the (already-applied) synchronisation suggestion - no-op.
+  Addressed claude: fold the DROP-entry global advance + per-database eviction into a single atomic
+  write (`writePersistedAppliedIndexDroppingDatabase`) to remove the two-write crash window;
+  document the one-time legacy-upgrade re-verification behavior (bounded and safe) in code and in the
+  "Upgrade behavior" section above.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -447,8 +447,13 @@ public class ArcadeStateMachine extends BaseStateMachine {
       // Record the index globally AND against the database this entry targeted, so the per-database
       // bootstrap replay-skip can trust a value that is not mixed across databases (issue #4824).
       // decoded.databaseName() is null only for database-agnostic entries (e.g. SECURITY_USERS_ENTRY),
-      // which advance the global position only.
-      writePersistedAppliedIndex(index, decoded.databaseName());
+      // which advance the global position only. A DROP entry removes the database, so we advance only
+      // the global position and evict its per-database entry below (avoids growing the map for the
+      // node lifetime with names of dropped databases).
+      final boolean droppedDatabase = decoded.type() == RaftLogEntryType.DROP_DATABASE_ENTRY;
+      writePersistedAppliedIndex(index, droppedDatabase ? null : decoded.databaseName());
+      if (droppedDatabase)
+        removePersistedAppliedIndexForDatabase(decoded.databaseName());
 
       // Wake up any threads waiting for this index (READ_YOUR_WRITES, waitForLocalApply)
       final RaftHAServer raftHA = this.raftHAServer;
@@ -1652,27 +1657,53 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * Records {@code index} as the global applied position and, when {@code dbName} is non-null, as the
    * per-database applied position for that database, then serialises the bookkeeping to disk.
    * Package-private for tests.
+   * <p>
+   * Synchronised on {@link #appliedIndexFileLock}: the apply thread and the snapshot-install thread
+   * (see {@link #writePersistedAppliedIndexForAllDatabases}) are the two writers, and the lock keeps
+   * the in-memory update and the temp-file write+rename atomic with respect to each other so the
+   * shared {@code applied-index.tmp} is never raced.
    */
   void writePersistedAppliedIndex(final long index, final String dbName) {
-    ensureAppliedIndexLoaded();
-    globalAppliedIndex = index;
-    if (dbName != null)
-      appliedIndexByDb.put(dbName, index);
-    persistAppliedIndexFile();
+    synchronized (appliedIndexFileLock) {
+      ensureAppliedIndexLoaded();
+      globalAppliedIndex = index;
+      if (dbName != null)
+        appliedIndexByDb.put(dbName, index);
+      persistAppliedIndexFile();
+    }
+  }
+
+  /**
+   * Removes {@code dbName} from the per-database applied-index map and serialises, so a dropped
+   * database does not leave a stale entry that grows the map and persisted JSON for the node lifetime
+   * (issue #4824). The global position is left untouched.
+   */
+  private void removePersistedAppliedIndexForDatabase(final String dbName) {
+    if (dbName == null)
+      return;
+    synchronized (appliedIndexFileLock) {
+      ensureAppliedIndexLoaded();
+      if (appliedIndexByDb.remove(dbName) != null)
+        persistAppliedIndexFile();
+    }
   }
 
   /**
    * Records {@code index} as the global applied position and as the per-database position for every
    * database currently present on this node, then serialises once. Used by the full state-machine
-   * snapshot install, after which every present database is at {@code index}.
+   * snapshot install, after which every present database is at {@code index}. Synchronised on
+   * {@link #appliedIndexFileLock} so it never races the apply-thread writer on the in-memory state or
+   * the shared temp file.
    */
-  private void writePersistedAppliedIndexForAllDatabases(final long index) {
-    ensureAppliedIndexLoaded();
-    globalAppliedIndex = index;
-    if (server != null)
-      for (final String dbName : server.getDatabaseNames())
-        appliedIndexByDb.put(dbName, index);
-    persistAppliedIndexFile();
+  void writePersistedAppliedIndexForAllDatabases(final long index) {
+    synchronized (appliedIndexFileLock) {
+      ensureAppliedIndexLoaded();
+      globalAppliedIndex = index;
+      if (server != null)
+        for (final String dbName : server.getDatabaseNames())
+          appliedIndexByDb.put(dbName, index);
+      persistAppliedIndexFile();
+    }
   }
 
   /**
@@ -1714,6 +1745,11 @@ public class ArcadeStateMachine extends BaseStateMachine {
   /**
    * Serialises the in-memory applied-index bookkeeping to {@code .raft/applied-index} via a temp file
    * and atomic rename, so a crash mid-write never leaves a corrupt file.
+   * <p>
+   * Called once per applied entry (the file was already rewritten every apply before this change).
+   * The per-database map is tiny (one entry per co-located database) and the small JSON it allocates
+   * is dominated by the {@code createDirectories} + {@code writeString} + atomic {@code move} syscalls
+   * that already ran every apply, so the extra allocation is negligible on the apply path.
    */
   private void persistAppliedIndexFile() {
     try {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -447,13 +447,13 @@ public class ArcadeStateMachine extends BaseStateMachine {
       // Record the index globally AND against the database this entry targeted, so the per-database
       // bootstrap replay-skip can trust a value that is not mixed across databases (issue #4824).
       // decoded.databaseName() is null only for database-agnostic entries (e.g. SECURITY_USERS_ENTRY),
-      // which advance the global position only. A DROP entry removes the database, so we advance only
-      // the global position and evict its per-database entry below (avoids growing the map for the
-      // node lifetime with names of dropped databases).
-      final boolean droppedDatabase = decoded.type() == RaftLogEntryType.DROP_DATABASE_ENTRY;
-      writePersistedAppliedIndex(index, droppedDatabase ? null : decoded.databaseName());
-      if (droppedDatabase)
-        removePersistedAppliedIndexForDatabase(decoded.databaseName());
+      // which advance the global position only. A DROP entry removes the database, so the global
+      // position advances and its per-database entry is evicted in a single atomic write (avoids
+      // growing the map for the node lifetime with names of dropped databases).
+      if (decoded.type() == RaftLogEntryType.DROP_DATABASE_ENTRY)
+        writePersistedAppliedIndexDroppingDatabase(index, decoded.databaseName());
+      else
+        writePersistedAppliedIndex(index, decoded.databaseName());
 
       // Wake up any threads waiting for this index (READ_YOUR_WRITES, waitForLocalApply)
       final RaftHAServer raftHA = this.raftHAServer;
@@ -1383,6 +1383,15 @@ public class ArcadeStateMachine extends BaseStateMachine {
     // advanced the global index past this entry must not suppress this database's verification
     // (issue #4824). Absent positive per-database evidence the verification re-runs, which is
     // idempotent (a fingerprint match returns immediately without moving any bytes).
+    //
+    // Upgrade note: a legacy plain-number applied-index file carries no per-database breakdown, so on
+    // the FIRST restart after upgrading, this read returns -1 for every database and verification
+    // re-runs for any bootstrap entry still above the latest Ratis snapshot. That is a bounded,
+    // one-time cost and is safe: a matching local fingerprint returns immediately; a locally-fresher
+    // copy (local lastTxId > baseline) hits the "refusing to overwrite local data" guard below (no
+    // data loss, just a SEVERE log line); a genuinely-behind copy re-installs from the leader, which
+    // is the correct action anyway. From the first post-upgrade apply onwards the per-database map is
+    // authoritative.
     final long persistedApplied = readPersistedAppliedIndex(dbName);
     if (persistedApplied >= index) {
       HALog.log(this, HALog.BASIC,
@@ -1674,17 +1683,19 @@ public class ArcadeStateMachine extends BaseStateMachine {
   }
 
   /**
-   * Removes {@code dbName} from the per-database applied-index map and serialises, so a dropped
-   * database does not leave a stale entry that grows the map and persisted JSON for the node lifetime
-   * (issue #4824). The global position is left untouched.
+   * Advances the global applied position to {@code index} and, in the SAME serialised write, evicts
+   * {@code dbName} from the per-database map. Used for a {@code DROP_DATABASE_ENTRY}: the database is
+   * gone, so its per-database entry must not linger and grow the map/persisted JSON for the node
+   * lifetime (issue #4824). Folding the global advance and the eviction into one atomic write avoids
+   * a crash window that could leave a stale per-database entry for a database that no longer exists.
    */
-  private void removePersistedAppliedIndexForDatabase(final String dbName) {
-    if (dbName == null)
-      return;
+  private void writePersistedAppliedIndexDroppingDatabase(final long index, final String dbName) {
     synchronized (appliedIndexFileLock) {
       ensureAppliedIndexLoaded();
-      if (appliedIndexByDb.remove(dbName) != null)
-        persistAppliedIndexFile();
+      globalAppliedIndex = index;
+      if (dbName != null)
+        appliedIndexByDb.remove(dbName);
+      persistAppliedIndexFile();
     }
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -124,6 +124,9 @@ public class ArcadeStateMachine extends BaseStateMachine {
   // which compares against the inherently global Ratis snapshot index) AND a per-database map (used by
   // the per-database bootstrap replay-skip). The values live in memory so the hot apply path never
   // reads the file back; the file is parsed once lazily on first access and serialised on each write.
+  // globalAppliedIndex mirrors lastAppliedIndex (the AtomicLong above) after each apply: they are
+  // seeded differently (this one from the persisted file on load, lastAppliedIndex in reinitialize())
+  // but both advance to the same value on every applyTransaction and must stay in sync.
   private final    Map<String, Long>         appliedIndexByDb     = new ConcurrentHashMap<>();
   private volatile long                      globalAppliedIndex   = -1;
   private volatile boolean                   appliedIndexLoaded   = false;
@@ -1688,8 +1691,9 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * gone, so its per-database entry must not linger and grow the map/persisted JSON for the node
    * lifetime (issue #4824). Folding the global advance and the eviction into one atomic write avoids
    * a crash window that could leave a stale per-database entry for a database that no longer exists.
+   * Package-private for tests.
    */
-  private void writePersistedAppliedIndexDroppingDatabase(final long index, final String dbName) {
+  void writePersistedAppliedIndexDroppingDatabase(final long index, final String dbName) {
     synchronized (appliedIndexFileLock) {
       ensureAppliedIndexLoaded();
       globalAppliedIndex = index;
@@ -1720,8 +1724,13 @@ public class ArcadeStateMachine extends BaseStateMachine {
   /**
    * Lazily parses the persisted applied-index file once into the in-memory cache. Accepts both the
    * new JSON document ({@code {"global": n, "db": {"name": n, ...}}}) and a legacy plain-number file
-   * (read as the global value with an empty per-database map). Failures leave the cache empty: a
-   * missing/unreadable file simply means "nothing persisted yet" (-1).
+   * (read as the global value with an empty per-database map). A missing/unreadable file simply means
+   * "nothing persisted yet" (-1) and still latches the cache as loaded.
+   * <p>
+   * When the file path cannot yet be resolved (no server wired, so {@code getAppliedIndexFile()} is
+   * {@code null}) the cache is NOT latched, so a later call retries once the server is available and
+   * a persisted file is no longer masked. In the current wiring {@code setServer(...)} always runs
+   * before the first read, so this only guards against a future reordering.
    */
   private void ensureAppliedIndexLoaded() {
     if (appliedIndexLoaded)
@@ -1729,9 +1738,11 @@ public class ArcadeStateMachine extends BaseStateMachine {
     synchronized (appliedIndexFileLock) {
       if (appliedIndexLoaded)
         return;
+      final Path file = getAppliedIndexFile();
+      if (file == null)
+        return; // server not wired yet: do not latch, retry once the path is resolvable
       try {
-        final Path file = getAppliedIndexFile();
-        if (file != null && Files.exists(file)) {
+        if (Files.exists(file)) {
           final String content = Files.readString(file).trim();
           if (!content.isEmpty()) {
             if (content.charAt(0) == '{') {
@@ -1748,6 +1759,8 @@ public class ArcadeStateMachine extends BaseStateMachine {
       } catch (final Exception e) {
         LogManager.instance().log(this, Level.FINE, "Could not read persisted applied index: %s", e.getMessage());
       } finally {
+        // The path was resolvable and we attempted a read: latch even on a parse failure so a corrupt
+        // file is not re-read on every apply (it degrades to -1, re-running the idempotent verification).
         appliedIndexLoaded = true;
       }
     }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -124,9 +124,11 @@ public class ArcadeStateMachine extends BaseStateMachine {
   // which compares against the inherently global Ratis snapshot index) AND a per-database map (used by
   // the per-database bootstrap replay-skip). The values live in memory so the hot apply path never
   // reads the file back; the file is parsed once lazily on first access and serialised on each write.
-  // globalAppliedIndex mirrors lastAppliedIndex (the AtomicLong above) after each apply: they are
-  // seeded differently (this one from the persisted file on load, lastAppliedIndex in reinitialize())
-  // but both advance to the same value on every applyTransaction and must stay in sync.
+  // globalAppliedIndex tracks the same value as lastAppliedIndex (the AtomicLong above) on the apply
+  // path. They are seeded independently (this one from the persisted file on load, lastAppliedIndex
+  // from the Ratis snapshot in reinitialize()) and can briefly differ after reinitialize() - e.g. when
+  // there is no snapshot lastAppliedIndex is -1 while globalAppliedIndex may hold the persisted value -
+  // but every applyTransaction advances both to the same index, reconverging them.
   private final    Map<String, Long>         appliedIndexByDb     = new ConcurrentHashMap<>();
   private volatile long                      globalAppliedIndex   = -1;
   private volatile boolean                   appliedIndexLoaded   = false;
@@ -1761,6 +1763,10 @@ public class ArcadeStateMachine extends BaseStateMachine {
       } finally {
         // The path was resolvable and we attempted a read: latch even on a parse failure so a corrupt
         // file is not re-read on every apply (it degrades to -1, re-running the idempotent verification).
+        // Deliberate coupling: a corrupt file leaving globalAppliedIndex at -1 also makes
+        // reinitialize()'s snapshot-gap check (persistedApplied >= 0 && ...) evaluate false, i.e. it
+        // suppresses the "snapshot ahead, download from leader" path. This matches the pre-change
+        // behavior (a parse failure already returned -1), so it is intentional, not a regression.
         appliedIndexLoaded = true;
       }
     }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -115,6 +115,19 @@ public class ArcadeStateMachine extends BaseStateMachine {
   private final    SimpleStateMachineStorage storage          = new SimpleStateMachineStorage();
   private final    AtomicLong                lastAppliedIndex = new AtomicLong(-1);
   private final    AtomicLong                electionCount    = new AtomicLong(0);
+
+  // Persisted applied-index bookkeeping. One ArcadeStateMachine multiplexes every database onto a
+  // single Raft group, so a single global scalar cannot answer a per-database question: a co-located
+  // database advancing the shared log past another database's entry would make the global value
+  // overstate that other database's progress (issue #4824). We keep BOTH: a global Raft-log position
+  // (the highest applied index across all databases, used by reinitialize()'s snapshot-gap check,
+  // which compares against the inherently global Ratis snapshot index) AND a per-database map (used by
+  // the per-database bootstrap replay-skip). The values live in memory so the hot apply path never
+  // reads the file back; the file is parsed once lazily on first access and serialised on each write.
+  private final    Map<String, Long>         appliedIndexByDb     = new ConcurrentHashMap<>();
+  private volatile long                      globalAppliedIndex   = -1;
+  private volatile boolean                   appliedIndexLoaded   = false;
+  private final    Object                    appliedIndexFileLock = new Object();
   private volatile long                      lastElectionTime = 0;
   private final    long                      startTime        = System.currentTimeMillis();
   // Tracks the previous leader so leader-change logs can show "X -> Y" instead of just "Y".
@@ -431,7 +444,11 @@ public class ArcadeStateMachine extends BaseStateMachine {
 
       final long previousApplied = lastAppliedIndex.getAndSet(index);
       updateLastAppliedTermIndex(termIndex.getTerm(), index);
-      writePersistedAppliedIndex(index);
+      // Record the index globally AND against the database this entry targeted, so the per-database
+      // bootstrap replay-skip can trust a value that is not mixed across databases (issue #4824).
+      // decoded.databaseName() is null only for database-agnostic entries (e.g. SECURITY_USERS_ENTRY),
+      // which advance the global position only.
+      writePersistedAppliedIndex(index, decoded.databaseName());
 
       // Wake up any threads waiting for this index (READ_YOUR_WRITES, waitForLocalApply)
       final RaftHAServer raftHA = this.raftHAServer;
@@ -910,10 +927,13 @@ public class ArcadeStateMachine extends BaseStateMachine {
           throw new IOException("Failed to register snapshot marker at index " + snapshotIndex);
 
         // Advance the local applied-index to the snapshot point so that the StateMachineUpdater
-        // knows which log entries have been consumed by this install.
+        // knows which log entries have been consumed by this install. A full state-machine install
+        // brings EVERY present database to the snapshot point, so record the snapshot index for each
+        // of them too (not just the global position) - this keeps the per-database bootstrap
+        // replay-skip honest after a full resync (issue #4824).
         lastAppliedIndex.set(snapshotIndex);
         updateLastAppliedTermIndex(snapshotTerm, snapshotIndex);
-        writePersistedAppliedIndex(snapshotIndex);
+        writePersistedAppliedIndexForAllDatabases(snapshotIndex);
 
         LogManager.instance().log(this, Level.INFO,
             "HA resync finished (mode=snapshot, result=ok): snapshotIndex=%d", snapshotIndex);
@@ -1353,7 +1373,12 @@ public class ArcadeStateMachine extends BaseStateMachine {
     // the install path here would race leader-discovery (the StateMachineUpdater thread is
     // inside applyTransaction and blocks Ratis leader-info notifications), exhaust the snapshot
     // retry budget with null leader addresses, and trip the critical-error halt.
-    final long persistedApplied = readPersistedAppliedIndex();
+    // This is a PER-DATABASE decision, so it must consult THIS database's applied index, not the
+    // global one: one ArcadeStateMachine multiplexes every database, and a co-located database that
+    // advanced the global index past this entry must not suppress this database's verification
+    // (issue #4824). Absent positive per-database evidence the verification re-runs, which is
+    // idempotent (a fingerprint match returns immediately without moving any bytes).
+    final long persistedApplied = readPersistedAppliedIndex(dbName);
     if (persistedApplied >= index) {
       HALog.log(this, HALog.BASIC,
           "Bootstrap baseline for '%s' already applied (persistedAppliedIndex=%d >= entryIndex=%d); skipping verification",
@@ -1597,26 +1622,114 @@ public class ArcadeStateMachine extends BaseStateMachine {
     HALog.log(this, HALog.DETAILED, "Applied SECURITY_USERS_ENTRY (%d bytes)", payload.length());
   }
 
-  private long readPersistedAppliedIndex() {
-    try {
-      final Path file = getAppliedIndexFile();
-      if (file != null && Files.exists(file))
-        return Long.parseLong(Files.readString(file).trim());
-    } catch (final Exception e) {
-      LogManager.instance().log(this, Level.FINE, "Could not read persisted applied index: %s", e.getMessage());
-    }
-    return -1;
+  /**
+   * Returns the GLOBAL persisted applied index: the highest Raft-log index applied across all
+   * databases multiplexed on this state machine, or {@code -1} if none was persisted. This is a
+   * Raft-log position, not a per-database guarantee; {@link #reinitialize()} compares it against the
+   * (inherently global) Ratis snapshot index. Package-private for tests.
+   */
+  long readPersistedAppliedIndex() {
+    ensureAppliedIndexLoaded();
+    return globalAppliedIndex;
   }
 
-  private void writePersistedAppliedIndex(final long index) {
+  /**
+   * Returns the persisted applied index for a single {@code dbName}, or {@code -1} when there is no
+   * per-database evidence that this database was advanced (issue #4824). A legacy plain-number file
+   * carries only the global value and therefore yields {@code -1} here: per-database decisions never
+   * fall back to the global value, so a co-located database can never falsely satisfy them.
+   * Package-private for tests.
+   */
+  long readPersistedAppliedIndex(final String dbName) {
+    if (dbName == null)
+      return -1;
+    ensureAppliedIndexLoaded();
+    final Long v = appliedIndexByDb.get(dbName);
+    return v != null ? v : -1;
+  }
+
+  /**
+   * Records {@code index} as the global applied position and, when {@code dbName} is non-null, as the
+   * per-database applied position for that database, then serialises the bookkeeping to disk.
+   * Package-private for tests.
+   */
+  void writePersistedAppliedIndex(final long index, final String dbName) {
+    ensureAppliedIndexLoaded();
+    globalAppliedIndex = index;
+    if (dbName != null)
+      appliedIndexByDb.put(dbName, index);
+    persistAppliedIndexFile();
+  }
+
+  /**
+   * Records {@code index} as the global applied position and as the per-database position for every
+   * database currently present on this node, then serialises once. Used by the full state-machine
+   * snapshot install, after which every present database is at {@code index}.
+   */
+  private void writePersistedAppliedIndexForAllDatabases(final long index) {
+    ensureAppliedIndexLoaded();
+    globalAppliedIndex = index;
+    if (server != null)
+      for (final String dbName : server.getDatabaseNames())
+        appliedIndexByDb.put(dbName, index);
+    persistAppliedIndexFile();
+  }
+
+  /**
+   * Lazily parses the persisted applied-index file once into the in-memory cache. Accepts both the
+   * new JSON document ({@code {"global": n, "db": {"name": n, ...}}}) and a legacy plain-number file
+   * (read as the global value with an empty per-database map). Failures leave the cache empty: a
+   * missing/unreadable file simply means "nothing persisted yet" (-1).
+   */
+  private void ensureAppliedIndexLoaded() {
+    if (appliedIndexLoaded)
+      return;
+    synchronized (appliedIndexFileLock) {
+      if (appliedIndexLoaded)
+        return;
+      try {
+        final Path file = getAppliedIndexFile();
+        if (file != null && Files.exists(file)) {
+          final String content = Files.readString(file).trim();
+          if (!content.isEmpty()) {
+            if (content.charAt(0) == '{') {
+              final JSONObject json = new JSONObject(content);
+              globalAppliedIndex = json.getLong("global", -1);
+              final JSONObject perDb = json.getJSONObject("db", new JSONObject());
+              for (final String name : perDb.keySet())
+                appliedIndexByDb.put(name, perDb.getLong(name, -1));
+            } else
+              // Legacy format: a single plain number is the global Raft-log position.
+              globalAppliedIndex = Long.parseLong(content);
+          }
+        }
+      } catch (final Exception e) {
+        LogManager.instance().log(this, Level.FINE, "Could not read persisted applied index: %s", e.getMessage());
+      } finally {
+        appliedIndexLoaded = true;
+      }
+    }
+  }
+
+  /**
+   * Serialises the in-memory applied-index bookkeeping to {@code .raft/applied-index} via a temp file
+   * and atomic rename, so a crash mid-write never leaves a corrupt file.
+   */
+  private void persistAppliedIndexFile() {
     try {
       final Path file = getAppliedIndexFile();
       if (file == null)
         return;
+      final JSONObject json = new JSONObject();
+      json.put("global", globalAppliedIndex);
+      final JSONObject perDb = new JSONObject();
+      for (final Map.Entry<String, Long> entry : appliedIndexByDb.entrySet())
+        perDb.put(entry.getKey(), entry.getValue());
+      json.put("db", perDb);
+
       Files.createDirectories(file.getParent());
-      // Write via a temp file + atomic rename to avoid corruption on crash
       final Path tmp = file.resolveSibling("applied-index.tmp");
-      Files.writeString(tmp, Long.toString(index));
+      Files.writeString(tmp, json.toString());
       Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.FINE, "Could not write persisted applied index: %s", e.getMessage());

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineAppliedIndexPerDatabaseTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineAppliedIndexPerDatabaseTest.java
@@ -220,4 +220,30 @@ class ArcadeStateMachineAppliedIndexPerDatabaseTest {
     assertThat(sm.readPersistedAppliedIndex(DB_A)).isEqualTo(500L);
     assertThat(sm.readPersistedAppliedIndex(DB_OTHER)).isEqualTo(500L);
   }
+
+  /**
+   * Dropping a database advances the global position and evicts that database's per-database entry in
+   * a single write, so the map does not retain a stale entry for a database that no longer exists.
+   */
+  @Test
+  void dropDatabaseEvictsPerDatabaseEntryAndAdvancesGlobal() {
+    final ArcadeDBServer server = mockServer();
+    final ArcadeStateMachine sm = newStateMachine(server);
+
+    sm.writePersistedAppliedIndex(40L, DB_A);
+    sm.writePersistedAppliedIndex(41L, DB_OTHER);
+    assertThat(sm.readPersistedAppliedIndex(DB_A)).isEqualTo(40L);
+
+    sm.writePersistedAppliedIndexDroppingDatabase(99L, DB_A);
+
+    assertThat(sm.readPersistedAppliedIndex(DB_A))
+        .as("the dropped database's per-database entry is evicted")
+        .isEqualTo(-1L);
+    assertThat(sm.readPersistedAppliedIndex(DB_OTHER))
+        .as("a co-located database's entry is untouched")
+        .isEqualTo(41L);
+    assertThat(sm.readPersistedAppliedIndex())
+        .as("the global position still advances on the drop entry")
+        .isEqualTo(99L);
+  }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineAppliedIndexPerDatabaseTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineAppliedIndexPerDatabaseTest.java
@@ -23,6 +23,7 @@ import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.BootstrapFingerprint;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.ServerDatabase;
 import com.arcadedb.utility.FileUtils;
@@ -232,6 +233,50 @@ class ArcadeStateMachineAppliedIndexPerDatabaseTest {
         .as("global tracks the last applied index across all databases")
         .isEqualTo(20L);
     assertThat(reopened.readPersistedAppliedIndex("never-seen")).isEqualTo(-1L);
+  }
+
+  /**
+   * The on-disk file is the new JSON document ({@code {"global": n, "db": {...}}}), not the legacy
+   * plain number. The round-trip test exercises the same read/write code on both ends, so a format
+   * regression that stayed internally consistent would still pass there; this asserts the actual bytes
+   * so the persisted shape is pinned independently of the reader.
+   */
+  @Test
+  void persistedFileIsJsonDocumentOnDisk() throws Exception {
+    final ArcadeStateMachine sm = newStateMachine();
+    sm.writePersistedAppliedIndex(10L, DB_A);
+    sm.writePersistedAppliedIndex(20L, DB_OTHER);
+
+    final String content = Files.readString(serverDir.resolve(".raft").resolve("applied-index")).trim();
+    assertThat(content).as("the persisted file is a JSON document, not a legacy plain number").startsWith("{");
+
+    final JSONObject json = new JSONObject(content);
+    assertThat(json.getLong("global", -1)).isEqualTo(20L);
+    final JSONObject perDb = json.getJSONObject("db", new JSONObject());
+    assertThat(perDb.getLong(DB_A, -1)).isEqualTo(10L);
+    assertThat(perDb.getLong(DB_OTHER, -1)).isEqualTo(20L);
+  }
+
+  /**
+   * A corrupt/unparseable applied-index file degrades to {@code -1} for both the global and any
+   * per-database read rather than throwing. This coupling is relied upon by {@code reinitialize()},
+   * whose snapshot-gap check ({@code persistedApplied >= 0 && ...}) then evaluates false and suppresses
+   * the "snapshot ahead, download from leader" path - matching the pre-change behaviour.
+   */
+  @Test
+  void corruptFileDegradesToMinusOne() throws Exception {
+    final Path raftDir = serverDir.resolve(".raft");
+    Files.createDirectories(raftDir);
+    // Looks like the new JSON document (leading '{') but is truncated, so JSON parsing fails.
+    Files.writeString(raftDir.resolve("applied-index"), "{\"global\": 42, \"db\": {\"db-a\":");
+
+    final ArcadeStateMachine sm = newStateMachine();
+    assertThat(sm.readPersistedAppliedIndex())
+        .as("a corrupt file degrades the global value to -1 instead of throwing")
+        .isEqualTo(-1L);
+    assertThat(sm.readPersistedAppliedIndex(DB_A))
+        .as("a corrupt file yields no per-database evidence")
+        .isEqualTo(-1L);
   }
 
   /**

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineAppliedIndexPerDatabaseTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineAppliedIndexPerDatabaseTest.java
@@ -246,4 +246,33 @@ class ArcadeStateMachineAppliedIndexPerDatabaseTest {
         .as("the global position still advances on the drop entry")
         .isEqualTo(99L);
   }
+
+  /**
+   * A write that targets one database must preserve the other databases' entries already on disk: the
+   * write loads the existing map before mutating (load-before-mutate), so an unrelated database's
+   * persisted index is not clobbered when the file is rewritten.
+   */
+  @Test
+  void writePreservesOtherDatabasesEntriesOnDisk() {
+    final ArcadeDBServer server = mockServer();
+
+    // First instance persists entries for both databases.
+    final ArcadeStateMachine writer = newStateMachine(server);
+    writer.writePersistedAppliedIndex(10L, DB_A);
+    writer.writePersistedAppliedIndex(20L, DB_OTHER);
+
+    // A fresh instance (no in-memory state) writes a NEW index for db-a only; db-other must survive.
+    final ArcadeStateMachine reopened = newStateMachine(server);
+    reopened.writePersistedAppliedIndex(30L, DB_A);
+
+    assertThat(reopened.readPersistedAppliedIndex(DB_A)).isEqualTo(30L);
+    assertThat(reopened.readPersistedAppliedIndex(DB_OTHER))
+        .as("an unrelated database's persisted entry survives a single-database rewrite")
+        .isEqualTo(20L);
+
+    // And it is durable: a third instance reading from disk still sees both.
+    final ArcadeStateMachine third = newStateMachine(server);
+    assertThat(third.readPersistedAppliedIndex(DB_A)).isEqualTo(30L);
+    assertThat(third.readPersistedAppliedIndex(DB_OTHER)).isEqualTo(20L);
+  }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineAppliedIndexPerDatabaseTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineAppliedIndexPerDatabaseTest.java
@@ -35,14 +35,9 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Regression tests for issue #4824.
@@ -57,6 +52,12 @@ import static org.mockito.Mockito.when;
  * <p>
  * The fix makes applied-index tracking per-database-aware: the skip now consults this database's own
  * applied index and only skips when there is positive per-database evidence.
+ * <p>
+ * The tests drive a real (unstarted) {@link ArcadeDBServer} with real {@link LocalDatabase}
+ * collaborators registered into its registry - no mocking framework. To observe whether the
+ * verification path was reached, a tiny {@link CountingServer} subclass tallies the single-argument
+ * {@code getDatabase} calls that {@code applyBootstrapFingerprintEntry} makes only after it decides
+ * NOT to skip.
  */
 class ArcadeStateMachineAppliedIndexPerDatabaseTest {
 
@@ -64,38 +65,70 @@ class ArcadeStateMachineAppliedIndexPerDatabaseTest {
   private static final String DB_OTHER = "db-other";
 
   @TempDir
-  private Path        serverDir;
-  private LocalDatabase localDbA;
-  private String        dbAPath;
+  private Path          serverDir;
+  private CountingServer server;
+  private LocalDatabase  localDbA;
+  private LocalDatabase  localDbOther;
+  private String         dbAPath;
+  private String         dbOtherPath;
+
+  /**
+   * A real {@link ArcadeDBServer} that records how many times the single-argument
+   * {@link #getDatabase(String)} - the call {@code applyBootstrapFingerprintEntry} reaches only on the
+   * non-skip (verification) path - has been invoked. Everything else delegates to the real server.
+   */
+  private static final class CountingServer extends ArcadeDBServer {
+    final AtomicInteger getDatabaseInvocations = new AtomicInteger();
+
+    CountingServer(final ContextConfiguration configuration) {
+      super(configuration);
+    }
+
+    @Override
+    public ServerDatabase getDatabase(final String databaseName) {
+      getDatabaseInvocations.incrementAndGet();
+      return super.getDatabase(databaseName);
+    }
+  }
 
   @BeforeEach
   void setUp() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY, serverDir.toString());
+    server = new CountingServer(config);
+
     dbAPath = serverDir.resolve(DB_A).toString();
     localDbA = (LocalDatabase) new DatabaseFactory(dbAPath).create();
+    server.registerDatabase(DB_A, localDbA);
   }
 
   @AfterEach
   void tearDown() {
     if (localDbA != null && localDbA.isOpen())
       localDbA.close();
-    FileUtils.deleteRecursively(new File(dbAPath));
+    if (localDbOther != null && localDbOther.isOpen())
+      localDbOther.close();
+    if (dbAPath != null)
+      FileUtils.deleteRecursively(new File(dbAPath));
+    if (dbOtherPath != null)
+      FileUtils.deleteRecursively(new File(dbOtherPath));
   }
 
-  private ArcadeStateMachine newStateMachine(final ArcadeDBServer server) {
+  private ArcadeStateMachine newStateMachine() {
     final ArcadeStateMachine sm = new ArcadeStateMachine();
     sm.setServer(server);
     return sm;
   }
 
-  private ArcadeDBServer mockServer() {
-    final ContextConfiguration config = new ContextConfiguration();
-    config.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY, serverDir.toString());
-
-    final ArcadeDBServer server = mock(ArcadeDBServer.class);
-    when(server.getConfiguration()).thenReturn(config);
-    when(server.existsDatabase(DB_A)).thenReturn(true);
-    when(server.getDatabase(DB_A)).thenReturn(new ServerDatabase(null, localDbA));
-    return server;
+  /**
+   * Registers a real second database so {@code getDatabaseNames()} reports it. Used by the
+   * full-install test, the only one that needs DB_OTHER actually present on the node (the others use
+   * the name purely as an applied-index map key).
+   */
+  private void registerSecondDatabase() {
+    dbOtherPath = serverDir.resolve(DB_OTHER).toString();
+    localDbOther = (LocalDatabase) new DatabaseFactory(dbOtherPath).create();
+    server.registerDatabase(DB_OTHER, localDbOther);
   }
 
   /**
@@ -106,8 +139,7 @@ class ArcadeStateMachineAppliedIndexPerDatabaseTest {
    */
   @Test
   void bootstrapSkipNotTriggeredByAnotherDatabasesAppliedIndex() throws Exception {
-    final ArcadeDBServer server = mockServer();
-    final ArcadeStateMachine sm = newStateMachine(server);
+    final ArcadeStateMachine sm = newStateMachine();
 
     // A co-located database advanced the shared Raft log far ahead of db-a's bootstrap entry.
     sm.writePersistedAppliedIndex(100L, DB_OTHER);
@@ -119,12 +151,16 @@ class ArcadeStateMachineAppliedIndexPerDatabaseTest {
     final ByteString encoded = RaftLogEntryCodec.encodeBootstrapFingerprintEntry(DB_A, realFingerprint, realLastTxId);
     final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(encoded);
 
+    final int callsBefore = server.getDatabaseInvocations.get();
+
     // db-a's own bootstrap entry sits at index 50, below the global 100.
     sm.applyBootstrapFingerprintEntry(decoded, 50L);
 
     // Verification must have run for db-a (its local state was read), proving the global index of a
     // different database did not suppress it.
-    verify(server, atLeastOnce()).getDatabase(DB_A);
+    assertThat(server.getDatabaseInvocations.get())
+        .as("verification consulted the local database despite a higher global applied index")
+        .isGreaterThan(callsBefore);
 
     // The baseline is recorded regardless of the skip decision.
     assertThat(sm.getBootstrapBaseline(DB_A)).isNotNull();
@@ -138,8 +174,7 @@ class ArcadeStateMachineAppliedIndexPerDatabaseTest {
    */
   @Test
   void bootstrapSkipHonorsPerDatabaseAppliedIndex() throws Exception {
-    final ArcadeDBServer server = mockServer();
-    final ArcadeStateMachine sm = newStateMachine(server);
+    final ArcadeStateMachine sm = newStateMachine();
 
     // Positive per-database evidence that db-a was already applied past its bootstrap entry index.
     sm.writePersistedAppliedIndex(50L, DB_A);
@@ -147,10 +182,14 @@ class ArcadeStateMachineAppliedIndexPerDatabaseTest {
     final ByteString encoded = RaftLogEntryCodec.encodeBootstrapFingerprintEntry(DB_A, "0".repeat(64), Long.MAX_VALUE);
     final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(encoded);
 
+    final int callsBefore = server.getDatabaseInvocations.get();
+
     sm.applyBootstrapFingerprintEntry(decoded, 50L);
 
     // Skipped: the local database was never consulted.
-    verify(server, never()).getDatabase(DB_A);
+    assertThat(server.getDatabaseInvocations.get())
+        .as("skip fired on positive per-database evidence; the local database is never consulted")
+        .isEqualTo(callsBefore);
     // Baseline is still recorded before the skip check.
     assertThat(sm.getBootstrapBaseline(DB_A)).isNotNull();
   }
@@ -162,8 +201,7 @@ class ArcadeStateMachineAppliedIndexPerDatabaseTest {
    */
   @Test
   void legacyPlainNumberFileReadAsGlobalNotPerDatabase() throws Exception {
-    final ArcadeDBServer server = mockServer();
-    final ArcadeStateMachine sm = newStateMachine(server);
+    final ArcadeStateMachine sm = newStateMachine();
 
     final Path raftDir = serverDir.resolve(".raft");
     Files.createDirectories(raftDir);
@@ -183,13 +221,11 @@ class ArcadeStateMachineAppliedIndexPerDatabaseTest {
    */
   @Test
   void perDatabaseValuesRoundTripAcrossRestart() {
-    final ArcadeDBServer server = mockServer();
-
-    final ArcadeStateMachine writer = newStateMachine(server);
+    final ArcadeStateMachine writer = newStateMachine();
     writer.writePersistedAppliedIndex(10L, DB_A);
     writer.writePersistedAppliedIndex(20L, DB_OTHER);
 
-    final ArcadeStateMachine reopened = newStateMachine(server);
+    final ArcadeStateMachine reopened = newStateMachine();
     assertThat(reopened.readPersistedAppliedIndex(DB_A)).isEqualTo(10L);
     assertThat(reopened.readPersistedAppliedIndex(DB_OTHER)).isEqualTo(20L);
     assertThat(reopened.readPersistedAppliedIndex())
@@ -206,14 +242,9 @@ class ArcadeStateMachineAppliedIndexPerDatabaseTest {
    */
   @Test
   void fullInstallRecordsSnapshotIndexForEveryPresentDatabase() {
-    final ContextConfiguration config = new ContextConfiguration();
-    config.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY, serverDir.toString());
+    registerSecondDatabase();
 
-    final ArcadeDBServer server = mock(ArcadeDBServer.class);
-    when(server.getConfiguration()).thenReturn(config);
-    when(server.getDatabaseNames()).thenReturn(Set.of(DB_A, DB_OTHER));
-
-    final ArcadeStateMachine sm = newStateMachine(server);
+    final ArcadeStateMachine sm = newStateMachine();
     sm.writePersistedAppliedIndexForAllDatabases(500L);
 
     assertThat(sm.readPersistedAppliedIndex()).isEqualTo(500L);
@@ -227,8 +258,7 @@ class ArcadeStateMachineAppliedIndexPerDatabaseTest {
    */
   @Test
   void dropDatabaseEvictsPerDatabaseEntryAndAdvancesGlobal() {
-    final ArcadeDBServer server = mockServer();
-    final ArcadeStateMachine sm = newStateMachine(server);
+    final ArcadeStateMachine sm = newStateMachine();
 
     sm.writePersistedAppliedIndex(40L, DB_A);
     sm.writePersistedAppliedIndex(41L, DB_OTHER);
@@ -254,15 +284,13 @@ class ArcadeStateMachineAppliedIndexPerDatabaseTest {
    */
   @Test
   void writePreservesOtherDatabasesEntriesOnDisk() {
-    final ArcadeDBServer server = mockServer();
-
     // First instance persists entries for both databases.
-    final ArcadeStateMachine writer = newStateMachine(server);
+    final ArcadeStateMachine writer = newStateMachine();
     writer.writePersistedAppliedIndex(10L, DB_A);
     writer.writePersistedAppliedIndex(20L, DB_OTHER);
 
     // A fresh instance (no in-memory state) writes a NEW index for db-a only; db-other must survive.
-    final ArcadeStateMachine reopened = newStateMachine(server);
+    final ArcadeStateMachine reopened = newStateMachine();
     reopened.writePersistedAppliedIndex(30L, DB_A);
 
     assertThat(reopened.readPersistedAppliedIndex(DB_A)).isEqualTo(30L);
@@ -271,7 +299,7 @@ class ArcadeStateMachineAppliedIndexPerDatabaseTest {
         .isEqualTo(20L);
 
     // And it is durable: a third instance reading from disk still sees both.
-    final ArcadeStateMachine third = newStateMachine(server);
+    final ArcadeStateMachine third = newStateMachine();
     assertThat(third.readPersistedAppliedIndex(DB_A)).isEqualTo(30L);
     assertThat(third.readPersistedAppliedIndex(DB_OTHER)).isEqualTo(20L);
   }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineAppliedIndexPerDatabaseTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineAppliedIndexPerDatabaseTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.atLeastOnce;
@@ -195,5 +196,28 @@ class ArcadeStateMachineAppliedIndexPerDatabaseTest {
         .as("global tracks the last applied index across all databases")
         .isEqualTo(20L);
     assertThat(reopened.readPersistedAppliedIndex("never-seen")).isEqualTo(-1L);
+  }
+
+  /**
+   * A full state-machine snapshot install records the snapshot index for EVERY present database, so a
+   * subsequent bootstrap entry for any of them is correctly recognised as already applied. This locks
+   * in the documented {@code writePersistedAppliedIndexForAllDatabases} behaviour and exercises the
+   * {@code getDatabaseNames()} path.
+   */
+  @Test
+  void fullInstallRecordsSnapshotIndexForEveryPresentDatabase() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY, serverDir.toString());
+
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+    when(server.getConfiguration()).thenReturn(config);
+    when(server.getDatabaseNames()).thenReturn(Set.of(DB_A, DB_OTHER));
+
+    final ArcadeStateMachine sm = newStateMachine(server);
+    sm.writePersistedAppliedIndexForAllDatabases(500L);
+
+    assertThat(sm.readPersistedAppliedIndex()).isEqualTo(500L);
+    assertThat(sm.readPersistedAppliedIndex(DB_A)).isEqualTo(500L);
+    assertThat(sm.readPersistedAppliedIndex(DB_OTHER)).isEqualTo(500L);
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineAppliedIndexPerDatabaseTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineAppliedIndexPerDatabaseTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.BootstrapFingerprint;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.ServerDatabase;
+import com.arcadedb.utility.FileUtils;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for issue #4824.
+ * <p>
+ * {@link ArcadeStateMachine} multiplexes every database onto one Raft group but used to persist a
+ * single global {@code .raft/applied-index} scalar. The replay-skip in
+ * {@link ArcadeStateMachine#applyBootstrapFingerprintEntry} ("this database's bootstrap baseline was
+ * already applied in a prior session, skip verification") consulted that GLOBAL value even though the
+ * decision is per-database. A co-located database that advanced the global index past this database's
+ * {@code BOOTSTRAP_FINGERPRINT_ENTRY} index would silently suppress the verification of a database
+ * that was never bootstrapped - the "value that mixes databases" defect.
+ * <p>
+ * The fix makes applied-index tracking per-database-aware: the skip now consults this database's own
+ * applied index and only skips when there is positive per-database evidence.
+ */
+class ArcadeStateMachineAppliedIndexPerDatabaseTest {
+
+  private static final String DB_A     = "db-a";
+  private static final String DB_OTHER = "db-other";
+
+  @TempDir
+  private Path        serverDir;
+  private LocalDatabase localDbA;
+  private String        dbAPath;
+
+  @BeforeEach
+  void setUp() {
+    dbAPath = serverDir.resolve(DB_A).toString();
+    localDbA = (LocalDatabase) new DatabaseFactory(dbAPath).create();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (localDbA != null && localDbA.isOpen())
+      localDbA.close();
+    FileUtils.deleteRecursively(new File(dbAPath));
+  }
+
+  private ArcadeStateMachine newStateMachine(final ArcadeDBServer server) {
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    sm.setServer(server);
+    return sm;
+  }
+
+  private ArcadeDBServer mockServer() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY, serverDir.toString());
+
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+    when(server.getConfiguration()).thenReturn(config);
+    when(server.existsDatabase(DB_A)).thenReturn(true);
+    when(server.getDatabase(DB_A)).thenReturn(new ServerDatabase(null, localDbA));
+    return server;
+  }
+
+  /**
+   * Regression: another database advancing the GLOBAL applied index past this database's bootstrap
+   * entry index must NOT skip this database's bootstrap verification. Before the fix the skip fired
+   * (global 100 &gt;= 50) and {@code applyBootstrapFingerprintEntry} returned before ever consulting
+   * the local database, so {@code server.getDatabase(DB_A)} was never called.
+   */
+  @Test
+  void bootstrapSkipNotTriggeredByAnotherDatabasesAppliedIndex() throws Exception {
+    final ArcadeDBServer server = mockServer();
+    final ArcadeStateMachine sm = newStateMachine(server);
+
+    // A co-located database advanced the shared Raft log far ahead of db-a's bootstrap entry.
+    sm.writePersistedAppliedIndex(100L, DB_OTHER);
+
+    // Build a MATCHING bootstrap entry for db-a so the verification path returns cleanly once reached
+    // (no snapshot install). The discriminator is purely "was the local database consulted?".
+    final String realFingerprint = BootstrapFingerprint.compute(new File(dbAPath));
+    final long realLastTxId = localDbA.getLastTransactionId();
+    final ByteString encoded = RaftLogEntryCodec.encodeBootstrapFingerprintEntry(DB_A, realFingerprint, realLastTxId);
+    final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(encoded);
+
+    // db-a's own bootstrap entry sits at index 50, below the global 100.
+    sm.applyBootstrapFingerprintEntry(decoded, 50L);
+
+    // Verification must have run for db-a (its local state was read), proving the global index of a
+    // different database did not suppress it.
+    verify(server, atLeastOnce()).getDatabase(DB_A);
+
+    // The baseline is recorded regardless of the skip decision.
+    assertThat(sm.getBootstrapBaseline(DB_A)).isNotNull();
+    assertThat(sm.getBootstrapBaseline(DB_A).fingerprint()).isEqualTo(realFingerprint);
+  }
+
+  /**
+   * A database's OWN per-database applied index at or beyond the bootstrap entry index still skips its
+   * verification (the legitimate replay-skip on restart is preserved). When skipped,
+   * {@code applyBootstrapFingerprintEntry} returns before consulting the local database.
+   */
+  @Test
+  void bootstrapSkipHonorsPerDatabaseAppliedIndex() throws Exception {
+    final ArcadeDBServer server = mockServer();
+    final ArcadeStateMachine sm = newStateMachine(server);
+
+    // Positive per-database evidence that db-a was already applied past its bootstrap entry index.
+    sm.writePersistedAppliedIndex(50L, DB_A);
+
+    final ByteString encoded = RaftLogEntryCodec.encodeBootstrapFingerprintEntry(DB_A, "0".repeat(64), Long.MAX_VALUE);
+    final RaftLogEntryCodec.DecodedEntry decoded = RaftLogEntryCodec.decode(encoded);
+
+    sm.applyBootstrapFingerprintEntry(decoded, 50L);
+
+    // Skipped: the local database was never consulted.
+    verify(server, never()).getDatabase(DB_A);
+    // Baseline is still recorded before the skip check.
+    assertThat(sm.getBootstrapBaseline(DB_A)).isNotNull();
+  }
+
+  /**
+   * A legacy plain-number {@code .raft/applied-index} file (written by an older version) is honoured
+   * as the GLOBAL value but yields NO per-database evidence: a per-database read returns -1, so it can
+   * never falsely skip a per-database decision.
+   */
+  @Test
+  void legacyPlainNumberFileReadAsGlobalNotPerDatabase() throws Exception {
+    final ArcadeDBServer server = mockServer();
+    final ArcadeStateMachine sm = newStateMachine(server);
+
+    final Path raftDir = serverDir.resolve(".raft");
+    Files.createDirectories(raftDir);
+    Files.writeString(raftDir.resolve("applied-index"), "77");
+
+    assertThat(sm.readPersistedAppliedIndex())
+        .as("legacy plain-number file is honoured as the global applied index")
+        .isEqualTo(77L);
+    assertThat(sm.readPersistedAppliedIndex(DB_A))
+        .as("legacy file carries no per-database evidence")
+        .isEqualTo(-1L);
+  }
+
+  /**
+   * Per-database and global values round-trip through the persisted file and are recovered by a fresh
+   * state machine instance (simulating a process restart).
+   */
+  @Test
+  void perDatabaseValuesRoundTripAcrossRestart() {
+    final ArcadeDBServer server = mockServer();
+
+    final ArcadeStateMachine writer = newStateMachine(server);
+    writer.writePersistedAppliedIndex(10L, DB_A);
+    writer.writePersistedAppliedIndex(20L, DB_OTHER);
+
+    final ArcadeStateMachine reopened = newStateMachine(server);
+    assertThat(reopened.readPersistedAppliedIndex(DB_A)).isEqualTo(10L);
+    assertThat(reopened.readPersistedAppliedIndex(DB_OTHER)).isEqualTo(20L);
+    assertThat(reopened.readPersistedAppliedIndex())
+        .as("global tracks the last applied index across all databases")
+        .isEqualTo(20L);
+    assertThat(reopened.readPersistedAppliedIndex("never-seen")).isEqualTo(-1L);
+  }
+}


### PR DESCRIPTION
Closes #4824

## Summary

`ArcadeStateMachine` multiplexes every database onto one Raft group but persisted a single global `.raft/applied-index` scalar that is advanced on every applied entry regardless of which database it targeted. The per-database bootstrap replay-skip in `applyBootstrapFingerprintEntry` ("this database's baseline was already applied in a prior session, skip verification") consulted that global value. A co-located database advancing the shared log past another database's `BOOTSTRAP_FINGERPRINT_ENTRY` index would therefore silently suppress verification of a database that was never bootstrapped - the "value that mixes databases" defect described in the issue.

This makes applied-index tracking per-database-aware (suggested fix option 2):

- The persisted file becomes a small JSON document: a `global` Raft-log position plus a `db` map of `database name -> highest applied Raft index`. A legacy plain-number file is read as the `global` value with an empty per-database map (honest: no per-database evidence).
- `applyTransaction` records the applied index against the database the entry targeted as well as the global position.
- `applyBootstrapFingerprintEntry` now consults this database's own applied index (strict, no global fallback): it skips verification only when there is positive per-database evidence. Absent that, it re-verifies, which is idempotent (a fingerprint match returns immediately).
- The full-state-machine Ratis install records the snapshot index for every present database (after a full install every database is at that index).
- `reinitialize()`'s snapshot-gap check keeps using the global value: it compares against the inherently global Ratis snapshot index, so its behaviour is unchanged.
- An in-memory cache (volatile global + `ConcurrentHashMap`) keeps the hot apply path cheap - the file is parsed once lazily and serialised on each write, the same single atomic-rename write as before.

## Test plan

- [x] `ArcadeStateMachineAppliedIndexPerDatabaseTest.bootstrapSkipNotTriggeredByAnotherDatabasesAppliedIndex` - regression: a co-located database's high applied index must not skip another database's bootstrap verification (verified failing before the fix, passing after).
- [x] `bootstrapSkipHonorsPerDatabaseAppliedIndex` - the legitimate per-database replay-skip on restart is preserved.
- [x] `legacyPlainNumberFileReadAsGlobalNotPerDatabase` - a legacy plain-number file is honoured as the global value and yields no per-database evidence.
- [x] `perDatabaseValuesRoundTripAcrossRestart` - per-database and global values round-trip through the file and recover in a fresh state machine.
- [x] Existing ha-raft state-machine / snapshot suites pass: `ArcadeStateMachine*Test`, `SnapshotInstaller*Test`, `WaitForApplyTest` (0 failures / 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)