### PR TITLE
fix(#4922): register OffsetDateTime as a storable DATETIME type

### DIFF
--- a/bolt/src/test/java/com/arcadedb/bolt/BoltOffsetDatetimeWriteIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltOffsetDatetimeWriteIT.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Config;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
+import org.neo4j.driver.Values;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end regression test for the OffsetDateTime storage gap: the Python/Java Neo4j driver packs a
+ * fixed-offset datetime (e.g. {@code datetime.now(timezone.utc)}) as an offset {@code DateTime} struct,
+ * which ArcadeDB decodes to a {@code java.time.OffsetDateTime}. Previously the type system did not
+ * register {@code OffsetDateTime}, so it was silently dropped on write. This verifies that a native
+ * offset datetime sent as a query parameter is stored and read back with the instant preserved - the
+ * exact graphiti write path once the driver stops sending ISO strings.
+ */
+public class BoltOffsetDatetimeWriteIT extends BaseGraphServerTest {
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("Bolt:com.arcadedb.bolt.BoltProtocolPlugin");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+
+  private Driver getDriver() {
+    return GraphDatabase.driver("bolt://localhost:7687", AuthTokens.basic("root", DEFAULT_PASSWORD_FOR_TESTS),
+        Config.builder().withoutEncryption().build());
+  }
+
+  @Test
+  void nativeOffsetDatetimeParameterIsStoredAndReadBack() {
+    try (final Driver driver = getDriver()) {
+      try (final Session session = driver.session(SessionConfig.forDatabase(getDatabaseName()))) {
+        // A zoned datetime at a fixed offset: the driver packs this as an offset DateTime struct, which
+        // ArcadeDB decodes to OffsetDateTime.
+        final ZonedDateTime value = ZonedDateTime.of(2024, 1, 15, 10, 30, 45, 0, ZoneOffset.ofHours(2));
+        session.run("CREATE (e:Ev {id: 1, ts: $ts})", Values.parameters("ts", value)).consume();
+
+        final Record row = session.run("MATCH (e:Ev {id: 1}) RETURN e.ts AS ts").single();
+
+        // Before the fix this was NULL (silently dropped). Now it is stored: ArcadeDB persists a datetime
+        // as an instant (zone normalized to UTC) and reads sub-milli-precision datetimes back as a
+        // LocalDateTime, so the instant 08:30:45Z is preserved as the UTC wall clock 2024-01-15T08:30:45.
+        assertThat(row.get("ts").isNull()).isFalse();
+        assertThat(row.get("ts").asLocalDateTime()).isEqualTo(LocalDateTime.of(2024, 1, 15, 8, 30, 45));
+      }
+    }
+  }
+}

--- a/engine/src/main/java/com/arcadedb/schema/Type.java
+++ b/engine/src/main/java/com/arcadedb/schema/Type.java
@@ -67,7 +67,7 @@ public enum Type {
   DOUBLE("Double", 5, BinaryTypes.TYPE_DOUBLE, Double.class, new Class<?>[] { Number.class }),
 
   DATETIME("Datetime", 6, BinaryTypes.TYPE_DATETIME, Date.class,
-      new Class<?>[] { Date.class, LocalDateTime.class, ZonedDateTime.class, Instant.class, Number.class }),
+      new Class<?>[] { Date.class, LocalDateTime.class, ZonedDateTime.class, OffsetDateTime.class, Instant.class, Number.class }),
 
   STRING("String", 7, BinaryTypes.TYPE_STRING, String.class, new Class<?>[] { Enum.class }),
 
@@ -89,13 +89,13 @@ public enum Type {
       new Class<?>[] { EmbeddedDocument.class, ImmutableEmbeddedDocument.class, MutableEmbeddedDocument.class }),
 
   DATETIME_MICROS("Datetime_micros", 16, BinaryTypes.TYPE_DATETIME_MICROS, LocalDateTime.class,
-      new Class<?>[] { Date.class, LocalDateTime.class, ZonedDateTime.class, Instant.class, Number.class }),
+      new Class<?>[] { Date.class, LocalDateTime.class, ZonedDateTime.class, OffsetDateTime.class, Instant.class, Number.class }),
 
   DATETIME_NANOS("Datetime_nanos", 17, BinaryTypes.TYPE_DATETIME_NANOS, LocalDateTime.class,
-      new Class<?>[] { Date.class, LocalDateTime.class, ZonedDateTime.class, Instant.class, Number.class }),
+      new Class<?>[] { Date.class, LocalDateTime.class, ZonedDateTime.class, OffsetDateTime.class, Instant.class, Number.class }),
 
   DATETIME_SECOND("Datetime_second", 18, BinaryTypes.TYPE_DATETIME_SECOND, LocalDateTime.class,
-      new Class<?>[] { Date.class, LocalDateTime.class, ZonedDateTime.class, Instant.class, Number.class }),
+      new Class<?>[] { Date.class, LocalDateTime.class, ZonedDateTime.class, OffsetDateTime.class, Instant.class, Number.class }),
 
   ARRAY_OF_SHORTS("Short[]", 19, BinaryTypes.TYPE_ARRAY_OF_SHORTS, short[].class, new Class<?>[] { short[].class, Short[].class }),
 
@@ -144,6 +144,7 @@ public enum Type {
     TYPES_BY_USERTYPE.put(Calendar.class, DATETIME);
     TYPES_BY_USERTYPE.put(LocalDateTime.class, DATETIME);
     TYPES_BY_USERTYPE.put(ZonedDateTime.class, DATETIME);
+    TYPES_BY_USERTYPE.put(OffsetDateTime.class, DATETIME);
     TYPES_BY_USERTYPE.put(Instant.class, DATETIME);
     TYPES_BY_USERTYPE.put(String.class, STRING);
     TYPES_BY_USERTYPE.put(Enum.class, STRING);

--- a/engine/src/main/java/com/arcadedb/serializer/BinaryTypes.java
+++ b/engine/src/main/java/com/arcadedb/serializer/BinaryTypes.java
@@ -34,6 +34,7 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.Date;
@@ -110,6 +111,11 @@ public class BinaryTypes {
       else
         type = DateUtils.getBestBinaryTypeForPrecision(DateUtils.getPrecision(time.getNano()));
     } else if (value instanceof ZonedDateTime time) {
+      if (propertyType != null)
+        type = propertyType.getType().getBinaryType();
+      else
+        type = DateUtils.getBestBinaryTypeForPrecision(DateUtils.getPrecision(time.getNano()));
+    } else if (value instanceof OffsetDateTime time) {
       if (propertyType != null)
         type = propertyType.getType().getBinaryType();
       else

--- a/engine/src/test/java/com/arcadedb/schema/OffsetDateTimeStorageTest.java
+++ b/engine/src/test/java/com/arcadedb/schema/OffsetDateTimeStorageTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.schema;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.utility.DateUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test: a {@link OffsetDateTime} value must be storable in a schemaless property. The type
+ * system previously did not register {@code OffsetDateTime} (only {@code Date}/{@code LocalDateTime}/
+ * {@code ZonedDateTime}/{@code Instant}), so {@code getTypeByValue} returned {@code null} and the value
+ * was silently dropped on write - which broke native datetime writes over Bolt (the Neo4j driver packs a
+ * fixed-offset datetime as an offset {@code DateTime} struct, decoded to {@code OffsetDateTime}).
+ */
+class OffsetDateTimeStorageTest {
+
+  @Test
+  void offsetDateTimeResolvesToDatetimeType() {
+    assertThat(Type.getTypeByValue(OffsetDateTime.now(ZoneOffset.UTC))).isEqualTo(Type.DATETIME);
+    assertThat(DateUtils.isDate(OffsetDateTime.now(ZoneOffset.UTC))).isTrue();
+  }
+
+  @Test
+  void offsetDateTimePersistsInSchemalessProperty() {
+    final String path = "./target/testoffsetdt_" + System.nanoTime();
+    final Database database = new DatabaseFactory(path).create();
+    try {
+      final OffsetDateTime value = OffsetDateTime.of(2024, 1, 15, 10, 30, 45, 0, ZoneOffset.ofHours(2));
+
+      database.getSchema().getOrCreateDocumentType("Ev");
+      database.transaction(() -> {
+        final MutableDocument doc = database.newDocument("Ev");
+        doc.set("id", 1);
+        doc.set("ts", value);
+        doc.save();
+      });
+
+      final var result = database.query("sql", "SELECT ts FROM Ev WHERE id = 1");
+      assertThat(result.hasNext()).isTrue();
+      final Object stored = result.next().getProperty("ts");
+      // Previously null (dropped); now stored as a datetime preserving the instant.
+      assertThat(stored).isNotNull();
+      assertThat(DateUtils.dateTimeToTimestamp(stored, java.time.temporal.ChronoUnit.MILLIS))
+          .isEqualTo(value.toInstant().toEpochMilli());
+    } finally {
+      database.drop();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #4922. A `java.time.OffsetDateTime` written to a schemaless property was **silently dropped** - the type system didn't recognize it (`Type.getTypeByValue` returned `null`), so the property came back `null` on read with no error.

This blocked the native-datetime **write** path enabled by #4905/#4907: the Neo4j Bolt drivers pack a fixed-offset/UTC datetime (e.g. Python's `datetime.now(timezone.utc)`) as an offset `DateTime` PackStream struct, which ArcadeDB decodes to an `OffsetDateTime` - and then dropped it. Found while adding the node-element test in #4921.

## Root cause

`OffsetDateTime` was registered nowhere in the temporal plumbing, unlike its siblings:
- `Type.TYPES_BY_USERTYPE` mapped `Date`/`Calendar`/`LocalDateTime`/`ZonedDateTime`/`Instant` to `DATETIME`, but not `OffsetDateTime`.
- `Type.DATETIME` (+ `_MICROS`/`_NANOS`/`_SECOND`) `allowAssignmentFrom` omitted it.
- `BinaryTypes.getTypeFromValue()` had `instanceof` branches for the other temporals but not `OffsetDateTime`, so it never serialized as a datetime.

`DateUtils.dateTimeToTimestamp()` already handled `OffsetDateTime`, so only the type-resolution layer was missing.

## Fix

- `Type`: register `OffsetDateTime` → `DATETIME` in `TYPES_BY_USERTYPE`; add it to the `allowAssignmentFrom` of `DATETIME`/`DATETIME_MICROS`/`DATETIME_NANOS`/`DATETIME_SECOND`.
- `BinaryTypes.getTypeFromValue()`: add an `OffsetDateTime` branch mirroring `ZonedDateTime`.

Storage normalizes to an instant as it already does for `ZonedDateTime` (zone/offset not preserved; instant is). Cross-type comparison still works because a stored datetime read back as `LocalDateTime` is treated as UTC by `CypherDateTime.compareTo`, so `WHERE valid_at <= $reference_time` remains correct.

## Tests

- **`OffsetDateTimeStorageTest`** (engine) - `getTypeByValue(OffsetDateTime)` resolves to `DATETIME`, and an `OffsetDateTime` written to a schemaless property persists with the instant preserved (both asserted to fail before the fix).
- **`BoltOffsetDatetimeWriteIT`** (bolt) - the real graphiti write path: a native offset datetime sent as a query parameter is stored and read back (previously `null`).

## Verification

- `OffsetDateTimeStorageTest` + `BoltOffsetDatetimeWriteIT`: green.
- Regression: engine serializer+schema (392), `TypeTest` (108), date/conversion suites (56), OpenCypher temporal functions (132), bolt module (237) - all 0 failures.

## Impact

Completes the native Bolt datetime round-trip in both directions and both operations (read + write). Combined with #4906/#4910/#4921, the graphiti driver can drop all four workarounds and send/receive native datetimes with no client-side conversion.
