### PR TITLE
fix(#5068): refcount page-flush suspension so overlapping suspenders own their windows

### DIFF
--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -363,6 +363,20 @@ that could starve the very snapshot resync meant to heal the node.
   the `activeWALFilePool` element publication (needs an `AtomicReferenceArray` refactor of a
   conflict-heavy file), the `createNewPage` rollback counter drift and the descending duplicate-run
   cursor rescan (perf-only).
+- **Storage: flush suspension is refcounted - overlapping backup/verify/snapshot each own their window
+  (2026-07 audit follow-up).** `suspendFlushAndExecute` ownership was first-caller-wins: with two
+  concurrent suspenders on the same database (SQL `BACKUP DATABASE`, the HA verify endpoint, HA snapshot
+  serving - any combination), only the FIRST caller owned the suspend flag while the other still streamed
+  the database files. The non-owner skipped the wait for the in-flight flush batch (so it could read a
+  page mid-write) and, worse, kept streaming while the owner's exit synchronously flushed the deferred
+  batches to disk - torn reads either way. The suspension is now a per-database REFCOUNT: flushing stays
+  suspended while the count is above zero and resumes (deferred batches flushed) only when the LAST
+  suspender exits, so every caller legitimately owns its whole window; a new suspender arriving while the
+  last exit is mid-way through the deferred-batch writes waits until that resume completes. The #4728
+  deferred-RAM backpressure accounting is unchanged, and the HA snapshot endpoint keeps its per-database
+  serialization (no longer needed for correctness, retained to serialize same-database zip streams and
+  keep each suspension window - and therefore the deferred backlog - short)
+  ([#5068](https://github.com/ArcadeData/arcadedb/issues/5068)).
 - **Transaction commit cleanups (2026-07 audit).** A phase-2 commit failure that happens BEFORE the
   transaction reaches the WAL now restores user-held record state like a phase-1 failure does (rollback):
   records created in the failed transaction get their optimistically-assigned RID reset to provisional and

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -231,17 +231,17 @@ public class PageManager extends LockContext {
 
   public void suspendFlushAndExecute(final Database database, final CallableNoReturn callback)
       throws IOException, InterruptedException {
-    // #4958: when the database is ALREADY suspended by an outer scope (nested backup/snapshot), the
-    // callback still runs - under the outer suspension - instead of being silently skipped as before.
-    // Only the outermost caller owns the flag and restores it on exit.
-    final boolean acquired = flushThread.setSuspended(database, true);
-    if (acquired)
-      flushThread.waitForCurrentFlushToComplete(database);
+    // #5068: the suspension is REFCOUNTED, so every caller (backup, verify, HA snapshot serving, nested
+    // scopes per #4958) owns its whole window even when the windows overlap on the same database: flushing
+    // is resumed (and the deferred batches flushed) only when the LAST suspender exits. The wait for the
+    // in-flight batch runs INSIDE the try so an interrupt during the wait still releases this caller's
+    // reference; it is cheap for non-first suspenders (the flush thread is already parked deferring).
+    flushThread.setSuspended(database, true);
     try {
+      flushThread.waitForCurrentFlushToComplete(database);
       CodeUtils.executeIgnoringExceptions(callback, "Error during suspend flush", true);
     } finally {
-      if (acquired)
-        flushThread.setSuspended(database, false);
+      flushThread.setSuspended(database, false);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -47,13 +48,22 @@ public class PageManagerFlushThread extends Thread {
   public final         ArrayBlockingQueue<PagesToFlush>                         queue;
   private final        String                                                   logContext;
   private volatile     boolean                                                  running             = true;
-  private final        ConcurrentHashMap<Database, Boolean>                     suspended           = new ConcurrentHashMap<>(); // USED DURING BACKUP
+  // Per-database suspension REFCOUNT (issue #5068): flushing is suspended while the count is > 0. Backup,
+  // verify and HA snapshot serving can overlap on the same database, and each caller must own its whole
+  // window: the count is bumped per suspender and the resume (deferred-batch flush + flag clear) runs only
+  // when the LAST suspender exits. Guarded by suspendLock(database) for every transition.
+  private final        ConcurrentHashMap<Database, Integer>                     suspended           = new ConcurrentHashMap<>();
+  // Databases whose LAST suspender is currently resuming (synchronously flushing the deferred batches).
+  // A new suspender arriving in that window waits on suspendLock(database) until the resume completes, so
+  // its suspension window can never overlap the resume's page writes (issue #5068).
+  private final        Set<Database>                                            resumingDatabases   = ConcurrentHashMap.newKeySet();
   private final static PagesToFlush                                             SHUTDOWN_THREAD     = new PagesToFlush(null);
   private final        AtomicReference<PagesToFlush>                            nextPagesToFlush    = new AtomicReference<>();
   private final        ConcurrentHashMap<Database, ConcurrentLinkedQueue<PagesToFlush>> deferredByDatabase = new ConcurrentHashMap<>();
   // Per-database lock serializing the suspend-flag check + defer in flushPagesFromQueueToDisk against the
   // flag-clear + deferred-detach in setSuspended(false). Without it a batch could be deferred AFTER the
   // unsuspend already drained the deferred map, leaving it stuck in deferredByDatabase / pageIndex forever.
+  // Also the monitor new suspenders wait on while a resume is in flight (see resumingDatabases).
   private final        ConcurrentHashMap<Database, Object>                      suspendLocks        = new ConcurrentHashMap<>();
 
   /**
@@ -342,10 +352,73 @@ public class PageManagerFlushThread extends Thread {
       Thread.sleep(1);
   }
 
+  /**
+   * Refcounted suspension (issue #5068). {@code value == true} adds a suspender: the return value is
+   * {@code true} only for the FIRST suspender (count 0 to 1). {@code value == false} releases one
+   * suspender: only the LAST release (count 1 to 0) resumes flushing - it synchronously flushes the
+   * deferred batches and clears the flag - and returns {@code true}; a non-last release just decrements
+   * the count and returns {@code false}, keeping the database suspended for the remaining suspenders.
+   * <p>
+   * A new suspender arriving while the last release is mid-resume waits until the resume completes:
+   * otherwise its freshly acquired window would overlap the resume's synchronous page writes, exactly the
+   * torn-read overlap this refcount exists to prevent. The wait is uninterruptible (the interrupt flag is
+   * preserved and restored) and timed, so a lost notification degrades to polling instead of a hang.
+   */
   public boolean setSuspended(final Database database, final boolean value) {
-    if (value)
-      return suspended.putIfAbsent(database, true) == null;
+    final Object lock = suspendLock(database);
 
+    if (value) {
+      synchronized (lock) {
+        boolean interrupted = false;
+        while (resumingDatabases.contains(database)) {
+          try {
+            lock.wait(100);
+          } catch (final InterruptedException e) {
+            interrupted = true;
+          }
+        }
+        if (interrupted)
+          Thread.currentThread().interrupt();
+
+        final int count = suspended.merge(database, 1, Integer::sum);
+        return count == 1;
+      }
+    }
+
+    synchronized (lock) {
+      final Integer count = suspended.get(database);
+      if (count == null)
+        // NOT SUSPENDED (E.G. UNBALANCED RELEASE OR DATABASE DROPPED MID-SUSPENSION): NOTHING TO RESUME
+        return false;
+      if (count > 1) {
+        // OTHER SUSPENDERS STILL OWN THE WINDOW: JUST RELEASE THIS CALLER'S REFERENCE
+        suspended.put(database, count - 1);
+        return false;
+      }
+      // LAST SUSPENDER: RESUME BELOW. The count stays at 1 through Phase 1 so the flush thread keeps
+      // deferring, and resumingDatabases blocks new suspenders until the flag is cleared in Phase 2.
+      if (!resumingDatabases.add(database))
+        // DEFENSIVE: A RESUME IS ALREADY IN FLIGHT (UNBALANCED CONCURRENT RELEASE)
+        return false;
+    }
+
+    try {
+      resumeFlushing(database);
+    } finally {
+      synchronized (lock) {
+        // Idempotent on the success path (Phase 2 already removed the entry and the resume gate kept
+        // anyone from re-adding it); on an unexpected exception out of the resume it heals the stuck
+        // count so the database does not stay suspended forever.
+        suspended.remove(database);
+        resumingDatabases.remove(database);
+        lock.notifyAll();
+      }
+    }
+    return true;
+  }
+
+  /** Executes the resume of the LAST suspender: flushes the deferred batches and clears the suspension. */
+  private void resumeFlushing(final Database database) {
     // Phase 1: synchronously flush all deferred batches accumulated while suspended. If the unsuspending
     // thread (e.g. backup/HA) is interrupted, the flag is consumed ONCE for the whole flush (a set flag makes
     // concurrentPageAccess reject every subsequent write, one throw+retry cycle per page) and restored at the
@@ -394,11 +467,13 @@ public class PageManagerFlushThread extends Thread {
       }
     }
 
-    // Phase 2 + Phase 3a: under the per-database lock, clear the suspended flag AND atomically detach any
-    // batches deferred during Phase 1. Holding the lock makes this transition mutually exclusive with the
-    // suspended-check + defer in flushPagesFromQueueToDisk: once the flag is cleared no further batch can be
-    // added to deferredByDatabase for this database, and every batch deferred up to that point is detached
-    // exactly once. A single detach therefore suffices - nothing can repopulate the map behind us.
+    // Phase 2 + Phase 3a: under the per-database lock, clear the suspension refcount AND atomically detach
+    // any batches deferred during Phase 1. Holding the lock makes this transition mutually exclusive with
+    // the suspended-check + defer in flushPagesFromQueueToDisk: once the flag is cleared no further batch
+    // can be added to deferredByDatabase for this database, and every batch deferred up to that point is
+    // detached exactly once. A single detach therefore suffices - nothing can repopulate the map behind us.
+    // New suspenders are still gated out by resumingDatabases (removed by the caller AFTER Phase 3b), so
+    // the count going 1 to 0 here cannot interleave with a concurrent acquire.
     final ConcurrentLinkedQueue<PagesToFlush> newDeferred;
     synchronized (suspendLock(database)) {
       suspended.remove(database);
@@ -437,13 +512,11 @@ public class PageManagerFlushThread extends Thread {
     if (restoreCallerInterrupt)
       // Consumed once during Phase 1: restore it so the caller still observes its own cancellation.
       Thread.currentThread().interrupt();
-
-    return true;
   }
 
   public boolean isSuspended(final Database database) {
-    final Boolean s = suspended.get(database);
-    return s != null ? s : false;
+    final Integer count = suspended.get(database);
+    return count != null && count > 0;
   }
 
   /** Returns the stable per-database monitor used to serialize the suspend check/defer against unsuspend. */
@@ -508,6 +581,7 @@ public class PageManagerFlushThread extends Thread {
     // pins) can be garbage collected instead of being retained for the flush thread's lifetime as a map key.
     suspendLocks.remove(database);
     suspended.remove(database);
+    resumingDatabases.remove(database);
     flushedPagesPerDatabase.remove(database);
     final ConcurrentLinkedQueue<PagesToFlush> droppedDeferred = deferredByDatabase.remove(database);
     if (droppedDeferred != null) {

--- a/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java
@@ -58,7 +58,9 @@ public class PageManagerFlushThread extends Thread {
   // its suspension window can never overlap the resume's page writes (issue #5068).
   private final        Set<Database>                                            resumingDatabases   = ConcurrentHashMap.newKeySet();
   private final static PagesToFlush                                             SHUTDOWN_THREAD     = new PagesToFlush(null);
-  private final        AtomicReference<PagesToFlush>                            nextPagesToFlush    = new AtomicReference<>();
+  // Package-private so the white-box regression test for issue #5068 can fabricate an in-flight batch and
+  // deterministically exercise an interrupt during waitForCurrentFlushToComplete.
+  final                AtomicReference<PagesToFlush>                            nextPagesToFlush    = new AtomicReference<>();
   private final        ConcurrentHashMap<Database, ConcurrentLinkedQueue<PagesToFlush>> deferredByDatabase = new ConcurrentHashMap<>();
   // Per-database lock serializing the suspend-flag check + defer in flushPagesFromQueueToDisk against the
   // flag-clear + deferred-detach in setSuspended(false). Without it a batch could be deferred AFTER the
@@ -363,6 +365,14 @@ public class PageManagerFlushThread extends Thread {
    * otherwise its freshly acquired window would overlap the resume's synchronous page writes, exactly the
    * torn-read overlap this refcount exists to prevent. The wait is uninterruptible (the interrupt flag is
    * preserved and restored) and timed, so a lost notification degrades to polling instead of a hang.
+   * <p>
+   * Parking here uninterruptibly is an ACCEPTED TRADEOFF (#5074 review): the wait is bounded by the
+   * resume's Phase 1, which writes at most {@code FLUSH_SUSPEND_MAX_DEFERRED_RAM} (the #4728 backpressure
+   * cap) of deferred pages, and the only suspenders are admin-path threads - SQL BACKUP DATABASE, database
+   * verify, and HA snapshot serving, the latter capped at {@code HA_SNAPSHOT_MAX_CONCURRENT} (default 2)
+   * of Undertow's 500 workers and serialized per database by {@code SnapshotHttpHandler}. No pool can be
+   * exhausted and shutdown is delayed by at most one bounded resume; a {@code flushPage} wedged on a dead
+   * disk stalls the flush thread itself first, so this wait is never the limiting factor.
    */
   public boolean setSuspended(final Database database, final boolean value) {
     final Object lock = suspendLock(database);

--- a/engine/src/test/java/com/arcadedb/engine/PageManagerFlushSuspendDeferRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageManagerFlushSuspendDeferRaceTest.java
@@ -45,8 +45,14 @@ import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
  * flushed all pages.
  * <p>
  * The fix holds a per-database lock across the suspended-check + defer and across the unsuspend's
- * flag-clear + deferred-detach, so a batch deferred during the unsuspend window is always handed back to
- * the main queue. The blocking re-enqueue runs outside the lock to avoid deadlocking the flush thread.
+ * flag-clear + deferred-detach, so a batch deferred during the unsuspend window is always either flushed
+ * by the unsuspend itself or handed back to the main queue - never stranded. The blocking re-enqueue runs
+ * outside the lock to avoid deadlocking the flush thread.
+ * <p>
+ * Since the refcounted suspension of issue #5068, the unsuspend's initial count-check takes the same
+ * per-database lock, so it serializes BEHIND the paused suspended-check of the flush thread: the batch is
+ * then already deferred when Phase 1 runs and is flushed synchronously rather than re-enqueued. Both
+ * outcomes are valid; the assertion below accepts either and only rejects the stranded case.
  */
 class PageManagerFlushSuspendDeferRaceTest extends TestHelper {
 
@@ -80,7 +86,9 @@ class PageManagerFlushSuspendDeferRaceTest extends TestHelper {
     final Database db = (Database) database;
     flush.setSuspended(db, true);
 
-    final PageId pageId = new PageId(database, 9, 1);
+    // Non-existent file id: if the unsuspend flushes the deferred batch synchronously (see class javadoc),
+    // the flush of this page is a silent skip - no real I/O on the test database.
+    final PageId pageId = new PageId(database, 999_888, 1);
     final MutablePage page = new MutablePage(pageId, 1024, new byte[1024], 0, 0);
     final PagesToFlush batch = new PagesToFlush(List.of(page));
     flush.pageIndex.put(pageId, page);
@@ -112,8 +120,12 @@ class PageManagerFlushSuspendDeferRaceTest extends TestHelper {
       unsuspender.join();
     });
 
-    // The batch deferred during the unsuspend window must have been re-enqueued for flushing, not stranded
-    // in the internal deferred map. queue.contains uses identity (same batch instance re-enqueued).
-    assertThat(flush.queue).contains(batch);
+    // The batch deferred during the unsuspend window must have been either re-enqueued for flushing
+    // (queue.contains uses identity: same batch instance) or flushed synchronously by the unsuspend
+    // itself (its pageIndex entry released) - never stranded in the internal deferred map, where its
+    // pageIndex entry would survive without the batch ever reaching the queue again.
+    final boolean reEnqueued = flush.queue.contains(batch);
+    final boolean flushedByUnsuspend = flush.getCachedPageFromMutablePageInQueue(pageId) == null;
+    assertThat(reEnqueued || flushedByUnsuspend).isTrue();
   }
 }

--- a/engine/src/test/java/com/arcadedb/engine/PageManagerFlushSuspendRefCountTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageManagerFlushSuspendRefCountTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.engine.PageManagerFlushThread.PagesToFlush;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+/**
+ * Regression test for issue #5068: {@code suspendFlushAndExecute} ownership was first-caller-wins.
+ * <p>
+ * {@code PageManagerFlushThread.setSuspended(db, true)} was {@code putIfAbsent}-based: only the FIRST
+ * caller owned the suspension, but {@code suspendFlushAndExecute} ran every caller's callback regardless
+ * (#4958). When the owner exited it resumed flushing (and synchronously flushed the deferred batches)
+ * while a concurrent non-owning caller (SQL BACKUP DATABASE, database verify, HA snapshot serving) was
+ * still reading the database files - torn reads.
+ * <p>
+ * The fix makes the suspension refcounted: flushing stays suspended while the refcount is greater than
+ * zero and is resumed (deferred batches flushed) only when the LAST suspender exits, so every caller of
+ * {@code suspendFlushAndExecute} legitimately owns its whole window.
+ */
+class PageManagerFlushSuspendRefCountTest extends TestHelper {
+
+  /**
+   * Two overlapping {@code suspendFlushAndExecute} windows on the same database: flushing must remain
+   * suspended for the whole union of the two windows and resume only after BOTH exited. On the pre-fix
+   * code the first caller's exit resumed flushing while the second caller was still inside its callback.
+   */
+  @Test
+  void overlappingSuspendersBothOwnTheirWindow() {
+    final Database db = (Database) database;
+    final PageManager pageManager = ((DatabaseInternal) database).getPageManager();
+
+    final CountDownLatch firstInside = new CountDownLatch(1);
+    final CountDownLatch secondInside = new CountDownLatch(1);
+    final CountDownLatch releaseFirst = new CountDownLatch(1);
+    final CountDownLatch releaseSecond = new CountDownLatch(1);
+    final AtomicBoolean secondSawSuspendedAfterFirstExit = new AtomicBoolean(false);
+
+    final Thread first = new Thread(() -> {
+      try {
+        pageManager.suspendFlushAndExecute(db, () -> {
+          firstInside.countDown();
+          releaseFirst.await(10, TimeUnit.SECONDS);
+        });
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    }, "test-suspender-1");
+
+    final Thread second = new Thread(() -> {
+      try {
+        pageManager.suspendFlushAndExecute(db, () -> {
+          secondInside.countDown();
+          releaseSecond.await(10, TimeUnit.SECONDS);
+          // By now the first suspender has exited: this window must STILL be suspended.
+          secondSawSuspendedAfterFirstExit.set(pageManager.isPageFlushingSuspended(db));
+        });
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    }, "test-suspender-2");
+
+    assertTimeoutPreemptively(Duration.ofSeconds(30), () -> {
+      first.start();
+      firstInside.await();
+
+      second.start();
+      secondInside.await();
+      assertThat(pageManager.isPageFlushingSuspended(db)).isTrue();
+
+      // The first suspender exits while the second is still inside its window.
+      releaseFirst.countDown();
+      first.join();
+
+      // Pre-fix: the first caller owned the flag, so its exit resumed flushing here.
+      assertThat(pageManager.isPageFlushingSuspended(db)).isTrue();
+
+      releaseSecond.countDown();
+      second.join();
+      assertThat(secondSawSuspendedAfterFirstExit.get()).isTrue();
+
+      // Only after the LAST suspender exits the flushing is resumed.
+      assertThat(pageManager.isPageFlushingSuspended(db)).isFalse();
+    });
+  }
+
+  /**
+   * White-box refcount contract on {@link PageManagerFlushThread#setSuspended}: only the transition
+   * 0 to 1 reports "acquired" and only the transition 1 to 0 reports "resumed"; a non-last release keeps
+   * the database suspended. On the pre-fix code the first release always cleared the flag.
+   */
+  @Test
+  void setSuspendedIsRefCounted() {
+    // Constructing the flush thread directly does NOT start the background thread.
+    final PageManagerFlushThread flush = new PageManagerFlushThread(PageManager.INSTANCE, new ContextConfiguration());
+    final Database db = (Database) database;
+
+    assertThat(flush.setSuspended(db, true)).isTrue(); // FIRST SUSPENDER: 0 -> 1
+    assertThat(flush.setSuspended(db, true)).isFalse(); // OVERLAPPING SUSPENDER: 1 -> 2
+    assertThat(flush.isSuspended(db)).isTrue();
+
+    assertThat(flush.setSuspended(db, false)).isFalse(); // NON-LAST RELEASE: 2 -> 1
+    assertThat(flush.isSuspended(db)).isTrue(); // PRE-FIX: THIS WAS false - THE FIRST RELEASE RESUMED FLUSHING
+
+    assertThat(flush.setSuspended(db, false)).isTrue(); // LAST RELEASE: 1 -> 0
+    assertThat(flush.isSuspended(db)).isFalse();
+
+    // A release without a matching suspend is a no-op instead of corrupting the refcount.
+    assertThat(flush.setSuspended(db, false)).isFalse();
+    assertThat(flush.isSuspended(db)).isFalse();
+  }
+
+  /**
+   * Contract test for the resume gate (not reproducible pre-fix, where an acquire during the resume
+   * simply became a non-owner): a NEW suspender arriving while the last release is synchronously flushing
+   * the deferred batches must WAIT until the resume completes, so its window can never overlap the
+   * deferred-batch writes. The deferred flush is stalled via the package-private
+   * {@code removeFromFlushIndex} hook invoked once per deferred page.
+   */
+  @Test
+  void suspendDuringResumeWaitsUntilDeferredFlushCompletes() {
+    final CountDownLatch resumeReachedDeferredFlush = new CountDownLatch(1);
+    final CountDownLatch allowResumeToComplete = new CountDownLatch(1);
+    final AtomicBoolean stalled = new AtomicBoolean(false);
+
+    final PageManagerFlushThread flush = new PageManagerFlushThread(PageManager.INSTANCE, new ContextConfiguration()) {
+      @Override
+      void removeFromFlushIndex(final MutablePage page) {
+        // Stall the resume exactly once, in the middle of the deferred-batch flush (Phase 1).
+        if (stalled.compareAndSet(false, true)) {
+          resumeReachedDeferredFlush.countDown();
+          try {
+            allowResumeToComplete.await(10, TimeUnit.SECONDS);
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+        }
+        super.removeFromFlushIndex(page);
+      }
+    };
+
+    final Database db = (Database) database;
+
+    assertTimeoutPreemptively(Duration.ofSeconds(30), () -> {
+      flush.setSuspended(db, true);
+
+      // Defer one batch while suspended. The fake file id does not exist, so the resume-time flush of
+      // this page is a silent skip - no real I/O is performed on the test database.
+      final PageId pageId = new PageId(database, 999_888, 0);
+      final MutablePage page = new MutablePage(pageId, 1024, new byte[1024], 0, 0);
+      final PagesToFlush batch = new PagesToFlush(List.of(page));
+      flush.pageIndex.put(pageId, page);
+      flush.queue.offer(batch);
+      flush.flushPagesFromQueueToDisk(null, 1_000L);
+      assertThat(flush.queue).isEmpty(); // THE BATCH WAS DEFERRED, NOT LEFT IN THE QUEUE
+
+      final Thread resumer = new Thread(() -> flush.setSuspended(db, false), "test-resumer");
+      resumer.start();
+      resumeReachedDeferredFlush.await();
+
+      // While the resume is mid-flight through the deferred writes, a new suspender must block.
+      final CountDownLatch acquired = new CountDownLatch(1);
+      final Thread newSuspender = new Thread(() -> {
+        flush.setSuspended(db, true);
+        acquired.countDown();
+      }, "test-new-suspender");
+      newSuspender.start();
+
+      assertThat(acquired.await(500, TimeUnit.MILLISECONDS)).isFalse(); // STILL BLOCKED ON THE RESUME
+
+      allowResumeToComplete.countDown();
+      resumer.join();
+
+      assertThat(acquired.await(10, TimeUnit.SECONDS)).isTrue(); // ACQUIRED AFTER THE RESUME COMPLETED
+      newSuspender.join();
+      assertThat(flush.isSuspended(db)).isTrue();
+
+      flush.setSuspended(db, false);
+      assertThat(flush.isSuspended(db)).isFalse();
+    });
+  }
+}

--- a/engine/src/test/java/com/arcadedb/engine/PageManagerFlushSuspendRefCountTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageManagerFlushSuspendRefCountTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
@@ -207,5 +208,60 @@ class PageManagerFlushSuspendRefCountTest extends TestHelper {
       flush.setSuspended(db, false);
       assertThat(flush.isSuspended(db)).isFalse();
     });
+  }
+
+  /**
+   * Regression test for the second half of the #5068 fix: an interrupt delivered while
+   * {@code suspendFlushAndExecute} waits for the in-flight batch ({@code waitForCurrentFlushToComplete})
+   * must still release this caller's suspension reference. Pre-fix the wait ran BEFORE the try block, so
+   * the {@code InterruptedException} skipped {@code setSuspended(false)} and the database stayed suspended
+   * forever. The interleaving is fully deterministic: the in-flight batch is fabricated through the
+   * package-private {@code nextPagesToFlush} marker and the suspender interrupts ITSELF before entering,
+   * so the wait's {@code Thread.sleep} throws immediately - no timing window.
+   */
+  @Test
+  void interruptDuringWaitForFlushStillReleasesSuspension() {
+    final Database db = (Database) database;
+    final PageManager pageManager = ((DatabaseInternal) database).getPageManager();
+    final PageManagerFlushThread flush = pageManager.getFlushThread();
+
+    // Fake in-flight batch for this database: makes waitForCurrentFlushToComplete actually wait. It is
+    // installed only in the marker (never in the queue), so no I/O can ever be attempted on it.
+    final PageId pageId = new PageId(database, 999_887, 0);
+    final MutablePage page = new MutablePage(pageId, 1024, new byte[1024], 0, 0);
+    final PagesToFlush inFlight = new PagesToFlush(List.of(page));
+
+    final AtomicBoolean callbackRan = new AtomicBoolean(false);
+    final AtomicReference<Throwable> thrown = new AtomicReference<>();
+
+    assertTimeoutPreemptively(Duration.ofSeconds(30), () -> {
+      // Install the marker only when the flush thread is idle (empty queue, no in-flight batch), so the
+      // real thread cannot clear it while the suspender is parked in the wait.
+      while (!(flush.queue.isEmpty() && flush.nextPagesToFlush.compareAndSet(null, inFlight)))
+        Thread.sleep(10);
+
+      try {
+        final Thread suspender = new Thread(() -> {
+          // Self-interrupt BEFORE entering: the wait's Thread.sleep(1) then throws on its first call,
+          // which is exactly an interrupt landing during waitForCurrentFlushToComplete.
+          Thread.currentThread().interrupt();
+          try {
+            pageManager.suspendFlushAndExecute(db, () -> callbackRan.set(true));
+          } catch (final Throwable t) {
+            thrown.set(t);
+          }
+        }, "test-interrupted-suspender");
+        suspender.start();
+        suspender.join();
+      } finally {
+        flush.nextPagesToFlush.compareAndSet(inFlight, null);
+      }
+    });
+
+    // The interrupt aborted the suspension before the callback could run...
+    assertThat(thrown.get()).isInstanceOf(InterruptedException.class);
+    assertThat(callbackRan.get()).isFalse();
+    // ...but this caller's reference was still released. Pre-fix this stayed true forever (the leak).
+    assertThat(pageManager.isPageFlushingSuspended(db)).isFalse();
   }
 }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/SnapshotHttpHandler.java
@@ -76,19 +76,18 @@ public class SnapshotHttpHandler implements HttpHandler {
   private static final Semaphore CONCURRENCY_SEMAPHORE =
       new Semaphore(GlobalConfiguration.HA_SNAPSHOT_MAX_CONCURRENT.getValueAsInteger(), true);
 
-  // #5063 (review round 5): PageManagerFlushThread.setSuspended is ownership-based (putIfAbsent) - only
-  // the FIRST caller owns the suspend flag, and suspendFlushAndExecute now ALWAYS runs the callback
-  // (issue #4958). A second thread entering for the same database would stream files WITHOUT owning the
-  // suspension: it skips waitForCurrentFlushToComplete (so a flush batch may still be mid-write), and
-  // when the owner exits, setSuspended(false) synchronously flushes the deferred batches to disk,
-  // tearing the files the non-owner is still reading. Neither existing guard prevents that overlap:
-  // CONCURRENCY_SEMAPHORE admits HA_SNAPSHOT_MAX_CONCURRENT (default 2) requests - possibly for the
-  // same database, e.g. two followers resyncing at once - and executeInReadLock is a SHARED lock.
-  // This per-database lock serializes the snapshot and checksums paths, so the single thread inside
-  // suspendFlushAndExecute always owns the suspension for its whole read. A concurrent request for the
-  // same database waits its turn; requests beyond the semaphore limit still get a fast 503. Overlap
-  // with OTHER suspendFlushAndExecute callers (SQL BACKUP DATABASE, database verify) is a pre-existing
-  // exposure of the ownership model, out of this handler's control.
+  // #5063 (review round 5) introduced this per-database lock because PageManagerFlushThread.setSuspended
+  // was ownership-based (putIfAbsent): only the FIRST caller owned the suspend flag, so a second thread
+  // streaming the same database could observe a resumed flush mid-read. Issue #5068 made the suspension
+  // REFCOUNTED in the engine - flushing resumes only when the LAST suspender exits - so overlapping
+  // suspendFlushAndExecute callers (this handler, SQL BACKUP DATABASE, database verify) each own their
+  // whole window and the lock is NO LONGER needed for suspension correctness.
+  // DECISION (#5068): the lock STAYS, for resource discipline rather than correctness. It serializes the
+  // whole zip streaming per database: two followers resyncing the same multi-GB database at once would
+  // double the read I/O and, with refcounted suspension, keep flushing suspended for the UNION of both
+  // windows, growing the deferred-page backlog toward the #4728 backpressure cap and throttling commits
+  // for longer. Serializing keeps each suspension window as short as possible. Requests beyond the
+  // CONCURRENCY_SEMAPHORE limit (HA_SNAPSHOT_MAX_CONCURRENT, default 2) still get a fast 503.
   // Entries are never pruned by design: one small ReentrantLock per database NAME ever snapshotted, bounded
   // by the server's database count (a dropped-and-recreated database safely reuses its lock). Pruning on
   // drop would need lifecycle callbacks this handler does not have, for negligible memory.
@@ -195,8 +194,8 @@ public class SnapshotHttpHandler implements HttpHandler {
       dbSuspendLock.lock();
       try {
         db.executeInReadLock(() -> {
-          // Serialized per database (see perDatabaseSuspendLock), so this call always OWNS the flush
-          // suspension: the callback streams the files with the flush thread parked for the whole read.
+          // The refcounted suspension (#5068) guarantees the flush thread is parked for this whole read;
+          // perDatabaseSuspendLock additionally serializes same-database zip streams (see its comment).
           db.getPageManager().suspendFlushAndExecute(db, () -> serveSnapshotZip(exchange, db, databaseName));
           return null;
         });
@@ -219,7 +218,8 @@ public class SnapshotHttpHandler implements HttpHandler {
     final DatabaseInternal db = server.getDatabase(databaseName);
 
     // Flush pages and hold a read lock to ensure a consistent point-in-time view of database files.
-    // Serialized per database (see perDatabaseSuspendLock) so this thread always OWNS the suspension.
+    // The refcounted suspension (#5068) guarantees ownership of the window; the per-database lock only
+    // serializes same-database reads with the snapshot zip path (see perDatabaseSuspendLock).
     final ReentrantLock dbSuspendLock = suspendLockFor(databaseName);
     dbSuspendLock.lock();
     try {
@@ -248,9 +248,10 @@ public class SnapshotHttpHandler implements HttpHandler {
 
   /**
    * Returns the per-database lock serializing every entry into {@code suspendFlushAndExecute} made by
-   * this handler (snapshot ZIP and checksums paths), so the entering thread always owns the flush
-   * suspension for its whole read (see {@link #perDatabaseSuspendLock}). One lock instance per database
-   * name for the lifetime of the handler. Package-private for unit testing.
+   * this handler (snapshot ZIP and checksums paths). Since the refcounted suspension of issue #5068 this
+   * is not needed for correctness; it is retained to serialize same-database zip streaming and keep each
+   * suspension window short (see {@link #perDatabaseSuspendLock}). One lock instance per database name
+   * for the lifetime of the handler. Package-private for unit testing.
    */
   ReentrantLock suspendLockFor(final String databaseName) {
     return perDatabaseSuspendLock.computeIfAbsent(databaseName, k -> new ReentrantLock());

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotHttpHandlerSuspendLockTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SnapshotHttpHandlerSuspendLockTest.java
@@ -25,10 +25,10 @@ import java.util.concurrent.locks.ReentrantLock;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * #5063 (review round 5): {@code PageManagerFlushThread.setSuspended} is ownership-based, so only ONE
- * thread at a time may be inside {@code suspendFlushAndExecute} for a given database or the non-owner
- * can observe a resumed flush mid-read. {@link SnapshotHttpHandler#suspendLockFor} provides the
- * per-database lock that serializes the handler's snapshot and checksums paths; these tests pin its
+ * #5063 (review round 5) added {@link SnapshotHttpHandler#suspendLockFor}: the per-database lock that
+ * serializes the handler's snapshot and checksums paths. Originally required for correctness (the flush
+ * suspension was first-caller-wins); since the refcounted suspension of issue #5068 it is retained to
+ * serialize same-database zip streaming and keep each suspension window short. These tests pin its
  * identity contract: same database name, same lock instance; different names, independent locks.
  */
 class SnapshotHttpHandlerSuspendLockTest {


### PR DESCRIPTION
Closes #5068. Part of the 2026-07 engine audit follow-up (#4962).

## Verdict per issue

| Issue | Verdict | Detail |
|---|---|---|
| #5068 | fixed | Reproduced on current main (red-first test), refcounted suspension implemented in `PageManagerFlushThread` / `PageManager.suspendFlushAndExecute` |

## Problem

`PageManagerFlushThread.setSuspended(db, true)` was `putIfAbsent`-based: only the FIRST caller owned the suspend flag, but `suspendFlushAndExecute` ran every caller's callback regardless (#4958). With two concurrent suspenders on the same database (SQL `BACKUP DATABASE`, HA verify endpoint, HA snapshot serving - any combination), the non-owner (a) skipped `waitForCurrentFlushToComplete`, so it could read a page while a flush batch was mid-write, and (b) kept streaming while the owner's exit synchronously flushed the deferred batches to disk - torn reads either way.

## Fix

Per-database suspension REFCOUNT, guarded by the existing per-database suspend lock:

- `setSuspended(db, true)` increments; returns true only for the first suspender (0 -> 1).
- `setSuspended(db, false)` decrements; only the LAST release (1 -> 0) runs the resume (Phase 1 synchronous deferred flush, Phase 2 flag clear + detach, Phase 3 re-enqueue - all unchanged) and returns true. A non-last release keeps the database suspended for the remaining suspenders. Unbalanced releases are no-ops.
- A new suspender arriving while the last release is mid-way through the deferred-batch writes waits (timed wait, uninterruptible with interrupt-flag restore) until the resume completes, so a fresh window can never overlap those page writes. The gate is cleared in a `finally` that also heals a stuck count if the resume ever escapes with an exception.
- `PageManager.suspendFlushAndExecute` acquires/releases one reference per caller and now runs `waitForCurrentFlushToComplete` INSIDE the try - fixing a pre-existing leak where an interrupt during that wait left the database suspended forever.

The #4728 deferred-RAM backpressure accounting and the #5012 per-database suspend bookkeeping are unchanged: batches deferred across overlapping windows are flushed exactly once, by the last suspender's exit.

## Decision: HA SnapshotHttpHandler per-database lock (from #5063 review round 5)

**The lock stays**, re-documented as resource discipline rather than correctness. With refcounting it is no longer needed for suspension ownership, but it serializes same-database zip streaming: two followers resyncing the same multi-GB database at once would double the read I/O and keep flushing suspended for the UNION of both windows, growing the deferred backlog toward the #4728 backpressure cap and throttling commits for longer. Serializing keeps each suspension window as short as possible. Comments in `SnapshotHttpHandler` and `SnapshotHttpHandlerSuspendLockTest` updated accordingly; no behavior change in the handler.

## TDD red-first evidence

`PageManagerFlushSuspendRefCountTest` was written first and run against unmodified main; all three methods failed on the exact defect:

- `overlappingSuspendersBothOwnTheirWindow`: `isPageFlushingSuspended` was false after the first of two overlapping `suspendFlushAndExecute` callers exited while the second was still inside its callback.
- `setSuspendedIsRefCounted`: the first release of two suspenders cleared the flag.
- `suspendDuringResumeWaitsUntilDeferredFlushCompletes`: a new suspender acquired immediately while the resume was mid-way through the deferred writes (contract test for the new gate; pre-fix it became a non-owner).

`PageManagerFlushSuspendDeferRaceTest` updated for the new semantics: the resume's count-check now takes the per-database lock, so it serializes behind the flush thread's paused suspended-check and the deferred batch is flushed synchronously in Phase 1 rather than re-enqueued; the assertion accepts either outcome (flushed or re-enqueued) and still rejects the stranded case. The fake page's file id is now non-existent so the (now reachable) synchronous flush cannot write into a real file of the test database.

## Test evidence (all green)

- engine `-Dtest='*Flush*,*Suspend*,*PageManager*'`: 28 tests, 0 failures (incl. FlushRobustnessTest, PageManagerLifecycleRefCountTest, PageManagerFlushSuspendBackpressureTest, PageManagerFlushThreadInterruptTest, PageManagerDeleteFileFlushCoordinationTest, WalRecoveryCorrectnessTest, Issue4958StorageStatsTest)
- ha-raft: SnapshotHttpHandlerSuspendLockTest, SnapshotWriteStallTest, SnapshotThrottleTest - 9 tests, 0 failures
- integration: BackupDatabaseTest (drives FullBackupFormat's `suspendFlushAndExecute` end-to-end) - 4 tests, 0 failures

## Conflict risks

- `docs/release-26.7.2.md`: appended one Fixes bullet; expected to conflict trivially with sibling audit-follow-up PRs.
- `engine/src/main/java/com/arcadedb/engine/PageManagerFlushThread.java` and `PageManager.java`: conflicts possible if a sibling touches the flush/suspend path; the change is confined to `setSuspended`/`isSuspended`/`suspendFlushAndExecute` plus two field declarations.