### PR TITLE
fix: bound the help-waiting loop on a wedged peer (follow-up to #5062)

### DIFF
--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -266,7 +266,9 @@ that could starve the very snapshot resync meant to heal the node.
   ([#4954](https://github.com/ArcadeData/arcadedb/issues/4954)). Follow-up hardening on the helping
   loop itself: a worker handing off a cross-slot task to a wedged-alive peer while its OWN queue is
   empty (so the deferral budget cannot grow) no longer spins forever - the same 60s progress-gated
-  backstop aborts the hand-off loudly via `onError` and the worker keeps serving its queue; and a
+  backstop aborts the hand-off loudly via `onError` and the worker keeps serving its queue (failure mode
+  when this trips on a bidirectional-edge follow-up: the outgoing direction is already persisted while the
+  dropped follow-up carried the incoming link - a PARTIAL edge until the operation is repeated); and a
   worker that consumed the shutdown marker while help-waiting now abandons the hand-off immediately,
   so `close()` returns within one offer window on that path instead of waiting out the grace period.
   Low-severity cleanups from the same audit: async executor settings (`parallelLevel`, `commitEvery`,

--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -261,10 +261,14 @@ that could starve the very snapshot resync meant to heal the node.
   task left in its queue instead of `queue.clear()`-ing them (threads blocked in `scanType()` /
   `waitCompletion()` hung forever), and `close()` no longer blocks unbounded on `queue.put(FORCE_EXIT)`
   under the lifecycle lock when a busy worker's queue is full - the marker is offered with a timeout,
-  the worker is interrupted on failure, and a worker still alive after the 10s grace period (e.g. one
-  that consumed the marker while help-waiting on a wedged peer's full queue) is escalated to an
-  interrupt and re-joined instead of being left running behind a returned `close()`
-  ([#4954](https://github.com/ArcadeData/arcadedb/issues/4954)).
+  the worker is interrupted on failure, and a worker still alive after the 10s grace period is
+  escalated to an interrupt and re-joined instead of being left running behind a returned `close()`
+  ([#4954](https://github.com/ArcadeData/arcadedb/issues/4954)). Follow-up hardening on the helping
+  loop itself: a worker handing off a cross-slot task to a wedged-alive peer while its OWN queue is
+  empty (so the deferral budget cannot grow) no longer spins forever - the same 60s progress-gated
+  backstop aborts the hand-off loudly via `onError` and the worker keeps serving its queue; and a
+  worker that consumed the shutdown marker while help-waiting now abandons the hand-off immediately,
+  so `close()` returns within one offer window on that path instead of waiting out the grace period.
   Low-severity cleanups from the same audit: async executor settings (`parallelLevel`, `commitEvery`,
   back-pressure, callbacks) are now `volatile` so post-startup changes reach the workers,
   `setCommitEvery(0)` is rejected instead of making every task fail on `count % 0`, the JVM-wide query

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -440,6 +440,8 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
         while (true) {
           final long remaining = timeout - (System.currentTimeMillis() - beginTime);
           if (remaining <= 0)
+            // #5062 review r6 (point 3): NOT A LEAK - markers already enqueued on earlier workers
+            // simply execute and count down a latch nobody awaits anymore.
             return false;
           if (threads[i].queue.offer(semaphores[i], Math.min(500, remaining), TimeUnit.MILLISECONDS))
             break;
@@ -1144,12 +1146,16 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
    * <p>
    * The parked backlog is capped at the queue capacity: past it the method gives up (returns false)
    * and the caller falls back to the bounded wait with stall detection, restoring queue-full
-   * backpressure on producers. There is deliberately NO liveness detector here beyond target death
-   * (#5062 review, point 2): a target wedged forever in user code is indistinguishable from one
-   * busy on a legitimately slow task, and throwing out of a worker mid-task rolls back its commit
-   * batch and silently drops the follow-up, which is the exact #4953 defect. As long as the target
-   * is alive it either progresses (offer eventually lands) or is itself parked cross-slot, in which
-   * case draining resolves the cycle or the budget above fails over to the detecting wait.
+   * backpressure on producers. A cheap-trigger liveness detector is deliberately absent: over short
+   * horizons a target busy on a legitimately slow task is indistinguishable from a wedged one, and
+   * throwing out of a worker mid-task rolls back its commit batch and drops the follow-up, which is
+   * the exact #4953 defect. Two bounded escapes exist nevertheless (#5062 review r6): with an EMPTY
+   * own queue the deferral budget can never grow, so a wedged-alive peer is covered by the same
+   * progress-gated {@code STALLED_NO_PROGRESS_WINDOWS} backstop as the producer path, failing the
+   * hand-off loudly (onError + batch rollback; the worker itself survives and keeps serving its
+   * queue) instead of spinning forever; and once {@code forceShutdown} is observed the hand-off is
+   * abandoned immediately, so close() does not sit out the grace period waiting for the interrupt
+   * escalation.
    *
    * @return true if the task was handed to the target queue, false if the deferral budget is
    * exhausted and the caller must fall back to the bounded wait of {@code offerWaiting}.
@@ -1159,7 +1165,18 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     final boolean prevWaiting = self.waitingCrossSlotOffer;
     self.waitingCrossSlotOffer = true;
     try {
+      long observedCompleted = target.completedTaskCount;
+      long windowStart = System.currentTimeMillis();
+      int windowsWithoutProgress = 0;
       while (true) {
+        // #5062 review r6 (point 2): consuming FORCE_EXIT below only sets the flag; keeping the
+        // hand-off alive on a possibly wedged peer would make close() pay the whole grace period
+        // before the interrupt escalation. Dropping the follow-up loudly at shutdown is fine - the
+        // workers are dying - and matches the target-dead branch below.
+        if (self.forceShutdown)
+          throw new DatabaseOperationException(
+              "Async executor has been shut down; cannot schedule asynchronous task " + task);
+
         // SHORT WINDOW WHEN THERE IS OWN WORK TO DRAIN, LONGER WHEN IDLE TO AVOID SPINNING. THE 1MS
         // WINDOW IS INTENTIONALLY AGGRESSIVE: EVERY ITERATION FREES A SLOT THE PARKED PEER MAY BE
         // WAITING ON, AND THE LOOP IS BOUNDED BY THE DEFERRAL BUDGET BELOW
@@ -1171,6 +1188,28 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
           throw new DatabaseOperationException(
               "Async executor has been shut down; cannot schedule asynchronous task " + task);
 
+        // #5062 review r6 (point 1): with an empty own queue the deferral budget below never grows,
+        // so a wedged-alive peer would spin this loop forever, silently losing both workers in
+        // normal operation. Same progress-gated bound as the producer-side wedged backstop; only the
+        // long, conservative count is used because aborting the hand-off costs the current task's
+        // batch (onError + rollback) - a peer parked on a slow chain is outlived as long as its
+        // individual tasks stay under STALLED_NO_PROGRESS_WINDOWS windows.
+        final long now = System.currentTimeMillis();
+        if (now - windowStart >= checkForStalledQueuesMaxDelay) {
+          final long nowCompleted = target.completedTaskCount;
+          if (nowCompleted == observedCompleted) {
+            if (++windowsWithoutProgress >= STALLED_NO_PROGRESS_WINDOWS)
+              throw new DatabaseOperationException(
+                  "Asynchronous queue of " + target.getName() + " is stalled: no task completed in the last " + (
+                      STALLED_NO_PROGRESS_WINDOWS * checkForStalledQueuesMaxDelay)
+                      + " ms while handing off a cross-slot task. The worker may be blocked inside a user task or callback");
+          } else {
+            windowsWithoutProgress = 0;
+            observedCompleted = nowCompleted;
+          }
+          windowStart = now;
+        }
+
         if (self.helpDeferredTasks.size() >= self.queueCapacity)
           // DEFERRAL BUDGET EXHAUSTED: STOP EXTENDING THE OWN QUEUE AND FALL BACK TO THE BOUNDED WAIT
           return false;
@@ -1181,8 +1220,9 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
 
         if (own == FORCE_EXIT)
           // GRACEFUL SHUTDOWN REQUESTED WHILE HELPING: THE MARKER IS CONSUMED HERE AND IT IS THE
-          // forceShutdown FLAG (NOT THE MARKER) THAT MAKES THE RUN LOOP EXIT ONCE THE CURRENT TASK
-          // UNWINDS, SO shutdownThreadsLocked'S BOUNDED join() STILL COMPLETES (#5062 review, point 5)
+          // forceShutdown FLAG (NOT THE MARKER) THAT DRIVES THE EXIT - THE NEXT LOOP ITERATION BAILS
+          // OUT AT THE TOP, THE CURRENT TASK UNWINDS LOUDLY AND THE RUN LOOP STOPS ON THE FLAG, SO
+          // shutdownThreadsLocked'S BOUNDED join() COMPLETES WITHOUT THE INTERRUPT ESCALATION
           self.forceShutdown = true;
         else
           self.helpDeferredTasks.addLast(own);

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -1177,6 +1177,7 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       long observedCompleted = target.completedTaskCount;
       long windowStart = System.currentTimeMillis();
       int windowsWithoutProgress = 0;
+      long noProgressSince = 0;
       while (true) {
         // #5062 review r6 (point 2): consuming FORCE_EXIT below only sets the flag; keeping the
         // hand-off alive on a possibly wedged peer would make close() pay the whole grace period
@@ -1207,10 +1208,14 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
         if (now - windowStart >= checkForStalledQueuesMaxDelay) {
           final long nowCompleted = target.completedTaskCount;
           if (nowCompleted == observedCompleted) {
+            if (windowsWithoutProgress == 0)
+              noProgressSince = now;
             if (++windowsWithoutProgress >= STALLED_NO_PROGRESS_WINDOWS)
+              // Report the MEASURED elapsed (#5072 review): at tiny configured delays each iteration is
+              // floored by the offer window, so the nominal windows-x-delay product would understate it.
               throw new DatabaseOperationException(
                   "Asynchronous queue of " + target.getName() + " is stalled: no task completed in the last " + (
-                      STALLED_NO_PROGRESS_WINDOWS * checkForStalledQueuesMaxDelay)
+                      now - noProgressSince)
                       + " ms while handing off a cross-slot task. The worker may be blocked inside a user task or callback");
           } else {
             windowsWithoutProgress = 0;

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -1177,7 +1177,7 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       long observedCompleted = target.completedTaskCount;
       long windowStart = System.currentTimeMillis();
       int windowsWithoutProgress = 0;
-      long noProgressSince = 0;
+      long lastProgressAt = System.currentTimeMillis();
       while (true) {
         // #5062 review r6 (point 2): consuming FORCE_EXIT below only sets the flag; keeping the
         // hand-off alive on a possibly wedged peer would make close() pay the whole grace period
@@ -1208,18 +1208,19 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
         if (now - windowStart >= checkForStalledQueuesMaxDelay) {
           final long nowCompleted = target.completedTaskCount;
           if (nowCompleted == observedCompleted) {
-            if (windowsWithoutProgress == 0)
-              noProgressSince = now;
             if (++windowsWithoutProgress >= STALLED_NO_PROGRESS_WINDOWS)
-              // Report the MEASURED elapsed (#5072 review): at tiny configured delays each iteration is
-              // floored by the offer window, so the nominal windows-x-delay product would understate it.
+              // Report the MEASURED span since the last observed progress (#5072 review): at tiny
+              // configured delays each iteration is floored by the offer window, so the nominal
+              // windows-x-delay product would understate it - and measuring from the last progress (not
+              // the first no-progress window) covers the full span, matching the 12-window trip.
               throw new DatabaseOperationException(
                   "Asynchronous queue of " + target.getName() + " is stalled: no task completed in the last " + (
-                      now - noProgressSince)
+                      now - lastProgressAt)
                       + " ms while handing off a cross-slot task. The worker may be blocked inside a user task or callback");
           } else {
             windowsWithoutProgress = 0;
             observedCompleted = nowCompleted;
+            lastProgressAt = now;
           }
           windowStart = now;
         }

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -124,8 +124,10 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     public          long                             count         = 0;
     // #4953: monotonic count of tasks this worker has finished (successfully or not). Producers
     // blocked on this worker's full queue use it as a progress probe: only written by the worker,
-    // read by any thread, hence volatile.
-    private volatile long                            completedTaskCount    = 0;
+    // read by any thread, hence volatile. Package-private (instead of private) so the backstop
+    // progress-reset regression test can simulate a slow-but-progressing peer deterministically (a
+    // real progressing peer frees queue slots, ending the park before enough windows elapse).
+    volatile         long                            completedTaskCount    = 0;
     // #4953: true while this worker is parked in scheduleTask waiting to hand a task to a queue.
     // Combined with a flat completedTaskCount it identifies a genuine cross-scheduling stall.
     private volatile boolean                         waitingCrossSlotOffer = false;
@@ -869,6 +871,13 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
   public static class DBAsyncStats {
     public long queueSize;
     public long scheduledTasks;
+  }
+
+  // Package-private test hook (#5072 review, point 4): rebuilds the worker pool so configuration
+  // changes (e.g. ASYNC_OPERATIONS_QUEUE_SIZE) are picked up deterministically, instead of the
+  // tests relying on setTransactionUseWAL()'s createThreads() side effect.
+  void recreateThreadsForTests() {
+    createThreads(parallelLevel);
   }
 
   private void createThreads(int parallelLevel) {

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncHelpingEmptyQueueBackstopTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncHelpingEmptyQueueBackstopTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the #5062 review, round 6 (point 1): a worker help-waiting on a wedged-alive
+ * peer with an EMPTY own queue had no backstop at all - the loop spun forever (offer fails, peer
+ * alive, deferral budget never grows because there is nothing to poll), losing both workers during
+ * normal operation with no error surfaced. The producer path already failed loudly after
+ * {@code STALLED_NO_PROGRESS_WINDOWS}; the helping loop now applies the same progress-gated bound,
+ * aborting the hand-off (onError + batch rollback, worker survives) instead of hanging forever.
+ */
+class AsyncHelpingEmptyQueueBackstopTest extends TestHelper {
+
+  @Test
+  @Timeout(60)
+  void helpWaitingWorkerWithEmptyQueueSurfacesWedgedPeerInsteadOfSpinningForever() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 2); // CAPACITY 1 PER WORKER
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
+    async.setParallelLevel(2);
+    // Force thread re-creation so the queue size above is picked up regardless of the previous level.
+    async.setTransactionUseWAL(true);
+    async.setCheckForStalledQueuesMaxDelay(50); // BACKSTOP = 12 x 50ms = 600ms
+
+    final List<Throwable> errors = new CopyOnWriteArrayList<>();
+    final CountDownLatch stallReported = new CountDownLatch(1);
+    async.onError(e -> {
+      errors.add(e);
+      if (String.valueOf(e.getMessage()).contains("stalled"))
+        stallReported.countDown();
+    });
+
+    final CountDownLatch wedgeStarted = new CountDownLatch(1);
+    final CountDownLatch releaseWedge = new CountDownLatch(1);
+    final CountDownLatch outerStarted = new CountDownLatch(1);
+    final CountDownLatch proceed = new CountDownLatch(1);
+    try {
+      // Worker 1: wedged in user code (alive, completing nothing) behind a full queue.
+      async.scheduleTask(1, awaitTask(wedgeStarted, releaseWedge), true, 0);
+      assertThat(wedgeStarted.await(5, TimeUnit.SECONDS)).isTrue();
+      assertThat(async.scheduleTask(1, noOpTask(), false, 0)).isTrue();
+
+      // Worker 0: hands a follow-up to worker 1's full queue with its OWN queue empty, so the
+      // deferral budget can never grow and only the backstop can end the wait.
+      async.scheduleTask(0, new DatabaseAsyncTask() {
+        @Override
+        public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+          outerStarted.countDown();
+          try {
+            if (!proceed.await(20, TimeUnit.SECONDS))
+              return;
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+          }
+          async.scheduleTask(1, noOpTask(), true, 0);
+        }
+
+        @Override
+        public boolean requiresActiveTx() {
+          return false;
+        }
+      }, true, 0);
+      assertThat(outerStarted.await(5, TimeUnit.SECONDS)).isTrue();
+      proceed.countDown();
+
+      // The buggy loop spun forever with no error: the backstop must surface the stall.
+      assertThat(stallReported.await(10, TimeUnit.SECONDS))
+          .as("the help-waiting worker must report the wedged peer instead of spinning forever")
+          .isTrue();
+
+      // The worker must survive the aborted hand-off and keep serving its queue.
+      final CountDownLatch survived = new CountDownLatch(1);
+      async.scheduleTask(0, countingTask(survived), true, 0);
+      assertThat(survived.await(5, TimeUnit.SECONDS))
+          .as("the worker must stay serviceable after the aborted hand-off")
+          .isTrue();
+    } finally {
+      releaseWedge.countDown();
+      proceed.countDown();
+    }
+
+    assertThat(async.waitCompletion(10_000)).isTrue();
+  }
+
+  private static DatabaseAsyncTask awaitTask(final CountDownLatch started, final CountDownLatch release) {
+    return new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        started.countDown();
+        try {
+          release.await(20, TimeUnit.SECONDS);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    };
+  }
+
+  private static DatabaseAsyncTask countingTask(final CountDownLatch latch) {
+    return new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        latch.countDown();
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    };
+  }
+
+  private static DatabaseAsyncTask noOpTask() {
+    return new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        // NO ACTIONS
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    };
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncHelpingSlowPeerProgressTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncHelpingSlowPeerProgressTest.java
@@ -24,8 +24,6 @@ import com.arcadedb.database.DatabaseInternal;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -35,18 +33,22 @@ import static com.arcadedb.database.async.AsyncTestTasks.noOpTask;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Regression test for the #5062 review, round 6 (point 1): a worker help-waiting on a wedged-alive
- * peer with an EMPTY own queue had no backstop at all - the loop spun forever (offer fails, peer
- * alive, deferral budget never grows because there is nothing to poll), losing both workers during
- * normal operation with no error surfaced. The producer path already failed loudly after
- * {@code STALLED_NO_PROGRESS_WINDOWS}; the helping loop now applies the same progress-gated bound,
- * aborting the hand-off (onError + batch rollback, worker survives) instead of hanging forever.
+ * Positive-case guard for the helping-loop backstop (#5072 review round 1, point 2): a peer that
+ * keeps COMPLETING tasks while its queue stays full must never trip the backstop, however long the
+ * hand-off takes - the no-progress window counter must reset on every progress tick, or any
+ * saturated-but-progressing pipeline would be falsely aborted once the bound elapses. The peer's
+ * progress is simulated white-box (ticking its package-private {@code completedTaskCount}) because
+ * a genuinely progressing peer frees queue slots and ends the park long before enough windows
+ * elapse; the tick keeps the queue full while showing steady progress, which is exactly the
+ * signature of a saturated pipeline refilled by faster producers.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-class AsyncHelpingEmptyQueueBackstopTest extends TestHelper {
+class AsyncHelpingSlowPeerProgressTest extends TestHelper {
 
   @Test
   @Timeout(60)
-  void helpWaitingWorkerWithEmptyQueueSurfacesWedgedPeerInsteadOfSpinningForever() throws Exception {
+  void progressingPeerNeverTripsHelpingBackstop() throws Exception {
     final DatabaseInternal db = (DatabaseInternal) database;
     db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 2); // CAPACITY 1 PER WORKER
     final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
@@ -55,10 +57,8 @@ class AsyncHelpingEmptyQueueBackstopTest extends TestHelper {
     async.recreateThreadsForTests();
     async.setCheckForStalledQueuesMaxDelay(50); // BACKSTOP = 12 x 50ms = 600ms
 
-    final List<Throwable> errors = new CopyOnWriteArrayList<>();
     final CountDownLatch stallReported = new CountDownLatch(1);
     async.onError(e -> {
-      errors.add(e);
       if (String.valueOf(e.getMessage()).contains("stalled"))
         stallReported.countDown();
     });
@@ -67,14 +67,16 @@ class AsyncHelpingEmptyQueueBackstopTest extends TestHelper {
     final CountDownLatch releaseWedge = new CountDownLatch(1);
     final CountDownLatch outerStarted = new CountDownLatch(1);
     final CountDownLatch proceed = new CountDownLatch(1);
+    final CountDownLatch markerRan = new CountDownLatch(1);
     try {
-      // Worker 1: wedged in user code (alive, completing nothing) behind a full queue.
+      // Worker 1: parked in user code behind a full queue, so the hand-off below stays blocked; its
+      // "progress" is injected below without freeing queue slots.
       async.scheduleTask(1, awaitTask(wedgeStarted, releaseWedge), true, 0);
       assertThat(wedgeStarted.await(5, TimeUnit.SECONDS)).isTrue();
       assertThat(async.scheduleTask(1, noOpTask(), false, 0)).isTrue();
 
-      // Worker 0: hands a follow-up to worker 1's full queue with its OWN queue empty, so the
-      // deferral budget can never grow and only the backstop can end the wait.
+      // Worker 0: hands off to worker 1's full queue with an empty own queue - the exact backstop
+      // scenario of AsyncHelpingEmptyQueueBackstopTest, except the peer now shows progress.
       async.scheduleTask(0, new DatabaseAsyncTask() {
         @Override
         public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
@@ -86,7 +88,7 @@ class AsyncHelpingEmptyQueueBackstopTest extends TestHelper {
             Thread.currentThread().interrupt();
             return;
           }
-          async.scheduleTask(1, noOpTask(), true, 0);
+          async.scheduleTask(1, countingTask(markerRan), true, 0);
         }
 
         @Override
@@ -97,16 +99,25 @@ class AsyncHelpingEmptyQueueBackstopTest extends TestHelper {
       assertThat(outerStarted.await(5, TimeUnit.SECONDS)).isTrue();
       proceed.countDown();
 
-      // The buggy loop spun forever with no error: the backstop must surface the stall.
-      assertThat(stallReported.await(10, TimeUnit.SECONDS))
-          .as("the help-waiting worker must report the wedged peer instead of spinning forever")
-          .isTrue();
+      // Tick the peer's completed-task counter every 100ms (a progress event every ~2 windows) for
+      // 2s = ~40 elapsed windows, far beyond the 12-window bound. The counter is only written by
+      // the (currently parked) peer, so the test thread is the single writer during this phase.
+      final DatabaseAsyncExecutorImpl.AsyncThread peer = findWorkerThread(db, 1);
+      final long tickUntil = System.currentTimeMillis() + 2_000;
+      while (System.currentTimeMillis() < tickUntil) {
+        peer.completedTaskCount++;
+        Thread.sleep(100);
+      }
 
-      // The worker must survive the aborted hand-off and keep serving its queue.
-      final CountDownLatch survived = new CountDownLatch(1);
-      async.scheduleTask(0, countingTask(survived), true, 0);
-      assertThat(survived.await(5, TimeUnit.SECONDS))
-          .as("the worker must stay serviceable after the aborted hand-off")
+      assertThat(stallReported.getCount())
+          .as("a progressing peer must keep resetting the backstop, not trip it")
+          .isEqualTo(1L);
+      assertThat(markerRan.getCount()).as("the hand-off must still be parked (queue never freed)").isEqualTo(1L);
+
+      // With the progress stopped, the backstop must resume counting from the last reset and fire:
+      // proves the counter was resetting (not merely never reaching the bound) during the ticks.
+      assertThat(stallReported.await(10, TimeUnit.SECONDS))
+          .as("once progress stops, the wedged peer must surface at the backstop")
           .isTrue();
     } finally {
       releaseWedge.countDown();
@@ -114,5 +125,12 @@ class AsyncHelpingEmptyQueueBackstopTest extends TestHelper {
     }
 
     assertThat(async.waitCompletion(10_000)).isTrue();
+  }
+
+  private static DatabaseAsyncExecutorImpl.AsyncThread findWorkerThread(final DatabaseInternal db, final int slot) {
+    final String name = "AsyncExecutor-" + db.getName() + "-" + slot;
+    return (DatabaseAsyncExecutorImpl.AsyncThread) Thread.getAllStackTraces().keySet().stream()
+        .filter(t -> t.getName().equals(name)).findFirst()
+        .orElseThrow(() -> new IllegalStateException("Worker thread " + name + " not found"));
   }
 }

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownPromptHelpingBailTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownPromptHelpingBailTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.Timeout;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static com.arcadedb.database.async.AsyncTestTasks.awaitTask;
+import static com.arcadedb.database.async.AsyncTestTasks.noOpTask;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -47,8 +49,8 @@ class AsyncShutdownPromptHelpingBailTest extends TestHelper {
     db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 2); // CAPACITY 1 PER WORKER
     final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
     async.setParallelLevel(2);
-    // Force thread re-creation so the queue size above is picked up regardless of the previous level.
-    async.setTransactionUseWAL(true);
+    // Rebuild the pool so the queue size above is picked up (dedicated hook, #5072 review point 4).
+    async.recreateThreadsForTests();
     // Large grace period: without the prompt bail, close() pays it in full on the helping worker
     // before the interrupt escalation kicks in.
     async.shutdownJoinTimeoutMs = 8_000;
@@ -106,38 +108,5 @@ class AsyncShutdownPromptHelpingBailTest extends TestHelper {
       releaseWedge.countDown();
       proceed.countDown();
     }
-  }
-
-  private static DatabaseAsyncTask awaitTask(final CountDownLatch started, final CountDownLatch release) {
-    return new DatabaseAsyncTask() {
-      @Override
-      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
-        started.countDown();
-        try {
-          release.await(20, TimeUnit.SECONDS);
-        } catch (final InterruptedException e) {
-          Thread.currentThread().interrupt();
-        }
-      }
-
-      @Override
-      public boolean requiresActiveTx() {
-        return false;
-      }
-    };
-  }
-
-  private static DatabaseAsyncTask noOpTask() {
-    return new DatabaseAsyncTask() {
-      @Override
-      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
-        // NO ACTIONS
-      }
-
-      @Override
-      public boolean requiresActiveTx() {
-        return false;
-      }
-    };
   }
 }

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownPromptHelpingBailTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownPromptHelpingBailTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for the #5062 review, round 6 (point 2): after consuming {@code FORCE_EXIT} the
+ * helping loop set {@code forceShutdown} but kept looping to hand off the follow-up. On a wedged
+ * peer the worker ignored its own shutdown request until the interrupt escalation fired after the
+ * full grace period, so {@code close()} paid the whole {@code shutdownJoinTimeoutMs} for a worker
+ * that already knew it had to exit. The loop now bails out promptly once the flag is set (the
+ * follow-up is dropped loudly via the shutdown exception - workers are dying, same as the
+ * target-dead branch).
+ */
+class AsyncShutdownPromptHelpingBailTest extends TestHelper {
+
+  @Test
+  @Timeout(60)
+  void closeReturnsPromptlyWhenHelpingWorkerConsumesForceExit() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 2); // CAPACITY 1 PER WORKER
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
+    async.setParallelLevel(2);
+    // Force thread re-creation so the queue size above is picked up regardless of the previous level.
+    async.setTransactionUseWAL(true);
+    // Large grace period: without the prompt bail, close() pays it in full on the helping worker
+    // before the interrupt escalation kicks in.
+    async.shutdownJoinTimeoutMs = 8_000;
+
+    final CountDownLatch wedgeStarted = new CountDownLatch(1);
+    final CountDownLatch releaseWedge = new CountDownLatch(1);
+    final CountDownLatch outerStarted = new CountDownLatch(1);
+    final CountDownLatch proceed = new CountDownLatch(1);
+    try {
+      // Worker 1: wedged behind a full queue, so the hand-off below cannot land before close().
+      async.scheduleTask(1, awaitTask(wedgeStarted, releaseWedge), true, 0);
+      assertThat(wedgeStarted.await(5, TimeUnit.SECONDS)).isTrue();
+      assertThat(async.scheduleTask(1, noOpTask(), false, 0)).isTrue();
+
+      // Worker 0: parks in offerHelping with an empty own queue; close()'s FORCE_EXIT offer lands
+      // there and the helping loop consumes it.
+      async.scheduleTask(0, new DatabaseAsyncTask() {
+        @Override
+        public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+          outerStarted.countDown();
+          try {
+            if (!proceed.await(20, TimeUnit.SECONDS))
+              return;
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+          }
+          async.scheduleTask(1, noOpTask(), true, 0);
+        }
+
+        @Override
+        public boolean requiresActiveTx() {
+          return false;
+        }
+      }, true, 0);
+      assertThat(outerStarted.await(5, TimeUnit.SECONDS)).isTrue();
+      proceed.countDown();
+      // Let worker 0 enter the helping loop before shutting down.
+      Thread.sleep(300);
+
+      // The wedge stays in place for the whole shutdown: worker 0 is handled first by close() and
+      // must exit on the consumed FORCE_EXIT alone (worker 1 is only interrupted afterwards, via
+      // the offer-failed path, and honors it).
+      final long start = System.currentTimeMillis();
+      async.close();
+      final long elapsed = System.currentTimeMillis() - start;
+
+      // Without the bail: worker 0 sat in the helping loop for the full 8s grace period before the
+      // escalation interrupt. With it: worker 0 exits within one offer window of consuming the
+      // marker.
+      assertThat(elapsed)
+          .as("close() must not pay the full grace period for a worker that already consumed FORCE_EXIT")
+          .isLessThan(5_000);
+    } finally {
+      releaseWedge.countDown();
+      proceed.countDown();
+    }
+  }
+
+  private static DatabaseAsyncTask awaitTask(final CountDownLatch started, final CountDownLatch release) {
+    return new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        started.countDown();
+        try {
+          release.await(20, TimeUnit.SECONDS);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    };
+  }
+
+  private static DatabaseAsyncTask noOpTask() {
+    return new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        // NO ACTIONS
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    };
+  }
+}

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncTestTasks.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncTestTasks.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.database.DatabaseInternal;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Shared task factories for the async executor regression tests (#5072 review, point 3).
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+final class AsyncTestTasks {
+  private AsyncTestTasks() {
+  }
+
+  /**
+   * A task that signals its start and then blocks until released (20s ceiling), restoring the
+   * interrupt flag: simulates a worker busy inside user code.
+   */
+  static DatabaseAsyncTask awaitTask(final CountDownLatch started, final CountDownLatch release) {
+    return new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        started.countDown();
+        try {
+          release.await(20, TimeUnit.SECONDS);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    };
+  }
+
+  /** A task that counts the given latch down when executed. */
+  static DatabaseAsyncTask countingTask(final CountDownLatch latch) {
+    return new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        latch.countDown();
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    };
+  }
+
+  /** A task with no effects, used to fill queues. */
+  static DatabaseAsyncTask noOpTask() {
+    return new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        // NO ACTIONS
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    };
+  }
+}


### PR DESCRIPTION
Follow-up to #5062, addressing the round-6 review findings that landed after the merge.

## The liveness hole (round-6 point 1)

`offerHelping` had NO backstop when the helping worker's OWN queue is empty. A worker handing off a cross-slot follow-up (the bidirectional-edge incoming-link task) to a wedged-alive peer spun forever:

- `offer` fails (peer's queue full, peer completes nothing but `isAlive()` is true);
- the deferral budget never grows (`helpDeferredTasks` stays empty - there is nothing to poll);
- `self.queue.poll()` returns `null`, `continue` - **forever**.

Both workers were silently lost during normal operation (not just shutdown), with no error surfaced - and the javadoc's liveness argument silently assumed a non-empty own queue. The producer path already failed loudly at the 12-window backstop; the cross-scheduling worker did not.

**Fix:** the helping loop now applies the same progress-gated `STALLED_NO_PROGRESS_WINDOWS` (12) backstop as the producer path, measured in wall-clock windows of `checkForStalledQueuesMaxDelay` (60s with defaults). On trip, the hand-off fails loudly: the exception unwinds through `scheduleTask` into `executeTask`'s catch - `onError` + batch rollback + `completed()` - and the worker itself survives and keeps serving its queue. Only the long, conservative bound is used (not the 3-window cross-slot one) because aborting mid-task costs the current batch; a peer parked on a legitimately slow chain is outlived as long as its individual tasks stay under the bound - the same operator cliff already documented for the producer backstop.

**Red-first evidence:** `AsyncHelpingEmptyQueueBackstopTest` - on the previous code it spun forever with no error (10s latch timeout); fixed code surfaces the stall in ~1.2s at a 50ms test window, and a follow-up task scheduled on the same worker still executes (the worker survives the aborted hand-off).

## Prompt shutdown bail (round-6 point 2)

After consuming `FORCE_EXIT` the helping loop set `forceShutdown` but kept looping to hand off the follow-up, so on a wedged peer `close()` paid the whole grace period before the #5062 interrupt escalation fired. The loop now bails out at the top of each iteration once the flag is set, dropping the follow-up loudly via the shutdown exception - workers are dying, same semantics as the target-dead branch. The interrupt escalation stays in place as the backstop for parks that never poll the marker (a budget-exhausted worker waiting in `offerWaiting`).

**Red-first evidence:** `AsyncShutdownPromptHelpingBailTest` - on the previous code `close()` paid the full 8s grace period (9.5s elapsed); fixed code returns in ~1.3s.

## waitCompletion note (round-6 point 3)

One-line comment at the enqueue-phase early return: completion markers already enqueued on earlier workers are not a leak - they execute and count down a latch nobody awaits anymore.

The `offerHelping` javadoc liveness claim is corrected to match the implementation, and the release notes are updated.

## Verification

`mvn -pl engine compile`; full `com.arcadedb.database.async` battery (22 tests, including the two new red-first regressions) plus `AsyncTest` (11) - all green, including the #5062 shutdown-escalation regression unchanged.