### PR TITLE
feat(#4890): native Bolt Duration, Point, Path + semantic errors (#4997, #4998, #4999)

### DIFF
--- a/bolt/conformance/spec.yaml
+++ b/bolt/conformance/spec.yaml
@@ -369,12 +369,7 @@ scenarios:
       - "When the driver runs 'MATCH p=(b:Beer)-[*1..2]-() RETURN p LIMIT 1'"
       - "Then the client receives a native Path value (sig 0x50) with correctly ordered nodes/relationships"
     applicable_driver_versions: all
-    current_status: expected-fail
-    known_limitation: >
-      structure/BoltPath.java exists but has zero call sites constructing
-      it anywhere in BoltStructureMapper - query results never actually
-      produce native Path structures today.
-    tracking_issue: "#4890"
+    current_status: passing
   - id: TYPE-004
     area: type-roundtrip
     title: "ByteArray round-trips as a bound parameter"
@@ -469,12 +464,7 @@ scenarios:
       - "When the driver runs 'RETURN $d AS echo' with params={d: <that duration>}"
       - "Then echo round-trips without precision loss"
     applicable_driver_versions: all
-    current_status: expected-fail
-    known_limitation: >
-      BoltStructureMapper/PackStreamWriter have no Duration handling at
-      all - not even a string fallback branch, falls through to generic
-      value.toString().
-    tracking_issue: "#4890"
+    current_status: passing
   - id: TYPE-012
     area: type-roundtrip
     title: "Point round-trips as a native Bolt Point structure"
@@ -490,14 +480,7 @@ scenarios:
       - "When the driver runs 'RETURN $p AS echo' with params={p: <that point>}"
       - "Then echo round-trips without precision loss"
     applicable_driver_versions: all
-    current_status: expected-fail
-    known_limitation: >
-      No Point/spatial type handling exists anywhere in
-      BoltStructureMapper or PackStreamWriter (confirmed even though the
-      underlying ArcadeDB Cypher engine itself does support point() -
-      verified point({x:12.34,y:56.78}) creates/stores correctly via
-      HTTP/embedded execution; the gap is Bolt wire serialization only).
-    tracking_issue: "#4890"
+    current_status: passing
   - id: ERR-001
     area: errors
     title: "Syntax error returns Neo.ClientError.Statement.SyntaxError"
@@ -519,16 +502,7 @@ scenarios:
       - "When the driver runs a semantically invalid query, e.g. referencing an undeclared variable in RETURN"
       - "Then the driver receives error code Neo.ClientError.Statement.SemanticError (BoltErrorCodes.SEMANTIC_ERROR)"
     applicable_driver_versions: all
-    current_status: expected-fail
-    known_limitation: >
-      CypherSemanticValidator correctly detects the undefined variable but
-      throws it via CommandParsingException, the same exception class used
-      for genuine ANTLR syntax errors - BoltNetworkExecutor's RUN handler
-      maps error codes by exception type, so it cannot distinguish semantic
-      from syntax errors, making Neo.ClientError.Statement.SemanticError
-      effectively dead code in the Bolt module - discovered while
-      implementing issue #4885's Python conformance suite.
-    tracking_issue: "#4890"
+    current_status: passing
   - id: ERR-003
     area: errors
     title: "Unauthenticated request returns Neo.ClientError.Security.Forbidden"

--- a/bolt/conformance/test_validate_spec.py
+++ b/bolt/conformance/test_validate_spec.py
@@ -85,10 +85,10 @@ class ValidateSpecTest(unittest.TestCase):
 
     def test_missing_gap_tracking_area_is_flagged(self):
         spec = minimal_valid_spec()
-        spec["scenarios"] = [s for s in spec["scenarios"] if s["id"] != "TYPE-900"]
+        spec["scenarios"] = [s for s in spec["scenarios"] if s["id"] != "CONN-900"]
         errors = validate(spec)
         self.assertTrue(
-            any("type-roundtrip" in e for e in errors), errors
+            any("connection" in e for e in errors), errors
         )
 
     def test_missing_driver_language_is_flagged(self):

--- a/bolt/conformance/validate_spec.py
+++ b/bolt/conformance/validate_spec.py
@@ -25,10 +25,11 @@ VALID_STATUSES = {"passing", "expected-fail", "not-applicable", "unverified"}
 REQUIRED_LANGUAGES = {"java", "javascript", "python", "csharp", "go"}
 KNOWN_GAP_TRACKING_ISSUE = "#4890"
 # Areas that must each carry at least one #4890-tracked expected-fail scenario:
-# connection (single-node-only ROUTE), errors (missing Neo.TransientError.*),
-# protocol (no Bolt 5.x negotiation), type-roundtrip (temporal-as-string,
-# missing Duration, missing Point).
-REQUIRED_GAP_AREAS = {"connection", "errors", "protocol", "type-roundtrip"}
+# connection (single-node-only ROUTE), protocol (no Bolt 5.x negotiation).
+# errors and type-roundtrip previously appeared here too (ERR-002 and
+# TYPE-003/011/012 respectively), but those were the only #4890-tracked gaps
+# in either area and all four are now closed and flipped to passing.
+REQUIRED_GAP_AREAS = {"connection", "protocol"}
 # Canonical AREA-NNN id prefix per area - not derivable from the area string
 # (e.g. transactions -> TX, multi-database -> MDB, causal-consistency ->
 # CAUSAL), so scenario ids are checked against this table rather than a

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -40,6 +40,7 @@ import com.arcadedb.database.DatabaseContext;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.ProtocolContext;
 import com.arcadedb.exception.CommandParsingException;
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.exception.NeedRetryException;
 import com.arcadedb.index.Index;
 import com.arcadedb.index.TypeIndex;
@@ -628,7 +629,7 @@ public class BoltNetworkExecutor extends Thread {
 
     } catch (final CommandParsingException e) {
       final String parseMsg = e.getMessage() != null ? e.getMessage() : "Query parsing error";
-      sendFailure(BoltException.SYNTAX_ERROR, parseMsg);
+      sendFailure(classifyParsingError(e), parseMsg);
       state = State.FAILED;
     } catch (final Exception e) {
       // MVCC conflicts (NeedRetryException) are expected under contention and auto-retried by the driver,
@@ -1635,6 +1636,15 @@ public class BoltNetworkExecutor extends Thread {
    */
   static String classifyExecutionError(final Throwable error, final String defaultCode) {
     return isRetryableConflict(error) ? BoltErrorCodes.TRANSIENT_CONFLICT_ERROR : defaultCode;
+  }
+
+  /**
+   * Classify a query-parsing error into a Bolt status code. {@link CommandSemanticException} marks a
+   * statement that parsed correctly but violates a semantic rule (e.g. an undefined variable), so it maps
+   * to Neo4j's SemanticError; every other {@link CommandParsingException} is a genuine syntax error.
+   */
+  static String classifyParsingError(final CommandParsingException error) {
+    return error instanceof CommandSemanticException ? BoltErrorCodes.SEMANTIC_ERROR : BoltErrorCodes.SYNTAX_ERROR;
   }
 
   /**

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltPointStructure.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltPointStructure.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt.structure;
+
+import com.arcadedb.bolt.packstream.PackStreamStructure;
+import com.arcadedb.bolt.packstream.PackStreamWriter;
+
+import java.io.IOException;
+
+/**
+ * A Bolt spatial Point PackStream structure. Point2D (signature 0x58) carries [srid, x, y];
+ * Point3D (signature 0x59) carries [srid, x, y, z]. srid is an integer; coordinates are doubles.
+ */
+public class BoltPointStructure implements PackStreamStructure {
+  public static final byte SIGNATURE_2D = 0x58;
+  public static final byte SIGNATURE_3D = 0x59;
+
+  private final int    srid;
+  private final double x;
+  private final double y;
+  private final Double z; // null for 2D
+
+  public BoltPointStructure(final int srid, final double x, final double y) {
+    this(srid, x, y, null);
+  }
+
+  public BoltPointStructure(final int srid, final double x, final double y, final Double z) {
+    this.srid = srid;
+    this.x = x;
+    this.y = y;
+    this.z = z;
+  }
+
+  @Override
+  public byte getSignature() {
+    return z == null ? SIGNATURE_2D : SIGNATURE_3D;
+  }
+
+  @Override
+  public int getFieldCount() {
+    return z == null ? 3 : 4;
+  }
+
+  @Override
+  public void writeTo(final PackStreamWriter writer) throws IOException {
+    writer.writeStructureHeader(getSignature(), getFieldCount());
+    writer.writeValue((long) srid);
+    writer.writeValue(x);
+    writer.writeValue(y);
+    if (z != null)
+      writer.writeValue(z);
+  }
+
+  public int getSrid() {
+    return srid;
+  }
+
+  public double getX() {
+    return x;
+  }
+
+  public double getY() {
+    return y;
+  }
+
+  public Double getZ() {
+    return z;
+  }
+}

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
@@ -31,6 +31,7 @@ import com.arcadedb.query.opencypher.temporal.CypherDuration;
 import com.arcadedb.query.opencypher.temporal.CypherLocalDateTime;
 import com.arcadedb.query.opencypher.temporal.CypherLocalTime;
 import com.arcadedb.query.opencypher.temporal.CypherTime;
+import com.arcadedb.query.opencypher.traversal.TraversalPath;
 import com.arcadedb.query.sql.executor.Result;
 
 import java.math.BigDecimal;
@@ -76,6 +77,9 @@ public class BoltStructureMapper {
     if (value instanceof Result result) {
       return resultToValue(result);
     }
+
+    if (value instanceof TraversalPath path)
+      return toPath(path);
 
     if (value instanceof RID rid) {
       return rid.toString();
@@ -196,6 +200,55 @@ public class BoltStructureMapper {
     final Map<String, Object> properties = toProperties(edge);
 
     return new BoltUnboundRelationship(id, type, properties, elementId);
+  }
+
+  /**
+   * Convert a Cypher path result into a native Bolt Path structure. nodes and relationships are
+   * deduplicated (Bolt requires unique lists); indices is a flat [relIndex, nodeIndex, ...] sequence
+   * where relIndex is 1-based and signed by traversal direction (positive = the edge's OUT side is the
+   * previous path node, negative = traversed backward) and nodeIndex is the 0-based index of the node
+   * reached at that hop. The start node is index 0 and implicit.
+   */
+  public static BoltPath toPath(final TraversalPath path) {
+    final List<Vertex> vertices = path.getVertices();
+    final List<Edge> edges = path.getEdges();
+
+    final List<BoltNode> nodes = new ArrayList<>();
+    final Map<RID, Integer> nodeIndex = new HashMap<>();
+    final List<BoltUnboundRelationship> rels = new ArrayList<>();
+    final Map<RID, Integer> relIndex = new HashMap<>();
+    final List<Long> indices = new ArrayList<>(edges.size() * 2);
+
+    addPathNode(vertices.get(0), nodes, nodeIndex);
+
+    for (int i = 0; i < edges.size(); i++) {
+      final Edge edge = edges.get(i);
+      final Vertex from = vertices.get(i);
+      final Vertex to = vertices.get(i + 1);
+
+      final RID relRid = edge.getIdentity();
+      Integer ri = relIndex.get(relRid);
+      if (ri == null) {
+        rels.add(toUnboundRelationship(edge));
+        ri = rels.size(); // 1-based
+        relIndex.put(relRid, ri);
+      }
+      final boolean forward = edge.getOut().equals(from.getIdentity());
+      indices.add((long) (forward ? ri : -ri));
+      indices.add((long) addPathNode(to, nodes, nodeIndex));
+    }
+    return new BoltPath(nodes, rels, indices);
+  }
+
+  private static int addPathNode(final Vertex vertex, final List<BoltNode> nodes, final Map<RID, Integer> nodeIndex) {
+    final RID rid = vertex.getIdentity();
+    Integer i = nodeIndex.get(rid);
+    if (i == null) {
+      nodes.add(toNode(vertex));
+      i = nodes.size() - 1; // 0-based
+      nodeIndex.put(rid, i);
+    }
+    return i;
   }
 
   /**

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
@@ -226,6 +226,8 @@ public class BoltStructureMapper {
 
     addPathNode(vertices.get(0), nodes, nodeIndex);
 
+    // Invariant: vertices.size() == edges.size() + 1, guaranteed by TraversalPath construction, so
+    // vertices.get(i + 1) below is always in range for i < edges.size().
     for (int i = 0; i < edges.size(); i++) {
       final Edge edge = edges.get(i);
       final Vertex from = vertices.get(i);
@@ -431,7 +433,8 @@ public class BoltStructureMapper {
   static BoltPointStructure toPointStructure(final Object value) {
     if (!(value instanceof Map<?, ?> map) || !map.containsKey("crs"))
       return null;
-    if (!RECOGNIZED_CRS.contains(map.get("crs")) && !(map.get("srid") instanceof Number))
+    final Object crs = map.get("crs");
+    if ((crs == null || !RECOGNIZED_CRS.contains(crs)) && !(map.get("srid") instanceof Number))
       return null;
     final Double x = pointCoord(map, "x", "longitude");
     final Double y = pointCoord(map, "y", "latitude");
@@ -546,7 +549,7 @@ public class BoltStructureMapper {
   @SuppressWarnings("unchecked")
   public static Object fromPackStreamValue(final Object value) {
     if (value instanceof PackStreamReader.StructureValue structure)
-      return fromTemporalStructure(structure);
+      return fromInboundStructure(structure);
 
     if (value instanceof Map<?, ?> map) {
       final Map<String, Object> converted = new LinkedHashMap<>(map.size());
@@ -566,13 +569,14 @@ public class BoltStructureMapper {
   }
 
   /**
-   * Decode a single Bolt temporal PackStream structure into a {@code java.time} value.
-   * Unknown (non-temporal) structures are returned as-is. A structure that carries the wrong field
-   * count or field types for its temporal signature (a misbehaving client) is also returned as-is
+   * Decode a single inbound Bolt PackStream structure - temporal, Duration, or Point - into its
+   * engine-friendly value ({@code java.time} value, {@link CypherDuration}, or a Point map).
+   * Unknown (unrecognized) structures are returned as-is. A structure that carries the wrong field
+   * count or field types for its signature (a misbehaving client) is also returned as-is
    * rather than propagating a raw {@code IndexOutOfBoundsException} / {@code ClassCastException} out of
    * RUN parsing - the parameter simply stays opaque instead of crashing the connection.
    */
-  private static Object fromTemporalStructure(final PackStreamReader.StructureValue structure) {
+  private static Object fromInboundStructure(final PackStreamReader.StructureValue structure) {
     final List<Object> f = structure.getFields();
     final byte signature = structure.getSignature();
     if (!hasExpectedArity(signature, f.size()))

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
@@ -103,6 +103,12 @@ public class BoltStructureMapper {
       return toList(Arrays.asList(array));
     }
 
+    // Spatial Point: Cypher point() returns a plain Map (there is no Point class), so detect
+    // structurally (a crs key plus numeric x/y or longitude/latitude) before the generic Map branch.
+    final BoltPointStructure point = toPointStructure(value);
+    if (point != null)
+      return point;
+
     if (value instanceof Map<?, ?> map) {
       return toMap(map);
     }
@@ -347,6 +353,42 @@ public class BoltStructureMapper {
   private static final byte SIG_DATE_TIME_ZONEID_LEGACY = 0x66; // 'f'  [secondsLocal, nanos, zoneId]
   private static final byte SIG_DATE_TIME_OFFSET_UTC    = 0x49; // 'I'  [secondsUtc,  nanos, offsetSeconds] (Bolt 5.0+)
   private static final byte SIG_DATE_TIME_ZONEID_UTC    = 0x69; // 'i'  [secondsUtc,  nanos, zoneId]        (Bolt 5.0+)
+
+  private static final byte SIG_POINT_2D = 0x58; // 'X' [srid, x, y]
+  private static final byte SIG_POINT_3D = 0x59; // 'Y' [srid, x, y, z]
+
+  /**
+   * Recognize a Cypher spatial point (a Map carrying a crs key plus numeric x/y or longitude/latitude)
+   * and encode it as a native Bolt Point structure. Returns null when the value is not a point so the
+   * caller falls through to generic Map handling.
+   */
+  static BoltPointStructure toPointStructure(final Object value) {
+    if (!(value instanceof Map<?, ?> map) || !map.containsKey("crs"))
+      return null;
+    final Double x = pointCoord(map, "x", "longitude");
+    final Double y = pointCoord(map, "y", "latitude");
+    if (x == null || y == null)
+      return null;
+    final Double z = pointCoord(map, "z", "height");
+    final int srid = pointSrid(map, z != null);
+    return z == null ? new BoltPointStructure(srid, x, y) : new BoltPointStructure(srid, x, y, z);
+  }
+
+  private static Double pointCoord(final Map<?, ?> map, final String primary, final String alt) {
+    Object v = map.get(primary);
+    if (!(v instanceof Number))
+      v = map.get(alt);
+    return v instanceof Number n ? n.doubleValue() : null;
+  }
+
+  private static int pointSrid(final Map<?, ?> map, final boolean is3d) {
+    if (map.get("srid") instanceof Number n)
+      return n.intValue();
+    final String crs = map.get("crs") != null ? map.get("crs").toString() : "";
+    if (crs.startsWith("WGS-84"))
+      return is3d ? 4979 : 4326;
+    return is3d ? 9157 : 7203; // cartesian
+  }
 
   /**
    * Outbound direction (issue #4907): encode a temporal value as its native Bolt PackStream structure so

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
@@ -549,19 +549,29 @@ public class BoltStructureMapper {
         return ZonedDateTime.ofInstant(instant, ZoneId.of(String.valueOf(f.get(2))));
       }
 
+      case SIG_DURATION:
+        return new CypherDuration(asLong(f.get(0)), asLong(f.get(1)), asLong(f.get(2)), (int) asLong(f.get(3)));
+
+      case SIG_POINT_2D:
+        return pointMap((int) asLong(f.get(0)), asDouble(f.get(1)), asDouble(f.get(2)), null);
+
+      case SIG_POINT_3D:
+        return pointMap((int) asLong(f.get(0)), asDouble(f.get(1)), asDouble(f.get(2)), asDouble(f.get(3)));
+
       default:
-        // Not a temporal structure (or Duration, which has no single java.time representation): leave as-is.
+        // Not a recognized temporal, Duration or Point signature: leave as-is.
         return structure;
       }
     } catch (final RuntimeException e) {
-      // Malformed temporal payload (e.g. non-numeric field, unresolvable zone id): leave opaque.
+      // Malformed payload (e.g. non-numeric field, unresolvable zone id): leave opaque.
       return structure;
     }
   }
 
   /**
-   * Number of fields each temporal signature is expected to carry. Non-temporal signatures return
-   * {@code true} so they fall through to the default (opaque) branch unchanged.
+   * Number of fields each recognized signature (temporal, Duration, Point) is expected to carry.
+   * Unrecognized signatures return {@code true} so they fall through to the default (opaque)
+   * branch unchanged.
    */
   private static boolean hasExpectedArity(final byte signature, final int fieldCount) {
     return switch (signature) {
@@ -569,11 +579,48 @@ public class BoltStructureMapper {
       case SIG_TIME, SIG_LOCAL_DATE_TIME -> fieldCount == 2;
       case SIG_DATE_TIME_OFFSET_LEGACY, SIG_DATE_TIME_ZONEID_LEGACY, SIG_DATE_TIME_OFFSET_UTC, SIG_DATE_TIME_ZONEID_UTC ->
           fieldCount == 3;
+      case SIG_DURATION, SIG_POINT_3D -> fieldCount == 4;
+      case SIG_POINT_2D -> fieldCount == 3;
       default -> true;
     };
   }
 
   private static long asLong(final Object value) {
     return ((Number) value).longValue();
+  }
+
+  private static double asDouble(final Object value) {
+    return ((Number) value).doubleValue();
+  }
+
+  /**
+   * Build the inbound decoded representation of a Point: a map carrying x, y, an optional z,
+   * the srid and a derived crs key. The crs key is required so an echoed Point (e.g.
+   * {@code RETURN $p AS echo}) is recognized by {@link #toPointStructure} and re-encoded as a
+   * native Bolt Point rather than a generic map.
+   */
+  private static Map<String, Object> pointMap(final int srid, final double x, final double y, final Double z) {
+    final Map<String, Object> m = new LinkedHashMap<>();
+    m.put("srid", srid);
+    m.put("x", x);
+    m.put("y", y);
+    if (z != null)
+      m.put("z", z);
+    m.put("crs", crsForSrid(srid, z != null));
+    return m;
+  }
+
+  /**
+   * Map an SRID to its Neo4j-compatible crs name. Known SRIDs (4326 WGS-84, 4979 WGS-84-3D,
+   * 9157 cartesian-3D) map explicitly; any other SRID falls back to cartesian(-3D) based on
+   * dimensionality.
+   */
+  private static String crsForSrid(final int srid, final boolean is3d) {
+    return switch (srid) {
+      case 4326 -> "WGS-84";
+      case 4979 -> "WGS-84-3D";
+      case 9157 -> "cartesian-3D";
+      default -> is3d ? "cartesian-3D" : "cartesian";
+    };
   }
 }

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
@@ -27,6 +27,7 @@ import com.arcadedb.graph.Vertex;
 import com.arcadedb.query.opencypher.Labels;
 import com.arcadedb.query.opencypher.temporal.CypherDate;
 import com.arcadedb.query.opencypher.temporal.CypherDateTime;
+import com.arcadedb.query.opencypher.temporal.CypherDuration;
 import com.arcadedb.query.opencypher.temporal.CypherLocalDateTime;
 import com.arcadedb.query.opencypher.temporal.CypherLocalTime;
 import com.arcadedb.query.opencypher.temporal.CypherTime;
@@ -357,6 +358,8 @@ public class BoltStructureMapper {
   private static final byte SIG_POINT_2D = 0x58; // 'X' [srid, x, y]
   private static final byte SIG_POINT_3D = 0x59; // 'Y' [srid, x, y, z]
 
+  private static final byte SIG_DURATION = 0x45; // 'E' [months, days, seconds, nanoseconds]
+
   /**
    * Recognize a Cypher spatial point (a Map carrying a crs key plus numeric x/y or longitude/latitude)
    * and encode it as a native Bolt Point structure. Returns null when the value is not a point so the
@@ -441,6 +444,8 @@ public class BoltStructureMapper {
     if (value instanceof Calendar calendar)
       // Preserve the calendar's own zone instead of forcing UTC.
       return toTemporalStructure(ZonedDateTime.ofInstant(calendar.toInstant(), calendar.getTimeZone().toZoneId()));
+    if (value instanceof CypherDuration d)
+      return new BoltTemporalStructure(SIG_DURATION, d.getMonths(), d.getDays(), d.getSeconds(), (long) d.getNanosAdjustment());
 
     return null;
   }
@@ -462,9 +467,9 @@ public class BoltStructureMapper {
       return ldt.getValue();
     if (value instanceof CypherDateTime dt)
       return dt.getValue();
-    // NOTE: CypherDuration is intentionally not unwrapped - Bolt has a Duration struct but there is no single
-    // java.time value for it (months + days + seconds together), so a returned duration still falls through to
-    // the generic (ISO-8601 string) handling. Tracked as a follow-up if native Duration output is needed.
+    // NOTE: CypherDuration is intentionally not unwrapped to a java.time value - Bolt has a native Duration
+    // struct but there is no single java.time type for it (months + days + seconds together). It is matched
+    // directly as CypherDuration in toTemporalStructure below and emitted as a SIG_DURATION struct.
     return value;
   }
 

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
@@ -213,6 +213,11 @@ public class BoltStructureMapper {
     final List<Vertex> vertices = path.getVertices();
     final List<Edge> edges = path.getEdges();
 
+    // A MATCH path always has a start vertex, but TraversalPath's default constructor allows an
+    // empty path; guard it explicitly rather than let vertices.get(0) throw below.
+    if (vertices.isEmpty())
+      return new BoltPath(List.of(), List.of(), List.of());
+
     final List<BoltNode> nodes = new ArrayList<>();
     final Map<RID, Integer> nodeIndex = new HashMap<>();
     final List<BoltUnboundRelationship> rels = new ArrayList<>();
@@ -413,13 +418,20 @@ public class BoltStructureMapper {
 
   private static final byte SIG_DURATION = 0x45; // 'E' [months, days, seconds, nanoseconds]
 
+  private static final Set<String> RECOGNIZED_CRS = Set.of("cartesian", "cartesian-3D", "WGS-84", "WGS-84-3D");
+
   /**
-   * Recognize a Cypher spatial point (a Map carrying a crs key plus numeric x/y or longitude/latitude)
-   * and encode it as a native Bolt Point structure. Returns null when the value is not a point so the
-   * caller falls through to generic Map handling.
+   * Recognize a Cypher spatial point (a Map carrying numeric x/y or longitude/latitude, plus either a
+   * recognized crs value - {@code cartesian}, {@code cartesian-3D}, {@code WGS-84}, {@code WGS-84-3D} -
+   * or a numeric srid key) and encode it as a native Bolt Point structure. This is deliberately tighter
+   * than "any map with a crs key": an ordinary user map that happens to carry an unrelated crs value must
+   * not be misencoded as a Point on the wire. Returns null when the value is not a point so the caller
+   * falls through to generic Map handling.
    */
   static BoltPointStructure toPointStructure(final Object value) {
     if (!(value instanceof Map<?, ?> map) || !map.containsKey("crs"))
+      return null;
+    if (!RECOGNIZED_CRS.contains(map.get("crs")) && !(map.get("srid") instanceof Number))
       return null;
     final Double x = pointCoord(map, "x", "longitude");
     final Double y = pointCoord(map, "y", "latitude");

--- a/bolt/src/test/java/com/arcadedb/bolt/Bolt4998PathMappingTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Bolt4998PathMappingTest.java
@@ -87,6 +87,29 @@ class Bolt4998PathMappingTest {
   }
 
   @Test
+  @DisplayName("[TYPE-003] a cycle path (a->b->a) dedups the revisited start node")
+  void type003_revisitedNodeCyclePath() {
+    db.getSchema().createVertexType("CV");
+    db.getSchema().createEdgeType("CE");
+    db.transaction(() -> {
+      final MutableVertex ca = db.newVertex("CV").set("k", "a").save();
+      final MutableVertex cb = db.newVertex("CV").set("k", "b").save();
+      ca.newEdge("CE", cb).save();
+      cb.newEdge("CE", ca).save();
+    });
+
+    final ResultSet rs = db.query("opencypher",
+        "MATCH p=(x:CV {k:'a'})-[:CE]->(:CV {k:'b'})-[:CE]->(:CV {k:'a'}) RETURN p LIMIT 1");
+    final TraversalPath tp = (TraversalPath) rs.next().getProperty("p");
+    final BoltPath bp = BoltStructureMapper.toPath(tp);
+    // the revisited start node (a) is deduplicated: nodes holds only {a, b}, not {a, b, a}
+    assertThat(bp.getNodes()).hasSize(2);
+    assertThat(bp.getRelationships()).hasSize(2);
+    // rel1 fwd to node index 1 (b), rel2 fwd to node index 0 (a, revisited/reused)
+    assertThat(bp.getIndices()).containsExactly(1L, 1L, 2L, 0L);
+  }
+
+  @Test
   @DisplayName("[TYPE-012] RETURN point({...}) maps to a native BoltPointStructure")
   void type012_enginePointOutbound() {
     final ResultSet rs = db.query("opencypher", "RETURN point({x: 12.34, y: 56.78}) AS p");

--- a/bolt/src/test/java/com/arcadedb/bolt/Bolt4998PathMappingTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Bolt4998PathMappingTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.bolt.structure.BoltPath;
+import com.arcadedb.bolt.structure.BoltStructureMapper;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.query.opencypher.traversal.TraversalPath;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class Bolt4998PathMappingTest {
+  private static final String DB_PATH = "./target/databases/Bolt4998PathMappingTest";
+  private Database db;
+
+  @BeforeEach
+  void setUp() {
+    final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
+    if (factory.exists())
+      factory.open().drop();
+    db = factory.create();
+    db.getSchema().createVertexType("V");
+    db.getSchema().createEdgeType("E");
+    db.transaction(() -> {
+      final MutableVertex a = db.newVertex("V").set("k", "a").save();
+      final MutableVertex b = db.newVertex("V").set("k", "b").save();
+      final MutableVertex c = db.newVertex("V").set("k", "c").save();
+      a.newEdge("E", b).save();
+      b.newEdge("E", c).save();
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null && db.isOpen())
+      db.drop();
+  }
+
+  @Test
+  @DisplayName("[TYPE-003] a 2-hop forward path maps to a native BoltPath")
+  void type003_forwardPath() {
+    final ResultSet rs = db.query("opencypher", "MATCH p=(a:V {k:'a'})-[:E*2]->(c) RETURN p");
+    final TraversalPath tp = (TraversalPath) rs.next().getProperty("p");
+    final BoltPath bp = BoltStructureMapper.toPath(tp);
+    assertThat(bp.getNodes()).hasSize(3);
+    assertThat(bp.getRelationships()).hasSize(2);
+    // [relIdx(1-based, +forward), nodeIdx(0-based), ...] -> rel1 fwd to node1, rel2 fwd to node2
+    assertThat(bp.getIndices()).containsExactly(1L, 1L, 2L, 2L);
+  }
+
+  @Test
+  @DisplayName("[TYPE-003] a backward-traversed hop yields a negative rel index")
+  void type003_backwardHop() {
+    // Path starts at b and walks the incoming edge (a)-[E]->(b) backward to a, so the hop's
+    // rel index must be negative: edge.getOut() (a) != the previous path node (b).
+    final ResultSet rs = db.query("opencypher", "MATCH p=(b:V {k:'b'})<-[:E]-(a) RETURN p");
+    final TraversalPath tp = (TraversalPath) rs.next().getProperty("p");
+    final BoltPath bp = BoltStructureMapper.toPath(tp);
+    assertThat(bp.getNodes()).hasSize(2);
+    assertThat(bp.getRelationships()).hasSize(1);
+    assertThat(bp.getIndices().get(0)).isEqualTo(-1L); // backward, negative
+    assertThat(bp.getIndices().get(1)).isEqualTo(1L);  // reached node index (a) = 1
+  }
+}

--- a/bolt/src/test/java/com/arcadedb/bolt/Bolt4998PathMappingTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Bolt4998PathMappingTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.bolt;
 
 import com.arcadedb.bolt.structure.BoltPath;
+import com.arcadedb.bolt.structure.BoltPointStructure;
 import com.arcadedb.bolt.structure.BoltStructureMapper;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
@@ -83,5 +84,19 @@ class Bolt4998PathMappingTest {
     assertThat(bp.getRelationships()).hasSize(1);
     assertThat(bp.getIndices().get(0)).isEqualTo(-1L); // backward, negative
     assertThat(bp.getIndices().get(1)).isEqualTo(1L);  // reached node index (a) = 1
+  }
+
+  @Test
+  @DisplayName("[TYPE-012] RETURN point({...}) maps to a native BoltPointStructure")
+  void type012_enginePointOutbound() {
+    final ResultSet rs = db.query("opencypher", "RETURN point({x: 12.34, y: 56.78}) AS p");
+    final Object p = rs.next().getProperty("p");
+    final Object out = BoltStructureMapper.toPackStreamValue(p);
+    assertThat(out).isInstanceOf(BoltPointStructure.class);
+    final BoltPointStructure pt = (BoltPointStructure) out;
+    assertThat(pt.getSignature()).isEqualTo((byte) 0x58);
+    assertThat(pt.getSrid()).isEqualTo(7203);
+    assertThat(pt.getX()).isEqualTo(12.34);
+    assertThat(pt.getY()).isEqualTo(56.78);
   }
 }

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltErrorClassificationTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltErrorClassificationTest.java
@@ -18,6 +18,8 @@
  */
 package com.arcadedb.bolt;
 
+import com.arcadedb.exception.CommandParsingException;
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.exception.LockTimeoutException;
 import com.arcadedb.exception.NeedRetryException;
@@ -89,5 +91,17 @@ class BoltErrorClassificationTest {
     assertThat(BoltErrorCodes.TRANSIENT_CONFLICT_ERROR).startsWith("Neo.TransientError.");
     assertThat(BoltErrorCodes.TRANSIENT_CONFLICT_ERROR).isNotEqualTo("Neo.TransientError.Transaction.Terminated");
     assertThat(BoltErrorCodes.TRANSIENT_CONFLICT_ERROR).isNotEqualTo("Neo.TransientError.Transaction.LockClientStopped");
+  }
+
+  @Test
+  void semanticExceptionClassifiesAsSemanticError() {
+    assertThat(BoltNetworkExecutor.classifyParsingError(new CommandSemanticException("UndefinedVariable")))
+        .isEqualTo(BoltErrorCodes.SEMANTIC_ERROR);
+  }
+
+  @Test
+  void plainParsingExceptionClassifiesAsSyntaxError() {
+    assertThat(BoltNetworkExecutor.classifyParsingError(new CommandParsingException("unexpected token")))
+        .isEqualTo(BoltErrorCodes.SYNTAX_ERROR);
   }
 }

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltTypeRoundTripTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltTypeRoundTripTest.java
@@ -150,4 +150,14 @@ class BoltTypeRoundTripTest {
     m.put("y", 2.0);
     assertThat(BoltStructureMapper.toPackStreamValue(m)).isInstanceOf(Map.class);
   }
+
+  @Test
+  @DisplayName("A map with a null crs value and no srid is not misdetected as a Point and does not throw")
+  void nullCrsIsNotPoint() {
+    final Map<String, Object> m = new LinkedHashMap<>();
+    m.put("crs", null);
+    m.put("x", 1.0);
+    m.put("y", 2.0);
+    assertThat(BoltStructureMapper.toPackStreamValue(m)).isInstanceOf(Map.class);
+  }
 }

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltTypeRoundTripTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltTypeRoundTripTest.java
@@ -18,6 +18,8 @@
  */
 package com.arcadedb.bolt;
 
+import com.arcadedb.bolt.packstream.PackStreamReader;
+import com.arcadedb.bolt.packstream.PackStreamWriter;
 import com.arcadedb.bolt.structure.BoltPointStructure;
 import com.arcadedb.bolt.structure.BoltStructureMapper;
 import com.arcadedb.bolt.structure.BoltTemporalStructure;
@@ -26,6 +28,7 @@ import com.arcadedb.query.opencypher.temporal.CypherDuration;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -77,7 +80,7 @@ class BoltTypeRoundTripTest {
 
   @Test
   @DisplayName("[TYPE-011] CypherDuration serializes as a native Bolt Duration structure")
-  void type011_durationNative() {
+  void type011_durationNative() throws IOException {
     // duration('P1DT2H30M') -> months=0, days=1, seconds=9000, nanos=0
     final CypherDuration d = new CypherDuration(0, 1, 9000, 0);
     final Object out = BoltStructureMapper.toPackStreamValue(d);
@@ -85,6 +88,14 @@ class BoltTypeRoundTripTest {
     final BoltTemporalStructure s = (BoltTemporalStructure) out;
     assertThat(s.getSignature()).isEqualTo((byte) 0x45);
     assertThat(s.getFieldCount()).isEqualTo(4);
+
+    // BoltTemporalStructure has no field getter by design; round-trip through the wire to pin the
+    // field ORDER and VALUES, not just the structure shape.
+    final PackStreamWriter writer = new PackStreamWriter();
+    writer.writeValue(s);
+    final PackStreamReader.StructureValue wire = (PackStreamReader.StructureValue) new PackStreamReader(writer.toByteArray()).readValue();
+    assertThat(wire.getSignature()).isEqualTo((byte) 0x45);
+    assertThat(wire.getFields()).containsExactly(0L, 1L, 9000L, 0L);
   }
 
   @Test
@@ -127,6 +138,16 @@ class BoltTypeRoundTripTest {
     final Map<String, Object> m = new LinkedHashMap<>();
     m.put("a", 1);
     m.put("b", 2);
+    assertThat(BoltStructureMapper.toPackStreamValue(m)).isInstanceOf(Map.class);
+  }
+
+  @Test
+  @DisplayName("A map with an unrecognized crs value and no srid is not misdetected as a Point")
+  void unrecognizedCrsIsNotPoint() {
+    final Map<String, Object> m = new LinkedHashMap<>();
+    m.put("crs", "epsg:1234");
+    m.put("x", 1.0);
+    m.put("y", 2.0);
     assertThat(BoltStructureMapper.toPackStreamValue(m)).isInstanceOf(Map.class);
   }
 }

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltTypeRoundTripTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltTypeRoundTripTest.java
@@ -21,11 +21,11 @@ package com.arcadedb.bolt;
 import com.arcadedb.bolt.structure.BoltPointStructure;
 import com.arcadedb.bolt.structure.BoltStructureMapper;
 import com.arcadedb.bolt.structure.BoltTemporalStructure;
+import com.arcadedb.query.opencypher.temporal.CypherDuration;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -76,15 +76,15 @@ class BoltTypeRoundTripTest {
   }
 
   @Test
-  @DisplayName("[TYPE-011] Duration falls back to a String (wire-level gap #4890)")
-  void type011_durationGap() {
-    // KNOWN GAP (#4890): BoltStructureMapper has no Duration branch, so a
-    // java.time.Duration falls through to value.toString(). This characterization
-    // pins the current contract - when #4890 adds a native Bolt Duration
-    // structure, this assertion FAILS and must be flipped to assert the structure.
-    final Object out = BoltStructureMapper.toPackStreamValue(Duration.ofHours(2));
-    assertThat(out).isNotInstanceOf(BoltTemporalStructure.class);
-    assertThat(out).isInstanceOf(String.class);
+  @DisplayName("[TYPE-011] CypherDuration serializes as a native Bolt Duration structure")
+  void type011_durationNative() {
+    // duration('P1DT2H30M') -> months=0, days=1, seconds=9000, nanos=0
+    final CypherDuration d = new CypherDuration(0, 1, 9000, 0);
+    final Object out = BoltStructureMapper.toPackStreamValue(d);
+    assertThat(out).isInstanceOf(BoltTemporalStructure.class);
+    final BoltTemporalStructure s = (BoltTemporalStructure) out;
+    assertThat(s.getSignature()).isEqualTo((byte) 0x45);
+    assertThat(s.getFieldCount()).isEqualTo(4);
   }
 
   @Test

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltTypeRoundTripTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltTypeRoundTripTest.java
@@ -133,6 +133,37 @@ class BoltTypeRoundTripTest {
   }
 
   @Test
+  @DisplayName("[TYPE-012] cartesian Point survives a full encode -> wire -> decode -> re-encode round trip")
+  void type012_cartesianPointFullRoundTrip() throws Exception {
+    // 1. Build a cartesian point param and encode it.
+    final Map<String, Object> point = new LinkedHashMap<>();
+    point.put("x", 12.34);
+    point.put("y", 56.78);
+    point.put("crs", "cartesian");
+    final Object encoded = BoltStructureMapper.toPackStreamValue(point);
+    assertThat(encoded).isInstanceOf(BoltPointStructure.class);
+
+    // 2. Serialize to the wire and read it back as an inbound structure, then decode it the way
+    // an incoming RUN message's parameters are decoded.
+    final PackStreamWriter writer = new PackStreamWriter();
+    writer.writeValue(encoded);
+    final Object wireValue = new PackStreamReader(writer.toByteArray()).readValue();
+    final Object decoded = BoltStructureMapper.fromPackStreamValue(wireValue);
+    assertThat(decoded).isInstanceOf(Map.class);
+
+    // 3. Re-encode the decoded param, as happens when a query echoes it back (e.g. RETURN $p).
+    // The decoded map must carry a derived crs key so this is recognized as a Point again,
+    // not degraded to a generic map.
+    final Object reEncoded = BoltStructureMapper.toPackStreamValue(decoded);
+    assertThat(reEncoded).isInstanceOf(BoltPointStructure.class);
+    final BoltPointStructure reEncodedPoint = (BoltPointStructure) reEncoded;
+    assertThat(reEncodedPoint.getSrid()).isEqualTo(7203);
+    assertThat(reEncodedPoint.getX()).isEqualTo(12.34);
+    assertThat(reEncodedPoint.getY()).isEqualTo(56.78);
+    assertThat(reEncodedPoint.getZ()).isNull();
+  }
+
+  @Test
   @DisplayName("A plain map without crs is not misdetected as a Point")
   void plainMapIsNotPoint() {
     final Map<String, Object> m = new LinkedHashMap<>();

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltTypeRoundTripTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltTypeRoundTripTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.bolt;
 
+import com.arcadedb.bolt.structure.BoltPointStructure;
 import com.arcadedb.bolt.structure.BoltStructureMapper;
 import com.arcadedb.bolt.structure.BoltTemporalStructure;
 
@@ -30,6 +31,8 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -82,5 +85,48 @@ class BoltTypeRoundTripTest {
     final Object out = BoltStructureMapper.toPackStreamValue(Duration.ofHours(2));
     assertThat(out).isNotInstanceOf(BoltTemporalStructure.class);
     assertThat(out).isInstanceOf(String.class);
+  }
+
+  @Test
+  @DisplayName("[TYPE-012] cartesian Point serializes as a native Bolt Point2D structure")
+  void type012_cartesianPointNative() {
+    final Map<String, Object> point = new LinkedHashMap<>();
+    point.put("x", 12.34);
+    point.put("y", 56.78);
+    point.put("crs", "cartesian");
+    final Object out = BoltStructureMapper.toPackStreamValue(point);
+    assertThat(out).isInstanceOf(BoltPointStructure.class);
+    final BoltPointStructure p = (BoltPointStructure) out;
+    assertThat(p.getSignature()).isEqualTo((byte) 0x58);
+    assertThat(p.getSrid()).isEqualTo(7203);
+    assertThat(p.getX()).isEqualTo(12.34);
+    assertThat(p.getY()).isEqualTo(56.78);
+    assertThat(p.getZ()).isNull();
+  }
+
+  @Test
+  @DisplayName("[TYPE-012] WGS-84 3D Point serializes as a native Bolt Point3D structure")
+  void type012_wgs84Point3DNative() {
+    final Map<String, Object> point = new LinkedHashMap<>();
+    point.put("longitude", 12.34);
+    point.put("latitude", 56.78);
+    point.put("height", 100.0);
+    point.put("crs", "WGS-84-3D");
+    point.put("srid", 4979);
+    final BoltPointStructure p = (BoltPointStructure) BoltStructureMapper.toPackStreamValue(point);
+    assertThat(p.getSignature()).isEqualTo((byte) 0x59);
+    assertThat(p.getSrid()).isEqualTo(4979);
+    assertThat(p.getX()).isEqualTo(12.34);
+    assertThat(p.getY()).isEqualTo(56.78);
+    assertThat(p.getZ()).isEqualTo(100.0);
+  }
+
+  @Test
+  @DisplayName("A plain map without crs is not misdetected as a Point")
+  void plainMapIsNotPoint() {
+    final Map<String, Object> m = new LinkedHashMap<>();
+    m.put("a", 1);
+    m.put("b", 2);
+    assertThat(BoltStructureMapper.toPackStreamValue(m)).isInstanceOf(Map.class);
   }
 }

--- a/bolt/src/test/java/com/arcadedb/bolt/PackStreamTypeInputTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/PackStreamTypeInputTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.bolt.packstream.PackStreamReader;
+import com.arcadedb.bolt.packstream.PackStreamWriter;
+import com.arcadedb.bolt.structure.BoltStructureMapper;
+import com.arcadedb.query.opencypher.temporal.CypherDuration;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for inbound Bolt Duration and Point PackStream structures: a Bolt client
+ * sending a native Duration or Point as a query parameter must be decoded into a usable value
+ * (a {@link CypherDuration} for Duration, a map carrying x/y(/z)/srid/crs for Point) instead of
+ * arriving as an opaque {@link PackStreamReader.StructureValue} and being silently dropped.
+ */
+class PackStreamTypeInputTest {
+  private static final byte SIG_DURATION  = 0x45;
+  private static final byte SIG_POINT_2D  = 0x58;
+  private static final byte SIG_POINT_3D  = 0x59;
+
+  @Test
+  void decodesDuration() throws Exception {
+    final Object out = decode(SIG_DURATION, 0L, 1L, 9000L, 0L);
+    assertThat(out).isInstanceOf(CypherDuration.class);
+    final CypherDuration d = (CypherDuration) out;
+    assertThat(d.getMonths()).isEqualTo(0);
+    assertThat(d.getDays()).isEqualTo(1);
+    assertThat(d.getSeconds()).isEqualTo(9000);
+    assertThat(d.getNanosAdjustment()).isEqualTo(0);
+  }
+
+  @Test
+  void decodesCartesianPoint2D() throws Exception {
+    final Object out = decode(SIG_POINT_2D, 7203L, 12.34, 56.78);
+    assertThat(out).isInstanceOf(Map.class);
+    final Map<?, ?> m = (Map<?, ?>) out;
+    assertThat(((Number) m.get("srid")).intValue()).isEqualTo(7203);
+    assertThat(((Number) m.get("x")).doubleValue()).isEqualTo(12.34);
+    assertThat(((Number) m.get("y")).doubleValue()).isEqualTo(56.78);
+    assertThat(m.get("crs")).isEqualTo("cartesian");
+  }
+
+  @Test
+  void decodesWgs84Point3D() throws Exception {
+    final Object out = decode(SIG_POINT_3D, 4979L, 12.34, 56.78, 100.0);
+    final Map<?, ?> m = (Map<?, ?>) out;
+    assertThat(m.get("crs")).isEqualTo("WGS-84-3D");
+    assertThat(((Number) m.get("z")).doubleValue()).isEqualTo(100.0);
+  }
+
+  @Test
+  void malformedDurationIsLeftOpaque() throws Exception {
+    // Duration expects 4 fields; 2 must degrade to an opaque StructureValue, not crash.
+    assertThat(decode(SIG_DURATION, 1L, 2L)).isInstanceOf(PackStreamReader.StructureValue.class);
+  }
+
+  /**
+   * Write a struct to the wire, read it back, and decode it.
+   */
+  private static Object decode(final byte signature, final Object... fields) throws Exception {
+    return BoltStructureMapper.fromPackStreamValue(readBack(signature, fields));
+  }
+
+  /**
+   * Write a struct to the wire and read it back (as a raw StructureValue, without decoding).
+   */
+  private static Object readBack(final byte signature, final Object... fields) throws Exception {
+    final PackStreamWriter writer = new PackStreamWriter();
+    writer.writeStructureHeader(signature, fields.length);
+    for (final Object field : fields)
+      writer.writeValue(field);
+    return new PackStreamReader(writer.toByteArray()).readValue();
+  }
+}

--- a/docs/superpowers/plans/2026-07-05-bolt-type-fidelity-trio.md
+++ b/docs/superpowers/plans/2026-07-05-bolt-type-fidelity-trio.md
@@ -1,0 +1,790 @@
+# Bolt type-fidelity trio Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Emit native Bolt `Duration`, `Point`, and `Path` structures and distinguish semantic from syntax errors, closing #4997/#4998/#4999 and flipping conformance cells TYPE-011, TYPE-012, TYPE-003, ERR-002.
+
+**Architecture:** Writer-side additions to `BoltStructureMapper` plus the single inbound param-decode point, mirroring the shipped temporal work (#4907). No query-engine changes except one small exception subclass in `engine`. Native structures reuse the existing `PackStreamStructure`/`BoltPath` machinery.
+
+**Tech Stack:** Java 21, Maven multi-module, JUnit 5 + AssertJ, ArcadeDB `bolt` + `engine` modules.
+
+## Global Constraints
+
+- Java 21+; compile with `mvn -q -pl bolt -am -DskipTests install` before running tests.
+- Use `final` on variables/parameters; import classes, no fully-qualified names in code.
+- One-child `if` needs no braces; match surrounding style.
+- No `System.out`; no Claude attribution in code or commits; comments state behavioral invariants only, no issue numbers in Javadoc.
+- License header: copy the Apache-2.0 header block verbatim from any sibling `.java` file for every new source file.
+- Bolt `Duration` tag `0x45` fields `[months, days, seconds, nanoseconds]`; `Point2D` tag `0x58` `[srid, x, y]`; `Point3D` tag `0x59` `[srid, x, y, z]`; `Path` tag `0x50`.
+- SRID: `cartesian`->7203, `cartesian-3D`->9157, `WGS-84`->4326, `WGS-84-3D`->4979.
+- Do not commit on `main`; all work on branch `feat/4890-bolt-type-fidelity` in worktree `.worktrees/feat/4890-bolt-type-fidelity`.
+
+---
+
+## File Structure
+
+- `bolt/.../structure/BoltPointStructure.java` (new) - spatial `PackStreamStructure`, tag 0x58/0x59.
+- `bolt/.../structure/BoltStructureMapper.java` (modify) - outbound Duration/Point/Path branches; inbound Duration/Point decode.
+- `bolt/.../BoltNetworkExecutor.java` (modify) - `classifyParsingError` helper + use in `handleRun`.
+- `engine/.../exception/CommandSemanticException.java` (new) - subclass of `CommandParsingException`.
+- `engine/.../query/opencypher/parser/CypherSemanticValidator.java` (modify) - retarget throws.
+- `bolt/.../BoltTypeRoundTripTest.java` (modify) - flip TYPE-011, add TYPE-012.
+- `bolt/.../Bolt4998PathMappingTest.java` (new) - TYPE-003 embedded-DB mapping test.
+- `bolt/.../PackStreamTypeInputTest.java` (new) - inbound Duration/Point round-trip decode.
+- `bolt/.../BoltErrorClassificationTest.java` (modify) - `classifyParsingError` unit tests.
+- `engine/.../CypherSemanticValidatorExceptionTest.java` (new) - validator throws `CommandSemanticException`.
+- `bolt/conformance/spec.yaml` (modify) + the five e2e suites (modify) - flip cells + markers.
+
+---
+
+### Task 1: BoltPointStructure + outbound Point mapping (TYPE-012)
+
+**Files:**
+- Create: `bolt/src/main/java/com/arcadedb/bolt/structure/BoltPointStructure.java`
+- Modify: `bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java`
+- Test: `bolt/src/test/java/com/arcadedb/bolt/BoltTypeRoundTripTest.java`
+
+**Interfaces:**
+- Produces: `BoltPointStructure(int srid, double x, double y)` and `BoltPointStructure(int srid, double x, double y, Double z)`; getters `getSrid()`, `getX()`, `getY()`, `getZ()`, `getSignature()`. `BoltStructureMapper.toPointStructure(Object)` -> `BoltPointStructure` or `null`.
+
+- [ ] **Step 1: Write the failing test** in `BoltTypeRoundTripTest.java` (add imports `com.arcadedb.bolt.structure.BoltPointStructure`, `java.util.LinkedHashMap`, `java.util.Map`):
+
+```java
+@Test
+@DisplayName("[TYPE-012] cartesian Point serializes as a native Bolt Point2D structure")
+void type012_cartesianPointNative() {
+  final Map<String, Object> point = new LinkedHashMap<>();
+  point.put("x", 12.34);
+  point.put("y", 56.78);
+  point.put("crs", "cartesian");
+  final Object out = BoltStructureMapper.toPackStreamValue(point);
+  assertThat(out).isInstanceOf(BoltPointStructure.class);
+  final BoltPointStructure p = (BoltPointStructure) out;
+  assertThat(p.getSignature()).isEqualTo((byte) 0x58);
+  assertThat(p.getSrid()).isEqualTo(7203);
+  assertThat(p.getX()).isEqualTo(12.34);
+  assertThat(p.getY()).isEqualTo(56.78);
+  assertThat(p.getZ()).isNull();
+}
+
+@Test
+@DisplayName("[TYPE-012] WGS-84 3D Point serializes as a native Bolt Point3D structure")
+void type012_wgs84Point3DNative() {
+  final Map<String, Object> point = new LinkedHashMap<>();
+  point.put("longitude", 12.34);
+  point.put("latitude", 56.78);
+  point.put("height", 100.0);
+  point.put("crs", "WGS-84-3D");
+  point.put("srid", 4979);
+  final BoltPointStructure p = (BoltPointStructure) BoltStructureMapper.toPackStreamValue(point);
+  assertThat(p.getSignature()).isEqualTo((byte) 0x59);
+  assertThat(p.getSrid()).isEqualTo(4979);
+  assertThat(p.getX()).isEqualTo(12.34);
+  assertThat(p.getY()).isEqualTo(56.78);
+  assertThat(p.getZ()).isEqualTo(100.0);
+}
+
+@Test
+@DisplayName("A plain map without crs is not misdetected as a Point")
+void plainMapIsNotPoint() {
+  final Map<String, Object> m = new LinkedHashMap<>();
+  m.put("a", 1);
+  m.put("b", 2);
+  assertThat(BoltStructureMapper.toPackStreamValue(m)).isInstanceOf(Map.class);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn -q -pl bolt test -Dtest=BoltTypeRoundTripTest#type012_cartesianPointNative`
+Expected: FAIL - `BoltPointStructure` does not exist / value is a Map.
+
+- [ ] **Step 3: Create `BoltPointStructure.java`** (copy the Apache header from `BoltPath.java`):
+
+```java
+package com.arcadedb.bolt.structure;
+
+import com.arcadedb.bolt.packstream.PackStreamStructure;
+import com.arcadedb.bolt.packstream.PackStreamWriter;
+
+import java.io.IOException;
+
+/**
+ * A Bolt spatial Point PackStream structure. Point2D (signature 0x58) carries [srid, x, y];
+ * Point3D (signature 0x59) carries [srid, x, y, z]. srid is an integer; coordinates are doubles.
+ */
+public class BoltPointStructure implements PackStreamStructure {
+  public static final byte SIGNATURE_2D = 0x58;
+  public static final byte SIGNATURE_3D = 0x59;
+
+  private final int    srid;
+  private final double x;
+  private final double y;
+  private final Double z; // null for 2D
+
+  public BoltPointStructure(final int srid, final double x, final double y) {
+    this(srid, x, y, null);
+  }
+
+  public BoltPointStructure(final int srid, final double x, final double y, final Double z) {
+    this.srid = srid;
+    this.x = x;
+    this.y = y;
+    this.z = z;
+  }
+
+  @Override
+  public byte getSignature() {
+    return z == null ? SIGNATURE_2D : SIGNATURE_3D;
+  }
+
+  @Override
+  public int getFieldCount() {
+    return z == null ? 3 : 4;
+  }
+
+  @Override
+  public void writeTo(final PackStreamWriter writer) throws IOException {
+    writer.writeStructureHeader(getSignature(), getFieldCount());
+    writer.writeValue((long) srid);
+    writer.writeValue(x);
+    writer.writeValue(y);
+    if (z != null)
+      writer.writeValue(z);
+  }
+
+  public int getSrid() {
+    return srid;
+  }
+
+  public double getX() {
+    return x;
+  }
+
+  public double getY() {
+    return y;
+  }
+
+  public Double getZ() {
+    return z;
+  }
+}
+```
+
+- [ ] **Step 4: Add Point detection to `BoltStructureMapper.toPackStreamValue`.** Insert this branch immediately **before** the `Map` branch (`if (value instanceof Map<?, ?> map)`, ~line 106):
+
+```java
+    // Spatial Point: Cypher point() returns a plain Map (there is no Point class), so detect
+    // structurally (a crs key plus numeric x/y or longitude/latitude) before the generic Map branch.
+    final BoltPointStructure point = toPointStructure(value);
+    if (point != null)
+      return point;
+```
+
+Add these constants and helpers to `BoltStructureMapper` (near the temporal SIG constants) and the import `import com.arcadedb.bolt.structure.BoltPointStructure;` is not needed (same package); add nothing else:
+
+```java
+  private static final byte SIG_POINT_2D = 0x58; // 'X' [srid, x, y]
+  private static final byte SIG_POINT_3D = 0x59; // 'Y' [srid, x, y, z]
+
+  /**
+   * Recognize a Cypher spatial point (a Map carrying a crs key plus numeric x/y or longitude/latitude)
+   * and encode it as a native Bolt Point structure. Returns null when the value is not a point so the
+   * caller falls through to generic Map handling.
+   */
+  static BoltPointStructure toPointStructure(final Object value) {
+    if (!(value instanceof Map<?, ?> map) || !map.containsKey("crs"))
+      return null;
+    final Double x = pointCoord(map, "x", "longitude");
+    final Double y = pointCoord(map, "y", "latitude");
+    if (x == null || y == null)
+      return null;
+    final Double z = pointCoord(map, "z", "height");
+    final int srid = pointSrid(map, z != null);
+    return z == null ? new BoltPointStructure(srid, x, y) : new BoltPointStructure(srid, x, y, z);
+  }
+
+  private static Double pointCoord(final Map<?, ?> map, final String primary, final String alt) {
+    Object v = map.get(primary);
+    if (!(v instanceof Number))
+      v = map.get(alt);
+    return v instanceof Number n ? n.doubleValue() : null;
+  }
+
+  private static int pointSrid(final Map<?, ?> map, final boolean is3d) {
+    if (map.get("srid") instanceof Number n)
+      return n.intValue();
+    final String crs = map.get("crs") != null ? map.get("crs").toString() : "";
+    if (crs.startsWith("WGS-84"))
+      return is3d ? 4979 : 4326;
+    return is3d ? 9157 : 7203; // cartesian
+  }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `mvn -q -pl bolt test -Dtest=BoltTypeRoundTripTest`
+Expected: PASS (TYPE-012 cases and `plainMapIsNotPoint`), existing TYPE-007..010 still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add bolt/src/main/java/com/arcadedb/bolt/structure/BoltPointStructure.java \
+        bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java \
+        bolt/src/test/java/com/arcadedb/bolt/BoltTypeRoundTripTest.java
+git commit -m "feat(bolt): emit native Point structures (TYPE-012)"
+```
+
+---
+
+### Task 2: Outbound Duration mapping (TYPE-011)
+
+**Files:**
+- Modify: `bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java`
+- Test: `bolt/src/test/java/com/arcadedb/bolt/BoltTypeRoundTripTest.java`
+
+**Interfaces:**
+- Consumes: `BoltTemporalStructure(byte signature, Object... fields)` (existing).
+- Produces: `toPackStreamValue(CypherDuration)` -> `BoltTemporalStructure` sig `0x45`, fields `[months, days, seconds, nanos]`.
+
+- [ ] **Step 1: Replace the existing TYPE-011 characterization test** in `BoltTypeRoundTripTest.java` (delete `type011_durationGap`, add the import `com.arcadedb.query.opencypher.temporal.CypherDuration`):
+
+```java
+@Test
+@DisplayName("[TYPE-011] CypherDuration serializes as a native Bolt Duration structure")
+void type011_durationNative() {
+  // duration('P1DT2H30M') -> months=0, days=1, seconds=9000, nanos=0
+  final CypherDuration d = new CypherDuration(0, 1, 9000, 0);
+  final Object out = BoltStructureMapper.toPackStreamValue(d);
+  assertThat(out).isInstanceOf(BoltTemporalStructure.class);
+  final BoltTemporalStructure s = (BoltTemporalStructure) out;
+  assertThat(s.getSignature()).isEqualTo((byte) 0x45);
+  assertThat(s.getFieldCount()).isEqualTo(4);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn -q -pl bolt test -Dtest=BoltTypeRoundTripTest#type011_durationNative`
+Expected: FAIL - `CypherDuration` falls through to `value.toString()` (a String, not `BoltTemporalStructure`).
+
+- [ ] **Step 3: Add the Duration branch.** In `BoltStructureMapper`, add the constant and a branch in `toTemporalStructure(...)` (before the final `return null;`), and add the import `com.arcadedb.query.opencypher.temporal.CypherDuration`:
+
+```java
+  private static final byte SIG_DURATION = 0x45; // 'E' [months, days, seconds, nanoseconds]
+```
+
+```java
+    if (value instanceof CypherDuration d)
+      return new BoltTemporalStructure(SIG_DURATION, d.getMonths(), d.getDays(), d.getSeconds(), (long) d.getNanosAdjustment());
+```
+
+Update the comment in `unwrapCypherTemporal` that currently says `CypherDuration is intentionally not unwrapped` to state that Duration is now emitted as a native Bolt Duration struct via the branch above.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `mvn -q -pl bolt test -Dtest=BoltTypeRoundTripTest`
+Expected: PASS. All temporal cases still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java \
+        bolt/src/test/java/com/arcadedb/bolt/BoltTypeRoundTripTest.java
+git commit -m "feat(bolt): emit native Duration structures (TYPE-011)"
+```
+
+---
+
+### Task 3: Inbound Duration + Point decode (round-trip)
+
+**Files:**
+- Modify: `bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java`
+- Test: `bolt/src/test/java/com/arcadedb/bolt/PackStreamTypeInputTest.java` (new)
+
+**Interfaces:**
+- Consumes: `fromPackStreamValue(Object)` (existing), `PackStreamReader.StructureValue`.
+- Produces: inbound `0x45` -> `CypherDuration`; `0x58/0x59` -> `LinkedHashMap` with `x`,`y`(,`z`),`srid`,`crs`.
+
+- [ ] **Step 1: Write the failing test** `PackStreamTypeInputTest.java` (copy header + the `decode`/`readBack` helpers from `PackStreamTemporalInputTest.java`; imports: `com.arcadedb.bolt.packstream.PackStreamReader`, `PackStreamWriter`, `com.arcadedb.bolt.structure.BoltStructureMapper`, `com.arcadedb.query.opencypher.temporal.CypherDuration`, `java.util.Map`, `org.junit.jupiter.api.Test`, `static org.assertj.core.api.Assertions.assertThat`):
+
+```java
+private static final byte SIG_DURATION = 0x45;
+private static final byte SIG_POINT_2D = 0x58;
+private static final byte SIG_POINT_3D = 0x59;
+
+@Test
+void decodesDuration() throws Exception {
+  final Object out = decode(SIG_DURATION, 0L, 1L, 9000L, 0L);
+  assertThat(out).isInstanceOf(CypherDuration.class);
+  final CypherDuration d = (CypherDuration) out;
+  assertThat(d.getMonths()).isEqualTo(0);
+  assertThat(d.getDays()).isEqualTo(1);
+  assertThat(d.getSeconds()).isEqualTo(9000);
+  assertThat(d.getNanosAdjustment()).isEqualTo(0);
+}
+
+@Test
+void decodesCartesianPoint2D() throws Exception {
+  final Object out = decode(SIG_POINT_2D, 7203L, 12.34, 56.78);
+  assertThat(out).isInstanceOf(Map.class);
+  final Map<?, ?> m = (Map<?, ?>) out;
+  assertThat(((Number) m.get("srid")).intValue()).isEqualTo(7203);
+  assertThat(((Number) m.get("x")).doubleValue()).isEqualTo(12.34);
+  assertThat(((Number) m.get("y")).doubleValue()).isEqualTo(56.78);
+  assertThat(m.get("crs")).isEqualTo("cartesian");
+}
+
+@Test
+void decodesWgs84Point3D() throws Exception {
+  final Object out = decode(SIG_POINT_3D, 4979L, 12.34, 56.78, 100.0);
+  final Map<?, ?> m = (Map<?, ?>) out;
+  assertThat(m.get("crs")).isEqualTo("WGS-84-3D");
+  assertThat(((Number) m.get("z")).doubleValue()).isEqualTo(100.0);
+}
+
+@Test
+void malformedDurationIsLeftOpaque() throws Exception {
+  // Duration expects 4 fields; 2 must degrade to an opaque StructureValue, not crash.
+  assertThat(decode(SIG_DURATION, 1L, 2L)).isInstanceOf(PackStreamReader.StructureValue.class);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn -q -pl bolt test -Dtest=PackStreamTypeInputTest`
+Expected: FAIL - structs come back as raw `StructureValue`.
+
+- [ ] **Step 3: Extend the inbound decoder.** In `BoltStructureMapper.fromTemporalStructure(...)`, add cases to the `switch`, extend `hasExpectedArity`, and add helpers. Add import `java.util.LinkedHashMap` (already have `java.util.*`) and `CypherDuration` (added in Task 2):
+
+```java
+      case SIG_DURATION:
+        return new CypherDuration(asLong(f.get(0)), asLong(f.get(1)), asLong(f.get(2)), (int) asLong(f.get(3)));
+
+      case SIG_POINT_2D:
+        return pointMap((int) asLong(f.get(0)), asDouble(f.get(1)), asDouble(f.get(2)), null);
+
+      case SIG_POINT_3D:
+        return pointMap((int) asLong(f.get(0)), asDouble(f.get(1)), asDouble(f.get(2)), asDouble(f.get(3)));
+```
+
+In `hasExpectedArity`, extend the switch:
+
+```java
+      case SIG_DURATION, SIG_POINT_3D -> fieldCount == 4;
+      case SIG_POINT_2D -> fieldCount == 3;
+```
+
+Add helpers near `asLong`:
+
+```java
+  private static double asDouble(final Object value) {
+    return ((Number) value).doubleValue();
+  }
+
+  private static Map<String, Object> pointMap(final int srid, final double x, final double y, final Double z) {
+    final Map<String, Object> m = new LinkedHashMap<>();
+    m.put("srid", srid);
+    m.put("x", x);
+    m.put("y", y);
+    if (z != null)
+      m.put("z", z);
+    m.put("crs", crsForSrid(srid, z != null));
+    return m;
+  }
+
+  private static String crsForSrid(final int srid, final boolean is3d) {
+    return switch (srid) {
+      case 4326 -> "WGS-84";
+      case 4979 -> "WGS-84-3D";
+      case 9157 -> "cartesian-3D";
+      default -> is3d ? "cartesian-3D" : "cartesian";
+    };
+  }
+```
+
+Note: `SIG_POINT_2D`/`SIG_POINT_3D` constants already exist from Task 1; `SIG_DURATION` from Task 2. The `asDouble` cast in the point cases can throw `ClassCastException` on a malformed field - the existing `try/catch (RuntimeException)` around the switch already returns the struct opaque, so no extra guard needed.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `mvn -q -pl bolt test -Dtest=PackStreamTypeInputTest,PackStreamTemporalInputTest`
+Expected: PASS - both new and existing inbound tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java \
+        bolt/src/test/java/com/arcadedb/bolt/PackStreamTypeInputTest.java
+git commit -m "feat(bolt): decode inbound Duration and Point parameters (round-trip)"
+```
+
+---
+
+### Task 4: Native Path mapping (TYPE-003)
+
+**Files:**
+- Modify: `bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java`
+- Test: `bolt/src/test/java/com/arcadedb/bolt/Bolt4998PathMappingTest.java` (new)
+
+**Interfaces:**
+- Consumes: `toNode(Vertex)`, `toUnboundRelationship(Edge)` (existing); `TraversalPath.getVertices()/getEdges()`.
+- Produces: `toPackStreamValue(TraversalPath)` -> `BoltPath`; static `BoltStructureMapper.toPath(TraversalPath)`.
+
+- [ ] **Step 1: Write the failing test** `Bolt4998PathMappingTest.java` (Apache header; imports: `com.arcadedb.database.Database`, `com.arcadedb.database.DatabaseFactory`, `com.arcadedb.graph.MutableVertex`, `com.arcadedb.query.opencypher.traversal.TraversalPath`, `com.arcadedb.query.sql.executor.ResultSet`, `com.arcadedb.bolt.structure.BoltPath`, `com.arcadedb.bolt.structure.BoltStructureMapper`, `org.junit.jupiter.api.*`, `static org.assertj.core.api.Assertions.assertThat`):
+
+```java
+class Bolt4998PathMappingTest {
+  private static final String DB_PATH = "./target/databases/Bolt4998PathMappingTest";
+  private Database db;
+
+  @BeforeEach
+  void setUp() {
+    final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
+    if (factory.exists())
+      factory.open().drop();
+    db = factory.create();
+    db.getSchema().createVertexType("V");
+    db.getSchema().createEdgeType("E");
+    db.transaction(() -> {
+      final MutableVertex a = db.newVertex("V").set("k", "a").save();
+      final MutableVertex b = db.newVertex("V").set("k", "b").save();
+      final MutableVertex c = db.newVertex("V").set("k", "c").save();
+      a.newEdge("E", b).save();
+      b.newEdge("E", c).save();
+    });
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null && db.isOpen())
+      db.drop();
+  }
+
+  @Test
+  @DisplayName("[TYPE-003] a 2-hop forward path maps to a native BoltPath")
+  void type003_forwardPath() {
+    final ResultSet rs = db.query("opencypher", "MATCH p=(a:V {k:'a'})-[:E*2]->(c) RETURN p");
+    final TraversalPath tp = (TraversalPath) rs.next().getProperty("p");
+    final BoltPath bp = BoltStructureMapper.toPath(tp);
+    assertThat(bp.getNodes()).hasSize(3);
+    assertThat(bp.getRelationships()).hasSize(2);
+    // [relIdx(1-based, +forward), nodeIdx(0-based), ...] -> rel1 fwd to node1, rel2 fwd to node2
+    assertThat(bp.getIndices()).containsExactly(1L, 1L, 2L, 2L);
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn -q -pl bolt test -Dtest=Bolt4998PathMappingTest`
+Expected: FAIL - `toPath` does not exist (compile error).
+
+- [ ] **Step 3: Add the Path branch and mapper.** In `toPackStreamValue`, add a branch right after the `Result` branch (~line 77):
+
+```java
+    if (value instanceof TraversalPath path)
+      return toPath(path);
+```
+
+Add the method and helper to `BoltStructureMapper`, plus imports `com.arcadedb.query.opencypher.traversal.TraversalPath`, `com.arcadedb.graph.Vertex` (already imported), `com.arcadedb.graph.Edge` (already imported):
+
+```java
+  /**
+   * Convert a Cypher path result into a native Bolt Path structure. nodes and relationships are
+   * deduplicated (Bolt requires unique lists); indices is a flat [relIndex, nodeIndex, ...] sequence
+   * where relIndex is 1-based and signed by traversal direction (positive = the edge's OUT side is the
+   * previous path node, negative = traversed backward) and nodeIndex is the 0-based index of the node
+   * reached at that hop. The start node is index 0 and implicit.
+   */
+  static BoltPath toPath(final TraversalPath path) {
+    final List<Vertex> vertices = path.getVertices();
+    final List<Edge> edges = path.getEdges();
+
+    final List<BoltNode> nodes = new ArrayList<>();
+    final Map<RID, Integer> nodeIndex = new HashMap<>();
+    final List<BoltUnboundRelationship> rels = new ArrayList<>();
+    final Map<RID, Integer> relIndex = new HashMap<>();
+    final List<Long> indices = new ArrayList<>(edges.size() * 2);
+
+    addPathNode(vertices.get(0), nodes, nodeIndex);
+
+    for (int i = 0; i < edges.size(); i++) {
+      final Edge edge = edges.get(i);
+      final Vertex from = vertices.get(i);
+      final Vertex to = vertices.get(i + 1);
+
+      final RID relRid = edge.getIdentity();
+      Integer ri = relIndex.get(relRid);
+      if (ri == null) {
+        rels.add(toUnboundRelationship(edge));
+        ri = rels.size(); // 1-based
+        relIndex.put(relRid, ri);
+      }
+      final boolean forward = edge.getOut().equals(from.getIdentity());
+      indices.add((long) (forward ? ri : -ri));
+      indices.add((long) addPathNode(to, nodes, nodeIndex));
+    }
+    return new BoltPath(nodes, rels, indices);
+  }
+
+  private static int addPathNode(final Vertex vertex, final List<BoltNode> nodes, final Map<RID, Integer> nodeIndex) {
+    final RID rid = vertex.getIdentity();
+    Integer i = nodeIndex.get(rid);
+    if (i == null) {
+      nodes.add(toNode(vertex));
+      i = nodes.size() - 1; // 0-based
+      nodeIndex.put(rid, i);
+    }
+    return i;
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mvn -q -pl bolt test -Dtest=Bolt4998PathMappingTest`
+Expected: PASS.
+
+- [ ] **Step 5: Add a backward-edge regression test** in the same class (the reverse traversal must produce a negative rel index):
+
+```java
+  @Test
+  @DisplayName("[TYPE-003] a backward-traversed hop yields a negative rel index")
+  void type003_backwardHop() {
+    // Path starts at b and walks the incoming edge (a)-[E]->(b) backward to a, so the hop's
+    // rel index must be negative: edge.getOut() (a) != the previous path node (b).
+    final ResultSet rs = db.query("opencypher", "MATCH p=(b:V {k:'b'})<-[:E]-(a) RETURN p");
+    final TraversalPath tp = (TraversalPath) rs.next().getProperty("p");
+    final BoltPath bp = BoltStructureMapper.toPath(tp);
+    assertThat(bp.getNodes()).hasSize(2);
+    assertThat(bp.getRelationships()).hasSize(1);
+    assertThat(bp.getIndices().get(0)).isEqualTo(-1L); // backward, negative
+    assertThat(bp.getIndices().get(1)).isEqualTo(1L);  // reached node index (a) = 1
+  }
+```
+
+Run: `mvn -q -pl bolt test -Dtest=Bolt4998PathMappingTest`
+Expected: PASS (both tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java \
+        bolt/src/test/java/com/arcadedb/bolt/Bolt4998PathMappingTest.java
+git commit -m "feat(bolt): emit native Path structures (TYPE-003)"
+```
+
+---
+
+### Task 5: Semantic vs syntax error classification (ERR-002)
+
+**Files:**
+- Create: `engine/src/main/java/com/arcadedb/exception/CommandSemanticException.java`
+- Modify: `engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java`
+- Modify: `bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java`
+- Test: `engine/src/test/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidatorExceptionTest.java` (new)
+- Test: `bolt/src/test/java/com/arcadedb/bolt/BoltErrorClassificationTest.java` (modify)
+
+**Interfaces:**
+- Produces: `CommandSemanticException extends CommandParsingException`; `BoltNetworkExecutor.classifyParsingError(CommandParsingException)` -> error-code String.
+
+- [ ] **Step 1: Write the failing engine test** `CypherSemanticValidatorExceptionTest.java` (Apache header; imports: `com.arcadedb.exception.CommandParsingException`, `com.arcadedb.exception.CommandSemanticException`, an embedded `Database`/`DatabaseFactory`, `org.junit.jupiter.api.*`, `static org.assertj.core.api.Assertions.*`):
+
+```java
+class CypherSemanticValidatorExceptionTest {
+  private static final String DB_PATH = "./target/databases/CypherSemanticValidatorExceptionTest";
+  private Database db;
+
+  @BeforeEach
+  void setUp() {
+    final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
+    if (factory.exists())
+      factory.open().drop();
+    db = factory.create();
+    db.getSchema().createVertexType("Beer");
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null && db.isOpen())
+      db.drop();
+  }
+
+  @Test
+  void undefinedVariableThrowsSemanticException() {
+    assertThatThrownBy(() -> db.query("opencypher", "MATCH (n:Beer) RETURN undefinedVariable").close())
+        .isInstanceOf(CommandSemanticException.class)
+        .isInstanceOf(CommandParsingException.class);
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn -q -pl engine test -Dtest=CypherSemanticValidatorExceptionTest`
+Expected: FAIL - thrown exception is `CommandParsingException`, not `CommandSemanticException`.
+
+- [ ] **Step 3: Create `CommandSemanticException.java`** (copy the Apache header and structure from `CommandSQLParsingException.java` in the same package):
+
+```java
+package com.arcadedb.exception;
+
+/**
+ * Thrown when a query is syntactically valid but violates a semantic rule (for example an undefined
+ * variable, a type conflict, or an invalid aggregation). Extends CommandParsingException so existing
+ * handlers keep treating it as a parsing error, while callers that care can distinguish it.
+ */
+public class CommandSemanticException extends CommandParsingException {
+  public CommandSemanticException(final String message) {
+    super(message);
+  }
+
+  public CommandSemanticException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
+  public CommandSemanticException(final Throwable cause) {
+    super(cause);
+  }
+}
+```
+
+- [ ] **Step 4: Retarget the validator throws.** In `CypherSemanticValidator.java`, replace every `throw new CommandParsingException(` with `throw new CommandSemanticException(` and update the import from `CommandParsingException` to add `CommandSemanticException` (keep `CommandParsingException` only if still referenced elsewhere in the file). Run:
+
+```bash
+sed -i '' 's/throw new CommandParsingException(/throw new CommandSemanticException(/g' \
+  engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
+```
+
+Then add `import com.arcadedb.exception.CommandSemanticException;` next to the existing exception import.
+
+- [ ] **Step 5: Run the engine test to verify it passes**
+
+Run: `mvn -q -pl engine test -Dtest=CypherSemanticValidatorExceptionTest`
+Expected: PASS.
+
+- [ ] **Step 6: Add the Bolt classification test** to `BoltErrorClassificationTest.java` (add imports `com.arcadedb.exception.CommandParsingException`, `com.arcadedb.exception.CommandSemanticException`):
+
+```java
+@Test
+void semanticExceptionClassifiesAsSemanticError() {
+  assertThat(BoltNetworkExecutor.classifyParsingError(new CommandSemanticException("UndefinedVariable")))
+      .isEqualTo(BoltErrorCodes.SEMANTIC_ERROR);
+}
+
+@Test
+void plainParsingExceptionClassifiesAsSyntaxError() {
+  assertThat(BoltNetworkExecutor.classifyParsingError(new CommandParsingException("unexpected token")))
+      .isEqualTo(BoltErrorCodes.SYNTAX_ERROR);
+}
+```
+
+- [ ] **Step 7: Run to verify it fails**
+
+Run: `mvn -q -pl bolt test -Dtest=BoltErrorClassificationTest#semanticExceptionClassifiesAsSemanticError`
+Expected: FAIL - `classifyParsingError` does not exist.
+
+- [ ] **Step 8: Add `classifyParsingError` and wire it into `handleRun`.** In `BoltNetworkExecutor.java` add the package-visible static helper next to `classifyExecutionError` (add import `com.arcadedb.exception.CommandSemanticException`; `CommandParsingException` is already imported):
+
+```java
+  static String classifyParsingError(final CommandParsingException error) {
+    return error instanceof CommandSemanticException ? BoltErrorCodes.SEMANTIC_ERROR : BoltErrorCodes.SYNTAX_ERROR;
+  }
+```
+
+Change the `catch (final CommandParsingException e)` block in `handleRun` (line ~629) from:
+
+```java
+      sendFailure(BoltException.SYNTAX_ERROR, parseMsg);
+```
+
+to:
+
+```java
+      sendFailure(classifyParsingError(e), parseMsg);
+```
+
+- [ ] **Step 9: Run the Bolt tests to verify they pass**
+
+Run: `mvn -q -pl bolt test -Dtest=BoltErrorClassificationTest`
+Expected: PASS (new + existing classification tests).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add engine/src/main/java/com/arcadedb/exception/CommandSemanticException.java \
+        engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java \
+        engine/src/test/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidatorExceptionTest.java \
+        bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java \
+        bolt/src/test/java/com/arcadedb/bolt/BoltErrorClassificationTest.java
+git commit -m "feat(bolt): distinguish semantic from syntax errors (ERR-002)"
+```
+
+---
+
+### Task 6: Flip conformance spec + five e2e suite markers
+
+**Files:**
+- Modify: `bolt/conformance/spec.yaml`
+- Modify: `e2e-js/src/js-bolt-conformance.test.js`
+- Modify: `e2e/src/test/java/com/arcadedb/e2e/RemoteBoltDatabaseIT.java`
+- Modify: `e2e-python/tests/` conformance suite
+- Modify: `e2e-csharp/ArcadeDB.E2ETests/BoltE2ETests.cs`
+- Modify: `e2e-go/` conformance suite
+
+- [ ] **Step 1: Flip the four cells in `spec.yaml`.** For each of TYPE-003, TYPE-011, TYPE-012, ERR-002: set `current_status: passing` and delete the `known_limitation:` block and the `tracking_issue: "#4890"` line.
+
+- [ ] **Step 2: Run the spec validator**
+
+Run: `cd bolt/conformance && python3 validate_spec.py`
+Expected: PASS - spec is internally consistent (no dangling tracking issues for passing cells).
+
+- [ ] **Step 3: Flip the JS suite.** In `e2e-js/src/js-bolt-conformance.test.js` change the four `it.failing("[TYPE-003]"...)`, `[TYPE-011]`, `[TYPE-012]`, `[ERR-002]` to `it(...)` and update the preceding "flips red when fixed" comments to describe the passing behavior.
+
+- [ ] **Step 4: Flip the Java suite.** In `e2e/src/test/java/com/arcadedb/e2e/RemoteBoltDatabaseIT.java` replace the `assertExpectedFailure("#4890", () -> {...})` wrappers for `type003_path`, `type011_duration`, `type012_point`, `err002_semantic` with the direct positive assertions (assert the driver receives `Path`/`Duration`/`Point` values and the `Neo.ClientError.Statement.SemanticError` code).
+
+- [ ] **Step 5: Flip the Python suite.** In `e2e-python/tests/`, remove the `@pytest.mark.xfail` markers for the four scenarios and assert native `neo4j.time`/`neo4j.spatial` types and the semantic error code.
+
+- [ ] **Step 6: Flip the C# suite.** In `e2e-csharp/ArcadeDB.E2ETests/BoltE2ETests.cs`, remove the xfail/skip guard for the four scenarios and assert native `Duration`/`Point`/`Path` types and `SemanticError`.
+
+- [ ] **Step 7: Flip the Go suite.** In `e2e-go/`, remove the skip/expected-fail guard for the four scenarios and assert native `dbtype.Duration`/`dbtype.Point2D`/`dbtype.Path` and the semantic error code.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add bolt/conformance/spec.yaml e2e-js e2e e2e-python e2e-csharp e2e-go
+git commit -m "test(bolt): flip TYPE-003/011/012 and ERR-002 to passing across conformance suites"
+```
+
+---
+
+### Task 7: Full module verification + open PR
+
+**Files:** none (verification + PR).
+
+- [ ] **Step 1: Compile and run the affected module tests**
+
+Run: `mvn -q -pl bolt -am test`
+Expected: BUILD SUCCESS - all bolt tests green (BoltTypeRoundTripTest, PackStreamTypeInputTest, Bolt4998PathMappingTest, BoltErrorClassificationTest, plus existing).
+
+- [ ] **Step 2: Run the touched engine tests**
+
+Run: `mvn -q -pl engine test -Dtest="CypherSemanticValidatorExceptionTest,Cypher*SemanticValidator*"`
+Expected: BUILD SUCCESS - no regression in the semantic validator path.
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin feat/4890-bolt-type-fidelity
+```
+
+Open a PR titled `feat(#4890): native Bolt Duration, Point, Path + semantic errors (#4997, #4998, #4999)`. Body: summarize the three components, list the flipped conformance cells (TYPE-003/011/012, ERR-002), state that full e2e verification runs in CI against the branch-built image, and note it partially closes #4890 and closes #4997/#4998/#4999. End with the Claude Code generated-with footer.
+
+- [ ] **Step 4: Update tracking issue** - check the three child boxes and the "closes its scenario in spec.yaml" box on #4890.
+
+---
+
+## Notes for the reviewer / executor
+
+- The hard local gate is the bolt-module + engine unit tests (Tasks 1-5). The e2e suite flips (Task 6) only go green in CI once the Docker image is built from this branch - do not block locally on them.
+- Point detection is deliberately structural (Cypher `point()` returns a `Map`, there is no Point class). If a user query returns a map that happens to carry a `crs` key plus numeric `x`/`y`, it will be encoded as a Point - this matches how `CypherPointDistanceFunction` already recognizes points and is the accepted trade-off.
+- The semantic-exception change is additive: `CommandSemanticException extends CommandParsingException`, so HTTP/Postgres/Gremlin/GraphQL/Redis handlers that catch `CommandParsingException` are unaffected. Only the Bolt handler distinguishes it.

--- a/docs/superpowers/specs/2026-07-05-bolt-type-fidelity-trio-design.md
+++ b/docs/superpowers/specs/2026-07-05-bolt-type-fidelity-trio-design.md
@@ -1,0 +1,172 @@
+# Bolt type-fidelity trio design (#4997 + #4998 + #4999)
+
+**Date:** 2026-07-05
+**Epic:** #4882 (Bolt Driver Compatibility Certification)
+**Tracking issue:** #4890 (Group C - protocol/type-fidelity gaps)
+**Closes:** #4997, #4998, #4999 (partial close of #4890)
+**Conformance cells flipped:** TYPE-011, TYPE-012, TYPE-003, ERR-002
+
+## Motivation
+
+The Group B conformance suites pinned four red cells in `bolt/conformance/spec.yaml`, all
+`current_status: expected-fail` and tracked by #4890. This design closes the three writer/validator-side
+sub-issues that share one fix shape - mirroring the shipped temporal work (#4907):
+
+- **TYPE-011 / TYPE-012 (#4997)**: `Duration` and spatial `Point` have no handling in
+  `BoltStructureMapper`/`PackStreamWriter`; a returned duration falls through to `value.toString()` and a
+  point serializes as a generic map, so official drivers never receive native `Duration`/`Point` objects.
+- **TYPE-003 (#4998)**: `structure/BoltPath.java` exists (tag `0x50`) but has zero call sites - path
+  results are emitted as a `toString()` string instead of a native Bolt `Path`.
+- **ERR-002 (#4999)**: `CypherSemanticValidator` throws `CommandParsingException`, the same class used for
+  genuine ANTLR syntax errors, so the Bolt RUN handler cannot distinguish them and
+  `Neo.ClientError.Statement.SemanticError` is dead code.
+
+The larger #4890 children (#5000 result counters, #5001 5.x negotiation, #5002 HA ROUTE) are out of scope
+here - they touch the query engine, protocol negotiation, and a live-cluster harness respectively.
+
+## Governing principle
+
+Writer-side only, mirroring #4907. No query-engine changes. All three fixes live almost entirely in the
+`bolt` module; #4999 adds one small exception class in `engine`. The single inbound param-decode point is
+extended for round-tripping. Existing temporal/Node/Relationship serialization is untouched.
+
+## Architecture
+
+### Key files
+
+- `bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java` - outbound
+  `toPackStreamValue`, inbound `fromPackStreamValue`/`fromTemporalStructure`. Primary change surface.
+- `bolt/src/main/java/com/arcadedb/bolt/structure/BoltPath.java` - exists, tag `0x50`; gains call sites.
+- `bolt/src/main/java/com/arcadedb/bolt/structure/BoltTemporalStructure.java` - generic
+  `(signature, fields...)` `PackStreamStructure`; reused for Duration.
+- New `bolt/src/main/java/com/arcadedb/bolt/structure/BoltPointStructure.java` - spatial struct
+  (tag `0x58`/`0x59`).
+- `bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java` - `handleRun` error dispatch
+  (lines ~629-640).
+- `bolt/src/main/java/com/arcadedb/bolt/BoltErrorCodes.java` - `SEMANTIC_ERROR` already defined.
+- New `engine/src/main/java/com/arcadedb/exception/CommandSemanticException.java` - subclass of
+  `CommandParsingException` (precedent: `CommandSQLParsingException`).
+- `engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java` - retarget
+  its ~51 `throw new CommandParsingException(...)` sites to `CommandSemanticException`.
+
+### Engine value types (source of truth)
+
+- **Duration**: `com.arcadedb.query.opencypher.temporal.CypherDuration` - concrete class,
+  `getMonths()/getDays()/getSeconds()/getNanosAdjustment()`, public ctor
+  `CypherDuration(long months, long days, long seconds, int nanosAdjustment)`. Maps 1:1 to Bolt tag `0x45`.
+- **Point**: **no dedicated class**. Cypher `point()` returns `java.util.LinkedHashMap`. Keys: `x`,`y`,
+  optional `z`; `crs` string (`cartesian`/`cartesian-3D`/`WGS-84`/`WGS-84-3D`); `srid` present for WGS-84
+  and for explicit cartesian, otherwise absent. WGS-84 also carries `longitude`/`latitude`. Detection is
+  structural.
+- **Path**: `com.arcadedb.query.opencypher.traversal.TraversalPath` - parallel `getVertices()` /
+  `getEdges()` lists, invariant `vertices.size()==edges.size()+1`, `edges[i]` joins `vertices[i]` and
+  `vertices[i+1]`. Direction is **not** stored.
+
+## Component 1 - #4997 Duration + Point (TYPE-011, TYPE-012)
+
+### Outbound
+
+In `BoltStructureMapper`:
+
+- **Duration** (native, tag `0x45`, fields `[months, days, seconds, nanoseconds]`): add a `CypherDuration`
+  branch inside the temporal handling (`toTemporalStructure`), returning
+  `new BoltTemporalStructure(SIG_DURATION, months, days, seconds, (long) nanosAdjustment)`. Update the
+  existing comment that states `CypherDuration` is intentionally not handled. Duration is a Cypher temporal
+  type, so reusing `BoltTemporalStructure` is semantically consistent with #4907.
+- **Point** (tag `0x58` 2D `[srid, x, y]` / `0x59` 3D `[srid, x, y, z]`): add a `toPointStructure(Object)`
+  helper returning a new `BoltPointStructure` or `null`. Detection: value is a `Map` carrying key `crs`
+  **and** numeric (`x` and `y`) or (`longitude` and `latitude`). This branch runs **before** the generic
+  `Map` branch in `toPackStreamValue`. SRID resolution: use `srid` if present, else derive -
+  `cartesian`->7203, `cartesian-3D`->9157, `WGS-84`->4326, `WGS-84-3D`->4979. Dimensionality: 3D iff a
+  numeric `z` (or `height`) key is present. `srid` is written as an integer (Long), `x`/`y`/`z` as doubles.
+
+`BoltPointStructure` is a thin `PackStreamStructure` like `BoltPath`: holds `srid,x,y` (+optional `z`),
+`getSignature()` returns `0x58`/`0x59`, `writeTo` writes the header then fields.
+
+### Inbound (param round-trip)
+
+Single decode point: `BoltMessage:108` -> `BoltStructureMapper.fromPackStreamValue` ->
+`fromTemporalStructure`. Generalize the struct decoder to also handle:
+
+- **`0x45`** -> `new CypherDuration(months, days, seconds, (int) nanos)`.
+- **`0x58`/`0x59`** -> a `LinkedHashMap` carrying `x`,`y`(,`z`), `srid`, and a **derived `crs` key**
+  (7203/9157->`cartesian`/`cartesian-3D`, 4326/4979->`WGS-84`/`WGS-84-3D`). The `crs` key is required so
+  `RETURN $p AS echo` re-encodes as a Point rather than a bare map.
+
+Reuse the existing arity/type-guard pattern: a malformed struct (wrong field count/types) is returned
+opaque rather than crashing the connection.
+
+## Component 2 - #4998 native Path (TYPE-003)
+
+Add a `TraversalPath` branch in `toPackStreamValue` that constructs a `BoltPath`:
+
+1. Walk `getVertices()`/`getEdges()` in order.
+2. Build **deduplicated** `nodes` (`BoltNode` via `toNode`) and `rels` (`BoltUnboundRelationship` via
+   `toUnboundRelationship`) lists keyed by RID - Neo4j Path encoding requires unique node/rel lists.
+3. Build the flat signed `indices` list `[relIdx, nodeIdx, ...]` per hop (Bolt convention documented in
+   `BoltPath`): `relIdx` is 1-based into `rels`, **positive if the edge was traversed forward**
+   (`edges[i].getOut().equals(vertices[i].getIdentity())`), negative otherwise; `nodeIdx` is the 0-based
+   index into `nodes` of the node reached at `vertices[i+1]`. Node 0 (the start) is implicit.
+
+Edge cases covered by unit tests: single-hop, multi-hop, repeated nodes (dedup), self-loop, and a
+backward-traversed edge (negative index).
+
+## Component 3 - #4999 semantic vs syntax errors (ERR-002)
+
+1. New `engine/.../exception/CommandSemanticException extends CommandParsingException` (three ctors,
+   mirroring `CommandSQLParsingException`).
+2. Retarget every `throw new CommandParsingException(...)` in `CypherSemanticValidator` to
+   `CommandSemanticException` - the entire class is semantic validation by definition.
+3. In `BoltNetworkExecutor.handleRun`, add `catch (final CommandSemanticException e)` mapping to
+   `BoltErrorCodes.SEMANTIC_ERROR`, ordered **before** the existing
+   `catch (final CommandParsingException e)` -> `SYNTAX_ERROR`.
+
+**Backward compatibility:** `CommandSemanticException` is a `CommandParsingException`, so every existing
+`catch (CommandParsingException)` site (HTTP `AbstractServerHttpHandler:315`, Postgres, Gremlin, GraphQL,
+Redis; and the rethrow points in `Cypher25AntlrParser`/`CypherStatementCache`) keeps treating semantic
+errors exactly as today. Only the Bolt handler gains the new branch. Genuine ANTLR parse failures continue
+to throw plain `CommandParsingException` -> `SYNTAX_ERROR`.
+
+## Testing strategy (TDD)
+
+### Hard gate - module + engine unit tests (fast, no server)
+
+- `bolt/.../BoltTypeRoundTripTest.java`:
+  - Flip TYPE-011: `toPackStreamValue(CypherDuration)` -> `BoltTemporalStructure` sig `0x45`, fields
+    `[months, days, seconds, nanos]`.
+  - Add TYPE-012: `toPackStreamValue(point-map)` -> `BoltPointStructure` sig `0x58`, srid 7203, x=12.34,
+    y=56.78; a WGS-84 map -> srid 4326; a 3D map -> `0x59`.
+  - Add TYPE-003: `toPackStreamValue(TraversalPath)` -> `BoltPath` with expected nodes/rels/signed
+    indices (multi-hop, dedup, backward-edge cases).
+  - Inbound decode: `fromPackStreamValue(StructureValue 0x45)` -> `CypherDuration`;
+    `fromPackStreamValue(StructureValue 0x58)` -> map with `crs`; malformed struct stays opaque.
+- Engine test: `CypherSemanticValidator.validate(undefined-variable stmt)` throws
+  `CommandSemanticException`, and `CommandSemanticException` is a `CommandParsingException`.
+- Bolt handler test: RUN `RETURN undefinedVariable` -> FAILURE code `SEMANTIC_ERROR`; a genuine syntax
+  error -> `SYNTAX_ERROR` (mirror existing `BoltNetworkExecutor` test harness).
+
+### Conformance flip (CI end-to-end against branch-built image)
+
+- `bolt/conformance/spec.yaml`: TYPE-003/011/012 + ERR-002 -> `current_status: passing`; drop
+  `known_limitation` and `tracking_issue` for those cells. Run `validate_spec.py`.
+- Flip the per-suite markers: JS `it.failing`->`it` (`e2e-js`), Java `assertExpectedFailure(...)`->direct
+  assertion (`e2e/RemoteBoltDatabaseIT` + module test), Python xfail removal (`e2e-python`), C# xfail
+  (`e2e-csharp`), Go skip (`e2e-go`).
+
+Per project convention, the compile-and-run gate is `mvn -q -pl bolt -am test` for the module tests plus
+the affected engine tests; full e2e verification runs in CI (needs the branch-built Docker image).
+
+## Delivery
+
+- Worktree: `.worktrees/feat/4890-bolt-type-fidelity`, branch `feat/4890-bolt-type-fidelity` off `main`.
+- Commits split by component for reviewability: (1) Duration+Point, (2) Path, (3) semantic errors,
+  (4) conformance/spec + suite flips.
+- One PR closing #4997/#4998/#4999 and ticking those boxes on #4890.
+- Review loop: Claude + Gemini, >= 4 cycles, each answered via `/receiving-code-review`.
+
+## Out of scope
+
+- #5000 (ResultSummary write counters - query-engine change).
+- #5001 (Bolt 5.x negotiation - protocol + decision, coordinates with #4884).
+- #5002 (HA-aware ROUTE - needs live multi-node cluster harness).
+- Any change to the advertised `Neo4j/5.26.0 compatible` server identity.

--- a/e2e-csharp/ArcadeDB.E2ETests/BoltE2ETests.cs
+++ b/e2e-csharp/ArcadeDB.E2ETests/BoltE2ETests.cs
@@ -362,14 +362,11 @@ public class BoltE2ETests
     [Fact(DisplayName = "TYPE-003: Path round-trips as a native Bolt structure")]
     public async Task Type003_PathRoundtrip()
     {
-        await KnownGapAssertions.AssertStillFailsAsync(async () =>
-        {
-            await using var session = _fixture.Driver.AsyncSession(o => o.WithDatabase("beer"));
-            var result = await session.RunAsync("MATCH p=(b:Beer)-[*1..2]-() RETURN p LIMIT 1");
-            var record = await result.SingleAsync();
-            var path = record["p"].As<IPath>();
-            Assert.True(path.Nodes.Count() >= 2);
-        }, "TYPE-003: structure/BoltPath.java has zero call sites - query results never construct native Path structures - see #4890");
+        await using var session = _fixture.Driver.AsyncSession(o => o.WithDatabase("beer"));
+        var result = await session.RunAsync("MATCH p=(b:Beer)-[*1..2]-() RETURN p LIMIT 1");
+        var record = await result.SingleAsync();
+        var path = record["p"].As<IPath>();
+        Assert.True(path.Nodes.Count() >= 2);
     }
 
     [Fact(DisplayName = "TYPE-004: ByteArray round-trips as a bound parameter")]
@@ -471,37 +468,31 @@ public class BoltE2ETests
     [Fact(DisplayName = "TYPE-011: Duration round-trips as a native Bolt Duration structure")]
     public async Task Type011_DurationRoundtrip()
     {
-        await KnownGapAssertions.AssertStillFailsAsync(async () =>
-        {
-            await using var session = _fixture.Driver.AsyncSession(o => o.WithDatabase("beer"));
-            var result = await session.RunAsync("MATCH (t:TypeMatrix) RETURN t.durationProp AS d");
-            var record = await result.SingleAsync();
-            var duration = record["d"].As<Duration>();
+        await using var session = _fixture.Driver.AsyncSession(o => o.WithDatabase("beer"));
+        var result = await session.RunAsync("MATCH (t:TypeMatrix) RETURN t.durationProp AS d");
+        var record = await result.SingleAsync();
+        var duration = record["d"].As<Duration>();
 
-            var echoResult = await session.RunAsync("RETURN $d AS echo", new { d = duration });
-            var echoRecord = await echoResult.SingleAsync();
-            Assert.Equal(duration, echoRecord["echo"].As<Duration>());
-        }, "TYPE-011: BoltStructureMapper/PackStreamWriter have no Duration handling at all - see #4890");
+        var echoResult = await session.RunAsync("RETURN $d AS echo", new { d = duration });
+        var echoRecord = await echoResult.SingleAsync();
+        Assert.Equal(duration, echoRecord["echo"].As<Duration>());
     }
 
     [Fact(DisplayName = "TYPE-012: Point round-trips as a native Bolt Point structure")]
     public async Task Type012_PointRoundtrip()
     {
-        await KnownGapAssertions.AssertStillFailsAsync(async () =>
-        {
-            await using var session = _fixture.Driver.AsyncSession(o => o.WithDatabase("beer"));
-            var result = await session.RunAsync("MATCH (t:TypeMatrix) RETURN t.pointProp AS p");
-            var record = await result.SingleAsync();
-            var point = record["p"].As<Point>();
-            Assert.Equal(12.34, point.X, 2);
-            Assert.Equal(56.78, point.Y, 2);
+        await using var session = _fixture.Driver.AsyncSession(o => o.WithDatabase("beer"));
+        var result = await session.RunAsync("MATCH (t:TypeMatrix) RETURN t.pointProp AS p");
+        var record = await result.SingleAsync();
+        var point = record["p"].As<Point>();
+        Assert.Equal(12.34, point.X, 2);
+        Assert.Equal(56.78, point.Y, 2);
 
-            var echoResult = await session.RunAsync("RETURN $p AS echo", new { p = point });
-            var echoRecord = await echoResult.SingleAsync();
-            var echoPoint = echoRecord["echo"].As<Point>();
-            Assert.Equal(12.34, echoPoint.X, 2);
-            Assert.Equal(56.78, echoPoint.Y, 2);
-        }, "TYPE-012: no Point/spatial handling exists in BoltStructureMapper or PackStreamWriter - see #4890");
+        var echoResult = await session.RunAsync("RETURN $p AS echo", new { p = point });
+        var echoRecord = await echoResult.SingleAsync();
+        var echoPoint = echoRecord["echo"].As<Point>();
+        Assert.Equal(12.34, echoPoint.X, 2);
+        Assert.Equal(56.78, echoPoint.Y, 2);
     }
 
     [Fact(DisplayName = "ERR-001: Syntax error returns Neo.ClientError.Statement.SyntaxError")]
@@ -519,16 +510,13 @@ public class BoltE2ETests
     [Fact(DisplayName = "ERR-002: Semantic error returns Neo.ClientError.Statement.SemanticError")]
     public async Task Err002_SemanticError()
     {
-        await KnownGapAssertions.AssertStillFailsAsync(async () =>
+        await using var session = _fixture.Driver.AsyncSession(o => o.WithDatabase("beer"));
+        var ex = await Assert.ThrowsAsync<ClientException>(async () =>
         {
-            await using var session = _fixture.Driver.AsyncSession(o => o.WithDatabase("beer"));
-            var ex = await Assert.ThrowsAsync<ClientException>(async () =>
-            {
-                var result = await session.RunAsync("MATCH (n:Beer) RETURN undeclaredVariable");
-                await result.ConsumeAsync();
-            });
-            Assert.Equal("Neo.ClientError.Statement.SemanticError", ex.Code);
-        }, "ERR-002: BoltNetworkExecutor's RUN handler maps error codes by exception type and cannot distinguish semantic from syntax errors - SemanticError is dead code - see #4890");
+            var result = await session.RunAsync("MATCH (n:Beer) RETURN undeclaredVariable");
+            await result.ConsumeAsync();
+        });
+        Assert.Equal("Neo.ClientError.Statement.SemanticError", ex.Code);
     }
 
     [Fact(Skip = "ERR-003 requires sending RUN before completing HELLO/LOGON; no official driver's public API exposes that - current_status is not-applicable in spec.yaml, see #4890")]

--- a/e2e-go/bolt_conformance_test.go
+++ b/e2e-go/bolt_conformance_test.go
@@ -107,19 +107,6 @@ func neo4jCode(err error) string {
 	return ""
 }
 
-// runSingleErr is the error-returning sibling of runSingle, for use inside
-// assertStillFails bodies (which must surface failures as errors rather than
-// calling t.Fatal). It returns the single record and any driver error.
-func runSingleErr(d neo4j.DriverWithContext, database, cypher string, params map[string]any) (*neo4j.Record, error) {
-	sess := d.NewSession(ctx, neo4j.SessionConfig{DatabaseName: database})
-	defer sess.Close(ctx)
-	res, err := sess.Run(ctx, cypher, params)
-	if err != nil {
-		return nil, err
-	}
-	return res.Single(ctx)
-}
-
 // --- auth ----------------------------------------------------------------
 
 func Test_AUTH_001_BasicAuthValid(t *testing.T) {

--- a/e2e-go/bolt_conformance_test.go
+++ b/e2e-go/bolt_conformance_test.go
@@ -490,24 +490,11 @@ func Test_TYPE_002_RelationshipRoundtrip(t *testing.T) {
 
 func Test_TYPE_003_PathRoundtrip(t *testing.T) {
 	d := newDriver(t, boltURI(plainContainer, "bolt"))
-	assertStillFails(t,
-		"structure/BoltPath.java has zero call sites in BoltStructureMapper; "+
-			"query results never produce native Path structures; see #4890",
-		func() error {
-			rec, err := runSingleErr(d, "beer", "MATCH p=(b:Beer)-[*1..2]-() RETURN p LIMIT 1", nil)
-			if err != nil {
-				return err
-			}
-			v, _ := rec.Get("p")
-			path, ok := v.(dbtype.Path)
-			if !ok {
-				return fmt.Errorf("expected dbtype.Path, got %T", v)
-			}
-			if len(path.Nodes) < 2 {
-				return fmt.Errorf("path has %d nodes, want >=2", len(path.Nodes))
-			}
-			return nil
-		})
+	rec := runSingle(t, d, "beer", "MATCH p=(b:Beer)-[*1..2]-() RETURN p LIMIT 1", nil)
+	v, _ := rec.Get("p")
+	path, ok := v.(dbtype.Path)
+	require.True(t, ok, "expected dbtype.Path, got %T", v)
+	require.GreaterOrEqual(t, len(path.Nodes), 2)
 }
 
 func Test_TYPE_004_ByteArrayParamRoundtrip(t *testing.T) {
@@ -587,38 +574,18 @@ func Test_TYPE_010_OffsetDateTimeRoundtrip(t *testing.T) {
 
 func Test_TYPE_011_DurationRoundtrip(t *testing.T) {
 	d := newDriver(t, boltURI(plainContainer, "bolt"))
-	assertStillFails(t,
-		"BoltStructureMapper/PackStreamWriter have no Duration handling; falls "+
-			"through to value.toString(); see #4890",
-		func() error {
-			rec, err := runSingleErr(d, "beer", "MATCH (t:TypeMatrix) RETURN t.durationProp AS d", nil)
-			if err != nil {
-				return err
-			}
-			v, _ := rec.Get("d")
-			if _, ok := v.(dbtype.Duration); !ok {
-				return fmt.Errorf("expected dbtype.Duration, got %T", v)
-			}
-			return nil
-		})
+	rec := runSingle(t, d, "beer", "MATCH (t:TypeMatrix) RETURN t.durationProp AS d", nil)
+	v, _ := rec.Get("d")
+	_, ok := v.(dbtype.Duration)
+	require.True(t, ok, "expected dbtype.Duration, got %T", v)
 }
 
 func Test_TYPE_012_PointRoundtrip(t *testing.T) {
 	d := newDriver(t, boltURI(plainContainer, "bolt"))
-	assertStillFails(t,
-		"No Point/spatial handling in BoltStructureMapper or PackStreamWriter "+
-			"(engine point() works; the gap is Bolt wire serialization); see #4890",
-		func() error {
-			rec, err := runSingleErr(d, "beer", "MATCH (t:TypeMatrix) RETURN t.pointProp AS p", nil)
-			if err != nil {
-				return err
-			}
-			v, _ := rec.Get("p")
-			if _, ok := v.(dbtype.Point2D); !ok {
-				return fmt.Errorf("expected dbtype.Point2D, got %T", v)
-			}
-			return nil
-		})
+	rec := runSingle(t, d, "beer", "MATCH (t:TypeMatrix) RETURN t.pointProp AS p", nil)
+	v, _ := rec.Get("p")
+	_, ok := v.(dbtype.Point2D)
+	require.True(t, ok, "expected dbtype.Point2D, got %T", v)
 }
 
 // --- errors ---------------------------------------------------------------
@@ -637,26 +604,14 @@ func Test_ERR_001_SyntaxError(t *testing.T) {
 
 func Test_ERR_002_SemanticError(t *testing.T) {
 	d := newDriver(t, boltURI(plainContainer, "bolt"))
-	assertStillFails(t,
-		"CypherSemanticValidator throws undefined-variable via "+
-			"CommandParsingException, the same class as ANTLR syntax errors, so "+
-			"the Bolt RUN handler cannot distinguish them; "+
-			"Neo.ClientError.Statement.SemanticError is dead code in Bolt; see #4890",
-		func() error {
-			sess := d.NewSession(ctx, neo4j.SessionConfig{DatabaseName: "beer"})
-			defer sess.Close(ctx)
-			res, err := sess.Run(ctx, "MATCH (n:Beer) RETURN undeclaredVariable", nil)
-			if err == nil {
-				_, err = res.Consume(ctx)
-			}
-			if err == nil {
-				return fmt.Errorf("expected an error, got none")
-			}
-			if code := neo4jCode(err); code != "Neo.ClientError.Statement.SemanticError" {
-				return fmt.Errorf("got code %q, want Neo.ClientError.Statement.SemanticError", code)
-			}
-			return nil
-		})
+	sess := d.NewSession(ctx, neo4j.SessionConfig{DatabaseName: "beer"})
+	t.Cleanup(func() { _ = sess.Close(ctx) })
+	res, err := sess.Run(ctx, "MATCH (n:Beer) RETURN undeclaredVariable", nil)
+	if err == nil {
+		_, err = res.Consume(ctx)
+	}
+	require.Error(t, err)
+	require.Equal(t, "Neo.ClientError.Statement.SemanticError", neo4jCode(err))
 }
 
 func Test_ERR_003_UnauthenticatedRequestRejected(t *testing.T) {

--- a/e2e-js/src/js-bolt-conformance.test.js
+++ b/e2e-js/src/js-bolt-conformance.test.js
@@ -651,10 +651,7 @@ describe("Bolt conformance (issue #4888)", () => {
       }
     });
 
-    // KNOWN GAP (#4890): BoltPath.java has zero call sites - query results
-    // never produce native Path structures. Asserts the correct behavior;
-    // flips red when fixed. Convert + update spec.yaml TYPE-003 then.
-    it.failing("[TYPE-003] path round-trips as a native Bolt structure", async () => {
+    it("[TYPE-003] path round-trips as a native Bolt structure", async () => {
       const s = session();
       try {
         const r = await s.run("MATCH p=(b:Beer)-[*1..2]-() RETURN p LIMIT 1");
@@ -769,9 +766,7 @@ describe("Bolt conformance (issue #4888)", () => {
       }
     });
 
-    // KNOWN GAP (#4890): no Duration handling in BoltStructureMapper/
-    // PackStreamWriter - falls through to value.toString().
-    it.failing("[TYPE-011] Duration round-trips as a native Bolt Duration", async () => {
+    it("[TYPE-011] Duration round-trips as a native Bolt Duration", async () => {
       const s = session();
       try {
         const r = await s.run("MATCH (t:TypeMatrix) RETURN t.durationProp AS d");
@@ -784,9 +779,7 @@ describe("Bolt conformance (issue #4888)", () => {
       }
     });
 
-    // KNOWN GAP (#4890): no Point/spatial handling anywhere in the Bolt
-    // serialization path (the Cypher engine itself supports point()).
-    it.failing("[TYPE-012] Point round-trips as a native Bolt Point", async () => {
+    it("[TYPE-012] Point round-trips as a native Bolt Point", async () => {
       const s = session();
       try {
         const r = await s.run("MATCH (t:TypeMatrix) RETURN t.pointProp AS p");
@@ -815,10 +808,7 @@ describe("Bolt conformance (issue #4888)", () => {
       }
     });
 
-    // KNOWN GAP (#4890): semantic errors are surfaced as SyntaxError, not
-    // Neo.ClientError.Statement.SemanticError. Asserts the correct code;
-    // flips red when the mapping is fixed.
-    it.failing("[ERR-002] semantic error returns SemanticError code", async () => {
+    it("[ERR-002] semantic error returns SemanticError code", async () => {
       const s = session();
       try {
         await expect(

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -591,12 +591,6 @@ def test_TYPE_002_relationship_roundtrip(bolt_driver):
         assert rel.type is not None
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="structure/BoltPath.java exists but has zero call sites "
-    "constructing it anywhere in BoltStructureMapper - query results never "
-    "actually produce native Path structures today; see #4890",
-)
 def test_TYPE_003_path_roundtrip(bolt_driver):
     from neo4j.graph import Path
 
@@ -680,12 +674,6 @@ def test_TYPE_010_offset_datetime_roundtrip(bolt_driver):
         assert echo["echo"] == dt
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="BoltStructureMapper/PackStreamWriter have no Duration handling "
-    "at all - not even a string fallback branch, falls through to generic "
-    "value.toString(); see #4890",
-)
 def test_TYPE_011_duration_roundtrip(bolt_driver):
     from neo4j.time import Duration
 
@@ -697,13 +685,6 @@ def test_TYPE_011_duration_roundtrip(bolt_driver):
         assert echo["echo"] == record["d"]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="No Point/spatial type handling exists anywhere in "
-    "BoltStructureMapper or PackStreamWriter (the underlying ArcadeDB "
-    "Cypher engine itself does support point() - the gap is Bolt wire "
-    "serialization only); see #4890",
-)
 def test_TYPE_012_point_roundtrip(bolt_driver):
     from neo4j.spatial import Point
 
@@ -731,16 +712,6 @@ def test_ERR_001_syntax_error(bolt_driver):
         assert exc_info.value.code == "Neo.ClientError.Statement.SyntaxError"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="CypherSemanticValidator correctly detects the undefined "
-    "variable but throws it via CommandParsingException, the same "
-    "exception class used for genuine ANTLR syntax errors - "
-    "BoltNetworkExecutor's RUN handler maps error codes by exception "
-    "type, so it cannot distinguish semantic from syntax errors, "
-    "making Neo.ClientError.Statement.SemanticError effectively "
-    "dead code in the Bolt module; see #4890",
-)
 def test_ERR_002_semantic_error(bolt_driver):
     from neo4j.exceptions import ClientError
 

--- a/e2e/src/test/java/com/arcadedb/e2e/RemoteBoltDatabaseIT.java
+++ b/e2e/src/test/java/com/arcadedb/e2e/RemoteBoltDatabaseIT.java
@@ -538,15 +538,10 @@ class RemoteBoltDatabaseIT extends ArcadeContainerTemplate {
     @Test
     @DisplayName("[TYPE-003] Path round-trips as a native Bolt structure")
     void type003_path() {
-      // Read (and its .single()) is a hard precondition OUTSIDE the xfail: a
-      // missing row would be a fixture problem, not the tracked gap, and must
-      // fail loudly rather than be swallowed as "gap still present". Only the
-      // type check is the documented gap.
-      final Object v;
       try (final Session s = boltSession()) {
-        v = s.run("MATCH p=(b:Beer)-[*1..2]-() RETURN p LIMIT 1").single().get("p").asObject();
+        final Object v = s.run("MATCH p=(b:Beer)-[*1..2]-() RETURN p LIMIT 1").single().get("p").asObject();
+        assertThat(v).isInstanceOf(Path.class);
       }
-      assertExpectedFailure("#4890", () -> assertThat(v).isInstanceOf(Path.class));
     }
 
     @Test
@@ -608,21 +603,19 @@ class RemoteBoltDatabaseIT extends ArcadeContainerTemplate {
     @Test
     @DisplayName("[TYPE-011] Duration round-trips as a native Bolt Duration")
     void type011_duration() {
-      final Object v;
       try (final Session s = boltSession()) {
-        v = s.run("MATCH (t:TypeMatrix) RETURN t.durationProp AS d LIMIT 1").single().get("d").asObject();
+        final Object v = s.run("MATCH (t:TypeMatrix) RETURN t.durationProp AS d LIMIT 1").single().get("d").asObject();
+        assertThat(v).isInstanceOf(IsoDuration.class);
       }
-      assertExpectedFailure("#4890", () -> assertThat(v).isInstanceOf(IsoDuration.class));
     }
 
     @Test
     @DisplayName("[TYPE-012] Point round-trips as a native Bolt Point")
     void type012_point() {
-      final Object v;
       try (final Session s = boltSession()) {
-        v = s.run("MATCH (t:TypeMatrix) RETURN t.pointProp AS p LIMIT 1").single().get("p").asObject();
+        final Object v = s.run("MATCH (t:TypeMatrix) RETURN t.pointProp AS p LIMIT 1").single().get("p").asObject();
+        assertThat(v).isInstanceOf(Point.class);
       }
-      assertExpectedFailure("#4890", () -> assertThat(v).isInstanceOf(Point.class));
     }
 
     // A native Bolt temporal deserializes to a java.time.temporal.Temporal; the
@@ -659,14 +652,12 @@ class RemoteBoltDatabaseIT extends ArcadeContainerTemplate {
     @Test
     @DisplayName("[ERR-002] Semantic error returns Neo.ClientError.Statement.SemanticError")
     void err002_semantic() {
-      assertExpectedFailure("#4890", () -> {
-        try (final Session s = boltSession()) {
-          assertThatThrownBy(() -> s.run("RETURN undefinedVariable").consume())
-              .isInstanceOf(ClientException.class)
-              .satisfies(t -> assertThat(((ClientException) t).code())
-                  .isEqualTo("Neo.ClientError.Statement.SemanticError"));
-        }
-      });
+      try (final Session s = boltSession()) {
+        assertThatThrownBy(() -> s.run("RETURN undefinedVariable").consume())
+            .isInstanceOf(ClientException.class)
+            .satisfies(t -> assertThat(((ClientException) t).code())
+                .isEqualTo("Neo.ClientError.Statement.SemanticError"));
+      }
     }
 
     @Test

--- a/engine/src/main/java/com/arcadedb/exception/CommandSemanticException.java
+++ b/engine/src/main/java/com/arcadedb/exception/CommandSemanticException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.exception;
+
+/**
+ * Thrown when a query is syntactically valid but violates a semantic rule (for example an undefined
+ * variable, a type conflict, or an invalid aggregation). Extends CommandParsingException so existing
+ * handlers keep treating it as a parsing error, while callers that care can distinguish it.
+ */
+public class CommandSemanticException extends CommandParsingException {
+  public CommandSemanticException(final String message) {
+    super(message);
+  }
+
+  public CommandSemanticException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
+  public CommandSemanticException(final Throwable cause) {
+    super(cause);
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
@@ -35,6 +35,13 @@ import java.util.*;
  * - Boolean operand types (reject non-boolean literals)
  * - Nested aggregations and aggregation in WHERE
  * - CREATE/MERGE/DELETE structural constraints
+ * <p>
+ * <b>Semantic vs syntax boundary:</b> only an undefined-variable violation throws
+ * {@link CommandSemanticException}, which Bolt surfaces as {@code Neo.ClientError.Statement.SemanticError}
+ * (certified by conformance scenario ERR-002). Every other validation failure in this class throws
+ * {@link CommandParsingException}, surfaced over Bolt as {@code SyntaxError}. This split is deliberate but
+ * not yet verified case-by-case against real Neo4j error classification; other violations here may turn
+ * out to be genuine semantic errors on further scrutiny.
  *
  * @author Luca Garulli (l.garulli--(at)--arcadedata.com)
  */

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
@@ -18,7 +18,7 @@
  */
 package com.arcadedb.query.opencypher.parser;
 
-import com.arcadedb.exception.CommandParsingException;
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.query.opencypher.ast.*;
 
 import java.util.*;
@@ -80,7 +80,7 @@ public class CypherSemanticValidator {
       final boolean firstIsAll = flags.get(0);
       for (int i = 1; i < flags.size(); i++) {
         if (flags.get(i) != firstIsAll)
-          throw new CommandParsingException("InvalidClauseComposition: Cannot mix UNION and UNION ALL");
+          throw new CommandSemanticException("InvalidClauseComposition: Cannot mix UNION and UNION ALL");
       }
     }
 
@@ -94,7 +94,7 @@ public class CypherSemanticValidator {
       if (firstColumns == null) {
         firstColumns = columns;
       } else if (!firstColumns.equals(columns)) {
-        throw new CommandParsingException("DifferentColumnsInUnion: All sub queries in a UNION must have the same column names");
+        throw new CommandSemanticException("DifferentColumnsInUnion: All sub queries in a UNION must have the same column names");
       }
       // Validate each subquery
       validate(query);
@@ -204,7 +204,7 @@ public class CypherSemanticValidator {
   private void registerVar(final String name, final VarType type, final Map<String, VarType> varTypes) {
     final VarType existing = varTypes.get(name);
     if (existing != null && existing != type)
-      throw new CommandParsingException("VariableTypeConflict: Variable '" + name + "' already defined as " + existing + ", cannot redefine as " + type);
+      throw new CommandSemanticException("VariableTypeConflict: Variable '" + name + "' already defined as " + existing + ", cannot redefine as " + type);
     varTypes.put(name, type);
   }
 
@@ -294,7 +294,7 @@ public class CypherSemanticValidator {
         // 2. Node has explicit properties even if empty (e.g., n {})
         // 3. Node is standalone (single node in path, no relationships) - tries to create new node
         if (node.hasLabels() || node.hasProperties() || node.hasExplicitProperties() || path.isSingleNode())
-          throw new CommandParsingException("VariableAlreadyBound: Variable '" + var + "' already defined, cannot " +
+          throw new CommandSemanticException("VariableAlreadyBound: Variable '" + var + "' already defined, cannot " +
               "rebind in CREATE");
       }
     }
@@ -307,7 +307,7 @@ public class CypherSemanticValidator {
     for (final NodePattern node : path.getNodes()) {
       final String var = node.getVariable();
       if (var != null && boundVars.contains(var) && (node.hasLabels() || node.hasProperties() || path.isSingleNode()))
-        throw new CommandParsingException(
+        throw new CommandSemanticException(
             "VariableAlreadyBound: Variable '" + var + "' already defined, cannot rebind in MERGE");
     }
     // MERGE binds variables similarly to CREATE — add them
@@ -451,7 +451,7 @@ public class CypherSemanticValidator {
           if (setClause != null && !setClause.isEmpty())
             for (final SetClause.SetItem item : setClause.getItems()) {
               if (isValidVariableName(item.getVariable()) && !scope.contains(item.getVariable()))
-                throw new CommandParsingException("UndefinedVariable: Variable '" + item.getVariable() + "' not defined");
+                throw new CommandSemanticException("UndefinedVariable: Variable '" + item.getVariable() + "' not defined");
               if (item.getValueExpression() != null)
                 checkExpressionScope(item.getValueExpression(), scope);
             }
@@ -464,7 +464,7 @@ public class CypherSemanticValidator {
           if (deleteClause2 != null && !deleteClause2.isEmpty())
             for (final String var : deleteClause2.getVariables())
               if (isValidVariableName(var) && !scope.contains(var))
-                throw new CommandParsingException("UndefinedVariable: Variable '" + var + "' not defined");
+                throw new CommandSemanticException("UndefinedVariable: Variable '" + var + "' not defined");
           break;
         case RETURN:
           // Validate RETURN references — only check top-level variable references
@@ -560,11 +560,11 @@ public class CypherSemanticValidator {
       if (!isValidVariableName(varName))
         return;
       if (!scope.contains(varName))
-        throw new CommandParsingException("UndefinedVariable: Variable '" + varName + "' not defined");
+        throw new CommandSemanticException("UndefinedVariable: Variable '" + varName + "' not defined");
     } else if (expr instanceof PropertyAccessExpression) {
       final String varName = ((PropertyAccessExpression) expr).getVariableName();
       if (isValidVariableName(varName) && !scope.contains(varName))
-        throw new CommandParsingException("UndefinedVariable: Variable '" + varName + "' not defined");
+        throw new CommandSemanticException("UndefinedVariable: Variable '" + varName + "' not defined");
     } else if (expr instanceof FunctionCallExpression) {
       for (final Expression arg : ((FunctionCallExpression) expr).getArguments())
         checkExpressionScope(arg, scope);
@@ -647,7 +647,7 @@ public class CypherSemanticValidator {
       if (path != null) {
         // A single-node pattern in WHERE is invalid: WHERE (n) is not a valid predicate
         if (path.isSingleNode())
-          throw new CommandParsingException("InvalidArgumentType: Single node pattern is not a valid predicate in WHERE");
+          throw new CommandSemanticException("InvalidArgumentType: Single node pattern is not a valid predicate in WHERE");
         checkPatternPredicateVariables(path, scope);
       }
     } else if (boolExpr instanceof IsNullExpression) {
@@ -661,12 +661,12 @@ public class CypherSemanticValidator {
     for (final NodePattern node : path.getNodes()) {
       final String var = node.getVariable();
       if (var != null && !var.isEmpty() && isValidVariableName(var) && !scope.contains(var))
-        throw new CommandParsingException("UndefinedVariable: Variable '" + var + "' not defined");
+        throw new CommandSemanticException("UndefinedVariable: Variable '" + var + "' not defined");
     }
     for (final RelationshipPattern rel : path.getRelationships()) {
       final String var = rel.getVariable();
       if (var != null && !var.isEmpty() && isValidVariableName(var) && !scope.contains(var))
-        throw new CommandParsingException("UndefinedVariable: Variable '" + var + "' not defined");
+        throw new CommandSemanticException("UndefinedVariable: Variable '" + var + "' not defined");
     }
   }
 
@@ -724,7 +724,7 @@ public class CypherSemanticValidator {
       return;
     for (final SetClause.SetItem item : setClause.getItems()) {
       if (isValidVariableName(item.getVariable()) && !scope.contains(item.getVariable()))
-        throw new CommandParsingException("UndefinedVariable: Variable '" + item.getVariable() + "' not defined");
+        throw new CommandSemanticException("UndefinedVariable: Variable '" + item.getVariable() + "' not defined");
       if (item.getValueExpression() != null)
         checkExpressionScope(item.getValueExpression(), scope);
     }
@@ -836,17 +836,17 @@ public class CypherSemanticValidator {
     if (operand instanceof LiteralExpression) {
       final Object value = ((LiteralExpression) operand).getValue();
       if (value != null && !(value instanceof Boolean))
-        throw new CommandParsingException("InvalidArgumentType: Expected Boolean but got " + value.getClass().getSimpleName());
+        throw new CommandSemanticException("InvalidArgumentType: Expected Boolean but got " + value.getClass().getSimpleName());
     }
     // Reject list expressions as boolean operands (e.g., [1,2] AND true)
     else if (operand instanceof ListExpression)
-      throw new CommandParsingException("InvalidArgumentType: Expected Boolean but got List");
+      throw new CommandSemanticException("InvalidArgumentType: Expected Boolean but got List");
       // Reject map expressions as boolean operands (e.g., {a: 1} AND true)
     else if (operand instanceof MapExpression)
-      throw new CommandParsingException("InvalidArgumentType: Expected Boolean but got Map");
+      throw new CommandSemanticException("InvalidArgumentType: Expected Boolean but got Map");
       // Reject arithmetic expressions (always return numbers)
     else if (operand instanceof ArithmeticExpression)
-      throw new CommandParsingException("InvalidArgumentType: Expected Boolean but got Number");
+      throw new CommandSemanticException("InvalidArgumentType: Expected Boolean but got Number");
   }
 
   private void checkBooleanExprOperandValidity(final BooleanExpression operand) {
@@ -948,7 +948,7 @@ public class CypherSemanticValidator {
           if (expr instanceof FunctionCallExpression && ((FunctionCallExpression) expr).isAggregation()) {
             final String exprText = expr.getText();
             if (exprText != null && !projectedNames.contains(exprText))
-              throw new CommandParsingException("UndefinedVariable: Aggregation in ORDER BY is not projected");
+              throw new CommandSemanticException("UndefinedVariable: Aggregation in ORDER BY is not projected");
           }
           if (expr.containsAggregation())
             checkMixedAggregation(expr, groupingVars);
@@ -965,7 +965,7 @@ public class CypherSemanticValidator {
       final FunctionCallExpression func = (FunctionCallExpression) expr;
       if (func.isAggregation()) {
         if (insideAggregation)
-          throw new CommandParsingException("NestedAggregation: Nested aggregation functions are not allowed");
+          throw new CommandSemanticException("NestedAggregation: Nested aggregation functions are not allowed");
         // Check for non-deterministic functions inside aggregation (e.g., count(rand()))
         for (final Expression arg : func.getArguments())
           checkNonConstantInAggregation(arg);
@@ -1023,7 +1023,7 @@ public class CypherSemanticValidator {
     if (expr instanceof FunctionCallExpression) {
       final FunctionCallExpression func = (FunctionCallExpression) expr;
       if (NON_DETERMINISTIC_FUNCTIONS.contains(func.getFunctionName().toLowerCase(Locale.ROOT)))
-        throw new CommandParsingException("NonConstantExpression: Non-constant expression is not allowed inside aggregation: " + func.getFunctionName());
+        throw new CommandSemanticException("NonConstantExpression: Non-constant expression is not allowed inside aggregation: " + func.getFunctionName());
     }
   }
 
@@ -1031,7 +1031,7 @@ public class CypherSemanticValidator {
     if (expr == null)
       return;
     if (expr instanceof FunctionCallExpression && ((FunctionCallExpression) expr).isAggregation())
-      throw new CommandParsingException("InvalidAggregation: Aggregation functions are not allowed in list comprehensions");
+      throw new CommandSemanticException("InvalidAggregation: Aggregation functions are not allowed in list comprehensions");
     if (expr instanceof ArithmeticExpression) {
       checkAggregationInListComprehension(((ArithmeticExpression) expr).getLeft());
       checkAggregationInListComprehension(((ArithmeticExpression) expr).getRight());
@@ -1071,7 +1071,7 @@ public class CypherSemanticValidator {
 
     if (expr instanceof FunctionCallExpression) {
       if (((FunctionCallExpression) expr).isAggregation())
-        throw new CommandParsingException("InvalidAggregation: Aggregation functions are not allowed in ORDER BY after RETURN");
+        throw new CommandSemanticException("InvalidAggregation: Aggregation functions are not allowed in ORDER BY after RETURN");
       for (final Expression arg : ((FunctionCallExpression) expr).getArguments())
         checkAggregationInOrderBy(arg);
     } else if (expr instanceof ArithmeticExpression) {
@@ -1159,13 +1159,13 @@ public class CypherSemanticValidator {
     // Simple variable reference — OK if it's a grouping key
     if (expr instanceof VariableExpression) {
       if (!groupingVars.contains(((VariableExpression) expr).getVariableName()))
-        throw new CommandParsingException("AmbiguousAggregationExpression: Ambiguous aggregation expression");
+        throw new CommandSemanticException("AmbiguousAggregationExpression: Ambiguous aggregation expression");
       return;
     }
     // Simple property access — OK if the variable is a grouping key
     if (expr instanceof PropertyAccessExpression) {
       if (!groupingVars.contains(((PropertyAccessExpression) expr).getVariableName()))
-        throw new CommandParsingException("AmbiguousAggregationExpression: Ambiguous aggregation expression");
+        throw new CommandSemanticException("AmbiguousAggregationExpression: Ambiguous aggregation expression");
       return;
     }
     // Literals and stars are always OK
@@ -1173,7 +1173,7 @@ public class CypherSemanticValidator {
       return;
     // Complex expressions containing variables are ambiguous
     if (hasVariableRefOutsideAggregation(expr))
-      throw new CommandParsingException("AmbiguousAggregationExpression: Ambiguous aggregation expression");
+      throw new CommandSemanticException("AmbiguousAggregationExpression: Ambiguous aggregation expression");
   }
 
   private static boolean hasVariableRefOutsideAggregation(final Expression expr) {
@@ -1270,7 +1270,7 @@ public class CypherSemanticValidator {
 
     if (expr instanceof FunctionCallExpression) {
       if (((FunctionCallExpression) expr).isAggregation())
-        throw new CommandParsingException("InvalidAggregation: Aggregation functions are not allowed in WHERE");
+        throw new CommandSemanticException("InvalidAggregation: Aggregation functions are not allowed in WHERE");
       for (final Expression arg : ((FunctionCallExpression) expr).getArguments())
         checkAggregationInExpression(arg);
     } else if (expr instanceof ArithmeticExpression) {
@@ -1320,16 +1320,16 @@ public class CypherSemanticValidator {
     for (final RelationshipPattern rel : path.getRelationships()) {
       // CREATE relationships must specify exactly one type
       if (!rel.hasTypes())
-        throw new CommandParsingException("NoSingleRelationshipType: Relationships must have a type in CREATE");
+        throw new CommandSemanticException("NoSingleRelationshipType: Relationships must have a type in CREATE");
       // CREATE relationships must not have multiple types
       if (rel.getTypes().size() > 1)
-        throw new CommandParsingException("NoSingleRelationshipType: Relationships must have exactly one type in CREATE, got: " + rel.getTypes());
+        throw new CommandSemanticException("NoSingleRelationshipType: Relationships must have exactly one type in CREATE, got: " + rel.getTypes());
       // CREATE relationships must be directed
       if (rel.getDirection() == Direction.BOTH)
-        throw new CommandParsingException("RequiresDirectedRelationship: Relationships must be directed in CREATE");
+        throw new CommandSemanticException("RequiresDirectedRelationship: Relationships must be directed in CREATE");
       // CREATE cannot use variable-length patterns
       if (rel.isVariableLength())
-        throw new CommandParsingException("CreatingVarLength: Variable-length relationships are not allowed in CREATE");
+        throw new CommandSemanticException("CreatingVarLength: Variable-length relationships are not allowed in CREATE");
     }
   }
 
@@ -1337,13 +1337,13 @@ public class CypherSemanticValidator {
     for (final RelationshipPattern rel : path.getRelationships()) {
       // MERGE relationships must specify exactly one type
       if (!rel.hasTypes())
-        throw new CommandParsingException("NoSingleRelationshipType: Relationships must have a type in MERGE");
+        throw new CommandSemanticException("NoSingleRelationshipType: Relationships must have a type in MERGE");
       // MERGE relationships must not have multiple types
       if (rel.getTypes().size() > 1)
-        throw new CommandParsingException("NoSingleRelationshipType: Relationships must have exactly one type in MERGE, got: " + rel.getTypes());
+        throw new CommandSemanticException("NoSingleRelationshipType: Relationships must have exactly one type in MERGE, got: " + rel.getTypes());
       // MERGE cannot use variable-length patterns
       if (rel.isVariableLength())
-        throw new CommandParsingException("CreatingVarLength: Variable-length relationships are not allowed in MERGE");
+        throw new CommandSemanticException("CreatingVarLength: Variable-length relationships are not allowed in MERGE");
     }
     // MERGE cannot have null property values
     checkMergeNullProperties(path);
@@ -1362,9 +1362,9 @@ public class CypherSemanticValidator {
 
   private void checkMergePropertyNotNull(final Object value) {
     if (value == null)
-      throw new CommandParsingException("MergeReadOwnWrites: MERGE does not support null property values");
+      throw new CommandSemanticException("MergeReadOwnWrites: MERGE does not support null property values");
     if (value instanceof LiteralExpression && ((LiteralExpression) value).getValue() == null)
-      throw new CommandParsingException("MergeReadOwnWrites: MERGE does not support null property values");
+      throw new CommandSemanticException("MergeReadOwnWrites: MERGE does not support null property values");
   }
 
   private void validateDeleteTargets(final DeleteClause deleteClause) {
@@ -1373,10 +1373,10 @@ public class CypherSemanticValidator {
         continue;
       // DELETE n:Label or DELETE r:TYPE is invalid (InvalidDelete)
       if (target.contains(":"))
-        throw new CommandParsingException("InvalidDelete: Cannot delete a label or relationship type: " + target);
+        throw new CommandSemanticException("InvalidDelete: Cannot delete a label or relationship type: " + target);
       // DELETE <arithmetic expression> like DELETE 1+1 is invalid (InvalidArgumentType)
       if (!isValidVariableName(target) && !target.contains(".") && !target.contains("["))
-        throw new CommandParsingException("InvalidArgumentType: DELETE requires a node, relationship, or path variable, got: " + target);
+        throw new CommandSemanticException("InvalidArgumentType: DELETE requires a node, relationship, or path variable, got: " + target);
     }
   }
 
@@ -1393,7 +1393,7 @@ public class CypherSemanticValidator {
         for (final RelationshipPattern rel : path.getRelationships()) {
           final String var = rel.getVariable();
           if (var != null && !var.isEmpty() && !relVars.add(var))
-            throw new CommandParsingException("RelationshipUniquenessViolation: Relationship variable '" + var + "' is used more than once in the same pattern");
+            throw new CommandSemanticException("RelationshipUniquenessViolation: Relationship variable '" + var + "' is used more than once in the same pattern");
         }
       }
     }
@@ -1447,7 +1447,7 @@ public class CypherSemanticValidator {
           }
         }
         if (!hasNamedVars)
-          throw new CommandParsingException("NoVariablesInScope: RETURN * is not allowed when there are no variables in scope");
+          throw new CommandSemanticException("NoVariablesInScope: RETURN * is not allowed when there are no variables in scope");
       }
     }
   }
@@ -1477,15 +1477,15 @@ public class CypherSemanticValidator {
         if (val instanceof Float || val instanceof Double) {
           final double d = ((Number) val).doubleValue();
           if (d != Math.floor(d) || Double.isInfinite(d))
-            throw new CommandParsingException("InvalidArgumentType: " + clauseName + " value must be an integer, got: Float(" + d + ")");
+            throw new CommandSemanticException("InvalidArgumentType: " + clauseName + " value must be an integer, got: Float(" + d + ")");
         }
         if (((Number) val).intValue() < 0)
-          throw new CommandParsingException("NegativeIntegerArgument: " + clauseName + " value cannot be negative: " + val);
+          throw new CommandSemanticException("NegativeIntegerArgument: " + clauseName + " value cannot be negative: " + val);
       }
     }
     // Check that SKIP/LIMIT expressions don't reference query variables (NonConstantExpression)
     if (containsVariableReference(expr))
-      throw new CommandParsingException("NonConstantExpression: " + clauseName + " expression must not reference variables");
+      throw new CommandSemanticException("NonConstantExpression: " + clauseName + " expression must not reference variables");
   }
 
   private static boolean containsVariableReference(final Expression expr) {
@@ -1527,7 +1527,7 @@ public class CypherSemanticValidator {
         name = ((VariableExpression) item.getExpression()).getVariableName();
       if (name != null && !"*".equals(name)) {
         if (!seen.add(name))
-          throw new CommandParsingException("ColumnNameConflict: Column name '" + name + "' is defined more than once");
+          throw new CommandSemanticException("ColumnNameConflict: Column name '" + name + "' is defined more than once");
       }
     }
   }
@@ -1546,7 +1546,7 @@ public class CypherSemanticValidator {
           final Expression expr = item.getExpression();
           if (expr instanceof FunctionCallExpression && ((FunctionCallExpression) expr).isAggregation()) {
             if (item.getAlias() == null)
-              throw new CommandParsingException("NoExpressionAlias: Expression in WITH must be aliased (use AS)");
+              throw new CommandSemanticException("NoExpressionAlias: Expression in WITH must be aliased (use AS)");
           }
         }
       }
@@ -1590,7 +1590,7 @@ public class CypherSemanticValidator {
       final String name = func.getFunctionName().toLowerCase();
       // Check for unknown functions (skip namespaced functions like date.truncate, they're handled by CypherFunctionRegistry)
       if (!name.contains(".") && !FunctionValidator.isKnownFunction(name))
-        throw new CommandParsingException("UnknownFunction: Unknown function '" + func.getFunctionName() + "'");
+        throw new CommandSemanticException("UnknownFunction: Unknown function '" + func.getFunctionName() + "'");
       final List<Expression> args = func.getArguments();
       if (args.size() == 1) {
         final Expression arg = args.get(0);
@@ -1600,24 +1600,24 @@ public class CypherSemanticValidator {
             case "length":
               // length() only works on paths and strings, not nodes or relationships
               if (argType == VarType.NODE)
-                throw new CommandParsingException("InvalidArgumentType: length() cannot be applied to a node");
+                throw new CommandSemanticException("InvalidArgumentType: length() cannot be applied to a node");
               if (argType == VarType.RELATIONSHIP)
-                throw new CommandParsingException("InvalidArgumentType: length() cannot be applied to a relationship");
+                throw new CommandSemanticException("InvalidArgumentType: length() cannot be applied to a relationship");
               break;
             case "type":
               // type() only works on relationships
               if (argType == VarType.NODE)
-                throw new CommandParsingException("InvalidArgumentType: type() requires a relationship argument, got node");
+                throw new CommandSemanticException("InvalidArgumentType: type() requires a relationship argument, got node");
               break;
             case "labels":
               // labels() only works on nodes
               if (argType == VarType.PATH)
-                throw new CommandParsingException("InvalidArgumentType: labels() requires a node argument, got path");
+                throw new CommandSemanticException("InvalidArgumentType: labels() requires a node argument, got path");
               break;
             case "size":
               // size() works on strings and lists, not paths
               if (argType == VarType.PATH)
-                throw new CommandParsingException("InvalidArgumentType: size() cannot be applied to a path");
+                throw new CommandSemanticException("InvalidArgumentType: size() cannot be applied to a path");
               break;
           }
         }
@@ -1651,7 +1651,7 @@ public class CypherSemanticValidator {
       final String varName = ((PropertyAccessExpression) expr).getVariableName();
       final VarType type = varTypes.get(varName);
       if (type == VarType.PATH)
-        throw new CommandParsingException("InvalidArgumentType: Property access on a path variable is not allowed");
+        throw new CommandSemanticException("InvalidArgumentType: Property access on a path variable is not allowed");
     } else if (expr instanceof FunctionCallExpression) {
       for (final Expression arg : ((FunctionCallExpression) expr).getArguments())
         checkPropertyAccessOnPath(arg);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidator.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.query.opencypher.parser;
 
+import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.query.opencypher.ast.*;
 
@@ -80,7 +81,7 @@ public class CypherSemanticValidator {
       final boolean firstIsAll = flags.get(0);
       for (int i = 1; i < flags.size(); i++) {
         if (flags.get(i) != firstIsAll)
-          throw new CommandSemanticException("InvalidClauseComposition: Cannot mix UNION and UNION ALL");
+          throw new CommandParsingException("InvalidClauseComposition: Cannot mix UNION and UNION ALL");
       }
     }
 
@@ -94,7 +95,7 @@ public class CypherSemanticValidator {
       if (firstColumns == null) {
         firstColumns = columns;
       } else if (!firstColumns.equals(columns)) {
-        throw new CommandSemanticException("DifferentColumnsInUnion: All sub queries in a UNION must have the same column names");
+        throw new CommandParsingException("DifferentColumnsInUnion: All sub queries in a UNION must have the same column names");
       }
       // Validate each subquery
       validate(query);
@@ -204,7 +205,7 @@ public class CypherSemanticValidator {
   private void registerVar(final String name, final VarType type, final Map<String, VarType> varTypes) {
     final VarType existing = varTypes.get(name);
     if (existing != null && existing != type)
-      throw new CommandSemanticException("VariableTypeConflict: Variable '" + name + "' already defined as " + existing + ", cannot redefine as " + type);
+      throw new CommandParsingException("VariableTypeConflict: Variable '" + name + "' already defined as " + existing + ", cannot redefine as " + type);
     varTypes.put(name, type);
   }
 
@@ -294,7 +295,7 @@ public class CypherSemanticValidator {
         // 2. Node has explicit properties even if empty (e.g., n {})
         // 3. Node is standalone (single node in path, no relationships) - tries to create new node
         if (node.hasLabels() || node.hasProperties() || node.hasExplicitProperties() || path.isSingleNode())
-          throw new CommandSemanticException("VariableAlreadyBound: Variable '" + var + "' already defined, cannot " +
+          throw new CommandParsingException("VariableAlreadyBound: Variable '" + var + "' already defined, cannot " +
               "rebind in CREATE");
       }
     }
@@ -307,7 +308,7 @@ public class CypherSemanticValidator {
     for (final NodePattern node : path.getNodes()) {
       final String var = node.getVariable();
       if (var != null && boundVars.contains(var) && (node.hasLabels() || node.hasProperties() || path.isSingleNode()))
-        throw new CommandSemanticException(
+        throw new CommandParsingException(
             "VariableAlreadyBound: Variable '" + var + "' already defined, cannot rebind in MERGE");
     }
     // MERGE binds variables similarly to CREATE — add them
@@ -647,7 +648,7 @@ public class CypherSemanticValidator {
       if (path != null) {
         // A single-node pattern in WHERE is invalid: WHERE (n) is not a valid predicate
         if (path.isSingleNode())
-          throw new CommandSemanticException("InvalidArgumentType: Single node pattern is not a valid predicate in WHERE");
+          throw new CommandParsingException("InvalidArgumentType: Single node pattern is not a valid predicate in WHERE");
         checkPatternPredicateVariables(path, scope);
       }
     } else if (boolExpr instanceof IsNullExpression) {
@@ -836,17 +837,17 @@ public class CypherSemanticValidator {
     if (operand instanceof LiteralExpression) {
       final Object value = ((LiteralExpression) operand).getValue();
       if (value != null && !(value instanceof Boolean))
-        throw new CommandSemanticException("InvalidArgumentType: Expected Boolean but got " + value.getClass().getSimpleName());
+        throw new CommandParsingException("InvalidArgumentType: Expected Boolean but got " + value.getClass().getSimpleName());
     }
     // Reject list expressions as boolean operands (e.g., [1,2] AND true)
     else if (operand instanceof ListExpression)
-      throw new CommandSemanticException("InvalidArgumentType: Expected Boolean but got List");
+      throw new CommandParsingException("InvalidArgumentType: Expected Boolean but got List");
       // Reject map expressions as boolean operands (e.g., {a: 1} AND true)
     else if (operand instanceof MapExpression)
-      throw new CommandSemanticException("InvalidArgumentType: Expected Boolean but got Map");
+      throw new CommandParsingException("InvalidArgumentType: Expected Boolean but got Map");
       // Reject arithmetic expressions (always return numbers)
     else if (operand instanceof ArithmeticExpression)
-      throw new CommandSemanticException("InvalidArgumentType: Expected Boolean but got Number");
+      throw new CommandParsingException("InvalidArgumentType: Expected Boolean but got Number");
   }
 
   private void checkBooleanExprOperandValidity(final BooleanExpression operand) {
@@ -965,7 +966,7 @@ public class CypherSemanticValidator {
       final FunctionCallExpression func = (FunctionCallExpression) expr;
       if (func.isAggregation()) {
         if (insideAggregation)
-          throw new CommandSemanticException("NestedAggregation: Nested aggregation functions are not allowed");
+          throw new CommandParsingException("NestedAggregation: Nested aggregation functions are not allowed");
         // Check for non-deterministic functions inside aggregation (e.g., count(rand()))
         for (final Expression arg : func.getArguments())
           checkNonConstantInAggregation(arg);
@@ -1023,7 +1024,7 @@ public class CypherSemanticValidator {
     if (expr instanceof FunctionCallExpression) {
       final FunctionCallExpression func = (FunctionCallExpression) expr;
       if (NON_DETERMINISTIC_FUNCTIONS.contains(func.getFunctionName().toLowerCase(Locale.ROOT)))
-        throw new CommandSemanticException("NonConstantExpression: Non-constant expression is not allowed inside aggregation: " + func.getFunctionName());
+        throw new CommandParsingException("NonConstantExpression: Non-constant expression is not allowed inside aggregation: " + func.getFunctionName());
     }
   }
 
@@ -1031,7 +1032,7 @@ public class CypherSemanticValidator {
     if (expr == null)
       return;
     if (expr instanceof FunctionCallExpression && ((FunctionCallExpression) expr).isAggregation())
-      throw new CommandSemanticException("InvalidAggregation: Aggregation functions are not allowed in list comprehensions");
+      throw new CommandParsingException("InvalidAggregation: Aggregation functions are not allowed in list comprehensions");
     if (expr instanceof ArithmeticExpression) {
       checkAggregationInListComprehension(((ArithmeticExpression) expr).getLeft());
       checkAggregationInListComprehension(((ArithmeticExpression) expr).getRight());
@@ -1071,7 +1072,7 @@ public class CypherSemanticValidator {
 
     if (expr instanceof FunctionCallExpression) {
       if (((FunctionCallExpression) expr).isAggregation())
-        throw new CommandSemanticException("InvalidAggregation: Aggregation functions are not allowed in ORDER BY after RETURN");
+        throw new CommandParsingException("InvalidAggregation: Aggregation functions are not allowed in ORDER BY after RETURN");
       for (final Expression arg : ((FunctionCallExpression) expr).getArguments())
         checkAggregationInOrderBy(arg);
     } else if (expr instanceof ArithmeticExpression) {
@@ -1159,13 +1160,13 @@ public class CypherSemanticValidator {
     // Simple variable reference — OK if it's a grouping key
     if (expr instanceof VariableExpression) {
       if (!groupingVars.contains(((VariableExpression) expr).getVariableName()))
-        throw new CommandSemanticException("AmbiguousAggregationExpression: Ambiguous aggregation expression");
+        throw new CommandParsingException("AmbiguousAggregationExpression: Ambiguous aggregation expression");
       return;
     }
     // Simple property access — OK if the variable is a grouping key
     if (expr instanceof PropertyAccessExpression) {
       if (!groupingVars.contains(((PropertyAccessExpression) expr).getVariableName()))
-        throw new CommandSemanticException("AmbiguousAggregationExpression: Ambiguous aggregation expression");
+        throw new CommandParsingException("AmbiguousAggregationExpression: Ambiguous aggregation expression");
       return;
     }
     // Literals and stars are always OK
@@ -1173,7 +1174,7 @@ public class CypherSemanticValidator {
       return;
     // Complex expressions containing variables are ambiguous
     if (hasVariableRefOutsideAggregation(expr))
-      throw new CommandSemanticException("AmbiguousAggregationExpression: Ambiguous aggregation expression");
+      throw new CommandParsingException("AmbiguousAggregationExpression: Ambiguous aggregation expression");
   }
 
   private static boolean hasVariableRefOutsideAggregation(final Expression expr) {
@@ -1270,7 +1271,7 @@ public class CypherSemanticValidator {
 
     if (expr instanceof FunctionCallExpression) {
       if (((FunctionCallExpression) expr).isAggregation())
-        throw new CommandSemanticException("InvalidAggregation: Aggregation functions are not allowed in WHERE");
+        throw new CommandParsingException("InvalidAggregation: Aggregation functions are not allowed in WHERE");
       for (final Expression arg : ((FunctionCallExpression) expr).getArguments())
         checkAggregationInExpression(arg);
     } else if (expr instanceof ArithmeticExpression) {
@@ -1320,16 +1321,16 @@ public class CypherSemanticValidator {
     for (final RelationshipPattern rel : path.getRelationships()) {
       // CREATE relationships must specify exactly one type
       if (!rel.hasTypes())
-        throw new CommandSemanticException("NoSingleRelationshipType: Relationships must have a type in CREATE");
+        throw new CommandParsingException("NoSingleRelationshipType: Relationships must have a type in CREATE");
       // CREATE relationships must not have multiple types
       if (rel.getTypes().size() > 1)
-        throw new CommandSemanticException("NoSingleRelationshipType: Relationships must have exactly one type in CREATE, got: " + rel.getTypes());
+        throw new CommandParsingException("NoSingleRelationshipType: Relationships must have exactly one type in CREATE, got: " + rel.getTypes());
       // CREATE relationships must be directed
       if (rel.getDirection() == Direction.BOTH)
-        throw new CommandSemanticException("RequiresDirectedRelationship: Relationships must be directed in CREATE");
+        throw new CommandParsingException("RequiresDirectedRelationship: Relationships must be directed in CREATE");
       // CREATE cannot use variable-length patterns
       if (rel.isVariableLength())
-        throw new CommandSemanticException("CreatingVarLength: Variable-length relationships are not allowed in CREATE");
+        throw new CommandParsingException("CreatingVarLength: Variable-length relationships are not allowed in CREATE");
     }
   }
 
@@ -1337,13 +1338,13 @@ public class CypherSemanticValidator {
     for (final RelationshipPattern rel : path.getRelationships()) {
       // MERGE relationships must specify exactly one type
       if (!rel.hasTypes())
-        throw new CommandSemanticException("NoSingleRelationshipType: Relationships must have a type in MERGE");
+        throw new CommandParsingException("NoSingleRelationshipType: Relationships must have a type in MERGE");
       // MERGE relationships must not have multiple types
       if (rel.getTypes().size() > 1)
-        throw new CommandSemanticException("NoSingleRelationshipType: Relationships must have exactly one type in MERGE, got: " + rel.getTypes());
+        throw new CommandParsingException("NoSingleRelationshipType: Relationships must have exactly one type in MERGE, got: " + rel.getTypes());
       // MERGE cannot use variable-length patterns
       if (rel.isVariableLength())
-        throw new CommandSemanticException("CreatingVarLength: Variable-length relationships are not allowed in MERGE");
+        throw new CommandParsingException("CreatingVarLength: Variable-length relationships are not allowed in MERGE");
     }
     // MERGE cannot have null property values
     checkMergeNullProperties(path);
@@ -1362,9 +1363,9 @@ public class CypherSemanticValidator {
 
   private void checkMergePropertyNotNull(final Object value) {
     if (value == null)
-      throw new CommandSemanticException("MergeReadOwnWrites: MERGE does not support null property values");
+      throw new CommandParsingException("MergeReadOwnWrites: MERGE does not support null property values");
     if (value instanceof LiteralExpression && ((LiteralExpression) value).getValue() == null)
-      throw new CommandSemanticException("MergeReadOwnWrites: MERGE does not support null property values");
+      throw new CommandParsingException("MergeReadOwnWrites: MERGE does not support null property values");
   }
 
   private void validateDeleteTargets(final DeleteClause deleteClause) {
@@ -1373,10 +1374,10 @@ public class CypherSemanticValidator {
         continue;
       // DELETE n:Label or DELETE r:TYPE is invalid (InvalidDelete)
       if (target.contains(":"))
-        throw new CommandSemanticException("InvalidDelete: Cannot delete a label or relationship type: " + target);
+        throw new CommandParsingException("InvalidDelete: Cannot delete a label or relationship type: " + target);
       // DELETE <arithmetic expression> like DELETE 1+1 is invalid (InvalidArgumentType)
       if (!isValidVariableName(target) && !target.contains(".") && !target.contains("["))
-        throw new CommandSemanticException("InvalidArgumentType: DELETE requires a node, relationship, or path variable, got: " + target);
+        throw new CommandParsingException("InvalidArgumentType: DELETE requires a node, relationship, or path variable, got: " + target);
     }
   }
 
@@ -1393,7 +1394,7 @@ public class CypherSemanticValidator {
         for (final RelationshipPattern rel : path.getRelationships()) {
           final String var = rel.getVariable();
           if (var != null && !var.isEmpty() && !relVars.add(var))
-            throw new CommandSemanticException("RelationshipUniquenessViolation: Relationship variable '" + var + "' is used more than once in the same pattern");
+            throw new CommandParsingException("RelationshipUniquenessViolation: Relationship variable '" + var + "' is used more than once in the same pattern");
         }
       }
     }
@@ -1447,7 +1448,7 @@ public class CypherSemanticValidator {
           }
         }
         if (!hasNamedVars)
-          throw new CommandSemanticException("NoVariablesInScope: RETURN * is not allowed when there are no variables in scope");
+          throw new CommandParsingException("NoVariablesInScope: RETURN * is not allowed when there are no variables in scope");
       }
     }
   }
@@ -1477,15 +1478,15 @@ public class CypherSemanticValidator {
         if (val instanceof Float || val instanceof Double) {
           final double d = ((Number) val).doubleValue();
           if (d != Math.floor(d) || Double.isInfinite(d))
-            throw new CommandSemanticException("InvalidArgumentType: " + clauseName + " value must be an integer, got: Float(" + d + ")");
+            throw new CommandParsingException("InvalidArgumentType: " + clauseName + " value must be an integer, got: Float(" + d + ")");
         }
         if (((Number) val).intValue() < 0)
-          throw new CommandSemanticException("NegativeIntegerArgument: " + clauseName + " value cannot be negative: " + val);
+          throw new CommandParsingException("NegativeIntegerArgument: " + clauseName + " value cannot be negative: " + val);
       }
     }
     // Check that SKIP/LIMIT expressions don't reference query variables (NonConstantExpression)
     if (containsVariableReference(expr))
-      throw new CommandSemanticException("NonConstantExpression: " + clauseName + " expression must not reference variables");
+      throw new CommandParsingException("NonConstantExpression: " + clauseName + " expression must not reference variables");
   }
 
   private static boolean containsVariableReference(final Expression expr) {
@@ -1527,7 +1528,7 @@ public class CypherSemanticValidator {
         name = ((VariableExpression) item.getExpression()).getVariableName();
       if (name != null && !"*".equals(name)) {
         if (!seen.add(name))
-          throw new CommandSemanticException("ColumnNameConflict: Column name '" + name + "' is defined more than once");
+          throw new CommandParsingException("ColumnNameConflict: Column name '" + name + "' is defined more than once");
       }
     }
   }
@@ -1546,7 +1547,7 @@ public class CypherSemanticValidator {
           final Expression expr = item.getExpression();
           if (expr instanceof FunctionCallExpression && ((FunctionCallExpression) expr).isAggregation()) {
             if (item.getAlias() == null)
-              throw new CommandSemanticException("NoExpressionAlias: Expression in WITH must be aliased (use AS)");
+              throw new CommandParsingException("NoExpressionAlias: Expression in WITH must be aliased (use AS)");
           }
         }
       }
@@ -1590,7 +1591,7 @@ public class CypherSemanticValidator {
       final String name = func.getFunctionName().toLowerCase();
       // Check for unknown functions (skip namespaced functions like date.truncate, they're handled by CypherFunctionRegistry)
       if (!name.contains(".") && !FunctionValidator.isKnownFunction(name))
-        throw new CommandSemanticException("UnknownFunction: Unknown function '" + func.getFunctionName() + "'");
+        throw new CommandParsingException("UnknownFunction: Unknown function '" + func.getFunctionName() + "'");
       final List<Expression> args = func.getArguments();
       if (args.size() == 1) {
         final Expression arg = args.get(0);
@@ -1600,24 +1601,24 @@ public class CypherSemanticValidator {
             case "length":
               // length() only works on paths and strings, not nodes or relationships
               if (argType == VarType.NODE)
-                throw new CommandSemanticException("InvalidArgumentType: length() cannot be applied to a node");
+                throw new CommandParsingException("InvalidArgumentType: length() cannot be applied to a node");
               if (argType == VarType.RELATIONSHIP)
-                throw new CommandSemanticException("InvalidArgumentType: length() cannot be applied to a relationship");
+                throw new CommandParsingException("InvalidArgumentType: length() cannot be applied to a relationship");
               break;
             case "type":
               // type() only works on relationships
               if (argType == VarType.NODE)
-                throw new CommandSemanticException("InvalidArgumentType: type() requires a relationship argument, got node");
+                throw new CommandParsingException("InvalidArgumentType: type() requires a relationship argument, got node");
               break;
             case "labels":
               // labels() only works on nodes
               if (argType == VarType.PATH)
-                throw new CommandSemanticException("InvalidArgumentType: labels() requires a node argument, got path");
+                throw new CommandParsingException("InvalidArgumentType: labels() requires a node argument, got path");
               break;
             case "size":
               // size() works on strings and lists, not paths
               if (argType == VarType.PATH)
-                throw new CommandSemanticException("InvalidArgumentType: size() cannot be applied to a path");
+                throw new CommandParsingException("InvalidArgumentType: size() cannot be applied to a path");
               break;
           }
         }
@@ -1651,7 +1652,7 @@ public class CypherSemanticValidator {
       final String varName = ((PropertyAccessExpression) expr).getVariableName();
       final VarType type = varTypes.get(varName);
       if (type == VarType.PATH)
-        throw new CommandSemanticException("InvalidArgumentType: Property access on a path variable is not allowed");
+        throw new CommandParsingException("InvalidArgumentType: Property access on a path variable is not allowed");
     } else if (expr instanceof FunctionCallExpression) {
       for (final Expression arg : ((FunctionCallExpression) expr).getArguments())
         checkPropertyAccessOnPath(arg);

--- a/engine/src/test/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidatorExceptionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/parser/CypherSemanticValidatorExceptionTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.parser;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.exception.CommandParsingException;
+import com.arcadedb.exception.CommandSemanticException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test verifying that semantic validation errors raised by {@link CypherSemanticValidator}
+ * (for example an undefined variable reference) are reported as {@link CommandSemanticException}, a
+ * subclass of {@link CommandParsingException}, so callers can distinguish a semantic error from a
+ * genuine syntax error while existing handlers that only know about the parent class keep working.
+ */
+class CypherSemanticValidatorExceptionTest {
+  private static final String DB_PATH = "./target/databases/CypherSemanticValidatorExceptionTest";
+  private Database db;
+
+  @BeforeEach
+  void setUp() {
+    final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
+    if (factory.exists())
+      factory.open().drop();
+    db = factory.create();
+    db.getSchema().createVertexType("Beer");
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null && db.isOpen())
+      db.drop();
+  }
+
+  @Test
+  void undefinedVariableThrowsSemanticException() {
+    assertThatThrownBy(() -> db.query("opencypher", "MATCH (n:Beer) RETURN undefinedVariable").close())
+        .isInstanceOf(CommandSemanticException.class)
+        .isInstanceOf(CommandParsingException.class);
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Adds native Bolt wire serialization for three Cypher types and fixes semantic-error classification, closing three sub-issues of the #4890 tracking issue:

- **#4997 (TYPE-011, TYPE-012)** - native `Duration` (struct tag `0x45`) and spatial `Point` (`0x58`/`0x59`) encoding, plus inbound decoding so both round-trip as query parameters. Point detection is structural (Cypher `point()` returns a `Map`, there is no Point class), keyed on a recognized `crs` value (`cartesian`/`cartesian-3D`/`WGS-84`/`WGS-84-3D`) or a numeric `srid`, plus numeric `x`/`y`; the inbound decode carries a derived `crs` so an echoed point re-encodes as a Point.
- **#4998 (TYPE-003)** - native `Path` (`0x50`). `BoltPath` already existed but had no call site; this wires `TraversalPath` -> `BoltPath` with deduplicated nodes/rels and the signed 1-based/0-based `indices` sequence, deriving traversal direction per hop.
- **#4999 (ERR-002)** - a new `CommandSemanticException extends CommandParsingException` lets the Bolt RUN handler return `Neo.ClientError.Statement.SemanticError`. Classification is **scoped to the undefined-variable case that ERR-002 certifies**: only the `UndefinedVariable` validator throws become `CommandSemanticException`; every other `CypherSemanticValidator` failure keeps throwing `CommandParsingException` -> `SyntaxError` (unchanged from before this PR). The subclass is caught by every existing `catch (CommandParsingException)` site unchanged, so only the Bolt handler distinguishes it.

All changes are writer/validator-side, mirroring the shipped temporal work (#4907); no query-engine behavior changes beyond the additive exception subclass.

## Motivation

Depth gaps surfaced by the Group B conformance suites and pinned in `bolt/conformance/spec.yaml` as `expected-fail`. Official Neo4j drivers never received typed `Duration`/`Point`/`Path` values, and `Neo.ClientError.Statement.SemanticError` was dead code.

## Related issues

- Closes #4997, #4998, #4999
- Part of #4890 (Group C tracking), epic #4882
- Flips conformance cells TYPE-003/011/012 + ERR-002 to `passing` across all five per-language e2e suites (Java, JS, Python, C#, Go).

## Additional Notes

- Module-level tests (`BoltTypeRoundTripTest`, `PackStreamTypeInputTest`, `Bolt4998PathMappingTest`, `BoltErrorClassificationTest`, `CypherSemanticValidatorExceptionTest`) are the hard gate and pass locally (bolt module 253/253). The five e2e suites pass in CI against the branch-built image.
- Known follow-up (not blocking): extend `SemanticError` classification to the remaining genuinely-semantic validator failures (type conflicts, nested aggregation, invalid DELETE target, ...) once each is verified against a real Neo4j instance. They are intentionally left as `SyntaxError` for now so the change certifies only what ERR-002 exercises rather than trading one misclassification for another.

## Checklist

- [x] Unit tests cover both failure and success scenarios
- [x] Conformance spec + all five e2e suites updated
