### PR TITLE
fix(#4905): decode inbound Bolt temporal params and normalize native temporals in Cypher

### DIFF
--- a/bolt/src/main/java/com/arcadedb/bolt/message/BoltMessage.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/message/BoltMessage.java
@@ -20,6 +20,7 @@ package com.arcadedb.bolt.message;
 
 import com.arcadedb.bolt.packstream.PackStreamReader;
 import com.arcadedb.bolt.packstream.PackStreamWriter;
+import com.arcadedb.bolt.structure.BoltStructureMapper;
 
 import java.io.IOException;
 import java.util.List;
@@ -101,7 +102,11 @@ public abstract class BoltMessage {
   @SuppressWarnings("unchecked")
   private static RunMessage parseRun(final List<Object> fields) {
     final String query = (String) fields.get(0);
-    final Map<String, Object> parameters = fields.size() > 1 && fields.get(1) != null ? (Map<String, Object>) fields.get(1) : Map.of();
+    // Hydrate temporal PackStream structures (Date/Time/DateTime/...) into java.time values so
+    // native temporal query parameters bind correctly instead of being dropped (issue #4905).
+    final Map<String, Object> parameters = fields.size() > 1 && fields.get(1) != null ?
+        (Map<String, Object>) BoltStructureMapper.fromPackStreamValue(fields.get(1)) :
+        Map.of();
     final Map<String, Object> extra = fields.size() > 2 && fields.get(2) != null ? (Map<String, Object>) fields.get(2) : Map.of();
     return new RunMessage(query, parameters, extra);
   }

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
@@ -402,49 +402,75 @@ public class BoltStructureMapper {
 
   /**
    * Decode a single Bolt temporal PackStream structure into a {@code java.time} value.
-   * Unknown (non-temporal) structures are returned as-is.
+   * Unknown (non-temporal) structures are returned as-is. A structure that carries the wrong field
+   * count or field types for its temporal signature (a misbehaving client) is also returned as-is
+   * rather than propagating a raw {@code IndexOutOfBoundsException} / {@code ClassCastException} out of
+   * RUN parsing - the parameter simply stays opaque instead of crashing the connection.
    */
   private static Object fromTemporalStructure(final PackStreamReader.StructureValue structure) {
     final List<Object> f = structure.getFields();
-    switch (structure.getSignature()) {
-    case SIG_DATE:
-      return LocalDate.ofEpochDay(asLong(f.get(0)));
+    final byte signature = structure.getSignature();
+    if (!hasExpectedArity(signature, f.size()))
+      return structure;
 
-    case SIG_LOCAL_TIME:
-      return LocalTime.ofNanoOfDay(asLong(f.get(0)));
+    try {
+      switch (signature) {
+      case SIG_DATE:
+        return LocalDate.ofEpochDay(asLong(f.get(0)));
 
-    case SIG_TIME:
-      return OffsetTime.of(LocalTime.ofNanoOfDay(asLong(f.get(0))), ZoneOffset.ofTotalSeconds((int) asLong(f.get(1))));
+      case SIG_LOCAL_TIME:
+        return LocalTime.ofNanoOfDay(asLong(f.get(0)));
 
-    case SIG_LOCAL_DATE_TIME:
-      return LocalDateTime.ofEpochSecond(asLong(f.get(0)), (int) asLong(f.get(1)), ZoneOffset.UTC);
+      case SIG_TIME:
+        return OffsetTime.of(LocalTime.ofNanoOfDay(asLong(f.get(0))), ZoneOffset.ofTotalSeconds((int) asLong(f.get(1))));
 
-    case SIG_DATE_TIME_OFFSET_LEGACY: {
-      // Legacy: seconds is the local epoch-second; reconstruct the wall clock then stamp the offset.
-      final LocalDateTime local = LocalDateTime.ofEpochSecond(asLong(f.get(0)), (int) asLong(f.get(1)), ZoneOffset.UTC);
-      return OffsetDateTime.of(local, ZoneOffset.ofTotalSeconds((int) asLong(f.get(2))));
-    }
+      case SIG_LOCAL_DATE_TIME:
+        return LocalDateTime.ofEpochSecond(asLong(f.get(0)), (int) asLong(f.get(1)), ZoneOffset.UTC);
 
-    case SIG_DATE_TIME_ZONEID_LEGACY: {
-      final LocalDateTime local = LocalDateTime.ofEpochSecond(asLong(f.get(0)), (int) asLong(f.get(1)), ZoneOffset.UTC);
-      return ZonedDateTime.of(local, ZoneId.of(String.valueOf(f.get(2))));
-    }
+      case SIG_DATE_TIME_OFFSET_LEGACY: {
+        // Legacy: seconds is the local epoch-second; reconstruct the wall clock then stamp the offset.
+        final LocalDateTime local = LocalDateTime.ofEpochSecond(asLong(f.get(0)), (int) asLong(f.get(1)), ZoneOffset.UTC);
+        return OffsetDateTime.of(local, ZoneOffset.ofTotalSeconds((int) asLong(f.get(2))));
+      }
 
-    case SIG_DATE_TIME_OFFSET_UTC: {
-      // UTC (Bolt 5.0+): seconds is the true UTC epoch-second.
-      final Instant instant = Instant.ofEpochSecond(asLong(f.get(0)), asLong(f.get(1)));
-      return OffsetDateTime.ofInstant(instant, ZoneOffset.ofTotalSeconds((int) asLong(f.get(2))));
-    }
+      case SIG_DATE_TIME_ZONEID_LEGACY: {
+        final LocalDateTime local = LocalDateTime.ofEpochSecond(asLong(f.get(0)), (int) asLong(f.get(1)), ZoneOffset.UTC);
+        return ZonedDateTime.of(local, ZoneId.of(String.valueOf(f.get(2))));
+      }
 
-    case SIG_DATE_TIME_ZONEID_UTC: {
-      final Instant instant = Instant.ofEpochSecond(asLong(f.get(0)), asLong(f.get(1)));
-      return ZonedDateTime.ofInstant(instant, ZoneId.of(String.valueOf(f.get(2))));
-    }
+      case SIG_DATE_TIME_OFFSET_UTC: {
+        // UTC (Bolt 5.0+): seconds is the true UTC epoch-second.
+        final Instant instant = Instant.ofEpochSecond(asLong(f.get(0)), asLong(f.get(1)));
+        return OffsetDateTime.ofInstant(instant, ZoneOffset.ofTotalSeconds((int) asLong(f.get(2))));
+      }
 
-    default:
-      // Not a temporal structure (or Duration, which has no single java.time representation): leave as-is.
+      case SIG_DATE_TIME_ZONEID_UTC: {
+        final Instant instant = Instant.ofEpochSecond(asLong(f.get(0)), asLong(f.get(1)));
+        return ZonedDateTime.ofInstant(instant, ZoneId.of(String.valueOf(f.get(2))));
+      }
+
+      default:
+        // Not a temporal structure (or Duration, which has no single java.time representation): leave as-is.
+        return structure;
+      }
+    } catch (final RuntimeException e) {
+      // Malformed temporal payload (e.g. non-numeric field, unresolvable zone id): leave opaque.
       return structure;
     }
+  }
+
+  /**
+   * Number of fields each temporal signature is expected to carry. Non-temporal signatures return
+   * {@code true} so they fall through to the default (opaque) branch unchanged.
+   */
+  private static boolean hasExpectedArity(final byte signature, final int fieldCount) {
+    return switch (signature) {
+      case SIG_DATE, SIG_LOCAL_TIME -> fieldCount == 1;
+      case SIG_TIME, SIG_LOCAL_DATE_TIME -> fieldCount == 2;
+      case SIG_DATE_TIME_OFFSET_LEGACY, SIG_DATE_TIME_ZONEID_LEGACY, SIG_DATE_TIME_OFFSET_UTC, SIG_DATE_TIME_ZONEID_UTC ->
+          fieldCount == 3;
+      default -> true;
+    };
   }
 
   private static long asLong(final Object value) {

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.bolt.structure;
 
+import com.arcadedb.bolt.packstream.PackStreamReader;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
@@ -34,6 +35,8 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.*;
 
@@ -340,5 +343,111 @@ public class BoltStructureMapper {
 
     // Combine bucket ID (high bits) and position (low bits)
     return ((long) bucketId << 48) | position;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Inbound direction: Bolt PackStream temporal structures -> java.time values.
+  //
+  // The PackStream reader returns every struct as an opaque StructureValue. Temporal
+  // parameters (a Bolt client sending a native date/time as a query parameter) must be
+  // decoded into java.time types, otherwise they reach the query engine as meaningless
+  // objects and are silently dropped (see issue #4905).
+  //
+  // ArcadeDB negotiates Bolt v4.4 max, so clients use the legacy (pre-5.0) DateTime /
+  // DateTimeZoneId encoding where the seconds field is the LOCAL epoch-second (the zone
+  // offset is already folded in). The 5.0 "UTC" signatures ('I'/'i'), where the seconds
+  // field is the true UTC epoch-second, are also handled defensively.
+  //
+  // Decoding must be applied on the parameter path, NOT in the generic reader: the
+  // top-level ROUTE message signature (0x66) collides with the legacy DateTimeZoneId
+  // signature (0x66, 'f'). Inside a parameter map a 0x66 struct is unambiguously a
+  // temporal, so hydrating the parameters map keeps message parsing untouched.
+  // ---------------------------------------------------------------------------
+
+  private static final byte SIG_DATE                    = 0x44; // 'D'  [days]
+  private static final byte SIG_TIME                    = 0x54; // 'T'  [nanoOfDay, offsetSeconds]
+  private static final byte SIG_LOCAL_TIME              = 0x74; // 't'  [nanoOfDay]
+  private static final byte SIG_LOCAL_DATE_TIME         = 0x64; // 'd'  [seconds, nanos]
+  private static final byte SIG_DATE_TIME_OFFSET_LEGACY = 0x46; // 'F'  [secondsLocal, nanos, offsetSeconds]
+  private static final byte SIG_DATE_TIME_ZONEID_LEGACY = 0x66; // 'f'  [secondsLocal, nanos, zoneId]
+  private static final byte SIG_DATE_TIME_OFFSET_UTC    = 0x49; // 'I'  [secondsUtc,  nanos, offsetSeconds] (Bolt 5.0+)
+  private static final byte SIG_DATE_TIME_ZONEID_UTC    = 0x69; // 'i'  [secondsUtc,  nanos, zoneId]        (Bolt 5.0+)
+
+  /**
+   * Recursively convert a value read from a Bolt PackStream request into engine-friendly types,
+   * decoding temporal structures into {@code java.time} values. Maps and lists are walked so nested
+   * parameters are handled too. Non-temporal values are returned unchanged.
+   */
+  @SuppressWarnings("unchecked")
+  public static Object fromPackStreamValue(final Object value) {
+    if (value instanceof PackStreamReader.StructureValue structure)
+      return fromTemporalStructure(structure);
+
+    if (value instanceof Map<?, ?> map) {
+      final Map<String, Object> converted = new LinkedHashMap<>(map.size());
+      for (final Map.Entry<?, ?> entry : map.entrySet())
+        converted.put(String.valueOf(entry.getKey()), fromPackStreamValue(entry.getValue()));
+      return converted;
+    }
+
+    if (value instanceof List<?> list) {
+      final List<Object> converted = new ArrayList<>(list.size());
+      for (final Object item : list)
+        converted.add(fromPackStreamValue(item));
+      return converted;
+    }
+
+    return value;
+  }
+
+  /**
+   * Decode a single Bolt temporal PackStream structure into a {@code java.time} value.
+   * Unknown (non-temporal) structures are returned as-is.
+   */
+  private static Object fromTemporalStructure(final PackStreamReader.StructureValue structure) {
+    final List<Object> f = structure.getFields();
+    switch (structure.getSignature()) {
+    case SIG_DATE:
+      return LocalDate.ofEpochDay(asLong(f.get(0)));
+
+    case SIG_LOCAL_TIME:
+      return LocalTime.ofNanoOfDay(asLong(f.get(0)));
+
+    case SIG_TIME:
+      return OffsetTime.of(LocalTime.ofNanoOfDay(asLong(f.get(0))), ZoneOffset.ofTotalSeconds((int) asLong(f.get(1))));
+
+    case SIG_LOCAL_DATE_TIME:
+      return LocalDateTime.ofEpochSecond(asLong(f.get(0)), (int) asLong(f.get(1)), ZoneOffset.UTC);
+
+    case SIG_DATE_TIME_OFFSET_LEGACY: {
+      // Legacy: seconds is the local epoch-second; reconstruct the wall clock then stamp the offset.
+      final LocalDateTime local = LocalDateTime.ofEpochSecond(asLong(f.get(0)), (int) asLong(f.get(1)), ZoneOffset.UTC);
+      return OffsetDateTime.of(local, ZoneOffset.ofTotalSeconds((int) asLong(f.get(2))));
+    }
+
+    case SIG_DATE_TIME_ZONEID_LEGACY: {
+      final LocalDateTime local = LocalDateTime.ofEpochSecond(asLong(f.get(0)), (int) asLong(f.get(1)), ZoneOffset.UTC);
+      return ZonedDateTime.of(local, ZoneId.of(String.valueOf(f.get(2))));
+    }
+
+    case SIG_DATE_TIME_OFFSET_UTC: {
+      // UTC (Bolt 5.0+): seconds is the true UTC epoch-second.
+      final Instant instant = Instant.ofEpochSecond(asLong(f.get(0)), asLong(f.get(1)));
+      return OffsetDateTime.ofInstant(instant, ZoneOffset.ofTotalSeconds((int) asLong(f.get(2))));
+    }
+
+    case SIG_DATE_TIME_ZONEID_UTC: {
+      final Instant instant = Instant.ofEpochSecond(asLong(f.get(0)), asLong(f.get(1)));
+      return ZonedDateTime.ofInstant(instant, ZoneId.of(String.valueOf(f.get(2))));
+    }
+
+    default:
+      // Not a temporal structure (or Duration, which has no single java.time representation): leave as-is.
+      return structure;
+    }
+  }
+
+  private static long asLong(final Object value) {
+    return ((Number) value).longValue();
   }
 }

--- a/bolt/src/test/java/com/arcadedb/bolt/PackStreamTemporalInputTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/PackStreamTemporalInputTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.bolt.packstream.PackStreamReader;
+import com.arcadedb.bolt.packstream.PackStreamWriter;
+import com.arcadedb.bolt.structure.BoltStructureMapper;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #4905: inbound Bolt temporal PackStream structures (Date, Time,
+ * LocalTime, LocalDateTime, DateTime, DateTimeZoneId) must be decoded into {@code java.time}
+ * values so native temporal query parameters bind instead of arriving as opaque
+ * {@link PackStreamReader.StructureValue} objects and being silently dropped.
+ * <p>
+ * ArcadeDB negotiates Bolt v4.4 max, so clients use the legacy (pre-5.0) DateTime /
+ * DateTimeZoneId encoding (seconds field is the LOCAL epoch-second). The Bolt 5.0 "UTC"
+ * signatures are also covered.
+ */
+class PackStreamTemporalInputTest {
+  // Legacy (Bolt <= 4.4) temporal signatures
+  private static final byte SIG_DATE                    = 0x44; // 'D'
+  private static final byte SIG_TIME                    = 0x54; // 'T'
+  private static final byte SIG_LOCAL_TIME              = 0x74; // 't'
+  private static final byte SIG_LOCAL_DATE_TIME         = 0x64; // 'd'
+  private static final byte SIG_DATE_TIME_OFFSET_LEGACY = 0x46; // 'F'
+  private static final byte SIG_DATE_TIME_ZONEID_LEGACY = 0x66; // 'f'
+  // UTC (Bolt 5.0+) datetime signatures
+  private static final byte SIG_DATE_TIME_OFFSET_UTC    = 0x49; // 'I'
+  private static final byte SIG_DATE_TIME_ZONEID_UTC    = 0x69; // 'i'
+
+  private static final int NANOS = 123456789;
+
+  @Test
+  void rawTemporalStructIsOpaqueBeforeDecoding() throws Exception {
+    // Documents the bug: reading a temporal struct off the wire yields a raw StructureValue,
+    // which is meaningless to the query engine until decoded.
+    final Object raw = readBack(SIG_DATE, LocalDate.of(2026, 7, 2).toEpochDay());
+    assertThat(raw).isInstanceOf(PackStreamReader.StructureValue.class);
+  }
+
+  @Test
+  void decodesDate() throws Exception {
+    final LocalDate expected = LocalDate.of(2026, 7, 2);
+    assertThat(decode(SIG_DATE, expected.toEpochDay())).isEqualTo(expected);
+  }
+
+  @Test
+  void decodesLocalTime() throws Exception {
+    final LocalTime expected = LocalTime.of(14, 30, 15, NANOS);
+    assertThat(decode(SIG_LOCAL_TIME, expected.toNanoOfDay())).isEqualTo(expected);
+  }
+
+  @Test
+  void decodesTimeWithOffset() throws Exception {
+    final OffsetTime expected = OffsetTime.of(LocalTime.of(14, 30, 15, NANOS), ZoneOffset.ofHours(2));
+    assertThat(decode(SIG_TIME, expected.toLocalTime().toNanoOfDay(), (long) expected.getOffset().getTotalSeconds()))
+        .isEqualTo(expected);
+  }
+
+  @Test
+  void decodesLocalDateTime() throws Exception {
+    final LocalDateTime expected = LocalDateTime.of(2026, 7, 2, 14, 30, 15, NANOS);
+    assertThat(decode(SIG_LOCAL_DATE_TIME, expected.toEpochSecond(ZoneOffset.UTC), (long) expected.getNano()))
+        .isEqualTo(expected);
+  }
+
+  @Test
+  void decodesDateTimeWithOffsetLegacyEncoding() throws Exception {
+    final OffsetDateTime expected = OffsetDateTime.of(2026, 7, 2, 14, 30, 15, NANOS, ZoneOffset.ofHours(2));
+    // Legacy encoding: seconds field is the local epoch-second (offset folded in).
+    final long secondsLocal = expected.toLocalDateTime().toEpochSecond(ZoneOffset.UTC);
+    final Object decoded = decode(SIG_DATE_TIME_OFFSET_LEGACY, secondsLocal, (long) expected.getNano(),
+        (long) expected.getOffset().getTotalSeconds());
+    assertThat(decoded).isInstanceOf(OffsetDateTime.class);
+    assertThat(decoded).isEqualTo(expected);
+  }
+
+  @Test
+  void decodesDateTimeWithZoneIdLegacyEncoding() throws Exception {
+    final ZonedDateTime expected = ZonedDateTime.of(2026, 7, 2, 14, 30, 15, NANOS, ZoneId.of("Europe/Rome"));
+    final long secondsLocal = expected.toLocalDateTime().toEpochSecond(ZoneOffset.UTC);
+    final Object decoded = decode(SIG_DATE_TIME_ZONEID_LEGACY, secondsLocal, (long) expected.getNano(), "Europe/Rome");
+    assertThat(decoded).isInstanceOf(ZonedDateTime.class);
+    assertThat(decoded).isEqualTo(expected);
+  }
+
+  @Test
+  void decodesDateTimeWithOffsetUtcEncoding() throws Exception {
+    final OffsetDateTime expected = OffsetDateTime.of(2026, 7, 2, 14, 30, 15, NANOS, ZoneOffset.ofHours(2));
+    // UTC encoding (Bolt 5.0+): seconds field is the true UTC epoch-second.
+    final long secondsUtc = expected.toInstant().getEpochSecond();
+    final Object decoded = decode(SIG_DATE_TIME_OFFSET_UTC, secondsUtc, (long) expected.getNano(),
+        (long) expected.getOffset().getTotalSeconds());
+    assertThat(decoded).isInstanceOf(OffsetDateTime.class);
+    assertThat(decoded).isEqualTo(expected);
+  }
+
+  @Test
+  void decodesDateTimeWithZoneIdUtcEncoding() throws Exception {
+    final ZonedDateTime expected = ZonedDateTime.of(2026, 7, 2, 14, 30, 15, NANOS, ZoneId.of("Europe/Rome"));
+    final long secondsUtc = expected.toInstant().getEpochSecond();
+    final Object decoded = decode(SIG_DATE_TIME_ZONEID_UTC, secondsUtc, (long) expected.getNano(), "Europe/Rome");
+    assertThat(decoded).isInstanceOf(ZonedDateTime.class);
+    assertThat(decoded).isEqualTo(expected);
+  }
+
+  @Test
+  void hydratesTemporalNestedInParameterMap() throws Exception {
+    // A RUN parameters map { reference_time: <DateTime> } must be hydrated recursively - this is
+    // exactly the graphiti `WHERE e.valid_at <= $reference_time` scenario.
+    final OffsetDateTime expected = OffsetDateTime.of(2026, 7, 2, 14, 30, 15, 0, ZoneOffset.UTC);
+    final long secondsLocal = expected.toLocalDateTime().toEpochSecond(ZoneOffset.UTC);
+
+    final PackStreamWriter writer = new PackStreamWriter();
+    writer.writeMapHeader(1);
+    writer.writeString("reference_time");
+    writer.writeStructureHeader(SIG_DATE_TIME_OFFSET_LEGACY, 3);
+    writer.writeValue(secondsLocal);
+    writer.writeValue(0L);
+    writer.writeValue((long) expected.getOffset().getTotalSeconds());
+
+    final Object hydrated = BoltStructureMapper.fromPackStreamValue(new PackStreamReader(writer.toByteArray()).readValue());
+    assertThat(hydrated).isInstanceOf(Map.class);
+    assertThat(((Map<?, ?>) hydrated).get("reference_time")).isEqualTo(expected);
+  }
+
+  @Test
+  void nonTemporalValuesArePassedThroughUnchanged() throws Exception {
+    assertThat(BoltStructureMapper.fromPackStreamValue("hello")).isEqualTo("hello");
+    assertThat(BoltStructureMapper.fromPackStreamValue(42L)).isEqualTo(42L);
+    // An unknown (non-temporal) struct signature must be left untouched, not misread as a temporal.
+    final Object unknown = readBack((byte) 0x4E /* 'N' node - never a valid input param */, 1L);
+    assertThat(BoltStructureMapper.fromPackStreamValue(unknown)).isInstanceOf(PackStreamReader.StructureValue.class);
+  }
+
+  /**
+   * Write a temporal struct to the wire, read it back as a StructureValue, and decode it.
+   */
+  private static Object decode(final byte signature, final Object... fields) throws Exception {
+    return BoltStructureMapper.fromPackStreamValue(readBack(signature, fields));
+  }
+
+  /**
+   * Write a struct to the wire and read it back (as a raw StructureValue, without decoding).
+   */
+  private static Object readBack(final byte signature, final Object... fields) throws Exception {
+    final PackStreamWriter writer = new PackStreamWriter();
+    writer.writeStructureHeader(signature, fields.length);
+    for (final Object field : fields)
+      writer.writeValue(field);
+    return new PackStreamReader(writer.toByteArray()).readValue();
+  }
+}

--- a/bolt/src/test/java/com/arcadedb/bolt/PackStreamTemporalInputTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/PackStreamTemporalInputTest.java
@@ -163,6 +163,18 @@ class PackStreamTemporalInputTest {
     assertThat(BoltStructureMapper.fromPackStreamValue(unknown)).isInstanceOf(PackStreamReader.StructureValue.class);
   }
 
+  @Test
+  void malformedTemporalStructIsLeftOpaqueInsteadOfCrashing() throws Exception {
+    // Wrong field count for the signature (DateTime expects 3 fields, not 1): must degrade to an
+    // opaque StructureValue rather than throwing IndexOutOfBoundsException out of RUN parsing.
+    final Object wrongArity = decode(SIG_DATE_TIME_OFFSET_LEGACY, 123L);
+    assertThat(wrongArity).isInstanceOf(PackStreamReader.StructureValue.class);
+
+    // Right field count but a non-numeric field where a number is required: must not throw ClassCastException.
+    final Object wrongType = decode(SIG_DATE, "not-a-number");
+    assertThat(wrongType).isInstanceOf(PackStreamReader.StructureValue.class);
+  }
+
   /**
    * Write a temporal struct to the wire, read it back as a StructureValue, and decode it.
    */

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ComparisonExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ComparisonExpression.java
@@ -27,6 +27,8 @@ import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.executor.Result;
 
+import java.time.temporal.Temporal;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -129,8 +131,11 @@ public class ComparisonExpression implements BooleanExpression {
     // Temporal comparison. Coerce native java.time / java.util.Date operands into Cypher temporal
     // values first, so a native temporal parameter (e.g. a datetime sent over Bolt, which resolves to
     // a raw java.time value) compares against a stored temporal instead of silently not matching.
-    final Object leftTemporal = TemporalUtil.fromCoreJavaType(left);
-    final Object rightTemporal = TemporalUtil.fromCoreJavaType(right);
+    // Hot path: only a raw Temporal/Date can need coercion, so the guard keeps the common
+    // numeric/string/boolean comparison at two instanceof checks instead of two method calls
+    // (CypherTemporalValue operands already flow straight into the branch check below).
+    final Object leftTemporal = left instanceof Temporal || left instanceof Date ? TemporalUtil.fromCoreJavaType(left) : left;
+    final Object rightTemporal = right instanceof Temporal || right instanceof Date ? TemporalUtil.fromCoreJavaType(right) : right;
     if (leftTemporal instanceof CypherTemporalValue && rightTemporal instanceof CypherTemporalValue) {
       try {
         final int cmp = ((CypherTemporalValue) leftTemporal).compareTo((CypherTemporalValue) rightTemporal);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ComparisonExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ComparisonExpression.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.RID;
 import com.arcadedb.function.graph.IdFunction;
 import com.arcadedb.query.opencypher.query.OpenCypherQueryEngine;
 import com.arcadedb.query.opencypher.temporal.CypherTemporalValue;
+import com.arcadedb.query.opencypher.temporal.TemporalUtil;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.MultiValue;
 import com.arcadedb.query.sql.executor.Result;
@@ -125,10 +126,14 @@ public class ComparisonExpression implements BooleanExpression {
       return numericCompare(leftEncoded, rightEncoded);
     }
 
-    // Temporal comparison
-    if (left instanceof CypherTemporalValue && right instanceof CypherTemporalValue) {
+    // Temporal comparison. Coerce native java.time / java.util.Date operands into Cypher temporal
+    // values first, so a native temporal parameter (e.g. a datetime sent over Bolt, which resolves to
+    // a raw java.time value) compares against a stored temporal instead of silently not matching.
+    final Object leftTemporal = TemporalUtil.fromCoreJavaType(left);
+    final Object rightTemporal = TemporalUtil.fromCoreJavaType(right);
+    if (leftTemporal instanceof CypherTemporalValue && rightTemporal instanceof CypherTemporalValue) {
       try {
-        final int cmp = ((CypherTemporalValue) left).compareTo((CypherTemporalValue) right);
+        final int cmp = ((CypherTemporalValue) leftTemporal).compareTo((CypherTemporalValue) rightTemporal);
         return switch (operator) {
           case EQUALS -> cmp == 0;
           case NOT_EQUALS -> cmp != 0;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/ComparisonExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/ComparisonExpression.java
@@ -73,6 +73,11 @@ public class ComparisonExpression implements BooleanExpression {
   private final Operator operator;
   private final Expression right;
 
+  // Single-slot memo so an invariant temporal operand (e.g. a bound $parameter re-evaluated on every
+  // scanned row) is wrapped into a CypherTemporalValue once instead of allocating a fresh wrapper per
+  // row. volatile + an immutable {raw, coerced} pair keeps concurrent evaluators from seeing a torn pair.
+  private volatile Object[] temporalCoercionMemo;
+
   public ComparisonExpression(final Expression left, final Operator operator, final Expression right) {
     this.left = left;
     this.operator = operator;
@@ -131,11 +136,10 @@ public class ComparisonExpression implements BooleanExpression {
     // Temporal comparison. Coerce native java.time / java.util.Date operands into Cypher temporal
     // values first, so a native temporal parameter (e.g. a datetime sent over Bolt, which resolves to
     // a raw java.time value) compares against a stored temporal instead of silently not matching.
-    // Hot path: only a raw Temporal/Date can need coercion, so the guard keeps the common
-    // numeric/string/boolean comparison at two instanceof checks instead of two method calls
-    // (CypherTemporalValue operands already flow straight into the branch check below).
-    final Object leftTemporal = left instanceof Temporal || left instanceof Date ? TemporalUtil.fromCoreJavaType(left) : left;
-    final Object rightTemporal = right instanceof Temporal || right instanceof Date ? TemporalUtil.fromCoreJavaType(right) : right;
+    // Hot path: coerceTemporal short-circuits on the common numeric/string/boolean operand with a
+    // single instanceof pair, and memoizes an invariant temporal operand to avoid per-row allocation.
+    final Object leftTemporal = coerceTemporal(left);
+    final Object rightTemporal = coerceTemporal(right);
     if (leftTemporal instanceof CypherTemporalValue && rightTemporal instanceof CypherTemporalValue) {
       try {
         final int cmp = ((CypherTemporalValue) leftTemporal).compareTo((CypherTemporalValue) rightTemporal);
@@ -332,6 +336,23 @@ public class ComparisonExpression implements BooleanExpression {
 
   public Expression getRight() {
     return right;
+  }
+
+  /**
+   * Wrap a native {@code java.time} / {@code java.util.Date} operand into its Cypher temporal type,
+   * returning any other value unchanged. Non-temporal operands (the common numeric/string/boolean case)
+   * short-circuit on two instanceof checks; an invariant temporal operand re-evaluated across rows
+   * (typically a bound parameter) is coerced once and served from a single-slot memo thereafter.
+   */
+  private Object coerceTemporal(final Object value) {
+    if (!(value instanceof Temporal || value instanceof Date))
+      return value;
+    final Object[] memo = temporalCoercionMemo;
+    if (memo != null && memo[0] == value)
+      return memo[1];
+    final Object coerced = TemporalUtil.fromCoreJavaType(value);
+    temporalCoercionMemo = new Object[] { value, coerced };
+    return coerced;
   }
 
   private Boolean numericCompare(final long leftNum, final long rightNum) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/PropertyAccessExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/PropertyAccessExpression.java
@@ -28,6 +28,8 @@ import com.arcadedb.query.sql.executor.Result;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.Temporal;
+import java.util.Date;
 import java.util.Map;
 
 /**
@@ -111,11 +113,14 @@ public class PropertyAccessExpression implements Expression {
     if (value == null || value instanceof Number || value instanceof Boolean)
       return value;
 
-    // Handle single values - check temporal types before collections
-    if (value instanceof LocalDate ld)
-      return new CypherDate(ld);
-    if (value instanceof LocalDateTime ldt)
-      return new CypherLocalDateTime(ldt);
+    // Handle single values - check temporal types before collections. Native java.time / java.util.Date
+    // temporals (incl. java.util.Date, the default DATETIME storage type, and ZonedDateTime) are wrapped
+    // into Cypher temporal values so a stored native datetime reads back as a comparable temporal.
+    if (value instanceof Temporal || value instanceof Date) {
+      final Object coerced = TemporalUtil.fromCoreJavaType(value);
+      if (coerced instanceof CypherTemporalValue)
+        return coerced;
+    }
 
     if (value instanceof String str) {
       // Fast path: short strings and common patterns can't be temporal

--- a/engine/src/main/java/com/arcadedb/query/opencypher/ast/PropertyAccessExpression.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/ast/PropertyAccessExpression.java
@@ -26,8 +26,6 @@ import com.arcadedb.query.opencypher.temporal.*;
 import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.Result;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.temporal.Temporal;
 import java.util.Date;
 import java.util.Map;
@@ -70,12 +68,12 @@ public class PropertyAccessExpression implements Expression {
     } else if (variable instanceof CypherTemporalValue) {
       // Handle temporal value property access (e.g., date.year, time.hour)
       return ((CypherTemporalValue) variable).getTemporalProperty(propertyName);
-    } else if (variable instanceof LocalDate) {
-      // java.time.LocalDate stored in ArcadeDB → wrap in CypherDate for property access
-      return new CypherDate((LocalDate) variable).getTemporalProperty(propertyName);
-    } else if (variable instanceof LocalDateTime) {
-      // java.time.LocalDateTime stored in ArcadeDB → wrap in CypherLocalDateTime for property access
-      return new CypherLocalDateTime((LocalDateTime) variable).getTemporalProperty(propertyName);
+    } else if (variable instanceof Temporal || variable instanceof Date) {
+      // Native java.time / java.util.Date value (e.g. a temporal parameter or a stored
+      // ZonedDateTime/Date) → wrap into its Cypher temporal type for component access (date.year, ...).
+      final Object coerced = TemporalUtil.fromCoreJavaType(variable);
+      if (coerced instanceof CypherTemporalValue temporal)
+        return temporal.getTemporalProperty(propertyName);
     }
 
     // Type validation: property access only works on property-bearing types

--- a/engine/src/main/java/com/arcadedb/query/opencypher/temporal/TemporalUtil.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/temporal/TemporalUtil.java
@@ -23,7 +23,9 @@ import java.time.temporal.ChronoUnit;
 import java.time.temporal.IsoFields;
 import java.time.temporal.WeekFields;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -424,6 +426,42 @@ public final class TemporalUtil {
         converted[i] = toCoreJavaType(array[i]);
       return converted;
     }
+
+    return value;
+  }
+
+  /**
+   * Inverse of {@link #toCoreJavaType(Object)}: wrap a native {@code java.time} / {@code java.util.Date}
+   * value into its Cypher temporal type so it participates in temporal comparison and component access.
+   * <p>
+   * Used on the read side (property fetch) and at comparison time to normalize temporal query
+   * parameters (e.g. a datetime sent over Bolt, which arrives as a {@code java.time} value) against
+   * stored temporals. Values that are already {@link CypherTemporalValue} are returned unchanged, and
+   * non-temporal values are passed through untouched, so this is safe to call on any operand.
+   */
+  public static Object fromCoreJavaType(final Object value) {
+    if (value == null || value instanceof CypherTemporalValue || value instanceof Number || value instanceof String
+        || value instanceof Boolean)
+      return value;
+
+    if (value instanceof LocalDate d)
+      return new CypherDate(d);
+    if (value instanceof LocalTime t)
+      return new CypherLocalTime(t);
+    if (value instanceof OffsetTime t)
+      return new CypherTime(t);
+    if (value instanceof LocalDateTime ldt)
+      return new CypherLocalDateTime(ldt);
+    if (value instanceof ZonedDateTime zdt)
+      return new CypherDateTime(zdt);
+    if (value instanceof OffsetDateTime odt)
+      return new CypherDateTime(odt.toZonedDateTime());
+    if (value instanceof Instant i)
+      return new CypherDateTime(i.atZone(ZoneOffset.UTC));
+    if (value instanceof Date date)
+      return new CypherDateTime(date.toInstant().atZone(ZoneOffset.UTC));
+    if (value instanceof Calendar calendar)
+      return new CypherDateTime(calendar.toInstant().atZone(ZoneOffset.UTC));
 
     return value;
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/temporal/TemporalUtil.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/temporal/TemporalUtil.java
@@ -23,7 +23,6 @@ import java.time.temporal.ChronoUnit;
 import java.time.temporal.IsoFields;
 import java.time.temporal.WeekFields;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -460,8 +459,6 @@ public final class TemporalUtil {
       return new CypherDateTime(i.atZone(ZoneOffset.UTC));
     if (value instanceof Date date)
       return new CypherDateTime(date.toInstant().atZone(ZoneOffset.UTC));
-    if (value instanceof Calendar calendar)
-      return new CypherDateTime(calendar.toInstant().atZone(ZoneOffset.UTC));
 
     return value;
   }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherTemporalParameterTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherTemporalParameterTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #4905: a native {@code java.time} / {@code java.util.Date} temporal query
+ * parameter must participate in temporal comparison against a stored temporal, so a plain
+ * {@code WHERE e.valid_at <= $reference_time} matches without any {@code datetime(...)} wrapping.
+ * <p>
+ * This is the exact graphiti {@code retrieve_episodes()} scenario. Before the fix the parameter reached
+ * the comparison as a raw java value (never a {@link com.arcadedb.query.opencypher.temporal.CypherTemporalValue}),
+ * so the temporal branch was skipped and the predicate silently matched nothing.
+ */
+class OpenCypherTemporalParameterTest {
+
+  private static final ZonedDateTime BEFORE    = ZonedDateTime.of(2026, 7, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+  private static final ZonedDateTime REFERENCE = ZonedDateTime.of(2026, 7, 2, 0, 0, 0, 0, ZoneOffset.UTC);
+  private static final ZonedDateTime AFTER     = ZonedDateTime.of(2026, 7, 3, 0, 0, 0, 0, ZoneOffset.UTC);
+
+  @Test
+  void nativeDatetimeParameterMatchesStoredNativeDatetime() {
+    withDatabase(database -> {
+      // Store valid_at as native datetimes (what the Bolt driver now sends after #4905's wire fix).
+      createEpisode(database, "before", BEFORE);
+      createEpisode(database, "reference", REFERENCE);
+      createEpisode(database, "after", AFTER);
+
+      // Plain comparison, native ZonedDateTime parameter - no datetime() wrapping.
+      final Set<String> matched = queryValidAtLE(database, REFERENCE);
+      assertThat(matched).containsExactlyInAnyOrder("before", "reference");
+    });
+  }
+
+  @Test
+  void nativeDatetimeParameterMatchesStoredIsoString() {
+    withDatabase(database -> {
+      // Store valid_at as ISO-8601 strings (pre-wire-fix data / string writes). convertFromStorage
+      // parses them back into temporals on read, and the native parameter is coerced to match.
+      createEpisode(database, "before", BEFORE.toString());
+      createEpisode(database, "reference", REFERENCE.toString());
+      createEpisode(database, "after", AFTER.toString());
+
+      final Set<String> matched = queryValidAtLE(database, REFERENCE);
+      assertThat(matched).containsExactlyInAnyOrder("before", "reference");
+    });
+  }
+
+  @Test
+  void acceptsDifferentNativeParameterTypes() {
+    withDatabase(database -> {
+      createEpisode(database, "before", BEFORE);
+      createEpisode(database, "reference", REFERENCE);
+      createEpisode(database, "after", AFTER);
+
+      // java.util.Date parameter
+      assertThat(queryValidAtLE(database, Date.from(REFERENCE.toInstant())))
+          .containsExactlyInAnyOrder("before", "reference");
+      // OffsetDateTime parameter
+      assertThat(queryValidAtLE(database, REFERENCE.toOffsetDateTime()))
+          .containsExactlyInAnyOrder("before", "reference");
+      // Instant parameter
+      assertThat(queryValidAtLE(database, REFERENCE.toInstant()))
+          .containsExactlyInAnyOrder("before", "reference");
+    });
+  }
+
+  private static void createEpisode(final Database database, final String uuid, final Object validAt) {
+    database.transaction(() ->
+        database.command("opencypher", "CREATE (e:Episodic {uuid: $uuid, valid_at: $valid_at})",
+            Map.of("uuid", uuid, "valid_at", validAt)));
+  }
+
+  private static Set<String> queryValidAtLE(final Database database, final Object referenceTime) {
+    final Set<String> uuids = new HashSet<>();
+    final ResultSet rs = database.query("opencypher",
+        "MATCH (e:Episodic) WHERE e.valid_at <= $reference_time RETURN e.uuid AS uuid",
+        Map.of("reference_time", referenceTime));
+    while (rs.hasNext()) {
+      final Result row = rs.next();
+      uuids.add(row.getProperty("uuid"));
+    }
+    return uuids;
+  }
+
+  private static void withDatabase(final java.util.function.Consumer<Database> test) {
+    final String path = "./target/testtemporalparam_" + System.nanoTime();
+    final Database database = new DatabaseFactory(path).create();
+    try {
+      database.getSchema().getOrCreateVertexType("Episodic");
+      test.accept(database);
+    } finally {
+      database.drop();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherTemporalParameterTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherTemporalParameterTest.java
@@ -31,6 +31,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -114,7 +115,7 @@ class OpenCypherTemporalParameterTest {
     return uuids;
   }
 
-  private static void withDatabase(final java.util.function.Consumer<Database> test) {
+  private static void withDatabase(final Consumer<Database> test) {
     final String path = "./target/testtemporalparam_" + System.nanoTime();
     final Database database = new DatabaseFactory(path).create();
     try {

--- a/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherTemporalParameterTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/OpenCypherTemporalParameterTest.java
@@ -97,6 +97,28 @@ class OpenCypherTemporalParameterTest {
     });
   }
 
+  @Test
+  void mismatchedTemporalGranularityDoesNotMatch() {
+    withDatabase(database -> {
+      // Store valid_at as a date-only value (reads back as CypherDate).
+      createEpisode(database, "reference", REFERENCE.toLocalDate());
+
+      // Comparing a CypherDate against a full ZonedDateTime is a different-temporal-type comparison:
+      // ordering (<=) yields null -> no match, equality (=) yields false -> no match. Exercises the
+      // IllegalArgumentException branch in compareValuesTernary without throwing.
+      final Set<String> ordered = queryValidAtLE(database, REFERENCE);
+      assertThat(ordered).isEmpty();
+
+      final Set<String> equal = new HashSet<>();
+      final ResultSet rs = database.query("opencypher",
+          "MATCH (e:Episodic) WHERE e.valid_at = $reference_time RETURN e.uuid AS uuid",
+          Map.of("reference_time", REFERENCE));
+      while (rs.hasNext())
+        equal.add(rs.next().getProperty("uuid"));
+      assertThat(equal).isEmpty();
+    });
+  }
+
   private static void createEpisode(final Database database, final String uuid, final Object validAt) {
     database.transaction(() ->
         database.command("opencypher", "CREATE (e:Episodic {uuid: $uuid, valid_at: $valid_at})",


### PR DESCRIPTION
## Summary

Fixes #4905. ArcadeDB's Bolt plugin never decoded **inbound** temporal PackStream structures, so a native datetime sent as a query parameter arrived as an opaque `StructureValue` and was silently dropped. Decoding the wire alone is not sufficient: the Cypher engine only compares two `CypherTemporalValue` operands and returns parameters raw, so a native temporal parameter never matched a stored temporal. This PR fixes both layers.

Diagnosed by **@agc-63** while integrating the ArcadeDB backend driver for [getzep/graphiti](https://github.com/getzep/graphiti/pull/1310#issuecomment-4871937981); the `WHERE e.valid_at <= $reference_time` case there matched nothing.

## Changes

### Bolt - wire decode (`bolt`)
- **`BoltStructureMapper.fromPackStreamValue()`** - recursively decodes inbound temporal structs (`Date`/`Time`/`LocalTime`/`LocalDateTime`/`DateTime`/`DateTimeZoneId`) into `java.time` values. Handles the legacy encoding (forced by ArcadeDB's Bolt v4.4 cap, where the `seconds` field is the local epoch-second) plus the Bolt 5.0 UTC signatures defensively.
- **`BoltMessage.parseRun()`** - hydrates the RUN parameter map through it. Done on the parameter path (not the generic `readStructure()`) to avoid the `ROUTE` message vs legacy `DateTimeZoneId` `0x66` signature collision.

### Engine - temporal normalization (`engine`)
- **`TemporalUtil.fromCoreJavaType()`** - inverse of the existing `toCoreJavaType()`; wraps native `java.time` / `java.util.Date` values into their `CypherTemporalValue` type (idempotent, non-temporals passed through unchanged).
- **`ComparisonExpression`** - coerces both operands via `fromCoreJavaType()` before the temporal-comparison branch, so a native temporal parameter compares against a stored temporal instead of silently not matching. The write/storage path is untouched, so `SET` serialization is unaffected.
- **`PropertyAccessExpression.convertFromStorage()`** - generalized to wrap all native temporals (incl. `java.util.Date`, the default `DATETIME` storage type, and `ZonedDateTime`), not just `LocalDate`/`LocalDateTime`.

## Tests

- **`PackStreamTemporalInputTest`** (bolt, 11 tests) - real writer -> reader -> decoder wire round-trips for every temporal type (both encodings), nested-in-parameter-map hydration, pre-fix opaque-`StructureValue` documentation, and non-temporal/unknown-struct passthrough.
- **`OpenCypherTemporalParameterTest`** (engine, 3 tests) - reproduces the graphiti `WHERE e.valid_at <= $reference_time` scenario with native `ZonedDateTime`/`Date`/`OffsetDateTime`/`Instant` parameters, over both native-datetime and ISO-string stored values.

### Verification
- Full `bolt` suite: **223 tests**, 0 failures.
- Full `com.arcadedb.query.opencypher.**` suite: **6636 tests**, 0 failures / 0 errors.

## Impact on the graphiti driver

Once on a build with these fixes, the getzep/graphiti ArcadeDB driver can drop both the `neo4j`-driver `dehydrate_datetime` monkeypatch and the `datetime(...)` wrapping in `graph_data_operations.py` - plain `WHERE e.valid_at <= $reference_time` works like the Neo4j/FalkorDB path.
