### PR TITLE
test(#4888): deepen e2e-js to the full Bolt conformance spec

### DIFF
--- a/docs/superpowers/plans/2026-07-04-e2e-js-bolt-conformance.md
+++ b/docs/superpowers/plans/2026-07-04-e2e-js-bolt-conformance.md
@@ -1,0 +1,1250 @@
+# e2e-js Bolt conformance suite Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deepen `e2e-js` to cover all 39 `bolt/conformance/spec.yaml` scenarios against the official `neo4j-driver`, at parity with the merged Python/Go/C# suites, without disturbing the existing VLP regression test.
+
+**Architecture:** One new Jest file `e2e-js/src/js-bolt-conformance.test.js` boots an ArcadeDB testcontainer (beer default DB + `type-matrix.cypher` seeded over HTTP), then exercises each scenario as a discrete `it()` named `[SCENARIO-ID] ...`. Known server gaps use Jest's native `it.failing()` (the `xfail(strict=True)` equivalent); infra-unavailable scenarios use `it.skip()`. TLS scenarios use a keytool-generated self-signed cert baked into a derived Docker image built at test time.
+
+**Tech Stack:** Node 24, Jest 30, `neo4j-driver` ^6.0.1, `testcontainers` ^12, `jest-junit` ^17, JDK `keytool` (TLS only). All already declared in `e2e-js/package.json`.
+
+## Global Constraints
+
+- **Do not modify** `e2e-js/src/js-bolt-e2e.test.js` or `e2e-js/src/js-pg-e2e.test.js` - the VLP regression (#4452/#4271) must be preserved byte-for-byte.
+- **Do not add a new npm dependency** - the required libraries are already present.
+- **Every test name is prefixed with its bracketed spec id**, e.g. `[TYPE-011] duration round-trip` (README traceability convention). `grep -oE '\[[A-Z]+-[0-9]+\]' e2e-js/src/js-bolt-conformance.test.js | sort -u` must list all 39 ids.
+- **Seed only over HTTP** (`/api/v1/server`, `/api/v1/command/beer`), never over Bolt - seeding must not exercise the serialization path under test.
+- **Image resolution:** `process.env.ARCADEDB_DOCKER_IMAGE || "arcadedata/arcadedb:latest"`.
+- **Root password:** `playwithdata`. **Base JAVA_OPTS** (verbatim): `-Darcadedb.server.rootPassword=playwithdata -Darcadedb.server.defaultDatabases=beer[root]{import:https://github.com/ArcadeData/arcadedb-datasets/raw/main/orientdb/OpenBeer.gz} -Darcadedb.server.plugins=BoltProtocolPlugin`.
+- **Target statuses = `main`'s reconciled `spec.yaml`:** 31 passing, 6 `it.failing` gaps (RESULT-004, TYPE-003, TYPE-011, TYPE-012, ERR-002, PROTO-002 - all track #4890), 2 skips (CONN-004 HA cluster, ERR-003 raw socket).
+- **License header:** every source file starts with the Apache-2.0 header block used by `js-bolt-e2e.test.js` (copy it verbatim).
+- **No `System.out`/stray `console.log`** except the intentional diagnostic in the two-writer race helper (mirrors the Python suite).
+- **Do not add Claude as an author** in file content.
+- **Commit trailer** on every commit: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+## File Structure
+
+- **Create:** `e2e-js/src/js-bolt-conformance.test.js` - the entire 39-scenario suite (fixtures + all `describe`/`it` blocks). Single file, mirroring the single-file Python `test_bolt.py`.
+- **Create:** `e2e-js/README.md` - driver-version band, run instructions, traceability note.
+- **Unchanged:** `e2e-js/package.json` (deps + jest-junit already wired), `e2e-js/src/js-bolt-e2e.test.js`, `e2e-js/src/js-pg-e2e.test.js`, `.github/workflows/mvn-test.yml` (the `js-e2e-tests` job already runs `npm test` and passes `ARCADEDB_DOCKER_IMAGE`).
+
+**Reference while implementing:** `e2e-python/tests/test_bolt.py` (authoritative template - same fixture strategy, same assertions, same gap reasons) and `bolt/conformance/spec.yaml` (scenario source of truth).
+
+**Verification note (applies to every task):** this is an e2e suite - a test can only run against a live container, so the "run the test" steps require a locally-built image. Build it once before starting:
+```bash
+cd /Users/frank/projects/arcade/arcadedb/.worktrees/feat/4888-e2e-js-bolt-conformance
+mvn -Pdocker -DskipTests -pl bolt,package -am -q
+# produces arcadedata/arcadedb:latest locally
+cd e2e-js && npm install
+```
+Run a single scenario during development with:
+```bash
+cd e2e-js && npx jest src/js-bolt-conformance.test.js -t '[CONN-001]'
+```
+
+---
+
+### Task 1: Fixture harness + first green connection tests (CONN-001, CONN-003)
+
+Proves the whole harness (container boot, HTTP seeding, driver connect) before fanning out. CONN-001 (`bolt://`) and CONN-003 (`neo4j://` single-node routing) both use the shared plain container and driver.
+
+**Files:**
+- Create: `e2e-js/src/js-bolt-conformance.test.js`
+
+**Interfaces:**
+- Produces (module-level constants/helpers other tasks rely on):
+  - `ROOT_PASSWORD = "playwithdata"`
+  - `IMAGE = process.env.ARCADEDB_DOCKER_IMAGE || "arcadedata/arcadedb:latest"`
+  - `BASE_JAVA_OPTS` (string, verbatim from Global Constraints)
+  - shared `container`, `driver` (created in `beforeAll`), `host`, `boltPort`, `httpPort`
+  - `boltUri(scheme = "bolt")` -> `${scheme}://${host}:${boltPort}`
+  - `httpCommand(path, body)` -> POSTs JSON to `http://host:httpPort/api/v1/<path>` with root basic auth, throws on non-2xx
+  - `session(database = "beer", extra = {})` -> `driver.session({ database, ...extra })`
+
+- [ ] **Step 1: Create the file with the license header, imports, and fixture scaffold**
+
+```js
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Bolt protocol conformance suite for issue #4888 (epic #4882, Group B).
+// Implements every scenario in bolt/conformance/spec.yaml (#4883) against the
+// official neo4j-driver. Each test name embeds its spec id ([AREA-NNN]) for
+// traceability, per bolt/conformance/README.md.
+//
+// ArcadeDB negotiates Bolt 4.4/4.0/3.0 at most (see PROTO-002 - it never
+// advertises 5.x). This suite depends on neo4j-driver continuing to silently
+// downgrade to 4.4; a future driver major dropping legacy negotiation would
+// break the whole suite, not just PROTO-002.
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { execFileSync } = require("child_process");
+const neo4j = require("neo4j-driver");
+const { GenericContainer, Wait } = require("testcontainers");
+
+const ROOT_PASSWORD = "playwithdata";
+const IMAGE = process.env.ARCADEDB_DOCKER_IMAGE || "arcadedata/arcadedb:latest";
+const BASE_JAVA_OPTS =
+  `-Darcadedb.server.rootPassword=${ROOT_PASSWORD}` +
+  " -Darcadedb.server.defaultDatabases=beer[root]{import:https://github.com/ArcadeData/arcadedb-datasets/raw/main/orientdb/OpenBeer.gz}" +
+  " -Darcadedb.server.plugins=BoltProtocolPlugin";
+
+const TYPE_MATRIX_FIXTURE = path.resolve(
+  __dirname,
+  "../../bolt/conformance/fixtures/type-matrix.cypher"
+);
+
+describe("Bolt conformance (issue #4888)", () => {
+  jest.setTimeout(180000);
+
+  let container;
+  let driver;
+  let host;
+  let httpPort;
+  let boltPort;
+
+  function boltUri(scheme = "bolt") {
+    return `${scheme}://${host}:${boltPort}`;
+  }
+
+  async function httpCommand(apiPath, body) {
+    const res = await fetch(`http://${host}:${httpPort}/api/v1/${apiPath}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization:
+          "Basic " + Buffer.from(`root:${ROOT_PASSWORD}`).toString("base64"),
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+    return res.json();
+  }
+
+  function session(database = "beer", extra = {}) {
+    return driver.session({ database, ...extra });
+  }
+
+  beforeAll(async () => {
+    if (!fs.existsSync(TYPE_MATRIX_FIXTURE))
+      throw new Error(`type-matrix fixture not found: ${TYPE_MATRIX_FIXTURE}`);
+
+    container = await new GenericContainer(IMAGE)
+      .withExposedPorts(2480, 7687)
+      .withEnvironment({ JAVA_OPTS: BASE_JAVA_OPTS })
+      .withStartupTimeout(120000)
+      .withWaitStrategy(
+        Wait.forHttp("/api/v1/ready", 2480).forStatusCodeMatching(
+          (sc) => sc === 204
+        )
+      )
+      .start();
+
+    host = container.getHost();
+    httpPort = container.getMappedPort(2480);
+    boltPort = container.getMappedPort(7687);
+
+    // Seed over HTTP only, never over Bolt.
+    await httpCommand("server", { command: "create database boltscratch" });
+    await httpCommand("command/beer", {
+      language: "cypher",
+      command: fs.readFileSync(TYPE_MATRIX_FIXTURE, "utf8"),
+    });
+
+    driver = neo4j.driver(
+      boltUri(),
+      neo4j.auth.basic("root", ROOT_PASSWORD)
+    );
+  });
+
+  afterAll(async () => {
+    if (driver) await driver.close();
+    if (container) await container.stop();
+  });
+
+  // --- connection --------------------------------------------------------
+  describe("connection", () => {
+    it("[CONN-001] connect via bolt:// scheme", async () => {
+      await driver.verifyConnectivity();
+    });
+
+    it("[CONN-003] neo4j:// routing discovery, single-node", async () => {
+      const d = neo4j.driver(
+        boltUri("neo4j"),
+        neo4j.auth.basic("root", ROOT_PASSWORD)
+      );
+      try {
+        await d.verifyConnectivity();
+        const s = d.session({ database: "beer" });
+        try {
+          const r = await s.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 1");
+          expect(r.records[0].get("name")).not.toBeNull();
+        } finally {
+          await s.close();
+        }
+      } finally {
+        await d.close();
+      }
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the two tests against the local image**
+
+Run: `cd e2e-js && npx jest src/js-bolt-conformance.test.js -t 'CONN-00'`
+Expected: PASS (2 passing). This proves boot + seeding + both schemes.
+
+- [ ] **Step 3: Confirm the existing regression file is untouched and still green**
+
+Run: `cd e2e-js && git status --porcelain src/js-bolt-e2e.test.js`
+Expected: no output (unmodified).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e-js/src/js-bolt-conformance.test.js
+git commit -m "test(#4888): e2e-js bolt conformance fixture + connection scenarios
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Auth scenarios (AUTH-001, AUTH-002, AUTH-003)
+
+**Files:**
+- Modify: `e2e-js/src/js-bolt-conformance.test.js` (add an `auth` describe block after `connection`)
+
+**Interfaces:**
+- Consumes: `boltUri`, `session`, `driver`, `ROOT_PASSWORD` from Task 1.
+
+- [ ] **Step 1: Add the auth block**
+
+Insert after the `connection` describe block, inside the top-level describe:
+
+```js
+  // --- auth --------------------------------------------------------------
+  describe("auth", () => {
+    it("[AUTH-001] basic auth succeeds with valid credentials", async () => {
+      await driver.verifyConnectivity();
+      const s = session();
+      try {
+        const r = await s.run("RETURN 1 AS value");
+        expect(r.records[0].get("value").toNumber()).toBe(1);
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[AUTH-002] basic auth fails with invalid credentials", async () => {
+      const d = neo4j.driver(boltUri(), neo4j.auth.basic("root", "wrong-password"));
+      try {
+        await expect(d.verifyConnectivity()).rejects.toMatchObject({
+          code: "Neo.ClientError.Security.Unauthorized",
+        });
+      } finally {
+        await d.close();
+      }
+    });
+
+    it("[AUTH-003] auth scheme 'none' is rejected (intentional)", async () => {
+      // The JS driver has no AuthTokens.none(); omitting the auth token is the
+      // 'none' equivalent. ArcadeDB deliberately rejects it (see AUTH-003).
+      const d = neo4j.driver(boltUri());
+      try {
+        await expect(d.verifyConnectivity()).rejects.toThrow();
+      } finally {
+        await d.close();
+      }
+    });
+  });
+```
+
+- [ ] **Step 2: Run the auth tests**
+
+Run: `cd e2e-js && npx jest src/js-bolt-conformance.test.js -t 'AUTH-0'`
+Expected: PASS (3 passing). If AUTH-003's no-auth form connects instead of rejecting, switch to reading the driver's `none` behavior empirically (try `neo4j.auth.bearer`/omitted token) and assert the rejection - the scenario certifies rejection, not the exact token API.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e-js/src/js-bolt-conformance.test.js
+git commit -m "test(#4888): auth conformance scenarios (AUTH-001..003)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Transaction scenarios (TX-001..TX-005)
+
+Includes the two-writer race helper shared with ERR-004 (Task 8).
+
+**Files:**
+- Modify: `e2e-js/src/js-bolt-conformance.test.js`
+
+**Interfaces:**
+- Consumes: `session`, `driver` from Task 1.
+- Produces: module-level `async function raceTwoWriters(database, marker)` returning `Promise<Error[]>` - the collected errors from two racing writers. Task 8's ERR-004 consumes it.
+
+- [ ] **Step 1: Add the race helper at module scope (above the top-level describe)**
+
+```js
+// Shared concurrency helper for TX-005 and ERR-004. Two sessions race to
+// update the same node inside explicit transactions, one held open past the
+// other's commit. Returns the list of errors raised. Timing-sensitive by
+// nature: callers assert on the whole collected set, not a single index.
+async function raceTwoWriters(driver, database, marker) {
+  const setup = driver.session({ database });
+  try {
+    await setup.run(
+      "MERGE (n:RaceProbe {marker: $marker}) SET n.value = 0",
+      { marker }
+    );
+  } finally {
+    await setup.close();
+  }
+
+  const errors = [];
+  async function racingWrite() {
+    const s = driver.session({ database });
+    const tx = s.beginTransaction();
+    try {
+      await tx.run(
+        "MATCH (n:RaceProbe {marker: $marker}) SET n.value = n.value + 1 RETURN n",
+        { marker }
+      );
+      await new Promise((r) => setTimeout(r, 500));
+      await tx.commit();
+    } catch (e) {
+      errors.push(e);
+      try { await tx.rollback(); } catch (_) { /* already broken */ }
+    } finally {
+      await s.close();
+    }
+  }
+
+  await Promise.all([racingWrite(), racingWrite()]);
+  // Diagnostic (printed unconditionally so it shows even on an unexpected
+  // pass): an isolated flip to a genuine TransientError is a real,
+  // actionable server-behavior change worth concrete evidence for.
+  errors.forEach((e, i) =>
+    console.log(`raceTwoWriters[${marker}] errors[${i}]: code=${e.code} msg=${e.message}`)
+  );
+  return errors;
+}
+```
+
+- [ ] **Step 2: Add the transactions describe block**
+
+```js
+  // --- transactions ------------------------------------------------------
+  describe("transactions", () => {
+    it("[TX-001] autocommit query executes and returns results", async () => {
+      const s = session();
+      try {
+        const r = await s.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 5");
+        expect(r.records).toHaveLength(5);
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[TX-002] explicit BEGIN/RUN/COMMIT persists changes", async () => {
+      const s = session();
+      try {
+        const tx = s.beginTransaction();
+        await tx.run("CREATE (:TxCommitProbe {marker: 'tx-002'})");
+        await tx.commit();
+        const r = await s.run(
+          "MATCH (n:TxCommitProbe {marker: 'tx-002'}) RETURN count(n) AS c"
+        );
+        expect(r.records[0].get("c").toNumber()).toBe(1);
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[TX-003] explicit BEGIN/RUN/ROLLBACK discards changes", async () => {
+      const s = session();
+      try {
+        const tx = s.beginTransaction();
+        await tx.run("CREATE (:TxRollbackProbe {marker: 'tx-003'})");
+        await tx.rollback();
+        const r = await s.run(
+          "MATCH (n:TxRollbackProbe {marker: 'tx-003'}) RETURN count(n) AS c"
+        );
+        expect(r.records[0].get("c").toNumber()).toBe(0);
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[TX-004] managed executeWrite commits on success", async () => {
+      const s = session();
+      try {
+        await s.executeWrite((tx) =>
+          tx.run("CREATE (:Beer {name: $n})", { n: "TX-004-Beer" })
+        );
+        const r = await s.run(
+          "MATCH (b:Beer {name: $n}) RETURN count(b) AS c",
+          { n: "TX-004-Beer" }
+        );
+        expect(r.records[0].get("c").toNumber()).toBe(1);
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[TX-005] managed transaction retries on Neo.TransientError.*", async () => {
+      const errors = await raceTwoWriters(driver, "beer", "tx-005");
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors.some((e) => String(e.code).startsWith("Neo.TransientError"))).toBe(true);
+    });
+  });
+```
+
+- [ ] **Step 3: Run the transaction tests**
+
+Run: `cd e2e-js && npx jest src/js-bolt-conformance.test.js -t 'TX-00'`
+Expected: PASS (5 passing). TX-005 is timing-sensitive; if it flakes, confirm the losing writer surfaces a code starting `Neo.TransientError` (the diagnostic line prints the actual code). Per `main` spec.yaml TX-005 is `passing`, so a TransientError is expected here.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e-js/src/js-bolt-conformance.test.js
+git commit -m "test(#4888): transaction conformance scenarios (TX-001..005)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Causal consistency + multi-database (CAUSAL-001, MDB-001, MDB-002)
+
+**Files:**
+- Modify: `e2e-js/src/js-bolt-conformance.test.js`
+
+**Interfaces:**
+- Consumes: `session`, `driver` from Task 1 (uses the `boltscratch` DB seeded in Task 1).
+
+- [ ] **Step 1: Add causal-consistency + multi-database blocks**
+
+```js
+  // --- causal-consistency ------------------------------------------------
+  describe("causal-consistency", () => {
+    it("[CAUSAL-001] bookmark enforces read-after-write across sessions", async () => {
+      const a = session();
+      let bookmarks;
+      try {
+        await a.run("CREATE (:CausalProbe {marker: 'causal-001'})");
+        bookmarks = a.lastBookmarks();
+      } finally {
+        await a.close();
+      }
+      const b = driver.session({ database: "beer", bookmarks });
+      try {
+        const r = await b.run(
+          "MATCH (n:CausalProbe {marker: 'causal-001'}) RETURN count(n) AS c"
+        );
+        expect(r.records[0].get("c").toNumber()).toBe(1);
+      } finally {
+        await b.close();
+      }
+    });
+  });
+
+  // --- multi-database ----------------------------------------------------
+  describe("multi-database", () => {
+    it("[MDB-001] session selects a specific named database", async () => {
+      const s = session("beer");
+      try {
+        const r = await s.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 1");
+        expect(r.records[0].get("name")).not.toBeNull();
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[MDB-002] sessions across databases are isolated", async () => {
+      const scratch = session("boltscratch");
+      const tx = scratch.beginTransaction();
+      try {
+        await tx.run("CREATE (:ScratchProbe {marker: 'mdb-002'})");
+        const beer = session("beer");
+        try {
+          const r = await beer.run(
+            "MATCH (n:ScratchProbe {marker: 'mdb-002'}) RETURN count(n) AS c"
+          );
+          expect(r.records[0].get("c").toNumber()).toBe(0);
+        } finally {
+          await beer.close();
+        }
+        await tx.commit();
+      } finally {
+        await scratch.close();
+      }
+      const verify = session("boltscratch");
+      try {
+        const r = await verify.run(
+          "MATCH (n:ScratchProbe {marker: 'mdb-002'}) RETURN count(n) AS c"
+        );
+        expect(r.records[0].get("c").toNumber()).toBe(1);
+      } finally {
+        await verify.close();
+      }
+    });
+  });
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cd e2e-js && npx jest src/js-bolt-conformance.test.js -t 'CAUSAL-0|MDB-0'`
+Expected: PASS (3 passing).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e-js/src/js-bolt-conformance.test.js
+git commit -m "test(#4888): causal-consistency + multi-database scenarios
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Result handling (RESULT-001..RESULT-004)
+
+RESULT-004 is a known gap -> `it.failing`.
+
+**Files:**
+- Modify: `e2e-js/src/js-bolt-conformance.test.js`
+
+**Interfaces:**
+- Consumes: `session`, `driver` from Task 1.
+
+- [ ] **Step 1: Add the result-handling block**
+
+```js
+  // --- result-handling ---------------------------------------------------
+  describe("result-handling", () => {
+    it("[RESULT-001] streaming PULL returns records incrementally", async () => {
+      const s = session();
+      try {
+        const result = s.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 10");
+        let seen = 0;
+        for await (const record of result) {
+          expect(record.get("name")).not.toBeNull();
+          seen += 1;
+        }
+        expect(seen).toBe(10);
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[RESULT-002] PULL n streams exactly n, further PULL continues", async () => {
+      const s = session("beer", { fetchSize: 2 });
+      try {
+        const result = s.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 5");
+        const it = result[Symbol.asyncIterator]();
+        const first = [await it.next(), await it.next()];
+        expect(first.every((x) => !x.done)).toBe(true);
+        let rest = 0;
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+          const n = await it.next();
+          if (n.done) break;
+          rest += 1;
+        }
+        expect(rest).toBe(3);
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[RESULT-003] DISCARD abandons remaining rows", async () => {
+      const s = session("beer", { fetchSize: 1 });
+      try {
+        const result = s.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 5");
+        const it = result[Symbol.asyncIterator]();
+        await it.next(); // pull 1
+        const summary = await result.consume(); // DISCARD remainder
+        expect(summary).toBeDefined();
+      } finally {
+        await s.close();
+      }
+    });
+
+    // KNOWN GAP (#4890): the Bolt layer never populates a 'stats' key in
+    // SUCCESS metadata for write queries, so counters are always empty. This
+    // it.failing asserts the Neo4j-correct behavior and flips red when fixed -
+    // convert to it() and update current_status in spec.yaml in the same PR.
+    it.failing("[RESULT-004] ResultSummary counters reflect writes", async () => {
+      const s = session();
+      try {
+        const result = await s.run(
+          "CREATE (:Beer {name: $n})-[:BREWED_BY]->(:Brewery {name: $b})",
+          { n: "RESULT-004-Beer", b: "RESULT-004-Brewery" }
+        );
+        const c = result.summary.counters.updates();
+        expect(c.nodesCreated).toBe(2);
+        expect(c.relationshipsCreated).toBe(1);
+        expect(c.propertiesSet).toBeGreaterThanOrEqual(2);
+      } finally {
+        await s.close();
+      }
+    });
+  });
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cd e2e-js && npx jest src/js-bolt-conformance.test.js -t 'RESULT-00'`
+Expected: PASS (4 passing - RESULT-004 passes *because* its body fails as the gap predicts). If RESULT-004 unexpectedly passes, the gap is fixed: convert to `it()` and flip spec.yaml RESULT-004 to `passing`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e-js/src/js-bolt-conformance.test.js
+git commit -m "test(#4888): result-handling scenarios incl. RESULT-004 known gap
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Type round-trip part A - graph/scalar (TYPE-001..TYPE-006)
+
+TYPE-003 is a known gap -> `it.failing`.
+
+**Files:**
+- Modify: `e2e-js/src/js-bolt-conformance.test.js`
+
+**Interfaces:**
+- Consumes: `session` from Task 1, `neo4j` module.
+
+- [ ] **Step 1: Open a `type-roundtrip` describe block with TYPE-001..006**
+
+```js
+  // --- type-roundtrip ----------------------------------------------------
+  describe("type-roundtrip", () => {
+    it("[TYPE-001] node round-trips as a native Bolt structure", async () => {
+      const s = session();
+      try {
+        const r = await s.run("MATCH (b:Beer) RETURN b LIMIT 1");
+        const node = r.records[0].get("b");
+        expect(node).toBeInstanceOf(neo4j.types.Node);
+        expect(node.labels).toContain("Beer");
+        expect(node.properties.name).toBeDefined();
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[TYPE-002] relationship round-trips as a native Bolt structure", async () => {
+      const s = session();
+      try {
+        const r = await s.run("MATCH ()-[rel]->() RETURN rel LIMIT 1");
+        const rel = r.records[0].get("rel");
+        expect(rel).toBeInstanceOf(neo4j.types.Relationship);
+        expect(rel.type).toBeDefined();
+      } finally {
+        await s.close();
+      }
+    });
+
+    // KNOWN GAP (#4890): BoltPath.java has zero call sites - query results
+    // never produce native Path structures. Asserts the correct behavior;
+    // flips red when fixed. Convert + update spec.yaml TYPE-003 then.
+    it.failing("[TYPE-003] path round-trips as a native Bolt structure", async () => {
+      const s = session();
+      try {
+        const r = await s.run("MATCH p=(b:Beer)-[*1..2]-() RETURN p LIMIT 1");
+        const p = r.records[0].get("p");
+        expect(p).toBeInstanceOf(neo4j.types.Path);
+        expect(p.segments.length).toBeGreaterThanOrEqual(1);
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[TYPE-004] ByteArray round-trips as a bound parameter", async () => {
+      const s = session();
+      try {
+        const payload = Int8Array.from([1, 2, 3, 4]);
+        const r = await s.run("RETURN $b AS echo", { b: payload });
+        const echo = r.records[0].get("echo");
+        expect(Array.from(echo)).toEqual([1, 2, 3, 4]);
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[TYPE-005] nested lists and maps round-trip structurally", async () => {
+      const s = session();
+      try {
+        const r = await s.run(
+          "MATCH (t:TypeMatrix) RETURN t.nestedListProp AS l, t.nestedMapProp AS m"
+        );
+        expect(r.records[0].get("l")).toEqual([
+          neo4j.int(1), neo4j.int(2), [neo4j.int(3), neo4j.int(4)],
+        ]);
+        expect(r.records[0].get("m")).toEqual({
+          a: neo4j.int(1), b: { c: neo4j.int(2) },
+        });
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[TYPE-006] null values round-trip", async () => {
+      const s = session();
+      try {
+        const r = await s.run("MATCH (t:TypeMatrix) RETURN t.nullProp AS n");
+        expect(r.records[0].get("n")).toBeNull();
+        const e = await s.run("RETURN $p AS echo", { p: null });
+        expect(e.records[0].get("echo")).toBeNull();
+      } finally {
+        await s.close();
+      }
+    });
+  });
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cd e2e-js && npx jest src/js-bolt-conformance.test.js -t 'TYPE-00[1-6]'`
+Expected: PASS (6 passing; TYPE-003 green because its body fails as predicted). TYPE-004's byte representation and TYPE-005's integer wrapping (`neo4j.int` vs plain number) are driver specifics - if an assertion mismatches, read the actual returned value from the failure output and adjust the expectation to the driver's real representation (the scenario certifies round-trip fidelity, not a hardcoded JS type). Note: leave the `describe("type-roundtrip")` block open; Task 7 appends TYPE-007..012 before its closing brace.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e-js/src/js-bolt-conformance.test.js
+git commit -m "test(#4888): type round-trip A (TYPE-001..006) incl. TYPE-003 gap
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Type round-trip part B - temporal/duration/point (TYPE-007..TYPE-012)
+
+TYPE-007..010 pass (native temporals work per `main` spec.yaml). TYPE-011 (Duration) and TYPE-012 (Point) are known gaps -> `it.failing`.
+
+**Files:**
+- Modify: `e2e-js/src/js-bolt-conformance.test.js`
+
+**Interfaces:**
+- Consumes: `session` from Task 1, `neo4j` module.
+
+- [ ] **Step 1: Append TYPE-007..012 inside the `type-roundtrip` describe block (after TYPE-006)**
+
+```js
+    it("[TYPE-007] LocalDate round-trips as a native Bolt Date", async () => {
+      const s = session();
+      try {
+        const r = await s.run("MATCH (t:TypeMatrix) RETURN t.localDateProp AS d");
+        const d = r.records[0].get("d");
+        expect(d).toBeInstanceOf(neo4j.types.Date);
+        const e = await s.run("RETURN $d AS echo", { d });
+        expect(e.records[0].get("echo")).toEqual(d);
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[TYPE-008] LocalTime round-trips as a native Bolt LocalTime", async () => {
+      const s = session();
+      try {
+        const r = await s.run("MATCH (t:TypeMatrix) RETURN t.localTimeProp AS t2");
+        const t2 = r.records[0].get("t2");
+        expect(t2).toBeInstanceOf(neo4j.types.LocalTime);
+        const e = await s.run("RETURN $t AS echo", { t: t2 });
+        expect(e.records[0].get("echo")).toEqual(t2);
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[TYPE-009] LocalDateTime round-trips as a native Bolt LocalDateTime", async () => {
+      const s = session();
+      try {
+        const r = await s.run("MATCH (t:TypeMatrix) RETURN t.localDateTimeProp AS dt");
+        const dt = r.records[0].get("dt");
+        expect(dt).toBeInstanceOf(neo4j.types.LocalDateTime);
+        const e = await s.run("RETURN $dt AS echo", { dt });
+        expect(e.records[0].get("echo")).toEqual(dt);
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[TYPE-010] offset DateTime round-trips as a native Bolt DateTime", async () => {
+      const s = session();
+      try {
+        const r = await s.run("MATCH (t:TypeMatrix) RETURN t.offsetDateTimeProp AS dt");
+        const dt = r.records[0].get("dt");
+        expect(dt).toBeInstanceOf(neo4j.types.DateTime);
+        // fixture offset is +02:00 -> 7200 seconds
+        expect(dt.timeZoneOffsetSeconds).toBe(7200);
+        const e = await s.run("RETURN $dt AS echo", { dt });
+        expect(e.records[0].get("echo")).toEqual(dt);
+      } finally {
+        await s.close();
+      }
+    });
+
+    // KNOWN GAP (#4890): no Duration handling in BoltStructureMapper/
+    // PackStreamWriter - falls through to value.toString().
+    it.failing("[TYPE-011] Duration round-trips as a native Bolt Duration", async () => {
+      const s = session();
+      try {
+        const r = await s.run("MATCH (t:TypeMatrix) RETURN t.durationProp AS d");
+        const d = r.records[0].get("d");
+        expect(d).toBeInstanceOf(neo4j.types.Duration);
+        const e = await s.run("RETURN $d AS echo", { d });
+        expect(e.records[0].get("echo")).toEqual(d);
+      } finally {
+        await s.close();
+      }
+    });
+
+    // KNOWN GAP (#4890): no Point/spatial handling anywhere in the Bolt
+    // serialization path (the Cypher engine itself supports point()).
+    it.failing("[TYPE-012] Point round-trips as a native Bolt Point", async () => {
+      const s = session();
+      try {
+        const r = await s.run("MATCH (t:TypeMatrix) RETURN t.pointProp AS p");
+        const p = r.records[0].get("p");
+        expect(p).toBeInstanceOf(neo4j.types.Point);
+        expect(p.x).toBeCloseTo(12.34);
+        expect(p.y).toBeCloseTo(56.78);
+        const e = await s.run("RETURN $p AS echo", { p });
+        expect(e.records[0].get("echo").x).toBeCloseTo(12.34);
+      } finally {
+        await s.close();
+      }
+    });
+  }); // close type-roundtrip describe
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cd e2e-js && npx jest src/js-bolt-conformance.test.js -t 'TYPE-0(07|08|09|10|11|12)'`
+Expected: PASS (6 passing; TYPE-011/012 green because their bodies fail as predicted). If a temporal `instanceof` mismatches (e.g. LocalTime returned as `Time`), adjust to the driver's actual class from the failure output - `main` spec.yaml marks TYPE-007..010 `passing`, so a native temporal type IS expected; only the exact class name is driver-specific. If TYPE-011/012 unexpectedly pass, the gap was fixed: convert to `it()` and update spec.yaml.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e-js/src/js-bolt-conformance.test.js
+git commit -m "test(#4888): type round-trip B (TYPE-007..012) incl. Duration/Point gaps
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Errors (ERR-001..ERR-004)
+
+ERR-002 known gap -> `it.failing`; ERR-003 not-applicable -> `it.skip`; ERR-004 uses the race helper.
+
+**Files:**
+- Modify: `e2e-js/src/js-bolt-conformance.test.js`
+
+**Interfaces:**
+- Consumes: `session`, `driver` from Task 1, `raceTwoWriters` from Task 3.
+
+- [ ] **Step 1: Add the errors describe block**
+
+```js
+  // --- errors ------------------------------------------------------------
+  describe("errors", () => {
+    it("[ERR-001] syntax error returns Neo.ClientError.Statement.SyntaxError", async () => {
+      const s = session();
+      try {
+        await expect(s.run("MATCH (n RETURN n")).rejects.toMatchObject({
+          code: "Neo.ClientError.Statement.SyntaxError",
+        });
+      } finally {
+        await s.close();
+      }
+    });
+
+    // KNOWN GAP (#4890): semantic errors are surfaced as SyntaxError, not
+    // Neo.ClientError.Statement.SemanticError. Asserts the correct code;
+    // flips red when the mapping is fixed.
+    it.failing("[ERR-002] semantic error returns SemanticError code", async () => {
+      const s = session();
+      try {
+        await expect(
+          s.run("MATCH (n:Beer) RETURN undefinedVariable")
+        ).rejects.toMatchObject({
+          code: "Neo.ClientError.Statement.SemanticError",
+        });
+      } finally {
+        await s.close();
+      }
+    });
+
+    // NOT APPLICABLE: exercising a RUN before HELLO/LOGON needs a raw Bolt
+    // socket; the managed neo4j-driver always authenticates first, so this
+    // cannot be driven through the official driver. Skipped as in the
+    // Python/Go/C# suites. See ERR-003 / #4890.
+    it.skip("[ERR-003] unauthenticated request returns Forbidden (raw socket)", () => {});
+
+    it("[ERR-004] transient conditions surface Neo.TransientError.*", async () => {
+      const errors = await raceTwoWriters(driver, "beer", "err-004");
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors.some((e) => String(e.code).startsWith("Neo.TransientError"))).toBe(true);
+    });
+  });
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cd e2e-js && npx jest src/js-bolt-conformance.test.js -t 'ERR-00'`
+Expected: PASS (3 pass + 1 skip; ERR-002 green because body fails as predicted). If ERR-002's error `code` is already `SemanticError`, the gap is fixed: convert to `it()` and update spec.yaml. ERR-004 mirrors TX-005; both certify the same transient-error surfacing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e-js/src/js-bolt-conformance.test.js
+git commit -m "test(#4888): error conformance scenarios (ERR-001..004)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Protocol (PROTO-001..PROTO-003)
+
+PROTO-002 known gap -> `it.failing`.
+
+**Files:**
+- Modify: `e2e-js/src/js-bolt-conformance.test.js`
+
+**Interfaces:**
+- Consumes: `session`, `driver`, `boltUri` from Task 1.
+
+- [ ] **Step 1: Add the protocol describe block**
+
+```js
+  // --- protocol ----------------------------------------------------------
+  describe("protocol", () => {
+    it("[PROTO-001] version negotiation succeeds (4.4/4.0/3.0)", async () => {
+      // A successful query proves the handshake negotiated a supported
+      // version; the pinned neo4j-driver offers a range including 4.4.
+      const s = session();
+      try {
+        const r = await s.run("RETURN 1 AS v");
+        expect(r.records[0].get("v").toNumber()).toBe(1);
+      } finally {
+        await s.close();
+      }
+    });
+
+    // KNOWN GAP (#4890): the server never advertises any Bolt 5.x version;
+    // 5.x-capable drivers only work by silently downgrading to 4.4, which is
+    // undocumented/untested as a deliberate stance. There is no driver knob
+    // to force 5.x-only negotiation through the managed API, so this asserts
+    // the documented-non-support fact: the server's negotiated protocol is
+    // <= 4.4. It flips red only if the server starts advertising 5.x.
+    it.failing("[PROTO-002] Bolt 5.x negotiation is supported", async () => {
+      const info = await driver.getServerInfo({ database: "beer" });
+      // protocolVersion is a number like 4.4 or 5.x; assert 5.x is negotiated.
+      expect(Number(info.protocolVersion)).toBeGreaterThanOrEqual(5);
+    });
+
+    it("[PROTO-003] RESET returns the connection to a clean state", async () => {
+      const s = session("beer", { fetchSize: 2 });
+      try {
+        // Start a partial stream (server holds remaining rows).
+        const first = s.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 5");
+        const it = first[Symbol.asyncIterator]();
+        await it.next();
+        await first.consume(); // discard/reset the pending stream
+        // The session accepts a fresh RUN immediately afterward.
+        const r = await s.run("RETURN 1 AS v");
+        expect(r.records[0].get("v").toNumber()).toBe(1);
+      } finally {
+        await s.close();
+      }
+    });
+  });
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cd e2e-js && npx jest src/js-bolt-conformance.test.js -t 'PROTO-00'`
+Expected: PASS (3 passing; PROTO-002 green because `protocolVersion` is 4.x, so its body fails as predicted). If `getServerInfo` does not expose `protocolVersion` in this driver version, read the actual server-info shape from the failure and assert on the negotiated version field the driver does expose; the certification point is that it is < 5.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e-js/src/js-bolt-conformance.test.js
+git commit -m "test(#4888): protocol conformance scenarios (PROTO-001..003)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: TLS scenarios (CONN-002, CONN-005)
+
+Highest-risk task: a keytool-generated self-signed keystore/truststore baked into a derived image, two extra containers started lazily. Direct port of `e2e-python`'s `generate_tls_certs`/`build_tls_image`/TLS fixtures.
+
+**Files:**
+- Modify: `e2e-js/src/js-bolt-conformance.test.js`
+
+**Interfaces:**
+- Consumes: `IMAGE`, `ROOT_PASSWORD`, `BASE_JAVA_OPTS`, `neo4j`, `GenericContainer`, `Wait` from Task 1.
+
+- [ ] **Step 1: Add module-level TLS helpers (above the top-level describe)**
+
+```js
+const TLS_STORE_PASSWORD = "changeit";
+
+// Generate a throwaway self-signed keystore/truststore with the JDK keytool.
+// ArcadeDB ships no default TLS store, so REQUIRED/OPTIONAL modes need one or
+// startup crashes. Returns the temp dir holding keystore.p12 + truststore.jks,
+// or null if keytool is unavailable (local runs without a JDK skip TLS).
+function generateTlsCerts() {
+  let keytool;
+  try {
+    keytool = execFileSync("which", ["keytool"]).toString().trim();
+  } catch (_) {
+    return null;
+  }
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bolt-tls-"));
+  const keystore = path.join(dir, "keystore.p12");
+  const truststore = path.join(dir, "truststore.jks");
+  const cert = path.join(dir, "bolt.cer");
+  execFileSync(keytool, [
+    "-genkeypair", "-alias", "bolt", "-keyalg", "RSA", "-keysize", "2048",
+    "-validity", "3650", "-keystore", keystore, "-storetype", "PKCS12",
+    "-storepass", TLS_STORE_PASSWORD, "-keypass", TLS_STORE_PASSWORD,
+    "-dname", "CN=localhost, OU=ArcadeDB, O=ArcadeDB, L=Test, ST=Test, C=US",
+  ]);
+  execFileSync(keytool, [
+    "-exportcert", "-alias", "bolt", "-keystore", keystore,
+    "-storetype", "PKCS12", "-storepass", TLS_STORE_PASSWORD, "-file", cert,
+  ]);
+  execFileSync(keytool, [
+    "-importcert", "-alias", "bolt", "-keystore", truststore,
+    "-storetype", "JKS", "-storepass", TLS_STORE_PASSWORD, "-file", cert, "-noprompt",
+  ]);
+  return dir;
+}
+
+// Build a derived image with the certs COPYied in (bind-mounts are unreliable
+// on some CI runners - the Python fixture documents empty mounted dirs). Uses
+// testcontainers' Dockerfile build so the COPY resolves its own context.
+async function buildTlsImage(certDir) {
+  fs.writeFileSync(
+    path.join(certDir, "Dockerfile"),
+    `FROM ${IMAGE}\n` +
+      "COPY --chown=arcadedb:arcadedb keystore.p12 truststore.jks /home/arcadedb/tls_certs/\n"
+  );
+  return GenericContainer.fromDockerfile(certDir).build("arcadedb-bolt-tls-test:latest");
+}
+
+function tlsJavaOpts(mode) {
+  return (
+    BASE_JAVA_OPTS +
+    ` -Darcadedb.bolt.ssl=${mode}` +
+    " -Darcadedb.ssl.keyStore=/home/arcadedb/tls_certs/keystore.p12" +
+    ` -Darcadedb.ssl.keyStorePassword=${TLS_STORE_PASSWORD}` +
+    " -Darcadedb.ssl.trustStore=/home/arcadedb/tls_certs/truststore.jks" +
+    ` -Darcadedb.ssl.trustStorePassword=${TLS_STORE_PASSWORD}`
+  );
+}
+```
+
+- [ ] **Step 2: Add a TLS describe block with its own lifecycle (inside the top-level describe)**
+
+```js
+  // --- connection: TLS ---------------------------------------------------
+  describe("connection-tls", () => {
+    let builtImage; // testcontainers-built derived image (or null if skipped)
+    let certDir;
+    let tlsRequired;
+    let tlsOptional;
+
+    beforeAll(async () => {
+      certDir = generateTlsCerts();
+      if (!certDir) return; // keytool absent -> tests below self-skip
+      builtImage = await buildTlsImage(certDir);
+    });
+
+    afterAll(async () => {
+      if (tlsRequired) await tlsRequired.stop();
+      if (tlsOptional) await tlsOptional.stop();
+    });
+
+    it("[CONN-002] connect via bolt+ssc:// with TLS required", async () => {
+      if (!certDir) return console.warn("keytool absent - skipping CONN-002");
+      tlsRequired = await builtImage
+        .withExposedPorts(2480, 7687)
+        .withEnvironment({ JAVA_OPTS: tlsJavaOpts("REQUIRED") })
+        .withStartupTimeout(120000)
+        .withWaitStrategy(
+          Wait.forHttp("/api/v1/ready", 2480).forStatusCodeMatching((sc) => sc === 204)
+        )
+        .start();
+      const uri = `bolt+ssc://${tlsRequired.getHost()}:${tlsRequired.getMappedPort(7687)}`;
+      const d = neo4j.driver(uri, neo4j.auth.basic("root", ROOT_PASSWORD));
+      try {
+        await d.verifyConnectivity();
+        const s = d.session({ database: "beer" });
+        try {
+          const r = await s.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 1");
+          expect(r.records[0].get("name")).not.toBeNull();
+        } finally {
+          await s.close();
+        }
+      } finally {
+        await d.close();
+      }
+    });
+
+    it("[CONN-005] TLS OPTIONAL falls back to plaintext bolt://", async () => {
+      if (!certDir) return console.warn("keytool absent - skipping CONN-005");
+      tlsOptional = await builtImage
+        .withExposedPorts(2480, 7687)
+        .withEnvironment({ JAVA_OPTS: tlsJavaOpts("OPTIONAL") })
+        .withStartupTimeout(120000)
+        .withWaitStrategy(
+          Wait.forHttp("/api/v1/ready", 2480).forStatusCodeMatching((sc) => sc === 204)
+        )
+        .start();
+      const uri = `bolt://${tlsOptional.getHost()}:${tlsOptional.getMappedPort(7687)}`;
+      const d = neo4j.driver(uri, neo4j.auth.basic("root", ROOT_PASSWORD));
+      try {
+        await d.verifyConnectivity();
+      } finally {
+        await d.close();
+      }
+    });
+  });
+```
+
+- [ ] **Step 3: Run the TLS tests (requires keytool on PATH)**
+
+Run: `cd e2e-js && npx jest src/js-bolt-conformance.test.js -t 'CONN-002|CONN-005'`
+Expected: PASS (2 passing) when `keytool` is available. If `GenericContainer.fromDockerfile(...).build(...)` API differs in `testcontainers` ^12, consult its typings (`node_modules/testcontainers/build/generic-container/...`) and adjust the build call; the fallback of last resort is a runtime bind mount, but prefer the derived-image build. If `keytool` is absent locally, both self-skip with a warning - that is acceptable locally; CI runners have a JDK.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e-js/src/js-bolt-conformance.test.js
+git commit -m "test(#4888): TLS conformance scenarios (CONN-002, CONN-005)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: README, full-suite verification, and coverage proof
+
+**Files:**
+- Create: `e2e-js/README.md`
+
+**Interfaces:** none (documentation + verification only).
+
+- [ ] **Step 1: Write `e2e-js/README.md`**
+
+```markdown
+# e2e-js
+
+End-to-end tests for ArcadeDB's JavaScript-facing wire protocols, run with Jest
+against a real ArcadeDB container (testcontainers).
+
+## Suites
+
+- `src/js-bolt-conformance.test.js` - Bolt conformance suite (issue #4888,
+  epic #4882). Implements all 39 scenarios in `bolt/conformance/spec.yaml`
+  against the official `neo4j-driver`. Each test name is prefixed with its
+  spec id (`[AREA-NNN]`) for traceability.
+- `src/js-bolt-e2e.test.js` - Bolt variable-length-path regression (#4452/#4271).
+- `src/js-pg-e2e.test.js` - PostgreSQL wire-protocol smoke test.
+
+## Driver version band
+
+`spec.yaml` assigns JS the bands `[oldest-supported-4.x, latest-5.x, latest-6.x]`.
+This suite PR-gates a single pinned `neo4j-driver` 6.x (`package.json`,
+currently `^6.0.1`). Exercising all three bands on a schedule is #4891.
+
+## Known gaps (asserted via `it.failing`, tracked in #4890)
+
+RESULT-004 (write counters), TYPE-003 (native Path), TYPE-011 (Duration),
+TYPE-012 (Point), ERR-002 (semantic-error code), PROTO-002 (Bolt 5.x).
+Skipped: CONN-004 (needs a 3-node HA cluster), ERR-003 (needs a raw socket).
+
+## Run
+
+```bash
+npm install
+ARCADEDB_DOCKER_IMAGE=arcadedata/arcadedb:latest npm test
+```
+
+TLS scenarios (CONN-002/CONN-005) need a JDK `keytool` on PATH; they self-skip
+with a warning if it is absent.
+```
+
+- [ ] **Step 2: Prove all 39 scenario ids are present**
+
+Run: `grep -oE '\[[A-Z]+-[0-9]+\]' e2e-js/src/js-bolt-conformance.test.js | sort -u | wc -l`
+Expected: `39`
+
+Run: `for id in CONN-001 CONN-002 CONN-003 CONN-004 CONN-005 AUTH-001 AUTH-002 AUTH-003 TX-001 TX-002 TX-003 TX-004 TX-005 CAUSAL-001 MDB-001 MDB-002 RESULT-001 RESULT-002 RESULT-003 RESULT-004 TYPE-001 TYPE-002 TYPE-003 TYPE-004 TYPE-005 TYPE-006 TYPE-007 TYPE-008 TYPE-009 TYPE-010 TYPE-011 TYPE-012 ERR-001 ERR-002 ERR-003 ERR-004 PROTO-001 PROTO-002 PROTO-003; do grep -q "\[$id\]" e2e-js/src/js-bolt-conformance.test.js || echo "MISSING $id"; done`
+Expected: no output (every id present).
+
+- [ ] **Step 3: Run the whole conformance suite against the local image**
+
+Run: `cd e2e-js && npx jest src/js-bolt-conformance.test.js`
+Expected: 39 tests accounted for - 31 passing, 6 passing-via-`it.failing`, 2 skipped (CONN-004, ERR-003). No unexpected XPASS. If a gap XPASSes, convert it to `it()` and update `bolt/conformance/spec.yaml`'s `current_status` for that scenario in this same change.
+
+- [ ] **Step 4: Run the full module (both bolt files + pg) to confirm no regressions**
+
+Run: `cd e2e-js && npm test`
+Expected: all suites green; `js-bolt-e2e.test.js` unchanged and passing; `reports/jest-junit.xml` produced.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e-js/README.md
+git commit -m "docs(#4888): e2e-js README with driver band + known-gap summary
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** Every `spec.yaml` scenario maps to a task - connection (T1/T10), auth (T2), transactions (T3), causal+multi-db (T4), result-handling (T5), type-roundtrip (T6/T7), errors (T8), protocol (T9); README + coverage proof (T11). All 6 known gaps use `it.failing`; both skips use `it.skip`/warn. Fixture strategy, image resolution, HTTP-only seeding, and the untouched-regression constraint are all honored.
+
+**Placeholder scan:** No TBD/TODO. Each code step carries complete code. The "adjust to the driver's actual type" notes are deliberate TDD guidance for driver-specific representations (byte array, temporal class names, server-info shape), not placeholders - the assertions are written concretely and only refined if the live driver differs.
+
+**Type consistency:** `raceTwoWriters(driver, database, marker)` is defined in T3 and called with the same signature in T3 (TX-005) and T8 (ERR-004). `session(database, extra)`, `boltUri(scheme)`, `httpCommand(path, body)`, `IMAGE`, `BASE_JAVA_OPTS`, `ROOT_PASSWORD`, `TLS_STORE_PASSWORD`, `tlsJavaOpts(mode)`, `generateTlsCerts()`, `buildTlsImage(certDir)` are all defined once and consumed consistently.

--- a/docs/superpowers/specs/2026-07-04-e2e-js-bolt-conformance-design.md
+++ b/docs/superpowers/specs/2026-07-04-e2e-js-bolt-conformance-design.md
@@ -1,0 +1,301 @@
+# e2e-js Bolt conformance suite - design (issue #4888)
+
+Part of epic #4882 (Bolt Driver Compatibility Certification), Group B.
+Depends on the shared conformance spec `bolt/conformance/spec.yaml` (#4883,
+merged to main). Sibling references, all merged to main: `e2e-python` (#4885),
+`e2e-csharp` (#4886), `e2e-go` (#4887). The Python suite
+(`e2e-python/tests/test_bolt.py`) is the authoritative template this design
+mirrors.
+
+## Problem
+
+JavaScript is one of the five official Neo4j driver languages. `e2e-js` already
+has a Bolt test file (`src/js-bolt-e2e.test.js`), but it covers only connect +
+WHERE-filter reads + one variable-length-path regression test (issues
+#4452/#4271). No transactions, error paths, result-handling, or type-round-trip
+coverage exists. Every other language now has a full conformance suite driven by
+the shared spec; JS is the last Group B gap. This issue deepens `e2e-js` to all
+39 `spec.yaml` scenarios, at parity with the merged siblings, without disturbing
+the existing regression test.
+
+## Governing constraints (from the epic)
+
+- **Certify depth, not presence.** Every one of the 39 `spec.yaml` scenarios is
+  implemented as a discrete, traceable test. A "not supported" outcome is a
+  valid, complete answer only when asserted as a known gap, never silently
+  absent.
+- **Official driver only.** `neo4j-driver` (npm), the driver already declared in
+  `e2e-js/package.json` (`^6.0.1`). No mocks, no bespoke Bolt clients.
+- **One shared spec, polyglot code.** No new multi-language Bolt module; this is
+  an idiomatic Jest suite driven by the same `spec.yaml` the other four suites
+  consume by hand.
+- **Mirror the established pattern.** Match the merged e2e-python/e2e-go/
+  e2e-csharp structure, fixture strategy, seeding approach, gap-handling, and
+  `current_status` semantics so results are comparable across languages.
+- **Advertised identity is fixed.** The server reports "Neo4j/5.26.0
+  compatible"; the suite depends on `neo4j-driver` continuing to negotiate
+  Bolt 4.4 (silent downgrade from its native 5.x), exactly as the other four
+  suites do. A future driver major that drops legacy negotiation would break
+  the whole suite, not just PROTO-002.
+
+## Scope
+
+**In scope (issue #4888 acceptance criteria):**
+1. New `e2e-js/src/js-bolt-conformance.test.js`, implementing all 39 scenarios,
+   with `current_status` outcomes identical to `main`'s reconciled `spec.yaml`.
+2. Beer-dataset + `type-matrix.cypher` fixture strategy, seeded over HTTP (never
+   over Bolt), matching the Python/Go/C# fixtures.
+3. TLS scenarios (CONN-002, CONN-005) via a keytool-generated self-signed
+   keystore/truststore baked into a derived Docker image built at test time.
+4. Existing `js-bolt-e2e.test.js` VLP regression test preserved byte-for-byte.
+5. Known-gap and infra-unavailable scenarios asserted/skipped with a reason and
+   a `#4890` reference, never silently absent.
+6. `jest-junit` output confirmed produced for the new suite (already wired in
+   `package.json`).
+
+**Out of scope (deferred, owned by other issues):**
+- Multi-version driver-band matrix + nightly scheduled run -> #4891.
+- JUnit-report aggregation / published compatibility matrix / badge -> #4891,
+  #4892. This suite emits `jest-junit.xml` (already configured) but does not add
+  cross-suite aggregation.
+- Any server-side protocol/type-fidelity fix (native Path, Duration, Point,
+  `Neo.TransientError.*` beyond what already works, HA-aware ROUTE, Bolt 5.x)
+  -> #4890. This suite only *observes and documents* those gaps.
+- 3-node HA cluster orchestration (CONN-004) - skipped here as in the Python/
+  Go/C# suites.
+
+## Decisions taken (were open questions; defaulted while user was away)
+
+- **Full mirror including TLS.** CONN-002/CONN-005 are implemented, not skipped.
+  Parity/comparability across all five languages is the epic's core aim;
+  skipping TLS in JS only would leave two cells uncertified relative to the
+  other four suites. Risk (derived-image build in testcontainers-js) is
+  mitigated below.
+- **Existing regression file left fully untouched.** The new conformance file
+  honors `ARCADEDB_DOCKER_IMAGE`; `js-bolt-e2e.test.js` keeps its hardcoded
+  `arcadedata/arcadedb:latest`, honoring the issue's "preserved unchanged"
+  requirement. (In CI the branch image is `docker load`ed and the env var is
+  passed to the new file; the old file already works against the loaded tag.)
+
+## Architecture
+
+A second Jest test file in the existing module - no new module, no `pom.xml`
+change (`e2e-js` already sits outside the Maven reactor). Jest runs with
+`--runInBand` (see `package.json` test script), so the two files' containers
+never run concurrently; each file owns its own container lifecycle.
+
+```
+e2e-js/
+  package.json                     # unchanged deps (neo4j-driver ^6.0.1,
+                                   #   testcontainers ^12, jest ^30, jest-junit ^17)
+  src/
+    js-bolt-e2e.test.js            # UNCHANGED - VLP regression (#4452/#4271)
+    js-pg-e2e.test.js              # UNCHANGED - Postgres wire
+    js-bolt-conformance.test.js    # NEW - all 39 spec.yaml scenarios
+```
+
+All 39 scenarios live in one new file, organized with a `describe()` per spec
+area (connection, auth, transactions, causal-consistency, multi-database,
+result-handling, type-roundtrip, errors, protocol) and one `it()`/`test()` per
+scenario. Per the README traceability convention, every test name is prefixed
+with the bracketed scenario id, e.g. `test('[TYPE-011] duration round-trip',
+...)`, so `grep -o '\[[A-Z]*-[0-9]*\]'` over the file proves 39/39 coverage.
+
+### Fixture strategy (mirrors the Python fixture exactly)
+
+- **Plain container** (used by ~35 scenarios): `GenericContainer` on the
+  resolved image, exposing 2480 (HTTP) + 7687 (Bolt), with base `JAVA_OPTS`:
+  ```
+  -Darcadedb.server.rootPassword=playwithdata
+  -Darcadedb.server.defaultDatabases=beer[root]{import:https://github.com/ArcadeData/arcadedb-datasets/raw/main/orientdb/OpenBeer.gz}
+  -Darcadedb.server.plugins=BoltProtocolPlugin
+  ```
+  Boot waits on `GET /api/v1/ready` -> 204 (`Wait.forHttp`, already used by the
+  existing file). Then, over HTTP only: `create database boltscratch` and seed
+  `type-matrix.cypher` into `beer` via `POST /api/v1/command/beer`
+  (`{language:"cypher", command:<file>}`). Seeding never touches Bolt so it does
+  not exercise the serialization path under test.
+- **Image resolution:** `process.env.ARCADEDB_DOCKER_IMAGE || "arcadedata/arcadedb:latest"`,
+  matching `ArcadeDbFixture.cs` / the Python fixture. In CI the branch-built
+  image tag is passed via that env var (the `js-e2e-tests` job already sets it).
+- **type-matrix fixture path:** read from
+  `path.resolve(__dirname, "../../bolt/conformance/fixtures/type-matrix.cypher")`
+  (`e2e-js/src` -> repo root). A one-time `fs.existsSync` guard fails with a
+  clear message if the path is wrong, rather than seeding an empty command.
+- **Lifecycle:** container start + seeding in `beforeAll`; a single shared
+  `driver` (basic auth root/playwithdata) created in `beforeAll` and closed in
+  `afterAll`; container stopped in `afterAll`. `jest.setTimeout(180000)` to
+  absorb the beer import + optional TLS image build (Python uses 60-120s waits).
+- **Write-collision avoidance:** write-emitting scenarios (TX-002/004,
+  CAUSAL-001, MDB-002, RESULT-004) use unique marker property values rather than
+  isolated databases and assert on marker-scoped counts, never on absolute
+  row/node totals - identical to the Python suite's rationale.
+
+### TLS strategy (CONN-002, CONN-005) - direct port of the Python fixture
+
+1. Generate a throwaway self-signed `keystore.p12` + `truststore.jks` with the
+   JDK `keytool` binary (present on `ubuntu-latest`; the two TLS tests skip with
+   a clear message if `keytool` is absent locally, matching Python).
+2. Build a derived image (`FROM <resolved base image>`, `COPY` the certs into
+   `/home/arcadedb/tls_certs/`) via testcontainers-js
+   `GenericContainer.fromDockerfile(contextDir).build(tag)`. A `docker build`
+   COPY resolves its own build context regardless of host/CI bind-mount quirks -
+   the Python fixture documents that GitHub runners have started containers with
+   an empty bind-mounted cert dir, so baking the certs in is the proven path.
+3. **CONN-002 (REQUIRED):** container with
+   `-Darcadedb.bolt.ssl=REQUIRED` + `arcadedb.ssl.keyStore/.trustStore` sysprops;
+   driver connects with the `bolt+ssc://` scheme (self-signed, no CA
+   verification) and runs a beer query.
+4. **CONN-005 (OPTIONAL):** container with `-Darcadedb.bolt.ssl=OPTIONAL`; a
+   plaintext `bolt://` driver connects successfully.
+
+TLS containers are started lazily inside the two TLS tests (or a dedicated
+nested `describe` with its own `beforeAll`/`afterAll`) so the ~35 non-TLS
+scenarios never pay TLS startup cost, and are torn down after. The derived image
+is removed in `afterAll`.
+
+### Strict-xfail: the Jest equivalent of `xfail(strict=True)`
+
+Jest ships this natively: **`test.failing()` / `it.failing()`** inverts the
+result - the test passes while its body throws (or an assertion fails), and
+**fails loudly if the body unexpectedly passes** (XPASS). That is exactly
+pytest's `xfail(strict=True)` and Go's `assertStillFails`, with no helper
+needed. Each known-gap test is written to assert the *Neo4j-correct* behavior
+(the behavior the gap currently prevents), wrapped in `it.failing(...)`, with a
+comment naming the gap and `#4890`. When the server gap is fixed the body starts
+passing, `it.failing` flips red, and whoever fixed it converts it to a normal
+`it()` and updates `current_status` in `spec.yaml` in the same PR.
+
+Passing scenarios use plain `it()` with `expect(...)`. Infra-unavailable
+scenarios use `it.skip()` (or `it()` early-returning after a logged skip
+reason for the `keytool`-absent case), carrying the same justification text the
+Python/Go suites use.
+
+## Scenario mapping (all 39) - target = `main`'s reconciled `spec.yaml`
+
+`current_status` values are taken verbatim from `main`'s `spec.yaml` (already
+reconciled by the merged Python/Go/C# PRs). The JS suite must reproduce the same
+outcome; where the `neo4j-driver` JS type mapping differs from Python's, the
+assertion checks the driver-returned concrete type, not a hardcoded guess (see
+notes).
+
+| Scenario | status | Jest handling |
+|---|---|---|
+| CONN-001 connect bolt:// | passing | `it`, `verifyConnectivity()` |
+| CONN-002 bolt+ssc TLS required | passing | TLS-required derived image, `bolt+ssc://` |
+| CONN-003 neo4j:// routing single-node | passing | `it`, `neo4j://` scheme |
+| CONN-004 neo4j:// HA topology | expected-fail | `it.skip` (needs 3-node cluster, #4890) |
+| CONN-005 TLS optional plaintext | passing | TLS-optional derived image, `bolt://` |
+| AUTH-001 basic auth valid | passing | `it` |
+| AUTH-002 basic auth invalid | passing | expect code `Neo.ClientError.Security.Unauthorized` |
+| AUTH-003 auth none rejected | passing | expect auth error (intentional rejection) |
+| TX-001 autocommit | passing | `it`, 5 rows |
+| TX-002 explicit commit persists | passing | `beginTransaction`/`commit`, marker count |
+| TX-003 explicit rollback discards | passing | `beginTransaction`/`rollback`, marker count 0 |
+| TX-004 managed executeWrite commits | unverified | assert passing via `executeWrite` |
+| TX-005 managed retry on transient | passing | two-writer race, expect `TransientError` |
+| CAUSAL-001 bookmark read-after-write | unverified | assert passing via `lastBookmarks()` |
+| MDB-001 session db selection | passing | `it` |
+| MDB-002 cross-db isolation | unverified | assert passing (boltscratch vs beer) |
+| RESULT-001 streaming pull | passing | `it`, iterate 10 |
+| RESULT-002 partial pull then continue | unverified | `fetchSize: 2`, assert passing |
+| RESULT-003 discard abandons remaining | passing | `it`, `result.consume()` |
+| RESULT-004 summary counters reflect writes | expected-fail | `it.failing` (empty counters) |
+| TYPE-001 node roundtrip | passing | `neo4j.types.Node` |
+| TYPE-002 relationship roundtrip | passing | `neo4j.types.Relationship` |
+| TYPE-003 path roundtrip | expected-fail | `it.failing` (no native Path) |
+| TYPE-004 bytearray param roundtrip | passing | byte-array param echo (concrete type confirmed in TDD) |
+| TYPE-005 nested list/map roundtrip | passing | `it`, deep-equal |
+| TYPE-006 null roundtrip | passing | `it`, null prop + null param |
+| TYPE-007 local date roundtrip | passing | `neo4j.types.Date` |
+| TYPE-008 local time roundtrip | passing | `neo4j.types.Time`/`LocalTime` |
+| TYPE-009 local datetime roundtrip | passing | `neo4j.types.LocalDateTime` |
+| TYPE-010 offset datetime roundtrip | passing | `neo4j.types.DateTime` w/ +02:00 offset |
+| TYPE-011 duration roundtrip | expected-fail | `it.failing` (comes back as string) |
+| TYPE-012 point roundtrip | expected-fail | `it.failing` (no Point handling) |
+| ERR-001 syntax error | passing | expect `Neo.ClientError.Statement.SyntaxError` |
+| ERR-002 semantic error | expected-fail | `it.failing` (mapped as SyntaxError) |
+| ERR-003 unauthenticated request rejected | not-applicable | `it.skip` (needs raw socket) |
+| ERR-004 transient condition code | passing | two-writer race, expect `TransientError` |
+| PROTO-001 negotiation succeeds | passing | `it` |
+| PROTO-002 Bolt 5.x negotiation documented | expected-fail | `it.failing` (never advertises 5.x) |
+| PROTO-003 reset mid-stream | unverified | `fetchSize: 2`, consume then re-run |
+
+Expected JS tally: **31 passing, 6 `it.failing` gaps** (RESULT-004, TYPE-003,
+TYPE-011, TYPE-012, ERR-002, PROTO-002), **2 skips** (CONN-004, ERR-003). Exact
+counts confirmed during TDD against the running container.
+
+**Notes on JS driver specifics (resolved empirically during TDD, not
+hardcoded):**
+- Temporal mapping: `neo4j-driver` returns `neo4j.types.Date`, `Time`/
+  `LocalTime`, `LocalDateTime`, `DateTime`. The assertion checks the concrete
+  returned type + a round-trip via `$param`, matching the Python suite intent.
+- Byte arrays: the JS driver's byte-array representation (e.g. `Int8Array`) is
+  confirmed against the running driver in TDD; TYPE-004 echoes a client-bound
+  byte array and asserts value equality.
+- The two-writer race (TX-005, ERR-004) is timing-sensitive: assert on the whole
+  collected error set for a `TransientError` (not a single index), and that no
+  non-retryable error appears - the Python suite's hardening.
+
+## Driver-version band
+
+`spec.yaml` assigns JS the bands `[oldest-supported-4.x, latest-5.x,
+latest-6.x]`, "resolved by #4888"; current repo baseline is `^6.0.1`. For
+PR-gating this suite pins a single concrete `neo4j-driver` 6.x version in
+`package.json` (the existing `^6.0.1`, or the latest 6.x patch if bumped during
+implementation), documented in `e2e-js/README.md` (added). Exercising all three
+bands on a schedule is #4891's responsibility; this issue must not front-run it
+(neither Python, Go, nor C# did).
+
+## CI
+
+No new CI job. The existing `js-e2e-tests` job in `.github/workflows/mvn-test.yml`
+runs `npm install && npm test`; Jest picks up the new `*.test.js` file
+automatically, and the job already passes `ARCADEDB_DOCKER_IMAGE` and loads the
+branch image. `jest-junit` (already configured in `package.json`)
+writes `reports/jest-junit.xml`. No CI edit is required for PR-gating; artifact
+upload/aggregation is deferred to #4891 (matching how the Go suite declined to
+front-run it).
+
+## Testing / verification approach
+
+TDD is awkward for a from-scratch e2e file (the container must exist before any
+test runs), so the practical sequence is:
+1. Scaffold the fixture (`beforeAll` container boot + HTTP seeding) plus a single
+   `[CONN-001]` test; get one green run against a locally-built branch image
+   first, proving the whole harness (boot, seed, connect) before fanning out.
+2. Add scenarios area by area (connection -> auth -> transactions -> ... ->
+   protocol), each verified against the real container as written.
+3. Verify the six `it.failing` scenarios genuinely reproduce their gap (the test
+   is green because the body throws/mismatches) - and sanity-check that
+   converting one to a plain `it()` makes it fail, proving the XPASS guard works.
+4. Wire and verify the TLS derived-image path locally (with `keytool` on PATH),
+   confirming CONN-002/CONN-005 pass; confirm the `keytool`-absent skip path.
+5. Full-suite run against a locally-built image
+   (`mvn -Pdocker -DskipTests -pl bolt,package -am` to produce
+   `arcadedata/arcadedb:latest`, the "debug against the real image" practice)
+   before opening the PR: 31 pass, 6 xfail-green, 2 skip, and the untouched
+   `js-bolt-e2e.test.js` still green.
+6. CI runs the existing job against the branch-built image; all cells behave as
+   above.
+
+No unit tests - this is an integration/e2e suite by nature, matching the sibling
+modules.
+
+## Risks / open points
+
+- **testcontainers-js `fromDockerfile` build** for the TLS derived image: if it
+  proves flaky in CI, the fallback is a runtime bind mount, but the
+  COPY-into-derived-image approach is the proven path across Python/Go/C# and is
+  preferred. Highest-risk item; validated locally in step 4 before the PR.
+- **JS driver temporal / byte-array concrete types**: resolved empirically in
+  TDD against the running container; the design does not hardcode them.
+- **Two container boots per `js-e2e-tests` job** (existing file + new file, run
+  sequentially under `--runInBand`): roughly doubles that job's wall-clock. This
+  is acceptable and matches the one-container-per-suite pattern; sharing a
+  container across the two files would require touching the "preserved
+  unchanged" regression file.
+- **Divergence from `spec.yaml`**: baseline target is `main`'s reconciled
+  statuses. If the JS driver empirically behaves differently from that (unlikely
+  for the shared server behavior), the JS suite asserts actual behavior and the
+  same PR reconciles `spec.yaml` - it is the shared source of truth.

--- a/e2e-js/.gitignore
+++ b/e2e-js/.gitignore
@@ -1,0 +1,2 @@
+# Jest / jest-junit test output
+reports/

--- a/e2e-js/README.md
+++ b/e2e-js/README.md
@@ -1,0 +1,55 @@
+# e2e-js
+
+End-to-end tests for ArcadeDB's JavaScript-facing wire protocols, run with Jest
+against a real ArcadeDB container (testcontainers).
+
+## Suites
+
+- `src/js-bolt-conformance.test.js` - Bolt conformance suite (issue #4888,
+  epic #4882). Implements all 39 scenarios in `bolt/conformance/spec.yaml`
+  against the official `neo4j-driver`. Each test name is prefixed with its
+  spec id (`[AREA-NNN]`) for traceability.
+- `src/js-bolt-e2e.test.js` - Bolt variable-length-path regression (#4452/#4271).
+- `src/js-pg-e2e.test.js` - PostgreSQL wire-protocol smoke test.
+
+## Driver version band
+
+`spec.yaml` assigns JS the bands `[oldest-supported-4.x, latest-5.x, latest-6.x]`.
+This suite PR-gates a single pinned `neo4j-driver` 6.x (`package.json`,
+currently `^6.0.1`). Exercising all three bands on a schedule is #4891.
+
+## Known gaps (asserted via `it.failing`, tracked in #4890)
+
+RESULT-004 (write counters), TYPE-003 (native Path), TYPE-011 (Duration),
+TYPE-012 (Point), ERR-002 (semantic-error code), PROTO-002 (Bolt 5.x). Each is
+written to assert the Neo4j-correct behavior, so `it.failing` stays green while
+the gap reproduces and turns red (XPASS) the moment the server is fixed - at
+which point convert it to `it()` and flip `current_status` in
+`bolt/conformance/spec.yaml` in the same change.
+
+Skipped: CONN-004 (needs a 3-node HA cluster), ERR-003 (needs a raw Bolt socket
+the managed driver cannot produce).
+
+## Run
+
+```bash
+npm install
+ARCADEDB_DOCKER_IMAGE=arcadedata/arcadedb:latest npm test
+```
+
+The `ARCADEDB_DOCKER_IMAGE` env var selects the image under test (CI passes the
+branch-built image); it defaults to `arcadedata/arcadedb:latest`.
+
+### Local (macOS) note
+
+CONN-003 (`neo4j://` routing) exercises the driver's routing-discovery path:
+the server's ROUTE reply advertises its own bind address, which on the Docker
+bridge network is only reachable from the host on Linux. On a macOS/Docker
+Desktop host that address is not routable, so CONN-003 times out locally; it
+passes on the Linux CI runners (same as the Python/Go/C# suites).
+
+### TLS scenarios
+
+CONN-002/CONN-005 need a JDK `keytool` on PATH to mint a throwaway self-signed
+keystore/truststore, baked into a derived image. They self-skip with a warning
+if `keytool` is absent.

--- a/e2e-js/src/js-bolt-conformance.test.js
+++ b/e2e-js/src/js-bolt-conformance.test.js
@@ -865,10 +865,10 @@ describe("Bolt conformance (issue #4888)", () => {
 
     // KNOWN GAP (#4890): the server never advertises any Bolt 5.x version;
     // 5.x-capable drivers only work by silently downgrading to 4.4, which is
-    // undocumented/untested as a deliberate stance. There is no driver knob to
-    // force 5.x-only negotiation through the managed API, so this asserts the
-    // documented-non-support fact: the negotiated protocol is < 5. It flips
-    // red only if the server starts advertising 5.x.
+    // undocumented/untested as a deliberate stance. Under it.failing this body
+    // asserts the Neo4j-correct behavior (negotiated protocol >= 5), so the
+    // test stays green while the gap reproduces (a 4.x version is negotiated)
+    // and flips red (XPASS) the moment the server starts advertising 5.x.
     it.failing("[PROTO-002] Bolt 5.x negotiation is supported", async () => {
       const info = await driver.getServerInfo({ database: "beer" });
       expect(Number(info.protocolVersion)).toBeGreaterThanOrEqual(5);

--- a/e2e-js/src/js-bolt-conformance.test.js
+++ b/e2e-js/src/js-bolt-conformance.test.js
@@ -1,0 +1,833 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Bolt protocol conformance suite for issue #4888 (epic #4882, Group B).
+// Implements every scenario in bolt/conformance/spec.yaml (#4883) against the
+// official neo4j-driver. Each test name embeds its spec id ([AREA-NNN]) for
+// traceability, per bolt/conformance/README.md.
+//
+// ArcadeDB negotiates Bolt 4.4/4.0/3.0 at most (see PROTO-002 - it never
+// advertises 5.x). This suite depends on neo4j-driver continuing to silently
+// downgrade to 4.4; a future driver major dropping legacy negotiation would
+// break the whole suite, not just PROTO-002.
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { execFileSync } = require("child_process");
+const neo4j = require("neo4j-driver");
+const { GenericContainer, Wait } = require("testcontainers");
+
+const ROOT_PASSWORD = "playwithdata";
+const IMAGE = process.env.ARCADEDB_DOCKER_IMAGE || "arcadedata/arcadedb:latest";
+const BASE_JAVA_OPTS =
+  `-Darcadedb.server.rootPassword=${ROOT_PASSWORD}` +
+  " -Darcadedb.server.defaultDatabases=beer[root]{import:https://github.com/ArcadeData/arcadedb-datasets/raw/main/orientdb/OpenBeer.gz}" +
+  " -Darcadedb.server.plugins=BoltProtocolPlugin";
+const TLS_STORE_PASSWORD = "changeit";
+
+const TYPE_MATRIX_FIXTURE = path.resolve(
+  __dirname,
+  "../../bolt/conformance/fixtures/type-matrix.cypher"
+);
+
+// Shared concurrency helper for TX-005 and ERR-004. Two sessions race to
+// update the same node inside explicit transactions, one held open past the
+// other's commit. Returns the list of errors raised. Timing-sensitive by
+// nature: callers assert on the whole collected set, not a single index.
+async function raceTwoWriters(driver, database, marker) {
+  const setup = driver.session({ database });
+  try {
+    await setup.run("MERGE (n:RaceProbe {marker: $marker}) SET n.value = 0", {
+      marker,
+    });
+  } finally {
+    await setup.close();
+  }
+
+  const errors = [];
+  async function racingWrite() {
+    const s = driver.session({ database });
+    const tx = s.beginTransaction();
+    try {
+      await tx.run(
+        "MATCH (n:RaceProbe {marker: $marker}) SET n.value = n.value + 1 RETURN n",
+        { marker }
+      );
+      await new Promise((r) => setTimeout(r, 500));
+      await tx.commit();
+    } catch (e) {
+      errors.push(e);
+      try {
+        await tx.rollback();
+      } catch (_) {
+        /* transaction already broken */
+      }
+    } finally {
+      await s.close();
+    }
+  }
+
+  await Promise.all([racingWrite(), racingWrite()]);
+  // Diagnostic (printed unconditionally so it shows even on an unexpected
+  // pass): an isolated flip to a genuine TransientError is a real, actionable
+  // server-behavior change worth concrete evidence for.
+  errors.forEach((e, i) =>
+    console.log(
+      `raceTwoWriters[${marker}] errors[${i}]: code=${e.code} msg=${e.message}`
+    )
+  );
+  return errors;
+}
+
+// Generate a throwaway self-signed keystore/truststore with the JDK keytool.
+// ArcadeDB ships no default TLS store, so REQUIRED/OPTIONAL modes need one or
+// startup crashes. Returns the temp dir holding keystore.p12 + truststore.jks,
+// or null if keytool is unavailable (local runs without a JDK skip TLS).
+function generateTlsCerts() {
+  let keytool;
+  try {
+    keytool = execFileSync("which", ["keytool"]).toString().trim();
+  } catch (_) {
+    return null;
+  }
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bolt-tls-"));
+  const keystore = path.join(dir, "keystore.p12");
+  const truststore = path.join(dir, "truststore.jks");
+  const cert = path.join(dir, "bolt.cer");
+  execFileSync(keytool, [
+    "-genkeypair", "-alias", "bolt", "-keyalg", "RSA", "-keysize", "2048",
+    "-validity", "3650", "-keystore", keystore, "-storetype", "PKCS12",
+    "-storepass", TLS_STORE_PASSWORD, "-keypass", TLS_STORE_PASSWORD,
+    "-dname", "CN=localhost, OU=ArcadeDB, O=ArcadeDB, L=Test, ST=Test, C=US",
+  ]);
+  execFileSync(keytool, [
+    "-exportcert", "-alias", "bolt", "-keystore", keystore,
+    "-storetype", "PKCS12", "-storepass", TLS_STORE_PASSWORD, "-file", cert,
+  ]);
+  execFileSync(keytool, [
+    "-importcert", "-alias", "bolt", "-keystore", truststore,
+    "-storetype", "JKS", "-storepass", TLS_STORE_PASSWORD, "-file", cert,
+    "-noprompt",
+  ]);
+  return dir;
+}
+
+// Build a derived image with the certs COPYied in (bind-mounts are unreliable
+// on some CI runners - the Python fixture documents empty mounted dirs). Uses
+// testcontainers' Dockerfile build so the COPY resolves its own context.
+async function buildTlsImage(certDir) {
+  fs.writeFileSync(
+    path.join(certDir, "Dockerfile"),
+    `FROM ${IMAGE}\n` +
+      "COPY --chown=arcadedb:arcadedb keystore.p12 truststore.jks /home/arcadedb/tls_certs/\n"
+  );
+  return GenericContainer.fromDockerfile(certDir).build(
+    "arcadedb-bolt-tls-test:latest"
+  );
+}
+
+function tlsJavaOpts(mode) {
+  return (
+    BASE_JAVA_OPTS +
+    ` -Darcadedb.bolt.ssl=${mode}` +
+    " -Darcadedb.ssl.keyStore=/home/arcadedb/tls_certs/keystore.p12" +
+    ` -Darcadedb.ssl.keyStorePassword=${TLS_STORE_PASSWORD}` +
+    " -Darcadedb.ssl.trustStore=/home/arcadedb/tls_certs/truststore.jks" +
+    ` -Darcadedb.ssl.trustStorePassword=${TLS_STORE_PASSWORD}`
+  );
+}
+
+describe("Bolt conformance (issue #4888)", () => {
+  jest.setTimeout(180000);
+
+  let container;
+  let driver;
+  let host;
+  let httpPort;
+  let boltPort;
+
+  function boltUri(scheme = "bolt") {
+    return `${scheme}://${host}:${boltPort}`;
+  }
+
+  async function httpCommand(apiPath, body) {
+    const res = await fetch(`http://${host}:${httpPort}/api/v1/${apiPath}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization:
+          "Basic " + Buffer.from(`root:${ROOT_PASSWORD}`).toString("base64"),
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+    return res.json();
+  }
+
+  function session(database = "beer", extra = {}) {
+    return driver.session({ database, ...extra });
+  }
+
+  beforeAll(async () => {
+    if (!fs.existsSync(TYPE_MATRIX_FIXTURE))
+      throw new Error(`type-matrix fixture not found: ${TYPE_MATRIX_FIXTURE}`);
+
+    container = await new GenericContainer(IMAGE)
+      .withExposedPorts(2480, 7687)
+      .withEnvironment({ JAVA_OPTS: BASE_JAVA_OPTS })
+      .withStartupTimeout(120000)
+      .withWaitStrategy(
+        Wait.forHttp("/api/v1/ready", 2480).forStatusCodeMatching(
+          (sc) => sc === 204
+        )
+      )
+      .start();
+
+    host = container.getHost();
+    httpPort = container.getMappedPort(2480);
+    boltPort = container.getMappedPort(7687);
+
+    // Seed over HTTP only, never over Bolt.
+    await httpCommand("server", { command: "create database boltscratch" });
+    await httpCommand("command/beer", {
+      language: "cypher",
+      command: fs.readFileSync(TYPE_MATRIX_FIXTURE, "utf8"),
+    });
+
+    driver = neo4j.driver(boltUri(), neo4j.auth.basic("root", ROOT_PASSWORD));
+  });
+
+  afterAll(async () => {
+    if (driver) await driver.close();
+    if (container) await container.stop();
+  });
+
+  // --- connection --------------------------------------------------------
+  describe("connection", () => {
+    it("[CONN-001] connect via bolt:// scheme", async () => {
+      await driver.verifyConnectivity();
+    });
+
+    it("[CONN-003] neo4j:// routing discovery, single-node", async () => {
+      const d = neo4j.driver(
+        boltUri("neo4j"),
+        neo4j.auth.basic("root", ROOT_PASSWORD)
+      );
+      try {
+        await d.verifyConnectivity();
+        const s = d.session({ database: "beer" });
+        try {
+          const r = await s.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 1");
+          expect(r.records[0].get("name")).not.toBeNull();
+        } finally {
+          await s.close();
+        }
+      } finally {
+        await d.close();
+      }
+    });
+
+    it.skip("[CONN-004] neo4j:// routing reflects HA cluster topology", () => {
+      // Requires a 3-node HA cluster; the single-node harness cannot
+      // meaningfully exercise this without new multi-node orchestration
+      // infrastructure. See CONN-004 / #4890.
+    });
+  });
+
+  // --- connection: TLS ---------------------------------------------------
+  describe("connection-tls", () => {
+    let builtImage; // testcontainers-built derived image (or null if skipped)
+    let certDir;
+    let tlsRequired;
+    let tlsOptional;
+
+    beforeAll(async () => {
+      certDir = generateTlsCerts();
+      if (!certDir) return; // keytool absent -> tests below self-skip
+      builtImage = await buildTlsImage(certDir);
+    });
+
+    afterAll(async () => {
+      if (tlsRequired) await tlsRequired.stop();
+      if (tlsOptional) await tlsOptional.stop();
+    });
+
+    it("[CONN-002] connect via bolt+ssc:// with TLS required", async () => {
+      if (!certDir) return console.warn("keytool absent - skipping CONN-002");
+      tlsRequired = await builtImage
+        .withExposedPorts(2480, 7687)
+        .withEnvironment({ JAVA_OPTS: tlsJavaOpts("REQUIRED") })
+        .withStartupTimeout(120000)
+        .withWaitStrategy(
+          Wait.forHttp("/api/v1/ready", 2480).forStatusCodeMatching(
+            (sc) => sc === 204
+          )
+        )
+        .start();
+      const uri = `bolt+ssc://${tlsRequired.getHost()}:${tlsRequired.getMappedPort(
+        7687
+      )}`;
+      const d = neo4j.driver(uri, neo4j.auth.basic("root", ROOT_PASSWORD));
+      try {
+        await d.verifyConnectivity();
+        const s = d.session({ database: "beer" });
+        try {
+          const r = await s.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 1");
+          expect(r.records[0].get("name")).not.toBeNull();
+        } finally {
+          await s.close();
+        }
+      } finally {
+        await d.close();
+      }
+    });
+
+    it("[CONN-005] TLS OPTIONAL falls back to plaintext bolt://", async () => {
+      if (!certDir) return console.warn("keytool absent - skipping CONN-005");
+      tlsOptional = await builtImage
+        .withExposedPorts(2480, 7687)
+        .withEnvironment({ JAVA_OPTS: tlsJavaOpts("OPTIONAL") })
+        .withStartupTimeout(120000)
+        .withWaitStrategy(
+          Wait.forHttp("/api/v1/ready", 2480).forStatusCodeMatching(
+            (sc) => sc === 204
+          )
+        )
+        .start();
+      const uri = `bolt://${tlsOptional.getHost()}:${tlsOptional.getMappedPort(
+        7687
+      )}`;
+      const d = neo4j.driver(uri, neo4j.auth.basic("root", ROOT_PASSWORD));
+      try {
+        await d.verifyConnectivity();
+      } finally {
+        await d.close();
+      }
+    });
+  });
+
+  // --- auth --------------------------------------------------------------
+  describe("auth", () => {
+    it("[AUTH-001] basic auth succeeds with valid credentials", async () => {
+      await driver.verifyConnectivity();
+      const s = session();
+      try {
+        const r = await s.run("RETURN 1 AS value");
+        expect(r.records[0].get("value").toNumber()).toBe(1);
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[AUTH-002] basic auth fails with invalid credentials", async () => {
+      const d = neo4j.driver(
+        boltUri(),
+        neo4j.auth.basic("root", "wrong-password")
+      );
+      try {
+        await expect(d.verifyConnectivity()).rejects.toMatchObject({
+          code: "Neo.ClientError.Security.Unauthorized",
+        });
+      } finally {
+        await d.close();
+      }
+    });
+
+    it("[AUTH-003] auth scheme 'none' is rejected (intentional)", async () => {
+      // The JS driver has no AuthTokens.none(); omitting the auth token is the
+      // 'none' equivalent. ArcadeDB deliberately rejects it (see AUTH-003).
+      const d = neo4j.driver(boltUri());
+      try {
+        await expect(d.verifyConnectivity()).rejects.toThrow();
+      } finally {
+        await d.close();
+      }
+    });
+  });
+
+  // --- transactions ------------------------------------------------------
+  describe("transactions", () => {
+    it("[TX-001] autocommit query executes and returns results", async () => {
+      const s = session();
+      try {
+        const r = await s.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 5");
+        expect(r.records).toHaveLength(5);
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[TX-002] explicit BEGIN/RUN/COMMIT persists changes", async () => {
+      const s = session();
+      try {
+        const tx = s.beginTransaction();
+        await tx.run("CREATE (:TxCommitProbe {marker: 'tx-002'})");
+        await tx.commit();
+        const r = await s.run(
+          "MATCH (n:TxCommitProbe {marker: 'tx-002'}) RETURN count(n) AS c"
+        );
+        expect(r.records[0].get("c").toNumber()).toBe(1);
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[TX-003] explicit BEGIN/RUN/ROLLBACK discards changes", async () => {
+      const s = session();
+      try {
+        const tx = s.beginTransaction();
+        await tx.run("CREATE (:TxRollbackProbe {marker: 'tx-003'})");
+        await tx.rollback();
+        const r = await s.run(
+          "MATCH (n:TxRollbackProbe {marker: 'tx-003'}) RETURN count(n) AS c"
+        );
+        expect(r.records[0].get("c").toNumber()).toBe(0);
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[TX-004] managed executeWrite commits on success", async () => {
+      const s = session();
+      try {
+        await s.executeWrite((tx) =>
+          tx.run("CREATE (:Beer {name: $n})", { n: "TX-004-Beer" })
+        );
+        const r = await s.run(
+          "MATCH (b:Beer {name: $n}) RETURN count(b) AS c",
+          { n: "TX-004-Beer" }
+        );
+        expect(r.records[0].get("c").toNumber()).toBe(1);
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[TX-005] managed transaction retries on Neo.TransientError.*", async () => {
+      const errors = await raceTwoWriters(driver, "beer", "tx-005");
+      expect(errors.length).toBeGreaterThan(0);
+      expect(
+        errors.some((e) => String(e.code).startsWith("Neo.TransientError"))
+      ).toBe(true);
+    });
+  });
+
+  // --- causal-consistency ------------------------------------------------
+  describe("causal-consistency", () => {
+    it("[CAUSAL-001] bookmark enforces read-after-write across sessions", async () => {
+      const a = session();
+      let bookmarks;
+      try {
+        await a.run("CREATE (:CausalProbe {marker: 'causal-001'})");
+        bookmarks = a.lastBookmarks();
+      } finally {
+        await a.close();
+      }
+      const b = driver.session({ database: "beer", bookmarks });
+      try {
+        const r = await b.run(
+          "MATCH (n:CausalProbe {marker: 'causal-001'}) RETURN count(n) AS c"
+        );
+        expect(r.records[0].get("c").toNumber()).toBe(1);
+      } finally {
+        await b.close();
+      }
+    });
+  });
+
+  // --- multi-database ----------------------------------------------------
+  describe("multi-database", () => {
+    it("[MDB-001] session selects a specific named database", async () => {
+      const s = session("beer");
+      try {
+        const r = await s.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 1");
+        expect(r.records[0].get("name")).not.toBeNull();
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[MDB-002] sessions across databases are isolated", async () => {
+      const scratch = session("boltscratch");
+      const tx = scratch.beginTransaction();
+      try {
+        await tx.run("CREATE (:ScratchProbe {marker: 'mdb-002'})");
+        const beer = session("beer");
+        try {
+          const r = await beer.run(
+            "MATCH (n:ScratchProbe {marker: 'mdb-002'}) RETURN count(n) AS c"
+          );
+          expect(r.records[0].get("c").toNumber()).toBe(0);
+        } finally {
+          await beer.close();
+        }
+        await tx.commit();
+      } finally {
+        await scratch.close();
+      }
+      const verify = session("boltscratch");
+      try {
+        const r = await verify.run(
+          "MATCH (n:ScratchProbe {marker: 'mdb-002'}) RETURN count(n) AS c"
+        );
+        expect(r.records[0].get("c").toNumber()).toBe(1);
+      } finally {
+        await verify.close();
+      }
+    });
+  });
+
+  // --- result-handling ---------------------------------------------------
+  describe("result-handling", () => {
+    it("[RESULT-001] streaming PULL returns records incrementally", async () => {
+      const s = session();
+      try {
+        const result = s.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 10");
+        let seen = 0;
+        for await (const record of result) {
+          expect(record.get("name")).not.toBeNull();
+          seen += 1;
+        }
+        expect(seen).toBe(10);
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[RESULT-002] PULL n streams exactly n, further PULL continues", async () => {
+      const s = session("beer", { fetchSize: 2 });
+      try {
+        const result = s.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 5");
+        const iter = result[Symbol.asyncIterator]();
+        const first = [await iter.next(), await iter.next()];
+        expect(first.every((x) => !x.done)).toBe(true);
+        let rest = 0;
+        while (true) {
+          const n = await iter.next();
+          if (n.done) break;
+          rest += 1;
+        }
+        expect(rest).toBe(3);
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[RESULT-003] DISCARD abandons remaining rows", async () => {
+      const s = session("beer", { fetchSize: 1 });
+      try {
+        // In neo4j-driver v6, result.summary() is the consume/DISCARD path: it
+        // ends the stream and returns a ResultSummary WITHOUT materializing the
+        // records into a user-facing array (unlike `await result`). Driving the
+        // async iterator first and then calling summary() deadlocks, so this
+        // consumes via summary() directly.
+        const result = s.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 5");
+        const summary = await result.summary();
+        expect(summary).toBeDefined();
+        expect(summary.query).toBeDefined();
+      } finally {
+        await s.close();
+      }
+    });
+
+    // KNOWN GAP (#4890): the Bolt layer never populates a 'stats' key in
+    // SUCCESS metadata for write queries, so counters are always empty. This
+    // it.failing asserts the Neo4j-correct behavior and flips red when fixed -
+    // convert to it() and update current_status in spec.yaml in the same PR.
+    it.failing("[RESULT-004] ResultSummary counters reflect writes", async () => {
+      const s = session();
+      try {
+        const result = await s.run(
+          "CREATE (:Beer {name: $n})-[:BREWED_BY]->(:Brewery {name: $b})",
+          { n: "RESULT-004-Beer", b: "RESULT-004-Brewery" }
+        );
+        const c = result.summary.counters.updates();
+        expect(c.nodesCreated).toBe(2);
+        expect(c.relationshipsCreated).toBe(1);
+        expect(c.propertiesSet).toBeGreaterThanOrEqual(2);
+      } finally {
+        await s.close();
+      }
+    });
+  });
+
+  // --- type-roundtrip ----------------------------------------------------
+  describe("type-roundtrip", () => {
+    it("[TYPE-001] node round-trips as a native Bolt structure", async () => {
+      const s = session();
+      try {
+        const r = await s.run("MATCH (b:Beer) RETURN b LIMIT 1");
+        const node = r.records[0].get("b");
+        expect(node).toBeInstanceOf(neo4j.types.Node);
+        expect(node.labels).toContain("Beer");
+        expect(node.properties.name).toBeDefined();
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[TYPE-002] relationship round-trips as a native Bolt structure", async () => {
+      const s = session();
+      try {
+        const r = await s.run("MATCH ()-[rel]->() RETURN rel LIMIT 1");
+        const rel = r.records[0].get("rel");
+        expect(rel).toBeInstanceOf(neo4j.types.Relationship);
+        expect(rel.type).toBeDefined();
+      } finally {
+        await s.close();
+      }
+    });
+
+    // KNOWN GAP (#4890): BoltPath.java has zero call sites - query results
+    // never produce native Path structures. Asserts the correct behavior;
+    // flips red when fixed. Convert + update spec.yaml TYPE-003 then.
+    it.failing("[TYPE-003] path round-trips as a native Bolt structure", async () => {
+      const s = session();
+      try {
+        const r = await s.run("MATCH p=(b:Beer)-[*1..2]-() RETURN p LIMIT 1");
+        const p = r.records[0].get("p");
+        expect(p).toBeInstanceOf(neo4j.types.Path);
+        expect(p.segments.length).toBeGreaterThanOrEqual(1);
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[TYPE-004] ByteArray round-trips as a bound parameter", async () => {
+      const s = session();
+      try {
+        const payload = Int8Array.from([1, 2, 3, 4]);
+        const r = await s.run("RETURN $b AS echo", { b: payload });
+        const echo = r.records[0].get("echo");
+        expect(Array.from(echo)).toEqual([1, 2, 3, 4]);
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[TYPE-005] nested lists and maps round-trip structurally", async () => {
+      const s = session();
+      try {
+        const r = await s.run(
+          "MATCH (t:TypeMatrix) RETURN t.nestedListProp AS l, t.nestedMapProp AS m"
+        );
+        expect(r.records[0].get("l")).toEqual([
+          neo4j.int(1),
+          neo4j.int(2),
+          [neo4j.int(3), neo4j.int(4)],
+        ]);
+        expect(r.records[0].get("m")).toEqual({
+          a: neo4j.int(1),
+          b: { c: neo4j.int(2) },
+        });
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[TYPE-006] null values round-trip", async () => {
+      const s = session();
+      try {
+        const r = await s.run("MATCH (t:TypeMatrix) RETURN t.nullProp AS n");
+        expect(r.records[0].get("n")).toBeNull();
+        const e = await s.run("RETURN $p AS echo", { p: null });
+        expect(e.records[0].get("echo")).toBeNull();
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[TYPE-007] LocalDate round-trips as a native Bolt Date", async () => {
+      const s = session();
+      try {
+        const r = await s.run("MATCH (t:TypeMatrix) RETURN t.localDateProp AS d");
+        const d = r.records[0].get("d");
+        expect(d).toBeInstanceOf(neo4j.types.Date);
+        const e = await s.run("RETURN $d AS echo", { d });
+        expect(e.records[0].get("echo")).toEqual(d);
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[TYPE-008] LocalTime round-trips as a native Bolt LocalTime", async () => {
+      const s = session();
+      try {
+        const r = await s.run("MATCH (t:TypeMatrix) RETURN t.localTimeProp AS t2");
+        const t2 = r.records[0].get("t2");
+        expect(t2).toBeInstanceOf(neo4j.types.LocalTime);
+        const e = await s.run("RETURN $t AS echo", { t: t2 });
+        expect(e.records[0].get("echo")).toEqual(t2);
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[TYPE-009] LocalDateTime round-trips as a native Bolt LocalDateTime", async () => {
+      const s = session();
+      try {
+        const r = await s.run(
+          "MATCH (t:TypeMatrix) RETURN t.localDateTimeProp AS dt"
+        );
+        const dt = r.records[0].get("dt");
+        expect(dt).toBeInstanceOf(neo4j.types.LocalDateTime);
+        const e = await s.run("RETURN $dt AS echo", { dt });
+        expect(e.records[0].get("echo")).toEqual(dt);
+      } finally {
+        await s.close();
+      }
+    });
+
+    it("[TYPE-010] offset DateTime round-trips as a native Bolt DateTime", async () => {
+      const s = session();
+      try {
+        const r = await s.run(
+          "MATCH (t:TypeMatrix) RETURN t.offsetDateTimeProp AS dt"
+        );
+        const dt = r.records[0].get("dt");
+        expect(dt).toBeInstanceOf(neo4j.types.DateTime);
+        // fixture offset is +02:00 -> 7200 seconds (driver returns a neo4j Integer)
+        const offset = dt.timeZoneOffsetSeconds;
+        expect(neo4j.isInt(offset) ? offset.toNumber() : offset).toBe(7200);
+        const e = await s.run("RETURN $dt AS echo", { dt });
+        expect(e.records[0].get("echo")).toEqual(dt);
+      } finally {
+        await s.close();
+      }
+    });
+
+    // KNOWN GAP (#4890): no Duration handling in BoltStructureMapper/
+    // PackStreamWriter - falls through to value.toString().
+    it.failing("[TYPE-011] Duration round-trips as a native Bolt Duration", async () => {
+      const s = session();
+      try {
+        const r = await s.run("MATCH (t:TypeMatrix) RETURN t.durationProp AS d");
+        const d = r.records[0].get("d");
+        expect(d).toBeInstanceOf(neo4j.types.Duration);
+        const e = await s.run("RETURN $d AS echo", { d });
+        expect(e.records[0].get("echo")).toEqual(d);
+      } finally {
+        await s.close();
+      }
+    });
+
+    // KNOWN GAP (#4890): no Point/spatial handling anywhere in the Bolt
+    // serialization path (the Cypher engine itself supports point()).
+    it.failing("[TYPE-012] Point round-trips as a native Bolt Point", async () => {
+      const s = session();
+      try {
+        const r = await s.run("MATCH (t:TypeMatrix) RETURN t.pointProp AS p");
+        const p = r.records[0].get("p");
+        expect(p).toBeInstanceOf(neo4j.types.Point);
+        expect(p.x).toBeCloseTo(12.34);
+        expect(p.y).toBeCloseTo(56.78);
+        const e = await s.run("RETURN $p AS echo", { p });
+        expect(e.records[0].get("echo").x).toBeCloseTo(12.34);
+      } finally {
+        await s.close();
+      }
+    });
+  });
+
+  // --- errors ------------------------------------------------------------
+  describe("errors", () => {
+    it("[ERR-001] syntax error returns Neo.ClientError.Statement.SyntaxError", async () => {
+      const s = session();
+      try {
+        await expect(s.run("MATCH (n RETURN n")).rejects.toMatchObject({
+          code: "Neo.ClientError.Statement.SyntaxError",
+        });
+      } finally {
+        await s.close();
+      }
+    });
+
+    // KNOWN GAP (#4890): semantic errors are surfaced as SyntaxError, not
+    // Neo.ClientError.Statement.SemanticError. Asserts the correct code;
+    // flips red when the mapping is fixed.
+    it.failing("[ERR-002] semantic error returns SemanticError code", async () => {
+      const s = session();
+      try {
+        await expect(
+          s.run("MATCH (n:Beer) RETURN undefinedVariable")
+        ).rejects.toMatchObject({
+          code: "Neo.ClientError.Statement.SemanticError",
+        });
+      } finally {
+        await s.close();
+      }
+    });
+
+    // NOT APPLICABLE: exercising a RUN before HELLO/LOGON needs a raw Bolt
+    // socket; the managed neo4j-driver always authenticates first, so this
+    // cannot be driven through the official driver. Skipped as in the
+    // Python/Go/C# suites. See ERR-003 / #4890.
+    it.skip("[ERR-003] unauthenticated request returns Forbidden (raw socket)", () => {});
+
+    it("[ERR-004] transient conditions surface Neo.TransientError.*", async () => {
+      const errors = await raceTwoWriters(driver, "beer", "err-004");
+      expect(errors.length).toBeGreaterThan(0);
+      expect(
+        errors.some((e) => String(e.code).startsWith("Neo.TransientError"))
+      ).toBe(true);
+    });
+  });
+
+  // --- protocol ----------------------------------------------------------
+  describe("protocol", () => {
+    it("[PROTO-001] version negotiation succeeds (4.4/4.0/3.0)", async () => {
+      // A successful query proves the handshake negotiated a supported
+      // version; the pinned neo4j-driver offers a range including 4.4.
+      const s = session();
+      try {
+        const r = await s.run("RETURN 1 AS v");
+        expect(r.records[0].get("v").toNumber()).toBe(1);
+      } finally {
+        await s.close();
+      }
+    });
+
+    // KNOWN GAP (#4890): the server never advertises any Bolt 5.x version;
+    // 5.x-capable drivers only work by silently downgrading to 4.4, which is
+    // undocumented/untested as a deliberate stance. There is no driver knob to
+    // force 5.x-only negotiation through the managed API, so this asserts the
+    // documented-non-support fact: the negotiated protocol is < 5. It flips
+    // red only if the server starts advertising 5.x.
+    it.failing("[PROTO-002] Bolt 5.x negotiation is supported", async () => {
+      const info = await driver.getServerInfo({ database: "beer" });
+      expect(Number(info.protocolVersion)).toBeGreaterThanOrEqual(5);
+    });
+
+    it("[PROTO-003] RESET returns the connection to a clean state", async () => {
+      const s = session("beer", { fetchSize: 2 });
+      try {
+        // Start a partial stream, then break out early: the async iterator's
+        // return() discards the remaining rows and returns the connection to a
+        // clean state (RESET/DISCARD semantics).
+        const first = s.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 5");
+        for await (const _record of first) break; // eslint-disable-line no-unused-vars
+        // The session accepts a fresh RUN immediately afterward.
+        const r = await s.run("RETURN 1 AS v");
+        expect(r.records[0].get("v").toNumber()).toBe(1);
+      } finally {
+        await s.close();
+      }
+    });
+  });
+});

--- a/e2e-js/src/js-bolt-conformance.test.js
+++ b/e2e-js/src/js-bolt-conformance.test.js
@@ -167,6 +167,28 @@ function tlsJavaOpts(mode) {
   );
 }
 
+// keytool availability decided at load time so the TLS scenarios report as a
+// real skip (not a misleading pass) on hosts without a JDK. CI runners have
+// one; local runs without keytool skip CONN-002/CONN-005 honestly.
+const KEYTOOL_AVAILABLE = (() => {
+  try {
+    execFileSync("which", ["keytool"]);
+    return true;
+  } catch (_) {
+    return false;
+  }
+})();
+const tlsIt = KEYTOOL_AVAILABLE ? it : it.skip;
+
+// True if the collected racing errors contain no non-retryable code: a
+// write-write conflict must surface as Neo.TransientError.* (retryable), never
+// as a ClientError/DatabaseError (mirrors the Python suite's negative check).
+function noNonRetryableErrors(errors) {
+  return errors.every(
+    (e) => !/^Neo\.(ClientError|DatabaseError)\./.test(String(e.code))
+  );
+}
+
 describe("Bolt conformance (issue #4888)", () => {
   jest.setTimeout(180000);
 
@@ -272,14 +294,24 @@ describe("Bolt conformance (issue #4888)", () => {
     let tlsOptional;
 
     beforeAll(async () => {
+      if (!KEYTOOL_AVAILABLE) return; // CONN-002/005 are it.skip in this case
       certDir = generateTlsCerts();
-      if (!certDir) return; // keytool absent -> tests below self-skip
+      if (!certDir) return;
       tlsImageTag = await buildTlsImage(certDir);
     });
 
     afterAll(async () => {
       if (tlsRequired) await tlsRequired.stop();
       if (tlsOptional) await tlsOptional.stop();
+      // Remove the throwaway derived image so it does not accumulate on
+      // developer machines (parity with the Python suite's teardown).
+      if (tlsImageTag) {
+        try {
+          execFileSync("docker", ["rmi", "-f", tlsImageTag]);
+        } catch (_) {
+          /* image may be in use or already gone; ignore */
+        }
+      }
       if (certDir) {
         try {
           fs.rmSync(certDir, { recursive: true, force: true });
@@ -289,8 +321,8 @@ describe("Bolt conformance (issue #4888)", () => {
       }
     });
 
-    it("[CONN-002] connect via bolt+ssc:// with TLS required", async () => {
-      if (!certDir) return console.warn("keytool absent - skipping CONN-002");
+    tlsIt("[CONN-002] connect via bolt+ssc:// with TLS required", async () => {
+      if (!certDir) return console.warn("keytool cert generation failed - skipping CONN-002");
       tlsRequired = await new GenericContainer(tlsImageTag)
         .withExposedPorts(2480, 7687)
         .withEnvironment({ JAVA_OPTS: tlsJavaOpts("REQUIRED") })
@@ -319,8 +351,8 @@ describe("Bolt conformance (issue #4888)", () => {
       }
     });
 
-    it("[CONN-005] TLS OPTIONAL falls back to plaintext bolt://", async () => {
-      if (!certDir) return console.warn("keytool absent - skipping CONN-005");
+    tlsIt("[CONN-005] TLS OPTIONAL falls back to plaintext bolt://", async () => {
+      if (!certDir) return console.warn("keytool cert generation failed - skipping CONN-005");
       tlsOptional = await new GenericContainer(tlsImageTag)
         .withExposedPorts(2480, 7687)
         .withEnvironment({ JAVA_OPTS: tlsJavaOpts("OPTIONAL") })
@@ -446,6 +478,9 @@ describe("Bolt conformance (issue #4888)", () => {
       expect(
         errors.some((e) => String(e.code).startsWith("Neo.TransientError"))
       ).toBe(true);
+      // The conflict must be retryable: no racing error is a non-retryable
+      // ClientError/DatabaseError (this is the part that proves retryability).
+      expect(noNonRetryableErrors(errors)).toBe(true);
     });
   });
 
@@ -808,6 +843,9 @@ describe("Bolt conformance (issue #4888)", () => {
       expect(
         errors.some((e) => String(e.code).startsWith("Neo.TransientError"))
       ).toBe(true);
+      // A transient conflict must not be misclassified as a non-retryable
+      // ClientError/DatabaseError.
+      expect(noNonRetryableErrors(errors)).toBe(true);
     });
   });
 

--- a/e2e-js/src/js-bolt-conformance.test.js
+++ b/e2e-js/src/js-bolt-conformance.test.js
@@ -110,36 +110,50 @@ function generateTlsCerts() {
   const keystore = path.join(dir, "keystore.p12");
   const truststore = path.join(dir, "truststore.jks");
   const cert = path.join(dir, "bolt.cer");
-  execFileSync(keytool, [
-    "-genkeypair", "-alias", "bolt", "-keyalg", "RSA", "-keysize", "2048",
-    "-validity", "3650", "-keystore", keystore, "-storetype", "PKCS12",
-    "-storepass", TLS_STORE_PASSWORD, "-keypass", TLS_STORE_PASSWORD,
-    "-dname", "CN=localhost, OU=ArcadeDB, O=ArcadeDB, L=Test, ST=Test, C=US",
-  ]);
-  execFileSync(keytool, [
-    "-exportcert", "-alias", "bolt", "-keystore", keystore,
-    "-storetype", "PKCS12", "-storepass", TLS_STORE_PASSWORD, "-file", cert,
-  ]);
-  execFileSync(keytool, [
-    "-importcert", "-alias", "bolt", "-keystore", truststore,
-    "-storetype", "JKS", "-storepass", TLS_STORE_PASSWORD, "-file", cert,
-    "-noprompt",
-  ]);
-  return dir;
+  try {
+    execFileSync(keytool, [
+      "-genkeypair", "-alias", "bolt", "-keyalg", "RSA", "-keysize", "2048",
+      "-validity", "3650", "-keystore", keystore, "-storetype", "PKCS12",
+      "-storepass", TLS_STORE_PASSWORD, "-keypass", TLS_STORE_PASSWORD,
+      "-dname", "CN=localhost, OU=ArcadeDB, O=ArcadeDB, L=Test, ST=Test, C=US",
+    ]);
+    execFileSync(keytool, [
+      "-exportcert", "-alias", "bolt", "-keystore", keystore,
+      "-storetype", "PKCS12", "-storepass", TLS_STORE_PASSWORD, "-file", cert,
+    ]);
+    execFileSync(keytool, [
+      "-importcert", "-alias", "bolt", "-keystore", truststore,
+      "-storetype", "JKS", "-storepass", TLS_STORE_PASSWORD, "-file", cert,
+      "-noprompt",
+    ]);
+    return dir;
+  } catch (_) {
+    // keytool present but failed (permissions, policy, JDK quirk): clean up and
+    // skip the TLS scenarios rather than crashing the whole suite.
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch (__) {
+      /* ignore cleanup failure */
+    }
+    return null;
+  }
 }
+
+const TLS_IMAGE_TAG = "arcadedb-bolt-tls-test:latest";
 
 // Build a derived image with the certs COPYied in (bind-mounts are unreliable
 // on some CI runners - the Python fixture documents empty mounted dirs). Uses
 // testcontainers' Dockerfile build so the COPY resolves its own context.
+// Returns the image tag; callers instantiate a fresh GenericContainer per test
+// rather than reusing (and mutating) one shared builder instance.
 async function buildTlsImage(certDir) {
   fs.writeFileSync(
     path.join(certDir, "Dockerfile"),
     `FROM ${IMAGE}\n` +
       "COPY --chown=arcadedb:arcadedb keystore.p12 truststore.jks /home/arcadedb/tls_certs/\n"
   );
-  return GenericContainer.fromDockerfile(certDir).build(
-    "arcadedb-bolt-tls-test:latest"
-  );
+  await GenericContainer.fromDockerfile(certDir).build(TLS_IMAGE_TAG);
+  return TLS_IMAGE_TAG;
 }
 
 function tlsJavaOpts(mode) {
@@ -252,7 +266,7 @@ describe("Bolt conformance (issue #4888)", () => {
 
   // --- connection: TLS ---------------------------------------------------
   describe("connection-tls", () => {
-    let builtImage; // testcontainers-built derived image (or null if skipped)
+    let tlsImageTag; // tag of the testcontainers-built derived image
     let certDir;
     let tlsRequired;
     let tlsOptional;
@@ -260,17 +274,24 @@ describe("Bolt conformance (issue #4888)", () => {
     beforeAll(async () => {
       certDir = generateTlsCerts();
       if (!certDir) return; // keytool absent -> tests below self-skip
-      builtImage = await buildTlsImage(certDir);
+      tlsImageTag = await buildTlsImage(certDir);
     });
 
     afterAll(async () => {
       if (tlsRequired) await tlsRequired.stop();
       if (tlsOptional) await tlsOptional.stop();
+      if (certDir) {
+        try {
+          fs.rmSync(certDir, { recursive: true, force: true });
+        } catch (_) {
+          /* ignore cleanup failure */
+        }
+      }
     });
 
     it("[CONN-002] connect via bolt+ssc:// with TLS required", async () => {
       if (!certDir) return console.warn("keytool absent - skipping CONN-002");
-      tlsRequired = await builtImage
+      tlsRequired = await new GenericContainer(tlsImageTag)
         .withExposedPorts(2480, 7687)
         .withEnvironment({ JAVA_OPTS: tlsJavaOpts("REQUIRED") })
         .withStartupTimeout(120000)
@@ -300,7 +321,7 @@ describe("Bolt conformance (issue #4888)", () => {
 
     it("[CONN-005] TLS OPTIONAL falls back to plaintext bolt://", async () => {
       if (!certDir) return console.warn("keytool absent - skipping CONN-005");
-      tlsOptional = await builtImage
+      tlsOptional = await new GenericContainer(tlsImageTag)
         .withExposedPorts(2480, 7687)
         .withEnvironment({ JAVA_OPTS: tlsJavaOpts("OPTIONAL") })
         .withStartupTimeout(120000)
@@ -532,12 +553,13 @@ describe("Bolt conformance (issue #4888)", () => {
     it("[RESULT-003] DISCARD abandons remaining rows", async () => {
       const s = session("beer", { fetchSize: 1 });
       try {
-        // In neo4j-driver v6, result.summary() is the consume/DISCARD path: it
-        // ends the stream and returns a ResultSummary WITHOUT materializing the
-        // records into a user-facing array (unlike `await result`). Driving the
-        // async iterator first and then calling summary() deadlocks, so this
-        // consumes via summary() directly.
+        // Pull exactly 1 row of a 5-row result, then DISCARD the remainder.
+        // `for await ... break` closes the async iterator cleanly (its return()
+        // discards the pending rows); result.summary() then returns the
+        // ResultSummary WITHOUT materializing the remaining records into a
+        // user-facing array (unlike `await result`).
         const result = s.run("MATCH (b:Beer) RETURN b.name AS name LIMIT 5");
+        for await (const _record of result) break; // eslint-disable-line no-unused-vars
         const summary = await result.summary();
         expect(summary).toBeDefined();
         expect(summary.query).toBeDefined();


### PR DESCRIPTION
## Summary

Closes #4888 (epic #4882, Group B). Deepens the `e2e-js` suite from connect + WHERE-filter reads to the **full 39-scenario Bolt conformance spec** (`bolt/conformance/spec.yaml`, #4883), at parity with the merged `e2e-python` (#4885), `e2e-csharp` (#4886), and `e2e-go` (#4887) suites.

A new `e2e-js/src/js-bolt-conformance.test.js` implements every scenario against the official `neo4j-driver`, mirroring the established sibling pattern. The existing VLP regression (`js-bolt-e2e.test.js`, #4452/#4271) is **left untouched**.

## What's covered

All 39 scenarios, named `[AREA-NNN]` for grep-able traceability:
- **connection** incl. `bolt://`, `neo4j://` routing, and TLS `bolt+ssc://` (CONN-002/005 via a keytool self-signed cert baked into a derived image)
- **auth** (valid / invalid / `none` rejected), **transactions** (autocommit, explicit, managed `executeWrite`, transient-retry), **bookmarks**, **multi-database isolation**
- **result-handling** (streaming, partial pull, discard, summary counters)
- **type round-trip** (Node, Relationship, Path, ByteArray, nested list/map, null, temporal, Duration, Point)
- **errors** (syntax, semantic, transient) and **protocol** (negotiation, 5.x, RESET)

## Fixture strategy

Mirrors the Python fixture exactly: beer default DB + `type-matrix.cypher` seeded **over HTTP only** (never over Bolt, so seeding never exercises the serialization path under test). Honors `ARCADEDB_DOCKER_IMAGE`.

## Known gaps (not regressions)

The 6 server-side gaps the matrix surfaces are asserted with Jest's native `it.failing()` (the `xfail(strict=True)` equivalent) - each asserts the **Neo4j-correct** behavior, stays green while the gap reproduces, and turns red (XPASS) the moment the server is fixed, forcing a `spec.yaml` update in the same PR. All track **#4890**:

| Scenario | Gap |
|---|---|
| RESULT-004 | write counters never populated |
| TYPE-003 | native Path never produced |
| TYPE-011 | Duration unimplemented |
| TYPE-012 | Point unimplemented |
| ERR-002 | semantic error mapped as SyntaxError |
| PROTO-002 | Bolt 5.x never advertised |

Skipped (infra): **CONN-004** (needs a 3-node HA cluster), **ERR-003** (needs a raw Bolt socket the managed driver can't produce).

## Verification

Local run against a branch-built image: **36 pass / 2 skip**. `CONN-003` (`neo4j://` routing) passes on the Linux CI runners but times out on macOS/Docker Desktop, where the Docker-bridge address advertised in the ROUTE reply isn't host-routable - identical behavior to the merged Python/Go/C# suites. No new CI job needed: the existing `js-e2e-tests` job runs `npm test` (Jest auto-discovers the new file) and already passes `ARCADEDB_DOCKER_IMAGE`. `jest-junit` output is already wired.

## Out of scope (deferred)

Multi-version driver-band matrix + nightly run (#4891), published compatibility matrix/badge (#4892), server-side gap fixes (#4890).

Design + plan: `docs/superpowers/specs/2026-07-04-e2e-js-bolt-conformance-design.md`, `docs/superpowers/plans/2026-07-04-e2e-js-bolt-conformance.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
