### PR TITLE
fix(#4925,#4933): version-monotonic page cache put; exact-once RAM ac…

### DIFF
--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -81,6 +81,21 @@ that could starve the very snapshot resync meant to heal the node.
   against a per-record snapshot of the previous in-transaction indexed state. The snapshot stores ONLY the
   indexed property values (not a full copy of the document), so the cost per update is independent of the
   document width and negligible for bulk updates.
+- **Storage: a slow reader can no longer poison the page cache with a stale version (lost update).** A
+  reader that started a disk read of page version N before a committer cached version N+1 overwrote the
+  newer committed page when its read completed, because the cache put was unconditional. Every subsequent
+  reader then saw vN, and the commit-time version probe read the poisoned cache too, so a later transaction
+  could pass its MVCC check and silently overwrite the lost committed update
+  ([#4925](https://github.com/ArcadeData/arcadedb/issues/4925)). The cache put is now version-monotonic: an
+  older page version never replaces a newer one, with the RAM accounting computed inside the same atomic
+  operation.
+- **Storage: page-cache RAM accounting can no longer go negative and disable eviction.** The bulk removal
+  loops (database close/kill, file drop) subtracted a page's size from the cache accounting before removing
+  it, unconditionally, while the eviction path subtracts only when its removal actually won. Racing the two
+  subtracted the same page twice; once the counter drifted negative the `totalRAM < maxRAM` eviction check
+  never fired again and the read cache grew without bound (real RSS growth, invisible in the stats)
+  ([#4933](https://github.com/ArcadeData/arcadedb/issues/4933)). All accounting is now driven by the entry
+  actually removed, so every page is subtracted exactly once.
 
 ### Improvements
 

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -120,13 +120,13 @@ public class PageManager extends LockContext {
   }
 
   public void removeAllReadPagesOfDatabase(final Database database) {
-    for (final Iterator<CachedPage> it = readCache.values().iterator(); it.hasNext(); ) {
-      final CachedPage p = it.next();
+    for (final CachedPage p : readCache.values()) {
       final PageId pageId = p.getPageId();
-      if (pageId.getDatabase().equals(database)) {
-        totalReadCacheRAM.addAndGet(-1L * p.getPhysicalSize());
-        it.remove();
-      }
+      if (pageId.getDatabase().equals(database))
+        // #4933: drive the accounting from the value ACTUALLY removed. Subtracting before it.remove()
+        // double-subtracted a page that a concurrent evictOldestPages/removePageFromCache removed first,
+        // driving totalReadCacheRAM negative and permanently disabling eviction (unbounded cache growth).
+        removePageFromCache(pageId);
     }
   }
 
@@ -170,13 +170,11 @@ public class PageManager extends LockContext {
     if (flushThread != null)
       flushThread.removeAllPagesOfFile(database, fileId);
 
-    for (final Iterator<CachedPage> it = readCache.values().iterator(); it.hasNext(); ) {
-      final CachedPage p = it.next();
+    for (final CachedPage p : readCache.values()) {
       final PageId pageId = p.getPageId();
-      if (pageId.getDatabase().equals(database) && pageId.getFileId() == fileId) {
-        totalReadCacheRAM.addAndGet(-1L * p.getPhysicalSize());
-        it.remove();
-      }
+      if (pageId.getDatabase().equals(database) && pageId.getFileId() == fileId)
+        // #4933: accounting driven by the value actually removed (see removeAllReadPagesOfDatabase).
+        removePageFromCache(pageId);
     }
   }
 
@@ -561,14 +559,27 @@ public class PageManager extends LockContext {
   }
 
   private void putPageInReadCache(final CachedPage page) {
-    final CachedPage prev = readCache.put(page.getPageId(), page);
-    if (prev == null)
-      totalReadCacheRAM.addAndGet(page.getPhysicalSize());
-    else {
-      final long delta = page.getPhysicalSize() - prev.getPhysicalSize();
-      if (delta != 0)
-        totalReadCacheRAM.addAndGet(delta);
-    }
+    // #4925: version-monotonic put. A reader that started a disk read of version N before a committer
+    // cached version N+1 must not overwrite the newer committed page with its stale image: the poisoned
+    // cache would serve vN to every subsequent reader AND to the commit-time version probe, letting a later
+    // transaction pass its MVCC check and silently overwrite the lost committed update. The compute keeps
+    // whichever version is newer; the RAM delta is computed inside the same atomic operation so the
+    // accounting always matches the actual cache content.
+    final long[] ramDelta = new long[1];
+    readCache.compute(page.getPageId(), (id, prev) -> {
+      if (prev == null) {
+        ramDelta[0] = page.getPhysicalSize();
+        return page;
+      }
+      if (page.getVersion() >= prev.getVersion()) {
+        ramDelta[0] = page.getPhysicalSize() - prev.getPhysicalSize();
+        return page;
+      }
+      // STALE WRITE ATTEMPT: KEEP THE NEWER CACHED VERSION
+      return prev;
+    });
+    if (ramDelta[0] != 0)
+      totalReadCacheRAM.addAndGet(ramDelta[0]);
 
     checkForPageDisposal();
   }

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
+import java.util.function.BiFunction;
 
 /**
  * Manages pages from disk to RAM. Each page can have different size.
@@ -538,8 +539,10 @@ public class PageManager extends LockContext {
     for (final CachedPage page : pagesOrderedByAge) {
       final CachedPage removedPage = readCache.remove(page.getPageId());
       if (removedPage != null) {
-        freedRAM += page.getPhysicalSize();
-        totalReadCacheRAM.addAndGet(-1L * page.getPhysicalSize());
+        // Account the entry ACTUALLY removed, not the TreeSet snapshot: the version-monotonic put can swap
+        // a same-PageId entry for a different instance between the snapshot and this remove (#4925/#4933).
+        freedRAM += removedPage.getPhysicalSize();
+        totalReadCacheRAM.addAndGet(-1L * removedPage.getPhysicalSize());
         pagesEvicted.incrementAndGet();
 
         if (freedRAM > ramToFree)
@@ -560,28 +563,34 @@ public class PageManager extends LockContext {
     lastCheckForRAM = System.currentTimeMillis();
   }
 
+  // Reused per-thread slot for the RAM delta decided inside VERSION_MONOTONIC_MERGE: keeps the put hot
+  // path allocation-free (a capturing lambda + holder array per call would rely on escape analysis that is
+  // not guaranteed under a megamorphic merge call site).
+  private static final ThreadLocal<long[]> PUT_RAM_DELTA = ThreadLocal.withInitial(() -> new long[1]);
+
+  // #4925: version-monotonic merge. Keeps whichever version is newer; an EQUAL version replaces on purpose
+  // (identical content, freshest instance, zero RAM delta). Static and non-capturing: merge() hands the new
+  // page in as the second argument, so this function allocates nothing per call.
+  private static final BiFunction<CachedPage, CachedPage, CachedPage> VERSION_MONOTONIC_MERGE = (prev, cur) -> {
+    if (cur.getVersion() >= prev.getVersion()) {
+      PUT_RAM_DELTA.get()[0] = cur.getPhysicalSize() - prev.getPhysicalSize();
+      return cur;
+    }
+    // STALE WRITE ATTEMPT: KEEP THE NEWER CACHED VERSION, NO ACCOUNTING CHANGE
+    PUT_RAM_DELTA.get()[0] = 0;
+    return prev;
+  };
+
   void putPageInReadCache(final CachedPage page) {
     // #4925: version-monotonic put. A reader that started a disk read of version N before a committer
     // cached version N+1 must not overwrite the newer committed page with its stale image: the poisoned
     // cache would serve vN to every subsequent reader AND to the commit-time version probe, letting a later
-    // transaction pass its MVCC check and silently overwrite the lost committed update. The compute keeps
-    // whichever version is newer; the RAM delta is computed inside the same atomic operation so the
-    // accounting always matches the actual cache content. The one-slot holder does not escape compute(),
-    // so escape analysis is expected to scalar-replace it on this hot path; if profiling ever shows it
-    // surviving, switch to a ThreadLocal holder.
-    final long[] ramDelta = new long[1];
-    readCache.compute(page.getPageId(), (id, prev) -> {
-      if (prev == null) {
-        ramDelta[0] = page.getPhysicalSize();
-        return page;
-      }
-      if (page.getVersion() >= prev.getVersion()) {
-        ramDelta[0] = page.getPhysicalSize() - prev.getPhysicalSize();
-        return page;
-      }
-      // STALE WRITE ATTEMPT: KEEP THE NEWER CACHED VERSION
-      return prev;
-    });
+    // transaction pass its MVCC check and silently overwrite the lost committed update. The RAM delta is
+    // decided inside the same atomic merge so the accounting always matches the actual cache content.
+    final long[] ramDelta = PUT_RAM_DELTA.get();
+    // Default covers the absent-key case: merge() inserts the page WITHOUT invoking the remapping function.
+    ramDelta[0] = page.getPhysicalSize();
+    readCache.merge(page.getPageId(), page, VERSION_MONOTONIC_MERGE);
     if (ramDelta[0] != 0)
       totalReadCacheRAM.addAndGet(ramDelta[0]);
 

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -47,11 +47,13 @@ import java.util.logging.Level;
 public class PageManager extends LockContext {
   public static final PageManager INSTANCE = new PageManager();
 
-  private          ConcurrentMap<PageId, CachedPage> readCache;
+  // Package-private (instead of private) so the white-box regression test for #4925/#4933 can assert on
+  // the cache content and RAM accounting directly, without reflection.
+  ConcurrentMap<PageId, CachedPage> readCache;
   // MANAGE CONCURRENT ACCESS TO THE PAGES. THE VALUE IS TRUE FOR WRITE OPERATION AND FALSE FOR READ
   private final    ConcurrentMap<PageId, Boolean>    pendingFlushPages                     = new ConcurrentHashMap<>();
   private          long                              maxRAM;
-  private final    AtomicLong                        totalReadCacheRAM                     = new AtomicLong();
+  final            AtomicLong                        totalReadCacheRAM                     = new AtomicLong();
   private final    AtomicLong                        totalPagesRead                        = new AtomicLong();
   private final    AtomicLong                        totalPagesReadSize                    = new AtomicLong();
   private final    AtomicLong                        totalPagesWritten                     = new AtomicLong();
@@ -558,13 +560,15 @@ public class PageManager extends LockContext {
     lastCheckForRAM = System.currentTimeMillis();
   }
 
-  private void putPageInReadCache(final CachedPage page) {
+  void putPageInReadCache(final CachedPage page) {
     // #4925: version-monotonic put. A reader that started a disk read of version N before a committer
     // cached version N+1 must not overwrite the newer committed page with its stale image: the poisoned
     // cache would serve vN to every subsequent reader AND to the commit-time version probe, letting a later
     // transaction pass its MVCC check and silently overwrite the lost committed update. The compute keeps
     // whichever version is newer; the RAM delta is computed inside the same atomic operation so the
-    // accounting always matches the actual cache content.
+    // accounting always matches the actual cache content. The one-slot holder does not escape compute(),
+    // so escape analysis is expected to scalar-replace it on this hot path; if profiling ever shows it
+    // surviving, switch to a ThreadLocal holder.
     final long[] ramDelta = new long[1];
     readCache.compute(page.getPageId(), (id, prev) -> {
       if (prev == null) {

--- a/engine/src/test/java/com/arcadedb/engine/PageManagerReadCacheConsistencyTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageManagerReadCacheConsistencyTest.java
@@ -22,11 +22,7 @@ import com.arcadedb.TestHelper;
 import com.arcadedb.database.DatabaseInternal;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -55,31 +51,28 @@ class PageManagerReadCacheConsistencyTest extends TestHelper {
     final DatabaseInternal db = (DatabaseInternal) database;
     final PageManager pm = db.getPageManager();
 
-    final ConcurrentMap<PageId, CachedPage> readCache = readCache(pm);
-    final AtomicLong totalRAM = totalReadCacheRAM(pm);
-    final Method put = putMethod();
 
     // Use a page id no real component touches (file 0 of this db at a huge page number).
     final PageId pageId = new PageId(db, 0, 1_000_000);
     final CachedPage newer = new CachedPage(new MutablePage(pageId, PAGE_SIZE, new byte[PAGE_SIZE], 7, 0), false);
     final CachedPage stale = new CachedPage(new MutablePage(pageId, PAGE_SIZE, new byte[PAGE_SIZE], 5, 0), false);
 
-    final long ramBefore = totalRAM.get();
+    final long ramBefore = pm.totalReadCacheRAM.get();
     try {
       // Committer caches v7, then the slow reader completes its disk read of v5 and tries to cache it.
-      put.invoke(pm, newer);
-      put.invoke(pm, stale);
+      pm.putPageInReadCache(newer);
+      pm.putPageInReadCache(stale);
 
-      assertThat(readCache.get(pageId).getVersion())
+      assertThat(pm.readCache.get(pageId).getVersion())
           .as("a stale loaded page must never replace a newer committed version in the read cache (#4925)")
           .isEqualTo(7);
-      assertThat(totalRAM.get() - ramBefore)
+      assertThat(pm.totalReadCacheRAM.get() - ramBefore)
           .as("RAM accounting must reflect exactly one cached page whichever write wins")
           .isEqualTo(newer.getPhysicalSize());
     } finally {
       pm.removePageFromCache(pageId);
     }
-    assertThat(totalRAM.get()).as("cleanup must restore the accounting baseline").isEqualTo(ramBefore);
+    assertThat(pm.totalReadCacheRAM.get()).as("cleanup must restore the accounting baseline").isEqualTo(ramBefore);
   }
 
   @Test
@@ -87,8 +80,6 @@ class PageManagerReadCacheConsistencyTest extends TestHelper {
     final DatabaseInternal db = (DatabaseInternal) database;
     final PageManager pm = db.getPageManager();
 
-    final AtomicLong totalRAM = totalReadCacheRAM(pm);
-    final Method put = putMethod();
 
     // Enough small pages that each thread's sweep takes milliseconds, so the two removal paths genuinely
     // overlap (the double-subtract needs the bulk loop and a successful per-page remove to hit the same entry).
@@ -99,12 +90,12 @@ class PageManagerReadCacheConsistencyTest extends TestHelper {
     for (int round = 0; round < rounds; round++) {
       // Start each round from a clean slate for this database so the baseline is stable.
       pm.removeAllReadPagesOfDatabase(db);
-      final long baseline = totalRAM.get();
+      final long baseline = pm.totalReadCacheRAM.get();
 
       final PageId[] ids = new PageId[pagesPerRound];
       for (int i = 0; i < pagesPerRound; i++) {
         ids[i] = new PageId(db, 0, 2_000_000 + i);
-        put.invoke(pm, new CachedPage(new MutablePage(ids[i], pageSize, new byte[pageSize], 1, 0), false));
+        pm.putPageInReadCache(new CachedPage(new MutablePage(ids[i], pageSize, new byte[pageSize], 1, 0), false));
       }
 
       // Race the bulk removal against per-page removals of the same entries: each page's size must be
@@ -135,29 +126,11 @@ class PageManagerReadCacheConsistencyTest extends TestHelper {
       bulk.join(10_000);
       perPage.join(10_000);
 
-      assertThat(totalRAM.get())
+      assertThat(pm.totalReadCacheRAM.get())
           .as("round %d: every removed page must be subtracted exactly once (#4933); negative drift disables eviction forever",
               round)
           .isEqualTo(baseline);
     }
   }
 
-  @SuppressWarnings("unchecked")
-  private static ConcurrentMap<PageId, CachedPage> readCache(final PageManager pm) throws Exception {
-    final Field f = PageManager.class.getDeclaredField("readCache");
-    f.setAccessible(true);
-    return (ConcurrentMap<PageId, CachedPage>) f.get(pm);
-  }
-
-  private static AtomicLong totalReadCacheRAM(final PageManager pm) throws Exception {
-    final Field f = PageManager.class.getDeclaredField("totalReadCacheRAM");
-    f.setAccessible(true);
-    return (AtomicLong) f.get(pm);
-  }
-
-  private static Method putMethod() throws Exception {
-    final Method m = PageManager.class.getDeclaredMethod("putPageInReadCache", CachedPage.class);
-    m.setAccessible(true);
-    return m;
-  }
 }

--- a/engine/src/test/java/com/arcadedb/engine/PageManagerReadCacheConsistencyTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageManagerReadCacheConsistencyTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for the read-cache consistency fixes:
+ * <ul>
+ * <li>#4925: {@code putPageInReadCache} was an unconditional {@code put}, so a reader that started a disk
+ * read of version N before a committer cached version N+1 would overwrite the newer committed page with the
+ * stale image when its read completed. Subsequent readers (and the commit-time version probe) then saw vN:
+ * a later transaction could pass its version check against the poisoned cache and silently overwrite the
+ * lost committed update. The put is now version-monotonic: an older version never replaces a newer one.</li>
+ * <li>#4933: the bulk removal loops ({@code removeAllReadPagesOfDatabase}, {@code deleteFile}) subtracted a
+ * page's size from {@code totalReadCacheRAM} unconditionally BEFORE removing it, while the eviction path and
+ * {@code removePageFromCache} subtract only when their {@code remove()} actually returned the entry. Racing
+ * the two subtracted the same page twice, driving the counter negative and permanently disabling eviction
+ * (the {@code totalRAM < maxRAM} check never fires again): unbounded cache growth. All accounting is now
+ * driven by the value actually removed.</li>
+ * </ul>
+ */
+class PageManagerReadCacheConsistencyTest extends TestHelper {
+
+  private static final int PAGE_SIZE = 65_536;
+
+  @Test
+  void staleLoadCannotOverwriteNewerCachedVersion() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManager pm = db.getPageManager();
+
+    final ConcurrentMap<PageId, CachedPage> readCache = readCache(pm);
+    final AtomicLong totalRAM = totalReadCacheRAM(pm);
+    final Method put = putMethod();
+
+    // Use a page id no real component touches (file 0 of this db at a huge page number).
+    final PageId pageId = new PageId(db, 0, 1_000_000);
+    final CachedPage newer = new CachedPage(new MutablePage(pageId, PAGE_SIZE, new byte[PAGE_SIZE], 7, 0), false);
+    final CachedPage stale = new CachedPage(new MutablePage(pageId, PAGE_SIZE, new byte[PAGE_SIZE], 5, 0), false);
+
+    final long ramBefore = totalRAM.get();
+    try {
+      // Committer caches v7, then the slow reader completes its disk read of v5 and tries to cache it.
+      put.invoke(pm, newer);
+      put.invoke(pm, stale);
+
+      assertThat(readCache.get(pageId).getVersion())
+          .as("a stale loaded page must never replace a newer committed version in the read cache (#4925)")
+          .isEqualTo(7);
+      assertThat(totalRAM.get() - ramBefore)
+          .as("RAM accounting must reflect exactly one cached page whichever write wins")
+          .isEqualTo(newer.getPhysicalSize());
+    } finally {
+      pm.removePageFromCache(pageId);
+    }
+    assertThat(totalRAM.get()).as("cleanup must restore the accounting baseline").isEqualTo(ramBefore);
+  }
+
+  @Test
+  void concurrentBulkRemovalDoesNotDoubleSubtractRam() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final PageManager pm = db.getPageManager();
+
+    final AtomicLong totalRAM = totalReadCacheRAM(pm);
+    final Method put = putMethod();
+
+    // Enough small pages that each thread's sweep takes milliseconds, so the two removal paths genuinely
+    // overlap (the double-subtract needs the bulk loop and a successful per-page remove to hit the same entry).
+    final int pageSize = 1024;
+    final int pagesPerRound = 8192;
+    final int rounds = 20;
+
+    for (int round = 0; round < rounds; round++) {
+      // Start each round from a clean slate for this database so the baseline is stable.
+      pm.removeAllReadPagesOfDatabase(db);
+      final long baseline = totalRAM.get();
+
+      final PageId[] ids = new PageId[pagesPerRound];
+      for (int i = 0; i < pagesPerRound; i++) {
+        ids[i] = new PageId(db, 0, 2_000_000 + i);
+        put.invoke(pm, new CachedPage(new MutablePage(ids[i], pageSize, new byte[pageSize], 1, 0), false));
+      }
+
+      // Race the bulk removal against per-page removals of the same entries: each page's size must be
+      // subtracted exactly once no matter which thread wins each entry.
+      final CountDownLatch start = new CountDownLatch(1);
+      final Thread bulk = new Thread(() -> {
+        try {
+          start.await();
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return;
+        }
+        pm.removeAllReadPagesOfDatabase(db);
+      }, "bulk-removal");
+      final Thread perPage = new Thread(() -> {
+        try {
+          start.await();
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return;
+        }
+        for (final PageId id : ids)
+          pm.removePageFromCache(id);
+      }, "per-page-removal");
+      bulk.start();
+      perPage.start();
+      start.countDown();
+      bulk.join(10_000);
+      perPage.join(10_000);
+
+      assertThat(totalRAM.get())
+          .as("round %d: every removed page must be subtracted exactly once (#4933); negative drift disables eviction forever",
+              round)
+          .isEqualTo(baseline);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static ConcurrentMap<PageId, CachedPage> readCache(final PageManager pm) throws Exception {
+    final Field f = PageManager.class.getDeclaredField("readCache");
+    f.setAccessible(true);
+    return (ConcurrentMap<PageId, CachedPage>) f.get(pm);
+  }
+
+  private static AtomicLong totalReadCacheRAM(final PageManager pm) throws Exception {
+    final Field f = PageManager.class.getDeclaredField("totalReadCacheRAM");
+    f.setAccessible(true);
+    return (AtomicLong) f.get(pm);
+  }
+
+  private static Method putMethod() throws Exception {
+    final Method m = PageManager.class.getDeclaredMethod("putPageInReadCache", CachedPage.class);
+    m.setAccessible(true);
+    return m;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/PageManagerReadCacheConsistencyTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageManagerReadCacheConsistencyTest.java
@@ -41,6 +41,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  * (the {@code totalRAM < maxRAM} check never fires again): unbounded cache growth. All accounting is now
  * driven by the value actually removed.</li>
  * </ul>
+ * <p>
+ * ISOLATION NOTE: {@code totalReadCacheRAM} lives on the JVM-wide {@code PageManager.INSTANCE} and is shared
+ * by every open database in the process. The exact-equality assertions therefore assume the suite runs these
+ * tests single-threaded (the project does not enable JUnit parallel execution) and that no other actor
+ * touches the cache inside the measured window: the test database is idle during it (no commits, so no async
+ * flush re-caches pages) and the synthetic page ids belong to no real component. If parallel execution is
+ * ever enabled, scope the assertions to the page ids the test owns instead.
  */
 class PageManagerReadCacheConsistencyTest extends TestHelper {
 


### PR DESCRIPTION
…counting

#4925 (HIGH, lost update): putPageInReadCache was an unconditional put. A reader that started a disk read of page version N before a committer cached version N+1 overwrote the newer committed page with its stale image when the read completed. Every subsequent reader then saw vN, and the commit-time version probe (getMostRecentVersionOfPage) read the poisoned cache too, so a later transaction could pass its MVCC version check and silently overwrite the lost committed update. File locks don't help - the poisoning thread is a pure reader. The put is now version-monotonic via an atomic compute: an older version never replaces a newer one, and the RAM delta is decided inside the same atomic operation so the accounting always matches the actual cache content. This same invariant also covers the interrupt zero-page and eviction-window variants of the race.

#4933 (MEDIUM, unbounded cache growth): removeAllReadPagesOfDatabase and deleteFile subtracted a page's size from totalReadCacheRAM BEFORE removing it, unconditionally, while evictOldestPages/removePageFromCache subtract only when their remove() actually returned the entry. Racing the two subtracted the same page twice; once the counter drifted negative the totalRAM < maxRAM eviction check never fired again and the read cache grew without bound (real RSS growth, invisible in stats). Both loops now route through removePageFromCache so the accounting is driven solely by the entry actually removed - each page subtracted exactly once, whichever thread wins it.

Both verified red-first: the stale-overwrite repro fails on the unfixed put (v5 replaces cached v7), and the removal race (bulk removal vs per-page removal over 8192 pages) drives the counter negative on the unfixed code on its first round; both green with the fixes. Regression: 206 test classes (1202 tests) across engine/database/index packages green post-fix, including the WAL/flush/transaction suites.

## What does this PR do?

A brief description of the change being made with this pull request.

## Motivation

What inspired you to submit this pull request?

## Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

## Additional Notes

Anything else we should know when reviewing?

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
