### PR TITLE
fix(#4953,#4954,#4961): async executor stall detector, shutdown draining, concurrency cleanups

### DIFF
--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -238,7 +238,15 @@ that could starve the very snapshot resync meant to heal the node.
   preserved), so two workers cross-scheduling into each other no longer deadlock - a cycle the
   old detector could only break by throwing inside the worker, rolling back the whole in-flight commit
   batch (up to `commitEvery - 1` already-executed operations silently discarded) and dropping the
-  follow-up (ghost half-edges) ([#4953](https://github.com/ArcadeData/arcadedb/issues/4953)). Shutdown no
+  follow-up (ghost half-edges) ([#4953](https://github.com/ArcadeData/arcadedb/issues/4953)). A
+  producer blocked on the full queue of a worker wedged inside user code (an infinite loop or a
+  blocking call in a task) still surfaces an error instead of hanging: a progress-gated backstop
+  throws after 12 consecutive stall windows with zero completed tasks (60s with the default
+  `checkForStalledQueuesMaxDelay` of 5s) - much longer than the old 10s false-positive-prone bound,
+  tunable via `setCheckForStalledQueuesMaxDelay()`. Known residual gap: with the opt-in
+  `arcadedb.asyncOperationsQueueImpl=fast` queue, a task whose enqueue races the target worker's
+  exit cannot be removed (`remove(Object)` unsupported) and its completion is never notified; a
+  WARNING is logged when this happens, and the default `standard` queue is not affected. Shutdown no
   longer strands completion waiters: an interrupted or exiting worker now notifies `completed()` on every
   task left in its queue instead of `queue.clear()`-ing them (threads blocked in `scanType()` /
   `waitCompletion()` hung forever), and `close()` no longer blocks unbounded on `queue.put(FORCE_EXIT)`

--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -245,7 +245,10 @@ that could starve the very snapshot resync meant to heal the node.
   `checkForStalledQueuesMaxDelay` of 5s) - much longer than the old 10s false-positive-prone bound,
   tunable via `setCheckForStalledQueuesMaxDelay()`; a worker parked handing a task cross-slot with a
   flat completed count (a likely scheduling cycle) is reported faster, after 3 consecutive stall
-  windows (15s by default), so a peer merely busy on one slow task does not trip it. Known residual
+  windows (15s by default), so a peer merely busy on one slow task does not trip it. Operators
+  running scheduling chains deeper than two workers with individual tasks slower than 15s should
+  raise `checkForStalledQueuesMaxDelay` (only the window duration is tunable, the counts are fixed),
+  or the cross-slot detector can fire on a chain that would have resolved. Known residual
   gap: with the opt-in
   `arcadedb.asyncOperationsQueueImpl=fast` queue, a task whose enqueue races the target worker's
   exit cannot be removed (`remove(Object)` unsupported) and its completion is never notified; a
@@ -253,8 +256,11 @@ that could starve the very snapshot resync meant to heal the node.
   longer strands completion waiters: an interrupted or exiting worker now notifies `completed()` on every
   task left in its queue instead of `queue.clear()`-ing them (threads blocked in `scanType()` /
   `waitCompletion()` hung forever), and `close()` no longer blocks unbounded on `queue.put(FORCE_EXIT)`
-  under the lifecycle lock when a busy worker's queue is full - the marker is offered with a timeout and
-  the worker is interrupted on failure ([#4954](https://github.com/ArcadeData/arcadedb/issues/4954)).
+  under the lifecycle lock when a busy worker's queue is full - the marker is offered with a timeout,
+  the worker is interrupted on failure, and a worker still alive after the 10s grace period (e.g. one
+  that consumed the marker while help-waiting on a wedged peer's full queue) is escalated to an
+  interrupt and re-joined instead of being left running behind a returned `close()`
+  ([#4954](https://github.com/ArcadeData/arcadedb/issues/4954)).
   Low-severity cleanups from the same audit: async executor settings (`parallelLevel`, `commitEvery`,
   back-pressure, callbacks) are now `volatile` so post-startup changes reach the workers,
   `setCommitEvery(0)` is rejected instead of making every task fail on `count % 0`, the JVM-wide query

--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -208,6 +208,29 @@ that could starve the very snapshot resync meant to heal the node.
   shadows committed RIDs whose key equals an uncommitted entry's key - is tracked in
   [#5055](https://github.com/ArcadeData/arcadedb/issues/5055).
 
+- **Async executor hardening (2026-07 audit).** Three fixes to the per-database async executor. The
+  queue stall detector no longer false-positives on a worker merely busy with one slow task (it compared
+  the identity of the queue head across two 5s windows, so any head task running longer than 10s made
+  innocent producers throw "Asynchronous queue is stalled"); detection is now progress-based (per-worker
+  completed-task counters) and, more importantly, a worker that schedules a cross-slot follow-up (the
+  bidirectional-edge incoming-link task) into another worker's full queue now drains and executes its OWN
+  queue while it waits, so two workers cross-scheduling into each other no longer deadlock - a cycle the
+  old detector could only break by throwing inside the worker, rolling back the whole in-flight commit
+  batch (up to `commitEvery - 1` already-executed operations silently discarded) and dropping the
+  follow-up (ghost half-edges) ([#4953](https://github.com/ArcadeData/arcadedb/issues/4953)). Shutdown no
+  longer strands completion waiters: an interrupted or exiting worker now notifies `completed()` on every
+  task left in its queue instead of `queue.clear()`-ing them (threads blocked in `scanType()` /
+  `waitCompletion()` hung forever), and `close()` no longer blocks unbounded on `queue.put(FORCE_EXIT)`
+  under the lifecycle lock when a busy worker's queue is full - the marker is offered with a timeout and
+  the worker is interrupted on failure ([#4954](https://github.com/ArcadeData/arcadedb/issues/4954)).
+  Low-severity cleanups from the same audit: async executor settings (`parallelLevel`, `commitEvery`,
+  back-pressure, callbacks) are now `volatile` so post-startup changes reach the workers,
+  `setCommitEvery(0)` is rejected instead of making every task fail on `count % 0`, the JVM-wide query
+  parallelism and sparse-vector pools cancel a `Future` rejected after pool shutdown instead of leaving
+  its waiter blocked forever, and `QueryEngineManager.register()` publishes a copy-on-write map so a
+  post-construction registration cannot corrupt concurrent readers
+  ([#4961](https://github.com/ArcadeData/arcadedb/issues/4961)).
+
 ### Improvements
 
 - **HA: throttled diverged-follower resync logging.** When a follower detects a WAL page-version gap it

--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -232,8 +232,10 @@ that could starve the very snapshot resync meant to heal the node.
   the identity of the queue head across two 5s windows, so any head task running longer than 10s made
   innocent producers throw "Asynchronous queue is stalled"); detection is now progress-based (per-worker
   completed-task counters) and, more importantly, a worker that schedules a cross-slot follow-up (the
-  bidirectional-edge incoming-link task) into another worker's full queue now drains and executes its OWN
-  queue while it waits, so two workers cross-scheduling into each other no longer deadlock - a cycle the
+  bidirectional-edge incoming-link task) into another worker's full queue now drains its OWN
+  queue while it waits (the polled tasks are parked and run once the current task unwinds, so no
+  transaction boundary can fall inside a suspended task's execution and per-task atomicity is
+  preserved), so two workers cross-scheduling into each other no longer deadlock - a cycle the
   old detector could only break by throwing inside the worker, rolling back the whole in-flight commit
   batch (up to `commitEvery - 1` already-executed operations silently discarded) and dropping the
   follow-up (ghost half-edges) ([#4953](https://github.com/ArcadeData/arcadedb/issues/4953)). Shutdown no

--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -245,7 +245,11 @@ that could starve the very snapshot resync meant to heal the node.
   `checkForStalledQueuesMaxDelay` of 5s) - much longer than the old 10s false-positive-prone bound,
   tunable via `setCheckForStalledQueuesMaxDelay()`; a worker parked handing a task cross-slot with a
   flat completed count (a likely scheduling cycle) is reported faster, after 3 consecutive stall
-  windows (15s by default), so a peer merely busy on one slow task does not trip it. Operators
+  windows (15s by default), so a peer merely busy on one slow task does not trip it. The same applies
+  to the backstop itself: a SINGLE legitimately long task (a large scan, a heavy user callback) that
+  exceeds 12 x `checkForStalledQueuesMaxDelay` (60s by default) while producers wait on that worker's
+  full queue is indistinguishable from a wedged one and trips the stall exception - raise the delay if
+  your tasks legitimately run that long. Operators
   running scheduling chains deeper than two workers with individual tasks slower than 15s should
   raise `checkForStalledQueuesMaxDelay` (only the window duration is tunable, the counts are fixed),
   or the cross-slot detector can fire on a chain that would have resolved. Known residual

--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -243,7 +243,10 @@ that could starve the very snapshot resync meant to heal the node.
   blocking call in a task) still surfaces an error instead of hanging: a progress-gated backstop
   throws after 12 consecutive stall windows with zero completed tasks (60s with the default
   `checkForStalledQueuesMaxDelay` of 5s) - much longer than the old 10s false-positive-prone bound,
-  tunable via `setCheckForStalledQueuesMaxDelay()`. Known residual gap: with the opt-in
+  tunable via `setCheckForStalledQueuesMaxDelay()`; a worker parked handing a task cross-slot with a
+  flat completed count (a likely scheduling cycle) is reported faster, after 3 consecutive stall
+  windows (15s by default), so a peer merely busy on one slow task does not trip it. Known residual
+  gap: with the opt-in
   `arcadedb.asyncOperationsQueueImpl=fast` queue, a task whose enqueue races the target worker's
   exit cannot be removed (`remove(Object)` unsupported) and its completion is never notified; a
   WARNING is logged when this happens, and the default `standard` queue is not affected. Shutdown no

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncBrowseIterator.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncBrowseIterator.java
@@ -39,18 +39,20 @@ public class DatabaseAsyncBrowseIterator implements DatabaseAsyncTask {
 
   @Override
   public void execute(final DatabaseAsyncExecutorImpl.AsyncThread async, final DatabaseInternal database) {
-    try {
-      while (iterator.hasNext()) {
-        if (!callback.onRecord(iterator.next().asDocument()))
-          break;
+    while (iterator.hasNext()) {
+      if (!callback.onRecord(iterator.next().asDocument()))
+        break;
 
-        if (async.isShutdown())
-          break;
-      }
-    } finally {
-      // UNLOCK THE CALLER THREAD
-      semaphore.countDown();
+      if (async.isShutdown())
+        break;
     }
+  }
+
+  @Override
+  public void completed() {
+    // UNLOCK THE CALLER THREAD. The worker invokes completed() after execute() but also when the
+    // task is dropped during shutdown (#4954), so the browsing caller never hangs on the latch.
+    semaphore.countDown();
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -41,7 +41,7 @@ import com.arcadedb.schema.EdgeType;
 import com.arcadedb.schema.LocalTimeSeriesType;
 import com.conversantmedia.util.concurrent.PushPullBlockingQueue;
 
-import java.util.ArrayList;
+import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -75,11 +75,6 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
   private final AtomicLong           commandRoundRobinIndex        = new AtomicLong();
   private final AtomicLong           tsAppendCounter               = new AtomicLong();
 
-  // #4953: cap for the re-entrant help-while-waiting recursion in scheduleTask. Each level consumes
-  // one task from the worker's own queue before nesting, so the stack depth is bounded; beyond the
-  // cap the worker falls back to plain bounded waiting with stall detection.
-  private static final int MAX_HELPING_DEPTH = 32;
-
   // SPECIAL TASKS
   public final static DatabaseAsyncTask FORCE_EXIT = new DatabaseAsyncTask() {
     @Override
@@ -112,8 +107,13 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     // #4953: true while this worker is parked in scheduleTask waiting to hand a task to a queue.
     // Combined with a flat completedTaskCount it identifies a genuine cross-scheduling stall.
     private volatile boolean                         waitingCrossSlotOffer = false;
-    // Thread-confined nesting level of the help-while-waiting loop (see offerHelping).
-    private          int                             helpingDepth          = 0;
+    // #5062 review (point 1): tasks polled from the own queue while help-waiting are NOT executed
+    // re-entrantly (a nested execution could commit or roll back the suspended task's partial
+    // writes, breaking per-task atomicity); they are parked here, in poll order, and run by the run
+    // loop once the current task unwinds. Thread-confined: only this worker touches it.
+    private final    ArrayDeque<DatabaseAsyncTask>   helpDeferredTasks     = new ArrayDeque<>();
+    // Capacity of the own queue, doubling as the helpDeferredTasks budget (see offerHelping).
+    private final    int                             queueCapacity;
 
     private AsyncThread(final DatabaseInternal database, final int id) {
       super("AsyncExecutor-" + database.getName() + "-" + id);
@@ -123,6 +123,7 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
           database.getConfiguration().getValueAsInteger(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE) / parallelLevel;
       if (queueSize < 1)
         queueSize = 1;
+      this.queueCapacity = queueSize;
 
       final String cfgQueueImpl =
           database.getConfiguration().getValueAsString(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_IMPL);
@@ -157,7 +158,10 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
 
       while (!forceShutdown) {
         try {
-          final DatabaseAsyncTask message = queue.poll(500, TimeUnit.MILLISECONDS);
+          // TASKS PARKED BY THE HELP-WHILE-WAITING PATH RUN FIRST, IN POLL ORDER, NOW THAT THE TASK
+          // THAT WAS SUSPENDED WHILE THEY WERE POLLED HAS FULLY UNWOUND (SEE offerHelping)
+          final DatabaseAsyncTask message =
+              helpDeferredTasks.isEmpty() ? queue.poll(500, TimeUnit.MILLISECONDS) : helpDeferredTasks.pollFirst();
           if (message != null) {
             if (message == FORCE_EXIT)
               break;
@@ -192,8 +196,9 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     /**
      * Executes a single task applying the shared transaction-batching contract (begin on demand,
      * commit every {@code commitEvery} tasks, rollback + onError on failure, always notify
-     * {@code completed()}). Called from the run loop and, re-entrantly, from scheduleTask's
-     * help-while-waiting path when this worker is parked on another worker's full queue (#4953).
+     * {@code completed()}). Called from the run loop only: the help-while-waiting path of #4953
+     * defers polled tasks back to the run loop instead of nesting executions, so that no
+     * transaction boundary can fall inside a suspended task's execution (#5062 review, point 1).
      */
     private void executeTask(final DatabaseAsyncTask message) {
       final boolean nested = executingTask.getAndSet(true);
@@ -207,15 +212,23 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
 
         message.execute(this, database);
 
-        count++;
+        // #5062 review (point 1): the commit-every-N boundary must never fire from a nested
+        // execution while an enclosing task is suspended mid-execute(), or it would commit that
+        // task's partial writes. The helping path defers tasks instead of nesting (see
+        // offerHelping), so today `nested` is always false here; the guard is defense-in-depth
+        // should a re-entrant call path ever be reintroduced.
+        if (!nested) {
+          count++;
 
-        if (database.isTransactionActive() && count % commitEvery == 0) {
-          database.commit();
-          database.begin();
+          if (database.isTransactionActive() && count % commitEvery == 0) {
+            database.commit();
+            database.begin();
+          }
         }
       } catch (final Throwable e) {
         onError(e);
-        if (database.isTransactionActive())
+        // SAME GUARD AS ABOVE: A NESTED ROLLBACK WOULD DESTROY THE SUSPENDED TASK'S WRITES
+        if (!nested && database.isTransactionActive())
           database.rollback();
       } finally {
         try {
@@ -229,7 +242,8 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
 
     private void drainQueueNotifyingWaiters() {
       DatabaseAsyncTask leftover;
-      while ((leftover = queue.poll()) != null)
+      // TASKS PARKED BY THE HELPING PATH ARE DROPPED TASKS TOO: NOTIFY THEM FIRST, THEN THE QUEUE
+      while ((leftover = helpDeferredTasks.isEmpty() ? queue.poll() : helpDeferredTasks.pollFirst()) != null)
         if (leftover != FORCE_EXIT)
           try {
             leftover.completed();
@@ -374,6 +388,10 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     if (threads == null)
       return true;
 
+    if (timeout <= 0)
+      timeout = Long.MAX_VALUE;
+    final long beginTime = System.currentTimeMillis();
+
     final DatabaseAsyncAbstractCallbackTask[] semaphores =
         new DatabaseAsyncAbstractCallbackTask[threads.length];
 
@@ -382,22 +400,28 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
         semaphores[i] = new DatabaseAsyncCompletion();
         // #4954: bounded offer with a liveness check instead of an untimed put(): a worker that
         // exited (shutdown) will never drain a full queue, so the old code hung here forever.
-        while (!threads[i].queue.offer(semaphores[i], 500, TimeUnit.MILLISECONDS))
+        // #5062 review (point 3): the timeout is a single budget spanning enqueue AND await, so a
+        // persistently full queue on a live worker cannot block the caller past the timeout.
+        while (true) {
+          final long remaining = timeout - (System.currentTimeMillis() - beginTime);
+          if (remaining <= 0)
+            return false;
+          if (threads[i].queue.offer(semaphores[i], Math.min(500, remaining), TimeUnit.MILLISECONDS))
+            break;
           if (!threads[i].isAlive()) {
             // NOTHING WILL EVER RUN ON THIS QUEUE ANYMORE: TREAT IT AS FLUSHED
             semaphores[i].completed();
             break;
           }
+        }
       } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();
         return false;
       }
 
-    if (timeout <= 0)
-      timeout = Long.MAX_VALUE;
-
-    long currentTimeout = timeout;
-    final long beginTime = System.currentTimeMillis();
+    long currentTimeout = timeout - (System.currentTimeMillis() - beginTime);
+    if (currentTimeout < 1)
+      return false;
 
     for (int i = 0; i < semaphores.length; ++i)
       try {
@@ -959,7 +983,10 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     try {
       return queue.remove(task);
     } catch (final UnsupportedOperationException e) {
-      // THE "fast" QUEUE (PushPullBlockingQueue) DOES NOT SUPPORT remove(Object)
+      // THE "fast" QUEUE (PushPullBlockingQueue) DOES NOT SUPPORT remove(Object): the offer cannot
+      // be undone, so a task that landed right after a dead worker's final drain stays queued and
+      // its completed() never fires (#5062 review, point 4). Known gap, accepted: the impl is
+      // opt-in and the window (an offer racing the worker's exit) is a few instructions wide.
       return false;
     }
   }
@@ -970,11 +997,13 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
    * Two behaviors depending on the calling thread:
    * <ul>
    *   <li><b>Worker of this executor (e.g. the cross-slot incoming-edge follow-up in newEdge):</b>
-   *   the worker drains and executes tasks from its OWN queue while it waits. Two workers
-   *   cross-scheduling into each other's full queues (bidirectional edge load) formed a wait cycle
-   *   the old head-identity stall detector could only break by throwing, which rolled back the
-   *   worker's whole in-flight commit batch and silently dropped the follow-up. Helping guarantees
-   *   system-wide progress without throwing.</li>
+   *   the worker drains tasks from its OWN queue into a parked list while it waits (see
+   *   {@code offerHelping}). Two workers cross-scheduling into each other's full queues
+   *   (bidirectional edge load) formed a wait cycle the old head-identity stall detector could only
+   *   break by throwing, which rolled back the worker's whole in-flight commit batch and silently
+   *   dropped the follow-up. Draining frees the slot the peer is parked on, so the cycle resolves
+   *   without throwing; if the deferral budget runs out the worker falls through to the bounded
+   *   wait below.</li>
    *   <li><b>Any other producer:</b> waits in windows of {@code checkForStalledQueuesMaxDelay} and
    *   throws only if the target worker completed no task over a whole window while itself being
    *   parked handing a task to another queue (a genuine scheduling cycle beyond the helping budget)
@@ -988,10 +1017,8 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     final AsyncThread self =
         Thread.currentThread() instanceof AsyncThread worker && worker.getOwner() == this ? worker : null;
 
-    if (self != null && self.helpingDepth < MAX_HELPING_DEPTH) {
-      offerHelping(self, target, task);
+    if (self != null && offerHelping(self, target, task))
       return;
-    }
 
     final BlockingQueue<DatabaseAsyncTask> queue = target.queue;
     final boolean prevWaiting = self != null && self.waitingCrossSlotOffer;
@@ -1024,50 +1051,60 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
   }
 
   /**
-   * Help-while-waiting loop (#4953): the calling worker keeps serving its own queue while it waits
-   * for space on the target queue, so workers never sleep on each other's queues and cross-slot
-   * cycles resolve on their own. Completion markers polled from the own queue are deferred until the
-   * hand-off succeeded, otherwise waitCompletion() could return while the current task's follow-up
-   * has not been scheduled yet.
+   * Help-while-waiting loop (#4953): the calling worker keeps draining its own queue while it waits
+   * for space on the target queue, so two workers cross-scheduling into each other's full queues
+   * free the slot the peer is parked on and the cycle resolves on its own. Polled tasks are NOT
+   * executed here: this worker is suspended mid-execute() of its current task, and a nested
+   * execution could commit or roll back that task's partial writes, breaking per-task atomicity
+   * (#5062 review, point 1). They are parked in {@code helpDeferredTasks} and run by the run loop,
+   * in poll order, once the current task unwinds; that is also after the hand-off, so a parked
+   * waitCompletion() marker cannot fire before the current task's follow-up has been scheduled.
+   * <p>
+   * The parked backlog is capped at the queue capacity: past it the method gives up (returns false)
+   * and the caller falls back to the bounded wait with stall detection, restoring queue-full
+   * backpressure on producers. There is deliberately NO liveness detector here beyond target death
+   * (#5062 review, point 2): a target wedged forever in user code is indistinguishable from one
+   * busy on a legitimately slow task, and throwing out of a worker mid-task rolls back its commit
+   * batch and silently drops the follow-up, which is the exact #4953 defect. As long as the target
+   * is alive it either progresses (offer eventually lands) or is itself parked cross-slot, in which
+   * case draining resolves the cycle or the budget above fails over to the detecting wait.
+   *
+   * @return true if the task was handed to the target queue, false if the deferral budget is
+   * exhausted and the caller must fall back to the bounded wait of {@code offerWaiting}.
    */
-  private void offerHelping(final AsyncThread self, final AsyncThread target, final DatabaseAsyncTask task)
+  private boolean offerHelping(final AsyncThread self, final AsyncThread target, final DatabaseAsyncTask task)
       throws InterruptedException {
-    List<DatabaseAsyncTask> deferred = null;
     final boolean prevWaiting = self.waitingCrossSlotOffer;
-    self.helpingDepth++;
     self.waitingCrossSlotOffer = true;
     try {
       while (true) {
-        // SHORT WINDOW WHEN THERE IS OWN WORK TO INTERLEAVE, LONGER WHEN IDLE TO AVOID SPINNING
+        // SHORT WINDOW WHEN THERE IS OWN WORK TO DRAIN, LONGER WHEN IDLE TO AVOID SPINNING
         final long window = self.queue.isEmpty() ? 100 : 1;
         if (target.queue.offer(task, window, TimeUnit.MILLISECONDS))
-          break;
+          return true;
 
         if (!target.isAlive())
           throw new DatabaseOperationException(
               "Async executor has been shut down; cannot schedule asynchronous task " + task);
+
+        if (self.helpDeferredTasks.size() >= self.queueCapacity)
+          // DEFERRAL BUDGET EXHAUSTED: STOP EXTENDING THE OWN QUEUE AND FALL BACK TO THE BOUNDED WAIT
+          return false;
 
         final DatabaseAsyncTask own = self.queue.poll();
         if (own == null)
           continue;
 
         if (own == FORCE_EXIT)
-          // GRACEFUL SHUTDOWN REQUESTED WHILE HELPING: HONORED BY THE RUN LOOP AS SOON AS THE
-          // CURRENT TASK UNWINDS
+          // GRACEFUL SHUTDOWN REQUESTED WHILE HELPING: THE MARKER IS CONSUMED HERE AND IT IS THE
+          // forceShutdown FLAG (NOT THE MARKER) THAT MAKES THE RUN LOOP EXIT ONCE THE CURRENT TASK
+          // UNWINDS, SO shutdownThreadsLocked'S BOUNDED join() STILL COMPLETES (#5062 review, point 5)
           self.forceShutdown = true;
-        else if (own instanceof DatabaseAsyncCompletion) {
-          if (deferred == null)
-            deferred = new ArrayList<>(2);
-          deferred.add(own);
-        } else
-          self.executeTask(own);
+        else
+          self.helpDeferredTasks.addLast(own);
       }
     } finally {
       self.waitingCrossSlotOffer = prevWaiting;
-      self.helpingDepth--;
-      if (deferred != null)
-        for (final DatabaseAsyncTask t : deferred)
-          self.executeTask(t);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -41,6 +41,7 @@ import com.arcadedb.schema.EdgeType;
 import com.arcadedb.schema.LocalTimeSeriesType;
 import com.conversantmedia.util.concurrent.PushPullBlockingQueue;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -62,15 +63,22 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
   // observe a half-built or just-nulled array. See lifecycleLock for the publish discipline.
   private volatile AsyncThread[]     executorThreads;
   private final Object               lifecycleLock                 = new Object();
-  private       int                  parallelLevel                 = 1;
-  private       int                  commitEvery;
-  private       int                  backPressurePercentage        = 0;
-  private       boolean              transactionUseWAL             = true;
-  private       WALFile.FlushType    transactionSync               = WALFile.FlushType.NO;
-  private       long                 checkForStalledQueuesMaxDelay = 5_000;
+  // #4961: these settings are written by user threads and read by the worker threads, so they must
+  // be volatile or a change applied after createThreads() may never become visible to the workers.
+  private volatile int               parallelLevel                 = 1;
+  private volatile int               commitEvery;
+  private volatile int               backPressurePercentage        = 0;
+  private volatile boolean           transactionUseWAL             = true;
+  private volatile WALFile.FlushType transactionSync               = WALFile.FlushType.NO;
+  private volatile long              checkForStalledQueuesMaxDelay = 5_000;
   private final AtomicLong           transactionCounter            = new AtomicLong();
   private final AtomicLong           commandRoundRobinIndex        = new AtomicLong();
   private final AtomicLong           tsAppendCounter               = new AtomicLong();
+
+  // #4953: cap for the re-entrant help-while-waiting recursion in scheduleTask. Each level consumes
+  // one task from the worker's own queue before nesting, so the stack depth is bounded; beyond the
+  // cap the worker falls back to plain bounded waiting with stall detection.
+  private static final int MAX_HELPING_DEPTH = 32;
 
   // SPECIAL TASKS
   public final static DatabaseAsyncTask FORCE_EXIT = new DatabaseAsyncTask() {
@@ -85,9 +93,10 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     }
   };
 
-  private OkCallback    onOkCallback;
-  private ErrorCallback onErrorCallback;
-  private AtomicLong    counterScheduledTasks = new AtomicLong();
+  // #4961: read by worker threads, written by user threads: must be volatile.
+  private volatile OkCallback    onOkCallback;
+  private volatile ErrorCallback onErrorCallback;
+  private final    AtomicLong    counterScheduledTasks = new AtomicLong();
 
   public class AsyncThread extends Thread {
     public final    BlockingQueue<DatabaseAsyncTask> queue;
@@ -96,6 +105,15 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     public volatile boolean                          forceShutdown = false;
     public          AtomicBoolean                    executingTask = new AtomicBoolean(false);
     public          long                             count         = 0;
+    // #4953: monotonic count of tasks this worker has finished (successfully or not). Producers
+    // blocked on this worker's full queue use it as a progress probe: only written by the worker,
+    // read by any thread, hence volatile.
+    private volatile long                            completedTaskCount    = 0;
+    // #4953: true while this worker is parked in scheduleTask waiting to hand a task to a queue.
+    // Combined with a flat completedTaskCount it identifies a genuine cross-scheduling stall.
+    private volatile boolean                         waitingCrossSlotOffer = false;
+    // Thread-confined nesting level of the help-while-waiting loop (see offerHelping).
+    private          int                             helpingDepth          = 0;
 
     private AsyncThread(final DatabaseInternal database, final int id) {
       super("AsyncExecutor-" + database.getName() + "-" + id);
@@ -141,47 +159,14 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
         try {
           final DatabaseAsyncTask message = queue.poll(500, TimeUnit.MILLISECONDS);
           if (message != null) {
-            executingTask.set(true);
-            try {
-              LogManager.instance()
-                  .log(this, Level.FINE, "Received async message %s (threadId=%d)", message,
-                      Thread.currentThread().threadId());
-
-              if (message == FORCE_EXIT) {
-                break;
-              } else {
-
-                if (message.requiresActiveTx() && !database.isTransactionActive())
-                  database.begin();
-
-                message.execute(this, database);
-
-                count++;
-
-                if (database.isTransactionActive() && count % commitEvery == 0) {
-                  database.commit();
-                  database.begin();
-                }
-
-              }
-            } catch (final Throwable e) {
-              onError(e);
-              if (database.isTransactionActive())
-                database.rollback();
-            } finally {
-              try {
-                message.completed();
-              } finally {
-                executingTask.set(false);
-              }
-            }
-
+            if (message == FORCE_EXIT)
+              break;
+            executeTask(message);
           } else if (shutdown)
             break;
 
         } catch (final InterruptedException e) {
           Thread.currentThread().interrupt();
-          queue.clear();
           break;
         } catch (final Throwable e) {
           LogManager.instance().log(this, Level.SEVERE, "Error on executing asynchronous operation (asyncThread=%s)",
@@ -196,6 +181,66 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       } catch (final Exception e) {
         onError(e);
       }
+
+      // #4954: whatever ended the loop (FORCE_EXIT, shutdown flag, interrupt), tasks may still sit in
+      // the queue and will never execute. Notify completed() on each so threads blocked in scanType()
+      // or waitCompletion() are released instead of hanging forever (the previous code queue.clear()-ed
+      // on interrupt, silently discarding them).
+      drainQueueNotifyingWaiters();
+    }
+
+    /**
+     * Executes a single task applying the shared transaction-batching contract (begin on demand,
+     * commit every {@code commitEvery} tasks, rollback + onError on failure, always notify
+     * {@code completed()}). Called from the run loop and, re-entrantly, from scheduleTask's
+     * help-while-waiting path when this worker is parked on another worker's full queue (#4953).
+     */
+    private void executeTask(final DatabaseAsyncTask message) {
+      final boolean nested = executingTask.getAndSet(true);
+      try {
+        LogManager.instance()
+            .log(this, Level.FINE, "Received async message %s (threadId=%d)", message,
+                Thread.currentThread().threadId());
+
+        if (message.requiresActiveTx() && !database.isTransactionActive())
+          database.begin();
+
+        message.execute(this, database);
+
+        count++;
+
+        if (database.isTransactionActive() && count % commitEvery == 0) {
+          database.commit();
+          database.begin();
+        }
+      } catch (final Throwable e) {
+        onError(e);
+        if (database.isTransactionActive())
+          database.rollback();
+      } finally {
+        try {
+          message.completed();
+        } finally {
+          completedTaskCount++;
+          executingTask.set(nested);
+        }
+      }
+    }
+
+    private void drainQueueNotifyingWaiters() {
+      DatabaseAsyncTask leftover;
+      while ((leftover = queue.poll()) != null)
+        if (leftover != FORCE_EXIT)
+          try {
+            leftover.completed();
+          } catch (final Throwable e) {
+            LogManager.instance()
+                .log(this, Level.SEVERE, "Error on notifying completion of dropped asynchronous task %s", e, leftover);
+          }
+    }
+
+    DatabaseAsyncExecutorImpl getOwner() {
+      return DatabaseAsyncExecutorImpl.this;
     }
 
     public void onError(final Throwable e) {
@@ -214,7 +259,8 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
   public DatabaseAsyncExecutorImpl(final DatabaseInternal database, final ContextConfiguration configuration) {
     this.database = database;
     this.configuration = configuration;
-    this.commitEvery = database.getConfiguration().getValueAsInteger(GlobalConfiguration.ASYNC_TX_BATCH_SIZE);
+    // #4961: a non-positive batch size would make every task fail on count % commitEvery.
+    this.commitEvery = Math.max(1, database.getConfiguration().getValueAsInteger(GlobalConfiguration.ASYNC_TX_BATCH_SIZE));
     createThreads(database.getConfiguration().getValueAsInteger(GlobalConfiguration.ASYNC_WORKER_THREADS));
   }
 
@@ -334,7 +380,14 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     for (int i = 0; i < threads.length; ++i)
       try {
         semaphores[i] = new DatabaseAsyncCompletion();
-        threads[i].queue.put(semaphores[i]);
+        // #4954: bounded offer with a liveness check instead of an untimed put(): a worker that
+        // exited (shutdown) will never drain a full queue, so the old code hung here forever.
+        while (!threads[i].queue.offer(semaphores[i], 500, TimeUnit.MILLISECONDS))
+          if (!threads[i].isAlive()) {
+            // NOTHING WILL EVER RUN ON THIS QUEUE ANYMORE: TREAT IT AS FLUSHED
+            semaphores[i].completed();
+            break;
+          }
       } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();
         return false;
@@ -740,6 +793,9 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
 
   @Override
   public void setCommitEvery(final int commitEvery) {
+    // #4961: 0 would make every task fail with an ArithmeticException on count % commitEvery.
+    if (commitEvery < 1)
+      throw new IllegalArgumentException("commitEvery must be >= 1 (was " + commitEvery + ")");
     this.commitEvery = commitEvery;
   }
 
@@ -790,20 +846,32 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
 
     // Unpublish first so concurrent readers stop seeing the about-to-die threads.
     executorThreads = null;
-    try {
-      // SET SHUTDOWN STATUS TO ALL THE THREADS
-      for (int i = 0; i < toClose.length; ++i)
-        toClose[i].shutdown = true;
 
-      // WAIT FOR SHUTDOWN, MAX 10S EACH
-      for (int i = 0; i < toClose.length; ++i) {
-        toClose[i].queue.put(FORCE_EXIT);
-        toClose[i].join(10000);
+    // SET SHUTDOWN STATUS TO ALL THE THREADS
+    for (int i = 0; i < toClose.length; ++i)
+      toClose[i].shutdown = true;
+
+    // #4954: the old untimed queue.put(FORCE_EXIT) under lifecycleLock hung database.close() (and
+    // any later createThreads()/kill()) for as long as a busy worker with a full queue kept running
+    // its current task. Bounded offer + interrupt on failure: the woken worker exits its loop and
+    // notifies completed() on whatever it could not execute (see drainQueueNotifyingWaiters).
+    boolean interrupted = false;
+    for (int i = 0; i < toClose.length; ++i) {
+      try {
+        if (!toClose[i].queue.offer(FORCE_EXIT, 1, TimeUnit.SECONDS))
+          toClose[i].interrupt();
+
+        // WAIT FOR SHUTDOWN, MAX 10S EACH
+        toClose[i].join(10_000);
+      } catch (final InterruptedException e) {
+        interrupted = true;
       }
-    } catch (final InterruptedException e) {
-      // IGNORE IT
-      Thread.currentThread().interrupt();
+      if (toClose[i].isAlive())
+        LogManager.instance()
+            .log(this, Level.WARNING, "AsyncThread %s did not stop within 10s after shutdown", toClose[i].getName());
     }
+    if (interrupted)
+      Thread.currentThread().interrupt();
   }
 
   @Override
@@ -850,7 +918,8 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
         throw new DatabaseOperationException(
             "Async executor has been shut down; cannot schedule asynchronous task " + task);
 
-      final BlockingQueue<DatabaseAsyncTask> queue = threads[slot].queue;
+      final AsyncThread target = threads[slot];
+      final BlockingQueue<DatabaseAsyncTask> queue = target.queue;
 
       if (applyBackPressureOnPercentage > 0) {
         final int queueFullAt = 100 - (queue.remainingCapacity() * 100 / (queue.remainingCapacity() + queue.size()));
@@ -860,41 +929,145 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
           Thread.sleep(queueFullAt);
       }
 
-      if (waitIfQueueIsFull) {
-        if (!queue.offer(task, checkForStalledQueuesMaxDelay, TimeUnit.MILLISECONDS)) {
-          // QUEUE FULL, RETRY WITH CHECK FOR QUEUE STALLED
+      final boolean scheduled;
+      if (queue.offer(task))
+        scheduled = true;
+      else if (waitIfQueueIsFull) {
+        offerWaiting(target, slot, task, applyBackPressureOnPercentage);
+        scheduled = true;
+      } else
+        scheduled = false;
 
-          final DatabaseAsyncTask firstInQueueAtBeginning = queue.peek();
-
-          while (!queue.offer(task, checkForStalledQueuesMaxDelay, TimeUnit.MILLISECONDS)) {
-            final DatabaseAsyncTask firstInQueue = queue.peek();
-            if (firstInQueue != null && firstInQueue == firstInQueueAtBeginning) {
-              // QUEUE STALLED
-              throw new DatabaseOperationException("Asynchronous queue " + slot
-                  + " is stalled. This could happen when an asynchronous task schedules more asynchronous tasks");
-            }
-
-            if (applyBackPressureOnPercentage > 0) {
-              final int queueFullAt =
-                  100 - (queue.remainingCapacity() * 100 / (queue.remainingCapacity() + queue.size()));
-              Thread.sleep(100 + (4L * queueFullAt));
-            }
-          }
-        }
-
+      if (scheduled) {
+        if (!target.isAlive() && removeQuietly(queue, task))
+          // The worker exited (shutdown) after its final queue drain but before this offer landed:
+          // the task would sit unexecuted forever. Undo the offer and fail like any post-shutdown
+          // scheduling attempt.
+          throw new DatabaseOperationException(
+              "Async executor has been shut down; cannot schedule asynchronous task " + task);
         counterScheduledTasks.incrementAndGet();
-
-        return true;
       }
-
-      final boolean result = queue.offer(task);
-      if (result)
-        counterScheduledTasks.incrementAndGet();
-      return result;
+      return scheduled;
 
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new DatabaseOperationException("Error on executing asynchronous task " + task);
+    }
+  }
+
+  private static boolean removeQuietly(final BlockingQueue<DatabaseAsyncTask> queue, final DatabaseAsyncTask task) {
+    try {
+      return queue.remove(task);
+    } catch (final UnsupportedOperationException e) {
+      // THE "fast" QUEUE (PushPullBlockingQueue) DOES NOT SUPPORT remove(Object)
+      return false;
+    }
+  }
+
+  /**
+   * Blocks until the task is enqueued on the target worker's currently full queue (#4953).
+   * <p>
+   * Two behaviors depending on the calling thread:
+   * <ul>
+   *   <li><b>Worker of this executor (e.g. the cross-slot incoming-edge follow-up in newEdge):</b>
+   *   the worker drains and executes tasks from its OWN queue while it waits. Two workers
+   *   cross-scheduling into each other's full queues (bidirectional edge load) formed a wait cycle
+   *   the old head-identity stall detector could only break by throwing, which rolled back the
+   *   worker's whole in-flight commit batch and silently dropped the follow-up. Helping guarantees
+   *   system-wide progress without throwing.</li>
+   *   <li><b>Any other producer:</b> waits in windows of {@code checkForStalledQueuesMaxDelay} and
+   *   throws only if the target worker completed no task over a whole window while itself being
+   *   parked handing a task to another queue (a genuine scheduling cycle beyond the helping budget)
+   *   or after the worker died. A worker merely busy on a single slow task no longer trips the
+   *   detector: the old code compared the identity of the queue head across two windows, so any
+   *   head task running longer than 2x the delay made innocent producers throw.</li>
+   * </ul>
+   */
+  private void offerWaiting(final AsyncThread target, final int slot, final DatabaseAsyncTask task,
+                            final int applyBackPressureOnPercentage) throws InterruptedException {
+    final AsyncThread self =
+        Thread.currentThread() instanceof AsyncThread worker && worker.getOwner() == this ? worker : null;
+
+    if (self != null && self.helpingDepth < MAX_HELPING_DEPTH) {
+      offerHelping(self, target, task);
+      return;
+    }
+
+    final BlockingQueue<DatabaseAsyncTask> queue = target.queue;
+    final boolean prevWaiting = self != null && self.waitingCrossSlotOffer;
+    if (self != null)
+      self.waitingCrossSlotOffer = true;
+    try {
+      long observedCompleted = target.completedTaskCount;
+      while (!queue.offer(task, checkForStalledQueuesMaxDelay, TimeUnit.MILLISECONDS)) {
+        if (!target.isAlive())
+          throw new DatabaseOperationException(
+              "Async executor has been shut down; cannot schedule asynchronous task " + task);
+
+        final long nowCompleted = target.completedTaskCount;
+        if (nowCompleted == observedCompleted && target.waitingCrossSlotOffer)
+          // NO TASK COMPLETED IN A WHOLE WINDOW WHILE THE WORKER IS ITSELF PARKED ON ANOTHER QUEUE
+          throw new DatabaseOperationException("Asynchronous queue " + slot
+              + " is stalled. This could happen when an asynchronous task schedules more asynchronous tasks");
+        observedCompleted = nowCompleted;
+
+        if (applyBackPressureOnPercentage > 0) {
+          final int queueFullAt =
+              100 - (queue.remainingCapacity() * 100 / (queue.remainingCapacity() + queue.size()));
+          Thread.sleep(100 + (4L * queueFullAt));
+        }
+      }
+    } finally {
+      if (self != null)
+        self.waitingCrossSlotOffer = prevWaiting;
+    }
+  }
+
+  /**
+   * Help-while-waiting loop (#4953): the calling worker keeps serving its own queue while it waits
+   * for space on the target queue, so workers never sleep on each other's queues and cross-slot
+   * cycles resolve on their own. Completion markers polled from the own queue are deferred until the
+   * hand-off succeeded, otherwise waitCompletion() could return while the current task's follow-up
+   * has not been scheduled yet.
+   */
+  private void offerHelping(final AsyncThread self, final AsyncThread target, final DatabaseAsyncTask task)
+      throws InterruptedException {
+    List<DatabaseAsyncTask> deferred = null;
+    final boolean prevWaiting = self.waitingCrossSlotOffer;
+    self.helpingDepth++;
+    self.waitingCrossSlotOffer = true;
+    try {
+      while (true) {
+        // SHORT WINDOW WHEN THERE IS OWN WORK TO INTERLEAVE, LONGER WHEN IDLE TO AVOID SPINNING
+        final long window = self.queue.isEmpty() ? 100 : 1;
+        if (target.queue.offer(task, window, TimeUnit.MILLISECONDS))
+          break;
+
+        if (!target.isAlive())
+          throw new DatabaseOperationException(
+              "Async executor has been shut down; cannot schedule asynchronous task " + task);
+
+        final DatabaseAsyncTask own = self.queue.poll();
+        if (own == null)
+          continue;
+
+        if (own == FORCE_EXIT)
+          // GRACEFUL SHUTDOWN REQUESTED WHILE HELPING: HONORED BY THE RUN LOOP AS SOON AS THE
+          // CURRENT TASK UNWINDS
+          self.forceShutdown = true;
+        else if (own instanceof DatabaseAsyncCompletion) {
+          if (deferred == null)
+            deferred = new ArrayList<>(2);
+          deferred.add(own);
+        } else
+          self.executeTask(own);
+      }
+    } finally {
+      self.waitingCrossSlotOffer = prevWaiting;
+      self.helpingDepth--;
+      if (deferred != null)
+        for (final DatabaseAsyncTask t : deferred)
+          self.executeTask(t);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -71,6 +71,11 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
   private volatile boolean           transactionUseWAL             = true;
   private volatile WALFile.FlushType transactionSync               = WALFile.FlushType.NO;
   private volatile long              checkForStalledQueuesMaxDelay = 5_000;
+  // #5062 review r4 (point 1): grace period each worker gets to exit on its own before shutdown
+  // escalates to interrupt() and again before giving up with a WARNING. Package-private (and
+  // volatile: written by tests, read by the closing thread) so shutdown regression tests can shrink
+  // it instead of waiting the production 10s.
+  volatile         long              shutdownJoinTimeoutMs         = 10_000;
   private final AtomicLong           transactionCounter            = new AtomicLong();
   private final AtomicLong           commandRoundRobinIndex        = new AtomicLong();
   private final AtomicLong           tsAppendCounter               = new AtomicLong();
@@ -79,7 +84,8 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
   // this many consecutive stall windows (checkForStalledQueuesMaxDelay each, 60s with the defaults)
   // in which the target worker completed NO task while its queue stayed full, offerWaiting throws
   // instead of letting the caller hang forever. Progress-gated so a single legitimately slow task
-  // does not trip it (the #4953 false positive); tune via setCheckForStalledQueuesMaxDelay().
+  // does not trip it (the #4953 false positive). Only the window DURATION is tunable, via the
+  // volatile setCheckForStalledQueuesMaxDelay(); this count and the cross-slot one below are fixed.
   private static final int STALLED_NO_PROGRESS_WINDOWS = 12;
 
   // #5062 review r3 (point 1): same progress gating for the cross-slot-park branch. A worker parked
@@ -338,6 +344,15 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     return checkForStalledQueuesMaxDelay;
   }
 
+  /**
+   * Sets the duration of one stall-detection window (default 5s). Producers blocked on a full queue
+   * throw after {@code STALLED_CROSS_SLOT_NO_PROGRESS_WINDOWS} (3) flat windows when the target
+   * worker is parked handing a task cross-slot, or after {@code STALLED_NO_PROGRESS_WINDOWS} (12)
+   * flat windows when it is not (wedged in user code). Only the window DURATION is tunable, the
+   * window counts are fixed. #5062 review r4 (point 2): scheduling chains deeper than two workers
+   * whose tail runs individual tasks longer than 3 windows (15s by default) can still trip the
+   * cross-slot detector even though the chain would resolve; raise this delay for such workloads.
+   */
   public void setCheckForStalledQueuesMaxDelay(final long checkForStalledQueuesMaxDelay) {
     this.checkForStalledQueuesMaxDelay = checkForStalledQueuesMaxDelay;
   }
@@ -905,14 +920,26 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
         if (!toClose[i].queue.offer(FORCE_EXIT, 1, TimeUnit.SECONDS))
           toClose[i].interrupt();
 
-        // WAIT FOR SHUTDOWN, MAX 10S EACH
-        toClose[i].join(10_000);
+        // WAIT FOR SHUTDOWN, MAX shutdownJoinTimeoutMs EACH (10S BY DEFAULT)
+        toClose[i].join(shutdownJoinTimeoutMs);
+
+        if (toClose[i].isAlive()) {
+          // #5062 review r4 (point 1): a successful FORCE_EXIT offer sends no interrupt, but the
+          // marker may have been consumed inside offerHelping, which only sets forceShutdown and
+          // keeps looping to hand off the current follow-up: on a wedged peer's full queue the flag
+          // is not re-checked until the stall backstop fires (up to ~60s). Escalate after the grace
+          // period: the interrupt wakes the offer park, unwinds the task loudly (onError) and the
+          // run loop exits on the flag.
+          toClose[i].interrupt();
+          toClose[i].join(shutdownJoinTimeoutMs);
+        }
       } catch (final InterruptedException e) {
         interrupted = true;
       }
       if (toClose[i].isAlive())
         LogManager.instance()
-            .log(this, Level.WARNING, "AsyncThread %s did not stop within 10s after shutdown", toClose[i].getName());
+            .log(this, Level.WARNING, "AsyncThread %s did not stop within %dms after shutdown (escalated to interrupt)",
+                toClose[i].getName(), shutdownJoinTimeoutMs);
     }
     if (interrupted)
       Thread.currentThread().interrupt();
@@ -989,6 +1016,9 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
           // scheduling attempt. #5062 review r3 (point 2): this recheck is best-effort, not total -
           // an offer landing after the final drain poll but before isAlive() flips to false passes
           // the guard and is orphaned; closing it would need a lock on this hot path.
+          // #5062 review r4 (point 4): completed() is deliberately NOT invoked on the removed task -
+          // unlike the shutdown drain, the scheduling caller is still on the stack and this
+          // exception informs it directly, so no waiter can be parked on the task yet.
           throw new DatabaseOperationException(
               "Async executor has been shut down; cannot schedule asynchronous task " + task);
         counterScheduledTasks.incrementAndGet();

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -82,6 +82,15 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
   // does not trip it (the #4953 false positive); tune via setCheckForStalledQueuesMaxDelay().
   private static final int STALLED_NO_PROGRESS_WINDOWS = 12;
 
+  // #5062 review r3 (point 1): same progress gating for the cross-slot-park branch. A worker parked
+  // handing a task to another queue with a flat completed count is much more likely to sit in a
+  // genuine scheduling cycle than a wedged one (it only reaches offerWaiting after exhausting its
+  // help-deferral budget), so the bound is far smaller than the wedged-worker one - but it must
+  // exceed 2, the old head-identity bound that a peer merely busy on one slow task could flatten,
+  // or the #4953 false positive recurs on producers targeting a budget-exhausted worker. 15s with
+  // the default 5s window: genuine capped cycles still fail loudly in bounded time.
+  private static final int STALLED_CROSS_SLOT_NO_PROGRESS_WINDOWS = 3;
+
   // SPECIAL TASKS
   public final static DatabaseAsyncTask FORCE_EXIT = new DatabaseAsyncTask() {
     @Override
@@ -118,6 +127,10 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     // re-entrantly (a nested execution could commit or roll back the suspended task's partial
     // writes, breaking per-task atomicity); they are parked here, in poll order, and run by the run
     // loop once the current task unwinds. Thread-confined: only this worker touches it.
+    // Memory bound (#5062 review r3, point 3): at most queueCapacity task references
+    // (ASYNC_OPERATIONS_QUEUE_SIZE / parallelLevel, so one extra queue's worth per worker in the
+    // worst case), a transient spike under sustained cross-slot pressure that drains as soon as the
+    // current task unwinds.
     private final    ArrayDeque<DatabaseAsyncTask>   helpDeferredTasks     = new ArrayDeque<>();
     // Capacity of the own queue, doubling as the helpDeferredTasks budget (see offerHelping).
     private final    int                             queueCapacity;
@@ -973,7 +986,9 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
         if (!target.isAlive() && removeQuietly(queue, task))
           // The worker exited (shutdown) after its final queue drain but before this offer landed:
           // the task would sit unexecuted forever. Undo the offer and fail like any post-shutdown
-          // scheduling attempt.
+          // scheduling attempt. #5062 review r3 (point 2): this recheck is best-effort, not total -
+          // an offer landing after the final drain poll but before isAlive() flips to false passes
+          // the guard and is orphaned; closing it would need a lock on this hot path.
           throw new DatabaseOperationException(
               "Async executor has been shut down; cannot schedule asynchronous task " + task);
         counterScheduledTasks.incrementAndGet();
@@ -1018,7 +1033,8 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
    *   without throwing; if the deferral budget runs out the worker falls through to the bounded
    *   wait below.</li>
    *   <li><b>Any other producer:</b> waits in windows of {@code checkForStalledQueuesMaxDelay} and
-   *   throws if the target worker completed no task over a whole window while itself being
+   *   throws if the target worker completed no task over
+   *   {@code STALLED_CROSS_SLOT_NO_PROGRESS_WINDOWS} consecutive windows while itself being
    *   parked handing a task to another queue (a genuine scheduling cycle beyond the helping budget),
    *   after the worker died, or - the backstop for a worker wedged inside user code - after
    *   {@code STALLED_NO_PROGRESS_WINDOWS} consecutive windows with zero completed tasks. A worker
@@ -1049,16 +1065,22 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
 
         final long nowCompleted = target.completedTaskCount;
         if (nowCompleted == observedCompleted) {
-          if (target.waitingCrossSlotOffer)
-            // NO TASK COMPLETED IN A WHOLE WINDOW WHILE THE WORKER IS ITSELF PARKED ON ANOTHER QUEUE
-            throw new DatabaseOperationException("Asynchronous queue " + slot
-                + " is stalled. This could happen when an asynchronous task schedules more asynchronous tasks");
+          ++windowsWithoutProgress;
 
-          // #5062 review r2 (point 1): a worker wedged inside user code (infinite loop or blocking
-          // call in a task's execute()/callback) never sets waitingCrossSlotOffer, so without this
-          // backstop the producer would hang here forever. Much longer than the old 2-window
-          // head-identity detector and progress-gated, so a single slow task does not trip it.
-          if (++windowsWithoutProgress >= STALLED_NO_PROGRESS_WINDOWS)
+          if (target.waitingCrossSlotOffer) {
+            // NO TASK COMPLETED OVER N CONSECUTIVE WINDOWS WHILE THE WORKER IS ITSELF PARKED HANDING
+            // A TASK TO ANOTHER QUEUE. #5062 review r3 (point 1): a single flat window used to throw
+            // here, but a budget-exhausted worker whose peer is merely busy on one slow task shows
+            // exactly that signature for a moment: require enough windows to outlive a slow peer.
+            if (windowsWithoutProgress >= STALLED_CROSS_SLOT_NO_PROGRESS_WINDOWS)
+              throw new DatabaseOperationException("Asynchronous queue " + slot
+                  + " is stalled. This could happen when an asynchronous task schedules more asynchronous tasks");
+
+            // #5062 review r2 (point 1): a worker wedged inside user code (infinite loop or blocking
+            // call in a task's execute()/callback) never sets waitingCrossSlotOffer, so without this
+            // backstop the producer would hang here forever. Much longer than the old 2-window
+            // head-identity detector and progress-gated, so a single slow task does not trip it.
+          } else if (windowsWithoutProgress >= STALLED_NO_PROGRESS_WINDOWS)
             throw new DatabaseOperationException(
                 "Asynchronous queue " + slot + " is stalled: no task completed in the last " + (
                     STALLED_NO_PROGRESS_WINDOWS * checkForStalledQueuesMaxDelay)

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -75,6 +75,13 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
   private final AtomicLong           commandRoundRobinIndex        = new AtomicLong();
   private final AtomicLong           tsAppendCounter               = new AtomicLong();
 
+  // #5062 review r2 (point 1): producer-side backstop for a worker wedged inside user code. After
+  // this many consecutive stall windows (checkForStalledQueuesMaxDelay each, 60s with the defaults)
+  // in which the target worker completed NO task while its queue stayed full, offerWaiting throws
+  // instead of letting the caller hang forever. Progress-gated so a single legitimately slow task
+  // does not trip it (the #4953 false positive); tune via setCheckForStalledQueuesMaxDelay().
+  private static final int STALLED_NO_PROGRESS_WINDOWS = 12;
+
   // SPECIAL TASKS
   public final static DatabaseAsyncTask FORCE_EXIT = new DatabaseAsyncTask() {
     @Override
@@ -986,7 +993,13 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       // THE "fast" QUEUE (PushPullBlockingQueue) DOES NOT SUPPORT remove(Object): the offer cannot
       // be undone, so a task that landed right after a dead worker's final drain stays queued and
       // its completed() never fires (#5062 review, point 4). Known gap, accepted: the impl is
-      // opt-in and the window (an offer racing the worker's exit) is a few instructions wide.
+      // opt-in and the window (an offer racing the worker's exit) is a few instructions wide. The
+      // WARNING below gives operators the reason should a scanType()/waitCompletion() waiter hang.
+      LogManager.instance()
+          .log(DatabaseAsyncExecutorImpl.class, Level.WARNING,
+              "Asynchronous task %s was scheduled on a worker that already shut down and cannot be removed from its "
+                  + "'fast' queue: its completion will never be notified. Use the 'standard' async queue implementation "
+                  + "to close this window", task);
       return false;
     }
   }
@@ -1005,11 +1018,13 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
    *   without throwing; if the deferral budget runs out the worker falls through to the bounded
    *   wait below.</li>
    *   <li><b>Any other producer:</b> waits in windows of {@code checkForStalledQueuesMaxDelay} and
-   *   throws only if the target worker completed no task over a whole window while itself being
-   *   parked handing a task to another queue (a genuine scheduling cycle beyond the helping budget)
-   *   or after the worker died. A worker merely busy on a single slow task no longer trips the
-   *   detector: the old code compared the identity of the queue head across two windows, so any
-   *   head task running longer than 2x the delay made innocent producers throw.</li>
+   *   throws if the target worker completed no task over a whole window while itself being
+   *   parked handing a task to another queue (a genuine scheduling cycle beyond the helping budget),
+   *   after the worker died, or - the backstop for a worker wedged inside user code - after
+   *   {@code STALLED_NO_PROGRESS_WINDOWS} consecutive windows with zero completed tasks. A worker
+   *   merely busy on a single slow task no longer trips the detector: the old code compared the
+   *   identity of the queue head across two windows, so any head task running longer than 2x the
+   *   delay made innocent producers throw.</li>
    * </ul>
    */
   private void offerWaiting(final AsyncThread target, final int slot, final DatabaseAsyncTask task,
@@ -1026,17 +1041,32 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       self.waitingCrossSlotOffer = true;
     try {
       long observedCompleted = target.completedTaskCount;
+      int windowsWithoutProgress = 0;
       while (!queue.offer(task, checkForStalledQueuesMaxDelay, TimeUnit.MILLISECONDS)) {
         if (!target.isAlive())
           throw new DatabaseOperationException(
               "Async executor has been shut down; cannot schedule asynchronous task " + task);
 
         final long nowCompleted = target.completedTaskCount;
-        if (nowCompleted == observedCompleted && target.waitingCrossSlotOffer)
-          // NO TASK COMPLETED IN A WHOLE WINDOW WHILE THE WORKER IS ITSELF PARKED ON ANOTHER QUEUE
-          throw new DatabaseOperationException("Asynchronous queue " + slot
-              + " is stalled. This could happen when an asynchronous task schedules more asynchronous tasks");
-        observedCompleted = nowCompleted;
+        if (nowCompleted == observedCompleted) {
+          if (target.waitingCrossSlotOffer)
+            // NO TASK COMPLETED IN A WHOLE WINDOW WHILE THE WORKER IS ITSELF PARKED ON ANOTHER QUEUE
+            throw new DatabaseOperationException("Asynchronous queue " + slot
+                + " is stalled. This could happen when an asynchronous task schedules more asynchronous tasks");
+
+          // #5062 review r2 (point 1): a worker wedged inside user code (infinite loop or blocking
+          // call in a task's execute()/callback) never sets waitingCrossSlotOffer, so without this
+          // backstop the producer would hang here forever. Much longer than the old 2-window
+          // head-identity detector and progress-gated, so a single slow task does not trip it.
+          if (++windowsWithoutProgress >= STALLED_NO_PROGRESS_WINDOWS)
+            throw new DatabaseOperationException(
+                "Asynchronous queue " + slot + " is stalled: no task completed in the last " + (
+                    STALLED_NO_PROGRESS_WINDOWS * checkForStalledQueuesMaxDelay)
+                    + " ms while its queue stayed full. The worker may be blocked inside a user task or callback");
+        } else {
+          windowsWithoutProgress = 0;
+          observedCompleted = nowCompleted;
+        }
 
         if (applyBackPressureOnPercentage > 0) {
           final int queueFullAt =
@@ -1078,7 +1108,9 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     self.waitingCrossSlotOffer = true;
     try {
       while (true) {
-        // SHORT WINDOW WHEN THERE IS OWN WORK TO DRAIN, LONGER WHEN IDLE TO AVOID SPINNING
+        // SHORT WINDOW WHEN THERE IS OWN WORK TO DRAIN, LONGER WHEN IDLE TO AVOID SPINNING. THE 1MS
+        // WINDOW IS INTENTIONALLY AGGRESSIVE: EVERY ITERATION FREES A SLOT THE PARKED PEER MAY BE
+        // WAITING ON, AND THE LOOP IS BOUNDED BY THE DEFERRAL BUDGET BELOW
         final long window = self.queue.isEmpty() ? 100 : 1;
         if (target.queue.offer(task, window, TimeUnit.MILLISECONDS))
           return true;

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncScanBucket.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncScanBucket.java
@@ -43,21 +43,22 @@ public class DatabaseAsyncScanBucket implements DatabaseAsyncTask {
 
   @Override
   public void execute(final DatabaseAsyncExecutorImpl.AsyncThread async, final DatabaseInternal database) {
-    try {
-      bucket.scan((rid, view) -> {
-        if (async.isShutdown())
-          return false;
+    bucket.scan((rid, view) -> {
+      if (async.isShutdown())
+        return false;
 
-        final Record record = database.getRecordFactory()
-            .newImmutableRecord(database, database.getSchema().getType(database.getSchema().getTypeNameByBucketId(rid.getBucketId())), rid, view, null);
+      final Record record = database.getRecordFactory()
+          .newImmutableRecord(database, database.getSchema().getType(database.getSchema().getTypeNameByBucketId(rid.getBucketId())), rid, view, null);
 
-        return userCallback.onRecord((Document) record);
-      }, errorRecordCallback);
+      return userCallback.onRecord((Document) record);
+    }, errorRecordCallback);
+  }
 
-    } finally {
-      // UNLOCK THE CALLER THREAD
-      semaphore.countDown();
-    }
+  @Override
+  public void completed() {
+    // UNLOCK THE CALLER THREAD. The worker invokes completed() after execute() but also when the
+    // task is dropped during shutdown (#4954), so scanType() never hangs on the latch.
+    semaphore.countDown();
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/index/sparsevector/SparseVectorScoringPool.java
+++ b/engine/src/main/java/com/arcadedb/index/sparsevector/SparseVectorScoringPool.java
@@ -23,6 +23,7 @@ import com.arcadedb.log.LogManager;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -141,6 +142,10 @@ public final class SparseVectorScoringPool {
           }
           if (!exec.isShutdown())
             task.run();
+          else if (task instanceof RunnableFuture<?> future)
+            // #4961: a task rejected because the pool is shut down would otherwise be neither run
+            // nor completed, leaving any caller blocked in an untimed Future.get() hanging forever.
+            future.cancel(false);
         });
     pool.allowCoreThreadTimeOut(true);
     this.executor = pool;

--- a/engine/src/main/java/com/arcadedb/query/QueryEngineManager.java
+++ b/engine/src/main/java/com/arcadedb/query/QueryEngineManager.java
@@ -29,6 +29,7 @@ import com.arcadedb.query.sql.SQLScriptQueryEngine;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -58,7 +59,10 @@ import java.util.logging.Level;
  */
 public class QueryEngineManager {
   private static final QueryEngineManager                         INSTANCE        = new QueryEngineManager();
-  private final        Map<String, QueryEngine.QueryEngineFactory> implementations = new LinkedHashMap<>();
+  // #4961: register() is public and may be called after construction while getEngine()/
+  // getAvailableLanguages() read the map without locks: registration publishes a new copy
+  // (copy-on-write) instead of mutating in place. Registration is rare, reads are hot.
+  private volatile     Map<String, QueryEngine.QueryEngineFactory> implementations = new LinkedHashMap<>();
   private final        ThreadPoolExecutor                          executorService;
   // Per-pool counter the {@link RejectedExecutionHandler} below increments every time the queue
   // saturates and the task falls back to the caller. ThreadPoolExecutor itself doesn't expose
@@ -113,6 +117,10 @@ public class QueryEngineManager {
       }
       if (!executor.isShutdown())
         task.run();
+      else if (task instanceof RunnableFuture<?> future)
+        // #4961: a task rejected because the pool is shut down would otherwise be neither run nor
+        // completed, leaving any caller blocked in an untimed Future.get() hanging forever.
+        future.cancel(false);
     });
     pool.allowCoreThreadTimeOut(true);
     executorService = pool;
@@ -158,8 +166,10 @@ public class QueryEngineManager {
     }
   }
 
-  public void register(final QueryEngine.QueryEngineFactory impl) {
-    implementations.put(impl.getLanguage().toLowerCase(Locale.ENGLISH), impl);
+  public synchronized void register(final QueryEngine.QueryEngineFactory impl) {
+    final Map<String, QueryEngine.QueryEngineFactory> copy = new LinkedHashMap<>(implementations);
+    copy.put(impl.getLanguage().toLowerCase(Locale.ENGLISH), impl);
+    implementations = copy;
   }
 
   public QueryEngine getEngine(final String language, final DatabaseInternal database) {

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncConfigValidationTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncConfigValidationTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.TestHelper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for #4961: {@code setCommitEvery(0)} was accepted and made every subsequent task
+ * fail with an {@code ArithmeticException} on {@code count % commitEvery}. The setter must reject
+ * non-positive values.
+ */
+class AsyncConfigValidationTest extends TestHelper {
+
+  @Test
+  void setCommitEveryRejectsNonPositiveValues() {
+    assertThatThrownBy(() -> database.async().setCommitEvery(0))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> database.async().setCommitEvery(-5))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    database.async().setCommitEvery(100);
+    assertThat(database.async().getCommitEvery()).isEqualTo(100);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncCrossSlotSchedulingDeadlockTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncCrossSlotSchedulingDeadlockTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for #4953 (deadlock branch): under bidirectional edge load, worker A schedules a
+ * follow-up task into worker B's slot (and vice versa) from inside its own task. With both queues
+ * full this is a real wait cycle; the old code "resolved" it by throwing
+ * {@code DatabaseOperationException("...is stalled")} inside the worker, which rolled back the whole
+ * in-flight commit batch and silently dropped the cross-slot follow-up (ghost edges).
+ * <p>
+ * The fixed executor lets a worker blocked on another worker's full queue drain its OWN queue while
+ * it waits, so the cycle resolves with every task executed and no error callback fired.
+ */
+class AsyncCrossSlotSchedulingDeadlockTest extends TestHelper {
+
+  @Test
+  void crossSlotSchedulingFromWorkersDoesNotStallOrDropTasks() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 2); // 1 PER WORKER
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
+    async.setParallelLevel(2);
+    // Force thread re-creation so the queue size above is picked up regardless of the previous level.
+    async.setTransactionUseWAL(true);
+    async.setCheckForStalledQueuesMaxDelay(100);
+
+    final List<Throwable> errors = new CopyOnWriteArrayList<>();
+    async.onError(errors::add);
+
+    final CountDownLatch bothCrossTasksRunning = new CountDownLatch(2);
+    final CountDownLatch release = new CountDownLatch(1);
+    final CountDownLatch markersExecuted = new CountDownLatch(2);
+    final CountDownLatch fillersExecuted = new CountDownLatch(2);
+
+    // Each cross task, once released, schedules a follow-up marker into the OTHER worker's slot.
+    async.scheduleTask(0, crossTask(async, 1, bothCrossTasksRunning, release, markersExecuted, errors), true, 0);
+    async.scheduleTask(1, crossTask(async, 0, bothCrossTasksRunning, release, markersExecuted, errors), true, 0);
+
+    assertThat(bothCrossTasksRunning.await(5, TimeUnit.SECONDS)).isTrue();
+
+    // Both workers are busy and their queues (capacity 1) are empty: fill them.
+    assertThat(async.scheduleTask(0, countingTask(fillersExecuted), false, 0)).isTrue();
+    assertThat(async.scheduleTask(1, countingTask(fillersExecuted), false, 0)).isTrue();
+
+    // Both workers now offer into each other's full queue at the same time: the textbook cycle.
+    release.countDown();
+
+    assertThat(markersExecuted.await(10, TimeUnit.SECONDS)).as("cross-slot follow-up tasks must execute").isTrue();
+    assertThat(fillersExecuted.await(10, TimeUnit.SECONDS)).as("queued filler tasks must execute").isTrue();
+    assertThat(errors).as("no worker may fail with a stall exception").isEmpty();
+  }
+
+  private static DatabaseAsyncTask crossTask(final DatabaseAsyncExecutorImpl async, final int targetSlot,
+                                             final CountDownLatch running, final CountDownLatch release,
+                                             final CountDownLatch markers, final List<Throwable> errors) {
+    return new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        running.countDown();
+        try {
+          if (!release.await(10, TimeUnit.SECONDS)) {
+            errors.add(new IllegalStateException("release latch never fired"));
+            return;
+          }
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+          errors.add(e);
+          return;
+        }
+        async.scheduleTask(targetSlot, countingTask(markers), true, 0);
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    };
+  }
+
+  private static DatabaseAsyncTask countingTask(final CountDownLatch latch) {
+    return new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        latch.countDown();
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    };
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncHelpingAtomicityTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncHelpingAtomicityTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the #5062 review (point 1): the help-while-waiting path of #4953 must not run
+ * queued tasks re-entrantly while the worker's current task is suspended mid-execute() inside
+ * scheduleTask. A helped task hitting the commit-every-N boundary (or managing the transaction
+ * itself, like {@code DatabaseAsyncTransaction}) would commit the suspended task's PARTIAL writes,
+ * breaking per-task atomicity: a crash in that window persists half a task. Tasks polled while
+ * help-waiting must instead be parked and executed only after the current task fully unwinds.
+ */
+class AsyncHelpingAtomicityTest extends TestHelper {
+
+  @Test
+  void helpedTaskMustNotCommitSuspendedTaskPartialWrites() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 2); // 1 PER WORKER
+    database.getSchema().createDocumentType("HelpAtomic");
+
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
+    async.setParallelLevel(2);
+    // Force thread re-creation so the queue size above is picked up regardless of the previous level.
+    async.setTransactionUseWAL(true);
+    async.setCommitEvery(1); // EVERY TASK BOUNDARY COMMITS: A NESTED EXECUTION WOULD COMMIT IMMEDIATELY
+
+    final List<Throwable> errors = new CopyOnWriteArrayList<>();
+    async.onError(errors::add);
+
+    final CountDownLatch blockerStarted = new CountDownLatch(1);
+    final CountDownLatch finish = new CountDownLatch(1);
+    final CountDownLatch outerWrote = new CountDownLatch(1);
+    final CountDownLatch proceed = new CountDownLatch(1);
+    final CountDownLatch helpedRan = new CountDownLatch(1);
+    final CountDownLatch markerRan = new CountDownLatch(1);
+
+    // Worker 1: busy until released, with a full queue behind it, so worker 0 has to help-wait.
+    async.scheduleTask(1, awaitTask(blockerStarted, finish, errors), true, 0);
+    assertThat(blockerStarted.await(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(async.scheduleTask(1, countingTask(new CountDownLatch(1)), false, 0)).isTrue();
+
+    // Worker 0: writes a document (uncommitted, commitEvery boundary not reached yet), then
+    // schedules a follow-up into worker 1's full queue, parking mid-execute in the helping loop.
+    async.scheduleTask(0, new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        database.newDocument("HelpAtomic").set("k", 1).save();
+        outerWrote.countDown();
+        try {
+          if (!proceed.await(20, TimeUnit.SECONDS)) {
+            errors.add(new IllegalStateException("proceed latch never fired"));
+            return;
+          }
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+          errors.add(e);
+          return;
+        }
+        async.scheduleTask(1, countingTask(markerRan), true, 0);
+      }
+    }, true, 0);
+
+    assertThat(outerWrote.await(5, TimeUnit.SECONDS)).isTrue();
+
+    // A task sits in worker 0's own queue: the helping loop will poll it while parked.
+    assertThat(async.scheduleTask(0, countingTask(helpedRan), false, 0)).isTrue();
+
+    proceed.countDown();
+
+    // Give the parked worker ample time to poll its own queue. The buggy code executed the polled
+    // task inline: with commitEvery=1 that committed the suspended task's partial write.
+    Thread.sleep(800);
+    database.transaction(
+        () -> assertThat(database.countType("HelpAtomic", true))
+            .as("the suspended task's partial write must not be committed by a helped task")
+            .isEqualTo(0L));
+
+    // Release everything: the cycle resolves, all tasks (including the parked one) must execute.
+    finish.countDown();
+
+    assertThat(async.waitCompletion(10_000)).isTrue();
+    assertThat(helpedRan.await(5, TimeUnit.SECONDS)).as("the task polled while helping must still execute").isTrue();
+    assertThat(markerRan.await(5, TimeUnit.SECONDS)).as("the cross-slot follow-up must execute").isTrue();
+    assertThat(errors).isEmpty();
+    database.transaction(
+        () -> assertThat(database.countType("HelpAtomic", true)).as("the write must be committed once the task completed")
+            .isEqualTo(1L));
+  }
+
+  private static DatabaseAsyncTask awaitTask(final CountDownLatch started, final CountDownLatch release,
+                                             final List<Throwable> errors) {
+    return new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        started.countDown();
+        try {
+          if (!release.await(20, TimeUnit.SECONDS))
+            errors.add(new IllegalStateException("release latch never fired"));
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    };
+  }
+
+  private static DatabaseAsyncTask countingTask(final CountDownLatch latch) {
+    return new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        latch.countDown();
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    };
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncHelpingAtomicityTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncHelpingAtomicityTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -59,8 +60,10 @@ class AsyncHelpingAtomicityTest extends TestHelper {
     final CountDownLatch finish = new CountDownLatch(1);
     final CountDownLatch outerWrote = new CountDownLatch(1);
     final CountDownLatch proceed = new CountDownLatch(1);
+    final CountDownLatch outerDone = new CountDownLatch(1);
     final CountDownLatch helpedRan = new CountDownLatch(1);
     final CountDownLatch markerRan = new CountDownLatch(1);
+    final AtomicBoolean helpedRanBeforeOuterFinished = new AtomicBoolean(false);
 
     // Worker 1: busy until released, with a full queue behind it, so worker 0 has to help-wait.
     async.scheduleTask(1, awaitTask(blockerStarted, finish, errors), true, 0);
@@ -86,18 +89,45 @@ class AsyncHelpingAtomicityTest extends TestHelper {
         }
         async.scheduleTask(1, countingTask(markerRan), true, 0);
       }
+
+      @Override
+      public void completed() {
+        // FIRES IN executeTask'S finally, AFTER THE commitEvery BOUNDARY OF THIS TASK
+        outerDone.countDown();
+      }
     }, true, 0);
 
     assertThat(outerWrote.await(5, TimeUnit.SECONDS)).isTrue();
 
-    // A task sits in worker 0's own queue: the helping loop will poll it while parked.
-    assertThat(async.scheduleTask(0, countingTask(helpedRan), false, 0)).isTrue();
+    // A task sits in worker 0's own queue: the helping loop will poll it while parked. The task
+    // records deterministically whether it ran before the suspended task finished: any such
+    // execution is nested inside the suspended task and, with commitEvery=1, committed its partial
+    // write on the buggy code (#5062 review r2, point 4: ordering probe instead of a timed sleep).
+    assertThat(async.scheduleTask(0, new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        helpedRanBeforeOuterFinished.set(outerDone.getCount() > 0);
+        helpedRan.countDown();
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    }, false, 0)).isTrue();
 
     proceed.countDown();
 
-    // Give the parked worker ample time to poll its own queue. The buggy code executed the polled
-    // task inline: with commitEvery=1 that committed the suspended task's partial write.
-    Thread.sleep(800);
+    // Wait until the parked worker's helping loop polls the probe out of its own queue: the
+    // aggregate queue size drops from 2 (probe + filler) to 1 (filler). This pins the interleaving
+    // without a timed sleep: from here on the helping episode has provably engaged.
+    final long spinDeadline = System.currentTimeMillis() + 10_000;
+    while (async.getStats().queueSize > 1 && System.currentTimeMillis() < spinDeadline)
+      Thread.sleep(10);
+    assertThat(async.getStats().queueSize).as("the helping loop must drain the worker's own queue").isEqualTo(1L);
+
+    // Deterministic under the fix: the suspended task cannot complete (hence cannot commit) while
+    // worker 1's queue is still full, so no write of it may be visible here.
     database.transaction(
         () -> assertThat(database.countType("HelpAtomic", true))
             .as("the suspended task's partial write must not be committed by a helped task")
@@ -108,6 +138,9 @@ class AsyncHelpingAtomicityTest extends TestHelper {
 
     assertThat(async.waitCompletion(10_000)).isTrue();
     assertThat(helpedRan.await(5, TimeUnit.SECONDS)).as("the task polled while helping must still execute").isTrue();
+    assertThat(helpedRanBeforeOuterFinished.get())
+        .as("the task polled while helping must not run before the suspended task fully unwound")
+        .isFalse();
     assertThat(markerRan.await(5, TimeUnit.SECONDS)).as("the cross-slot follow-up must execute").isTrue();
     assertThat(errors).isEmpty();
     database.transaction(

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownDrainTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownDrainTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for #4954: shutdown/interrupt paths dropped queued tasks without ever invoking
+ * their {@code completed()} callback, so any thread blocked in {@code scanType()} /
+ * {@code waitCompletion()} on those tasks hung forever. Additionally {@code shutdownThreadsLocked}
+ * blocked on an untimed {@code queue.put(FORCE_EXIT)} while holding the lifecycle lock: a busy
+ * worker with a full queue wedged {@code database.close()} for as long as its current task ran.
+ */
+class AsyncShutdownDrainTest extends TestHelper {
+
+  @Test
+  void killNotifiesCompletionOfDroppedQueuedTasks() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 4);
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
+    async.setParallelLevel(1);
+    // Force thread re-creation so the queue size above is picked up regardless of the previous level.
+    async.setTransactionUseWAL(true);
+
+    final CountDownLatch blockerStarted = new CountDownLatch(1);
+    async.scheduleTask(0, blockerTask(blockerStarted, 10_000), true, 0);
+    assertThat(blockerStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+    // Queue up tasks behind the blocker; their completed() must run even if they are dropped.
+    final CountDownLatch probesCompleted = new CountDownLatch(3);
+    for (int i = 0; i < 3; i++)
+      assertThat(async.scheduleTask(0, probeTask(probesCompleted), false, 0)).isTrue();
+
+    async.kill();
+
+    assertThat(probesCompleted.await(5, TimeUnit.SECONDS))
+        .as("queued tasks dropped by kill() must still be completed() so waiters do not hang")
+        .isTrue();
+  }
+
+  @Test
+  void closeDoesNotBlockOnFullQueueOfBusyWorker() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 2);
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
+    async.setParallelLevel(1);
+    // Force thread re-creation so the queue size above is picked up regardless of the previous level.
+    async.setTransactionUseWAL(true);
+
+    final CountDownLatch blockerStarted = new CountDownLatch(1);
+    async.scheduleTask(0, blockerTask(blockerStarted, 15_000), true, 0);
+    assertThat(blockerStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+    // Fill the queue (capacity 2) so the FORCE_EXIT marker cannot be enqueued.
+    final CountDownLatch probesCompleted = new CountDownLatch(2);
+    for (int i = 0; i < 2; i++)
+      assertThat(async.scheduleTask(0, probeTask(probesCompleted), false, 0)).isTrue();
+
+    // The old code blocked in queue.put(FORCE_EXIT) under the lifecycle lock until the blocker
+    // finished (~15s). The fixed code times out the offer, interrupts the worker and returns.
+    final CountDownLatch closed = new CountDownLatch(1);
+    final Thread closer = new Thread(() -> {
+      async.close();
+      closed.countDown();
+    }, getClass().getSimpleName() + "-closer");
+    closer.start();
+
+    assertThat(closed.await(8, TimeUnit.SECONDS))
+        .as("close() must not hang on a busy worker with a full queue")
+        .isTrue();
+    assertThat(probesCompleted.await(5, TimeUnit.SECONDS))
+        .as("queued tasks must be executed or completed() during shutdown")
+        .isTrue();
+    closer.join(5_000);
+  }
+
+  private static DatabaseAsyncTask blockerTask(final CountDownLatch started, final long sleepMs) {
+    return new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        started.countDown();
+        try {
+          Thread.sleep(sleepMs);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    };
+  }
+
+  private static DatabaseAsyncTask probeTask(final CountDownLatch completedLatch) {
+    return new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        // NO ACTIONS
+      }
+
+      @Override
+      public void completed() {
+        completedLatch.countDown();
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    };
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownEscalationTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownEscalationTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the #5062 review, round 4 (point 1): {@code shutdownThreadsLocked} sent
+ * {@code interrupt()} only when the {@code offer(FORCE_EXIT, 1s)} FAILED. But the marker can be
+ * consumed inside {@code offerHelping} - which sets {@code forceShutdown} and keeps looping to hand
+ * off the current task's follow-up - so a worker parked on a wedged peer's full queue re-checks the
+ * flag only when the hand-off resolves (up to the stall backstop, ~60s with defaults). The offer
+ * SUCCEEDED, so no interrupt was ever sent: {@code join} timed out, a WARNING was logged, and
+ * {@code close()} returned with the worker still alive. The fixed shutdown escalates: a worker
+ * still alive after the grace period is interrupted and re-joined.
+ */
+class AsyncShutdownEscalationTest extends TestHelper {
+
+  @Test
+  @Timeout(60)
+  void closeInterruptsWorkerParkedInHelpingLoopAfterConsumingForceExit() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 4); // 2 PER WORKER
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
+    async.setParallelLevel(2);
+    // Force thread re-creation so the queue size above is picked up regardless of the previous level.
+    async.setTransactionUseWAL(true);
+    // Shrink the shutdown grace period so the escalation (not the wedge ceiling) decides the timing.
+    async.shutdownJoinTimeoutMs = 500;
+
+    final CountDownLatch wedgeStarted = new CountDownLatch(1);
+    final CountDownLatch releaseWedge = new CountDownLatch(1);
+    final CountDownLatch outerStarted = new CountDownLatch(1);
+    final CountDownLatch proceed = new CountDownLatch(1);
+    try {
+      // Worker 1: wedged in user code that SWALLOWS interrupts (so the close() interrupt for its
+      // full queue does not free it), keeping the hand-off target full for the whole shutdown.
+      async.scheduleTask(1, interruptSwallowingWedge(wedgeStarted, releaseWedge), true, 0);
+      assertThat(wedgeStarted.await(5, TimeUnit.SECONDS)).isTrue();
+      for (int i = 0; i < 2; i++)
+        assertThat(async.scheduleTask(1, noOpTask(), false, 0)).isTrue();
+
+      // Worker 0: parks in offerHelping handing a follow-up to worker 1's full queue. Its own queue
+      // is empty, so close()'s FORCE_EXIT offer SUCCEEDS and the helping loop consumes the marker.
+      async.scheduleTask(0, new DatabaseAsyncTask() {
+        @Override
+        public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+          outerStarted.countDown();
+          try {
+            if (!proceed.await(20, TimeUnit.SECONDS))
+              return;
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+          }
+          async.scheduleTask(1, noOpTask(), true, 0);
+        }
+
+        @Override
+        public boolean requiresActiveTx() {
+          return false;
+        }
+      }, true, 0);
+      assertThat(outerStarted.await(5, TimeUnit.SECONDS)).isTrue();
+      proceed.countDown();
+      // Let worker 0 enter the helping loop before shutting down.
+      Thread.sleep(300);
+
+      final long start = System.currentTimeMillis();
+      async.close();
+      assertThat(System.currentTimeMillis() - start).as("close() must stay bounded").isLessThan(15_000);
+
+      // The escalation must not leave worker 0 behind: without it, worker 0 kept looping in
+      // offerHelping (forceShutdown set but unchecked until the hand-off resolves, and the wedged
+      // peer never resolves it). Worker 1 itself legitimately survives - its user code swallows
+      // interrupts - which is exactly why worker 0's park never frees on its own.
+      final long deadline = System.currentTimeMillis() + 5_000;
+      while (helpingWorkerAlive(db) && System.currentTimeMillis() < deadline)
+        Thread.sleep(50);
+      assertThat(helpingWorkerAlive(db))
+          .as("close() must not return leaving the help-waiting worker alive")
+          .isFalse();
+    } finally {
+      releaseWedge.countDown();
+      proceed.countDown();
+    }
+  }
+
+  private static boolean helpingWorkerAlive(final DatabaseInternal db) {
+    final String name = "AsyncExecutor-" + db.getName() + "-0";
+    return Thread.getAllStackTraces().keySet().stream().anyMatch(t -> t.getName().equals(name) && t.isAlive());
+  }
+
+  private static DatabaseAsyncTask interruptSwallowingWedge(final CountDownLatch started, final CountDownLatch release) {
+    return new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        started.countDown();
+        final long deadline = System.currentTimeMillis() + 20_000;
+        while (System.currentTimeMillis() < deadline)
+          try {
+            if (release.await(Math.max(1, deadline - System.currentTimeMillis()), TimeUnit.MILLISECONDS))
+              return;
+          } catch (final InterruptedException e) {
+            // SIMULATES USER CODE THAT SWALLOWS INTERRUPTS: KEEP WAITING
+          }
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    };
+  }
+
+  private static DatabaseAsyncTask noOpTask() {
+    return new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        // NO ACTIONS
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    };
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncSlowPeerNoFalseStallTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncSlowPeerNoFalseStallTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the #5062 review, round 3 (point 1): a producer offering onto the full queue
+ * of a worker that exhausted its help-deferral budget and fell into the bounded wait (so
+ * {@code waitingCrossSlotOffer} is true and its completed-task count is flat) threw the
+ * "Asynchronous queue is stalled" exception after a SINGLE no-progress window, even when the
+ * worker's cross-slot peer was merely busy on one slow task and about to accept the hand-off - a
+ * narrower recurrence of the #4953 false positive. The cross-slot-park branch now requires
+ * {@code STALLED_CROSS_SLOT_NO_PROGRESS_WINDOWS} consecutive flat windows before throwing.
+ */
+class AsyncSlowPeerNoFalseStallTest extends TestHelper {
+
+  @Test
+  @Timeout(60)
+  void producerMustNotThrowWhileHelpWaitingWorkerPeerIsMerelySlow() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 2); // CAPACITY 1 PER WORKER
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
+    async.setParallelLevel(2);
+    // Force thread re-creation so the queue size above is picked up regardless of the previous level.
+    async.setTransactionUseWAL(true);
+    // 500ms window: the old code threw after ONE flat window (~500ms), the fixed code needs three
+    // (1.5s); the slow peer is released after ~700ms, comfortably between the two bounds.
+    async.setCheckForStalledQueuesMaxDelay(500);
+
+    final List<Throwable> errors = new CopyOnWriteArrayList<>();
+    async.onError(errors::add);
+
+    final CountDownLatch slowPeerStarted = new CountDownLatch(1);
+    final CountDownLatch releaseSlowPeer = new CountDownLatch(1);
+    final CountDownLatch outerStarted = new CountDownLatch(1);
+    final CountDownLatch proceed = new CountDownLatch(1);
+    final CountDownLatch executed = new CountDownLatch(4); // PARKED + MARKER + 2 PRODUCER TASKS
+
+    // Worker 1 (the slow-but-live peer): busy until released, with a full queue behind it.
+    async.scheduleTask(1, awaitTask(slowPeerStarted, releaseSlowPeer, errors), true, 0);
+    assertThat(slowPeerStarted.await(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(async.scheduleTask(1, countingTask(executed), false, 0)).isTrue();
+
+    // Worker 0: once released, hands a follow-up to worker 1's full queue. With queue capacity 1
+    // its help-deferral budget is a single task, so it parks the one queued task below and falls
+    // into the bounded wait with waitingCrossSlotOffer=true and a flat completed count.
+    async.scheduleTask(0, new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        outerStarted.countDown();
+        try {
+          if (!proceed.await(20, TimeUnit.SECONDS)) {
+            errors.add(new IllegalStateException("proceed latch never fired"));
+            return;
+          }
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+          errors.add(e);
+          return;
+        }
+        async.scheduleTask(1, countingTask(executed), true, 0);
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    }, true, 0);
+    assertThat(outerStarted.await(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(async.scheduleTask(0, countingTask(executed), false, 0)).isTrue(); // THE TASK IT WILL PARK
+
+    proceed.countDown();
+
+    // Wait until worker 0 parked the queued task (aggregate queue size drops to the peer's filler
+    // only): from here on it is budget-exhausted inside the bounded wait.
+    final long spinDeadline = System.currentTimeMillis() + 10_000;
+    while (async.getStats().queueSize > 1 && System.currentTimeMillis() < spinDeadline)
+      Thread.sleep(10);
+    assertThat(async.getStats().queueSize).as("worker 0 must park its queued task and fall back").isEqualTo(1L);
+
+    // The producer: first task fills worker 0's queue, second blocks on it while worker 0 shows a
+    // flat completed count and waitingCrossSlotOffer=true. It must NOT be thrown a stall exception
+    // while the peer is merely slow.
+    final AtomicReference<Throwable> producerFailure = new AtomicReference<>();
+    final Thread producer = new Thread(() -> {
+      try {
+        async.scheduleTask(0, countingTask(executed), true, 0);
+        async.scheduleTask(0, countingTask(executed), true, 0);
+      } catch (final Throwable t) {
+        producerFailure.set(t);
+      }
+    }, getClass().getSimpleName() + "-producer");
+    producer.start();
+
+    // Let the producer sit through more than one flat window (the old throw bound), then release
+    // the slow peer well before the three-window cross-slot bound.
+    Thread.sleep(700);
+    releaseSlowPeer.countDown();
+
+    producer.join(20_000);
+    assertThat(producer.isAlive()).as("producer must unblock once the peer drains").isFalse();
+    assertThat(producerFailure.get())
+        .as("a slow-but-live cross-slot peer must not surface as a stall on the producer")
+        .isNull();
+    assertThat(async.waitCompletion(10_000)).isTrue();
+    assertThat(executed.await(5, TimeUnit.SECONDS)).as("every scheduled task must execute").isTrue();
+    assertThat(errors).isEmpty();
+  }
+
+  private static DatabaseAsyncTask awaitTask(final CountDownLatch started, final CountDownLatch release,
+                                             final List<Throwable> errors) {
+    return new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        started.countDown();
+        try {
+          if (!release.await(20, TimeUnit.SECONDS))
+            errors.add(new IllegalStateException("release latch never fired"));
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    };
+  }
+
+  private static DatabaseAsyncTask countingTask(final CountDownLatch latch) {
+    return new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        latch.countDown();
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    };
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncStallDetectorFalsePositiveTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncStallDetectorFalsePositiveTest.java
@@ -45,7 +45,10 @@ class AsyncStallDetectorFalsePositiveTest extends TestHelper {
     async.setParallelLevel(1);
     // Force thread re-creation so the queue size above is picked up regardless of the previous level.
     async.setTransactionUseWAL(true);
-    async.setCheckForStalledQueuesMaxDelay(100);
+    // 300ms window: the 1.2s head task is 4x the old 2-window false-positive bound, while staying
+    // well below the wedged-worker backstop (STALLED_NO_PROGRESS_WINDOWS x 300ms = 3.6s), which
+    // must not fire for a single legitimately slow task.
+    async.setCheckForStalledQueuesMaxDelay(300);
 
     final CountDownLatch slowTaskStarted = new CountDownLatch(1);
     final CountDownLatch executed = new CountDownLatch(4);

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncStallDetectorFalsePositiveTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncStallDetectorFalsePositiveTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for #4953 (false-positive branch): the stall detector in
+ * {@code DatabaseAsyncExecutorImpl.scheduleTask} compared the identity of the queue head across two
+ * offer windows. A worker busy on a single task longer than 2x {@code checkForStalledQueuesMaxDelay}
+ * left the (untouched) head identical, so a healthy producer blocked on the full queue was thrown a
+ * spurious {@code DatabaseOperationException("Asynchronous queue ... is stalled")}.
+ */
+class AsyncStallDetectorFalsePositiveTest extends TestHelper {
+
+  @Test
+  void slowHeadTaskDoesNotTripStallDetector() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 2);
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
+    async.setParallelLevel(1);
+    // Force thread re-creation so the queue size above is picked up regardless of the previous level.
+    async.setTransactionUseWAL(true);
+    async.setCheckForStalledQueuesMaxDelay(100);
+
+    final CountDownLatch slowTaskStarted = new CountDownLatch(1);
+    final CountDownLatch executed = new CountDownLatch(4);
+
+    // Head task busy for ~1.2s: much longer than 2x the stall-check delay.
+    async.scheduleTask(0, new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        slowTaskStarted.countDown();
+        try {
+          Thread.sleep(1_200);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+        executed.countDown();
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    }, true, 0);
+
+    assertThat(slowTaskStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+    // Fill the queue (capacity 2) while the worker is busy.
+    for (int i = 0; i < 2; i++)
+      assertThat(async.scheduleTask(0, countingTask(executed), true, 0)).isTrue();
+
+    // This producer must wait for the (healthy but slow) worker instead of throwing
+    // "Asynchronous queue 0 is stalled" after 2x checkForStalledQueuesMaxDelay.
+    assertThat(async.scheduleTask(0, countingTask(executed), true, 0)).isTrue();
+
+    assertThat(executed.await(10, TimeUnit.SECONDS)).as("all scheduled tasks must execute").isTrue();
+  }
+
+  private static DatabaseAsyncTask countingTask(final CountDownLatch latch) {
+    return new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        latch.countDown();
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    };
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncWaitCompletionTimeoutTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncWaitCompletionTimeoutTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the #5062 review (point 3): {@code waitCompletion(timeout)} bounded the await
+ * phase but not the enqueue phase, which retried a 500ms offer for as long as the worker stayed
+ * alive. A caller passing a 1s timeout could block for the whole duration of a slow task on a
+ * worker with a persistently full queue. The timeout is a single budget spanning both phases.
+ */
+class AsyncWaitCompletionTimeoutTest extends TestHelper {
+
+  @Test
+  @Timeout(30)
+  void waitCompletionHonorsTimeoutWhileQueueIsFull() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 2);
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
+    async.setParallelLevel(1);
+    // Force thread re-creation so the queue size above is picked up regardless of the previous level.
+    async.setTransactionUseWAL(true);
+
+    final CountDownLatch blockerStarted = new CountDownLatch(1);
+    final CountDownLatch release = new CountDownLatch(1);
+    async.scheduleTask(0, blockerTask(blockerStarted, release), true, 0);
+    assertThat(blockerStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+    // Fill the queue (capacity 2) so the completion marker cannot be enqueued.
+    for (int i = 0; i < 2; i++)
+      assertThat(async.scheduleTask(0, noOpTask(), false, 0)).isTrue();
+
+    final long start = System.currentTimeMillis();
+    final boolean flushed = async.waitCompletion(700);
+    final long elapsed = System.currentTimeMillis() - start;
+
+    assertThat(flushed).as("waitCompletion must report the timeout instead of a flush").isFalse();
+    assertThat(elapsed).as("the timeout budget must also bound the enqueue phase").isLessThan(5_000);
+
+    release.countDown();
+    assertThat(async.waitCompletion(10_000)).isTrue();
+  }
+
+  private static DatabaseAsyncTask blockerTask(final CountDownLatch started, final CountDownLatch release) {
+    return new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        started.countDown();
+        try {
+          release.await(15, TimeUnit.SECONDS);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    };
+  }
+
+  private static DatabaseAsyncTask noOpTask() {
+    return new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        // NO ACTIONS
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    };
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncWedgedWorkerStallTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncWedgedWorkerStallTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.exception.DatabaseOperationException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for the #5062 review, round 2 (point 1): the progress-based stall detector of
+ * #4953 fired only when the target worker was itself parked handing a task cross-slot
+ * ({@code waitingCrossSlotOffer}). A worker genuinely wedged inside a user {@code execute()} (an
+ * infinite loop or a blocking call) never sets that flag, so a producer blocked on its full queue
+ * waited forever with no exit: the (false-positive-prone) old head-identity detector at least
+ * converted that hang into an exception. The backstop now throws after a much longer, progress-gated
+ * bound: {@code STALLED_NO_PROGRESS_WINDOWS} consecutive stall windows with zero completed tasks.
+ */
+class AsyncWedgedWorkerStallTest extends TestHelper {
+
+  @Test
+  @Timeout(30)
+  void producerBlockedOnWedgedWorkerEventuallyThrows() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 2);
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
+    async.setParallelLevel(1);
+    // Force thread re-creation so the queue size above is picked up regardless of the previous level.
+    async.setTransactionUseWAL(true);
+    async.setCheckForStalledQueuesMaxDelay(50);
+
+    final CountDownLatch wedgeStarted = new CountDownLatch(1);
+    final CountDownLatch release = new CountDownLatch(1);
+    try {
+      // Simulates a worker wedged in user code: alive, not parked cross-slot, completing nothing.
+      async.scheduleTask(0, new DatabaseAsyncTask() {
+        @Override
+        public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+          wedgeStarted.countDown();
+          try {
+            release.await(15, TimeUnit.SECONDS);
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+        }
+
+        @Override
+        public boolean requiresActiveTx() {
+          return false;
+        }
+      }, true, 0);
+      assertThat(wedgeStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+      // Fill the queue (capacity 2) so the next producer has to wait.
+      for (int i = 0; i < 2; i++)
+        assertThat(async.scheduleTask(0, noOpTask(), false, 0)).isTrue();
+
+      final long start = System.currentTimeMillis();
+      assertThatThrownBy(() -> async.scheduleTask(0, noOpTask(), true, 0))
+          .as("a producer must not hang forever on a worker wedged in user code")
+          .isInstanceOf(DatabaseOperationException.class)
+          .hasMessageContaining("stalled");
+      assertThat(System.currentTimeMillis() - start)
+          .as("the backstop must fire after the configured no-progress bound, not the wedge duration")
+          .isLessThan(10_000);
+    } finally {
+      release.countDown();
+    }
+
+    assertThat(async.waitCompletion(10_000)).isTrue();
+  }
+
+  private static DatabaseAsyncTask noOpTask() {
+    return new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        // NO ACTIONS
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    };
+  }
+}


### PR DESCRIPTION
Part of the 2026-07 engine audit remediation (#4962), group **async-executor**.

## Per-issue verdicts

### #4953 - stall detector false-positives and rolls back the in-flight batch: **fixed**
Re-verified against current main: `scheduleTask` still peeked the queue head across two `checkForStalledQueuesMaxDelay` windows and threw on identical identity, and `newEdge`'s cross-slot incoming-edge follow-up still blocked one worker on another worker's full queue (a real wait cycle the detector broke by throwing inside the worker, rolling back up to `commitEvery - 1` already-executed ops and dropping the follow-up).

Fix (both parts, coherently in `scheduleTask`):
- **Help-while-waiting (park-then-run)**: a worker of this executor that must wait on a full queue drains its OWN queue in the meantime, but does NOT execute the polled tasks re-entrantly - a nested execution could commit or roll back the suspended task's partial writes, breaking per-task atomicity (this replaced an earlier re-entrant design during review). Polled tasks are parked in a thread-confined `helpDeferredTasks` deque and executed by the run loop, in poll order, once the current task fully unwinds; draining alone frees the slot the parked peer is waiting on, so cross-slot cycles resolve with every task executed, no exception, no rollback. The parked backlog is bounded by the worker's queue capacity; past that budget the worker falls back to the detecting bounded wait below.
- **Progress-based detection for external producers**: per-worker monotonic `completedTaskCount` + a `waitingCrossSlotOffer` flag, with two thresholds. A target parked handing a task cross-slot with a flat completed count (a likely scheduling cycle, only reachable after budget exhaustion) surfaces after 3 consecutive no-progress windows (15s by default), so a peer merely busy on one slow task does not trip it; a target wedged inside user code (infinite loop / blocking call, flag never set) surfaces after 12 windows (60s by default) instead of hanging the producer forever. Both tunable via `setCheckForStalledQueuesMaxDelay()`. A worker merely busy on a slow task no longer trips anything.

### #4954 - shutdown/interrupt drops queued tasks, hanging completion waiters: **fixed**
Re-verified: the interrupt handler still did `queue.clear()` (dropping tasks whose `completed()` never ran, hanging `scanType()`/`waitCompletion()`), and `shutdownThreadsLocked` still blocked on an untimed `queue.put(FORCE_EXIT)` under `lifecycleLock` (a busy worker with a full queue wedged `database.close()`).

Fix: every run-loop exit path now drains the queue (and the parked help-deferral list) notifying `completed()` on each leftover task; `DatabaseAsyncScanBucket` / `DatabaseAsyncBrowseIterator` count their latches down from `completed()` (invoked on execution AND drop) instead of inside `execute()`; shutdown offers `FORCE_EXIT` with a 1s timeout and interrupts the worker on failure (with a WARNING if it will not die within 10s); `waitCompletion(timeout)` treats the timeout as a single budget spanning the enqueue and await phases, with a worker-liveness check instead of an untimed `put`; `scheduleTask` undoes an offer that lands after the target worker's final drain (best-effort: documented residual races for the opt-in `fast` queue, which cannot remove, and for an offer landing before `isAlive()` flips; the former logs a WARNING).

### #4961 - low-severity concurrency cleanups: **fixed** (all three checkboxes)
- Async executor settings (`parallelLevel`, `commitEvery`, `backPressurePercentage`, `transactionUseWAL`, `transactionSync`, `checkForStalledQueuesMaxDelay`, onOk/onError callbacks) are now `volatile`; `setCommitEvery` rejects values < 1 (0 made every task fail on `count % 0`) and the constructor clamps the configured batch size.
- `QueryEngineManager` and `SparseVectorScoringPool` rejection handlers now cancel a `RunnableFuture` rejected after pool shutdown instead of leaving its waiter blocked in an untimed `Future.get()` forever (no test: both pools are JVM-wide singletons that are never shut down inside a test JVM without breaking sibling tests; the change is the minimal safe branch).
- `QueryEngineManager.register()` is `synchronized` and publishes a copy-on-write map, so the public post-construction registration path cannot corrupt the lock-free `getEngine`/`getAvailableLanguages` readers.

## Test evidence (red-first)
All nine new regression tests fail on unfixed code exactly on the audited defect, and pass after the fix:
- `AsyncStallDetectorFalsePositiveTest`: unfixed threw `DatabaseOperationException: Asynchronous queue 0 is stalled` for a healthy worker busy 1.2s.
- `AsyncCrossSlotSchedulingDeadlockTest`: deterministic 2-worker cross-offer cycle (queue capacity 1); unfixed dropped both follow-up markers (latch timeout) and fired the stall exception.
- `AsyncHelpingAtomicityTest`: deterministic ordering probe; with re-entrant helping the polled task runs (and with `commitEvery=1` commits the suspended task's partial write) before the suspended task unwinds.
- `AsyncWedgedWorkerStallTest`: unfixed let a producer hang for the full wedge duration on a worker blocked in user code; fixed throws at the 12-window backstop.
- `AsyncSlowPeerNoFalseStallTest`: unfixed threw the stall exception after a single flat window at a producer targeting a budget-exhausted worker whose cross-slot peer was merely slow; fixed waits 3 windows and completes normally.
- `AsyncShutdownDrainTest.killNotifiesCompletionOfDroppedQueuedTasks`: unfixed never called `completed()` on the queued probes (latch timeout).
- `AsyncShutdownDrainTest.closeDoesNotBlockOnFullQueueOfBusyWorker`: unfixed `close()` blocked ~15s in `put(FORCE_EXIT)` (await(8s) failed).
- `AsyncWaitCompletionTimeoutTest`: unfixed `waitCompletion(700)` blocked far past its timeout while the enqueue phase retried on a full queue.
- `AsyncConfigValidationTest`: unfixed accepted `setCommitEvery(0)`.

Focused suites run green: `com.arcadedb.database.async.*` (19 tests), `AsyncTest`, `SelectExecutionTest`, `QueryEngineManagerLanguagesTest`, `QueryEngineManagerPoolTest`, `GraphBatchTest`, `GraphBatchUniqueIndexTest`, `GraphBatchCommitRetryTest`, `ACIDTransactionTest`, `MVCCTest`.

## Conflict risks with sibling audit branches
- `docs/release-26.7.2.md` (expected: every audit group appends here)
- `engine/src/main/java/com/arcadedb/query/QueryEngineManager.java` (concurrency/pool layer; touched for the #4961 rejection-handler and register() items)
- `engine/src/main/java/com/arcadedb/index/sparsevector/SparseVectorScoringPool.java` (same reason)

All other changes are confined to `com.arcadedb.database.async`.
