### PR TITLE
chore: post-audit cleanup - error-message unit fix and comment scaffolding trim

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/DatabaseFactory.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseFactory.java
@@ -90,7 +90,7 @@ public class DatabaseFactory implements AutoCloseable {
       return database;
     } catch (final Throwable e) {
       // Balance the acquire above so a failed open does not leak the flush thread (#4991) - but EXACTLY
-      // once per instance (#5070 review): when registerActiveInstance loses a same-path open race it closes
+      // once per instance (#5070): when registerActiveInstance loses a same-path open race it closes
       // the database itself, and that close already consumed this reference; releasing again here would
       // double-decrement and could tear the manager down under the race winner.
       if (database == null || !database.isPageManagerReferenceReleased())
@@ -117,7 +117,7 @@ public class DatabaseFactory implements AutoCloseable {
       return database;
     } catch (final Throwable e) {
       // Balance the acquire above so a failed create does not leak the flush thread (#4991) - but EXACTLY
-      // once per instance (#5070 review): see open().
+      // once per instance (#5070): see open().
       if (database == null || !database.isPageManagerReferenceReleased())
         PageManager.INSTANCE.release();
       throw e;
@@ -165,7 +165,7 @@ public class DatabaseFactory implements AutoCloseable {
 
   protected static boolean removeActiveDatabaseInstance(final String databasePath, final Database instance) {
     final var normalizedPath = getNormalizedPath(databasePath);
-    // Keyed to the instance (#5070 review): when registerActiveInstance closes a same-path open-race LOSER,
+    // Keyed to the instance (#5070): when registerActiveInstance closes a same-path open-race LOSER,
     // the loser's close must not remove the WINNER's still-live mapping - a plain remove(path) did, orphaning
     // the winner from the registry and letting a third open of the same path pass checkForActiveInstance.
     ACTIVE_INSTANCES.remove(normalizedPath, instance);

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -1339,7 +1339,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
           // concurrency-induced duplicate can succeed on retry, and one retry is enough to disambiguate:
           // fail fast instead of burning all the remaining attempts plus their retry delays.
           //
-          // #5061 review: a TRANSIENT duplicate from an in-flight sibling transaction that later rolls back
+          // #5061: a TRANSIENT duplicate from an in-flight sibling transaction that later rolls back
           // is unreachable - checkUniqueIndexKeys reads committed pages plus THIS transaction's own overlay
           // (TransactionIndexContext is per-transaction), so uncommitted sibling entries are invisible and a
           // detected duplicate is always against durable state (or this same transaction). The one retry
@@ -2202,7 +2202,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     // Unconditional on purpose: a KILLED database (crash simulation) reaches close() with open == false and
     // must still unregister - removeActiveDatabaseInstance is naturally idempotent (false on the second
     // call), which is exactly how the pre-#4927 code stayed double-close-safe. The executor teardown stays
-    // on the map-emptiness heuristic DELIBERATELY (#5070 review): unlike the flush thread, a shutdown
+    // on the map-emptiness heuristic DELIBERATELY (#5070): unlike the flush thread, a shutdown
     // executor lazily re-creates itself on the next getExecutor(), so the mid-flight-open race self-heals.
     // A redundant double-close of the LAST database calls it twice (the empty map returns true again):
     // harmless, closeExecutor() is idempotent (early-returns on null/isShutdown under its class lock).
@@ -2212,7 +2212,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     // #4927: paired with the acquire in DatabaseFactory.open/create - the flush machinery is torn down by
     // the refcount reaching zero, never by the racy "was this the last registered instance" check (an open
     // in flight on another thread holds a reference before it registers, so it can no longer be pulled out
-    // from under). The atomic flag makes the release EXACTLY ONCE per database instance (#5070 review): a
+    // from under). The atomic flag makes the release EXACTLY ONCE per database instance (#5070): a
     // redundant double-close cannot steal another database's reference, and when registerActiveInstance
     // closes a same-path open race loser, the factory's catch sees the flag and does not release again.
     if (pageManagerReferenceReleased.compareAndSet(false, true))
@@ -2360,7 +2360,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
   }
 
   /**
-   * #5053 review: set when a commit fails AFTER its transaction was appended to the WAL (the point of no
+   * #5053: set when a commit fails AFTER its transaction was appended to the WAL (the point of no
    * return) but BEFORE its pages were published. From that moment the WAL and the live state diverge: the
    * transaction is durable (recovery will replay it) but invisible, and letting new transactions run would
    * let them bump the same page versions and append conflicting WAL records for the same target versions.
@@ -2394,7 +2394,7 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     if (!open)
       throw new DatabaseIsClosedException(name);
     if (fenceReason != null)
-      // #5053 review: a commit failed AFTER its WAL append - the WAL holds a record whose pages were never
+      // #5053: a commit failed AFTER its WAL append - the WAL holds a record whose pages were never
       // published, so the live in-memory state diverges from what recovery will reconstruct. Every further
       // operation is fenced until the database is closed (the close-time ack gate preserves the WAL, since
       // the orphaned record's pages were never flush-acked) and reopened, which replays the record.

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -709,7 +709,7 @@ public class TransactionContext implements Transaction {
     status = STATUS.COMMIT_1ST_PHASE;
 
     try {
-      // #4937 review: explicit-lock mode captured before checkExplicitLocks nulls explicitLockedFiles, so the
+      // #4937: explicit-lock mode captured before checkExplicitLocks nulls explicitLockedFiles, so the
       // late-joiner block below can still tell an explicit-lock transaction from an auto-locked one.
       boolean explicitLockMode = false;
       if (isLeader) {
@@ -723,7 +723,7 @@ public class TransactionContext implements Transaction {
         final IntHashSet modifiedFiles = lockFilesFromChanges();
 
         // checkExplicitLocks nulls explicitLockedFiles on success, so remember the mode now for the
-        // late-joiner check further down (#4937 review): otherwise that check always sees null and would
+        // late-joiner check further down (#4937): otherwise that check always sees null and would
         // silently expand an explicit-lock transaction's lock set, defeating the explicit-locking contract.
         explicitLockMode = explicitLockedFiles != null;
 
@@ -875,7 +875,7 @@ public class TransactionContext implements Transaction {
       throw e;
     } catch (final TransactionException e) {
       // Already a first-class transaction error (e.g. the explicit-lock contract violation): rethrow as-is
-      // instead of double-wrapping it in a generic "Transaction error on commit" (#5053 review).
+      // instead of double-wrapping it in a generic "Transaction error on commit" (#5053).
       rollback();
       throw e;
     } catch (final Exception e) {
@@ -914,7 +914,7 @@ public class TransactionContext implements Transaction {
       // data never committed. The bump below mutates only this transaction's private MutablePage instances,
       // so a WAL-append failure still aborts cleanly with nothing observable. The in-between window is safe
       // because every modified file's lock is held (#4937 guarantees coverage) until reset().
-      // #5053 review: refuse to commit on a fenced database, before doing any work. The file locks this
+      // #5053: refuse to commit on a fenced database, before doing any work. The file locks this
       // transaction acquired in phase 1 give the happens-before edge: for any transaction sharing a page
       // with the failed one, the fence write (made before the failed commit's reset() released those locks)
       // is visible here - it cannot append a WAL record targeting the same page version the orphaned record
@@ -1013,7 +1013,7 @@ public class TransactionContext implements Transaction {
         try {
           rollback();
         } catch (final Throwable rollbackError) {
-          // #5061 review: the cleanup must never SUPPRESS the primary commit exception - e.g. a failed
+          // #5061: the cleanup must never SUPPRESS the primary commit exception - e.g. a failed
           // dictionary reload here would surface a retryable ConcurrentModificationException as a
           // non-retryable SchemaException, breaking the caller's retry loop. Log the secondary failure and
           // degrade to reset() so locks and status are still released (reset() is safe after a partial
@@ -1223,7 +1223,7 @@ public class TransactionContext implements Transaction {
   }
 
   /**
-   * #4937 review: late-joiner coverage check for an EXPLICIT-lock transaction. By this point the earlier
+   * #4937: late-joiner coverage check for an EXPLICIT-lock transaction. By this point the earlier
    * {@link #checkExplicitLocks} has moved the user's explicit lock set into {@code lockedFiles} (and nulled
    * {@code explicitLockedFiles}), so a file in the transaction's page set that is NOT in {@code lockedFiles}
    * is one the user did not lock. Surface it as the same contract violation a direct modification of an

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -2059,7 +2059,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     if (!firstRun && System.currentTimeMillis() - timeOfLastStats <= MAX_TIMEOUT_GATHER_STATS)
       return;
 
-    // #5063 review round 2: consume the change counter atomically at the decision point. The previous
+    // #5063: consume the change counter atomically at the decision point. The previous
     // get() > 0 check paired with a set(0L) at the end of the scan wiped any increment landing while the
     // scan ran; getAndSet(0L) carries those increments into the next cycle instead of losing them.
     final long consumedChanges = changesFromLastStats.getAndSet(0L);
@@ -2093,7 +2093,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
           timeOfLastStats = System.currentTimeMillis();
         }
       } catch (Exception e) {
-        // #5063 review round 3: THE COUNTER WAS ALREADY CONSUMED. RESTORE THE FULL CONSUMED COUNT (NOT A
+        // #5063: THE COUNTER WAS ALREADY CONSUMED. RESTORE THE FULL CONSUMED COUNT (NOT A
         // SINGLE INCREMENT, WHICH UNDERCOUNTED THE PENDING CHANGES) SO THE FAILED SCAN IS RETRIED AT THE
         // NEXT CYCLE; max(consumed, 1) COVERS THE firstRun CASE WHERE THE CONSUMED COUNT MAY BE ZERO
         changesFromLastStats.addAndGet(Math.max(consumedChanges, 1L));

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -65,10 +65,10 @@ public class PageManager extends LockContext {
   private final    AtomicLong                        evictionRuns                          = new AtomicLong();
   private final    AtomicLong                        pagesEvicted                          = new AtomicLong();
   private volatile long                              lastCheckForRAM                       = 0;
-  // LIFECYCLE INVARIANT (#5070 review): flushThread and readCache are written only under LIFECYCLE_LOCK
+  // LIFECYCLE INVARIANT (#5070): flushThread and readCache are written only under LIFECYCLE_LOCK
   // during the 0->1 startup / 1->0 shutdown transitions, and read lock-free on the hot paths. That is safe
   // ONLY because a reader implies refcount > 0 (its database holds a reference), so no transition can run
-  // concurrently. volatile (three review rounds converged on it): the barrier cost is negligible next to the
+  // concurrently. volatile: the barrier cost is negligible next to the
   // ConcurrentHashMap barriers already on these paths, and it removes the reliance on the external
   // database-publication happens-before for cross-thread visibility of the startup() writes.
   private volatile PageManagerFlushThread             flushThread;
@@ -118,7 +118,7 @@ public class PageManager extends LockContext {
         try {
           startup();
         } catch (final RuntimeException | Error e) {
-          // #5070 review: startup() can throw (e.g. ConfigurationException on a negative MAX_PAGE_RAM). The
+          // #5070: startup() can throw (e.g. ConfigurationException on a negative MAX_PAGE_RAM). The
           // increment must not survive it, or the counter is left at 1 with no flush thread and the NEXT
           // acquire sees 1 -> 2 and never starts one - a wedged manager the caller's catch cannot repair
           // (its release() would just decrement back to the same broken state at 1).
@@ -145,7 +145,7 @@ public class PageManager extends LockContext {
    * no-op at runtime: with no database open the next {@link #acquire()} reads the fresh settings anyway
    * (and starting a flush thread with zero databases - the old behavior - leaked it until the next
    * lifecycle transition); with databases OPEN a live shutdown+startup swap would race the hot paths, which
-   * read {@code flushThread}/{@code readCache} without the lifecycle lock (#5070 review) - so a live
+   * read {@code flushThread}/{@code readCache} without the lifecycle lock (#5070) - so a live
    * profile change is refused loudly instead. Set the PROFILE before opening databases.
    */
   public void configure() {
@@ -160,7 +160,7 @@ public class PageManager extends LockContext {
   /**
    * Force teardown regardless of refcount (test/emergency API): the counter resets so the next acquire
    * starts fresh. ONLY safe when no database is open: a live database's eventual release() would decrement
-   * the NEW manager started by a later acquire and tear it down under that newcomer (#5070 review).
+   * the NEW manager started by a later acquire and tear it down under that newcomer (#5070).
    */
   public void close() {
     synchronized (LIFECYCLE_LOCK) {
@@ -176,14 +176,15 @@ public class PageManager extends LockContext {
 
     this.maxRAM = configuration.getValueAsLong(GlobalConfiguration.MAX_PAGE_RAM) * 1024 * 1024;
     if (this.maxRAM < 0)
-      throw new ConfigurationException(GlobalConfiguration.MAX_PAGE_RAM.getKey() + " configuration is invalid (" + maxRAM + " MB)");
+      throw new ConfigurationException(
+          GlobalConfiguration.MAX_PAGE_RAM.getKey() + " configuration is invalid (" + (maxRAM / (1024 * 1024)) + " MB)");
 
     flushThread = new PageManagerFlushThread(this, configuration);
     flushThread.start();
   }
 
   /**
-   * INVARIANT (#5070 review): runs under LIFECYCLE_LOCK and joins the flush thread - the flush thread must
+   * INVARIANT (#5070): runs under LIFECYCLE_LOCK and joins the flush thread - the flush thread must
    * therefore NEVER call acquire()/release()/configure()/close(), or this join becomes a deadlock (the
    * flush thread blocking on the lock this thread holds while waiting for it to exit). Verified true today.
    */
@@ -194,14 +195,14 @@ public class PageManager extends LockContext {
       } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();
       } finally {
-        // Null out regardless of interrupt (#5070 review): a stale dead reference with refcount 0 was
+        // Null out regardless of interrupt (#5070): a stale dead reference with refcount 0 was
         // harmless (the next startup() overwrites it) but inconsistent.
         flushThread = null;
       }
     }
 
     if (readCache != null)
-      // close() is a reachable test/emergency API and may run before any startup() (#5070 review).
+      // close() is a reachable test/emergency API and may run before any startup() (#5070).
       readCache.clear();
     totalReadCacheRAM.set(0L);
   }

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -256,7 +256,7 @@ public class TransactionManager {
 
   public void notifyPageFlushed(final MutablePage page) {
     // takeWALFile (not get) so the ack is released exactly once even when this races the file-dropped
-    // flush branch or the dropped-file batch purge on the same page (#4928 review).
+    // flush branch or the dropped-file batch purge on the same page (#4928).
     final WALFile walFile = page.takeWALFile();
     if (walFile != null)
       walFile.notifyPageFlushed();
@@ -396,7 +396,7 @@ public class TransactionManager {
               try {
                 // Files.move (vs File.renameTo, which just returns false) fails with a cause and performs an
                 // atomic rename where the filesystem supports it. Best-effort semantics preserved: log and continue.
-                // REPLACE_EXISTING (#5063 review round 4): a prior ABORTED recovery can leave a same-named
+                // REPLACE_EXISTING (#5063): a prior ABORTED recovery can leave a same-named
                 // .corrupt file behind; without it the move throws FileAlreadyExistsException and the original
                 // .wal stays in place, re-scanned and re-aborted on every restart - the exact loop this breaks.
                 // The stale .corrupt it replaces is evidence from the SAME file's earlier failed attempt.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PartitionedTriangleOp.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/PartitionedTriangleOp.java
@@ -103,7 +103,7 @@ public final class PartitionedTriangleOp implements CountOp {
       // was reached from a pool thread (or with the pool full of blocked producers), the caller waited on
       // tasks queued behind threads that were themselves waiting: a pool-starvation deadlock only mitigated
       // by the bounded queue's caller-runs rejection.
-      // #5063 review round 3: chunk 0 runs inside try/finally so the submitted chunks are ALWAYS awaited.
+      // #5063: chunk 0 runs inside try/finally so the submitted chunks are ALWAYS awaited.
       // Without it, a chunk-0 exception unwound this frame while chunks 1..N-1 kept running and writing
       // into partialCounts (and holding pool threads) behind the caller's back.
       boolean chunk0Completed = false;


### PR DESCRIPTION
The two housekeeping items deferred from the audit PRs' final review rounds:

1. **MAX_PAGE_RAM error message unit** (flagged in #5070 round 12): the ConfigurationException printed the byte value with an `MB` suffix; it now divides back to megabytes.
2. **Review-scaffolding trim** (asked in #5063/#5060/#5070 final rounds): comments across the audit-touched files keep their invariant statements but drop the review-round chronology.

No behavior change beyond the message unit. Focused suites green (lifecycle, commit ordering, context lifecycle, flush robustness).