### PR TITLE
feat(#5000): populate Bolt ResultSummary counters for write queries

### DIFF
--- a/bindings/python/examples/10_stackoverflow_graph_olap.py
+++ b/bindings/python/examples/10_stackoverflow_graph_olap.py
@@ -4143,9 +4143,7 @@ def execute_arcadedb_fast_asker_answerer_pairs(db) -> List[Dict[str, Any]]:
 
 def execute_arcadedb_fast_top_questions_by_total_comments(db) -> List[Dict[str, Any]]:
     question_ids: List[int] = []
-    for row in db.query(
-        "sql", "SELECT Id AS question_id FROM Question"
-    ).to_json_list():
+    for row in db.query("sql", "SELECT Id AS question_id FROM Question").to_json_list():
         qid = row.get("question_id")
         if qid is None:
             continue

--- a/bindings/python/scripts/build-native.sh
+++ b/bindings/python/scripts/build-native.sh
@@ -212,7 +212,7 @@ BRIDGE_CLASSES=$(mktemp -d)
 # conversion for args containing `*`, so javac.exe gets an unreadable POSIX
 # path). Build an explicit platform-correct jar list instead.
 case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
+    MINGW* | MSYS* | CYGWIN*)
         BRIDGE_CP=$(find "$JARS_DIR" -name '*.jar' -exec cygpath -m {} \; | paste -sd ';' -)
         ;;
     *)

--- a/bindings/python/scripts/build.sh
+++ b/bindings/python/scripts/build.sh
@@ -413,9 +413,9 @@ if [ -z "${CI:-}" ] && command -v uv > /dev/null 2>&1; then
     if [ -n "$REPO_ROOT" ] && [ -f "$REPO_ROOT/pyproject.toml" ]; then
         echo -e "${CYAN}🔄 Refreshing uv dev environment at repo root...${NC}"
         (
-            cd "$REPO_ROOT" \
-                && uv lock --upgrade-package arcadedb-embedded \
-                && uv sync --reinstall-package arcadedb-embedded
+            cd "$REPO_ROOT" &&
+                uv lock --upgrade-package arcadedb-embedded &&
+                uv sync --reinstall-package arcadedb-embedded
         )
     fi
 fi

--- a/bindings/python/src/arcadedb_embedded/core.py
+++ b/bindings/python/src/arcadedb_embedded/core.py
@@ -15,8 +15,8 @@ from .importer import ImportResult
 from .importer import import_documents as run_document_import
 from .jvm import start_jvm
 from .results import ResultSet
-from .type_conversion import convert_python_to_java
 from .transactions import TransactionContext
+from .type_conversion import convert_python_to_java
 from .vector import to_java_float_array
 
 try:  # optional; hoisted to module scope to keep it out of per-call hot paths

--- a/bindings/python/src/arcadedb_embedded/results.py
+++ b/bindings/python/src/arcadedb_embedded/results.py
@@ -225,9 +225,7 @@ class ResultSet:
             for col in header["cols"]:
                 name, ctype = col["name"], col["type"]
                 nulls_len = col["nulls"]
-                null_bits = np.frombuffer(
-                    buf[pos : pos + nulls_len], dtype=np.uint8
-                )
+                null_bits = np.frombuffer(buf[pos : pos + nulls_len], dtype=np.uint8)
                 has_nulls = bool(null_bits.any())
                 if has_nulls:
                     mask = np.unpackbits(null_bits, bitorder="little")[:count].astype(
@@ -268,9 +266,11 @@ class ResultSet:
                     chars = bytes(data[(count + 1) * 4 :])
                     if has_nulls:
                         values = [
-                            None
-                            if mask[i]
-                            else chars[offs[i] : offs[i + 1]].decode("utf-8")
+                            (
+                                None
+                                if mask[i]
+                                else chars[offs[i] : offs[i + 1]].decode("utf-8")
+                            )
                             for i in range(count)
                         ]
                     else:
@@ -311,9 +311,7 @@ class ResultSet:
             np_parts = [p for p in parts if not isinstance(p, list)]
             if parts and len(np_parts) == len(parts):
                 try:
-                    out[name] = (
-                        np.concatenate(parts) if len(parts) > 1 else parts[0]
-                    )
+                    out[name] = np.concatenate(parts) if len(parts) > 1 else parts[0]
                     continue
                 except Exception:  # nosec B110 - fall through to generic merge
                     pass

--- a/bindings/python/src/arcadedb_embedded/type_conversion.py
+++ b/bindings/python/src/arcadedb_embedded/type_conversion.py
@@ -274,8 +274,7 @@ _conv_offset_datetime = _conv_zoned_datetime
 
 def _conv_map(value):
     return {
-        convert_java_to_python(k): convert_java_to_python(v)
-        for k, v in value.items()
+        convert_java_to_python(k): convert_java_to_python(v) for k, v in value.items()
     }
 
 

--- a/bindings/python/tests/test_core.py
+++ b/bindings/python/tests/test_core.py
@@ -966,9 +966,9 @@ def test_to_json_list_bulk_materialization(temp_db_path):
                 )
 
         # batch_size smaller than the result forces multiple Java batches
-        rows = db.query("sql", "SELECT n, name, active, emb FROM Item ORDER BY n").to_json_list(
-            batch_size=10
-        )
+        rows = db.query(
+            "sql", "SELECT n, name, active, emb FROM Item ORDER BY n"
+        ).to_json_list(batch_size=10)
         assert len(rows) == 25
         assert rows[3]["n"] == 3
         assert rows[3]["name"] == "item-3"

--- a/bindings/python/tests/test_graph.py
+++ b/bindings/python/tests/test_graph.py
@@ -1,5 +1,3 @@
-
-
 def test_graph_batch_new_edges_bulk(tmp_path):
     """new_edges buffers many property-less edges in one crossing."""
     import arcadedb_embedded as arcadedb

--- a/bindings/python/tests/test_schema.py
+++ b/bindings/python/tests/test_schema.py
@@ -709,7 +709,7 @@ class TestMapIndexByKeyValue:
         with test_db.transaction():
             test_db.command(
                 "sql",
-                'INSERT INTO Movie CONTENT '
+                "INSERT INTO Movie CONTENT "
                 '{"title": "M1", "thumbs": {"banner": "b1", "poster": "p1"}}',
             )
             test_db.command(

--- a/bindings/python/tests/test_type_conversion.py
+++ b/bindings/python/tests/test_type_conversion.py
@@ -120,7 +120,6 @@ def test_offset_datetime_conversion(temp_db_path):
     OffsetDateTime (e.g. from an expression, not storage) converts directly.
     """
     import jpype
-
     from arcadedb_embedded import convert_java_to_python
 
     with arcadedb.create_database(temp_db_path) as db:  # starts the JVM
@@ -132,9 +131,7 @@ def test_offset_datetime_conversion(temp_db_path):
         # direct converter path: offset applied, tz-aware UTC result
         converted = convert_java_to_python(odt)
         assert isinstance(converted, datetime)
-        assert converted == datetime(
-            2026, 7, 5, 8, 30, 0, 250000, tzinfo=timezone.utc
-        )
+        assert converted == datetime(2026, 7, 5, 8, 30, 0, 250000, tzinfo=timezone.utc)
 
         with db.transaction():
             doc = db.new_document("OffsetTest")

--- a/bindings/python/tests/test_vector_sql.py
+++ b/bindings/python/tests/test_vector_sql.py
@@ -7,10 +7,9 @@ Tests cover:
 
 import math
 
+import arcadedb_embedded as arcadedb
 import jpype.types as jtypes
 import pytest
-
-import arcadedb_embedded as arcadedb
 from arcadedb_embedded import create_database
 
 

--- a/bolt/conformance/spec.yaml
+++ b/bolt/conformance/spec.yaml
@@ -326,17 +326,7 @@ scenarios:
       - "When the driver runs 'CREATE (:Beer {name: $n})-[:BREWED_BY]->(:Brewery {name: $b})'"
       - "Then summary.counters().nodesCreated() == 2, relationshipsCreated() == 1, and propertiesSet() matches"
     applicable_driver_versions: all
-    current_status: expected-fail
-    known_limitation: >
-      ResultSummary counters (nodesCreated, relationshipsCreated,
-      propertiesSet, etc.) are never populated for Bolt write queries -
-      BoltNetworkExecutor's handleRun/handlePull/handleDiscard build no
-      'stats' map in the SUCCESS response, and no CRUD-counter tracking
-      exists in the underlying query engine (Cypher's
-      CreateStep/SetStep/DeleteStep don't aggregate counts) to source such
-      values from even if the Bolt layer were fixed - discovered while
-      implementing issue #4885's Python conformance suite.
-    tracking_issue: "#4890"
+    current_status: passing
   - id: TYPE-001
     area: type-roundtrip
     title: "Node round-trips as a native Bolt structure"

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -766,6 +766,8 @@ public class BoltNetworkExecutor extends Thread {
     // Discard all remaining records
     Optional<QueryStatistics> stats = Optional.empty();
     if (currentResultSet != null) {
+      // Statistics are computed eagerly when the write is materialized in the query plan, so they
+      // are valid to read before draining/closing the result set.
       stats = currentResultSet.getStatistics();
       while (currentResultSet.hasNext()) {
         currentResultSet.next();

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -47,6 +47,7 @@ import com.arcadedb.index.TypeIndex;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.query.sql.executor.ExecutionPlan;
 import com.arcadedb.query.sql.executor.ExecutionStep;
+import com.arcadedb.query.sql.executor.QueryStatistics;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
@@ -79,6 +80,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.logging.Level;
@@ -714,6 +716,10 @@ public class BoltNetworkExecutor extends Thread {
           metadata.put(currentPlanMetadataKey, currentPlanMetadata);
 
         if (currentResultSet != null) {
+          final Optional<QueryStatistics> stats = currentResultSet.getStatistics();
+          if (stats.isPresent() && stats.get().containsUpdates())
+            metadata.put("stats", BoltResultStats.toStatsMap(stats.get()));
+
           try {
             currentResultSet.close();
           } catch (final Exception e) {
@@ -758,7 +764,9 @@ public class BoltNetworkExecutor extends Thread {
     }
 
     // Discard all remaining records
+    Optional<QueryStatistics> stats = Optional.empty();
     if (currentResultSet != null) {
+      stats = currentResultSet.getStatistics();
       while (currentResultSet.hasNext()) {
         currentResultSet.next();
       }
@@ -781,6 +789,8 @@ public class BoltNetworkExecutor extends Thread {
       metadata.put(currentPlanMetadataKey, currentPlanMetadata);
     currentPlanMetadata = null;
     currentPlanMetadataKey = null;
+    if (stats.isPresent() && stats.get().containsUpdates())
+      metadata.put("stats", BoltResultStats.toStatsMap(stats.get()));
     metadata.put("has_more", false);
 
     sendSuccess(metadata);

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltResultStats.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltResultStats.java
@@ -44,6 +44,8 @@ final class BoltResultStats {
     putIfNonZero(stats, "indexes-removed", s.getIndexesRemoved());
     putIfNonZero(stats, "constraints-added", s.getConstraintsAdded());
     putIfNonZero(stats, "constraints-removed", s.getConstraintsRemoved());
+    // contains-updates is emitted unconditionally as true, so callers must only invoke this when
+    // the source statistics report containsUpdates().
     stats.put("contains-updates", true);
     return stats;
   }

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltResultStats.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltResultStats.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.query.sql.executor.QueryStatistics;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Maps engine QueryStatistics to the Neo4j Bolt SUCCESS "stats" metadata map. Emits only non-zero
+ * counters plus contains-updates, matching how Neo4j server reports write summaries.
+ */
+final class BoltResultStats {
+  private BoltResultStats() {
+  }
+
+  static Map<String, Object> toStatsMap(final QueryStatistics s) {
+    final Map<String, Object> stats = new LinkedHashMap<>();
+    putIfNonZero(stats, "nodes-created", s.getNodesCreated());
+    putIfNonZero(stats, "nodes-deleted", s.getNodesDeleted());
+    putIfNonZero(stats, "relationships-created", s.getRelationshipsCreated());
+    putIfNonZero(stats, "relationships-deleted", s.getRelationshipsDeleted());
+    putIfNonZero(stats, "properties-set", s.getPropertiesSet());
+    putIfNonZero(stats, "labels-added", s.getLabelsAdded());
+    putIfNonZero(stats, "labels-removed", s.getLabelsRemoved());
+    putIfNonZero(stats, "indexes-added", s.getIndexesAdded());
+    putIfNonZero(stats, "indexes-removed", s.getIndexesRemoved());
+    putIfNonZero(stats, "constraints-added", s.getConstraintsAdded());
+    putIfNonZero(stats, "constraints-removed", s.getConstraintsRemoved());
+    stats.put("contains-updates", true);
+    return stats;
+  }
+
+  private static void putIfNonZero(final Map<String, Object> stats, final String key, final int value) {
+    if (value != 0)
+      stats.put(key, (long) value);
+  }
+}

--- a/bolt/src/test/java/com/arcadedb/bolt/Bolt5000ResultCountersIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Bolt5000ResultCountersIT.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Config;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
+import org.neo4j.driver.Values;
+import org.neo4j.driver.summary.SummaryCounters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end wire test: a Bolt write query must populate summary.counters() on the neo4j driver.
+ */
+public class Bolt5000ResultCountersIT extends BaseGraphServerTest {
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("Bolt:com.arcadedb.bolt.BoltProtocolPlugin");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+
+  private Driver getDriver() {
+    return GraphDatabase.driver("bolt://localhost:7687", AuthTokens.basic("root", DEFAULT_PASSWORD_FOR_TESTS),
+        Config.builder().withoutEncryption().build());
+  }
+
+  @Test
+  void writeCountersReflectActualWrites() {
+    try (final Driver driver = getDriver();
+         final Session session = driver.session(SessionConfig.forDatabase(getDatabaseName()))) {
+      final SummaryCounters counters = session.run(
+          "CREATE (:Beer {name:$n})-[:BREWED_BY]->(:Brewery {name:$b})",
+          Values.parameters("n", "IPA", "b", "Acme")).consume().counters();
+      assertThat(counters.nodesCreated()).isEqualTo(2);
+      assertThat(counters.relationshipsCreated()).isEqualTo(1);
+      assertThat(counters.propertiesSet()).isEqualTo(2);
+      assertThat(counters.containsUpdates()).isTrue();
+    }
+  }
+
+  @Test
+  void readQueryReportsNoUpdates() {
+    try (final Driver driver = getDriver();
+         final Session session = driver.session(SessionConfig.forDatabase(getDatabaseName()))) {
+      session.run("CREATE (:Thing {id:1})").consume();
+      final SummaryCounters counters = session.run("MATCH (n:Thing) RETURN n").consume().counters();
+      assertThat(counters.containsUpdates()).isFalse();
+      assertThat(counters.nodesCreated()).isZero();
+    }
+  }
+
+  @Test
+  void discardAfterWriteStillReportsCounters() {
+    try (final Driver driver = getDriver();
+         final Session session = driver.session(SessionConfig.forDatabase(getDatabaseName()))) {
+      // A tiny result-set batch size (Session default pull is used by the driver's run()+consume(),
+      // which triggers a DISCARD instead of exhausting via PULL for a query producing no records to stream).
+      final SummaryCounters counters = session.run("CREATE (:Widget {id:1})").consume().counters();
+      assertThat(counters.nodesCreated()).isEqualTo(1);
+      assertThat(counters.propertiesSet()).isEqualTo(1);
+      assertThat(counters.containsUpdates()).isTrue();
+    }
+  }
+}

--- a/docs/superpowers/plans/2026-07-06-bolt-result-counters.md
+++ b/docs/superpowers/plans/2026-07-06-bolt-result-counters.md
@@ -1,0 +1,860 @@
+# Bolt ResultSummary counters for write queries Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Populate Neo4j-driver `summary.counters()` for Bolt write queries by tracking CRUD/DDL counts in the Cypher engine and emitting a `stats` map in the Bolt terminal SUCCESS metadata.
+
+**Architecture:** A single `QueryStatistics` accumulator lives on the shared `CommandContext` that every Cypher execution step already carries. Mutation steps increment it; the DDL path increments a local instance. `CypherExecutionPlan.execute()` and `OpenCypherQueryEngine.executeDDL()` attach it to the returned `ResultSet` through a new `ResultSet.getStatistics()` default method (mirroring `getExecutionPlan()`). `BoltNetworkExecutor` reads it at the terminal PULL/DISCARD and emits a Neo4j-style `stats` map.
+
+**Tech Stack:** Java 21, native OpenCypher engine (`com.arcadedb.query.opencypher`), Bolt module (`com.arcadedb.bolt`), JUnit 5 + AssertJ, `neo4j-java-driver` for integration tests.
+
+## Global Constraints
+
+- Java 21+; import classes, do not use fully-qualified names.
+- Use the `final` keyword on variables and parameters where possible.
+- One-child `if` statements omit curly braces (match existing style).
+- Performance/GC: read queries must allocate no `QueryStatistics` and take no new branches on the hot path; counters are primitive `int`.
+- No new dependencies.
+- All new server-side code covered by a test case; include a regression test.
+- Do not add Claude as author anywhere; no issue numbers in Javadoc/source comments (behavioral invariants only).
+- Cypher test language string is `"opencypher"` (both `command` and `query`).
+- Remove any debug `System.out` before finishing.
+
+---
+
+### Task 1: `QueryStatistics` value object + `CommandContext` accessor
+
+**Files:**
+- Create: `engine/src/main/java/com/arcadedb/query/sql/executor/QueryStatistics.java`
+- Modify: `engine/src/main/java/com/arcadedb/query/sql/executor/CommandContext.java` (add one method to the interface)
+- Modify: `engine/src/main/java/com/arcadedb/query/sql/executor/BasicCommandContext.java` (add a lazily-created field + accessor)
+- Test: `engine/src/test/java/com/arcadedb/query/sql/executor/QueryStatisticsTest.java`
+
+**Interfaces:**
+- Produces: `class QueryStatistics` with primitive `int` fields and increment methods:
+  `incNodesCreated()`, `incNodesDeleted()`, `incRelationshipsCreated()`, `incRelationshipsDeleted()`,
+  `addPropertiesSet(int n)`, `addLabelsAdded(int n)`, `addLabelsRemoved(int n)`,
+  `incIndexesAdded()`, `incIndexesRemoved()`, `incConstraintsAdded()`, `incConstraintsRemoved()`;
+  getters `getNodesCreated()` ... `getConstraintsRemoved()`; `boolean containsUpdates()`.
+- Produces: `QueryStatistics CommandContext.getStatistics()` - never null; lazily creates and caches on first call so mutation steps can increment; read queries never call it.
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+package com.arcadedb.query.sql.executor;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QueryStatisticsTest {
+  @Test
+  void freshInstanceHasNoUpdates() {
+    final QueryStatistics s = new QueryStatistics();
+    assertThat(s.containsUpdates()).isFalse();
+    assertThat(s.getNodesCreated()).isZero();
+  }
+
+  @Test
+  void incrementsAreTracked() {
+    final QueryStatistics s = new QueryStatistics();
+    s.incNodesCreated();
+    s.incNodesCreated();
+    s.incRelationshipsCreated();
+    s.addPropertiesSet(3);
+    s.addLabelsAdded(2);
+    assertThat(s.getNodesCreated()).isEqualTo(2);
+    assertThat(s.getRelationshipsCreated()).isEqualTo(1);
+    assertThat(s.getPropertiesSet()).isEqualTo(3);
+    assertThat(s.getLabelsAdded()).isEqualTo(2);
+    assertThat(s.containsUpdates()).isTrue();
+  }
+
+  @Test
+  void addingZeroPropertiesKeepsNoUpdatesWhenNothingElseChanged() {
+    final QueryStatistics s = new QueryStatistics();
+    s.addPropertiesSet(0);
+    s.addLabelsAdded(0);
+    assertThat(s.containsUpdates()).isFalse();
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd engine && mvn -q test -Dtest=QueryStatisticsTest`
+Expected: FAIL - `QueryStatistics` does not exist (compilation error).
+
+- [ ] **Step 3: Create `QueryStatistics`**
+
+Copy the Apache license header from an existing engine file (e.g. `IteratorResultSet.java`) verbatim as the first lines, then:
+
+```java
+package com.arcadedb.query.sql.executor;
+
+/**
+ * Mutable, allocation-light accumulator of CRUD and schema mutation counts produced while executing
+ * a single command. Held on the {@link CommandContext} and read once when the result set is
+ * assembled. All counters are primitive ints; instances are created only for write commands.
+ */
+public class QueryStatistics {
+  private int nodesCreated;
+  private int nodesDeleted;
+  private int relationshipsCreated;
+  private int relationshipsDeleted;
+  private int propertiesSet;
+  private int labelsAdded;
+  private int labelsRemoved;
+  private int indexesAdded;
+  private int indexesRemoved;
+  private int constraintsAdded;
+  private int constraintsRemoved;
+
+  public void incNodesCreated()          { nodesCreated++; }
+  public void incNodesDeleted()          { nodesDeleted++; }
+  public void incRelationshipsCreated()  { relationshipsCreated++; }
+  public void incRelationshipsDeleted()  { relationshipsDeleted++; }
+  public void addPropertiesSet(final int n) { propertiesSet += n; }
+  public void addLabelsAdded(final int n)   { labelsAdded += n; }
+  public void addLabelsRemoved(final int n) { labelsRemoved += n; }
+  public void incIndexesAdded()          { indexesAdded++; }
+  public void incIndexesRemoved()        { indexesRemoved++; }
+  public void incConstraintsAdded()      { constraintsAdded++; }
+  public void incConstraintsRemoved()    { constraintsRemoved++; }
+
+  public int getNodesCreated()          { return nodesCreated; }
+  public int getNodesDeleted()          { return nodesDeleted; }
+  public int getRelationshipsCreated()  { return relationshipsCreated; }
+  public int getRelationshipsDeleted()  { return relationshipsDeleted; }
+  public int getPropertiesSet()         { return propertiesSet; }
+  public int getLabelsAdded()           { return labelsAdded; }
+  public int getLabelsRemoved()         { return labelsRemoved; }
+  public int getIndexesAdded()          { return indexesAdded; }
+  public int getIndexesRemoved()        { return indexesRemoved; }
+  public int getConstraintsAdded()      { return constraintsAdded; }
+  public int getConstraintsRemoved()    { return constraintsRemoved; }
+
+  public boolean containsUpdates() {
+    return nodesCreated != 0 || nodesDeleted != 0 || relationshipsCreated != 0 || relationshipsDeleted != 0
+        || propertiesSet != 0 || labelsAdded != 0 || labelsRemoved != 0
+        || indexesAdded != 0 || indexesRemoved != 0 || constraintsAdded != 0 || constraintsRemoved != 0;
+  }
+}
+```
+
+- [ ] **Step 4: Add the `CommandContext.getStatistics()` interface method**
+
+In `CommandContext.java`, next to `DatabaseInternal getDatabase();`, add:
+
+```java
+  QueryStatistics getStatistics();
+```
+
+- [ ] **Step 5: Implement in `BasicCommandContext`**
+
+Add a field near `protected Map<String, Object> variables;`:
+
+```java
+  protected QueryStatistics statistics;
+```
+
+Add the accessor (lazy create so it is only allocated when a mutation step asks for it):
+
+```java
+  @Override
+  public QueryStatistics getStatistics() {
+    if (statistics == null)
+      statistics = new QueryStatistics();
+    return statistics;
+  }
+```
+
+If any other `CommandContext` implementor exists that is not `BasicCommandContext` and does not inherit from it, add the same lazy accessor there. Run `grep -rl "implements CommandContext" engine/src/main` to confirm; `BasicCommandContext` is expected to be the only direct implementor.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd engine && mvn -q test -Dtest=QueryStatisticsTest`
+Expected: PASS (3 tests).
+
+- [ ] **Step 7: Compile the engine module**
+
+Run: `cd engine && mvn -q -DskipTests compile`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add engine/src/main/java/com/arcadedb/query/sql/executor/QueryStatistics.java \
+        engine/src/main/java/com/arcadedb/query/sql/executor/CommandContext.java \
+        engine/src/main/java/com/arcadedb/query/sql/executor/BasicCommandContext.java \
+        engine/src/test/java/com/arcadedb/query/sql/executor/QueryStatisticsTest.java
+git commit -m "feat(#5000): QueryStatistics accumulator on CommandContext"
+```
+
+---
+
+### Task 2: Surface statistics through `ResultSet`
+
+**Files:**
+- Modify: `engine/src/main/java/com/arcadedb/query/sql/executor/ResultSet.java` (add a default method near `getExecutionPlan()`, line ~64)
+- Modify: `engine/src/main/java/com/arcadedb/query/sql/executor/IteratorResultSet.java` (carry an optional statistics reference)
+- Modify: `engine/src/main/java/com/arcadedb/query/sql/executor/InternalResultSet.java` (carry an optional statistics reference)
+- Test: `engine/src/test/java/com/arcadedb/query/sql/executor/ResultSetStatisticsTest.java`
+
+**Interfaces:**
+- Consumes: `QueryStatistics` (Task 1).
+- Produces: `default Optional<QueryStatistics> ResultSet.getStatistics()` returning `Optional.empty()`.
+- Produces: `IteratorResultSet.setStatistics(QueryStatistics)` and `InternalResultSet.setStatistics(QueryStatistics)`, both returning `this`-friendly `void`, with overridden `getStatistics()`.
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+package com.arcadedb.query.sql.executor;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ResultSetStatisticsTest {
+  @Test
+  void defaultResultSetHasNoStatistics() {
+    final IteratorResultSet rs = new IteratorResultSet(Collections.emptyIterator());
+    assertThat(rs.getStatistics()).isEmpty();
+  }
+
+  @Test
+  void attachedStatisticsAreReturned() {
+    final QueryStatistics stats = new QueryStatistics();
+    stats.incNodesCreated();
+    final IteratorResultSet rs = new IteratorResultSet(Collections.emptyIterator());
+    rs.setStatistics(stats);
+    assertThat(rs.getStatistics()).isPresent();
+    assertThat(rs.getStatistics().get().getNodesCreated()).isEqualTo(1);
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd engine && mvn -q test -Dtest=ResultSetStatisticsTest`
+Expected: FAIL - `setStatistics` does not exist.
+
+- [ ] **Step 3: Add the `ResultSet` default method**
+
+In `ResultSet.java`, directly after the `getExecutionPlan()` default (line ~64-66), add:
+
+```java
+  default Optional<QueryStatistics> getStatistics() {
+    return Optional.empty();
+  }
+```
+
+(`java.util.*` is already imported, so `Optional` needs no new import.)
+
+- [ ] **Step 4: Carry statistics in `IteratorResultSet`**
+
+Add a field, setter, and override:
+
+```java
+  protected QueryStatistics statistics;
+
+  public void setStatistics(final QueryStatistics statistics) {
+    this.statistics = statistics;
+  }
+
+  @Override
+  public Optional<QueryStatistics> getStatistics() {
+    return Optional.ofNullable(statistics);
+  }
+```
+
+Add `import java.util.Optional;` if not present.
+
+- [ ] **Step 5: Carry statistics in `InternalResultSet`**
+
+Add the identical field, setter, and `getStatistics()` override in `InternalResultSet.java` (it already imports `Optional` for `getExecutionPlan`).
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cd engine && mvn -q test -Dtest=ResultSetStatisticsTest`
+Expected: PASS (2 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add engine/src/main/java/com/arcadedb/query/sql/executor/ResultSet.java \
+        engine/src/main/java/com/arcadedb/query/sql/executor/IteratorResultSet.java \
+        engine/src/main/java/com/arcadedb/query/sql/executor/InternalResultSet.java \
+        engine/src/test/java/com/arcadedb/query/sql/executor/ResultSetStatisticsTest.java
+git commit -m "feat(#5000): carry QueryStatistics on ResultSet"
+```
+
+---
+
+### Task 3: Instrument CRUD mutation steps + surface from the plan
+
+**Files:**
+- Modify: `engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CreateStep.java`
+- Modify: `engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java`
+- Modify: `engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/DeleteStep.java`
+- Modify: `engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java`
+- Modify: `engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java`
+- Modify: `engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java` (attach stats in `execute()`)
+- Test: `engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java`
+
+**Interfaces:**
+- Consumes: `context.getStatistics()` (Task 1), `IteratorResultSet.setStatistics` (Task 2).
+- Produces: after `db.command("opencypher", <write>)`, `resultSet.getStatistics()` is present and reflects the writes.
+
+**Counting semantics (Neo4j-compatible, pinned by the test):**
+- `CREATE (n:A:B {p:1,q:2})` -> nodesCreated +1, labelsAdded +2, propertiesSet +2. A label-less `CREATE ()` adds 0 labels.
+- `CREATE ()-[:R {w:1}]->()` -> relationshipsCreated +1, propertiesSet +1 (edge property).
+- `SET n.x = 1` -> propertiesSet +1; `SET n:Label` -> labelsAdded +1.
+- `REMOVE n.x` -> propertiesSet +1 (Neo4j counts removals under propertiesSet); `REMOVE n:Label` -> labelsRemoved +1.
+- `DELETE n` (vertex) -> nodesDeleted +1; `DELETE r` (edge) -> relationshipsDeleted +1.
+- `MERGE` that creates routes through the create/set counting; a `MERGE` that matches an existing node adds nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.query.sql.executor.QueryStatistics;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that write commands populate QueryStatistics with Neo4j-compatible CRUD counts,
+ * and that read queries carry no statistics.
+ */
+class CypherQueryStatisticsTest extends CypherTestBase {
+
+  private QueryStatistics statsOf(final Database db, final String cypher) {
+    final ResultSet rs = db.command("opencypher", cypher);
+    while (rs.hasNext())
+      rs.next();
+    final Optional<QueryStatistics> s = rs.getStatistics();
+    assertThat(s).isPresent();
+    return s.get();
+  }
+
+  @Test
+  void createNodesRelationshipAndProperties() {
+    database.transaction(() -> {
+      final QueryStatistics s = statsOf(database,
+          "CREATE (:Beer {name:'IPA'})-[:BREWED_BY {since:1990}]->(:Brewery {name:'Acme'})");
+      assertThat(s.getNodesCreated()).isEqualTo(2);
+      assertThat(s.getRelationshipsCreated()).isEqualTo(1);
+      assertThat(s.getPropertiesSet()).isEqualTo(3); // name, since, name
+      assertThat(s.getLabelsAdded()).isEqualTo(2);   // Beer, Brewery
+      assertThat(s.containsUpdates()).isTrue();
+    });
+  }
+
+  @Test
+  void setPropertyAndLabel() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Person {name:'a'})");
+      final QueryStatistics s = statsOf(database, "MATCH (n:Person {name:'a'}) SET n.age = 30, n:Employee");
+      assertThat(s.getPropertiesSet()).isEqualTo(1);
+      assertThat(s.getLabelsAdded()).isEqualTo(1);
+    });
+  }
+
+  @Test
+  void removePropertyAndLabel() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Tag:Old {name:'x'})");
+      final QueryStatistics s = statsOf(database, "MATCH (n:Tag {name:'x'}) REMOVE n.name, n:Old");
+      assertThat(s.getPropertiesSet()).isEqualTo(1);
+      assertThat(s.getLabelsRemoved()).isEqualTo(1);
+    });
+  }
+
+  @Test
+  void deleteNode() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Doomed {id:1})");
+      final QueryStatistics s = statsOf(database, "MATCH (n:Doomed {id:1}) DELETE n");
+      assertThat(s.getNodesDeleted()).isEqualTo(1);
+    });
+  }
+
+  @Test
+  void mergeCreatesOnlyOnce() {
+    database.transaction(() -> {
+      final QueryStatistics first = statsOf(database, "MERGE (:City {name:'Rome'})");
+      assertThat(first.getNodesCreated()).isEqualTo(1);
+      final ResultSet rs = database.command("opencypher", "MERGE (:City {name:'Rome'})");
+      while (rs.hasNext()) rs.next();
+      assertThat(rs.getStatistics().get().getNodesCreated()).isZero();
+    });
+  }
+
+  @Test
+  void readQueryHasNoStatistics() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:R {n:1})");
+      final ResultSet rs = database.query("opencypher", "MATCH (n:R) RETURN n");
+      while (rs.hasNext()) rs.next();
+      assertThat(rs.getStatistics()).isEmpty();
+    });
+  }
+}
+```
+
+Note: match the base-class harness used by existing Cypher tests. Inspect a sibling test (e.g. `engine/src/test/java/com/arcadedb/query/opencypher/` - find one extending a shared base that exposes a `database` field). If the base class is named differently than `CypherTestBase`, use the actual name and its setup idiom; keep the test bodies unchanged.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd engine && mvn -q test -Dtest=CypherQueryStatisticsTest`
+Expected: FAIL - `getStatistics()` empty for writes (counters not yet incremented / not surfaced).
+
+- [ ] **Step 3: Instrument `CreateStep`**
+
+In `createVertex(...)`, after `vertex.save();` (line ~386) and OUTSIDE the `if (context.isProfiling())` block, add unconditional counting:
+
+```java
+    vertex.save();
+    final QueryStatistics stats = context.getStatistics();
+    stats.incNodesCreated();
+    if (nodePattern.hasLabels())
+      stats.addLabelsAdded(nodePattern.getLabels().size());
+    stats.addPropertiesSet(vertex.getPropertyNames().size());
+```
+
+Keep the existing profiling block (`vertexCount++` etc.) intact below it. In `createEdge(...)`, after the edge is created (line ~427), add:
+
+```java
+    final QueryStatistics stats = context.getStatistics();
+    stats.incRelationshipsCreated();
+    stats.addPropertiesSet(edge.getPropertyNames().size());
+```
+
+Add `import com.arcadedb.query.sql.executor.QueryStatistics;`. `MutableVertex`/`MutableEdge` expose `getPropertyNames()` (a `Set<String>`); for a freshly created record it equals the user properties just set.
+
+- [ ] **Step 4: Instrument `SetStep`**
+
+At each property write site (`mutableDoc.set(name, value)` followed by `save()`), increment once per property assigned. Where a whole map is applied, increment by the number of entries. Add near the top of the row-processing method:
+
+```java
+    final QueryStatistics stats = context.getStatistics();
+```
+
+and after each `set(...)`:
+
+```java
+    stats.addPropertiesSet(1);
+```
+
+For `SET n:Label` handling, add `stats.addLabelsAdded(<number of labels added>)`. Follow the existing label-set branch in `SetStep`. Add the `QueryStatistics` import.
+
+- [ ] **Step 5: Instrument `RemoveStep`**
+
+In `removeProperty(...)` after `mutableDoc.remove(property)` / `save()`, add `context.getStatistics().addPropertiesSet(1);`. In `removeLabels(...)`, add `context.getStatistics().addLabelsRemoved(<number of labels removed>);`. Add the import.
+
+- [ ] **Step 6: Instrument `DeleteStep`**
+
+In `deleteVertex(...)` before/after `vertex.delete()`, add `context.getStatistics().incNodesDeleted();`. In `deleteEdge(...)` after `edge.delete()`, add `context.getStatistics().incRelationshipsDeleted();`. For the generic `.delete()` sites at other lines, determine whether the record is a vertex or edge (`record instanceof Vertex`) and increment the matching counter. Add the import.
+
+- [ ] **Step 7: Verify `MergeStep` routes through counting**
+
+`MergeStep` performs its create via the same create/set logic. Confirm its create branch either delegates to the shared create helper or performs `newVertex/newEdge` + `save` directly. If it creates directly (not via `CreateStep`), add the same increments used in Step 3 at its create sites. If it delegates, no change is needed. Match branch (existing node found) must add nothing. Add the import if edits are needed.
+
+- [ ] **Step 8: Surface statistics from `CypherExecutionPlan.execute()`**
+
+In `execute()`, inside the `if (hasWriteOps)` block (lines ~267-279), read the accumulator once and attach it to both write return paths:
+
+```java
+    if (hasWriteOps) {
+      final List<ResultInternal> materializedResults = new ArrayList<>();
+      while (resultSet.hasNext()) {
+        materializedResults.add((ResultInternal) resultSet.next());
+      }
+      final QueryStatistics stats = context.getStatistics();
+      if (statement.getReturnClause() == null || statement.hasFinishClause()) {
+        final IteratorResultSet empty = new IteratorResultSet(Collections.<Result>emptyList().iterator());
+        empty.setStatistics(stats);
+        return empty;
+      }
+      final IteratorResultSet out = new IteratorResultSet(materializedResults.iterator());
+      out.setStatistics(stats);
+      return out;
+    }
+```
+
+Use `context.getStatistics()` (never null after a write, since the mutation steps already created it; if a "write" statement performed no mutation it returns a fresh empty-but-present accumulator, which is correct: `containsUpdates()` is false). Add `import com.arcadedb.query.sql.executor.QueryStatistics;`.
+
+- [ ] **Step 9: Run the test to verify it passes**
+
+Run: `cd engine && mvn -q test -Dtest=CypherQueryStatisticsTest`
+Expected: PASS (6 tests). If `propertiesSet` for CREATE differs (e.g. system properties counted), adjust the counting site to count only user-supplied property keys and re-run - the test values are the contract.
+
+- [ ] **Step 10: Run the broader Cypher mutation regression subset**
+
+Run: `cd engine && mvn -q test -Dtest="Cypher*Create*,Cypher*Merge*,Cypher*Delete*,Cypher*Set*"`
+Expected: PASS - no regressions in existing mutation tests.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CreateStep.java \
+        engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java \
+        engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/DeleteStep.java \
+        engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java \
+        engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java \
+        engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java \
+        engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
+git commit -m "feat(#5000): track CRUD counts in Cypher mutation steps"
+```
+
+---
+
+### Task 4: Instrument the Cypher DDL path (indexes/constraints)
+
+**Files:**
+- Modify: `engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java` (`executeDDL` + the four `executeCreate/Drop*` methods)
+- Test: add cases to `engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java`
+
+**Interfaces:**
+- Consumes: `QueryStatistics` (Task 1), `InternalResultSet.setStatistics` (Task 2).
+- Produces: `db.command("opencypher", "CREATE INDEX ...")` returns a ResultSet whose `getStatistics().get().getIndexesAdded() == 1`.
+
+**Counting semantics:** CREATE INDEX -> indexesAdded +1 (0 if `IF NOT EXISTS` and it already existed); DROP INDEX -> indexesRemoved +1 (0 if `IF EXISTS` and absent). CREATE/DROP CONSTRAINT -> constraintsAdded/Removed +1 with the same no-op guards.
+
+- [ ] **Step 1: Add failing DDL test cases**
+
+Append to `CypherQueryStatisticsTest`:
+
+```java
+  @Test
+  void createIndexCounts() {
+    database.command("opencypher", "CREATE (:Product {sku:'a'})"); // ensure type exists
+    final ResultSet rs = database.command("opencypher", "CREATE INDEX FOR (p:Product) ON (p.sku)");
+    while (rs.hasNext()) rs.next();
+    assertThat(rs.getStatistics()).isPresent();
+    assertThat(rs.getStatistics().get().getIndexesAdded()).isEqualTo(1);
+    assertThat(rs.getStatistics().get().containsUpdates()).isTrue();
+  }
+```
+
+(Use the exact CREATE INDEX / CREATE CONSTRAINT syntax the parser accepts - confirm against an existing DDL test under `engine/src/test/java/com/arcadedb/query/opencypher/` before finalizing the query strings.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd engine && mvn -q test -Dtest=CypherQueryStatisticsTest#createIndexCounts`
+Expected: FAIL - statistics empty (DDL returns a bare `InternalResultSet`).
+
+- [ ] **Step 3: Thread a `QueryStatistics` through `executeDDL`**
+
+Rewrite `executeDDL` to accumulate and attach:
+
+```java
+  private ResultSet executeDDL(final CypherDDLStatement ddl) {
+    final Schema schema = database.getSchema();
+    final QueryStatistics stats = new QueryStatistics();
+
+    switch (ddl.getKind()) {
+    case CREATE_CONSTRAINT:
+      executeCreateConstraint(ddl, schema, stats);
+      break;
+    case DROP_CONSTRAINT:
+      executeDropConstraint(ddl, schema, stats);
+      break;
+    case CREATE_INDEX:
+      executeCreateIndex(ddl, schema, stats);
+      break;
+    case DROP_INDEX:
+      executeDropIndex(ddl, schema, stats);
+      break;
+    }
+
+    final InternalResultSet result = new InternalResultSet();
+    result.setStatistics(stats);
+    return result;
+  }
+```
+
+Add `stats` as a parameter to the four `executeCreate/Drop*` methods and increment inside them at the point the schema change actually succeeds (after the builder `create()` / index build call, and only on the branch that performed the change - not the `ignoreIfExists`/`ifExists` no-op branch). Example for `executeCreateIndex`: after the index is created, `stats.incIndexesAdded();`. Add `import com.arcadedb.query.sql.executor.QueryStatistics;`.
+
+- [ ] **Step 4: Run DDL test to verify it passes**
+
+Run: `cd engine && mvn -q test -Dtest=CypherQueryStatisticsTest`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Run the Cypher DDL regression subset**
+
+Run: `cd engine && mvn -q test -Dtest="*Cypher*Index*,*Cypher*Constraint*,*Cypher*DDL*"`
+Expected: PASS - no regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java \
+        engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
+git commit -m "feat(#5000): count Cypher index/constraint DDL"
+```
+
+---
+
+### Task 5: Emit the Bolt `stats` map
+
+**Files:**
+- Modify: `bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java` (`handlePull` terminal block ~700-731, `handleDiscard` ~777-786)
+- Create: `bolt/src/main/java/com/arcadedb/bolt/BoltResultStats.java` (maps `QueryStatistics` -> Neo4j `stats` map)
+- Test: `bolt/src/test/java/com/arcadedb/bolt/Bolt5000ResultCountersIT.java`
+
+**Interfaces:**
+- Consumes: `currentResultSet.getStatistics()` (Task 2).
+- Produces: terminal PULL/DISCARD SUCCESS metadata contains `stats` -> `Map<String,Object>` with hyphenated Neo4j keys + `contains-updates=true`, only when the result carries a statistics object with updates.
+
+**Neo4j `stats` map keys:** `nodes-created`, `nodes-deleted`, `relationships-created`, `relationships-deleted`, `properties-set`, `labels-added`, `labels-removed`, `indexes-added`, `indexes-removed`, `constraints-added`, `constraints-removed`, `contains-updates`. Emit only non-zero counters, always include `contains-updates`.
+
+- [ ] **Step 1: Write the failing Bolt IT**
+
+```java
+package com.arcadedb.bolt;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Config;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
+import org.neo4j.driver.summary.SummaryCounters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end wire test: a Bolt write query must populate summary.counters() on the neo4j driver.
+ */
+public class Bolt5000ResultCountersIT extends BaseGraphServerTest {
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("Bolt:com.arcadedb.bolt.BoltProtocolPlugin");
+  }
+
+  @AfterEach
+  @Override
+  public void endTest() {
+    GlobalConfiguration.SERVER_PLUGINS.setValue("");
+    super.endTest();
+  }
+
+  private Driver getDriver() {
+    return GraphDatabase.driver("bolt://localhost:7687", AuthTokens.basic("root", DEFAULT_PASSWORD_FOR_TESTS),
+        Config.builder().withoutEncryption().build());
+  }
+
+  @Test
+  void writeCountersReflectActualWrites() {
+    try (final Driver driver = getDriver();
+         final Session session = driver.session(SessionConfig.forDatabase(getDatabaseName()))) {
+      final SummaryCounters counters = session.run(
+          "CREATE (:Beer {name:$n})-[:BREWED_BY]->(:Brewery {name:$b})",
+          org.neo4j.driver.Values.parameters("n", "IPA", "b", "Acme")).consume().counters();
+      assertThat(counters.nodesCreated()).isEqualTo(2);
+      assertThat(counters.relationshipsCreated()).isEqualTo(1);
+      assertThat(counters.propertiesSet()).isEqualTo(2);
+      assertThat(counters.containsUpdates()).isTrue();
+    }
+  }
+
+  @Test
+  void readQueryReportsNoUpdates() {
+    try (final Driver driver = getDriver();
+         final Session session = driver.session(SessionConfig.forDatabase(getDatabaseName()))) {
+      session.run("CREATE (:Thing {id:1})").consume();
+      final SummaryCounters counters = session.run("MATCH (n:Thing) RETURN n").consume().counters();
+      assertThat(counters.containsUpdates()).isFalse();
+      assertThat(counters.nodesCreated()).isZero();
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd bolt && mvn -q -DskipITs=false test -Dtest=Bolt5000ResultCountersIT`
+Expected: FAIL - `nodesCreated()` is 0 (no `stats` emitted).
+
+- [ ] **Step 3: Create the Bolt stats mapper**
+
+Copy the Apache header, then:
+
+```java
+package com.arcadedb.bolt;
+
+import com.arcadedb.query.sql.executor.QueryStatistics;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Maps engine QueryStatistics to the Neo4j Bolt SUCCESS "stats" metadata map. Emits only non-zero
+ * counters plus contains-updates, matching how Neo4j server reports write summaries.
+ */
+final class BoltResultStats {
+  private BoltResultStats() {
+  }
+
+  static Map<String, Object> toStatsMap(final QueryStatistics s) {
+    final Map<String, Object> stats = new LinkedHashMap<>();
+    putIfNonZero(stats, "nodes-created", s.getNodesCreated());
+    putIfNonZero(stats, "nodes-deleted", s.getNodesDeleted());
+    putIfNonZero(stats, "relationships-created", s.getRelationshipsCreated());
+    putIfNonZero(stats, "relationships-deleted", s.getRelationshipsDeleted());
+    putIfNonZero(stats, "properties-set", s.getPropertiesSet());
+    putIfNonZero(stats, "labels-added", s.getLabelsAdded());
+    putIfNonZero(stats, "labels-removed", s.getLabelsRemoved());
+    putIfNonZero(stats, "indexes-added", s.getIndexesAdded());
+    putIfNonZero(stats, "indexes-removed", s.getIndexesRemoved());
+    putIfNonZero(stats, "constraints-added", s.getConstraintsAdded());
+    putIfNonZero(stats, "constraints-removed", s.getConstraintsRemoved());
+    stats.put("contains-updates", true);
+    return stats;
+  }
+
+  private static void putIfNonZero(final Map<String, Object> stats, final String key, final int value) {
+    if (value != 0)
+      stats.put(key, (long) value);
+  }
+}
+```
+
+(Bolt integers are encoded as longs; cast keeps the driver's counter parsing happy.)
+
+- [ ] **Step 4: Emit `stats` in `handlePull`**
+
+In the terminal `if (!hasMore)` block, BEFORE `currentResultSet.close()` (line ~716), read and attach:
+
+```java
+        if (currentResultSet != null) {
+          final Optional<QueryStatistics> stats = currentResultSet.getStatistics();
+          if (stats.isPresent() && stats.get().containsUpdates())
+            metadata.put("stats", BoltResultStats.toStatsMap(stats.get()));
+        }
+```
+
+Place it just inside the `if (!hasMore)` block, above the existing `if (currentResultSet != null) { close... }`. Add `import com.arcadedb.query.sql.executor.QueryStatistics;` and `import java.util.Optional;` if absent.
+
+- [ ] **Step 5: Emit `stats` in `handleDiscard`**
+
+Before the drain/close at line ~761, capture the statistics (they are computed at execute time, so reading before drain is fine):
+
+```java
+    if (currentResultSet != null) {
+      final Optional<QueryStatistics> stats = currentResultSet.getStatistics();
+      if (stats.isPresent() && stats.get().containsUpdates())
+        metadata.put("stats", BoltResultStats.toStatsMap(stats.get()));
+      ...existing drain + close...
+    }
+```
+
+Note `metadata` is declared at line ~777; move the statistics capture to after `metadata` is created, or hoist a local `QueryStatistics` captured before the drain and add it to `metadata` after creation. Keep the `stats` entry out of read-query responses (guarded by `containsUpdates()`).
+
+- [ ] **Step 6: Run the Bolt IT to verify it passes**
+
+Run: `cd bolt && mvn -q -DskipITs=false test -Dtest=Bolt5000ResultCountersIT`
+Expected: PASS (2 tests).
+
+- [ ] **Step 7: Run the existing Bolt IT subset for regressions**
+
+Run: `cd bolt && mvn -q -DskipITs=false test -Dtest="Bolt*"`
+Expected: PASS - existing Bolt suites unaffected.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add bolt/src/main/java/com/arcadedb/bolt/BoltResultStats.java \
+        bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java \
+        bolt/src/test/java/com/arcadedb/bolt/Bolt5000ResultCountersIT.java
+git commit -m "feat(#5000): emit Bolt stats map for write summaries"
+```
+
+---
+
+### Task 6: Flip RESULT-004 to passing in the conformance spec
+
+**Files:**
+- Modify: `bolt/conformance/spec.yaml` (RESULT-004, lines ~316-339)
+
+**Interfaces:**
+- Consumes: nothing (documentation/state flip).
+- Produces: `RESULT-004.current_status: passing`; removes the `known_limitation`/`tracking_issue` markers per the spec-validator's rules for passing cells.
+
+- [ ] **Step 1: Inspect the spec-validator's requirements**
+
+Run: `grep -rn "current_status\|known_limitation\|tracking_issue\|passing\|expected-fail" bolt/conformance/ | grep -i "valid\|require\|test" | head`
+Also read the validator test (search `grep -rl "spec.yaml\|current_status" --include=*.java bolt engine server`) to learn whether a `passing` cell must NOT have `tracking_issue`/`known_limitation`. Follow whatever the validator enforces (mirror how a currently-`passing` cell in `spec.yaml` is shaped).
+
+- [ ] **Step 2: Edit RESULT-004**
+
+Set `current_status: passing`. If the validator forbids `known_limitation`/`tracking_issue` on passing cells (confirmed in Step 1), remove those two keys from RESULT-004. Match the exact shape of an existing `passing` scenario in the same file.
+
+- [ ] **Step 3: Run the spec-validator test**
+
+Run: `grep -rl "spec.yaml" --include=*.java . | head` then run that test class, e.g. `cd bolt && mvn -q test -Dtest=<SpecValidatorTestClass>`
+Expected: PASS - spec remains valid with RESULT-004 flipped.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bolt/conformance/spec.yaml
+git commit -m "test(#5000): flip RESULT-004 to passing"
+```
+
+---
+
+### Task 7: Full-module verification + open the HTTP/gRPC follow-up issue
+
+**Files:** none (verification + issue creation).
+
+- [ ] **Step 1: Build and test the touched modules**
+
+Run: `mvn -q -pl engine,bolt -am install`
+Expected: BUILD SUCCESS with all new and existing tests green.
+
+- [ ] **Step 2: Confirm no debug output or stray fully-qualified names remain**
+
+Run: `git diff origin/main --unified=0 | grep -nE "System\.out|System\.err"`
+Expected: no matches.
+
+- [ ] **Step 3: Open the follow-up issue**
+
+Open a GitHub issue (child of #4890, milestone 26.7.2): "HTTP/gRPC: surface QueryStatistics write counters via ResultSet.getStatistics()". Motivation: the engine now tracks CRUD/DDL counts and exposes them via `ResultSet.getStatistics()`; HTTP `/command` and gRPC hold a `ResultSet` and can surface the same counters cheaply. Acceptance: HTTP `/command` JSON includes a `stats` object; gRPC result summary carries the counters; both covered by tests. Reference this PR.
+
+- [ ] **Step 4: Final commit (if any doc/notes changed)**
+
+Only if files changed in this task; otherwise skip.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Two missing layers (Bolt `stats` + engine counters) -> Tasks 3-5. ✓
+- `QueryStatistics` allocation-light, primitive ints, off read hot path -> Task 1 (lazy accessor) + Task 3 read-query test asserting empty statistics. ✓
+- Full Neo4j counter set incl. DDL -> Task 3 (CRUD) + Task 4 (indexes/constraints). ✓
+- Reusable channel via `ResultSet.getStatistics()` default -> Task 2. ✓
+- Bolt terminal PULL + DISCARD -> Task 5 (both handlers). ✓
+- RESULT-004 flip -> Task 6. ✓
+- HTTP/gRPC deferred to follow-up issue -> Task 7. ✓
+- No stats on read queries (matches Neo4j) -> Task 3 read test + Task 5 `containsUpdates()` guard + Task 5 read IT. ✓
+
+**Placeholder scan:** No TBD/TODO. Instrumentation steps that cannot be pinned to an exact current line (SetStep/RemoveStep/DeleteStep/MergeStep internal sites, DDL no-op guards, spec-validator rules) carry explicit "confirm against sibling X" instructions plus the exact increment call to add - the ambiguity is in *where the existing code is*, not in *what to write*.
+
+**Type consistency:** `QueryStatistics` method names (`incNodesCreated`, `addPropertiesSet(int)`, `addLabelsAdded(int)`, `getNodesCreated()`, `containsUpdates()`) are identical across Tasks 1, 3, 4, 5. `ResultSet.getStatistics()` returns `Optional<QueryStatistics>` in Tasks 2 and 5. `IteratorResultSet.setStatistics` / `InternalResultSet.setStatistics` used consistently in Tasks 2, 3, 4. Bolt map keys match the design's Neo4j key list.

--- a/docs/superpowers/specs/2026-07-06-bolt-result-counters-design.md
+++ b/docs/superpowers/specs/2026-07-06-bolt-result-counters-design.md
@@ -1,0 +1,167 @@
+# Bolt ResultSummary counters for write queries (#5000)
+
+- Issue: [#5000](https://github.com/ArcadeData/arcadedb/issues/5000)
+- Tracking: [#4890](https://github.com/ArcadeData/arcadedb/issues/4890) (Group C protocol/type-fidelity gaps)
+- Epic: [#4882](https://github.com/ArcadeData/arcadedb/issues/4882) (Bolt Driver Compatibility Certification)
+- Conformance scenario: `RESULT-004` in `bolt/conformance/spec.yaml` (`expected-fail` -> `passing`)
+
+## Problem
+
+`ResultSummary` counters (`nodesCreated`, `relationshipsCreated`, `propertiesSet`, etc.) are
+never populated for Bolt write queries. Two layers are missing:
+
+1. `BoltNetworkExecutor`'s `handleRun`/`handlePull`/`handleDiscard` build no `stats` map in the
+   SUCCESS response metadata.
+2. The underlying Cypher engine has no CRUD-counter tracking. The mutation steps
+   (`CreateStep`/`SetStep`/`DeleteStep`/`MergeStep`/`RemoveStep`) do not aggregate counts, so even
+   a Bolt-layer fix would have nothing to report. `CreateStep` keeps `vertexCount`/`edgeCount`
+   fields but they are used only for `prettyPrint` profiling output, never surfaced.
+
+The DDL path (`CREATE`/`DROP INDEX`, `CREATE`/`DROP CONSTRAINT`) executes directly in
+`OpenCypherQueryEngine.executeDDL()`, outside the step pipeline, so index/constraint counts need
+their own small instrumentation point.
+
+This is the largest of the #4890 gaps because it is cross-cutting into the query engine, not
+writer-only.
+
+## Goals
+
+- Populate the Bolt terminal-PULL/DISCARD SUCCESS metadata with a `stats` map so official Neo4j
+  drivers report accurate `summary.counters()`.
+- Track the full Neo4j counter set that maps to ArcadeDB's Cypher mutation and DDL paths.
+- Add no measurable overhead and no allocation to read queries.
+- Build the accumulator as a reusable engine capability so HTTP and gRPC can surface the same
+  counters later at low cost (follow-up issue).
+
+## Non-goals
+
+- Wiring HTTP `/command` or gRPC responses in this PR. A follow-up issue tracks that; the engine
+  channel is designed so it is cheap.
+- SQL-engine write statistics beyond the existing scalar affected-row `count` row.
+- Neo4j `contains-system-updates` semantics (system database of users/roles) - ArcadeDB has no
+  equivalent; it is reported as absent/false.
+
+## Design
+
+### Data flow
+
+```
+Cypher mutation steps ── increment ─▶ QueryStatistics (held on CommandContext)
+        │                                      │
+        │  DDL path: executeDDL() increments a QueryStatistics directly
+        ▼                                      ▼
+CypherExecutionPlan.execute() / executeDDL() ── attach ─▶ ResultSet.getStatistics()
+                                                              │
+BoltNetworkExecutor.handlePull / handleDiscard ── read ──────┘
+        │
+        ▼
+   terminal SUCCESS metadata { ..., "stats": { "nodes-created": 2, ... } }
+```
+
+One accumulator object threaded through the shared `CommandContext` that every execution step
+already carries, read once at ResultSet assembly, surfaced through a new `ResultSet` channel,
+consumed by the Bolt layer.
+
+### Component: `QueryStatistics`
+
+New value object in `com.arcadedb.query.sql.executor` (alongside `ResultSet`), primitive `int`
+counters only (allocation-light, GC-friendly):
+
+- `nodesCreated`, `nodesDeleted`
+- `relationshipsCreated`, `relationshipsDeleted`
+- `propertiesSet`
+- `labelsAdded`, `labelsRemoved`
+- `indexesAdded`, `indexesRemoved`
+- `constraintsAdded`, `constraintsRemoved`
+
+Plus `boolean containsUpdates()` (true if any counter > 0) and increment methods. The object is
+engine-neutral: it does not know about Bolt wire keys. Mapping to hyphenated Bolt keys lives in the
+Bolt module.
+
+### Engine accumulator
+
+- `CommandContext`: add `QueryStatistics getStatistics()`. Implemented on `BasicCommandContext` as
+  a first-class nullable field, lazily created on first mutation. Read queries never touch it, so it
+  stays `null` and allocates nothing.
+- Instrument the five mutation steps (all extend `AbstractExecutionStep`, so `context` is in hand):
+  - `CreateStep`: `+nodesCreated` per vertex, `+relationshipsCreated` per edge, `+propertiesSet`
+    per inline property assigned at creation, `+labelsAdded` per label. Reuses the existing
+    `vertexCount`/`edgeCount` increment sites.
+  - `SetStep`: `+propertiesSet` per property write; `+labelsAdded` for `SET n:Label`.
+  - `RemoveStep`: `+propertiesSet` per property removed (Neo4j counts property removals under
+    `propertiesSet`); `+labelsRemoved` per label removed.
+  - `DeleteStep`: `+nodesDeleted` / `+relationshipsDeleted` per deleted record.
+  - `MergeStep`: on-create routes through the same create/set counting.
+- DDL path in `OpenCypherQueryEngine`: `+indexesAdded`/`+indexesRemoved`,
+  `+constraintsAdded`/`+constraintsRemoved` in `executeCreateIndex`/`executeDropIndex`/
+  `executeCreateConstraint`/`executeDropConstraint`, guarded so `IF NOT EXISTS` / `IF EXISTS`
+  no-ops do not over-count.
+
+### Surfacing channel: `ResultSet.getStatistics()`
+
+Add to the `ResultSet` interface:
+
+```java
+default Optional<QueryStatistics> getStatistics() {
+  return Optional.empty();
+}
+```
+
+This mirrors the existing `getExecutionPlan()` default exactly. Because it is a default method, the
+blast radius on the many `ResultSet` implementations is zero; only the Cypher result path overrides
+it. Populated:
+
+- in `CypherExecutionPlan.execute()`, read from `context.getStatistics()` after the write path has
+  been materialized (writes are fully materialized before `execute()` returns);
+- in `OpenCypherQueryEngine.executeDDL()`, from the `QueryStatistics` incremented inline.
+
+This is the reusable channel HTTP and gRPC will consume in the follow-up issue - both hold a
+`ResultSet`, so surfacing there becomes a few lines.
+
+### Bolt consumer
+
+In `BoltNetworkExecutor`:
+
+- `handlePull`, terminal `!hasMore` block (alongside `type` / `t_last` / plan metadata): read
+  `currentResultSet.getStatistics()`; if present and `containsUpdates()`, put a `stats` map into the
+  SUCCESS metadata.
+- `handleDiscard`: same, before the final `sendSuccess(metadata)`.
+
+The `stats` map uses Neo4j Bolt hyphenated keys and includes only non-zero counters plus
+`contains-updates: true`:
+
+`nodes-created`, `nodes-deleted`, `relationships-created`, `relationships-deleted`,
+`properties-set`, `labels-added`, `labels-removed`, `indexes-added`, `indexes-removed`,
+`constraints-added`, `constraints-removed`, `contains-updates`.
+
+Read queries produce no `stats` key, matching Neo4j behavior.
+
+## Testing
+
+Test-first (TDD), server-side code covered by test cases per project convention.
+
+- Engine unit test (`CypherQueryStatisticsTest` in `engine`): assert counters for CREATE, SET,
+  DELETE, MERGE (match vs create), REMOVE, `SET n:Label`, `REMOVE n:Label`, `CREATE INDEX`,
+  `CREATE CONSTRAINT`, `DROP INDEX`, `DROP CONSTRAINT`, including the RESULT-004 shape
+  `CREATE (:Beer {name})-[:BREWED_BY]->(:Brewery {name})` -> 2 nodes, 1 rel, 2 properties.
+- Read-query regression: a `MATCH ... RETURN` leaves `getStatistics()` empty and allocates no
+  `QueryStatistics`.
+- Bolt IT (`bolt` module or `RemoteBoltDatabaseIT`): via the real `neo4j-java-driver`, assert
+  `summary.counters().nodesCreated()`, `relationshipsCreated()`, `propertiesSet()` for a write; and
+  that a read reports no updates (`containsUpdates() == false`).
+- Conformance: flip `RESULT-004` `current_status` `expected-fail` -> `passing` in
+  `bolt/conformance/spec.yaml`; keep the spec-validator unit test green.
+
+## Verification of done
+
+- `RESULT-004` passes across the five per-language e2e suites; `summary.counters()` reflects actual
+  writes.
+- Read queries carry no `stats` key and allocate no `QueryStatistics` (no measurable overhead).
+- No regression in existing write-query behavior.
+- Follow-up issue opened for HTTP `/command` (and gRPC) to surface the same `QueryStatistics`.
+
+## Follow-up
+
+- New issue (child of #4890 or a fresh tracking item): surface `QueryStatistics` in the HTTP
+  `/command` JSON response and in the gRPC result summary, consuming the `ResultSet.getStatistics()`
+  channel added here.

--- a/e2e-csharp/ArcadeDB.E2ETests/BoltE2ETests.cs
+++ b/e2e-csharp/ArcadeDB.E2ETests/BoltE2ETests.cs
@@ -324,18 +324,15 @@ public class BoltE2ETests
     [Fact(DisplayName = "RESULT-004: ResultSummary counters accurately reflect write operations")]
     public async Task Result004_SummaryCountersReflectWrites()
     {
-        await KnownGapAssertions.AssertStillFailsAsync(async () =>
-        {
-            await using var session = _fixture.Driver.AsyncSession(o => o.WithDatabase("beer"));
-            var result = await session.RunAsync(
-                "CREATE (:Beer {name: $n})-[:BREWED_BY]->(:Brewery {name: $b})",
-                new { n = "RESULT-004-Beer", b = "RESULT-004-Brewery" });
-            var summary = await result.ConsumeAsync();
+        await using var session = _fixture.Driver.AsyncSession(o => o.WithDatabase("beer"));
+        var result = await session.RunAsync(
+            "CREATE (:Beer {name: $n})-[:BREWED_BY]->(:Brewery {name: $b})",
+            new { n = "RESULT-004-Beer", b = "RESULT-004-Brewery" });
+        var summary = await result.ConsumeAsync();
 
-            Assert.Equal(2, summary.Counters.NodesCreated);
-            Assert.Equal(1, summary.Counters.RelationshipsCreated);
-            Assert.True(summary.Counters.PropertiesSet >= 2);
-        }, "RESULT-004: BoltNetworkExecutor never populates SUCCESS 'stats' for write queries - see #4890");
+        Assert.Equal(2, summary.Counters.NodesCreated);
+        Assert.Equal(1, summary.Counters.RelationshipsCreated);
+        Assert.True(summary.Counters.PropertiesSet >= 2);
     }
 
     [Fact(DisplayName = "TYPE-001: Node round-trips as a native Bolt structure")]

--- a/e2e-go/bolt_conformance_test.go
+++ b/e2e-go/bolt_conformance_test.go
@@ -423,35 +423,31 @@ func Test_RESULT_003_DiscardAbandonsRemaining(t *testing.T) {
 
 func Test_RESULT_004_SummaryCountersReflectWrites(t *testing.T) {
 	d := newDriver(t, boltURI(plainContainer, "bolt"))
-	assertStillFails(t,
-		"BoltNetworkExecutor.handlePull/handleDiscard never populate a 'stats' "+
-			"key in SUCCESS metadata for writes, so SummaryCounters is always "+
-			"empty; see RESULT-004 in spec.yaml (#4890)",
-		func() error {
-			sess := d.NewSession(ctx, neo4j.SessionConfig{DatabaseName: "beer"})
-			defer sess.Close(ctx)
-			res, err := sess.Run(ctx,
-				"CREATE (:Beer {name: $n})-[:BREWED_BY]->(:Brewery {name: $b})",
-				map[string]any{"n": "RESULT-004-Beer", "b": "RESULT-004-Brewery"})
-			if err != nil {
-				return err
-			}
-			summary, err := res.Consume(ctx)
-			if err != nil {
-				return err
-			}
-			cnt := summary.Counters()
-			if cnt.NodesCreated() != 2 {
-				return fmt.Errorf("nodes_created=%d, want 2", cnt.NodesCreated())
-			}
-			if cnt.RelationshipsCreated() != 1 {
-				return fmt.Errorf("relationships_created=%d, want 1", cnt.RelationshipsCreated())
-			}
-			if cnt.PropertiesSet() < 2 {
-				return fmt.Errorf("properties_set=%d, want >=2", cnt.PropertiesSet())
-			}
-			return nil
-		})
+	require.NoError(t, func() error {
+		sess := d.NewSession(ctx, neo4j.SessionConfig{DatabaseName: "beer"})
+		defer sess.Close(ctx)
+		res, err := sess.Run(ctx,
+			"CREATE (:Beer {name: $n})-[:BREWED_BY]->(:Brewery {name: $b})",
+			map[string]any{"n": "RESULT-004-Beer", "b": "RESULT-004-Brewery"})
+		if err != nil {
+			return err
+		}
+		summary, err := res.Consume(ctx)
+		if err != nil {
+			return err
+		}
+		cnt := summary.Counters()
+		if cnt.NodesCreated() != 2 {
+			return fmt.Errorf("nodes_created=%d, want 2", cnt.NodesCreated())
+		}
+		if cnt.RelationshipsCreated() != 1 {
+			return fmt.Errorf("relationships_created=%d, want 1", cnt.RelationshipsCreated())
+		}
+		if cnt.PropertiesSet() < 2 {
+			return fmt.Errorf("properties_set=%d, want >=2", cnt.PropertiesSet())
+		}
+		return nil
+	}())
 }
 
 // --- type-roundtrip ---------------------------------------------------

--- a/e2e-js/src/js-bolt-conformance.test.js
+++ b/e2e-js/src/js-bolt-conformance.test.js
@@ -603,11 +603,7 @@ describe("Bolt conformance (issue #4888)", () => {
       }
     });
 
-    // KNOWN GAP (#4890): the Bolt layer never populates a 'stats' key in
-    // SUCCESS metadata for write queries, so counters are always empty. This
-    // it.failing asserts the Neo4j-correct behavior and flips red when fixed -
-    // convert to it() and update current_status in spec.yaml in the same PR.
-    it.failing("[RESULT-004] ResultSummary counters reflect writes", async () => {
+    it("[RESULT-004] ResultSummary counters reflect writes", async () => {
       const s = session();
       try {
         const result = await s.run(

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -545,15 +545,6 @@ def test_RESULT_003_discard_abandons_remaining(bolt_driver):
         assert summary is not None
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="BoltNetworkExecutor.handlePull/handleDiscard never populate a "
-    "'stats' key in the SUCCESS message metadata for write queries - the "
-    "engine's Cypher CREATE/SET/DELETE steps do not track node/relationship/"
-    "property counters anywhere that the Bolt layer could surface, so the "
-    "neo4j driver always parses an empty SummaryCounters; see RESULT-004 in "
-    "bolt/conformance/spec.yaml",
-)
 def test_RESULT_004_summary_counters_reflect_writes(bolt_driver):
     with bolt_driver.session(database="beer") as session:
         result = session.run(

--- a/e2e/src/test/java/com/arcadedb/e2e/ArcadeContainerTemplate.java
+++ b/e2e/src/test/java/com/arcadedb/e2e/ArcadeContainerTemplate.java
@@ -18,11 +18,15 @@
  */
 package com.arcadedb.e2e;
 
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.time.Duration;
 
+@ExtendWith(ArcadeContainerTemplate.ContainerLogOnFailure.class)
 public abstract class ArcadeContainerTemplate {
   static final GenericContainer<?> ARCADE;
 
@@ -52,4 +56,22 @@ public abstract class ArcadeContainerTemplate {
   protected int    gremlinPort = ARCADE.getMappedPort(8182);
   protected int    grpcPort    = ARCADE.getMappedPort(50051);
   protected int    boltPort    = ARCADE.getMappedPort(7687);
+
+  /**
+   * Dumps the ArcadeDB container's server log when a test fails. Wire-protocol drivers surface only a
+   * generic message (e.g. "Error executing Cypher command"), so the server-side cause is otherwise
+   * invisible in CI output. Best-effort: never fails the test itself.
+   */
+  static class ContainerLogOnFailure implements TestWatcher {
+    @Override
+    public void testFailed(final ExtensionContext context, final Throwable cause) {
+      try {
+        System.out.println("===== ArcadeDB container log (failed: " + context.getDisplayName() + ") =====");
+        System.out.println(ARCADE.getLogs());
+        System.out.println("===== end ArcadeDB container log =====");
+      } catch (final RuntimeException ignored) {
+        // best-effort diagnostic only
+      }
+    }
+  }
 }

--- a/e2e/src/test/java/com/arcadedb/e2e/RemoteBoltDatabaseIT.java
+++ b/e2e/src/test/java/com/arcadedb/e2e/RemoteBoltDatabaseIT.java
@@ -490,19 +490,17 @@ class RemoteBoltDatabaseIT extends ArcadeContainerTemplate {
     @DisplayName("[RESULT-004] ResultSummary counters reflect writes")
     void result004_counters() {
       // Run inside an explicit transaction and roll back: counters are populated
-      // from the RUN/PULL summary regardless of commit, so the gap is still
-      // certified without leaving probe nodes in the shared beer database.
-      assertExpectedFailure("#4890", () -> {
-        try (final Session s = boltSession();
-            final Transaction tx = s.beginTransaction()) {
-          final ResultSummary summary = tx.run(
-              "CREATE (:Beer {name: $n})-[:BREWED_BY]->(:Brewery {name: $b})",
-              Map.of("n", "RESULT-004-Beer", "b", "RESULT-004-Brewery")).consume();
-          tx.rollback();
-          assertThat(summary.counters().nodesCreated()).isEqualTo(2);
-          assertThat(summary.counters().relationshipsCreated()).isEqualTo(1);
-        }
-      });
+      // from the RUN/PULL summary regardless of commit, so this stays certified
+      // working without leaving probe nodes in the shared beer database.
+      try (final Session s = boltSession();
+          final Transaction tx = s.beginTransaction()) {
+        final ResultSummary summary = tx.run(
+            "CREATE (:Beer {name: $n})-[:BREWED_BY]->(:Brewery {name: $b})",
+            Map.of("n", "RESULT-004-Beer", "b", "RESULT-004-Brewery")).consume();
+        tx.rollback();
+        assertThat(summary.counters().nodesCreated()).isEqualTo(2);
+        assertThat(summary.counters().relationshipsCreated()).isEqualTo(1);
+      }
     }
   }
 

--- a/e2e/src/test/java/com/arcadedb/e2e/RemoteBoltDatabaseIT.java
+++ b/e2e/src/test/java/com/arcadedb/e2e/RemoteBoltDatabaseIT.java
@@ -129,6 +129,7 @@ class RemoteBoltDatabaseIT extends ArcadeContainerTemplate {
       try (final Session s = boltSession()) {
         s.run("MATCH (n) WHERE n:TxProbe OR n:RaceProbe OR n:CausalProbe DETACH DELETE n").consume();
         s.run("MATCH (b:Beer) WHERE b.name IN ['TX-004-Beer', 'RESULT-004-Beer'] DETACH DELETE b").consume();
+        s.run("MATCH (b:Brewery) WHERE b.name = 'RESULT-004-Brewery' DETACH DELETE b").consume();
       } catch (final RuntimeException ignored) {
         // best-effort cleanup; never fail the suite on teardown
       }
@@ -493,15 +494,14 @@ class RemoteBoltDatabaseIT extends ArcadeContainerTemplate {
     @Test
     @DisplayName("[RESULT-004] ResultSummary counters reflect writes")
     void result004_counters() {
-      // Run inside an explicit transaction and roll back: counters are populated
-      // from the RUN/PULL summary regardless of commit, so this stays certified
-      // working without leaving probe nodes in the shared beer database.
-      try (final Session s = boltSession();
-          final Transaction tx = s.beginTransaction()) {
-        final ResultSummary summary = tx.run(
+      // Autocommit CREATE, matching the python/go/js/csharp suites: the RUN/PULL summary carries the
+      // write counters regardless of commit. The probe nodes are removed by the per-test cleanup.
+      // An explicit transaction is intentionally not used - auto-creating the BREWED_BY edge type
+      // (schema DDL) inside an explicit transaction is a separate concern this scenario does not test.
+      try (final Session s = boltSession()) {
+        final ResultSummary summary = s.run(
             "CREATE (:Beer {name: $n})-[:BREWED_BY]->(:Brewery {name: $b})",
             Map.of("n", "RESULT-004-Beer", "b", "RESULT-004-Brewery")).consume();
-        tx.rollback();
         assertThat(summary.counters().nodesCreated()).isEqualTo(2);
         assertThat(summary.counters().relationshipsCreated()).isEqualTo(1);
       }

--- a/e2e/src/test/java/com/arcadedb/e2e/RemoteBoltDatabaseIT.java
+++ b/e2e/src/test/java/com/arcadedb/e2e/RemoteBoltDatabaseIT.java
@@ -127,9 +127,8 @@ class RemoteBoltDatabaseIT extends ArcadeContainerTemplate {
       // Sweep the probe nodes the write scenarios leave in the shared beer
       // database so a later suite that asserts an unscoped count is not surprised.
       try (final Session s = boltSession()) {
-        s.run("MATCH (n) WHERE n:TxProbe OR n:RaceProbe OR n:CausalProbe DETACH DELETE n").consume();
-        s.run("MATCH (b:Beer) WHERE b.name IN ['TX-004-Beer', 'RESULT-004-Beer'] DETACH DELETE b").consume();
-        s.run("MATCH (b:Brewery) WHERE b.name = 'RESULT-004-Brewery' DETACH DELETE b").consume();
+        s.run("MATCH (n) WHERE n:TxProbe OR n:RaceProbe OR n:CausalProbe OR n:R004Src OR n:R004Dst DETACH DELETE n").consume();
+        s.run("MATCH (b:Beer) WHERE b.name = 'TX-004-Beer' DETACH DELETE b").consume();
       } catch (final RuntimeException ignored) {
         // best-effort cleanup; never fail the suite on teardown
       }
@@ -494,14 +493,14 @@ class RemoteBoltDatabaseIT extends ArcadeContainerTemplate {
     @Test
     @DisplayName("[RESULT-004] ResultSummary counters reflect writes")
     void result004_counters() {
-      // Autocommit CREATE, matching the python/go/js/csharp suites: the RUN/PULL summary carries the
-      // write counters regardless of commit. The probe nodes are removed by the per-test cleanup.
-      // An explicit transaction is intentionally not used - auto-creating the BREWED_BY edge type
-      // (schema DDL) inside an explicit transaction is a separate concern this scenario does not test.
+      // Certifies that the RUN summary carries write counters. Uses dedicated types rather than the
+      // fixture's Beer/Brewery: the ArcadeDB container is shared across all e2e IT classes, and
+      // RemoteDatabaseJavaApiIT renames the Beer type (ALTER TYPE ... NAME), which corrupts Beer's
+      // edge buckets for any later suite. Dedicated types keep this scenario order-independent.
       try (final Session s = boltSession()) {
         final ResultSummary summary = s.run(
-            "CREATE (:Beer {name: $n})-[:BREWED_BY]->(:Brewery {name: $b})",
-            Map.of("n", "RESULT-004-Beer", "b", "RESULT-004-Brewery")).consume();
+            "CREATE (:R004Src {name: $n})-[:R004_MADE]->(:R004Dst {name: $b})",
+            Map.of("n", "R004-Src", "b", "R004-Dst")).consume();
         assertThat(summary.counters().nodesCreated()).isEqualTo(2);
         assertThat(summary.counters().relationshipsCreated()).isEqualTo(1);
       }

--- a/e2e/src/test/java/com/arcadedb/e2e/RemoteBoltDatabaseIT.java
+++ b/e2e/src/test/java/com/arcadedb/e2e/RemoteBoltDatabaseIT.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.Config;
@@ -263,6 +265,8 @@ class RemoteBoltDatabaseIT extends ArcadeContainerTemplate {
     }
 
     @Test
+    @DisabledOnOs(value = { OS.MAC, OS.WINDOWS }, disabledReason = "neo4j:// single-node routing advertises the container bridge IP, "
+        + "which is not host-routable on Docker Desktop (macOS/Windows); verified in Linux CI only")
     @DisplayName("[CONN-003] neo4j:// routing discovery, single-node")
     void conn003_routingSingleNode() {
       // handleRoute advertises the server's own bound address

--- a/e2e/src/test/java/com/arcadedb/e2e/RemoteDatabaseJavaApiIT.java
+++ b/e2e/src/test/java/com/arcadedb/e2e/RemoteDatabaseJavaApiIT.java
@@ -162,6 +162,12 @@ class RemoteDatabaseJavaApiIT extends ArcadeContainerTemplate {
     result = database.query("sql", "select * from Birra limit 10");
     assertThat(result.stream().count()).isEqualTo(10);
 
+    // Restore the original type name: the ArcadeDB container is a static instance shared across all
+    // e2e IT classes, so leaving 'Beer' renamed to 'Birra' corrupts the beer fixture for later
+    // suites (e.g. a Bolt CREATE (:Beer)-[...]->() then fails resolving the renamed edge buckets).
+    // Clear the 'Beer' alias first, otherwise renaming back reports 'Beer already exists'.
+    database.command("sql", "ALTER TYPE Birra ALIASES NULL");
+    database.command("sql", "ALTER TYPE Birra NAME Beer");
   }
 
   @Test

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -105,6 +105,7 @@ import com.arcadedb.query.sql.executor.CommandContext;
 import com.arcadedb.query.sql.executor.ExecutionStep;
 import com.arcadedb.query.sql.executor.InternalResultSet;
 import com.arcadedb.query.sql.executor.IteratorResultSet;
+import com.arcadedb.query.sql.executor.QueryStatistics;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
@@ -270,12 +271,22 @@ public class CypherExecutionPlan {
       while (resultSet.hasNext()) {
         materializedResults.add((ResultInternal) resultSet.next());
       }
+      // Surface the CRUD-count accumulator built up by the mutation steps (CreateStep, SetStep,
+      // DeleteStep, RemoveStep, MergeStep) on the returned result set. Always present after a
+      // write statement, even if it performed no actual mutation (containsUpdates() is false then).
+      final QueryStatistics stats = context.getStatistics();
+
       // If no RETURN clause (or GQL FINISH was used), return empty results
       // (write side effects still happened). Issue #3365 section 1.3.
-      if (statement.getReturnClause() == null || statement.hasFinishClause())
-        return new IteratorResultSet(Collections.<Result>emptyList().iterator());
+      if (statement.getReturnClause() == null || statement.hasFinishClause()) {
+        final IteratorResultSet empty = new IteratorResultSet(Collections.<Result>emptyList().iterator());
+        empty.setStatistics(stats);
+        return empty;
+      }
       // Return the materialized results
-      return new IteratorResultSet(materializedResults.iterator());
+      final IteratorResultSet out = new IteratorResultSet(materializedResults.iterator());
+      out.setStatistics(stats);
+      return out;
     }
 
     // Read-only path: GQL FINISH still suppresses any rows the MATCH would have produced.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -309,6 +309,10 @@ public class CypherExecutionPlan {
    * @return result set from the inner query execution
    */
   public ResultSet executeWithSeedRow(final Result seedRow) {
+    // Limitation: each branch/inner plan runs with its own BasicCommandContext, so QueryStatistics
+    // from writes performed inside this CALL subquery are not aggregated into the outer plan's
+    // statistics. The ResultSet returned to the caller only reflects top-level mutation steps.
+
     // Handle UNION inside CALL subqueries: execute each branch with the seed row
     if (statement instanceof UnionStatement unionStmt) {
       final List<CypherExecutionPlan> branchPlans = new ArrayList<>();
@@ -400,6 +404,10 @@ public class CypherExecutionPlan {
    * @return combined result set
    */
   private ResultSet executeUnion() {
+    // Limitation: each UNION branch executes as its own sub-plan with its own QueryStatistics, so
+    // write statistics from inside a branch are not aggregated into the combined ResultSet's
+    // statistics; only top-level mutation steps outside the UNION are reflected there.
+
     // Use UnionStep to combine results from all subqueries
     final BasicCommandContext context = new BasicCommandContext();
     context.setDatabase(database);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CreateStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CreateStep.java
@@ -384,6 +384,13 @@ public class CreateStep extends AbstractExecutionStep {
 
     final long startSave = context.isProfiling() ? System.nanoTime() : 0;
     vertex.save();
+
+    final QueryStatistics stats = context.getStatistics();
+    stats.incNodesCreated();
+    if (nodePattern.hasLabels())
+      stats.addLabelsAdded(nodePattern.getLabels().size());
+    stats.addPropertiesSet(vertex.getPropertyNames().size());
+
     if (context.isProfiling()) {
       saveOperationTime += System.nanoTime() - startSave;
       vertexCount++;
@@ -425,6 +432,11 @@ public class CreateStep extends AbstractExecutionStep {
     final MutableEdge edge = edgeProperties != null
         ? fromVertex.newEdge(type, toVertex, edgeProperties)
         : fromVertex.newEdge(type, toVertex);
+
+    final QueryStatistics stats = context.getStatistics();
+    stats.incRelationshipsCreated();
+    stats.addPropertiesSet(edge.getPropertyNames().size());
+
     if (context.isProfiling()) {
       saveOperationTime += System.nanoTime() - startSave;
       edgeCount++;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CreateStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CreateStep.java
@@ -388,7 +388,9 @@ public class CreateStep extends AbstractExecutionStep {
     final QueryStatistics stats = context.getStatistics();
     stats.incNodesCreated();
     if (nodePattern.hasLabels())
-      stats.addLabelsAdded(nodePattern.getLabels().size());
+      // ArcadeDB dedups labels (Labels.ensureCompositeType), so count distinct labels only,
+      // matching the actual number of labels added to the vertex.
+      stats.addLabelsAdded((int) nodePattern.getLabels().stream().distinct().count());
     stats.addPropertiesSet(vertex.getPropertyNames().size());
 
     if (context.isProfiling()) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CreateStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CreateStep.java
@@ -391,6 +391,7 @@ public class CreateStep extends AbstractExecutionStep {
       // ArcadeDB dedups labels (Labels.ensureCompositeType), so count distinct labels only,
       // matching the actual number of labels added to the vertex.
       stats.addLabelsAdded((int) nodePattern.getLabels().stream().distinct().count());
+    // getPropertyNames() on a freshly created record is exactly the user-set properties (labels/type are not properties).
     stats.addPropertiesSet(vertex.getPropertyNames().size());
 
     if (context.isProfiling()) {
@@ -437,6 +438,7 @@ public class CreateStep extends AbstractExecutionStep {
 
     final QueryStatistics stats = context.getStatistics();
     stats.incRelationshipsCreated();
+    // getPropertyNames() on a freshly created record is exactly the user-set properties (labels/type are not properties).
     stats.addPropertiesSet(edge.getPropertyNames().size());
 
     if (context.isProfiling()) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CreateStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CreateStep.java
@@ -220,10 +220,15 @@ public class CreateStep extends AbstractExecutionStep {
   private Result createPatterns(final Result inputResult) {
     final Database database = context.getDatabase();
     final AtomicReference<ResultInternal> resultRef = new AtomicReference<>();
+    final QueryStatistics stats = context.getStatistics();
+    final QueryStatistics statsSnapshot = stats.copy();
 
     // Use database.transaction() for automatic retry on NeedRetryException/ConcurrentModificationException
     // joinCurrentTx=true means it will join an existing transaction if one is active
     database.transaction(() -> {
+      // database.transaction retries this block on MVCC/duplicate-key conflict; reset the counters
+      // to the pre-attempt snapshot so a retried attempt does not double-count creations.
+      stats.restore(statsSnapshot);
       final ResultInternal result = new ResultInternal();
 
       // Copy input properties if present
@@ -254,9 +259,16 @@ public class CreateStep extends AbstractExecutionStep {
   private List<Result> createPatternsBatch(final List<Result> inputResults) {
     final Database database = context.getDatabase();
     final List<Result> createdResults = new ArrayList<>(inputResults.size());
+    final QueryStatistics stats = context.getStatistics();
+    final QueryStatistics statsSnapshot = stats.copy();
 
     // Execute all creates in a SINGLE transaction
     database.transaction(() -> {
+      // database.transaction retries this block on MVCC/duplicate-key conflict; reset the counters
+      // to the pre-attempt snapshot so a retried attempt does not double-count creations, and clear
+      // any partial results accumulated by a previous attempt.
+      stats.restore(statsSnapshot);
+      createdResults.clear();
       for (final Result inputResult : inputResults) {
         final ResultInternal result = new ResultInternal();
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/DeleteStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/DeleteStep.java
@@ -19,6 +19,7 @@
 package com.arcadedb.query.opencypher.executor.steps;
 
 import com.arcadedb.database.Document;
+import com.arcadedb.database.RID;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.TimeoutException;
@@ -38,7 +39,6 @@ import com.arcadedb.query.sql.executor.ResultSet;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -498,27 +498,25 @@ public class DeleteStep extends AbstractExecutionStep {
    * @param vertex vertex whose edges should be deleted
    */
   private void deleteAllEdges(final Vertex vertex) {
-    // Collect all edges to delete (both incoming and outgoing)
-    // We collect first to avoid concurrent modification
+    // Collect connected edges in both directions, de-duplicating self-loops (which appear in both
+    // OUT and IN) so a self-loop relationship is deleted and counted exactly once.
     final List<Edge> edgesToDelete = new ArrayList<>();
+    final Set<RID> seen = new HashSet<>();
+    for (final Edge edge : vertex.getEdges(Vertex.DIRECTION.OUT))
+      if (seen.add(edge.getIdentity()))
+        edgesToDelete.add(edge);
+    for (final Edge edge : vertex.getEdges(Vertex.DIRECTION.IN))
+      if (seen.add(edge.getIdentity()))
+        edgesToDelete.add(edge);
 
-    // Collect outgoing edges
-    final Iterator<Edge> outgoing = vertex.getEdges(Vertex.DIRECTION.OUT).iterator();
-    while (outgoing.hasNext()) {
-      edgesToDelete.add(outgoing.next());
-    }
-
-    // Collect incoming edges
-    final Iterator<Edge> incoming = vertex.getEdges(Vertex.DIRECTION.IN).iterator();
-    while (incoming.hasNext()) {
-      edgesToDelete.add(incoming.next());
-    }
-
-    // Delete all collected edges
     final QueryStatistics stats = context.getStatistics();
     for (final Edge edge : edgesToDelete) {
-      edge.delete();
-      stats.incRelationshipsDeleted();
+      try {
+        edge.delete();
+        stats.incRelationshipsDeleted();
+      } catch (final RecordNotFoundException ignored) {
+        // already removed (e.g. a shared edge deleted when the other endpoint was detached) - do not count again
+      }
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/DeleteStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/DeleteStep.java
@@ -30,6 +30,7 @@ import com.arcadedb.query.opencypher.executor.DeletedEntityMarker;
 import com.arcadedb.query.opencypher.traversal.TraversalPath;
 import com.arcadedb.query.sql.executor.AbstractExecutionStep;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.QueryStatistics;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
@@ -241,14 +242,16 @@ public class DeleteStep extends AbstractExecutionStep {
       else
         others.add(entry);
     }
+    final QueryStatistics stats = context.getStatistics();
     final Set<Object> deleted = new HashSet<>();
     for (final Object edge : edges)
-      deleteObjectStatic(edge, deleted);
+      deleteObjectStatic(edge, deleted, stats);
     for (final DeferredDeleteTarget entry : others) {
       final Object target = entry.target();
       if (target instanceof Vertex v && !deleted.contains(v)) {
         if (entry.detach() || hasNoEdges(v)) {
           v.delete();
+          stats.incNodesDeleted();
           deleted.add(v);
         } else {
           throw new CommandExecutionException("DeleteConnectedNode: Cannot delete node "
@@ -256,7 +259,7 @@ public class DeleteStep extends AbstractExecutionStep {
               + " its relationships, or use DETACH DELETE");
         }
       } else {
-        deleteObjectStatic(target, deleted);
+        deleteObjectStatic(target, deleted, stats);
       }
     }
     batch.clear();
@@ -271,15 +274,17 @@ public class DeleteStep extends AbstractExecutionStep {
     }
   }
 
-  private static void deleteObjectStatic(final Object obj, final Set<Object> deleted) {
+  private static void deleteObjectStatic(final Object obj, final Set<Object> deleted, final QueryStatistics stats) {
     if (obj == null || deleted.contains(obj))
       return;
     try {
-      if (obj instanceof Edge)
-        ((Edge) obj).delete();
-      else if (obj instanceof Vertex)
-        ((Vertex) obj).delete();
-      else if (obj instanceof Document)
+      if (obj instanceof Edge e) {
+        e.delete();
+        stats.incRelationshipsDeleted();
+      } else if (obj instanceof Vertex v) {
+        v.delete();
+        stats.incNodesDeleted();
+      } else if (obj instanceof Document)
         ((Document) obj).delete();
       deleted.add(obj);
     } catch (final RecordNotFoundException ignored) {
@@ -466,6 +471,7 @@ public class DeleteStep extends AbstractExecutionStep {
     }
 
     vertex.delete();
+    context.getStatistics().incNodesDeleted();
   }
 
   /**
@@ -491,8 +497,10 @@ public class DeleteStep extends AbstractExecutionStep {
     }
 
     // Delete all collected edges
+    final QueryStatistics stats = context.getStatistics();
     for (final Edge edge : edgesToDelete) {
       edge.delete();
+      stats.incRelationshipsDeleted();
     }
   }
 
@@ -503,6 +511,7 @@ public class DeleteStep extends AbstractExecutionStep {
    */
   private void deleteEdge(final Edge edge) {
     edge.delete();
+    context.getStatistics().incRelationshipsDeleted();
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/DeleteStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/DeleteStep.java
@@ -250,6 +250,11 @@ public class DeleteStep extends AbstractExecutionStep {
       final Object target = entry.target();
       if (target instanceof Vertex v && !deleted.contains(v)) {
         if (entry.detach() || hasNoEdges(v)) {
+          if (entry.detach())
+            // DETACH removes connected relationships; count each one not already deleted so
+            // relationships-deleted matches Neo4j (deleteObjectStatic skips any already in `deleted`).
+            for (final Edge edge : collectConnectedEdges(v))
+              deleteObjectStatic(edge, deleted, stats);
           v.delete();
           stats.incNodesDeleted();
           deleted.add(v);
@@ -272,6 +277,19 @@ public class DeleteStep extends AbstractExecutionStep {
       // vertex was already removed by the batch flush - treat as isolated
       return true;
     }
+  }
+
+  private static List<Edge> collectConnectedEdges(final Vertex v) {
+    final List<Edge> edges = new ArrayList<>();
+    try {
+      for (final Edge e : v.getEdges(Vertex.DIRECTION.OUT))
+        edges.add(e);
+      for (final Edge e : v.getEdges(Vertex.DIRECTION.IN))
+        edges.add(e);
+    } catch (final RecordNotFoundException ignored) {
+      // vertex was already removed by the batch flush - return what was collected so far
+    }
+    return edges;
   }
 
   private static void deleteObjectStatic(final Object obj, final Set<Object> deleted, final QueryStatistics stats) {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -42,6 +42,7 @@ import com.arcadedb.query.opencypher.parser.CypherASTBuilder;
 import com.arcadedb.query.opencypher.temporal.TemporalUtil;
 import com.arcadedb.query.sql.executor.AbstractExecutionStep;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.QueryStatistics;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
@@ -1159,6 +1160,13 @@ public class MergeStep extends AbstractExecutionStep {
     }
 
     vertex.save();
+
+    final QueryStatistics stats = context.getStatistics();
+    stats.incNodesCreated();
+    if (nodePattern.hasLabels())
+      stats.addLabelsAdded(nodePattern.getLabels().size());
+    stats.addPropertiesSet(vertex.getPropertyNames().size());
+
     return vertex;
   }
 
@@ -1193,9 +1201,15 @@ public class MergeStep extends AbstractExecutionStep {
     } else
       edgeProperties = null;
 
-    return edgeProperties != null
+    final Edge edge = edgeProperties != null
         ? fromVertex.newEdge(type, toVertex, edgeProperties)
         : fromVertex.newEdge(type, toVertex);
+
+    final QueryStatistics stats = context.getStatistics();
+    stats.incRelationshipsCreated();
+    stats.addPropertiesSet(edge.getPropertyNames().size());
+
+    return edge;
   }
 
   /**
@@ -1299,6 +1313,7 @@ public class MergeStep extends AbstractExecutionStep {
               final MutableDocument mutableDoc = doc.modify();
               mutableDoc.remove(property);
               mutableDoc.save();
+              context.getStatistics().addPropertiesSet(1);
               ((ResultInternal) result).setProperty(variable, mutableDoc);
             }
           } else {
@@ -1309,6 +1324,7 @@ public class MergeStep extends AbstractExecutionStep {
               final MutableDocument mutableDoc = doc.modify();
               mutableDoc.set(property, coerced);
               mutableDoc.save();
+              context.getStatistics().addPropertiesSet(1);
               ((ResultInternal) result).setProperty(variable, mutableDoc);
             }
           }
@@ -1329,10 +1345,14 @@ public class MergeStep extends AbstractExecutionStep {
           for (final String prop : new HashSet<>(mutableDoc.getPropertyNames()))
             if (!prop.startsWith("@"))
               mutableDoc.remove(prop);
+          int propertiesSet = 0;
           for (final Map.Entry<String, Object> entry : map.entrySet())
-            if (entry.getValue() != null)
+            if (entry.getValue() != null) {
               mutableDoc.set(entry.getKey(), TemporalUtil.toCoreJavaType(entry.getValue()));
+              propertiesSet++;
+            }
           mutableDoc.save();
+          context.getStatistics().addPropertiesSet(propertiesSet);
           ((ResultInternal) result).setProperty(variable, mutableDoc);
           break;
         }
@@ -1354,6 +1374,8 @@ public class MergeStep extends AbstractExecutionStep {
             else
               mutableDoc.set(entry.getKey(), TemporalUtil.toCoreJavaType(entry.getValue()));
           mutableDoc.save();
+          // Every map entry mutates a property, whether set (non-null) or removed (null value).
+          context.getStatistics().addPropertiesSet(map.size());
           ((ResultInternal) result).setProperty(variable, mutableDoc);
           break;
         }
@@ -1362,9 +1384,12 @@ public class MergeStep extends AbstractExecutionStep {
             break;
           final List<String> existingLabels = Labels.getLabels(vertex);
           final List<String> allLabels = new ArrayList<>(existingLabels);
+          int newLabelsCount = 0;
           for (final String label : item.getLabels())
-            if (!allLabels.contains(label))
+            if (!allLabels.contains(label)) {
               allLabels.add(label);
+              newLabelsCount++;
+            }
           final String newTypeName = Labels.ensureCompositeType(
               context.getDatabase().getSchema(), allLabels);
           if (!vertex.getTypeName().equals(newTypeName)) {
@@ -1372,6 +1397,8 @@ public class MergeStep extends AbstractExecutionStep {
             for (final String prop : vertex.getPropertyNames())
               newVertex.set(prop, vertex.get(prop));
             newVertex.save();
+            if (newLabelsCount > 0)
+              context.getStatistics().addLabelsAdded(newLabelsCount);
             for (final Edge edge : vertex.getEdges(Vertex.DIRECTION.OUT))
               newVertex.newEdge(edge.getTypeName(), edge.getVertex(Vertex.DIRECTION.IN));
             for (final Edge edge : vertex.getEdges(Vertex.DIRECTION.IN))

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -1378,14 +1378,20 @@ public class MergeStep extends AbstractExecutionStep {
           else
             break;
           final MutableDocument mutableDoc = doc.modify();
+          int mergedPropertiesSet = 0;
           for (final Map.Entry<String, Object> entry : map.entrySet())
-            if (entry.getValue() == null)
-              mutableDoc.remove(entry.getKey());
-            else
+            if (entry.getValue() == null) {
+              if (mutableDoc.has(entry.getKey())) {
+                mutableDoc.remove(entry.getKey());
+                mergedPropertiesSet++;
+              }
+            } else {
               mutableDoc.set(entry.getKey(), TemporalUtil.toCoreJavaType(entry.getValue()));
+              mergedPropertiesSet++;
+            }
           mutableDoc.save();
-          // Every map entry mutates a property, whether set (non-null) or removed (null value).
-          context.getStatistics().addPropertiesSet(map.size());
+          // A null value removes a property; removing an absent property is a no-op and is not counted.
+          context.getStatistics().addPropertiesSet(mergedPropertiesSet);
           ((ResultInternal) result).setProperty(variable, mutableDoc);
           break;
         }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -57,6 +57,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 
 /**
  * Execution step for MERGE clause.
@@ -1164,7 +1165,9 @@ public class MergeStep extends AbstractExecutionStep {
     final QueryStatistics stats = context.getStatistics();
     stats.incNodesCreated();
     if (nodePattern.hasLabels())
-      stats.addLabelsAdded(nodePattern.getLabels().size());
+      // ArcadeDB dedups labels (Labels.ensureCompositeType), so count distinct labels only,
+      // matching the actual number of labels added to the vertex.
+      stats.addLabelsAdded((int) nodePattern.getLabels().stream().distinct().count());
     stats.addPropertiesSet(vertex.getPropertyNames().size());
 
     return vertex;
@@ -1342,7 +1345,8 @@ public class MergeStep extends AbstractExecutionStep {
           else
             break;
           final MutableDocument mutableDoc = doc.modify();
-          for (final String prop : new HashSet<>(mutableDoc.getPropertyNames()))
+          final Set<String> existingProps = new HashSet<>(mutableDoc.getPropertyNames());
+          for (final String prop : existingProps)
             if (!prop.startsWith("@"))
               mutableDoc.remove(prop);
           int propertiesSet = 0;
@@ -1351,6 +1355,12 @@ public class MergeStep extends AbstractExecutionStep {
               mutableDoc.set(entry.getKey(), TemporalUtil.toCoreJavaType(entry.getValue()));
               propertiesSet++;
             }
+          // Neo4j counts both the properties written and the pre-existing properties removed by
+          // the replace (i.e. not re-set with a non-null value), matching the PROPERTY/MERGE_MAP
+          // branches above.
+          for (final String prop : existingProps)
+            if (!prop.startsWith("@") && map.get(prop) == null)
+              propertiesSet++;
           mutableDoc.save();
           context.getStatistics().addPropertiesSet(propertiesSet);
           ((ResultInternal) result).setProperty(variable, mutableDoc);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -1321,13 +1321,14 @@ public class MergeStep extends AbstractExecutionStep {
             }
           } else {
             final Object coerced = TemporalUtil.toCoreJavaType(value);
-            // Skip write when value is unchanged to avoid a needless MVCC version bump (which would
-            // make concurrent readers of this record fail with ConcurrentModificationException).
+            // Neo4j counts a non-null assignment whether or not the value actually changed.
+            context.getStatistics().addPropertiesSet(1);
+            // Skip the write when the value is unchanged to avoid a needless MVCC version bump
+            // (concurrent readers of this record would otherwise fail with ConcurrentModificationException).
             if (!valuesEqual(doc.get(property), coerced)) {
               final MutableDocument mutableDoc = doc.modify();
               mutableDoc.set(property, coerced);
               mutableDoc.save();
-              context.getStatistics().addPropertiesSet(1);
               ((ResultInternal) result).setProperty(variable, mutableDoc);
             }
           }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
@@ -191,6 +191,10 @@ public class RemoveStep extends AbstractExecutionStep {
 
     final Document doc = (Document) obj;
 
+    // Removing a property that isn't there is a no-op for Neo4j-compatible statistics: only
+    // count it when the property actually existed before the removal.
+    final boolean propertyExisted = doc.has(property);
+
     // Make document mutable
     final MutableDocument mutableDoc = doc.modify();
 
@@ -200,8 +204,8 @@ public class RemoveStep extends AbstractExecutionStep {
     // Save the modified document
     mutableDoc.save();
 
-    // Neo4j-compatible statistics: property removals are counted under "properties set".
-    context.getStatistics().addPropertiesSet(1);
+    if (propertyExisted)
+      context.getStatistics().addPropertiesSet(1);
 
     // Update the result with the modified document
     ((ResultInternal) result).setProperty(variable, mutableDoc);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/RemoveStep.java
@@ -28,6 +28,7 @@ import com.arcadedb.query.opencypher.Labels;
 import com.arcadedb.query.opencypher.ast.RemoveClause;
 import com.arcadedb.query.sql.executor.AbstractExecutionStep;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.QueryStatistics;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
@@ -199,6 +200,9 @@ public class RemoveStep extends AbstractExecutionStep {
     // Save the modified document
     mutableDoc.save();
 
+    // Neo4j-compatible statistics: property removals are counted under "properties set".
+    context.getStatistics().addPropertiesSet(1);
+
     // Update the result with the modified document
     ((ResultInternal) result).setProperty(variable, mutableDoc);
   }
@@ -216,15 +220,12 @@ public class RemoveStep extends AbstractExecutionStep {
     final List<String> currentLabels = Labels.getLabels(vertex);
     final List<String> labelsToRemove = item.getLabels();
 
-    // Check if any of the labels to remove actually exist
-    boolean needsChange = false;
-    for (final String label : labelsToRemove) {
-      if (currentLabels.contains(label)) {
-        needsChange = true;
-        break;
-      }
-    }
-    if (!needsChange)
+    // Check how many of the labels to remove actually exist on the vertex
+    int removedLabelsCount = 0;
+    for (final String label : labelsToRemove)
+      if (currentLabels.contains(label))
+        removedLabelsCount++;
+    if (removedLabelsCount == 0)
       return;
 
     // Compute remaining labels
@@ -248,6 +249,9 @@ public class RemoveStep extends AbstractExecutionStep {
     for (final String prop : vertex.getPropertyNames())
       newVertex.set(prop, vertex.get(prop));
     newVertex.save();
+
+    final QueryStatistics stats = context.getStatistics();
+    stats.addLabelsRemoved(removedLabelsCount);
 
     // Migrate edges
     for (final Edge edge : vertex.getEdges(Vertex.DIRECTION.OUT))

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
@@ -32,6 +32,7 @@ import com.arcadedb.query.opencypher.executor.CypherFunctionFactory;
 import com.arcadedb.query.opencypher.executor.ExpressionEvaluator;
 import com.arcadedb.query.sql.executor.AbstractExecutionStep;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.QueryStatistics;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
@@ -221,6 +222,9 @@ public class SetStep extends AbstractExecutionStep {
       mutableDoc.set(item.getProperty(), value);
     }
     mutableDoc.save();
+    // Neo4j counts both a property assignment and a null-valued removal under "properties set".
+    final QueryStatistics stats = context.getStatistics();
+    stats.addPropertiesSet(1);
 
     // Record the latest written state so subsequent rows can read through it.
     final RID savedRid = mutableDoc.getIdentity();
@@ -257,12 +261,17 @@ public class SetStep extends AbstractExecutionStep {
     }
 
     // Set new properties from map (skip null values - they mean "remove")
+    int propertiesSet = 0;
     for (final Map.Entry<String, Object> entry : map.entrySet()) {
-      if (entry.getValue() != null)
+      if (entry.getValue() != null) {
         mutableDoc.set(entry.getKey(), TemporalUtil.toCoreJavaType(entry.getValue()));
+        propertiesSet++;
+      }
     }
 
     mutableDoc.save();
+    final QueryStatistics stats = context.getStatistics();
+    stats.addPropertiesSet(propertiesSet);
     final RID savedRid = mutableDoc.getIdentity();
     if (savedRid != null)
       writtenDocs.put(savedRid, mutableDoc);
@@ -296,6 +305,9 @@ public class SetStep extends AbstractExecutionStep {
     }
 
     mutableDoc.save();
+    // Every map entry mutates a property, whether set (non-null) or removed (null value).
+    final QueryStatistics stats = context.getStatistics();
+    stats.addPropertiesSet(map.size());
     final RID savedRid = mutableDoc.getIdentity();
     if (savedRid != null)
       writtenDocs.put(savedRid, mutableDoc);
@@ -356,9 +368,12 @@ public class SetStep extends AbstractExecutionStep {
     // Get existing labels and add new ones
     final List<String> existingLabels = Labels.getLabels(vertex);
     final List<String> allLabels = new ArrayList<>(existingLabels);
+    int newLabelsCount = 0;
     for (final String label : item.getLabels())
-      if (!allLabels.contains(label))
+      if (!allLabels.contains(label)) {
         allLabels.add(label);
+        newLabelsCount++;
+      }
 
     // Create the composite type for the combined labels
     final String newTypeName = Labels.ensureCompositeType(
@@ -373,6 +388,8 @@ public class SetStep extends AbstractExecutionStep {
     for (final String prop : vertex.getPropertyNames())
       newVertex.set(prop, vertex.get(prop));
     newVertex.save();
+    if (newLabelsCount > 0)
+      context.getStatistics().addLabelsAdded(newLabelsCount);
 
     // Copy edges from old vertex to new vertex
     for (final Edge edge : vertex.getEdges(Vertex.DIRECTION.OUT))

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
@@ -214,17 +214,24 @@ public class SetStep extends AbstractExecutionStep {
       ((ResultInternal) result).setProperty(variableToUpdate, mutableDoc);
 
     Object value = evaluator.evaluate(item.getValueExpression(), result, context);
-    if (value == null)
+    final boolean propertyExisted;
+    if (value == null) {
+      // Removing an absent property is a no-op for Neo4j-compatible statistics: only count it
+      // when the property actually existed before the removal.
+      propertyExisted = mutableDoc.has(item.getProperty());
       mutableDoc.remove(item.getProperty());
-    else {
+    } else {
       value = TemporalUtil.toCoreJavaType(value);
       validatePropertyValue(value);
       mutableDoc.set(item.getProperty(), value);
+      propertyExisted = true;
     }
     mutableDoc.save();
-    // Neo4j counts both a property assignment and a null-valued removal under "properties set".
+    // Neo4j counts both a property assignment and a genuine (existing-property) null-valued
+    // removal under "properties set".
     final QueryStatistics stats = context.getStatistics();
-    stats.addPropertiesSet(1);
+    if (propertyExisted)
+      stats.addPropertiesSet(1);
 
     // Record the latest written state so subsequent rows can read through it.
     final RID savedRid = mutableDoc.getIdentity();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
@@ -269,6 +269,12 @@ public class SetStep extends AbstractExecutionStep {
       }
     }
 
+    // Neo4j counts both the properties written and the pre-existing properties removed by the
+    // replace (i.e. not re-set with a non-null value), matching applyPropertySet/applyMergeMap.
+    for (final String prop : existingProps)
+      if (!prop.startsWith("@") && map.get(prop) == null)
+        propertiesSet++;
+
     mutableDoc.save();
     final QueryStatistics stats = context.getStatistics();
     stats.addPropertiesSet(propertiesSet);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
@@ -309,18 +309,24 @@ public class SetStep extends AbstractExecutionStep {
     if (mutableDoc != doc)
       ((ResultInternal) result).setProperty(item.getVariable(), mutableDoc);
 
-    // Merge: add/update properties from map, null removes
+    // Merge: non-null values set the property, a null value removes it. Removing a property that
+    // does not exist is a no-op and is not counted (Neo4j reports properties-set only for changes).
+    int propertiesSet = 0;
     for (final Map.Entry<String, Object> entry : map.entrySet()) {
-      if (entry.getValue() == null)
-        mutableDoc.remove(entry.getKey());
-      else
+      if (entry.getValue() == null) {
+        if (mutableDoc.has(entry.getKey())) {
+          mutableDoc.remove(entry.getKey());
+          propertiesSet++;
+        }
+      } else {
         mutableDoc.set(entry.getKey(), TemporalUtil.toCoreJavaType(entry.getValue()));
+        propertiesSet++;
+      }
     }
 
     mutableDoc.save();
-    // Every map entry mutates a property, whether set (non-null) or removed (null value).
     final QueryStatistics stats = context.getStatistics();
-    stats.addPropertiesSet(map.size());
+    stats.addPropertiesSet(propertiesSet);
     final RID savedRid = mutableDoc.getIdentity();
     if (savedRid != null)
       writtenDocs.put(savedRid, mutableDoc);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
@@ -334,6 +334,10 @@ public class OpenCypherQueryEngine implements QueryEngine {
    * (indexes/constraints added) only count schema changes that actually happened.
    */
   private static boolean indexExistsOnProperties(final Schema schema, final String typeName, final String[] propertyNames) {
+    // Both callers auto-create the type before this runs, so it normally exists. Guard defensively:
+    // a missing type has no index, and getType would otherwise throw for a future caller.
+    if (!schema.existsType(typeName))
+      return false;
     final DocumentType type = schema.getType(typeName);
     return type.getIndexByProperties(propertyNames) != null || type.getPolymorphicIndexByProperties(propertyNames) != null;
   }

--- a/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
@@ -42,6 +42,7 @@ import com.arcadedb.query.opencypher.optimizer.plan.PhysicalPlan;
 import com.arcadedb.query.opencypher.planner.CypherExecutionPlanner;
 import com.arcadedb.query.sql.executor.BasicCommandContext;
 import com.arcadedb.query.sql.executor.InternalResultSet;
+import com.arcadedb.query.sql.executor.QueryStatistics;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.utility.CollectionUtils;
@@ -304,26 +305,40 @@ public class OpenCypherQueryEngine implements QueryEngine {
    */
   private ResultSet executeDDL(final CypherDDLStatement ddl) {
     final Schema schema = database.getSchema();
+    final QueryStatistics stats = new QueryStatistics();
 
     switch (ddl.getKind()) {
     case CREATE_CONSTRAINT:
-      executeCreateConstraint(ddl, schema);
+      executeCreateConstraint(ddl, schema, stats);
       break;
     case DROP_CONSTRAINT:
-      executeDropConstraint(ddl, schema);
+      executeDropConstraint(ddl, schema, stats);
       break;
     case CREATE_INDEX:
-      executeCreateIndex(ddl, schema);
+      executeCreateIndex(ddl, schema, stats);
       break;
     case DROP_INDEX:
-      executeDropIndex(ddl, schema);
+      executeDropIndex(ddl, schema, stats);
       break;
     }
 
-    return new InternalResultSet();
+    final InternalResultSet result = new InternalResultSet();
+    result.setStatistics(stats);
+    return result;
   }
 
-  private void executeCreateConstraint(final CypherDDLStatement ddl, final Schema schema) {
+  /**
+   * Checks whether a type index already covers exactly {@code propertyNames}, looking both at the
+   * type's own indexes and any inherited from a parent type. Used by Cypher constraint/index DDL to
+   * tell whether an {@code IF NOT EXISTS} create is a genuine no-op, so the DDL result statistics
+   * (indexes/constraints added) only count schema changes that actually happened.
+   */
+  private static boolean indexExistsOnProperties(final Schema schema, final String typeName, final String[] propertyNames) {
+    final DocumentType type = schema.getType(typeName);
+    return type.getIndexByProperties(propertyNames) != null || type.getPolymorphicIndexByProperties(propertyNames) != null;
+  }
+
+  private void executeCreateConstraint(final CypherDDLStatement ddl, final Schema schema, final QueryStatistics stats) {
     final String typeName = ddl.getLabelName();
     final String[] propertyNames = ddl.getPropertyNames().toArray(new String[0]);
 
@@ -343,15 +358,20 @@ public class OpenCypherQueryEngine implements QueryEngine {
     // without coercing future writes (see issue #4222).
     final Type[] defaultKeyTypes = new Type[propertyNames.length];
     boolean anyUndeclared = false;
+    // Tracks whether the TYPED branch below actually created/changed a property; if every property
+    // already had the requested type this loop is a no-op and must not count toward the statistics.
+    boolean typedChanged = false;
     for (int i = 0; i < propertyNames.length; i++) {
       final String propName = propertyNames[i];
       final Property existing = schema.getType(typeName).getPropertyIfExists(propName);
       if (isTyped) {
-        if (existing == null)
+        if (existing == null) {
           schema.getType(typeName).createProperty(propName, explicitPropertyType);
-        else if (existing.getType() != explicitPropertyType) {
+          typedChanged = true;
+        } else if (existing.getType() != explicitPropertyType) {
           schema.getType(typeName).dropProperty(propName);
           schema.getType(typeName).createProperty(propName, explicitPropertyType);
+          typedChanged = true;
         }
       } else if (existing == null) {
         final Type inferred = inferPropertyTypeFromExistingData(typeName, propName);
@@ -366,6 +386,7 @@ public class OpenCypherQueryEngine implements QueryEngine {
 
     switch (ddl.getConstraintKind()) {
     case UNIQUE: {
+      final boolean existedBefore = indexExistsOnProperties(schema, typeName, propertyNames);
       final TypeIndexBuilder b = schema.buildTypeIndex(typeName, propertyNames);
       b.withType(Schema.INDEX_TYPE.LSM_TREE);
       b.withUnique(true);
@@ -373,22 +394,34 @@ public class OpenCypherQueryEngine implements QueryEngine {
       if (anyUndeclared)
         b.withDefaultKeyTypesForUndeclaredProperties(defaultKeyTypes);
       b.create();
+      if (!existedBefore)
+        stats.incConstraintsAdded();
       break;
     }
 
-    case NOT_NULL:
+    case NOT_NULL: {
+      boolean changed = false;
       for (final String propName : propertyNames) {
         Property prop = schema.getType(typeName).getPropertyIfExists(propName);
-        if (prop == null)
+        if (prop == null) {
           // NOT NULL implies the property must be tracked, declare it with a generic STRING
           // since we have no value yet to infer from.
           prop = schema.getType(typeName).createProperty(propName, Type.STRING);
-        prop.setMandatory(true);
+          changed = true;
+        }
+        if (!prop.isMandatory()) {
+          prop.setMandatory(true);
+          changed = true;
+        }
       }
+      if (changed)
+        stats.incConstraintsAdded();
       break;
+    }
 
     case KEY: {
       // NODE KEY = unique index + mandatory properties
+      final boolean existedBefore = indexExistsOnProperties(schema, typeName, propertyNames);
       final TypeIndexBuilder b = schema.buildTypeIndex(typeName, propertyNames);
       b.withType(Schema.INDEX_TYPE.LSM_TREE);
       b.withUnique(true);
@@ -402,11 +435,15 @@ public class OpenCypherQueryEngine implements QueryEngine {
           prop = schema.getType(typeName).createProperty(propName, Type.STRING);
         prop.setMandatory(true);
       }
+      if (!existedBefore)
+        stats.incConstraintsAdded();
       break;
     }
 
     case TYPED:
       // Property type already set above; for IF NOT EXISTS, silently succeed if property already has the correct type
+      if (typedChanged)
+        stats.incConstraintsAdded();
       break;
     }
   }
@@ -652,17 +689,20 @@ public class OpenCypherQueryEngine implements QueryEngine {
     return resultSet;
   }
 
-  private void executeDropConstraint(final CypherDDLStatement ddl, final Schema schema) {
+  private void executeDropConstraint(final CypherDDLStatement ddl, final Schema schema, final QueryStatistics stats) {
     final String constraintName = ddl.getConstraintName();
     if (ddl.isIfExists()) {
-      if (schema.existsIndex(constraintName))
+      if (schema.existsIndex(constraintName)) {
         schema.dropIndex(constraintName);
+        stats.incConstraintsRemoved();
+      }
     } else {
       schema.dropIndex(constraintName);
+      stats.incConstraintsRemoved();
     }
   }
 
-  private void executeCreateIndex(final CypherDDLStatement ddl, final Schema schema) {
+  private void executeCreateIndex(final CypherDDLStatement ddl, final Schema schema, final QueryStatistics stats) {
     final String typeName = ddl.getLabelName();
     final String[] propertyNames = ddl.getPropertyNames().toArray(new String[0]);
 
@@ -699,6 +739,7 @@ public class OpenCypherQueryEngine implements QueryEngine {
       }
     }
 
+    final boolean existedBefore = indexExistsOnProperties(schema, typeName, propertyNames);
     final TypeIndexBuilder builder = schema.buildTypeIndex(typeName, propertyNames);
     builder.withType(Schema.INDEX_TYPE.LSM_TREE);
     builder.withUnique(false);
@@ -706,6 +747,8 @@ public class OpenCypherQueryEngine implements QueryEngine {
     if (anyUndeclared)
       builder.withDefaultKeyTypesForUndeclaredProperties(defaultKeyTypes);
     builder.create();
+    if (!existedBefore)
+      stats.incIndexesAdded();
   }
 
   /**
@@ -744,13 +787,16 @@ public class OpenCypherQueryEngine implements QueryEngine {
     return null;
   }
 
-  private void executeDropIndex(final CypherDDLStatement ddl, final Schema schema) {
+  private void executeDropIndex(final CypherDDLStatement ddl, final Schema schema, final QueryStatistics stats) {
     final String indexName = ddl.getConstraintName();
     if (ddl.isIfExists()) {
-      if (schema.existsIndex(indexName))
+      if (schema.existsIndex(indexName)) {
         schema.dropIndex(indexName);
+        stats.incIndexesRemoved();
+      }
     } else {
       schema.dropIndex(indexName);
+      stats.incIndexesRemoved();
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/BasicCommandContext.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/BasicCommandContext.java
@@ -41,6 +41,7 @@ public class BasicCommandContext implements CommandContext {
   protected       CommandContext       parent;
   protected       CommandContext       child;
   protected       Map<String, Object>  variables;
+  protected       QueryStatistics      statistics;
   protected       Map<String, Object>  cachedValues;
   protected       Map<String, Object>  inputParameters;
   protected       ContextConfiguration configuration           = new ContextConfiguration();
@@ -447,6 +448,13 @@ public class BasicCommandContext implements CommandContext {
       return parent.getDatabase();
 
     return null;
+  }
+
+  @Override
+  public QueryStatistics getStatistics() {
+    if (statistics == null)
+      statistics = new QueryStatistics();
+    return statistics;
   }
 
   public CommandContext setDatabase(final Database database) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/BasicCommandContext.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/BasicCommandContext.java
@@ -409,6 +409,9 @@ public class BasicCommandContext implements CommandContext {
     copy.parent = parent;
     copy.child = child;
     copy.profiling = profiling;
+    // Share the same statistics accumulator so mutations performed through the copied context
+    // aggregate into one place instead of silently vanishing.
+    copy.statistics = statistics;
     return copy;
   }
 

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CommandContext.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CommandContext.java
@@ -78,6 +78,8 @@ public interface CommandContext {
 
   DatabaseInternal getDatabase();
 
+  QueryStatistics getStatistics();
+
   void declareScriptVariable(String varName);
 
   boolean isScriptVariableDeclared(String varName);

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/InternalResultSet.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/InternalResultSet.java
@@ -29,9 +29,10 @@ import java.util.Optional;
  * Created by luigidellaquila on 07/07/16.
  */
 public class InternalResultSet implements ResultSet, ResettableIterator<Result> {
-  private   List<Result>  content = new ArrayList<>();
-  private   int           next    = 0;
-  protected ExecutionPlan plan;
+  private   List<Result>      content = new ArrayList<>();
+  private   int               next    = 0;
+  protected ExecutionPlan     plan;
+  protected QueryStatistics   statistics;
 
   public InternalResultSet() {
   }
@@ -72,6 +73,15 @@ public class InternalResultSet implements ResultSet, ResettableIterator<Result> 
 
   public void setPlan(final ExecutionPlan plan) {
     this.plan = plan;
+  }
+
+  @Override
+  public Optional<QueryStatistics> getStatistics() {
+    return Optional.ofNullable(statistics);
+  }
+
+  public void setStatistics(final QueryStatistics statistics) {
+    this.statistics = statistics;
   }
 
   public InternalResultSet add(final Result nextResult) {

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/IteratorResultSet.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/IteratorResultSet.java
@@ -21,15 +21,21 @@ package com.arcadedb.query.sql.executor;
 import com.arcadedb.database.Document;
 
 import java.util.Iterator;
+import java.util.Optional;
 
 /**
  * Created by luigidellaquila on 07/07/16.
  */
 public class IteratorResultSet implements ResultSet {
   protected final Iterator iterator;
+  protected QueryStatistics statistics;
 
   public IteratorResultSet(final Iterator iter) {
     this.iterator = iter;
+  }
+
+  public void setStatistics(final QueryStatistics statistics) {
+    this.statistics = statistics;
   }
 
   @Override
@@ -46,5 +52,10 @@ public class IteratorResultSet implements ResultSet {
     return val instanceof Document d ?
         new ResultInternal(d) :
         new ResultInternal().setProperty("value", val);
+  }
+
+  @Override
+  public Optional<QueryStatistics> getStatistics() {
+    return Optional.ofNullable(statistics);
   }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/QueryStatistics.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/QueryStatistics.java
@@ -67,4 +67,41 @@ public class QueryStatistics {
         || propertiesSet != 0 || labelsAdded != 0 || labelsRemoved != 0
         || indexesAdded != 0 || indexesRemoved != 0 || constraintsAdded != 0 || constraintsRemoved != 0;
   }
+
+  /**
+   * Returns an independent snapshot of the current counter values.
+   */
+  public QueryStatistics copy() {
+    final QueryStatistics c = new QueryStatistics();
+    c.nodesCreated = nodesCreated;
+    c.nodesDeleted = nodesDeleted;
+    c.relationshipsCreated = relationshipsCreated;
+    c.relationshipsDeleted = relationshipsDeleted;
+    c.propertiesSet = propertiesSet;
+    c.labelsAdded = labelsAdded;
+    c.labelsRemoved = labelsRemoved;
+    c.indexesAdded = indexesAdded;
+    c.indexesRemoved = indexesRemoved;
+    c.constraintsAdded = constraintsAdded;
+    c.constraintsRemoved = constraintsRemoved;
+    return c;
+  }
+
+  /**
+   * Restores all counters to the values captured in the given snapshot. Used to roll back the
+   * increments of a transaction attempt that is about to be retried, so a retry does not double-count.
+   */
+  public void restore(final QueryStatistics snapshot) {
+    nodesCreated = snapshot.nodesCreated;
+    nodesDeleted = snapshot.nodesDeleted;
+    relationshipsCreated = snapshot.relationshipsCreated;
+    relationshipsDeleted = snapshot.relationshipsDeleted;
+    propertiesSet = snapshot.propertiesSet;
+    labelsAdded = snapshot.labelsAdded;
+    labelsRemoved = snapshot.labelsRemoved;
+    indexesAdded = snapshot.indexesAdded;
+    indexesRemoved = snapshot.indexesRemoved;
+    constraintsAdded = snapshot.constraintsAdded;
+    constraintsRemoved = snapshot.constraintsRemoved;
+  }
 }

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/QueryStatistics.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/QueryStatistics.java
@@ -22,6 +22,8 @@ package com.arcadedb.query.sql.executor;
  * Mutable, allocation-light accumulator of CRUD and schema mutation counts produced while executing
  * a single command. Held on the {@link CommandContext} and read once when the result set is
  * assembled. All counters are primitive ints; instances are created only for write commands.
+ * Not thread-safe: a single command context is written by one query thread at a time; counters are
+ * plain ints with no synchronization.
  */
 public class QueryStatistics {
   private int nodesCreated;

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/QueryStatistics.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/QueryStatistics.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.sql.executor;
+
+/**
+ * Mutable, allocation-light accumulator of CRUD and schema mutation counts produced while executing
+ * a single command. Held on the {@link CommandContext} and read once when the result set is
+ * assembled. All counters are primitive ints; instances are created only for write commands.
+ */
+public class QueryStatistics {
+  private int nodesCreated;
+  private int nodesDeleted;
+  private int relationshipsCreated;
+  private int relationshipsDeleted;
+  private int propertiesSet;
+  private int labelsAdded;
+  private int labelsRemoved;
+  private int indexesAdded;
+  private int indexesRemoved;
+  private int constraintsAdded;
+  private int constraintsRemoved;
+
+  public void incNodesCreated()          { nodesCreated++; }
+  public void incNodesDeleted()          { nodesDeleted++; }
+  public void incRelationshipsCreated()  { relationshipsCreated++; }
+  public void incRelationshipsDeleted()  { relationshipsDeleted++; }
+  public void addPropertiesSet(final int n) { propertiesSet += n; }
+  public void addLabelsAdded(final int n)   { labelsAdded += n; }
+  public void addLabelsRemoved(final int n) { labelsRemoved += n; }
+  public void incIndexesAdded()          { indexesAdded++; }
+  public void incIndexesRemoved()        { indexesRemoved++; }
+  public void incConstraintsAdded()      { constraintsAdded++; }
+  public void incConstraintsRemoved()    { constraintsRemoved++; }
+
+  public int getNodesCreated()          { return nodesCreated; }
+  public int getNodesDeleted()          { return nodesDeleted; }
+  public int getRelationshipsCreated()  { return relationshipsCreated; }
+  public int getRelationshipsDeleted()  { return relationshipsDeleted; }
+  public int getPropertiesSet()         { return propertiesSet; }
+  public int getLabelsAdded()           { return labelsAdded; }
+  public int getLabelsRemoved()         { return labelsRemoved; }
+  public int getIndexesAdded()          { return indexesAdded; }
+  public int getIndexesRemoved()        { return indexesRemoved; }
+  public int getConstraintsAdded()      { return constraintsAdded; }
+  public int getConstraintsRemoved()    { return constraintsRemoved; }
+
+  public boolean containsUpdates() {
+    return nodesCreated != 0 || nodesDeleted != 0 || relationshipsCreated != 0 || relationshipsDeleted != 0
+        || propertiesSet != 0 || labelsAdded != 0 || labelsRemoved != 0
+        || indexesAdded != 0 || indexesRemoved != 0 || constraintsAdded != 0 || constraintsRemoved != 0;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/ResultSet.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/ResultSet.java
@@ -65,6 +65,10 @@ public interface ResultSet extends Spliterator<Result>, Iterator<Result>, AutoCl
     return Optional.empty();
   }
 
+  default Optional<QueryStatistics> getStatistics() {
+    return Optional.empty();
+  }
+
   default void reset() {
     throw new UnsupportedOperationException("Implement RESET on " + getClass().getSimpleName());
   }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Database;
+import com.arcadedb.query.sql.executor.QueryStatistics;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that write commands populate QueryStatistics with Neo4j-compatible CRUD counts,
+ * and that read queries carry no statistics.
+ */
+class CypherQueryStatisticsTest extends TestHelper {
+
+  private QueryStatistics statsOf(final Database db, final String cypher) {
+    final ResultSet rs = db.command("opencypher", cypher);
+    while (rs.hasNext())
+      rs.next();
+    final Optional<QueryStatistics> s = rs.getStatistics();
+    assertThat(s).isPresent();
+    return s.get();
+  }
+
+  @Test
+  void createNodesRelationshipAndProperties() {
+    database.transaction(() -> {
+      final QueryStatistics s = statsOf(database,
+          "CREATE (:Beer {name:'IPA'})-[:BREWED_BY {since:1990}]->(:Brewery {name:'Acme'})");
+      assertThat(s.getNodesCreated()).isEqualTo(2);
+      assertThat(s.getRelationshipsCreated()).isEqualTo(1);
+      assertThat(s.getPropertiesSet()).isEqualTo(3); // name, since, name
+      assertThat(s.getLabelsAdded()).isEqualTo(2);   // Beer, Brewery
+      assertThat(s.containsUpdates()).isTrue();
+    });
+  }
+
+  @Test
+  void setPropertyAndLabel() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Person {name:'a'})");
+      final QueryStatistics s = statsOf(database, "MATCH (n:Person {name:'a'}) SET n.age = 30, n:Employee");
+      assertThat(s.getPropertiesSet()).isEqualTo(1);
+      assertThat(s.getLabelsAdded()).isEqualTo(1);
+    });
+  }
+
+  @Test
+  void removePropertyAndLabel() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Tag:Old {name:'x'})");
+      final QueryStatistics s = statsOf(database, "MATCH (n:Tag {name:'x'}) REMOVE n.name, n:Old");
+      assertThat(s.getPropertiesSet()).isEqualTo(1);
+      assertThat(s.getLabelsRemoved()).isEqualTo(1);
+    });
+  }
+
+  @Test
+  void deleteNode() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Doomed {id:1})");
+      final QueryStatistics s = statsOf(database, "MATCH (n:Doomed {id:1}) DELETE n");
+      assertThat(s.getNodesDeleted()).isEqualTo(1);
+    });
+  }
+
+  @Test
+  void mergeCreatesOnlyOnce() {
+    database.transaction(() -> {
+      final QueryStatistics first = statsOf(database, "MERGE (:City {name:'Rome'})");
+      assertThat(first.getNodesCreated()).isEqualTo(1);
+      final ResultSet rs = database.command("opencypher", "MERGE (:City {name:'Rome'})");
+      while (rs.hasNext()) rs.next();
+      assertThat(rs.getStatistics().get().getNodesCreated()).isZero();
+    });
+  }
+
+  @Test
+  void readQueryHasNoStatistics() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:R {n:1})");
+      final ResultSet rs = database.query("opencypher", "MATCH (n:R) RETURN n");
+      while (rs.hasNext()) rs.next();
+      assertThat(rs.getStatistics()).isEmpty();
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
@@ -188,6 +188,26 @@ class CypherQueryStatisticsTest extends TestHelper {
   }
 
   @Test
+  void mergeMapPlusWithNullValuesCountsOnlyRealChanges() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Widget {a:1, b:2})");
+      // += : c set (new, +1), b removed (existing null, +1), z removed (absent null, +0) = 2
+      final QueryStatistics s = statsOf(database, "MATCH (n:Widget) SET n += {c: 3, b: null, z: null}");
+      assertThat(s.getPropertiesSet()).isEqualTo(2);
+    });
+  }
+
+  @Test
+  void mergeOnMatchSetPlusMapWithNullCountsOnlyRealChanges() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Gadget {k:'x', a:1})");
+      // ON MATCH SET += : a removed (existing null, +1), absent removed (+0), b set (+1) = 2
+      final QueryStatistics s = statsOf(database, "MERGE (n:Gadget {k:'x'}) ON MATCH SET n += {a: null, absent: null, b: 2}");
+      assertThat(s.getPropertiesSet()).isEqualTo(2);
+    });
+  }
+
+  @Test
   void createIndexCounts() {
     database.command("opencypher", "CREATE (:Product {sku:'a'})"); // ensure type exists
     final ResultSet rs = database.command("opencypher", "CREATE INDEX FOR (p:Product) ON (p.sku)");

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
@@ -283,4 +283,36 @@ class CypherQueryStatisticsTest extends TestHelper {
     assertThat(s.getConstraintsRemoved()).isEqualTo(1);
     assertThat(s.containsUpdates()).isTrue();
   }
+
+  @Test
+  void detachDeleteCountsNodeAndRelationship() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:DA {id:1})-[:REL]->(:DB {id:2})");
+      final QueryStatistics s = statsOf(database, "MATCH (a:DA {id:1}) DETACH DELETE a");
+      assertThat(s.getNodesDeleted()).isEqualTo(1);
+      assertThat(s.getRelationshipsDeleted()).isEqualTo(1);
+    });
+  }
+
+  @Test
+  void foreachDetachDeleteCountsRelationship() {
+    // Deferred path: FOREACH queues deletes via DeleteStep.DEFERRED_DELETE_BATCH_VAR and flushes
+    // them through DeleteStep.flushDeferredDeletes, which must count cascaded relationships too.
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:FA {id:1})-[:REL]->(:FB {id:2})");
+      final QueryStatistics s = statsOf(database,
+          "MATCH (a:FA {id:1}) WITH collect(a) AS xs FOREACH (x IN xs | DETACH DELETE x)");
+      assertThat(s.getNodesDeleted()).isEqualTo(1);
+      assertThat(s.getRelationshipsDeleted()).isEqualTo(1);
+    });
+  }
+
+  @Test
+  void mergeOnMatchSetUnchangedValueStillCountsPropertySet() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:MM {k:'x', p:1})");
+      final QueryStatistics s = statsOf(database, "MERGE (n:MM {k:'x'}) ON MATCH SET n.p = 1");
+      assertThat(s.getPropertiesSet()).isEqualTo(1);
+    });
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
@@ -81,6 +81,38 @@ class CypherQueryStatisticsTest extends TestHelper {
   }
 
   @Test
+  void removeAbsentPropertyCountsZero() {
+    // Neo4j reports properties-set: 0 when REMOVE targets a property that isn't present.
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Widget3 {name:'x'})");
+      final QueryStatistics s = statsOf(database, "MATCH (n:Widget3 {name:'x'}) REMOVE n.doesNotExist");
+      assertThat(s.getPropertiesSet()).isZero();
+      assertThat(s.containsUpdates()).isFalse();
+    });
+  }
+
+  @Test
+  void setAbsentPropertyToNullCountsZero() {
+    // SET n.absent = null on a property that was never set is a no-op removal: Neo4j counts 0.
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Widget4 {name:'x'})");
+      final QueryStatistics s = statsOf(database, "MATCH (n:Widget4 {name:'x'}) SET n.absent = null");
+      assertThat(s.getPropertiesSet()).isZero();
+    });
+  }
+
+  @Test
+  void removeExistingPropertyStillCountsOne() {
+    // Control: removing a property that genuinely exists must still count 1 (guards against
+    // regressing the existing-property removal path while fixing the absent-property case above).
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Widget5 {name:'x'})");
+      final QueryStatistics s = statsOf(database, "MATCH (n:Widget5 {name:'x'}) REMOVE n.name");
+      assertThat(s.getPropertiesSet()).isEqualTo(1);
+    });
+  }
+
+  @Test
   void deleteNode() {
     database.transaction(() -> {
       database.command("opencypher", "CREATE (:Doomed {id:1})");

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
@@ -61,6 +61,16 @@ class CypherQueryStatisticsTest extends TestHelper {
   }
 
   @Test
+  void createWithInlineNullPropertyDoesNotCountIt() {
+    database.transaction(() -> {
+      // Neo4j does not store a null-valued property, so it is not counted: only 'a' is set.
+      final QueryStatistics s = statsOf(database, "CREATE (:Foo {a: 1, b: null})");
+      assertThat(s.getNodesCreated()).isEqualTo(1);
+      assertThat(s.getPropertiesSet()).isEqualTo(1);
+    });
+  }
+
+  @Test
   void setPropertyAndLabel() {
     database.transaction(() -> {
       database.command("opencypher", "CREATE (:Person {name:'a'})");

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
@@ -105,4 +105,49 @@ class CypherQueryStatisticsTest extends TestHelper {
       assertThat(rs.getStatistics()).isEmpty();
     });
   }
+
+  @Test
+  void createVertexWithDuplicateLabelCountsDistinctLabels() {
+    // ArcadeDB dedups labels (Labels.ensureCompositeType), so CREATE (n:Dup:Dup) creates a
+    // single-label vertex. Neo4j-compatible statistics must report 1 label added, not 2.
+    database.transaction(() -> {
+      final QueryStatistics s = statsOf(database, "CREATE (n:Dup:Dup) RETURN n");
+      assertThat(s.getNodesCreated()).isEqualTo(1);
+      assertThat(s.getLabelsAdded()).isEqualTo(1);
+    });
+  }
+
+  @Test
+  void mergeCreateWithDuplicateLabelCountsDistinctLabels() {
+    database.transaction(() -> {
+      final QueryStatistics s = statsOf(database, "MERGE (n:Twin:Twin {id:1}) RETURN n");
+      assertThat(s.getNodesCreated()).isEqualTo(1);
+      assertThat(s.getLabelsAdded()).isEqualTo(1);
+    });
+  }
+
+  @Test
+  void setReplaceMapCountsRemovedPreexistingProperties() {
+    // n originally has 3 properties (a, b, c). SET n = {a:10, d:4} keeps/updates "a", adds "d",
+    // and removes "b" and "c" since they are absent from the new map. Neo4j-compatible
+    // "properties set" counts both the 2 written entries (a, d) and the 2 removed ones (b, c) = 4.
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Item {a:1, b:2, c:3})");
+      final QueryStatistics s = statsOf(database, "MATCH (n:Item) SET n = {a:10, d:4}");
+      assertThat(s.getPropertiesSet()).isEqualTo(4);
+    });
+  }
+
+  @Test
+  void mergeOnMatchSetReplaceMapCountsRemovedPreexistingProperties() {
+    // Same replace-map semantics as above (a kept/updated, d added, b and c removed = 4), but
+    // exercised through MERGE ... ON MATCH SET, which duplicates the REPLACE_MAP branch in
+    // MergeStep.applySetClause.
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:Widget {a:1, b:2, c:3})");
+      final QueryStatistics s = statsOf(database,
+          "MERGE (n:Widget {a:1}) ON MATCH SET n = {a:10, d:4}");
+      assertThat(s.getPropertiesSet()).isEqualTo(4);
+    });
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
@@ -315,4 +315,18 @@ class CypherQueryStatisticsTest extends TestHelper {
       assertThat(s.getPropertiesSet()).isEqualTo(1);
     });
   }
+
+  @Test
+  void detachDeleteSelfLoopCountsRelationshipOnce() {
+    // A self-loop relationship is returned by both vertex.getEdges(OUT) and vertex.getEdges(IN),
+    // so the immediate (non-FOREACH) DETACH DELETE path must de-dup it: exactly 1 relationship
+    // deleted, not 2, and no RecordNotFoundException from deleting the same edge twice.
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (a:SL {id:1})");
+      database.command("opencypher", "MATCH (a:SL {id:1}) CREATE (a)-[:LOOP]->(a)");
+      final QueryStatistics s = statsOf(database, "MATCH (a:SL {id:1}) DETACH DELETE a");
+      assertThat(s.getNodesDeleted()).isEqualTo(1);
+      assertThat(s.getRelationshipsDeleted()).isEqualTo(1);
+    });
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
@@ -20,10 +20,14 @@ package com.arcadedb.query.opencypher;
 
 import com.arcadedb.TestHelper;
 import com.arcadedb.database.Database;
+import com.arcadedb.index.TypeIndex;
 import com.arcadedb.query.sql.executor.QueryStatistics;
 import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -149,5 +153,72 @@ class CypherQueryStatisticsTest extends TestHelper {
           "MERGE (n:Widget {a:1}) ON MATCH SET n = {a:10, d:4}");
       assertThat(s.getPropertiesSet()).isEqualTo(4);
     });
+  }
+
+  @Test
+  void createIndexCounts() {
+    database.command("opencypher", "CREATE (:Product {sku:'a'})"); // ensure type exists
+    final ResultSet rs = database.command("opencypher", "CREATE INDEX FOR (p:Product) ON (p.sku)");
+    while (rs.hasNext())
+      rs.next();
+    assertThat(rs.getStatistics()).isPresent();
+    assertThat(rs.getStatistics().get().getIndexesAdded()).isEqualTo(1);
+    assertThat(rs.getStatistics().get().containsUpdates()).isTrue();
+  }
+
+  @Test
+  void createIndexIfNotExistsAlreadyPresentCountsZero() {
+    database.command("opencypher", "CREATE (:Widget2 {code:'a'})");
+    database.command("opencypher", "CREATE INDEX IF NOT EXISTS FOR (w:Widget2) ON (w.code)");
+    // Second run is a genuine no-op: the index already exists, so nothing changed.
+    final QueryStatistics s = statsOf(database, "CREATE INDEX IF NOT EXISTS FOR (w:Widget2) ON (w.code)");
+    assertThat(s.getIndexesAdded()).isZero();
+  }
+
+  @Test
+  void dropIndexCounts() {
+    database.command("opencypher", "CREATE (:Gadget {code:'a'})");
+    database.command("opencypher", "CREATE INDEX FOR (g:Gadget) ON (g.code)");
+
+    final Collection<TypeIndex> indexes = database.getSchema().getType("Gadget").getAllIndexes(false);
+    assertThat(indexes).isNotEmpty();
+    final String indexName = indexes.iterator().next().getName();
+
+    final QueryStatistics s = statsOf(database, "DROP INDEX `" + indexName + "`");
+    assertThat(s.getIndexesRemoved()).isEqualTo(1);
+    assertThat(s.containsUpdates()).isTrue();
+  }
+
+  @Test
+  void createConstraintCounts() {
+    final QueryStatistics s = statsOf(database, "CREATE CONSTRAINT FOR (p:Employee) REQUIRE p.id IS UNIQUE");
+    assertThat(s.getConstraintsAdded()).isEqualTo(1);
+    assertThat(s.containsUpdates()).isTrue();
+  }
+
+  @Test
+  void createConstraintIfNotExistsAlreadyPresentCountsZero() {
+    database.command("opencypher", "CREATE CONSTRAINT IF NOT EXISTS FOR (p:Employee2) REQUIRE p.id IS UNIQUE");
+    // Second run is a genuine no-op: the constraint already exists, so nothing changed.
+    final QueryStatistics s = statsOf(database, "CREATE CONSTRAINT IF NOT EXISTS FOR (p:Employee2) REQUIRE p.id IS UNIQUE");
+    assertThat(s.getConstraintsAdded()).isZero();
+  }
+
+  @Test
+  void dropConstraintCounts() {
+    database.getSchema().createVertexType("Manager");
+    database.getSchema().getType("Manager").createProperty("id", Type.STRING);
+    database.getSchema().buildTypeIndex("Manager", new String[] { "id" })
+        .withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withUnique(true)
+        .create();
+
+    final Collection<TypeIndex> indexes = database.getSchema().getType("Manager").getAllIndexes(false);
+    assertThat(indexes).isNotEmpty();
+    final String constraintName = indexes.iterator().next().getName();
+
+    final QueryStatistics s = statsOf(database, "DROP CONSTRAINT `" + constraintName + "`");
+    assertThat(s.getConstraintsRemoved()).isEqualTo(1);
+    assertThat(s.containsUpdates()).isTrue();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/QueryStatisticsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/QueryStatisticsTest.java
@@ -72,4 +72,16 @@ class QueryStatisticsTest {
     s.incNodesCreated();
     assertThat(snapshot.getNodesCreated()).isEqualTo(1);
   }
+
+  @Test
+  void copiedContextSharesStatisticsAccumulator() {
+    final BasicCommandContext ctx = new BasicCommandContext();
+    ctx.getStatistics().incNodesCreated();
+    final CommandContext copy = ctx.copy();
+    // The copy shares the same accumulator, so increments through it aggregate into one total
+    // instead of vanishing.
+    copy.getStatistics().incNodesCreated();
+    assertThat(copy.getStatistics()).isSameAs(ctx.getStatistics());
+    assertThat(ctx.getStatistics().getNodesCreated()).isEqualTo(2);
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/QueryStatisticsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/QueryStatisticsTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.arcadedb.query.sql.executor;
 
 import org.junit.jupiter.api.Test;

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/QueryStatisticsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/QueryStatisticsTest.java
@@ -1,0 +1,37 @@
+package com.arcadedb.query.sql.executor;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QueryStatisticsTest {
+  @Test
+  void freshInstanceHasNoUpdates() {
+    final QueryStatistics s = new QueryStatistics();
+    assertThat(s.containsUpdates()).isFalse();
+    assertThat(s.getNodesCreated()).isZero();
+  }
+
+  @Test
+  void incrementsAreTracked() {
+    final QueryStatistics s = new QueryStatistics();
+    s.incNodesCreated();
+    s.incNodesCreated();
+    s.incRelationshipsCreated();
+    s.addPropertiesSet(3);
+    s.addLabelsAdded(2);
+    assertThat(s.getNodesCreated()).isEqualTo(2);
+    assertThat(s.getRelationshipsCreated()).isEqualTo(1);
+    assertThat(s.getPropertiesSet()).isEqualTo(3);
+    assertThat(s.getLabelsAdded()).isEqualTo(2);
+    assertThat(s.containsUpdates()).isTrue();
+  }
+
+  @Test
+  void addingZeroPropertiesKeepsNoUpdatesWhenNothingElseChanged() {
+    final QueryStatistics s = new QueryStatistics();
+    s.addPropertiesSet(0);
+    s.addLabelsAdded(0);
+    assertThat(s.containsUpdates()).isFalse();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/QueryStatisticsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/QueryStatisticsTest.java
@@ -52,4 +52,24 @@ class QueryStatisticsTest {
     s.addLabelsAdded(0);
     assertThat(s.containsUpdates()).isFalse();
   }
+
+  @Test
+  void copyAndRestoreRollBackIncrements() {
+    final QueryStatistics s = new QueryStatistics();
+    s.incNodesCreated();
+    s.addPropertiesSet(2);
+    final QueryStatistics snapshot = s.copy();
+    // simulate a failed attempt that incremented further
+    s.incNodesCreated();
+    s.incRelationshipsCreated();
+    s.addPropertiesSet(5);
+    // roll back to the snapshot (as a retry would)
+    s.restore(snapshot);
+    assertThat(s.getNodesCreated()).isEqualTo(1);
+    assertThat(s.getRelationshipsCreated()).isZero();
+    assertThat(s.getPropertiesSet()).isEqualTo(2);
+    // copy is independent: mutating the original must not change the snapshot
+    s.incNodesCreated();
+    assertThat(snapshot.getNodesCreated()).isEqualTo(1);
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ResultSetStatisticsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ResultSetStatisticsTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.arcadedb.query.sql.executor;
 
 import org.junit.jupiter.api.Test;

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/ResultSetStatisticsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/ResultSetStatisticsTest.java
@@ -1,0 +1,25 @@
+package com.arcadedb.query.sql.executor;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ResultSetStatisticsTest {
+  @Test
+  void defaultResultSetHasNoStatistics() {
+    final IteratorResultSet rs = new IteratorResultSet(Collections.emptyIterator());
+    assertThat(rs.getStatistics()).isEmpty();
+  }
+
+  @Test
+  void attachedStatisticsAreReturned() {
+    final QueryStatistics stats = new QueryStatistics();
+    stats.incNodesCreated();
+    final IteratorResultSet rs = new IteratorResultSet(Collections.emptyIterator());
+    rs.setStatistics(stats);
+    assertThat(rs.getStatistics()).isPresent();
+    assertThat(rs.getStatistics().get().getNodesCreated()).isEqualTo(1);
+  }
+}


### PR DESCRIPTION
Closes #5000. Part of #4890 (Group C protocol/type-fidelity gaps), epic #4882 (Bolt Driver Compatibility Certification).

## Problem
`ResultSummary` counters (`nodesCreated`, `relationshipsCreated`, `propertiesSet`, ...) were never populated for Bolt write queries. Two layers were missing: (1) `BoltNetworkExecutor` built no `stats` map in the SUCCESS metadata, and (2) the native Cypher engine had no CRUD-counter tracking to source it from.

## Approach
A reusable, allocation-light engine capability, consumed by the Bolt layer:

- **`QueryStatistics`** - a mutable accumulator of primitive `int` counters (nodes/relationships created/deleted, properties-set, labels added/removed, indexes/constraints added/removed) with `containsUpdates()`.
- **`CommandContext.getStatistics()`** - lazily allocated, so pure read queries (`MATCH`/`RETURN`) never create one and take no new hot-path branch.
- **Mutation steps** (`CreateStep`, `SetStep`, `DeleteStep`, `MergeStep`, `RemoveStep`) increment the accumulator with Neo4j-compatible semantics; the DDL path (`OpenCypherQueryEngine.executeDDL`) counts index/constraint add/remove, guarded so `IF [NOT] EXISTS` no-ops don't over-count.
- **`ResultSet.getStatistics()`** - a new `default` method mirroring `getExecutionPlan()` (zero blast radius on other implementations); `CypherExecutionPlan.execute()` and `executeDDL()` attach the accumulator to the returned result set.
- **`BoltNetworkExecutor`** - `handlePull`/`handleDiscard` read it and emit a Neo4j hyphenated `stats` map (non-zero counters + `contains-updates`) on the terminal SUCCESS, only for writes.

Counters reflect the statement's work regardless of a later transaction rollback (Neo4j-correct).

## Conformance
Flips `RESULT-004` in `bolt/conformance/spec.yaml` from `expected-fail` to `passing`, and unwraps the expected-fail harness in all five per-language e2e suites (Java, JS, Python, Go, C#) so each asserts the real counters.

## Testing
- Engine unit tests (`QueryStatisticsTest`, `ResultSetStatisticsTest`, `CypherQueryStatisticsTest`): 21 cases covering CREATE/SET/DELETE/MERGE/REMOVE, `SET`/`REMOVE` label, `CREATE`/`DROP INDEX`/`CONSTRAINT`, distinct-label dedup, `SET n = {map}` replace semantics, absent-property removal (counts 0), and a read-query-allocates-nothing regression.
- Bolt IT (`Bolt5000ResultCountersIT`) via the real `neo4j-java-driver`: asserts `summary.counters()` for a write and no updates for a read.
- Cypher mutation + DDL regression subsets and the full `com.arcadedb.query.opencypher` package: green.
- Spec validator (`bolt/conformance/validate_spec.py`): 39 scenarios OK.

## Scope / follow-up
Scoped to the engine accumulator + Bolt consumption. Surfacing the same counters over HTTP `/command` and gRPC, aggregating counts across top-level `UNION` writes and `CALL { ... }` write subqueries (currently documented in-code as returning zero to the caller), and constraint-kind test coverage are tracked in #5015.

🤖 Generated with [Claude Code](https://claude.com/claude-code)