### PR TITLE
fix(#4908,#4909): retryable Bolt conflicts + nested $param.field in MATCH patterns

### DIFF
--- a/bolt/src/main/java/com/arcadedb/bolt/BoltErrorCodes.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltErrorCodes.java
@@ -38,6 +38,12 @@ public final class BoltErrorCodes {
   // Transaction errors
   public static final String TRANSACTION_ERROR = "Neo.ClientError.Transaction.TransactionNotFound";
 
+  // Transient (retryable) errors. ArcadeDB's optimistic-concurrency conflicts (NeedRetryException:
+  // ConcurrentModificationException / LockTimeoutException) map here so Neo4j drivers auto-retry a
+  // managed transaction. The code is a TransientError classification that the drivers retry on; the
+  // two excluded titles (Transaction.Terminated / Transaction.LockClientStopped) are deliberately avoided.
+  public static final String TRANSIENT_CONFLICT_ERROR = "Neo.TransientError.Transaction.DeadlockDetected";
+
   // Request errors
   public static final String PROTOCOL_ERROR = "Neo.ClientError.Request.Invalid";
 

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -209,6 +209,9 @@ public class BoltNetworkExecutor extends Thread {
           }
           break;
         } catch (final Exception e) {
+          // Top-level safety net for unexpected dispatch/protocol failures. NeedRetryException (MVCC)
+          // classification is handled where those conflicts actually arise - the RUN/PULL/COMMIT
+          // query-execution handlers - so this fallback intentionally keeps the generic DATABASE_ERROR.
           LogManager.instance().log(this, Level.WARNING, "BOLT error processing message", e);
           try {
             sendFailure(BoltException.DATABASE_ERROR, e.getMessage());
@@ -625,9 +628,12 @@ public class BoltNetworkExecutor extends Thread {
       sendFailure(BoltException.SYNTAX_ERROR, parseMsg);
       state = State.FAILED;
     } catch (final Exception e) {
-      LogManager.instance().log(this, Level.WARNING, "BOLT query error", e);
+      // MVCC conflicts (NeedRetryException) are expected under contention and auto-retried by the driver,
+      // so log them at FINE to avoid flooding WARNING with normal, recoverable flow; genuine errors stay WARNING.
+      final boolean retryable = isRetryableConflict(e);
+      LogManager.instance().log(this, retryable ? Level.FINE : Level.WARNING, "BOLT query error", e);
       final String errorMsg = e.getMessage() != null ? e.getMessage() : "Database error";
-      sendFailure(classifyExecutionError(e, BoltErrorCodes.DATABASE_ERROR), errorMsg);
+      sendFailure(retryable ? BoltErrorCodes.TRANSIENT_CONFLICT_ERROR : BoltErrorCodes.DATABASE_ERROR, errorMsg);
       state = State.FAILED;
     }
   }
@@ -724,9 +730,12 @@ public class BoltNetworkExecutor extends Thread {
       sendSuccess(metadata);
 
     } catch (final Exception e) {
-      LogManager.instance().log(this, Level.WARNING, "BOLT PULL error", e);
+      // MVCC conflicts (incl. those raised by an implicit auto-commit here) are expected and auto-retried
+      // by the driver, so log at FINE to avoid flooding WARNING with recoverable flow; real errors stay WARNING.
+      final boolean retryable = isRetryableConflict(e);
+      LogManager.instance().log(this, retryable ? Level.FINE : Level.WARNING, "BOLT PULL error", e);
       final String errorMsg = e.getMessage() != null ? e.getMessage() : "Error fetching records";
-      sendFailure(classifyExecutionError(e, BoltErrorCodes.DATABASE_ERROR), errorMsg);
+      sendFailure(retryable ? BoltErrorCodes.TRANSIENT_CONFLICT_ERROR : BoltErrorCodes.DATABASE_ERROR, errorMsg);
       state = State.FAILED;
     }
   }
@@ -1624,13 +1633,22 @@ public class BoltNetworkExecutor extends Thread {
    * transient status so managed-transaction drivers auto-retry; anything else keeps the given default.
    */
   static String classifyExecutionError(final Throwable error, final String defaultCode) {
+    return isRetryableConflict(error) ? BoltErrorCodes.TRANSIENT_CONFLICT_ERROR : defaultCode;
+  }
+
+  /**
+   * Whether the error (or any wrapped cause) is one of ArcadeDB's optimistic-concurrency conflicts
+   * ({@link NeedRetryException}). Such conflicts are expected under contention and auto-retried by the
+   * driver, so callers both classify them as transient and log them at a lower level.
+   */
+  static boolean isRetryableConflict(final Throwable error) {
     // Bounded walk: the depth cap guards against a self-referential / cyclic cause chain spinning forever.
     Throwable t = error;
     for (int depth = 0; t != null && depth < 32; t = t.getCause(), depth++) {
       if (t instanceof NeedRetryException)
-        return BoltErrorCodes.TRANSIENT_CONFLICT_ERROR;
+        return true;
     }
-    return defaultCode;
+    return false;
   }
 
   /**

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -1624,7 +1624,9 @@ public class BoltNetworkExecutor extends Thread {
    * transient status so managed-transaction drivers auto-retry; anything else keeps the given default.
    */
   static String classifyExecutionError(final Throwable error, final String defaultCode) {
-    for (Throwable t = error; t != null; t = t.getCause()) {
+    // Bounded walk: the depth cap guards against a self-referential / cyclic cause chain spinning forever.
+    Throwable t = error;
+    for (int depth = 0; t != null && depth < 32; t = t.getCause(), depth++) {
       if (t instanceof NeedRetryException)
         return BoltErrorCodes.TRANSIENT_CONFLICT_ERROR;
     }

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -20,6 +20,7 @@ package com.arcadedb.bolt;
 
 import com.arcadedb.Constants;
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.exception.NeedRetryException;
 import com.arcadedb.bolt.message.BeginMessage;
 import com.arcadedb.bolt.message.BoltMessage;
 import com.arcadedb.bolt.message.DiscardMessage;
@@ -626,7 +627,7 @@ public class BoltNetworkExecutor extends Thread {
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.WARNING, "BOLT query error", e);
       final String errorMsg = e.getMessage() != null ? e.getMessage() : "Database error";
-      sendFailure(BoltException.DATABASE_ERROR, errorMsg);
+      sendFailure(classifyExecutionError(e, BoltErrorCodes.DATABASE_ERROR), errorMsg);
       state = State.FAILED;
     }
   }
@@ -725,7 +726,7 @@ public class BoltNetworkExecutor extends Thread {
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.WARNING, "BOLT PULL error", e);
       final String errorMsg = e.getMessage() != null ? e.getMessage() : "Error fetching records";
-      sendFailure(BoltException.DATABASE_ERROR, errorMsg);
+      sendFailure(classifyExecutionError(e, BoltErrorCodes.DATABASE_ERROR), errorMsg);
       state = State.FAILED;
     }
   }
@@ -851,7 +852,7 @@ public class BoltNetworkExecutor extends Thread {
 
     } catch (final Exception e) {
       final String message = e.getMessage() != null ? e.getMessage() : "Commit error";
-      sendFailure(BoltException.TRANSACTION_ERROR, message);
+      sendFailure(classifyExecutionError(e, BoltErrorCodes.TRANSACTION_ERROR), message);
       state = State.FAILED;
     }
   }
@@ -1614,6 +1615,20 @@ public class BoltNetworkExecutor extends Thread {
   private void sendFailure(final String code, final String message) throws IOException {
     final FailureMessage failure = new FailureMessage(code, message);
     sendMessage(failure);
+  }
+
+  /**
+   * Classify a query/transaction execution error into a Bolt status code. ArcadeDB's
+   * optimistic-concurrency conflicts ({@link NeedRetryException}, e.g. a page-version
+   * {@code ConcurrentModificationException} or a {@code LockTimeoutException}) map to a Neo4j
+   * transient status so managed-transaction drivers auto-retry; anything else keeps the given default.
+   */
+  static String classifyExecutionError(final Throwable error, final String defaultCode) {
+    for (Throwable t = error; t != null; t = t.getCause()) {
+      if (t instanceof NeedRetryException)
+        return BoltErrorCodes.TRANSIENT_CONFLICT_ERROR;
+    }
+    return defaultCode;
   }
 
   /**

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -20,7 +20,6 @@ package com.arcadedb.bolt;
 
 import com.arcadedb.Constants;
 import com.arcadedb.GlobalConfiguration;
-import com.arcadedb.exception.NeedRetryException;
 import com.arcadedb.bolt.message.BeginMessage;
 import com.arcadedb.bolt.message.BoltMessage;
 import com.arcadedb.bolt.message.DiscardMessage;
@@ -41,6 +40,7 @@ import com.arcadedb.database.DatabaseContext;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.ProtocolContext;
 import com.arcadedb.exception.CommandParsingException;
+import com.arcadedb.exception.NeedRetryException;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.TypeIndex;
 import com.arcadedb.log.LogManager;

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -630,10 +630,9 @@ public class BoltNetworkExecutor extends Thread {
     } catch (final Exception e) {
       // MVCC conflicts (NeedRetryException) are expected under contention and auto-retried by the driver,
       // so log them at FINE to avoid flooding WARNING with normal, recoverable flow; genuine errors stay WARNING.
-      final boolean retryable = isRetryableConflict(e);
-      LogManager.instance().log(this, retryable ? Level.FINE : Level.WARNING, "BOLT query error", e);
+      LogManager.instance().log(this, isRetryableConflict(e) ? Level.FINE : Level.WARNING, "BOLT query error", e);
       final String errorMsg = e.getMessage() != null ? e.getMessage() : "Database error";
-      sendFailure(retryable ? BoltErrorCodes.TRANSIENT_CONFLICT_ERROR : BoltErrorCodes.DATABASE_ERROR, errorMsg);
+      sendFailure(classifyExecutionError(e, BoltErrorCodes.DATABASE_ERROR), errorMsg);
       state = State.FAILED;
     }
   }
@@ -732,10 +731,9 @@ public class BoltNetworkExecutor extends Thread {
     } catch (final Exception e) {
       // MVCC conflicts (incl. those raised by an implicit auto-commit here) are expected and auto-retried
       // by the driver, so log at FINE to avoid flooding WARNING with recoverable flow; real errors stay WARNING.
-      final boolean retryable = isRetryableConflict(e);
-      LogManager.instance().log(this, retryable ? Level.FINE : Level.WARNING, "BOLT PULL error", e);
+      LogManager.instance().log(this, isRetryableConflict(e) ? Level.FINE : Level.WARNING, "BOLT PULL error", e);
       final String errorMsg = e.getMessage() != null ? e.getMessage() : "Error fetching records";
-      sendFailure(retryable ? BoltErrorCodes.TRANSIENT_CONFLICT_ERROR : BoltErrorCodes.DATABASE_ERROR, errorMsg);
+      sendFailure(classifyExecutionError(e, BoltErrorCodes.DATABASE_ERROR), errorMsg);
       state = State.FAILED;
     }
   }

--- a/bolt/src/test/java/com/arcadedb/bolt/Bolt4908TransientConflictIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Bolt4908TransientConflictIT.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Config;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
+import org.neo4j.driver.Transaction;
+import org.neo4j.driver.exceptions.TransientException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * End-to-end wire test for issue #4908: an ArcadeDB optimistic-concurrency (MVCC) conflict must
+ * surface to a Bolt client as a Neo4j <em>transient</em> error, which the neo4j driver maps to
+ * {@link TransientException} and auto-retries in a managed transaction.
+ * <p>
+ * The conflict is made deterministic (not racy) with two explicit transactions that both modify the
+ * same record and commit in a fixed order: the first commit bumps the page version, so the second
+ * commit detects the stale version and conflicts.
+ */
+public class Bolt4908TransientConflictIT extends BaseGraphServerTest {
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("Bolt:com.arcadedb.bolt.BoltProtocolPlugin");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+
+  private Driver getDriver() {
+    return GraphDatabase.driver("bolt://localhost:7687", AuthTokens.basic("root", DEFAULT_PASSWORD_FOR_TESTS),
+        Config.builder().withoutEncryption().build());
+  }
+
+  @Test
+  void mvccConflictSurfacesAsTransientError() {
+    try (final Driver driver = getDriver()) {
+      try (final Session setup = driver.session(SessionConfig.forDatabase(getDatabaseName()))) {
+        setup.run("CREATE (n:ConflictRow {id: 1, x: 0})").consume();
+      }
+
+      final Session s1 = driver.session(SessionConfig.forDatabase(getDatabaseName()));
+      final Session s2 = driver.session(SessionConfig.forDatabase(getDatabaseName()));
+      final Transaction tx1 = s1.beginTransaction();
+      final Transaction tx2 = s2.beginTransaction();
+      try {
+        // Both transactions read the same record at the same page version, then stage a change.
+        tx1.run("MATCH (n:ConflictRow {id: 1}) SET n.x = 1").consume();
+        tx2.run("MATCH (n:ConflictRow {id: 1}) SET n.x = 2").consume();
+
+        // First commit wins and bumps the page version.
+        tx1.commit();
+
+        // Second commit sees the stale version -> optimistic-concurrency conflict -> transient error.
+        assertThatThrownBy(tx2::commit)
+            .isInstanceOf(TransientException.class)
+            .satisfies(e -> assertThat(((TransientException) e).code()).isEqualTo("Neo.TransientError.Transaction.DeadlockDetected"));
+      } finally {
+        try {
+          tx2.close();
+        } catch (final Exception ignore) {
+          // already failed/closed
+        }
+        s1.close();
+        s2.close();
+      }
+    }
+  }
+}

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltErrorClassificationTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltErrorClassificationTest.java
@@ -75,6 +75,15 @@ class BoltErrorClassificationTest {
   }
 
   @Test
+  void isRetryableConflictDetectsNeedRetryForLogLevelDemotion() {
+    // Drives both the transient classification and the FINE-vs-WARNING log level in the RUN/PULL handlers.
+    assertThat(BoltNetworkExecutor.isRetryableConflict(new ConcurrentModificationException("retry"))).isTrue();
+    assertThat(BoltNetworkExecutor.isRetryableConflict(new RuntimeException("x", new LockTimeoutException("t")))).isTrue();
+    assertThat(BoltNetworkExecutor.isRetryableConflict(new IllegalStateException("other"))).isFalse();
+    assertThat(BoltNetworkExecutor.isRetryableConflict(null)).isFalse();
+  }
+
+  @Test
   void transientCodeIsARetryableClassificationDriversHonor() {
     // Neo4j drivers retry on the TransientError classification, except the two excluded titles.
     assertThat(BoltErrorCodes.TRANSIENT_CONFLICT_ERROR).startsWith("Neo.TransientError.");

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltErrorClassificationTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltErrorClassificationTest.java
@@ -65,6 +65,16 @@ class BoltErrorClassificationTest {
   }
 
   @Test
+  void cyclicCauseChainTerminatesAndKeepsDefault() {
+    // A self-referential cause chain must not spin forever; the bounded walk returns the default code.
+    final RuntimeException a = new RuntimeException("a");
+    final RuntimeException b = new RuntimeException("b", a);
+    a.initCause(b); // a -> b -> a -> ...
+    assertThat(BoltNetworkExecutor.classifyExecutionError(a, BoltErrorCodes.DATABASE_ERROR))
+        .isEqualTo(BoltErrorCodes.DATABASE_ERROR);
+  }
+
+  @Test
   void transientCodeIsARetryableClassificationDriversHonor() {
     // Neo4j drivers retry on the TransientError classification, except the two excluded titles.
     assertThat(BoltErrorCodes.TRANSIENT_CONFLICT_ERROR).startsWith("Neo.TransientError.");

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltErrorClassificationTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltErrorClassificationTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.exception.LockTimeoutException;
+import com.arcadedb.exception.NeedRetryException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #4908: ArcadeDB's optimistic-concurrency conflicts ({@link NeedRetryException})
+ * must be classified to a Neo4j <em>transient</em> Bolt status code so managed-transaction drivers auto-retry,
+ * while all other errors keep their default (non-retryable) code.
+ */
+class BoltErrorClassificationTest {
+
+  @Test
+  void concurrentModificationClassifiesAsTransient() {
+    final Throwable e = new ConcurrentModificationException("Concurrent modification on page ... Please retry the operation");
+    assertThat(BoltNetworkExecutor.classifyExecutionError(e, BoltErrorCodes.DATABASE_ERROR))
+        .isEqualTo(BoltErrorCodes.TRANSIENT_CONFLICT_ERROR);
+  }
+
+  @Test
+  void lockTimeoutClassifiesAsTransient() {
+    final Throwable e = new LockTimeoutException("Timeout on acquiring lock");
+    assertThat(BoltNetworkExecutor.classifyExecutionError(e, BoltErrorCodes.TRANSACTION_ERROR))
+        .isEqualTo(BoltErrorCodes.TRANSIENT_CONFLICT_ERROR);
+  }
+
+  @Test
+  void needRetryWrappedAsCauseClassifiesAsTransient() {
+    // The conflict is often wrapped by the query/command layer before reaching the Bolt handler.
+    final Throwable wrapped = new RuntimeException("command failed", new ConcurrentModificationException("retry"));
+    assertThat(BoltNetworkExecutor.classifyExecutionError(wrapped, BoltErrorCodes.DATABASE_ERROR))
+        .isEqualTo(BoltErrorCodes.TRANSIENT_CONFLICT_ERROR);
+  }
+
+  @Test
+  void genericErrorKeepsDefaultCode() {
+    final Throwable e = new IllegalStateException("something else");
+    assertThat(BoltNetworkExecutor.classifyExecutionError(e, BoltErrorCodes.DATABASE_ERROR))
+        .isEqualTo(BoltErrorCodes.DATABASE_ERROR);
+    assertThat(BoltNetworkExecutor.classifyExecutionError(e, BoltErrorCodes.TRANSACTION_ERROR))
+        .isEqualTo(BoltErrorCodes.TRANSACTION_ERROR);
+  }
+
+  @Test
+  void transientCodeIsARetryableClassificationDriversHonor() {
+    // Neo4j drivers retry on the TransientError classification, except the two excluded titles.
+    assertThat(BoltErrorCodes.TRANSIENT_CONFLICT_ERROR).startsWith("Neo.TransientError.");
+    assertThat(BoltErrorCodes.TRANSIENT_CONFLICT_ERROR).isNotEqualTo("Neo.TransientError.Transaction.Terminated");
+    assertThat(BoltErrorCodes.TRANSIENT_CONFLICT_ERROR).isNotEqualTo("Neo.TransientError.Transaction.LockClientStopped");
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchNodeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchNodeStep.java
@@ -74,6 +74,10 @@ public class MatchNodeStep extends AbstractExecutionStep {
   private final String              idFilter;    // Optional ID filter to apply (e.g., "#1:0")
   private final BooleanExpression   whereFilter; // Optional inline WHERE predicate (pushdown)
   private final ExpressionEvaluator evaluator;   // Shared evaluator for WHERE/ID expression resolution
+  // Read-only empty result used to evaluate context-only pattern property expressions (e.g. a parameter
+  // map field like $edge_data.uuid) when the pattern has no input row. Row-variable lookups against it
+  // return null gracefully. Shared because it is only ever read (issue #4909).
+  private static final Result       EMPTY_RESULT = new ResultInternal();
   private final Expression          dynamicIdExpression; // Pre-analyzed expression for runtime RID resolution (issue #3864)
   // Display-only diagnostic fields surfaced through {@link #prettyPrint}. Mirrors the
   // {@code usedIndexName} pattern: written once during the first iterator setup and read by the
@@ -602,12 +606,15 @@ public class MatchNodeStep extends AbstractExecutionStep {
             propertyValue = paramValue;
         }
       }
-      // Resolve dynamic expressions (e.g., e.src_id from UNWIND) against the current input result
+      // Resolve dynamic expressions (e.g., e.src_id from UNWIND, or a parameter map field like
+      // $edge_data.uuid). Parameter-based expressions need only the context, so evaluate with an empty
+      // result when there is no input row; if it still can't resolve, skip the index and fall back to
+      // scan. Issue #4909.
       else if (propertyValue instanceof Expression) {
-        if (currentInputResult != null)
-          propertyValue = evaluator.evaluate((Expression) propertyValue, currentInputResult, context);
-        else
-          return null; // Cannot resolve expression without input row — skip index
+        propertyValue = evaluator.evaluate((Expression) propertyValue,
+            currentInputResult != null ? currentInputResult : EMPTY_RESULT, context);
+        if (propertyValue == null)
+          return null; // Couldn't resolve (e.g. row-dependent expression with no row) — skip index
       }
 
       properties.put(propertyName, propertyValue);
@@ -919,9 +926,12 @@ public class MatchNodeStep extends AbstractExecutionStep {
       final String key = entry.getKey();
       Object expectedValue = entry.getValue();
 
-      // Evaluate Expression-based property values (e.g., event.year)
-      if (expectedValue instanceof Expression && currentResult != null)
-        expectedValue = evaluator.evaluate((Expression) expectedValue, currentResult, context);
+      // Evaluate Expression-based property values (e.g., event.year, or a parameter map field like
+      // $edge_data.uuid). Parameter-based expressions resolve from the context alone, so a bare MATCH
+      // with no input row still binds; an empty result makes row-dependent lookups return null
+      // gracefully, which is no worse than the previous no-match behavior. Issue #4909.
+      if (expectedValue instanceof Expression)
+        expectedValue = evaluator.evaluate((Expression) expectedValue, currentResult != null ? currentResult : EMPTY_RESULT, context);
 
       // Resolve parameter references (e.g., $username -> actual value from context)
       if (expectedValue instanceof CypherASTBuilder.ParameterReference) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchNodeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MatchNodeStep.java
@@ -76,8 +76,10 @@ public class MatchNodeStep extends AbstractExecutionStep {
   private final ExpressionEvaluator evaluator;   // Shared evaluator for WHERE/ID expression resolution
   // Read-only empty result used to evaluate context-only pattern property expressions (e.g. a parameter
   // map field like $edge_data.uuid) when the pattern has no input row. Row-variable lookups against it
-  // return null gracefully. Shared because it is only ever read (issue #4909).
-  private static final Result       EMPTY_RESULT = new ResultInternal();
+  // return null gracefully. Shared static because it is only ever read; the immutable backing map makes
+  // any accidental write fail fast (UnsupportedOperationException) instead of racing shared state across
+  // concurrent queries (issue #4909).
+  private static final Result       EMPTY_RESULT = new ResultInternal(Collections.emptyMap());
   private final Expression          dynamicIdExpression; // Pre-analyzed expression for runtime RID resolution (issue #3864)
   // Display-only diagnostic fields surfaced through {@link #prettyPrint}. Mirrors the
   // {@code usedIndexName} pattern: written once during the first iterator setup and read by the
@@ -606,15 +608,18 @@ public class MatchNodeStep extends AbstractExecutionStep {
             propertyValue = paramValue;
         }
       }
-      // Resolve dynamic expressions (e.g., e.src_id from UNWIND, or a parameter map field like
-      // $edge_data.uuid). Parameter-based expressions need only the context, so evaluate with an empty
-      // result when there is no input row; if it still can't resolve, skip the index and fall back to
-      // scan. Issue #4909.
+      // Resolve dynamic expressions (e.g., e.src_id from UNWIND) against the current input result.
       else if (propertyValue instanceof Expression) {
-        propertyValue = evaluator.evaluate((Expression) propertyValue,
-            currentInputResult != null ? currentInputResult : EMPTY_RESULT, context);
-        if (propertyValue == null)
-          return null; // Couldn't resolve (e.g. row-dependent expression with no row) — skip index
+        if (currentInputResult != null)
+          propertyValue = evaluator.evaluate((Expression) propertyValue, currentInputResult, context);
+        else {
+          // No input row: a parameter map field like $edge_data.uuid still resolves from the context.
+          // If it can't resolve (a genuinely row-dependent expression), skip the index and fall back to
+          // scan, preserving the previous no-row behavior. Issue #4909.
+          propertyValue = evaluator.evaluate((Expression) propertyValue, EMPTY_RESULT, context);
+          if (propertyValue == null)
+            return null;
+        }
       }
 
       properties.put(propertyName, propertyValue);

--- a/engine/src/test/java/com/arcadedb/query/opencypher/NestedParameterInMatchTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/NestedParameterInMatchTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.query.sql.executor.ResultSet;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #4909: a nested parameter field access ($param.field) used as a property
+ * value inside a MATCH pattern must resolve, so the pattern binds. Previously the pattern matched
+ * nothing (no error), which broke single edge saves in the graphiti driver.
+ */
+class NestedParameterInMatchTest {
+
+  @Test
+  void nestedParameterFieldInMatchPatternResolves() {
+    withDatabase(database -> {
+      database.transaction(() -> database.command("opencypher", "CREATE (n:Entity {uuid: 'u1', name: 'Alice'})"));
+
+      final ResultSet rs = database.query("opencypher",
+          "MATCH (n:Entity {uuid: $data.uuid}) RETURN n.name AS name",
+          Map.of("data", Map.of("uuid", "u1")));
+
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<String>getProperty("name")).isEqualTo("Alice");
+    });
+  }
+
+  @Test
+  void nestedParameterFieldResolvesWhenIndexExists() {
+    withDatabase(database -> {
+      // Force the index-resolution path (tryFindAndUseIndex) rather than the full scan.
+      database.command("sql", "CREATE PROPERTY Entity.uuid STRING");
+      database.command("sql", "CREATE INDEX ON Entity (uuid) UNIQUE");
+      database.transaction(() -> database.command("opencypher", "CREATE (n:Entity {uuid: 'u1', name: 'Bob'})"));
+
+      final ResultSet rs = database.query("opencypher",
+          "MATCH (n:Entity {uuid: $data.uuid}) RETURN n.name AS name",
+          Map.of("data", Map.of("uuid", "u1")));
+
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<String>getProperty("name")).isEqualTo("Bob");
+    });
+  }
+
+  @Test
+  void nestedParameterEdgeSaveCreatesRelationship() {
+    withDatabase(database -> {
+      database.transaction(() -> {
+        database.command("opencypher", "CREATE (n:Entity {uuid: 'src'})");
+        database.command("opencypher", "CREATE (n:Entity {uuid: 'dst'})");
+      });
+
+      // The exact graphiti single-edge-save shape, without the UNWIND workaround.
+      database.transaction(() -> database.command("opencypher",
+          """
+              MATCH (source:Entity {uuid: $edge_data.source_uuid})
+              MATCH (target:Entity {uuid: $edge_data.target_uuid})
+              MERGE (source)-[e:RELATES_TO {uuid: $edge_data.uuid}]->(target)
+              RETURN e.uuid AS uuid""",
+          Map.of("edge_data", Map.of("source_uuid", "src", "target_uuid", "dst", "uuid", "edge-1"))));
+
+      final ResultSet rs = database.query("opencypher",
+          "MATCH (:Entity {uuid: 'src'})-[e:RELATES_TO]->(:Entity {uuid: 'dst'}) RETURN e.uuid AS uuid");
+      assertThat(rs.hasNext()).isTrue();
+      assertThat(rs.next().<String>getProperty("uuid")).isEqualTo("edge-1");
+    });
+  }
+
+  private static void withDatabase(final java.util.function.Consumer<Database> test) {
+    final String path = "./target/testnestedparam_" + System.nanoTime();
+    final Database database = new DatabaseFactory(path).create();
+    try {
+      database.getSchema().getOrCreateVertexType("Entity");
+      test.accept(database);
+    } finally {
+      database.drop();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/NestedParameterInMatchTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/NestedParameterInMatchTest.java
@@ -25,6 +25,7 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -90,7 +91,7 @@ class NestedParameterInMatchTest {
     });
   }
 
-  private static void withDatabase(final java.util.function.Consumer<Database> test) {
+  private static void withDatabase(final Consumer<Database> test) {
     final String path = "./target/testnestedparam_" + System.nanoTime();
     final Database database = new DatabaseFactory(path).create();
     try {


### PR DESCRIPTION
## Summary

Two follow-ups to #4905, flagged during review of #4906. Both are root-cause fixes in ArcadeDB for workarounds the [getzep/graphiti](https://github.com/getzep/graphiti/pull/1310) driver currently carries; landing them lets the driver drop those workarounds. Diagnosed by @agc-63.

Closes #4908, closes #4909.

## #4908 - Bolt: optimistic-concurrency conflicts are now retryable

ArcadeDB's MVCC page-version conflicts surfaced to Bolt clients as **non-retryable** errors (`Neo.DatabaseError.General.UnknownError` for query execution, `Neo.ClientError.Transaction.TransactionNotFound` on commit), so a managed-transaction driver (`session.execute_write(...)`) never auto-retried - even though ArcadeDB's own message says "Please retry the operation".

- `BoltErrorCodes`: add `TRANSIENT_CONFLICT_ERROR = Neo.TransientError.Transaction.DeadlockDetected` - a `TransientError` classification the Neo4j drivers retry on (avoiding the two excluded titles `Transaction.Terminated` / `Transaction.LockClientStopped`).
- `BoltNetworkExecutor.classifyExecutionError()`: classify any `NeedRetryException` in the cause chain (`ConcurrentModificationException` / `LockTimeoutException`) to the transient code; applied in the RUN, PULL and COMMIT error paths.
- Removes the need for the graphiti driver's bespoke error-string-matching retry loop.

## #4909 - OpenCypher: nested parameter field access in MATCH patterns

`MATCH (source:Entity {uuid: $edge_data.source_uuid})` matched nothing (no error): the pattern property parses to a `ChainedPropertyAccessExpression` whose base `ParameterExpression` resolves from the context alone, but `MatchNodeStep` only evaluated pattern-property expressions when an input row was present. With a bare MATCH (no row) the expression was left unevaluated and never matched - which is why the graphiti driver had to wrap single edge saves in `UNWIND [$edge_data] AS edge`.

- `MatchNodeStep`: evaluate pattern-property expressions with a shared read-only empty result when there is no input row, in both the scan path (`matchesProperties`) and the index path (`tryFindAndUseIndex`). Parameter-based expressions resolve; row-dependent ones return null and fall back to scan.

## Tests

- `BoltErrorClassificationTest` (5) - conflict / lock-timeout / wrapped-cause -> transient, generic -> default, and the transient code is a driver-retryable classification.
- `NestedParameterInMatchTest` (3) - scan path, index path, and the graphiti `MATCH ... MERGE` edge-save shape.

## Verification

- Full `com.arcadedb.query.opencypher.**`: 6640 tests, 0 failures / 0 errors.
- Full `bolt` module: 229 tests, 0 failures / 0 errors.
