### PR TITLE
fix(#5034): root-gate AI activation and make chat/config file writes atomic

### DIFF
--- a/docs/5034-ai-activation-root-gate-atomic-writes.md
+++ b/docs/5034-ai-activation-root-gate-atomic-writes.md
@@ -1,0 +1,32 @@
+# Issue #5034 - AI module: activation not root-gated + non-atomic, unsynchronized chat/config writes
+
+## Symptom
+- `POST /api/v1/ai/activate` was reachable by any authenticated (non-root) user, letting them push a
+  subscription key to the gateway and overwrite server-wide `config/ai.json`.
+- `ChatStorage.saveChat` used a truncating `FileOutputStream` with no lock, no atomic rename, and it
+  swallowed write errors: concurrent saves/reads produced spliced or partial JSON ("chat disappears"),
+  and failures were reported as success.
+- `AiConfiguration.save`, `MCPConfiguration.save`, and `PostServerCommandHandler.setBackupConfig` all
+  rewrite config files in place; a crash mid-write corrupts the previously valid file.
+
+## Root cause
+- `AiActivateHandler.execute` never called `checkRootUser(user)` (unlike `MCPConfigHandler`, `PostUserHandler`).
+- `ChatStorage.saveChat` did a direct in-place truncating write with no serialization and swallowed exceptions.
+- Config writers used `Files.writeString` / `FileOutputStream` directly onto the live file.
+
+## Fix
+- `AiActivateHandler.execute`: call `checkRootUser(user)` first; non-root -> 403.
+- `ChatStorage.saveChat`: write to `<chat>.json.tmp` then `Files.move(..., ATOMIC_MOVE)` (fallback to a
+  non-atomic replacing move if the FS rejects ATOMIC_MOVE); serialize per-`(user, chatId)` writers via a
+  lock stripe; propagate write failures as an unchecked exception instead of swallowing them.
+- `AiConfiguration.save`, `MCPConfiguration.save`, `PostServerCommandHandler.setBackupConfig`: reuse an
+  atomic write helper (temp file + `ATOMIC_MOVE`) so a crash mid-write leaves the prior file intact.
+
+## Tests
+- `AiServerTest.activateRejectsNonRootUser` - non-root POST /api/v1/ai/activate returns 403.
+- `ChatStorageTest` - atomic-save concurrency: concurrent saves never corrupt the file; a save failure surfaces.
+- `AiConfigurationTest` / `MCPConfigurationTest` - config file stays valid, temp file cleaned up.
+
+## Impact
+- Closes a MEDIUM privilege-escalation hole and a MEDIUM durability/concurrency defect in the AI module,
+  plus hardens the remaining non-atomic config writes.

--- a/docs/5034-ai-activation-root-gate-atomic-writes.md
+++ b/docs/5034-ai-activation-root-gate-atomic-writes.md
@@ -45,11 +45,29 @@
 - Cycle 2 - head `2ed4fb11f` (after applying the fixes): gemini-code-assist re-posted the same HIGH
   comment, which is now stale/already-resolved (HEAD already passes `ATOMIC_MOVE, REPLACE_EXISTING`);
   no action required. The `claude` bot again did not post within the 15-minute window.
+- Cycle 3 - head `ae22c687` (docs update): `claude` LGTM with 6 minor/non-blocking observations;
+  gemini's inline comment on this SHA was the stale re-anchored `REPLACE_EXISTING` note (already
+  resolved). Applied three: (1) streaming path now logs (not throws) a `saveChat` failure because the
+  SSE exchange is already committed - re-throwing would attempt a second response on the committed
+  exchange; (2) dropped the redundant `mkdirs()` in `saveChat` (`atomicWriteFile` already creates the
+  parent dir); (3) tightened the lock-stripe comment to state the anti-splice guarantee comes from the
+  atomic rename, not the lock. All 24 AI/config tests pass. Pushed as `e11e0473`.
+- Cycle 4 - head `e11e0473`: `claude` fresh review (LGTM, "none are blockers"). Its one substantive
+  item (non-streaming path returns 500 on a persistence failure, discarding a possibly-billed AI
+  answer) is a deliberate design decision that directly matches issue #5034's acceptance criterion
+  "a save failure surfaces as an error" - not auto-reversed; deferred to the developer. Remaining
+  items (parent-dir fsync, dropping the lock stripe, @Tag("slow"), 0600 perms) were skipped with
+  rationale (dropping the lock would contradict the issue's "add a per-(user, chatId) lock" criterion;
+  the concurrency test measured 0.201 s so is not "slow"). No code change this cycle. `gemini` did not
+  post a fresh review on this HEAD within the window (only the stale re-anchored inline comment).
 
 ## Deferred items
-- None.
+- `docs/review-deferred-e11e0473.md` (local-only, not committed) - Item 1: non-streaming persistence
+  failure returns 500 vs. preserving a billed AI answer. Default recommendation: keep current behavior
+  (matches issue acceptance criteria). Also records the skipped optional items with rationale.
 
 ## Final state
-- `timeout`: all actionable review feedback (gemini's two items) was applied in cycle 1 and verified;
-  the gating `claude` bot never responded within the per-cycle 15-minute window on either commit.
-  PR left open for the developer. Merge remains the developer's responsibility.
+- `deferred-items`: all clearly-actionable feedback was applied in cycle 3 and verified (24 tests
+  green). The one remaining substantive suggestion (cycle 4, item 1) is a conscious product decision
+  surfaced to the developer rather than auto-applied, because reversing it would contradict issue
+  #5034's explicit acceptance criteria. PR left open. Merge remains the developer's responsibility.

--- a/docs/5034-ai-activation-root-gate-atomic-writes.md
+++ b/docs/5034-ai-activation-root-gate-atomic-writes.md
@@ -30,3 +30,26 @@
 ## Impact
 - Closes a MEDIUM privilege-escalation hole and a MEDIUM durability/concurrency defect in the AI module,
   plus hardens the remaining non-atomic config writes.
+
+## PR
+- https://github.com/ArcadeData/arcadedb/pull/5057
+
+## Review cycles
+- Cycle 1 - head `00d9e5303`: gemini-code-assist COMMENTED with two actionable items on
+  `FileUtils.atomicWriteFile` (both verified correct and applied):
+  - HIGH: `ATOMIC_MOVE` must be paired with `REPLACE_EXISTING` to overwrite an existing target on
+    platforms such as Windows (otherwise `FileAlreadyExistsException`).
+  - MEDIUM: resolve the target to an absolute path so the temp file lands on the same file store
+    (a relative path gave a null parent -> system temp dir -> non-atomic fallback).
+  The `claude` bot did not post a review within the 15-minute window.
+- Cycle 2 - head `2ed4fb11f` (after applying the fixes): gemini-code-assist re-posted the same HIGH
+  comment, which is now stale/already-resolved (HEAD already passes `ATOMIC_MOVE, REPLACE_EXISTING`);
+  no action required. The `claude` bot again did not post within the 15-minute window.
+
+## Deferred items
+- None.
+
+## Final state
+- `timeout`: all actionable review feedback (gemini's two items) was applied in cycle 1 and verified;
+  the gating `claude` bot never responded within the per-cycle 15-minute window on either commit.
+  PR left open for the developer. Merge remains the developer's responsibility.

--- a/engine/src/main/java/com/arcadedb/utility/FileUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/FileUtils.java
@@ -38,10 +38,13 @@ import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.net.URLEncoder;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.logging.Level;
@@ -350,6 +353,37 @@ public class FileUtils {
   public static void writeContentToStream(final File file, final byte[] content) throws IOException {
     try (final FileOutputStream fos = new FileOutputStream(file)) {
       fos.write(content);
+    }
+  }
+
+  /**
+   * Writes {@code content} to {@code file} atomically: the bytes are first written to a sibling
+   * temporary file (flushed and fsync'd), then moved onto the target with {@code ATOMIC_MOVE} so a
+   * concurrent reader always sees either the previous complete file or the new complete file, never a
+   * partial/spliced one. If a crash happens mid-write, the previous valid file is left untouched.
+   * When the underlying filesystem cannot perform an atomic move, it falls back to a
+   * {@code REPLACE_EXISTING} move (still a single rename, just without the cross-crash guarantee).
+   */
+  public static void atomicWriteFile(final File file, final String content) throws IOException {
+    final Path target = file.toPath();
+    final Path dir = target.getParent();
+    if (dir != null)
+      Files.createDirectories(dir);
+
+    final Path tmp = Files.createTempFile(dir, file.getName() + ".", ".tmp");
+    try {
+      try (final FileOutputStream fos = new FileOutputStream(tmp.toFile())) {
+        fos.write(content.getBytes(StandardCharsets.UTF_8));
+        fos.flush();
+        fos.getFD().sync();
+      }
+      try {
+        Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE);
+      } catch (final AtomicMoveNotSupportedException e) {
+        Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
+      }
+    } finally {
+      Files.deleteIfExists(tmp);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/utility/FileUtils.java
+++ b/engine/src/main/java/com/arcadedb/utility/FileUtils.java
@@ -365,10 +365,12 @@ public class FileUtils {
    * {@code REPLACE_EXISTING} move (still a single rename, just without the cross-crash guarantee).
    */
   public static void atomicWriteFile(final File file, final String content) throws IOException {
-    final Path target = file.toPath();
+    // Resolve to an absolute path so getParent() is never null for relative inputs (e.g. new
+    // File("ai.json")); this keeps the temp file on the same file store as the target, which is
+    // required for the ATOMIC_MOVE below to actually be atomic instead of falling back to a copy.
+    final Path target = file.toPath().toAbsolutePath();
     final Path dir = target.getParent();
-    if (dir != null)
-      Files.createDirectories(dir);
+    Files.createDirectories(dir);
 
     final Path tmp = Files.createTempFile(dir, file.getName() + ".", ".tmp");
     try {
@@ -378,7 +380,9 @@ public class FileUtils {
         fos.getFD().sync();
       }
       try {
-        Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE);
+        // REPLACE_EXISTING is required for ATOMIC_MOVE to overwrite an existing target on some
+        // platforms (notably Windows), where the move otherwise throws FileAlreadyExistsException.
+        Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
       } catch (final AtomicMoveNotSupportedException e) {
         Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
       }

--- a/engine/src/test/java/com/arcadedb/utility/FileUtilsTest.java
+++ b/engine/src/test/java/com/arcadedb/utility/FileUtilsTest.java
@@ -356,4 +356,26 @@ class FileUtilsTest {
     assertThat(result).contains("3:");
     assertThat(result).doesNotContain("4:");
   }
+
+  @Test
+  void atomicWriteFileCreatesDirsAndWritesContent() throws IOException {
+    final Path target = tempDir.resolve("nested/dir/config.json");
+    FileUtils.atomicWriteFile(target.toFile(), "{\"a\":1}");
+
+    assertThat(Files.exists(target)).isTrue();
+    assertThat(new String(Files.readAllBytes(target), StandardCharsets.UTF_8)).isEqualTo("{\"a\":1}");
+    // No temporary artifacts must survive a successful write.
+    try (var stream = Files.list(target.getParent())) {
+      assertThat(stream.map(p -> p.getFileName().toString()).anyMatch(n -> n.endsWith(".tmp"))).isFalse();
+    }
+  }
+
+  @Test
+  void atomicWriteFileReplacesExistingContentAtomically() throws IOException {
+    final Path target = tempDir.resolve("value.txt");
+    FileUtils.atomicWriteFile(target.toFile(), "first");
+    FileUtils.atomicWriteFile(target.toFile(), "second-longer-content");
+
+    assertThat(new String(Files.readAllBytes(target), StandardCharsets.UTF_8)).isEqualTo("second-longer-content");
+  }
 }

--- a/server/src/main/java/com/arcadedb/server/ai/AiActivateHandler.java
+++ b/server/src/main/java/com/arcadedb/server/ai/AiActivateHandler.java
@@ -62,6 +62,11 @@ public class AiActivateHandler extends AbstractServerHttpHandler {
 
   @Override
   protected ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user, final JSONObject payload) {
+    // Activation writes server-wide config (config/ai.json) and pushes a subscription key to the
+    // gateway, so it is a server-administration action restricted to the root user, consistent with
+    // MCPConfigHandler, PostUserHandler, etc.
+    checkRootUser(user);
+
     if (payload == null)
       return new ExecutionResponse(400, errorJson("Request body is required"));
 

--- a/server/src/main/java/com/arcadedb/server/ai/AiChatHandler.java
+++ b/server/src/main/java/com/arcadedb/server/ai/AiChatHandler.java
@@ -369,7 +369,18 @@ public class AiChatHandler extends AbstractServerHttpHandler {
       messages.put(assistantMsg);
       chat.put("messages", messages);
       chat.put("updated", Instant.now().toString());
-      chatStorage.saveChat(username, chat);
+      // The SSE response has already been fully streamed and the output closed above, so the
+      // exchange is committed: we can no longer turn a persistence failure into an HTTP error for
+      // the client. Unlike the non-streaming path (buildResponse), let saveChat's failure only be
+      // logged here - re-throwing would bubble up to execute()'s catch and attempt a second
+      // response on the already-committed exchange.
+      try {
+        chatStorage.saveChat(username, chat);
+      } catch (final RuntimeException e) {
+        LogManager.instance().log(this, Level.WARNING,
+            "Failed to persist chat history after streaming response (chatId=%s): %s",
+            chat.getString("id", null), e.getMessage());
+      }
     }
 
     return null; // response already sent

--- a/server/src/main/java/com/arcadedb/server/ai/AiConfiguration.java
+++ b/server/src/main/java/com/arcadedb/server/ai/AiConfiguration.java
@@ -20,10 +20,9 @@ package com.arcadedb.server.ai;
 
 import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.FileUtils;
 
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -70,12 +69,9 @@ public class AiConfiguration {
   }
 
   public synchronized void save() {
-    final File configDir = Paths.get(rootPath, "config").toFile();
-    if (!configDir.exists())
-      configDir.mkdirs();
-
-    try (final OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(getConfigFile()), StandardCharsets.UTF_8)) {
-      writer.write(toFullJSON().toString(2));
+    try {
+      // Atomic write so a crash mid-write leaves the previous valid config/ai.json intact.
+      FileUtils.atomicWriteFile(getConfigFile(), toFullJSON().toString(2));
     } catch (final Exception e) {
       LogManager.instance().log(this, Level.WARNING, "Error saving AI configuration: %s", e.getMessage());
     }

--- a/server/src/main/java/com/arcadedb/server/ai/ChatStorage.java
+++ b/server/src/main/java/com/arcadedb/server/ai/ChatStorage.java
@@ -21,10 +21,10 @@ package com.arcadedb.server.ai;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.FileUtils;
 
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.OutputStreamWriter;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 
 /**
@@ -40,10 +41,18 @@ import java.util.logging.Level;
  * Chats are stored as JSON files under {serverRoot}/chats/{username}/.
  */
 public class ChatStorage {
+  // Fixed stripe of locks: a single write to a given (user, chatId) is serialized against other
+  // writes to the same chat so two concurrent saves never splice their JSON. Sized as a power of
+  // two so the index masks cleanly; collisions across unrelated chats are harmless (they just wait).
+  private static final int            LOCK_STRIPES = 64;
+  private final        ReentrantLock[] writeLocks   = new ReentrantLock[LOCK_STRIPES];
+
   private final String rootPath;
 
   public ChatStorage(final String rootPath) {
     this.rootPath = rootPath;
+    for (int i = 0; i < LOCK_STRIPES; i++)
+      writeLocks[i] = new ReentrantLock();
   }
 
   /**
@@ -100,6 +109,13 @@ public class ChatStorage {
 
   /**
    * Saves a chat. Creates the user directory if needed.
+   *
+   * <p>The write is atomic (temp file + atomic rename) and serialized per {@code (username, chatId)}
+   * so concurrent writers never produce a spliced file and a reader never observes a partial one.
+   * A write failure is propagated as an unchecked exception rather than swallowed, so the caller does
+   * not report success while nothing persisted.
+   *
+   * @throws IllegalStateException if the chat could not be persisted.
    */
   public void saveChat(final String username, final JSONObject chat) {
     final File userDir = getUserDir(username);
@@ -108,12 +124,23 @@ public class ChatStorage {
 
     final String chatId = chat.getString("id");
     final File file = getChatFile(username, chatId);
+    final String content = chat.toString(2);
 
-    try (final OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8)) {
-      writer.write(chat.toString(2));
-    } catch (final Exception e) {
+    final ReentrantLock lock = lockFor(username, chatId);
+    lock.lock();
+    try {
+      FileUtils.atomicWriteFile(file, content);
+    } catch (final IOException e) {
       LogManager.instance().log(this, Level.WARNING, "Error saving chat %s: %s", chatId, e.getMessage());
+      throw new IllegalStateException("Error saving chat " + chatId, e);
+    } finally {
+      lock.unlock();
     }
+  }
+
+  private ReentrantLock lockFor(final String username, final String chatId) {
+    final int idx = (username + '/' + chatId).hashCode() & (LOCK_STRIPES - 1);
+    return writeLocks[idx];
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/ai/ChatStorage.java
+++ b/server/src/main/java/com/arcadedb/server/ai/ChatStorage.java
@@ -41,9 +41,11 @@ import java.util.logging.Level;
  * Chats are stored as JSON files under {serverRoot}/chats/{username}/.
  */
 public class ChatStorage {
-  // Fixed stripe of locks: a single write to a given (user, chatId) is serialized against other
-  // writes to the same chat so two concurrent saves never splice their JSON. Sized as a power of
-  // two so the index masks cleanly; collisions across unrelated chats are harmless (they just wait).
+  // Fixed stripe of locks giving concurrent writers to the same (user, chatId) a deterministic
+  // last-writer-wins ordering. The "never a partial/spliced file" guarantee actually comes from
+  // atomicWriteFile()'s atomic rename, not from this lock; the read-modify-write cycle in the
+  // handler reads outside the lock, so this stripe does not prevent lost updates. Sized as a power
+  // of two so the index masks cleanly; collisions across unrelated chats are harmless (they wait).
   private static final int            LOCK_STRIPES = 64;
   private final        ReentrantLock[] writeLocks   = new ReentrantLock[LOCK_STRIPES];
 
@@ -118,10 +120,8 @@ public class ChatStorage {
    * @throws IllegalStateException if the chat could not be persisted.
    */
   public void saveChat(final String username, final JSONObject chat) {
-    final File userDir = getUserDir(username);
-    if (!userDir.exists())
-      userDir.mkdirs();
-
+    // No explicit mkdirs here: atomicWriteFile() creates the target's parent directory (the user
+    // dir) before writing, so a separate mkdirs would be redundant.
     final String chatId = chat.getString("id");
     final File file = getChatFile(username, chatId);
     final String content = chat.toString(2);

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -39,6 +39,7 @@ import com.arcadedb.server.HAServerPlugin;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.security.ServerSecurityException;
 import com.arcadedb.server.security.ServerSecurityUser;
+import com.arcadedb.utility.FileUtils;
 import io.micrometer.core.instrument.Metrics;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HeaderValues;
@@ -835,13 +836,9 @@ public class PostServerCommandHandler extends AbstractServerHttpHandler {
     // Save configuration to file
     final Path configPath = Paths.get(server.getRootPath(), "config", AutoBackupConfig.CONFIG_FILE_NAME);
 
-    // Ensure config directory exists
-    final Path configDir = configPath.getParent();
-    if (!Files.exists(configDir))
-      Files.createDirectories(configDir);
-
-    // Write configuration
-    Files.writeString(configPath, configJson.toString(2));
+    // Write configuration atomically so a crash mid-write leaves the previous valid file intact.
+    // atomicWriteFile also creates the parent config directory if needed.
+    FileUtils.atomicWriteFile(configPath.toFile(), configJson.toString(2));
 
     // Reload configuration in the plugin
     final AutoBackupSchedulerPlugin plugin = getBackupPlugin(server);

--- a/server/src/main/java/com/arcadedb/server/mcp/MCPConfiguration.java
+++ b/server/src/main/java/com/arcadedb/server/mcp/MCPConfiguration.java
@@ -21,11 +21,10 @@ package com.arcadedb.server.mcp;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.FileUtils;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -88,12 +87,9 @@ public class MCPConfiguration {
   }
 
   public synchronized void save() {
-    final File configDir = Paths.get(rootPath, "config").toFile();
-    if (!configDir.exists())
-      configDir.mkdirs();
-
-    try (final OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(getConfigFile()), StandardCharsets.UTF_8)) {
-      writer.write(toJSON().toString(2));
+    try {
+      // Atomic write so a crash mid-write leaves the previous valid config/mcp-config.json intact.
+      FileUtils.atomicWriteFile(getConfigFile(), toJSON().toString(2));
     } catch (final IOException e) {
       LogManager.instance().log(this, Level.WARNING, "Error saving MCP configuration: %s", e.getMessage());
     }

--- a/server/src/test/java/com/arcadedb/server/ai/AiConfigurationTest.java
+++ b/server/src/test/java/com/arcadedb/server/ai/AiConfigurationTest.java
@@ -102,6 +102,23 @@ class AiConfigurationTest {
     assertThat(config.isConfigured()).isFalse();
   }
 
+  @Test
+  void saveWritesValidFileAndLeavesNoTempArtifacts() {
+    final AiConfiguration config = new AiConfiguration(TEST_ROOT);
+    config.activate("token-abc", "127.0.0.1", "hw-1", "1.2.3");
+
+    // Reload from disk: the persisted file must be complete and valid.
+    final AiConfiguration reloaded = new AiConfiguration(TEST_ROOT);
+    reloaded.load();
+    assertThat(reloaded.isConfigured()).isTrue();
+    assertThat(reloaded.getSubscriptionToken()).isEqualTo("token-abc");
+
+    // The atomic write must not leave any temporary files behind.
+    final File configDir = Paths.get(TEST_ROOT, "config").toFile();
+    final File[] leftovers = configDir.listFiles((dir, name) -> name.endsWith(".tmp"));
+    assertThat(leftovers).isNullOrEmpty();
+  }
+
   private void writeConfigFile(final JSONObject json) throws Exception {
     final File configDir = Paths.get(TEST_ROOT, "config").toFile();
     configDir.mkdirs();

--- a/server/src/test/java/com/arcadedb/server/ai/AiServerTest.java
+++ b/server/src/test/java/com/arcadedb/server/ai/AiServerTest.java
@@ -152,6 +152,37 @@ class AiServerTest extends BaseGraphServerTest {
   }
 
   @Test
+  void activateRejectsNonRootUser() throws Exception {
+    // A non-root, authenticated user must not be able to activate an AI subscription: activation
+    // pushes a subscription key to the gateway and overwrites server-wide config/ai.json.
+    if (!getServer(0).getSecurity().existsUser("aiuser"))
+      getServer(0).getSecurity().createUser("aiuser", "aipassword");
+
+    final String nonRootAuth = "Basic " + Base64.getEncoder()
+        .encodeToString("aiuser:aipassword".getBytes(StandardCharsets.UTF_8));
+
+    final HttpURLConnection connection = (HttpURLConnection) new URI(getAiUrl("/activate")).toURL().openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization", nonRootAuth);
+    connection.setRequestProperty("Content-Type", "application/json");
+    connection.setDoOutput(true);
+
+    final JSONObject payload = new JSONObject().put("subscriptionKey", "some-key");
+    try (final DataOutputStream out = new DataOutputStream(connection.getOutputStream())) {
+      out.write(payload.toString().getBytes(StandardCharsets.UTF_8));
+    }
+    connection.connect();
+
+    try {
+      assertThat(connection.getResponseCode()).isEqualTo(403);
+      // The server-wide config must not have been activated by the non-root request.
+      assertThat(getServer(0).getAiConfiguration().isConfigured()).isFalse();
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  @Test
   void requiresAuthentication() throws Exception {
     final HttpURLConnection connection = (HttpURLConnection) new URI(getAiUrl("/config")).toURL().openConnection();
     connection.setRequestMethod("GET");

--- a/server/src/test/java/com/arcadedb/server/ai/ChatStorageTest.java
+++ b/server/src/test/java/com/arcadedb/server/ai/ChatStorageTest.java
@@ -26,10 +26,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ChatStorageTest {
   private static final String TEST_ROOT = "target/test-chat-storage";
@@ -146,6 +154,87 @@ class ChatStorageTest {
     assertThat(ChatStorage.sanitizeFilename("../../../etc/passwd")).isEqualTo("_________etc_passwd");
     assertThat(ChatStorage.sanitizeFilename(null)).isEqualTo("default");
     assertThat(ChatStorage.sanitizeFilename("")).isEqualTo("default");
+  }
+
+  @Test
+  void concurrentSavesNeverCorruptTheChatFile() throws Exception {
+    // Writers repeatedly persist a growing chat while readers repeatedly load it. With the atomic,
+    // per-(user, chatId) serialized write, a reader must always observe a complete, valid JSON file
+    // (never null / partial), and the final file must be readable.
+    final JSONObject chat = ChatStorage.createNewChat("db", "Concurrent chat");
+    final String chatId = chat.getString("id");
+    chatStorage.saveChat("root", chat);
+
+    final int threads = 8;
+    final int iterations = 200;
+    final ExecutorService pool = Executors.newFixedThreadPool(threads);
+    final CountDownLatch start = new CountDownLatch(1);
+    final AtomicBoolean corruption = new AtomicBoolean(false);
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+
+    for (int t = 0; t < threads; t++) {
+      final int threadId = t;
+      pool.submit(() -> {
+        try {
+          start.await();
+          for (int i = 0; i < iterations; i++) {
+            if (threadId % 2 == 0) {
+              final JSONObject copy = new JSONObject(chat.toString());
+              final JSONArray messages = copy.getJSONArray("messages");
+              final JSONObject msg = new JSONObject();
+              msg.put("role", "user");
+              msg.put("content", "message " + threadId + "-" + i);
+              messages.put(msg);
+              copy.put("updated", Instant.now().toString());
+              chatStorage.saveChat("root", copy);
+            } else {
+              final JSONObject loaded = chatStorage.getChat("root", chatId);
+              // A partial/spliced write would surface as null (unparseable) or a wrong id.
+              if (loaded == null || !chatId.equals(loaded.getString("id", "")))
+                corruption.set(true);
+            }
+          }
+        } catch (final Throwable e) {
+          failure.set(e);
+        }
+      });
+    }
+
+    start.countDown();
+    pool.shutdown();
+    assertThat(pool.awaitTermination(60, TimeUnit.SECONDS)).isTrue();
+
+    assertThat(failure.get()).isNull();
+    assertThat(corruption.get()).isFalse();
+
+    // Final file is still valid and complete.
+    final JSONObject finalChat = chatStorage.getChat("root", chatId);
+    assertThat(finalChat).isNotNull();
+    assertThat(finalChat.getString("id")).isEqualTo(chatId);
+  }
+
+  @Test
+  void saveChatPropagatesWriteFailure() {
+    // Place a regular file where the user's chat directory should be so the write cannot create the
+    // target directory. The failure must surface (not be silently swallowed as a false success).
+    final File chatsDir = Paths.get(TEST_ROOT, "chats").toFile();
+    chatsDir.mkdirs();
+    final File blocker = Paths.get(TEST_ROOT, "chats", "blockeduser").toFile();
+    assertThat(writeEmptyFile(blocker)).isTrue();
+
+    final JSONObject chat = ChatStorage.createNewChat("db", "Will fail");
+
+    assertThatThrownBy(() -> chatStorage.saveChat("blockeduser", chat))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  private static boolean writeEmptyFile(final File file) {
+    try {
+      FileUtils.writeFile(file, "");
+      return file.isFile();
+    } catch (final Exception e) {
+      return false;
+    }
   }
 
   @Test


### PR DESCRIPTION
Closes #5034

## Summary

Resolves the 2026-07 `server`-module audit findings in the AI module plus the remaining non-atomic config writes:

- **Defect 1 (MEDIUM security):** `AiActivateHandler.execute` now calls `checkRootUser(user)` first, so only the root user can activate an AI subscription. Previously any authenticated user (including a single-database API-token user) could POST `/api/v1/ai/activate`, push a subscription key to the gateway, and overwrite server-wide `config/ai.json`. Non-root requests now return `403`.
- **Defect 2 (MEDIUM durability/concurrency):** `ChatStorage.saveChat` now writes to a temp file and renames with `ATOMIC_MOVE`, serializes writers per `(user, chatId)` via a lock stripe, and propagates write failures as an `IllegalStateException` instead of swallowing them and reporting success. This stops spliced/partial JSON ("chat disappears") under concurrent save/read.
- **Defect 3 (LOW durability):** `AiConfiguration.save`, `MCPConfiguration.save`, and `PostServerCommandHandler.setBackupConfig` now write their config files atomically via a new shared `FileUtils.atomicWriteFile` helper (temp file + fsync + `ATOMIC_MOVE`, with a `REPLACE_EXISTING` fallback), so a crash mid-write leaves the previous valid file intact.

## Test plan

- [ ] `AiServerTest.activateRejectsNonRootUser` - non-root `POST /api/v1/ai/activate` returns 403 and does not activate config.
- [ ] `ChatStorageTest.concurrentSavesNeverCorruptTheChatFile` - concurrent writers/readers never observe a partial/null chat.
- [ ] `ChatStorageTest.saveChatPropagatesWriteFailure` - a save failure surfaces as an exception.
- [ ] `AiConfigurationTest.saveWritesValidFileAndLeavesNoTempArtifacts` - config persists valid, no `.tmp` leftovers.
- [ ] `FileUtilsTest.atomicWriteFile*` - helper creates dirs, replaces content, leaves no temp artifacts.
- [ ] Regression: `MCPServerPluginTest`, `MCPPermissionsTest`, `AiChatHandlerStreamingTest`, `BackupApiCommandsIT`, `PostServerCommandHandlerIT` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)