### PR TITLE
fix(#4916): handle Bolt 4.4+ extra::Map shape in ROUTE message parsing

### DIFF
--- a/bolt/src/main/java/com/arcadedb/bolt/message/BoltMessage.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/message/BoltMessage.java
@@ -139,7 +139,15 @@ public abstract class BoltMessage {
   private static RouteMessage parseRoute(final List<Object> fields) {
     final Map<String, Object> routing = fields.isEmpty() || fields.get(0) == null ? Map.of() : (Map<String, Object>) fields.get(0);
     final List<String> bookmarks = fields.size() > 1 && fields.get(1) != null ? (List<String>) fields.get(1) : List.of();
-    final String database = fields.size() > 2 ? (String) fields.get(2) : null;
+    final Object thirdField = fields.size() > 2 ? fields.get(2) : null;
+    // Bolt <=4.3 sends db::String; Bolt 4.4+ sends extra::Map{db, imp_user} (issue #4916).
+    final String database;
+    if (thirdField instanceof Map<?, ?> extra) {
+      final Object db = extra.get("db");
+      database = db != null ? db.toString() : null;
+    } else {
+      database = (String) thirdField;
+    }
     return new RouteMessage(routing, bookmarks, database);
   }
 

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltMessageTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltMessageTest.java
@@ -648,6 +648,74 @@ class BoltMessageTest {
     assertThat(route.getDatabase()).isNull();
   }
 
+  // Bolt protocol 4.4+ shape: the third ROUTE field is extra::Map{db, imp_user}, not db::String (issue #4916).
+  @Test
+  void parseRouteMessageWithBolt44ExtraMapDatabase() throws Exception {
+    final PackStreamWriter writer = new PackStreamWriter();
+    writer.writeStructureHeader(BoltMessage.ROUTE, 3);
+    writer.writeMap(Map.of("region", "us-east"));
+    writer.writeList(List.of("bm1", "bm2"));
+    writer.writeMap(Map.of("db", "mydb"));
+
+    final PackStreamReader reader = new PackStreamReader(writer.toByteArray());
+    final PackStreamReader.StructureValue struct = (PackStreamReader.StructureValue) reader.readValue();
+    final BoltMessage msg = BoltMessage.parse(struct);
+
+    assertThat(msg).isInstanceOf(RouteMessage.class);
+    final RouteMessage route = (RouteMessage) msg;
+    assertThat(route.getRouting()).containsEntry("region", "us-east");
+    assertThat(route.getBookmarks()).containsExactly("bm1", "bm2");
+    assertThat(route.getDatabase()).isEqualTo("mydb");
+  }
+
+  @Test
+  void parseRouteMessageWithBolt44ExtraMapDatabaseAndImpUser() throws Exception {
+    final PackStreamWriter writer = new PackStreamWriter();
+    writer.writeStructureHeader(BoltMessage.ROUTE, 3);
+    writer.writeMap(Map.of());
+    writer.writeList(List.of());
+    writer.writeMap(Map.of("db", "neo4j", "imp_user", "alice"));
+
+    final PackStreamReader reader = new PackStreamReader(writer.toByteArray());
+    final PackStreamReader.StructureValue struct = (PackStreamReader.StructureValue) reader.readValue();
+    final BoltMessage msg = BoltMessage.parse(struct);
+
+    assertThat(msg).isInstanceOf(RouteMessage.class);
+    assertThat(((RouteMessage) msg).getDatabase()).isEqualTo("neo4j");
+  }
+
+  @Test
+  void parseRouteMessageWithBolt44ExtraMapNoDb() throws Exception {
+    final PackStreamWriter writer = new PackStreamWriter();
+    writer.writeStructureHeader(BoltMessage.ROUTE, 3);
+    writer.writeMap(Map.of());
+    writer.writeList(List.of());
+    writer.writeMap(Map.of("imp_user", "alice"));
+
+    final PackStreamReader reader = new PackStreamReader(writer.toByteArray());
+    final PackStreamReader.StructureValue struct = (PackStreamReader.StructureValue) reader.readValue();
+    final BoltMessage msg = BoltMessage.parse(struct);
+
+    assertThat(msg).isInstanceOf(RouteMessage.class);
+    assertThat(((RouteMessage) msg).getDatabase()).isNull();
+  }
+
+  @Test
+  void parseRouteMessageWithBolt44EmptyExtraMap() throws Exception {
+    final PackStreamWriter writer = new PackStreamWriter();
+    writer.writeStructureHeader(BoltMessage.ROUTE, 3);
+    writer.writeMap(Map.of());
+    writer.writeList(List.of());
+    writer.writeMap(Map.of());
+
+    final PackStreamReader reader = new PackStreamReader(writer.toByteArray());
+    final PackStreamReader.StructureValue struct = (PackStreamReader.StructureValue) reader.readValue();
+    final BoltMessage msg = BoltMessage.parse(struct);
+
+    assertThat(msg).isInstanceOf(RouteMessage.class);
+    assertThat(((RouteMessage) msg).getDatabase()).isNull();
+  }
+
   @Test
   void parseUnknownSignatureThrowsException() throws Exception {
     final PackStreamWriter writer = new PackStreamWriter();

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltProtocolIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltProtocolIT.java
@@ -98,6 +98,26 @@ public class BoltProtocolIT extends BaseGraphServerTest {
     }
   }
 
+  // Reproduces issue #4916: the neo4j:// routing scheme sends a ROUTE message whose third field is
+  // extra::Map{db, imp_user} under the negotiated Bolt 4.4 protocol, not the pre-4.4 db::String shape.
+  @Test
+  void routingConnection() {
+    try (Driver driver = GraphDatabase.driver(
+        "neo4j://localhost:7687",
+        AuthTokens.basic("root", DEFAULT_PASSWORD_FOR_TESTS),
+        Config.builder()
+            .withoutEncryption()
+            .build())) {
+      driver.verifyConnectivity();
+
+      try (Session session = driver.session(SessionConfig.forDatabase(getDatabaseName()))) {
+        final Result result = session.run("RETURN 1 AS value");
+        assertThat(result.hasNext()).isTrue();
+        assertThat(result.next().get("value").asLong()).isEqualTo(1L);
+      }
+    }
+  }
+
   @Test
   void simpleQuery() {
     try (Driver driver = getDriver()) {

--- a/docs/4916-bolt-route-classcastexception.md
+++ b/docs/4916-bolt-route-classcastexception.md
@@ -1,0 +1,70 @@
+# Issue #4916 - Bolt ROUTE crashes with ClassCastException under negotiated protocol 4.4
+
+## Problem
+
+`BoltNetworkExecutor.SUPPORTED_VERSIONS` advertises Bolt 4.4 as the highest
+negotiable protocol version. Under Bolt 4.4+ the ROUTE message's third field
+changed shape from `db::String` (pre-4.4) to `extra::Map{db, imp_user}`.
+`BoltMessage.parseRoute` unconditionally cast the third field to `String`,
+so any `neo4j://` routing-scheme connection (official Neo4j drivers
+negotiate 4.4 by default) threw `ClassCastException: class
+java.util.LinkedHashMap cannot be cast to class java.lang.String`, surfaced
+to the client as `Neo.DatabaseError.General.UnknownError`. Every
+`neo4j://` connection failed outright, even against a trivial single-node
+deployment.
+
+## Root cause
+
+`BoltMessage.parseRoute(List<Object> fields)` read `fields.get(2)` and cast
+it directly to `String` regardless of the negotiated protocol version.
+
+## Fix
+
+`parseRoute` now branches on the runtime shape of the third field instead of
+threading protocol-version state through the parser:
+- If it is a `Map`, treat it as Bolt 4.4+'s `extra` map and pull `db` out of
+  it (missing/null `db` yields `null`, matching prior behavior for no
+  database specified).
+- Otherwise, treat it as the pre-4.4 `db::String` field directly.
+
+`imp_user` is not extracted since nothing downstream currently consumes
+impersonation, keeping the fix minimal and localized to the parsing gap
+described in the issue.
+
+## Tests
+
+- `BoltMessageTest` (new unit tests on `BoltMessage.parse`):
+  - `parseRouteMessageWithBolt44ExtraMapDatabase` - 4.4+ shape extracts `db`
+  - `parseRouteMessageWithBolt44ExtraMapDatabaseAndImpUser` - `db` extracted, `imp_user` ignored without error
+  - `parseRouteMessageWithBolt44ExtraMapNoDb` - map without `db` yields `null`, no exception
+  - `parseRouteMessageWithBolt44EmptyExtraMap` - empty map yields `null`, no exception
+  - Existing `parseRouteMessage`/`parseRouteMessageMinimalFields` continue to cover the pre-4.4 `db::String` shape and confirm no regression.
+- `BoltProtocolIT` (new integration test, real Neo4j Java driver 6.2.0 against a live embedded server):
+  - `routingConnection` - connects via `neo4j://localhost:7687` (routing scheme), calls `verifyConnectivity()`, and runs a query.
+
+## Test results
+
+- Confirmed the bug: with the fix reverted, both the new `BoltMessageTest`
+  cases and `BoltProtocolIT.routingConnection` failed with the exact
+  reported `ClassCastException` (the IT surfaced it wrapped as
+  `BoltFailureException` / `ServiceUnavailable` client-side, matching the
+  issue's repro).
+- With the fix applied: `mvn -pl bolt test` - 228 tests, 0 failures.
+  `mvn -pl bolt test -Dtest=BoltProtocolIT` - 77 tests, 0 failures
+  (includes the new routing test).
+
+## Impact
+
+Localized to `BoltMessage.parseRoute`; no other ROUTE consumers
+(`RouteMessage`, `BoltNetworkExecutor.handleRoute`) needed changes since
+they already operate on the parsed `String database` field. Fixes
+`neo4j://` routing-scheme connectivity for single-node deployments; ROUTE
+remains single-node-only (not HA-cluster-aware), which is a separate,
+already-tracked gap in issue #4916's parent scope.
+
+`bolt/conformance/spec.yaml`'s CONN-003 already claims `current_status:
+passing`; with this fix that claim becomes accurate for the single-node
+case, so no change was needed there. Automated verification of CONN-003
+via the `e2e-python` Bolt conformance suite (#4885) was not performed as
+part of this fix - that suite does not yet have Bolt/Neo4j driver tests
+implemented in this repository.


### PR DESCRIPTION
Closes #4916

`BoltMessage.parseRoute` unconditionally cast the ROUTE message's third field to `String`, but Bolt protocol 4.4+ sends `extra::Map{db, imp_user}` instead of the pre-4.4 `db::String`. Since official Neo4j drivers negotiate 4.4 by default, every `neo4j://` routing-scheme connection threw a `ClassCastException` (surfaced to clients as `Neo.DatabaseError.General.UnknownError`), even against a trivial single-node deployment. The fix branches on the runtime shape of the third field: a `Map` is treated as the 4.4+ `extra` map and `db` is pulled out of it; anything else falls back to the pre-4.4 `db::String` behavior.

See `docs/4916-bolt-route-classcastexception.md` for the full analysis.

## Test plan

- [x] New unit tests in `BoltMessageTest` covering the Bolt 4.4+ `extra::Map` shape (with/without `db`, with `imp_user` present, empty map) and confirming the pre-4.4 `db::String` shape still works.
- [x] New integration test `BoltProtocolIT.routingConnection` connects via `neo4j://localhost:7687` with the real Neo4j Java driver (6.2.0, same version that negotiates protocol 4.4) against a live embedded server and runs a query.
- [x] Confirmed both new tests fail with the exact reported `ClassCastException` when the fix is reverted, and pass with it applied.
- [x] `mvn -pl bolt test` - 228 tests, 0 failures.
- [x] `mvn -pl bolt test -Dtest=BoltProtocolIT` - 77 tests, 0 failures.