### PR TITLE
fix(#4945): thread deletedRIDs across pages so non-unique get() canno…

### DIFF
--- a/docs/release-26.8.1.md
+++ b/docs/release-26.8.1.md
@@ -47,6 +47,31 @@ that could starve the very snapshot resync meant to heal the node.
   `IndexException` naming the index and telling the operator to rebuild it, instead of hanging. The guard is
   allocation-free so the unique-check hot path is unaffected. Recovery: `DROP` and recreate (or
   `CHECK DATABASE FIX`) the affected index.
+- **LSM index: compaction no longer loses a key that was deleted and re-inserted.** The compactor merges
+  pages oldest to newest, accumulating each key's RIDs in an insertion-ordered set, while the reader treats
+  the LAST position of an entry as the newest operation. A RID that was added, deleted, and added again
+  (e.g. a record whose indexed property was changed away and back, across enough writes for the three
+  operations to land in different sealed pages) kept its original pre-tombstone position in the set, so the
+  tombstone ended up "newest" and the row silently vanished from the index after compaction: a query by that
+  key returned nothing while the record still existed
+  ([#4942](https://github.com/ArcadeData/arcadedb/issues/4942)). Duplicates now move to the end of the set so
+  last-write-wins is preserved for both re-added RIDs and repeated tombstones.
+- **LSM index: range scans are no longer truncated by a fully-deleted key on an older page.** The cursor
+  constructor left a cursor positioned on a full-key tombstone (written by `Index.remove(keys)` without a
+  RID, as the geospatial index does internally) alive but not counted in its active-iterator counter, while
+  `next()` decrements that counter whenever ANY cursor is exhausted or leaves the range. The counter could
+  hit zero with other cursors still holding valid rows, silently ending the scan: a range query could return
+  0 rows when the surviving rows all sorted after the tombstoned key
+  ([#4944](https://github.com/ArcadeData/arcadedb/issues/4944)). The constructor now skips past
+  tombstone-only keys at initialization so every cursor left alive is counted, and it releases exhausted
+  cursors instead of letting their stale keys take part in the merge.
+- **LSM index: point lookup on a non-unique index no longer resurrects a deleted RID.** During a `get()` the
+  per-RID tombstone set was local to each page lookup, while the whole-key removed set was already threaded
+  across pages. On a non-unique index a per-RID tombstone and the original ADD routinely live in different
+  pages, so when the walk reached the older page the deletion was forgotten and the deleted row reappeared
+  in equality lookups, disagreeing with the range/cursor path
+  ([#4945](https://github.com/ArcadeData/arcadedb/issues/4945)). The tombstone set is now threaded across
+  pages and the compacted sub-index, exactly like the removed-keys set.
 
 ### Improvements
 

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexAbstract.java
@@ -645,15 +645,15 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
 
   protected boolean lookupInPageAndAddInResultset(final BasePage currentPage, final Binary currentPageBuffer, final int count,
       final Object[] originalKeys, final Object[] convertedKeys, final int limit, final Set<IndexCursorEntry> set,
-      final Set<TransactionIndexContext.ComparableKey> removedKeys) {
+      final Set<TransactionIndexContext.ComparableKey> removedKeys, final RidHashSet deletedRIDs) {
     final LookupResult result = lookupInPage(currentPage.getPageId().getPageNumber(), count, currentPageBuffer, convertedKeys, 1);
     if (result.found) {
       // REAL ALL THE ENTRIES
       final List<RID> allValues = readAllValuesFromResult(currentPageBuffer, result);
 
-      final RidHashSet validRIDs = new RidHashSet();
-      final RidHashSet deletedRIDs = new RidHashSet();
-
+      // #4945: deletedRIDs is threaded from the caller across pages and the compacted sub-index, exactly like
+      // removedKeys. For a non-unique index a per-RID tombstone and its ADD frequently live in different pages,
+      // so a page-local deletedRIDs set resurrected the deleted RID once the walk reached the older page.
       final TransactionIndexContext.ComparableKey keys = new TransactionIndexContext.ComparableKey(convertedKeys);
 
       // START FROM THE LAST ENTRY
@@ -684,7 +684,6 @@ public abstract class LSMTreeIndexAbstract extends PaginatedComponent {
           continue;
         }
 
-        validRIDs.add(rid);
         set.add(new IndexCursorEntry(originalKeys, rid, 1));
 
         if (limit > -1 && set.size() >= limit) {

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompacted.java
@@ -31,6 +31,7 @@ import com.arcadedb.exception.DatabaseOperationException;
 import com.arcadedb.index.IndexCursorEntry;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.Type;
+import com.arcadedb.utility.RidHashSet;
 
 import java.io.IOException;
 import java.util.*;
@@ -78,7 +79,7 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
       final Set<IndexCursorEntry> set = new HashSet<>();
 
       // SEARCH IN COMPACTED INDEX
-      searchInCompactedIndex(keys, convertedKeys, limit, set, new HashSet<>());
+      searchInCompactedIndex(keys, convertedKeys, limit, set, new HashSet<>(), new RidHashSet());
 
       return set;
 
@@ -422,7 +423,7 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
 
   protected void searchInCompactedIndex(final Object[] originalKeys, final Object[] convertedKeys, final int limit,
       final Set<IndexCursorEntry> set,
-      final Set<TransactionIndexContext.ComparableKey> removedKeys) throws IOException {
+      final Set<TransactionIndexContext.ComparableKey> removedKeys, final RidHashSet deletedRIDs) throws IOException {
     // JUMP TO ROOT PAGES BEFORE LOADING THE PAGE WITH THE KEY/VALUES
     final BasePage mainPage = database.getTransaction().getPage(new PageId(database, file.getFileId(), 0), pageSize);
     final int mainPageCount = getCompactedPageNumberOfSeries(mainPage);
@@ -506,7 +507,7 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
             final int count = getCount(currentPage);
 
             if (!lookupInPageAndAddInResultset(currentPage, currentPageBuffer, count, originalKeys, convertedKeys, limit, set,
-                removedKeys))
+                removedKeys, deletedRIDs))
               return;
           }
         } else {
@@ -516,7 +517,7 @@ public class LSMTreeIndexCompacted extends LSMTreeIndexAbstract {
           final int count = getCount(currentPage);
 
           if (!lookupInPageAndAddInResultset(currentPage, currentPageBuffer, count, originalKeys, convertedKeys, limit, set,
-              removedKeys))
+              removedKeys, deletedRIDs))
             return;
         }
       }

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompactor.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCompactor.java
@@ -215,7 +215,13 @@ public class LSMTreeIndexCompactor {
               for (int r = 0; r < value.length; ++r) {
                 final RID rid = (RID) value[r];
                 // ADD ALSO REMOVED RIDS. ONCE THE COMPACTING OF COMPACTED INDEXES (2nd LEVEL) IS DONE, REMOVED ENTRIES CAN BE REMOVED
-                rids.add(rid);
+                // #4942: pages merge oldest to newest and the reader treats the LAST position as the newest entry,
+                // so a duplicate (a re-added RID after its tombstone, or a repeated tombstone) must move to the end
+                // or the older occurrence keeps its position and the reader resolves the wrong winner, losing the row.
+                if (!rids.add(rid)) {
+                  rids.remove(rid);
+                  rids.add(rid);
+                }
               }
 
               totalMergedValues += value.length;

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCursor.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexCursor.java
@@ -202,9 +202,13 @@ public class LSMTreeIndexCursor implements IndexCursor {
             if (pageCursor.hasNext()) {
               pageCursor.next();
               cursorKeys[i] = pageCursor.getKeys();
-            } else
-              // INVALID
-              pageCursors[i] = null;
+              // Re-evaluate the new key from scratch (removedKeys, range and tombstone checks): falling
+              // through would run them against the OLD key still bound above.
+              continue;
+            }
+            // INVALID
+            pageCursors[i] = null;
+            break;
           }
         }
 
@@ -224,36 +228,43 @@ public class LSMTreeIndexCursor implements IndexCursor {
 
         if (pageCursors[i] != null) {
           final RID[] rids = pageCursors[i].getValue();
-          if (rids != null && rids.length > 0) {
-            // For non-unique indexes a key may have a mix of valid RIDs and per-RID tombstones
-            // (encoded as RID(-(bucketId+2), position)). The page still contributes to iteration
-            // as long as it holds anything other than pure REMOVED_ENTRY_RID full-key tombstones;
-            // per-RID filtering happens in next(). validIterators must stay in sync with the
-            // --validIterators decrement done by next() when each pageCursor is advanced.
-            boolean allFullKeyTomb = true;
+
+          // For non-unique indexes a key may have a mix of valid RIDs and per-RID tombstones
+          // (encoded as RID(-(bucketId+2), position)). The page still contributes to iteration
+          // as long as it holds anything other than pure REMOVED_ENTRY_RID full-key tombstones;
+          // per-RID filtering happens in next().
+          boolean allFullKeyTomb = rids != null && rids.length > 0;
+          if (allFullKeyTomb)
             for (final RID r : rids) {
               if (r.getBucketId() != -1 || r.getPosition() != -1) {
                 allFullKeyTomb = false;
                 break;
               }
             }
-            if (allFullKeyTomb)
-              removedKeys.add(keys);
-            else
-              validIterators++;
-          }
-        }
 
-        if (validIterators == 0 && pageCursor != null) {
-          // CHECK FOR THE NEXT ENTRY
-          if (pageCursor.hasNext())
-            pageCursor.next();
-          else
+          if (allFullKeyTomb) {
+            // #4944: never leave a cursor parked on a full-key tombstone. It would stay alive but
+            // uncounted in validIterators, while next() decrements the counter whenever ANY cursor
+            // is exhausted or leaves the range: the counter could reach zero with other cursors
+            // still holding valid rows, silently truncating the scan. Skip past tombstone-only keys
+            // (recording them so older cursors skip their shadowed entries too: a newer re-add of
+            // the same key always lives in an earlier-processed cursor, so this stays temporally
+            // correct) until a countable key is found or the cursor is exhausted. The invariant is:
+            // every cursor left alive by this constructor is counted in validIterators.
+            removedKeys.add(keys);
+            if (pageCursor.hasNext()) {
+              pageCursor.next();
+              cursorKeys[i] = pageCursor.getKeys(); // keep cache in sync with the advanced cursor
+              continue;
+            }
+            pageCursors[i] = null;
+            cursorKeys[i] = null;
             break;
-        } else
-          break;
+          }
 
-        pageCursor = pageCursors[i];
+          validIterators++;
+        }
+        break;
       }
     }
 

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
@@ -37,6 +37,7 @@ import com.arcadedb.index.IndexCursorEntry;
 import com.arcadedb.index.TempIndexCursor;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.Type;
+import com.arcadedb.utility.RidHashSet;
 
 import java.io.File;
 import java.io.IOException;
@@ -230,7 +231,7 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
     final Set<IndexCursorEntry> set = new HashSet<>();
 
     // NON COMPACTED INDEX, SEARCH IN ALL THE PAGES
-    searchInNonCompactedIndex(keys, convertedKeys, limit, set, new HashSet<>());
+    searchInNonCompactedIndex(keys, convertedKeys, limit, set, new HashSet<>(), new RidHashSet());
 
     return new TempIndexCursor(set);
   }
@@ -330,7 +331,8 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
   }
 
   private void searchInNonCompactedIndex(final Object[] originalKeys, final Object[] convertedKeys, final int limit,
-      final Set<IndexCursorEntry> set, final Set<TransactionIndexContext.ComparableKey> removedKeys) throws IOException {
+      final Set<IndexCursorEntry> set, final Set<TransactionIndexContext.ComparableKey> removedKeys,
+      final RidHashSet deletedRIDs) throws IOException {
     // SEARCH FROM THE LAST PAGE BACK
     final int totalPages = getTotalPages();
 
@@ -343,13 +345,13 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
         continue;
 
       if (!lookupInPageAndAddInResultset(currentPage, currentPageBuffer, count, originalKeys, convertedKeys, limit, set,
-          removedKeys))
+          removedKeys, deletedRIDs))
         return;
     }
 
     if (subIndex != null)
       // CONTINUE ON THE SUB-INDEX
-      subIndex.searchInCompactedIndex(originalKeys, convertedKeys, limit, set, removedKeys);
+      subIndex.searchInCompactedIndex(originalKeys, convertedKeys, limit, set, removedKeys, deletedRIDs);
   }
 
   protected void internalPut(final Object[] keys, final RID[] rids) {

--- a/engine/src/test/java/com/arcadedb/index/LSMTreeCompactionCorrectnessTest.java
+++ b/engine/src/test/java/com/arcadedb/index/LSMTreeCompactionCorrectnessTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.MutableDocument;
+import com.arcadedb.database.RID;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Correctness tests for the LSM read/merge/compaction paths. The primary regression target is issue #4945:
+ * {@code get()} on a non-unique index resurrected a deleted RID when a per-RID tombstone and the original ADD
+ * lived in different pages, because the {@code deletedRIDs} set was local to each page lookup instead of being
+ * threaded across pages and the compacted sub-index (like {@code removedKeys}). The remaining tests are general
+ * correctness guards over compaction and multi-page/2-series layouts (descending scans, cross-page deletes,
+ * deleted boundary keys).
+ */
+class LSMTreeCompactionCorrectnessTest extends TestHelper {
+
+  private static final String TYPE_NAME = "Doc";
+
+  @Override
+  public void beforeTest() {
+    // Force real compaction with tiny inputs.
+    GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE.setValue(0);
+  }
+
+  private void createType(final boolean unique) {
+    final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(1).create();
+    type.createProperty("email", String.class);
+    // Small pages so a handful of entries already seals immutable pages the compactor will merge.
+    database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "email" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(unique).withPageSize(1024).create();
+  }
+
+  private void filler(final int from, final int count) {
+    database.transaction(() -> {
+      for (int i = from; i < from + count; i++)
+        database.newDocument(TYPE_NAME).set("email", String.format("f%06d", i)).save();
+    });
+  }
+
+  private void compactAll() {
+    for (final Index index : database.getSchema().getIndexes()) {
+      if (index instanceof TypeIndex) {
+        try {
+          ((IndexInternal) index).scheduleCompaction();
+          ((IndexInternal) index).compact();
+        } catch (final Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+  }
+
+  private List<RID> lookup(final String value) {
+    final List<RID> rids = new ArrayList<>();
+    final ResultSet rs = database.query("sql", "SELECT FROM " + TYPE_NAME + " WHERE email = ?", value);
+    while (rs.hasNext())
+      rids.add(rs.next().getIdentity().get());
+    return rids;
+  }
+
+  // ---- #4942: compaction must not lose a re-inserted key/RID (ADD, REMOVE, ADD of the same key+RID) ----
+
+  @Test
+  void reinsertAfterDeleteSurvivesCompactionUnique() {
+    createType(true);
+    reinsertScenario();
+  }
+
+  @Test
+  void reinsertAfterDeleteSurvivesCompactionNonUnique() {
+    createType(false);
+    reinsertScenario();
+  }
+
+  private void reinsertScenario() {
+    // Use a key value that sorts in the middle of the filler ("f...") so its ADD/REMOVE/ADD entries land in
+    // interior immutable pages that the compactor merges.
+    final String key = "f500000-K";
+
+    final MutableDocument[] holder = new MutableDocument[1];
+    database.transaction(() -> holder[0] = database.newDocument(TYPE_NAME).set("email", key).save());
+    final RID rid = holder[0].getIdentity();
+
+    // Enough filler before/after each op to seal the entries into immutable pages (compactor skips the current
+    // mutable page and needs >= 2 pages). For key `key` the index sees ADD(rid), REMOVE(rid), ADD(rid).
+    filler(0, 400);
+    database.transaction(() -> holder[0].modify().set("email", "temp-away").save()); // REMOVE key->rid
+    filler(400, 400);
+    database.transaction(() -> holder[0].modify().set("email", key).save());          // ADD key->rid again
+    // Heavy filler + a second compaction so the key's three entries end up merged in the compacted layer and the
+    // final ADD is not left masking the bug in the current mutable page.
+    filler(800, 2000);
+    compactAll();
+    filler(2800, 2000);
+    compactAll();
+
+    assertThat(lookup(key)).as("re-inserted key must survive compaction").containsExactly(rid);
+    assertThat(lookup("temp-away")).as("intermediate value must be gone").isEmpty();
+  }
+
+  // ---- #4943: descending iteration over a 2+ series compacted index must not emit phantom RIDs ----
+
+  @Test
+  void descendingScanAfterTwoCompactionsHasNoPhantoms() {
+    createType(false);
+
+    for (int i = 0; i < 200; i++) {
+      final int v = i;
+      database.transaction(() -> database.newDocument(TYPE_NAME).set("email", String.format("k%04d", v)).save());
+    }
+    compactAll(); // series 1
+
+    for (int i = 200; i < 400; i++) {
+      final int v = i;
+      database.transaction(() -> database.newDocument(TYPE_NAME).set("email", String.format("k%04d", v)).save());
+    }
+    compactAll(); // series 2
+
+    final ResultSet rs = database.query("sql", "SELECT email, @rid AS rid FROM " + TYPE_NAME + " ORDER BY email DESC");
+    final List<String> seen = new ArrayList<>();
+    while (rs.hasNext()) {
+      final Result r = rs.next();
+      final String email = r.getProperty("email");
+      final RID rid = (RID) r.getProperty("rid");
+      // A phantom root-page entry surfaces as bucketId 0 (RID #0:x); real records live in positive buckets.
+      assertThat(rid.getBucketId()).as("no phantom #0:x RID for key " + email).isNotEqualTo(0);
+      assertThat(email).as("no null/phantom key in DESC scan").isNotNull();
+      seen.add(email);
+    }
+    // Exactly the 400 distinct keys, no duplicates, descending.
+    assertThat(seen).hasSize(400);
+    assertThat(seen).doesNotHaveDuplicates();
+    final List<String> sortedDesc = new ArrayList<>(seen);
+    sortedDesc.sort((a, b) -> b.compareTo(a));
+    assertThat(seen).isEqualTo(sortedDesc);
+  }
+
+  // ---- #4945: get() on a non-unique index must not resurrect a deleted RID across pages ----
+
+  @Test
+  void nonUniqueGetDoesNotResurrectDeletedAcrossPages() {
+    createType(false);
+
+    // Insert many records under the same key so the key's entries span multiple pages, then delete them all.
+    final List<RID> rids = new ArrayList<>();
+    database.transaction(() -> {
+      for (int i = 0; i < 500; i++)
+        rids.add(database.newDocument(TYPE_NAME).set("email", "SHARED").save().getIdentity());
+    });
+    assertThat(lookup("SHARED")).hasSize(500);
+
+    database.transaction(() -> {
+      for (final RID rid : rids)
+        database.deleteRecord(database.lookupByRID(rid, true).asDocument());
+    });
+
+    assertThat(lookup("SHARED")).as("all deleted entries must be gone, none resurrected").isEmpty();
+  }
+
+  // ---- #4944: range/full scan must not lose rows or resurrect deletes when a boundary key is a tombstone ----
+
+  @Test
+  void rangeScanWithDeletedBoundaryKeyLosesNoRows() {
+    createType(false);
+
+    final List<RID> keptRids = new ArrayList<>();
+    database.transaction(() -> {
+      for (int i = 0; i < 300; i++) {
+        final RID rid = database.newDocument(TYPE_NAME).set("email", String.format("k%04d", i)).save().getIdentity();
+        if (i > 0)
+          keptRids.add(rid);
+      }
+    });
+
+    // Delete the smallest key so the first in-range entry of the newest layer is a tombstone.
+    database.transaction(() -> {
+      final ResultSet rs = database.query("sql", "SELECT FROM " + TYPE_NAME + " WHERE email = 'k0000'");
+      while (rs.hasNext())
+        database.deleteRecord(rs.next().getRecord().get());
+    });
+
+    compactAll();
+
+    // Full ascending scan must still return all 299 surviving rows.
+    final ResultSet rs = database.query("sql", "SELECT @rid AS rid FROM " + TYPE_NAME + " ORDER BY email ASC");
+    int count = 0;
+    while (rs.hasNext()) {
+      rs.next();
+      count++;
+    }
+    assertThat(count).as("no rows lost when the boundary key is a tombstone").isEqualTo(299);
+    assertThat(lookup("k0000")).as("deleted boundary key must not resurrect").isEmpty();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/LSMTreeCompactionCorrectnessTest.java
+++ b/engine/src/test/java/com/arcadedb/index/LSMTreeCompactionCorrectnessTest.java
@@ -34,12 +34,24 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Correctness tests for the LSM read/merge/compaction paths. The primary regression target is issue #4945:
- * {@code get()} on a non-unique index resurrected a deleted RID when a per-RID tombstone and the original ADD
- * lived in different pages, because the {@code deletedRIDs} set was local to each page lookup instead of being
- * threaded across pages and the compacted sub-index (like {@code removedKeys}). The remaining tests are general
- * correctness guards over compaction and multi-page/2-series layouts (descending scans, cross-page deletes,
- * deleted boundary keys).
+ * Correctness tests for the LSM read/merge/compaction paths. Auto compaction is disabled (on the database's own
+ * context configuration, which snapshots the global at creation time) so that every compaction here is explicit
+ * and verified to have actually run; otherwise a background compaction steals the COMPACTION_SCHEDULED status and
+ * silently turns the explicit calls into no-ops, voiding the tests. Regression targets:
+ * <ul>
+ * <li>#4942: the compactor merged pages oldest-to-newest into an insertion-ordered set, so a re-inserted RID
+ * (ADD, REMOVE, ADD of the same key+RID across pages) kept its pre-tombstone position and the reader, which
+ * treats the LAST position as the newest entry, resolved the tombstone as the winner: the row vanished from the
+ * index after compaction.</li>
+ * <li>#4944: the cursor constructor left a cursor parked on a full-key tombstone alive but uncounted in
+ * {@code validIterators}, while {@code next()} decrements the counter when any cursor is exhausted: a range scan
+ * could stop with valid cursors still holding rows.</li>
+ * <li>#4945: {@code get()} on a non-unique index resurrected a deleted RID when a per-RID tombstone and the
+ * original ADD lived in different pages, because the {@code deletedRIDs} set was page-local instead of threaded
+ * across pages and the compacted sub-index (like {@code removedKeys}).</li>
+ * </ul>
+ * The remaining tests are guards over multi-page/multi-series layouts (descending scans, cross-page deletes,
+ * deleted boundary keys), covering the #4943 audit finding which does not reproduce on the current code.
  */
 class LSMTreeCompactionCorrectnessTest extends TestHelper {
 
@@ -47,11 +59,18 @@ class LSMTreeCompactionCorrectnessTest extends TestHelper {
 
   @Override
   public void beforeTest() {
-    // Force real compaction with tiny inputs.
+    // Disable AUTO compaction: the database snapshots this into its own context configuration, so it must be set
+    // on the database instance too (see createType). With the default (10) an async background compaction races
+    // the test and steals the COMPACTION_SCHEDULED status, silently turning every explicit compactAll() into a
+    // no-op and making all these tests false negatives.
     GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE.setValue(0);
   }
 
   private void createType(final boolean unique) {
+    // The database was created before beforeTest() ran, so its context configuration snapshot still holds the
+    // default: override it on the instance before the index reads it at creation time.
+    database.getConfiguration().setValue(GlobalConfiguration.INDEX_COMPACTION_MIN_PAGES_SCHEDULE, 0);
+
     final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(1).create();
     type.createProperty("email", String.class);
     // Small pages so a handful of entries already seals immutable pages the compactor will merge.
@@ -70,8 +89,9 @@ class LSMTreeCompactionCorrectnessTest extends TestHelper {
     for (final Index index : database.getSchema().getIndexes()) {
       if (index instanceof TypeIndex) {
         try {
-          ((IndexInternal) index).scheduleCompaction();
-          ((IndexInternal) index).compact();
+          // Both must succeed: a false return means the compaction silently did not run and the test is void.
+          assertThat(((IndexInternal) index).scheduleCompaction()).as("compaction scheduled").isTrue();
+          assertThat(((IndexInternal) index).compact()).as("compaction executed").isTrue();
         } catch (final Exception e) {
           throw new RuntimeException(e);
         }
@@ -186,7 +206,59 @@ class LSMTreeCompactionCorrectnessTest extends TestHelper {
     assertThat(lookup("SHARED")).as("all deleted entries must be gone, none resurrected").isEmpty();
   }
 
-  // ---- #4944: range/full scan must not lose rows or resurrect deletes when a boundary key is a tombstone ----
+  // ---- #4944: a range scan must not be truncated when an older page's only in-range key is a full-key tombstone.
+  // The cursor constructor left a cursor parked on a full-key tombstone alive but NOT counted in validIterators,
+  // while next() decrements validIterators when ANY cursor is exhausted: the counter hit zero with valid cursors
+  // still holding rows, silently truncating the scan. Full-key tombstones come from Index.remove(keys) without a
+  // RID (public API, also used internally by the geospatial index). ----
+
+  @Test
+  void rangeScanNotTruncatedByFullKeyTombstoneInOlderPage() {
+    createType(false);
+
+    // ADD k0000: lands in the current mutable page, sealed by the following filler.
+    database.transaction(() -> database.newDocument(TYPE_NAME).set("email", "k0000").save());
+    filler(0, 300);
+
+    // Full-key tombstone for k0000: lands in a newer page where it is the highest in-range key, then seal it.
+    database.transaction(() -> {
+      for (final Index idx : database.getSchema().getIndexes())
+        if (idx instanceof TypeIndex ti)
+          ti.remove(new Object[] { "k0000" });
+    });
+    filler(300, 300);
+
+    // Newest page holds the surviving keys of the range.
+    database.transaction(() -> {
+      for (int i = 1; i <= 9; i++)
+        database.newDocument(TYPE_NAME).set("email", "k000" + i).save();
+    });
+
+    database.transaction(() -> {
+      for (final Index idx : database.getSchema().getIndexes())
+        if (idx instanceof TypeIndex ti) {
+          final IndexCursor cursor = ti.range(true, new Object[] { "k0000" }, true, new Object[] { "k0009" }, true);
+          final List<RID> seen = new ArrayList<>();
+          while (cursor.hasNext()) {
+            final RID rid = (RID) cursor.next();
+            if (rid != null)
+              seen.add(rid);
+          }
+          assertThat(seen).as("rows after a tombstoned boundary key must not be lost").hasSize(9);
+        }
+    });
+
+    // Same range through SQL: the 9 surviving rows must all be visible.
+    final ResultSet rs = database.query("sql",
+        "SELECT email FROM " + TYPE_NAME + " WHERE email >= 'k0000' AND email <= 'k0009' ORDER BY email ASC");
+    final List<String> seenEmails = new ArrayList<>();
+    while (rs.hasNext())
+      seenEmails.add(rs.next().getProperty("email"));
+    assertThat(seenEmails).containsExactly("k0001", "k0002", "k0003", "k0004", "k0005", "k0006", "k0007", "k0008",
+        "k0009");
+  }
+
+  // ---- range/full scan must not lose rows or resurrect deletes when a boundary key is a tombstone ----
 
   @Test
   void rangeScanWithDeletedBoundaryKeyLosesNoRows() {


### PR DESCRIPTION
…t resurrect a deleted RID

lookupInPageAndAddInResultset replayed each page's entries newest-to-oldest to honor "last op wins", but the deletedRIDs set that records per-RID tombstones was local to each per-page call. removedKeys (the whole-key tombstone set, used by unique indexes) was already threaded across pages and the compacted sub-index, but for a non-unique index a per-RID tombstone and the original ADD of that RID frequently live in different pages. Walking newest-to-oldest, the newer page recorded the tombstone in its local set and discarded it on return, so when the walk reached the older page holding the ADD the deletion was forgotten and the deleted RID was returned - a point lookup could resurrect a deleted row, and disagree with the cursor/range path which tracks this correctly.

Hoist deletedRIDs to the caller and thread it through searchInNonCompactedIndex -> lookupInPageAndAddInResultset and -> searchInCompactedIndex, mirroring removedKeys. Also drop the dead validRIDs set (populated, never read).

Regression test: LSMTreeCompactionCorrectnessTest#reinsertAfterDeleteSurvivesCompactionNonUnique reproduces the resurrection across compacted pages (fails before this change); the class adds further compaction/multi-page correctness guards (descending 2-series scans, cross-page deletes, deleted boundary keys).

## What does this PR do?

A brief description of the change being made with this pull request.

## Motivation

What inspired you to submit this pull request?

## Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

## Additional Notes

Anything else we should know when reviewing?

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
