### PR TITLE
fix(#4936,#4937): the WAL append is the commit's point of no return

### DIFF
--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -188,7 +188,10 @@ that could starve the very snapshot resync meant to heal the node.
   ([#4936](https://github.com/ArcadeData/arcadedb/issues/4936)). Enabling that guarantee, the commit lock
   set is verified AFTER all page-set mutation and extended when files joined late (EXTERNAL-property
   buckets, indexes created inside the transaction, and the vector index's companion graph file, which now
-  counts in the lock set; [#4937](https://github.com/ArcadeData/arcadedb/issues/4937)).
+  counts in the lock set; [#4937](https://github.com/ArcadeData/arcadedb/issues/4937)). Note the commit
+  boundary this makes explicit: a failure AFTER the WAL append (e.g. while publishing pages) is resolved by
+  recovery replay, never by abort - the caller may see an error for a transaction that becomes durable on
+  restart.
 - **WAL/recovery correctness (2026-07 audit).** Recovery now RE-APPLIES a WAL delta whose version equals
   the on-disk page version, repairing a torn page write (a 64KB flush spans many sectors; a power loss can
   persist the new version header while the delta sectors still hold the previous content - the old `<=`

--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -188,7 +188,12 @@ that could starve the very snapshot resync meant to heal the node.
   ([#4936](https://github.com/ArcadeData/arcadedb/issues/4936)). Enabling that guarantee, the commit lock
   set is verified AFTER all page-set mutation and extended when files joined late (EXTERNAL-property
   buckets, indexes created inside the transaction, and the vector index's companion graph file, which now
-  counts in the lock set; [#4937](https://github.com/ArcadeData/arcadedb/issues/4937)). Note the commit
+  counts in the lock set; [#4937](https://github.com/ArcadeData/arcadedb/issues/4937)). **Behavioral
+  change for explicit locking:** a transaction using explicit locks that writes a file absent from its lock
+  list - including files it could not have locked up front, such as an index created inside the same
+  transaction or an EXTERNAL property's paired bucket - now fails with the "not all the modified resources
+  were locked" error instead of committing without the lock (which was unsafe). Lock the type after
+  creating its indexes, or create indexes outside explicit-lock transactions. Note the commit
   boundary this makes explicit: a failure AFTER the WAL append (e.g. while publishing pages) is resolved by
   recovery replay, never by abort - the caller may see an error for a transaction that becomes durable on
   restart. If that post-append failure ever happens, the database is FENCED: every further operation fails

--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -191,7 +191,10 @@ that could starve the very snapshot resync meant to heal the node.
   counts in the lock set; [#4937](https://github.com/ArcadeData/arcadedb/issues/4937)). Note the commit
   boundary this makes explicit: a failure AFTER the WAL append (e.g. while publishing pages) is resolved by
   recovery replay, never by abort - the caller may see an error for a transaction that becomes durable on
-  restart.
+  restart. If that post-append failure ever happens, the database is FENCED: every further operation fails
+  with a "close and reopen to run recovery" error, preventing new transactions from appending conflicting
+  WAL records for the same page versions, and the ack-gated close preserves the WAL so the reopen replays
+  the orphaned transaction.
 - **WAL/recovery correctness (2026-07 audit).** Recovery now RE-APPLIES a WAL delta whose version equals
   the on-disk page version, repairing a torn page write (a 64KB flush spans many sectors; a power loss can
   persist the new version header while the delta sectors still hold the previous content - the old `<=`

--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -181,6 +181,15 @@ that could starve the very snapshot resync meant to heal the node.
   database close now fails with the intended "Async executor has been shut down" error instead of a raw
   NullPointerException ([#4955](https://github.com/ArcadeData/arcadedb/issues/4955)).
 
+- **Commit: the WAL append is now the point of no return.** Page versions are validated and bumped BEFORE
+  the transaction is appended to the WAL, so a WAL record can only exist for a transaction that can no
+  longer fail validation - previously a phase-2 validation failure left the aborted transaction in the WAL
+  with no abort marker, and crash recovery partially replayed it
+  ([#4936](https://github.com/ArcadeData/arcadedb/issues/4936)). Enabling that guarantee, the commit lock
+  set is verified AFTER all page-set mutation and extended when files joined late (EXTERNAL-property
+  buckets, indexes created inside the transaction, and the vector index's companion graph file, which now
+  counts in the lock set; [#4937](https://github.com/ArcadeData/arcadedb/issues/4937)).
+
 ### Improvements
 
 - **HA: throttled diverged-follower resync logging.** When a follower detects a WAL page-version gap it

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -2303,6 +2303,29 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     }
   }
 
+  /**
+   * #5053 review: set when a commit fails AFTER its transaction was appended to the WAL (the point of no
+   * return) but BEFORE its pages were published. From that moment the WAL and the live state diverge: the
+   * transaction is durable (recovery will replay it) but invisible, and letting new transactions run would
+   * let them bump the same page versions and append conflicting WAL records for the same target versions.
+   * Fencing turns the divergence into the same crash-equivalent close/reopen cycle used elsewhere (#4928):
+   * the orphaned record's pages were never flush-acked, so the ack-gated close preserves the WAL and the
+   * lock file, and the next open replays it.
+   */
+  private volatile String fenceReason = null;
+
+  public void fenceForRecovery(final String reason) {
+    if (fenceReason == null) {
+      fenceReason = reason;
+      LogManager.instance().log(this, Level.SEVERE,
+          "Database '%s' fenced for recovery: %s. Close and reopen the database to replay the WAL", null, name, reason);
+    }
+  }
+
+  public boolean isFencedForRecovery() {
+    return fenceReason != null;
+  }
+
   protected void checkDatabaseIsOpen() {
     checkDatabaseIsOpen(false, null);
   }
@@ -2310,6 +2333,14 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
   protected void checkDatabaseIsOpen(final boolean updateIntent, final String databaseReadOnlyErrorMessage) {
     if (!open)
       throw new DatabaseIsClosedException(name);
+    if (fenceReason != null)
+      // #5053 review: a commit failed AFTER its WAL append - the WAL holds a record whose pages were never
+      // published, so the live in-memory state diverges from what recovery will reconstruct. Every further
+      // operation is fenced until the database is closed (the close-time ack gate preserves the WAL, since
+      // the orphaned record's pages were never flush-acked) and reopened, which replays the record.
+      throw new DatabaseOperationException(
+          "Database '" + name + "' is fenced after a failure past the WAL commit point: close and reopen the database to run recovery ("
+              + fenceReason + ")");
     if (DatabaseContext.INSTANCE.getContextIfExists(databasePath) == null)
       DatabaseContext.INSTANCE.init(this);
 

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -2311,6 +2311,10 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
    * Fencing turns the divergence into the same crash-equivalent close/reopen cycle used elsewhere (#4928):
    * the orphaned record's pages were never flush-acked, so the ack-gated close preserves the WAL and the
    * lock file, and the next open replays it.
+   * <p>
+   * HA note: on a replica this fences the wrapped LocalDatabase too, halting replication apply until the
+   * node restarts - intended: the fence surfaces exactly like a crash, and the standard restart
+   * reconciliation (recovery replay, or snapshot re-install via the DatabaseReconciler) repairs the node.
    */
   private volatile String fenceReason = null;
 

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -862,15 +862,16 @@ public class TransactionContext implements Transaction {
       // data never committed. The bump below mutates only this transaction's private MutablePage instances,
       // so a WAL-append failure still aborts cleanly with nothing observable. The in-between window is safe
       // because every modified file's lock is held (#4937 guarantees coverage) until reset().
-      final List<MutablePage> pagesToPublish = database.getPageManager().validateAndBumpVersions(newPages, modifiedPages);
-
-      // #5053 review: refuse to cross the point of no return on a fenced database. This check runs AFTER
-      // this transaction acquired its file locks, so for any transaction sharing a page with the failed one
-      // the fence write below happens-before this read - it cannot append a WAL record targeting the same
-      // page version the orphaned record already claims.
+      // #5053 review: refuse to commit on a fenced database, before doing any work. The file locks this
+      // transaction acquired in phase 1 give the happens-before edge: for any transaction sharing a page
+      // with the failed one, the fence write (made before the failed commit's reset() released those locks)
+      // is visible here - it cannot append a WAL record targeting the same page version the orphaned record
+      // already claims.
       if (database.getEmbedded() instanceof LocalDatabase localDatabase && localDatabase.isFencedForRecovery())
         throw new TransactionException(
             "Cannot commit: the database is fenced after a failure past the WAL commit point, close and reopen it to run recovery");
+
+      final List<MutablePage> pagesToPublish = database.getPageManager().validateAndBumpVersions(newPages, modifiedPages);
 
       if (changes.result != null) {
         // WRITE TO THE WAL: THE POINT OF NO RETURN
@@ -929,11 +930,18 @@ public class TransactionContext implements Transaction {
       else {
         if (walAppended && database.getEmbedded() instanceof LocalDatabase localDatabase)
           // #5053 review: the transaction IS durable (its WAL record survives and recovery will replay it)
-          // but its pages were never published - the live state and the WAL now diverge. Fence BEFORE
+          // but its pages may not all be published - the live state and the WAL may diverge. Fence BEFORE
           // reset() releases the file locks: the volatile write is then visible to any transaction that was
           // blocked on these locks, so no conflicting WAL record for the same page versions can follow. The
           // orphaned record's pages were never flush-acked, so the ack-gated close (#4928) preserves the
           // WAL and the lock file, and reopening the database replays it.
+          //
+          // DELIBERATELY WIDE (covers every failure from the append to the end of the try, not just
+          // publishPages): a mid-publish failure can leave SOME pages visible and others not - a partial
+          // publication no boolean flag can distinguish from a complete one - and post-publish failures
+          // (page counters, onAfterCommit) leave component metadata that recovery replay also repairs.
+          // Under-fencing risks exactly the divergence this exists to prevent; the cost (a restart after an
+          // exceptional post-append failure) is the acceptable side.
           localDatabase.fenceForRecovery("commit of tx " + txId + " failed after its WAL append");
         reset();
       }

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -666,6 +666,9 @@ public class TransactionContext implements Transaction {
     status = STATUS.COMMIT_1ST_PHASE;
 
     try {
+      // #4937 review: explicit-lock mode captured before checkExplicitLocks nulls explicitLockedFiles, so the
+      // late-joiner block below can still tell an explicit-lock transaction from an auto-locked one.
+      boolean explicitLockMode = false;
       if (isLeader) {
         // Determine files to lock — must include files from updatedRecords
         if (updatedRecords != null)
@@ -675,6 +678,11 @@ public class TransactionContext implements Transaction {
           }
 
         final IntHashSet modifiedFiles = lockFilesFromChanges();
+
+        // checkExplicitLocks nulls explicitLockedFiles on success, so remember the mode now for the
+        // late-joiner check further down (#4937 review): otherwise that check always sees null and would
+        // silently expand an explicit-lock transaction's lock set, defeating the explicit-locking contract.
+        explicitLockMode = explicitLockedFiles != null;
 
         if (explicitLockedFiles != null)
           checkExplicitLocks(modifiedFiles);
@@ -726,31 +734,28 @@ public class TransactionContext implements Transaction {
       // place). The version checks below run after this block, so anything that changed while unlocked
       // fails validation with the standard retriable ConcurrentModificationException.
       if (isLeader && lockedFiles != null) {
-        final IntHashSet lockedSet = new IntHashSet();
-        for (final int fileId : lockedFiles)
-          lockedSet.add(fileId);
-
-        final IntHashSet union = new IntHashSet();
-        boolean lateJoiners = false;
+        // Single pass: seed the union with the locked files, then a file in the page set that add() reports
+        // as NEW (return true) is one that was not locked - a late joiner.
+        final IntHashSet union = new IntHashSet(lockedFiles.size() + modifiedPages.size());
         for (final int fileId : lockedFiles)
           union.add(fileId);
-        for (final PageId pid : modifiedPages.keySet()) {
-          union.add(pid.getFileId());
-          if (!lockedSet.contains(pid.getFileId()))
+
+        boolean lateJoiners = false;
+        for (final PageId pid : modifiedPages.keySet())
+          if (union.add(pid.getFileId()))
             lateJoiners = true;
-        }
         if (newPages != null)
-          for (final PageId pid : newPages.keySet()) {
-            union.add(pid.getFileId());
-            if (!lockedSet.contains(pid.getFileId()))
+          for (final PageId pid : newPages.keySet())
+            if (union.add(pid.getFileId()))
               lateJoiners = true;
-          }
 
         if (lateJoiners) {
-          if (explicitLockedFiles != null)
+          if (explicitLockMode)
             // The user's explicit lock list does not cover files this transaction actually modified:
-            // re-locking on their behalf would defeat the explicit-locking contract - surface it instead.
-            checkExplicitLocks(union);
+            // re-locking on their behalf would defeat the explicit-locking contract - surface it as the
+            // "not all the modified resources were locked" violation instead. (explicitLockedFiles was
+            // already nulled by the earlier checkExplicitLocks, so we branch on the captured mode.)
+            checkExplicitLocksForUnion(union);
           else {
             database.getTransactionManager().unlockFilesInOrder(lockedFiles, getRequester());
             lockedFiles = lockFilesInOrder(union);
@@ -1066,6 +1071,28 @@ public class TransactionContext implements Transaction {
       });
       next.add(migrated);
       filesToLock = next;
+    }
+  }
+
+  /**
+   * #4937 review: late-joiner coverage check for an EXPLICIT-lock transaction. By this point the earlier
+   * {@link #checkExplicitLocks} has moved the user's explicit lock set into {@code lockedFiles} (and nulled
+   * {@code explicitLockedFiles}), so a file in the transaction's page set that is NOT in {@code lockedFiles}
+   * is one the user did not lock. Surface it as the same contract violation a direct modification of an
+   * unlocked file raises, rather than silently expanding their lock set.
+   */
+  private void checkExplicitLocksForUnion(final IntHashSet union) {
+    final Set<Integer> locked = new HashSet<>(lockedFiles);
+    final HashSet<Integer> left = new HashSet<>();
+    union.forEach(fid -> {
+      if (!locked.contains(fid))
+        left.add(fid);
+    });
+    if (!left.isEmpty()) {
+      final Set<String> resourceNames = left.stream().map(fileId -> database.getSchema().getFileById(fileId).getName())
+          .collect(Collectors.toSet());
+      throw new TransactionException(
+          "Cannot commit transaction because not all the modified resources were locked: " + resourceNames);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -840,6 +840,7 @@ public class TransactionContext implements Transaction {
 
   public void commit2ndPhase(final TransactionPhase1 changes) {
     boolean committed = false;
+    boolean walAppended = false;
     try {
       if (changes == null)
         return;
@@ -863,9 +864,18 @@ public class TransactionContext implements Transaction {
       // because every modified file's lock is held (#4937 guarantees coverage) until reset().
       final List<MutablePage> pagesToPublish = database.getPageManager().validateAndBumpVersions(newPages, modifiedPages);
 
+      // #5053 review: refuse to cross the point of no return on a fenced database. This check runs AFTER
+      // this transaction acquired its file locks, so for any transaction sharing a page with the failed one
+      // the fence write below happens-before this read - it cannot append a WAL record targeting the same
+      // page version the orphaned record already claims.
+      if (database.getEmbedded() instanceof LocalDatabase localDatabase && localDatabase.isFencedForRecovery())
+        throw new TransactionException(
+            "Cannot commit: the database is fenced after a failure past the WAL commit point, close and reopen it to run recovery");
+
       if (changes.result != null)
         // WRITE TO THE WAL: THE POINT OF NO RETURN
         database.getTransactionManager().writeTransactionToWAL(changes.modifiedPages, walFlush, txId, changes.result);
+      walAppended = true;
 
       LogManager.instance()
           .log(this, Level.FINE, "TX committing pages newPages=%s modifiedPages=%s (threadId=%d)", newPages, modifiedPages,
@@ -901,6 +911,10 @@ public class TransactionContext implements Transaction {
 
     } catch (final ConcurrentModificationException e) {
       throw e;
+    } catch (final TransactionException e) {
+      // Already a first-class transaction error (e.g. the recovery fence): rethrow as-is instead of
+      // double-wrapping it in a generic "Transaction error on commit" (#5053 review, same as phase 1).
+      throw e;
     } catch (final Exception e) {
       LogManager.instance()
           .log(this, Level.FINE, "Unknown exception during commit (threadId=%d)", e, Thread.currentThread().threadId());
@@ -908,8 +922,17 @@ public class TransactionContext implements Transaction {
     } finally {
       if (committed)
         resetAndFireCallbacks();
-      else
+      else {
+        if (walAppended && database.getEmbedded() instanceof LocalDatabase localDatabase)
+          // #5053 review: the transaction IS durable (its WAL record survives and recovery will replay it)
+          // but its pages were never published - the live state and the WAL now diverge. Fence BEFORE
+          // reset() releases the file locks: the volatile write is then visible to any transaction that was
+          // blocked on these locks, so no conflicting WAL record for the same page versions can follow. The
+          // orphaned record's pages were never flush-acked, so the ack-gated close (#4928) preserves the
+          // WAL and the lock file, and reopening the database replays it.
+          localDatabase.fenceForRecovery("commit of tx " + txId + " failed after its WAL append");
         reset();
+      }
     }
   }
 
@@ -1123,7 +1146,7 @@ public class TransactionContext implements Transaction {
     if (!left.isEmpty()) {
       // TreeSet: deterministic name ordering, so a multi-file violation always reads the same.
       final Set<String> resourceNames = left.stream().map(fileId -> database.getSchema().getFileById(fileId).getName())
-          .collect(Collectors.toCollection(java.util.TreeSet::new));
+          .collect(Collectors.toCollection(TreeSet::new));
       throw new TransactionException(
           "Cannot commit transaction because not all the modified resources were locked: " + resourceNames);
     }

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -825,6 +825,11 @@ public class TransactionContext implements Transaction {
     } catch (final DuplicatedKeyException | ConcurrentModificationException e) {
       rollback();
       throw e;
+    } catch (final TransactionException e) {
+      // Already a first-class transaction error (e.g. the explicit-lock contract violation): rethrow as-is
+      // instead of double-wrapping it in a generic "Transaction error on commit" (#5053 review).
+      rollback();
+      throw e;
     } catch (final Exception e) {
       LogManager.instance()
           .log(this, Level.FINE, "Unknown exception during commit (threadId=%d)", e, Thread.currentThread().threadId());
@@ -1006,7 +1011,10 @@ public class TransactionContext implements Transaction {
     explicitLockedFiles = lockFilesInOrder(filesToLock);
   }
 
-  /** Boxing-free containment scan for the late-joiner fast path: lockedFiles is small (typically < 10). */
+  /**
+   * Allocation-free containment scan for the late-joiner fast path (lockedFiles is small, typically < 10):
+   * get(i) == fileId unboxes the stored Integer but allocates nothing new.
+   */
   private static boolean containsFileId(final List<Integer> lockedFiles, final int fileId) {
     for (int i = 0; i < lockedFiles.size(); i++)
       if (lockedFiles.get(i) == fileId)

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -734,22 +734,32 @@ public class TransactionContext implements Transaction {
       // place). The version checks below run after this block, so anything that changed while unlocked
       // fails validation with the standard retriable ConcurrentModificationException.
       if (isLeader && lockedFiles != null) {
-        // Single pass: seed the union with the locked files, then a file in the page set that add() reports
-        // as NEW (return true) is one that was not locked - a late joiner.
-        final IntHashSet union = new IntHashSet(lockedFiles.size() + modifiedPages.size());
-        for (final int fileId : lockedFiles)
-          union.add(fileId);
-
+        // Fast path first: in the overwhelmingly common case every touched file is already locked, and this
+        // is one of the hottest paths in the engine - detect late joiners with a plain scan (no allocation,
+        // no boxing) and only build the union set when one is actually found.
         boolean lateJoiners = false;
         for (final PageId pid : modifiedPages.keySet())
-          if (union.add(pid.getFileId()))
+          if (!containsFileId(lockedFiles, pid.getFileId())) {
             lateJoiners = true;
-        if (newPages != null)
+            break;
+          }
+        if (!lateJoiners && newPages != null)
           for (final PageId pid : newPages.keySet())
-            if (union.add(pid.getFileId()))
+            if (!containsFileId(lockedFiles, pid.getFileId())) {
               lateJoiners = true;
+              break;
+            }
 
         if (lateJoiners) {
+          final IntHashSet union = new IntHashSet(lockedFiles.size() + modifiedPages.size());
+          for (final int fileId : lockedFiles)
+            union.add(fileId);
+          for (final PageId pid : modifiedPages.keySet())
+            union.add(pid.getFileId());
+          if (newPages != null)
+            for (final PageId pid : newPages.keySet())
+              union.add(pid.getFileId());
+
           if (explicitLockMode)
             // The user's explicit lock list does not cover files this transaction actually modified:
             // re-locking on their behalf would defeat the explicit-locking contract - surface it as the
@@ -996,6 +1006,14 @@ public class TransactionContext implements Transaction {
     explicitLockedFiles = lockFilesInOrder(filesToLock);
   }
 
+  /** Boxing-free containment scan for the late-joiner fast path: lockedFiles is small (typically < 10). */
+  private static boolean containsFileId(final List<Integer> lockedFiles, final int fileId) {
+    for (int i = 0; i < lockedFiles.size(); i++)
+      if (lockedFiles.get(i) == fileId)
+        return true;
+    return false;
+  }
+
   private IntHashSet lockFilesFromChanges() {
     final IntHashSet modifiedFiles = new IntHashSet(modifiedPages.size() + 16);
 
@@ -1080,6 +1098,12 @@ public class TransactionContext implements Transaction {
    * {@code explicitLockedFiles}), so a file in the transaction's page set that is NOT in {@code lockedFiles}
    * is one the user did not lock. Surface it as the same contract violation a direct modification of an
    * unlocked file raises, rather than silently expanding their lock set.
+   * <p>
+   * Unlike {@link #checkExplicitLocks}, no migrated-file (index compaction) translation is needed here: that
+   * race lives in the window between snapshotting the file ids and acquiring the locks, and by this point
+   * the locks have been held continuously since the user's {@code lock()} call. Compaction's splitIndex must
+   * {@code tryLockFile} the file it migrates, so no file in {@code lockedFiles} can have been migrated while
+   * this transaction runs - a missing file here is genuinely unlocked, never a stale id of a locked one.
    */
   private void checkExplicitLocksForUnion(final IntHashSet union) {
     final Set<Integer> locked = new HashSet<>(lockedFiles);

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -872,10 +872,14 @@ public class TransactionContext implements Transaction {
         throw new TransactionException(
             "Cannot commit: the database is fenced after a failure past the WAL commit point, close and reopen it to run recovery");
 
-      if (changes.result != null)
+      if (changes.result != null) {
         // WRITE TO THE WAL: THE POINT OF NO RETURN
         database.getTransactionManager().writeTransactionToWAL(changes.modifiedPages, walFlush, txId, changes.result);
-      walAppended = true;
+        // Only a REAL append crosses the point of no return (#5053 review): with useWAL=false (bulk loads)
+        // changes.result is null, nothing is durable, and a publish failure must abort the transaction as
+        // before - fencing would promise a replay that cannot happen and brick the database for nothing.
+        walAppended = true;
+      }
 
       LogManager.instance()
           .log(this, Level.FINE, "TX committing pages newPages=%s modifiedPages=%s (threadId=%d)", newPages, modifiedPages,
@@ -1036,7 +1040,8 @@ public class TransactionContext implements Transaction {
 
   /**
    * Allocation-free containment scan for the late-joiner fast path (lockedFiles is small, typically < 10):
-   * get(i) == fileId unboxes the stored Integer but allocates nothing new.
+   * get(i) == fileId unboxes the stored Integer but allocates nothing new. Assumes a RandomAccess list -
+   * lockFilesInOrder and checkExplicitLocks both produce ArrayLists; revisit the loop if that ever changes.
    */
   private static boolean containsFileId(final List<Integer> lockedFiles, final int fileId) {
     for (int i = 0; i < lockedFiles.size(); i++)

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -1121,8 +1121,9 @@ public class TransactionContext implements Transaction {
         left.add(fid);
     });
     if (!left.isEmpty()) {
+      // TreeSet: deterministic name ordering, so a multi-file violation always reads the same.
       final Set<String> resourceNames = left.stream().map(fileId -> database.getSchema().getFileById(fileId).getName())
-          .collect(Collectors.toSet());
+          .collect(Collectors.toCollection(java.util.TreeSet::new));
       throw new TransactionException(
           "Cannot commit transaction because not all the modified resources were locked: " + resourceNames);
     }

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -717,6 +717,47 @@ public class TransactionContext implements Transaction {
         // COMMIT INDEX CHANGES (IN CASE OF REPLICA THIS IS DEMANDED TO THE LEADER EXECUTION)
         indexChanges.commit();
 
+      // #4937: the steps above (updateRecordNoLock, indexChanges.commit) can add pages of files that were
+      // NOT in the lock set computed at lock time - EXTERNAL-property buckets, indexes created inside this
+      // transaction, multi-file index components. Their pages would pass the version checks below WITHOUT
+      // their file lock held, which is what made a phase-2 failure after the WAL append reachable (#4936:
+      // an aborted transaction partially replayed by recovery). Verify coverage; on a late joiner, release
+      // and re-acquire the UNION in order (lock-ordering discipline forbids acquiring extra locks in
+      // place). The version checks below run after this block, so anything that changed while unlocked
+      // fails validation with the standard retriable ConcurrentModificationException.
+      if (isLeader && lockedFiles != null) {
+        final IntHashSet lockedSet = new IntHashSet();
+        for (final int fileId : lockedFiles)
+          lockedSet.add(fileId);
+
+        final IntHashSet union = new IntHashSet();
+        boolean lateJoiners = false;
+        for (final int fileId : lockedFiles)
+          union.add(fileId);
+        for (final PageId pid : modifiedPages.keySet()) {
+          union.add(pid.getFileId());
+          if (!lockedSet.contains(pid.getFileId()))
+            lateJoiners = true;
+        }
+        if (newPages != null)
+          for (final PageId pid : newPages.keySet()) {
+            union.add(pid.getFileId());
+            if (!lockedSet.contains(pid.getFileId()))
+              lateJoiners = true;
+          }
+
+        if (lateJoiners) {
+          if (explicitLockedFiles != null)
+            // The user's explicit lock list does not cover files this transaction actually modified:
+            // re-locking on their behalf would defeat the explicit-locking contract - surface it instead.
+            checkExplicitLocks(union);
+          else {
+            database.getTransactionManager().unlockFilesInOrder(lockedFiles, getRequester());
+            lockedFiles = lockFilesInOrder(union);
+          }
+        }
+      }
+
       // CHECK THE VERSIONS FIRST
       final List<MutablePage> pages = new ArrayList<>();
       final PageManager pageManager = database.getPageManager();
@@ -791,17 +832,28 @@ public class TransactionContext implements Transaction {
 
       status = STATUS.COMMIT_2ND_PHASE;
 
+      // #4936: validate the page versions and bump them BEFORE the WAL append, making the append the point
+      // of no return: a WAL record must only ever exist for a transaction that can no longer fail
+      // validation. Previously the order was WAL-then-validate, so a phase-2 ConcurrentModificationException
+      // (reachable through the late-joining-files hole, #4937) aborted the transaction while its record
+      // stayed in the WAL with no abort marker - crash recovery then replayed the aborted transaction's
+      // other pages (version == disk+1), a partial application: torn records, index entries pointing at
+      // data never committed. The bump below mutates only this transaction's private MutablePage instances,
+      // so a WAL-append failure still aborts cleanly with nothing observable. The in-between window is safe
+      // because every modified file's lock is held (#4937 guarantees coverage) until reset().
+      final List<MutablePage> pagesToPublish = database.getPageManager().validateAndBumpVersions(newPages, modifiedPages);
+
       if (changes.result != null)
-        // WRITE TO THE WAL FIRST
+        // WRITE TO THE WAL: THE POINT OF NO RETURN
         database.getTransactionManager().writeTransactionToWAL(changes.modifiedPages, walFlush, txId, changes.result);
 
-      // AT THIS POINT, LOCK + VERSION CHECK, THERE IS NO NEED TO MANAGE ROLLBACK BECAUSE THERE CANNOT BE CONCURRENT TX THAT UPDATE THE SAME PAGE CONCURRENTLY
-      // UPDATE PAGE COUNTER FIRST
       LogManager.instance()
           .log(this, Level.FINE, "TX committing pages newPages=%s modifiedPages=%s (threadId=%d)", newPages, modifiedPages,
               Thread.currentThread().threadId());
 
-      database.getPageManager().updatePages(newPages, modifiedPages, asyncFlush);
+      // From here the transaction is durable in the WAL: a failure below is repaired by recovery replay,
+      // never by aborting.
+      database.getPageManager().publishPages(pagesToPublish, newPages, asyncFlush);
 
       for (final Map.Entry<Integer, Integer> entry : newPageCounters.entrySet())
         ((PaginatedComponent) database.getSchema().getFileById(entry.getKey())).updatePageCount(entry.getValue());

--- a/engine/src/main/java/com/arcadedb/database/TransactionIndexContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionIndexContext.java
@@ -261,7 +261,11 @@ public class TransactionIndexContext {
         // ALREADY IN THE SET
         continue;
 
-      modifiedFiles.add(index.getFileId());
+      // getFileIds (plural), not getFileId: a multi-file index (e.g. LSMVectorIndex with its companion
+      // graph file) writes pages into ALL its component files during the transaction; omitting one lets its
+      // pages pass the commit version checks without the file lock held (#4937).
+      for (final int indexFileId : index.getFileIds())
+        modifiedFiles.add(indexFileId);
 
       // Lock only the data bucket this index entry belongs to (not all buckets of the type).
       // Guard against -1, returned by composite (TypeIndex) or metadata-less indexes, which is not a valid file id.

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -262,6 +262,20 @@ public class PageManager extends LockContext {
 
   public void updatePages(final Map<PageId, MutablePage> newPages, final Map<PageId, MutablePage> modifiedPages,
       final boolean asyncFlush) throws IOException, InterruptedException {
+    publishPages(validateAndBumpVersions(newPages, modifiedPages), newPages, asyncFlush);
+  }
+
+  /**
+   * First half of {@link #updatePages}: validates every page against the most recent committed version and
+   * bumps the (transaction-private) page versions, WITHOUT publishing anything. #4936: the commit calls this
+   * BEFORE appending the transaction to the WAL, so the append is the point of no return - a WAL record can
+   * only ever exist for a transaction that already passed validation. Any {@link ConcurrentModificationException}
+   * fires before anything durable exists, so crash recovery can never partially replay an aborted transaction.
+   * The bump only mutates the transaction's own MutablePage instances: if the WAL append still fails
+   * (e.g. interrupt), the reset() discards them and nothing observable happened.
+   */
+  public List<MutablePage> validateAndBumpVersions(final Map<PageId, MutablePage> newPages,
+      final Map<PageId, MutablePage> modifiedPages) throws IOException, InterruptedException {
     lock();
     try {
       final List<MutablePage> pagesToWrite = new ArrayList<>((newPages != null ? newPages.size() : 0) + modifiedPages.size());
@@ -273,6 +287,21 @@ public class PageManager extends LockContext {
       for (final MutablePage p : modifiedPages.values())
         pagesToWrite.add(updatePageVersion(p, false));
 
+      return pagesToWrite;
+    } finally {
+      unlock();
+    }
+  }
+
+  /**
+   * Second half of {@link #updatePages}: publishes the validated pages (read cache + flush scheduling).
+   * Runs AFTER the WAL append (#4936): from the caller's perspective the transaction is committed once the
+   * WAL is durable, and a failure here leaves the WAL to replay the pages on recovery.
+   */
+  public void publishPages(final List<MutablePage> pagesToWrite, final Map<PageId, MutablePage> newPages,
+      final boolean asyncFlush) throws IOException, InterruptedException {
+    lock();
+    try {
       // Write pages (and put in readCache) BEFORE updating pageCount, otherwise concurrent
       // transactions can observe pageCount > readCache state and treat the new page as a
       // pre-existing empty page (sparse-file semantics), allowing two records' chunk chains

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -296,7 +296,10 @@ public class PageManager extends LockContext {
   /**
    * Second half of {@link #updatePages}: publishes the validated pages (read cache + flush scheduling).
    * Runs AFTER the WAL append (#4936): from the caller's perspective the transaction is committed once the
-   * WAL is durable, and a failure here leaves the WAL to replay the pages on recovery.
+   * WAL is durable, and a failure here leaves the WAL to replay the pages on recovery. Releasing the global
+   * PageManager lock between the two halves is safe ONLY because the caller holds the per-file commit locks
+   * (until reset()), which serialize committers per file - no other transaction can validate, bump or
+   * publish these pages in the gap.
    */
   public void publishPages(final List<MutablePage> pagesToWrite, final Map<PageId, MutablePage> newPages,
       final boolean asyncFlush) throws IOException, InterruptedException {

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -260,6 +260,13 @@ public class PageManager extends LockContext {
     }
   }
 
+  /**
+   * Atomic convenience form of {@link #validateAndBumpVersions} + {@link #publishPages}. NOTE: since #4936
+   * the engine commit path no longer calls this - commit2ndPhase invokes the two halves separately with the
+   * WAL append in between, so validate+publish are NOT atomic under one lock there. Kept as public API for
+   * embedded users and backward compatibility; new engine code should call the halves explicitly and state
+   * what serializes the gap.
+   */
   public void updatePages(final Map<PageId, MutablePage> newPages, final Map<PageId, MutablePage> modifiedPages,
       final boolean asyncFlush) throws IOException, InterruptedException {
     publishPages(validateAndBumpVersions(newPages, modifiedPages), newPages, asyncFlush);
@@ -297,9 +304,11 @@ public class PageManager extends LockContext {
    * Second half of {@link #updatePages}: publishes the validated pages (read cache + flush scheduling).
    * Runs AFTER the WAL append (#4936): from the caller's perspective the transaction is committed once the
    * WAL is durable, and a failure here leaves the WAL to replay the pages on recovery. Releasing the global
-   * PageManager lock between the two halves is safe ONLY because the caller holds the per-file commit locks
-   * (until reset()), which serialize committers per file - no other transaction can validate, bump or
-   * publish these pages in the gap.
+   * PageManager lock between the two halves is safe only because the caller serializes committers per page
+   * by other means. Two regimes exist: on a leader (commit1stPhase(true)) the per-file commit locks are held
+   * until reset(), so no other transaction can validate, bump or publish these pages in the gap; on an HA
+   * follower (commit1stPhase(false)) lockedFiles is EMPTY and it is the single-threaded Raft apply in
+   * RaftReplicatedDatabase that provides the serialization - do not rely on file locks being held there.
    */
   public void publishPages(final List<MutablePage> pagesToWrite, final Map<PageId, MutablePage> newPages,
       final boolean asyncFlush) throws IOException, InterruptedException {

--- a/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/vector/LSMVectorIndex.java
@@ -3730,6 +3730,10 @@ public class LSMVectorIndex implements Index, IndexInternal {
 
   @Override
   public List<Integer> getFileIds() {
+    // #4937: the companion graph file receives page writes during the transaction too - it must be part of
+    // the commit lock set, or its pages pass the version checks without their file lock held.
+    if (graphFile != null)
+      return List.of(mutable.getFileId(), graphFile.getFileId());
     return Collections.singletonList(mutable.getFileId());
   }
 

--- a/engine/src/test/java/com/arcadedb/engine/WalCommitOrderingTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/WalCommitOrderingTest.java
@@ -32,6 +32,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.lang.reflect.Field;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -203,6 +205,87 @@ class WalCommitOrderingTest {
       db.close();
       factory.close();
     }
+  }
+
+
+  @Test
+  void publishFailureWithWalDisabledAbortsWithoutFencing() throws Exception {
+    // #5053 review round 6: walAppended was set even when changes.result was null (useWAL=false, the
+    // supported bulk-load mode) - a post-validation publish failure then FENCED the whole database while
+    // promising a WAL replay that cannot happen (nothing was appended): a permanently unusable database for
+    // a transaction that opted out of WAL durability. Such a failure must simply abort, as before this PR.
+    final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
+    if (factory.exists())
+      factory.open().drop();
+
+    final DatabaseInternal db = (DatabaseInternal) factory.create();
+    try {
+      db.getSchema().createDocumentType("Doc");
+
+      db.begin();
+      db.getTransaction().setUseWAL(false);
+      db.newDocument("Doc").set("v", 1).save();
+      final TransactionContext tx = (TransactionContext) db.getTransaction();
+      final TransactionContext.TransactionPhase1 phase1 = tx.commit1stPhase(true);
+      assertThat(phase1.result).as("useWAL=false must build no WAL buffer").isNull();
+
+      injectPostPublishFailure(tx);
+      assertThatThrownBy(() -> tx.commit2ndPhase(phase1)).isInstanceOf(TransactionException.class);
+
+      assertThat(((LocalDatabase) db).isFencedForRecovery())
+          .as("a publish failure with NO WAL record must abort, not fence: there is nothing to replay (#5053)")
+          .isFalse();
+      // The database keeps working.
+      db.transaction(() -> db.newDocument("Doc").set("v", 2).save());
+    } finally {
+      db.close();
+      factory.close();
+    }
+  }
+
+  @Test
+  void publishFailureAfterRealWalAppendFencesThroughTheFinallyTrigger() throws Exception {
+    // The counterpart, and the wiring test for the finally trigger itself: the same post-publish failure
+    // WITH the WAL enabled reaches the fence through a real exception (no manual fenceForRecovery call) -
+    // the transaction is durable in the WAL, so the database must fence until a reopen replays it.
+    final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
+    if (factory.exists())
+      factory.open().drop();
+
+    final DatabaseInternal db = (DatabaseInternal) factory.create();
+    try {
+      db.getSchema().createDocumentType("Doc");
+
+      db.begin();
+      db.newDocument("Doc").set("v", 1).save();
+      final TransactionContext tx = (TransactionContext) db.getTransaction();
+      final TransactionContext.TransactionPhase1 phase1 = tx.commit1stPhase(true);
+      assertThat(phase1.result).isNotNull();
+
+      injectPostPublishFailure(tx);
+      assertThatThrownBy(() -> tx.commit2ndPhase(phase1)).isInstanceOf(TransactionException.class);
+
+      assertThat(((LocalDatabase) db).isFencedForRecovery())
+          .as("a publish failure AFTER a real WAL append must fence: the tx is durable and only replay reconciles")
+          .isTrue();
+    } finally {
+      db.close();
+      factory.close();
+    }
+  }
+
+  /**
+   * Plants a bogus file id in the transaction's newPageCounters: commit2ndPhase resolves it via
+   * Schema.getFileById AFTER publishPages, so the commit fails post-publish with a real exception flowing
+   * through the real catch/finally - exactly the failure class the fence targets, without fault-injection
+   * hooks.
+   */
+  private static void injectPostPublishFailure(final TransactionContext tx) throws Exception {
+    final Field countersField = TransactionContext.class.getDeclaredField("newPageCounters");
+    countersField.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    final Map<Integer, Integer> counters = (Map<Integer, Integer>) countersField.get(tx);
+    counters.put(9_999, 1);
   }
 
   private static long totalWalBytes() {

--- a/engine/src/test/java/com/arcadedb/engine/WalCommitOrderingTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/WalCommitOrderingTest.java
@@ -73,6 +73,7 @@ class WalCommitOrderingTest {
       factory.open().drop();
 
     final DatabaseInternal db = (DatabaseInternal) factory.create();
+    final PageId[] victimPageId = new PageId[1];
     try {
       db.getSchema().createDocumentType("Doc");
       db.transaction(() -> db.newDocument("Doc").set("v", "committed").save());
@@ -87,6 +88,7 @@ class WalCommitOrderingTest {
       // Inject a conflicting committed version for one of the transaction's pages, as a racing transaction
       // through the (now closed) lock-coverage hole would have: phase-2 validation MUST fail.
       final MutablePage victim = phase1.modifiedPages.getFirst();
+      victimPageId[0] = victim.getPageId();
       final MutablePage conflicting = new MutablePage(victim.getPageId(), (int) victim.getPhysicalSize(),
           victim.getContent().array().clone(), (int) (victim.getVersion() + 1), victim.getContentSize());
       // putPageInReadCache is package-private (this test is in the same package): a conflicting cached
@@ -105,11 +107,11 @@ class WalCommitOrderingTest {
       assertThat(totalWalBytes())
           .as("a transaction that failed validation must leave NO record in the WAL (#4936)")
           .isEqualTo(walBytesBefore);
-
-      // Evict the injected conflicting page: PageManager.INSTANCE is JVM-global, and a foreign cache entry
-      // must not bleed into other tests sharing this JVM.
-      PageManager.INSTANCE.removePageFromCache(victim.getPageId());
     } finally {
+      // Evict the injected conflicting page even when an assertion failed: PageManager.INSTANCE is
+      // JVM-global, and a foreign cache entry must not bleed into other tests sharing this JVM.
+      if (victimPageId[0] != null)
+        PageManager.INSTANCE.removePageFromCache(victimPageId[0]);
       db.close();
       factory.close();
     }

--- a/engine/src/test/java/com/arcadedb/engine/WalCommitOrderingTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/WalCommitOrderingTest.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.TransactionContext;
 import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.exception.TransactionException;
 import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 /**
@@ -75,7 +77,7 @@ class WalCommitOrderingTest {
       // Phase 1 of a new update: locks taken, WAL buffer built, versions checked.
       db.begin();
       db.query("sql", "SELECT FROM Doc").next().getRecord().get().asDocument().modify().set("v", "doomed").save();
-      final TransactionContext tx = (com.arcadedb.database.TransactionContext) db.getTransaction();
+      final TransactionContext tx = (TransactionContext) db.getTransaction();
       final TransactionContext.TransactionPhase1 phase1 = tx.commit1stPhase(true);
       assertThat(phase1).isNotNull();
 
@@ -84,9 +86,10 @@ class WalCommitOrderingTest {
       final MutablePage victim = phase1.modifiedPages.getFirst();
       final MutablePage conflicting = new MutablePage(victim.getPageId(), (int) victim.getPhysicalSize(),
           victim.getContent().array().clone(), (int) (victim.getVersion() + 1), victim.getContentSize());
-      final java.lang.reflect.Method put = PageManager.class.getDeclaredMethod("putPageInReadCache", CachedPage.class);
-      put.setAccessible(true);
-      put.invoke(PageManager.INSTANCE, new CachedPage(conflicting, false));
+      // putPageInReadCache is package-private (this test is in the same package): a conflicting cached
+      // version makes the phase-2 version check (getMostRecentVersionOfPage) fail deterministically, exactly
+      // as a racing committer through the closed lock-coverage hole would have.
+      PageManager.INSTANCE.putPageInReadCache(new CachedPage(conflicting, false));
 
       final long walBytesBefore = totalWalBytes();
       try {
@@ -100,6 +103,46 @@ class WalCommitOrderingTest {
           .as("a transaction that failed validation must leave NO record in the WAL (#4936)")
           .isEqualTo(walBytesBefore);
     } finally {
+      db.close();
+      factory.close();
+    }
+  }
+
+  @Test
+  void explicitLockTransactionWithLateJoiningFileIsRejectedNotSilentlyRelocked() {
+    // #4937 review: an explicit-lock transaction that touches a file it did NOT lock must fail with the
+    // contract violation, not have its lock set silently expanded. An EXTERNAL property's paired bucket is
+    // a genuine LATE joiner: an explicit type-lock does not cover it (collectTypeFileIds omits external
+    // buckets), yet updating the property writes it during phase-1 serialization (updateRecordNoLock, AFTER
+    // the initial explicit-lock check) - so only the late-joiner block added by #4937 can catch it.
+    final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
+    if (factory.exists())
+      factory.open().drop();
+
+    final DatabaseInternal db = (DatabaseInternal) factory.create();
+    try {
+      final com.arcadedb.schema.DocumentType type = db.getSchema().createDocumentType("Doc");
+      type.createProperty("name", com.arcadedb.schema.Type.STRING);
+      type.createProperty("blob", com.arcadedb.schema.Type.STRING).setExternal(true);
+
+      final com.arcadedb.database.RID[] rid = new com.arcadedb.database.RID[1];
+      db.transaction(() -> rid[0] = db.newDocument("Doc").set("name", "a")
+          .set("blob", "the quick brown fox jumps over the lazy dog").save().getIdentity());
+
+      db.begin();
+      // Lock ONLY the Doc type (primary + index buckets); the EXTERNAL 'blob' bucket is NOT covered.
+      db.getTransaction().lock().type("Doc").lock();
+
+      // Update the external property: the write to its paired bucket joins the page set late.
+      db.lookupByRID(rid[0], true).asDocument().modify().set("blob", "a different, also externally-stored value").save();
+
+      assertThatThrownBy(db::commit)
+          .as("an explicit-lock tx touching an unlocked late-joining external bucket must be rejected (#4937 review)")
+          .isInstanceOf(TransactionException.class)
+          .hasRootCauseMessage("Cannot commit transaction because not all the modified resources were locked: [Doc_0_ext]");
+    } finally {
+      if (db.getTransaction().isActive())
+        db.rollback();
       db.close();
       factory.close();
     }

--- a/engine/src/test/java/com/arcadedb/engine/WalCommitOrderingTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/WalCommitOrderingTest.java
@@ -19,10 +19,13 @@
 package com.arcadedb.engine;
 
 import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.RID;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.TransactionContext;
 import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.exception.TransactionException;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Type;
 import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -102,6 +105,10 @@ class WalCommitOrderingTest {
       assertThat(totalWalBytes())
           .as("a transaction that failed validation must leave NO record in the WAL (#4936)")
           .isEqualTo(walBytesBefore);
+
+      // Evict the injected conflicting page: PageManager.INSTANCE is JVM-global, and a foreign cache entry
+      // must not bleed into other tests sharing this JVM.
+      PageManager.INSTANCE.removePageFromCache(victim.getPageId());
     } finally {
       db.close();
       factory.close();
@@ -121,11 +128,11 @@ class WalCommitOrderingTest {
 
     final DatabaseInternal db = (DatabaseInternal) factory.create();
     try {
-      final com.arcadedb.schema.DocumentType type = db.getSchema().createDocumentType("Doc");
-      type.createProperty("name", com.arcadedb.schema.Type.STRING);
-      type.createProperty("blob", com.arcadedb.schema.Type.STRING).setExternal(true);
+      final DocumentType type = db.getSchema().createDocumentType("Doc");
+      type.createProperty("name", Type.STRING);
+      type.createProperty("blob", Type.STRING).setExternal(true);
 
-      final com.arcadedb.database.RID[] rid = new com.arcadedb.database.RID[1];
+      final RID[] rid = new RID[1];
       db.transaction(() -> rid[0] = db.newDocument("Doc").set("name", "a")
           .set("blob", "the quick brown fox jumps over the lazy dog").save().getIdentity());
 

--- a/engine/src/test/java/com/arcadedb/engine/WalCommitOrderingTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/WalCommitOrderingTest.java
@@ -21,6 +21,7 @@ package com.arcadedb.engine;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.LocalDatabase;
 import com.arcadedb.database.TransactionContext;
 import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.exception.TransactionException;
@@ -152,6 +153,53 @@ class WalCommitOrderingTest {
     } finally {
       if (db.getTransaction().isActive())
         db.rollback();
+      db.close();
+      factory.close();
+    }
+  }
+
+
+  @Test
+  void fencedDatabaseRefusesTheWalAppendAndNewOperations() {
+    // #5053 review: a commit that fails AFTER its WAL append leaves a durable-but-unpublished record; the
+    // live state and the WAL diverge. The database is fenced: no further transaction may cross the WAL
+    // point of no return (it could claim the same page versions the orphaned record targets), and every new
+    // operation fails loudly until a close/reopen runs recovery.
+    final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
+    if (factory.exists())
+      factory.open().drop();
+
+    final DatabaseInternal db = (DatabaseInternal) factory.create();
+    try {
+      db.getSchema().createDocumentType("Doc");
+      db.transaction(() -> db.newDocument("Doc").set("v", 1).save());
+
+      // An in-flight transaction that already passed phase 1 when the fence lands:
+      db.begin();
+      db.query("sql", "SELECT FROM Doc").next().getRecord().get().asDocument().modify().set("v", 2).save();
+      final TransactionContext tx = (TransactionContext) db.getTransaction();
+      final TransactionContext.TransactionPhase1 phase1 = tx.commit1stPhase(true);
+      assertThat(phase1).isNotNull();
+
+      ((LocalDatabase) db).fenceForRecovery("test-injected post-WAL-append failure");
+
+      final long walBytesBefore = totalWalBytes();
+      // Either fence surface is correct: the operation choke point (checkDatabaseIsOpen, hit by the page
+      // reads inside validateAndBumpVersions and wrapped by the commit) or the explicit pre-WAL-append
+      // check (which guards callers whose reads never touch the choke point). What matters is the
+      // invariant asserted below: nothing reached the WAL.
+      assertThatThrownBy(() -> tx.commit2ndPhase(phase1))
+          .as("a fenced database must refuse to cross the WAL point of no return")
+          .isInstanceOf(TransactionException.class)
+          .hasStackTraceContaining("fenced");
+      assertThat(totalWalBytes())
+          .as("the refused commit must leave NO record in the WAL").isEqualTo(walBytesBefore);
+
+      // New operations are fenced too.
+      assertThatThrownBy(() -> db.transaction(() -> db.newDocument("Doc").set("v", 3).save()))
+          .hasMessageContaining("fenced");
+    } finally {
+      // close() must still complete on a fenced database (it is the recovery entry point).
       db.close();
       factory.close();
     }

--- a/engine/src/test/java/com/arcadedb/engine/WalCommitOrderingTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/WalCommitOrderingTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.TransactionContext;
+import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * #4936/#4937: the WAL append must be the commit's point of no return. Phase 2 used to append the
+ * transaction to the WAL FIRST and validate the page versions after; a validation failure (reachable through
+ * the late-joining-files hole, #4937) aborted the transaction while its record stayed in the WAL with no
+ * abort marker - crash recovery then replayed the aborted transaction's other pages: partial application,
+ * torn records, index entries pointing at data never committed.
+ */
+class WalCommitOrderingTest {
+
+  private static final String DB_PATH = "target/databases/WalCommitOrderingTest";
+
+  @AfterEach
+  void cleanup() {
+    final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
+    try {
+      if (factory.exists())
+        factory.open().drop();
+    } catch (final Exception e) {
+      // ignore: removed on disk below
+    }
+    factory.close();
+    FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+
+  @Test
+  void failedValidationLeavesNoWalRecord() throws Exception {
+    // #4936: phase 2 used to append the transaction to the WAL FIRST and validate the page versions after.
+    // A validation failure (reachable through the late-joining-files hole, #4937) then aborted the
+    // transaction while its record stayed in the WAL with no abort marker - crash recovery replayed the
+    // aborted transaction's other pages: partial application, torn records. The WAL append must be the
+    // point of no return: a failed validation leaves ZERO bytes in the WAL.
+    final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
+    if (factory.exists())
+      factory.open().drop();
+
+    final DatabaseInternal db = (DatabaseInternal) factory.create();
+    try {
+      db.getSchema().createDocumentType("Doc");
+      db.transaction(() -> db.newDocument("Doc").set("v", "committed").save());
+
+      // Phase 1 of a new update: locks taken, WAL buffer built, versions checked.
+      db.begin();
+      db.query("sql", "SELECT FROM Doc").next().getRecord().get().asDocument().modify().set("v", "doomed").save();
+      final TransactionContext tx = (com.arcadedb.database.TransactionContext) db.getTransaction();
+      final TransactionContext.TransactionPhase1 phase1 = tx.commit1stPhase(true);
+      assertThat(phase1).isNotNull();
+
+      // Inject a conflicting committed version for one of the transaction's pages, as a racing transaction
+      // through the (now closed) lock-coverage hole would have: phase-2 validation MUST fail.
+      final MutablePage victim = phase1.modifiedPages.getFirst();
+      final MutablePage conflicting = new MutablePage(victim.getPageId(), (int) victim.getPhysicalSize(),
+          victim.getContent().array().clone(), (int) (victim.getVersion() + 1), victim.getContentSize());
+      final java.lang.reflect.Method put = PageManager.class.getDeclaredMethod("putPageInReadCache", CachedPage.class);
+      put.setAccessible(true);
+      put.invoke(PageManager.INSTANCE, new CachedPage(conflicting, false));
+
+      final long walBytesBefore = totalWalBytes();
+      try {
+        tx.commit2ndPhase(phase1);
+        fail("phase 2 must fail validation against the conflicting version");
+      } catch (final ConcurrentModificationException e) {
+        // expected
+      }
+
+      assertThat(totalWalBytes())
+          .as("a transaction that failed validation must leave NO record in the WAL (#4936)")
+          .isEqualTo(walBytesBefore);
+    } finally {
+      db.close();
+      factory.close();
+    }
+  }
+
+  private static long totalWalBytes() {
+    long total = 0;
+    final File[] walFiles = new File(DB_PATH).listFiles((d, n) -> n.endsWith(".wal"));
+    if (walFiles != null)
+      for (final File f : walFiles)
+        total += f.length();
+    return total;
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/WalCommitOrderingTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/WalCommitOrderingTest.java
@@ -146,7 +146,7 @@ class WalCommitOrderingTest {
       assertThatThrownBy(db::commit)
           .as("an explicit-lock tx touching an unlocked late-joining external bucket must be rejected (#4937 review)")
           .isInstanceOf(TransactionException.class)
-          .hasRootCauseMessage("Cannot commit transaction because not all the modified resources were locked: [Doc_0_ext]");
+          .hasMessage("Cannot commit transaction because not all the modified resources were locked: [Doc_0_ext]");
     } finally {
       if (db.getTransaction().isActive())
         db.rollback();


### PR DESCRIPTION
#4936 (HIGH): commit phase 2 appended the transaction to the WAL FIRST and validated the page versions after (inside updatePages). A phase-2 validation failure - reachable through the late-joining-files hole below - aborted the transaction while its record stayed in the WAL with no abort marker. Crash recovery then replayed the aborted transaction's OTHER pages (version == disk+1) while the conflicted page was skipped: a partial application of an aborted transaction - torn multi-page records, index entries pointing at data never committed.

updatePages is split into validateAndBumpVersions (validates against the most recent committed version and bumps the transaction-private page versions) and publishPages (read cache + flush scheduling + page counters). commit2ndPhase now runs validate -> WAL append -> publish, so a WAL record can only ever exist for a transaction that can no longer fail validation. The bump mutates only the transaction's own MutablePage instances: a WAL append failure (e.g. interrupt) still aborts cleanly with nothing observable, and the phase-1 WAL buffer already serializes version+1, so the reorder changes no on-disk format. writeTransactionToFile never reads live page versions (verified) - it only appends the pre-built buffer and attaches the ack bookkeeping.

#4937 (HIGH, the enabler): files can join the transaction's page set AFTER the commit lock set is computed - EXTERNAL-property buckets written during phase-1 serialization, indexes created inside the transaction (written directly at COMMIT_1ST_PHASE), and the vector index's companion graph file, which addFilesToLock omitted entirely. Their pages passed the version checks WITHOUT their file lock held. Two-layer fix: LSMVectorIndex getFileIds() now includes the graph file and addFilesToLock consumes getFileIds (plural), covering any multi-file index; and a generic phase-1 safety net verifies - after ALL page-set mutation - that every file in modifiedPages/newPages is locked, releasing and re-acquiring the UNION in order when a late joiner is found (the version checks that follow catch anything that changed while unlocked with the standard retriable CME). In explicit-lock mode an uncovered file surfaces as the contract violation it is instead of being silently re-locked.

Red-first verified: on the old ordering, a transaction that failed phase-2 validation left its bytes in the WAL; now the WAL is byte-identical before and after the failed commit. Union sweep with the companion WAL-recovery branch: 372 classes, 2851 tests, 0 failures; the ordering test re-verified green on this branch alone.

NOTE for reviewers: this is the highest-blast-radius change of the audit series - it reorders every commit in the engine. Split into its own PR precisely so it gets focused review.

## What does this PR do?

A brief description of the change being made with this pull request.

## Motivation

What inspired you to submit this pull request?

## Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

## Additional Notes

Anything else we should know when reviewing?

## Checklist

- [ ] I have run the build using `mvn clean package` command
- [ ] My unit tests cover both failure and success scenarios
