### PR TITLE
feat(#5001): advertise and negotiate Bolt 5.0-5.4 with version-gated wire encoding

### DIFF
--- a/bolt/conformance/spec.yaml
+++ b/bolt/conformance/spec.yaml
@@ -550,13 +550,7 @@ scenarios:
       - "When a driver's handshake proposes only Bolt 5.x version ranges"
       - "Then the server should either negotiate a 5.x version, or the negotiation failure/fallback behavior should be documented and intentional"
     applicable_driver_versions: all
-    current_status: expected-fail
-    known_limitation: >
-      BoltNetworkExecutor.SUPPORTED_VERSIONS (line 96) never advertises
-      any Bolt 5.x version; current drivers that support 5.x only work
-      today by silently downgrading to 4.4, which is undocumented and
-      untested as a deliberate compatibility stance.
-    tracking_issue: "#4890"
+    current_status: passing
   - id: PROTO-003
     area: protocol
     title: "RESET returns the connection to a clean state mid-stream"

--- a/bolt/conformance/validate_spec.py
+++ b/bolt/conformance/validate_spec.py
@@ -25,11 +25,12 @@ VALID_STATUSES = {"passing", "expected-fail", "not-applicable", "unverified"}
 REQUIRED_LANGUAGES = {"java", "javascript", "python", "csharp", "go"}
 KNOWN_GAP_TRACKING_ISSUE = "#4890"
 # Areas that must each carry at least one #4890-tracked expected-fail scenario:
-# connection (single-node-only ROUTE), protocol (no Bolt 5.x negotiation).
-# errors and type-roundtrip previously appeared here too (ERR-002 and
-# TYPE-003/011/012 respectively), but those were the only #4890-tracked gaps
-# in either area and all four are now closed and flipped to passing.
-REQUIRED_GAP_AREAS = {"connection", "protocol"}
+# connection (single-node-only ROUTE).
+# errors, type-roundtrip, and protocol previously appeared here too (ERR-002,
+# TYPE-003/011/012, and PROTO-002 respectively), but those were the only
+# #4890-tracked gaps in their areas and all are now closed and flipped to
+# passing.
+REQUIRED_GAP_AREAS = {"connection"}
 # Canonical AREA-NNN id prefix per area - not derivable from the area string
 # (e.g. transactions -> TX, multi-database -> MDB, causal-consistency ->
 # CAUSAL), so scenario ids are checked against this table rather than a

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -95,9 +95,13 @@ public class BoltNetworkExecutor extends Thread {
   // BOLT magic bytes
   private static final byte[] BOLT_MAGIC = { 0x60, 0x60, (byte) 0xB0, 0x17 };
 
-  // Supported protocol versions (in order of preference)
+  // Supported protocol versions (in order of preference). Package-private so the negotiation unit
+  // test asserts against the real advertised set rather than a drifting copy.
   // Encoding: [unused(8)][range(8)][minor(8)][major(8)] — major = value & 0xFF, minor = (value >> 8) & 0xFF
-  private static final int[] SUPPORTED_VERSIONS = { 0x00000404, 0x00000004, 0x00000003 }; // v4.4, v4.0, v3.0
+  static final int[] SUPPORTED_VERSIONS = {
+      0x00000405, 0x00000305, 0x00000205, 0x00000105, 0x00000005, // v5.4, v5.3, v5.2, v5.1, v5.0
+      0x00000404, 0x00000004, 0x00000003                          // v4.4, v4.0, v3.0
+  };
 
   // Server states
   private enum State {
@@ -1709,7 +1713,7 @@ public class BoltNetworkExecutor extends Thread {
       LogManager.instance().log(this, Level.FINE, "BOLT >> %s", message);
     }
 
-    final PackStreamWriter writer = new PackStreamWriter();
+    final PackStreamWriter writer = new PackStreamWriter().boltMajorVersion(getMajorVersion(protocolVersion));
     message.writeTo(writer);
     output.writeMessage(writer.toByteArray());
   }

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -301,30 +301,7 @@ public class BoltNetworkExecutor extends Thread {
       LogManager.instance().log(this, Level.FINE, "BOLT client versions: %s",
           Arrays.toString(Arrays.stream(clientVersions).mapToObj(v -> String.format("0x%08X", v)).toArray()));
 
-    // Select best matching version using Bolt version negotiation with range support.
-    // The range means the client supports minor versions from (minor - range) up to minor
-    // (inclusive) for the given major version. Zero entries are trailing padding per the Bolt spec.
-    protocolVersion = 0;
-    for (final int clientVersion : clientVersions) {
-      if (clientVersion == 0)
-        break;
-
-      final int clientMajor = getMajorVersion(clientVersion);
-      final int clientMinor = getMinorVersion(clientVersion);
-      final int clientRange = getVersionRange(clientVersion);
-
-      for (final int supportedVersion : SUPPORTED_VERSIONS) {
-        final int serverMajor = getMajorVersion(supportedVersion);
-        final int serverMinor = getMinorVersion(supportedVersion);
-
-        if (clientMajor == serverMajor && serverMinor <= clientMinor && serverMinor >= clientMinor - clientRange) {
-          protocolVersion = supportedVersion;
-          break;
-        }
-      }
-      if (protocolVersion != 0)
-        break;
-    }
+    protocolVersion = selectVersion(clientVersions);
 
     // Send selected version
     output.writeRawInt(protocolVersion);
@@ -383,7 +360,12 @@ public class BoltNetworkExecutor extends Thread {
       handleRoute((RouteMessage) message);
       break;
     case BoltMessage.TELEMETRY:
-      sendSuccess(Map.of());
+      // A FAILED connection must respond IGNORED to every request except RESET (Bolt state machine),
+      // consistent with the other request handlers; otherwise acknowledge with SUCCESS.
+      if (state == State.FAILED)
+        sendIgnored();
+      else
+        sendSuccess(Map.of());
       break;
     default:
       sendFailure(BoltException.PROTOCOL_ERROR, "Unknown message: " + BoltMessage.signatureName(message.getSignature()));
@@ -1912,6 +1894,32 @@ public class BoltNetworkExecutor extends Thread {
    * such a HELLO is accepted (awaiting LOGON) instead of being rejected as "missing credentials".
    * Pre-5.1 keeps HELLO-embedded auth; an explicit scheme (incl. "none") is never a deferral.
    */
+  /**
+   * Select the highest-preference server version compatible with the client's proposals, or 0 if none match.
+   * Client proposals are tried in order; for each, the range means the client supports minor versions from
+   * (minor - range) up to minor inclusive for that major. A zero entry is trailing padding and stops the scan.
+   * Pure function over {@link #SUPPORTED_VERSIONS} so the negotiation logic is exercised directly by tests.
+   */
+  static int selectVersion(final int[] clientVersions) {
+    for (final int clientVersion : clientVersions) {
+      if (clientVersion == 0)
+        break;
+
+      final int clientMajor = getMajorVersion(clientVersion);
+      final int clientMinor = getMinorVersion(clientVersion);
+      final int clientRange = getVersionRange(clientVersion);
+
+      for (final int supportedVersion : SUPPORTED_VERSIONS) {
+        final int serverMajor = getMajorVersion(supportedVersion);
+        final int serverMinor = getMinorVersion(supportedVersion);
+
+        if (clientMajor == serverMajor && serverMinor <= clientMinor && serverMinor >= clientMinor - clientRange)
+          return supportedVersion;
+      }
+    }
+    return 0;
+  }
+
   static boolean deferAuthToLogon(final int protocolVersion, final String scheme, final String principal,
       final String credentials) {
     final int major = getMajorVersion(protocolVersion);

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -1889,12 +1889,6 @@ public class BoltNetworkExecutor extends Thread {
   }
 
   /**
-   * A Bolt 5.1+ HELLO carries no authentication - the driver authenticates with a separate LOGON.
-   * Returns true only when the negotiated version is >= 5.1 and the HELLO omits all auth fields, so
-   * such a HELLO is accepted (awaiting LOGON) instead of being rejected as "missing credentials".
-   * Pre-5.1 keeps HELLO-embedded auth; an explicit scheme (incl. "none") is never a deferral.
-   */
-  /**
    * Select the highest-preference server version compatible with the client's proposals, or 0 if none match.
    * Client proposals are tried in order; for each, the range means the client supports minor versions from
    * (minor - range) up to minor inclusive for that major. A zero entry is trailing padding and stops the scan.
@@ -1920,6 +1914,12 @@ public class BoltNetworkExecutor extends Thread {
     return 0;
   }
 
+  /**
+   * A Bolt 5.1+ HELLO carries no authentication - the driver authenticates with a separate LOGON.
+   * Returns true only when the negotiated version is >= 5.1 and the HELLO omits all auth fields, so
+   * such a HELLO is accepted (awaiting LOGON) instead of being rejected as "missing credentials".
+   * Pre-5.1 keeps HELLO-embedded auth; an explicit scheme (incl. "none") is never a deferral.
+   */
   static boolean deferAuthToLogon(final int protocolVersion, final String scheme, final String principal,
       final String credentials) {
     final int major = getMajorVersion(protocolVersion);

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -430,7 +430,7 @@ public class BoltNetworkExecutor extends Thread {
   private Map<String, Object> buildHelloSuccessMetadata() {
     final Map<String, Object> metadata = new LinkedHashMap<>();
     metadata.put("server", "Neo4j/5.26.0 compatible (ArcadeDB " + Constants.getRawVersion() + ")");
-    metadata.put("connection_id", "bolt-" + Thread.currentThread().getId());
+    metadata.put("connection_id", "bolt-" + Thread.currentThread().threadId());
     return metadata;
   }
 

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -1916,6 +1916,9 @@ public class BoltNetworkExecutor extends Thread {
       final String credentials) {
     final int major = getMajorVersion(protocolVersion);
     final int minor = getMinorVersion(protocolVersion);
-    return major >= 5 && minor >= 1 && scheme == null && principal == null && credentials == null;
+    // Lexicographic >= 5.1 so a higher major with minor 0 (e.g. a hypothetical 6.0) still defers,
+    // rather than being excluded by an independent minor >= 1 test.
+    final boolean atLeast51 = major > 5 || (major == 5 && minor >= 1);
+    return atLeast51 && scheme == null && principal == null && credentials == null;
   }
 }

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -378,6 +378,9 @@ public class BoltNetworkExecutor extends Thread {
     case BoltMessage.ROUTE:
       handleRoute((RouteMessage) message);
       break;
+    case BoltMessage.TELEMETRY:
+      sendSuccess(Map.of());
+      break;
     default:
       sendFailure(BoltException.PROTOCOL_ERROR, "Unknown message: " + BoltMessage.signatureName(message.getSignature()));
     }
@@ -406,6 +409,13 @@ public class BoltNetworkExecutor extends Thread {
       }
     }
 
+    if (deferAuthToLogon(protocolVersion, scheme, principal, credentials)) {
+      // Bolt 5.1+ handshake: accept HELLO now, authenticate on the subsequent LOGON.
+      sendSuccess(buildHelloSuccessMetadata());
+      state = State.AUTHENTICATION;
+      return;
+    }
+
     // Try to authenticate
     if ("none".equals(scheme)) {
       // Explicit no-auth is always rejected.
@@ -416,24 +426,26 @@ public class BoltNetworkExecutor extends Thread {
     // Covers "basic" with credentials, any other/missing scheme with credentials, and
     // the missing-scheme/missing-credentials case (authenticateUser null-checks and
     // rejects with "Missing credentials" rather than treating it as implicitly
-    // authenticated).
-    // NOTE (Bolt 5.1+): a legitimate 5.1+ HELLO carries no auth at all - it moves to the
-    // separate LOGON message (see handleLogon) - so this call would incorrectly reject
-    // that valid handshake. Safe today because SUPPORTED_VERSIONS never advertises 5.x,
-    // so no compliant driver reaches here without a scheme/principal/credentials; guard
-    // on negotiated protocol version before 5.x negotiation is enabled.
+    // authenticated). A legitimate Bolt 5.1+ HELLO with no auth fields never reaches this
+    // point - the deferAuthToLogon() check above already routed it to await LOGON.
     if (!authenticateUser(principal, credentials)) {
       return;
     }
 
-    // Build success response with server info
-    // Use "Neo4j" prefix for compatibility with official Neo4j drivers
+    sendSuccess(buildHelloSuccessMetadata());
+    state = State.READY;
+  }
+
+  /**
+   * Builds the HELLO success metadata shared by the authenticated-success path and the Bolt 5.1+
+   * auth-deferral path. The "Neo4j" server prefix is used for compatibility with official Neo4j drivers.
+   * Insertion order (server first, then connection_id) is significant for wire equality.
+   */
+  private Map<String, Object> buildHelloSuccessMetadata() {
     final Map<String, Object> metadata = new LinkedHashMap<>();
     metadata.put("server", "Neo4j/5.26.0 compatible (ArcadeDB " + Constants.getRawVersion() + ")");
     metadata.put("connection_id", "bolt-" + Thread.currentThread().getId());
-
-    sendSuccess(metadata);
-    state = State.READY;
+    return metadata;
   }
 
   /**
@@ -1888,5 +1900,18 @@ public class BoltNetworkExecutor extends Thread {
 
   static int getVersionRange(final int version) {
     return (version >> 16) & 0xFF;
+  }
+
+  /**
+   * A Bolt 5.1+ HELLO carries no authentication - the driver authenticates with a separate LOGON.
+   * Returns true only when the negotiated version is >= 5.1 and the HELLO omits all auth fields, so
+   * such a HELLO is accepted (awaiting LOGON) instead of being rejected as "missing credentials".
+   * Pre-5.1 keeps HELLO-embedded auth; an explicit scheme (incl. "none") is never a deferral.
+   */
+  static boolean deferAuthToLogon(final int protocolVersion, final String scheme, final String principal,
+      final String credentials) {
+    final int major = getMajorVersion(protocolVersion);
+    final int minor = getMinorVersion(protocolVersion);
+    return major >= 5 && minor >= 1 && scheme == null && principal == null && credentials == null;
   }
 }

--- a/bolt/src/main/java/com/arcadedb/bolt/message/BoltMessage.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/message/BoltMessage.java
@@ -47,6 +47,9 @@ public abstract class BoltMessage {
   public static final byte LOGOFF = 0x6B;
   public static final byte ROUTE  = 0x66;
 
+  // Additional request signature for BOLT 5.4
+  public static final byte TELEMETRY = 0x54;
+
   // Response message signatures
   public static final byte SUCCESS = 0x70;
   public static final byte RECORD  = 0x71;
@@ -89,6 +92,7 @@ public abstract class BoltMessage {
       case LOGON -> parseLogon(fields);
       case LOGOFF -> new LogoffMessage();
       case ROUTE -> parseRoute(fields);
+      case TELEMETRY -> new TelemetryMessage();
       default -> throw new IOException("Unknown message signature: 0x" + Integer.toHexString(sig & 0xFF));
     };
   }
@@ -169,6 +173,7 @@ public abstract class BoltMessage {
       case LOGON -> "LOGON";
       case LOGOFF -> "LOGOFF";
       case ROUTE -> "ROUTE";
+      case TELEMETRY -> "TELEMETRY";
       default -> "UNKNOWN(0x" + Integer.toHexString(sig & 0xFF) + ")";
     };
   }

--- a/bolt/src/main/java/com/arcadedb/bolt/message/TelemetryMessage.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/message/TelemetryMessage.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt.message;
+
+import com.arcadedb.bolt.packstream.PackStreamWriter;
+
+import java.io.IOException;
+
+/**
+ * TELEMETRY message (Bolt 5.4+).
+ * Signature: 0x54
+ * Fields: a single integer API code, ignored - ArcadeDB does not advertise telemetry hints, so a
+ * compliant driver never sends this; it is accepted and acknowledged defensively.
+ */
+public class TelemetryMessage extends BoltMessage {
+
+  public TelemetryMessage() {
+    super(TELEMETRY);
+  }
+
+  @Override
+  public void writeTo(final PackStreamWriter writer) throws IOException {
+    writer.writeStructureHeader(signature, 0);
+  }
+
+  @Override
+  public String toString() {
+    return "TELEMETRY";
+  }
+}

--- a/bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamWriter.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamWriter.java
@@ -81,6 +81,21 @@ public class PackStreamWriter {
     this.out = new DataOutputStream(buffer);
   }
 
+  private int boltMajorVersion = 4;
+
+  /**
+   * Sets the negotiated Bolt major version driving version-dependent structure encoding
+   * (element_id fields on graph elements, UTC vs legacy datetime signatures). Defaults to 4.
+   */
+  public PackStreamWriter boltMajorVersion(final int boltMajorVersion) {
+    this.boltMajorVersion = boltMajorVersion;
+    return this;
+  }
+
+  public int getBoltMajorVersion() {
+    return boltMajorVersion;
+  }
+
   /**
    * Write null value.
    */

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltDateTimeStructure.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltDateTimeStructure.java
@@ -64,6 +64,7 @@ public class BoltDateTimeStructure implements PackStreamStructure {
 
   @Override
   public byte getSignature() {
+    // Legacy (Bolt 4.x) signature; writeTo is authoritative and emits the UTC signature ('I'/'i') when the writer negotiated Bolt >= 5.
     return zoneId ? SIG_ZONEID_LEGACY : SIG_OFFSET_LEGACY;
   }
 

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltDateTimeStructure.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltDateTimeStructure.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt.structure;
+
+import com.arcadedb.bolt.packstream.PackStreamStructure;
+import com.arcadedb.bolt.packstream.PackStreamWriter;
+
+import java.io.IOException;
+
+/**
+ * Bolt DateTime / DateTimeZoneId structure whose wire form depends on the negotiated protocol version.
+ * Bolt 4.x uses the legacy signatures 'F'/'f' with the LOCAL epoch-second (wall clock treated as UTC).
+ * Bolt 5.0+ uses 'I'/'i' with the true UTC epoch-second. Both epoch bases are computed at build time
+ * from the source java.time value; writeTo selects by {@link PackStreamWriter#getBoltMajorVersion()}.
+ */
+public class BoltDateTimeStructure implements PackStreamStructure {
+  private static final byte SIG_OFFSET_LEGACY = 0x46; // 'F' [secondsLocal, nanos, offsetSeconds]
+  private static final byte SIG_ZONEID_LEGACY = 0x66; // 'f' [secondsLocal, nanos, zoneId]
+  private static final byte SIG_OFFSET_UTC    = 0x49; // 'I' [secondsUtc,  nanos, offsetSeconds]
+  private static final byte SIG_ZONEID_UTC    = 0x69; // 'i' [secondsUtc,  nanos, zoneId]
+
+  private final boolean zoneId;
+  private final long    localEpochSeconds;
+  private final long    utcEpochSeconds;
+  private final int     nanos;
+  private final int     offsetSeconds; // used when zoneId == false
+  private final String  zone;          // used when zoneId == true
+
+  private BoltDateTimeStructure(final boolean zoneId, final long localEpochSeconds, final long utcEpochSeconds,
+      final int nanos, final int offsetSeconds, final String zone) {
+    this.zoneId = zoneId;
+    this.localEpochSeconds = localEpochSeconds;
+    this.utcEpochSeconds = utcEpochSeconds;
+    this.nanos = nanos;
+    this.offsetSeconds = offsetSeconds;
+    this.zone = zone;
+  }
+
+  public static BoltDateTimeStructure offset(final long localEpochSeconds, final long utcEpochSeconds, final int nanos,
+      final int offsetSeconds) {
+    return new BoltDateTimeStructure(false, localEpochSeconds, utcEpochSeconds, nanos, offsetSeconds, null);
+  }
+
+  public static BoltDateTimeStructure zoneId(final long localEpochSeconds, final long utcEpochSeconds, final int nanos,
+      final String zone) {
+    return new BoltDateTimeStructure(true, localEpochSeconds, utcEpochSeconds, nanos, 0, zone);
+  }
+
+  @Override
+  public byte getSignature() {
+    return zoneId ? SIG_ZONEID_LEGACY : SIG_OFFSET_LEGACY;
+  }
+
+  @Override
+  public int getFieldCount() {
+    return 3;
+  }
+
+  @Override
+  public void writeTo(final PackStreamWriter writer) throws IOException {
+    final boolean utc = writer.getBoltMajorVersion() >= 5;
+    final long seconds = utc ? utcEpochSeconds : localEpochSeconds;
+    if (zoneId) {
+      writer.writeStructureHeader(utc ? SIG_ZONEID_UTC : SIG_ZONEID_LEGACY, 3);
+      writer.writeInteger(seconds);
+      writer.writeInteger(nanos);
+      writer.writeString(zone);
+    } else {
+      writer.writeStructureHeader(utc ? SIG_OFFSET_UTC : SIG_OFFSET_LEGACY, 3);
+      writer.writeInteger(seconds);
+      writer.writeInteger(nanos);
+      writer.writeInteger(offsetSeconds);
+    }
+  }
+}

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltNode.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltNode.java
@@ -58,12 +58,18 @@ public class BoltNode implements PackStreamStructure {
 
   @Override
   public void writeTo(final PackStreamWriter writer) throws IOException {
-    // Use BOLT v4.x format with 3 fields for compatibility
-    writer.writeStructureHeader(SIGNATURE, 3);
-    writer.writeInteger(id);
-    writer.writeList(labels);
-    writer.writeMap(properties);
-    // Note: element_id is omitted for v4.x compatibility
+    if (writer.getBoltMajorVersion() >= 5) {
+      writer.writeStructureHeader(SIGNATURE, 4);
+      writer.writeInteger(id);
+      writer.writeList(labels);
+      writer.writeMap(properties);
+      writer.writeString(elementId);
+    } else {
+      writer.writeStructureHeader(SIGNATURE, 3);
+      writer.writeInteger(id);
+      writer.writeList(labels);
+      writer.writeMap(properties);
+    }
   }
 
   public long getId() {

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltNode.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltNode.java
@@ -53,7 +53,8 @@ public class BoltNode implements PackStreamStructure {
 
   @Override
   public int getFieldCount() {
-    return 3; // id, labels, properties (v4.x format)
+    // v4.x base count; writeTo is authoritative and emits 4 fields (adds element_id) when the writer negotiated Bolt >= 5.
+    return 3;
   }
 
   @Override

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltRelationship.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltRelationship.java
@@ -62,7 +62,8 @@ public class BoltRelationship implements PackStreamStructure {
 
   @Override
   public int getFieldCount() {
-    return 5; // BOLT v4.x format
+    // v4.x base count; writeTo is authoritative and emits 8 fields (adds element_id + start/end element ids) when the writer negotiated Bolt >= 5.
+    return 5;
   }
 
   @Override

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltRelationship.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltRelationship.java
@@ -67,14 +67,24 @@ public class BoltRelationship implements PackStreamStructure {
 
   @Override
   public void writeTo(final PackStreamWriter writer) throws IOException {
-    // Use BOLT v4.x format with 5 fields for compatibility
-    writer.writeStructureHeader(SIGNATURE, 5);
-    writer.writeInteger(id);
-    writer.writeInteger(startNodeId);
-    writer.writeInteger(endNodeId);
-    writer.writeString(type);
-    writer.writeMap(properties);
-    // Note: element_id fields are omitted for v4.x compatibility
+    if (writer.getBoltMajorVersion() >= 5) {
+      writer.writeStructureHeader(SIGNATURE, 8);
+      writer.writeInteger(id);
+      writer.writeInteger(startNodeId);
+      writer.writeInteger(endNodeId);
+      writer.writeString(type);
+      writer.writeMap(properties);
+      writer.writeString(elementId);
+      writer.writeString(startNodeElementId);
+      writer.writeString(endNodeElementId);
+    } else {
+      writer.writeStructureHeader(SIGNATURE, 5);
+      writer.writeInteger(id);
+      writer.writeInteger(startNodeId);
+      writer.writeInteger(endNodeId);
+      writer.writeString(type);
+      writer.writeMap(properties);
+    }
   }
 
   public long getId() {

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java
@@ -19,6 +19,7 @@
 package com.arcadedb.bolt.structure;
 
 import com.arcadedb.bolt.packstream.PackStreamReader;
+import com.arcadedb.bolt.packstream.PackStreamStructure;
 import com.arcadedb.database.Document;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.RID;
@@ -468,16 +469,13 @@ public class BoltStructureMapper {
    * wrappers (from a scalar {@code RETURN e.valid_at}), which are unwrapped to their {@code java.time} value
    * first. Returns {@code null} when the value is not a temporal (so the caller can fall through).
    * <p>
-   * <b>Encoding is tied to the negotiated protocol version.</b> ArcadeDB advertises Bolt v4.4 max
-   * ({@code BoltNetworkExecutor.SUPPORTED_VERSIONS = { 4.4, 4.0, 3.0 }}), so the legacy (pre-5.0)
-   * DateTime / DateTimeZoneId encoding is always correct here: the seconds field is the LOCAL epoch-second
-   * (offset folded in), matching the legacy branch of {@link #fromPackStreamValue}. The inbound path already
-   * decodes both the legacy and the 5.0 "UTC" signatures, but this outbound path emits legacy only.
-   * TODO: if {@code SUPPORTED_VERSIONS} ever gains Bolt 5.0 (where seconds is the true UTC epoch-second),
-   * branch on the negotiated version here and emit {@code SIG_*_UTC}, otherwise a 5.0 driver would decode
-   * these structs to the wrong instant.
+   * <b>Encoding is tied to the negotiated protocol version.</b> DateTime / DateTimeZoneId values carry both
+   * epoch bases (local and true UTC) computed here at build time; {@link BoltDateTimeStructure#writeTo} then
+   * picks the legacy 'F'/'f' signature and local epoch-second for Bolt 4.x, or the 'I'/'i' signature and true
+   * UTC epoch-second for Bolt 5.0+, based on the writer's negotiated major version. All other temporal kinds
+   * (Date, Time, LocalTime, LocalDateTime, Duration) are version-invariant and stay on {@link BoltTemporalStructure}.
    */
-  static BoltTemporalStructure toTemporalStructure(final Object rawValue) {
+  static PackStreamStructure toTemporalStructure(final Object rawValue) {
     final Object value = unwrapCypherTemporal(rawValue);
 
     if (value instanceof LocalDate d)
@@ -493,8 +491,8 @@ public class BoltStructureMapper {
     if (value instanceof ZonedDateTime zdt) {
       if (zdt.getZone() instanceof ZoneOffset offset)
         return dateTimeWithOffset(zdt.toLocalDateTime(), offset);
-      return new BoltTemporalStructure(SIG_DATE_TIME_ZONEID_LEGACY, zdt.toLocalDateTime().toEpochSecond(ZoneOffset.UTC),
-          (long) zdt.getNano(), zdt.getZone().getId());
+      return BoltDateTimeStructure.zoneId(zdt.toLocalDateTime().toEpochSecond(ZoneOffset.UTC), zdt.toEpochSecond(),
+          zdt.getNano(), zdt.getZone().getId());
     }
     // A bare instant (Instant / java.util.Date) has no zone; Bolt has no pure-instant type, so it is
     // deliberately widened to a DateTime struct at UTC. The instant is preserved; the client receives a
@@ -518,10 +516,10 @@ public class BoltStructureMapper {
     return null;
   }
 
-  private static BoltTemporalStructure dateTimeWithOffset(final LocalDateTime local, final ZoneOffset offset) {
-    // Legacy encoding: seconds is the local epoch-second (the wall clock treated as if UTC).
-    return new BoltTemporalStructure(SIG_DATE_TIME_OFFSET_LEGACY, local.toEpochSecond(ZoneOffset.UTC), (long) local.getNano(),
-        (long) offset.getTotalSeconds());
+  private static BoltDateTimeStructure dateTimeWithOffset(final LocalDateTime local, final ZoneOffset offset) {
+    // localEpoch: wall clock treated as UTC (legacy basis). utcEpoch: the true instant (5.0+ basis).
+    return BoltDateTimeStructure.offset(local.toEpochSecond(ZoneOffset.UTC), local.toEpochSecond(offset),
+        local.getNano(), offset.getTotalSeconds());
   }
 
   private static Object unwrapCypherTemporal(final Object value) {

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltUnboundRelationship.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltUnboundRelationship.java
@@ -53,7 +53,8 @@ public class BoltUnboundRelationship implements PackStreamStructure {
 
   @Override
   public int getFieldCount() {
-    return 3; // BOLT v4.x format
+    // v4.x base count; writeTo is authoritative and emits 4 fields (adds element_id) when the writer negotiated Bolt >= 5.
+    return 3;
   }
 
   @Override

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltUnboundRelationship.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltUnboundRelationship.java
@@ -58,12 +58,18 @@ public class BoltUnboundRelationship implements PackStreamStructure {
 
   @Override
   public void writeTo(final PackStreamWriter writer) throws IOException {
-    // Use BOLT v4.x format with 3 fields for compatibility
-    writer.writeStructureHeader(SIGNATURE, 3);
-    writer.writeInteger(id);
-    writer.writeString(type);
-    writer.writeMap(properties);
-    // Note: element_id is omitted for v4.x compatibility
+    if (writer.getBoltMajorVersion() >= 5) {
+      writer.writeStructureHeader(SIGNATURE, 4);
+      writer.writeInteger(id);
+      writer.writeString(type);
+      writer.writeMap(properties);
+      writer.writeString(elementId);
+    } else {
+      writer.writeStructureHeader(SIGNATURE, 3);
+      writer.writeInteger(id);
+      writer.writeString(type);
+      writer.writeMap(properties);
+    }
   }
 
   public long getId() {

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltDateTimeStructureTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltDateTimeStructureTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.bolt.packstream.PackStreamReader;
+import com.arcadedb.bolt.packstream.PackStreamStructure;
+import com.arcadedb.bolt.packstream.PackStreamWriter;
+import com.arcadedb.bolt.structure.BoltDateTimeStructure;
+import com.arcadedb.bolt.structure.BoltStructureMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BoltDateTimeStructureTest {
+
+  // 2024-01-15T10:30:45 at +02:00.
+  private static final LocalDateTime LOCAL = LocalDateTime.of(2024, 1, 15, 10, 30, 45);
+  private static final ZoneOffset    OFFSET = ZoneOffset.ofHours(2);
+
+  private static PackStreamReader.StructureValue roundTrip(final BoltDateTimeStructure s, final int major)
+      throws Exception {
+    final PackStreamWriter writer = new PackStreamWriter().boltMajorVersion(major);
+    s.writeTo(writer);
+    return (PackStreamReader.StructureValue) new PackStreamReader(writer.toByteArray()).readValue();
+  }
+
+  // Drives the PRODUCTION mapper path (BoltStructureMapper.toPackStreamValue, the public entrypoint that
+  // internally calls the package-private toTemporalStructure) so the epoch-basis arguments the mapper feeds
+  // into the two BoltDateTimeStructure factories are pinned end-to-end, not just the factories in isolation.
+  private static PackStreamReader.StructureValue mapperRoundTrip(final Object value, final int major)
+      throws Exception {
+    final PackStreamStructure s = (PackStreamStructure) BoltStructureMapper.toPackStreamValue(value);
+    final PackStreamWriter writer = new PackStreamWriter().boltMajorVersion(major);
+    s.writeTo(writer);
+    return (PackStreamReader.StructureValue) new PackStreamReader(writer.toByteArray()).readValue();
+  }
+
+  @Test
+  void offsetDateTimeUsesLegacySignatureAndLocalEpochOnBolt4() throws Exception {
+    final BoltDateTimeStructure s = BoltDateTimeStructure.offset(
+        LOCAL.toEpochSecond(ZoneOffset.UTC), LOCAL.toEpochSecond(OFFSET), LOCAL.getNano(), OFFSET.getTotalSeconds());
+    final PackStreamReader.StructureValue v = roundTrip(s, 4);
+    assertThat(v.getSignature()).isEqualTo((byte) 0x46);              // 'F'
+    assertThat(((Number) v.getFields().get(0)).longValue())
+        .isEqualTo(LOCAL.toEpochSecond(ZoneOffset.UTC));             // local epoch-second
+    assertThat(((Number) v.getFields().get(2)).longValue()).isEqualTo(7200L);
+  }
+
+  @Test
+  void offsetDateTimeUsesUtcSignatureAndUtcEpochOnBolt5() throws Exception {
+    final BoltDateTimeStructure s = BoltDateTimeStructure.offset(
+        LOCAL.toEpochSecond(ZoneOffset.UTC), LOCAL.toEpochSecond(OFFSET), LOCAL.getNano(), OFFSET.getTotalSeconds());
+    final PackStreamReader.StructureValue v = roundTrip(s, 5);
+    assertThat(v.getSignature()).isEqualTo((byte) 0x49);              // 'I'
+    assertThat(((Number) v.getFields().get(0)).longValue())
+        .isEqualTo(LOCAL.toEpochSecond(OFFSET));                     // true UTC epoch-second
+    assertThat(((Number) v.getFields().get(2)).longValue()).isEqualTo(7200L);
+  }
+
+  @Test
+  void zoneIdDateTimeSwitchesSignatureByVersion() throws Exception {
+    final BoltDateTimeStructure s = BoltDateTimeStructure.zoneId(
+        LOCAL.toEpochSecond(ZoneOffset.UTC), LOCAL.toEpochSecond(OFFSET), LOCAL.getNano(), "Europe/Rome");
+    final PackStreamReader.StructureValue v4 = roundTrip(s, 4);
+    final PackStreamReader.StructureValue v5 = roundTrip(s, 5);
+    assertThat(v4.getSignature()).isEqualTo((byte) 0x66); // 'f'
+    assertThat(v5.getSignature()).isEqualTo((byte) 0x69); // 'i'
+    // v4 emits the local epoch-second (wall clock treated as UTC); v5 emits the true UTC epoch-second.
+    assertThat(((Number) v4.getFields().get(0)).longValue()).isEqualTo(LOCAL.toEpochSecond(ZoneOffset.UTC));
+    assertThat(((Number) v5.getFields().get(0)).longValue()).isEqualTo(LOCAL.toEpochSecond(OFFSET));
+    assertThat(List.of("Europe/Rome")).contains((String) v5.getFields().get(2));
+  }
+
+  // ----- Mapper-driven tests: exercise the real BoltStructureMapper path end-to-end so a regression in the
+  //       epoch-basis argument the mapper passes to the factories (local vs true-UTC) is caught. -----
+
+  @Test
+  void mapperOffsetDateTimeEmitsUtcEpochOnBolt5() throws Exception {
+    // Non-zero offset so utc epoch != local epoch.
+    final OffsetDateTime odt = OffsetDateTime.of(2024, 1, 15, 10, 30, 45, 0, ZoneOffset.ofHours(2));
+    final PackStreamReader.StructureValue v = mapperRoundTrip(odt, 5);
+    assertThat(v.getSignature()).isEqualTo((byte) 0x49);              // 'I'
+    assertThat(((Number) v.getFields().get(0)).longValue()).isEqualTo(odt.toEpochSecond()); // true UTC epoch
+    assertThat(((Number) v.getFields().get(2)).longValue()).isEqualTo(7200L);
+  }
+
+  @Test
+  void mapperOffsetDateTimeEmitsLocalEpochOnBolt4() throws Exception {
+    final OffsetDateTime odt = OffsetDateTime.of(2024, 1, 15, 10, 30, 45, 0, ZoneOffset.ofHours(2));
+    final PackStreamReader.StructureValue v = mapperRoundTrip(odt, 4);
+    assertThat(v.getSignature()).isEqualTo((byte) 0x46);              // 'F'
+    assertThat(((Number) v.getFields().get(0)).longValue())
+        .isEqualTo(odt.toLocalDateTime().toEpochSecond(ZoneOffset.UTC)); // local epoch (wall clock as UTC)
+    assertThat(((Number) v.getFields().get(2)).longValue()).isEqualTo(7200L);
+  }
+
+  @Test
+  void mapperZoneIdDateTimeEmitsUtcEpochOnBolt5() throws Exception {
+    // Genuine named zone whose offset is non-zero (Europe/Rome = CEST +2 in June) so utc epoch != local epoch,
+    // and so the mapper takes the zone-id branch (not the offset collapse).
+    final ZonedDateTime zdt = ZonedDateTime.of(2024, 6, 15, 10, 30, 45, 0, ZoneId.of("Europe/Rome"));
+    final PackStreamReader.StructureValue v = mapperRoundTrip(zdt, 5);
+    assertThat(v.getSignature()).isEqualTo((byte) 0x69);              // 'i'
+    assertThat(((Number) v.getFields().get(0)).longValue()).isEqualTo(zdt.toEpochSecond()); // true UTC epoch
+    assertThat((String) v.getFields().get(2)).isEqualTo("Europe/Rome");
+  }
+
+  @Test
+  void mapperZoneIdDateTimeEmitsLocalEpochOnBolt4() throws Exception {
+    final ZonedDateTime zdt = ZonedDateTime.of(2024, 6, 15, 10, 30, 45, 0, ZoneId.of("Europe/Rome"));
+    final PackStreamReader.StructureValue v = mapperRoundTrip(zdt, 4);
+    assertThat(v.getSignature()).isEqualTo((byte) 0x66);              // 'f'
+    assertThat(((Number) v.getFields().get(0)).longValue())
+        .isEqualTo(zdt.toLocalDateTime().toEpochSecond(ZoneOffset.UTC)); // local epoch (wall clock as UTC)
+    assertThat((String) v.getFields().get(2)).isEqualTo("Europe/Rome");
+  }
+}

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltMessageTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltMessageTest.java
@@ -334,6 +334,16 @@ class BoltMessageTest {
   }
 
   @Test
+  void telemetryMessageCreation() throws Exception {
+    final TelemetryMessage msg = new TelemetryMessage();
+    assertThat(msg.getSignature()).isEqualTo(BoltMessage.TELEMETRY);
+
+    final PackStreamWriter writer = new PackStreamWriter();
+    msg.writeTo(writer);
+    assertThat(writer.toByteArray()).isNotEmpty();
+  }
+
+  @Test
   void routeMessageCreation() throws Exception {
     final RouteMessage msg = new RouteMessage(
         Map.of("region", "us-east"),
@@ -378,6 +388,7 @@ class BoltMessageTest {
     assertThat(BoltMessage.signatureName(BoltMessage.LOGON)).isEqualTo("LOGON");
     assertThat(BoltMessage.signatureName(BoltMessage.LOGOFF)).isEqualTo("LOGOFF");
     assertThat(BoltMessage.signatureName(BoltMessage.ROUTE)).isEqualTo("ROUTE");
+    assertThat(BoltMessage.signatureName(BoltMessage.TELEMETRY)).isEqualTo("TELEMETRY");
   }
 
   @Test
@@ -717,6 +728,19 @@ class BoltMessageTest {
   }
 
   @Test
+  void parseTelemetryMessage() throws Exception {
+    final PackStreamWriter writer = new PackStreamWriter();
+    writer.writeStructureHeader(BoltMessage.TELEMETRY, 1);
+    writer.writeInteger(0); // API code, ignored by the server
+
+    final PackStreamReader reader = new PackStreamReader(writer.toByteArray());
+    final PackStreamReader.StructureValue struct = (PackStreamReader.StructureValue) reader.readValue();
+    final BoltMessage msg = BoltMessage.parse(struct);
+
+    assertThat(msg).isInstanceOf(TelemetryMessage.class);
+  }
+
+  @Test
   void parseUnknownSignatureThrowsException() throws Exception {
     final PackStreamWriter writer = new PackStreamWriter();
     writer.writeStructureHeader((byte) 0xFF, 0);
@@ -749,5 +773,6 @@ class BoltMessageTest {
     assertThat(new LogonMessage(Map.of()).toString()).contains("LOGON");
     assertThat(new LogoffMessage().toString()).contains("LOGOFF");
     assertThat(new RouteMessage(Map.of(), List.of(), "db").toString()).contains("ROUTE");
+    assertThat(new TelemetryMessage().toString()).contains("TELEMETRY");
   }
 }

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltStructureTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltStructureTest.java
@@ -263,6 +263,54 @@ class BoltStructureTest {
     assertThat(str).contains("relationships=1");
   }
 
+  @Test
+  void nodeWritesElementIdOnBolt5() throws Exception {
+    final BoltNode node = new BoltNode(1L, List.of("Person"), Map.of("name", "Alice"), "#1:0");
+
+    final PackStreamWriter v4 = new PackStreamWriter();
+    node.writeTo(v4);
+    // Tiny-struct marker: 0xB0 | fieldCount. v4 => 3 fields, signature 0x4E.
+    assertThat(v4.toByteArray()[0]).isEqualTo((byte) (0xB0 | 3));
+    assertThat(v4.toByteArray()[1]).isEqualTo(BoltNode.SIGNATURE);
+
+    final PackStreamWriter v5 = new PackStreamWriter().boltMajorVersion(5);
+    node.writeTo(v5);
+    assertThat(v5.toByteArray()[0]).isEqualTo((byte) (0xB0 | 4));
+    assertThat(v5.toByteArray()[1]).isEqualTo(BoltNode.SIGNATURE);
+    // Last field is the element_id string "#1:0" -> tiny-string 0x84 then ASCII bytes.
+    final byte[] b = v5.toByteArray();
+    assertThat(b[b.length - 5]).isEqualTo((byte) (0x80 | 4));
+    assertThat(new String(b, b.length - 4, 4, java.nio.charset.StandardCharsets.UTF_8)).isEqualTo("#1:0");
+  }
+
+  @Test
+  void relationshipWritesElementIdsOnBolt5() throws Exception {
+    final BoltRelationship rel = new BoltRelationship(10L, 1L, 2L, "KNOWS", Map.of(), "#10:0", "#1:0", "#2:0");
+
+    final PackStreamWriter v4 = new PackStreamWriter();
+    rel.writeTo(v4);
+    assertThat(v4.toByteArray()[0]).isEqualTo((byte) (0xB0 | 5));
+
+    final PackStreamWriter v5 = new PackStreamWriter().boltMajorVersion(5);
+    rel.writeTo(v5);
+    assertThat(v5.toByteArray()[0]).isEqualTo((byte) (0xB0 | 8));
+    assertThat(v5.toByteArray()[1]).isEqualTo(BoltRelationship.SIGNATURE);
+  }
+
+  @Test
+  void unboundRelationshipWritesElementIdOnBolt5() throws Exception {
+    final BoltUnboundRelationship rel = new BoltUnboundRelationship(10L, "KNOWS", Map.of(), "#10:0");
+
+    final PackStreamWriter v4 = new PackStreamWriter();
+    rel.writeTo(v4);
+    assertThat(v4.toByteArray()[0]).isEqualTo((byte) (0xB0 | 3));
+
+    final PackStreamWriter v5 = new PackStreamWriter().boltMajorVersion(5);
+    rel.writeTo(v5);
+    assertThat(v5.toByteArray()[0]).isEqualTo((byte) (0xB0 | 4));
+    assertThat(v5.toByteArray()[1]).isEqualTo(BoltUnboundRelationship.SIGNATURE);
+  }
+
   // ============ BoltStructureMapper tests ============
 
   @Test

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltTypeRoundTripTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltTypeRoundTripTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.bolt;
 
 import com.arcadedb.bolt.packstream.PackStreamReader;
+import com.arcadedb.bolt.packstream.PackStreamStructure;
 import com.arcadedb.bolt.packstream.PackStreamWriter;
 import com.arcadedb.bolt.structure.BoltPointStructure;
 import com.arcadedb.bolt.structure.BoltStructureMapper;
@@ -75,7 +76,10 @@ class BoltTypeRoundTripTest {
   void type010_offsetDateTimeNative() {
     final Object out = BoltStructureMapper.toPackStreamValue(
         OffsetDateTime.of(2026, 1, 15, 14, 30, 0, 0, ZoneOffset.ofHours(2)));
-    assertThat(out).isInstanceOf(BoltTemporalStructure.class);
+    // DateTime/DateTimeZoneId now carry both epoch bases and pick their wire signature at writeTo()
+    // time from the negotiated Bolt major version (see BoltDateTimeStructure), so this is no longer a
+    // BoltTemporalStructure - it is still a native Bolt structure though, just a version-aware one.
+    assertThat(out).isInstanceOf(PackStreamStructure.class);
   }
 
   @Test

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltVersionNegotiationTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltVersionNegotiationTest.java
@@ -67,8 +67,6 @@ class BoltVersionNegotiationTest {
   // These test the negotiation algorithm by simulating what performHandshake() does
   // with various client version proposals against the server's SUPPORTED_VERSIONS.
 
-  private static final int[] SUPPORTED_VERSIONS = { 0x00000404, 0x00000004, 0x00000003 }; // v4.4, v4.0, v3.0
-
   /**
    * Simulates the version negotiation logic from BoltNetworkExecutor.performHandshake().
    */
@@ -81,7 +79,7 @@ class BoltVersionNegotiationTest {
       final int clientMinor = BoltNetworkExecutor.getMinorVersion(clientVersion);
       final int clientRange = BoltNetworkExecutor.getVersionRange(clientVersion);
 
-      for (final int supportedVersion : SUPPORTED_VERSIONS) {
+      for (final int supportedVersion : BoltNetworkExecutor.SUPPORTED_VERSIONS) {
         final int serverMajor = BoltNetworkExecutor.getMajorVersion(supportedVersion);
         final int serverMinor = BoltNetworkExecutor.getMinorVersion(supportedVersion);
 
@@ -144,8 +142,8 @@ class BoltVersionNegotiationTest {
 
   @Test
   void noMatchUnsupportedMajorVersion() {
-    // Client only supports Bolt v5.x
-    final int result = negotiate(new int[] { 0x00020405, 0x00000005, 0, 0 });
+    // Client only supports Bolt v6.x, which the server does not (yet) advertise.
+    final int result = negotiate(new int[] { 0x00020406, 0x00000006, 0, 0 });
     assertThat(result).isEqualTo(0);
   }
 
@@ -154,8 +152,8 @@ class BoltVersionNegotiationTest {
     // Simulate a modern Neo4j 5.x driver proposing:
     // v5.4 range=2 (5.2-5.4), v5.1 range=1 (5.0-5.1), v4.4 range=1 (4.3-4.4), v4.2 exact
     final int result = negotiate(new int[] { 0x00020405, 0x00010105, 0x00010404, 0x00000204 });
-    // Server doesn't support 5.x, should negotiate to v4.4
-    assertThat(result).isEqualTo(0x00000404);
+    // Server now supports 5.x, should negotiate to the server's ceiling v5.4
+    assertThat(result).isEqualTo(0x00000405);
   }
 
   @Test
@@ -168,9 +166,9 @@ class BoltVersionNegotiationTest {
 
   @Test
   void clientPrefersHigherVersionFirst() {
-    // Client proposes v5.0 first then v4.4 — should pick v4.4 (first match)
+    // Client proposes v5.0 first then v4.4 — v5.0 is now supported, so it matches first.
     final int result = negotiate(new int[] { 0x00000005, 0x00000404, 0, 0 });
-    assertThat(result).isEqualTo(0x00000404);
+    assertThat(result).isEqualTo(0x00000005);
   }
 
   @Test
@@ -181,9 +179,9 @@ class BoltVersionNegotiationTest {
 
   @Test
   void zeroAfterValidVersionStopsProcessing() {
-    // First entry is unsupported v5.0, second is zero (padding), third would match v4.4
+    // First entry is unsupported v6.0, second is zero (padding), third would match v4.4
     // but should stop at zero per Bolt spec
-    final int result = negotiate(new int[] { 0x00000005, 0, 0x00000404, 0 });
+    final int result = negotiate(new int[] { 0x00000006, 0, 0x00000404, 0 });
     assertThat(result).isEqualTo(0);
   }
 
@@ -193,6 +191,31 @@ class BoltVersionNegotiationTest {
     // Server's first supported version is v4.4, which should be picked (highest preference)
     final int result = negotiate(new int[] { 0x00040404, 0, 0, 0 });
     assertThat(result).isEqualTo(0x00000404);
+  }
+
+  @Test
+  void negotiatesHighest5xForModern5xOnlyDriver() {
+    // Driver offers 5.x with a wide range (5.0..5.8) plus padding.
+    final int result = negotiate(new int[] { 0x00080805, 0, 0, 0 });
+    assertThat(result).isEqualTo(0x00000405); // server ceiling v5.4
+  }
+
+  @Test
+  void negotiates5xWhenDriverOffersBoth5xAnd44() {
+    // Modern driver proposes 5.x (range to 5.0) first, then 4.4 fallback.
+    final int result = negotiate(new int[] { 0x00080805, 0x00000404, 0, 0 });
+    assertThat(result).isEqualTo(0x00000405); // upgrades to v5.4, not v4.4
+  }
+
+  @Test
+  void stillNegotiates44ForLegacyOnlyDriver() {
+    final int result = negotiate(new int[] { 0x00000404, 0x00000004, 0x00000003, 0 });
+    assertThat(result).isEqualTo(0x00000404); // unchanged
+  }
+
+  @Test
+  void exactMatchV5_2() {
+    assertThat(negotiate(new int[] { 0x00000205, 0, 0, 0 })).isEqualTo(0x00000205);
   }
 
   // ============ Bolt 5.1+ auth-deferral gate tests ============

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltVersionNegotiationTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltVersionNegotiationTest.java
@@ -229,6 +229,9 @@ class BoltVersionNegotiationTest {
     assertThat(BoltNetworkExecutor.deferAuthToLogon(0x00000005, null, null, null)).isFalse();
     // 4.4 never defers.
     assertThat(BoltNetworkExecutor.deferAuthToLogon(0x00000404, null, null, null)).isFalse();
+    // A higher major with minor 0 (hypothetical 6.0) still defers - the >= 5.1 check is lexicographic,
+    // not an independent major >= 5 && minor >= 1 test.
+    assertThat(BoltNetworkExecutor.deferAuthToLogon(0x00000006, null, null, null)).isTrue();
     // Any auth field present means it is a real HELLO auth (or explicit none) - do not defer.
     assertThat(BoltNetworkExecutor.deferAuthToLogon(0x00000405, "basic", "root", "pw")).isFalse();
     assertThat(BoltNetworkExecutor.deferAuthToLogon(0x00000405, "none", null, null)).isFalse();

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltVersionNegotiationTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltVersionNegotiationTest.java
@@ -68,27 +68,11 @@ class BoltVersionNegotiationTest {
   // with various client version proposals against the server's SUPPORTED_VERSIONS.
 
   /**
-   * Simulates the version negotiation logic from BoltNetworkExecutor.performHandshake().
+   * Exercises the real negotiation matching used by BoltNetworkExecutor.negotiateVersion(), so the test
+   * cannot drift from production behavior.
    */
   private static int negotiate(final int[] clientVersions) {
-    for (final int clientVersion : clientVersions) {
-      if (clientVersion == 0)
-        break;
-
-      final int clientMajor = BoltNetworkExecutor.getMajorVersion(clientVersion);
-      final int clientMinor = BoltNetworkExecutor.getMinorVersion(clientVersion);
-      final int clientRange = BoltNetworkExecutor.getVersionRange(clientVersion);
-
-      for (final int supportedVersion : BoltNetworkExecutor.SUPPORTED_VERSIONS) {
-        final int serverMajor = BoltNetworkExecutor.getMajorVersion(supportedVersion);
-        final int serverMinor = BoltNetworkExecutor.getMinorVersion(supportedVersion);
-
-        if (clientMajor == serverMajor && serverMinor <= clientMinor && serverMinor >= clientMinor - clientRange) {
-          return supportedVersion;
-        }
-      }
-    }
-    return 0;
+    return BoltNetworkExecutor.selectVersion(clientVersions);
   }
 
   @Test

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltVersionNegotiationTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltVersionNegotiationTest.java
@@ -194,4 +194,20 @@ class BoltVersionNegotiationTest {
     final int result = negotiate(new int[] { 0x00040404, 0, 0, 0 });
     assertThat(result).isEqualTo(0x00000404);
   }
+
+  // ============ Bolt 5.1+ auth-deferral gate tests ============
+
+  @Test
+  void deferAuthToLogonOnlyForBolt51PlusWithoutCredentials() {
+    // 5.1+ HELLO with no auth fields defers to LOGON.
+    assertThat(BoltNetworkExecutor.deferAuthToLogon(0x00000105, null, null, null)).isTrue(); // 5.1
+    assertThat(BoltNetworkExecutor.deferAuthToLogon(0x00000405, null, null, null)).isTrue(); // 5.4
+    // 5.0 keeps HELLO-embedded auth: no deferral.
+    assertThat(BoltNetworkExecutor.deferAuthToLogon(0x00000005, null, null, null)).isFalse();
+    // 4.4 never defers.
+    assertThat(BoltNetworkExecutor.deferAuthToLogon(0x00000404, null, null, null)).isFalse();
+    // Any auth field present means it is a real HELLO auth (or explicit none) - do not defer.
+    assertThat(BoltNetworkExecutor.deferAuthToLogon(0x00000405, "basic", "root", "pw")).isFalse();
+    assertThat(BoltNetworkExecutor.deferAuthToLogon(0x00000405, "none", null, null)).isFalse();
+  }
 }

--- a/docs/superpowers/plans/2026-07-06-bolt-5x-negotiation.md
+++ b/docs/superpowers/plans/2026-07-06-bolt-5x-negotiation.md
@@ -1,0 +1,655 @@
+# Bolt 5.x Version Negotiation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Advertise Bolt 5.0-5.4 in the handshake and version-gate the outbound wire encoders so a 5.x driver connects natively without being lied to (closes `PROTO-002` / issue #5001).
+
+**Architecture:** The negotiated Bolt major version is the single switch. Outbound graph-element structs (`BoltNode`/`BoltRelationship`/`BoltUnboundRelationship`) and datetime structs consult the negotiated major version at `writeTo` time via the `PackStreamWriter` (the serialization context, set once per outgoing message from the connection's negotiated version). Adding 5.x to `SUPPORTED_VERSIONS` and wiring the writer's version happen last and atomically, so every intermediate commit stays green and the existing (currently-passing) TYPE round-trip and temporal ITs become the regression guard for the flip.
+
+**Tech Stack:** Java 21, JUnit 5 (Jupiter), AssertJ (`assertThat(...)`), the `bolt` Maven module, `neo4j-java-driver` 6.2.0 (real-driver ITs).
+
+## Global Constraints
+
+- Java 21; use the `final` keyword on new variables and parameters.
+- New source files carry the standard Apache-2.0 license header (copy verbatim from any existing file in the module); do not add Claude as an author.
+- Tests use AssertJ: `assertThat(actual).isEqualTo(expected)` / `.isTrue()` style.
+- Do not commit to git beyond the per-task commits in this plan; the user reviews and merges. (These per-task commits happen on the feature branch inside the worktree.)
+- Bolt version encoding is `[unused(8)][range(8)][minor(8)][major(8)]`: `major = v & 0xFF`, `minor = (v >> 8) & 0xFF`, `range = (v >> 16) & 0xFF`.
+- Keep the Bolt 4.x wire path byte-identical; every 5.x branch is strictly additive.
+
+---
+
+### Task 1: Version-aware `PackStreamWriter` + gated graph-element structs
+
+**Files:**
+- Modify: `bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamWriter.java:71-82`
+- Modify: `bolt/src/main/java/com/arcadedb/bolt/structure/BoltNode.java:59-67`
+- Modify: `bolt/src/main/java/com/arcadedb/bolt/structure/BoltRelationship.java:68-78`
+- Modify: `bolt/src/main/java/com/arcadedb/bolt/structure/BoltUnboundRelationship.java:59-67`
+- Test: `bolt/src/test/java/com/arcadedb/bolt/BoltStructureTest.java`
+
+**Interfaces:**
+- Produces: `PackStreamWriter.boltMajorVersion(int)` (fluent setter, returns `this`) and `int PackStreamWriter.getBoltMajorVersion()` (default `4`). `BoltNode`/`BoltRelationship`/`BoltUnboundRelationship` `.writeTo(writer)` emit 4/8/4 fields when `writer.getBoltMajorVersion() >= 5`, else 3/5/3.
+- Consumes: nothing from earlier tasks.
+
+- [ ] **Step 1: Write the failing test** — append to `BoltStructureTest.java`:
+
+```java
+@Test
+void nodeWritesElementIdOnBolt5() throws Exception {
+  final BoltNode node = new BoltNode(1L, List.of("Person"), Map.of("name", "Alice"), "#1:0");
+
+  final PackStreamWriter v4 = new PackStreamWriter();
+  node.writeTo(v4);
+  // Tiny-struct marker: 0xB0 | fieldCount. v4 => 3 fields, signature 0x4E.
+  assertThat(v4.toByteArray()[0]).isEqualTo((byte) (0xB0 | 3));
+  assertThat(v4.toByteArray()[1]).isEqualTo(BoltNode.SIGNATURE);
+
+  final PackStreamWriter v5 = new PackStreamWriter().boltMajorVersion(5);
+  node.writeTo(v5);
+  assertThat(v5.toByteArray()[0]).isEqualTo((byte) (0xB0 | 4));
+  assertThat(v5.toByteArray()[1]).isEqualTo(BoltNode.SIGNATURE);
+  // Last field is the element_id string "#1:0" -> tiny-string 0x84 then ASCII bytes.
+  final byte[] b = v5.toByteArray();
+  assertThat(b[b.length - 5]).isEqualTo((byte) (0x80 | 4));
+  assertThat(new String(b, b.length - 4, 4, java.nio.charset.StandardCharsets.UTF_8)).isEqualTo("#1:0");
+}
+
+@Test
+void relationshipWritesElementIdsOnBolt5() throws Exception {
+  final BoltRelationship rel = new BoltRelationship(10L, 1L, 2L, "KNOWS", Map.of(), "#10:0", "#1:0", "#2:0");
+
+  final PackStreamWriter v4 = new PackStreamWriter();
+  rel.writeTo(v4);
+  assertThat(v4.toByteArray()[0]).isEqualTo((byte) (0xB0 | 5));
+
+  final PackStreamWriter v5 = new PackStreamWriter().boltMajorVersion(5);
+  rel.writeTo(v5);
+  assertThat(v5.toByteArray()[0]).isEqualTo((byte) (0xB0 | 8));
+  assertThat(v5.toByteArray()[1]).isEqualTo(BoltRelationship.SIGNATURE);
+}
+
+@Test
+void unboundRelationshipWritesElementIdOnBolt5() throws Exception {
+  final BoltUnboundRelationship rel = new BoltUnboundRelationship(10L, "KNOWS", Map.of(), "#10:0");
+
+  final PackStreamWriter v4 = new PackStreamWriter();
+  rel.writeTo(v4);
+  assertThat(v4.toByteArray()[0]).isEqualTo((byte) (0xB0 | 3));
+
+  final PackStreamWriter v5 = new PackStreamWriter().boltMajorVersion(5);
+  rel.writeTo(v5);
+  assertThat(v5.toByteArray()[0]).isEqualTo((byte) (0xB0 | 4));
+  assertThat(v5.toByteArray()[1]).isEqualTo(BoltUnboundRelationship.SIGNATURE);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mvn -pl bolt test -Dtest=BoltStructureTest`
+Expected: FAIL - `boltMajorVersion(int)` does not exist / v5 markers still show 3 and 5 fields.
+
+- [ ] **Step 3: Add version awareness to `PackStreamWriter`** — after the constructors (line 82), add:
+
+```java
+  private int boltMajorVersion = 4;
+
+  /**
+   * Sets the negotiated Bolt major version driving version-dependent structure encoding
+   * (element_id fields on graph elements, UTC vs legacy datetime signatures). Defaults to 4.
+   */
+  public PackStreamWriter boltMajorVersion(final int boltMajorVersion) {
+    this.boltMajorVersion = boltMajorVersion;
+    return this;
+  }
+
+  public int getBoltMajorVersion() {
+    return boltMajorVersion;
+  }
+```
+
+- [ ] **Step 4: Gate `BoltNode.writeTo`** — replace lines 59-67:
+
+```java
+  @Override
+  public void writeTo(final PackStreamWriter writer) throws IOException {
+    if (writer.getBoltMajorVersion() >= 5) {
+      writer.writeStructureHeader(SIGNATURE, 4);
+      writer.writeInteger(id);
+      writer.writeList(labels);
+      writer.writeMap(properties);
+      writer.writeString(elementId);
+    } else {
+      writer.writeStructureHeader(SIGNATURE, 3);
+      writer.writeInteger(id);
+      writer.writeList(labels);
+      writer.writeMap(properties);
+    }
+  }
+```
+
+- [ ] **Step 5: Gate `BoltRelationship.writeTo`** — replace lines 68-78:
+
+```java
+  @Override
+  public void writeTo(final PackStreamWriter writer) throws IOException {
+    if (writer.getBoltMajorVersion() >= 5) {
+      writer.writeStructureHeader(SIGNATURE, 8);
+      writer.writeInteger(id);
+      writer.writeInteger(startNodeId);
+      writer.writeInteger(endNodeId);
+      writer.writeString(type);
+      writer.writeMap(properties);
+      writer.writeString(elementId);
+      writer.writeString(startNodeElementId);
+      writer.writeString(endNodeElementId);
+    } else {
+      writer.writeStructureHeader(SIGNATURE, 5);
+      writer.writeInteger(id);
+      writer.writeInteger(startNodeId);
+      writer.writeInteger(endNodeId);
+      writer.writeString(type);
+      writer.writeMap(properties);
+    }
+  }
+```
+
+- [ ] **Step 6: Gate `BoltUnboundRelationship.writeTo`** — replace lines 59-67:
+
+```java
+  @Override
+  public void writeTo(final PackStreamWriter writer) throws IOException {
+    if (writer.getBoltMajorVersion() >= 5) {
+      writer.writeStructureHeader(SIGNATURE, 4);
+      writer.writeInteger(id);
+      writer.writeString(type);
+      writer.writeMap(properties);
+      writer.writeString(elementId);
+    } else {
+      writer.writeStructureHeader(SIGNATURE, 3);
+      writer.writeInteger(id);
+      writer.writeString(type);
+      writer.writeMap(properties);
+    }
+  }
+```
+
+Leave each `getFieldCount()` returning the v4 base count (3/5/3) - `BoltStructureTest` asserts those and `writeTo` is now authoritative for the wire.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `mvn -pl bolt test -Dtest=BoltStructureTest`
+Expected: PASS (existing assertions and the three new v5 tests).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamWriter.java \
+        bolt/src/main/java/com/arcadedb/bolt/structure/BoltNode.java \
+        bolt/src/main/java/com/arcadedb/bolt/structure/BoltRelationship.java \
+        bolt/src/main/java/com/arcadedb/bolt/structure/BoltUnboundRelationship.java \
+        bolt/src/test/java/com/arcadedb/bolt/BoltStructureTest.java
+git commit -m "feat(#5001): version-gate Bolt graph-element structs on negotiated major version"
+```
+
+---
+
+### Task 2: Version-aware datetime structure (legacy vs UTC signatures)
+
+**Files:**
+- Create: `bolt/src/main/java/com/arcadedb/bolt/structure/BoltDateTimeStructure.java`
+- Modify: `bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java:480-525` (temporal builder)
+- Test: `bolt/src/test/java/com/arcadedb/bolt/BoltDateTimeStructureTest.java`
+
+**Interfaces:**
+- Consumes: `PackStreamWriter.getBoltMajorVersion()` (Task 1).
+- Produces: `BoltDateTimeStructure` (implements `PackStreamStructure`) that at `writeTo` emits signature `'F'`/`'f'` + local-epoch seconds for major < 5, and `'I'`/`'i'` + true-UTC-epoch seconds for major >= 5. `BoltStructureMapper.toTemporalStructure(Object)` now returns `PackStreamStructure` and builds `BoltDateTimeStructure` for the two DateTime variants.
+
+- [ ] **Step 1: Write the failing test** — create `BoltDateTimeStructureTest.java`:
+
+```java
+/* <copy the Apache-2.0 license header from BoltStructureTest.java> */
+package com.arcadedb.bolt;
+
+import com.arcadedb.bolt.packstream.PackStreamReader;
+import com.arcadedb.bolt.packstream.PackStreamWriter;
+import com.arcadedb.bolt.structure.BoltDateTimeStructure;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BoltDateTimeStructureTest {
+
+  // 2024-01-15T10:30:45 at +02:00.
+  private static final LocalDateTime LOCAL = LocalDateTime.of(2024, 1, 15, 10, 30, 45);
+  private static final ZoneOffset    OFFSET = ZoneOffset.ofHours(2);
+
+  private static PackStreamReader.StructureValue roundTrip(final BoltDateTimeStructure s, final int major)
+      throws Exception {
+    final PackStreamWriter writer = new PackStreamWriter().boltMajorVersion(major);
+    s.writeTo(writer);
+    return (PackStreamReader.StructureValue) new PackStreamReader(writer.toByteArray()).readValue();
+  }
+
+  @Test
+  void offsetDateTimeUsesLegacySignatureAndLocalEpochOnBolt4() throws Exception {
+    final BoltDateTimeStructure s = BoltDateTimeStructure.offset(
+        LOCAL.toEpochSecond(ZoneOffset.UTC), LOCAL.toEpochSecond(OFFSET), LOCAL.getNano(), OFFSET.getTotalSeconds());
+    final PackStreamReader.StructureValue v = roundTrip(s, 4);
+    assertThat(v.getSignature()).isEqualTo((byte) 0x46);              // 'F'
+    assertThat(((Number) v.getFields().get(0)).longValue())
+        .isEqualTo(LOCAL.toEpochSecond(ZoneOffset.UTC));             // local epoch-second
+    assertThat(((Number) v.getFields().get(2)).longValue()).isEqualTo(7200L);
+  }
+
+  @Test
+  void offsetDateTimeUsesUtcSignatureAndUtcEpochOnBolt5() throws Exception {
+    final BoltDateTimeStructure s = BoltDateTimeStructure.offset(
+        LOCAL.toEpochSecond(ZoneOffset.UTC), LOCAL.toEpochSecond(OFFSET), LOCAL.getNano(), OFFSET.getTotalSeconds());
+    final PackStreamReader.StructureValue v = roundTrip(s, 5);
+    assertThat(v.getSignature()).isEqualTo((byte) 0x49);              // 'I'
+    assertThat(((Number) v.getFields().get(0)).longValue())
+        .isEqualTo(LOCAL.toEpochSecond(OFFSET));                     // true UTC epoch-second
+    assertThat(((Number) v.getFields().get(2)).longValue()).isEqualTo(7200L);
+  }
+
+  @Test
+  void zoneIdDateTimeSwitchesSignatureByVersion() throws Exception {
+    final BoltDateTimeStructure s = BoltDateTimeStructure.zoneId(
+        LOCAL.toEpochSecond(ZoneOffset.UTC), LOCAL.toEpochSecond(OFFSET), LOCAL.getNano(), "Europe/Rome");
+    assertThat(roundTrip(s, 4).getSignature()).isEqualTo((byte) 0x66); // 'f'
+    assertThat(roundTrip(s, 5).getSignature()).isEqualTo((byte) 0x69); // 'i'
+    assertThat(List.of("Europe/Rome")).contains((String) roundTrip(s, 5).getFields().get(2));
+  }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mvn -pl bolt test -Dtest=BoltDateTimeStructureTest`
+Expected: FAIL - `BoltDateTimeStructure` does not exist (compile error).
+
+- [ ] **Step 3: Create `BoltDateTimeStructure`**:
+
+```java
+/* <Apache-2.0 license header copied from a sibling file> */
+package com.arcadedb.bolt.structure;
+
+import com.arcadedb.bolt.packstream.PackStreamStructure;
+import com.arcadedb.bolt.packstream.PackStreamWriter;
+
+import java.io.IOException;
+
+/**
+ * Bolt DateTime / DateTimeZoneId structure whose wire form depends on the negotiated protocol version.
+ * Bolt 4.x uses the legacy signatures 'F'/'f' with the LOCAL epoch-second (wall clock treated as UTC).
+ * Bolt 5.0+ uses 'I'/'i' with the true UTC epoch-second. Both epoch bases are computed at build time
+ * from the source java.time value; writeTo selects by {@link PackStreamWriter#getBoltMajorVersion()}.
+ */
+public class BoltDateTimeStructure implements PackStreamStructure {
+  private static final byte SIG_OFFSET_LEGACY = 0x46; // 'F' [secondsLocal, nanos, offsetSeconds]
+  private static final byte SIG_ZONEID_LEGACY = 0x66; // 'f' [secondsLocal, nanos, zoneId]
+  private static final byte SIG_OFFSET_UTC    = 0x49; // 'I' [secondsUtc,  nanos, offsetSeconds]
+  private static final byte SIG_ZONEID_UTC    = 0x69; // 'i' [secondsUtc,  nanos, zoneId]
+
+  private final boolean zoneId;
+  private final long    localEpochSeconds;
+  private final long    utcEpochSeconds;
+  private final int     nanos;
+  private final int     offsetSeconds; // used when zoneId == false
+  private final String  zone;          // used when zoneId == true
+
+  private BoltDateTimeStructure(final boolean zoneId, final long localEpochSeconds, final long utcEpochSeconds,
+      final int nanos, final int offsetSeconds, final String zone) {
+    this.zoneId = zoneId;
+    this.localEpochSeconds = localEpochSeconds;
+    this.utcEpochSeconds = utcEpochSeconds;
+    this.nanos = nanos;
+    this.offsetSeconds = offsetSeconds;
+    this.zone = zone;
+  }
+
+  public static BoltDateTimeStructure offset(final long localEpochSeconds, final long utcEpochSeconds, final int nanos,
+      final int offsetSeconds) {
+    return new BoltDateTimeStructure(false, localEpochSeconds, utcEpochSeconds, nanos, offsetSeconds, null);
+  }
+
+  public static BoltDateTimeStructure zoneId(final long localEpochSeconds, final long utcEpochSeconds, final int nanos,
+      final String zone) {
+    return new BoltDateTimeStructure(true, localEpochSeconds, utcEpochSeconds, nanos, 0, zone);
+  }
+
+  @Override
+  public byte getSignature() {
+    return zoneId ? SIG_ZONEID_LEGACY : SIG_OFFSET_LEGACY;
+  }
+
+  @Override
+  public int getFieldCount() {
+    return 3;
+  }
+
+  @Override
+  public void writeTo(final PackStreamWriter writer) throws IOException {
+    final boolean utc = writer.getBoltMajorVersion() >= 5;
+    final long seconds = utc ? utcEpochSeconds : localEpochSeconds;
+    if (zoneId) {
+      writer.writeStructureHeader(utc ? SIG_ZONEID_UTC : SIG_ZONEID_LEGACY, 3);
+      writer.writeInteger(seconds);
+      writer.writeInteger(nanos);
+      writer.writeString(zone);
+    } else {
+      writer.writeStructureHeader(utc ? SIG_OFFSET_UTC : SIG_OFFSET_LEGACY, 3);
+      writer.writeInteger(seconds);
+      writer.writeInteger(nanos);
+      writer.writeInteger(offsetSeconds);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Build `BoltDateTimeStructure` from the mapper** — in `BoltStructureMapper.java`:
+
+  1. Change the `toTemporalStructure` return type (line 480) from `static BoltTemporalStructure toTemporalStructure(final Object rawValue)` to `static PackStreamStructure toTemporalStructure(final Object rawValue)`. Add `import com.arcadedb.bolt.packstream.PackStreamStructure;` if absent.
+
+  2. Replace the offset builder `dateTimeWithOffset` (lines 521-525) with:
+
+```java
+  private static BoltDateTimeStructure dateTimeWithOffset(final LocalDateTime local, final ZoneOffset offset) {
+    // localEpoch: wall clock treated as UTC (legacy basis). utcEpoch: the true instant (5.0+ basis).
+    return BoltDateTimeStructure.offset(local.toEpochSecond(ZoneOffset.UTC), local.toEpochSecond(offset),
+        local.getNano(), offset.getTotalSeconds());
+  }
+```
+
+  3. Replace the ZonedDateTime zone-id branch (around lines 496-497) with:
+
+```java
+      return BoltDateTimeStructure.zoneId(zdt.toLocalDateTime().toEpochSecond(ZoneOffset.UTC), zdt.toEpochSecond(),
+          zdt.getNano(), zdt.getZone().getId());
+```
+
+`Date` / `Time` / `LocalTime` / `LocalDateTime` / `Duration` keep using `BoltTemporalStructure` unchanged (version-invariant).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `mvn -pl bolt test -Dtest=BoltDateTimeStructureTest,BoltStructureTest,PackStreamTemporalInputTest`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add bolt/src/main/java/com/arcadedb/bolt/structure/BoltDateTimeStructure.java \
+        bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java \
+        bolt/src/test/java/com/arcadedb/bolt/BoltDateTimeStructureTest.java
+git commit -m "feat(#5001): version-aware Bolt DateTime encoding (legacy 'F'/'f' vs UTC 'I'/'i')"
+```
+
+---
+
+### Task 3: Bolt 5.1+ auth-flow gate + graceful TELEMETRY
+
+**Files:**
+- Modify: `bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java` (`handleHello` ~389-427; `processMessage` switch ~344-383; add helper near the version helpers ~1889)
+- Create: `bolt/src/main/java/com/arcadedb/bolt/message/TelemetryMessage.java`
+- Modify: `bolt/src/main/java/com/arcadedb/bolt/message/BoltMessage.java` (signature constant ~34-49; `parse` switch ~92)
+- Test: `bolt/src/test/java/com/arcadedb/bolt/BoltVersionNegotiationTest.java` (add auth-gate unit tests)
+
+**Interfaces:**
+- Consumes: `BoltNetworkExecutor.getMajorVersion/getMinorVersion` (existing).
+- Produces: `static boolean BoltNetworkExecutor.deferAuthToLogon(int protocolVersion, String scheme, String principal, String credentials)` returning true iff major >= 5, minor >= 1, and all three auth fields are null. `BoltMessage.TELEMETRY` signature `0x54` with a `TelemetryMessage` parsed and acked with SUCCESS.
+
+- [ ] **Step 1: Write the failing test** — append to `BoltVersionNegotiationTest.java`:
+
+```java
+@Test
+void deferAuthToLogonOnlyForBolt51PlusWithoutCredentials() {
+  // 5.1+ HELLO with no auth fields defers to LOGON.
+  assertThat(BoltNetworkExecutor.deferAuthToLogon(0x00000105, null, null, null)).isTrue(); // 5.1
+  assertThat(BoltNetworkExecutor.deferAuthToLogon(0x00000405, null, null, null)).isTrue(); // 5.4
+  // 5.0 keeps HELLO-embedded auth: no deferral.
+  assertThat(BoltNetworkExecutor.deferAuthToLogon(0x00000005, null, null, null)).isFalse();
+  // 4.4 never defers.
+  assertThat(BoltNetworkExecutor.deferAuthToLogon(0x00000404, null, null, null)).isFalse();
+  // Any auth field present means it is a real HELLO auth (or explicit none) - do not defer.
+  assertThat(BoltNetworkExecutor.deferAuthToLogon(0x00000405, "basic", "root", "pw")).isFalse();
+  assertThat(BoltNetworkExecutor.deferAuthToLogon(0x00000405, "none", null, null)).isFalse();
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mvn -pl bolt test -Dtest=BoltVersionNegotiationTest`
+Expected: FAIL - `deferAuthToLogon` does not exist.
+
+- [ ] **Step 3: Add the helper** — in `BoltNetworkExecutor.java`, after `getVersionRange` (~line 1891):
+
+```java
+  /**
+   * A Bolt 5.1+ HELLO carries no authentication - the driver authenticates with a separate LOGON.
+   * Returns true only when the negotiated version is >= 5.1 and the HELLO omits all auth fields, so
+   * such a HELLO is accepted (awaiting LOGON) instead of being rejected as "missing credentials".
+   * Pre-5.1 keeps HELLO-embedded auth; an explicit scheme (incl. "none") is never a deferral.
+   */
+  static boolean deferAuthToLogon(final int protocolVersion, final String scheme, final String principal,
+      final String credentials) {
+    final int major = getMajorVersion(protocolVersion);
+    final int minor = getMinorVersion(protocolVersion);
+    return major >= 5 && minor >= 1 && scheme == null && principal == null && credentials == null;
+  }
+```
+
+- [ ] **Step 4: Use the helper in `handleHello`** — in `BoltNetworkExecutor.java`, immediately before the `if ("none".equals(scheme))` block (~line 410), insert:
+
+```java
+    if (deferAuthToLogon(protocolVersion, scheme, principal, credentials)) {
+      // Bolt 5.1+ handshake: accept HELLO now, authenticate on the subsequent LOGON.
+      final Map<String, Object> metadata = new LinkedHashMap<>();
+      metadata.put("server", "Neo4j/5.26.0 compatible (ArcadeDB " + Constants.getRawVersion() + ")");
+      metadata.put("connection_id", "bolt-" + Thread.currentThread().getId());
+      sendSuccess(metadata);
+      state = State.AUTHENTICATION;
+      return;
+    }
+```
+
+- [ ] **Step 5: Add TELEMETRY message class** — create `bolt/src/main/java/com/arcadedb/bolt/message/TelemetryMessage.java`:
+
+```java
+/* <Apache-2.0 license header copied from a sibling message file> */
+package com.arcadedb.bolt.message;
+
+/**
+ * Bolt 5.4 TELEMETRY request (signature 0x54). ArcadeDB does not advertise telemetry hints, so a
+ * compliant driver never sends this; it is accepted and acknowledged defensively. The payload (a
+ * single integer API code) is ignored.
+ */
+public class TelemetryMessage extends BoltMessage {
+  public TelemetryMessage() {
+    super(TELEMETRY);
+  }
+}
+```
+
+- [ ] **Step 6: Register the signature and parse path** — in `BoltMessage.java`:
+
+  Add near the other 4.x request signatures (~line 45):
+
+```java
+  public static final byte TELEMETRY = 0x54; // Bolt 5.4
+```
+
+  Add a case in the `parse` switch (before the `default ->` at ~line 92):
+
+```java
+      case TELEMETRY -> new TelemetryMessage();
+```
+
+- [ ] **Step 7: Ack TELEMETRY in the executor** — in `processMessage` (~line 378, alongside the other cases), add:
+
+```java
+    case BoltMessage.TELEMETRY:
+      sendSuccess(Map.of());
+      break;
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `mvn -pl bolt test -Dtest=BoltVersionNegotiationTest,BoltMessageTest`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java \
+        bolt/src/main/java/com/arcadedb/bolt/message/TelemetryMessage.java \
+        bolt/src/main/java/com/arcadedb/bolt/message/BoltMessage.java \
+        bolt/src/test/java/com/arcadedb/bolt/BoltVersionNegotiationTest.java
+git commit -m "feat(#5001): defer auth to LOGON on Bolt 5.1+ HELLO and ack TELEMETRY"
+```
+
+---
+
+### Task 4: Advertise Bolt 5.0-5.4 and wire the writer version (go-live)
+
+**Files:**
+- Modify: `bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java` (`SUPPORTED_VERSIONS` line 100; `sendMessage` line 1700)
+- Modify: `bolt/src/test/java/com/arcadedb/bolt/BoltVersionNegotiationTest.java` (use the real array; add 5.x cases)
+
+**Interfaces:**
+- Consumes: Tasks 1-3 (version-gated encoders, auth gate).
+- Produces: `SUPPORTED_VERSIONS` becomes package-private `static final int[]` advertising `{5.4, 5.3, 5.2, 5.1, 5.0, 4.4, 4.0, 3.0}`; every outgoing message is serialized with the negotiated major version.
+
+- [ ] **Step 1: Write the failing test** — in `BoltVersionNegotiationTest.java`, delete the local `private static final int[] SUPPORTED_VERSIONS = {...}` (~line 71) and make `negotiate` use the production array `BoltNetworkExecutor.SUPPORTED_VERSIONS`. Then append:
+
+```java
+@Test
+void negotiatesHighest5xForModern5xOnlyDriver() {
+  // Driver offers 5.x with a wide range (5.0..5.8) plus padding.
+  final int result = negotiate(new int[] { 0x00080805, 0, 0, 0 });
+  assertThat(result).isEqualTo(0x00000405); // server ceiling v5.4
+}
+
+@Test
+void negotiates5xWhenDriverOffersBoth5xAnd44() {
+  // Modern driver proposes 5.x (range to 5.0) first, then 4.4 fallback.
+  final int result = negotiate(new int[] { 0x00080805, 0x00000404, 0, 0 });
+  assertThat(result).isEqualTo(0x00000405); // upgrades to v5.4, not v4.4
+}
+
+@Test
+void stillNegotiates44ForLegacyOnlyDriver() {
+  final int result = negotiate(new int[] { 0x00000404, 0x00000004, 0x00000003, 0 });
+  assertThat(result).isEqualTo(0x00000404); // unchanged
+}
+
+@Test
+void exactMatchV5_2() {
+  assertThat(negotiate(new int[] { 0x00000205, 0, 0, 0 })).isEqualTo(0x00000205);
+}
+```
+
+(Also update the existing `negotiate(...)` helper's inner loop to iterate `BoltNetworkExecutor.SUPPORTED_VERSIONS` instead of the deleted local copy, removing the duplication drift.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mvn -pl bolt test -Dtest=BoltVersionNegotiationTest`
+Expected: FAIL - `SUPPORTED_VERSIONS` is `private` (compile error) and/or the 5.x expectations are unmet.
+
+- [ ] **Step 3: Advertise 5.0-5.4** — in `BoltNetworkExecutor.java` replace line 100:
+
+```java
+  // Supported protocol versions (in order of preference). Package-private so the negotiation unit
+  // test asserts against the real advertised set rather than a drifting copy.
+  // Encoding: [unused(8)][range(8)][minor(8)][major(8)] — major = value & 0xFF, minor = (value >> 8) & 0xFF
+  static final int[] SUPPORTED_VERSIONS = {
+      0x00000405, 0x00000305, 0x00000205, 0x00000105, 0x00000005, // v5.4, v5.3, v5.2, v5.1, v5.0
+      0x00000404, 0x00000004, 0x00000003                          // v4.4, v4.0, v3.0
+  };
+```
+
+- [ ] **Step 4: Wire the negotiated version into the writer** — in `sendMessage` (line 1700) replace:
+
+```java
+    final PackStreamWriter writer = new PackStreamWriter();
+```
+
+with:
+
+```java
+    final PackStreamWriter writer = new PackStreamWriter().boltMajorVersion(getMajorVersion(protocolVersion));
+```
+
+- [ ] **Step 5: Run the full bolt unit suite**
+
+Run: `mvn -pl bolt test -Dtest=BoltVersionNegotiationTest,BoltStructureTest,BoltDateTimeStructureTest,BoltMessageTest,BoltStructureTest`
+Expected: PASS. This is the go-live point: the encoders (Tasks 1-2) now activate for any negotiated 5.x connection.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java \
+        bolt/src/test/java/com/arcadedb/bolt/BoltVersionNegotiationTest.java
+git commit -m "feat(#5001): advertise Bolt 5.0-5.4 and encode outbound records at the negotiated version"
+```
+
+---
+
+### Task 5: Flip PROTO-002 in the conformance spec + full-driver verification
+
+**Files:**
+- Modify: `bolt/conformance/spec.yaml` (the `PROTO-002` scenario)
+- Verify (no change expected): `bolt/src/test/java/com/arcadedb/bolt/Bolt4907TemporalOutputIT.java`, `BoltOffsetDatetimeWriteIT.java`, `BoltTypeRoundTripTest.java`, `BoltProtocolIT.java`, `BoltMultiLabelIT.java`
+
+**Interfaces:**
+- Consumes: Task 4 (5.x live end-to-end).
+- Produces: `PROTO-002` marked `passing`; the real `neo4j-java-driver` ITs green under the now-negotiated Bolt 5.4.
+
+- [ ] **Step 1: Flip the scenario** — in `bolt/conformance/spec.yaml`, in the `PROTO-002` block: change `current_status: expected-fail` to `current_status: passing`, remove the `known_limitation:` block, and remove the `tracking_issue: "#4890"` line. Leave `PROTO-001` untouched.
+
+- [ ] **Step 2: Validate the spec file**
+
+Run: `cd bolt/conformance && python3 validate_spec.py` (or `python3 -m pytest test_validate_spec.py` if that is the module's entry point)
+Expected: PASS - spec is well-formed and PROTO-002 is now `passing`.
+
+- [ ] **Step 3: Run the real-driver ITs (these exercise the 5.4 flip end-to-end)**
+
+Run: `mvn -pl bolt verify -Dtest=Bolt4907TemporalOutputIT,BoltOffsetDatetimeWriteIT,BoltTypeRoundTripTest,BoltProtocolIT,BoltMultiLabelIT`
+Expected: PASS. These assert decoded java.time / node / relationship values through the real driver; with the driver now negotiating 5.4, correct UTC datetime and element_id encoding keep them green. If any assert a raw wire signature/field-count for 4.x, update that assertion to the 5.x form and note it in the commit body.
+
+- [ ] **Step 4: Run the whole bolt module**
+
+Run: `mvn -pl bolt verify`
+Expected: PASS (unit + ITs). Investigate and fix any red before committing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bolt/conformance/spec.yaml
+git commit -m "test(#5001): mark PROTO-002 passing - Bolt 5.x negotiation certified"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Decision to advertise 5.0-5.4 → Task 4 (`SUPPORTED_VERSIONS`). ✓
+- Version-gated Node/Relationship/UnboundRelationship field counts → Task 1. ✓
+- Version-gated DateTime signatures (legacy vs UTC) → Task 2. ✓
+- Inbound temporal params unchanged → confirmed (no task needed; reader already decodes both). ✓
+- Auth-flow gate for 5.1+ auth-less HELLO; `none` still rejected → Task 3. ✓
+- TELEMETRY graceful ack → Task 3. ✓
+- Existing 3.0/4.0/4.4 negotiation unaffected → Task 4 Step 1 `stillNegotiates44ForLegacyOnlyDriver`. ✓
+- PROTO-002 flipped; TYPE round-trip stays green → Task 5. ✓
+- Handshake manifest (5.7/5.8) and 5.5/5.6 excluded → not implemented (non-goal); documented for #4884. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code. The one `<copy license header>` note is an explicit instruction, not a code placeholder.
+
+**Type consistency:** `boltMajorVersion(int)` / `getBoltMajorVersion()` used consistently across Tasks 1, 2, 4. `deferAuthToLogon(int,String,String,String)` signature identical in Task 3 test and impl. `BoltDateTimeStructure.offset(...)` / `.zoneId(...)` factory signatures match between the class (Task 2 Step 3) and its test (Task 2 Step 1) and the mapper call sites (Task 2 Step 4). `toTemporalStructure` return type widened to `PackStreamStructure` in the same task that relies on it.
+
+**Note on refinement vs spec §4.3:** the spec suggested making the negotiated version available at *mapping* time for temporals; this plan refines that to a *writer-driven* mechanism (the datetime struct carries both epoch bases and picks at `writeTo`), which is cleaner and yields identical wire bytes - nested temporals inside node/map/list properties are handled automatically without threading a version param through the mapper recursion.

--- a/docs/superpowers/specs/2026-07-06-bolt-5x-negotiation-design.md
+++ b/docs/superpowers/specs/2026-07-06-bolt-5x-negotiation-design.md
@@ -1,0 +1,184 @@
+# Bolt 5.x Version Negotiation - Design Spec
+
+**Issue:** [#5001](https://github.com/ArcadeData/arcadedb/issues/5001) - Bolt: decide and implement 5.x version negotiation
+**Parent tracking:** [#4890](https://github.com/ArcadeData/arcadedb/issues/4890) - protocol/type-fidelity gaps
+**Epic:** [#4882](https://github.com/ArcadeData/arcadedb/issues/4882) - Bolt Driver Compatibility Certification
+**Conformance scenario:** `PROTO-002` (`bolt/conformance/spec.yaml`), currently `current_status: expected-fail`
+**Date:** 2026-07-06
+**Effort:** M
+
+---
+
+## 1. Decision
+
+**Advertise Bolt 5.0 through 5.4 natively, and version-gate the outbound wire encoders in the same change.**
+
+The alternative - formally accepting 4.4-only as a documented limitation - was rejected. It would leave the advertised `Neo4j/5.26.0 compatible` identity dishonest and keep 5.x drivers on an undocumented silent downgrade, which the epic's governing principle ("certify depth, not presence; never a silent omission") explicitly rules out.
+
+The ceiling is **5.4**, not higher, because:
+
+- All 5.x minors share the *same* struct-level wire deltas (`element_id` fields on graph elements; UTC datetime signatures). Higher minors only add message-flow surface, not encoding.
+- 5.4 is a clean, bounded envelope: LOGON/LOGOFF auth (5.1, already implemented), notification-config + `bolt_agent` HELLO keys (5.2 / 5.3, safely ignored as unknown extra keys), and TELEMETRY (5.4, acked defensively).
+- Staying at or below 5.6 keeps the server on the **classic handshake**. The 5.7/5.8 handshake manifest is out of scope; manifest-capable drivers fall back to classic negotiation against our advertised ceiling, so `bolt://` / `neo4j://` still connect.
+- 5.5 / 5.6 (GQL-status notification metadata) add optional surface with no must-pass conformance cell, so they are deliberately excluded from this change.
+
+---
+
+## 2. The governing invariant: never lie to a driver
+
+The negotiated Bolt version is the single switch that selects wire encoding. Adding 5.x to `SUPPORTED_VERSIONS` and version-gating the encoders **must land atomically**, because the pinned `neo4j-java-driver` 6.2.0 already proposes both 4.4 and 5.x during handshake. The instant 5.x is advertised, that driver negotiates 5.4 and then *expects* 5.0-style structures. Advertising 5.x without honoring the deltas would break the currently-green TYPE round-trip scenarios.
+
+This coupling is a feature, not a hazard: the existing, passing round-trip tests become the regression guard for the encoder changes.
+
+---
+
+## 3. Handshake negotiation
+
+**File:** `bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java`
+
+`SUPPORTED_VERSIONS` changes from:
+
+```java
+private static final int[] SUPPORTED_VERSIONS = { 0x00000404, 0x00000004, 0x00000003 }; // v4.4, v4.0, v3.0
+```
+
+to (high-to-low preference; encoding is `[unused(8)][range(8)][minor(8)][major(8)]`):
+
+```java
+private static final int[] SUPPORTED_VERSIONS = {
+    0x00000405, 0x00000305, 0x00000205, 0x00000105, 0x00000005, // v5.4, v5.3, v5.2, v5.1, v5.0
+    0x00000404, 0x00000004, 0x00000003                          // v4.4, v4.0, v3.0
+};
+```
+
+**No change to `negotiateVersion()` logic.** The existing loop iterates client proposals (outer) against `SUPPORTED_VERSIONS` (inner, ordered high-to-low) and picks the first server version inside the client's `[minor - range, minor]` window for a matching major. Consequences:
+
+- A 5.x-only driver (e.g. proposes `5.8` with range down to `5.0`) → negotiates **5.4** (highest server 5.x inside its window).
+- A driver proposing 5.x *and* 4.4 → now negotiates **5.4** (was 4.4). This is the intended upgrade.
+- A driver proposing only `{4.4, 4.0, 3.0}` → unchanged.
+
+The server response remains a single concrete version (no range byte); the range byte in `SUPPORTED_VERSIONS` entries stays `0x00` - it is only consumed on the *client* proposal side.
+
+**Handshake manifest (5.7 / 5.8): explicitly not implemented.** Documented as an intentional boundary in the A2 server-identity doc (#4884).
+
+---
+
+## 4. Version-gated serialization
+
+A negotiated-version signal is threaded into the serialization context (the `PackStreamWriter`, set once after handshake completes) so encoders branch on `major >= 5`.
+
+### 4.1 Graph-element field counts
+
+**Files:** `bolt/src/main/java/com/arcadedb/bolt/structure/BoltNode.java`, `BoltRelationship.java`, `BoltUnboundRelationship.java`
+
+| Struct | Signature | 4.x (current, hardcoded) | 5.0+ (gated) |
+|---|---|---|---|
+| `BoltNode` | `0x4E` | 3 fields: `id, labels, properties` | 4 fields: `+ element_id` |
+| `BoltRelationship` | `0x52` | 5 fields: `id, startId, endId, type, properties` | 8 fields: `+ element_id, start_node_element_id, end_node_element_id` |
+| `BoltUnboundRelationship` | `0x72` | 3 fields: `id, type, properties` | 4 fields: `+ element_id` |
+
+The `element_id` values are already carried on the objects (built by `BoltStructureMapper` from the RID). Today `writeTo` simply omits them by writing a fixed lower field count. The gate makes the field count and the trailing `element_id` writes conditional on the writer's negotiated major version. `BoltRelationship` additionally needs `start_node_element_id` / `end_node_element_id`; these derive from the start/end RIDs already available at mapping time (added to the object if not already present).
+
+### 4.2 Temporal signatures
+
+**File:** `bolt/src/main/java/com/arcadedb/bolt/structure/BoltStructureMapper.java`
+
+Outbound `DateTime` / `DateTimeZoneId` construction is version-dependent - the signature *and* the epoch basis differ:
+
+| Version | Offset DateTime | ZoneId DateTime | Seconds field |
+|---|---|---|---|
+| 4.x (current) | `'F'` `0x46` | `'f'` `0x66` | local epoch-second (offset folded in) |
+| 5.0+ (gated) | `'I'` `0x49` | `'i'` `0x69` | true UTC epoch-second |
+
+The temporal builder (currently hardcoding `SIG_DATE_TIME_OFFSET_LEGACY` at `BoltStructureMapper.java:523`) selects signature and computes the seconds field per negotiated version. Because the choice is baked into the `BoltTemporalStructure` value object at construction, the negotiated version must be available at *mapping* time, not only at `writeTo` time.
+
+**Unchanged across 4.x <-> 5.x** (no gate needed): `Date` `'D'`, `Time` `'T'`, `LocalTime` `'t'`, `LocalDateTime` `'d'`, `Duration` `'E'`, `Point2D` `'X'`, `Point3D` `'Y'`.
+
+### 4.3 Threading mechanism
+
+The negotiated major version is set on the `PackStreamWriter` (the serialization context) per outgoing message from the connection's negotiated version. Every version-dependent struct reads it at `writeTo` time:
+
+- Graph elements (`BoltNode`/`BoltRelationship`/`BoltUnboundRelationship`) already carry their `element_id` values; `writeTo` gates the field count and the trailing `element_id` writes on `writer.getBoltMajorVersion() >= 5`.
+- Datetime values are emitted through a dedicated `BoltDateTimeStructure` that carries *both* epoch bases (local-epoch and true-UTC-epoch, computed at build time from the source `java.time` value) plus the offset/zone. `writeTo` selects signature (`'F'`/`'f'` vs `'I'`/`'i'`) and seconds field by the writer's major version.
+
+This keeps all version logic at `writeTo` time driven by the single writer signal - no version parameter is threaded through the `BoltStructureMapper` recursion, so a datetime nested inside node/map/list properties is encoded correctly automatically. The 4.x path stays byte-identical (the gate is purely additive).
+
+### 4.4 Inbound (parameters): no change
+
+The `PackStreamReader` parameter-hydration path already decodes *both* legacy (`'F'`/`'f'`) and UTC (`'I'`/`'i'`) temporal signatures defensively (`BoltStructureMapper.java:599-616`). A 5.x driver sending a native datetime parameter is already handled.
+
+---
+
+## 5. Auth-flow gate (resolves the standing `NOTE (Bolt 5.1+)`)
+
+**File:** `bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java` (`handleHello`, ~line 420)
+
+The existing code has a documented latent bug: `handleHello` rejects any HELLO without credentials. A legitimate Bolt 5.1+ HELLO carries no auth (it moves to a separate LOGON), so it would be wrongly rejected. Safe today only because 5.x is never negotiated.
+
+New behavior:
+
+- **Negotiated `minor >= 1` (5.1+) AND HELLO has no scheme/principal/credentials** → HELLO succeeds (SUCCESS + server metadata), connection stays in the authentication state awaiting LOGON. The existing `handleLogon` then authenticates.
+- **Negotiated `< 5.1`** → current HELLO-embedded auth behavior, unchanged.
+- **`none` scheme** → still deliberately rejected in both flows (preserves `AUTH-003`). At 5.1+ this arrives as a LOGON with scheme `none`; `handleLogon` -> `authenticateUser(null, null)` rejects with a structured auth error.
+
+### TELEMETRY (5.4)
+
+A `TELEMETRY` message (signature `0x54`) is acked defensively with SUCCESS. Drivers send TELEMETRY only when the server advertises telemetry hints in HELLO SUCCESS metadata, which ArcadeDB will not do, so in practice no compliant driver sends it. The graceful ack is belt-and-suspenders against a misconfigured/eager driver rather than a required feature.
+
+---
+
+## 6. Testing (TDD - written first)
+
+### 6.1 Bolt-module unit / ITs (`bolt/src/test/java`, fast guard)
+
+1. **Handshake negotiation matrix**
+   - 5.x-only proposal → server responds `5.4`.
+   - 5.x-with-4.4-fallback proposal → `5.4`.
+   - Pure `{4.4, 4.0, 3.0}` proposals → unchanged (4.4 / 4.0 / 3.0 respectively).
+   - Directly pins PROTO-001 (stays green) and PROTO-002's mechanic.
+
+2. **Version-gated struct encoding** (the "don't lie" guard)
+   - Serialize Node / Relationship / UnboundRelationship / DateTime through a `PackStreamWriter` pinned to major 4 vs major 5.
+   - Assert exact field counts: `3/5/3` (v4) vs `4/8/4` (v5).
+   - Assert datetime signature `'F'` (v4) vs `'I'` (v5) and the correct seconds field (local vs UTC epoch).
+
+3. **Auth-flow gate**
+   - Auth-less HELLO at negotiated 5.1+ → SUCCESS + awaits LOGON.
+   - Auth-less HELLO at 4.4 → unchanged rejection.
+   - `none` scheme → rejected in both flows.
+
+### 6.2 Cross-language conformance
+
+- Flip `PROTO-002` in `bolt/conformance/spec.yaml`: `current_status: expected-fail` → `passing`; remove its `known_limitation` block.
+- The real `neo4j-java-driver` IT (`RemoteBoltDatabaseIT`) negotiates 5.4 end-to-end.
+- **All existing TYPE round-trip scenarios re-run under 5.4 and must stay green** - the atomic-change regression guard.
+
+### 6.3 Verification commands
+
+- `mvn -pl bolt test` (unit + module ITs).
+- `RemoteBoltDatabaseIT` against a live server (real driver end-to-end).
+- Confirm the currently-green TYPE / graph-element scenarios remain green under the new negotiated 5.4.
+
+---
+
+## 7. Risks & coordination
+
+- **PROTO-001 test expectation.** Confirm the suite forces specific proposed versions rather than asserting "driver X lands on 4.4". If any test hard-codes the previously negotiated version for a modern driver, update its expectation to 5.4. Checked during implementation.
+- **#4884 / A2 (server-identity doc).** This change makes the `Neo4j/5.26.0 compatible` identity honest up to Bolt 5.4 for the first time. The doc absorbs: the 5.4 ceiling, the classic-handshake-only stance, and the 5.5-5.8 / manifest non-support as documented boundaries.
+- **Serialization hot-path blast radius.** The gate touches the outbound result-encoding path. Mitigated by the field-count/signature unit tests and by keeping the 4.x branch byte-identical (additive gate only).
+
+---
+
+## 8. Acceptance criteria (from #5001)
+
+- [ ] PROTO-002 passes: a 5.x-only driver connects and negotiates a documented-supported 5.x version (5.4).
+- [ ] The negotiated version set is consistent with the advertised `Neo4j/5.26.0 compatible` identity up to 5.4; the 5.4 ceiling and manifest non-support are documented (coordinated with #4884).
+- [ ] Existing 3.0 / 4.0 / 4.4 negotiation unaffected.
+- [ ] All existing TYPE round-trip conformance scenarios stay green under the new negotiated 5.4.
+
+## 9. Non-goals
+
+- Handshake manifest (Bolt 5.7 / 5.8).
+- Bolt 5.5 / 5.6 GQL-status notification metadata.
+- HA-aware ROUTE (CONN-004) - separate sub-issue #5002.
+- Changing the advertised `server_agent` string away from `5.26.0` (epic non-goal; A2 documents the existing choice).

--- a/e2e/src/test/java/com/arcadedb/e2e/RemoteBoltDatabaseIT.java
+++ b/e2e/src/test/java/com/arcadedb/e2e/RemoteBoltDatabaseIT.java
@@ -695,20 +695,16 @@ class RemoteBoltDatabaseIT extends ArcadeContainerTemplate {
     @DisplayName("[PROTO-002] Bolt 5.x negotiation is supported")
     void proto002_bolt5() {
       // Assert on the version actually negotiated with the pinned (5.x-capable)
-      // driver. The server advertises only 3.0/4.0/4.4, so it negotiates 4.4
-      // today and the >= 5.0 assertion fails (documenting the gap). When Bolt
-      // 5.x support is added, the negotiated version rises to 5.x, the assertion
-      // passes, and assertExpectedFailure fails loudly - so this xfail actually
-      // self-closes rather than being a hardcoded marker.
+      // driver. The server now advertises Bolt 5.0-5.4 (in addition to legacy
+      // 3.0/4.0/4.4), so it negotiates a 5.x version with this driver.
       final String negotiated;
       try (final Session s = boltSession()) {
         negotiated = s.run("RETURN 1").consume().server().protocolVersion();
       }
       // Compare on the integer major so 5.10 is not mis-parsed (Double would
-      // read it as 5.1); parsing happens outside the xfail so a null/non-numeric
-      // value surfaces as a real error rather than a false "gap present".
+      // read it as 5.1).
       final int major = Integer.parseInt(negotiated.split("\\.")[0]);
-      assertExpectedFailure("#4890", () -> assertThat(major).isGreaterThanOrEqualTo(5));
+      assertThat(major).isGreaterThanOrEqualTo(5);
     }
 
     @Test


### PR DESCRIPTION
## What does this PR do?

Advertises Bolt **5.0 through 5.4** in the handshake (previously 3.0/4.0/4.4 only) and version-gates the outbound wire encoders so a 5.x driver connects natively instead of silently downgrading to 4.4. Closes conformance scenario **PROTO-002**.

The negotiated Bolt major version is the single switch, threaded through the per-message `PackStreamWriter`:

- **Graph elements** - `Node` / `Relationship` / `UnboundRelationship` emit their Bolt 5.0 layouts (with `element_id` / `start_node_element_id` / `end_node_element_id`, field counts 4/8/4) when the negotiated major is >= 5, and stay byte-identical (3/5/3) on 4.x.
- **Temporals** - a new `BoltDateTimeStructure` carries both epoch bases and emits the legacy `'F'`/`'f'` signatures with the local epoch-second on 4.x, and the UTC `'I'`/`'i'` signatures with the true UTC epoch-second on 5.0+.
- **Auth flow** - a Bolt 5.1+ auth-less `HELLO` is now accepted and defers to the separate `LOGON` (resolving the standing `NOTE (Bolt 5.1+)` latent bug); `AuthTokens.none()` stays deliberately rejected. `TELEMETRY` (5.4) is acknowledged.
- **Handshake** - `SUPPORTED_VERSIONS` advertises `{5.4, 5.3, 5.2, 5.1, 5.0, 4.4, 4.0, 3.0}`; the existing range-matching logic is unchanged, so 3.0/4.0/4.4 drivers negotiate exactly as before.

The change advertises 5.x and honors its wire deltas atomically, so the advertised `Neo4j/5.26.0 compatible` identity is honest up to Bolt 5.4. The 5.7/5.8 handshake manifest and 5.5/5.6 GQL notification metadata are intentionally out of scope (classic-handshake-only); manifest-capable drivers fall back to classic negotiation against the 5.4 ceiling.

## Motivation

`BoltNetworkExecutor.SUPPORTED_VERSIONS` never advertised any Bolt 5.x version, so 5.x drivers worked only by an undocumented, untested silent downgrade to 4.4 - while the server still advertised a 5.26-compatible identity, setting a 5.x feature expectation the handshake did not honor. This closes that gap without lying to drivers: adding 5.x and honoring the `element_id` / UTC-datetime wire deltas land together, guarded by the existing real-driver type round-trip ITs.

## Related issues

- Closes #5001 (Bolt: decide and implement 5.x version negotiation - PROTO-002)
- Part of #4890 (tracking issue: protocol/type-fidelity gaps)
- Epic #4882 (Bolt Driver Compatibility Certification)
- Coordinates with #4884 (advertised server-identity doc): the 5.4 ceiling and classic-handshake-only stance are documented boundaries for that doc to absorb.

## Additional Notes

- Design spec and implementation plan are included under `docs/superpowers/`.
- `bolt/conformance/spec.yaml`: PROTO-002 flipped `expected-fail` -> `passing`; the self-closing e2e xfail `RemoteBoltDatabaseIT#proto002_bolt5` is un-wrapped to a direct assertion; `validate_spec.py` drops the now-nonexistent `protocol`-area #4890 gap (CONN-004's `connection`-area gap is untouched).
- Not in scope (separate sub-issues): HA-aware ROUTE / CONN-004 (#5002), Bolt 5.7/5.8 handshake manifest.

## Checklist

- [x] I have run the build using `mvn clean package` command (verified `mvn -pl bolt verify`: 275 unit + 110 IT green, including the real `neo4j-java-driver` ITs - `BoltProtocolIT` 78/78, temporal/type round-trip ITs - with no assertion changes needed)
- [x] My unit tests cover both failure and success scenarios (handshake negotiation matrix incl. no-match; version-gated struct field counts and datetime signatures at major 4 vs 5; auth-deferral truth table incl. `none`-rejected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)