### PR TITLE
fix(#4940,#4959): phase-2 pre-WAL failure rolls back record state; tx-layer cleanups

### DIFF
--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -208,6 +208,24 @@ that could starve the very snapshot resync meant to heal the node.
   shadows committed RIDs whose key equals an uncommitted entry's key - is tracked in
   [#5055](https://github.com/ArcadeData/arcadedb/issues/5055).
 
+- **Transaction commit cleanups (2026-07 audit).** A phase-2 commit failure that happens BEFORE the
+  transaction reaches the WAL now restores user-held record state like a phase-1 failure does (rollback):
+  records created in the failed transaction get their optimistically-assigned RID reset to provisional and
+  modified records are reloaded to their committed content, so retrying with the same in-memory objects
+  re-inserts them instead of updating a record that was never persisted; a failure after the WAL append
+  still keeps the assigned RIDs, since the transaction is durable and recovery replays it
+  ([#4940](https://github.com/ArcadeData/arcadedb/issues/4940)). From the low-severity group
+  ([#4959](https://github.com/ArcadeData/arcadedb/issues/4959)): a deferred update whose record was deleted
+  by a concurrent transaction now fails the commit with a retryable `ConcurrentModificationException`
+  instead of being silently skipped while the rest of the transaction commits (silent partial commit);
+  `transaction()` no longer burns every retry attempt (plus retry delays) on a deterministic
+  `DuplicatedKeyException` - one retry disambiguates it from a concurrency-induced duplicate;
+  `executeLockingFiles` now locks on behalf of the current transaction's requester (thread or session), so
+  a thread acting for a session no longer times out on locks its own session already holds; and the
+  page-level MVCC isolation contract (no read-set validation: write skew and phantoms possible under both
+  levels, unbounded per-transaction page cache under `REPEATABLE_READ`) is now documented on
+  `Database.TRANSACTION_ISOLATION_LEVEL` and pinned by tests.
+
 ### Improvements
 
 - **HA: throttled diverged-follower resync logging.** When a follower detects a WAL page-version gap it

--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -238,7 +238,10 @@ that could starve the very snapshot resync meant to heal the node.
   by a concurrent transaction now fails the commit with a retryable `ConcurrentModificationException`
   instead of being silently skipped while the rest of the transaction commits (silent partial commit);
   `transaction()` no longer burns every retry attempt (plus retry delays) on a deterministic
-  `DuplicatedKeyException` - one retry disambiguates it from a concurrency-induced duplicate;
+  `DuplicatedKeyException` - one retry disambiguates it from a concurrency-induced duplicate. **Behavioral
+  change:** `transaction(block, joinTx, attempts)` now caps duplicate-key retries at 2 attempts regardless
+  of the `attempts` argument (duplicates are detected against durable state only, so a duplicate that
+  survives one retry is deterministic and further attempts just burn time and retry delays);
   `executeLockingFiles` now locks on behalf of the current transaction's requester (thread or session), so
   a thread acting for a session no longer times out on locks its own session already holds; and the
   page-level MVCC isolation contract (no read-set validation: write skew and phantoms possible under both

--- a/engine/src/main/java/com/arcadedb/database/Database.java
+++ b/engine/src/main/java/com/arcadedb/database/Database.java
@@ -39,6 +39,22 @@ import java.util.concurrent.Callable;
 
 @ExcludeFromJacocoGeneratedReport
 public interface Database extends BasicDatabase {
+  /**
+   * Transaction isolation levels. ArcadeDB implements isolation with page-level MVCC (optimistic locking on the
+   * page version): only WRITE-WRITE conflicts on the same page are detected, surfacing at commit as a retryable
+   * {@link com.arcadedb.exception.ConcurrentModificationException}. There is NO read-set validation at commit, so
+   * under BOTH levels write skew and phantom reads are possible (see {@code TransactionIsolationContractTest},
+   * which pins this contract).
+   * <ul>
+   * <li>{@code READ_COMMITTED} (default): every read fetches the most recently committed version of the page. A
+   * reader can observe pages published by transactions that committed after this one began, and a concurrent
+   * multi-page commit being published may be observed partially (some of its pages already visible, others not
+   * yet).</li>
+   * <li>{@code REPEATABLE_READ}: pages read by the transaction are cached in the transaction context and re-read
+   * from there, giving repeatable reads at the page level. The cache is unbounded: a transaction that scans a
+   * large portion of the database retains every visited page in RAM until commit or rollback.</li>
+   * </ul>
+   */
   enum TRANSACTION_ISOLATION_LEVEL {
     READ_COMMITTED, REPEATABLE_READ
   }

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -1294,6 +1294,8 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
 
     final int retryDelay = GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger();
 
+    boolean duplicatedKeyRetried = false;
+
     for (int retry = 0; retry < attempts; ++retry) {
       boolean createdNewTx = true;
 
@@ -1322,6 +1324,15 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
 
         if (error != null)
           error.call(e);
+
+        if (e instanceof DuplicatedKeyException) {
+          // #4959: a genuine duplicate is deterministic and fails identically on every attempt. Only a
+          // concurrency-induced duplicate can succeed on retry, and one retry is enough to disambiguate:
+          // fail fast instead of burning all the remaining attempts plus their retry delays.
+          if (duplicatedKeyRetried)
+            throw e;
+          duplicatedKeyRetried = true;
+        }
 
         if (retry < attempts - 1)
           delayBetweenRetries(retryDelay);
@@ -1788,9 +1799,16 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
 
   @Override
   public <RET> RET executeLockingFiles(final Collection<Integer> fileIds, Callable<RET> callable) {
+    // #4959: file locks are keyed by requester (thread or session). Lock on behalf of the current
+    // transaction's requester when one exists, so a thread acting for a session does not time out on locks
+    // its own session already holds (a re-acquisition by the same requester is ALREADY_ACQUIRED and is not
+    // released below, only the locks actually acquired here are).
+    final TransactionContext tx = getTransactionIfExists();
+    final Object requester = tx != null ? tx.getRequester() : Thread.currentThread();
+
     List<Integer> lockedFiles = null;
     try {
-      lockedFiles = transactionManager.tryLockFiles(fileIds, 5_000, Thread.currentThread());
+      lockedFiles = transactionManager.tryLockFiles(fileIds, 5_000, requester);
 
       return callable.call();
 
@@ -1802,7 +1820,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
 
     } finally {
       if (lockedFiles != null)
-        transactionManager.unlockFilesInOrder(lockedFiles, Thread.currentThread());
+        transactionManager.unlockFilesInOrder(lockedFiles, requester);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -1329,6 +1329,12 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
           // #4959: a genuine duplicate is deterministic and fails identically on every attempt. Only a
           // concurrency-induced duplicate can succeed on retry, and one retry is enough to disambiguate:
           // fail fast instead of burning all the remaining attempts plus their retry delays.
+          //
+          // #5061 review: a TRANSIENT duplicate from an in-flight sibling transaction that later rolls back
+          // is unreachable - checkUniqueIndexKeys reads committed pages plus THIS transaction's own overlay
+          // (TransactionIndexContext is per-transaction), so uncommitted sibling entries are invisible and a
+          // detected duplicate is always against durable state (or this same transaction). The one retry
+          // covers the only nondeterministic case: racing a COMMIT that lands between attempts.
           if (duplicatedKeyRetried)
             throw e;
           duplicatedKeyRetried = true;

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -787,12 +787,16 @@ public class TransactionContext implements Transaction {
   }
 
   public void commit2ndPhase(final TransactionPhase1 changes) {
+    if (changes == null) {
+      // Nothing to apply: release resources without touching user-held record state (the pre-#4940 behavior for
+      // this no-op call; entering the try would route it to the rollback() branch below).
+      reset();
+      return;
+    }
+
     boolean committed = false;
     boolean walAppended = false;
     try {
-      if (changes == null)
-        return;
-
       if (database.getMode() == ComponentFile.MODE.READ_ONLY)
         throw new TransactionException("Cannot commit changes because the database is open in read-only mode");
 
@@ -801,10 +805,15 @@ public class TransactionContext implements Transaction {
 
       status = STATUS.COMMIT_2ND_PHASE;
 
-      if (changes.result != null)
+      if (changes.result != null) {
         // WRITE TO THE WAL FIRST
         database.getTransactionManager().writeTransactionToWAL(changes.modifiedPages, walFlush, txId, changes.result);
-      walAppended = true;
+        // Only a REAL append is a durability point: with useWAL=false changes.result is null, nothing is durable
+        // and there is no WAL record for recovery to replay, so a publish failure below must still roll the
+        // transaction back like any other pre-durability failure (#4940). This also keeps the flag's meaning
+        // aligned with the point-of-no-return boundary #4936 formalizes.
+        walAppended = true;
+      }
 
       // AT THIS POINT, LOCK + VERSION CHECK, THERE IS NO NEED TO MANAGE ROLLBACK BECAUSE THERE CANNOT BE CONCURRENT TX THAT UPDATE THE SAME PAGE CONCURRENTLY
       // UPDATE PAGE COUNTER FIRST
@@ -848,9 +857,9 @@ public class TransactionContext implements Transaction {
       if (committed)
         resetAndFireCallbacks();
       else if (walAppended)
-        // The transaction reached the WAL: it is (or may be) durable and recovery replays it, so the RIDs
-        // optimistically assigned to records created in this transaction remain valid. Release resources
-        // without touching user-held record state.
+        // The transaction reached the WAL: it is durable and recovery replays it, so the RIDs optimistically
+        // assigned to records created in this transaction remain valid. Release resources without touching
+        // user-held record state.
         reset();
       else
         // #4940: the failure happened BEFORE anything durable exists. Restore user-held records exactly like

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -554,7 +554,11 @@ public class TransactionContext implements Transaction {
     immutablePages.clear();
   }
 
-  private Object getRequester() {
+  /**
+   * Returns the identity file locks are keyed by for this transaction: the explicit requester (e.g. a server-side
+   * session) when one was set via {@link #setRequester(Object)}, the current thread otherwise (#4959).
+   */
+  public Object getRequester() {
     return requester != null ? requester : Thread.currentThread();
   }
 
@@ -692,8 +696,13 @@ public class TransactionContext implements Transaction {
           try {
             database.updateRecordNoLock(rec, false);
           } catch (final RecordNotFoundException e) {
-            LogManager.instance()
-                .log(this, Level.WARNING, "Attempt to update the delete record %s in transaction", rec.getIdentity());
+            // #4959: the record vanished between the in-tx update and the commit (deleted by a concurrent
+            // transaction whose effect this tx's page was loaded after, so the MVCC page-version check cannot
+            // see the conflict; an in-tx delete removes the entry from updatedRecords and never gets here).
+            // Silently skipping would commit the rest of the transaction without this update (a silent
+            // partial commit): fail the whole transaction with a retryable conflict instead.
+            throw new ConcurrentModificationException(
+                "Record " + rec.getIdentity() + " updated in transaction was deleted by a concurrent transaction");
           }
         updatedRecords = null;
         // The indexed-state snapshots (#4935) share updatedRecords' lifecycle: no further updateRecord can
@@ -779,6 +788,7 @@ public class TransactionContext implements Transaction {
 
   public void commit2ndPhase(final TransactionPhase1 changes) {
     boolean committed = false;
+    boolean walAppended = false;
     try {
       if (changes == null)
         return;
@@ -794,6 +804,7 @@ public class TransactionContext implements Transaction {
       if (changes.result != null)
         // WRITE TO THE WAL FIRST
         database.getTransactionManager().writeTransactionToWAL(changes.modifiedPages, walFlush, txId, changes.result);
+      walAppended = true;
 
       // AT THIS POINT, LOCK + VERSION CHECK, THERE IS NO NEED TO MANAGE ROLLBACK BECAUSE THERE CANNOT BE CONCURRENT TX THAT UPDATE THE SAME PAGE CONCURRENTLY
       // UPDATE PAGE COUNTER FIRST
@@ -836,8 +847,17 @@ public class TransactionContext implements Transaction {
     } finally {
       if (committed)
         resetAndFireCallbacks();
-      else
+      else if (walAppended)
+        // The transaction reached the WAL: it is (or may be) durable and recovery replays it, so the RIDs
+        // optimistically assigned to records created in this transaction remain valid. Release resources
+        // without touching user-held record state.
         reset();
+      else
+        // #4940: the failure happened BEFORE anything durable exists. Restore user-held records exactly like
+        // a phase-1 failure does: reload the modified records to their committed content and reset the
+        // identity of records created in this transaction to provisional, so a retry re-inserts them instead
+        // of updating a record that was never persisted (#4562).
+        rollback();
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -984,6 +984,9 @@ public class TransactionContext implements Transaction {
           // The #4940 core must survive the degraded path too: rollback() can only throw at the dictionary
           // reload, which runs BEFORE its identity reset - without this, records created in the failed tx
           // would keep their dangling RID, the exact defect #4940 fixes. The loop is cheap and cannot throw.
+          // Documented asymmetry vs the happy rollback(): user-held MODIFIED records are NOT reloaded here
+          // (that loop also never ran) and keep their uncommitted in-memory content - the safest available
+          // degradation, since reloading is exactly what just failed.
           for (final Record newRecord : newRecords)
             ((RecordInternal) newRecord).setIdentity(null);
           reset();

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -981,6 +981,11 @@ public class TransactionContext implements Transaction {
           // rollback: it null-guards the lock lists and only releases what is still held).
           LogManager.instance().log(this, Level.WARNING,
               "Error during phase-2 failure rollback (the primary commit error is propagated)", rollbackError);
+          // The #4940 core must survive the degraded path too: rollback() can only throw at the dictionary
+          // reload, which runs BEFORE its identity reset - without this, records created in the failed tx
+          // would keep their dangling RID, the exact defect #4940 fixes. The loop is cheap and cannot throw.
+          for (final Record newRecord : newRecords)
+            ((RecordInternal) newRecord).setIdentity(null);
           reset();
         }
     }

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -971,7 +971,18 @@ public class TransactionContext implements Transaction {
         // a phase-1 failure does: reload the modified records to their committed content and reset the
         // identity of records created in this transaction to provisional, so a retry re-inserts them instead
         // of updating a record that was never persisted (#4562).
-        rollback();
+        try {
+          rollback();
+        } catch (final Throwable rollbackError) {
+          // #5061 review: the cleanup must never SUPPRESS the primary commit exception - e.g. a failed
+          // dictionary reload here would surface a retryable ConcurrentModificationException as a
+          // non-retryable SchemaException, breaking the caller's retry loop. Log the secondary failure and
+          // degrade to reset() so locks and status are still released (reset() is safe after a partial
+          // rollback: it null-guards the lock lists and only releases what is still held).
+          LogManager.instance().log(this, Level.WARNING,
+              "Error during phase-2 failure rollback (the primary commit error is propagated)", rollbackError);
+          reset();
+        }
     }
   }
 

--- a/engine/src/test/java/com/arcadedb/database/Issue4940Phase2FailureRollbackTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue4940Phase2FailureRollbackTest.java
@@ -19,10 +19,16 @@
 package com.arcadedb.database;
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.engine.LocalBucket;
+import com.arcadedb.engine.MutablePage;
+import com.arcadedb.engine.PageId;
+import com.arcadedb.engine.PageManager;
+import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.exception.TransactionException;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -108,5 +114,54 @@ class Issue4940Phase2FailureRollbackTest extends TestHelper {
     database.begin();
     assertThat(database.lookupByRID(rid, true).asDocument().getString("name")).isEqualTo("committed");
     database.commit();
+  }
+
+  @Test
+  void phase2PublishFailureWithoutWalStillRollsBack() throws Exception {
+    // With useWAL=false there is NO WAL append at all: nothing is ever durable in phase 2, so even a failure in the
+    // page-publish stage (past the point where a WAL-enabled transaction would have crossed durability) must roll
+    // back like any other pre-durability failure. Guards the placement of the walAppended flag: only a REAL append
+    // may suppress the rollback.
+    final MutableDocument[] holder = new MutableDocument[1];
+    database.transaction(() -> {
+      final MutableDocument doc = database.newDocument(TYPE);
+      doc.set("name", "committed");
+      doc.save();
+      holder[0] = doc;
+    });
+    final RID rid = holder[0].getIdentity();
+
+    database.begin();
+    database.setUseWAL(false);
+
+    final MutableDocument modified = database.lookupByRID(rid, true).asDocument().modify();
+    modified.set("name", "uncommitted");
+    modified.save();
+
+    final MutableDocument created = database.newDocument(TYPE);
+    created.set("name", "new");
+    created.save();
+    assertThat(created.getIdentity()).isNotNull();
+
+    final TransactionContext tx = ((DatabaseInternal) database).getTransaction();
+    final TransactionContext.TransactionPhase1 phase1 = tx.commit1stPhase(true);
+    assertThat(phase1).isNotNull();
+    assertThat(phase1.result).as("useWAL=false produces no WAL buffer").isNull();
+
+    // Sabotage the publish stage: bump the committed version of the record's page behind the transaction's back, so
+    // commit2ndPhase fails with a ConcurrentModificationException INSIDE updatePages - after the (skipped) WAL stage.
+    final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(rid.getBucketId());
+    final PageId pageId = new PageId(database, rid.getBucketId(), (int) (rid.getPosition() / bucket.getMaxRecordsInPage()));
+    final PageManager pageManager = ((DatabaseInternal) database).getPageManager();
+    final MutablePage conflicting = pageManager.getMutablePage(pageId, bucket.getPageSize(), false, false);
+    pageManager.updatePages(null, Map.of(pageId, conflicting), false);
+
+    final Throwable error = catchThrowable(() -> tx.commit2ndPhase(phase1));
+    assertThat(error).isInstanceOf(ConcurrentModificationException.class);
+    assertThat(database.isTransactionActive()).isFalse();
+
+    // nothing was durable: the failed transaction must be rolled back, not just reset
+    assertThat(created.getIdentity()).as("identity must be reset: no WAL record exists to ever replay this tx").isNull();
+    assertThat(modified.getString("name")).as("modified record must be reloaded to the committed version").isEqualTo("committed");
   }
 }

--- a/engine/src/test/java/com/arcadedb/database/Issue4940Phase2FailureRollbackTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue4940Phase2FailureRollbackTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.exception.TransactionException;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+/**
+ * Issue #4940: a {@code commit2ndPhase} failure that happens BEFORE the transaction is appended to the WAL must
+ * restore user-held record state exactly like a phase-1 failure does ({@code rollback()}), not just release
+ * resources ({@code reset()}). Otherwise records created in the failed transaction keep an optimistically-assigned
+ * RID pointing at a record that was never persisted, and re-saving them in a retry silently updates a missing
+ * record instead of re-inserting (the #4562 class of bug, resurfacing through the phase-2 failure path).
+ * <p>
+ * A failure AFTER the WAL append is intentionally NOT rolled back: the transaction is durable and recovery replays
+ * it, so the assigned RIDs remain valid.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue4940Phase2FailureRollbackTest extends TestHelper {
+
+  private static final String TYPE = "Issue4940Doc";
+
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> database.getSchema().createDocumentType(TYPE));
+  }
+
+  @Test
+  void phase2FailureBeforeWalAppendResetsCreatedRecordIdentity() {
+    database.begin();
+    final MutableDocument doc = database.newDocument(TYPE);
+    doc.set("name", "one");
+    doc.save();
+    assertThat(doc.getIdentity()).as("record gets an optimistic RID at creation").isNotNull();
+
+    final TransactionContext tx = ((DatabaseInternal) database).getTransaction();
+
+    // Force a phase-2 failure BEFORE the WAL append: invoking the 2nd phase without having run the 1st fails the
+    // status precondition, which is one of the pre-durability failure points of commit2ndPhase (same finally block
+    // as a WAL-append failure).
+    final Throwable error = catchThrowable(
+        () -> tx.commit2ndPhase(new TransactionContext.TransactionPhase1(null, List.of())));
+    assertThat(error).isInstanceOf(TransactionException.class);
+    assertThat(database.isTransactionActive()).isFalse();
+
+    // #4940: nothing durable exists, so the failure must behave like any other failed commit: the identity is
+    // provisional again and the same in-memory object can be cleanly re-inserted on retry.
+    assertThat(doc.getIdentity()).as("identity must be reset after a pre-durability phase-2 failure").isNull();
+
+    database.begin();
+    doc.save();
+    database.commit();
+
+    assertThat(doc.getIdentity()).isNotNull();
+    assertThat(database.countType(TYPE, false)).isEqualTo(1);
+    database.begin();
+    assertThat(database.lookupByRID(doc.getIdentity(), true).asDocument().getString("name")).isEqualTo("one");
+    database.commit();
+  }
+
+  @Test
+  void phase2FailureBeforeWalAppendReloadsModifiedRecords() {
+    final MutableDocument[] holder = new MutableDocument[1];
+    database.transaction(() -> {
+      final MutableDocument doc = database.newDocument(TYPE);
+      doc.set("name", "committed");
+      doc.save();
+      holder[0] = doc;
+    });
+    final RID rid = holder[0].getIdentity();
+
+    database.begin();
+    final MutableDocument doc = database.lookupByRID(rid, true).asDocument().modify();
+    doc.set("name", "uncommitted");
+    doc.save();
+
+    final TransactionContext tx = ((DatabaseInternal) database).getTransaction();
+    final Throwable error = catchThrowable(
+        () -> tx.commit2ndPhase(new TransactionContext.TransactionPhase1(null, List.of())));
+    assertThat(error).isInstanceOf(TransactionException.class);
+
+    // #4940: the user-held object must be reloaded to its committed content, like rollback() does.
+    assertThat(doc.getString("name")).as("modified record must be reloaded to the committed version").isEqualTo("committed");
+
+    database.begin();
+    assertThat(database.lookupByRID(rid, true).asDocument().getString("name")).isEqualTo("committed");
+    database.commit();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/Issue4959TransactionCleanupsTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue4959TransactionCleanupsTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.engine.TransactionManager;
+import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.exception.DuplicatedKeyException;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.utility.LockManager;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Issue #4959: low-severity transaction-layer cleanups.
+ * <ul>
+ * <li>A deferred update whose record was deleted by a concurrent transaction must FAIL the commit with a retryable
+ * conflict instead of being silently skipped while the rest of the transaction commits (silent partial commit).</li>
+ * <li>{@code transaction()} must not burn every retry attempt on a deterministic {@link DuplicatedKeyException}:
+ * only a concurrency-induced duplicate can succeed on retry, and one retry is enough to disambiguate.</li>
+ * <li>{@code executeLockingFiles} must lock on behalf of the current transaction's requester (thread or session),
+ * so a thread acting for a session does not time out on locks its own session already holds.</li>
+ * </ul>
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue4959TransactionCleanupsTest extends TestHelper {
+
+  private static final String TYPE         = "Issue4959Doc";
+  private static final String TYPE_INDEXED = "Issue4959Indexed";
+
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType(TYPE);
+      final DocumentType indexed = database.getSchema().createDocumentType(TYPE_INDEXED);
+      indexed.createProperty("id", String.class);
+      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, TYPE_INDEXED, "id");
+    });
+  }
+
+  @Test
+  void deferredUpdateOfConcurrentlyDeletedRecordFailsTheCommit() throws Exception {
+    final MutableDocument[] holder = new MutableDocument[1];
+    database.transaction(() -> {
+      final MutableDocument doc = database.newDocument(TYPE);
+      doc.set("name", "committed");
+      doc.save();
+      holder[0] = doc;
+    });
+    final RID rid = holder[0].getIdentity();
+
+    database.begin();
+    final MutableDocument doc = database.lookupByRID(rid, true).asDocument().modify();
+
+    // Concurrent transaction (own thread = own transaction context) deletes the record and commits. The current
+    // transaction holds no locks yet, so the delete goes through.
+    final Thread concurrentDelete = new Thread(
+        () -> database.transaction(() -> database.deleteRecord(database.lookupByRID(rid, true))));
+    concurrentDelete.start();
+    concurrentDelete.join();
+
+    // Deferred update: the page is loaded AFTER the delete committed, so the MVCC page-version check cannot see
+    // the conflict. Before the fix the commit succeeded and the update was silently dropped.
+    doc.set("name", "lost");
+    doc.save();
+
+    assertThatThrownBy(() -> database.commit()).isInstanceOf(ConcurrentModificationException.class);
+    assertThat(database.isTransactionActive()).isFalse();
+  }
+
+  @Test
+  void deterministicDuplicatedKeyIsRetriedAtMostOnce() {
+    database.transaction(() -> {
+      final MutableDocument doc = database.newDocument(TYPE_INDEXED);
+      doc.set("id", "K");
+      doc.save();
+    });
+
+    final AtomicInteger attemptsRun = new AtomicInteger();
+
+    assertThatThrownBy(() -> database.transaction(() -> {
+      attemptsRun.incrementAndGet();
+      final MutableDocument dup = database.newDocument(TYPE_INDEXED);
+      dup.set("id", "K");
+      dup.save();
+    }, false, 10)).isInstanceOf(DuplicatedKeyException.class);
+
+    // A genuine duplicate fails identically every attempt: one retry is enough to disambiguate from a
+    // concurrency-induced duplicate. Before the fix all 10 attempts (plus retry delays) were burned.
+    assertThat(attemptsRun.get()).as("a deterministic duplicate must be retried at most once").isEqualTo(2);
+  }
+
+  @Test
+  void executeLockingFilesUsesTheTransactionRequester() throws Exception {
+    final int fileId = database.getSchema().getType(TYPE).getBuckets(false).getFirst().getFileId();
+
+    final TransactionManager transactionManager = ((DatabaseInternal) database).getTransactionManager();
+    final Object session = new Object();
+
+    // The session (not the thread) holds the file lock, as it happens for server-side transactions keyed by session.
+    final List<Integer> locked = transactionManager.tryLockFiles(List.of(fileId), 2_000, session);
+    try {
+      database.begin();
+      ((DatabaseInternal) database).getTransaction().setRequester(session);
+
+      // Before the fix this timed out after 5s: the lock was requested as Thread.currentThread() while the
+      // same logical owner (the session) already held it.
+      final Boolean executed = ((DatabaseInternal) database).executeLockingFiles(List.of(fileId), () -> true);
+      assertThat(executed).isTrue();
+
+      // The session lock must still be held afterwards (executeLockingFiles releases only what it acquired).
+      assertThat(transactionManager.tryLockFile(fileId, 100, new Object())).isEqualTo(LockManager.LOCK_STATUS.NO);
+    } finally {
+      database.rollback();
+      transactionManager.unlockFilesInOrder(locked, session);
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/TransactionIsolationContractTest.java
+++ b/engine/src/test/java/com/arcadedb/database/TransactionIsolationContractTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database;
+
+import com.arcadedb.TestHelper;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #4959: pins the DOCUMENTED isolation contract. ArcadeDB implements isolation with page-level MVCC
+ * (optimistic write-write conflict detection on page versions) and performs no read-set validation. As a
+ * consequence WRITE SKEW is possible under both READ_COMMITTED and REPEATABLE_READ: two transactions can each
+ * read state the other is about to invalidate and both commit, because their write sets touch disjoint pages.
+ * <p>
+ * This is a legitimate, documented property of the engine (see {@link Database.TRANSACTION_ISOLATION_LEVEL}),
+ * not a bug: this test exists so that any future change to the contract is a conscious one.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class TransactionIsolationContractTest extends TestHelper {
+
+  private static final String TYPE_X = "IsolationAccountX";
+  private static final String TYPE_Y = "IsolationAccountY";
+
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> {
+      // Two separate types = two separate files/pages, so the two writers never conflict at the page level.
+      database.getSchema().createDocumentType(TYPE_X);
+      database.getSchema().createDocumentType(TYPE_Y);
+      database.newDocument(TYPE_X).set("balance", 100).save();
+      database.newDocument(TYPE_Y).set("balance", 100).save();
+    });
+  }
+
+  @Test
+  void writeSkewIsPossibleUnderReadCommitted() throws Exception {
+    runWriteSkew(Database.TRANSACTION_ISOLATION_LEVEL.READ_COMMITTED);
+  }
+
+  @Test
+  void writeSkewIsPossibleUnderRepeatableRead() throws Exception {
+    runWriteSkew(Database.TRANSACTION_ISOLATION_LEVEL.REPEATABLE_READ);
+  }
+
+  /**
+   * Classic write skew: the invariant "balance(X) + balance(Y) >= 100" is checked by both transactions, each
+   * withdraws 100 from a DIFFERENT account, and both commit. Any serial execution preserves the invariant; the
+   * concurrent execution violates it because neither transaction's read set is validated at commit.
+   */
+  private void runWriteSkew(final Database.TRANSACTION_ISOLATION_LEVEL isolationLevel) throws Exception {
+    final CyclicBarrier bothHaveRead = new CyclicBarrier(2);
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+
+    final Thread t1 = new Thread(() -> withdrawIfCovered(isolationLevel, TYPE_X, bothHaveRead, failure));
+    final Thread t2 = new Thread(() -> withdrawIfCovered(isolationLevel, TYPE_Y, bothHaveRead, failure));
+    t1.start();
+    t2.start();
+    t1.join();
+    t2.join();
+
+    assertThat(failure.get()).as("both transactions must commit without conflicts").isNull();
+
+    database.begin();
+    final int sum = getBalance(TYPE_X) + getBalance(TYPE_Y);
+    database.commit();
+
+    // 200 - 100 - 100: the invariant sum >= 100 is violated, pinning that write skew IS possible.
+    assertThat(sum).as("write skew: both withdrawals committed despite the shared invariant").isEqualTo(0);
+  }
+
+  private void withdrawIfCovered(final Database.TRANSACTION_ISOLATION_LEVEL isolationLevel, final String accountType,
+      final CyclicBarrier bothHaveRead, final AtomicReference<Throwable> failure) {
+    try {
+      database.begin(isolationLevel);
+
+      // Read BOTH balances (the read set spans both accounts), then wait for the other transaction to have
+      // read too, so neither can see the other's write.
+      final int sum = getBalance(TYPE_X) + getBalance(TYPE_Y);
+      bothHaveRead.await();
+
+      if (sum - 100 >= 100) {
+        final MutableDocument account = database.iterateType(accountType, false).next().asDocument().modify();
+        account.set("balance", account.getInteger("balance") - 100);
+        account.save();
+      }
+      database.commit();
+    } catch (final Throwable e) {
+      failure.compareAndSet(null, e);
+      if (database.isTransactionActive())
+        database.rollback();
+    }
+  }
+
+  private int getBalance(final String type) {
+    return database.iterateType(type, false).next().asDocument().getInteger("balance");
+  }
+}


### PR DESCRIPTION
Part of the 2026-07 engine audit remediation (#4962), tx-commit group.

## Per-issue verdicts

### #4940 - fixed
Re-verified against current main: `commit2ndPhase`'s `finally` still calls `reset()` on every failure, skipping the two record-restoration steps `rollback()` performs (reloading `modifiedRecordsCache` and resetting the identity of `newRecords`, the #4562 fix). User-held documents created in the failed tx kept a dangling RID; re-saving them in a retry updated a missing record.

The fix distinguishes durability with a `walAppended` flag:
- failure **before** the transaction reaches the WAL -> `rollback()` (nothing durable exists; behave exactly like a phase-1 failure);
- failure **after** the WAL append -> `reset()` as before (the tx is durable, recovery replays it, so the assigned RIDs remain valid and must not be reverted).

This is deliberately shaped to compose with #5053 (point-of-no-return reordering), which adds fencing to the same post-append branch. Checked the only external split-phase caller (`RaftReplicatedDatabase`): its phase-2 failure handling reconciles from the payload's WAL bytes and steps down, independent of tx state, so the change composes there too.

### #4959 - fixed (all four checkboxes)
1. **Silent dropped update**: a deferred `updatedRecords` entry whose record was deleted by a concurrent transaction (page loaded after the delete committed, so the MVCC version check cannot see it) was WARN-logged and skipped while the rest committed. Now fails the whole tx with a retryable `ConcurrentModificationException`. An in-tx delete removes the entry from `updatedRecords` (`LocalBucket` -> `removeRecordFromCache`) and never hits this path.
2. **Futile duplicate-key retries**: `transaction()` burned all `TX_RETRIES` + `TX_RETRY_DELAY` sleeps on a deterministic `DuplicatedKeyException`. It is now retried at most once (one retry disambiguates a concurrency-induced duplicate); the second identical failure is rethrown immediately.
3. **Isolation contract**: documented on `Database.TRANSACTION_ISOLATION_LEVEL` (page-level MVCC, no read-set validation, write skew/phantoms possible under both levels, torn multi-page visibility under READ_COMMITTED, unbounded per-tx page cache under REPEATABLE_READ) and pinned with `TransactionIsolationContractTest` (write skew demonstrated under both levels).
4. **Requester identity**: `executeLockingFiles` hardcoded `Thread.currentThread()`; it now locks on behalf of the current transaction's requester (`TransactionContext.getRequester()`, widened to public), so a thread acting for a session no longer times out on locks its own session holds. Only the locks it actually acquired are released on exit.

## Test evidence (red-first)

All five fix-targeting tests fail on unfixed code:
- `Issue4940Phase2FailureRollbackTest.phase2FailureBeforeWalAppendResetsCreatedRecordIdentity`: `expected: null but was: #1:0`
- `Issue4940Phase2FailureRollbackTest.phase2FailureBeforeWalAppendReloadsModifiedRecords`: `expected: "committed" but was: "uncommitted"`
- `Issue4959TransactionCleanupsTest.deferredUpdateOfConcurrentlyDeletedRecordFailsTheCommit`: `Expecting code to raise a throwable` (commit succeeded, update silently dropped)
- `Issue4959TransactionCleanupsTest.deterministicDuplicatedKeyIsRetriedAtMostOnce`: `expected: 2 but was: 10`
- `Issue4959TransactionCleanupsTest.executeLockingFilesUsesTheTransactionRequester`: `LockTimeoutException` after the 5000ms timeout

Green after the fix. Focused suites run: `com.arcadedb.database.**` (all 38 classes incl. async), `ACIDTransactionTest`, `ExplicitLockingTransactionTest`, `LocalTransactionExplicitLockRetryTest`, `MVCCTest` - 123 tests, 0 failures, 0 errors. (`TransactionTest` and `WalCommitOrderingTest` do not exist on main; the latter arrives with #5053.)

## Conflict risks

Sibling audit branches may touch:
- `engine/src/main/java/com/arcadedb/database/TransactionContext.java` - **#5053 rewrites the same `commit2ndPhase` try/finally** (it also introduces its own `walAppended` flag; the merge resolution is: keep #5053's fencing in the post-append branch and this PR's `rollback()` in the pre-append branch)
- `engine/src/main/java/com/arcadedb/database/LocalDatabase.java`
- `docs/release-26.7.2.md` (expected, entries are additive)