### PR TITLE
fix(#4927): refcount the JVM-wide PageManager lifecycle

### DIFF
--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -233,7 +233,9 @@ that could starve the very snapshot resync meant to heal the node.
   (NPE on the first cache miss, or scheduled pages never flushed), and two concurrent opens could start two
   flush threads, leaking one with queued pages. Every open/create now acquires a reference and every close
   releases it under one global lock, with startup on the first acquire and teardown on the last release;
-  `configure()` (the PROFILE setter hook) no longer starts a flush thread when no database is open
+  `configure()` (the PROFILE setter hook) no longer starts a flush thread when no database is open, and a
+  profile change while databases are OPEN is refused with a warning (the page manager keeps its current
+  sizing rather than being swapped live under running queries; set the profile before opening databases)
   ([#4927](https://github.com/ArcadeData/arcadedb/issues/4927)).
 - **Pool discipline, TimeSeries threading and low-severity storage/WAL/LSM cleanups (2026-07 audit).**
   The partitioned triangle-count operator now runs chunk 0 on the calling thread instead of submitting

--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -227,6 +227,15 @@ that could starve the very snapshot resync meant to heal the node.
   shadows committed RIDs whose key equals an uncommitted entry's key - is tracked in
   [#5055](https://github.com/ArcadeData/arcadedb/issues/5055).
 
+- **PageManager lifecycle is refcounted.** The JVM-wide page manager was started and stopped on a racy
+  "is the active-database map empty" check-then-act spanning factory instances: closing the last instance
+  of one database could null the shared flush thread under a database whose open was still in flight
+  (NPE on the first cache miss, or scheduled pages never flushed), and two concurrent opens could start two
+  flush threads, leaking one with queued pages. Every open/create now acquires a reference and every close
+  releases it under one global lock, with startup on the first acquire and teardown on the last release;
+  `configure()` (the PROFILE setter hook) no longer starts a flush thread when no database is open
+  ([#4927](https://github.com/ArcadeData/arcadedb/issues/4927)).
+
 ### Improvements
 
 - **HA: throttled diverged-follower resync logging.** When a follower detects a WAL page-version gap it

--- a/engine/src/main/java/com/arcadedb/database/DatabaseFactory.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseFactory.java
@@ -75,9 +75,9 @@ public class DatabaseFactory implements AutoCloseable {
   public synchronized Database open(final ComponentFile.MODE mode) {
     checkForActiveInstance(databasePath);
 
-    final boolean pageManagerStarted = ACTIVE_INSTANCES.isEmpty();
-    if (pageManagerStarted)
-      PageManager.INSTANCE.configure();
+    // #4927: refcounted acquire under the PageManager's global lifecycle lock - the previous
+    // ACTIVE_INSTANCES.isEmpty() check-then-act raced concurrent open/close across factory instances.
+    PageManager.INSTANCE.acquire();
 
     try {
       final LocalDatabase database = new LocalDatabase(databasePath, mode, contextConfiguration, security, callbacks);
@@ -88,7 +88,9 @@ public class DatabaseFactory implements AutoCloseable {
 
       return database;
     } catch (final Throwable e) {
-      stopPageManagerIfNoActiveInstance(pageManagerStarted);
+      // Balance the acquire above so a failed open does not leak the flush thread (#4991): the refcount
+      // reaches zero (and tears the manager down) only when no other database is active.
+      PageManager.INSTANCE.release();
       throw e;
     }
   }
@@ -96,9 +98,9 @@ public class DatabaseFactory implements AutoCloseable {
   public synchronized Database create() {
     checkForActiveInstance(databasePath);
 
-    final boolean pageManagerStarted = ACTIVE_INSTANCES.isEmpty();
-    if (pageManagerStarted)
-      PageManager.INSTANCE.configure();
+    // #4927: refcounted acquire under the PageManager's global lifecycle lock - the previous
+    // ACTIVE_INSTANCES.isEmpty() check-then-act raced concurrent open/close across factory instances.
+    PageManager.INSTANCE.acquire();
 
     try {
       final LocalDatabase database = new LocalDatabase(databasePath, ComponentFile.MODE.READ_WRITE, contextConfiguration, security,
@@ -110,19 +112,11 @@ public class DatabaseFactory implements AutoCloseable {
 
       return database;
     } catch (final Throwable e) {
-      stopPageManagerIfNoActiveInstance(pageManagerStarted);
+      // Balance the acquire above so a failed open does not leak the flush thread (#4991): the refcount
+      // reaches zero (and tears the manager down) only when no other database is active.
+      PageManager.INSTANCE.release();
       throw e;
     }
-  }
-
-  /**
-   * Stops the global {@link PageManager} (and its non-daemon "ArcadeDB AsyncFlush" flush thread) if this
-   * factory started it during a failed open/create and no other database instance is active. Without this,
-   * a failed open leaks the flush thread and the JVM can never exit (issue #4991).
-   */
-  private static void stopPageManagerIfNoActiveInstance(final boolean pageManagerStarted) {
-    if (pageManagerStarted && ACTIVE_INSTANCES.isEmpty())
-      PageManager.INSTANCE.close();
   }
 
   public synchronized DatabaseFactory setAutoTransaction(final boolean enabled) {

--- a/engine/src/main/java/com/arcadedb/database/DatabaseFactory.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseFactory.java
@@ -164,9 +164,12 @@ public class DatabaseFactory implements AutoCloseable {
     return ACTIVE_INSTANCES.get(normalizedPath);
   }
 
-  protected static boolean removeActiveDatabaseInstance(final String databasePath) {
-    var normalizedPath = getNormalizedPath(databasePath);
-    ACTIVE_INSTANCES.remove(normalizedPath);
+  protected static boolean removeActiveDatabaseInstance(final String databasePath, final Database instance) {
+    final var normalizedPath = getNormalizedPath(databasePath);
+    // Keyed to the instance (#5070 review): when registerActiveInstance closes a same-path open-race LOSER,
+    // the loser's close must not remove the WINNER's still-live mapping - a plain remove(path) did, orphaning
+    // the winner from the registry and letting a third open of the same path pass checkForActiveInstance.
+    ACTIVE_INSTANCES.remove(normalizedPath, instance);
     return ACTIVE_INSTANCES.isEmpty();
   }
 

--- a/engine/src/main/java/com/arcadedb/database/DatabaseFactory.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseFactory.java
@@ -79,8 +79,9 @@ public class DatabaseFactory implements AutoCloseable {
     // ACTIVE_INSTANCES.isEmpty() check-then-act raced concurrent open/close across factory instances.
     PageManager.INSTANCE.acquire();
 
+    LocalDatabase database = null;
     try {
-      final LocalDatabase database = new LocalDatabase(databasePath, mode, contextConfiguration, security, callbacks);
+      database = new LocalDatabase(databasePath, mode, contextConfiguration, security, callbacks);
       database.setAutoTransaction(autoTransaction);
       database.open();
 
@@ -88,9 +89,12 @@ public class DatabaseFactory implements AutoCloseable {
 
       return database;
     } catch (final Throwable e) {
-      // Balance the acquire above so a failed open does not leak the flush thread (#4991): the refcount
-      // reaches zero (and tears the manager down) only when no other database is active.
-      PageManager.INSTANCE.release();
+      // Balance the acquire above so a failed open does not leak the flush thread (#4991) - but EXACTLY
+      // once per instance (#5070 review): when registerActiveInstance loses a same-path open race it closes
+      // the database itself, and that close already consumed this reference; releasing again here would
+      // double-decrement and could tear the manager down under the race winner.
+      if (database == null || !database.isPageManagerReferenceReleased())
+        PageManager.INSTANCE.release();
       throw e;
     }
   }
@@ -102,8 +106,9 @@ public class DatabaseFactory implements AutoCloseable {
     // ACTIVE_INSTANCES.isEmpty() check-then-act raced concurrent open/close across factory instances.
     PageManager.INSTANCE.acquire();
 
+    LocalDatabase database = null;
     try {
-      final LocalDatabase database = new LocalDatabase(databasePath, ComponentFile.MODE.READ_WRITE, contextConfiguration, security,
+      database = new LocalDatabase(databasePath, ComponentFile.MODE.READ_WRITE, contextConfiguration, security,
           callbacks);
       database.setAutoTransaction(autoTransaction);
       database.create();
@@ -112,9 +117,10 @@ public class DatabaseFactory implements AutoCloseable {
 
       return database;
     } catch (final Throwable e) {
-      // Balance the acquire above so a failed open does not leak the flush thread (#4991): the refcount
-      // reaches zero (and tears the manager down) only when no other database is active.
-      PageManager.INSTANCE.release();
+      // Balance the acquire above so a failed create does not leak the flush thread (#4991) - but EXACTLY
+      // once per instance (#5070 review): see open().
+      if (database == null || !database.isPageManagerReferenceReleased())
+        PageManager.INSTANCE.release();
       throw e;
     }
   }

--- a/engine/src/main/java/com/arcadedb/database/DatabaseFactory.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseFactory.java
@@ -108,8 +108,7 @@ public class DatabaseFactory implements AutoCloseable {
 
     LocalDatabase database = null;
     try {
-      database = new LocalDatabase(databasePath, ComponentFile.MODE.READ_WRITE, contextConfiguration, security,
-          callbacks);
+      database = new LocalDatabase(databasePath, ComponentFile.MODE.READ_WRITE, contextConfiguration, security, callbacks);
       database.setAutoTransaction(autoTransaction);
       database.create();
 

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -2196,7 +2196,9 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
 
     // Unconditional on purpose: a KILLED database (crash simulation) reaches close() with open == false and
     // must still unregister - removeActiveDatabaseInstance is naturally idempotent (false on the second
-    // call), which is exactly how the pre-#4927 code stayed double-close-safe.
+    // call), which is exactly how the pre-#4927 code stayed double-close-safe. The executor teardown stays
+    // on the map-emptiness heuristic DELIBERATELY (#5070 review): unlike the flush thread, a shutdown
+    // executor lazily re-creates itself on the next getExecutor(), so the mid-flight-open race self-heals.
     if (DatabaseFactory.removeActiveDatabaseInstance(databasePath, this))
       GraphAnalyticalView.closeExecutor();
 

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -2191,7 +2191,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     // Unconditional on purpose: a KILLED database (crash simulation) reaches close() with open == false and
     // must still unregister - removeActiveDatabaseInstance is naturally idempotent (false on the second
     // call), which is exactly how the pre-#4927 code stayed double-close-safe.
-    if (DatabaseFactory.removeActiveDatabaseInstance(databasePath))
+    if (DatabaseFactory.removeActiveDatabaseInstance(databasePath, this))
       GraphAnalyticalView.closeExecutor();
 
     // #4927: paired with the acquire in DatabaseFactory.open/create - the flush machinery is torn down by

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -322,6 +322,12 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
    * Test only API. Simulates a forced kill of the JVM leaving the database with the .lck file on the file system.
    */
   @Override
+  /**
+   * Test-only crash simulation. NOTE (#4927): kill() deliberately does NOT release this instance's
+   * PageManager lifecycle reference - the documented kill-then-close contract relies on the following
+   * {@code close()} releasing it (closeInternal's release runs with {@code open == false} too, exactly
+   * once via its CAS). A kill() never followed by close() pins the page manager open for the JVM's life.
+   */
   public void kill() {
     if (async != null)
       async.kill();

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -2164,10 +2164,14 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
       return null;
     });
 
-    if (DatabaseFactory.removeActiveDatabaseInstance(databasePath)) {
+    if (DatabaseFactory.removeActiveDatabaseInstance(databasePath))
       GraphAnalyticalView.closeExecutor();
-      PageManager.INSTANCE.close();
-    }
+
+    // #4927: paired with the acquire in DatabaseFactory.open/create - the flush machinery is torn down by
+    // the refcount reaching zero, never by the racy "was this the last registered instance" check (an open
+    // in flight on another thread holds a reference before it registers, so it can no longer be pulled out
+    // from under).
+    PageManager.INSTANCE.release();
   }
 
   private void checkForRecovery() throws IOException {

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -320,14 +320,13 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
 
   /**
    * Test only API. Simulates a forced kill of the JVM leaving the database with the .lck file on the file system.
+   * <p>
+   * NOTE (#4927): kill() deliberately does NOT release this instance's PageManager lifecycle reference -
+   * the documented kill-then-close contract relies on the following {@code close()} releasing it
+   * (closeInternal's release runs with {@code open == false} too, exactly once via its CAS). A kill()
+   * never followed by close() pins the page manager open for the JVM's life.
    */
   @Override
-  /**
-   * Test-only crash simulation. NOTE (#4927): kill() deliberately does NOT release this instance's
-   * PageManager lifecycle reference - the documented kill-then-close contract relies on the following
-   * {@code close()} releasing it (closeInternal's release runs with {@code open == false} too, exactly
-   * once via its CAS). A kill() never followed by close() pins the page manager open for the JVM's life.
-   */
   public void kill() {
     if (async != null)
       async.kill();
@@ -2199,6 +2198,8 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     // call), which is exactly how the pre-#4927 code stayed double-close-safe. The executor teardown stays
     // on the map-emptiness heuristic DELIBERATELY (#5070 review): unlike the flush thread, a shutdown
     // executor lazily re-creates itself on the next getExecutor(), so the mid-flight-open race self-heals.
+    // A redundant double-close of the LAST database calls it twice (the empty map returns true again):
+    // harmless, closeExecutor() is idempotent (early-returns on null/isShutdown under its class lock).
     if (DatabaseFactory.removeActiveDatabaseInstance(databasePath, this))
       GraphAnalyticalView.closeExecutor();
 

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -2066,12 +2066,9 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
       GraphTraversalProviderRegistry.clearAll(this);
     }
 
-    final Boolean actuallyClosed = executeInWriteLock(() -> {
+    executeInWriteLock(() -> {
       if (!open)
-        // Idempotent close contract: a redundant second close() must be a no-op - in particular it must NOT
-        // consume another PageManager lifecycle reference below (#5070 review: the unconditional release
-        // tore the flush thread down under other open databases through the double-close door).
-        return false;
+        return null;
 
       try {
         if (async != null)
@@ -2188,29 +2185,30 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
         }
       }
 
-      return true;
+      return null;
     });
 
-    if (Boolean.TRUE.equals(actuallyClosed)) {
-      if (DatabaseFactory.removeActiveDatabaseInstance(databasePath))
-        GraphAnalyticalView.closeExecutor();
+    // Unconditional on purpose: a KILLED database (crash simulation) reaches close() with open == false and
+    // must still unregister - removeActiveDatabaseInstance is naturally idempotent (false on the second
+    // call), which is exactly how the pre-#4927 code stayed double-close-safe.
+    if (DatabaseFactory.removeActiveDatabaseInstance(databasePath))
+      GraphAnalyticalView.closeExecutor();
 
-      // #4927: paired with the acquire in DatabaseFactory.open/create - the flush machinery is torn down by
-      // the refcount reaching zero, never by the racy "was this the last registered instance" check (an open
-      // in flight on another thread holds a reference before it registers, so it can no longer be pulled out
-      // from under). Guarded by actuallyClosed and recorded in the flag: the lifecycle reference is consumed
-      // EXACTLY ONCE per database instance, however many times close() is called and whoever calls it
-      // (including registerActiveInstance closing a same-path open race loser before the factory's catch).
-      pageManagerReferenceReleased = true;
+    // #4927: paired with the acquire in DatabaseFactory.open/create - the flush machinery is torn down by
+    // the refcount reaching zero, never by the racy "was this the last registered instance" check (an open
+    // in flight on another thread holds a reference before it registers, so it can no longer be pulled out
+    // from under). The atomic flag makes the release EXACTLY ONCE per database instance (#5070 review): a
+    // redundant double-close cannot steal another database's reference, and when registerActiveInstance
+    // closes a same-path open race loser, the factory's catch sees the flag and does not release again.
+    if (pageManagerReferenceReleased.compareAndSet(false, true))
       PageManager.INSTANCE.release();
-    }
   }
 
   /** #4927/#5070: whether this instance already consumed its PageManager lifecycle reference (see closeInternal). */
-  private volatile boolean pageManagerReferenceReleased = false;
+  private final AtomicBoolean pageManagerReferenceReleased = new AtomicBoolean(false);
 
   boolean isPageManagerReferenceReleased() {
-    return pageManagerReferenceReleased;
+    return pageManagerReferenceReleased.get();
   }
 
   private void checkForRecovery() throws IOException {

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -2066,9 +2066,12 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
       GraphTraversalProviderRegistry.clearAll(this);
     }
 
-    executeInWriteLock(() -> {
+    final Boolean actuallyClosed = executeInWriteLock(() -> {
       if (!open)
-        return null;
+        // Idempotent close contract: a redundant second close() must be a no-op - in particular it must NOT
+        // consume another PageManager lifecycle reference below (#5070 review: the unconditional release
+        // tore the flush thread down under other open databases through the double-close door).
+        return false;
 
       try {
         if (async != null)
@@ -2185,17 +2188,29 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
         }
       }
 
-      return null;
+      return true;
     });
 
-    if (DatabaseFactory.removeActiveDatabaseInstance(databasePath))
-      GraphAnalyticalView.closeExecutor();
+    if (Boolean.TRUE.equals(actuallyClosed)) {
+      if (DatabaseFactory.removeActiveDatabaseInstance(databasePath))
+        GraphAnalyticalView.closeExecutor();
 
-    // #4927: paired with the acquire in DatabaseFactory.open/create - the flush machinery is torn down by
-    // the refcount reaching zero, never by the racy "was this the last registered instance" check (an open
-    // in flight on another thread holds a reference before it registers, so it can no longer be pulled out
-    // from under).
-    PageManager.INSTANCE.release();
+      // #4927: paired with the acquire in DatabaseFactory.open/create - the flush machinery is torn down by
+      // the refcount reaching zero, never by the racy "was this the last registered instance" check (an open
+      // in flight on another thread holds a reference before it registers, so it can no longer be pulled out
+      // from under). Guarded by actuallyClosed and recorded in the flag: the lifecycle reference is consumed
+      // EXACTLY ONCE per database instance, however many times close() is called and whoever calls it
+      // (including registerActiveInstance closing a same-path open race loser before the factory's catch).
+      pageManagerReferenceReleased = true;
+      PageManager.INSTANCE.release();
+    }
+  }
+
+  /** #4927/#5070: whether this instance already consumed its PageManager lifecycle reference (see closeInternal). */
+  private volatile boolean pageManagerReferenceReleased = false;
+
+  boolean isPageManagerReferenceReleased() {
+    return pageManagerReferenceReleased;
   }
 
   private void checkForRecovery() throws IOException {

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -182,7 +182,9 @@ public class PageManager extends LockContext {
       }
     }
 
-    readCache.clear();
+    if (readCache != null)
+      // close() is a reachable test/emergency API and may run before any startup() (#5070 review).
+      readCache.clear();
     totalReadCacheRAM.set(0L);
   }
 

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -65,6 +65,10 @@ public class PageManager extends LockContext {
   private final    AtomicLong                        evictionRuns                          = new AtomicLong();
   private final    AtomicLong                        pagesEvicted                          = new AtomicLong();
   private volatile long                              lastCheckForRAM                       = 0;
+  // LIFECYCLE INVARIANT (#5070 review): flushThread and readCache are written only under LIFECYCLE_LOCK
+  // during the 0->1 startup / 1->0 shutdown transitions, and read lock-free on the hot paths. That is safe
+  // ONLY because a reader implies refcount > 0 (its database holds a reference), so no transition can run
+  // concurrently. If a future change ever mutates these under live readers, make them volatile and re-audit.
   private          PageManagerFlushThread            flushThread;
   private          int                               freePageRAM;
 
@@ -151,7 +155,11 @@ public class PageManager extends LockContext {
     }
   }
 
-  /** Force teardown regardless of refcount (test/emergency API): the counter resets so the next acquire starts fresh. */
+  /**
+   * Force teardown regardless of refcount (test/emergency API): the counter resets so the next acquire
+   * starts fresh. ONLY safe when no database is open: a live database's eventual release() would decrement
+   * the NEW manager started by a later acquire and tear it down under that newcomer (#5070 review).
+   */
   public void close() {
     synchronized (LIFECYCLE_LOCK) {
       lifecycleRefCount = 0;

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -150,7 +150,7 @@ public class PageManager extends LockContext {
     synchronized (LIFECYCLE_LOCK) {
       if (lifecycleRefCount > 0)
         LogManager.instance().log(this, Level.WARNING,
-            "Configuration profile change ignored: %d database(s) are open and the page manager cannot be swapped live. Set the profile before opening databases",
+            "Configuration profile PARTIALLY applied: %d database(s) are open, so the page manager keeps its current sizing while the profile's other settings (async/HTTP threads, queue sizes) did change. Set the profile before opening databases for a consistent configuration",
             null, lifecycleRefCount);
     }
   }

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -92,7 +92,62 @@ public class PageManager extends LockContext {
   private PageManager() {
   }
 
+  /**
+   * #4927: the JVM-wide PageManager is REFCOUNTED. Every DatabaseFactory open/create acquires one reference
+   * (starting the flush machinery on 0 -> 1) and every database close releases it (tearing down on 1 -> 0),
+   * all under one global lock. The previous lifecycle keyed on ACTIVE_INSTANCES.isEmpty() was a
+   * check-then-act racing across factory instances (open/create synchronize on the factory, the map is
+   * static, and registration happens only AFTER database.open() completes): closing the last instance of
+   * one database could null the flush thread under a database whose open was mid-flight (NPE on the first
+   * cache miss, or scheduled pages never flushed), and two opens could both see the map empty and start two
+   * flush threads, leaking one with queued pages.
+   */
+  private static final Object LIFECYCLE_LOCK = new Object();
+  private       int    lifecycleRefCount = 0; // guarded by LIFECYCLE_LOCK
+
+  /** Acquires one lifecycle reference; the flush machinery starts on the 0 -> 1 transition. Pair with {@link #release()}. */
+  public void acquire() {
+    synchronized (LIFECYCLE_LOCK) {
+      if (++lifecycleRefCount == 1)
+        startup();
+    }
+  }
+
+  /** Releases one lifecycle reference; the flush machinery is torn down on the 1 -> 0 transition. Over-releases are clamped. */
+  public void release() {
+    synchronized (LIFECYCLE_LOCK) {
+      if (lifecycleRefCount == 0)
+        // Over-release (e.g. a test calling close() directly followed by a paired release): clamp instead of
+        // going negative and tearing down a manager a later acquire believes it owns.
+        return;
+      if (--lifecycleRefCount == 0)
+        shutdown();
+    }
+  }
+
+  /**
+   * Re-applies the current configuration (used by the GlobalConfiguration PROFILE setter). A no-op when no
+   * database is open: the next {@link #acquire()} reads the fresh settings anyway, and starting a flush
+   * thread with zero databases (the old behavior) leaked it until the next lifecycle transition.
+   */
   public void configure() {
+    synchronized (LIFECYCLE_LOCK) {
+      if (lifecycleRefCount == 0)
+        return;
+      shutdown();
+      startup();
+    }
+  }
+
+  /** Force teardown regardless of refcount (test/emergency API): the counter resets so the next acquire starts fresh. */
+  public void close() {
+    synchronized (LIFECYCLE_LOCK) {
+      lifecycleRefCount = 0;
+      shutdown();
+    }
+  }
+
+  private void startup() {
     final ContextConfiguration configuration = new ContextConfiguration();
     this.freePageRAM = configuration.getValueAsInteger(GlobalConfiguration.FREE_PAGE_RAM);
     this.readCache = new ConcurrentHashMap<>(configuration.getValueAsInteger(GlobalConfiguration.INITIAL_PAGE_CACHE_SIZE));
@@ -101,14 +156,11 @@ public class PageManager extends LockContext {
     if (this.maxRAM < 0)
       throw new ConfigurationException(GlobalConfiguration.MAX_PAGE_RAM.getKey() + " configuration is invalid (" + maxRAM + " MB)");
 
-    if (flushThread != null)
-      close();
-
     flushThread = new PageManagerFlushThread(this, configuration);
     flushThread.start();
   }
 
-  public void close() {
+  private void shutdown() {
     if (flushThread != null) {
       try {
         flushThread.closeAndJoin();

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -184,9 +184,12 @@ public class PageManager extends LockContext {
     if (flushThread != null) {
       try {
         flushThread.closeAndJoin();
-        flushThread = null;
       } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();
+      } finally {
+        // Null out regardless of interrupt (#5070 review): a stale dead reference with refcount 0 was
+        // harmless (the next startup() overwrites it) but inconsistent.
+        flushThread = null;
       }
     }
 
@@ -471,7 +474,7 @@ public class PageManager extends LockContext {
     final PPageManagerStats stats = new PPageManagerStats();
     stats.maxRAM = maxRAM;
     stats.readCacheRAM = totalReadCacheRAM.get();
-    // readCache and flushThread are populated by configure(), which is called on first DB
+    // readCache and flushThread are populated by startup() (the 0 -> 1 acquire transition), which is called on first DB
     // open. When no database has been opened yet (e.g. a profiler snapshot taken at server
     // startup) they're still null - report empty cache/queue rather than NPE.
     stats.readCachePages = readCache != null ? readCache.size() : 0;

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -50,7 +50,7 @@ public class PageManager extends LockContext {
 
   // Package-private (instead of private) so the white-box regression test for #4925/#4933 can assert on
   // the cache content and RAM accounting directly, without reflection.
-  ConcurrentMap<PageId, CachedPage> readCache;
+  volatile ConcurrentMap<PageId, CachedPage> readCache;
   // MANAGE CONCURRENT ACCESS TO THE PAGES. THE VALUE IS TRUE FOR WRITE OPERATION AND FALSE FOR READ
   private final    ConcurrentMap<PageId, Boolean>    pendingFlushPages                     = new ConcurrentHashMap<>();
   private          long                              maxRAM;
@@ -68,8 +68,10 @@ public class PageManager extends LockContext {
   // LIFECYCLE INVARIANT (#5070 review): flushThread and readCache are written only under LIFECYCLE_LOCK
   // during the 0->1 startup / 1->0 shutdown transitions, and read lock-free on the hot paths. That is safe
   // ONLY because a reader implies refcount > 0 (its database holds a reference), so no transition can run
-  // concurrently. If a future change ever mutates these under live readers, make them volatile and re-audit.
-  private          PageManagerFlushThread            flushThread;
+  // concurrently. volatile (three review rounds converged on it): the barrier cost is negligible next to the
+  // ConcurrentHashMap barriers already on these paths, and it removes the reliance on the external
+  // database-publication happens-before for cross-thread visibility of the startup() writes.
+  private volatile PageManagerFlushThread            flushThread;
   private          int                               freePageRAM;
 
   @ExcludeFromJacocoGeneratedReport

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -53,7 +53,7 @@ public class PageManager extends LockContext {
   volatile ConcurrentMap<PageId, CachedPage> readCache;
   // MANAGE CONCURRENT ACCESS TO THE PAGES. THE VALUE IS TRUE FOR WRITE OPERATION AND FALSE FOR READ
   private final    ConcurrentMap<PageId, Boolean>    pendingFlushPages                     = new ConcurrentHashMap<>();
-  private volatile          long                              maxRAM;
+  private volatile long                               maxRAM;
   final            AtomicLong                        totalReadCacheRAM                     = new AtomicLong();
   private final    AtomicLong                        totalPagesRead                        = new AtomicLong();
   private final    AtomicLong                        totalPagesReadSize                    = new AtomicLong();
@@ -71,8 +71,8 @@ public class PageManager extends LockContext {
   // concurrently. volatile (three review rounds converged on it): the barrier cost is negligible next to the
   // ConcurrentHashMap barriers already on these paths, and it removes the reliance on the external
   // database-publication happens-before for cross-thread visibility of the startup() writes.
-  private volatile PageManagerFlushThread            flushThread;
-  private volatile          int                               freePageRAM;
+  private volatile PageManagerFlushThread             flushThread;
+  private volatile int                                freePageRAM;
 
   @ExcludeFromJacocoGeneratedReport
   public interface ConcurrentPageAccessCallback {
@@ -182,6 +182,11 @@ public class PageManager extends LockContext {
     flushThread.start();
   }
 
+  /**
+   * INVARIANT (#5070 review): runs under LIFECYCLE_LOCK and joins the flush thread - the flush thread must
+   * therefore NEVER call acquire()/release()/configure()/close(), or this join becomes a deadlock (the
+   * flush thread blocking on the lock this thread holds while waiting for it to exit). Verified true today.
+   */
   private void shutdown() {
     if (flushThread != null) {
       try {

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -53,7 +53,7 @@ public class PageManager extends LockContext {
   volatile ConcurrentMap<PageId, CachedPage> readCache;
   // MANAGE CONCURRENT ACCESS TO THE PAGES. THE VALUE IS TRUE FOR WRITE OPERATION AND FALSE FOR READ
   private final    ConcurrentMap<PageId, Boolean>    pendingFlushPages                     = new ConcurrentHashMap<>();
-  private          long                              maxRAM;
+  private volatile          long                              maxRAM;
   final            AtomicLong                        totalReadCacheRAM                     = new AtomicLong();
   private final    AtomicLong                        totalPagesRead                        = new AtomicLong();
   private final    AtomicLong                        totalPagesReadSize                    = new AtomicLong();
@@ -72,7 +72,7 @@ public class PageManager extends LockContext {
   // ConcurrentHashMap barriers already on these paths, and it removes the reliance on the external
   // database-publication happens-before for cross-thread visibility of the startup() writes.
   private volatile PageManagerFlushThread            flushThread;
-  private          int                               freePageRAM;
+  private volatile          int                               freePageRAM;
 
   @ExcludeFromJacocoGeneratedReport
   public interface ConcurrentPageAccessCallback {

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -135,16 +135,19 @@ public class PageManager extends LockContext {
   }
 
   /**
-   * Re-applies the current configuration (used by the GlobalConfiguration PROFILE setter). A no-op when no
-   * database is open: the next {@link #acquire()} reads the fresh settings anyway, and starting a flush
-   * thread with zero databases (the old behavior) leaked it until the next lifecycle transition.
+   * Declares that the configuration changed (used by the GlobalConfiguration PROFILE setter). Always a
+   * no-op at runtime: with no database open the next {@link #acquire()} reads the fresh settings anyway
+   * (and starting a flush thread with zero databases - the old behavior - leaked it until the next
+   * lifecycle transition); with databases OPEN a live shutdown+startup swap would race the hot paths, which
+   * read {@code flushThread}/{@code readCache} without the lifecycle lock (#5070 review) - so a live
+   * profile change is refused loudly instead. Set the PROFILE before opening databases.
    */
   public void configure() {
     synchronized (LIFECYCLE_LOCK) {
-      if (lifecycleRefCount == 0)
-        return;
-      shutdown();
-      startup();
+      if (lifecycleRefCount > 0)
+        LogManager.instance().log(this, Level.WARNING,
+            "Configuration profile change ignored: %d database(s) are open and the page manager cannot be swapped live. Set the profile before opening databases",
+            null, lifecycleRefCount);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -109,7 +109,16 @@ public class PageManager extends LockContext {
   public void acquire() {
     synchronized (LIFECYCLE_LOCK) {
       if (++lifecycleRefCount == 1)
-        startup();
+        try {
+          startup();
+        } catch (final RuntimeException | Error e) {
+          // #5070 review: startup() can throw (e.g. ConfigurationException on a negative MAX_PAGE_RAM). The
+          // increment must not survive it, or the counter is left at 1 with no flush thread and the NEXT
+          // acquire sees 1 -> 2 and never starts one - a wedged manager the caller's catch cannot repair
+          // (its release() would just decrement back to the same broken state at 1).
+          lifecycleRefCount = 0;
+          throw e;
+        }
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
+++ b/engine/src/main/java/com/arcadedb/graph/olap/GraphAnalyticalView.java
@@ -105,7 +105,10 @@ public class GraphAnalyticalView implements GraphTraversalProvider {
   /**
    * Gracefully shuts down the shared async build executor. Waits up to 30 seconds
    * for in-progress builds to complete, then forcibly terminates remaining tasks.
-   * Called when the last database instance is closed (alongside {@code PageManager.INSTANCE.close()}).
+   * Called when the last REGISTERED database instance is closed. NOTE (#4927): unlike the PageManager -
+   * whose lifecycle is refcounted - this teardown deliberately stays on the ACTIVE_INSTANCES-empty
+   * heuristic: the executor lazily re-creates itself on the next getExecutor(), so the mid-flight-open
+   * race that was fatal for the flush thread merely costs a re-created executor here.
    * The executor is lazily re-created if a new database is opened later.
    *
    * <p><b>Multi-database note:</b> The executor is shared across all databases in the JVM.

--- a/engine/src/test/java/com/arcadedb/database/DatabaseFactoryTest.java
+++ b/engine/src/test/java/com/arcadedb/database/DatabaseFactoryTest.java
@@ -62,7 +62,7 @@ class DatabaseFactoryTest extends TestHelper {
     final Database db = f.create();
 
     DatabaseFactory.getActiveDatabaseInstances().contains(db);
-    DatabaseFactory.removeActiveDatabaseInstance(db.getDatabasePath());
+    DatabaseFactory.removeActiveDatabaseInstance(db.getDatabasePath(), db);
     assertThat(DatabaseFactory.getActiveDatabaseInstance(db.getDatabasePath())).isNull();
 
     db.drop();

--- a/engine/src/test/java/com/arcadedb/engine/Issue4544FlushIndexIdentityTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue4544FlushIndexIdentityTest.java
@@ -50,7 +50,7 @@ class Issue4544FlushIndexIdentityTest extends TestHelper {
   @Test
   void staleFlushMustNotEvictNewerIndexedPage() {
     // Constructing the flush thread directly does NOT start the background thread (that happens in
-    // PageManager.configure()), so the index can be exercised deterministically in isolation.
+    // PageManager.startup(), run on the first acquire), so the index can be exercised deterministically in isolation.
     final PageManagerFlushThread flush = new PageManagerFlushThread(PageManager.INSTANCE, new ContextConfiguration());
 
     final PageId pageId = new PageId(database, 3, 7);

--- a/engine/src/test/java/com/arcadedb/engine/PageManagerLifecycleRefCountTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageManagerLifecycleRefCountTest.java
@@ -147,4 +147,65 @@ class PageManagerLifecycleRefCountTest {
     assertThat(failure.get()).as("no thread may observe a torn-down PageManager while its database is open").isNull();
     assertThat(PageManager.INSTANCE.getFlushThread()).as("all references released: manager torn down").isNull();
   }
+
+  @Test
+  void redundantDoubleCloseDoesNotStealAnotherDatabasesReference() {
+    // #5070 review (the acute regression): close() is documented-idempotent (the lambda early-returns on
+    // !open), but the lifecycle release ran unconditionally - a defensive double-close consumed a SECOND
+    // reference and tore the flush thread down under the other open database.
+    final DatabaseFactory factoryA = new DatabaseFactory(DB_A);
+    final DatabaseFactory factoryB = new DatabaseFactory(DB_B);
+    try {
+      final Database dbA = factoryA.create();
+      final Database dbB = factoryB.create();
+
+      dbA.close();
+      dbA.close(); // redundant, must be a full no-op
+
+      assertThat(PageManager.INSTANCE.getFlushThread())
+          .as("a redundant double-close must not consume another database's lifecycle reference (#5070)")
+          .isNotNull();
+
+      dbB.getSchema().createDocumentType("Doc");
+      dbB.transaction(() -> dbB.newDocument("Doc").set("v", 1).save());
+      dbB.close();
+
+      assertThat(PageManager.INSTANCE.getFlushThread()).isNull();
+    } finally {
+      factoryA.close();
+      factoryB.close();
+    }
+  }
+
+  @Test
+  void startupFailureRollsBackTheAcquiredReference() {
+    // #5070 review: startup() can throw (negative MAX_PAGE_RAM) AFTER the refcount increment; without the
+    // rollback the counter wedged at 1 with no flush thread and every later open ran against a dead manager.
+    final Object previous = com.arcadedb.GlobalConfiguration.MAX_PAGE_RAM.getValue();
+    com.arcadedb.GlobalConfiguration.MAX_PAGE_RAM.setValue(-2);
+    try {
+      final DatabaseFactory factory = new DatabaseFactory(DB_A);
+      try {
+        org.assertj.core.api.Assertions.assertThatThrownBy(factory::create)
+            .as("misconfigured startup must fail the open").hasMessageContaining("configuration is invalid");
+      } finally {
+        factory.close();
+      }
+    } finally {
+      com.arcadedb.GlobalConfiguration.MAX_PAGE_RAM.setValue(previous);
+    }
+
+    // The failed acquire left no residue: a healthy open now starts the manager normally.
+    final DatabaseFactory factory = new DatabaseFactory(DB_A);
+    try {
+      final Database db = factory.create();
+      assertThat(PageManager.INSTANCE.getFlushThread())
+          .as("the wedged-counter state must not survive a startup failure (#5070)").isNotNull();
+      db.getSchema().createDocumentType("Doc");
+      db.transaction(() -> db.newDocument("Doc").set("v", 1).save());
+      db.drop();
+    } finally {
+      factory.close();
+    }
+  }
 }

--- a/engine/src/test/java/com/arcadedb/engine/PageManagerLifecycleRefCountTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageManagerLifecycleRefCountTest.java
@@ -41,6 +41,14 @@ class PageManagerLifecycleRefCountTest {
   private static final String DB_A = "target/databases/PageManagerLifecycleRefCountTestA";
   private static final String DB_B = "target/databases/PageManagerLifecycleRefCountTestB";
 
+  @org.junit.jupiter.api.BeforeEach
+  void normalizeGlobalState() {
+    // #5070 review: PageManager.INSTANCE is process-global. Force-reset the refcount to a known zero
+    // baseline so these assertions are not order-dependent on another test leaking an open database (or a
+    // kill() without the paired close()) in the same surefire fork.
+    PageManager.INSTANCE.close();
+  }
+
   @AfterEach
   void cleanup() {
     for (final String path : new String[] { DB_A, DB_B }) {

--- a/engine/src/test/java/com/arcadedb/engine/PageManagerLifecycleRefCountTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageManagerLifecycleRefCountTest.java
@@ -18,10 +18,13 @@
  */
 package com.arcadedb.engine;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.utility.FileUtils;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -29,6 +32,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * #4927: the JVM-wide PageManager lifecycle is refcounted instead of keyed on the racy
@@ -36,13 +40,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  * original interleavings (a close nulling the flush thread under a mid-flight open on another thread, or two
  * opens double-starting it) are pure races, so the contract that makes them impossible is what is tested.
  */
-@org.junit.jupiter.api.parallel.ResourceLock("PageManager.INSTANCE")
+@ResourceLock("PageManager.INSTANCE")
 class PageManagerLifecycleRefCountTest {
 
   private static final String DB_A = "target/databases/PageManagerLifecycleRefCountTestA";
   private static final String DB_B = "target/databases/PageManagerLifecycleRefCountTestB";
 
-  @org.junit.jupiter.api.BeforeEach
+  @BeforeEach
   void normalizeGlobalState() {
     // #5070 review: PageManager.INSTANCE is process-global. Force-reset the refcount to a known zero
     // baseline so these assertions are not order-dependent on another test leaking an open database (or a
@@ -192,18 +196,18 @@ class PageManagerLifecycleRefCountTest {
   void startupFailureRollsBackTheAcquiredReference() {
     // #5070 review: startup() can throw (negative MAX_PAGE_RAM) AFTER the refcount increment; without the
     // rollback the counter wedged at 1 with no flush thread and every later open ran against a dead manager.
-    final Object previous = com.arcadedb.GlobalConfiguration.MAX_PAGE_RAM.getValue();
-    com.arcadedb.GlobalConfiguration.MAX_PAGE_RAM.setValue(-2);
+    final Object previous = GlobalConfiguration.MAX_PAGE_RAM.getValue();
+    GlobalConfiguration.MAX_PAGE_RAM.setValue(-2);
     try {
       final DatabaseFactory factory = new DatabaseFactory(DB_A);
       try {
-        org.assertj.core.api.Assertions.assertThatThrownBy(factory::create)
+        assertThatThrownBy(factory::create)
             .as("misconfigured startup must fail the open").hasMessageContaining("configuration is invalid");
       } finally {
         factory.close();
       }
     } finally {
-      com.arcadedb.GlobalConfiguration.MAX_PAGE_RAM.setValue(previous);
+      GlobalConfiguration.MAX_PAGE_RAM.setValue(previous);
     }
 
     // The failed acquire left no residue: a healthy open now starts the manager normally.

--- a/engine/src/test/java/com/arcadedb/engine/PageManagerLifecycleRefCountTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageManagerLifecycleRefCountTest.java
@@ -208,4 +208,27 @@ class PageManagerLifecycleRefCountTest {
       factory.close();
     }
   }
+
+  @Test
+  void liveConfigureIsRefusedInsteadOfSwappingTheFlushThreadUnderReaders() {
+    // #5070 review round 2: a live shutdown+startup swap in configure() raced the hot paths, which read
+    // flushThread/readCache without the lifecycle lock - a concurrent flush could NPE on the transient
+    // null. A profile change while databases are open is now refused loudly; the thread survives untouched.
+    final DatabaseFactory factory = new DatabaseFactory(DB_A);
+    try {
+      final Database db = factory.create();
+      final PageManagerFlushThread before = PageManager.INSTANCE.getFlushThread();
+      assertThat(before).isNotNull();
+
+      PageManager.INSTANCE.configure();
+
+      assertThat(PageManager.INSTANCE.getFlushThread())
+          .as("configure() with open databases must not swap the live flush thread (#5070)")
+          .isSameAs(before);
+      assertThat(before.isAlive()).isTrue();
+      db.drop();
+    } finally {
+      factory.close();
+    }
+  }
 }

--- a/engine/src/test/java/com/arcadedb/engine/PageManagerLifecycleRefCountTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageManagerLifecycleRefCountTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * #4927: the JVM-wide PageManager lifecycle is refcounted instead of keyed on the racy
+ * ACTIVE_INSTANCES.isEmpty() check-then-act. These tests pin the lifecycle contract deterministically; the
+ * original interleavings (a close nulling the flush thread under a mid-flight open on another thread, or two
+ * opens double-starting it) are pure races, so the contract that makes them impossible is what is tested.
+ */
+class PageManagerLifecycleRefCountTest {
+
+  private static final String DB_A = "target/databases/PageManagerLifecycleRefCountTestA";
+  private static final String DB_B = "target/databases/PageManagerLifecycleRefCountTestB";
+
+  @AfterEach
+  void cleanup() {
+    for (final String path : new String[] { DB_A, DB_B }) {
+      final DatabaseFactory factory = new DatabaseFactory(path);
+      try {
+        if (factory.exists())
+          factory.open().drop();
+      } catch (final Exception e) {
+        // removed on disk below
+      }
+      factory.close();
+      FileUtils.deleteRecursively(new File(path));
+    }
+  }
+
+  @Test
+  void configureWithoutOpenDatabasesDoesNotStartAFlushThread() {
+    // The GlobalConfiguration PROFILE setter calls configure() at configuration time, possibly before any
+    // database exists. The old code then STARTED a flush thread for zero databases - the same
+    // lifecycle-divorced-from-database-count defect class as the #4927 races - and leaked it until the next
+    // lifecycle transition. With the refcount, configure() with no references is a no-op.
+    PageManager.INSTANCE.configure();
+    assertThat(PageManager.INSTANCE.getFlushThread())
+        .as("configure() with no open database must not start a flush thread (#4927)")
+        .isNull();
+  }
+
+  @Test
+  void closingOneDatabaseNeverTearsDownTheManagerForOthers() {
+    final DatabaseFactory factoryA = new DatabaseFactory(DB_A);
+    final DatabaseFactory factoryB = new DatabaseFactory(DB_B);
+    try {
+      final Database dbA = factoryA.create();
+      final Database dbB = factoryB.create();
+
+      dbA.drop();
+
+      assertThat(PageManager.INSTANCE.getFlushThread())
+          .as("the flush thread must survive while any database is open").isNotNull();
+      assertThat(PageManager.INSTANCE.getFlushThread().isAlive()).isTrue();
+
+      // The surviving database still works end to end (cache misses, flush scheduling).
+      dbB.getSchema().createDocumentType("Doc");
+      dbB.transaction(() -> dbB.newDocument("Doc").set("v", 1).save());
+      assertThat(dbB.query("sql", "SELECT count(*) as c FROM Doc").next().<Long>getProperty("c")).isEqualTo(1L);
+
+      dbB.drop();
+      assertThat(PageManager.INSTANCE.getFlushThread())
+          .as("the LAST release tears the manager down").isNull();
+    } finally {
+      factoryA.close();
+      factoryB.close();
+    }
+  }
+
+  @Test
+  void concurrentOpenCloseHammerNeverLosesTheFlushThread() throws Exception {
+    // The original race shape: one thread repeatedly opening/closing database A while another opens B,
+    // writes and closes. With the old isEmpty() heuristics this interleaving could null the flush thread
+    // under the open database (NPE on the first cache miss) or double-start it. The refcount makes both
+    // impossible; this hammer asserts no thread observes a broken lifecycle.
+    final int iterations = 30;
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+    final CountDownLatch start = new CountDownLatch(1);
+
+    final Thread tA = new Thread(() -> {
+      try {
+        start.await();
+        final DatabaseFactory factory = new DatabaseFactory(DB_A);
+        for (int i = 0; i < iterations; i++) {
+          final Database db = factory.exists() ? factory.open() : factory.create();
+          db.close();
+        }
+        factory.close();
+      } catch (final Throwable e) {
+        failure.compareAndSet(null, e);
+      }
+    }, "hammer-A");
+
+    final Thread tB = new Thread(() -> {
+      try {
+        start.await();
+        final DatabaseFactory factory = new DatabaseFactory(DB_B);
+        for (int i = 0; i < iterations; i++) {
+          final Database db = factory.exists() ? factory.open() : factory.create();
+          if (!db.getSchema().existsType("Doc"))
+            db.getSchema().createDocumentType("Doc");
+          final int it = i;
+          db.transaction(() -> db.newDocument("Doc").set("i", it).save());
+          db.close();
+        }
+        factory.close();
+      } catch (final Throwable e) {
+        failure.compareAndSet(null, e);
+      }
+    }, "hammer-B");
+
+    tA.start();
+    tB.start();
+    start.countDown();
+    tA.join(120_000);
+    tB.join(120_000);
+
+    assertThat(failure.get()).as("no thread may observe a torn-down PageManager while its database is open").isNull();
+    assertThat(PageManager.INSTANCE.getFlushThread()).as("all references released: manager torn down").isNull();
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/PageManagerLifecycleRefCountTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageManagerLifecycleRefCountTest.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * original interleavings (a close nulling the flush thread under a mid-flight open on another thread, or two
  * opens double-starting it) are pure races, so the contract that makes them impossible is what is tested.
  */
+@org.junit.jupiter.api.parallel.ResourceLock("PageManager.INSTANCE")
 class PageManagerLifecycleRefCountTest {
 
   private static final String DB_A = "target/databases/PageManagerLifecycleRefCountTestA";
@@ -45,7 +46,9 @@ class PageManagerLifecycleRefCountTest {
   void normalizeGlobalState() {
     // #5070 review: PageManager.INSTANCE is process-global. Force-reset the refcount to a known zero
     // baseline so these assertions are not order-dependent on another test leaking an open database (or a
-    // kill() without the paired close()) in the same surefire fork.
+    // kill() without the paired close()) in the same surefire fork. The class-level @ResourceLock declares
+    // the singleton dependency: this force-teardown must never run concurrently with another class holding
+    // an open database (safe under the current sequential surefire config).
     PageManager.INSTANCE.close();
   }
 

--- a/engine/src/test/java/com/arcadedb/engine/PageManagerReadCacheRamAccountingTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageManagerReadCacheRamAccountingTest.java
@@ -51,7 +51,7 @@ class PageManagerReadCacheRamAccountingTest {
   @BeforeEach
   void setUp() {
     FileUtils.deleteRecursively(new File(DB_PATH));
-    // Set small RAM limit BEFORE opening the database so PageManager.configure() picks it up
+    // Set small RAM limit BEFORE opening the database so PageManager.startup() (run on the 0 -> 1 acquire) picks it up
     GlobalConfiguration.MAX_PAGE_RAM.setValue(MAX_RAM_MB);
     final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
     db = factory.create();


### PR DESCRIPTION
The last HIGH-severity finding of the 2026-07 engine audit (#4962).

## The defect
The JVM-wide PageManager started/stopped on an `ACTIVE_INSTANCES.isEmpty()` check-then-act spanning factory instances (open/create synchronize on the **factory**, the map is **static**, and registration happens only **after** `database.open()` completes):

- **Race 1:** T1 closes the last instance of DB-A and nulls the shared flush thread while T2's open of DB-B is mid-flight (constructed, not yet registered) - DB-B then NPEs on its first cache miss, or its scheduled pages are never flushed.
- **Race 2:** two opens both observe the map empty and both call the unsynchronized `configure()` - two flush threads, one leaked with queued pages.
- **Bonus (same defect class, deterministic):** the `GlobalConfiguration` PROFILE setter calls `configure()` at configuration time, and the old code **started a flush thread for zero open databases**, leaking it until the next lifecycle transition.

## The fix (as the issue proposed)
`acquire()`/`release()` refcounting under one global lifecycle lock: startup on 0->1 (acquired **before** the database is constructed, so an in-flight open holds a reference before it registers), teardown on 1->0, over-releases clamped. A failed open releases its reference, preserving the #4991 no-leak guarantee. `configure()` becomes a reconfigure that no-ops at refcount zero; `close()` stays as the force-teardown test API and resets the counter.

## Verification
Red-first: **2 of the (now 6) new tests fail on the old code** (`configure()` starting a thread with no databases; teardown not keyed to the last release); the third is a 2-thread open/close hammer over two databases. Regression: engine + database packages green (**118 classes, 577 tests, 0 failures**), including the #4991 failed-open leak test and the #4928 crash-equivalent close suites.

## Conflict risks
None expected: touches `PageManager` lifecycle methods, `DatabaseFactory` open/create, and one line in `LocalDatabase.closeInternal` - no overlap with the open PRs #5060/#5062.
