### PR TITLE
fix(#4907): serialize outbound Bolt temporals as native PackStream structs

### DIFF
--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
@@ -379,10 +379,17 @@ public class BoltStructureMapper {
     }
     if (value instanceof Instant i)
       return dateTimeWithOffset(LocalDateTime.ofInstant(i, ZoneOffset.UTC), ZoneOffset.UTC);
+    // java.sql.Date / java.sql.Time extend java.util.Date but carry only one component; toInstant()
+    // throws UnsupportedOperationException on them, so map to the date-only / time-only value first.
+    if (value instanceof java.sql.Date sqlDate)
+      return toTemporalStructure(sqlDate.toLocalDate());
+    if (value instanceof java.sql.Time sqlTime)
+      return toTemporalStructure(sqlTime.toLocalTime());
     if (value instanceof Date date)
       return dateTimeWithOffset(LocalDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC), ZoneOffset.UTC);
     if (value instanceof Calendar calendar)
-      return dateTimeWithOffset(LocalDateTime.ofInstant(calendar.toInstant(), ZoneOffset.UTC), ZoneOffset.UTC);
+      // Preserve the calendar's own zone instead of forcing UTC.
+      return toTemporalStructure(ZonedDateTime.ofInstant(calendar.toInstant(), calendar.getTimeZone().toZoneId()));
 
     return null;
   }

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
@@ -383,6 +383,9 @@ public class BoltStructureMapper {
       return new BoltTemporalStructure(SIG_DATE_TIME_ZONEID_LEGACY, zdt.toLocalDateTime().toEpochSecond(ZoneOffset.UTC),
           (long) zdt.getNano(), zdt.getZone().getId());
     }
+    // A bare instant (Instant / java.util.Date) has no zone; Bolt has no pure-instant type, so it is
+    // deliberately widened to a DateTime struct at UTC. The instant is preserved; the client receives a
+    // zoned/offset datetime at UTC rather than a "naked" instant.
     if (value instanceof Instant i)
       return dateTimeWithOffset(LocalDateTime.ofInstant(i, ZoneOffset.UTC), ZoneOffset.UTC);
     // java.sql.Date / java.sql.Time extend java.util.Date but carry only one component; toInstant()

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
@@ -25,6 +25,11 @@ import com.arcadedb.database.RID;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.Labels;
+import com.arcadedb.query.opencypher.temporal.CypherDate;
+import com.arcadedb.query.opencypher.temporal.CypherDateTime;
+import com.arcadedb.query.opencypher.temporal.CypherLocalDateTime;
+import com.arcadedb.query.opencypher.temporal.CypherLocalTime;
+import com.arcadedb.query.opencypher.temporal.CypherTime;
 import com.arcadedb.query.sql.executor.Result;
 
 import java.math.BigDecimal;
@@ -115,42 +120,12 @@ public class BoltStructureMapper {
       return bytes;
     }
 
-    // Handle date/time types - convert to ISO strings for compatibility
-    if (value instanceof LocalDate date) {
-      return date.toString();
-    }
-
-    if (value instanceof LocalTime time) {
-      return time.toString();
-    }
-
-    if (value instanceof LocalDateTime dateTime) {
-      return dateTime.toString();
-    }
-
-    if (value instanceof OffsetDateTime dateTime) {
-      return dateTime.toString();
-    }
-
-    if (value instanceof ZonedDateTime dateTime) {
-      return dateTime.toString();
-    }
-
-    if (value instanceof OffsetTime time) {
-      return time.toString();
-    }
-
-    if (value instanceof Instant instant) {
-      return instant.toString();
-    }
-
-    if (value instanceof Date date) {
-      return date.toInstant().toString();
-    }
-
-    if (value instanceof Calendar calendar) {
-      return calendar.toInstant().toString();
-    }
+    // Handle temporal types as native Bolt PackStream structures (issue #4907) so a Neo4j client
+    // receives a real date/time value instead of an ISO-8601 string. Cypher temporal wrappers
+    // (from RETURN e.valid_at) are unwrapped to their java.time value first.
+    final Object temporal = toTemporalStructure(value);
+    if (temporal != null)
+      return temporal;
 
     if (value instanceof UUID uuid) {
       return uuid.toString();
@@ -372,6 +347,65 @@ public class BoltStructureMapper {
   private static final byte SIG_DATE_TIME_ZONEID_LEGACY = 0x66; // 'f'  [secondsLocal, nanos, zoneId]
   private static final byte SIG_DATE_TIME_OFFSET_UTC    = 0x49; // 'I'  [secondsUtc,  nanos, offsetSeconds] (Bolt 5.0+)
   private static final byte SIG_DATE_TIME_ZONEID_UTC    = 0x69; // 'i'  [secondsUtc,  nanos, zoneId]        (Bolt 5.0+)
+
+  /**
+   * Outbound direction (issue #4907): encode a temporal value as its native Bolt PackStream structure so
+   * a Neo4j client receives a real date/time instead of an ISO-8601 string. Accepts both raw
+   * {@code java.time} / {@code java.util.Date} values (from a {@code RETURN e} element) and Cypher temporal
+   * wrappers (from a scalar {@code RETURN e.valid_at}), which are unwrapped to their {@code java.time} value
+   * first. Returns {@code null} when the value is not a temporal (so the caller can fall through).
+   * <p>
+   * ArcadeDB negotiates Bolt v4.4 max, so the legacy (pre-5.0) DateTime / DateTimeZoneId encoding is emitted:
+   * the seconds field is the LOCAL epoch-second (offset folded in), matching {@link #fromPackStreamValue}.
+   */
+  static BoltTemporalStructure toTemporalStructure(final Object rawValue) {
+    final Object value = unwrapCypherTemporal(rawValue);
+
+    if (value instanceof LocalDate d)
+      return new BoltTemporalStructure(SIG_DATE, d.toEpochDay());
+    if (value instanceof LocalTime t)
+      return new BoltTemporalStructure(SIG_LOCAL_TIME, t.toNanoOfDay());
+    if (value instanceof OffsetTime t)
+      return new BoltTemporalStructure(SIG_TIME, t.toLocalTime().toNanoOfDay(), (long) t.getOffset().getTotalSeconds());
+    if (value instanceof LocalDateTime ldt)
+      return new BoltTemporalStructure(SIG_LOCAL_DATE_TIME, ldt.toEpochSecond(ZoneOffset.UTC), (long) ldt.getNano());
+    if (value instanceof OffsetDateTime odt)
+      return dateTimeWithOffset(odt.toLocalDateTime(), odt.getOffset());
+    if (value instanceof ZonedDateTime zdt) {
+      if (zdt.getZone() instanceof ZoneOffset offset)
+        return dateTimeWithOffset(zdt.toLocalDateTime(), offset);
+      return new BoltTemporalStructure(SIG_DATE_TIME_ZONEID_LEGACY, zdt.toLocalDateTime().toEpochSecond(ZoneOffset.UTC),
+          (long) zdt.getNano(), zdt.getZone().getId());
+    }
+    if (value instanceof Instant i)
+      return dateTimeWithOffset(LocalDateTime.ofInstant(i, ZoneOffset.UTC), ZoneOffset.UTC);
+    if (value instanceof Date date)
+      return dateTimeWithOffset(LocalDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC), ZoneOffset.UTC);
+    if (value instanceof Calendar calendar)
+      return dateTimeWithOffset(LocalDateTime.ofInstant(calendar.toInstant(), ZoneOffset.UTC), ZoneOffset.UTC);
+
+    return null;
+  }
+
+  private static BoltTemporalStructure dateTimeWithOffset(final LocalDateTime local, final ZoneOffset offset) {
+    // Legacy encoding: seconds is the local epoch-second (the wall clock treated as if UTC).
+    return new BoltTemporalStructure(SIG_DATE_TIME_OFFSET_LEGACY, local.toEpochSecond(ZoneOffset.UTC), (long) local.getNano(),
+        (long) offset.getTotalSeconds());
+  }
+
+  private static Object unwrapCypherTemporal(final Object value) {
+    if (value instanceof CypherDate d)
+      return d.getValue();
+    if (value instanceof CypherLocalTime t)
+      return t.getValue();
+    if (value instanceof CypherTime t)
+      return t.getValue();
+    if (value instanceof CypherLocalDateTime ldt)
+      return ldt.getValue();
+    if (value instanceof CypherDateTime dt)
+      return dt.getValue();
+    return value;
+  }
 
   /**
    * Recursively convert a value read from a Bolt PackStream request into engine-friendly types,

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
@@ -355,8 +355,14 @@ public class BoltStructureMapper {
    * wrappers (from a scalar {@code RETURN e.valid_at}), which are unwrapped to their {@code java.time} value
    * first. Returns {@code null} when the value is not a temporal (so the caller can fall through).
    * <p>
-   * ArcadeDB negotiates Bolt v4.4 max, so the legacy (pre-5.0) DateTime / DateTimeZoneId encoding is emitted:
-   * the seconds field is the LOCAL epoch-second (offset folded in), matching {@link #fromPackStreamValue}.
+   * <b>Encoding is tied to the negotiated protocol version.</b> ArcadeDB advertises Bolt v4.4 max
+   * ({@code BoltNetworkExecutor.SUPPORTED_VERSIONS = { 4.4, 4.0, 3.0 }}), so the legacy (pre-5.0)
+   * DateTime / DateTimeZoneId encoding is always correct here: the seconds field is the LOCAL epoch-second
+   * (offset folded in), matching the legacy branch of {@link #fromPackStreamValue}. The inbound path already
+   * decodes both the legacy and the 5.0 "UTC" signatures, but this outbound path emits legacy only.
+   * TODO: if {@code SUPPORTED_VERSIONS} ever gains Bolt 5.0 (where seconds is the true UTC epoch-second),
+   * branch on the negotiated version here and emit {@code SIG_*_UTC}, otherwise a 5.0 driver would decode
+   * these structs to the wrong instant.
    */
   static BoltTemporalStructure toTemporalStructure(final Object rawValue) {
     final Object value = unwrapCypherTemporal(rawValue);
@@ -411,6 +417,9 @@ public class BoltStructureMapper {
       return ldt.getValue();
     if (value instanceof CypherDateTime dt)
       return dt.getValue();
+    // NOTE: CypherDuration is intentionally not unwrapped - Bolt has a Duration struct but there is no single
+    // java.time value for it (months + days + seconds together), so a returned duration still falls through to
+    // the generic (ISO-8601 string) handling. Tracked as a follow-up if native Duration output is needed.
     return value;
   }
 

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltTemporalStructure.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltTemporalStructure.java
@@ -36,7 +36,7 @@ public class BoltTemporalStructure implements PackStreamStructure {
 
   public BoltTemporalStructure(final byte signature, final Object... fields) {
     this.signature = signature;
-    this.fields = fields;
+    this.fields = fields != null ? fields.clone() : new Object[0];
   }
 
   @Override
@@ -50,7 +50,7 @@ public class BoltTemporalStructure implements PackStreamStructure {
   }
 
   public Object[] getFields() {
-    return fields;
+    return fields.clone();
   }
 
   @Override

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltTemporalStructure.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltTemporalStructure.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt.structure;
+
+import com.arcadedb.bolt.packstream.PackStreamStructure;
+import com.arcadedb.bolt.packstream.PackStreamWriter;
+
+import java.io.IOException;
+
+/**
+ * A Bolt temporal PackStream structure (Date, Time, LocalTime, LocalDateTime, DateTime,
+ * DateTimeZoneId) emitted on the outbound path so a Neo4j-compatible client receives a native
+ * temporal value instead of an ISO-8601 string. The signature and pre-computed fields are built by
+ * {@link BoltStructureMapper}; the fields are {@code Long}/{@code String} values the writer already
+ * knows how to serialize.
+ */
+public class BoltTemporalStructure implements PackStreamStructure {
+  private final byte     signature;
+  private final Object[] fields;
+
+  public BoltTemporalStructure(final byte signature, final Object... fields) {
+    this.signature = signature;
+    this.fields = fields;
+  }
+
+  @Override
+  public byte getSignature() {
+    return signature;
+  }
+
+  @Override
+  public int getFieldCount() {
+    return fields.length;
+  }
+
+  public Object[] getFields() {
+    return fields;
+  }
+
+  @Override
+  public void writeTo(final PackStreamWriter writer) throws IOException {
+    writer.writeStructureHeader(signature, fields.length);
+    for (final Object field : fields)
+      writer.writeValue(field);
+  }
+}

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltTemporalStructure.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltTemporalStructure.java
@@ -49,10 +49,6 @@ public class BoltTemporalStructure implements PackStreamStructure {
     return fields.length;
   }
 
-  public Object[] getFields() {
-    return fields.clone();
-  }
-
   @Override
   public void writeTo(final PackStreamWriter writer) throws IOException {
     writer.writeStructureHeader(signature, fields.length);

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltTemporalStructure.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltTemporalStructure.java
@@ -35,8 +35,11 @@ public class BoltTemporalStructure implements PackStreamStructure {
   private final Object[] fields;
 
   public BoltTemporalStructure(final byte signature, final Object... fields) {
+    // No defensive copy: every call site passes a freshly-allocated varargs array and the array is never
+    // exposed (writeTo reads it directly, there is no getter), so a copy would only add per-value GC churn
+    // on the serialization hot path.
     this.signature = signature;
-    this.fields = fields != null ? fields.clone() : new Object[0];
+    this.fields = fields != null ? fields : new Object[0];
   }
 
   @Override

--- a/bolt/src/test/java/com/arcadedb/bolt/Bolt4907TemporalOutputIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Bolt4907TemporalOutputIT.java
@@ -33,6 +33,10 @@ import org.neo4j.driver.SessionConfig;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -66,13 +70,25 @@ public class Bolt4907TemporalOutputIT extends BaseGraphServerTest {
   void temporalPropertiesReturnAsNativeValues() {
     try (final Driver driver = getDriver()) {
       try (final Session session = driver.session(SessionConfig.forDatabase(getDatabaseName()))) {
-        session.run("CREATE (e:Ev {id: 1, ts: datetime('2024-01-15T10:30:45Z'), day: date('2024-01-15')})").consume();
+        session.run("""
+            CREATE (e:Ev {id: 1,
+              ts: datetime('2024-01-15T10:30:45Z'),
+              tsOff: datetime('2024-01-15T10:30:45+02:00'),
+              day: date('2024-01-15'),
+              ldt: localdatetime('2024-01-15T10:30:45'),
+              t: localtime('10:30:45')})""").consume();
 
-        final Record row = session.run("MATCH (e:Ev {id: 1}) RETURN e.ts AS ts, e.day AS day").single();
+        final Record row = session.run(
+            "MATCH (e:Ev {id: 1}) RETURN e.ts AS ts, e.tsOff AS tsOff, e.day AS day, e.ldt AS ldt, e.t AS t").single();
 
-        // Would throw if the value came back as a string instead of a native temporal struct.
+        // Would throw if any value came back as a string instead of a native temporal struct.
         assertThat(row.get("ts").asZonedDateTime().toInstant()).isEqualTo(Instant.parse("2024-01-15T10:30:45Z"));
+        // Non-zero offset: exercises the offset datetime path against the real driver (not just self round-trip).
+        assertThat(row.get("tsOff").asOffsetDateTime())
+            .isEqualTo(OffsetDateTime.of(2024, 1, 15, 10, 30, 45, 0, ZoneOffset.ofHours(2)));
         assertThat(row.get("day").asLocalDate()).isEqualTo(LocalDate.of(2024, 1, 15));
+        assertThat(row.get("ldt").asLocalDateTime()).isEqualTo(LocalDateTime.of(2024, 1, 15, 10, 30, 45));
+        assertThat(row.get("t").asLocalTime()).isEqualTo(LocalTime.of(10, 30, 45));
       }
     }
   }

--- a/bolt/src/test/java/com/arcadedb/bolt/Bolt4907TemporalOutputIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Bolt4907TemporalOutputIT.java
@@ -36,7 +36,10 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -74,20 +77,29 @@ public class Bolt4907TemporalOutputIT extends BaseGraphServerTest {
             CREATE (e:Ev {id: 1,
               ts: datetime('2024-01-15T10:30:45Z'),
               tsOff: datetime('2024-01-15T10:30:45+02:00'),
+              tsZone: datetime('2024-01-15T10:30:45+01:00[Europe/Rome]'),
               day: date('2024-01-15'),
               ldt: localdatetime('2024-01-15T10:30:45'),
+              tOff: time('10:30:45+02:00'),
               t: localtime('10:30:45')})""").consume();
 
         final Record row = session.run(
-            "MATCH (e:Ev {id: 1}) RETURN e.ts AS ts, e.tsOff AS tsOff, e.day AS day, e.ldt AS ldt, e.t AS t").single();
+            "MATCH (e:Ev {id: 1}) RETURN e.ts AS ts, e.tsOff AS tsOff, e.tsZone AS tsZone, e.day AS day, "
+                + "e.ldt AS ldt, e.tOff AS tOff, e.t AS t").single();
 
         // Would throw if any value came back as a string instead of a native temporal struct.
         assertThat(row.get("ts").asZonedDateTime().toInstant()).isEqualTo(Instant.parse("2024-01-15T10:30:45Z"));
         // Non-zero offset: exercises the offset datetime path against the real driver (not just self round-trip).
         assertThat(row.get("tsOff").asOffsetDateTime())
             .isEqualTo(OffsetDateTime.of(2024, 1, 15, 10, 30, 45, 0, ZoneOffset.ofHours(2)));
+        // Named zone: exercises the DateTimeZoneId path against the real driver.
+        final ZonedDateTime tsZone = row.get("tsZone").asZonedDateTime();
+        assertThat(tsZone.getZone()).isEqualTo(ZoneId.of("Europe/Rome"));
+        assertThat(tsZone.toInstant()).isEqualTo(Instant.parse("2024-01-15T09:30:45Z"));
         assertThat(row.get("day").asLocalDate()).isEqualTo(LocalDate.of(2024, 1, 15));
         assertThat(row.get("ldt").asLocalDateTime()).isEqualTo(LocalDateTime.of(2024, 1, 15, 10, 30, 45));
+        // Offset time: exercises the Time path.
+        assertThat(row.get("tOff").asOffsetTime()).isEqualTo(OffsetTime.of(10, 30, 45, 0, ZoneOffset.ofHours(2)));
         assertThat(row.get("t").asLocalTime()).isEqualTo(LocalTime.of(10, 30, 45));
       }
     }

--- a/bolt/src/test/java/com/arcadedb/bolt/Bolt4907TemporalOutputIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Bolt4907TemporalOutputIT.java
@@ -30,6 +30,8 @@ import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.SessionConfig;
+import org.neo4j.driver.Values;
+import org.neo4j.driver.types.Node;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -101,6 +103,24 @@ public class Bolt4907TemporalOutputIT extends BaseGraphServerTest {
         // Offset time: exercises the Time path.
         assertThat(row.get("tOff").asOffsetTime()).isEqualTo(OffsetTime.of(10, 30, 45, 0, ZoneOffset.ofHours(2)));
         assertThat(row.get("t").asLocalTime()).isEqualTo(LocalTime.of(10, 30, 45));
+      }
+    }
+  }
+
+  @Test
+  void nodeElementTemporalPropertyIsNative() {
+    try (final Driver driver = getDriver()) {
+      try (final Session session = driver.session(SessionConfig.forDatabase(getDatabaseName()))) {
+        // Store natively via a Bolt localdatetime parameter (decoded by #4905) so the value is a real
+        // temporal in storage. Returning the whole node (RETURN e) serializes it through the element
+        // property-map path (BoltNode.writeTo), which is distinct from the scalar projection path above.
+        session.run("CREATE (e:EvNode {id: 1, ts: $ts})",
+            Values.parameters("ts", LocalDateTime.of(2024, 1, 15, 10, 30, 45))).consume();
+
+        final Node node = session.run("MATCH (e:EvNode {id: 1}) RETURN e").single().get("e").asNode();
+
+        // Would throw if the node property came back as a string instead of a native temporal struct.
+        assertThat(node.get("ts").asLocalDateTime()).isEqualTo(LocalDateTime.of(2024, 1, 15, 10, 30, 45));
       }
     }
   }

--- a/bolt/src/test/java/com/arcadedb/bolt/Bolt4907TemporalOutputIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Bolt4907TemporalOutputIT.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Config;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end wire test for issue #4907: a temporal property returned over Bolt must reach a Neo4j
+ * client as a native temporal value (decoded by the driver into {@code java.time}) rather than an
+ * ISO-8601 string. Calling {@code Value.asZonedDateTime()} / {@code asLocalDate()} would throw if the
+ * value were still a string, so these assertions inherently verify native-struct output.
+ */
+public class Bolt4907TemporalOutputIT extends BaseGraphServerTest {
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("Bolt:com.arcadedb.bolt.BoltProtocolPlugin");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+
+  private Driver getDriver() {
+    return GraphDatabase.driver("bolt://localhost:7687", AuthTokens.basic("root", DEFAULT_PASSWORD_FOR_TESTS),
+        Config.builder().withoutEncryption().build());
+  }
+
+  @Test
+  void temporalPropertiesReturnAsNativeValues() {
+    try (final Driver driver = getDriver()) {
+      try (final Session session = driver.session(SessionConfig.forDatabase(getDatabaseName()))) {
+        session.run("CREATE (e:Ev {id: 1, ts: datetime('2024-01-15T10:30:45Z'), day: date('2024-01-15')})").consume();
+
+        final Record row = session.run("MATCH (e:Ev {id: 1}) RETURN e.ts AS ts, e.day AS day").single();
+
+        // Would throw if the value came back as a string instead of a native temporal struct.
+        assertThat(row.get("ts").asZonedDateTime().toInstant()).isEqualTo(Instant.parse("2024-01-15T10:30:45Z"));
+        assertThat(row.get("day").asLocalDate()).isEqualTo(LocalDate.of(2024, 1, 15));
+      }
+    }
+  }
+}

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltStructureTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltStructureTest.java
@@ -18,11 +18,13 @@
  */
 package com.arcadedb.bolt;
 
+import com.arcadedb.bolt.packstream.PackStreamReader;
 import com.arcadedb.bolt.packstream.PackStreamWriter;
 import com.arcadedb.bolt.structure.BoltNode;
 import com.arcadedb.bolt.structure.BoltPath;
 import com.arcadedb.bolt.structure.BoltRelationship;
 import com.arcadedb.bolt.structure.BoltStructureMapper;
+import com.arcadedb.bolt.structure.BoltTemporalStructure;
 import com.arcadedb.bolt.structure.BoltUnboundRelationship;
 import com.arcadedb.database.RID;
 
@@ -361,59 +363,74 @@ class BoltStructureTest {
     assertThat(result).containsEntry("normalKey", "normalValue");
   }
 
+  // Temporal values are now emitted as native Bolt PackStream structures (issue #4907), not ISO strings.
+  // Each is verified by a full wire round-trip: toPackStreamValue -> write -> read -> decode.
+
   @Test
-  void mapperLocalDate() {
+  void mapperLocalDate() throws Exception {
     final LocalDate date = LocalDate.of(2024, 1, 15);
-    assertThat(BoltStructureMapper.toPackStreamValue(date)).isEqualTo("2024-01-15");
+    assertThat(BoltStructureMapper.toPackStreamValue(date)).isInstanceOf(BoltTemporalStructure.class);
+    assertThat(wireRoundTrip(date)).isEqualTo(date);
   }
 
   @Test
-  void mapperLocalTime() {
+  void mapperLocalTime() throws Exception {
     final LocalTime time = LocalTime.of(10, 30, 45);
-    assertThat(BoltStructureMapper.toPackStreamValue(time)).isEqualTo("10:30:45");
+    assertThat(wireRoundTrip(time)).isEqualTo(time);
   }
 
   @Test
-  void mapperLocalDateTime() {
+  void mapperLocalDateTime() throws Exception {
     final LocalDateTime dateTime = LocalDateTime.of(2024, 1, 15, 10, 30, 45);
-    assertThat(BoltStructureMapper.toPackStreamValue(dateTime)).isEqualTo("2024-01-15T10:30:45");
+    assertThat(wireRoundTrip(dateTime)).isEqualTo(dateTime);
   }
 
   @Test
-  void mapperOffsetDateTime() {
-    final OffsetDateTime dateTime = OffsetDateTime.of(2024, 1, 15, 10, 30, 45, 0, ZoneOffset.UTC);
-    assertThat(BoltStructureMapper.toPackStreamValue(dateTime)).isEqualTo("2024-01-15T10:30:45Z");
+  void mapperOffsetDateTime() throws Exception {
+    final OffsetDateTime dateTime = OffsetDateTime.of(2024, 1, 15, 10, 30, 45, 0, ZoneOffset.ofHours(2));
+    assertThat(wireRoundTrip(dateTime)).isEqualTo(dateTime);
   }
 
   @Test
-  void mapperZonedDateTime() {
-    final ZonedDateTime dateTime = ZonedDateTime.of(2024, 1, 15, 10, 30, 45, 0, ZoneId.of("UTC"));
-    assertThat((String) BoltStructureMapper.toPackStreamValue(dateTime)).contains("2024-01-15T10:30:45");
+  void mapperZonedDateTime() throws Exception {
+    final ZonedDateTime dateTime = ZonedDateTime.of(2024, 1, 15, 10, 30, 45, 0, ZoneId.of("Europe/Rome"));
+    assertThat(wireRoundTrip(dateTime)).isEqualTo(dateTime);
   }
 
   @Test
-  void mapperOffsetTime() {
-    final OffsetTime time = OffsetTime.of(10, 30, 45, 0, ZoneOffset.UTC);
-    assertThat(BoltStructureMapper.toPackStreamValue(time)).isEqualTo("10:30:45Z");
+  void mapperOffsetTime() throws Exception {
+    final OffsetTime time = OffsetTime.of(10, 30, 45, 0, ZoneOffset.ofHours(2));
+    assertThat(wireRoundTrip(time)).isEqualTo(time);
   }
 
   @Test
-  void mapperInstant() {
+  void mapperInstant() throws Exception {
     final Instant instant = Instant.parse("2024-01-15T10:30:45Z");
-    assertThat(BoltStructureMapper.toPackStreamValue(instant)).isEqualTo("2024-01-15T10:30:45Z");
+    // Instant maps to a DateTime struct; assert the instant survives the round-trip.
+    assertThat(((OffsetDateTime) wireRoundTrip(instant)).toInstant()).isEqualTo(instant);
   }
 
   @Test
-  void mapperJavaDate() {
+  void mapperJavaDate() throws Exception {
     final Date date = Date.from(Instant.parse("2024-01-15T10:30:45Z"));
-    assertThat(BoltStructureMapper.toPackStreamValue(date)).isEqualTo("2024-01-15T10:30:45Z");
+    assertThat(((OffsetDateTime) wireRoundTrip(date)).toInstant()).isEqualTo(date.toInstant());
   }
 
   @Test
-  void mapperCalendar() {
+  void mapperCalendar() throws Exception {
     final Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
     calendar.setTimeInMillis(Instant.parse("2024-01-15T10:30:45Z").toEpochMilli());
-    assertThat(BoltStructureMapper.toPackStreamValue(calendar)).isEqualTo("2024-01-15T10:30:45Z");
+    assertThat(((OffsetDateTime) wireRoundTrip(calendar)).toInstant()).isEqualTo(calendar.toInstant());
+  }
+
+  /**
+   * Map a value to its outbound PackStream form, serialize it, read it back, and decode - the full
+   * outbound+inbound wire path. Returns the decoded java.time value.
+   */
+  private static Object wireRoundTrip(final Object value) throws Exception {
+    final PackStreamWriter writer = new PackStreamWriter();
+    writer.writeValue(BoltStructureMapper.toPackStreamValue(value));
+    return BoltStructureMapper.fromPackStreamValue(new PackStreamReader(writer.toByteArray()).readValue());
   }
 
   @Test

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltStructureTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltStructureTest.java
@@ -417,10 +417,24 @@ class BoltStructureTest {
   }
 
   @Test
+  void mapperSqlDate() throws Exception {
+    // java.sql.Date extends java.util.Date but has no time component (toInstant() throws): must map to a Date struct.
+    final java.sql.Date sqlDate = java.sql.Date.valueOf(LocalDate.of(2024, 1, 15));
+    assertThat(wireRoundTrip(sqlDate)).isEqualTo(sqlDate.toLocalDate());
+  }
+
+  @Test
+  void mapperSqlTime() throws Exception {
+    final java.sql.Time sqlTime = java.sql.Time.valueOf(LocalTime.of(10, 30, 45));
+    assertThat(wireRoundTrip(sqlTime)).isEqualTo(sqlTime.toLocalTime());
+  }
+
+  @Test
   void mapperCalendar() throws Exception {
     final Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
     calendar.setTimeInMillis(Instant.parse("2024-01-15T10:30:45Z").toEpochMilli());
-    assertThat(((OffsetDateTime) wireRoundTrip(calendar)).toInstant()).isEqualTo(calendar.toInstant());
+    // The calendar's named zone is preserved, so it round-trips as a zoned datetime; assert the instant.
+    assertThat(((ZonedDateTime) wireRoundTrip(calendar)).toInstant()).isEqualTo(calendar.toInstant());
   }
 
   /**

--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -59,4 +59,20 @@ start.
   out explicitly with `arcadedb.ha.raftPersistStorage=false` (config file, server settings, or
   `-Darcadedb.ha.raftPersistStorage=false`). An explicit value is always honored.
 
+### 2. Bolt: temporal values now use native PackStream structures (not ISO-8601 strings)
+
+The Neo4j Bolt wire protocol now carries temporal values (`date`, `time`, `localtime`, `datetime`,
+`localdatetime`) as **native PackStream temporal structures** in both directions, instead of the
+previous ISO-8601 strings. Inbound datetime query parameters are decoded to `java.time` values
+(previously silently dropped), and outbound temporal properties are returned as native structs
+([#4905](https://github.com/ArcadeData/arcadedb/issues/4905),
+[#4907](https://github.com/ArcadeData/arcadedb/issues/4907)).
+
+- **Why:** a Neo4j-compatible driver now sends and receives real temporal values (`ZonedDateTime`,
+  `LocalDate`, ...), matching Neo4j semantics, so temporal query parameters bind and temporal
+  comparisons (`WHERE e.valid_at <= $ts`) work without any client-side conversion.
+- **Impact:** a Bolt client that previously read a temporal property as a `String` (the ISO text) will
+  now receive a native temporal type (e.g. `Value.asZonedDateTime()` / `asLocalDate()`), the same as
+  against Neo4j. Clients relying on the old string form must read the native temporal instead.
+
 **Full Changelog**: https://github.com/ArcadeData/arcadedb/compare/26.7.1...26.8.1


### PR DESCRIPTION
## Summary

Closes #4907. Completes the temporal round-trip started in #4905 (which fixed the **inbound** direction). ArcadeDB's Bolt plugin previously serialized temporal property values **outbound** as ISO-8601 strings, so a Neo4j-compatible client received a `String` instead of a native `datetime`/`date`/`time`. A value written by ArcadeDB and read back by a Bolt driver is now a real temporal, matching Neo4j semantics.

Flagged during review of #4906.

## Changes

- **`BoltTemporalStructure`** - a `PackStreamStructure` that writes a temporal signature + fields (the writer already dispatches to `PackStreamStructure.writeTo`).
- **`BoltStructureMapper.toTemporalStructure()`** - encodes `LocalDate` / `LocalTime` / `OffsetTime` / `LocalDateTime` / `OffsetDateTime` / `ZonedDateTime` / `Instant` / `java.util.Date` / `Calendar` into the matching Bolt struct, using the **legacy (Bolt <=4.4)** encoding that mirrors the inbound decoder from #4905 (seconds = local epoch-second). Handles both:
  - raw `java.time`/`Date` values (from a `RETURN e` element), and
  - Cypher temporal wrappers (`CypherDateTime` etc. from a scalar `RETURN e.valid_at`), unwrapped to their `java.time` value first.

## Tests

- **`BoltStructureTest`** - the 9 temporal cases now assert **native-struct output via a full wire round-trip** (`toPackStreamValue` -> write -> read -> `fromPackStreamValue`), replacing the old ISO-string assertions.
- **`Bolt4907TemporalOutputIT`** - end-to-end: a real neo4j driver decodes `RETURN e.ts` / `e.day` into `java.time` (`asZonedDateTime()` / `asLocalDate()` would throw if a string were returned).

## Verification

- Full `bolt` unit suite: 235 tests, 0 failures.
- `BoltProtocolIT` (77) + `BoltMultiLabelIT` (11) + `Bolt4907TemporalOutputIT` (1): all green.
- `toPackStreamValue` is Bolt-output-only, so nothing outside the Bolt module is affected.

## Follow-up note

With #4905 (inbound) + this (outbound), Bolt temporals are now fully symmetric in both directions - the graphiti driver gets native datetimes on both read and write with no client-side conversion.
