### PR TITLE
fix(ha): reconstruct exact leader exception type on forwarded commands

### DIFF
--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -50,9 +50,15 @@ import com.arcadedb.engine.TransactionManager;
 import com.arcadedb.engine.WALFile;
 import com.arcadedb.engine.WALFileFactory;
 import com.arcadedb.exception.ArcadeDBException;
+import com.arcadedb.exception.CommandExecutionException;
+import com.arcadedb.exception.CommandParsingException;
 import com.arcadedb.exception.DuplicatedKeyException;
+import com.arcadedb.exception.LockTimeoutException;
 import com.arcadedb.exception.NeedRetryException;
+import com.arcadedb.exception.SchemaException;
+import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.exception.TransactionException;
+import com.arcadedb.exception.ValidationException;
 import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.GraphBatch;
 import com.arcadedb.graph.GraphEngine;
@@ -100,6 +106,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 
@@ -1760,11 +1767,39 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
   }
 
   /**
+   * Registry of leader-side exception class names to a factory that rebuilds the same type from its
+   * message. Reconstructing the exact type (rather than collapsing to a common supertype) preserves
+   * retry semantics for callers: a {@link com.arcadedb.exception.ConcurrentModificationException} or
+   * {@link LockTimeoutException} stays a {@link NeedRetryException} subtype and therefore retryable,
+   * while a non-retryable {@link TimeoutException} stays distinct instead of being mistaken for a
+   * retryable one. It also lets callers catch the specific type directly.
+   * <p>
+   * Only exceptions with a single {@code (String)} constructor belong here; types that need
+   * structured arguments (e.g. {@link DuplicatedKeyException}) are reconstructed explicitly in
+   * {@link #reconstructLeaderException}. New entries are safe to add as one line each; extending
+   * this map is preferred over reflectively instantiating an arbitrary class name from the response.
+   * <p>
+   * ArcadeDB's {@code ConcurrentModificationException} is referenced by its fully qualified name
+   * because this file imports {@link java.util.ConcurrentModificationException}.
+   */
+  private static final Map<String, Function<String, RuntimeException>> LEADER_EXCEPTION_FACTORIES = Map.of(
+      NeedRetryException.class.getName(), NeedRetryException::new,
+      com.arcadedb.exception.ConcurrentModificationException.class.getName(), com.arcadedb.exception.ConcurrentModificationException::new,
+      LockTimeoutException.class.getName(), LockTimeoutException::new,
+      TimeoutException.class.getName(), TimeoutException::new,
+      TransactionException.class.getName(), TransactionException::new,
+      CommandExecutionException.class.getName(), CommandExecutionException::new,
+      CommandParsingException.class.getName(), CommandParsingException::new,
+      ValidationException.class.getName(), ValidationException::new,
+      SchemaException.class.getName(), SchemaException::new);
+
+  /**
    * Parses the JSON error body returned by the leader and reconstructs the original exception so
    * the Follower throws the same type the Leader would have thrown locally. For example, a
    * {@link DuplicatedKeyException} is reconstructed with its index name, keys, and existing RID so
    * callers can catch it directly instead of having to inspect a generic
-   * {@link TransactionException} message string.
+   * {@link TransactionException} message string. Other known types are reconstructed via
+   * {@link #LEADER_EXCEPTION_FACTORIES} to keep their exact type (and retry semantics).
    * <p>
    * If the body is non-JSON, empty, or the exception class is not recognised, a generic
    * {@link TransactionException} wrapping the full response body is returned as a safe fallback.
@@ -1789,6 +1824,8 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     if (exceptionClass == null)
       return new TransactionException(message);
 
+    // DuplicatedKeyException carries structured args (index name, keys, existing RID), so it is
+    // reconstructed explicitly rather than from a plain message.
     if (DuplicatedKeyException.class.getName().equals(exceptionClass) && exceptionArgs != null) {
       final String[] parts = exceptionArgs.split("\\|", 3);
       if (parts.length == 3)
@@ -1799,12 +1836,9 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
         }
     }
 
-    if (NeedRetryException.class.getName().equals(exceptionClass)
-        || "com.arcadedb.exception.ConcurrentModificationException".equals(exceptionClass))
-      return new NeedRetryException(detail != null ? detail : message);
-
-    if (TransactionException.class.getName().equals(exceptionClass))
-      return new TransactionException(detail != null ? detail : message);
+    final Function<String, RuntimeException> factory = LEADER_EXCEPTION_FACTORIES.get(exceptionClass);
+    if (factory != null)
+      return factory.apply(detail != null ? detail : message);
 
     return new TransactionException(message);
   }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -52,9 +52,12 @@ import com.arcadedb.engine.WALFileFactory;
 import com.arcadedb.exception.ArcadeDBException;
 import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.CommandParsingException;
+import com.arcadedb.exception.CommandSQLParsingException;
+import com.arcadedb.exception.CommandSemanticException;
 import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.exception.LockTimeoutException;
 import com.arcadedb.exception.NeedRetryException;
+import com.arcadedb.exception.QueryNotIdempotentException;
 import com.arcadedb.exception.SchemaException;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.exception.TransactionException;
@@ -156,24 +159,31 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * while a non-retryable {@link TimeoutException} stays distinct instead of being mistaken for a
    * retryable one. It also lets callers catch the specific type directly.
    * <p>
-   * Only exceptions with a single {@code (String)} constructor belong here; types that need
-   * structured arguments (e.g. {@link DuplicatedKeyException}) are reconstructed explicitly in
-   * {@link #reconstructLeaderException}. New entries are safe to add as one line each; extending
-   * this map is preferred over reflectively instantiating an arbitrary class name from the response.
+   * Only {@link ArcadeDBException} subtypes with a single {@code (String)} constructor belong here:
+   * non-{@code ArcadeDBException} types (e.g. {@code SecurityException}) would not be caught by the
+   * {@code catch (ArcadeDBException)} on the forwarding path and would be re-wrapped anyway, and
+   * types that need structured arguments (e.g. {@link DuplicatedKeyException}) are reconstructed
+   * explicitly in {@link #reconstructLeaderException}. New entries are safe to add as one line each;
+   * extending this map is preferred over reflectively instantiating an arbitrary class name from the
+   * response. {@link Map#ofEntries} is used (rather than {@link Map#of}) because the latter caps at
+   * ten pairs.
    * <p>
    * ArcadeDB's {@code ConcurrentModificationException} is referenced by its fully qualified name
    * because this file imports {@link java.util.ConcurrentModificationException}.
    */
-  private static final Map<String, Function<String, RuntimeException>> LEADER_EXCEPTION_FACTORIES = Map.of(
-      NeedRetryException.class.getName(), NeedRetryException::new,
-      com.arcadedb.exception.ConcurrentModificationException.class.getName(), com.arcadedb.exception.ConcurrentModificationException::new,
-      LockTimeoutException.class.getName(), LockTimeoutException::new,
-      TimeoutException.class.getName(), TimeoutException::new,
-      TransactionException.class.getName(), TransactionException::new,
-      CommandExecutionException.class.getName(), CommandExecutionException::new,
-      CommandParsingException.class.getName(), CommandParsingException::new,
-      ValidationException.class.getName(), ValidationException::new,
-      SchemaException.class.getName(), SchemaException::new);
+  private static final Map<String, Function<String, RuntimeException>> LEADER_EXCEPTION_FACTORIES = Map.ofEntries(
+      Map.entry(NeedRetryException.class.getName(), NeedRetryException::new),
+      Map.entry(com.arcadedb.exception.ConcurrentModificationException.class.getName(), com.arcadedb.exception.ConcurrentModificationException::new),
+      Map.entry(LockTimeoutException.class.getName(), LockTimeoutException::new),
+      Map.entry(TimeoutException.class.getName(), TimeoutException::new),
+      Map.entry(TransactionException.class.getName(), TransactionException::new),
+      Map.entry(CommandExecutionException.class.getName(), CommandExecutionException::new),
+      Map.entry(CommandParsingException.class.getName(), CommandParsingException::new),
+      Map.entry(CommandSQLParsingException.class.getName(), CommandSQLParsingException::new),
+      Map.entry(CommandSemanticException.class.getName(), CommandSemanticException::new),
+      Map.entry(QueryNotIdempotentException.class.getName(), QueryNotIdempotentException::new),
+      Map.entry(ValidationException.class.getName(), ValidationException::new),
+      Map.entry(SchemaException.class.getName(), SchemaException::new));
 
   /** Poll cadence while waiting for a leader to be (re)elected before forwarding a write (issue #4728 follow-up). */
   private static final long LEADER_WAIT_POLL_INTERVAL_MS = 100;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -147,6 +147,34 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
 
   private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
 
+  /**
+   * Registry of leader-side exception class names to a factory that rebuilds the same type from its
+   * message, used by {@link #reconstructLeaderException} on forwarded-command errors. Reconstructing
+   * the exact type (rather than collapsing to a common supertype) preserves retry semantics for
+   * callers: a {@link com.arcadedb.exception.ConcurrentModificationException} or
+   * {@link LockTimeoutException} stays a {@link NeedRetryException} subtype and therefore retryable,
+   * while a non-retryable {@link TimeoutException} stays distinct instead of being mistaken for a
+   * retryable one. It also lets callers catch the specific type directly.
+   * <p>
+   * Only exceptions with a single {@code (String)} constructor belong here; types that need
+   * structured arguments (e.g. {@link DuplicatedKeyException}) are reconstructed explicitly in
+   * {@link #reconstructLeaderException}. New entries are safe to add as one line each; extending
+   * this map is preferred over reflectively instantiating an arbitrary class name from the response.
+   * <p>
+   * ArcadeDB's {@code ConcurrentModificationException} is referenced by its fully qualified name
+   * because this file imports {@link java.util.ConcurrentModificationException}.
+   */
+  private static final Map<String, Function<String, RuntimeException>> LEADER_EXCEPTION_FACTORIES = Map.of(
+      NeedRetryException.class.getName(), NeedRetryException::new,
+      com.arcadedb.exception.ConcurrentModificationException.class.getName(), com.arcadedb.exception.ConcurrentModificationException::new,
+      LockTimeoutException.class.getName(), LockTimeoutException::new,
+      TimeoutException.class.getName(), TimeoutException::new,
+      TransactionException.class.getName(), TransactionException::new,
+      CommandExecutionException.class.getName(), CommandExecutionException::new,
+      CommandParsingException.class.getName(), CommandParsingException::new,
+      ValidationException.class.getName(), ValidationException::new,
+      SchemaException.class.getName(), SchemaException::new);
+
   /** Poll cadence while waiting for a leader to be (re)elected before forwarding a write (issue #4728 follow-up). */
   private static final long LEADER_WAIT_POLL_INTERVAL_MS = 100;
 
@@ -1765,33 +1793,6 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
 
     return resultSet;
   }
-
-  /**
-   * Registry of leader-side exception class names to a factory that rebuilds the same type from its
-   * message. Reconstructing the exact type (rather than collapsing to a common supertype) preserves
-   * retry semantics for callers: a {@link com.arcadedb.exception.ConcurrentModificationException} or
-   * {@link LockTimeoutException} stays a {@link NeedRetryException} subtype and therefore retryable,
-   * while a non-retryable {@link TimeoutException} stays distinct instead of being mistaken for a
-   * retryable one. It also lets callers catch the specific type directly.
-   * <p>
-   * Only exceptions with a single {@code (String)} constructor belong here; types that need
-   * structured arguments (e.g. {@link DuplicatedKeyException}) are reconstructed explicitly in
-   * {@link #reconstructLeaderException}. New entries are safe to add as one line each; extending
-   * this map is preferred over reflectively instantiating an arbitrary class name from the response.
-   * <p>
-   * ArcadeDB's {@code ConcurrentModificationException} is referenced by its fully qualified name
-   * because this file imports {@link java.util.ConcurrentModificationException}.
-   */
-  private static final Map<String, Function<String, RuntimeException>> LEADER_EXCEPTION_FACTORIES = Map.of(
-      NeedRetryException.class.getName(), NeedRetryException::new,
-      com.arcadedb.exception.ConcurrentModificationException.class.getName(), com.arcadedb.exception.ConcurrentModificationException::new,
-      LockTimeoutException.class.getName(), LockTimeoutException::new,
-      TimeoutException.class.getName(), TimeoutException::new,
-      TransactionException.class.getName(), TransactionException::new,
-      CommandExecutionException.class.getName(), CommandExecutionException::new,
-      CommandParsingException.class.getName(), CommandParsingException::new,
-      ValidationException.class.getName(), ValidationException::new,
-      SchemaException.class.getName(), SchemaException::new);
 
   /**
    * Parses the JSON error body returned by the leader and reconstructs the original exception so

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabaseTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabaseTest.java
@@ -20,8 +20,11 @@ package com.arcadedb.server.ha.raft;
 
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
+import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.exception.DuplicatedKeyException;
+import com.arcadedb.exception.LockTimeoutException;
 import com.arcadedb.exception.NeedRetryException;
+import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.exception.TransactionException;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
@@ -124,8 +127,40 @@ class RaftReplicatedDatabaseTest {
 
     final RuntimeException result = RaftReplicatedDatabase.reconstructLeaderException(503, body);
 
+    // Reconstructed as the exact type, not collapsed to its NeedRetryException supertype, so a
+    // caller catching ConcurrentModificationException specifically still matches.
+    assertThat(result).isInstanceOf(ConcurrentModificationException.class);
     assertThat(result).isInstanceOf(NeedRetryException.class);
     assertThat(result.getMessage()).isEqualTo("Concurrent modification detected");
+  }
+
+  @Test
+  void reconstructLeaderExceptionLockTimeoutIsRetryable() {
+    final String body = "{\"error\":\"Cannot execute command\","
+        + "\"detail\":\"Timeout on acquiring lock\","
+        + "\"exception\":\"com.arcadedb.exception.LockTimeoutException\"}";
+
+    final RuntimeException result = RaftReplicatedDatabase.reconstructLeaderException(503, body);
+
+    // LockTimeoutException extends NeedRetryException: it must stay retryable on the Follower.
+    assertThat(result).isInstanceOf(LockTimeoutException.class);
+    assertThat(result).isInstanceOf(NeedRetryException.class);
+    assertThat(result.getMessage()).isEqualTo("Timeout on acquiring lock");
+  }
+
+  @Test
+  void reconstructLeaderExceptionTimeoutIsNotRetryable() {
+    final String body = "{\"error\":\"Cannot execute command\","
+        + "\"detail\":\"Query timeout\","
+        + "\"exception\":\"com.arcadedb.exception.TimeoutException\"}";
+
+    final RuntimeException result = RaftReplicatedDatabase.reconstructLeaderException(500, body);
+
+    // A plain (query-deadline) TimeoutException is NOT retryable and must not become a
+    // NeedRetryException, otherwise callers would wrongly retry it.
+    assertThat(result).isInstanceOf(TimeoutException.class);
+    assertThat(result).isNotInstanceOf(NeedRetryException.class);
+    assertThat(result.getMessage()).isEqualTo("Query timeout");
   }
 
   @Test

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabaseTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabaseTest.java
@@ -20,10 +20,13 @@ package com.arcadedb.server.ha.raft;
 
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.RID;
+import com.arcadedb.exception.CommandParsingException;
+import com.arcadedb.exception.CommandSQLParsingException;
 import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.exception.LockTimeoutException;
 import com.arcadedb.exception.NeedRetryException;
+import com.arcadedb.exception.QueryNotIdempotentException;
 import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.exception.TransactionException;
 import com.arcadedb.query.sql.executor.Result;
@@ -161,6 +164,32 @@ class RaftReplicatedDatabaseTest {
     assertThat(result).isInstanceOf(TimeoutException.class);
     assertThat(result).isNotInstanceOf(NeedRetryException.class);
     assertThat(result.getMessage()).isEqualTo("Query timeout");
+  }
+
+  @Test
+  void reconstructLeaderExceptionSqlParsingKeepsSubtype() {
+    final String body = "{\"error\":\"Error on parsing query\","
+        + "\"detail\":\"Syntax error near 'SELCT'\","
+        + "\"exception\":\"com.arcadedb.exception.CommandSQLParsingException\"}";
+
+    final RuntimeException result = RaftReplicatedDatabase.reconstructLeaderException(500, body);
+
+    // Reconstructed as the exact subtype, so a caller catching CommandParsingException matches too.
+    assertThat(result).isInstanceOf(CommandSQLParsingException.class);
+    assertThat(result).isInstanceOf(CommandParsingException.class);
+    assertThat(result.getMessage()).isEqualTo("Syntax error near 'SELCT'");
+  }
+
+  @Test
+  void reconstructLeaderExceptionQueryNotIdempotent() {
+    final String body = "{\"error\":\"Cannot execute command\","
+        + "\"detail\":\"Query is not idempotent\","
+        + "\"exception\":\"com.arcadedb.exception.QueryNotIdempotentException\"}";
+
+    final RuntimeException result = RaftReplicatedDatabase.reconstructLeaderException(500, body);
+
+    assertThat(result).isInstanceOf(QueryNotIdempotentException.class);
+    assertThat(result.getMessage()).isEqualTo("Query is not idempotent");
   }
 
   @Test


### PR DESCRIPTION
Follow-up to #5014 (customer report: exceptions from the Leader not propagated as their real type on forwarded commands).

#5014 reconstructs a handful of leader-side exceptions on the Follower, but collapses retryable subtypes onto their `NeedRetryException` supertype. A caller doing `catch (ConcurrentModificationException)` (the specific subtype) would then miss it, and - more importantly - the retryable/non-retryable timeout distinction was lost.

## What this does

`RaftReplicatedDatabase.reconstructLeaderException` now rebuilds the **exact** leader-side type via an explicit registry (`LEADER_EXCEPTION_FACTORIES`) instead of an if-chain that flattens types:

- `ConcurrentModificationException` is reconstructed as itself (still a `NeedRetryException` subtype, so retry logic is unchanged) so specific-type catches match.
- `LockTimeoutException` (retryable) and `TimeoutException` (**non-retryable**) are kept distinct - a query-deadline `TimeoutException` must not be turned into something retryable.
- Common command types (`CommandExecutionException`, `CommandParsingException`, `ValidationException`, `SchemaException`) are reconstructed faithfully too.
- `DuplicatedKeyException` keeps its structured 3-arg reconstruction; unknown classes still fall back to `TransactionException`.
- **No reflection** - the registry map is a safe, one-line-per-type extension point (avoids instantiating an arbitrary class name from a network response).

ArcadeDB's `ConcurrentModificationException` is referenced by FQN in the map because this file imports `java.util.ConcurrentModificationException`.

## Tests

`RaftReplicatedDatabaseTest`: strengthened the CME test to assert the exact type, added `reconstructLeaderExceptionLockTimeoutIsRetryable` and `reconstructLeaderExceptionTimeoutIsNotRetryable`. 16 tests, all passing.

```
Tests run: 16, Failures: 0, Errors: 0, Skipped: 0 -- in com.arcadedb.server.ha.raft.RaftReplicatedDatabaseTest
```

## Note (not addressed here)

`RaftReplicatedDatabase` line ~390 does `if (e instanceof ConcurrentModificationException)` where the name resolves to the **JDK** `java.util` type (via the existing import), while the engine throws ArcadeDB's `com.arcadedb.exception.ConcurrentModificationException` for page-version conflicts. That may be a latent dead branch in the phase-2 "step down" log path - unrelated to this change, flagged for a separate look.