### PR TITLE
feat(#4885): e2e-python neo4j driver Bolt conformance suite

### DIFF
--- a/bolt/conformance/spec.yaml
+++ b/bolt/conformance/spec.yaml
@@ -95,12 +95,13 @@ scenarios:
     applicable_driver_versions: all
     current_status: expected-fail
     known_limitation: >
-      BoltMessage.parseRoute (bolt/src/main/java/com/arcadedb/bolt/message/BoltMessage.java:142)
-      casts the ROUTE message's third field straight to String, but under
-      negotiated Bolt 4.4 it is actually a Map, causing a server-side
-      ClassCastException - discovered while implementing issue #4885's
-      Python conformance suite.
-    tracking_issue: "#4916"
+      Fixed by commit 39e4eaedb (PR #4917, closing #4916) - BoltMessage.parseRoute
+      no longer casts the ROUTE message's third field straight to String under
+      negotiated Bolt 4.4. Merged to main, but not yet present in the published
+      arcadedata/arcadedb:latest Docker image this spec's e2e suites test
+      against as of 2026-07-03 - flip current_status back to passing once a
+      released image includes the fix.
+    tracking_issue: "#4916 (fixed, pending image release)"
   - id: CONN-004
     area: connection
     title: "neo4j:// routing reflects actual multi-node HA cluster topology"

--- a/bolt/conformance/spec.yaml
+++ b/bolt/conformance/spec.yaml
@@ -95,13 +95,14 @@ scenarios:
     applicable_driver_versions: all
     current_status: expected-fail
     known_limitation: >
-      Fixed by commit 39e4eaedb (PR #4917, closing #4916) - BoltMessage.parseRoute
-      no longer casts the ROUTE message's third field straight to String under
-      negotiated Bolt 4.4. Merged to main, but not yet present in the published
-      arcadedata/arcadedb:latest Docker image this spec's e2e suites test
-      against as of 2026-07-03 - flip current_status back to passing once a
-      released image includes the fix.
-    tracking_issue: "#4916 (fixed, pending image release)"
+      BoltNetworkExecutor.getBoltAddress reports socket.getLocalAddress() (the
+      server's own view of its address) in the ROUTE response's WRITE/READ/ROUTE
+      entries. Behind port mapping (e.g. containerized/NAT'd single-node
+      deployments), that is not the externally reachable address the driver
+      connected through, so driver-side routing-aware reconnects fail.
+      ArcadeDB has no advertised-address override to correct this - discovered
+      while implementing issue #4885's Python conformance suite.
+    tracking_issue: "#4890"
   - id: CONN-004
     area: connection
     title: "neo4j:// routing reflects actual multi-node HA cluster topology"

--- a/bolt/conformance/spec.yaml
+++ b/bolt/conformance/spec.yaml
@@ -337,7 +337,17 @@ scenarios:
       - "When the driver runs 'CREATE (:Beer {name: $n})-[:BREWED_BY]->(:Brewery {name: $b})'"
       - "Then summary.counters().nodesCreated() == 2, relationshipsCreated() == 1, and propertiesSet() matches"
     applicable_driver_versions: all
-    current_status: unverified
+    current_status: expected-fail
+    known_limitation: >
+      ResultSummary counters (nodesCreated, relationshipsCreated,
+      propertiesSet, etc.) are never populated for Bolt write queries -
+      BoltNetworkExecutor's handleRun/handlePull/handleDiscard build no
+      'stats' map in the SUCCESS response, and no CRUD-counter tracking
+      exists in the underlying query engine (Cypher's
+      CreateStep/SetStep/DeleteStep don't aggregate counts) to source such
+      values from even if the Bolt layer were fixed - discovered while
+      implementing issue #4885's Python conformance suite.
+    tracking_issue: "#4890"
   - id: TYPE-001
     area: type-roundtrip
     title: "Node round-trips as a native Bolt structure"

--- a/bolt/conformance/spec.yaml
+++ b/bolt/conformance/spec.yaml
@@ -93,16 +93,7 @@ scenarios:
       - "When the driver connects to neo4j://<host>:7687"
       - "Then the driver receives a routing table listing that one node as reader/writer/router and runs queries successfully"
     applicable_driver_versions: all
-    current_status: expected-fail
-    known_limitation: >
-      BoltNetworkExecutor.getBoltAddress reports socket.getLocalAddress() (the
-      server's own view of its address) in the ROUTE response's WRITE/READ/ROUTE
-      entries. Behind port mapping (e.g. containerized/NAT'd single-node
-      deployments), that is not the externally reachable address the driver
-      connected through, so driver-side routing-aware reconnects fail.
-      ArcadeDB has no advertised-address override to correct this - discovered
-      while implementing issue #4885's Python conformance suite.
-    tracking_issue: "#4890"
+    current_status: passing
   - id: CONN-004
     area: connection
     title: "neo4j:// routing reflects actual multi-node HA cluster topology"

--- a/bolt/conformance/spec.yaml
+++ b/bolt/conformance/spec.yaml
@@ -93,7 +93,14 @@ scenarios:
       - "When the driver connects to neo4j://<host>:7687"
       - "Then the driver receives a routing table listing that one node as reader/writer/router and runs queries successfully"
     applicable_driver_versions: all
-    current_status: passing
+    current_status: expected-fail
+    known_limitation: >
+      BoltMessage.parseRoute (bolt/src/main/java/com/arcadedb/bolt/message/BoltMessage.java:142)
+      casts the ROUTE message's third field straight to String, but under
+      negotiated Bolt 4.4 it is actually a Map, causing a server-side
+      ClassCastException - discovered while implementing issue #4885's
+      Python conformance suite.
+    tracking_issue: "#4916"
   - id: CONN-004
     area: connection
     title: "neo4j:// routing reflects actual multi-node HA cluster topology"

--- a/bolt/conformance/spec.yaml
+++ b/bolt/conformance/spec.yaml
@@ -548,7 +548,16 @@ scenarios:
       - "When the driver runs a semantically invalid query, e.g. referencing an undeclared variable in RETURN"
       - "Then the driver receives error code Neo.ClientError.Statement.SemanticError (BoltErrorCodes.SEMANTIC_ERROR)"
     applicable_driver_versions: all
-    current_status: passing
+    current_status: expected-fail
+    known_limitation: >
+      CypherSemanticValidator correctly detects the undefined variable but
+      throws it via CommandParsingException, the same exception class used
+      for genuine ANTLR syntax errors - BoltNetworkExecutor's RUN handler
+      maps error codes by exception type, so it cannot distinguish semantic
+      from syntax errors, making Neo.ClientError.Statement.SemanticError
+      effectively dead code in the Bolt module - discovered while
+      implementing issue #4885's Python conformance suite.
+    tracking_issue: "#4890"
   - id: ERR-003
     area: errors
     title: "Unauthenticated request returns Neo.ClientError.Security.Forbidden"

--- a/bolt/conformance/spec.yaml
+++ b/bolt/conformance/spec.yaml
@@ -559,7 +559,12 @@ scenarios:
       - "When the driver sends RUN before completing HELLO/LOGON"
       - "Then the driver receives error code Neo.ClientError.Security.Forbidden (BoltErrorCodes.FORBIDDEN_ERROR)"
     applicable_driver_versions: all
-    current_status: passing
+    current_status: not-applicable
+    known_limitation: >
+      Cannot be triggered through any official driver's public API - every
+      official Neo4j driver completes HELLO/LOGON internally before exposing
+      session/query methods to user code. Testable only via a bespoke
+      raw-socket client, which the epic's governing principles exclude.
   - id: ERR-004
     area: errors
     title: "Transient conditions surface Neo.TransientError.* codes"

--- a/bolt/conformance/spec.yaml
+++ b/bolt/conformance/spec.yaml
@@ -231,13 +231,7 @@ scenarios:
       - "When the failure occurs inside an executeWrite callback"
       - "Then the driver should see a Neo.TransientError.* code and retry automatically per its built-in policy"
     applicable_driver_versions: all
-    current_status: expected-fail
-    known_limitation: >
-      BoltErrorCodes.java defines only 7 codes, all Neo.ClientError.*/
-      Neo.DatabaseError.* - no Neo.TransientError.* code exists, so
-      ArcadeDB never signals a retryable condition and driver-side
-      transient-retry logic cannot be exercised.
-    tracking_issue: "#4890"
+    current_status: passing
   - id: CAUSAL-001
     area: causal-consistency
     title: "Bookmark enforces read-after-write across sessions"
@@ -424,12 +418,7 @@ scenarios:
       - "When the driver runs 'MATCH (t:TypeMatrix) RETURN t.localDateProp AS d'"
       - "Then d is a native LocalDate/Date driver type, and 'RETURN $d AS echo' with params={d: <that date>} round-trips it unchanged"
     applicable_driver_versions: all
-    current_status: expected-fail
-    known_limitation: >
-      BoltStructureMapper.toPackStreamValue (lines 116-150) converts
-      LocalDate via .toString()/ISO string fallback instead of the native
-      Bolt Date structure (sig 0x44).
-    tracking_issue: "#4890"
+    current_status: passing
   - id: TYPE-008
     area: type-roundtrip
     title: "LocalTime round-trips as a native Bolt LocalTime structure"
@@ -440,11 +429,7 @@ scenarios:
       - "When the driver runs 'MATCH (t:TypeMatrix) RETURN t.localTimeProp AS t2'"
       - "Then t2 is a native LocalTime driver type, and round-trips via $-parameter unchanged"
     applicable_driver_versions: all
-    current_status: expected-fail
-    known_limitation: >
-      Same ISO-string fallback as TYPE-007, for LocalTime (native Bolt
-      LocalTime structure sig 0x74 not produced).
-    tracking_issue: "#4890"
+    current_status: passing
   - id: TYPE-009
     area: type-roundtrip
     title: "LocalDateTime round-trips as a native Bolt LocalDateTime structure"
@@ -455,11 +440,7 @@ scenarios:
       - "When the driver runs 'MATCH (t:TypeMatrix) RETURN t.localDateTimeProp AS dt'"
       - "Then dt is a native LocalDateTime driver type, and round-trips via $-parameter unchanged"
     applicable_driver_versions: all
-    current_status: expected-fail
-    known_limitation: >
-      Same ISO-string fallback as TYPE-007, for LocalDateTime (native Bolt
-      LocalDateTime structure sig 0x64 not produced).
-    tracking_issue: "#4890"
+    current_status: passing
   - id: TYPE-010
     area: type-roundtrip
     title: "Offset/zoned DateTime round-trips as a native Bolt DateTime structure"
@@ -470,12 +451,7 @@ scenarios:
       - "When the driver runs 'MATCH (t:TypeMatrix) RETURN t.offsetDateTimeProp AS dt'"
       - "Then dt is a native OffsetDateTime/ZonedDateTime driver type preserving the +02:00 offset, and round-trips via $-parameter unchanged"
     applicable_driver_versions: all
-    current_status: expected-fail
-    known_limitation: >
-      Same ISO-string fallback as TYPE-007, for OffsetDateTime/ZonedDateTime
-      (native Bolt DateTime/DateTimeZoneId structures, sig 0x49/0x69, not
-      produced).
-    tracking_issue: "#4890"
+    current_status: passing
   - id: TYPE-011
     area: type-roundtrip
     title: "Duration round-trips as a native Bolt Duration structure"
@@ -583,12 +559,7 @@ scenarios:
       - "When the losing session's write fails"
       - "Then it should receive a Neo.TransientError.* code, not a ClientError/DatabaseError code"
     applicable_driver_versions: all
-    current_status: expected-fail
-    known_limitation: >
-      BoltErrorCodes.java defines only Neo.ClientError.*/Neo.DatabaseError.*
-      codes (7 total) - no Neo.TransientError.* code exists anywhere in the
-      Bolt module.
-    tracking_issue: "#4890"
+    current_status: passing
   - id: PROTO-001
     area: protocol
     title: "Version negotiation succeeds for Bolt 4.4, 4.0, and 3.0"

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -414,6 +414,12 @@ public class BoltNetworkExecutor extends Thread {
       if (!authenticateUser(principal, credentials)) {
         return;
       }
+    } else {
+      // No recognized scheme and no credentials supplied - reject rather than
+      // treating the connection as implicitly authenticated.
+      if (!authenticateUser(principal, credentials)) {
+        return;
+      }
     }
 
     // Build success response with server info

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -400,26 +400,23 @@ public class BoltNetworkExecutor extends Thread {
     }
 
     // Try to authenticate
-    if ("basic".equals(scheme) && principal != null && credentials != null) {
-      if (!authenticateUser(principal, credentials)) {
-        return;
-      }
-    } else if ("none".equals(scheme)) {
-      // No authentication - reject (authentication is always required)
+    if ("none".equals(scheme)) {
+      // Explicit no-auth is always rejected.
       sendFailure(BoltException.AUTHENTICATION_ERROR, "Authentication required");
       state = State.FAILED;
       return;
-    } else if (principal != null && credentials != null) {
-      // Try basic auth even without explicit scheme
-      if (!authenticateUser(principal, credentials)) {
-        return;
-      }
-    } else {
-      // No recognized scheme and no credentials supplied - reject rather than
-      // treating the connection as implicitly authenticated.
-      if (!authenticateUser(principal, credentials)) {
-        return;
-      }
+    }
+    // Covers "basic" with credentials, any other/missing scheme with credentials, and
+    // the missing-scheme/missing-credentials case (authenticateUser null-checks and
+    // rejects with "Missing credentials" rather than treating it as implicitly
+    // authenticated).
+    // NOTE (Bolt 5.1+): a legitimate 5.1+ HELLO carries no auth at all - it moves to the
+    // separate LOGON message (see handleLogon) - so this call would incorrectly reject
+    // that valid handshake. Safe today because SUPPORTED_VERSIONS never advertises 5.x,
+    // so no compliant driver reaches here without a scheme/principal/credentials; guard
+    // on negotiated protocol version before 5.x negotiation is enabled.
+    if (!authenticateUser(principal, credentials)) {
+      return;
     }
 
     // Build success response with server info

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltProtocolIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltProtocolIT.java
@@ -131,6 +131,8 @@ public class BoltProtocolIT extends BaseGraphServerTest {
       final BoltChunkedInput chunkedIn = new BoltChunkedInput(socket.getInputStream());
       final byte[] response = chunkedIn.readMessage();
 
+      // response[0] = TINY_STRUCT|fieldCount marker, response[1] = signature byte
+      // (SuccessMessage/FailureMessage are both single-field structures).
       assertThat(response[1]).as("HELLO with no scheme/principal/credentials must be rejected")
           .isEqualTo(BoltMessage.FAILURE);
     }

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltProtocolIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltProtocolIT.java
@@ -19,6 +19,8 @@
 package com.arcadedb.bolt;
 
 import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.bolt.message.BoltMessage;
+import com.arcadedb.bolt.packstream.PackStreamWriter;
 import com.arcadedb.database.Database;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.Type;
@@ -95,6 +97,42 @@ public class BoltProtocolIT extends BaseGraphServerTest {
   void connection() {
     try (Driver driver = getDriver()) {
       driver.verifyConnectivity();
+    }
+  }
+
+  @Test
+  void helloWithoutAuthSchemeIsRejected() throws Exception {
+    // A HELLO extra map with no "scheme", "principal", or "credentials" key at all - not
+    // even scheme:"none" - must still be rejected rather than treated as authenticated.
+    try (Socket socket = new Socket("localhost", 7687)) {
+      final OutputStream rawOut = socket.getOutputStream();
+
+      final ByteBuffer handshake = ByteBuffer.allocate(20);
+      handshake.put((byte) 0x60).put((byte) 0x60).put((byte) 0xB0).put((byte) 0x17); // magic
+      handshake.putInt(0x00020404); // v4.4 with range 2
+      handshake.putInt(0x00000004); // v4.0
+      handshake.putInt(0x00000003); // v3.0
+      handshake.putInt(0x00000000); // padding
+      handshake.flip();
+      rawOut.write(handshake.array());
+      rawOut.flush();
+
+      final DataInputStream rawIn = new DataInputStream(socket.getInputStream());
+      final byte[] negotiatedVersion = new byte[4];
+      rawIn.readFully(negotiatedVersion);
+
+      final PackStreamWriter writer = new PackStreamWriter();
+      writer.writeStructureHeader(BoltMessage.HELLO, 1);
+      writer.writeMap(Map.of("user_agent", "helloWithoutAuthSchemeIsRejected/1.0"));
+
+      final BoltChunkedOutput chunkedOut = new BoltChunkedOutput(rawOut);
+      chunkedOut.writeMessage(writer.toByteArray());
+
+      final BoltChunkedInput chunkedIn = new BoltChunkedInput(socket.getInputStream());
+      final byte[] response = chunkedIn.readMessage();
+
+      assertThat(response[1]).as("HELLO with no scheme/principal/credentials must be rejected")
+          .isEqualTo(BoltMessage.FAILURE);
     }
   }
 

--- a/docs/superpowers/plans/2026-07-03-e2e-python-bolt-conformance.md
+++ b/docs/superpowers/plans/2026-07-03-e2e-python-bolt-conformance.md
@@ -1,0 +1,1114 @@
+# e2e-python Bolt Conformance Suite Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement all 39 scenarios from `bolt/conformance/spec.yaml` (issue #4883) as pytest tests in a new `e2e-python/tests/test_bolt.py`, certifying the `neo4j` Python driver against ArcadeDB's Bolt protocol implementation, wired into the existing `python-e2e-tests` CI job (issue #4885).
+
+**Architecture:** A single new test file with three module-scoped Testcontainers fixtures (one default TLS-disabled container hosting 37 scenarios, two dedicated TLS-mode containers for the 2 TLS scenarios), mirroring the existing `test_arcadedb.py` container pattern but adding port `7687` and `BoltProtocolPlugin`. Every scenario becomes one test function named `test_<AREA>_<NNN>_<slug>`. The 10 genuinely-known-gap scenarios use `pytest.mark.xfail(strict=True)`; one scenario (CONN-004, needs a 3-node HA cluster) uses `pytest.mark.skip`; the rest are ordinary assertions.
+
+**Tech Stack:** Python 3.13 (CI) / >=3.10 (declared floor), pytest, `neo4j` (official Python driver) >=6.2.0, `testcontainers`, `requests` (all already available or newly added to `e2e-python/pyproject.toml`).
+
+## Global Constraints
+
+- Design spec: `docs/superpowers/specs/2026-07-03-e2e-python-bolt-conformance-design.md` - read it before starting; every task below implements one of its decisions.
+- Source of truth for scenario content: `bolt/conformance/spec.yaml` (39 scenarios) - every `known_limitation` string quoted in this plan is copied verbatim from that file for `xfail` reason consistency.
+- No protocol/server code changes anywhere in this plan - test-only.
+- No `conftest.py` - all fixtures live inline in `test_bolt.py`, matching every other `e2e-python` test file.
+- Auth for all containers: user `root`, password `playwithdata` (matches every existing e2e suite in this repo).
+- Do not commit until each task's tests are confirmed to run correctly against a real Docker container (Docker must be available locally to execute this plan).
+- Do not add Claude as a commit author.
+- Remove any stray debug `print()` statements before each commit.
+
+---
+
+### Task 1: Add the `neo4j` driver dependency
+
+**Files:**
+- Modify: `e2e-python/pyproject.toml`
+
+**Interfaces:**
+- Produces: `neo4j` package importable in `e2e-python`'s environment for all later tasks.
+
+- [ ] **Step 1: Edit `pyproject.toml`**
+
+Change:
+```toml
+requires-python = ">=3.8"
+```
+to:
+```toml
+requires-python = ">=3.10"
+```
+
+(The `neo4j` 6.x driver line requires Python >=3.10; CI's `python-e2e-tests` job already pins Python `3.13.0`, so this is a metadata-accuracy fix with no practical CI impact.)
+
+Add `"neo4j>=6.2.0"` to the `dependencies` list, keeping the existing `>=`-floor style and alphabetical-ish grouping used by the other entries:
+
+```toml
+dependencies = [
+    "testcontainers>=4.14.2",
+    "pytest>=9.1.1",
+    "pytest-check>=2.8.0",
+    "pytest-asyncio>=1.4.0",
+    "docker>=7.1.0",
+    "psycopg>=3.3.4",
+    "psycopg-binary>=3.3.4",
+    "asyncpg>=0.31.0",
+    "requests>=2.34.2",
+    "sqlalchemy>=2.0.51",
+    "neo4j>=6.2.0"
+]
+```
+
+- [ ] **Step 2: Install and verify the import**
+
+Run (from `e2e-python/`):
+```bash
+cd e2e-python
+pip install -e .
+python3 -c "import neo4j; print(neo4j.__version__)"
+```
+Expected: prints a version string `>= 6.2.0`, no `ModuleNotFoundError`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e-python/pyproject.toml
+git commit -m "build(#4885): add neo4j driver dependency to e2e-python"
+```
+
+---
+
+### Task 2: Base Bolt container fixture + connectivity smoke test (CONN-001)
+
+**Files:**
+- Create: `e2e-python/tests/test_bolt.py`
+
+**Interfaces:**
+- Consumes: `neo4j` package (Task 1).
+- Produces (used by every later task in this plan):
+  - `ROOT_PASSWORD` constant
+  - `wait_for_http_endpoint(container, path, port, expected_status, timeout=60)` function
+  - `bolt_uri(container, scheme="bolt")` function
+  - `create_database(container, db_name)` function
+  - `seed_type_matrix(container)` function
+  - `bolt_container` module-scoped fixture (yields a started `DockerContainer`, `beer` + `boltscratch` databases present, `type-matrix.cypher` seeded)
+  - `bolt_driver` module-scoped fixture (yields a `neo4j.Driver` connected to `bolt_container`)
+
+- [ ] **Step 1: Write the file with imports, helpers, the base fixture, and the first test**
+
+```python
+#
+# Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Bolt protocol conformance suite for issue #4885, implementing every scenario
+in bolt/conformance/spec.yaml (issue #4883) against the official `neo4j`
+Python driver. Each test function name embeds its spec.yaml scenario id
+(test_<AREA>_<NNN>_<slug>) for traceability, per bolt/conformance/README.md's
+"Traceability convention".
+"""
+
+import datetime
+import threading
+import time
+from pathlib import Path
+
+import pytest
+import requests
+from neo4j import GraphDatabase, basic_auth
+from testcontainers.core.container import DockerContainer
+
+ROOT_PASSWORD = "playwithdata"
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TYPE_MATRIX_FIXTURE = REPO_ROOT / "bolt" / "conformance" / "fixtures" / "type-matrix.cypher"
+
+
+def wait_for_http_endpoint(container, path, port, expected_status, timeout=60):
+    """Wait for an HTTP endpoint to return the expected status code."""
+    host = container.get_container_host_ip()
+    url = f"http://{host}:{container.get_exposed_port(port)}{path}"
+
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        try:
+            response = requests.get(url, timeout=2)
+            if response.status_code == expected_status:
+                return True
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
+            pass
+        time.sleep(1)
+    raise TimeoutError(f"Container didn't respond with status {expected_status} at {url} within {timeout} seconds")
+
+
+def bolt_uri(container, scheme="bolt"):
+    host = container.get_container_host_ip()
+    port = container.get_exposed_port(7687)
+    return f"{scheme}://{host}:{port}"
+
+
+def create_database(container, db_name):
+    host = container.get_container_host_ip()
+    port = container.get_exposed_port(2480)
+    response = requests.post(
+        f"http://{host}:{port}/api/v1/server",
+        auth=("root", ROOT_PASSWORD),
+        json={"command": f"create database {db_name}"},
+        timeout=10,
+    )
+    response.raise_for_status()
+
+
+def seed_type_matrix(container):
+    host = container.get_container_host_ip()
+    port = container.get_exposed_port(2480)
+    command = TYPE_MATRIX_FIXTURE.read_text()
+    response = requests.post(
+        f"http://{host}:{port}/api/v1/command/beer",
+        auth=("root", ROOT_PASSWORD),
+        json={"language": "cypher", "command": command},
+        timeout=10,
+    )
+    response.raise_for_status()
+
+
+@pytest.fixture(scope="module")
+def bolt_container():
+    container = (
+        DockerContainer("arcadedata/arcadedb:latest")
+        .with_exposed_ports(2480, 7687)
+        .with_env(
+            "JAVA_OPTS",
+            "-Darcadedb.server.rootPassword=" + ROOT_PASSWORD + " "
+            "-Darcadedb.server.defaultDatabases=beer[root]{import:https://github.com/ArcadeData/arcadedb-datasets/raw/main/orientdb/OpenBeer.gz} "
+            "-Darcadedb.server.plugins=BoltProtocolPlugin",
+        )
+    )
+    container.start()
+    wait_for_http_endpoint(container, "/api/v1/ready", 2480, 204, 60)
+    create_database(container, "boltscratch")
+    seed_type_matrix(container)
+    yield container
+    container.stop()
+
+
+@pytest.fixture(scope="module")
+def bolt_driver(bolt_container):
+    driver = GraphDatabase.driver(bolt_uri(bolt_container), auth=basic_auth("root", ROOT_PASSWORD))
+    yield driver
+    driver.close()
+
+
+# --- connection ---------------------------------------------------------
+
+
+def test_CONN_001_connect_bolt(bolt_driver):
+    bolt_driver.verify_connectivity()
+```
+
+- [ ] **Step 2: Run it to verify it passes**
+
+```bash
+cd e2e-python
+pytest tests/test_bolt.py -v
+```
+Expected: `test_CONN_001_connect_bolt PASSED` (requires Docker running locally; container pull + boot may take ~30-60s).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e-python/tests/test_bolt.py
+git commit -m "test(#4885): add Bolt container fixture and CONN-001 connectivity test"
+```
+
+---
+
+### Task 3: Remaining connection scenarios (CONN-002..005) + TLS fixtures
+
+**Files:**
+- Modify: `e2e-python/tests/test_bolt.py`
+
+**Interfaces:**
+- Consumes: `ROOT_PASSWORD`, `wait_for_http_endpoint`, `bolt_uri`, `bolt_container`, `bolt_driver` (Task 2).
+- Produces: `bolt_container_tls_required`, `bolt_container_tls_optional` fixtures (used only within this task).
+
+- [ ] **Step 1: Append the TLS fixtures and CONN-002/003/004/005 tests**
+
+Append to `e2e-python/tests/test_bolt.py`, directly after `test_CONN_001_connect_bolt`:
+
+```python
+@pytest.fixture(scope="module")
+def bolt_container_tls_required():
+    container = (
+        DockerContainer("arcadedata/arcadedb:latest")
+        .with_exposed_ports(2480, 7687)
+        .with_env(
+            "JAVA_OPTS",
+            "-Darcadedb.server.rootPassword=" + ROOT_PASSWORD + " "
+            "-Darcadedb.server.defaultDatabases=beer[root]{import:https://github.com/ArcadeData/arcadedb-datasets/raw/main/orientdb/OpenBeer.gz} "
+            "-Darcadedb.server.plugins=BoltProtocolPlugin "
+            "-Darcadedb.bolt.ssl=REQUIRED",
+        )
+    )
+    container.start()
+    wait_for_http_endpoint(container, "/api/v1/ready", 2480, 204, 60)
+    yield container
+    container.stop()
+
+
+@pytest.fixture(scope="module")
+def bolt_container_tls_optional():
+    container = (
+        DockerContainer("arcadedata/arcadedb:latest")
+        .with_exposed_ports(2480, 7687)
+        .with_env(
+            "JAVA_OPTS",
+            "-Darcadedb.server.rootPassword=" + ROOT_PASSWORD + " "
+            "-Darcadedb.server.defaultDatabases=beer[root]{import:https://github.com/ArcadeData/arcadedb-datasets/raw/main/orientdb/OpenBeer.gz} "
+            "-Darcadedb.server.plugins=BoltProtocolPlugin "
+            "-Darcadedb.bolt.ssl=OPTIONAL",
+        )
+    )
+    container.start()
+    wait_for_http_endpoint(container, "/api/v1/ready", 2480, 204, 60)
+    yield container
+    container.stop()
+
+
+def test_CONN_002_tls_required(bolt_container_tls_required):
+    driver = GraphDatabase.driver(
+        bolt_uri(bolt_container_tls_required, scheme="bolt+ssc"),
+        auth=basic_auth("root", ROOT_PASSWORD),
+    )
+    try:
+        driver.verify_connectivity()
+        with driver.session(database="beer") as session:
+            result = session.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 1")
+            assert result.single()["name"] is not None
+    finally:
+        driver.close()
+
+
+def test_CONN_003_neo4j_routing_single_node(bolt_container):
+    driver = GraphDatabase.driver(bolt_uri(bolt_container, scheme="neo4j"), auth=basic_auth("root", ROOT_PASSWORD))
+    try:
+        driver.verify_connectivity()
+        with driver.session(database="beer") as session:
+            result = session.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 1")
+            assert result.single()["name"] is not None
+    finally:
+        driver.close()
+
+
+@pytest.mark.skip(
+    reason="Requires a 3-node HA cluster; e2e-python's single-node harness "
+    "cannot meaningfully exercise this scenario without new multi-node "
+    "orchestration infrastructure - see #4890"
+)
+def test_CONN_004_neo4j_routing_ha_topology():
+    pass
+
+
+def test_CONN_005_tls_optional_plaintext_connects(bolt_container_tls_optional):
+    driver = GraphDatabase.driver(
+        bolt_uri(bolt_container_tls_optional, scheme="bolt"),
+        auth=basic_auth("root", ROOT_PASSWORD),
+    )
+    try:
+        driver.verify_connectivity()
+    finally:
+        driver.close()
+```
+
+- [ ] **Step 2: Run it to verify it passes**
+
+```bash
+cd e2e-python
+pytest tests/test_bolt.py -v -k "CONN"
+```
+Expected: `test_CONN_001_connect_bolt PASSED`, `test_CONN_002_tls_required PASSED`, `test_CONN_003_neo4j_routing_single_node PASSED`, `test_CONN_004_neo4j_routing_ha_topology SKIPPED`, `test_CONN_005_tls_optional_plaintext_connects PASSED`.
+
+If `test_CONN_002_tls_required` fails to connect (certificate/handshake error), try scheme `bolt+s` instead of `bolt+ssc` and re-run - the difference is whether the driver trusts a self-signed cert (`+ssc`) or requires system-trusted CA (`+s`); ArcadeDB's default TLS keystore is self-signed, so `+ssc` is expected to be correct, but confirm empirically against the real container.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e-python/tests/test_bolt.py
+git commit -m "test(#4885): add remaining connection scenarios (CONN-002..005)"
+```
+
+---
+
+### Task 4: Auth scenarios (AUTH-001..003)
+
+**Files:**
+- Modify: `e2e-python/tests/test_bolt.py`
+
+**Interfaces:**
+- Consumes: `ROOT_PASSWORD`, `bolt_uri`, `bolt_container` (Task 2).
+
+- [ ] **Step 1: Append the auth tests**
+
+```python
+# --- auth ----------------------------------------------------------------
+
+
+def test_AUTH_001_basic_auth_valid(bolt_container):
+    driver = GraphDatabase.driver(bolt_uri(bolt_container), auth=basic_auth("root", ROOT_PASSWORD))
+    try:
+        driver.verify_connectivity()
+        with driver.session(database="beer") as session:
+            assert session.run("RETURN 1 AS value").single()["value"] == 1
+    finally:
+        driver.close()
+
+
+def test_AUTH_002_basic_auth_invalid(bolt_container):
+    from neo4j.exceptions import AuthError
+
+    driver = GraphDatabase.driver(bolt_uri(bolt_container), auth=basic_auth("root", "wrong-password"))
+    try:
+        with pytest.raises(AuthError) as exc_info:
+            driver.verify_connectivity()
+        assert exc_info.value.code == "Neo.ClientError.Security.Unauthorized"
+    finally:
+        driver.close()
+
+
+def test_AUTH_003_auth_none_rejected(bolt_container):
+    from neo4j.exceptions import AuthError, ServiceUnavailable
+
+    driver = GraphDatabase.driver(bolt_uri(bolt_container), auth=None)
+    try:
+        with pytest.raises((AuthError, ServiceUnavailable)):
+            driver.verify_connectivity()
+    finally:
+        driver.close()
+```
+
+- [ ] **Step 2: Run it to verify it passes**
+
+```bash
+cd e2e-python
+pytest tests/test_bolt.py -v -k "AUTH"
+```
+Expected: all 3 `PASSED`. If `test_AUTH_002_basic_auth_invalid` fails because the raised exception isn't `AuthError` or the `.code` differs, inspect the actual exception type/code printed in the failure and adjust the `pytest.raises` type/assertion to match reality - the spec's `known_limitation` fields don't cover AUTH scenarios (they're all `current_status: passing`), so any mismatch here is a real finding, not an expected gap.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e-python/tests/test_bolt.py
+git commit -m "test(#4885): add auth scenarios (AUTH-001..003)"
+```
+
+---
+
+### Task 5: Transaction scenarios (TX-001..005)
+
+**Files:**
+- Modify: `e2e-python/tests/test_bolt.py`
+
+**Interfaces:**
+- Consumes: `ROOT_PASSWORD`, `bolt_driver` (Task 2).
+
+- [ ] **Step 1: Append the transaction tests**
+
+```python
+# --- transactions ----------------------------------------------------------
+
+
+def test_TX_001_autocommit_query(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        result = session.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 5")
+        records = list(result)
+        assert len(records) == 5
+
+
+def test_TX_002_explicit_commit_persists(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        tx = session.begin_transaction()
+        tx.run("CREATE (:TxCommitProbe {marker: 'tx-002'})")
+        tx.commit()
+
+        result = session.run("MATCH (n:TxCommitProbe {marker: 'tx-002'}) RETURN count(n) AS c")
+        assert result.single()["c"] == 1
+
+
+def test_TX_003_explicit_rollback_discards(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        tx = session.begin_transaction()
+        tx.run("CREATE (:TxRollbackProbe {marker: 'tx-003'})")
+        tx.rollback()
+
+        result = session.run("MATCH (n:TxRollbackProbe {marker: 'tx-003'}) RETURN count(n) AS c")
+        assert result.single()["c"] == 0
+
+
+def test_TX_004_managed_write_commits(bolt_driver):
+    def create_beer(tx):
+        tx.run("CREATE (:Beer {name: $n})", n="TX-004-Beer")
+
+    with bolt_driver.session(database="beer") as session:
+        session.execute_write(create_beer)
+        result = session.run("MATCH (b:Beer {name: $n}) RETURN count(b) AS c", n="TX-004-Beer")
+        assert result.single()["c"] == 1
+
+
+def _race_two_writers(driver, database, marker):
+    """Shared concurrency helper for TX-005 and ERR-004: two sessions race to
+    update the same node inside an explicit transaction, one held open past
+    the other's commit attempt. Returns the list of exceptions raised."""
+    with driver.session(database=database) as setup_session:
+        setup_session.run(
+            "MERGE (n:RaceProbe {marker: $marker}) SET n.value = 0", marker=marker
+        ).consume()
+
+    barrier = threading.Barrier(2)
+    errors = []
+
+    def racing_write():
+        with driver.session(database=database) as session:
+            try:
+                barrier.wait(timeout=5)
+                tx = session.begin_transaction()
+                tx.run(
+                    "MATCH (n:RaceProbe {marker: $marker}) SET n.value = n.value + 1 RETURN n",
+                    marker=marker,
+                ).consume()
+                time.sleep(0.5)
+                tx.commit()
+            except Exception as exc:  # noqa: BLE001 - want to inspect any driver-surfaced error
+                errors.append(exc)
+
+    threads = [threading.Thread(target=racing_write) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+    return errors
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="BoltErrorCodes.java defines only 7 codes, all Neo.ClientError.*/ "
+    "Neo.DatabaseError.* - no Neo.TransientError.* code exists, so ArcadeDB "
+    "never signals a retryable condition and driver-side transient-retry "
+    "logic cannot be exercised; see #4890",
+)
+def test_TX_005_managed_write_retries_on_transient_error(bolt_driver):
+    from neo4j.exceptions import TransientError
+
+    errors = _race_two_writers(bolt_driver, "beer", "tx-005")
+
+    assert errors, "expected at least one racing session to fail on the write conflict"
+    assert isinstance(errors[0], TransientError), (
+        f"expected Neo.TransientError.*, got {type(errors[0]).__name__}: {errors[0]}"
+    )
+```
+
+- [ ] **Step 2: Run it to verify it passes**
+
+```bash
+cd e2e-python
+pytest tests/test_bolt.py -v -k "TX"
+```
+Expected: `test_TX_001..004 PASSED`, `test_TX_005_managed_write_retries_on_transient_error XFAIL`. If TX-001..004 fail unexpectedly, inspect and fix the test against real observed behavior (these are `current_status: passing` in spec.yaml). If TX-005 unexpectedly **passes** (no error raised at all, meaning the race didn't produce contention), increase contention by tightening the `barrier.wait`/`time.sleep` timing or by having both threads target the exact same `tx.run` line without a gap; if the underlying error *is* raised but as some other exception type, capture the real type and update the assertion - but keep `xfail(strict=True)` since the root problem (no `TransientError` code path) still holds either way, and flag this in the task's commit message if you had to adjust the concurrency mechanics.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e-python/tests/test_bolt.py
+git commit -m "test(#4885): add transaction scenarios (TX-001..005)"
+```
+
+---
+
+### Task 6: Causal-consistency and multi-database scenarios (CAUSAL-001, MDB-001..002)
+
+**Files:**
+- Modify: `e2e-python/tests/test_bolt.py`
+
+**Interfaces:**
+- Consumes: `bolt_driver` (Task 2), `boltscratch` database (created by `bolt_container` fixture in Task 2).
+
+- [ ] **Step 1: Append the causal-consistency and multi-database tests**
+
+```python
+# --- causal-consistency ---------------------------------------------------
+
+
+def test_CAUSAL_001_bookmark_read_after_write(bolt_driver):
+    with bolt_driver.session(database="beer") as session_a:
+        session_a.run("CREATE (:CausalProbe {marker: 'causal-001'})").consume()
+        bookmarks = session_a.last_bookmarks()
+
+    with bolt_driver.session(database="beer", bookmarks=bookmarks) as session_b:
+        result = session_b.run("MATCH (n:CausalProbe {marker: 'causal-001'}) RETURN count(n) AS c")
+        assert result.single()["c"] == 1
+
+
+# --- multi-database --------------------------------------------------------
+
+
+def test_MDB_001_session_selects_named_database(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        result = session.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 1")
+        assert result.single()["name"] is not None
+
+
+def test_MDB_002_sessions_across_databases_are_isolated(bolt_driver):
+    with bolt_driver.session(database="boltscratch") as scratch_session:
+        tx = scratch_session.begin_transaction()
+        tx.run("CREATE (:ScratchProbe {marker: 'mdb-002'})")
+
+        with bolt_driver.session(database="beer") as beer_session:
+            result = beer_session.run("MATCH (n:ScratchProbe {marker: 'mdb-002'}) RETURN count(n) AS c")
+            assert result.single()["c"] == 0
+
+        tx.commit()
+
+    with bolt_driver.session(database="boltscratch") as verify_session:
+        result = verify_session.run("MATCH (n:ScratchProbe {marker: 'mdb-002'}) RETURN count(n) AS c")
+        assert result.single()["c"] == 1
+```
+
+- [ ] **Step 2: Run it to verify it passes**
+
+```bash
+cd e2e-python
+pytest tests/test_bolt.py -v -k "CAUSAL or MDB"
+```
+Expected: all 3 `PASSED`. Both `CAUSAL-001` and `MDB-002` are `current_status: unverified` in spec.yaml - if either fails, this is new information: inspect the failure, and if it looks like a genuine gap (not a test bug), change the decorator to `@pytest.mark.xfail(strict=True, reason="<describe the observed failure>; see #4890")` and update the corresponding scenario's `current_status`/`known_limitation`/`tracking_issue` in `bolt/conformance/spec.yaml` in this same task's commit (reuse `#4890` if the failure matches one of the 4 confirmed gap categories, otherwise flag it explicitly in the commit message for the user to decide whether a new tracking issue is warranted - do not open one automatically).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e-python/tests/test_bolt.py
+git commit -m "test(#4885): add causal-consistency and multi-database scenarios"
+```
+
+---
+
+### Task 7: Result-handling scenarios (RESULT-001..004)
+
+**Files:**
+- Modify: `e2e-python/tests/test_bolt.py`
+
+**Interfaces:**
+- Consumes: `bolt_driver` (Task 2).
+
+- [ ] **Step 1: Append the result-handling tests**
+
+```python
+# --- result-handling ---------------------------------------------------
+
+
+def test_RESULT_001_streaming_pull_incremental(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        result = session.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 10")
+        seen = 0
+        for record in result:
+            assert record["name"] is not None
+            seen += 1
+        assert seen == 10
+
+
+def test_RESULT_002_partial_pull_then_continue(bolt_driver):
+    with bolt_driver.session(database="beer", fetch_size=2) as session:
+        result = session.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 5")
+        iterator = iter(result)
+        first_two = [next(iterator), next(iterator)]
+        assert len(first_two) == 2
+
+        remaining = list(result)
+        assert len(remaining) == 3
+
+
+def test_RESULT_003_discard_abandons_remaining(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        result = session.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 5")
+        next(iter(result))
+        summary = result.consume()
+        assert summary is not None
+
+
+def test_RESULT_004_summary_counters_reflect_writes(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        result = session.run(
+            "CREATE (:Beer {name: $n})-[:BREWED_BY]->(:Brewery {name: $b})",
+            n="RESULT-004-Beer",
+            b="RESULT-004-Brewery",
+        )
+        counters = result.consume().counters
+        assert counters.nodes_created == 2
+        assert counters.relationships_created == 1
+        assert counters.properties_set >= 2
+```
+
+- [ ] **Step 2: Run it to verify it passes**
+
+```bash
+cd e2e-python
+pytest tests/test_bolt.py -v -k "RESULT"
+```
+Expected: all 4 `PASSED`. `RESULT-002` and `RESULT-004` are `current_status: unverified` - same instruction as Task 6 applies if either fails: investigate, and if it's a real gap, convert to `xfail(strict=True)` with a reason and update `spec.yaml` in this task's commit.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e-python/tests/test_bolt.py
+git commit -m "test(#4885): add result-handling scenarios (RESULT-001..004)"
+```
+
+---
+
+### Task 8: Type-roundtrip scenarios (TYPE-001..012)
+
+**Files:**
+- Modify: `e2e-python/tests/test_bolt.py`
+
+**Interfaces:**
+- Consumes: `bolt_driver` (Task 2), `type_matrix` fixture data seeded into `beer` (Task 2's `seed_type_matrix`).
+
+- [ ] **Step 1: Append the type-roundtrip tests**
+
+```python
+# --- type-roundtrip ---------------------------------------------------
+
+
+def test_TYPE_001_node_roundtrip(bolt_driver):
+    from neo4j.graph import Node
+
+    with bolt_driver.session(database="beer") as session:
+        record = session.run("MATCH (b:Beer) RETURN b LIMIT 1").single()
+        node = record["b"]
+        assert isinstance(node, Node)
+        assert "Beer" in node.labels
+        assert node.get("name") is not None
+
+
+def test_TYPE_002_relationship_roundtrip(bolt_driver):
+    from neo4j.graph import Relationship
+
+    with bolt_driver.session(database="beer") as session:
+        record = session.run("MATCH ()-[r]->() RETURN r LIMIT 1").single()
+        rel = record["r"]
+        assert isinstance(rel, Relationship)
+        assert rel.type is not None
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="structure/BoltPath.java exists but has zero call sites "
+    "constructing it anywhere in BoltStructureMapper - query results never "
+    "actually produce native Path structures today; see #4890",
+)
+def test_TYPE_003_path_roundtrip(bolt_driver):
+    from neo4j.graph import Path
+
+    with bolt_driver.session(database="beer") as session:
+        record = session.run("MATCH p=(b:Beer)-[*1..2]-() RETURN p LIMIT 1").single()
+        path = record["p"]
+        assert isinstance(path, Path)
+        assert len(path.nodes) >= 2
+
+
+def test_TYPE_004_bytearray_param_roundtrip(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        payload = bytearray([1, 2, 3, 4])
+        record = session.run("RETURN $b AS echo", b=payload).single()
+        assert bytes(record["echo"]) == bytes(payload)
+
+
+def test_TYPE_005_nested_list_map_roundtrip(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        record = session.run(
+            "MATCH (t:TypeMatrix) RETURN t.nestedListProp AS l, t.nestedMapProp AS m"
+        ).single()
+        assert record["l"] == [1, 2, [3, 4]]
+        assert record["m"] == {"a": 1, "b": {"c": 2}}
+
+
+def test_TYPE_006_null_roundtrip(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        record = session.run("MATCH (t:TypeMatrix) RETURN t.nullProp AS n").single()
+        assert record["n"] is None
+
+        echo = session.run("RETURN $p AS echo", p=None).single()
+        assert echo["echo"] is None
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="BoltStructureMapper.toPackStreamValue converts LocalDate via "
+    ".toString()/ISO string fallback instead of the native Bolt Date "
+    "structure (sig 0x44); see #4890",
+)
+def test_TYPE_007_local_date_roundtrip(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        record = session.run("MATCH (t:TypeMatrix) RETURN t.localDateProp AS d").single()
+        assert isinstance(record["d"], datetime.date)
+
+        echo = session.run("RETURN $d AS echo", d=record["d"]).single()
+        assert echo["echo"] == record["d"]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Same ISO-string fallback as TYPE-007, for LocalTime (native Bolt "
+    "LocalTime structure sig 0x74 not produced); see #4890",
+)
+def test_TYPE_008_local_time_roundtrip(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        record = session.run("MATCH (t:TypeMatrix) RETURN t.localTimeProp AS t2").single()
+        assert isinstance(record["t2"], datetime.time)
+
+        echo = session.run("RETURN $t AS echo", t=record["t2"]).single()
+        assert echo["echo"] == record["t2"]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Same ISO-string fallback as TYPE-007, for LocalDateTime (native "
+    "Bolt LocalDateTime structure sig 0x64 not produced); see #4890",
+)
+def test_TYPE_009_local_datetime_roundtrip(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        record = session.run("MATCH (t:TypeMatrix) RETURN t.localDateTimeProp AS dt").single()
+        assert isinstance(record["dt"], datetime.datetime)
+
+        echo = session.run("RETURN $dt AS echo", dt=record["dt"]).single()
+        assert echo["echo"] == record["dt"]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Same ISO-string fallback as TYPE-007, for OffsetDateTime/"
+    "ZonedDateTime (native Bolt DateTime/DateTimeZoneId structures, sig "
+    "0x49/0x69, not produced); see #4890",
+)
+def test_TYPE_010_offset_datetime_roundtrip(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        record = session.run("MATCH (t:TypeMatrix) RETURN t.offsetDateTimeProp AS dt").single()
+        dt = record["dt"]
+        assert isinstance(dt, datetime.datetime)
+        assert dt.utcoffset() == datetime.timedelta(hours=2)
+
+        echo = session.run("RETURN $dt AS echo", dt=dt).single()
+        assert echo["echo"] == dt
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="BoltStructureMapper/PackStreamWriter have no Duration handling "
+    "at all - not even a string fallback branch, falls through to generic "
+    "value.toString(); see #4890",
+)
+def test_TYPE_011_duration_roundtrip(bolt_driver):
+    from neo4j.time import Duration
+
+    with bolt_driver.session(database="beer") as session:
+        record = session.run("MATCH (t:TypeMatrix) RETURN t.durationProp AS d").single()
+        assert isinstance(record["d"], Duration)
+
+        echo = session.run("RETURN $d AS echo", d=record["d"]).single()
+        assert echo["echo"] == record["d"]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="No Point/spatial type handling exists anywhere in "
+    "BoltStructureMapper or PackStreamWriter (the underlying ArcadeDB "
+    "Cypher engine itself does support point() - the gap is Bolt wire "
+    "serialization only); see #4890",
+)
+def test_TYPE_012_point_roundtrip(bolt_driver):
+    from neo4j.spatial import Point
+
+    with bolt_driver.session(database="beer") as session:
+        record = session.run("MATCH (t:TypeMatrix) RETURN t.pointProp AS p").single()
+        point = record["p"]
+        assert isinstance(point, Point)
+        assert point.x == pytest.approx(12.34)
+        assert point.y == pytest.approx(56.78)
+
+        echo = session.run("RETURN $p AS echo", p=point).single()
+        assert echo["echo"].x == pytest.approx(12.34)
+        assert echo["echo"].y == pytest.approx(56.78)
+```
+
+- [ ] **Step 2: Run it to verify it passes**
+
+```bash
+cd e2e-python
+pytest tests/test_bolt.py -v -k "TYPE"
+```
+Expected: `TYPE-001, 002, 004, 005, 006 PASSED`; `TYPE-003, 007, 008, 009, 010, 011, 012 XFAIL`. If any of the `expected-fail` scenarios unexpectedly PASS (meaning the gap has already been fixed on `main` since the spec was authored), `xfail(strict=True)` will report it as a hard failure (XPASS) - do not weaken the assertion to force it back to xfail; instead remove the `xfail` decorator for that scenario and update `bolt/conformance/spec.yaml`'s `current_status` for it to `passing` (drop `known_limitation`/`tracking_issue`) in this task's commit, since that would mean issue #4890 has already been partially resolved.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e-python/tests/test_bolt.py
+git commit -m "test(#4885): add type-roundtrip scenarios (TYPE-001..012)"
+```
+
+---
+
+### Task 9: Error scenarios (ERR-001..004)
+
+**Files:**
+- Modify: `e2e-python/tests/test_bolt.py`
+- Modify: `bolt/conformance/spec.yaml` (ERR-003 status correction, see Step 1 note)
+
+**Interfaces:**
+- Consumes: `bolt_driver` (Task 2), `_race_two_writers` (Task 5).
+
+- [ ] **Step 1: Append the error tests**
+
+**Important finding to apply before writing this step:** ERR-003 ("Unauthenticated request returns Neo.ClientError.Security.Forbidden") requires sending `RUN` before completing `HELLO`/`LOGON`. The official `neo4j` Python driver's public API always completes the Bolt handshake and `HELLO` internally before any session/query method becomes usable - there is no way to reach "RUN before auth" through the driver's public API without a bespoke raw-socket client, which is out of scope per the epic's "test the real official drivers only" governing principle. This is a genuine testability finding, not a code gap: `bolt/conformance/spec.yaml` currently marks `ERR-003` as `current_status: passing`, but for a driver-based suite it should be `not-applicable` (a valid `current_status` value per `bolt/conformance/README.md`'s "Scenario fields" table and `validate_spec.py`'s `VALID_STATUSES`, requiring no `known_limitation`/`tracking_issue`). Update it as part of this task:
+
+In `bolt/conformance/spec.yaml`, find the `ERR-003` entry and change:
+```yaml
+    applicable_driver_versions: all
+    current_status: passing
+```
+to:
+```yaml
+    applicable_driver_versions: all
+    current_status: not-applicable
+    known_limitation: >
+      Cannot be triggered through any official driver's public API - every
+      official Neo4j driver completes HELLO/LOGON internally before exposing
+      session/query methods to user code. Testable only via a bespoke
+      raw-socket client, which the epic's governing principles exclude.
+```
+
+Run `python3 bolt/conformance/validate_spec.py bolt/conformance/spec.yaml` from the repo root after this edit to confirm it still validates (see Task 10 for the full validator invocation).
+
+Now append the error tests to `test_bolt.py`:
+
+```python
+# --- errors ---------------------------------------------------------------
+
+
+def test_ERR_001_syntax_error(bolt_driver):
+    from neo4j.exceptions import ClientError
+
+    with bolt_driver.session(database="beer") as session:
+        with pytest.raises(ClientError) as exc_info:
+            session.run("MATCH (n RETURN n").consume()
+        assert exc_info.value.code == "Neo.ClientError.Statement.SyntaxError"
+
+
+def test_ERR_002_semantic_error(bolt_driver):
+    from neo4j.exceptions import ClientError
+
+    with bolt_driver.session(database="beer") as session:
+        with pytest.raises(ClientError) as exc_info:
+            session.run("MATCH (n:Beer) RETURN undeclaredVariable").consume()
+        assert exc_info.value.code == "Neo.ClientError.Statement.SemanticError"
+
+
+@pytest.mark.skip(
+    reason="ERR-003 requires sending RUN before completing HELLO/LOGON; the "
+    "official neo4j driver's public API always completes the handshake "
+    "internally, so this cannot be triggered without a bespoke raw-socket "
+    "client, which is out of scope per the epic's 'official drivers only' "
+    "principle. spec.yaml's ERR-003 current_status has been updated to "
+    "not-applicable to reflect this."
+)
+def test_ERR_003_unauthenticated_request_rejected():
+    pass
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="BoltErrorCodes.java defines only Neo.ClientError.*/"
+    "Neo.DatabaseError.* codes (7 total) - no Neo.TransientError.* code "
+    "exists anywhere in the Bolt module; see #4890",
+)
+def test_ERR_004_transient_condition_error_code(bolt_driver):
+    from neo4j.exceptions import TransientError
+
+    errors = _race_two_writers(bolt_driver, "beer", "err-004")
+
+    assert errors, "expected at least one racing session to fail on the write conflict"
+    assert isinstance(errors[0], TransientError), (
+        f"expected Neo.TransientError.*, got {type(errors[0]).__name__}: {errors[0]}"
+    )
+```
+
+- [ ] **Step 2: Run it to verify it passes**
+
+```bash
+cd e2e-python
+pytest tests/test_bolt.py -v -k "ERR"
+```
+Expected: `ERR-001, 002 PASSED`, `ERR-003 SKIPPED`, `ERR-004 XFAIL`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e-python/tests/test_bolt.py bolt/conformance/spec.yaml
+git commit -m "test(#4885): add error scenarios (ERR-001..004), correct ERR-003 spec status"
+```
+
+---
+
+### Task 10: Protocol scenarios (PROTO-001..003)
+
+**Files:**
+- Modify: `e2e-python/tests/test_bolt.py`
+
+**Interfaces:**
+- Consumes: `bolt_driver` (Task 2).
+
+- [ ] **Step 1: Append the protocol tests**
+
+```python
+# --- protocol ---------------------------------------------------------
+
+
+def test_PROTO_001_version_negotiation_succeeds(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        assert session.run("RETURN 1 AS value").single()["value"] == 1
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="BoltNetworkExecutor.SUPPORTED_VERSIONS never advertises any "
+    "Bolt 5.x version; drivers that support 5.x only work today by "
+    "silently downgrading to 4.4, which is undocumented and untested as a "
+    "deliberate compatibility stance; see #4890",
+)
+def test_PROTO_002_bolt_5x_negotiation_is_documented(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        summary = session.run("RETURN 1 AS value").consume()
+        negotiated_version = summary.server.protocol_version
+        assert negotiated_version[0] >= 5, (
+            f"driver silently downgraded to Bolt {negotiated_version} "
+            "instead of negotiating a documented Bolt 5.x version"
+        )
+
+
+def test_PROTO_003_reset_mid_stream(bolt_driver):
+    with bolt_driver.session(database="beer", fetch_size=2) as session:
+        result = session.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 10")
+        next(iter(result))
+        result.consume()  # abandon the remaining stream mid-flight
+
+        follow_up = session.run("RETURN 1 AS value")
+        assert follow_up.single()["value"] == 1
+```
+
+- [ ] **Step 2: Run it to verify it passes**
+
+```bash
+cd e2e-python
+pytest tests/test_bolt.py -v -k "PROTO"
+```
+Expected: `PROTO-001 PASSED`, `PROTO-002 XFAIL`, `PROTO-003 PASSED` (`PROTO-003` is `current_status: unverified` - same instruction as Task 6 if it fails).
+
+If `summary.server.protocol_version` doesn't exist on the installed `neo4j` driver version (API surface can shift between minor versions), check `neo4j.api.ServerInfo`'s actual attributes via `python3 -c "from neo4j.api import ServerInfo; help(ServerInfo)"` and adjust `test_PROTO_002_bolt_5x_negotiation_is_documented` to use the correct attribute name - the assertion's intent (negotiated version's major number is 5 or higher) must be preserved.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e-python/tests/test_bolt.py
+git commit -m "test(#4885): add protocol scenarios (PROTO-001..003)"
+```
+
+---
+
+### Task 11: Full-suite verification and scenario coverage cross-check
+
+**Files:**
+- No new files - verification only, plus a possible final fix-up commit.
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-10.
+
+- [ ] **Step 1: Run the full Bolt suite verbosely**
+
+```bash
+cd e2e-python
+pytest tests/test_bolt.py -v
+```
+Expected: 39 scenarios accounted for -
+- `PASSED`: the scenarios that were `current_status: passing` and any `unverified` ones confirmed correct (should be roughly 22-28 depending on how many `unverified` scenarios resolved as passing).
+- `XFAIL`: the 10 `expected-fail` scenarios other than CONN-004, plus any `unverified` scenario that was promoted to `xfail` during Tasks 6/7/10.
+- `SKIPPED`: exactly 2 - `CONN-004` and `ERR-003`, each with a clear reason string visible in the `-v` output.
+- No unexplained `FAILED` or `SKIPPED` without a `reason=`.
+
+If anything is unaccounted for, go back to the relevant task and fix it before proceeding.
+
+- [ ] **Step 2: Cross-check every spec.yaml scenario has exactly one test**
+
+```bash
+cd /Users/frank/projects/arcade/arcadedb/.worktrees/feat/4885-e2e-python-bolt-conformance
+python3 - <<'EOF'
+import re
+import yaml
+
+spec = yaml.safe_load(open("bolt/conformance/spec.yaml"))
+spec_ids = {s["id"] for s in spec["scenarios"]}
+
+test_source = open("e2e-python/tests/test_bolt.py").read()
+test_ids = set()
+for match in re.finditer(r"def test_([A-Z]+)_(\d+)_", test_source):
+    area_prefix, number = match.groups()
+    test_ids.add(f"{area_prefix}-{number}")
+
+missing = spec_ids - test_ids
+extra = test_ids - spec_ids
+print(f"spec scenarios: {len(spec_ids)}, test functions: {len(test_ids)}")
+print(f"missing (in spec, no test): {sorted(missing) or 'none'}")
+print(f"extra (test with no spec id): {sorted(extra) or 'none'}")
+assert not missing, f"missing tests for: {sorted(missing)}"
+EOF
+```
+Expected: `spec scenarios: 39, test functions: 39`, `missing (in spec, no test): none`, `extra (test with no spec id): none`. (Requires `pyyaml` - already a dependency of `bolt/conformance/validate_spec.py`; install with `pip install pyyaml` if not present in the active environment.)
+
+If `missing` is non-empty, add the missing test function(s) before proceeding - every scenario in `spec.yaml` must have a corresponding test per issue #4885's acceptance criteria ("`test_bolt.py` implements every A1 scenario").
+
+- [ ] **Step 3: Validate the spec.yaml edit from Task 9 still passes structural validation**
+
+```bash
+cd bolt/conformance
+pip install -r requirements.txt
+python3 validate_spec.py spec.yaml
+python3 -m unittest test_validate_spec.py -v
+```
+Expected: both commands exit 0 with no errors reported.
+
+- [ ] **Step 4: Run the full existing e2e-python suite to confirm no regression**
+
+```bash
+cd e2e-python
+pytest tests/ -v
+```
+Expected: all pre-existing Postgres-wire tests (`test_arcadedb.py`, `test_asyncpg.py`, `test_sqlalchemy.py`) still pass, plus all of `test_bolt.py`'s PASSED/XFAIL/SKIPPED results from Step 1.
+
+- [ ] **Step 5: Final commit (if Steps 1-4 required any fix-ups)**
+
+```bash
+git add -A
+git status   # confirm only expected files are staged
+git commit -m "test(#4885): fix up scenario coverage gaps found during verification"
+```
+
+Skip this step entirely if Steps 1-4 required no changes.

--- a/docs/superpowers/specs/2026-07-03-e2e-python-bolt-conformance-design.md
+++ b/docs/superpowers/specs/2026-07-03-e2e-python-bolt-conformance-design.md
@@ -1,0 +1,174 @@
+# Design: e2e-python Bolt conformance suite (issue #4885)
+
+## Context
+
+Part of epic #4882 (Bolt Driver Compatibility Certification), Group B ("per-language
+implementations"). Issue #4883 authored the shared, language-neutral conformance
+spec (`bolt/conformance/spec.yaml`, 39 scenarios across 9 areas) and issue #4884
+documented the advertised server identity (`bolt/SERVER_IDENTITY.md`) - both
+already merged to `main` (`e14057ed6`, `67f6bedb6`).
+
+`e2e-python` today has zero Bolt/`neo4j`-driver footprint - it tests only
+Postgres-wire (`psycopg`, `asyncpg`, `sqlalchemy`) against a shared
+`DockerContainer`-based ArcadeDB instance. This design covers hand-implementing
+every scenario from `spec.yaml` as native pytest tests in a new
+`e2e-python/tests/test_bolt.py`, wired into the already PR-gating
+`python-e2e-tests` CI job. No protocol code changes - this is test-only, mirroring
+what #4886-#4889 will each do for their own language.
+
+## Grounding (verified against the codebase and `origin/main`)
+
+- `bolt/conformance/spec.yaml`: 39 scenarios - `connection`(5), `auth`(3),
+  `transactions`(5), `causal-consistency`(1), `multi-database`(2),
+  `result-handling`(4), `type-roundtrip`(12), `errors`(4), `protocol`(3).
+  `current_status` values: `passing` (22 scenarios), `expected-fail` (11
+  scenarios, all tied to the epic's 4 confirmed gaps and tagged
+  `tracking_issue: "#4890"`), or `unverified` (6 scenarios; spec-authoring time
+  did not confirm these either way - README explicitly defers resolving them
+  to each B-task's first implementation run).
+- `bolt/conformance/README.md`: consumption model is "hand-write the test, embed
+  the scenario ID for traceability" - no suite parses `spec.yaml` at runtime.
+  Python convention given verbatim: `def test_TYPE_011_duration_roundtrip(): ...`.
+- `bolt/conformance/fixtures/type-matrix.cypher`: a single `CREATE (:TypeMatrix
+  {...})` statement (temporal props, Duration, Point, nested list/map, null) that
+  must be seeded via HTTP `/command`, never via Bolt (would exercise the very
+  serialization path several `type-roundtrip` scenarios test).
+- `e2e-python/pyproject.toml`: `requires-python = ">=3.8"`; deps are all
+  `>=` floors (`testcontainers>=4.14.2`, `pytest>=9.1.1`, `pytest-check>=2.8.0`,
+  etc.), no `neo4j` driver present. No `conftest.py` anywhere in the module.
+- `e2e-python/tests/test_arcadedb.py` (and sibling Postgres-wire files) establish
+  the pattern to mirror: a module-level `DockerContainer("arcadedata/arcadedb:latest")`
+  with `.with_exposed_ports(...)` / `.with_env("JAVA_OPTS", ...)`, started by a
+  `@pytest.fixture(scope="module", autouse=True)`, readiness polled via
+  `GET /api/v1/ready` expecting HTTP 204.
+- `e2e/src/test/java/.../ArcadeContainerTemplate.java` (Java's shared e2e base)
+  and `e2e-js/src/js-bolt-e2e.test.js` confirm the exact plugin/port pattern
+  needed: expose port `7687`, add `BoltProtocolPlugin` to
+  `-Darcadedb.server.plugins=...`. `GlobalConfiguration` shows Bolt's defaults
+  (host `0.0.0.0`, port `7687`, TLS `DISABLED`) need no extra sysprops beyond
+  listing the plugin, except for the two TLS scenarios (`arcadedb.bolt.ssl=
+  REQUIRED`/`OPTIONAL`).
+- Root `pom.xml` pins Java's `neo4j-driver.version` to `6.2.0`; `e2e-js` pins
+  `^6.0.1`. Current PyPI `neo4j` driver is `6.2.0` (released 2026-05-04),
+  requiring Python `>=3.10`.
+- `.github/workflows/mvn-test.yml`'s `python-e2e-tests` job already runs
+  `pytest tests/` with no path filtering - a new `test_bolt.py` file needs no
+  workflow changes to be picked up.
+- Server HTTP command endpoint confirmed via
+  `server/.../handler/PostCommandHandler.java`: `POST /api/v1/command/{database}`,
+  JSON body `{"language": "...", "command": "..."}`, Basic auth.
+
+## Decisions
+
+### 1. Known-gap scenarios: `pytest.mark.xfail(strict=True)`
+
+The 11 `expected-fail` scenarios are implemented as ordinary tests asserting the
+*correct*, Neo4j-compatible behavior (e.g. "Duration comes back as a native
+`neo4j.time.Duration`"), decorated `@pytest.mark.xfail(strict=True, reason="...
+see #4890")`. This satisfies both of #4885's acceptance criteria at once:
+failures are visible in the pytest report with a reason referencing the tracking
+issue (not a silent skip), and the run still exits green. `strict=True` means if
+the underlying gap is ever closed, the test flips from XFAIL to a hard failure
+(XPASS-as-failure) instead of quietly staying green - forcing `spec.yaml`'s
+`current_status` to be updated in that future PR. This is the standard pytest
+idiom for "known, tracked, not-yet-fixed" and needs no custom tooling.
+
+**Rejected alternative: characterization tests** (assert today's actual broken
+output, e.g. "Duration comes back as a string", as a plain passing test). Rejected
+because a plain `PASS` in the report is indistinguishable from a real conformance
+pass to a future reader or to the CI-aggregation matrix (#4891/#4892), which
+misrepresents certification status for exactly the scenarios meant to be flagged.
+
+### 2. Unverified scenarios: implement as real assertions, promote to xfail if they fail
+
+The spec's `unverified` scenarios were not confirmed either way at spec-authoring
+time. Each is implemented as a normal assertion of correct behavior. If one fails
+during implementation and the failure looks like a genuine gap (not a scenario
+authoring error), per `bolt/conformance/README.md`'s own instructions: mark it
+`xfail(strict=True)`, and in the same PR update `spec.yaml`'s
+`current_status`/`known_limitation`/`tracking_issue` (reusing `#4890` if it fits
+the same root cause, otherwise opening a new tracking issue).
+
+### 3. CONN-004 (HA routing topology) is `pytest.mark.skip`, not `xfail`, with a clear reason
+
+CONN-004's precondition is a 3-node HA cluster - standing that up would require
+new multi-container HA orchestration code in `e2e-python` that no other suite in
+this module has. Unlike the other 10 `expected-fail` scenarios, this one cannot
+be meaningfully expressed as an `xfail` against a single-node container: the
+"correct" assertion (routing table lists multiple distinct nodes reflecting real
+leader/follower topology) would keep failing forever even after
+`BoltNetworkExecutor.handleRoute` is fixed, because a single-node deployment
+*correctly* has only one node to report - `strict=True`'s self-correcting
+property (Decision 1) would never trigger, silently misrepresenting the scenario
+as permanently broken. Marking it `pytest.mark.skip(reason="requires a 3-node HA
+cluster; e2e-python's single-node harness cannot meaningfully exercise this
+scenario - see #4890")` is the honest signal here: it is loud (shown as SKIPPED
+with the reason in every test report, unlike an unexplained/absent test) without
+falsely implying it's testable in this harness. If a real multi-node HA e2e
+harness is ever built (in this module or elsewhere), this scenario should be
+revisited to run against it as a proper `xfail`/`pass`.
+
+### 4. Three container fixtures, one test file
+
+- `bolt_container` (module-scoped, TLS disabled): the default container -
+  `beer` dataset preloaded (existing pattern), plus port `7687` and
+  `BoltProtocolPlugin` added to the plugin list. At setup this fixture also:
+  - creates a second database (`boltscratch`) via
+    `POST /api/v1/server` (`create database boltscratch`) for MDB-002's
+    cross-database isolation scenario;
+  - seeds `bolt/conformance/fixtures/type-matrix.cypher` into `beer` via
+    `POST /api/v1/command/beer` (`language: cypher`) over HTTP - never Bolt.
+  Hosts the remaining 37 scenarios (39 total minus CONN-002 and CONN-005).
+- `bolt_container_tls_required` / `bolt_container_tls_optional` (module-scoped,
+  fixture-requested only by CONN-002 / CONN-005): dedicated containers started
+  with `arcadedb.bolt.ssl=REQUIRED` / `OPTIONAL`. Kept in the same file as
+  separate fixtures (pytest only boots a fixture when a test requests it) rather
+  than a separate file, since `spec.yaml` traceability is scenario-ID-based, not
+  file-based.
+
+No `conftest.py` is introduced - consistent with the rest of `e2e-python` today.
+
+### 5. Dependency: `neo4j>=6.2.0`, bump `requires-python` to `>=3.10`
+
+Adds `neo4j>=6.2.0` to `pyproject.toml` (matching the `>=` floor style of every
+existing dependency, and Java's pinned `6.2.0` baseline). The 6.x driver line
+requires Python `>=3.10`, so `requires-python` moves from `>=3.8` to `>=3.10`.
+Harmless in practice - CI's `python-e2e-tests` job already pins Python `3.13.0`.
+Per `spec.yaml`'s `driver_version_bands.python` (`lts`/`current`/`latest`), this
+PR resolves the band to a single concrete version (`current`, `6.2.0`) and
+records it in `resolution_note` - matching the design decision from #4883 that
+each B-task resolves its own bands and records them where dependency versions
+already live. Testing across all three bands is out of scope (see below).
+
+### 6. Traceability
+
+Every test named `test_<AREA>_<NNN>_<slug>` per the README's Python convention,
+e.g. `test_TYPE_011_duration_roundtrip`. A module-level docstring or comment
+notes the scenario `id` maps 1:1 to `spec.yaml`, so a future CI-aggregation
+script (#4891/#4892) can cross-reference by name pattern.
+
+## Out of scope
+
+- Any protocol/server code change (tracked under #4890).
+- Testing across all three driver-version bands (`lts`/`current`/`latest`) in
+  this suite's own CI run - one pinned version now; multi-version matrix testing
+  is #4891's nightly-scheduled job, not a per-B-task concern.
+- Building real multi-node HA cluster test infrastructure in `e2e-python`
+  (CONN-004 is scoped down per Decision 3).
+- JUnit XML report generation/aggregation (D-group, #4891/#4892).
+- The other four per-language suites (#4886-#4889).
+
+## Verification plan
+
+1. `pytest tests/test_bolt.py -v` run locally (Docker required) against the
+   `beer`+`BoltProtocolPlugin` container - confirms every scenario is a genuine
+   `PASS`, an `XFAIL` with a reason string, or (CONN-004 only) a `SKIPPED` with
+   a reason string - never an unexpected `FAIL` or an unexplained skip.
+2. Cross-check scenario coverage: every `id` in `spec.yaml` has exactly one
+   corresponding `test_<id>_*` function in `test_bolt.py` (manual grep check,
+   documented in the plan's final verification step).
+3. Full existing `e2e-python` suite (`pytest tests/`) still passes - confirms no
+   regression to the Postgres-wire tests sharing plugin-list/container-fixture
+   patterns.
+4. `python-e2e-tests` CI job run (via the PR) confirms the suite is green in
+   the real pipeline, not just locally.

--- a/e2e-python/pyproject.toml
+++ b/e2e-python/pyproject.toml
@@ -19,7 +19,7 @@ name = "arcadedb-e2e-python"
 version = "0.1.0"
 description = "End-to-end Python tests for ArcadeDB"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = {text = "Apache-2.0"}
 
 dependencies = [
@@ -32,7 +32,8 @@ dependencies = [
     "psycopg-binary>=3.3.4",
     "asyncpg>=0.31.0",
     "requests>=2.34.2",
-    "sqlalchemy>=2.0.51"
+    "sqlalchemy>=2.0.51",
+    "neo4j>=6.2.0"
 ]
 
 [build-system]

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -256,6 +256,13 @@ def test_CONN_002_tls_required(bolt_container_tls_required):
         driver.close()
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason="BoltMessage.parseRoute (bolt/src/main/java/com/arcadedb/bolt/message/"
+    "BoltMessage.java:142) casts the ROUTE message's third field straight to "
+    "String, but under negotiated Bolt 4.4 it is actually a Map, causing a "
+    "server-side ClassCastException; see #4916",
+)
 def test_CONN_003_neo4j_routing_single_node(bolt_container):
     driver = GraphDatabase.driver(bolt_uri(bolt_container, scheme="neo4j"), auth=basic_auth("root", ROOT_PASSWORD))
     try:

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -512,3 +512,167 @@ def test_RESULT_004_summary_counters_reflect_writes(bolt_driver):
         assert counters.nodes_created == 2
         assert counters.relationships_created == 1
         assert counters.properties_set >= 2
+
+
+# --- type-roundtrip ---------------------------------------------------
+
+
+def test_TYPE_001_node_roundtrip(bolt_driver):
+    from neo4j.graph import Node
+
+    with bolt_driver.session(database="beer") as session:
+        record = session.run("MATCH (b:Beer) RETURN b LIMIT 1").single()
+        node = record["b"]
+        assert isinstance(node, Node)
+        assert "Beer" in node.labels
+        assert node.get("name") is not None
+
+
+def test_TYPE_002_relationship_roundtrip(bolt_driver):
+    from neo4j.graph import Relationship
+
+    with bolt_driver.session(database="beer") as session:
+        record = session.run("MATCH ()-[r]->() RETURN r LIMIT 1").single()
+        rel = record["r"]
+        assert isinstance(rel, Relationship)
+        assert rel.type is not None
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="structure/BoltPath.java exists but has zero call sites "
+    "constructing it anywhere in BoltStructureMapper - query results never "
+    "actually produce native Path structures today; see #4890",
+)
+def test_TYPE_003_path_roundtrip(bolt_driver):
+    from neo4j.graph import Path
+
+    with bolt_driver.session(database="beer") as session:
+        record = session.run("MATCH p=(b:Beer)-[*1..2]-() RETURN p LIMIT 1").single()
+        path = record["p"]
+        assert isinstance(path, Path)
+        assert len(path.nodes) >= 2
+
+
+def test_TYPE_004_bytearray_param_roundtrip(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        payload = bytearray([1, 2, 3, 4])
+        record = session.run("RETURN $b AS echo", b=payload).single()
+        assert bytes(record["echo"]) == bytes(payload)
+
+
+def test_TYPE_005_nested_list_map_roundtrip(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        record = session.run(
+            "MATCH (t:TypeMatrix) RETURN t.nestedListProp AS l, t.nestedMapProp AS m"
+        ).single()
+        assert record["l"] == [1, 2, [3, 4]]
+        assert record["m"] == {"a": 1, "b": {"c": 2}}
+
+
+def test_TYPE_006_null_roundtrip(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        record = session.run("MATCH (t:TypeMatrix) RETURN t.nullProp AS n").single()
+        assert record["n"] is None
+
+        echo = session.run("RETURN $p AS echo", p=None).single()
+        assert echo["echo"] is None
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="BoltStructureMapper.toPackStreamValue converts LocalDate via "
+    ".toString()/ISO string fallback instead of the native Bolt Date "
+    "structure (sig 0x44); see #4890",
+)
+def test_TYPE_007_local_date_roundtrip(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        record = session.run("MATCH (t:TypeMatrix) RETURN t.localDateProp AS d").single()
+        assert isinstance(record["d"], datetime.date)
+
+        echo = session.run("RETURN $d AS echo", d=record["d"]).single()
+        assert echo["echo"] == record["d"]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Same ISO-string fallback as TYPE-007, for LocalTime (native Bolt "
+    "LocalTime structure sig 0x74 not produced); see #4890",
+)
+def test_TYPE_008_local_time_roundtrip(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        record = session.run("MATCH (t:TypeMatrix) RETURN t.localTimeProp AS t2").single()
+        assert isinstance(record["t2"], datetime.time)
+
+        echo = session.run("RETURN $t AS echo", t=record["t2"]).single()
+        assert echo["echo"] == record["t2"]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Same ISO-string fallback as TYPE-007, for LocalDateTime (native "
+    "Bolt LocalDateTime structure sig 0x64 not produced); see #4890",
+)
+def test_TYPE_009_local_datetime_roundtrip(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        record = session.run("MATCH (t:TypeMatrix) RETURN t.localDateTimeProp AS dt").single()
+        assert isinstance(record["dt"], datetime.datetime)
+
+        echo = session.run("RETURN $dt AS echo", dt=record["dt"]).single()
+        assert echo["echo"] == record["dt"]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Same ISO-string fallback as TYPE-007, for OffsetDateTime/"
+    "ZonedDateTime (native Bolt DateTime/DateTimeZoneId structures, sig "
+    "0x49/0x69, not produced); see #4890",
+)
+def test_TYPE_010_offset_datetime_roundtrip(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        record = session.run("MATCH (t:TypeMatrix) RETURN t.offsetDateTimeProp AS dt").single()
+        dt = record["dt"]
+        assert isinstance(dt, datetime.datetime)
+        assert dt.utcoffset() == datetime.timedelta(hours=2)
+
+        echo = session.run("RETURN $dt AS echo", dt=dt).single()
+        assert echo["echo"] == dt
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="BoltStructureMapper/PackStreamWriter have no Duration handling "
+    "at all - not even a string fallback branch, falls through to generic "
+    "value.toString(); see #4890",
+)
+def test_TYPE_011_duration_roundtrip(bolt_driver):
+    from neo4j.time import Duration
+
+    with bolt_driver.session(database="beer") as session:
+        record = session.run("MATCH (t:TypeMatrix) RETURN t.durationProp AS d").single()
+        assert isinstance(record["d"], Duration)
+
+        echo = session.run("RETURN $d AS echo", d=record["d"]).single()
+        assert echo["echo"] == record["d"]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="No Point/spatial type handling exists anywhere in "
+    "BoltStructureMapper or PackStreamWriter (the underlying ArcadeDB "
+    "Cypher engine itself does support point() - the gap is Bolt wire "
+    "serialization only); see #4890",
+)
+def test_TYPE_012_point_roundtrip(bolt_driver):
+    from neo4j.spatial import Point
+
+    with bolt_driver.session(database="beer") as session:
+        record = session.run("MATCH (t:TypeMatrix) RETURN t.pointProp AS p").single()
+        point = record["p"]
+        assert isinstance(point, Point)
+        assert point.x == pytest.approx(12.34)
+        assert point.y == pytest.approx(56.78)
+
+        echo = session.run("RETURN $p AS echo", p=point).single()
+        assert echo["echo"].x == pytest.approx(12.34)
+        assert echo["echo"].y == pytest.approx(56.78)

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -292,3 +292,39 @@ def test_CONN_005_tls_optional_plaintext_connects(bolt_container_tls_optional):
         driver.verify_connectivity()
     finally:
         driver.close()
+
+
+# --- auth ----------------------------------------------------------------
+
+
+def test_AUTH_001_basic_auth_valid(bolt_container):
+    driver = GraphDatabase.driver(bolt_uri(bolt_container), auth=basic_auth("root", ROOT_PASSWORD))
+    try:
+        driver.verify_connectivity()
+        with driver.session(database="beer") as session:
+            assert session.run("RETURN 1 AS value").single()["value"] == 1
+    finally:
+        driver.close()
+
+
+def test_AUTH_002_basic_auth_invalid(bolt_container):
+    from neo4j.exceptions import AuthError
+
+    driver = GraphDatabase.driver(bolt_uri(bolt_container), auth=basic_auth("root", "wrong-password"))
+    try:
+        with pytest.raises(AuthError) as exc_info:
+            driver.verify_connectivity()
+        assert exc_info.value.code == "Neo.ClientError.Security.Unauthorized"
+    finally:
+        driver.close()
+
+
+def test_AUTH_003_auth_none_rejected(bolt_container):
+    from neo4j.exceptions import AuthError, ServiceUnavailable
+
+    driver = GraphDatabase.driver(bolt_uri(bolt_container), auth=None)
+    try:
+        with pytest.raises((AuthError, ServiceUnavailable)):
+            driver.verify_connectivity()
+    finally:
+        driver.close()

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -258,11 +258,15 @@ def test_CONN_002_tls_required(bolt_container_tls_required):
 
 @pytest.mark.xfail(
     strict=True,
-    reason="Fixed in BoltMessage.parseRoute by commit 39e4eaedb (PR #4917, "
-    "closing #4916), merged to main - but not yet present in the published "
-    "arcadedata/arcadedb:latest image this suite tests against (image "
-    "predates the fix as of 2026-07-03). Remove this marker once the image "
-    "is rebuilt/released with the fix.",
+    reason="BoltNetworkExecutor.getBoltAddress reports socket.getLocalAddress() "
+    "(the server's own view of its address) in the ROUTE response's WRITE/READ/"
+    "ROUTE entries. Inside a container behind port mapping (as in this "
+    "testcontainers-based suite, and any NAT'd/containerized single-node "
+    "deployment), that is the container-internal address, not the externally "
+    "reachable one the driver connected through - so the driver's routing-aware "
+    "reconnect for the READ role fails. ArcadeDB has no advertised-address "
+    "override to correct this (unlike, e.g., Neo4j's "
+    "server.bolt.advertised_address); see #4890.",
 )
 def test_CONN_003_neo4j_routing_single_node(bolt_container):
     driver = GraphDatabase.driver(bolt_uri(bolt_container, scheme="neo4j"), auth=basic_auth("root", ROOT_PASSWORD))
@@ -320,14 +324,6 @@ def test_AUTH_002_basic_auth_invalid(bolt_container):
         driver.close()
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Fixed in BoltNetworkExecutor.handleHello by commit 93925a474, merged "
-    "to this branch - but not yet present in the published "
-    "arcadedata/arcadedb:latest image this suite tests against as of "
-    "2026-07-03. Remove this marker once the image is rebuilt/released "
-    "with the fix.",
-)
 def test_AUTH_003_auth_none_rejected(bolt_container):
     from neo4j.exceptions import AuthError, ServiceUnavailable
 

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -676,3 +676,53 @@ def test_TYPE_012_point_roundtrip(bolt_driver):
         echo = session.run("RETURN $p AS echo", p=point).single()
         assert echo["echo"].x == pytest.approx(12.34)
         assert echo["echo"].y == pytest.approx(56.78)
+
+
+# --- errors ---------------------------------------------------------------
+
+
+def test_ERR_001_syntax_error(bolt_driver):
+    from neo4j.exceptions import ClientError
+
+    with bolt_driver.session(database="beer") as session:
+        with pytest.raises(ClientError) as exc_info:
+            session.run("MATCH (n RETURN n").consume()
+        assert exc_info.value.code == "Neo.ClientError.Statement.SyntaxError"
+
+
+def test_ERR_002_semantic_error(bolt_driver):
+    from neo4j.exceptions import ClientError
+
+    with bolt_driver.session(database="beer") as session:
+        with pytest.raises(ClientError) as exc_info:
+            session.run("MATCH (n:Beer) RETURN undeclaredVariable").consume()
+        assert exc_info.value.code == "Neo.ClientError.Statement.SemanticError"
+
+
+@pytest.mark.skip(
+    reason="ERR-003 requires sending RUN before completing HELLO/LOGON; the "
+    "official neo4j driver's public API always completes the handshake "
+    "internally, so this cannot be triggered without a bespoke raw-socket "
+    "client, which is out of scope per the epic's 'official drivers only' "
+    "principle. spec.yaml's ERR-003 current_status has been updated to "
+    "not-applicable to reflect this."
+)
+def test_ERR_003_unauthenticated_request_rejected():
+    pass
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="BoltErrorCodes.java defines only Neo.ClientError.*/"
+    "Neo.DatabaseError.* codes (7 total) - no Neo.TransientError.* code "
+    "exists anywhere in the Bolt module; see #4890",
+)
+def test_ERR_004_transient_condition_error_code(bolt_driver):
+    from neo4j.exceptions import TransientError
+
+    errors = _race_two_writers(bolt_driver, "beer", "err-004")
+
+    assert errors, "expected at least one racing session to fail on the write conflict"
+    assert isinstance(errors[0], TransientError), (
+        f"expected Neo.TransientError.*, got {type(errors[0]).__name__}: {errors[0]}"
+    )

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -20,6 +20,12 @@ Implements every scenario in bolt/conformance/spec.yaml (issue #4883)
 against the official `neo4j` Python driver. Each test function name embeds
 its spec.yaml scenario id (test_<AREA>_<NNN>_<slug>) for traceability, per
 bolt/conformance/README.md's "Traceability convention".
+
+Note: ArcadeDB negotiates Bolt 4.4/4.0/3.0 at most (see PROTO-002 - it
+never advertises 5.x). This entire suite depends on the pinned `neo4j`
+driver continuing to silently downgrade to 4.4 rather than requiring 5.x -
+a future driver major version that drops legacy protocol negotiation would
+break every test here, not just PROTO-002.
 """
 
 import datetime

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -29,6 +29,7 @@ import threading
 import time
 from pathlib import Path
 
+import docker
 import pytest
 import requests
 from neo4j import GraphDatabase, basic_auth
@@ -165,6 +166,28 @@ def generate_tls_certs(cert_dir):
     return keystore_path, truststore_path
 
 
+def build_tls_image(cert_dir):
+    """Build a throwaway image with the TLS keystore/truststore baked in via COPY.
+
+    Bind-mounting the host cert_dir (testcontainers `with_volume_mapping`)
+    works locally but is unreliable in some CI environments - GitHub Actions
+    runners have been observed to start the container with the mounted
+    directory present but empty, so ArcadeDB's BoltSslHelper fails with
+    "Could not load resource from path" even though the same fixture passes
+    locally. A `docker build` COPY always resolves its own build context
+    correctly regardless of host/CI path-translation quirks, so this bakes
+    the certs into a derived image instead of mounting them at runtime.
+    """
+    dockerfile = cert_dir / "Dockerfile"
+    dockerfile.write_text(
+        "FROM arcadedata/arcadedb:latest\n"
+        "COPY --chown=arcadedb:arcadedb keystore.p12 truststore.jks /home/arcadedb/tls_certs/\n"
+    )
+    client = docker.from_env()
+    image, _logs = client.images.build(path=str(cert_dir), tag="arcadedb-bolt-tls-test:latest", rm=True)
+    return image.tags[0]
+
+
 @pytest.fixture(scope="module")
 def bolt_container():
     # This tag is loaded from the CI-built branch image (build-and-package's
@@ -217,26 +240,24 @@ def test_CONN_001_connect_bolt(bolt_driver):
 @pytest.fixture(scope="module")
 def tls_certs(tmp_path_factory):
     cert_dir = tmp_path_factory.mktemp("bolt-tls-certs")
-    keystore_path, truststore_path = generate_tls_certs(cert_dir)
-    return cert_dir, keystore_path.name, truststore_path.name
+    generate_tls_certs(cert_dir)
+    return build_tls_image(cert_dir)
 
 
 @pytest.fixture(scope="module")
 def bolt_container_tls_required(tls_certs):
-    cert_dir, keystore_name, truststore_name = tls_certs
     container = (
-        DockerContainer("arcadedata/arcadedb:latest")
+        DockerContainer(tls_certs)
         .with_exposed_ports(2480, 7687)
-        .with_volume_mapping(str(cert_dir), "/home/arcadedb/tls_certs", "ro")
         .with_env(
             "JAVA_OPTS",
             "-Darcadedb.server.rootPassword=" + ROOT_PASSWORD + " "
             "-Darcadedb.server.defaultDatabases=beer[root]{import:https://github.com/ArcadeData/arcadedb-datasets/raw/main/orientdb/OpenBeer.gz} "
             "-Darcadedb.server.plugins=BoltProtocolPlugin "
             "-Darcadedb.bolt.ssl=REQUIRED "
-            "-Darcadedb.ssl.keyStore=/home/arcadedb/tls_certs/" + keystore_name + " "
+            "-Darcadedb.ssl.keyStore=/home/arcadedb/tls_certs/keystore.p12 "
             "-Darcadedb.ssl.keyStorePassword=" + TLS_STORE_PASSWORD + " "
-            "-Darcadedb.ssl.trustStore=/home/arcadedb/tls_certs/" + truststore_name + " "
+            "-Darcadedb.ssl.trustStore=/home/arcadedb/tls_certs/truststore.jks "
             "-Darcadedb.ssl.trustStorePassword=" + TLS_STORE_PASSWORD,
         )
     )
@@ -252,20 +273,18 @@ def bolt_container_tls_required(tls_certs):
 
 @pytest.fixture(scope="module")
 def bolt_container_tls_optional(tls_certs):
-    cert_dir, keystore_name, truststore_name = tls_certs
     container = (
-        DockerContainer("arcadedata/arcadedb:latest")
+        DockerContainer(tls_certs)
         .with_exposed_ports(2480, 7687)
-        .with_volume_mapping(str(cert_dir), "/home/arcadedb/tls_certs", "ro")
         .with_env(
             "JAVA_OPTS",
             "-Darcadedb.server.rootPassword=" + ROOT_PASSWORD + " "
             "-Darcadedb.server.defaultDatabases=beer[root]{import:https://github.com/ArcadeData/arcadedb-datasets/raw/main/orientdb/OpenBeer.gz} "
             "-Darcadedb.server.plugins=BoltProtocolPlugin "
             "-Darcadedb.bolt.ssl=OPTIONAL "
-            "-Darcadedb.ssl.keyStore=/home/arcadedb/tls_certs/" + keystore_name + " "
+            "-Darcadedb.ssl.keyStore=/home/arcadedb/tls_certs/keystore.p12 "
             "-Darcadedb.ssl.keyStorePassword=" + TLS_STORE_PASSWORD + " "
-            "-Darcadedb.ssl.trustStore=/home/arcadedb/tls_certs/" + truststore_name + " "
+            "-Darcadedb.ssl.trustStore=/home/arcadedb/tls_certs/truststore.jks "
             "-Darcadedb.ssl.trustStorePassword=" + TLS_STORE_PASSWORD,
         )
     )

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -328,3 +328,95 @@ def test_AUTH_003_auth_none_rejected(bolt_container):
             driver.verify_connectivity()
     finally:
         driver.close()
+
+
+# --- transactions ----------------------------------------------------------
+
+
+def test_TX_001_autocommit_query(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        result = session.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 5")
+        records = list(result)
+        assert len(records) == 5
+
+
+def test_TX_002_explicit_commit_persists(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        tx = session.begin_transaction()
+        tx.run("CREATE (:TxCommitProbe {marker: 'tx-002'})")
+        tx.commit()
+
+        result = session.run("MATCH (n:TxCommitProbe {marker: 'tx-002'}) RETURN count(n) AS c")
+        assert result.single()["c"] == 1
+
+
+def test_TX_003_explicit_rollback_discards(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        tx = session.begin_transaction()
+        tx.run("CREATE (:TxRollbackProbe {marker: 'tx-003'})")
+        tx.rollback()
+
+        result = session.run("MATCH (n:TxRollbackProbe {marker: 'tx-003'}) RETURN count(n) AS c")
+        assert result.single()["c"] == 0
+
+
+def test_TX_004_managed_write_commits(bolt_driver):
+    def create_beer(tx):
+        tx.run("CREATE (:Beer {name: $n})", n="TX-004-Beer")
+
+    with bolt_driver.session(database="beer") as session:
+        session.execute_write(create_beer)
+        result = session.run("MATCH (b:Beer {name: $n}) RETURN count(b) AS c", n="TX-004-Beer")
+        assert result.single()["c"] == 1
+
+
+def _race_two_writers(driver, database, marker):
+    """Shared concurrency helper for TX-005 and ERR-004: two sessions race to
+    update the same node inside an explicit transaction, one held open past
+    the other's commit attempt. Returns the list of exceptions raised."""
+    with driver.session(database=database) as setup_session:
+        setup_session.run(
+            "MERGE (n:RaceProbe {marker: $marker}) SET n.value = 0", marker=marker
+        ).consume()
+
+    barrier = threading.Barrier(2)
+    errors = []
+
+    def racing_write():
+        with driver.session(database=database) as session:
+            try:
+                barrier.wait(timeout=5)
+                tx = session.begin_transaction()
+                tx.run(
+                    "MATCH (n:RaceProbe {marker: $marker}) SET n.value = n.value + 1 RETURN n",
+                    marker=marker,
+                ).consume()
+                time.sleep(0.5)
+                tx.commit()
+            except Exception as exc:  # noqa: BLE001 - want to inspect any driver-surfaced error
+                errors.append(exc)
+
+    threads = [threading.Thread(target=racing_write) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+    return errors
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="BoltErrorCodes.java defines only 7 codes, all Neo.ClientError.*/ "
+    "Neo.DatabaseError.* - no Neo.TransientError.* code exists, so ArcadeDB "
+    "never signals a retryable condition and driver-side transient-retry "
+    "logic cannot be exercised; see #4890",
+)
+def test_TX_005_managed_write_retries_on_transient_error(bolt_driver):
+    from neo4j.exceptions import TransientError
+
+    errors = _race_two_writers(bolt_driver, "beer", "tx-005")
+
+    assert errors, "expected at least one racing session to fail on the write conflict"
+    assert isinstance(errors[0], TransientError), (
+        f"expected Neo.TransientError.*, got {type(errors[0]).__name__}: {errors[0]}"
+    )

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -444,6 +444,16 @@ def _race_two_writers(driver, database, marker):
         t.start()
     for t in threads:
         t.join(timeout=10)
+
+    # Diagnostic only (printed unconditionally, not just on failure, so it
+    # shows up in captured-stdout even for an unexpected XPASS): this race is
+    # inherently timing-sensitive, and an isolated flip to a genuine
+    # Neo.TransientError.* would be a real, actionable server-behavior
+    # change worth having concrete evidence for rather than a bare XPASS.
+    for i, err in enumerate(errors):
+        code = getattr(err, "code", None)
+        print(f"_race_two_writers[{marker}] errors[{i}]: {type(err).__name__} code={code!r} msg={err}")
+
     return errors
 
 

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -457,13 +457,6 @@ def _race_two_writers(driver, database, marker):
     return errors
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="BoltErrorCodes.java defines only 7 codes, all Neo.ClientError.*/ "
-    "Neo.DatabaseError.* - no Neo.TransientError.* code exists, so ArcadeDB "
-    "never signals a retryable condition and driver-side transient-retry "
-    "logic cannot be exercised; see #4890",
-)
 def test_TX_005_managed_write_retries_on_transient_error(bolt_driver):
     from neo4j.exceptions import TransientError
 
@@ -632,61 +625,49 @@ def test_TYPE_006_null_roundtrip(bolt_driver):
         assert echo["echo"] is None
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="BoltStructureMapper.toPackStreamValue converts LocalDate via "
-    ".toString()/ISO string fallback instead of the native Bolt Date "
-    "structure (sig 0x44); see #4890",
-)
 def test_TYPE_007_local_date_roundtrip(bolt_driver):
+    from neo4j.time import Date
+
     with bolt_driver.session(database="beer") as session:
         record = session.run("MATCH (t:TypeMatrix) RETURN t.localDateProp AS d").single()
-        assert isinstance(record["d"], datetime.date)
+        assert isinstance(record["d"], Date)
 
         echo = session.run("RETURN $d AS echo", d=record["d"]).single()
         assert echo["echo"] == record["d"]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Same ISO-string fallback as TYPE-007, for LocalTime (native Bolt "
-    "LocalTime structure sig 0x74 not produced); see #4890",
-)
 def test_TYPE_008_local_time_roundtrip(bolt_driver):
+    from neo4j.time import Time
+
     with bolt_driver.session(database="beer") as session:
         record = session.run("MATCH (t:TypeMatrix) RETURN t.localTimeProp AS t2").single()
-        assert isinstance(record["t2"], datetime.time)
+        assert isinstance(record["t2"], Time)
 
         echo = session.run("RETURN $t AS echo", t=record["t2"]).single()
         assert echo["echo"] == record["t2"]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Same ISO-string fallback as TYPE-007, for LocalDateTime (native "
-    "Bolt LocalDateTime structure sig 0x64 not produced); see #4890",
-)
 def test_TYPE_009_local_datetime_roundtrip(bolt_driver):
+    from neo4j.time import DateTime
+
     with bolt_driver.session(database="beer") as session:
         record = session.run("MATCH (t:TypeMatrix) RETURN t.localDateTimeProp AS dt").single()
-        assert isinstance(record["dt"], datetime.datetime)
+        assert isinstance(record["dt"], DateTime)
 
         echo = session.run("RETURN $dt AS echo", dt=record["dt"]).single()
         assert echo["echo"] == record["dt"]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Same ISO-string fallback as TYPE-007, for OffsetDateTime/"
-    "ZonedDateTime (native Bolt DateTime/DateTimeZoneId structures, sig "
-    "0x49/0x69, not produced); see #4890",
-)
 def test_TYPE_010_offset_datetime_roundtrip(bolt_driver):
+    import datetime as dt_module
+
+    from neo4j.time import DateTime
+
     with bolt_driver.session(database="beer") as session:
         record = session.run("MATCH (t:TypeMatrix) RETURN t.offsetDateTimeProp AS dt").single()
         dt = record["dt"]
-        assert isinstance(dt, datetime.datetime)
-        assert dt.utcoffset() == datetime.timedelta(hours=2)
+        assert isinstance(dt, DateTime)
+        assert dt.utc_offset() == dt_module.timedelta(hours=2)
 
         echo = session.run("RETURN $dt AS echo", dt=dt).single()
         assert echo["echo"] == dt
@@ -774,12 +755,6 @@ def test_ERR_003_unauthenticated_request_rejected():
     pass
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="BoltErrorCodes.java defines only Neo.ClientError.*/"
-    "Neo.DatabaseError.* codes (7 total) - no Neo.TransientError.* code "
-    "exists anywhere in the Bolt module; see #4890",
-)
 def test_ERR_004_transient_condition_error_code(bolt_driver):
     from neo4j.exceptions import TransientError
 

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -320,6 +320,14 @@ def test_AUTH_002_basic_auth_invalid(bolt_container):
         driver.close()
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason="Fixed in BoltNetworkExecutor.handleHello by commit 93925a474, merged "
+    "to this branch - but not yet present in the published "
+    "arcadedata/arcadedb:latest image this suite tests against as of "
+    "2026-07-03. Remove this marker once the image is rebuilt/released "
+    "with the fix.",
+)
 def test_AUTH_003_auth_none_rejected(bolt_container):
     from neo4j.exceptions import AuthError, ServiceUnavailable
 

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -44,6 +44,15 @@ from testcontainers.core.container import DockerContainer
 ROOT_PASSWORD = "playwithdata"
 TLS_STORE_PASSWORD = "changeit"
 
+# Shared by all three container fixtures below (bolt_container,
+# bolt_container_tls_required, bolt_container_tls_optional) - the TLS variants
+# append their own arcadedb.bolt.ssl/arcadedb.ssl.* sysprops to this.
+BASE_JAVA_OPTS = (
+    "-Darcadedb.server.rootPassword=" + ROOT_PASSWORD + " "
+    "-Darcadedb.server.defaultDatabases=beer[root]{import:https://github.com/ArcadeData/arcadedb-datasets/raw/main/orientdb/OpenBeer.gz} "
+    "-Darcadedb.server.plugins=BoltProtocolPlugin"
+)
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TYPE_MATRIX_FIXTURE = REPO_ROOT / "bolt" / "conformance" / "fixtures" / "type-matrix.cypher"
 
@@ -206,12 +215,7 @@ def bolt_container():
     container = (
         DockerContainer("arcadedata/arcadedb:latest")
         .with_exposed_ports(2480, 7687)
-        .with_env(
-            "JAVA_OPTS",
-            "-Darcadedb.server.rootPassword=" + ROOT_PASSWORD + " "
-            "-Darcadedb.server.defaultDatabases=beer[root]{import:https://github.com/ArcadeData/arcadedb-datasets/raw/main/orientdb/OpenBeer.gz} "
-            "-Darcadedb.server.plugins=BoltProtocolPlugin",
-        )
+        .with_env("JAVA_OPTS", BASE_JAVA_OPTS)
     )
     container.start()
     try:
@@ -247,7 +251,11 @@ def test_CONN_001_connect_bolt(bolt_driver):
 def tls_certs(tmp_path_factory):
     cert_dir = tmp_path_factory.mktemp("bolt-tls-certs")
     generate_tls_certs(cert_dir)
-    return build_tls_image(cert_dir)
+    image_tag = build_tls_image(cert_dir)
+    yield image_tag
+    # Both bolt_container_tls_required/optional depend on this fixture, so
+    # pytest tears them (and their containers) down before this runs.
+    docker.from_env().images.remove(image_tag, force=True)
 
 
 @pytest.fixture(scope="module")
@@ -257,9 +265,7 @@ def bolt_container_tls_required(tls_certs):
         .with_exposed_ports(2480, 7687)
         .with_env(
             "JAVA_OPTS",
-            "-Darcadedb.server.rootPassword=" + ROOT_PASSWORD + " "
-            "-Darcadedb.server.defaultDatabases=beer[root]{import:https://github.com/ArcadeData/arcadedb-datasets/raw/main/orientdb/OpenBeer.gz} "
-            "-Darcadedb.server.plugins=BoltProtocolPlugin "
+            BASE_JAVA_OPTS + " "
             "-Darcadedb.bolt.ssl=REQUIRED "
             "-Darcadedb.ssl.keyStore=/home/arcadedb/tls_certs/keystore.p12 "
             "-Darcadedb.ssl.keyStorePassword=" + TLS_STORE_PASSWORD + " "
@@ -284,9 +290,7 @@ def bolt_container_tls_optional(tls_certs):
         .with_exposed_ports(2480, 7687)
         .with_env(
             "JAVA_OPTS",
-            "-Darcadedb.server.rootPassword=" + ROOT_PASSWORD + " "
-            "-Darcadedb.server.defaultDatabases=beer[root]{import:https://github.com/ArcadeData/arcadedb-datasets/raw/main/orientdb/OpenBeer.gz} "
-            "-Darcadedb.server.plugins=BoltProtocolPlugin "
+            BASE_JAVA_OPTS + " "
             "-Darcadedb.bolt.ssl=OPTIONAL "
             "-Darcadedb.ssl.keyStore=/home/arcadedb/tls_certs/keystore.p12 "
             "-Darcadedb.ssl.keyStorePassword=" + TLS_STORE_PASSWORD + " "

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -420,3 +420,41 @@ def test_TX_005_managed_write_retries_on_transient_error(bolt_driver):
     assert isinstance(errors[0], TransientError), (
         f"expected Neo.TransientError.*, got {type(errors[0]).__name__}: {errors[0]}"
     )
+
+
+# --- causal-consistency ---------------------------------------------------
+
+
+def test_CAUSAL_001_bookmark_read_after_write(bolt_driver):
+    with bolt_driver.session(database="beer") as session_a:
+        session_a.run("CREATE (:CausalProbe {marker: 'causal-001'})").consume()
+        bookmarks = session_a.last_bookmarks()
+
+    with bolt_driver.session(database="beer", bookmarks=bookmarks) as session_b:
+        result = session_b.run("MATCH (n:CausalProbe {marker: 'causal-001'}) RETURN count(n) AS c")
+        assert result.single()["c"] == 1
+
+
+# --- multi-database --------------------------------------------------------
+
+
+def test_MDB_001_session_selects_named_database(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        result = session.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 1")
+        assert result.single()["name"] is not None
+
+
+def test_MDB_002_sessions_across_databases_are_isolated(bolt_driver):
+    with bolt_driver.session(database="boltscratch") as scratch_session:
+        tx = scratch_session.begin_transaction()
+        tx.run("CREATE (:ScratchProbe {marker: 'mdb-002'})")
+
+        with bolt_driver.session(database="beer") as beer_session:
+            result = beer_session.run("MATCH (n:ScratchProbe {marker: 'mdb-002'}) RETURN count(n) AS c")
+            assert result.single()["c"] == 0
+
+        tx.commit()
+
+    with bolt_driver.session(database="boltscratch") as verify_session:
+        result = verify_session.run("MATCH (n:ScratchProbe {marker: 'mdb-002'}) RETURN count(n) AS c")
+        assert result.single()["c"] == 1

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -1,0 +1,120 @@
+#
+# Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Bolt protocol conformance suite for issue #4885, implementing every scenario
+in bolt/conformance/spec.yaml (issue #4883) against the official `neo4j`
+Python driver. Each test function name embeds its spec.yaml scenario id
+(test_<AREA>_<NNN>_<slug>) for traceability, per bolt/conformance/README.md's
+"Traceability convention".
+"""
+
+import datetime
+import threading
+import time
+from pathlib import Path
+
+import pytest
+import requests
+from neo4j import GraphDatabase, basic_auth
+from testcontainers.core.container import DockerContainer
+
+ROOT_PASSWORD = "playwithdata"
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TYPE_MATRIX_FIXTURE = REPO_ROOT / "bolt" / "conformance" / "fixtures" / "type-matrix.cypher"
+
+
+def wait_for_http_endpoint(container, path, port, expected_status, timeout=60):
+    """Wait for an HTTP endpoint to return the expected status code."""
+    host = container.get_container_host_ip()
+    url = f"http://{host}:{container.get_exposed_port(port)}{path}"
+
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        try:
+            response = requests.get(url, timeout=2)
+            if response.status_code == expected_status:
+                return True
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
+            pass
+        time.sleep(1)
+    raise TimeoutError(f"Container didn't respond with status {expected_status} at {url} within {timeout} seconds")
+
+
+def bolt_uri(container, scheme="bolt"):
+    host = container.get_container_host_ip()
+    port = container.get_exposed_port(7687)
+    return f"{scheme}://{host}:{port}"
+
+
+def create_database(container, db_name):
+    host = container.get_container_host_ip()
+    port = container.get_exposed_port(2480)
+    response = requests.post(
+        f"http://{host}:{port}/api/v1/server",
+        auth=("root", ROOT_PASSWORD),
+        json={"command": f"create database {db_name}"},
+        timeout=10,
+    )
+    response.raise_for_status()
+
+
+def seed_type_matrix(container):
+    host = container.get_container_host_ip()
+    port = container.get_exposed_port(2480)
+    command = TYPE_MATRIX_FIXTURE.read_text()
+    response = requests.post(
+        f"http://{host}:{port}/api/v1/command/beer",
+        auth=("root", ROOT_PASSWORD),
+        json={"language": "cypher", "command": command},
+        timeout=10,
+    )
+    response.raise_for_status()
+
+
+@pytest.fixture(scope="module")
+def bolt_container():
+    container = (
+        DockerContainer("arcadedata/arcadedb:latest")
+        .with_exposed_ports(2480, 7687)
+        .with_env(
+            "JAVA_OPTS",
+            "-Darcadedb.server.rootPassword=" + ROOT_PASSWORD + " "
+            "-Darcadedb.server.defaultDatabases=beer[root]{import:https://github.com/ArcadeData/arcadedb-datasets/raw/main/orientdb/OpenBeer.gz} "
+            "-Darcadedb.server.plugins=BoltProtocolPlugin",
+        )
+    )
+    container.start()
+    wait_for_http_endpoint(container, "/api/v1/ready", 2480, 204, 60)
+    create_database(container, "boltscratch")
+    seed_type_matrix(container)
+    yield container
+    container.stop()
+
+
+@pytest.fixture(scope="module")
+def bolt_driver(bolt_container):
+    driver = GraphDatabase.driver(bolt_uri(bolt_container), auth=basic_auth("root", ROOT_PASSWORD))
+    yield driver
+    driver.close()
+
+
+# --- connection ---------------------------------------------------------
+
+
+def test_CONN_001_connect_bolt(bolt_driver):
+    bolt_driver.verify_connectivity()

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -736,3 +736,38 @@ def test_ERR_004_transient_condition_error_code(bolt_driver):
     assert isinstance(errors[0], TransientError), (
         f"expected Neo.TransientError.*, got {type(errors[0]).__name__}: {errors[0]}"
     )
+
+
+# --- protocol ---------------------------------------------------------
+
+
+def test_PROTO_001_version_negotiation_succeeds(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        assert session.run("RETURN 1 AS value").single()["value"] == 1
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="BoltNetworkExecutor.SUPPORTED_VERSIONS never advertises any "
+    "Bolt 5.x version; drivers that support 5.x only work today by "
+    "silently downgrading to 4.4, which is undocumented and untested as a "
+    "deliberate compatibility stance; see #4890",
+)
+def test_PROTO_002_bolt_5x_negotiation_is_documented(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        summary = session.run("RETURN 1 AS value").consume()
+        negotiated_version = summary.server.protocol_version
+        assert negotiated_version[0] >= 5, (
+            f"driver silently downgraded to Bolt {negotiated_version} "
+            "instead of negotiating a documented Bolt 5.x version"
+        )
+
+
+def test_PROTO_003_reset_mid_stream(bolt_driver):
+    with bolt_driver.session(database="beer", fetch_size=2) as session:
+        result = session.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 10")
+        next(iter(result))
+        result.consume()  # abandon the remaining stream mid-flight
+
+        follow_up = session.run("RETURN 1 AS value")
+        assert follow_up.single()["value"] == 1

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -14,15 +14,16 @@
 # limitations under the License.
 #
 
-"""
-Bolt protocol conformance suite for issue #4885, implementing every scenario
-in bolt/conformance/spec.yaml (issue #4883) against the official `neo4j`
-Python driver. Each test function name embeds its spec.yaml scenario id
-(test_<AREA>_<NNN>_<slug>) for traceability, per bolt/conformance/README.md's
-"Traceability convention".
+"""Bolt protocol conformance suite for issue #4885.
+
+Implements every scenario in bolt/conformance/spec.yaml (issue #4883)
+against the official `neo4j` Python driver. Each test function name embeds
+its spec.yaml scenario id (test_<AREA>_<NNN>_<slug>) for traceability, per
+bolt/conformance/README.md's "Traceability convention".
 """
 
 import datetime
+import shutil
 import subprocess
 import threading
 import time
@@ -94,21 +95,29 @@ def seed_type_matrix(container):
 
 
 def generate_tls_certs(cert_dir):
-    """Generate a throwaway self-signed PKCS12 keystore + JKS truststore for BOLT TLS
-    fixtures, via the JDK `keytool` binary. ArcadeDB does not ship a default TLS
+    """Generate a throwaway self-signed keystore/truststore pair for BOLT TLS fixtures.
+
+    Uses the JDK `keytool` binary. ArcadeDB does not ship a default TLS
     keystore (arcadedb.ssl.keyStore/.trustStore have no defaults - see
     BoltSslHelper.getRequiredProperty), so enabling arcadedb.bolt.ssl=REQUIRED/OPTIONAL
     without one crashes server startup with a ConfigurationException. This mirrors
     exactly what an operator would set up: a self-signed cert, trusted by the driver
     via bolt+ssc:// instead of a CA-signed one.
     """
+    keytool = shutil.which("keytool")
+    if keytool is None:
+        raise FileNotFoundError(
+            "keytool not found on PATH - a JDK is required to run the TLS scenarios "
+            "(CONN-002/CONN-005); ensure a Java runtime is available in this environment"
+        )
+
     keystore_path = cert_dir / "keystore.p12"
     truststore_path = cert_dir / "truststore.jks"
     cert_path = cert_dir / "bolt.cer"
 
     subprocess.run(
         [
-            "keytool",
+            keytool,
             "-genkeypair",
             "-alias", "bolt",
             "-keyalg", "RSA",
@@ -126,7 +135,7 @@ def generate_tls_certs(cert_dir):
     )
     subprocess.run(
         [
-            "keytool",
+            keytool,
             "-exportcert",
             "-alias", "bolt",
             "-keystore", str(keystore_path),
@@ -140,7 +149,7 @@ def generate_tls_certs(cert_dir):
     )
     subprocess.run(
         [
-            "keytool",
+            keytool,
             "-importcert",
             "-alias", "bolt",
             "-keystore", str(truststore_path),
@@ -158,6 +167,13 @@ def generate_tls_certs(cert_dir):
 
 @pytest.fixture(scope="module")
 def bolt_container():
+    # This tag is loaded from the CI-built branch image (build-and-package's
+    # `mvn -Pdocker` output via docker save/load in mvn-test.yml), not pulled
+    # from Docker Hub - `docker load` populates the local daemon under this
+    # same tag, so testcontainers uses it without a network pull. Running
+    # this suite after an explicit `docker pull arcadedata/arcadedb:latest`
+    # (overwriting the local tag with the published Hub image) will behave
+    # differently, since that image may lag behind this branch's fixes.
     container = (
         DockerContainer("arcadedata/arcadedb:latest")
         .with_exposed_ports(2480, 7687)
@@ -169,15 +185,23 @@ def bolt_container():
         )
     )
     container.start()
-    wait_for_http_endpoint(container, "/api/v1/ready", 2480, 204, 60)
-    create_database(container, "boltscratch")
-    seed_type_matrix(container)
-    yield container
-    container.stop()
+    try:
+        wait_for_http_endpoint(container, "/api/v1/ready", 2480, 204, 60)
+        create_database(container, "boltscratch")
+        seed_type_matrix(container)
+        yield container
+    finally:
+        container.stop()
 
 
 @pytest.fixture(scope="module")
 def bolt_driver(bolt_container):
+    # Several tests below (TX-002/004, CAUSAL-001, MDB-002, RESULT-004) write
+    # into this module-scoped "beer" database and rely on unique marker values
+    # rather than isolated databases to avoid cross-test collisions - no test
+    # currently asserts an exact row/node count, so this is intentional, not
+    # an oversight. A count-based assertion added later should target the
+    # dedicated "boltscratch" database instead.
     driver = GraphDatabase.driver(bolt_uri(bolt_container), auth=basic_auth("root", ROOT_PASSWORD))
     yield driver
     driver.close()
@@ -217,11 +241,13 @@ def bolt_container_tls_required(tls_certs):
         )
     )
     container.start()
-    # TLS keystore/truststore loading adds startup latency beyond the default
-    # container's margin, especially on shared CI runners - give it more room.
-    wait_for_http_endpoint(container, "/api/v1/ready", 2480, 204, 120)
-    yield container
-    container.stop()
+    try:
+        # TLS keystore/truststore loading adds startup latency beyond the default
+        # container's margin, especially on shared CI runners - give it more room.
+        wait_for_http_endpoint(container, "/api/v1/ready", 2480, 204, 120)
+        yield container
+    finally:
+        container.stop()
 
 
 @pytest.fixture(scope="module")
@@ -244,35 +270,31 @@ def bolt_container_tls_optional(tls_certs):
         )
     )
     container.start()
-    # See bolt_container_tls_required's comment: TLS startup needs extra margin.
-    wait_for_http_endpoint(container, "/api/v1/ready", 2480, 204, 120)
-    yield container
-    container.stop()
+    try:
+        # See bolt_container_tls_required's comment: TLS startup needs extra margin.
+        wait_for_http_endpoint(container, "/api/v1/ready", 2480, 204, 120)
+        yield container
+    finally:
+        container.stop()
 
 
 def test_CONN_002_tls_required(bolt_container_tls_required):
-    driver = GraphDatabase.driver(
+    with GraphDatabase.driver(
         bolt_uri(bolt_container_tls_required, scheme="bolt+ssc"),
         auth=basic_auth("root", ROOT_PASSWORD),
-    )
-    try:
+    ) as driver:
         driver.verify_connectivity()
         with driver.session(database="beer") as session:
             result = session.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 1")
             assert result.single()["name"] is not None
-    finally:
-        driver.close()
 
 
 def test_CONN_003_neo4j_routing_single_node(bolt_container):
-    driver = GraphDatabase.driver(bolt_uri(bolt_container, scheme="neo4j"), auth=basic_auth("root", ROOT_PASSWORD))
-    try:
+    with GraphDatabase.driver(bolt_uri(bolt_container, scheme="neo4j"), auth=basic_auth("root", ROOT_PASSWORD)) as driver:
         driver.verify_connectivity()
         with driver.session(database="beer") as session:
             result = session.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 1")
             assert result.single()["name"] is not None
-    finally:
-        driver.close()
 
 
 @pytest.mark.skip(
@@ -285,50 +307,38 @@ def test_CONN_004_neo4j_routing_ha_topology():
 
 
 def test_CONN_005_tls_optional_plaintext_connects(bolt_container_tls_optional):
-    driver = GraphDatabase.driver(
+    with GraphDatabase.driver(
         bolt_uri(bolt_container_tls_optional, scheme="bolt"),
         auth=basic_auth("root", ROOT_PASSWORD),
-    )
-    try:
+    ) as driver:
         driver.verify_connectivity()
-    finally:
-        driver.close()
 
 
 # --- auth ----------------------------------------------------------------
 
 
 def test_AUTH_001_basic_auth_valid(bolt_container):
-    driver = GraphDatabase.driver(bolt_uri(bolt_container), auth=basic_auth("root", ROOT_PASSWORD))
-    try:
+    with GraphDatabase.driver(bolt_uri(bolt_container), auth=basic_auth("root", ROOT_PASSWORD)) as driver:
         driver.verify_connectivity()
         with driver.session(database="beer") as session:
             assert session.run("RETURN 1 AS value").single()["value"] == 1
-    finally:
-        driver.close()
 
 
 def test_AUTH_002_basic_auth_invalid(bolt_container):
     from neo4j.exceptions import AuthError
 
-    driver = GraphDatabase.driver(bolt_uri(bolt_container), auth=basic_auth("root", "wrong-password"))
-    try:
+    with GraphDatabase.driver(bolt_uri(bolt_container), auth=basic_auth("root", "wrong-password")) as driver:
         with pytest.raises(AuthError) as exc_info:
             driver.verify_connectivity()
         assert exc_info.value.code == "Neo.ClientError.Security.Unauthorized"
-    finally:
-        driver.close()
 
 
 def test_AUTH_003_auth_none_rejected(bolt_container):
     from neo4j.exceptions import AuthError, ServiceUnavailable
 
-    driver = GraphDatabase.driver(bolt_uri(bolt_container), auth=None)
-    try:
+    with GraphDatabase.driver(bolt_uri(bolt_container), auth=None) as driver:
         with pytest.raises((AuthError, ServiceUnavailable)):
             driver.verify_connectivity()
-    finally:
-        driver.close()
 
 
 # --- transactions ----------------------------------------------------------
@@ -372,9 +382,12 @@ def test_TX_004_managed_write_commits(bolt_driver):
 
 
 def _race_two_writers(driver, database, marker):
-    """Shared concurrency helper for TX-005 and ERR-004: two sessions race to
-    update the same node inside an explicit transaction, one held open past
-    the other's commit attempt. Returns the list of exceptions raised."""
+    """Shared concurrency helper for TX-005 and ERR-004.
+
+    Two sessions race to update the same node inside an explicit
+    transaction, one held open past the other's commit attempt. Returns the
+    list of exceptions raised.
+    """
     with driver.session(database=database) as setup_session:
         setup_session.run(
             "MERGE (n:RaceProbe {marker: $marker}) SET n.value = 0", marker=marker

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -54,7 +54,12 @@ def wait_for_http_endpoint(container, path, port, expected_status, timeout=60):
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
             pass
         time.sleep(1)
-    raise TimeoutError(f"Container didn't respond with status {expected_status} at {url} within {timeout} seconds")
+    stdout, stderr = container.get_logs()
+    raise TimeoutError(
+        f"Container didn't respond with status {expected_status} at {url} within "
+        f"{timeout} seconds\n--- container stdout ---\n{stdout.decode(errors='replace')}\n"
+        f"--- container stderr ---\n{stderr.decode(errors='replace')}"
+    )
 
 
 def bolt_uri(container, scheme="bolt"):

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -458,3 +458,57 @@ def test_MDB_002_sessions_across_databases_are_isolated(bolt_driver):
     with bolt_driver.session(database="boltscratch") as verify_session:
         result = verify_session.run("MATCH (n:ScratchProbe {marker: 'mdb-002'}) RETURN count(n) AS c")
         assert result.single()["c"] == 1
+
+
+# --- result-handling ---------------------------------------------------
+
+
+def test_RESULT_001_streaming_pull_incremental(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        result = session.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 10")
+        seen = 0
+        for record in result:
+            assert record["name"] is not None
+            seen += 1
+        assert seen == 10
+
+
+def test_RESULT_002_partial_pull_then_continue(bolt_driver):
+    with bolt_driver.session(database="beer", fetch_size=2) as session:
+        result = session.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 5")
+        iterator = iter(result)
+        first_two = [next(iterator), next(iterator)]
+        assert len(first_two) == 2
+
+        remaining = list(result)
+        assert len(remaining) == 3
+
+
+def test_RESULT_003_discard_abandons_remaining(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        result = session.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 5")
+        next(iter(result))
+        summary = result.consume()
+        assert summary is not None
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="BoltNetworkExecutor.handlePull/handleDiscard never populate a "
+    "'stats' key in the SUCCESS message metadata for write queries - the "
+    "engine's Cypher CREATE/SET/DELETE steps do not track node/relationship/"
+    "property counters anywhere that the Bolt layer could surface, so the "
+    "neo4j driver always parses an empty SummaryCounters; see RESULT-004 in "
+    "bolt/conformance/spec.yaml",
+)
+def test_RESULT_004_summary_counters_reflect_writes(bolt_driver):
+    with bolt_driver.session(database="beer") as session:
+        result = session.run(
+            "CREATE (:Beer {name: $n})-[:BREWED_BY]->(:Brewery {name: $b})",
+            n="RESULT-004-Beer",
+            b="RESULT-004-Brewery",
+        )
+        counters = result.consume().counters
+        assert counters.nodes_created == 2
+        assert counters.relationships_created == 1
+        assert counters.properties_set >= 2

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -23,6 +23,7 @@ Python driver. Each test function name embeds its spec.yaml scenario id
 """
 
 import datetime
+import subprocess
 import threading
 import time
 from pathlib import Path
@@ -33,6 +34,7 @@ from neo4j import GraphDatabase, basic_auth
 from testcontainers.core.container import DockerContainer
 
 ROOT_PASSWORD = "playwithdata"
+TLS_STORE_PASSWORD = "changeit"
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TYPE_MATRIX_FIXTURE = REPO_ROOT / "bolt" / "conformance" / "fixtures" / "type-matrix.cypher"
@@ -86,6 +88,69 @@ def seed_type_matrix(container):
     response.raise_for_status()
 
 
+def generate_tls_certs(cert_dir):
+    """Generate a throwaway self-signed PKCS12 keystore + JKS truststore for BOLT TLS
+    fixtures, via the JDK `keytool` binary. ArcadeDB does not ship a default TLS
+    keystore (arcadedb.ssl.keyStore/.trustStore have no defaults - see
+    BoltSslHelper.getRequiredProperty), so enabling arcadedb.bolt.ssl=REQUIRED/OPTIONAL
+    without one crashes server startup with a ConfigurationException. This mirrors
+    exactly what an operator would set up: a self-signed cert, trusted by the driver
+    via bolt+ssc:// instead of a CA-signed one.
+    """
+    keystore_path = cert_dir / "keystore.p12"
+    truststore_path = cert_dir / "truststore.jks"
+    cert_path = cert_dir / "bolt.cer"
+
+    subprocess.run(
+        [
+            "keytool",
+            "-genkeypair",
+            "-alias", "bolt",
+            "-keyalg", "RSA",
+            "-keysize", "2048",
+            "-validity", "3650",
+            "-keystore", str(keystore_path),
+            "-storetype", "PKCS12",
+            "-storepass", TLS_STORE_PASSWORD,
+            "-keypass", TLS_STORE_PASSWORD,
+            "-dname", "CN=localhost, OU=ArcadeDB, O=ArcadeDB, L=Test, ST=Test, C=US",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        [
+            "keytool",
+            "-exportcert",
+            "-alias", "bolt",
+            "-keystore", str(keystore_path),
+            "-storetype", "PKCS12",
+            "-storepass", TLS_STORE_PASSWORD,
+            "-file", str(cert_path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        [
+            "keytool",
+            "-importcert",
+            "-alias", "bolt",
+            "-keystore", str(truststore_path),
+            "-storetype", "JKS",
+            "-storepass", TLS_STORE_PASSWORD,
+            "-file", str(cert_path),
+            "-noprompt",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return keystore_path, truststore_path
+
+
 @pytest.fixture(scope="module")
 def bolt_container():
     container = (
@@ -118,3 +183,105 @@ def bolt_driver(bolt_container):
 
 def test_CONN_001_connect_bolt(bolt_driver):
     bolt_driver.verify_connectivity()
+
+
+@pytest.fixture(scope="module")
+def tls_certs(tmp_path_factory):
+    cert_dir = tmp_path_factory.mktemp("bolt-tls-certs")
+    keystore_path, truststore_path = generate_tls_certs(cert_dir)
+    return cert_dir, keystore_path.name, truststore_path.name
+
+
+@pytest.fixture(scope="module")
+def bolt_container_tls_required(tls_certs):
+    cert_dir, keystore_name, truststore_name = tls_certs
+    container = (
+        DockerContainer("arcadedata/arcadedb:latest")
+        .with_exposed_ports(2480, 7687)
+        .with_volume_mapping(str(cert_dir), "/home/arcadedb/tls_certs", "ro")
+        .with_env(
+            "JAVA_OPTS",
+            "-Darcadedb.server.rootPassword=" + ROOT_PASSWORD + " "
+            "-Darcadedb.server.defaultDatabases=beer[root]{import:https://github.com/ArcadeData/arcadedb-datasets/raw/main/orientdb/OpenBeer.gz} "
+            "-Darcadedb.server.plugins=BoltProtocolPlugin "
+            "-Darcadedb.bolt.ssl=REQUIRED "
+            "-Darcadedb.ssl.keyStore=/home/arcadedb/tls_certs/" + keystore_name + " "
+            "-Darcadedb.ssl.keyStorePassword=" + TLS_STORE_PASSWORD + " "
+            "-Darcadedb.ssl.trustStore=/home/arcadedb/tls_certs/" + truststore_name + " "
+            "-Darcadedb.ssl.trustStorePassword=" + TLS_STORE_PASSWORD,
+        )
+    )
+    container.start()
+    wait_for_http_endpoint(container, "/api/v1/ready", 2480, 204, 60)
+    yield container
+    container.stop()
+
+
+@pytest.fixture(scope="module")
+def bolt_container_tls_optional(tls_certs):
+    cert_dir, keystore_name, truststore_name = tls_certs
+    container = (
+        DockerContainer("arcadedata/arcadedb:latest")
+        .with_exposed_ports(2480, 7687)
+        .with_volume_mapping(str(cert_dir), "/home/arcadedb/tls_certs", "ro")
+        .with_env(
+            "JAVA_OPTS",
+            "-Darcadedb.server.rootPassword=" + ROOT_PASSWORD + " "
+            "-Darcadedb.server.defaultDatabases=beer[root]{import:https://github.com/ArcadeData/arcadedb-datasets/raw/main/orientdb/OpenBeer.gz} "
+            "-Darcadedb.server.plugins=BoltProtocolPlugin "
+            "-Darcadedb.bolt.ssl=OPTIONAL "
+            "-Darcadedb.ssl.keyStore=/home/arcadedb/tls_certs/" + keystore_name + " "
+            "-Darcadedb.ssl.keyStorePassword=" + TLS_STORE_PASSWORD + " "
+            "-Darcadedb.ssl.trustStore=/home/arcadedb/tls_certs/" + truststore_name + " "
+            "-Darcadedb.ssl.trustStorePassword=" + TLS_STORE_PASSWORD,
+        )
+    )
+    container.start()
+    wait_for_http_endpoint(container, "/api/v1/ready", 2480, 204, 60)
+    yield container
+    container.stop()
+
+
+def test_CONN_002_tls_required(bolt_container_tls_required):
+    driver = GraphDatabase.driver(
+        bolt_uri(bolt_container_tls_required, scheme="bolt+ssc"),
+        auth=basic_auth("root", ROOT_PASSWORD),
+    )
+    try:
+        driver.verify_connectivity()
+        with driver.session(database="beer") as session:
+            result = session.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 1")
+            assert result.single()["name"] is not None
+    finally:
+        driver.close()
+
+
+def test_CONN_003_neo4j_routing_single_node(bolt_container):
+    driver = GraphDatabase.driver(bolt_uri(bolt_container, scheme="neo4j"), auth=basic_auth("root", ROOT_PASSWORD))
+    try:
+        driver.verify_connectivity()
+        with driver.session(database="beer") as session:
+            result = session.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 1")
+            assert result.single()["name"] is not None
+    finally:
+        driver.close()
+
+
+@pytest.mark.skip(
+    reason="Requires a 3-node HA cluster; e2e-python's single-node harness "
+    "cannot meaningfully exercise this scenario without new multi-node "
+    "orchestration infrastructure - see #4890"
+)
+def test_CONN_004_neo4j_routing_ha_topology():
+    pass
+
+
+def test_CONN_005_tls_optional_plaintext_connects(bolt_container_tls_optional):
+    driver = GraphDatabase.driver(
+        bolt_uri(bolt_container_tls_optional, scheme="bolt"),
+        auth=basic_auth("root", ROOT_PASSWORD),
+    )
+    try:
+        driver.verify_connectivity()
+    finally:
+        driver.close()

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -258,10 +258,11 @@ def test_CONN_002_tls_required(bolt_container_tls_required):
 
 @pytest.mark.xfail(
     strict=True,
-    reason="BoltMessage.parseRoute (bolt/src/main/java/com/arcadedb/bolt/message/"
-    "BoltMessage.java:142) casts the ROUTE message's third field straight to "
-    "String, but under negotiated Bolt 4.4 it is actually a Map, causing a "
-    "server-side ClassCastException; see #4916",
+    reason="Fixed in BoltMessage.parseRoute by commit 39e4eaedb (PR #4917, "
+    "closing #4916), merged to main - but not yet present in the published "
+    "arcadedata/arcadedb:latest image this suite tests against (image "
+    "predates the fix as of 2026-07-03). Remove this marker once the image "
+    "is rebuilt/released with the fix.",
 )
 def test_CONN_003_neo4j_routing_single_node(bolt_container):
     driver = GraphDatabase.driver(bolt_uri(bolt_container, scheme="neo4j"), auth=basic_auth("root", ROOT_PASSWORD))

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -458,13 +458,20 @@ def _race_two_writers(driver, database, marker):
 
 
 def test_TX_005_managed_write_retries_on_transient_error(bolt_driver):
-    from neo4j.exceptions import TransientError
+    from neo4j.exceptions import ClientError, DatabaseError, TransientError
 
     errors = _race_two_writers(bolt_driver, "beer", "tx-005")
 
     assert errors, "expected at least one racing session to fail on the write conflict"
-    assert isinstance(errors[0], TransientError), (
-        f"expected Neo.TransientError.*, got {type(errors[0]).__name__}: {errors[0]}"
+    # Check the whole collection, not just errors[0] - which of the two racing
+    # threads appends first is nondeterministic, and this matches the scenario's
+    # actual intent: the conflict must be retryable, not merely present.
+    assert any(isinstance(e, TransientError) for e in errors), (
+        f"expected at least one Neo.TransientError.*, got {[type(e).__name__ for e in errors]}"
+    )
+    assert not any(isinstance(e, (ClientError, DatabaseError)) for e in errors), (
+        f"expected no non-retryable ClientError/DatabaseError among the racing "
+        f"errors, got {[type(e).__name__ for e in errors]}"
     )
 
 
@@ -756,13 +763,20 @@ def test_ERR_003_unauthenticated_request_rejected():
 
 
 def test_ERR_004_transient_condition_error_code(bolt_driver):
-    from neo4j.exceptions import TransientError
+    from neo4j.exceptions import ClientError, DatabaseError, TransientError
 
     errors = _race_two_writers(bolt_driver, "beer", "err-004")
 
     assert errors, "expected at least one racing session to fail on the write conflict"
-    assert isinstance(errors[0], TransientError), (
-        f"expected Neo.TransientError.*, got {type(errors[0]).__name__}: {errors[0]}"
+    # Check the whole collection, not just errors[0] - which of the two racing
+    # threads appends first is nondeterministic, and this matches the scenario's
+    # actual intent: the conflict must be retryable, not merely present.
+    assert any(isinstance(e, TransientError) for e in errors), (
+        f"expected at least one Neo.TransientError.*, got {[type(e).__name__ for e in errors]}"
+    )
+    assert not any(isinstance(e, (ClientError, DatabaseError)) for e in errors), (
+        f"expected no non-retryable ClientError/DatabaseError among the racing "
+        f"errors, got {[type(e).__name__ for e in errors]}"
     )
 
 

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -212,7 +212,9 @@ def bolt_container_tls_required(tls_certs):
         )
     )
     container.start()
-    wait_for_http_endpoint(container, "/api/v1/ready", 2480, 204, 60)
+    # TLS keystore/truststore loading adds startup latency beyond the default
+    # container's margin, especially on shared CI runners - give it more room.
+    wait_for_http_endpoint(container, "/api/v1/ready", 2480, 204, 120)
     yield container
     container.stop()
 
@@ -237,7 +239,8 @@ def bolt_container_tls_optional(tls_certs):
         )
     )
     container.start()
-    wait_for_http_endpoint(container, "/api/v1/ready", 2480, 204, 60)
+    # See bolt_container_tls_required's comment: TLS startup needs extra margin.
+    wait_for_http_endpoint(container, "/api/v1/ready", 2480, 204, 120)
     yield container
     container.stop()
 
@@ -256,18 +259,6 @@ def test_CONN_002_tls_required(bolt_container_tls_required):
         driver.close()
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="BoltNetworkExecutor.getBoltAddress reports socket.getLocalAddress() "
-    "(the server's own view of its address) in the ROUTE response's WRITE/READ/"
-    "ROUTE entries. Inside a container behind port mapping (as in this "
-    "testcontainers-based suite, and any NAT'd/containerized single-node "
-    "deployment), that is the container-internal address, not the externally "
-    "reachable one the driver connected through - so the driver's routing-aware "
-    "reconnect for the READ role fails. ArcadeDB has no advertised-address "
-    "override to correct this (unlike, e.g., Neo4j's "
-    "server.bolt.advertised_address); see #4890.",
-)
 def test_CONN_003_neo4j_routing_single_node(bolt_container):
     driver = GraphDatabase.driver(bolt_uri(bolt_container, scheme="neo4j"), auth=basic_auth("root", ROOT_PASSWORD))
     try:

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -690,6 +690,16 @@ def test_ERR_001_syntax_error(bolt_driver):
         assert exc_info.value.code == "Neo.ClientError.Statement.SyntaxError"
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason="CypherSemanticValidator correctly detects the undefined "
+    "variable but throws it via CommandParsingException, the same "
+    "exception class used for genuine ANTLR syntax errors - "
+    "BoltNetworkExecutor's RUN handler maps error codes by exception "
+    "type, so it cannot distinguish semantic from syntax errors, "
+    "making Neo.ClientError.Statement.SemanticError effectively "
+    "dead code in the Bolt module; see #4890",
+)
 def test_ERR_002_semantic_error(bolt_driver):
     from neo4j.exceptions import ClientError
 


### PR DESCRIPTION
## What does this PR do?

Adds `e2e-python/tests/test_bolt.py`, implementing all 39 scenarios from the shared Bolt conformance spec (`bolt/conformance/spec.yaml`, issue #4883) against the official `neo4j` Python driver, wired into the existing `python-e2e-tests` CI job (no workflow changes needed - it already runs `pytest tests/`).

Final tally, verified against real CI (`python-e2e-tests` job, which builds and loads this branch's own image via `mvn -Pdocker`): **25 passed, 0 failed, 2 skipped, 12 xfailed = 39/39 scenarios accounted for.** Full `e2e-python` suite (including the pre-existing Postgres-wire tests): 43 passed, 0 failed, 2 skipped, 12 xfailed.

Also included, as real findings surfaced during implementation:

- **A fix for a Bolt authentication gap** in `BoltNetworkExecutor.handleHello`: a `HELLO` message whose extra map has no `scheme`, `principal`, or `credentials` at all (exactly what the `neo4j` driver sends when constructed with `auth=None`) fell through every branch to an implicit success response instead of being rejected. Fixed by collapsing the branch chain to a single `authenticateUser` call guarded only by the explicit `scheme:"none"` reject - `authenticateUser` already null-checks, so this closes the gap without adding new logic. Regression test: `BoltProtocolIT#helloWithoutAuthSchemeIsRejected`, a raw-socket test constructing a scheme-less `HELLO` and asserting a `FAILURE` response - confirmed failing before the fix, passing after (TDD).
- **CONN-003**'s `neo4j://` routing `ClassCastException` (#4916) was already fixed on `main` (merged into this branch) - verified passing against the real CI-built image, so it's an ordinary passing assertion, not a tracked gap.
- Two other real product gaps, each documented as `xfail(strict=True)` with a matching `spec.yaml` correction, both tracked under #4890:
  - `RESULT-004`: Bolt write queries never populate `ResultSummary` counters (no `stats` map built server-side, no CRUD-counter tracking in the underlying query engine).
  - `ERR-002`: semantic errors (undefined variable references) are misclassified as syntax errors, because both go through the same exception class server-side - `Neo.ClientError.Statement.SemanticError` is currently dead code in the Bolt module.
- `ERR-003` (RUN before HELLO/LOGON) is `not-applicable` rather than `expected-fail`: no official driver's public API can trigger that sequence, since every driver completes the handshake internally before exposing session methods.
- `CONN-004` (HA-aware routing across a real multi-node cluster, gap tracked under #4890) is `pytest.mark.skip`, not `xfail`: a single-node harness can't meaningfully assert multi-node topology, and the assertion would never self-correct.

## Motivation

Part of epic #4882 (Bolt Driver Compatibility Certification). `e2e-python` had zero Bolt/`neo4j`-driver footprint before this PR - it tested only Postgres-wire (`psycopg`, `asyncpg`, `sqlalchemy`). Python is one of the five official Neo4j driver languages and had no certification coverage.

## Related issues

Closes #4885. Part of epic #4882, Group B. Depends on the already-merged #4883 (`bolt/conformance/spec.yaml`) and #4884 (`bolt/SERVER_IDENTITY.md`). The `handleHello` fix and the two remaining documented gaps (RESULT-004, ERR-002) feed into #4890 (protocol/type-fidelity gaps tracking issue), alongside CONN-004.

## Additional Notes

- Built via brainstorming -> writing-plans -> subagent-driven-development, matching this epic's established convention (see #4883/PR #4911, #4884/PR #4914). Design spec: `docs/superpowers/specs/2026-07-03-e2e-python-bolt-conformance-design.md`. Implementation plan: `docs/superpowers/plans/2026-07-03-e2e-python-bolt-conformance.md`.
- Every one of the 11 plan tasks passed individual spec-compliance + quality review. The `handleHello` fix additionally got a dedicated, high-scrutiny review (exhaustive 16-case `scheme`/`principal`/`credentials` boolean enumeration, confirming the fix closes every fall-through path, including one broader than originally scoped). The whole branch then passed a final review; its one Critical finding (an incorrect assumption that CI tests the published Docker Hub image rather than this branch's own build) was verified and corrected by rebuilding the image from source exactly as CI does and re-running the affected scenarios against it.
- Real CI failures (not just review feedback) surfaced two further fixes after that: CONN-003's actual routing-address status only became clear once tested against a genuinely CI-equivalent image (see above), and the TLS fixtures (CONN-002/CONN-005) were failing because a bind-mounted keystore was empty inside the container specifically on GitHub Actions' runners (works locally, not in CI) - fixed by baking the certs into a small derived image via `docker build COPY` instead of a bind mount, which resolves consistently across Docker environments.
- `neo4j>=6.2.0` added to `e2e-python/pyproject.toml` (matches the Java driver's pinned baseline); `requires-python` bumped from `>=3.8` to `>=3.10` (the 6.x driver's floor) - harmless in practice since CI already pins Python 3.13.0. The whole suite depends on this driver continuing to silently downgrade to Bolt 4.4 (ArcadeDB never advertises 5.x) - noted in the module docstring for whoever next bumps the pin.
- Multi-driver-version-band testing (`lts`/`current`/`latest`) is intentionally out of scope for this PR - that's issue #4891's nightly-scheduled job, not a per-language-suite concern.

## Checklist

- [x] I have run the build using `mvn clean package` command (bolt module: `mvn -pl bolt test`, 228/228 passing; full Python suite verified green against real CI, `python-e2e-tests` job)
- [x] My unit tests cover both failure and success scenarios