### PR TITLE
fix(#4926,#4934): torn-write repair on recovery; fsync-gated WAL dele…

### DIFF
--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -181,6 +181,16 @@ that could starve the very snapshot resync meant to heal the node.
   database close now fails with the intended "Async executor has been shut down" error instead of a raw
   NullPointerException ([#4955](https://github.com/ArcadeData/arcadedb/issues/4955)).
 
+- **WAL/recovery correctness (2026-07 audit).** Recovery now RE-APPLIES a WAL delta whose version equals
+  the on-disk page version, repairing a torn page write (a 64KB flush spans many sectors; a power loss can
+  persist the new version header while the delta sectors still hold the previous content - the old `<=`
+  skip declared such a page "already applied" and left it silently corrupt despite an intact WAL,
+  [#4926](https://github.com/ArcadeData/arcadedb/issues/4926)). A clean close whose data fsync failed now
+  preserves the WAL and the lock file for recovery instead of deleting them (after a failed fsync the OS
+  may have dropped the dirty pages, so the WAL held the only durable copy;
+  [#4934](https://github.com/ArcadeData/arcadedb/issues/4934) - the runtime WAL rotation also skips its
+  drop pass when the pre-drop fsync fails).
+
 ### Improvements
 
 - **HA: throttled diverged-follower resync logging.** When a follower detects a WAL page-version gap it

--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -185,7 +185,10 @@ that could starve the very snapshot resync meant to heal the node.
   the on-disk page version, repairing a torn page write (a 64KB flush spans many sectors; a power loss can
   persist the new version header while the delta sectors still hold the previous content - the old `<=`
   skip declared such a page "already applied" and left it silently corrupt despite an intact WAL,
-  [#4926](https://github.com/ArcadeData/arcadedb/issues/4926)). A clean close whose data fsync failed now
+  [#4926](https://github.com/ArcadeData/arcadedb/issues/4926); known limitation: async flush can coalesce
+  several committed versions into one physical write, and only the newest version's region is repaired -
+  fully closing the multi-version case needs per-page checksums to detect which pages are torn, tracked in
+  [#5054](https://github.com/ArcadeData/arcadedb/issues/5054)). A clean close whose data fsync failed now
   preserves the WAL and the lock file for recovery instead of deleting them (after a failed fsync the OS
   may have dropped the dirty pages, so the WAL held the only durable copy;
   [#4934](https://github.com/ArcadeData/arcadedb/issues/4934) - the runtime WAL rotation also skips its

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -2065,12 +2065,13 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
       // deleting the only durable copy of them.
       boolean dataSafeOnDisk = PageManager.INSTANCE.waitAllPagesOfDatabaseAreFlushed(this);
 
-      if (!drop && !fileManager.syncFiles())
+      if (!drop && !fileManager.syncFiles()) {
         // #4934: the fsync failed, so the OS may have dropped the dirty pages (fsyncgate semantics) - the
         // pages the wait above considered flushed may never reach the platter. Deleting the WAL below would
         // then make the committed data unrecoverable after a power loss, with only a log line as evidence.
         // Treat the close as crash-equivalent instead: preserve WAL + lock file, recover on next open.
         dataSafeOnDisk = false;
+      }
 
       final boolean preserveWalForRecovery = !dataSafeOnDisk && !drop;
 

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -2063,11 +2063,16 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
       // CRASH-EQUIVALENT: the WAL files and the lock file are preserved below, so the next open runs
       // recovery and replays the pages that never reached the disk, instead of this close silently
       // deleting the only durable copy of them.
-      final boolean allPagesFlushed = PageManager.INSTANCE.waitAllPagesOfDatabaseAreFlushed(this);
-      final boolean preserveWalForRecovery = !allPagesFlushed && !drop;
+      boolean dataSafeOnDisk = PageManager.INSTANCE.waitAllPagesOfDatabaseAreFlushed(this);
 
-      if (!drop)
-        fileManager.syncFiles();
+      if (!drop && !fileManager.syncFiles())
+        // #4934: the fsync failed, so the OS may have dropped the dirty pages (fsyncgate semantics) - the
+        // pages the wait above considered flushed may never reach the platter. Deleting the WAL below would
+        // then make the committed data unrecoverable after a power loss, with only a log line as evidence.
+        // Treat the close as crash-equivalent instead: preserve WAL + lock file, recover on next open.
+        dataSafeOnDisk = false;
+
+      final boolean preserveWalForRecovery = !dataSafeOnDisk && !drop;
 
       open = false;
 

--- a/engine/src/main/java/com/arcadedb/engine/FileManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/FileManager.java
@@ -177,18 +177,26 @@ public class FileManager {
     recordedChanges = null;
   }
 
-  public void syncFiles() {
+  /**
+   * @return {@code true} when every file was fsynced; {@code false} when any fsync failed (#4934). After a
+   *     failed fsync the OS may have DROPPED the dirty pages (fsyncgate semantics), so the callers that were
+   *     about to delete the WAL protecting that data must preserve it instead: the clean-close path keeps
+   *     the WAL and the lock file so the next open recovers, and the runtime WAL-rotation path skips the
+   *     drop and retries on the next pass.
+   */
+  public boolean syncFiles() {
+    boolean allSynced = true;
     for (final ComponentFile f : fileNameMap.values()) {
       if (f instanceof PaginatedComponentFile pcf) {
         try {
           pcf.force(true);
         } catch (final IOException e) {
-          // Log at SEVERE: the caller proceeds to delete WAL files, so a failed fsync here
-          // leaves committed data unrecoverable on a subsequent OS crash.
           LogManager.instance().log(this, Level.SEVERE, "Error on syncing file '%s' to disk", e, f.getFileName());
+          allSynced = false;
         }
       }
     }
+    return allSynced;
   }
 
   public synchronized void close() {

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -461,17 +461,23 @@ public class TransactionManager {
             .log(this, Level.FINE, "-- checking page %s versionInLog=%d versionInDB=%d", null, pageId, txPage.currentPageVersion,
                 page.getVersion());
 
-        if (txPage.currentPageVersion <= page.getVersion()) {
-          // Always skip already-applied pages instead of aborting the entire transaction.
-          // During Raft state machine replay or crash recovery, a partial apply may have
-          // written some pages but not others. Skipping only the already-applied pages
-          // (instead of throwing ConcurrentModificationException and aborting the loop)
-          // ensures the remaining un-applied pages in the same transaction are still processed.
-          // This prevents version-gap cascades where skipping a multi-page transaction leaves
-          // some pages behind, causing WALVersionGapException on all subsequent transactions
-          // that touch those pages.
+        if (txPage.currentPageVersion < page.getVersion()) {
+          // Always skip OLDER pages instead of aborting the entire transaction. During Raft state machine
+          // replay or crash recovery, a partial apply may have written some pages but not others. Skipping
+          // only the superseded pages (instead of throwing ConcurrentModificationException and aborting the
+          // loop) ensures the remaining un-applied pages in the same transaction are still processed. This
+          // prevents version-gap cascades where skipping a multi-page transaction leaves some pages behind,
+          // causing WALVersionGapException on all subsequent transactions that touch those pages.
+          //
+          // #4926: STRICTLY older only - the equal-version case falls through and RE-APPLIES the delta. A
+          // 64KB page flush is many disk sectors and the version header lives in sector 0: a torn write at
+          // power loss can persist the new version header while the delta sectors still hold the previous
+          // content. The old `<=` skip declared such a page "already applied" and left it silently corrupt
+          // (new version, old bytes) despite an intact WAL. Re-applying at equal version is idempotent (the
+          // WAL delta carries absolute bytes for exactly this version) and repairs the torn state; skipping
+          // a STRICTLY older entry remains required, because its delta would overwrite newer content.
           LogManager.instance().log(this, Level.FINE,
-              "Skipping already-applied page %s (log v.%d <= db v.%d)", null,
+              "Skipping superseded page %s (log v.%d < db v.%d)", null,
               pageId, txPage.currentPageVersion, page.getVersion());
           continue;
         }
@@ -866,7 +872,10 @@ public class TransactionManager {
             // Make the data pages durable before the WAL that protects them is deleted. fsync once, lazily,
             // right before the first WAL file is actually dropped in this pass (issue #4509).
             if (syncDataOnDrop && !dataSynced) {
-              database.getFileManager().syncFiles();
+              if (!database.getFileManager().syncFiles())
+                // #4934: the fsync failed - the data this WAL protects may never reach the disk. Dropping
+                // the WAL now would make it unrecoverable; abort this pass, the rotation retries later.
+                return false;
               dataSynced = true;
             }
             file.drop();

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -476,6 +476,17 @@ public class TransactionManager {
           // (new version, old bytes) despite an intact WAL. Re-applying at equal version is idempotent (the
           // WAL delta carries absolute bytes for exactly this version) and repairs the torn state; skipping
           // a STRICTLY older entry remains required, because its delta would overwrite newer content.
+          //
+          // KNOWN LIMITATION (multi-version accumulation): async flush coalesces several committed versions
+          // into a single physical page write, so a page can jump v1(on-disk) -> v2 -> v3 -> v4 with only the
+          // v4 flush hitting the platter. If THAT flush tears, only v4's delta region is repaired here; the
+          // regions changed by v2/v3 (skipped as strictly-older) can stay torn. The version header alone
+          // cannot tell a torn page from an intact one, so detecting which pages need the older deltas
+          // re-applied needs a per-page checksum (the longer-term fix noted in #4926, tracked in #5054); an
+          // unconditional
+          // in-order replay of every entry <= disk version would repair it but changes the recovery
+          // semantics that also govern the version-gap/forceApply paths, out of scope here. This fix still
+          // strictly improves on `<=` (which repaired nothing) and fully covers the single-flush case.
           LogManager.instance().log(this, Level.FINE,
               "Skipping superseded page %s (log v.%d < db v.%d)", null,
               pageId, txPage.currentPageVersion, page.getVersion());
@@ -872,10 +883,11 @@ public class TransactionManager {
             // Make the data pages durable before the WAL that protects them is deleted. fsync once, lazily,
             // right before the first WAL file is actually dropped in this pass (issue #4509).
             if (syncDataOnDrop && !dataSynced) {
-              if (!database.getFileManager().syncFiles())
+              if (!database.getFileManager().syncFiles()) {
                 // #4934: the fsync failed - the data this WAL protects may never reach the disk. Dropping
                 // the WAL now would make it unrecoverable; abort this pass, the rotation retries later.
                 return false;
+              }
               dataSynced = true;
             }
             file.drop();

--- a/engine/src/test/java/com/arcadedb/engine/WalRecoveryCorrectnessTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/WalRecoveryCorrectnessTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.RandomAccessFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * WAL/recovery correctness tests.
+ * <p>
+ * #4926: a 64KB page flush spans many disk sectors and the MVCC version header lives in sector 0. A torn
+ * write at power loss can persist the NEW version header while the delta sectors still hold the PREVIOUS
+ * content. Recovery's old {@code <=} skip declared such a page "already applied" and left it silently
+ * corrupt (new version, old bytes) despite an intact, fully-fsynced WAL - undetectable, since every later
+ * MVCC check accepts the page. The equal-version case must RE-APPLY the delta (idempotent when the page is
+ * intact, repairing when it is torn).
+ */
+class WalRecoveryCorrectnessTest {
+
+  private static final String DB_PATH = "target/databases/WalRecoveryCorrectnessTest";
+
+  @AfterEach
+  void cleanup() {
+    final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
+    try {
+      if (factory.exists())
+        factory.open().drop();
+    } catch (final Exception e) {
+      // A test may deliberately leave the database unreopenable (broken file): remove it on disk below.
+    }
+    factory.close();
+    FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+  @Test
+  void tornPageWriteIsRepairedByWalReplayAtEqualVersion() throws Exception {
+    final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
+    if (factory.exists())
+      factory.open().drop();
+
+    String bucketFilePath;
+    // 1. Create the row and make sure its page (v1) is fully on disk.
+    {
+      final DatabaseInternal db = (DatabaseInternal) factory.create();
+      db.getSchema().createDocumentType("Doc");
+      db.transaction(() -> db.newDocument("Doc").set("v", "A").save());
+      db.getPageManager().waitAllPagesOfDatabaseAreFlushed(db);
+
+      final PaginatedComponent bucket = (PaginatedComponent) db.getSchema().getType("Doc").getBuckets(false).getFirst();
+      bucketFilePath = db.getFileManager().getFile(bucket.getFileId()).getFilePath();
+
+      // 2. Commit the update to 'B' (bumping the page to v2, WAL entry written) but make sure the DATA page
+      // never reaches the disk: flushing is suspended, then the database is killed (crash simulation that
+      // preserves the WAL and the lock file, purging the pending flush).
+      PageManager.INSTANCE.getFlushThread().setSuspended(db, true);
+      db.transaction(() -> db.query("sql", "SELECT FROM Doc").next().getRecord().get().asDocument().modify()
+          .set("v", "B").save());
+      ((LocalDatabase) db).kill();
+      // close() on a killed instance only unregisters it from the factory (WAL and lock file survive):
+      // same pattern as ACIDTransactionTest's kill-then-reopen flows.
+      db.close();
+    }
+
+    // 3. Forge the TORN write: the disk page still holds the v1 content ('A'), but the version header
+    // (bytes 0-3 of the page, the first sector a torn flush can persist alone) claims v2.
+    try (final RandomAccessFile raf = new RandomAccessFile(bucketFilePath, "rw")) {
+      raf.seek(0);
+      final int diskVersion = raf.readInt();
+      assertThat(diskVersion).as("the update's page must not have reached the disk").isEqualTo(1);
+      raf.seek(0);
+      raf.writeInt(2);
+    }
+
+    // 4. Reopen: the lock file triggers recovery, the WAL holds the v2 delta, the disk page SAYS v2 but
+    // still contains the v1 bytes. Replay must repair it - the old <= skip left 'A' behind forever.
+    final Database reopened = factory.open();
+    try {
+      assertThat(reopened.query("sql", "SELECT v FROM Doc").next().<String>getProperty("v"))
+          .as("recovery must re-apply the equal-version WAL delta and repair the torn page (#4926)")
+          .isEqualTo("B");
+    } finally {
+      reopened.close();
+      factory.close();
+    }
+  }
+
+  @Test
+  void cleanCloseAfterFailedFsyncPreservesWal() throws Exception {
+    // #4934: if the pre-close data fsync fails, the OS may have dropped the dirty pages (fsyncgate
+    // semantics), yet close() used to delete every WAL file anyway - making the committed data
+    // unrecoverable after a power loss, with only a SEVERE log line as evidence. A failed fsync must make
+    // the close crash-equivalent: WAL and lock file preserved for recovery on the next open.
+    final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
+    if (factory.exists())
+      factory.open().drop();
+
+    final DatabaseInternal db = (DatabaseInternal) factory.create();
+    db.getSchema().createDocumentType("Doc");
+    db.transaction(() -> db.newDocument("Doc").set("v", 1).save());
+
+    // Break one file so its fsync fails: channel closed underneath + OS file deleted, so the #4930 reopen
+    // guard surfaces the failure from force() instead of silently re-creating the dropped file.
+    final PaginatedComponent bucket = (PaginatedComponent) db.getSchema().getType("Doc").getBuckets(false).getFirst();
+    final PaginatedComponentFile file = (PaginatedComponentFile) db.getFileManager().getFile(bucket.getFileId());
+    db.getPageManager().waitAllPagesOfDatabaseAreFlushed(db);
+    final java.lang.reflect.Field channelField = PaginatedComponentFile.class.getDeclaredField("channel");
+    channelField.setAccessible(true);
+    ((java.nio.channels.FileChannel) channelField.get(file)).close();
+    assertThat(new File(file.getFilePath()).delete()).isTrue();
+
+    db.close();
+
+    final File dbDir = new File(DB_PATH);
+    assertThat(dbDir.listFiles((d, n) -> n.endsWith(".wal")))
+        .as("the WAL must survive a close whose data fsync failed (#4934)").isNotEmpty();
+    assertThat(new File(dbDir, "database.lck"))
+        .as("the lock file must be preserved so the next open runs recovery (#4934)").exists();
+  }
+
+
+}

--- a/engine/src/test/java/com/arcadedb/engine/WalRecoveryCorrectnessTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/WalRecoveryCorrectnessTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.RandomAccessFile;
+import java.lang.reflect.Field;
+import java.nio.channels.FileChannel;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -78,7 +80,8 @@ class WalRecoveryCorrectnessTest {
       // 2. Commit the update to 'B' (bumping the page to v2, WAL entry written) but make sure the DATA page
       // never reaches the disk: flushing is suspended, then the database is killed (crash simulation that
       // preserves the WAL and the lock file, purging the pending flush).
-      PageManager.INSTANCE.getFlushThread().setSuspended(db, true);
+      assertThat(PageManager.INSTANCE.getFlushThread().setSuspended(db, true))
+          .as("flush suspension must engage or the page could reach disk, invalidating the test").isTrue();
       db.transaction(() -> db.query("sql", "SELECT FROM Doc").next().getRecord().get().asDocument().modify()
           .set("v", "B").save());
       ((LocalDatabase) db).kill();
@@ -129,9 +132,9 @@ class WalRecoveryCorrectnessTest {
     final PaginatedComponent bucket = (PaginatedComponent) db.getSchema().getType("Doc").getBuckets(false).getFirst();
     final PaginatedComponentFile file = (PaginatedComponentFile) db.getFileManager().getFile(bucket.getFileId());
     db.getPageManager().waitAllPagesOfDatabaseAreFlushed(db);
-    final java.lang.reflect.Field channelField = PaginatedComponentFile.class.getDeclaredField("channel");
+    final Field channelField = PaginatedComponentFile.class.getDeclaredField("channel");
     channelField.setAccessible(true);
-    ((java.nio.channels.FileChannel) channelField.get(file)).close();
+    ((FileChannel) channelField.get(file)).close();
     assertThat(new File(file.getFilePath()).delete()).isTrue();
 
     db.close();
@@ -142,6 +145,4 @@ class WalRecoveryCorrectnessTest {
     assertThat(new File(dbDir, "database.lck"))
         .as("the lock file must be preserved so the next open runs recovery (#4934)").exists();
   }
-
-
 }


### PR DESCRIPTION
…tion on close

#4926 (HIGH, silent corruption): a 64KB page flush spans many disk sectors and the MVCC version header lives in sector 0. A torn write at power loss can persist the NEW version header while the delta sectors still hold the PREVIOUS content. Recovery's <= skip declared such a page 'already applied' and left it silently corrupt (new version, old bytes) despite an intact, fully-fsynced WAL - undetectable, since every later MVCC check accepts the page. The skip is now strictly <, and the equal-version case RE-APPLIES the WAL delta: idempotent when the page is intact (the delta carries absolute bytes for exactly that version), repairing when it is torn. Skipping STRICTLY older entries remains, as their delta would overwrite newer content. Red-first verified with a forged torn write (version header says v2, content still v1): the old code left the stale value behind forever, the fix recovers the committed one.

#4934 (MEDIUM, unrecoverable committed data): a clean close deleted every WAL file even when the preceding data fsync FAILED - and after a failed fsync the OS may have dropped the dirty pages (fsyncgate semantics), so the WAL held the only durable copy. FileManager.syncFiles() now reports failure; a failed pre-close fsync makes the close crash-equivalent (WAL and lock file preserved via the #5012 machinery, recovery on next open), and the runtime WAL-rotation drop pass aborts when its pre-drop fsync fails, retrying on the next pass. Red-first verified: the old code deleted the WAL despite the failed fsync.

Verified with the full commit-path sweep (union with the companion point-of-no-return branch): 372 classes, 2851 tests, 0 failures.

## What does this PR do?

A brief description of the change being made with this pull request.

## Motivation

What inspired you to submit this pull request?

## Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

## Additional Notes

Anything else we should know when reviewing?

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
