### PR TITLE
fix(#4939,#4941,#4956): DatabaseContext lifecycle - abandoned-tx rollback on dead-thread sweep, virtual-thread-correct liveness, thread-safe context maps

### DIFF
--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -250,7 +250,9 @@ that could starve the very snapshot resync meant to heal the node.
   rollback (double unlock, concurrent record reloads on shared caches); the sweep additionally claims each
   per-database context with a value-keyed remove, closing the same double-rollback race against
   `closeInternal`'s `removeAllContexts()` (which rolls back foreign contexts under the DB write lock the
-  sweep does not take).
+  sweep does not take); the lazy requester capture is now an explicit `captureRequester()` invoked only
+  from the lock-acquisition paths, with `getRequester()` a pure read for the release paths, so a future
+  non-owner call can no longer pin the wrong lock identity (structural guard for the #4941 invariant).
 - **Pool discipline, TimeSeries threading and low-severity storage/WAL/LSM cleanups (2026-07 audit).**
   The partitioned triangle-count operator now runs chunk 0 on the calling thread instead of submitting
   every chunk to the shared query pool and blocking on all of them - the same caller-runs-chunk-0

--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -244,7 +244,10 @@ that could starve the very snapshot resync meant to heal the node.
   foreign registry entries, closing a data race with the owner thread's `init()` that could corrupt the plain
   `HashMap` or unregister a live context ([#4939](https://github.com/ArcadeData/arcadedb/issues/4939); the
   reported mid-commit cross-thread rollback interleaving is already excluded by the database RW lock - commit
-  holds the read lock for its whole duration while close's rollbacks run under the write lock).
+  holds the read lock for its whole duration while close's rollbacks run under the write lock). Review
+  follow-up: concurrent sweeps (two threads landing on the periodic boundary together) now claim each dead
+  entry atomically, so its abandoned transactions are rolled back exactly once instead of racing a double
+  rollback (double unlock, concurrent record reloads on shared caches).
 - **Pool discipline, TimeSeries threading and low-severity storage/WAL/LSM cleanups (2026-07 audit).**
   The partitioned triangle-count operator now runs chunk 0 on the calling thread instead of submitting
   every chunk to the shared query pool and blocking on all of them - the same caller-runs-chunk-0

--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -253,6 +253,9 @@ that could starve the very snapshot resync meant to heal the node.
   sweep does not take); the lazy requester capture is now an explicit `captureRequester()` invoked only
   from the lock-acquisition paths, with `getRequester()` a pure read for the release paths, so a future
   non-owner call can no longer pin the wrong lock identity (structural guard for the #4941 invariant).
+  A sweep that performs real rollback work now emits a single attributable WARNING (transaction count,
+  thread ids, databases; zero-work sweeps stay silent), and the exactly-once arguments are pinned to the
+  JDK 21+ `Thread.threadId()` non-reuse guarantee at the registry declaration.
 - **PageManager lifecycle is refcounted.** The JVM-wide page manager was started and stopped on a racy
   "is the active-database map empty" check-then-act spanning factory instances: closing the last instance
   of one database could null the shared flush thread under a database whose open was still in flight

--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -208,6 +208,25 @@ that could starve the very snapshot resync meant to heal the node.
   shadows committed RIDs whose key equals an uncommitted entry's key - is tracked in
   [#5055](https://github.com/ArcadeData/arcadedb/issues/5055).
 
+- **Thread-context lifecycle hardening (2026-07 audit).** The periodic dead-thread sweep of the per-thread
+  database contexts now rolls back any transaction the dead thread abandoned, releasing its file locks:
+  before, a thread dying with an open transaction holding explicit locks (`acquireLock().type(...).lock()`)
+  left the `LockManager` files owned by the dead thread forever, and every later commit touching them timed
+  out until restart ([#4941](https://github.com/ArcadeData/arcadedb/issues/4941)); the cross-thread unlock
+  works because the lock requester is now captured once at lock-acquisition time instead of being re-resolved
+  as the calling thread at release time. Dead-thread detection no longer uses `Thread.getAllStackTraces()`,
+  which misses virtual threads (a LIVE virtual thread's context was pruned as dead while its transaction was
+  running) and captures every platform-thread stack at a global safepoint (a periodic multi-ms latency spike);
+  each context entry now holds a `WeakReference<Thread>` checked with `isAlive()` - O(1), safepoint-free,
+  virtual-thread-correct - and the GraphAnalyticalView async build/rebuild/compaction workers unregister their
+  thread contexts on completion instead of leaking them until the next sweep
+  ([#4956](https://github.com/ArcadeData/arcadedb/issues/4956)). The per-thread contexts map is now a
+  `ConcurrentHashMap` and `removeAllContexts` (database close/drop from another thread) no longer prunes
+  foreign registry entries, closing a data race with the owner thread's `init()` that could corrupt the plain
+  `HashMap` or unregister a live context ([#4939](https://github.com/ArcadeData/arcadedb/issues/4939); the
+  reported mid-commit cross-thread rollback interleaving is already excluded by the database RW lock - commit
+  holds the read lock for its whole duration while close's rollbacks run under the write lock).
+
 ### Improvements
 
 - **HA: throttled diverged-follower resync logging.** When a follower detects a WAL page-version gap it

--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -247,7 +247,10 @@ that could starve the very snapshot resync meant to heal the node.
   holds the read lock for its whole duration while close's rollbacks run under the write lock). Review
   follow-up: concurrent sweeps (two threads landing on the periodic boundary together) now claim each dead
   entry atomically, so its abandoned transactions are rolled back exactly once instead of racing a double
-  rollback (double unlock, concurrent record reloads on shared caches).
+  rollback (double unlock, concurrent record reloads on shared caches); the sweep additionally claims each
+  per-database context with a value-keyed remove, closing the same double-rollback race against
+  `closeInternal`'s `removeAllContexts()` (which rolls back foreign contexts under the DB write lock the
+  sweep does not take).
 - **Pool discipline, TimeSeries threading and low-severity storage/WAL/LSM cleanups (2026-07 audit).**
   The partitioned triangle-count operator now runs chunk 0 on the calling thread instead of submitting
   every chunk to the shared query pool and blocking on all of them - the same caller-runs-chunk-0

--- a/engine/src/main/java/com/arcadedb/database/DatabaseContext.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseContext.java
@@ -234,6 +234,9 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
    * re-enter this class on the sweeping thread (record reloads resolve the sweeper's own transaction context);
    * that is safe because the dead entry is atomically claimed and unlinked before the rollbacks start and the
    * CONTEXTS traversal is weakly consistent.
+   * A rollback can also re-enter init() and, on the 1000th call, trigger a NESTED full sweep - safe for the
+   * same reasons (weakly-consistent traversal + the atomic claim: a nested sweep cannot double-roll-back a
+   * claimed entry), noted so the recursion is a documented possibility rather than a surprise.
    * <p>
    * Package-private (instead of private) for tests only.
    */

--- a/engine/src/main/java/com/arcadedb/database/DatabaseContext.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseContext.java
@@ -32,10 +32,10 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Thread local to store transaction data.
  */
 public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.DatabaseContextTL>> {
-  public static final  DatabaseContext                          INSTANCE          = new DatabaseContext();
-  private static final ConcurrentHashMap<Long, ThreadContexts>  CONTEXTS          = new ConcurrentHashMap<>();
-  private static final AtomicInteger                            INIT_CALL_COUNTER = new AtomicInteger();
-  private static final int                                      CLEANUP_INTERVAL  = 1000;
+  public static final  DatabaseContext                         INSTANCE          = new DatabaseContext();
+  private static final ConcurrentHashMap<Long, ThreadContexts> CONTEXTS          = new ConcurrentHashMap<>();
+  private static final AtomicInteger                           INIT_CALL_COUNTER = new AtomicInteger();
+  private static final int                                     CLEANUP_INTERVAL  = 1000;
 
   /**
    * One CONTEXTS entry: the per-thread contexts map plus a weak reference to the owning thread, used for the
@@ -100,7 +100,7 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
       }
     }
 
-    // ALWAYS ENSURE THE MAP IS REGISTERED IN CONTEXTS (the dead-thread sweep may have pruned a reused thread id).
+    // ALWAYS ENSURE THE MAP IS REGISTERED IN CONTEXTS (the dead-thread sweep may have pruned this entry).
     // AVOID THE PUT (AND THE WeakReference ALLOCATION) WHEN THE SAME MAP IS ALREADY REGISTERED: THE MAP IS
     // PER-THREAD, SO IDENTITY IMPLIES THE ENTRY BELONGS TO THIS THREAD
     final Thread currentThread = Thread.currentThread();
@@ -244,7 +244,9 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
   private static void rollbackAbandonedTransactions(final DatabaseContextTL tl) {
     for (int i = tl.transactions.size() - 1; i > -1; --i) {
       try {
-        tl.transactions.get(i).rollback();
+        final TransactionContext tx = tl.transactions.get(i);
+        if (tx.isActive())
+          tx.rollback();
       } catch (final Throwable e) {
         // IGNORE ERRORS: BEST-EFFORT CLEANUP OF TRANSACTIONS ABANDONED BY A DEAD THREAD
       }

--- a/engine/src/main/java/com/arcadedb/database/DatabaseContext.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseContext.java
@@ -20,6 +20,7 @@ package com.arcadedb.database;
 
 import com.arcadedb.exception.DatabaseOperationException;
 import com.arcadedb.exception.TransactionException;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.query.QuerySession;
 import com.arcadedb.security.SecurityDatabaseUser;
 
@@ -27,12 +28,18 @@ import java.lang.ref.WeakReference;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
 
 /**
  * Thread local to store transaction data.
  */
 public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.DatabaseContextTL>> {
   public static final  DatabaseContext                         INSTANCE          = new DatabaseContext();
+  // KEYED BY Thread.threadId(): ON JDK 21+ (THIS PROJECT'S BASELINE) threadId() IS SPECIFIED AS A POSITIVE ID
+  // GENERATED WHEN THE THREAD IS CREATED AND NEVER REUSED - UNLIKE THE OLD Thread.getId(), WHOSE CONTRACT
+  // EXPLICITLY PERMITTED REUSE AFTER TERMINATION. EVERY EXACTLY-ONCE CLAIM/REMOVE ARGUMENT IN THIS CLASS
+  // (THE SWEEP'S KEYED CLAIM, removeContext, removeCurrentThreadContexts) DEPENDS ON THIS NON-REUSE:
+  // DO NOT REFACTOR TO getId() OR ANY OTHER REUSABLE KEY, AND RE-VERIFY THE GUARANTEE ON JDK MAJOR BUMPS
   private static final ConcurrentHashMap<Long, ThreadContexts> CONTEXTS          = new ConcurrentHashMap<>();
   private static final AtomicInteger                           INIT_CALL_COUNTER = new AtomicInteger();
   private static final int                                     CLEANUP_INTERVAL  = 1000;
@@ -134,8 +141,8 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
       if (map.isEmpty()) {
         // REMOVE THE THREAD LOCAL WHEN THE MAP IS EMPTY. THE UNCONDITIONAL (NON-VALUE-KEYED) REMOVE IS SAFE,
         // UNLIKE IN THE SWEEP: THIS RUNS ON THE OWNER THREAD, ONLY THE OWNER EVER REGISTERS UNDER ITS OWN
-        // NEVER-REUSED THREAD ID AND THE SWEEP ONLY CLAIMS DEAD THREADS, SO THE ENTRY UNDER THIS KEY CAN ONLY
-        // BE THIS THREAD'S OWN CURRENT REGISTRATION
+        // NEVER-REUSED THREAD ID (SEE THE threadId() PROVENANCE NOTE ON CONTEXTS) AND THE SWEEP ONLY CLAIMS
+        // DEAD THREADS, SO THE ENTRY UNDER THIS KEY CAN ONLY BE THIS THREAD'S OWN CURRENT REGISTRATION
         super.remove();
         CONTEXTS.remove(Thread.currentThread().threadId());
       }
@@ -214,7 +221,8 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
   public void removeCurrentThreadContexts() {
     super.remove();
     // UNCONDITIONAL REMOVE IS SAFE FOR THE SAME REASON AS IN removeContext(): OWNER-THREAD-ONLY KEY,
-    // THREAD IDS NEVER REUSED, THE SWEEP ONLY CLAIMS DEAD THREADS
+    // THREAD IDS NEVER REUSED (SEE THE threadId() PROVENANCE NOTE ON CONTEXTS), THE SWEEP ONLY CLAIMS
+    // DEAD THREADS
     CONTEXTS.remove(Thread.currentThread().threadId());
   }
 
@@ -230,7 +238,9 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
    * The rollbacks run INLINE on the triggering thread: unlike the pre-#4941 sweep (a cheap map cleanup), the
    * unlucky request whose {@code init()} hits the periodic boundary pays for the full rollback (callbacks, page
    * reloads, lock release) of every transaction the dead threads abandoned. Acceptable for a safety-net path,
-   * but operators should expect a tail-latency blip when the sweep finds abandoned work. The rollback may also
+   * but operators should expect a tail-latency blip when the sweep finds abandoned work; a sweep that performs
+   * real rollback work emits a single WARNING summarizing count, thread ids and databases so the blip is
+   * attributable (zero-work sweeps stay silent). The rollback may also
    * re-enter this class on the sweeping thread (record reloads resolve the sweeper's own transaction context);
    * that is safe because the dead entry is atomically claimed and unlinked before the rollbacks start and the
    * CONTEXTS traversal is weakly consistent.
@@ -247,6 +257,9 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
    * Package-private (instead of private) for tests only.
    */
   static void cleanupDeadThreads() {
+    int rolledBack = 0;
+    StringBuilder details = null;
+
     for (final Map.Entry<Long, ThreadContexts> entry : CONTEXTS.entrySet()) {
       final ThreadContexts threadContexts = entry.getValue();
       final Thread owner = threadContexts.owner.get();
@@ -262,7 +275,8 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
         //
         // ATOMICALLY CLAIM THE DEAD ENTRY: TWO THREADS CAN SWEEP CONCURRENTLY (BOTH LANDING ON THE PERIODIC
         // init() BOUNDARY) AND THE ABANDONED TRANSACTIONS MUST BE ROLLED BACK EXACTLY ONCE. THREAD IDS ARE
-        // NEVER REUSED, SO THE KEYED REMOVE CANNOT DROP AN ENTRY BELONGING TO A DIFFERENT THREAD
+        // NEVER REUSED (SEE THE threadId() PROVENANCE NOTE ON THE CONTEXTS FIELD), SO THE KEYED REMOVE
+        // CANNOT DROP AN ENTRY BELONGING TO A DIFFERENT THREAD
         if (CONTEXTS.remove(entry.getKey(), threadContexts))
           for (final Map.Entry<String, DatabaseContextTL> ctx : threadContexts.contexts.entrySet())
             // CLAIM EACH PER-DATABASE CONTEXT TOO: closeInternal (DATABASE CLOSE/DROP) CONCURRENTLY CLAIMS
@@ -270,10 +284,28 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
             // WRITE LOCK, WHICH THE SWEEP DOES NOT TAKE. THE VALUE-KEYED REMOVE GUARANTEES EXACTLY ONE OF
             // THE TWO PATHS ROLLS BACK EACH ABANDONED TRANSACTION - SAME HAZARD CLASS AS THE
             // SWEEPER-VS-SWEEPER CLAIM ABOVE (DOUBLE UNLOCK, CONCURRENT MUTATION OF tl.transactions)
-            if (threadContexts.contexts.remove(ctx.getKey(), ctx.getValue()))
-              rollbackAbandonedTransactions(ctx.getValue());
+            if (threadContexts.contexts.remove(ctx.getKey(), ctx.getValue())) {
+              final int rolled = rollbackAbandonedTransactions(ctx.getValue());
+              if (rolled > 0) {
+                rolledBack += rolled;
+                if (details == null)
+                  details = new StringBuilder();
+                else
+                  details.append(", ");
+                details.append("threadId=").append(entry.getKey()).append(" database='").append(ctx.getKey())
+                    .append("' transactions=").append(rolled);
+              }
+            }
       }
     }
+
+    // OPERABILITY (#5060 REVIEW): ONE SUMMARY LINE PER SWEEP THAT DID REAL WORK, SO THE INLINE ROLLBACK'S
+    // TAIL-LATENCY BLIP ON THE TRIGGERING THREAD IS ATTRIBUTABLE INSTEAD OF MYSTERIOUS. ZERO-WORK SWEEPS
+    // (THE OVERWHELMINGLY COMMON CASE) STAY SILENT AND ALLOCATE NOTHING
+    if (rolledBack > 0)
+      LogManager.instance().log(DatabaseContext.class, Level.WARNING,
+          "Dead-thread sweep rolled back %d abandoned transaction(s) inline on thread '%s': %s", rolledBack,
+          Thread.currentThread().getName(), details);
   }
 
   /**
@@ -282,19 +314,24 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
    * {@code TransactionContext#getRequester()}), which the {@code LockManager} explicitly supports. Nobody else can
    * touch these transactions: the owner is dead and the caller atomically claimed the tl at BOTH levels (the
    * CONTEXTS entry against concurrent sweepers, the per-database key against closeInternal's
-   * removeAllContexts()), so the cross-thread access is exclusive.
+   * removeAllContexts()), so the cross-thread access is exclusive. Returns the number of ACTIVE transactions
+   * rolled back, feeding the sweep's operability summary log.
    */
-  private static void rollbackAbandonedTransactions(final DatabaseContextTL tl) {
+  private static int rollbackAbandonedTransactions(final DatabaseContextTL tl) {
+    int rolledBack = 0;
     for (int i = tl.transactions.size() - 1; i > -1; --i) {
       try {
         final TransactionContext tx = tl.transactions.get(i);
-        if (tx.isActive())
+        if (tx.isActive()) {
           tx.rollback();
+          ++rolledBack;
+        }
       } catch (final Throwable e) {
         // IGNORE ERRORS: BEST-EFFORT CLEANUP OF TRANSACTIONS ABANDONED BY A DEAD THREAD
       }
     }
     tl.transactions.clear();
+    return rolledBack;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/database/DatabaseContext.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseContext.java
@@ -151,8 +151,10 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
       if (tl != null)
         result.add(tl);
       // DO NOT PRUNE THE CONTEXTS ENTRY HERE EVEN WHEN THE MAP BECAME EMPTY: THIS RUNS ON THE CLOSING THREAD AND
-      // WOULD RACE THE OWNER THREAD'S init() RE-REGISTRATION, UNREGISTERING A LIVE CONTEXT (ISSUE #4939). EMPTY
-      // ENTRIES ARE PRUNED BY THE OWNER (removeContext/removeCurrentThreadContexts) OR BY THE DEAD-THREAD SWEEP
+      // WOULD RACE THE OWNER THREAD'S init() RE-REGISTRATION, UNREGISTERING A LIVE CONTEXT (ISSUE #4939). AN
+      // EMPTY ENTRY LINGERS UNTIL ITS OWNER NEXT TOUCHES THE CONTEXT API (removeContext/
+      // removeCurrentThreadContexts) OR DIES (DEAD-THREAD SWEEP): AN IDLE LIVE THREAD KEEPS A TINY EMPTY-MAP
+      // ENTRY MEANWHILE, BOUNDED BY THE LIVE-THREAD COUNT
     }
     return result;
   }
@@ -220,16 +222,34 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
    * example via {@code acquireLock().type(...).lock()}) stayed owned by the dead thread forever and every later
    * commit touching them timed out until restart (issue #4941).
    * <p>
+   * The rollbacks run INLINE on the triggering thread: unlike the pre-#4941 sweep (a cheap map cleanup), the
+   * unlucky request whose {@code init()} hits the periodic boundary pays for the full rollback (callbacks, page
+   * reloads, lock release) of every transaction the dead threads abandoned. Acceptable for a safety-net path,
+   * but operators should expect a tail-latency blip when the sweep finds abandoned work. The rollback may also
+   * re-enter this class on the sweeping thread (record reloads resolve the sweeper's own transaction context);
+   * that is safe because the dead entry is atomically claimed and unlinked before the rollbacks start and the
+   * CONTEXTS traversal is weakly consistent.
+   * <p>
    * Package-private (instead of private) for tests only.
    */
   static void cleanupDeadThreads() {
-    for (final Iterator<ThreadContexts> it = CONTEXTS.values().iterator(); it.hasNext(); ) {
-      final ThreadContexts threadContexts = it.next();
+    for (final Map.Entry<Long, ThreadContexts> entry : CONTEXTS.entrySet()) {
+      final ThreadContexts threadContexts = entry.getValue();
       final Thread owner = threadContexts.owner.get();
       if (owner == null || !owner.isAlive()) {
-        it.remove();
-        for (final DatabaseContextTL tl : threadContexts.contexts.values())
-          rollbackAbandonedTransactions(tl);
+        // MEMORY VISIBILITY: THE isAlive() == false CHECK IS LOAD-BEARING, NOT JUST A LIVENESS TEST. PER JLS
+        // 17.4.4 THE FINAL ACTION OF A TERMINATED THREAD SYNCHRONIZES-WITH ANOTHER THREAD DETECTING THE
+        // TERMINATION VIA isAlive()/join(), SO THIS THREAD IS GUARANTEED TO SEE ALL THE DEAD OWNER'S WRITES
+        // (E.G. TransactionContext.requester, WHICH IS NON-VOLATILE). DO NOT REPLACE IT WITH A BARE
+        // WeakReference STALENESS CHECK. THE owner == null BRANCH LACKS THE FORMAL GUARANTEE BUT A GC-CLEARED
+        // Thread IS LONG TERMINATED (AND ITS WRITES LONG PUBLISHED) IN PRACTICE.
+        //
+        // ATOMICALLY CLAIM THE DEAD ENTRY: TWO THREADS CAN SWEEP CONCURRENTLY (BOTH LANDING ON THE PERIODIC
+        // init() BOUNDARY) AND THE ABANDONED TRANSACTIONS MUST BE ROLLED BACK EXACTLY ONCE. THREAD IDS ARE
+        // NEVER REUSED, SO THE KEYED REMOVE CANNOT DROP AN ENTRY BELONGING TO A DIFFERENT THREAD
+        if (CONTEXTS.remove(entry.getKey(), threadContexts))
+          for (final DatabaseContextTL tl : threadContexts.contexts.values())
+            rollbackAbandonedTransactions(tl);
       }
     }
   }

--- a/engine/src/main/java/com/arcadedb/database/DatabaseContext.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseContext.java
@@ -267,7 +267,7 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
         // MEMORY VISIBILITY: THE isAlive() == false CHECK IS LOAD-BEARING, NOT JUST A LIVENESS TEST. PER JLS
         // 17.4.4 THE FINAL ACTION OF A TERMINATED THREAD SYNCHRONIZES-WITH ANOTHER THREAD DETECTING THE
         // TERMINATION VIA isAlive()/join(), SO THIS THREAD IS GUARANTEED TO SEE ALL THE DEAD OWNER'S WRITES
-        // EVEN THE NON-VOLATILE ONES (TransactionContext.requester IS VOLATILE SINCE ROUND 3 FOR THE
+        // EVEN THE NON-VOLATILE ONES (TransactionContext.requester IS VOLATILE FOR THE
         // LIVE-OWNER CLOSE PATH, BUT THE DEAD-OWNER GUARANTEE HERE DOES NOT DEPEND ON THAT). DO NOT REPLACE
         // THE LIVENESS TEST WITH A BARE
         // WeakReference STALENESS CHECK. THE owner == null BRANCH LACKS THE FORMAL GUARANTEE BUT A GC-CLEARED
@@ -285,7 +285,7 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
             // THE TWO PATHS ROLLS BACK EACH ABANDONED TRANSACTION - SAME HAZARD CLASS AS THE
             // SWEEPER-VS-SWEEPER CLAIM ABOVE (DOUBLE UNLOCK, CONCURRENT MUTATION OF tl.transactions)
             if (threadContexts.contexts.remove(ctx.getKey(), ctx.getValue())) {
-              final int rolled = rollbackAbandonedTransactions(ctx.getValue());
+              final int rolled = rollbackAbandonedTransactions(ctx.getValue(), entry.getKey(), ctx.getKey());
               if (rolled > 0) {
                 rolledBack += rolled;
                 if (details == null)
@@ -317,7 +317,7 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
    * removeAllContexts()), so the cross-thread access is exclusive. Returns the number of ACTIVE transactions
    * rolled back, feeding the sweep's operability summary log.
    */
-  private static int rollbackAbandonedTransactions(final DatabaseContextTL tl) {
+  private static int rollbackAbandonedTransactions(final DatabaseContextTL tl, final long threadId, final String databaseName) {
     int rolledBack = 0;
     for (int i = tl.transactions.size() - 1; i > -1; --i) {
       try {
@@ -327,7 +327,12 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
           ++rolledBack;
         }
       } catch (final Throwable e) {
-        // IGNORE ERRORS: BEST-EFFORT CLEANUP OF TRANSACTIONS ABANDONED BY A DEAD THREAD
+        // BEST-EFFORT CLEANUP, BUT NEVER SILENT (#5060): A FAILED ROLLBACK MEANS THE ABANDONED
+        // TRANSACTION'S FILE LOCKS MAY STILL BE HELD - THE EXACT LEAK THIS SWEEP EXISTS TO FIX - SO THE
+        // OPERATOR MUST SEE IT. THE SWEEP CONTINUES WITH THE REMAINING TRANSACTIONS EITHER WAY.
+        LogManager.instance().log(DatabaseContext.class, Level.WARNING,
+            "Dead-thread sweep failed to roll back an abandoned transaction (threadId=%d, database='%s'): its file locks may remain held",
+            e, threadId, databaseName);
       }
     }
     tl.transactions.clear();

--- a/engine/src/main/java/com/arcadedb/database/DatabaseContext.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseContext.java
@@ -23,6 +23,7 @@ import com.arcadedb.exception.TransactionException;
 import com.arcadedb.query.QuerySession;
 import com.arcadedb.security.SecurityDatabaseUser;
 
+import java.lang.ref.WeakReference;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -31,10 +32,30 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Thread local to store transaction data.
  */
 public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.DatabaseContextTL>> {
-  public static final  DatabaseContext                                           INSTANCE          = new DatabaseContext();
-  private static final ConcurrentHashMap<Long, Map<String, DatabaseContextTL>> CONTEXTS          = new ConcurrentHashMap<>();
-  private static final AtomicInteger                                             INIT_CALL_COUNTER = new AtomicInteger();
-  private static final int                                                       CLEANUP_INTERVAL  = 1000;
+  public static final  DatabaseContext                          INSTANCE          = new DatabaseContext();
+  private static final ConcurrentHashMap<Long, ThreadContexts>  CONTEXTS          = new ConcurrentHashMap<>();
+  private static final AtomicInteger                            INIT_CALL_COUNTER = new AtomicInteger();
+  private static final int                                      CLEANUP_INTERVAL  = 1000;
+
+  /**
+   * One CONTEXTS entry: the per-thread contexts map plus a weak reference to the owning thread, used for the
+   * liveness check of the periodic dead-thread sweep. The previous implementation asked
+   * {@code Thread.getAllStackTraces()} for the live thread ids, which is wrong for virtual threads (they never
+   * appear in it, so a live virtual thread's entry was pruned as dead while it was still running its transaction)
+   * and captures the full stack of every platform thread at a global safepoint, injecting a latency spike into
+   * whichever request happened to be the 1000th {@code init()} (issue #4956). {@code Thread#isAlive()} on the
+   * weak reference is O(1) per entry, safepoint-free and correct for both thread kinds; the weak reference avoids
+   * pinning terminated threads (and their stacks) in memory.
+   */
+  private static final class ThreadContexts {
+    private final WeakReference<Thread>          owner;
+    private final Map<String, DatabaseContextTL> contexts;
+
+    private ThreadContexts(final Thread owner, final Map<String, DatabaseContextTL> contexts) {
+      this.owner = new WeakReference<>(owner);
+      this.contexts = contexts;
+    }
+  }
 
   public DatabaseContextTL init(final DatabaseInternal database) {
     return init(database, null);
@@ -52,7 +73,10 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
     DatabaseContextTL current;
 
     if (map == null) {
-      map = new HashMap<>();
+      // CONCURRENT MAP BECAUSE removeAllContexts() (DATABASE CLOSE/DROP ON ANOTHER THREAD) MUTATES THIS MAP
+      // CONCURRENTLY WITH THE OWNER THREAD'S init()/removeContext(); A PLAIN HashMap COULD LOSE ENTRIES OR
+      // CORRUPT THE TABLE (ISSUE #4939)
+      map = new ConcurrentHashMap<>();
       set(map);
       current = new DatabaseContextTL();
       map.put(key, current);
@@ -76,8 +100,13 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
       }
     }
 
-    // ALWAYS ENSURE THE MAP IS REGISTERED IN CONTEXTS (may have been removed by removeAllContexts)
-    CONTEXTS.put(Thread.currentThread().threadId(), map);
+    // ALWAYS ENSURE THE MAP IS REGISTERED IN CONTEXTS (the dead-thread sweep may have pruned a reused thread id).
+    // AVOID THE PUT (AND THE WeakReference ALLOCATION) WHEN THE SAME MAP IS ALREADY REGISTERED: THE MAP IS
+    // PER-THREAD, SO IDENTITY IMPLIES THE ENTRY BELONGS TO THIS THREAD
+    final Thread currentThread = Thread.currentThread();
+    final ThreadContexts registered = CONTEXTS.get(currentThread.threadId());
+    if (registered == null || registered.contexts != map)
+      CONTEXTS.put(currentThread.threadId(), new ThreadContexts(currentThread, map));
 
     if (current.transactions.isEmpty())
       current.transactions.add(
@@ -117,15 +146,13 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
    */
   public List<DatabaseContextTL> removeAllContexts(final String databaseName) {
     final List<DatabaseContextTL> result = new ArrayList<>();
-    for (final Map.Entry<Long, Map<String, DatabaseContextTL>> entry : CONTEXTS.entrySet()) {
-      final Map<String, DatabaseContextTL> map = entry.getValue();
-      if (map != null) {
-        final DatabaseContextTL tl = map.remove(databaseName);
-        if (map.isEmpty())
-          CONTEXTS.remove(entry.getKey());
-        if (tl != null)
-          result.add(tl);
-      }
+    for (final ThreadContexts threadContexts : CONTEXTS.values()) {
+      final DatabaseContextTL tl = threadContexts.contexts.remove(databaseName);
+      if (tl != null)
+        result.add(tl);
+      // DO NOT PRUNE THE CONTEXTS ENTRY HERE EVEN WHEN THE MAP BECAME EMPTY: THIS RUNS ON THE CLOSING THREAD AND
+      // WOULD RACE THE OWNER THREAD'S init() RE-REGISTRATION, UNREGISTERING A LIVE CONTEXT (ISSUE #4939). EMPTY
+      // ENTRIES ARE PRUNED BY THE OWNER (removeContext/removeCurrentThreadContexts) OR BY THE DEAD-THREAD SWEEP
     }
     return result;
   }
@@ -185,13 +212,58 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
   }
 
   /**
-   * Scans CONTEXTS and removes entries for thread IDs that are no longer alive. Called periodically as a safety net.
+   * Scans CONTEXTS and removes the entries whose owning thread is no longer alive, rolling back any transaction
+   * they abandoned. Called periodically as a safety net. Liveness is checked per entry via the thread weak
+   * reference ({@link ThreadContexts}), which is virtual-thread-correct and safepoint-free (issue #4956).
+   * Rolling back the abandoned transactions releases their file locks: before this, the sweep dropped the map
+   * entries only, so the {@code LockManager} files locked by a thread that died with an open transaction (for
+   * example via {@code acquireLock().type(...).lock()}) stayed owned by the dead thread forever and every later
+   * commit touching them timed out until restart (issue #4941).
+   * <p>
+   * Package-private (instead of private) for tests only.
    */
-  private static void cleanupDeadThreads() {
-    final Set<Long> liveThreadIds = new HashSet<>();
-    for (final Thread t : Thread.getAllStackTraces().keySet())
-      liveThreadIds.add(t.threadId());
-    CONTEXTS.keySet().removeIf(id -> !liveThreadIds.contains(id));
+  static void cleanupDeadThreads() {
+    for (final Iterator<ThreadContexts> it = CONTEXTS.values().iterator(); it.hasNext(); ) {
+      final ThreadContexts threadContexts = it.next();
+      final Thread owner = threadContexts.owner.get();
+      if (owner == null || !owner.isAlive()) {
+        it.remove();
+        for (final DatabaseContextTL tl : threadContexts.contexts.values())
+          rollbackAbandonedTransactions(tl);
+      }
+    }
+  }
+
+  /**
+   * Rolls back, from last to first, the transactions abandoned by a dead thread. The rollback is executed on the
+   * sweeping thread but releases the file locks with the requester captured at lock-acquisition time (see
+   * {@code TransactionContext#getRequester()}), which the {@code LockManager} explicitly supports. Nobody else can
+   * touch these transactions (the owner is dead and the entry was already unlinked from CONTEXTS), so the
+   * cross-thread access is safe.
+   */
+  private static void rollbackAbandonedTransactions(final DatabaseContextTL tl) {
+    for (int i = tl.transactions.size() - 1; i > -1; --i) {
+      try {
+        tl.transactions.get(i).rollback();
+      } catch (final Throwable e) {
+        // IGNORE ERRORS: BEST-EFFORT CLEANUP OF TRANSACTIONS ABANDONED BY A DEAD THREAD
+      }
+    }
+    tl.transactions.clear();
+  }
+
+  /**
+   * Package-private test hook: returns true when the given thread id has a registered context entry.
+   */
+  static boolean isThreadRegistered(final long threadId) {
+    return CONTEXTS.containsKey(threadId);
+  }
+
+  /**
+   * Package-private test hook: returns a snapshot of the registered thread ids.
+   */
+  static Set<Long> registeredThreadIds() {
+    return new HashSet<>(CONTEXTS.keySet());
   }
 
   public static class DatabaseContextTL {

--- a/engine/src/main/java/com/arcadedb/database/DatabaseContext.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseContext.java
@@ -132,7 +132,10 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
     if (map != null) {
       final DatabaseContextTL tl = map.remove(name);
       if (map.isEmpty()) {
-        // REMOVE THE THREAD LOCAL WHEN THE MAP IS EMPTY
+        // REMOVE THE THREAD LOCAL WHEN THE MAP IS EMPTY. THE UNCONDITIONAL (NON-VALUE-KEYED) REMOVE IS SAFE,
+        // UNLIKE IN THE SWEEP: THIS RUNS ON THE OWNER THREAD, ONLY THE OWNER EVER REGISTERS UNDER ITS OWN
+        // NEVER-REUSED THREAD ID AND THE SWEEP ONLY CLAIMS DEAD THREADS, SO THE ENTRY UNDER THIS KEY CAN ONLY
+        // BE THIS THREAD'S OWN CURRENT REGISTRATION
         super.remove();
         CONTEXTS.remove(Thread.currentThread().threadId());
       }
@@ -210,6 +213,8 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
    */
   public void removeCurrentThreadContexts() {
     super.remove();
+    // UNCONDITIONAL REMOVE IS SAFE FOR THE SAME REASON AS IN removeContext(): OWNER-THREAD-ONLY KEY,
+    // THREAD IDS NEVER REUSED, THE SWEEP ONLY CLAIMS DEAD THREADS
     CONTEXTS.remove(Thread.currentThread().threadId());
   }
 
@@ -248,8 +253,14 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
         // init() BOUNDARY) AND THE ABANDONED TRANSACTIONS MUST BE ROLLED BACK EXACTLY ONCE. THREAD IDS ARE
         // NEVER REUSED, SO THE KEYED REMOVE CANNOT DROP AN ENTRY BELONGING TO A DIFFERENT THREAD
         if (CONTEXTS.remove(entry.getKey(), threadContexts))
-          for (final DatabaseContextTL tl : threadContexts.contexts.values())
-            rollbackAbandonedTransactions(tl);
+          for (final Map.Entry<String, DatabaseContextTL> ctx : threadContexts.contexts.entrySet())
+            // CLAIM EACH PER-DATABASE CONTEXT TOO: closeInternal (DATABASE CLOSE/DROP) CONCURRENTLY CLAIMS
+            // THE SAME tl VIA removeAllContexts()'s remove(databaseName) AND ROLLS IT BACK UNDER THE DB
+            // WRITE LOCK, WHICH THE SWEEP DOES NOT TAKE. THE VALUE-KEYED REMOVE GUARANTEES EXACTLY ONE OF
+            // THE TWO PATHS ROLLS BACK EACH ABANDONED TRANSACTION - SAME HAZARD CLASS AS THE
+            // SWEEPER-VS-SWEEPER CLAIM ABOVE (DOUBLE UNLOCK, CONCURRENT MUTATION OF tl.transactions)
+            if (threadContexts.contexts.remove(ctx.getKey(), ctx.getValue()))
+              rollbackAbandonedTransactions(ctx.getValue());
       }
     }
   }
@@ -258,8 +269,9 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
    * Rolls back, from last to first, the transactions abandoned by a dead thread. The rollback is executed on the
    * sweeping thread but releases the file locks with the requester captured at lock-acquisition time (see
    * {@code TransactionContext#getRequester()}), which the {@code LockManager} explicitly supports. Nobody else can
-   * touch these transactions (the owner is dead and the entry was already unlinked from CONTEXTS), so the
-   * cross-thread access is safe.
+   * touch these transactions: the owner is dead and the caller atomically claimed the tl at BOTH levels (the
+   * CONTEXTS entry against concurrent sweepers, the per-database key against closeInternal's
+   * removeAllContexts()), so the cross-thread access is exclusive.
    */
   private static void rollbackAbandonedTransactions(final DatabaseContextTL tl) {
     for (int i = tl.transactions.size() - 1; i > -1; --i) {

--- a/engine/src/main/java/com/arcadedb/database/DatabaseContext.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseContext.java
@@ -238,6 +238,12 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
    * same reasons (weakly-consistent traversal + the atomic claim: a nested sweep cannot double-roll-back a
    * claimed entry), noted so the recursion is a documented possibility rather than a surprise.
    * <p>
+   * Offloading the rollbacks to {@code DatabaseAsyncExecutor} was considered and rejected: that executor is
+   * PER-DATABASE and may itself be closing or saturated exactly when the sweep runs (the sweep reclaims
+   * contexts for ANY database, including ones mid-close), and a rollback queued behind a stalled async queue
+   * delays the lock release this sweep exists to guarantee. Revisit only with a dedicated JVM-wide cleanup
+   * executor if the inline cost ever shows up in practice.
+   * <p>
    * Package-private (instead of private) for tests only.
    */
   static void cleanupDeadThreads() {
@@ -248,7 +254,9 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
         // MEMORY VISIBILITY: THE isAlive() == false CHECK IS LOAD-BEARING, NOT JUST A LIVENESS TEST. PER JLS
         // 17.4.4 THE FINAL ACTION OF A TERMINATED THREAD SYNCHRONIZES-WITH ANOTHER THREAD DETECTING THE
         // TERMINATION VIA isAlive()/join(), SO THIS THREAD IS GUARANTEED TO SEE ALL THE DEAD OWNER'S WRITES
-        // (E.G. TransactionContext.requester, WHICH IS NON-VOLATILE). DO NOT REPLACE IT WITH A BARE
+        // EVEN THE NON-VOLATILE ONES (TransactionContext.requester IS VOLATILE SINCE ROUND 3 FOR THE
+        // LIVE-OWNER CLOSE PATH, BUT THE DEAD-OWNER GUARANTEE HERE DOES NOT DEPEND ON THAT). DO NOT REPLACE
+        // THE LIVENESS TEST WITH A BARE
         // WeakReference STALENESS CHECK. THE owner == null BRANCH LACKS THE FORMAL GUARANTEE BUT A GC-CLEARED
         // Thread IS LONG TERMINATED (AND ITS WRITES LONG PUBLISHED) IN PRACTICE.
         //
@@ -297,10 +305,18 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
   }
 
   /**
-   * Package-private test hook: returns a snapshot of the registered thread ids.
+   * Package-private test hook: returns true when any registered entry is owned by a still-reachable thread
+   * whose name starts with the given prefix. Lets tests key assertions to specific worker threads (e.g. the
+   * GAV "gav-worker-" virtual threads) instead of diffing JVM-wide id snapshots, which would go spuriously
+   * red whenever an unrelated thread registered a context between the snapshots.
    */
-  static Set<Long> registeredThreadIds() {
-    return new HashSet<>(CONTEXTS.keySet());
+  static boolean isThreadRegisteredWithNamePrefix(final String prefix) {
+    for (final ThreadContexts threadContexts : CONTEXTS.values()) {
+      final Thread owner = threadContexts.owner.get();
+      if (owner != null && owner.getName().startsWith(prefix))
+        return true;
+    }
+    return false;
   }
 
   public static class DatabaseContextTL {

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -355,6 +355,10 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
 
       // CLEAR ANY THREAD-LOCAL CONTEXT POINTING AT THIS (NOW DEAD) DATABASE, OTHERWISE A SUBSEQUENT OPERATION ON THE SAME
       // THREAD (E.G. RESOLVING A BARE RID) WOULD STILL FIND THE KILLED DATABASE AS THE ACTIVE ONE. MIRRORS close().
+      // UNLIKE closeInternal, THE RETURNED CONTEXTS ARE NOT ROLLED BACK, AND ONCE UNLINKED HERE THE DEAD-THREAD
+      // SWEEP CAN NEVER REACH THEM EITHER. THAT IS SAFE ONLY IN THIS TEST-ONLY CRASH SIMULATION: THE FILE LOCKS
+      // THEY COULD HOLD LIVE IN THIS INSTANCE'S TransactionManager LockManager, WHICH transactionManager.kill()
+      // ALREADY CLOSED ABOVE - A REOPENED DATABASE STARTS WITH A FRESH LockManager, SO NOTHING CAN LEAK
       try {
         DatabaseContext.INSTANCE.removeAllContexts(databasePath);
       } catch (final Throwable e) {
@@ -1808,9 +1812,11 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     // #4959: file locks are keyed by requester (thread or session). Lock on behalf of the current
     // transaction's requester when one exists, so a thread acting for a session does not time out on locks
     // its own session already holds (a re-acquisition by the same requester is ALREADY_ACQUIRED and is not
-    // released below, only the locks actually acquired here are).
+    // released below, only the locks actually acquired here are). ACQUISITION PATH: captureRequester()
+    // pins the identity on the owner thread (getTransactionIfExists resolves the CURRENT thread's tx, so
+    // this thread IS the owner); see the INVARIANT on TransactionContext.requester (#4941).
     final TransactionContext tx = getTransactionIfExists();
-    final Object requester = tx != null ? tx.getRequester() : Thread.currentThread();
+    final Object requester = tx != null ? tx.captureRequester() : Thread.currentThread();
 
     List<Integer> lockedFiles = null;
     try {

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -109,7 +109,7 @@ public class TransactionContext implements Transaction {
   // capture on a non-owner thread would key later lock operations inconsistently and leak the file locks
   // forever (#4941). The check-then-set in captureRequester() is not atomic and is safe only under this
   // single-writer discipline.
-  // volatile (#5060 review round 3): the DEAD-owner release path gets its happens-before from
+  // volatile (#5060): the DEAD-owner release path gets its happens-before from
   // isAlive()==false (JLS 17.4.4), but closeInternal can roll back a LIVE owner's context, where no such
   // edge exists - a plain read could see a stale null, re-capture the closing thread and key the unlock
   // wrong, leaking the very locks #4941 fixes. The volatile read extends the guarantee to live owners
@@ -577,9 +577,12 @@ public class TransactionContext implements Transaction {
    * executeLockingFiles) may capture.
    */
   Object captureRequester() {
-    if (requester == null)
-      requester = Thread.currentThread();
-    return requester;
+    Object captured = requester;
+    if (captured == null) {
+      captured = Thread.currentThread();
+      requester = captured;
+    }
+    return captured;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -555,7 +555,15 @@ public class TransactionContext implements Transaction {
   }
 
   private Object getRequester() {
-    return requester != null ? requester : Thread.currentThread();
+    // CAPTURE THE REQUESTER LAZILY AT FIRST USE, WHICH IS ALWAYS LOCK-ACQUISITION TIME ON THE OWNING THREAD.
+    // RESOLVING Thread.currentThread() ON EVERY CALL RETURNED THE WRONG REQUESTER WHEN THE LOCKS WERE RELEASED
+    // BY ANOTHER THREAD (DATABASE CLOSE ROLLING BACK FOREIGN CONTEXTS, OR THE DEAD-THREAD SWEEP ROLLING BACK AN
+    // ABANDONED TRANSACTION): THE UNLOCK FAILED WITH LockException AND THE FILE LOCKS LEAKED FOREVER (#4941).
+    // THE LockManager EXPLICITLY SUPPORTS ACQUIRE-ON-ONE-THREAD/RELEASE-ON-ANOTHER AS LONG AS THE REQUESTER
+    // OBJECT IS THE SAME
+    if (requester == null)
+      requester = Thread.currentThread();
+    return requester;
   }
 
   public Map<Integer, Integer> getBucketRecordDelta() {

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -101,6 +101,14 @@ public class TransactionContext implements Transaction {
   private       Map<RID, Document>                   updatedRecordsIndexSnapshot = null;
   private       Database.TRANSACTION_ISOLATION_LEVEL isolationLevel              = Database.TRANSACTION_ISOLATION_LEVEL.READ_COMMITTED;
   private       LocalTransactionExplicitLock         explicitLock;
+  // INVARIANT (#4941/#4959): this field is written by exactly two paths. (1) setRequester(), the explicit
+  // protocol-session identity, which always wins. (2) captureRequester(), the lazy owner-thread capture,
+  // called ONLY from the lock-ACQUISITION paths (lockFilesInOrder's tryLockFiles, LocalDatabase's
+  // executeLockingFiles) and therefore always on the owning thread BEFORE any lock exists. Release paths
+  // (reset, kill, the commit unlocks) must use the PURE getRequester() and must never write the field: a
+  // capture on a non-owner thread would key later lock operations inconsistently and leak the file locks
+  // forever (#4941). The check-then-set in captureRequester() is not atomic and is safe only under this
+  // single-writer discipline.
   // volatile (#5060 review round 3): the DEAD-owner release path gets its happens-before from
   // isAlive()==false (JLS 17.4.4), but closeInternal can roll back a LIVE owner's context, where no such
   // edge exists - a plain read could see a stale null, re-capture the closing thread and key the unlock
@@ -560,20 +568,34 @@ public class TransactionContext implements Transaction {
   }
 
   /**
-   * Returns the identity file locks are keyed by for this transaction: the explicit requester (e.g. a
-   * server-side session) when one was set via {@link #setRequester(Object)} (#4959), otherwise the OWNING
-   * thread, captured lazily at first use - which is always lock-acquisition time on the owner (#4941).
+   * Captures (lazily) and returns the identity file locks are keyed by for this transaction: the explicit
+   * requester (e.g. a server-side session) when one was set via {@link #setRequester(Object)} (#4959),
+   * otherwise the OWNING thread, captured at first call - which is always lock-acquisition time on the
+   * owner (#4941). MUST be called only from the lock-acquisition paths on the owning thread; see the
+   * INVARIANT note on the {@code requester} field. Release paths use the pure {@link #getRequester()}.
+   * Package-private on purpose: only same-package acquisition code (this class and LocalDatabase's
+   * executeLockingFiles) may capture.
+   */
+  Object captureRequester() {
+    if (requester == null)
+      requester = Thread.currentThread();
+    return requester;
+  }
+
+  /**
+   * PURE read of the identity file locks are keyed by for this transaction (no capture, safe to call from
+   * any thread): the explicit requester when one was set via {@link #setRequester(Object)} (#4959),
+   * otherwise the owning thread captured by {@link #captureRequester()} at lock-acquisition time (#4941).
    * Re-resolving Thread.currentThread() per call returned the WRONG requester when the locks were released
    * by another thread (database close rolling back foreign contexts, or the dead-thread sweep rolling back
    * an abandoned transaction): the unlock failed with LockException and the file locks leaked forever. The
    * LockManager explicitly supports acquire-on-one-thread/release-on-another as long as the requester
-   * object is identical. An explicit setRequester always wins: it assigns the field directly, whether it
-   * runs before or after the lazy capture.
+   * object is identical. The current-thread fallback is harmless: a null requester at release time means
+   * this transaction never acquired a file lock, so there is nothing keyed by it to release.
    */
   public Object getRequester() {
-    if (requester == null)
-      requester = Thread.currentThread();
-    return requester;
+    final Object captured = requester;
+    return captured != null ? captured : Thread.currentThread();
   }
 
   public Map<Integer, Integer> getBucketRecordDelta() {
@@ -1154,7 +1176,8 @@ public class TransactionContext implements Transaction {
     // file id is authoritative because the buffered index entries are resolved by index name at commit time and
     // therefore land in the current (migrated) file regardless of which id we lock here.
     for (int attempt = 0; ; ++attempt) {
-      final List<Integer> locked = database.getTransactionManager().tryLockFiles(filesToLock.toArray(), timeout, getRequester());
+      // ACQUISITION PATH: CAPTURES THE REQUESTER ON THE OWNER THREAD (SEE THE INVARIANT ON THE FIELD)
+      final List<Integer> locked = database.getTransactionManager().tryLockFiles(filesToLock.toArray(), timeout, captureRequester());
 
       // CHECK IF ALL THE LOCKED FILES STILL EXIST. FILE MISSING CAN HAPPEN IN CASE OF INDEX COMPACTION OR DROP OF A BUCKET OR AN INDEX.
       int missingFile = -1;

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -101,7 +101,12 @@ public class TransactionContext implements Transaction {
   private       Map<RID, Document>                   updatedRecordsIndexSnapshot = null;
   private       Database.TRANSACTION_ISOLATION_LEVEL isolationLevel              = Database.TRANSACTION_ISOLATION_LEVEL.READ_COMMITTED;
   private       LocalTransactionExplicitLock         explicitLock;
-  private       Object                               requester;
+  // volatile (#5060 review round 3): the DEAD-owner release path gets its happens-before from
+  // isAlive()==false (JLS 17.4.4), but closeInternal can roll back a LIVE owner's context, where no such
+  // edge exists - a plain read could see a stale null, re-capture the closing thread and key the unlock
+  // wrong, leaking the very locks #4941 fixes. The volatile read extends the guarantee to live owners
+  // whose lazy capture ran at lock-acquisition time (well before the close).
+  private volatile Object                             requester;
   private       List<Runnable>                       afterCommitCallbacks        = null;
   private       Set<String>                          registeredCallbackKeys      = null;
 

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -1482,6 +1482,9 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
             }
             // #4956: drop this worker's DatabaseContext entry (see buildAsync). Last statement because
             // applyDelta() above may touch the database on this thread and re-register a context.
+            // NOTE: this ordering deliberately DIFFERS from buildAsync/rebuild (which unregister FIRST): here
+            // applyDelta(forced) runs synchronously after taskCompleted() and can re-register a context on this
+            // same thread, so the unregister must be the true last statement.
             DatabaseContext.INSTANCE.removeCurrentThreadContexts();
           }
         });

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -20,6 +20,7 @@ package com.arcadedb.graph.olap;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseContext;
 import com.arcadedb.database.RID;
 import com.arcadedb.event.AfterRecordCreateListener;
 import com.arcadedb.event.AfterRecordDeleteListener;
@@ -351,6 +352,10 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
           else
             LogManager.instance().log(this, Level.SEVERE, "Async build of GraphAnalyticalView '%s' failed", e, name);
         } finally {
+          // #4956: this virtual thread dies right after the task, but its DatabaseContext entry (pinning Binary
+          // temp buffers) would otherwise linger until the next periodic sweep. Remove it before the latch is
+          // released so callers observing readiness see a clean state.
+          DatabaseContext.INSTANCE.removeCurrentThreadContexts();
           BUILD_PERMITS.release();
           buildQueued.set(false);
           latch.countDown();
@@ -1324,6 +1329,8 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
             else
               LogManager.instance().log(this, Level.WARNING, "Failed to rebuild GraphAnalyticalView '%s'", e, name);
           } finally {
+            // #4956: drop this worker's DatabaseContext entry (see buildAsync)
+            DatabaseContext.INSTANCE.removeCurrentThreadContexts();
             BUILD_PERMITS.release();
             compacting.set(false);
             latch.countDown();
@@ -1470,6 +1477,9 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
               forced.edgePropertiesUpdated = true;
               applyDelta(forced);
             }
+            // #4956: drop this worker's DatabaseContext entry (see buildAsync). Last statement because
+            // applyDelta() above may touch the database on this thread and re-register a context.
+            DatabaseContext.INSTANCE.removeCurrentThreadContexts();
           }
         });
       } catch (final RejectedExecutionException e) {

--- a/engine/src/test/java/com/arcadedb/database/DatabaseContextLifecycleTest.java
+++ b/engine/src/test/java/com/arcadedb/database/DatabaseContextLifecycleTest.java
@@ -27,7 +27,9 @@ import org.junit.jupiter.api.Test;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -167,6 +169,72 @@ class DatabaseContextLifecycleTest extends TestHelper {
       assertThat(leaked).isEmpty();
     } finally {
       gav.drop();
+    }
+  }
+
+  @Test
+  void concurrentSweepsRollBackAbandonedTransactionsExactlyOnce() throws Exception {
+    // CONTRACT TEST: two threads can run cleanupDeadThreads() concurrently (both landing on the periodic
+    // 1000th-init() boundary). Each dead entry must be CLAIMED atomically so its abandoned transactions are
+    // rolled back exactly once; without the claim both sweepers could pass the liveness check on the same
+    // entry and double-roll-back the same transaction (probabilistic race, no deterministic repro).
+    final DatabaseInternal internal = (DatabaseInternal) database;
+
+    final class CountingTransaction extends TransactionContext {
+      private final AtomicInteger rollbacks = new AtomicInteger();
+
+      private CountingTransaction() {
+        super(internal.getWrappedDatabaseInstance());
+      }
+
+      @Override
+      public boolean isActive() {
+        return true;
+      }
+
+      @Override
+      public void rollback() {
+        rollbacks.incrementAndGet();
+      }
+    }
+
+    final int workers = 16;
+    final CountingTransaction[] transactions = new CountingTransaction[workers];
+    final Thread[] threads = new Thread[workers];
+    for (int i = 0; i < workers; i++) {
+      final CountingTransaction tx = new CountingTransaction();
+      transactions[i] = tx;
+      threads[i] = new Thread(() -> DatabaseContext.INSTANCE.init(internal, tx), "ctx-lifecycle-sweep-race-" + i);
+      threads[i].start();
+    }
+    for (final Thread thread : threads) {
+      thread.join(10_000);
+      assertThat(thread.isAlive()).isFalse();
+    }
+
+    final CyclicBarrier barrier = new CyclicBarrier(2);
+    final AtomicReference<Throwable> error = new AtomicReference<>();
+    final Runnable sweeper = () -> {
+      try {
+        barrier.await(10, TimeUnit.SECONDS);
+        DatabaseContext.cleanupDeadThreads();
+      } catch (final Throwable e) {
+        error.set(e);
+      }
+    };
+    final Thread sweeper1 = new Thread(sweeper, "ctx-lifecycle-sweeper-1");
+    final Thread sweeper2 = new Thread(sweeper, "ctx-lifecycle-sweeper-2");
+    sweeper1.start();
+    sweeper2.start();
+    sweeper1.join(10_000);
+    sweeper2.join(10_000);
+    assertThat(sweeper1.isAlive()).isFalse();
+    assertThat(sweeper2.isAlive()).isFalse();
+    assertThat(error.get()).isNull();
+
+    for (int i = 0; i < workers; i++) {
+      assertThat(transactions[i].rollbacks.get()).as("worker %d rollback count", i).isEqualTo(1);
+      assertThat(DatabaseContext.isThreadRegistered(threads[i].threadId())).isFalse();
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/database/DatabaseContextLifecycleTest.java
+++ b/engine/src/test/java/com/arcadedb/database/DatabaseContextLifecycleTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.olap.GraphAnalyticalView;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for the DatabaseContext lifecycle findings of the 2026-07 engine audit:
+ * <ul>
+ *   <li>#4941: a thread that dies with an open transaction holding explicit file locks must have its
+ *   transaction rolled back by the dead-thread sweep, releasing the locks; before, the sweep only dropped
+ *   the map entry and the LockManager files stayed owned by the dead thread forever (every later commit
+ *   timing out until restart).</li>
+ *   <li>#4956: the sweep must not prune LIVE virtual threads (Thread.getAllStackTraces() returned platform
+ *   threads only, so a live virtual thread's entry was removed while its transaction was running), must
+ *   detect DEAD virtual threads, and the GraphAnalyticalView async workers must unregister their contexts.</li>
+ *   <li>#4939: contexts maps are mutated concurrently by the owner thread and by close/drop on another
+ *   thread; the concurrent hammering must never corrupt them (contract test: the race itself has no
+ *   deterministic repro).</li>
+ * </ul>
+ */
+class DatabaseContextLifecycleTest extends TestHelper {
+
+  private static final long LOCK_TIMEOUT_MS = 2_000L;
+
+  @Override
+  protected void beginTest() {
+    database.getConfiguration().setValue(GlobalConfiguration.COMMIT_LOCK_TIMEOUT, LOCK_TIMEOUT_MS);
+    database.getSchema().getOrCreateDocumentType("Product");
+  }
+
+  @Test
+  void deadPlatformThreadWithExplicitLockIsSweptAndLocksReleased() throws Exception {
+    final Thread worker = new Thread(() -> {
+      database.begin();
+      database.acquireLock().type("Product").lock();
+      // DIES WITHOUT COMMIT NOR ROLLBACK: THE EXPLICIT LOCKS ARE ABANDONED
+    }, "ctx-lifecycle-dead-platform");
+    worker.start();
+    worker.join(10_000);
+    assertThat(worker.isAlive()).isFalse();
+
+    DatabaseContext.cleanupDeadThreads();
+
+    assertThat(DatabaseContext.isThreadRegistered(worker.threadId())).isFalse();
+
+    // THE SWEEP MUST HAVE ROLLED BACK THE ABANDONED TRANSACTION AND RELEASED ITS FILE LOCKS: A COMMIT
+    // TOUCHING THE SAME TYPE MUST SUCCEED INSTEAD OF FAILING WITH LockTimeoutException
+    database.begin();
+    database.newDocument("Product").set("name", "after-sweep").save();
+    database.commit();
+
+    assertThat(database.countType("Product", true)).isEqualTo(1);
+  }
+
+  @Test
+  void liveVirtualThreadContextSurvivesSweep() throws Exception {
+    final CountDownLatch started = new CountDownLatch(1);
+    final CountDownLatch release = new CountDownLatch(1);
+    final AtomicReference<Throwable> workerError = new AtomicReference<>();
+
+    final Thread worker = Thread.ofVirtual().name("ctx-lifecycle-live-virtual").start(() -> {
+      try {
+        database.begin();
+        try {
+          started.countDown();
+          release.await(10, TimeUnit.SECONDS);
+        } finally {
+          database.rollback();
+          DatabaseContext.INSTANCE.removeCurrentThreadContexts();
+        }
+      } catch (final Throwable e) {
+        workerError.set(e);
+      }
+    });
+
+    assertThat(started.await(10, TimeUnit.SECONDS)).isTrue();
+    try {
+      // THE WORKER IS ALIVE (PARKED INSIDE ITS TRANSACTION): THE SWEEP MUST NOT PRUNE ITS CONTEXT.
+      // Thread.getAllStackTraces() BASED DETECTION PRUNED LIVE VIRTUAL THREADS BECAUSE THEY NEVER APPEAR IN IT
+      DatabaseContext.cleanupDeadThreads();
+      assertThat(DatabaseContext.isThreadRegistered(worker.threadId())).isTrue();
+    } finally {
+      release.countDown();
+    }
+
+    worker.join(10_000);
+    assertThat(worker.isAlive()).isFalse();
+    assertThat(workerError.get()).isNull();
+    // THE WORKER UNREGISTERED ITSELF ON EXIT
+    assertThat(DatabaseContext.isThreadRegistered(worker.threadId())).isFalse();
+  }
+
+  @Test
+  void deadVirtualThreadWithExplicitLockIsSweptAndLocksReleased() throws Exception {
+    final Thread worker = Thread.ofVirtual().name("ctx-lifecycle-dead-virtual").start(() -> {
+      database.begin();
+      database.acquireLock().type("Product").lock();
+      // DIES WITHOUT COMMIT NOR ROLLBACK
+    });
+    worker.join(10_000);
+    assertThat(worker.isAlive()).isFalse();
+
+    DatabaseContext.cleanupDeadThreads();
+
+    assertThat(DatabaseContext.isThreadRegistered(worker.threadId())).isFalse();
+
+    database.begin();
+    database.newDocument("Product").set("name", "after-virtual-sweep").save();
+    database.commit();
+
+    assertThat(database.countType("Product", true)).isEqualTo(1);
+  }
+
+  @Test
+  void gavAsyncBuildUnregistersWorkerContext() {
+    database.getSchema().getOrCreateVertexType("Person");
+    database.getSchema().getOrCreateEdgeType("Knows");
+
+    database.transaction(() -> {
+      final MutableVertex a = database.newVertex("Person").set("name", "Alice").save();
+      final MutableVertex b = database.newVertex("Person").set("name", "Bob").save();
+      a.newEdge("Knows", b);
+    });
+
+    final Set<Long> before = DatabaseContext.registeredThreadIds();
+
+    final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
+        .withVertexTypes("Person")
+        .withEdgeTypes("Knows")
+        .buildAsync();
+    try {
+      assertThat(gav.awaitReady(10, TimeUnit.SECONDS)).isTrue();
+
+      // THE ASYNC BUILD WORKER (A DIED-AFTER-TASK VIRTUAL THREAD) MUST HAVE REMOVED ITS OWN CONTEXT ENTRY
+      // BEFORE RELEASING THE READY LATCH; BEFORE THE FIX THE ENTRY LINGERED UNTIL THE NEXT PERIODIC SWEEP
+      final Set<Long> leaked = new HashSet<>(DatabaseContext.registeredThreadIds());
+      leaked.removeAll(before);
+      assertThat(leaked).isEmpty();
+    } finally {
+      gav.drop();
+    }
+  }
+
+  @Test
+  void concurrentInitAndRemoveAllContextsDoNotCorruptContexts() throws Exception {
+    // CONTRACT TEST FOR #4939: the per-thread contexts map is mutated by the owner (init/removeContext) and
+    // by removeAllContexts() from another thread. A deterministic corruption repro is impossible (pure data
+    // race on the old plain HashMap); this hammers the two paths concurrently and asserts that no exception
+    // surfaces and the owner thread's context always survives for the database that is never closed.
+    final DatabaseInternal internal = (DatabaseInternal) database;
+    final AtomicReference<Throwable> error = new AtomicReference<>();
+    final CountDownLatch done = new CountDownLatch(1);
+    final String otherName = "not-existing-database-path";
+
+    final Thread owner = new Thread(() -> {
+      try {
+        for (int i = 0; i < 20_000; i++) {
+          DatabaseContext.INSTANCE.init(internal);
+          final DatabaseContext.DatabaseContextTL ctx = DatabaseContext.INSTANCE.getContextIfExists(
+              internal.getDatabasePath());
+          if (ctx == null)
+            throw new IllegalStateException("Owner thread lost its own context at iteration " + i);
+        }
+      } catch (final Throwable e) {
+        error.set(e);
+      } finally {
+        DatabaseContext.INSTANCE.removeCurrentThreadContexts();
+        done.countDown();
+      }
+    }, "ctx-lifecycle-owner");
+    owner.start();
+
+    // HAMMER removeAllContexts FROM THIS THREAD (SIMULATES CLOSE/DROP OF ANOTHER DATABASE) WHILE THE OWNER
+    // KEEPS MUTATING ITS OWN PER-THREAD MAP
+    while (done.getCount() > 0) {
+      DatabaseContext.INSTANCE.removeAllContexts(otherName);
+      if (!done.await(0, TimeUnit.MILLISECONDS))
+        Thread.onSpinWait();
+    }
+
+    owner.join(30_000);
+    assertThat(owner.isAlive()).isFalse();
+    assertThat(error.get()).isNull();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/DatabaseContextLifecycleTest.java
+++ b/engine/src/test/java/com/arcadedb/database/DatabaseContextLifecycleTest.java
@@ -24,11 +24,18 @@ import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.olap.GraphAnalyticalView;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -229,60 +236,67 @@ class DatabaseContextLifecycleTest extends TestHelper {
     // even hammered, the pre-fix window (sub-microsecond, between the closer fetching the ThreadContexts and
     // its inner remove) never reproduced locally; this is an exactly-once CONTRACT test, not a red-first
     // repro - post-fix the invariant is guaranteed by the two-level atomic claim.
-    final DatabaseInternal internal = (DatabaseInternal) database;
-    final int rounds = 100;
-    final int workers = 4;
+    // A DEDICATED THROWAWAY DATABASE ISOLATES THE SIMULATED CLOSE: removeAllContexts() ON THE SHARED LIVE
+    // TEST DATABASE WOULD ALSO STRIP THE MAIN THREAD'S REAL REGISTRY ENTRY EVERY ROUND
+    final Database throwaway = createThrowawayDatabase("_closerace");
+    try {
+      final DatabaseInternal internal = (DatabaseInternal) throwaway;
+      final int rounds = 100;
+      final int workers = 4;
 
-    for (int round = 0; round < rounds; round++) {
-      final CountingTransaction[] transactions = new CountingTransaction[workers];
-      final Thread[] threads = new Thread[workers];
-      for (int i = 0; i < workers; i++) {
-        final CountingTransaction tx = new CountingTransaction(internal);
-        transactions[i] = tx;
-        threads[i] = new Thread(() -> DatabaseContext.INSTANCE.init(internal, tx), "ctx-lifecycle-close-race-" + i);
-        threads[i].start();
-      }
-      for (final Thread thread : threads) {
-        thread.join(10_000);
-        assertThat(thread.isAlive()).isFalse();
-      }
-
-      final CyclicBarrier barrier = new CyclicBarrier(2);
-      final AtomicReference<Throwable> error = new AtomicReference<>();
-      final Thread sweeper = new Thread(() -> {
-        try {
-          barrier.await(10, TimeUnit.SECONDS);
-          DatabaseContext.cleanupDeadThreads();
-        } catch (final Throwable e) {
-          error.set(e);
+      for (int round = 0; round < rounds; round++) {
+        final CountingTransaction[] transactions = new CountingTransaction[workers];
+        final Thread[] threads = new Thread[workers];
+        for (int i = 0; i < workers; i++) {
+          final CountingTransaction tx = new CountingTransaction(internal);
+          transactions[i] = tx;
+          threads[i] = new Thread(() -> DatabaseContext.INSTANCE.init(internal, tx), "ctx-lifecycle-close-race-" + i);
+          threads[i].start();
         }
-      }, "ctx-lifecycle-close-race-sweeper");
-      final Thread closer = new Thread(() -> {
-        try {
-          barrier.await(10, TimeUnit.SECONDS);
-          for (final DatabaseContext.DatabaseContextTL tl : DatabaseContext.INSTANCE.removeAllContexts(
-              internal.getDatabasePath())) {
-            for (int i = tl.transactions.size() - 1; i > -1; --i) {
-              final TransactionContext tx = tl.transactions.get(i);
-              if (tx.isActive())
-                tx.rollback();
-            }
-            tl.transactions.clear();
+        for (final Thread thread : threads) {
+          thread.join(10_000);
+          assertThat(thread.isAlive()).isFalse();
+        }
+
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+        final Thread sweeper = new Thread(() -> {
+          try {
+            barrier.await(10, TimeUnit.SECONDS);
+            DatabaseContext.cleanupDeadThreads();
+          } catch (final Throwable e) {
+            error.set(e);
           }
-        } catch (final Throwable e) {
-          error.set(e);
-        }
-      }, "ctx-lifecycle-close-race-closer");
-      sweeper.start();
-      closer.start();
-      sweeper.join(10_000);
-      closer.join(10_000);
-      assertThat(sweeper.isAlive()).isFalse();
-      assertThat(closer.isAlive()).isFalse();
-      assertThat(error.get()).isNull();
+        }, "ctx-lifecycle-close-race-sweeper");
+        final Thread closer = new Thread(() -> {
+          try {
+            barrier.await(10, TimeUnit.SECONDS);
+            for (final DatabaseContext.DatabaseContextTL tl : DatabaseContext.INSTANCE.removeAllContexts(
+                internal.getDatabasePath())) {
+              for (int i = tl.transactions.size() - 1; i > -1; --i) {
+                final TransactionContext tx = tl.transactions.get(i);
+                if (tx.isActive())
+                  tx.rollback();
+              }
+              tl.transactions.clear();
+            }
+          } catch (final Throwable e) {
+            error.set(e);
+          }
+        }, "ctx-lifecycle-close-race-closer");
+        sweeper.start();
+        closer.start();
+        sweeper.join(10_000);
+        closer.join(10_000);
+        assertThat(sweeper.isAlive()).isFalse();
+        assertThat(closer.isAlive()).isFalse();
+        assertThat(error.get()).isNull();
 
-      for (int i = 0; i < workers; i++)
-        assertThat(transactions[i].rollbacks.get()).as("round %d worker %d rollback count", round, i).isEqualTo(1);
+        for (int i = 0; i < workers; i++)
+          assertThat(transactions[i].rollbacks.get()).as("round %d worker %d rollback count", round, i).isEqualTo(1);
+      }
+    } finally {
+      throwaway.drop();
     }
   }
 
@@ -292,40 +306,116 @@ class DatabaseContextLifecycleTest extends TestHelper {
     // by removeAllContexts() from another thread. A deterministic corruption repro is impossible (pure data
     // race on the old plain HashMap); this hammers the two paths concurrently and asserts that no exception
     // surfaces and the owner thread's context always survives for the database that is never closed.
-    final DatabaseInternal internal = (DatabaseInternal) database;
-    final AtomicReference<Throwable> error = new AtomicReference<>();
-    final CountDownLatch done = new CountDownLatch(1);
-    final String otherName = "not-existing-database-path";
+    // THE FOREIGN KEY IS A GENUINELY REGISTERED THROWAWAY DATABASE: THE OWNER RE-REGISTERS IT EVERY
+    // ITERATION, SO removeAllContexts() EXERCISES A REAL SAME-KEY remove() ON THE OWNER'S MAP RACING THE
+    // OWNER'S put() - A NEVER-REGISTERED NAME WOULD ONLY EXERCISE THE CONTEXTS ITERATION, NEVER THE REMOVAL
+    final Database foreign = createThrowawayDatabase("_foreign");
+    try {
+      final DatabaseInternal internal = (DatabaseInternal) database;
+      final DatabaseInternal foreignInternal = (DatabaseInternal) foreign;
+      final AtomicReference<Throwable> error = new AtomicReference<>();
+      final CountDownLatch done = new CountDownLatch(1);
 
-    final Thread owner = new Thread(() -> {
-      try {
-        for (int i = 0; i < 20_000; i++) {
-          DatabaseContext.INSTANCE.init(internal);
-          final DatabaseContext.DatabaseContextTL ctx = DatabaseContext.INSTANCE.getContextIfExists(
-              internal.getDatabasePath());
-          if (ctx == null)
-            throw new IllegalStateException("Owner thread lost its own context at iteration " + i);
+      final Thread owner = new Thread(() -> {
+        try {
+          for (int i = 0; i < 20_000; i++) {
+            DatabaseContext.INSTANCE.init(internal);
+            DatabaseContext.INSTANCE.init(foreignInternal);
+            final DatabaseContext.DatabaseContextTL ctx = DatabaseContext.INSTANCE.getContextIfExists(
+                internal.getDatabasePath());
+            if (ctx == null)
+              throw new IllegalStateException("Owner thread lost its own context at iteration " + i);
+          }
+        } catch (final Throwable e) {
+          error.set(e);
+        } finally {
+          DatabaseContext.INSTANCE.removeCurrentThreadContexts();
+          done.countDown();
         }
-      } catch (final Throwable e) {
-        error.set(e);
-      } finally {
-        DatabaseContext.INSTANCE.removeCurrentThreadContexts();
-        done.countDown();
+      }, "ctx-lifecycle-owner");
+      owner.start();
+
+      // HAMMER removeAllContexts FROM THIS THREAD (SIMULATES CLOSE/DROP OF THE FOREIGN DATABASE) WHILE THE
+      // OWNER KEEPS MUTATING ITS OWN PER-THREAD MAP, RE-REGISTERING THE FOREIGN KEY EVERY ITERATION
+      while (done.getCount() > 0) {
+        DatabaseContext.INSTANCE.removeAllContexts(foreignInternal.getDatabasePath());
+        if (!done.await(0, TimeUnit.MILLISECONDS))
+          Thread.onSpinWait();
       }
-    }, "ctx-lifecycle-owner");
-    owner.start();
 
-    // HAMMER removeAllContexts FROM THIS THREAD (SIMULATES CLOSE/DROP OF ANOTHER DATABASE) WHILE THE OWNER
-    // KEEPS MUTATING ITS OWN PER-THREAD MAP
-    while (done.getCount() > 0) {
-      DatabaseContext.INSTANCE.removeAllContexts(otherName);
-      if (!done.await(0, TimeUnit.MILLISECONDS))
-        Thread.onSpinWait();
+      owner.join(30_000);
+      assertThat(owner.isAlive()).isFalse();
+      assertThat(error.get()).isNull();
+    } finally {
+      foreign.drop();
     }
+  }
 
-    owner.join(30_000);
-    assertThat(owner.isAlive()).isFalse();
-    assertThat(error.get()).isNull();
+  @Test
+  void sweepEmitsSingleSummaryWarningWhenItRollsBackWork() throws Exception {
+    // OPERABILITY CONTRACT: a sweep that performs real rollback work must emit ONE attributable WARNING
+    // (count + thread id + database), so the inline tail-latency blip on the triggering thread can be traced;
+    // zero-work sweeps stay silent. The test raises the DatabaseContext logger to WARNING because the shared
+    // test logging config caps com.arcadedb at SEVERE.
+    final DatabaseInternal internal = (DatabaseInternal) database;
+    final Logger sweepLogger = Logger.getLogger(DatabaseContext.class.getName());
+    final List<LogRecord> warnings = Collections.synchronizedList(new ArrayList<>());
+    final Handler capture = new Handler() {
+      @Override
+      public void publish(final LogRecord logRecord) {
+        if (logRecord.getLevel() == Level.WARNING)
+          warnings.add(logRecord);
+      }
+
+      @Override
+      public void flush() {
+        // NOTHING TO FLUSH
+      }
+
+      @Override
+      public void close() {
+        // NOTHING TO CLOSE
+      }
+    };
+    final Level previousLevel = sweepLogger.getLevel();
+    sweepLogger.setLevel(Level.WARNING);
+    sweepLogger.addHandler(capture);
+    try {
+      // DRAIN ANY DEAD ENTRIES LEFT BY EARLIER TESTS IN THE SAME JVM, THEN PROVE A ZERO-WORK SWEEP IS SILENT
+      DatabaseContext.cleanupDeadThreads();
+      warnings.clear();
+      DatabaseContext.cleanupDeadThreads();
+      assertThat(warnings).isEmpty();
+
+      final CountingTransaction tx = new CountingTransaction(internal);
+      final Thread worker = new Thread(() -> DatabaseContext.INSTANCE.init(internal, tx), "ctx-lifecycle-sweep-log");
+      worker.start();
+      worker.join(10_000);
+      assertThat(worker.isAlive()).isFalse();
+
+      DatabaseContext.cleanupDeadThreads();
+
+      assertThat(tx.rollbacks.get()).isEqualTo(1);
+      assertThat(warnings).hasSize(1);
+      final String message = warnings.get(0).getMessage();
+      assertThat(message).contains("1 abandoned transaction");
+      assertThat(message).contains("threadId=" + worker.threadId());
+      assertThat(message).contains(internal.getDatabasePath());
+    } finally {
+      sweepLogger.removeHandler(capture);
+      sweepLogger.setLevel(previousLevel);
+    }
+  }
+
+  /**
+   * Creates a dedicated throwaway database next to the shared test one, so contract tests that simulate a
+   * database close (removeAllContexts) do not reach into the live shared instance's registry entries.
+   */
+  private Database createThrowawayDatabase(final String suffix) {
+    final DatabaseFactory factory = new DatabaseFactory(database.getDatabasePath() + suffix);
+    if (factory.exists())
+      factory.open().drop();
+    return factory.create();
   }
 
   /**

--- a/engine/src/test/java/com/arcadedb/database/DatabaseContextLifecycleTest.java
+++ b/engine/src/test/java/com/arcadedb/database/DatabaseContextLifecycleTest.java
@@ -24,8 +24,6 @@ import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.olap.GraphAnalyticalView;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashSet;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
@@ -153,8 +151,6 @@ class DatabaseContextLifecycleTest extends TestHelper {
       a.newEdge("Knows", b);
     });
 
-    final Set<Long> before = DatabaseContext.registeredThreadIds();
-
     final GraphAnalyticalView gav = GraphAnalyticalView.builder(database)
         .withVertexTypes("Person")
         .withEdgeTypes("Knows")
@@ -162,11 +158,11 @@ class DatabaseContextLifecycleTest extends TestHelper {
     try {
       assertThat(gav.awaitReady(10, TimeUnit.SECONDS)).isTrue();
 
-      // THE ASYNC BUILD WORKER (A DIED-AFTER-TASK VIRTUAL THREAD) MUST HAVE REMOVED ITS OWN CONTEXT ENTRY
-      // BEFORE RELEASING THE READY LATCH; BEFORE THE FIX THE ENTRY LINGERED UNTIL THE NEXT PERIODIC SWEEP
-      final Set<Long> leaked = new HashSet<>(DatabaseContext.registeredThreadIds());
-      leaked.removeAll(before);
-      assertThat(leaked).isEmpty();
+      // THE ASYNC BUILD WORKER (A DIED-AFTER-TASK "gav-worker-*" VIRTUAL THREAD) MUST HAVE REMOVED ITS OWN
+      // CONTEXT ENTRY BEFORE RELEASING THE READY LATCH; BEFORE THE FIX THE ENTRY LINGERED UNTIL THE NEXT
+      // PERIODIC SWEEP. KEYED TO THE WORKER THREAD NAME PREFIX: A JVM-WIDE SNAPSHOT DIFF WOULD GO SPURIOUSLY
+      // RED IF ANY UNRELATED THREAD REGISTERED A CONTEXT DURING THE BUILD
+      assertThat(DatabaseContext.isThreadRegisteredWithNamePrefix("gav-worker-")).isFalse();
     } finally {
       gav.drop();
     }

--- a/engine/src/test/java/com/arcadedb/database/DatabaseContextLifecycleTest.java
+++ b/engine/src/test/java/com/arcadedb/database/DatabaseContextLifecycleTest.java
@@ -180,29 +180,11 @@ class DatabaseContextLifecycleTest extends TestHelper {
     // entry and double-roll-back the same transaction (probabilistic race, no deterministic repro).
     final DatabaseInternal internal = (DatabaseInternal) database;
 
-    final class CountingTransaction extends TransactionContext {
-      private final AtomicInteger rollbacks = new AtomicInteger();
-
-      private CountingTransaction() {
-        super(internal.getWrappedDatabaseInstance());
-      }
-
-      @Override
-      public boolean isActive() {
-        return true;
-      }
-
-      @Override
-      public void rollback() {
-        rollbacks.incrementAndGet();
-      }
-    }
-
     final int workers = 16;
     final CountingTransaction[] transactions = new CountingTransaction[workers];
     final Thread[] threads = new Thread[workers];
     for (int i = 0; i < workers; i++) {
-      final CountingTransaction tx = new CountingTransaction();
+      final CountingTransaction tx = new CountingTransaction(internal);
       transactions[i] = tx;
       threads[i] = new Thread(() -> DatabaseContext.INSTANCE.init(internal, tx), "ctx-lifecycle-sweep-race-" + i);
       threads[i].start();
@@ -235,6 +217,76 @@ class DatabaseContextLifecycleTest extends TestHelper {
     for (int i = 0; i < workers; i++) {
       assertThat(transactions[i].rollbacks.get()).as("worker %d rollback count", i).isEqualTo(1);
       assertThat(DatabaseContext.isThreadRegistered(threads[i].threadId())).isFalse();
+    }
+  }
+
+  @Test
+  void sweepAndDatabaseCloseRollBackAbandonedTransactionsExactlyOnce() throws Exception {
+    // CONTRACT TEST: LocalDatabase.closeInternal claims each per-thread context of the closing database via
+    // removeAllContexts() and rolls it back under the DB write lock; the dead-thread sweep rolls back the
+    // same contexts with NO db lock, so the commit-read-lock/close-write-lock isolation argument does not
+    // cover this pair. Each abandoned transaction must be rolled back by exactly one of the two paths;
+    // without the sweep's per-database value-keyed claim both could obtain the same tl and double-roll-back
+    // it. The closeInternal side is simulated faithfully (removeAllContexts() plus rollback of the returned
+    // contexts, as LocalDatabase.closeInternal does). The race window is a single iteration crossover per
+    // sweep (both paths traverse CONTEXTS in the same order), so the race is retried over many rounds. NOTE:
+    // even hammered, the pre-fix window (sub-microsecond, between the closer fetching the ThreadContexts and
+    // its inner remove) never reproduced locally; this is an exactly-once CONTRACT test, not a red-first
+    // repro - post-fix the invariant is guaranteed by the two-level atomic claim.
+    final DatabaseInternal internal = (DatabaseInternal) database;
+    final int rounds = 100;
+    final int workers = 4;
+
+    for (int round = 0; round < rounds; round++) {
+      final CountingTransaction[] transactions = new CountingTransaction[workers];
+      final Thread[] threads = new Thread[workers];
+      for (int i = 0; i < workers; i++) {
+        final CountingTransaction tx = new CountingTransaction(internal);
+        transactions[i] = tx;
+        threads[i] = new Thread(() -> DatabaseContext.INSTANCE.init(internal, tx), "ctx-lifecycle-close-race-" + i);
+        threads[i].start();
+      }
+      for (final Thread thread : threads) {
+        thread.join(10_000);
+        assertThat(thread.isAlive()).isFalse();
+      }
+
+      final CyclicBarrier barrier = new CyclicBarrier(2);
+      final AtomicReference<Throwable> error = new AtomicReference<>();
+      final Thread sweeper = new Thread(() -> {
+        try {
+          barrier.await(10, TimeUnit.SECONDS);
+          DatabaseContext.cleanupDeadThreads();
+        } catch (final Throwable e) {
+          error.set(e);
+        }
+      }, "ctx-lifecycle-close-race-sweeper");
+      final Thread closer = new Thread(() -> {
+        try {
+          barrier.await(10, TimeUnit.SECONDS);
+          for (final DatabaseContext.DatabaseContextTL tl : DatabaseContext.INSTANCE.removeAllContexts(
+              internal.getDatabasePath())) {
+            for (int i = tl.transactions.size() - 1; i > -1; --i) {
+              final TransactionContext tx = tl.transactions.get(i);
+              if (tx.isActive())
+                tx.rollback();
+            }
+            tl.transactions.clear();
+          }
+        } catch (final Throwable e) {
+          error.set(e);
+        }
+      }, "ctx-lifecycle-close-race-closer");
+      sweeper.start();
+      closer.start();
+      sweeper.join(10_000);
+      closer.join(10_000);
+      assertThat(sweeper.isAlive()).isFalse();
+      assertThat(closer.isAlive()).isFalse();
+      assertThat(error.get()).isNull();
+
+      for (int i = 0; i < workers; i++)
+        assertThat(transactions[i].rollbacks.get()).as("round %d worker %d rollback count", round, i).isEqualTo(1);
     }
   }
 
@@ -278,5 +330,27 @@ class DatabaseContextLifecycleTest extends TestHelper {
     owner.join(30_000);
     assertThat(owner.isAlive()).isFalse();
     assertThat(error.get()).isNull();
+  }
+
+  /**
+   * Always-active transaction stub whose rollback only counts invocations: lets the exactly-once contract
+   * tests detect a double rollback of the same abandoned transaction without touching real storage.
+   */
+  private static final class CountingTransaction extends TransactionContext {
+    private final AtomicInteger rollbacks = new AtomicInteger();
+
+    private CountingTransaction(final DatabaseInternal database) {
+      super(database.getWrappedDatabaseInstance());
+    }
+
+    @Override
+    public boolean isActive() {
+      return true;
+    }
+
+    @Override
+    public void rollback() {
+      rollbacks.incrementAndGet();
+    }
   }
 }


### PR DESCRIPTION
Part of the 2026-07 engine audit follow-up (#4962), db-lifecycle group.

## Per-issue verdicts

### #4941 - explicit file locks leaked forever by dead threads: FIXED
Re-verified on current main: `cleanupDeadThreads()` only pruned the CONTEXTS map, so a thread dying with an open transaction holding explicit locks left the `LockManager` files owned by the dead `Thread` object; every later commit touching them timed out until restart. The sweep now rolls back the abandoned transactions (releasing the locks via `reset()`). Prerequisite fix: `TransactionContext.getRequester()` captures the requester once at first use (always lock-acquisition time on the owner thread) instead of re-resolving `Thread.currentThread()` at release time - the old behavior made any cross-thread unlock (sweep, `closeInternal`) throw `LockException` and leak. `LockManager` explicitly supports acquire-on-one-thread/release-on-another for equal requesters.

### #4956 - `getAllStackTraces()` wrong for virtual threads + safepoint spike: FIXED
Re-verified: live virtual threads (e.g. GraphAnalyticalView build workers mid-transaction) were pruned as dead, and every 1000th `init()` paid a global-safepoint all-stacks capture. Each CONTEXTS entry now carries a `WeakReference<Thread>` checked with `isAlive()` - O(entries), safepoint-free, correct for platform and virtual threads, no pinning of terminated threads. The three GAV async tasks (build, rebuild, compaction) now call `removeCurrentThreadContexts()` in their `finally` blocks so thread-per-task contexts no longer accumulate until the next sweep.

### #4939 - cross-thread mutation of non-thread-safe context state: PARTIALLY REPRODUCIBLE, the real part FIXED
The map race is real: `removeAllContexts()` (close/drop on another thread) mutated per-thread plain `HashMap`s concurrently with the owner's `init()`. Fix: per-thread maps are now `ConcurrentHashMap`, and `removeAllContexts` no longer prunes foreign CONTEXTS registry entries (that removal raced the owner's `init()` re-registration and could unregister a live context forever). The reported mid-commit interleaving (close rolling back a tx while its owner is inside `commit1stPhase`) is NOT reproducible on current main: `commit()` runs entirely under the database read lock while `closeInternal`'s rollbacks run under the write lock of the same `RWLockContext`, so they cannot overlap. The pre-existing cross-thread rollback in `closeInternal` now also releases foreign locks correctly: guaranteed for terminated owners (isAlive happens-before) and, with the volatile requester from review round 3, for live owners whose locks were acquired before the close.

## Test evidence (red-first)
New regression suite `DatabaseContextLifecycleTest` (5 tests). Run against the old behavior (test hooks kept, behavioral hunks reverted), 4 of 5 fail exactly as the audit predicted:
- `deadPlatformThreadWithExplicitLockIsSweptAndLocksReleased`: `LockTimeoutException: Timeout on locking file 1 (Product_0.1.65536.v0.bucket) during commit (fileIds=[1], timeout=2000ms`
- `deadVirtualThreadWithExplicitLockIsSweptAndLocksReleased`: same `LockTimeoutException`
- `liveVirtualThreadContextSurvivesSweep`: live virtual thread's entry pruned
- `gavAsyncBuildUnregistersWorkerContext`: dead GAV worker's entry lingered after `awaitReady()`
- `concurrentInitAndRemoveAllContextsDoNotCorruptContexts`: contract test for the #4939 race (pure data race, no deterministic repro - stated honestly; green on both, guards the contract)

All green with the fix. Focused suites green: `com.arcadedb.database.**` (102 tests incl. async), `ExplicitLockingTransactionTest`, `LocalTransactionExplicitLockRetryTest`, `GraphAnalyticalViewTest` (126), `GraphAnalyticalViewRegistryTest`.

## Conflict risks with sibling audit branches
- `docs/release-26.7.2.md` (expected, every audit group appends here)
- `engine/src/main/java/com/arcadedb/database/TransactionContext.java` (10-line change to `getRequester()`; tx/MVCC-group branches may touch this file)
- `engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java` (3 one-line `finally` additions)

## Second verification pass (2026-07-06)
The whole group was independently re-verified from scratch against current main before the follow-up commit: the regression suite was re-run red-first against the unfixed code and reproduced all four deterministic failures exactly (2x `LockTimeoutException` lock leak for #4941 on both platform and virtual threads, live-virtual-thread context pruned for #4956, GAV worker context leak). Follow-up commit: the sweep's rollback now skips INACTIVE transactions (mirrors `closeInternal`; every context holds at least one inactive `TransactionContext`, rolling those back was pointless work), plus a stale comment fix. Focused suites re-run on the final tree, all green: `DatabaseContextLifecycleTest` (5), `com.arcadedb.database.**` (108 tests, 37 classes), `ExplicitLockingTransactionTest` (5), `LocalTransactionExplicitLockRetryTest` (1), `com.arcadedb.graph.olap.**` (208 tests).

