### PR TITLE
fix(#4952,#4957,#4958,#4960): pool discipline, TimeSeries threading, storage/WAL and LSM low-severity cleanups (2026-07 audit)

### DIFF
--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -230,7 +230,8 @@ that could starve the very snapshot resync meant to heal the node.
   the inner callback under the outer suspension instead of silently skipping it; WAL files preserved by an
   aborted recovery are renamed to `.wal.corrupt` and the WAL pool counter is seeded past existing files,
   so preserved content is never adopted as an active WAL (appending new transactions after corrupt bytes)
-  nor replayed again; per-bucket free-space statistics now measure the usable content region (not the
+  nor replayed again (the HA Raft snapshot checksum skips the preserved `.corrupt` files like it already
+  skipped `.wal`); per-bucket free-space statistics now measure the usable content region (not the
   physical page size) and their counters are thread-safe. Low-severity LSM cleanups
   ([#4960](https://github.com/ArcadeData/arcadedb/issues/4960)): `BufferBloomFilter` (not yet wired into
   the read path) hardened before use - the bit index can no longer land one bit past the region, `add` is
@@ -239,10 +240,12 @@ that could starve the very snapshot resync meant to heal the node.
   (unlocked readers could observe a stale or partially published instance after a compaction swap);
   `close()` now cancels a scheduled-but-not-started compaction instead of silently doing nothing and logs
   loudly when an in-progress compaction blocks the close; `splitIndex` verifies the new-file lock outcome
-  instead of ignoring it. Items deliberately left open on #4958/#4960 with reasoning on the issues: the
-  `activeWALFilePool` element publication (needs an `AtomicReferenceArray` refactor of a conflict-heavy
-  file), the `currentMutablePages` reload undercount (pre-existing TODO affecting only compaction pacing)
-  and the descending duplicate-run cursor rescan (perf-only).
+  instead of ignoring it; a reloaded mutable index restores its uncompacted-pages counter from the file
+  instead of hardcoding 1, so auto-compaction is no longer deferred by up to a full threshold of new
+  pages after every restart. Items deliberately left open on #4958/#4960 with reasoning on the issues:
+  the `activeWALFilePool` element publication (needs an `AtomicReferenceArray` refactor of a
+  conflict-heavy file), the `createNewPage` rollback counter drift and the descending duplicate-run
+  cursor rescan (perf-only).
 
 ### Improvements
 

--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -227,7 +227,11 @@ that could starve the very snapshot resync meant to heal the node.
   `TransactionManager.getStats()` no longer inflates its totals with polling frequency and no longer NPEs
   on read-only databases; the page cache-miss counter is actually incremented (it stayed at ~0 forever, so
   the hit/miss ratio was meaningless); a nested `suspendFlushAndExecute` (snapshot during backup) now runs
-  the inner callback under the outer suspension instead of silently skipping it; WAL files preserved by an
+  the inner callback under the outer suspension instead of silently skipping it, and the HA Raft
+  snapshot/checksums endpoint now serializes per database so a concurrent snapshot request can never
+  stream files without owning the flush suspension (the suspend flag is first-caller-owned; the owner's
+  exit would have resumed flushing mid-read for the other request, tearing the streamed files - reachable
+  with the default `HA_SNAPSHOT_MAX_CONCURRENT` of 2); WAL files preserved by an
   aborted recovery are renamed to `.wal.corrupt` and the WAL pool counter is seeded past existing files,
   so preserved content is never adopted as an active WAL (appending new transactions after corrupt bytes)
   nor replayed again (the HA Raft snapshot checksum skips the preserved `.corrupt` files like it already

--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -208,6 +208,42 @@ that could starve the very snapshot resync meant to heal the node.
   shadows committed RIDs whose key equals an uncommitted entry's key - is tracked in
   [#5055](https://github.com/ArcadeData/arcadedb/issues/5055).
 
+- **Pool discipline, TimeSeries threading and low-severity storage/WAL/LSM cleanups (2026-07 audit).**
+  The partitioned triangle-count operator now runs chunk 0 on the calling thread instead of submitting
+  every chunk to the shared query pool and blocking on all of them - the same caller-runs-chunk-0
+  discipline as `parallelForRange`, removing a pool-starvation deadlock risk when the operator is reached
+  from a pool thread ([#4952](https://github.com/ArcadeData/arcadedb/issues/4952)).
+  `TimeSeriesEngine.appendBatch` no longer dispatches shard writes to the shard executor when the calling
+  thread has an enclosing transaction open - each TS-Shard thread ran with its own fresh transaction,
+  publishing the shard pages out of band with the enclosing commit and, under HA, reordering the page
+  versions on the Raft log; the per-shard sub-batches are now written sequentially in-thread in that case,
+  honoring the `appendSamples` threading contract
+  ([#4957](https://github.com/ArcadeData/arcadedb/issues/4957)). Low-severity storage/WAL cleanups
+  ([#4958](https://github.com/ArcadeData/arcadedb/issues/4958)): the WAL read/write helpers now loop until
+  complete with per-call buffers (a partial read decoded stale garbage from a shared buffer; a partial
+  write left a torn record the gap detector then flagged as corruption); a corrupt per-page WAL header can
+  no longer trigger a ~2GB transient allocation during recovery (the declared delta is clamped to the
+  remaining file size - before, the resulting `OutOfMemoryError` escaped the recovery guard entirely);
+  `TransactionManager.getStats()` no longer inflates its totals with polling frequency and no longer NPEs
+  on read-only databases; the page cache-miss counter is actually incremented (it stayed at ~0 forever, so
+  the hit/miss ratio was meaningless); a nested `suspendFlushAndExecute` (snapshot during backup) now runs
+  the inner callback under the outer suspension instead of silently skipping it; WAL files preserved by an
+  aborted recovery are renamed to `.wal.corrupt` and the WAL pool counter is seeded past existing files,
+  so preserved content is never adopted as an active WAL (appending new transactions after corrupt bytes)
+  nor replayed again; per-bucket free-space statistics now measure the usable content region (not the
+  physical page size) and their counters are thread-safe. Low-severity LSM cleanups
+  ([#4960](https://github.com/ArcadeData/arcadedb/issues/4960)): `BufferBloomFilter` (not yet wired into
+  the read path) hardened before use - the bit index can no longer land one bit past the region, `add` is
+  atomic (a dropped bit is a false negative, the one failure a bloom filter must never have) and two
+  probes are derived from the 64-bit Murmur halves; the LSM mutable-index reference is now `volatile`
+  (unlocked readers could observe a stale or partially published instance after a compaction swap);
+  `close()` now cancels a scheduled-but-not-started compaction instead of silently doing nothing and logs
+  loudly when an in-progress compaction blocks the close; `splitIndex` verifies the new-file lock outcome
+  instead of ignoring it. Items deliberately left open on #4958/#4960 with reasoning on the issues: the
+  `activeWALFilePool` element publication (needs an `AtomicReferenceArray` refactor of a conflict-heavy
+  file), the `currentMutablePages` reload undercount (pre-existing TODO affecting only compaction pacing)
+  and the descending duplicate-run cursor rescan (perf-only).
+
 ### Improvements
 
 - **HA: throttled diverged-follower resync logging.** When a follower detects a WAL page-version gap it

--- a/engine/src/main/java/com/arcadedb/engine/BufferBloomFilter.java
+++ b/engine/src/main/java/com/arcadedb/engine/BufferBloomFilter.java
@@ -20,6 +20,21 @@ package com.arcadedb.engine;
 
 import com.arcadedb.database.Binary;
 
+/**
+ * Bloom filter over a caller-provided {@link Binary} region of {@code slots} bits.
+ * <p>
+ * #4960 hardening (before wiring into the LSM read path):
+ * <ul>
+ *   <li>the bit index is always reduced modulo {@code capacity}: the previous conditional reduction let
+ *   a hash equal to {@code capacity} address one bit PAST the region, corrupting the adjacent byte of
+ *   the shared buffer;</li>
+ *   <li>{@link #add} is synchronized: the unsynchronized read-modify-write on shared bytes could drop a
+ *   concurrently-set bit, turning into a FALSE NEGATIVE - the one failure a bloom filter must never
+ *   have. {@link #mightContain} stays lock-free (a filter is built, then published for reading);</li>
+ *   <li>two probes (k=2) are derived from the two halves of the 64-bit Murmur hash instead of a single
+ *   32-bit probe, roughly halving the false-positive exponent at the same size.</li>
+ * </ul>
+ */
 public class BufferBloomFilter {
   private final Binary buffer;
   private final int    hashSeed;
@@ -33,27 +48,30 @@ public class BufferBloomFilter {
     this.capacity = slots;
   }
 
-  public void add(final int value) {
-    final int[] result = compute(value);
-    final byte v = buffer.getByte(result[0]);
-    buffer.putByte(result[0], (byte) (v | (1 << result[1])));
+  public synchronized void add(final int value) {
+    final long hash = hash64(value);
+    setBit(Math.floorMod((int) (hash >>> 32), capacity));
+    setBit(Math.floorMod((int) hash, capacity));
   }
 
   public boolean mightContain(final int value) {
-    final int[] result = compute(value);
-    final byte v = buffer.getByte(result[0]);
-    return ((v >> result[1]) & 1) == 1;
+    final long hash = hash64(value);
+    return testBit(Math.floorMod((int) (hash >>> 32), capacity)) && testBit(Math.floorMod((int) hash, capacity));
   }
 
-  private int[] compute(final int value) {
+  private long hash64(final int value) {
     final byte[] b = new byte[] { (byte) (value >>> 24), (byte) (value >>> 16), (byte) (value >>> 8), (byte) value };
-    final int hash = MurmurHash.hash32(b, 4, hashSeed);
-    final int h = hash != Integer.MIN_VALUE ? Math.abs(hash) : Integer.MAX_VALUE;
+    return MurmurHash.hash64(b, 4, hashSeed);
+  }
 
-    final int bit2change = h > capacity ? h % capacity : h;
-    final int byte2change = bit2change / 8;
-    final int bitInByte2change = bit2change % 8;
+  private void setBit(final int bit) {
+    final int byte2change = bit / 8;
+    final byte v = buffer.getByte(byte2change);
+    buffer.putByte(byte2change, (byte) (v | (1 << (bit % 8))));
+  }
 
-    return new int[] { byte2change, bitInByte2change };
+  private boolean testBit(final int bit) {
+    final byte v = buffer.getByte(bit / 8);
+    return ((v >> (bit % 8)) & 1) == 1;
   }
 }

--- a/engine/src/main/java/com/arcadedb/engine/BufferBloomFilter.java
+++ b/engine/src/main/java/com/arcadedb/engine/BufferBloomFilter.java
@@ -35,18 +35,36 @@ import com.arcadedb.database.Binary;
  *   32-bit probe, roughly halving the false-positive exponent at the same size.</li>
  * </ul>
  * <p>
- * Invariant: the backing {@code buffer} must be at least {@code ceil(slots / 8)} bytes. The
- * {@code floorMod} reduction can address bit {@code slots - 1}, i.e. the top byte of the region, so an
- * undersized buffer would read/write past the region on the highest slots.
+ * Invariant: the backing {@code buffer} must be at least {@code ceil(slots / 8)} bytes (validated by
+ * the constructor). The {@code floorMod} reduction can address bit {@code slots - 1}, i.e. the top byte
+ * of the region, so an undersized buffer would read/write past the region on the highest slots.
  */
 public class BufferBloomFilter {
   private final Binary buffer;
   private final int    hashSeed;
   private final int    capacity;
 
+  /**
+   * Builds a filter over the first {@code ceil(slots / 8)} bytes of {@code buffer}.
+   * <p>
+   * Publication requirement: {@link #mightContain} is lock-free, so once the build phase is over the
+   * filter instance MUST be handed to readers through a safe-publication edge - a {@code final} or
+   * {@code volatile} field, or a happens-before established by a lock or a concurrent collection.
+   * Publishing it through a plain field lets a reader observe stale buffer bytes and return a FALSE
+   * NEGATIVE, the one failure a bloom filter must never have.
+   *
+   * @throws IllegalArgumentException if {@code slots} is not a multiple of 8, or if {@code buffer}
+   *                                  cannot address the {@code ceil(slots / 8)} bytes the filter spans
+   */
   public BufferBloomFilter(final Binary buffer, final int slots, final int hashSeed) {
     if (slots % 8 > 0)
       throw new IllegalArgumentException("Slots must be a multiplier of 8");
+
+    final int requiredBytes = (slots + 7) / 8;
+    if (buffer.limit() < requiredBytes)
+      throw new IllegalArgumentException(
+          "Buffer too small for " + slots + " slots: addressable bytes " + buffer.limit() + ", required " + requiredBytes);
+
     this.buffer = buffer;
     this.hashSeed = hashSeed;
     this.capacity = slots;

--- a/engine/src/main/java/com/arcadedb/engine/BufferBloomFilter.java
+++ b/engine/src/main/java/com/arcadedb/engine/BufferBloomFilter.java
@@ -34,6 +34,10 @@ import com.arcadedb.database.Binary;
  *   <li>two probes (k=2) are derived from the two halves of the 64-bit Murmur hash instead of a single
  *   32-bit probe, roughly halving the false-positive exponent at the same size.</li>
  * </ul>
+ * <p>
+ * Invariant: the backing {@code buffer} must be at least {@code ceil(slots / 8)} bytes. The
+ * {@code floorMod} reduction can address bit {@code slots - 1}, i.e. the top byte of the region, so an
+ * undersized buffer would read/write past the region on the highest slots.
  */
 public class BufferBloomFilter {
   private final Binary buffer;
@@ -54,6 +58,11 @@ public class BufferBloomFilter {
     setBit(Math.floorMod((int) hash, capacity));
   }
 
+  /**
+   * Lock-free read: only safe after the filter has been fully built and safely published (no concurrent
+   * {@link #add}s). Without a happens-before edge between a concurrent add and this read, a stale byte
+   * could be observed and produce a false negative.
+   */
   public boolean mightContain(final int value) {
     final long hash = hash64(value);
     return testBit(Math.floorMod((int) (hash >>> 32), capacity)) && testBit(Math.floorMod((int) hash, capacity));

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -2062,7 +2062,8 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     // #5063 review round 2: consume the change counter atomically at the decision point. The previous
     // get() > 0 check paired with a set(0L) at the end of the scan wiped any increment landing while the
     // scan ran; getAndSet(0L) carries those increments into the next cycle instead of losing them.
-    if (changesFromLastStats.getAndSet(0L) > 0 || firstRun)
+    final long consumedChanges = changesFromLastStats.getAndSet(0L);
+    if (consumedChanges > 0 || firstRun)
       try {
         int txPageCount = getTotalPages();
 
@@ -2092,8 +2093,10 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
           timeOfLastStats = System.currentTimeMillis();
         }
       } catch (Exception e) {
-        // THE COUNTER WAS ALREADY CONSUMED: BUMP IT BACK SO THE FAILED SCAN IS RETRIED AT THE NEXT CYCLE
-        changesFromLastStats.incrementAndGet();
+        // #5063 review round 3: THE COUNTER WAS ALREADY CONSUMED. RESTORE THE FULL CONSUMED COUNT (NOT A
+        // SINGLE INCREMENT, WHICH UNDERCOUNTED THE PENDING CHANGES) SO THE FAILED SCAN IS RETRIED AT THE
+        // NEXT CYCLE; max(consumed, 1) COVERS THE firstRun CASE WHERE THE CONSUMED COUNT MAY BE ZERO
+        changesFromLastStats.addAndGet(Math.max(consumedChanges, 1L));
         LogManager.instance().log(this, Level.WARNING, "Error on gathering statistics on bucket '%s'", e, getName());
       }
   }

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -119,8 +119,10 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
   // access is enforced by `synchronized (freeSpaceInPages)` blocks at every callsite.
   private final          IntIntHashMap             freeSpaceInPages                 = new IntIntHashMap();
   private final          REUSE_SPACE_MODE          reuseSpaceMode;
-  private                long                      timeOfLastStats                  = 0L;
-  private                long                      changesFromLastStats             = 0L;
+  // #4958: both fields are read/written outside the freeSpaceInPages monitor on some paths (delete,
+  // updatePageStatistics), so they must be safe on their own: volatile timestamp + atomic counter.
+  private volatile       long                      timeOfLastStats                  = 0L;
+  private final          AtomicLong                changesFromLastStats             = new AtomicLong();
 
   private enum REUSE_SPACE_MODE {
     LOW, MEDIUM, HIGH
@@ -1169,7 +1171,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
             getFreeSpaceInPage(pageAnalysis);
             updatePageStatistics(pageId, pageAnalysis.spaceAvailableInCurrentPage, (int) ((recordSize[0] + recordSize[1]) * -1));
           } else
-            ++changesFromLastStats;
+            changesFromLastStats.incrementAndGet();
         }
 
       } else {
@@ -2054,7 +2056,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    */
   public void gatherPageStatistics() {
     if (timeOfLastStats == 0L || (System.currentTimeMillis() - timeOfLastStats > MAX_TIMEOUT_GATHER_STATS
-            && changesFromLastStats > 0))
+            && changesFromLastStats.get() > 0))
       try {
         int txPageCount = getTotalPages();
 
@@ -2064,13 +2066,15 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
             final short recordCountInPage = page.readShort(PAGE_RECORD_COUNT_IN_PAGE_OFFSET);
             final List<int[]> orderedRecordContentInPage = getOrderedRecordsInPage(page, recordCountInPage, true);
 
-            int freeSpaceInPage = getPageSize() - contentHeaderSize;
+            // #4958: measure against the usable content region (getMaxContentSize), not the physical
+            // page size: the latter overstated the free space of every page by the page header size.
+            int freeSpaceInPage = page.getMaxContentSize() - contentHeaderSize;
             if (!orderedRecordContentInPage.isEmpty()) {
               final int[] lastRecord = orderedRecordContentInPage.getLast();
-              freeSpaceInPage = getPageSize() - (lastRecord[0] + lastRecord[1]);
+              freeSpaceInPage = page.getMaxContentSize() - (lastRecord[0] + lastRecord[1]);
             }
 
-            final int freeSpacePerc = freeSpaceInPage * 100 / (getPageSize() - contentHeaderSize);
+            final int freeSpacePerc = freeSpaceInPage * 100 / (page.getMaxContentSize() - contentHeaderSize);
 
             if (freeSpacePerc > GATHER_STATS_MIN_SPACE_PERC)
               freeSpaceInPages.put(pageId, freeSpaceInPage);
@@ -2080,7 +2084,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
           }
 
           timeOfLastStats = System.currentTimeMillis();
-          changesFromLastStats = 0L;
+          changesFromLastStats.set(0L);
         }
       } catch (Exception e) {
         LogManager.instance().log(this, Level.WARNING, "Error on gathering statistics on bucket '%s'", e, getName());
@@ -2091,7 +2095,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * Update the in memory statistics about the free space in page.
    */
   private void updatePageStatistics(final int pageId, final int availableSpace, final int delta) {
-    ++changesFromLastStats;
+    changesFromLastStats.incrementAndGet();
 
     if (reuseSpaceMode.ordinal() < REUSE_SPACE_MODE.HIGH.ordinal())
       return;

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -2055,8 +2055,14 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
    * 3. if the tree map is full (size > MAX_PAGES_GATHER_STATS), stop
    */
   public void gatherPageStatistics() {
-    if (timeOfLastStats == 0L || (System.currentTimeMillis() - timeOfLastStats > MAX_TIMEOUT_GATHER_STATS
-            && changesFromLastStats.get() > 0))
+    final boolean firstRun = timeOfLastStats == 0L;
+    if (!firstRun && System.currentTimeMillis() - timeOfLastStats <= MAX_TIMEOUT_GATHER_STATS)
+      return;
+
+    // #5063 review round 2: consume the change counter atomically at the decision point. The previous
+    // get() > 0 check paired with a set(0L) at the end of the scan wiped any increment landing while the
+    // scan ran; getAndSet(0L) carries those increments into the next cycle instead of losing them.
+    if (changesFromLastStats.getAndSet(0L) > 0 || firstRun)
       try {
         int txPageCount = getTotalPages();
 
@@ -2084,9 +2090,10 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
           }
 
           timeOfLastStats = System.currentTimeMillis();
-          changesFromLastStats.set(0L);
         }
       } catch (Exception e) {
+        // THE COUNTER WAS ALREADY CONSUMED: BUMP IT BACK SO THE FAILED SCAN IS RETRIED AT THE NEXT CYCLE
+        changesFromLastStats.incrementAndGet();
         LogManager.instance().log(this, Level.WARNING, "Error on gathering statistics on bucket '%s'", e, getName());
       }
   }

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -147,13 +147,17 @@ public class PageManager extends LockContext {
 
   public void suspendFlushAndExecute(final Database database, final CallableNoReturn callback)
       throws IOException, InterruptedException {
-    if (flushThread.setSuspended(database, true)) {
+    // #4958: when the database is ALREADY suspended by an outer scope (nested backup/snapshot), the
+    // callback still runs - under the outer suspension - instead of being silently skipped as before.
+    // Only the outermost caller owns the flag and restores it on exit.
+    final boolean acquired = flushThread.setSuspended(database, true);
+    if (acquired)
       flushThread.waitForCurrentFlushToComplete(database);
-      try {
-        CodeUtils.executeIgnoringExceptions(callback, "Error during suspend flush", true);
-      } finally {
+    try {
+      CodeUtils.executeIgnoringExceptions(callback, "Error during suspend flush", true);
+    } finally {
+      if (acquired)
         flushThread.setSuspended(database, false);
-      }
     }
   }
 
@@ -613,14 +617,17 @@ public class PageManager extends LockContext {
 
     CachedPage page = readCache.get(pageId);
     if (page == null) {
+      // #4958: count the miss BEFORE returning the freshly loaded page. The counter used to be bumped
+      // only on the page-not-found fall-through below, so cacheMiss stayed at ~0 forever and the
+      // hit/miss ratio in the stats was meaningless.
+      cacheMiss.incrementAndGet();
+
       page = loadPage(pageId, pageSize, createIfNotExists, true);
       if (page == null) {
         if (isNew)
           return null;
       } else
         return page;
-
-      cacheMiss.incrementAndGet();
 
     } else {
       cacheHits.incrementAndGet();

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -35,6 +35,7 @@ import java.io.*;
 import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicLong;
@@ -395,7 +396,12 @@ public class TransactionManager {
               try {
                 // Files.move (vs File.renameTo, which just returns false) fails with a cause and performs an
                 // atomic rename where the filesystem supports it. Best-effort semantics preserved: log and continue.
-                Files.move(walFile.toPath(), walFile.toPath().resolveSibling(walFile.getName() + ".corrupt"));
+                // REPLACE_EXISTING (#5063 review round 4): a prior ABORTED recovery can leave a same-named
+                // .corrupt file behind; without it the move throws FileAlreadyExistsException and the original
+                // .wal stays in place, re-scanned and re-aborted on every restart - the exact loop this breaks.
+                // The stale .corrupt it replaces is evidence from the SAME file's earlier failed attempt.
+                Files.move(walFile.toPath(), walFile.toPath().resolveSibling(walFile.getName() + ".corrupt"),
+                    StandardCopyOption.REPLACE_EXISTING);
               } catch (final IOException e) {
                 LogManager.instance().log(this, Level.WARNING,
                     "Error on renaming preserved WAL file '%s' to '%s.corrupt'", e, walFile, walFile.getName());

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -376,7 +376,11 @@ public class TransactionManager {
             }
           }
         } else {
-          // Close WAL files without deleting: preserve for manual inspection after gap detection
+          // Close WAL files without deleting: preserve for manual inspection after gap detection.
+          // #4958: renamed to '<name>.corrupt' so the next open can neither adopt a preserved file as an
+          // active WAL (appending new transactions after the corrupt content) nor re-scan and re-abort on
+          // it at every recovery. Recovery is aborted for ALL the files (no further transaction will ever
+          // be replayed from them), so all of them are moved aside.
           for (final WALFile file : activeWALFilePool) {
             if (file == null)
               continue;
@@ -385,9 +389,13 @@ public class TransactionManager {
             } catch (final IOException e) {
               LogManager.instance().log(this, Level.WARNING, "Error on closing WAL file '%s'", e, file);
             }
+            final File walFile = new File(file.getFilePath());
+            if (walFile.exists() && !walFile.renameTo(new File(walFile.getParentFile(), walFile.getName() + ".corrupt")))
+              LogManager.instance().log(this, Level.WARNING,
+                  "Error on renaming preserved WAL file '%s' to '%s.corrupt'", null, walFile, walFile.getName());
           }
           LogManager.instance().log(this, Level.SEVERE,
-              "WAL files for database '%s' have been preserved in '%s' for manual inspection.",
+              "WAL files for database '%s' have been preserved in '%s' with the '.corrupt' extension for manual inspection.",
               null, database, database.getDatabasePath());
         }
         createWALFilePool();
@@ -402,16 +410,25 @@ public class TransactionManager {
     final Map<String, Object> map = new HashMap<>();
     map.put("logFiles", logFileCounter.get());
 
-    for (final WALFile file : activeWALFilePool) {
-      if (file != null) {
-        final Map<String, Object> stats = file.getStats();
-        statsPagesWritten.addAndGet((Long) stats.get("pagesWritten"));
-        statsBytesWritten.addAndGet((Long) stats.get("bytesWritten"));
-      }
-    }
+    // #4958: compute a SNAPSHOT of the totals. The previous code folded each active file's cumulative
+    // counters into the long-lived accumulators on every call, so the numbers inflated with polling
+    // frequency and were double-counted again when the file was retired in cleanWALFiles(). The
+    // accumulators are only mutated at file retirement; here the active files' current counters are
+    // added on the fly without persisting them. Also guards the read-only case (no active pool).
+    long pagesWritten = statsPagesWritten.get();
+    long bytesWritten = statsBytesWritten.get();
 
-    map.put("pagesWritten", statsPagesWritten.get());
-    map.put("bytesWritten", statsBytesWritten.get());
+    final WALFile[] pool = activeWALFilePool;
+    if (pool != null)
+      for (final WALFile file : pool)
+        if (file != null) {
+          final Map<String, Object> stats = file.getStats();
+          pagesWritten += (Long) stats.get("pagesWritten");
+          bytesWritten += (Long) stats.get("bytesWritten");
+        }
+
+    map.put("pagesWritten", pagesWritten);
+    map.put("bytesWritten", bytesWritten);
     return map;
   }
 
@@ -809,6 +826,24 @@ public class TransactionManager {
   }
 
   private void createWALFilePool() {
+    // #4958: seed the counter PAST any existing txlog_<n>.wal. WALFile opens its path in "rw" mode
+    // without truncation, so restarting the counter from 0 while preserved WAL files are still on disk
+    // (corrupt-gap detection or a #4928 crash-equivalent close) silently reused them as active WALs:
+    // new transactions were appended after the old content and the old records replayed again.
+    final File[] existingWALFiles = new File(database.getDatabasePath()).listFiles((dir, name) -> name.endsWith(".wal"));
+    if (existingWALFiles != null)
+      for (final File existing : existingWALFiles) {
+        final String name = existing.getName();
+        if (name.startsWith("txlog_"))
+          try {
+            final long counter = Long.parseLong(name.substring("txlog_".length(), name.length() - ".wal".length()));
+            if (counter >= logFileCounter.get())
+              logFileCounter.set(counter + 1);
+          } catch (final NumberFormatException e) {
+            // NOT A POOL FILE, IGNORE IT
+          }
+      }
+
     activeWALFilePool = new WALFile[database.getConfiguration().getValueAsInteger(GlobalConfiguration.TX_WAL_FILES)];
     for (int i = 0; i < activeWALFilePool.length; ++i) {
       final long counter = logFileCounter.getAndIncrement();

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -34,6 +34,7 @@ import com.arcadedb.utility.LockManager;
 import java.io.*;
 import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.ClosedChannelException;
+import java.nio.file.Files;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicLong;
@@ -390,9 +391,15 @@ public class TransactionManager {
               LogManager.instance().log(this, Level.WARNING, "Error on closing WAL file '%s'", e, file);
             }
             final File walFile = new File(file.getFilePath());
-            if (walFile.exists() && !walFile.renameTo(new File(walFile.getParentFile(), walFile.getName() + ".corrupt")))
-              LogManager.instance().log(this, Level.WARNING,
-                  "Error on renaming preserved WAL file '%s' to '%s.corrupt'", null, walFile, walFile.getName());
+            if (walFile.exists())
+              try {
+                // Files.move (vs File.renameTo, which just returns false) fails with a cause and performs an
+                // atomic rename where the filesystem supports it. Best-effort semantics preserved: log and continue.
+                Files.move(walFile.toPath(), walFile.toPath().resolveSibling(walFile.getName() + ".corrupt"));
+              } catch (final IOException e) {
+                LogManager.instance().log(this, Level.WARNING,
+                    "Error on renaming preserved WAL file '%s' to '%s.corrupt'", e, walFile, walFile.getName());
+              }
           }
           LogManager.instance().log(this, Level.SEVERE,
               "WAL files for database '%s' have been preserved in '%s' with the '.corrupt' extension for manual inspection.",

--- a/engine/src/main/java/com/arcadedb/engine/WALFile.java
+++ b/engine/src/main/java/com/arcadedb/engine/WALFile.java
@@ -26,6 +26,7 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.utility.FileUtils;
 import com.arcadedb.utility.LockContext;
 
+import java.io.EOFException;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -64,9 +65,6 @@ public class WALFile extends LockContext {
   private final    AtomicInteger    pagesToFlush      = new AtomicInteger();
   private          long             statsPagesWritten = 0;
   private          long             statsBytesWritten = 0;
-  // STATIC BUFFERS USED FOR RECOVERY
-  private final    ByteBuffer       bufferLong        = ByteBuffer.allocate(Binary.LONG_SERIALIZED_SIZE);
-  private final    ByteBuffer       bufferInt         = ByteBuffer.allocate(Binary.INT_SERIALIZED_SIZE);
 
   public static class WALTransaction {
     public long      txId;
@@ -206,10 +204,12 @@ public class WALFile extends LockContext {
         pos += Binary.INT_SERIALIZED_SIZE;
 
         // Reject obviously corrupted page headers so ByteBuffer.allocate cannot blow up with a
-        // negative size and a garbage delta cannot be applied to disk. The outer segment-size
-        // check above already bounds total memory by file size, so a per-page upper cap is not
-        // needed here.
-        if (deltaSize <= 0 || tx.pages[i].changesFrom < 0)
+        // negative size and a garbage delta cannot be applied to disk. #4958: the delta must also
+        // fit in the remaining file - the outer segment-size check bounds the SEGMENT by file size,
+        // but a corrupt per-page header can still declare a huge deltaSize (up to Integer.MAX_VALUE)
+        // and trigger a transient ~2GB allocation, or an OutOfMemoryError that escapes the
+        // catch(Exception) recovery guard below, before the read would fail.
+        if (deltaSize <= 0 || tx.pages[i].changesFrom < 0 || pos + deltaSize > getSize())
           return null;
 
         final ByteBuffer buffer = ByteBuffer.allocate(deltaSize);
@@ -235,6 +235,9 @@ public class WALFile extends LockContext {
       tx.endPositionInLog = pos + Binary.INT_SERIALIZED_SIZE + Binary.LONG_SERIALIZED_SIZE;
 
       return tx;
+    } catch (final EOFException e) {
+      // TRUNCATED FILE: same benign outcome as the explicit size checks above.
+      return null;
     } catch (final IOException e) {
       throw new WALException("Error reading WAL file " + filePath, e);
     } catch (final Exception e) {
@@ -414,6 +417,10 @@ public class WALFile extends LockContext {
     return channel.size();
   }
 
+  public String getFilePath() {
+    return filePath;
+  }
+
   @Override
   public String toString() {
     return filePath;
@@ -440,19 +447,35 @@ public class WALFile extends LockContext {
   }
 
   private long readLong(final long pos) throws IOException {
-    bufferLong.rewind();
-    channel.read(bufferLong, pos);
-    return bufferLong.getLong(0);
+    // #4958: per-call buffer (the shared instance buffers were unsynchronized) filled with a full-read
+    // loop: a single channel.read may return early and the old code then decoded stale garbage.
+    final ByteBuffer buffer = ByteBuffer.allocate(Binary.LONG_SERIALIZED_SIZE);
+    readFully(buffer, pos);
+    return buffer.getLong(0);
   }
 
   private int readInt(final long pos) throws IOException {
-    bufferInt.rewind();
-    channel.read(bufferInt, pos);
-    return bufferInt.getInt(0);
+    final ByteBuffer buffer = ByteBuffer.allocate(Binary.INT_SERIALIZED_SIZE);
+    readFully(buffer, pos);
+    return buffer.getInt(0);
+  }
+
+  private void readFully(final ByteBuffer buffer, final long pos) throws IOException {
+    long readPos = pos;
+    while (buffer.hasRemaining()) {
+      final int n = channel.read(buffer, readPos);
+      if (n == -1)
+        throw new EOFException("EOF reading " + buffer.capacity() + " bytes at position " + pos + " of WAL file " + filePath);
+      readPos += n;
+    }
   }
 
   protected void append(final ByteBuffer buffer) throws IOException {
     buffer.rewind();
-    channel.write(buffer, channel.size());
+    // #4958: loop until the buffer is fully written. A single channel.write may write only part of the
+    // record, leaving a torn entry that the #4508 gap detector would then flag as corruption.
+    long writePos = channel.size();
+    while (buffer.hasRemaining())
+      writePos += channel.write(buffer, writePos);
   }
 }

--- a/engine/src/main/java/com/arcadedb/engine/WALFile.java
+++ b/engine/src/main/java/com/arcadedb/engine/WALFile.java
@@ -474,6 +474,9 @@ public class WALFile extends LockContext {
     buffer.rewind();
     // #4958: loop until the buffer is fully written. A single channel.write may write only part of the
     // record, leaving a torn entry that the #4508 gap detector would then flag as corruption.
+    // Single-writer assumption (same as the pre-loop code that wrote at channel.size() once): appends to a
+    // WALFile are externally serialized by acquire(); two concurrent appenders would both seed writePos from
+    // the same channel.size() and interleave. The local writePos only tolerates PARTIAL writes, not writers.
     long writePos = channel.size();
     while (buffer.hasRemaining())
       writePos += channel.write(buffer, writePos);

--- a/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
+++ b/engine/src/main/java/com/arcadedb/engine/timeseries/TimeSeriesEngine.java
@@ -132,6 +132,13 @@ public class TimeSeriesEngine implements AutoCloseable {
    * shard's write is dispatched to the shared {@code shardExecutor} so all active
    * shards write in parallel when multiple CPU cores are available.
    * <p>
+   * <b>Threading (#4957):</b> the parallel dispatch is only used when NO transaction is active on the
+   * calling thread. With an enclosing transaction open, each TS-Shard thread would run with its own fresh
+   * {@code DatabaseContext}/transaction, publishing the shard pages out of band with the enclosing commit
+   * and, under HA, reordering the page versions on the Raft log - exactly the hazard documented on
+   * {@link #appendSamples}. In that case the per-shard sub-batches are written sequentially on the calling
+   * thread, preserving the batched-transaction saving (at most S nested-TX cycles) without the parallelism.
+   * <p>
    * Data layout: {@code allColumnValues[colIndex][sampleIndex]}.
    *
    * @param allTimestamps   array of N sample timestamps
@@ -162,8 +169,13 @@ public class TimeSeriesEngine implements AutoCloseable {
       shardGroups[s].add(i);
     }
 
-    // Build per-shard arrays and dispatch parallel writes to shardExecutor.
-    final List<CompletableFuture<Void>> futures = new ArrayList<>(shardCount);
+    // #4957: with an enclosing transaction on the calling thread the shard writes MUST stay in-thread
+    // (see the threading note in the javadoc); routing them to shardExecutor would publish the pages
+    // out of band with the enclosing commit. The per-shard grouping is kept in both cases.
+    final boolean inThread = database.isTransactionActive();
+
+    // Build per-shard arrays and either write them in-thread or dispatch parallel writes to shardExecutor.
+    final List<CompletableFuture<Void>> futures = inThread ? null : new ArrayList<>(shardCount);
 
     for (int s = 0; s < shardCount; s++) {
       final List<Integer> group = shardGroups[s];
@@ -182,6 +194,11 @@ public class TimeSeriesEngine implements AutoCloseable {
       }
 
       final int shardIdx = s;
+      if (inThread) {
+        shards[shardIdx].appendSamples(shardTs, shardCols);
+        continue;
+      }
+
       futures.add(CompletableFuture.runAsync(() -> {
         try {
           shards[shardIdx].appendSamples(shardTs, shardCols);
@@ -190,6 +207,9 @@ public class TimeSeriesEngine implements AutoCloseable {
         }
       }, shardExecutor));
     }
+
+    if (inThread)
+      return;
 
     try {
       CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java
@@ -82,7 +82,10 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
   private              TypeIndex                     typeIndex;
   private              boolean                       valid        = true;
   private              IndexMetadata                 metadata;
-  protected            LSMTreeIndexMutable           mutable;
+  // #4960: volatile because the reference is swapped under the write lock (splitIndex) but read
+  // WITHOUT the lock by getFileId/getKeyTypes/getBinaryKeyTypes/convertKeys and the metadata paths:
+  // an unfenced reader could otherwise see a stale (or partially constructed) instance.
+  protected volatile   LSMTreeIndexMutable           mutable;
 
   public static class LSMTreeIndexFactoryHandler implements IndexFactoryHandler {
     @Override
@@ -337,13 +340,22 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
   @Override
   public void close() {
     checkIsValid();
-    if (status.compareAndSet(INDEX_STATUS.AVAILABLE, INDEX_STATUS.UNAVAILABLE)) {
+    // #4960: a compaction that is merely SCHEDULED has not started yet, so it is safely cancelled here
+    // (its own CAS COMPACTION_SCHEDULED -> COMPACTION_IN_PROGRESS will fail) and the close proceeds.
+    // Before this fix the AVAILABLE-only CAS made close() a silent no-op in that state, leaving the
+    // index files open and the compactor free to start against a closing database.
+    if (status.compareAndSet(INDEX_STATUS.AVAILABLE, INDEX_STATUS.UNAVAILABLE)
+        || status.compareAndSet(INDEX_STATUS.COMPACTION_SCHEDULED, INDEX_STATUS.UNAVAILABLE)) {
       lock.executeInWriteLock(() -> {
         if (mutable != null)
           mutable.close();
         return null;
       });
-    }
+    } else if (status.get() == INDEX_STATUS.COMPACTION_IN_PROGRESS)
+      // An actually running compaction cannot be cancelled here without corrupting its output: leave it
+      // to fail against the closed files, but do it loudly instead of silently skipping the close.
+      LogManager.instance().log(this, Level.WARNING,
+          "Index '%s' not closed because a compaction is in progress", null, name);
   }
 
   public void drop() {
@@ -647,8 +659,13 @@ public class LSMTreeIndex implements RangeIndex, IndexInternal {
             "splitIndex: replaced mutable for index '%s' (oldName='%s' oldFileId=%d) with newName='%s' newFileId=%d",
             null, getName(), mutable.getName(), mutable.getFileId(), newName, newMutableIndex.getFileId());
 
-        // LOCK NEW FILE
-        database.getTransactionManager().tryLockFile(newMutableIndex.getFileId(), 0, Thread.currentThread());
+        // LOCK NEW FILE. #4960: check the outcome instead of ignoring it - the id is brand new so a
+        // failure can only be a bug, but proceeding unlocked would corrupt the swap in silence.
+        final LockManager.LOCK_STATUS newFileLocked = database.getTransactionManager()
+            .tryLockFile(newMutableIndex.getFileId(), 0, Thread.currentThread());
+        if (newFileLocked == LockManager.LOCK_STATUS.NO)
+          throw new IllegalStateException(
+              "Cannot replace compacted index because cannot lock the new index file " + newMutableIndex.getFileId());
         lockedNewFileId.set(newMutableIndex.getFileId());
 
         final List<MutablePage> modifiedPages = new ArrayList<>(2 + mutable.getTotalPages() - startingFromPage);

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
@@ -107,8 +107,10 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
 
       int pos = INT_SERIALIZED_SIZE + INT_SERIALIZED_SIZE + BYTE_SERIALIZED_SIZE + INT_SERIALIZED_SIZE;
 
-      // TODO: COUNT THE MUTABLE PAGES FROM THE TAIL BACK TO THE HEAD
-      currentMutablePages = 1;
+      // #4960: every page in this file was created after the last compaction (splitIndex starts a fresh
+      // file), so the whole file counts towards the next auto-compaction. Hardcoding 1 here undercounted
+      // after every restart, deferring the scheduled compaction by up to a full threshold of new pages.
+      currentMutablePages = Math.max(1, getTotalPages());
 
       final int subIndexFileId = currentPage.readInt(pos);
 
@@ -300,6 +302,10 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
 
   public void setCurrentMutablePages(final int currentMutablePages) {
     this.currentMutablePages = currentMutablePages;
+  }
+
+  public int getCurrentMutablePages() {
+    return currentMutablePages;
   }
 
   protected MutablePage createNewPage() throws IOException {

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PartitionedTriangleOp.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PartitionedTriangleOp.java
@@ -103,11 +103,26 @@ public final class PartitionedTriangleOp implements CountOp {
       // was reached from a pool thread (or with the pool full of blocked producers), the caller waited on
       // tasks queued behind threads that were themselves waiting: a pool-starvation deadlock only mitigated
       // by the bounded queue's caller-runs rejection.
-      partialCounts[0] = countRange(knowsView, nbrs, personPartition, 0, Math.min(chunkSize, nodeCount));
-      // #4951: awaitFutures throws on interrupt (cancelling the outstanding chunks) instead of returning,
-      // so a killed/timed-out query can never sum partial (and still-being-written) partialCounts as a
-      // complete answer.
-      GraphAlgorithms.awaitFutures(futures, launched);
+      // #5063 review round 3: chunk 0 runs inside try/finally so the submitted chunks are ALWAYS awaited.
+      // Without it, a chunk-0 exception unwound this frame while chunks 1..N-1 kept running and writing
+      // into partialCounts (and holding pool threads) behind the caller's back.
+      boolean chunk0Completed = false;
+      try {
+        partialCounts[0] = countRange(knowsView, nbrs, personPartition, 0, Math.min(chunkSize, nodeCount));
+        chunk0Completed = true;
+      } finally {
+        // #4951: awaitFutures throws on interrupt (cancelling the outstanding chunks) instead of returning,
+        // so a killed/timed-out query can never sum partial (and still-being-written) partialCounts as a
+        // complete answer.
+        try {
+          GraphAlgorithms.awaitFutures(futures, launched);
+        } catch (final RuntimeException awaitError) {
+          if (chunk0Completed)
+            throw awaitError;
+          // Chunk 0's own exception is already propagating and stays primary; the await above only had to
+          // guarantee that no background chunk outlives this frame.
+        }
+      }
     }
 
     long total = 0;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PartitionedTriangleOp.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PartitionedTriangleOp.java
@@ -86,19 +86,28 @@ public final class PartitionedTriangleOp implements CountOp {
       partialCounts[0] = countRange(knowsView, nbrs, personPartition, 0, nodeCount);
     } else {
       final ExecutorService executor = QueryEngineManager.getInstance().getExecutorService();
-      final Future<?>[] futures = new Future<?>[threadCount];
+      final Future<?>[] futures = new Future<?>[threadCount - 1];
       final int chunkSize = (nodeCount + threadCount - 1) / threadCount;
-      for (int t = 0; t < threadCount; t++) {
+      int launched = 0;
+      for (int t = 1; t < threadCount; t++) {
         final int start = t * chunkSize;
         final int end = Math.min(start + chunkSize, nodeCount);
+        if (start >= nodeCount)
+          break;
         final int threadIdx = t;
-        futures[t] = executor.submit(() ->
+        futures[launched++] = executor.submit(() ->
             partialCounts[threadIdx] = countRange(knowsView, nbrs, personPartition, start, end));
       }
+      // #4952: the calling thread runs chunk 0 itself (same discipline as GraphAlgorithms.parallelForRange)
+      // instead of submitting ALL chunks and blocking. Submitting everything meant that, when this operator
+      // was reached from a pool thread (or with the pool full of blocked producers), the caller waited on
+      // tasks queued behind threads that were themselves waiting: a pool-starvation deadlock only mitigated
+      // by the bounded queue's caller-runs rejection.
+      partialCounts[0] = countRange(knowsView, nbrs, personPartition, 0, Math.min(chunkSize, nodeCount));
       // #4951: awaitFutures throws on interrupt (cancelling the outstanding chunks) instead of returning,
       // so a killed/timed-out query can never sum partial (and still-being-written) partialCounts as a
       // complete answer.
-      GraphAlgorithms.awaitFutures(futures, futures.length);
+      GraphAlgorithms.awaitFutures(futures, launched);
     }
 
     long total = 0;

--- a/engine/src/test/java/com/arcadedb/engine/BufferBloomFilterCorrectnessTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/BufferBloomFilterCorrectnessTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Regression tests for the {@link BufferBloomFilter} findings grouped in issue #4960. The class is not
@@ -96,5 +97,25 @@ class BufferBloomFilterCorrectnessTest {
       assertThat(bf.mightContain(v))
           .as("concurrently added value %d must never be a false negative", v)
           .isTrue();
+  }
+
+  /**
+   * #5063 review round 2: the constructor must reject a buffer that cannot address the
+   * {@code ceil(slots / 8)} bytes the filter spans, otherwise the highest slots read/write past the
+   * region at runtime.
+   */
+  @Test
+  void undersizedBufferIsRejectedAtConstruction() {
+    final int slots = 1 << 16;
+    assertThatThrownBy(() -> new BufferBloomFilter(new Binary(slots / 8 - 1), slots, 23))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Buffer too small");
+
+    // EXACTLY-SIZED BUFFER IS ACCEPTED AND FULLY USABLE ON THE HIGHEST SLOTS TOO
+    final BufferBloomFilter bf = new BufferBloomFilter(new Binary(slots / 8), slots, 23);
+    for (int i = 0; i < 1_000; i++)
+      bf.add(i);
+    for (int i = 0; i < 1_000; i++)
+      assertThat(bf.mightContain(i)).isTrue();
   }
 }

--- a/engine/src/test/java/com/arcadedb/engine/BufferBloomFilterCorrectnessTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/BufferBloomFilterCorrectnessTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.database.Binary;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for the {@link BufferBloomFilter} findings grouped in issue #4960. The class is not
+ * wired into the LSM read path yet, but the defects had to be fixed before it can be:
+ * <ul>
+ *   <li>the bit index could equal {@code capacity} (one bit past the region), corrupting the adjacent
+ *   byte of the shared buffer or overflowing it;</li>
+ *   <li>{@code add()} was a non-atomic read-modify-write on shared bytes, so concurrent adds could drop
+ *   a bit - a FALSE NEGATIVE, the one failure mode a bloom filter must never have;</li>
+ *   <li>a single probe (k=1) gave a needlessly high false-positive rate; two probes are now derived
+ *   from the two halves of the 64-bit Murmur hash.</li>
+ * </ul>
+ */
+class BufferBloomFilterCorrectnessTest {
+
+  @Test
+  void noFalseNegativesSingleThread() {
+    final int slots = 1 << 16;
+    final BufferBloomFilter bf = new BufferBloomFilter(new Binary(slots / 8), slots, 23);
+
+    for (int i = 0; i < 5_000; i++)
+      bf.add(i * 31 + 7);
+
+    for (int i = 0; i < 5_000; i++)
+      assertThat(bf.mightContain(i * 31 + 7))
+          .as("added value %d must always be reported as possibly present", i * 31 + 7)
+          .isTrue();
+  }
+
+  /**
+   * #4960: before the fix {@code add()} performed get-or-put on the shared byte without any
+   * synchronization, so two threads landing on the same byte could each read the same original value
+   * and one bit-set overwrote the other. The lost bit turned into a false negative. The interleaving is
+   * a race so a single run cannot PROVE its absence, but with 8 threads hammering a small region the
+   * unfixed code fails practically always; the fixed code is deterministic.
+   */
+  @Test
+  void concurrentAddsDoNotDropBits() throws Exception {
+    final int slots = 8192;
+    final BufferBloomFilter bf = new BufferBloomFilter(new Binary(slots / 8), slots, 23);
+
+    final int threads = 8;
+    final int perThread = 25_000;
+    final CountDownLatch start = new CountDownLatch(1);
+    final List<Thread> workers = new ArrayList<>(threads);
+    for (int t = 0; t < threads; t++) {
+      final int base = t * perThread;
+      final Thread worker = new Thread(() -> {
+        try {
+          start.await();
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return;
+        }
+        for (int i = 0; i < perThread; i++)
+          bf.add(base + i);
+      });
+      worker.start();
+      workers.add(worker);
+    }
+
+    start.countDown();
+    for (final Thread worker : workers)
+      worker.join();
+
+    for (int v = 0; v < threads * perThread; v++)
+      assertThat(bf.mightContain(v))
+          .as("concurrently added value %d must never be a false negative", v)
+          .isTrue();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/Issue4508TornWALRecoveryTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue4508TornWALRecoveryTest.java
@@ -156,9 +156,14 @@ class Issue4508TornWALRecoveryTest extends TestHelper {
 
     reopenExpectingRecovery();
 
-    assertThat(new File(dbPath, tornWalName))
-        .as("WAL file with mid-file corruption must be preserved, not dropped")
+    // #4958: preserved WAL files are renamed to .corrupt so a later open can neither adopt them as
+    // active WALs (appending after the corrupt content) nor re-scan and re-abort on them forever.
+    assertThat(new File(dbPath, tornWalName + ".corrupt"))
+        .as("WAL file with mid-file corruption must be preserved (as .corrupt), not dropped")
         .exists();
+    assertThat(new File(dbPath, tornWalName))
+        .as("the corrupt WAL must not survive under its active .wal name")
+        .doesNotExist();
   }
 
   @Test

--- a/engine/src/test/java/com/arcadedb/engine/Issue4958PreservedWALTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue4958PreservedWALTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for the preserved-WAL findings grouped in issue #4958:
+ * <ul>
+ *   <li>{@code TransactionManager.createWALFilePool} started {@code logFileCounter} from 0 on every open
+ *   and {@code WALFile} opens its path in "rw" mode WITHOUT truncation. A WAL file preserved by a previous
+ *   open (corrupt-gap detection or a #4928 crash-equivalent close) was therefore silently reused as an
+ *   active WAL: new transactions were appended AFTER the old (possibly corrupt) content, and the old
+ *   records replayed again on the next recovery.</li>
+ *   <li>When recovery aborted on a corrupt-gap, the WAL files were preserved under their original
+ *   {@code .wal} names, so beside the reuse above the next recovery re-scanned and re-flagged them
+ *   forever. They are now renamed to {@code .wal.corrupt} for manual inspection.</li>
+ * </ul>
+ */
+class Issue4958PreservedWALTest extends TestHelper {
+
+  // Layout constants mirroring the private statics in WALFile.
+  private static final int TX_HEADER_SIZE   = 24; // txId(8) + timestamp(8) + pages(4) + segmentSize(4)
+  private static final int PAGE_HEADER_SIZE = 24; // fileId(4) + pageNumber(4) + from(4) + to(4) + version(4) + size(4)
+  private static final int TX_FOOTER_SIZE   = 12; // segmentSize(4) + MAGIC_NUMBER(8)
+
+  @Override
+  protected void beginTest() {
+    database.getSchema().getOrCreateDocumentType("PreservedWALType");
+  }
+
+  @Test
+  void preservedWalFileIsNeverReusedAsActiveWal() throws Exception {
+    final String dbPath = database.getDatabasePath();
+    database.close();
+
+    // Simulate a WAL file preserved by a previous open (e.g. after corrupt-gap detection): a stray
+    // txlog_0.wal that the new WAL pool must NOT adopt and append to.
+    final byte[] preservedContent = new byte[64];
+    Arrays.fill(preservedContent, (byte) 0x7F);
+    final File preserved = new File(dbPath, "txlog_0.wal");
+    Files.write(preserved.toPath(), preservedContent);
+
+    // A single-file pool makes the test deterministic: every commit maps to pool slot 0, the exact
+    // slot that (before the fix) reopened the preserved txlog_0.wal and appended after its content.
+    final Object previousWalFiles = GlobalConfiguration.TX_WAL_FILES.getValue();
+    GlobalConfiguration.TX_WAL_FILES.setValue(1);
+    try {
+      database = factory.open();
+
+      database.transaction(() -> database.newDocument("PreservedWALType").set("k", 1).save());
+
+      assertThat(preserved.length())
+          .as("the preserved WAL file must not be appended to by the new active WAL pool")
+          .isEqualTo((long) preservedContent.length);
+      assertThat(Files.readAllBytes(preserved.toPath())).isEqualTo(preservedContent);
+    } finally {
+      GlobalConfiguration.TX_WAL_FILES.setValue(previousWalFiles);
+    }
+  }
+
+  @Test
+  void corruptGapWalFilesAreRenamedForManualInspection() throws Exception {
+    final String dbPath = database.getDatabasePath();
+
+    // Craft a WAL with a corrupt first record FOLLOWED by a valid transaction record: exactly the
+    // pattern the #4508 gap detector aborts recovery on and preserves the files for.
+    final byte[] garbage = new byte[32];
+    Arrays.fill(garbage, (byte) 0x7F);
+
+    final byte[] delta = { 1, 2, 3, 4, 5 };
+    final int segmentSize = PAGE_HEADER_SIZE + delta.length;
+    final ByteBuffer buf = ByteBuffer.allocate(garbage.length + TX_HEADER_SIZE + segmentSize + TX_FOOTER_SIZE);
+    buf.put(garbage);
+    buf.putLong(42L);              // txId
+    buf.putLong(123456L);          // timestamp
+    buf.putInt(1);                 // page count
+    buf.putInt(segmentSize);
+    buf.putInt(3);                 // fileId
+    buf.putInt(0);                 // pageNumber
+    buf.putInt(0);                 // changesFrom
+    buf.putInt(delta.length - 1);  // changesTo
+    buf.putInt(1);                 // currentPageVersion
+    buf.putInt(1024);              // currentPageSize
+    buf.put(delta);
+    buf.putInt(segmentSize);
+    buf.putLong(WALFile.MAGIC_NUMBER);
+
+    final File corrupt = new File(dbPath, "txlog_777.wal");
+    Files.write(corrupt.toPath(), buf.array());
+
+    ((DatabaseInternal) database).getTransactionManager().checkIntegrity();
+
+    assertThat(corrupt)
+        .as("a WAL flagged by the corrupt-gap detector must not survive under its active .wal name")
+        .doesNotExist();
+    assertThat(new File(dbPath, "txlog_777.wal.corrupt"))
+        .as("the corrupt WAL must be preserved for manual inspection under the .corrupt suffix")
+        .exists();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/Issue4958StorageStatsTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue4958StorageStatsTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for the low-severity storage/WAL findings grouped in issue #4958 that are observable
+ * through public engine behavior:
+ * <ul>
+ *   <li>{@code TransactionManager.getStats()} used to fold every active WAL file's CUMULATIVE counters
+ *   into the long-lived accumulators on each call, so the reported numbers inflated with polling
+ *   frequency (each poll re-added everything the active files ever wrote).</li>
+ *   <li>{@code TransactionManager.getStats()} used to NPE on a read-only database, where no active WAL
+ *   file pool is created.</li>
+ *   <li>{@code PageManager.getCachedPage} returned before bumping the cache-miss counter, so
+ *   {@code cacheMiss} stayed at ~0 forever and the hit/miss ratio was meaningless.</li>
+ *   <li>{@code PageManager.suspendFlushAndExecute} silently SKIPPED the callback when the database was
+ *   already suspended by an outer scope (nested backup/snapshot).</li>
+ * </ul>
+ */
+class Issue4958StorageStatsTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.getSchema().createDocumentType("StatsType");
+  }
+
+  @Test
+  void walStatsAreNotInflatedByPolling() {
+    database.transaction(() -> database.newDocument("StatsType").set("k", 1).save());
+
+    final TransactionManager txManager = ((DatabaseInternal) database).getTransactionManager();
+
+    final Map<String, Object> first = txManager.getStats();
+    final Map<String, Object> second = txManager.getStats();
+    final Map<String, Object> third = txManager.getStats();
+
+    // No writes happened between the calls: polling must not change the totals.
+    assertThat(second.get("pagesWritten")).as("pagesWritten must not inflate with polling")
+        .isEqualTo(first.get("pagesWritten"));
+    assertThat(third.get("pagesWritten")).isEqualTo(first.get("pagesWritten"));
+    assertThat(second.get("bytesWritten")).as("bytesWritten must not inflate with polling")
+        .isEqualTo(first.get("bytesWritten"));
+    assertThat(third.get("bytesWritten")).isEqualTo(first.get("bytesWritten"));
+
+    // The counters must still reflect the write that DID happen.
+    assertThat((Long) first.get("pagesWritten")).isGreaterThan(0L);
+    assertThat((Long) first.get("bytesWritten")).isGreaterThan(0L);
+  }
+
+  @Test
+  void walStatsOnReadOnlyDatabaseDoesNotThrow() {
+    database.transaction(() -> database.newDocument("StatsType").set("k", 2).save());
+
+    reopenDatabaseInReadOnlyMode();
+    try {
+      final TransactionManager txManager = ((DatabaseInternal) database).getTransactionManager();
+      // Read-only databases have no active WAL file pool: getStats() must not NPE.
+      final Map<String, Object> stats = txManager.getStats();
+      assertThat(stats).containsKeys("logFiles", "pagesWritten", "bytesWritten");
+    } finally {
+      reopenDatabase();
+    }
+  }
+
+  @Test
+  void pageCacheMissIsCounted() {
+    database.transaction(() -> {
+      for (int i = 0; i < 100; i++)
+        database.newDocument("StatsType").set("k", i).save();
+    });
+
+    // Reopening drops this database's pages from the shared read cache, so the scan below must
+    // load at least one page from disk = at least one cache miss.
+    final long missBefore = ((DatabaseInternal) database).getPageManager().getStats().cacheMiss;
+
+    reopenDatabase();
+    database.begin();
+    database.iterateType("StatsType", false).forEachRemaining(r -> r.asDocument().get("k"));
+    database.commit();
+
+    final long missAfter = ((DatabaseInternal) database).getPageManager().getStats().cacheMiss;
+    assertThat(missAfter)
+        .as("loading uncached pages from disk must increment the cacheMiss counter")
+        .isGreaterThan(missBefore);
+  }
+
+  @Test
+  void nestedSuspendFlushStillExecutesTheCallback() throws Exception {
+    final PageManager pageManager = ((DatabaseInternal) database).getPageManager();
+    final AtomicBoolean innerCallbackRan = new AtomicBoolean(false);
+
+    pageManager.suspendFlushAndExecute(database, () ->
+        // Nested suspension (e.g. a snapshot triggered during a backup): the inner callback must
+        // still run under the outer scope's suspension instead of being silently skipped.
+        pageManager.suspendFlushAndExecute(database, () -> innerCallbackRan.set(true)));
+
+    assertThat(innerCallbackRan.get())
+        .as("a nested suspendFlushAndExecute must execute its callback, not silently skip it")
+        .isTrue();
+    assertThat(pageManager.isPageFlushingSuspended(database))
+        .as("the outer scope must have restored the flush on exit")
+        .isFalse();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/Issue4958WALLowSeverityTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue4958WALLowSeverityTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the low-severity WALFile findings grouped in issue #4958.
+ * <ul>
+ *   <li>A corrupt page header whose {@code changesFrom}/{@code changesTo} imply a huge delta must be
+ *   rejected against the remaining file size BEFORE any buffer allocation. Before the fix,
+ *   {@code getTransaction} attempted {@code ByteBuffer.allocate(Integer.MAX_VALUE)} - an
+ *   {@link OutOfMemoryError} ("Requested array size exceeds VM limit") that escaped the
+ *   {@code catch (Exception)} recovery guard.</li>
+ *   <li>{@code readLong}/{@code readInt} must not rely on a single unlooped {@code channel.read} into a
+ *   shared instance buffer: covered indirectly by the round-trip test (the new implementation loops
+ *   until the buffer is full and uses per-call buffers).</li>
+ * </ul>
+ */
+class Issue4958WALLowSeverityTest {
+
+  // Layout constants mirroring the private statics in WALFile.
+  private static final int TX_HEADER_SIZE   = 24; // txId(8) + timestamp(8) + pages(4) + segmentSize(4)
+  private static final int PAGE_HEADER_SIZE = 24; // fileId(4) + pageNumber(4) + from(4) + to(4) + version(4) + size(4)
+  private static final int TX_FOOTER_SIZE   = 12; // segmentSize(4) + MAGIC_NUMBER(8)
+
+  @Test
+  void corruptDeltaSizeIsRejectedWithoutHugeAllocation() throws Exception {
+    final File tempFile = File.createTempFile("wal-corrupt-delta-", ".wal");
+    tempFile.deleteOnExit();
+    WALFile walFile = null;
+    try {
+      // A record whose declared segment size is small (passes the outer bound check) but whose page
+      // header declares changesFrom=0, changesTo=Integer.MAX_VALUE-1 -> deltaSize == Integer.MAX_VALUE.
+      final int deltaBytesOnDisk = 8;
+      final int segmentSize = PAGE_HEADER_SIZE + deltaBytesOnDisk;
+      final ByteBuffer buf = ByteBuffer.allocate(TX_HEADER_SIZE + segmentSize + TX_FOOTER_SIZE);
+      buf.putLong(1L);                       // txId
+      buf.putLong(1L);                       // timestamp
+      buf.putInt(1);                         // page count
+      buf.putInt(segmentSize);
+      buf.putInt(9);                         // fileId
+      buf.putInt(0);                         // pageNumber
+      buf.putInt(0);                         // changesFrom
+      buf.putInt(Integer.MAX_VALUE - 1);     // changesTo -> deltaSize = Integer.MAX_VALUE
+      buf.putInt(1);                         // currentPageVersion
+      buf.putInt(512);                       // currentPageSize
+      buf.put(new byte[deltaBytesOnDisk]);   // the bytes actually on disk
+      buf.putInt(segmentSize);
+      buf.putLong(WALFile.MAGIC_NUMBER);
+      buf.rewind();
+
+      try (final RandomAccessFile raf = new RandomAccessFile(tempFile, "rw")) {
+        final FileChannel ch = raf.getChannel();
+        ch.write(buf, 0);
+      }
+
+      walFile = new WALFile(tempFile.getAbsolutePath());
+
+      // Before the fix: OutOfMemoryError("Requested array size exceeds VM limit") from
+      // ByteBuffer.allocate(Integer.MAX_VALUE). After the fix: the delta is clamped against the
+      // remaining file size and the record is rejected as corrupt.
+      assertThat(walFile.getTransaction(0))
+          .as("a page delta larger than the remaining file must be rejected as corrupt")
+          .isNull();
+    } finally {
+      if (walFile != null)
+        walFile.close();
+      tempFile.delete();
+    }
+  }
+
+  @Test
+  void appendedTransactionRoundTripsThroughReadHelpers() throws Exception {
+    final File tempFile = File.createTempFile("wal-roundtrip-", ".wal");
+    tempFile.deleteOnExit();
+    WALFile walFile = null;
+    try {
+      final byte[] delta = { 10, 20, 30, 40, 50 };
+      final int segmentSize = PAGE_HEADER_SIZE + delta.length;
+      final ByteBuffer buf = ByteBuffer.allocate(TX_HEADER_SIZE + segmentSize + TX_FOOTER_SIZE);
+      buf.putLong(77L);
+      buf.putLong(123456L);
+      buf.putInt(1);
+      buf.putInt(segmentSize);
+      buf.putInt(3);                          // fileId
+      buf.putInt(2);                          // pageNumber
+      buf.putInt(0);                          // changesFrom
+      buf.putInt(delta.length - 1);           // changesTo
+      buf.putInt(4);                          // currentPageVersion
+      buf.putInt(1024);                       // currentPageSize
+      buf.put(delta);
+      buf.putInt(segmentSize);
+      buf.putLong(WALFile.MAGIC_NUMBER);
+
+      walFile = new WALFile(tempFile.getAbsolutePath());
+      walFile.append(buf);
+
+      final WALFile.WALTransaction tx = walFile.getTransaction(0);
+      assertThat(tx).isNotNull();
+      assertThat(tx.txId).isEqualTo(77L);
+      assertThat(tx.timestamp).isEqualTo(123456L);
+      assertThat(tx.pages).hasSize(1);
+      assertThat(tx.pages[0].fileId).isEqualTo(3);
+      assertThat(tx.pages[0].pageNumber).isEqualTo(2);
+      assertThat(tx.pages[0].currentContent.getContent()).startsWith(delta);
+    } finally {
+      if (walFile != null)
+        walFile.close();
+      tempFile.delete();
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/WALVersionGapRecoveryTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/WALVersionGapRecoveryTest.java
@@ -163,9 +163,11 @@ class WALVersionGapRecoveryTest extends TestHelper {
         .as("DB_NOT_CLOSED callback must fire - recovery must have run")
         .isTrue();
 
-    final File[] walFilesAfterReopen = dbDir.listFiles((d, n) -> n.endsWith(".wal"));
-    assertThat(walFilesAfterReopen)
-        .as("WAL files must be preserved when a version gap is detected during recovery")
+    // #4958: the preserved files carry the .corrupt suffix so the fresh active pool cannot reuse them
+    // and their stale records are never replayed again.
+    final File[] preservedAfterReopen = dbDir.listFiles((d, n) -> n.endsWith(".corrupt"));
+    assertThat(preservedAfterReopen)
+        .as("WAL files must be preserved (renamed .corrupt) when a version gap is detected during recovery")
         .isNotEmpty();
   }
 

--- a/engine/src/test/java/com/arcadedb/engine/timeseries/Issue4957AppendBatchTransactionTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/timeseries/Issue4957AppendBatchTransactionTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine.timeseries;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4957: {@link TimeSeriesEngine#appendBatch} dispatched every shard write to the
+ * shared {@code shardExecutor} even when the caller had an enclosing transaction open. Each TS-Shard thread
+ * then ran with its own fresh {@code DatabaseContext}/transaction, so the shard page writes were published
+ * out of band with the enclosing commit and, under HA, the page versions were reordered on the Raft log -
+ * exactly the hazard the {@link TimeSeriesEngine#appendSamples} javadoc documents and forbids.
+ * <p>
+ * The HA page-version reordering itself needs a cluster to observe, so this test verifies the fix's
+ * observable single-node contract instead: when a transaction is active on the calling thread the shard
+ * writes MUST run in-thread (sequential fallback), never on the {@code ArcadeDB-TS-Shard-*} executor
+ * threads. The executor's threads are created lazily on first dispatch, so their very existence after the
+ * call is a deterministic signal of which path ran.
+ */
+class Issue4957AppendBatchTransactionTest extends TestHelper {
+
+  private static final int SHARDS = 2;
+
+  @Test
+  void appendBatchInsideEnclosingTransactionRunsInThread() throws Exception {
+    final String typeName = "tx_batch";
+    final TimeSeriesEngine engine = createEngine(typeName);
+    try {
+      final int n = 10;
+      final long[] timestamps = new long[n];
+      final Object[][] columnValues = new Object[1][n];
+      for (int i = 0; i < n; i++) {
+        timestamps[i] = 1000L + i;
+        columnValues[0][i] = (double) i;
+      }
+
+      database.begin();
+      engine.appendBatch(timestamps, columnValues);
+      database.commit();
+
+      // #4957: with an enclosing transaction active, no shard write may be routed to the executor.
+      // The fixed-pool threads are created lazily on the first submitted task, so any live
+      // ArcadeDB-TS-Shard thread for this type proves the forbidden dispatch happened.
+      assertThat(shardThreadsOf(typeName))
+          .as("appendBatch inside an enclosing transaction must write the shards on the calling thread")
+          .isEmpty();
+
+      database.begin();
+      final List<Object[]> rows = engine.query(0L, 10_000L, null, null);
+      database.commit();
+
+      assertThat(rows).hasSize(n);
+      for (int i = 0; i < n; i++)
+        assertThat((long) rows.get(i)[0]).isEqualTo(1000L + i);
+    } finally {
+      engine.close();
+    }
+  }
+
+  @Test
+  void appendBatchOutsideTransactionStillWritesAllSamplesInParallel() throws Exception {
+    final String typeName = "notx_batch";
+    final TimeSeriesEngine engine = createEngine(typeName);
+    try {
+      final int n = 25;
+      final long[] timestamps = new long[n];
+      final Object[][] columnValues = new Object[1][n];
+      for (int i = 0; i < n; i++) {
+        timestamps[i] = 1000L + i;
+        columnValues[0][i] = (double) i;
+      }
+
+      // No enclosing transaction: the parallel per-shard dispatch path stays in effect.
+      engine.appendBatch(timestamps, columnValues);
+
+      assertThat(shardThreadsOf(typeName))
+          .as("without an enclosing transaction the parallel shard dispatch must be preserved")
+          .isNotEmpty();
+
+      database.begin();
+      final List<Object[]> rows = engine.query(0L, 10_000L, null, null);
+      database.commit();
+
+      assertThat(rows).hasSize(n);
+      for (int i = 0; i < n; i++)
+        assertThat((long) rows.get(i)[0]).isEqualTo(1000L + i);
+    } finally {
+      engine.close();
+    }
+  }
+
+  private TimeSeriesEngine createEngine(final String typeName) throws Exception {
+    final List<ColumnDefinition> cols = List.of(
+        new ColumnDefinition("ts", Type.LONG, ColumnDefinition.ColumnRole.TIMESTAMP),
+        new ColumnDefinition("value", Type.DOUBLE, ColumnDefinition.ColumnRole.FIELD));
+
+    database.begin();
+    final TimeSeriesEngine engine = new TimeSeriesEngine((DatabaseInternal) database, typeName, cols, SHARDS);
+    database.commit();
+    return engine;
+  }
+
+  private static Set<String> shardThreadsOf(final String typeName) {
+    final String prefix = "ArcadeDB-TS-Shard-" + typeName + "-";
+    return Thread.getAllStackTraces().keySet().stream()
+        .map(Thread::getName)
+        .filter(name -> name.startsWith(prefix))
+        .collect(Collectors.toSet());
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/Issue4960LSMReloadCompactionCounterTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue4960LSMReloadCompactionCounterTest.java
@@ -68,7 +68,8 @@ class Issue4960LSMReloadCompactionCounterTest extends TestHelper {
     final LSMTreeIndexMutable after = bucketMutableIndex();
     assertThat(after.getTotalPages()).isEqualTo(pagesBeforeReopen);
     assertThat(after.getCurrentMutablePages())
-        .as("after a reload the mutable-pages counter must reflect the pages actually in the file, "
+        .as("after a reload the mutable-pages counter must track the file's page count (approximate: "
+            + "getTotalPages() includes the header/root page, which is fine for a pacing-only signal), "
             + "otherwise auto-compaction is deferred by a full threshold every restart")
         .isEqualTo(after.getTotalPages());
   }

--- a/engine/src/test/java/com/arcadedb/index/Issue4960LSMReloadCompactionCounterTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue4960LSMReloadCompactionCounterTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.index.lsm.LSMTreeIndex;
+import com.arcadedb.index.lsm.LSMTreeIndexMutable;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4960: {@code LSMTreeIndexMutable.onAfterLoad()} hardcoded
+ * {@code currentMutablePages = 1} regardless of how many uncompacted pages the reloaded file actually
+ * contains. After a restart, an index that had accumulated N pages (but had not yet crossed the
+ * auto-compaction threshold) restarted its counter at 1, deferring the scheduled compaction by up to a
+ * full threshold's worth of new pages every restart.
+ */
+class Issue4960LSMReloadCompactionCounterTest extends TestHelper {
+  private static final String TYPE_NAME = "ReloadItem";
+  private static final int    PAGE_SIZE = 4096;
+
+  @Test
+  void reloadedIndexRestoresMutablePageCountFromFile() {
+    database.transaction(() -> {
+      final DocumentType type = database.getSchema().buildDocumentType().withName(TYPE_NAME).withTotalBuckets(1).create();
+      type.createProperty("id", Integer.class);
+      database.getSchema().buildTypeIndex(TYPE_NAME, new String[] { "id" })
+          .withType(Schema.INDEX_TYPE.LSM_TREE).withUnique(false).withPageSize(PAGE_SIZE).create();
+    });
+
+    final LSMTreeIndexMutable before = bucketMutableIndex();
+    final int bucketId = database.getSchema().getType(TYPE_NAME).getFirstBucketId();
+
+    // Enough entries to span several 4K pages, but below the auto-compaction threshold (default 10)
+    // so no compaction interferes with the counter.
+    database.transaction(() -> {
+      for (int i = 0; i < 1200; ++i)
+        before.put(new Object[] { i }, new RID[] { new RID(bucketId, i) });
+    });
+
+    final int pagesBeforeReopen = before.getTotalPages();
+    assertThat(pagesBeforeReopen).as("the index must span multiple pages for the test to be meaningful")
+        .isGreaterThan(1);
+
+    reopenDatabase();
+
+    final LSMTreeIndexMutable after = bucketMutableIndex();
+    assertThat(after.getTotalPages()).isEqualTo(pagesBeforeReopen);
+    assertThat(after.getCurrentMutablePages())
+        .as("after a reload the mutable-pages counter must reflect the pages actually in the file, "
+            + "otherwise auto-compaction is deferred by a full threshold every restart")
+        .isEqualTo(after.getTotalPages());
+  }
+
+  private LSMTreeIndexMutable bucketMutableIndex() {
+    final TypeIndex typeIndex = database.getSchema().getType(TYPE_NAME).getIndexesByProperties("id").getFirst();
+    for (final Index bucketIndex : typeIndex.getIndexesOnBuckets())
+      if (bucketIndex instanceof LSMTreeIndex lsmIndex)
+        return lsmIndex.getMutableIndex();
+    throw new IllegalStateException("No LSM bucket index found for type " + TYPE_NAME);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/lsm/Issue4960LSMCloseDuringCompactionTest.java
+++ b/engine/src/test/java/com/arcadedb/index/lsm/Issue4960LSMCloseDuringCompactionTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index.lsm;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.index.IndexInternal;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the {@link LSMTreeIndex#close()} finding in issue #4960: close() only CASed
+ * {@code AVAILABLE -> UNAVAILABLE}, so when a compaction was merely SCHEDULED (not yet running) the CAS
+ * failed and close() silently did nothing - the index files stayed open and the compactor could still
+ * kick in against a closing database. A scheduled-but-not-started compaction is now cancelled and the
+ * index closed; an actually running compaction is logged loudly instead of being ignored in silence.
+ */
+class Issue4960LSMCloseDuringCompactionTest extends TestHelper {
+
+  @Test
+  void closeCancelsScheduledCompaction() throws Exception {
+    database.transaction(() -> {
+      database.getSchema().createDocumentType("CloseIdx").createProperty("id", Type.INTEGER);
+      database.getSchema().createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, false, "CloseIdx", "id");
+      for (int i = 0; i < 10; i++)
+        database.newDocument("CloseIdx").set("id", i).save();
+    });
+
+    final LSMTreeIndex lsm = Arrays.stream(database.getSchema().getIndexes())
+        .filter(LSMTreeIndex.class::isInstance)
+        .map(LSMTreeIndex.class::cast)
+        .findFirst()
+        .orElseThrow();
+
+    assertThat(lsm.scheduleCompaction()).isTrue();
+
+    lsm.close();
+
+    assertThat(lsm.status.get())
+        .as("close() must cancel a scheduled-but-not-started compaction and mark the index unavailable")
+        .isEqualTo(IndexInternal.INDEX_STATUS.UNAVAILABLE);
+
+    // A cancelled schedule must not be compactable afterwards.
+    assertThat(lsm.compact()).isFalse();
+
+    reopenDatabase();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/PartitionedTriangleOpCallerRunsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/PartitionedTriangleOpCallerRunsTest.java
@@ -25,9 +25,13 @@ import com.arcadedb.graph.Vertex;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Regression test for issue #4952: {@link PartitionedTriangleOp} submitted ALL chunks (including chunk 0)
@@ -195,5 +199,69 @@ class PartitionedTriangleOpCallerRunsTest {
     assertThat(node0Thread.get())
         .as("chunk 0 must be processed by the calling thread, not a pool thread")
         .isSameAs(Thread.currentThread());
+  }
+
+  /**
+   * #5063 review round 3: if chunk 0 (run on the calling thread) throws, the already-submitted chunks
+   * 1..N-1 must still be awaited before the exception unwinds {@code execute()}, otherwise they keep
+   * writing into {@code partialCounts} (and holding pool threads) after the caller has returned.
+   * <p>
+   * The KNOWS view throws on every {@code offset()} call made by the calling thread (chunk 0 fails
+   * immediately) while background chunks sleep once before touching the view, so any background call
+   * observed after {@code execute()} has unwound proves the leak.
+   */
+  @Test
+  void chunkZeroFailureStillAwaitsBackgroundChunks() throws Exception {
+    // Empty adjacency: countRange still calls offset()/offsetEnd() for every node of every chunk.
+    final int[] offsets = new int[NODE_COUNT + 1];
+    final int[] neighbors = new int[0];
+
+    final Thread caller = Thread.currentThread();
+    final AtomicLong lastBackgroundCall = new AtomicLong();
+    final Set<Thread> sleptThreads = ConcurrentHashMap.newKeySet();
+
+    final NeighborView knowsView = new NeighborView(NODE_COUNT, offsets, neighbors) {
+      @Override
+      public int offset(final int nodeId) {
+        if (Thread.currentThread() == caller)
+          // Only countRange touches the KNOWS view, so this fails chunk 0 on its very first node.
+          throw new IllegalStateException("simulated chunk-0 failure");
+        if (sleptThreads.add(Thread.currentThread()))
+          // Keep the background chunks provably in flight while chunk 0 fails.
+          try {
+            Thread.sleep(150);
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+        lastBackgroundCall.set(System.nanoTime());
+        return super.offset(nodeId);
+      }
+    };
+
+    // Partition chain of length 1: every node points to node 1, so all nodes share partition 1.
+    final int[] partitionOffsets = new int[NODE_COUNT + 1];
+    final int[] partitionNeighbors = new int[NODE_COUNT];
+    for (int i = 0; i < NODE_COUNT; i++) {
+      partitionOffsets[i] = i;
+      partitionNeighbors[i] = 1;
+    }
+    partitionOffsets[NODE_COUNT] = NODE_COUNT;
+    final NeighborView partitionView = new NeighborView(NODE_COUNT, partitionOffsets, partitionNeighbors);
+
+    final PartitionedTriangleOp op = new PartitionedTriangleOp(new String[] { "IN_CITY" },
+        new Vertex.DIRECTION[] { Vertex.DIRECTION.OUT }, "KNOWS");
+
+    assertThatThrownBy(() -> op.execute(new StubProvider(knowsView, partitionView), null))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("simulated chunk-0 failure");
+
+    final long unwoundAt = System.nanoTime();
+
+    // Give leaked chunks (pre-fix behavior) time to wake from their sleep and touch the view.
+    Thread.sleep(300);
+
+    assertThat(lastBackgroundCall.get())
+        .as("no background chunk may still be running after execute() has unwound")
+        .isLessThan(unwoundAt);
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/PartitionedTriangleOpCallerRunsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/PartitionedTriangleOpCallerRunsTest.java
@@ -27,11 +27,14 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Regression test for issue #4952: {@link PartitionedTriangleOp} submitted ALL chunks (including chunk 0)
@@ -206,34 +209,57 @@ class PartitionedTriangleOpCallerRunsTest {
    * 1..N-1 must still be awaited before the exception unwinds {@code execute()}, otherwise they keep
    * writing into {@code partialCounts} (and holding pool threads) after the caller has returned.
    * <p>
-   * The KNOWS view throws on every {@code offset()} call made by the calling thread (chunk 0 fails
-   * immediately) while background chunks sleep once before touching the view, so any background call
-   * observed after {@code execute()} has unwound proves the leak.
+   * #5063 review round 5: the leak detection is a pure latch handshake, no wall-clock sleeps. Every
+   * background chunk parks on {@code releaseBackground} at its FIRST view access, and chunk 0 throws
+   * only after at least one background chunk is provably parked. With the try/finally fix in place,
+   * {@code execute()} cannot unwind until the backgrounds finish, so a releaser thread frees them once
+   * it observes the calling thread parked in {@code awaitFutures} (an untimed {@code Future.get()},
+   * i.e. Java-level WAITING - a merely-descheduled thread still reports RUNNABLE, so CI load cannot
+   * fake this). Without the fix, {@code execute()} unwinds while every background chunk is still
+   * parked, so {@code backgroundDone} is provably still up when the caller captures it: the failure is
+   * deterministic in both directions, not a timing race.
    */
   @Test
   void chunkZeroFailureStillAwaitsBackgroundChunks() throws Exception {
-    // Empty adjacency: countRange still calls offset()/offsetEnd() for every node of every chunk.
+    // Empty adjacency: countRange calls offset() exactly once per node of every chunk (no neighbors,
+    // so no inner offset(v) calls), which makes the background call count exactly predictable.
     final int[] offsets = new int[NODE_COUNT + 1];
     final int[] neighbors = new int[0];
 
+    // Mirror the chunk layout of PartitionedTriangleOp.execute(): chunk 0 covers [0, chunkSize),
+    // background chunks cover [chunkSize, NODE_COUNT) with one offset() call per node.
+    final int threadCount = Math.max(1, Runtime.getRuntime().availableProcessors());
+    final int chunkSize = (NODE_COUNT + threadCount - 1) / threadCount;
+    final int expectedBackgroundCalls = NODE_COUNT - Math.min(chunkSize, NODE_COUNT);
+    assumeTrue(expectedBackgroundCalls > 0, "needs at least 2 processors to launch background chunks");
+
     final Thread caller = Thread.currentThread();
-    final AtomicLong lastBackgroundCall = new AtomicLong();
-    final Set<Thread> sleptThreads = ConcurrentHashMap.newKeySet();
+    final CountDownLatch backgroundStarted = new CountDownLatch(1);
+    final CountDownLatch releaseBackground = new CountDownLatch(1);
+    final CountDownLatch chunk0Throwing = new CountDownLatch(1);
+    final CountDownLatch backgroundDone = new CountDownLatch(1);
+    final CountDownLatch unwound = new CountDownLatch(1);
+    final AtomicInteger backgroundCalls = new AtomicInteger();
+    final Set<Thread> parkedOnce = ConcurrentHashMap.newKeySet();
 
     final NeighborView knowsView = new NeighborView(NODE_COUNT, offsets, neighbors) {
       @Override
       public int offset(final int nodeId) {
-        if (Thread.currentThread() == caller)
-          // Only countRange touches the KNOWS view, so this fails chunk 0 on its very first node.
+        if (Thread.currentThread() == caller) {
+          // Only countRange touches the KNOWS view, so this fails chunk 0 on its very first node -
+          // but only once at least one background chunk is provably in flight (and parked).
+          awaitHandshake(backgroundStarted);
+          chunk0Throwing.countDown();
           throw new IllegalStateException("simulated chunk-0 failure");
-        if (sleptThreads.add(Thread.currentThread()))
-          // Keep the background chunks provably in flight while chunk 0 fails.
-          try {
-            Thread.sleep(150);
-          } catch (final InterruptedException e) {
-            Thread.currentThread().interrupt();
-          }
-        lastBackgroundCall.set(System.nanoTime());
+        }
+        if (parkedOnce.add(Thread.currentThread())) {
+          backgroundStarted.countDown();
+          // Park across chunk 0's failure: if execute() unwinds without awaiting the futures, every
+          // background chunk is still HERE, so backgroundDone cannot have been counted down yet.
+          awaitHandshake(releaseBackground);
+        }
+        if (backgroundCalls.incrementAndGet() == expectedBackgroundCalls)
+          backgroundDone.countDown();
         return super.offset(nodeId);
       }
     };
@@ -251,17 +277,57 @@ class PartitionedTriangleOpCallerRunsTest {
     final PartitionedTriangleOp op = new PartitionedTriangleOp(new String[] { "IN_CITY" },
         new Vertex.DIRECTION[] { Vertex.DIRECTION.OUT }, "KNOWS");
 
+    // Fixed-path releaser: with the try/finally in place the caller blocks in awaitFutures while every
+    // background chunk is parked on releaseBackground, and nothing inside execute() can free them. Free
+    // them once the caller is genuinely parked AFTER chunk 0 threw (only awaitFutures parks there). On
+    // the broken path the caller never parks between the throw and the leak capture below, so this
+    // thread stays idle until `unwound` fires.
+    final Thread releaser = new Thread(() -> {
+      try {
+        while (!unwound.await(1, TimeUnit.MILLISECONDS)) {
+          final Thread.State state = caller.getState();
+          if (chunk0Throwing.getCount() == 0
+              && (state == Thread.State.WAITING || state == Thread.State.TIMED_WAITING)) {
+            releaseBackground.countDown();
+            return;
+          }
+        }
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }, "chunk0-leak-test-releaser");
+    releaser.start();
+
     assertThatThrownBy(() -> op.execute(new StubProvider(knowsView, partitionView), null))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("simulated chunk-0 failure");
 
-    final long unwoundAt = System.nanoTime();
+    // Capture the evidence BEFORE releasing anything: on the fixed path the background chunks counted
+    // backgroundDone down strictly before execute() unwound (happens-before via Future.get()); on the
+    // broken path they are all still parked on releaseBackground, so the latch is provably still up.
+    final boolean backgroundDoneBeforeUnwind = backgroundDone.getCount() == 0;
 
-    // Give leaked chunks (pre-fix behavior) time to wake from their sleep and touch the view.
-    Thread.sleep(300);
+    unwound.countDown();
+    releaseBackground.countDown();
+    // Drain any leaked chunks (broken path) so they do not outlive this test, then reap the releaser.
+    assertThat(backgroundDone.await(30, TimeUnit.SECONDS))
+        .as("all background chunks must eventually complete")
+        .isTrue();
+    releaser.join(TimeUnit.SECONDS.toMillis(30));
 
-    assertThat(lastBackgroundCall.get())
-        .as("no background chunk may still be running after execute() has unwound")
-        .isLessThan(unwoundAt);
+    assertThat(backgroundDoneBeforeUnwind)
+        .as("background chunks must have completed before execute() unwound")
+        .isTrue();
+  }
+
+  /** Bounded await used by the handshake: a 30s timeout is a hang guard, not part of the detection. */
+  private static void awaitHandshake(final CountDownLatch latch) {
+    try {
+      if (!latch.await(30, TimeUnit.SECONDS))
+        throw new IllegalStateException("test handshake latch timed out");
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("test handshake interrupted", e);
+    }
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/PartitionedTriangleOpCallerRunsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/PartitionedTriangleOpCallerRunsTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.executor.steps;
+
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.GraphTraversalProvider;
+import com.arcadedb.graph.NeighborView;
+import com.arcadedb.graph.Vertex;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #4952: {@link PartitionedTriangleOp} submitted ALL chunks (including chunk 0)
+ * to the shared query-engine pool and blocked in {@code Future.get()}. Unlike
+ * {@code GraphAlgorithms.parallelForRange}, it did not run chunk 0 on the calling thread, so a caller that
+ * is itself a pool thread could starve waiting on tasks queued behind blocked pool threads.
+ * <p>
+ * The pool-starvation deadlock itself is a scheduling race that cannot be reproduced deterministically
+ * against the JVM-wide shared pool, so this test verifies the fix's observable contract instead: on the
+ * parallel path (nodeCount above the 1000 threshold) chunk 0 MUST be processed by the calling thread, and
+ * the merged triangle count must stay correct.
+ */
+class PartitionedTriangleOpCallerRunsTest {
+
+  private static final int NODE_COUNT = 2000;
+
+  /** NeighborView that records which thread iterated node 0 as the outer loop variable. */
+  private static final class RecordingNeighborView extends NeighborView {
+    private final AtomicReference<Thread> node0Thread;
+
+    private RecordingNeighborView(final int nodeCount, final int[] offsets, final int[] neighbors,
+        final AtomicReference<Thread> node0Thread) {
+      super(nodeCount, offsets, neighbors);
+      this.node0Thread = node0Thread;
+    }
+
+    @Override
+    public int offset(final int nodeId) {
+      // Node 0 has no incoming KNOWS references, so offset(0) is invoked exactly once: by the
+      // thread that owns chunk 0 of the partitioned range.
+      if (nodeId == 0)
+        node0Thread.set(Thread.currentThread());
+      return super.offset(nodeId);
+    }
+  }
+
+  private static final class StubProvider implements GraphTraversalProvider {
+    private final NeighborView knowsView;
+    private final NeighborView partitionView;
+
+    private StubProvider(final NeighborView knowsView, final NeighborView partitionView) {
+      this.knowsView = knowsView;
+      this.partitionView = partitionView;
+    }
+
+    @Override
+    public int getNodeCount() {
+      return NODE_COUNT;
+    }
+
+    @Override
+    public NeighborView getNeighborView(final Vertex.DIRECTION direction, final String... edgeTypes) {
+      if (edgeTypes.length == 1 && "KNOWS".equals(edgeTypes[0]))
+        return knowsView;
+      if (edgeTypes.length == 1 && "IN_CITY".equals(edgeTypes[0]))
+        return partitionView;
+      return null;
+    }
+
+    @Override
+    public boolean isReady() {
+      return true;
+    }
+
+    @Override
+    public String getName() {
+      return "stub";
+    }
+
+    @Override
+    public boolean coversVertexType(final String typeName) {
+      return true;
+    }
+
+    @Override
+    public boolean coversEdgeType(final String edgeTypeName) {
+      return true;
+    }
+
+    @Override
+    public int getNodeId(final RID rid) {
+      return -1;
+    }
+
+    @Override
+    public RID getRID(final int nodeId) {
+      return null;
+    }
+
+    @Override
+    public int[] getNeighborIds(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long countEdges(final int nodeId, final Vertex.DIRECTION direction, final String... edgeTypes) {
+      return 0;
+    }
+
+    @Override
+    public boolean isConnectedTo(final int nodeA, final int nodeB, final Vertex.DIRECTION direction,
+        final String... edgeTypes) {
+      return false;
+    }
+
+    @Override
+    public Object getProperty(final int nodeId, final String propertyName) {
+      return null;
+    }
+  }
+
+  @Test
+  void chunkZeroRunsOnCallingThreadAndCountIsCorrect() {
+    // Build a synthetic CSR: 10 disjoint triangles (t, t+1, t+2) starting at node 10.
+    // Node 0 has NO KNOWS neighbors and is never referenced by anyone, so its offset() call
+    // can only come from the outer loop of chunk 0.
+    final int triangles = 10;
+    final int[][] adjacency = new int[NODE_COUNT][];
+    for (int i = 0; i < NODE_COUNT; i++)
+      adjacency[i] = new int[0];
+    for (int t = 0; t < triangles; t++) {
+      final int a = 10 + t * 3, b = a + 1, c = a + 2;
+      adjacency[a] = new int[] { b, c };
+      adjacency[b] = new int[] { a, c };
+      adjacency[c] = new int[] { a, b };
+    }
+
+    int edgeCount = 0;
+    for (final int[] adj : adjacency)
+      edgeCount += adj.length;
+
+    final int[] offsets = new int[NODE_COUNT + 1];
+    final int[] neighbors = new int[edgeCount];
+    int pos = 0;
+    for (int i = 0; i < NODE_COUNT; i++) {
+      offsets[i] = pos;
+      for (final int n : adjacency[i])
+        neighbors[pos++] = n;
+    }
+    offsets[NODE_COUNT] = pos;
+
+    final AtomicReference<Thread> node0Thread = new AtomicReference<>();
+    final NeighborView knowsView = new RecordingNeighborView(NODE_COUNT, offsets, neighbors, node0Thread);
+
+    // Partition chain of length 1: every node points to node 1, so all nodes share partition 1.
+    final int[] partitionOffsets = new int[NODE_COUNT + 1];
+    final int[] partitionNeighbors = new int[NODE_COUNT];
+    for (int i = 0; i < NODE_COUNT; i++) {
+      partitionOffsets[i] = i;
+      partitionNeighbors[i] = 1;
+    }
+    partitionOffsets[NODE_COUNT] = NODE_COUNT;
+    final NeighborView partitionView = new NeighborView(NODE_COUNT, partitionOffsets, partitionNeighbors);
+
+    final PartitionedTriangleOp op = new PartitionedTriangleOp(new String[] { "IN_CITY" },
+        new Vertex.DIRECTION[] { Vertex.DIRECTION.OUT }, "KNOWS");
+
+    final long count = op.execute(new StubProvider(knowsView, partitionView), null);
+
+    // Each triangle is counted 6 times (each of the 3 nodes as u, each of its 2 neighbors as v).
+    assertThat(count).isEqualTo(6L * triangles);
+
+    // #4952: chunk 0 must run on the calling thread (caller-runs-chunk-0 discipline), never be
+    // queued behind potentially-blocked pool threads.
+    assertThat(node0Thread.get())
+        .as("chunk 0 must be processed by the calling thread, not a pool thread")
+        .isSameAs(Thread.currentThread());
+  }
+}

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
@@ -89,6 +89,9 @@ public class SnapshotHttpHandler implements HttpHandler {
   // same database waits its turn; requests beyond the semaphore limit still get a fast 503. Overlap
   // with OTHER suspendFlushAndExecute callers (SQL BACKUP DATABASE, database verify) is a pre-existing
   // exposure of the ownership model, out of this handler's control.
+  // Entries are never pruned by design: one small ReentrantLock per database NAME ever snapshotted, bounded
+  // by the server's database count (a dropped-and-recreated database safely reuses its lock). Pruning on
+  // drop would need lifecycle callbacks this handler does not have, for negligible memory.
   private final ConcurrentHashMap<String, ReentrantLock> perDatabaseSuspendLock = new ConcurrentHashMap<>();
 
   private final ScheduledExecutorService watchdogExecutor =

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
@@ -49,6 +49,7 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -56,6 +57,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.zip.CRC32;
 import java.util.zip.CheckedInputStream;
@@ -73,6 +75,21 @@ public class SnapshotHttpHandler implements HttpHandler {
 
   private static final Semaphore CONCURRENCY_SEMAPHORE =
       new Semaphore(GlobalConfiguration.HA_SNAPSHOT_MAX_CONCURRENT.getValueAsInteger(), true);
+
+  // #5063 (review round 5): PageManagerFlushThread.setSuspended is ownership-based (putIfAbsent) - only
+  // the FIRST caller owns the suspend flag, and suspendFlushAndExecute now ALWAYS runs the callback
+  // (issue #4958). A second thread entering for the same database would stream files WITHOUT owning the
+  // suspension: it skips waitForCurrentFlushToComplete (so a flush batch may still be mid-write), and
+  // when the owner exits, setSuspended(false) synchronously flushes the deferred batches to disk,
+  // tearing the files the non-owner is still reading. Neither existing guard prevents that overlap:
+  // CONCURRENCY_SEMAPHORE admits HA_SNAPSHOT_MAX_CONCURRENT (default 2) requests - possibly for the
+  // same database, e.g. two followers resyncing at once - and executeInReadLock is a SHARED lock.
+  // This per-database lock serializes the snapshot and checksums paths, so the single thread inside
+  // suspendFlushAndExecute always owns the suspension for its whole read. A concurrent request for the
+  // same database waits its turn; requests beyond the semaphore limit still get a fast 503. Overlap
+  // with OTHER suspendFlushAndExecute callers (SQL BACKUP DATABASE, database verify) is a pre-existing
+  // exposure of the ownership model, out of this handler's control.
+  private final ConcurrentHashMap<String, ReentrantLock> perDatabaseSuspendLock = new ConcurrentHashMap<>();
 
   private final ScheduledExecutorService watchdogExecutor =
       Executors.newSingleThreadScheduledExecutor(r -> {
@@ -171,22 +188,18 @@ public class SnapshotHttpHandler implements HttpHandler {
 
       final DatabaseInternal db = server.getDatabase(databaseName);
 
-      db.executeInReadLock(() -> {
-        // suspendFlushAndExecute uses a putIfAbsent-based guard that only one concurrent
-        // caller can "own" the suspend. If flush is already suspended (e.g. a concurrent
-        // snapshot request), isPageFlushingSuspended() is true and it is safe to read files
-        // directly since the flush thread is not writing. In both cases we serve the snapshot.
-        final boolean[] executed = { false };
-        db.getPageManager().suspendFlushAndExecute(db, () -> {
-          executed[0] = true;
-          serveSnapshotZip(exchange, db, databaseName);
+      final ReentrantLock dbSuspendLock = suspendLockFor(databaseName);
+      dbSuspendLock.lock();
+      try {
+        db.executeInReadLock(() -> {
+          // Serialized per database (see perDatabaseSuspendLock), so this call always OWNS the flush
+          // suspension: the callback streams the files with the flush thread parked for the whole read.
+          db.getPageManager().suspendFlushAndExecute(db, () -> serveSnapshotZip(exchange, db, databaseName));
+          return null;
         });
-        if (!executed[0]) {
-          // Flush was already suspended by another concurrent snapshot request; serve directly.
-          serveSnapshotZip(exchange, db, databaseName);
-        }
-        return null;
-      });
+      } finally {
+        dbSuspendLock.unlock();
+      }
     } finally {
       CONCURRENCY_SEMAPHORE.release();
     }
@@ -202,25 +215,42 @@ public class SnapshotHttpHandler implements HttpHandler {
 
     final DatabaseInternal db = server.getDatabase(databaseName);
 
-    // Flush pages and hold a read lock to ensure a consistent point-in-time view of database files
-    db.executeInReadLock(() -> {
-      db.getPageManager().suspendFlushAndExecute(db, () -> {
-        try {
-          final File dbDir = new File(db.getDatabasePath());
-          final Map<String, Long> checksums = SnapshotManager.computeFileChecksums(dbDir);
-          final JSONObject response = new JSONObject();
-          for (final var entry : checksums.entrySet())
-            response.put(entry.getKey(), entry.getValue());
+    // Flush pages and hold a read lock to ensure a consistent point-in-time view of database files.
+    // Serialized per database (see perDatabaseSuspendLock) so this thread always OWNS the suspension.
+    final ReentrantLock dbSuspendLock = suspendLockFor(databaseName);
+    dbSuspendLock.lock();
+    try {
+      db.executeInReadLock(() -> {
+        db.getPageManager().suspendFlushAndExecute(db, () -> {
+          try {
+            final File dbDir = new File(db.getDatabasePath());
+            final Map<String, Long> checksums = SnapshotManager.computeFileChecksums(dbDir);
+            final JSONObject response = new JSONObject();
+            for (final var entry : checksums.entrySet())
+              response.put(entry.getKey(), entry.getValue());
 
-          exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
-          exchange.getResponseSender().send(response.toString());
-        } catch (final Exception e) {
-          exchange.setStatusCode(500);
-          exchange.getResponseSender().send("Error computing checksums: " + e.getMessage());
-        }
+            exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
+            exchange.getResponseSender().send(response.toString());
+          } catch (final Exception e) {
+            exchange.setStatusCode(500);
+            exchange.getResponseSender().send("Error computing checksums: " + e.getMessage());
+          }
+        });
+        return null;
       });
-      return null;
-    });
+    } finally {
+      dbSuspendLock.unlock();
+    }
+  }
+
+  /**
+   * Returns the per-database lock serializing every entry into {@code suspendFlushAndExecute} made by
+   * this handler (snapshot ZIP and checksums paths), so the entering thread always owns the flush
+   * suspension for its whole read (see {@link #perDatabaseSuspendLock}). One lock instance per database
+   * name for the lifetime of the handler. Package-private for unit testing.
+   */
+  ReentrantLock suspendLockFor(final String databaseName) {
+    return perDatabaseSuspendLock.computeIfAbsent(databaseName, k -> new ReentrantLock());
   }
 
   private ServerSecurityUser authenticate(final HttpServerExchange exchange) {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotManager.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotManager.java
@@ -127,8 +127,9 @@ public final class SnapshotManager {
     final byte[] buffer = new byte[8192];
     for (final File file : files) {
       final String name = file.getName();
-      // Skip transient files that differ between nodes: WAL logs, schema backups, lock files
-      if (name.endsWith(".wal") || name.endsWith(".prev.json") || name.endsWith(".lock"))
+      // Skip transient files that differ between nodes: WAL logs, schema backups, lock files,
+      // and WAL files preserved as .corrupt evidence after an aborted recovery (#4958)
+      if (name.endsWith(".wal") || name.endsWith(".prev.json") || name.endsWith(".lock") || name.endsWith(".corrupt"))
         continue;
 
       final CRC32 crc = new CRC32();

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotHttpHandlerSuspendLockTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotHttpHandlerSuspendLockTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * #5063 (review round 5): {@code PageManagerFlushThread.setSuspended} is ownership-based, so only ONE
+ * thread at a time may be inside {@code suspendFlushAndExecute} for a given database or the non-owner
+ * can observe a resumed flush mid-read. {@link SnapshotHttpHandler#suspendLockFor} provides the
+ * per-database lock that serializes the handler's snapshot and checksums paths; these tests pin its
+ * identity contract: same database name, same lock instance; different names, independent locks.
+ */
+class SnapshotHttpHandlerSuspendLockTest {
+
+  @Test
+  void sameDatabaseNameAlwaysMapsToTheSameLockInstance() {
+    final SnapshotHttpHandler handler = new SnapshotHttpHandler(null);
+    final ReentrantLock first = handler.suspendLockFor("mydb");
+    assertThat(handler.suspendLockFor("mydb")).isSameAs(first);
+  }
+
+  @Test
+  void differentDatabaseNamesDoNotShareALock() {
+    final SnapshotHttpHandler handler = new SnapshotHttpHandler(null);
+    assertThat(handler.suspendLockFor("db1")).isNotSameAs(handler.suspendLockFor("db2"));
+  }
+
+  @Test
+  void lockIsHeldExclusivelyAcrossThreads() throws Exception {
+    final SnapshotHttpHandler handler = new SnapshotHttpHandler(null);
+    final ReentrantLock lock = handler.suspendLockFor("mydb");
+    lock.lock();
+    try {
+      final boolean[] acquiredByOtherThread = { true };
+      final Thread other = new Thread(() -> acquiredByOtherThread[0] = handler.suspendLockFor("mydb").tryLock());
+      other.start();
+      other.join(10_000);
+      assertThat(acquiredByOtherThread[0])
+          .as("a second thread must not enter the snapshot suspend section for the same database")
+          .isFalse();
+    } finally {
+      lock.unlock();
+    }
+  }
+}


### PR DESCRIPTION
Fixes the "pools-and-lows" group of the 2026-07 engine audit (tracking issue #4962): closes #4952, closes #4957, closes #4958 (fixed items listed below), closes #4960 (fixed items listed below).

## Per-issue verdicts

| Issue | Verdict | Summary |
|---|---|---|
| #4952 | **fixed** | `PartitionedTriangleOp` now runs chunk 0 on the calling thread (caller-runs-chunk-0 discipline of `parallelForRange`) instead of submitting all chunks and blocking - removes the pool-starvation deadlock risk when reached from a pool thread. |
| #4957 | **fixed** | `TimeSeriesEngine.appendBatch` falls back to sequential in-thread shard writes when the calling thread has an enclosing transaction (honors the `appendSamples` threading contract; keeps parallel dispatch otherwise). |
| #4958 | **fixed** (7 of 9 checkboxes; 1 already-fixed, 1 left open with rationale) | WAL read/write helpers loop to completion with per-call buffers; per-page delta clamped to remaining file size (OOM-Error escape during recovery); `getStats()` snapshot semantics + read-only NPE guard; cache-miss counter actually counted; nested `suspendFlushAndExecute` runs the callback; preserved WALs renamed to `.wal.corrupt` + WAL pool counter seeded past existing files (and the ha-raft snapshot checksum skips the preserved `.corrupt` files like it already skipped `.wal`); `LocalBucket` free-space stats measured on the content region with thread-safe counters. |
| #4960 | **fixed** (5 of 6 checkboxes; the rollback counter drift and the DESC rescan left open with rationale) | `BufferBloomFilter` hardened (modulo bound, atomic `add`, k=2 probes from the Murmur64 halves); `LSMTreeIndex.mutable` made `volatile`; `close()` cancels a scheduled compaction instead of a silent no-op and logs when one is in progress; `splitIndex` verifies the new-file lock outcome; `onAfterLoad` restores the uncompacted-pages counter from the file instead of hardcoding 1 (auto-compaction was deferred by up to a full threshold of new pages after every restart). |

### Items deliberately left open
- **#4958 `activeWALFilePool` element publication**: a proper fix is an `AtomicReferenceArray` refactor across `TransactionManager` (a conflict epicenter for the sibling audit branches); a minimal VarHandle variant was prototyped and discarded for the same reason. The committer's 10 ms retry loop re-reads the element through a synchronized `acquire`, bounding staleness in practice. Marked as remaining on the issue.
- **#4958 `waitAllPagesOfDatabaseAreFlushed` forever-loop while suspended**: already fixed by the #4928 bounded no-progress wait (verified against current main).
- **#4960 `createNewPage` counter drift on rollback** (second half of the `currentMutablePages` checkbox): still open; the reload undercount - the impactful half - is fixed here, and the drift self-corrects on the next reload with that fix in place.
- **#4960 `getKeys()` descending O(n^2)**: perf-only, no correctness impact.

## Red-first evidence
Every deterministic finding got a failing test before the fix (details in the commit messages):
- `PartitionedTriangleOpCallerRunsTest`: chunk 0 observed on `ArcadeDB-QueryWorker-1` instead of the calling thread (the deadlock itself is a scheduling race; the test pins the fix's thread-affinity contract).
- `Issue4957AppendBatchTransactionTest`: live `ArcadeDB-TS-Shard-*` threads spawned by a batch appended inside a transaction (lazy pool-thread creation makes the forbidden dispatch deterministically observable).
- `Issue4958WALLowSeverityTest`: crafted corrupt page header made `ByteBuffer.allocate(Integer.MAX_VALUE)` throw an `OutOfMemoryError` that escaped the recovery guard and killed the surefire fork.
- `Issue4958StorageStatsTest`: stats inflation with polling, read-only NPE, cache-miss stuck at 0, nested suspend silently skipping the callback (the single production caller is full backup - the nested case produced a silent no-op backup).
- `Issue4958PreservedWALTest`: stray `txlog_0.wal` grew from 64 bytes after one commit (adopted as active WAL); corrupt-gap file survived under its `.wal` name.
- `Issue4960LSMCloseDuringCompactionTest`: `close()` left the index `COMPACTION_SCHEDULED` and open.
- `Issue4960LSMReloadCompactionCounterTest`: after a reopen the counter read 1 while the reloaded file held 4 uncompacted pages.
- `BufferBloomFilterCorrectnessTest`: honest note - the dropped-bit race did not reproduce deterministically (saturation masks drops; unsaturated filters make same-byte interleavings rare), so the atomicity fix is verified analytically and by contract; the no-false-negative property is tested single- and multi-threaded.

`Issue4508TornWALRecoveryTest` and `WALVersionGapRecoveryTest` were updated for the deliberate behavior change (preserved corrupt WALs now carry the `.corrupt` suffix).

## Tests
- 16 new regression tests across 8 classes, all green.
- Focused suites `com.arcadedb.graph.**`, `com.arcadedb.index.**`, `com.arcadedb.engine.**` (includes `engine.timeseries`) with `-DexcludedGroups=benchmark,slow`: **1296 tests, 0 failures, 0 errors** (re-run after the follow-up commit).
- ha-raft `SnapshotManagerTest` + `SnapshotManifestVerificationTest`: 13 tests, 0 failures.
- OpenCypher triangle/GAV algo tests: 62 tests, 0 failures (AlgoTriangleCount, AlgoLocalClusteringCoefficient, GAVEligibility, MatchRelationshipStepOptimization).

## Conflict risks (files sibling audit branches may touch)
- `docs/release-26.7.2.md` - every audit branch appends here; conflict expected and trivial.
- `engine/src/main/java/com/arcadedb/engine/TransactionManager.java`, `PageManager.java` - shared with the WAL/tx sibling groups (changes here are small and localized: getStats, createWALFilePool seeding, checkIntegrity rename, cache-miss counter, suspendFlushAndExecute).
- `engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndex.java`, `LSMTreeIndexMutable.java` - just modified by the merged fix/4946-4947 branch; these changes were written against that state.
- `engine/src/test/java/com/arcadedb/engine/Issue4508TornWALRecoveryTest.java`, `WALVersionGapRecoveryTest.java` - assertions updated for the `.corrupt` rename.
- `ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotManager.java` - one-line skip-list extension; sibling HA branches may touch this file.
