### PR TITLE
fix(#5064): distinct contract for post-quorum local commit failure (committed-but-local-apply-failed)

### DIFF
--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -390,7 +390,9 @@ that could starve the very snapshot resync meant to heal the node.
   whether the local pages were reconciled, and that it must NOT be retried - instead of a generic commit
   failure that invited retries. The identities of records created in such a transaction are no longer reset
   to provisional (they are the identities the cluster committed), so an application-level retry no longer
-  inserts duplicates of already-committed records
+  inserts duplicates of already-committed records. The contract also survives the wire: the HTTP command
+  endpoint maps it to 409 Conflict (not a retry-worthy 5xx), and a follower forwarding a write to the
+  leader reconstructs the same exception type instead of a generic commit failure
   ([#5064](https://github.com/ArcadeData/arcadedb/issues/5064)).
 
 ### Improvements

--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -384,6 +384,15 @@ that could starve the very snapshot resync meant to heal the node.
   levels, unbounded per-transaction page cache under `REPEATABLE_READ`) is now documented on
   `Database.TRANSACTION_ISOLATION_LEVEL` and pinned by tests.
 
+- **HA: a distinct error for "committed cluster-wide, local apply failed".** When the replication quorum
+  durably commits a transaction but the leader's local phase-2 apply then fails, the application now
+  receives `TransactionCommittedRemotelyException` - stating the transaction IS committed on the cluster,
+  whether the local pages were reconciled, and that it must NOT be retried - instead of a generic commit
+  failure that invited retries. The identities of records created in such a transaction are no longer reset
+  to provisional (they are the identities the cluster committed), so an application-level retry no longer
+  inserts duplicates of already-committed records
+  ([#5064](https://github.com/ArcadeData/arcadedb/issues/5064)).
+
 ### Improvements
 
 - **HA: throttled diverged-follower resync logging.** When a follower detects a WAL page-version gap it

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -145,11 +145,11 @@ public class TransactionContext implements Transaction {
 
   @Override
   public void begin(final Database.TRANSACTION_ISOLATION_LEVEL isolationLevel) {
-        // #5064: the base context is REUSED across transactions on this thread - the regime flag must never
+    // #5064: the base context is REUSED across transactions on this thread - the regime flag must never
     // leak from a previous (Raft-committed) transaction into a fresh one, or a plain local failure would
     // silently skip the #4940 rollback. Cleared here AND in reset() (belt and braces).
     remotelyCommitted = false;
-this.isolationLevel = isolationLevel;
+    this.isolationLevel = isolationLevel;
 
     if (status != STATUS.INACTIVE)
       throw new TransactionException("Transaction already begun");
@@ -1075,8 +1075,8 @@ this.isolationLevel = isolationLevel;
   }
 
   public void reset() {
-        remotelyCommitted = false;
-status = STATUS.INACTIVE;
+    remotelyCommitted = false;
+    status = STATUS.INACTIVE;
 
     if (explicitLockedFiles != null) {
       database.getTransactionManager().unlockFilesInOrder(explicitLockedFiles, getRequester());

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -145,7 +145,11 @@ public class TransactionContext implements Transaction {
 
   @Override
   public void begin(final Database.TRANSACTION_ISOLATION_LEVEL isolationLevel) {
-    this.isolationLevel = isolationLevel;
+        // #5064: the base context is REUSED across transactions on this thread - the regime flag must never
+    // leak from a previous (Raft-committed) transaction into a fresh one, or a plain local failure would
+    // silently skip the #4940 rollback. Cleared here AND in reset() (belt and braces).
+    remotelyCommitted = false;
+this.isolationLevel = isolationLevel;
 
     if (status != STATUS.INACTIVE)
       throw new TransactionException("Transaction already begun");
@@ -1015,8 +1019,11 @@ public class TransactionContext implements Transaction {
         // LOCAL apply failed, before anything local was durable. The records the user holds carry the
         // identities the cluster committed, so rollback()'s identity reset would invite an application
         // retry to INSERT DUPLICATES of already-committed records - release resources WITHOUT touching
-        // user-held record state. No fence either: there is no orphaned local WAL record to diverge from,
-        // and the Raft layer reconciles the local pages from the replicated payload right after this.
+        // user-held record state. No fence in THIS branch because it is only reachable pre-append (no
+        // orphaned local WAL record to diverge from; the Raft layer reconciles the pages from the
+        // replicated payload). A failure AFTER the local append takes the walAppended branch above and
+        // still fences, INTENTIONALLY: an orphaned local WAL record exists there regardless of the remote
+        // commit, and that branch also preserves identities via reset().
         reset();
       else if (database.getEmbedded() instanceof LocalDatabase localDatabase && localDatabase.isFencedForRecovery())
         // A fence-REFUSED commit (this tx appended nothing; the fence came from an earlier failure) cannot
@@ -1068,7 +1075,8 @@ public class TransactionContext implements Transaction {
   }
 
   public void reset() {
-    status = STATUS.INACTIVE;
+        remotelyCommitted = false;
+status = STATUS.INACTIVE;
 
     if (explicitLockedFiles != null) {
       database.getTransactionManager().unlockFilesInOrder(explicitLockedFiles, getRequester());

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -1023,7 +1023,9 @@ public class TransactionContext implements Transaction {
         // orphaned local WAL record to diverge from; the Raft layer reconciles the pages from the
         // replicated payload). A failure AFTER the local append takes the walAppended branch above and
         // still fences, INTENTIONALLY: an orphaned local WAL record exists there regardless of the remote
-        // commit, and that branch also preserves identities via reset().
+        // commit, and that branch also preserves identities via reset(). Unlike the #4940 rollback below,
+        // modified records are intentionally NOT reloaded: their in-memory content is exactly what the
+        // cluster committed, so there is nothing to restore.
         reset();
       else if (database.getEmbedded() instanceof LocalDatabase localDatabase && localDatabase.isFencedForRecovery())
         // A fence-REFUSED commit (this tx appended nothing; the fence came from an earlier failure) cannot

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -82,6 +82,12 @@ public class TransactionContext implements Transaction {
   private       Map<PageId, MutablePage>             modifiedPages;
   private       Map<PageId, MutablePage>             newPages;
   private       boolean                              useWAL;
+  // #5064: set by the HA layer AFTER the replication quorum durably committed this transaction and BEFORE
+  // the local phase-2 apply. Shifts the durability boundary for the failure regimes in commit2ndPhase's
+  // finally: a local failure past this point must never roll back user-held record identities (the cluster
+  // committed them - a retry would duplicate) nor fence the database (no orphaned local WAL record exists;
+  // the Raft layer reconciles pages from the replicated payload).
+  private       boolean                              remotelyCommitted;
   private       boolean                              asyncFlush            = true;
   private       WALFile.FlushType                    walFlush;
   private       List<Integer>                        lockedFiles;
@@ -183,6 +189,11 @@ public class TransactionContext implements Transaction {
 
   public Database.TRANSACTION_ISOLATION_LEVEL getIsolationLevel() {
     return isolationLevel;
+  }
+
+  /** #5064: see the {@code remotelyCommitted} field - HA-layer only, call after quorum commit, before phase 2. */
+  public void setRemotelyCommitted(final boolean remotelyCommitted) {
+    this.remotelyCommitted = remotelyCommitted;
   }
 
   public void setRequester(final Object requester) {
@@ -999,7 +1010,15 @@ public class TransactionContext implements Transaction {
         // The RIDs optimistically assigned to records created in this transaction remain valid (the replay
         // makes them real): release resources WITHOUT touching user-held record state.
         reset();
-      } else if (database.getEmbedded() instanceof LocalDatabase localDatabase && localDatabase.isFencedForRecovery())
+      } else if (remotelyCommitted)
+        // #5064: the replication QUORUM already durably committed this transaction cluster-wide; only the
+        // LOCAL apply failed, before anything local was durable. The records the user holds carry the
+        // identities the cluster committed, so rollback()'s identity reset would invite an application
+        // retry to INSERT DUPLICATES of already-committed records - release resources WITHOUT touching
+        // user-held record state. No fence either: there is no orphaned local WAL record to diverge from,
+        // and the Raft layer reconciles the local pages from the replicated payload right after this.
+        reset();
+      else if (database.getEmbedded() instanceof LocalDatabase localDatabase && localDatabase.isFencedForRecovery())
         // A fence-REFUSED commit (this tx appended nothing; the fence came from an earlier failure) cannot
         // roll back its record state: rollback()'s record reload would hit the fence choke point itself and
         // replace the fence error with a confusing secondary failure. Release resources only - the database

--- a/engine/src/main/java/com/arcadedb/exception/TransactionCommittedRemotelyException.java
+++ b/engine/src/main/java/com/arcadedb/exception/TransactionCommittedRemotelyException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.exception;
+
+/**
+ * Thrown when a transaction IS durably committed cluster-wide (the replication quorum accepted it) but the
+ * local apply failed afterwards (#5064). The data exists on the cluster and will be present locally after
+ * reconciliation or restart.
+ * <p>
+ * <b>Do NOT retry the transaction</b>: a retry would apply the changes a second time (for inserts, creating
+ * duplicates). Treat this as a commit that succeeded remotely: reload any records you hold and continue. The
+ * identities of records created in the failed-locally transaction remain valid - they are the identities the
+ * cluster committed.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class TransactionCommittedRemotelyException extends TransactionException {
+  public TransactionCommittedRemotelyException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/engine/src/main/java/com/arcadedb/exception/TransactionCommittedRemotelyException.java
+++ b/engine/src/main/java/com/arcadedb/exception/TransactionCommittedRemotelyException.java
@@ -31,6 +31,11 @@ package com.arcadedb.exception;
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class TransactionCommittedRemotelyException extends TransactionException {
+  /** Message-only form, used when reconstructing the exception from a wire response (forwarded writes). */
+  public TransactionCommittedRemotelyException(final String message) {
+    super(message);
+  }
+
   public TransactionCommittedRemotelyException(final String message, final Throwable cause) {
     super(message, cause);
   }

--- a/engine/src/main/java/com/arcadedb/exception/TransactionCommittedRemotelyException.java
+++ b/engine/src/main/java/com/arcadedb/exception/TransactionCommittedRemotelyException.java
@@ -24,7 +24,8 @@ package com.arcadedb.exception;
  * reconciliation or restart.
  * <p>
  * <b>Do NOT retry the transaction</b>: a retry would apply the changes a second time (for inserts, creating
- * duplicates). Treat this as a commit that succeeded remotely: reload any records you hold and continue. The
+ * duplicates). Treat this as a commit that succeeded remotely and continue; reloading held records is
+ * optional (for freshness) - their in-memory content already matches what the cluster committed. The
  * identities of records created in the failed-locally transaction remain valid - they are the identities the
  * cluster committed.
  *

--- a/engine/src/test/java/com/arcadedb/engine/WalCommitOrderingTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/WalCommitOrderingTest.java
@@ -302,6 +302,7 @@ class WalCommitOrderingTest {
 
     final DatabaseInternal db = (DatabaseInternal) factory.create();
     final PageId[] victimPageId = new PageId[1];
+    final PageId[] victim2PageId = new PageId[1];
     try {
       db.getSchema().createDocumentType("Doc");
       db.transaction(() -> db.newDocument("Doc").set("v", "committed").save());
@@ -345,6 +346,7 @@ class WalCommitOrderingTest {
       final TransactionContext tx2 = (TransactionContext) db.getTransaction();
       final TransactionContext.TransactionPhase1 phase2 = tx2.commit1stPhase(true);
       final MutablePage victim2 = phase2.modifiedPages.getFirst();
+      victim2PageId[0] = victim2.getPageId();
       final MutablePage conflicting2 = new MutablePage(victim2.getPageId(), (int) victim2.getPhysicalSize(),
           victim2.getContent().array().clone(), (int) (victim2.getVersion() + 1), victim2.getContentSize());
       PageManager.INSTANCE.putPageInReadCache(new CachedPage(conflicting2, false));
@@ -355,6 +357,9 @@ class WalCommitOrderingTest {
     } finally {
       if (victimPageId[0] != null)
         PageManager.INSTANCE.removePageFromCache(victimPageId[0]);
+      if (victim2PageId[0] != null)
+        // Both poisoned pages evicted (#5075 review): PageManager.INSTANCE is process-global.
+        PageManager.INSTANCE.removePageFromCache(victim2PageId[0]);
       db.close();
       factory.close();
     }

--- a/engine/src/test/java/com/arcadedb/engine/WalCommitOrderingTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/WalCommitOrderingTest.java
@@ -22,6 +22,7 @@ import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.TransactionContext;
 import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.exception.TransactionException;
@@ -286,6 +287,78 @@ class WalCommitOrderingTest {
     @SuppressWarnings("unchecked")
     final Map<Integer, Integer> counters = (Map<Integer, Integer>) countersField.get(tx);
     counters.put(9_999, 1);
+  }
+
+
+  @Test
+  void remotelyCommittedRegimePreservesIdentitiesOnPreWalFailure() throws Exception {
+    // #5064 (engine branch): when the HA layer marked the transaction remotely committed (quorum accepted
+    // it) and the LOCAL apply then fails BEFORE the local WAL append, the finally must take the
+    // reset()-without-rollback regime: the identities the cluster committed survive on the user-held
+    // records (rollback would reset them to provisional and an application retry would insert duplicates),
+    // and the database is NOT fenced (nothing local is durable; the Raft layer reconciles the pages).
+    final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
+    if (factory.exists())
+      factory.open().drop();
+
+    final DatabaseInternal db = (DatabaseInternal) factory.create();
+    final PageId[] victimPageId = new PageId[1];
+    try {
+      db.getSchema().createDocumentType("Doc");
+      db.transaction(() -> db.newDocument("Doc").set("v", "committed").save());
+
+      db.begin();
+      final MutableDocument held = db.newDocument("Doc").set("v", "remote");
+      held.save();
+      final Object identityAtSave = held.getIdentity();
+      assertThat(identityAtSave).isNotNull();
+
+      final TransactionContext tx = (TransactionContext) db.getTransaction();
+      final TransactionContext.TransactionPhase1 phase1 = tx.commit1stPhase(true);
+      assertThat(phase1).isNotNull();
+
+      // Simulate the HA layer: quorum committed, local phase 2 about to run.
+      tx.setRemotelyCommitted(true);
+
+      // Inject a conflicting committed version so validateAndBumpVersions fails PRE-WAL (same toolkit as
+      // failedValidationLeavesNoWalRecord).
+      final MutablePage victim = phase1.modifiedPages.getFirst();
+      victimPageId[0] = victim.getPageId();
+      final MutablePage conflicting = new MutablePage(victim.getPageId(), (int) victim.getPhysicalSize(),
+          victim.getContent().array().clone(), (int) (victim.getVersion() + 1), victim.getContentSize());
+      PageManager.INSTANCE.putPageInReadCache(new CachedPage(conflicting, false));
+
+      assertThatThrownBy(() -> tx.commit2ndPhase(phase1)).isInstanceOf(ConcurrentModificationException.class);
+
+      assertThat(held.getIdentity())
+          .as("the remotely-committed regime must preserve the cluster-committed identity (#5064)")
+          .isEqualTo(identityAtSave);
+      assertThat(((LocalDatabase) db).isFencedForRecovery())
+          .as("no fence: nothing local is durable, the Raft layer reconciles").isFalse();
+
+      // The flag is single-transaction-scoped: a FRESH transaction failing the same way must roll back
+      // normally (#4940) - the sticky-flag hazard the review caught.
+      db.begin();
+      // Deliberately the SAME reused base context object - the reviewer's sticky-flag hazard: only
+      // begin()/reset() clearing the flag protects this second transaction.
+      final MutableDocument held2 = db.newDocument("Doc").set("v", "local-only");
+      held2.save();
+      final TransactionContext tx2 = (TransactionContext) db.getTransaction();
+      final TransactionContext.TransactionPhase1 phase2 = tx2.commit1stPhase(true);
+      final MutablePage victim2 = phase2.modifiedPages.getFirst();
+      final MutablePage conflicting2 = new MutablePage(victim2.getPageId(), (int) victim2.getPhysicalSize(),
+          victim2.getContent().array().clone(), (int) (victim2.getVersion() + 1), victim2.getContentSize());
+      PageManager.INSTANCE.putPageInReadCache(new CachedPage(conflicting2, false));
+      assertThatThrownBy(() -> tx2.commit2ndPhase(phase2)).isInstanceOf(ConcurrentModificationException.class);
+      assertThat(held2.getIdentity())
+          .as("a plain local failure on the SAME thread context must still roll back identities (#4940)")
+          .isNull();
+    } finally {
+      if (victimPageId[0] != null)
+        PageManager.INSTANCE.removePageFromCache(victimPageId[0]);
+      db.close();
+      factory.close();
+    }
   }
 
   private static long totalWalBytes() {

--- a/engine/src/test/java/com/arcadedb/engine/WalCommitOrderingTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/WalCommitOrderingTest.java
@@ -289,7 +289,6 @@ class WalCommitOrderingTest {
     counters.put(9_999, 1);
   }
 
-
   @Test
   void remotelyCommittedRegimePreservesIdentitiesOnPreWalFailure() throws Exception {
     // #5064 (engine branch): when the HA layer marked the transaction remotely committed (quorum accepted

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -447,11 +447,11 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
         // #5064: the user must be able to distinguish 'retry me' from 'already committed cluster-wide'.
         // The generic rethrow here told applications the commit FAILED while the data was durably committed
         // on the quorum - and an application-level retry of the same records would insert duplicates.
+        final String reconcileOutcome = reconciled ? " (local pages reconciled from the replicated payload)"
+            : " (local reconciliation ALSO failed - this node steps down and repairs on rejoin)";
         throw new TransactionCommittedRemotelyException(
             "Transaction " + payload.tx() + " is committed cluster-wide but the local apply failed"
-                + (reconciled ? " (local pages reconciled from the replicated payload)"
-                : " (local reconciliation ALSO failed - this node steps down and repairs on rejoin)")
-                + ". Do NOT retry: reload the records and continue", e);
+                + reconcileOutcome + ". Do NOT retry: reload the records and continue", e);
       } finally {
         current.popIfNotLastTransaction();
       }
@@ -469,6 +469,10 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       final DatabaseContext.DatabaseContextTL current = DatabaseContext.INSTANCE.getContext(proxied.getDatabasePath());
       try {
         // #5064: MAJORITY already committed - same durability-boundary shift as the main phase-2 path.
+        // Unlike that path, a failure here is NOT surfaced as TransactionCommittedRemotelyException: this is
+        // background ALL-quorum recovery with no user caller waiting on this commit - the reconcile +
+        // step-down below are the whole remedy, and the flag only steers the finally away from the
+        // identity rollback.
         payload.tx().setRemotelyCommitted(true);
         payload.tx().commit2ndPhase(payload.phase1());
         if (getSchema().getEmbedded().isDirty())

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -447,6 +447,10 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
           getSchema().getEmbedded().saveConfiguration();
       } catch (final Exception e) {
         LogManager.instance().log(this, Level.SEVERE, phase2CommitFailureMessage(e), getName(), payload.tx(), e.getMessage());
+        // NOTE (#5075 review): this catch also fires when commit2ndPhase SUCCEEDED and only the
+        // saveConfiguration() after it threw. Reconciling then replays the payload WAL against pages the
+        // commit already published - safe by the #4926 replay semantics: an equal-version entry re-applies
+        // the same absolute bytes (idempotent), a lower-version one is skipped.
         final boolean reconciled = reconcileLeaderPagesAfterPhase2Failure(payload);
         recoverLeadershipAfterPhase2Failure(payload.tx().toString());
         // #5064: the user must be able to distinguish 'retry me' from 'already committed cluster-wide'.

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -122,8 +122,9 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
   /**
    * Carries transaction state between Phase 1 (WAL capture under lock) and
    * Replication (without lock) and Phase 2 (local apply under lock).
+   * Package-private so unit tests can build one for {@link #applyLocallyAfterMajorityCommit}.
    */
-  private record ReplicationPayload(
+  record ReplicationPayload(
       TransactionContext tx,
       TransactionContext.TransactionPhase1 phase1,
       byte[] walData,
@@ -179,6 +180,10 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
       Map.entry(LockTimeoutException.class.getName(), LockTimeoutException::new),
       Map.entry(TimeoutException.class.getName(), TimeoutException::new),
       Map.entry(TransactionException.class.getName(), TransactionException::new),
+      // #5064: preserves the 'committed cluster-wide, do NOT retry' contract when a follower forwards a
+      // write to the leader - without this entry the 409 body would collapse to a generic
+      // TransactionException on the follower and the client would lose the do-not-retry signal.
+      Map.entry(TransactionCommittedRemotelyException.class.getName(), TransactionCommittedRemotelyException::new),
       Map.entry(CommandExecutionException.class.getName(), CommandExecutionException::new),
       Map.entry(CommandParsingException.class.getName(), CommandParsingException::new),
       Map.entry(CommandSQLParsingException.class.getName(), CommandSQLParsingException::new),
@@ -463,8 +468,10 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * Applies phase 2 locally when ALL-quorum watch fails after MAJORITY commit.
    * The Raft entry is durably committed (MAJORITY applied it, including origin-skip on the leader),
    * so we must write the local pages to prevent permanent divergence.
+   * Package-private for direct unit testing (the real trigger needs an ALL-quorum cluster whose
+   * watch fails after MAJORITY commit, which depends on Ratis watch timeouts).
    */
-  private void applyLocallyAfterMajorityCommit(final ReplicationPayload payload) {
+  void applyLocallyAfterMajorityCommit(final ReplicationPayload payload) {
     proxied.executeInReadLock(() -> {
       final DatabaseContext.DatabaseContextTL current = DatabaseContext.INSTANCE.getContext(proxied.getDatabasePath());
       try {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -582,6 +582,10 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * this node steps down (issue #4740 Fix 2 makes that recoverable instead of fatal).
    */
   private boolean reconcileLeaderPagesAfterPhase2Failure(final ReplicationPayload payload) {
+    // #5075 review: this also runs when the post-append failure FENCED the database. applyChanges operates
+    // at the FileManager/PageManager level and never passes through checkDatabaseIsOpen (the fence's only
+    // choke point besides the pre-append guard), so reconciliation works on a fenced database - it is the
+    // same page-level machinery recovery replay uses on reopen.
     try {
       final WALFile.WALTransaction walTx = ArcadeStateMachine.deserializeWalTransaction(payload.walData());
       proxied.getTransactionManager().applyChanges(walTx, payload.bucketDeltas(), true);

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabase.java
@@ -60,6 +60,7 @@ import com.arcadedb.exception.NeedRetryException;
 import com.arcadedb.exception.QueryNotIdempotentException;
 import com.arcadedb.exception.SchemaException;
 import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.exception.TransactionCommittedRemotelyException;
 import com.arcadedb.exception.TransactionException;
 import com.arcadedb.exception.ValidationException;
 import com.arcadedb.graph.Edge;
@@ -423,6 +424,13 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     proxied.executeInReadLock(() -> {
       final DatabaseContext.DatabaseContextTL current = DatabaseContext.INSTANCE.getContext(proxied.getDatabasePath());
       try {
+        // #5064: from here the transaction is durably committed CLUSTER-WIDE (the quorum accepted it) -
+        // shift the transaction's durability boundary so a local phase-2 failure below releases resources
+        // without rolling back user-held record identities (a retry would insert duplicates of records the
+        // cluster already committed) and without fencing (no orphaned local WAL record; pages are
+        // reconciled from the replicated payload in the catch).
+        payload.tx().setRemotelyCommitted(true);
+
         // Test-only fault injection: simulate a phase-2 commit failure while followers are ahead.
         final Consumer<String> phase2Fault = TEST_PHASE2_COMMIT_FAULT;
         if (phase2Fault != null)
@@ -434,9 +442,16 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
           getSchema().getEmbedded().saveConfiguration();
       } catch (final Exception e) {
         LogManager.instance().log(this, Level.SEVERE, phase2CommitFailureMessage(e), getName(), payload.tx(), e.getMessage());
-        reconcileLeaderPagesAfterPhase2Failure(payload);
+        final boolean reconciled = reconcileLeaderPagesAfterPhase2Failure(payload);
         recoverLeadershipAfterPhase2Failure(payload.tx().toString());
-        throw e;
+        // #5064: the user must be able to distinguish 'retry me' from 'already committed cluster-wide'.
+        // The generic rethrow here told applications the commit FAILED while the data was durably committed
+        // on the quorum - and an application-level retry of the same records would insert duplicates.
+        throw new TransactionCommittedRemotelyException(
+            "Transaction " + payload.tx() + " is committed cluster-wide but the local apply failed"
+                + (reconciled ? " (local pages reconciled from the replicated payload)"
+                : " (local reconciliation ALSO failed - this node steps down and repairs on rejoin)")
+                + ". Do NOT retry: reload the records and continue", e);
       } finally {
         current.popIfNotLastTransaction();
       }
@@ -453,6 +468,8 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
     proxied.executeInReadLock(() -> {
       final DatabaseContext.DatabaseContextTL current = DatabaseContext.INSTANCE.getContext(proxied.getDatabasePath());
       try {
+        // #5064: MAJORITY already committed - same durability-boundary shift as the main phase-2 path.
+        payload.tx().setRemotelyCommitted(true);
         payload.tx().commit2ndPhase(payload.phase1());
         if (getSchema().getEmbedded().isDirty())
           getSchema().getEmbedded().saveConfiguration();
@@ -549,16 +566,18 @@ public class RaftReplicatedDatabase implements DatabaseInternal, HAReplicatedDat
    * is applied; any page it cannot is left for the normal follower-side WAL-gap path to resync once
    * this node steps down (issue #4740 Fix 2 makes that recoverable instead of fatal).
    */
-  private void reconcileLeaderPagesAfterPhase2Failure(final ReplicationPayload payload) {
+  private boolean reconcileLeaderPagesAfterPhase2Failure(final ReplicationPayload payload) {
     try {
       final WALFile.WALTransaction walTx = ArcadeStateMachine.deserializeWalTransaction(payload.walData());
       proxied.getTransactionManager().applyChanges(walTx, payload.bucketDeltas(), true);
       LogManager.instance().log(this, Level.INFO,
           "Phase 2 failure: leader pages reconciled via WAL replay (db=%s, tx=%s)", getName(), payload.tx());
+      return true;
     } catch (final Exception reconcileEx) {
       LogManager.instance().log(this, Level.SEVERE,
           "Phase 2 failure: leader page reconciliation also failed (db=%s, tx=%s): %s",
           getName(), payload.tx(), reconcileEx.getMessage());
+      return false;
     }
   }
 

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5064ApplyLocallyAfterMajorityCommitTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5064ApplyLocallyAfterMajorityCommitTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.database.DatabaseContext;
+import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.database.TransactionContext;
+import com.arcadedb.engine.TransactionManager;
+import com.arcadedb.schema.Schema;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * #5064: the ALL-quorum recovery path. When the MAJORITY durably committed a transaction but the
+ * ALL-quorum watch failed, {@code applyLocallyAfterMajorityCommit} applies phase 2 locally. A failure
+ * there must (a) have set {@code remotelyCommitted} on the transaction BEFORE the apply, so that
+ * {@code commit2ndPhase}'s finally releases resources without the #4940 identity rollback (the flag's
+ * engine-side semantics are pinned by {@code WalCommitOrderingTest}), (b) stay SILENT to the caller
+ * (unlike the main phase-2 path this is background recovery: the caller already receives
+ * {@code MajorityCommittedAllFailedException}; the reconcile + step-down below are the whole remedy),
+ * and (c) still fire the reconcile + step-down remedy.
+ * <p>
+ * Unit-level by design: the real trigger needs an ALL-quorum cluster whose Ratis watch fails after
+ * MAJORITY commit plus a concurrent local-apply fault, which hinges on Ratis watch timeouts and is
+ * not deterministically reproducible in an IT. The failure is injected through the payload's
+ * transaction instead, exercising the REAL {@code applyLocallyAfterMajorityCommit} body.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5064ApplyLocallyAfterMajorityCommitTest {
+
+  private static final String DB_PATH = "/tmp/issue5064-apply-locally-test";
+
+  private LocalDatabase      proxied;
+  private RaftHAServer       raftServer;
+  private TransactionContext tx;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    proxied = mock(LocalDatabase.class);
+    when(proxied.getDatabasePath()).thenReturn(DB_PATH);
+    when(proxied.getName()).thenReturn("issue5064");
+    when(proxied.getTransactionManager()).thenReturn(mock(TransactionManager.class));
+    when(proxied.executeInReadLock(any())).thenAnswer(invocation -> ((Callable<?>) invocation.getArgument(0)).call());
+
+    raftServer = mock(RaftHAServer.class);
+    when(raftServer.isLeader()).thenReturn(true);
+
+    tx = mock(TransactionContext.class);
+  }
+
+  @AfterEach
+  void tearDown() {
+    DatabaseContext.INSTANCE.removeContext(DB_PATH);
+  }
+
+  @Test
+  void localApplyFailureStaysSilentSetsFlagBeforeApplyAndStepsDown() {
+    final RaftReplicatedDatabase database = new RaftReplicatedDatabase(null, proxied, raftServer);
+    // Bind the thread-local context the method resolves via DatabaseContext.getContext().
+    DatabaseContext.INSTANCE.init(proxied, tx);
+
+    doThrow(new IllegalStateException("simulated local apply failure")).when(tx).commit2ndPhase(any());
+
+    // 24 zero bytes deserialize to an empty WAL transaction (txId=0, 0 pages), so the reconcile
+    // remedy runs deterministically against the mocked TransactionManager.
+    final RaftReplicatedDatabase.ReplicationPayload payload =
+        new RaftReplicatedDatabase.ReplicationPayload(tx, null, new byte[24], Map.of());
+
+    // (b) SILENT: the local-apply failure must not surface - the caller of commit() already gets
+    // MajorityCommittedAllFailedException; surfacing a second exception here would replace it.
+    assertThatCode(() -> database.applyLocallyAfterMajorityCommit(payload)).doesNotThrowAnyException();
+
+    // (a) The durability-boundary shift is active DURING the apply: the flag is set before
+    // commit2ndPhase, so its finally takes the remotelyCommitted reset() branch instead of the
+    // #4940 identity rollback (branch semantics pinned by the engine's WalCommitOrderingTest).
+    final InOrder order = inOrder(tx);
+    order.verify(tx).setRemotelyCommitted(true);
+    order.verify(tx).commit2ndPhase(any());
+
+    // ...and this path itself must never add an identity rollback around the failed apply.
+    verify(tx, never()).rollback();
+
+    // (c) The remedy fires: the leader steps down so a node with correct state takes over.
+    verify(raftServer).stepDown();
+  }
+
+  @Test
+  void successfulApplyDoesNotStepDown() {
+    final RaftReplicatedDatabase database = new RaftReplicatedDatabase(null, proxied, raftServer);
+    DatabaseContext.INSTANCE.init(proxied, tx);
+    when(proxied.getSchema()).thenReturn(mock(Schema.class, RETURNS_DEEP_STUBS));
+
+    final RaftReplicatedDatabase.ReplicationPayload payload =
+        new RaftReplicatedDatabase.ReplicationPayload(tx, null, new byte[24], Map.of());
+
+    assertThatCode(() -> database.applyLocallyAfterMajorityCommit(payload)).doesNotThrowAnyException();
+
+    // The boundary shift precedes the apply on the success path too.
+    final InOrder order = inOrder(tx);
+    order.verify(tx).setRemotelyCommitted(true);
+    order.verify(tx).commit2ndPhase(any());
+
+    verify(raftServer, never()).stepDown();
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5064CommittedRemotelyContractIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5064CommittedRemotelyContractIT.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.exception.TransactionCommittedRemotelyException;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.log.LogManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * #5064: the user-visible contract for a post-quorum local commit failure. When the Raft quorum durably
+ * committed the transaction but the leader's LOCAL phase-2 apply fails, the application must receive
+ * {@link TransactionCommittedRemotelyException} ("committed cluster-wide, do NOT retry") instead of a
+ * generic commit failure - and the identities of records created in the transaction must remain valid (they
+ * are the identities the cluster committed), so an application-level retry no longer INSERTS DUPLICATES of
+ * already-committed records.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5064CommittedRemotelyContractIT extends BaseRaftHATest {
+
+  private static final String VERTEX_TYPE = "Contract5064";
+
+  @AfterEach
+  void disarmHooks() {
+    RaftReplicatedDatabase.TEST_PHASE2_COMMIT_FAULT = null;
+  }
+
+  @Test
+  void postQuorumLocalFailureSurfacesTheCommittedRemotelyContract() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+    leaderDb.transaction(() -> {
+      if (!leaderDb.getSchema().existsType(VERTEX_TYPE))
+        leaderDb.getSchema().createVertexType(VERTEX_TYPE, 1);
+    });
+    // Baseline vertex: registers the property name in the dictionary so its INTERNAL transaction (fired
+    // lazily from save() -> Dictionary.getIdByName) does not consume the single-shot fault below.
+    leaderDb.transaction(() -> leaderDb.newVertex(VERTEX_TYPE).set("k", "baseline").save());
+    assertClusterConsistency();
+
+    // Arm a single-shot phase-2 fault: replication reaches quorum, then the local apply throws.
+    final AtomicBoolean faultFired = new AtomicBoolean(false);
+    RaftReplicatedDatabase.TEST_PHASE2_COMMIT_FAULT = dbName -> {
+      if (!faultFired.compareAndSet(false, true))
+        return;
+      LogManager.instance().log(Issue5064CommittedRemotelyContractIT.class, Level.INFO,
+          "TEST: injecting phase-2 commit fault for db=%s on leader %d", dbName, leaderIndex);
+      throw new ConcurrentModificationException("TEST fault injection: simulated post-quorum local failure (#5064)");
+    };
+
+    final MutableVertex held;
+    leaderDb.begin();
+    held = leaderDb.newVertex(VERTEX_TYPE);
+    held.set("k", "committed-remotely");
+    held.save();
+    final Object identityAtSave = held.getIdentity();
+    assertThat(identityAtSave).as("save() assigns the optimistic identity").isNotNull();
+
+    try {
+      leaderDb.commit();
+      fail("the faulted commit must not report plain success");
+    } catch (final TransactionCommittedRemotelyException e) {
+      // The contract: distinct type, actionable message.
+      assertThat(e.getMessage()).contains("committed cluster-wide").contains("Do NOT retry");
+    }
+
+    assertThat(faultFired.get()).as("the phase-2 fault hook must have fired").isTrue();
+
+    // #4940-composition: the user-held record keeps the identity the cluster committed - it must NOT have
+    // been reset to provisional (that reset is what turned application retries into duplicate inserts).
+    assertThat(held.getIdentity())
+        .as("the identity of a remotely-committed record must survive the local failure (#5064)")
+        .isEqualTo(identityAtSave);
+
+    // The data is genuinely committed: a post-step-down write drives the log forward (same pattern as
+    // Issue4740Phase2ReconcileIT), then every node must serve BOTH vertices - the baseline and the
+    // remotely-committed one whose local apply failed.
+    final int newLeaderIndex = findLeaderIndex();
+    assertThat(newLeaderIndex).as("A leader must be elected after the phase-2 step-down").isGreaterThanOrEqualTo(0);
+    final Database newLeaderDb = getServerDatabase(newLeaderIndex, getDatabaseName());
+    newLeaderDb.transaction(() -> newLeaderDb.newVertex(VERTEX_TYPE).set("k", "post-stepdown").save());
+
+    for (int i = 0; i < getServerCount(); i++)
+      waitForReplicationIsCompleted(i);
+
+    assertClusterConsistency();
+    for (int i = 0; i < getServerCount(); i++) {
+      final Database db = getServerDatabase(i, getDatabaseName());
+      assertThat(db.countType(VERTEX_TYPE, true))
+          .as("Node %d must hold the baseline, the remotely-committed and the post-stepdown vertices", i)
+          .isEqualTo(3L);
+    }
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5064CommittedRemotelyContractIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5064CommittedRemotelyContractIT.java
@@ -24,6 +24,7 @@ import com.arcadedb.exception.TransactionCommittedRemotelyException;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.log.LogManager;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -42,6 +43,7 @@ import static org.assertj.core.api.Assertions.fail;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
+@Tag("slow")
 class Issue5064CommittedRemotelyContractIT extends BaseRaftHATest {
 
   private static final String VERTEX_TYPE = "Contract5064";

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5064CommittedRemotelyContractIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/Issue5064CommittedRemotelyContractIT.java
@@ -23,10 +23,16 @@ import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.exception.TransactionCommittedRemotelyException;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.serializer.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Base64;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
@@ -118,6 +124,88 @@ class Issue5064CommittedRemotelyContractIT extends BaseRaftHATest {
       final Database db = getServerDatabase(i, getDatabaseName());
       assertThat(db.countType(VERTEX_TYPE, true))
           .as("Node %d must hold the baseline, the remotely-committed and the post-stepdown vertices", i)
+          .isEqualTo(3L);
+    }
+  }
+
+  /**
+   * The wire-facing half of the contract (#5075 review, round 4): the same post-quorum local failure
+   * surfaced through the HTTP command endpoint must map to 409 Conflict with an explicit do-not-retry
+   * detail - never a retry-worthy 5xx that would invite clients and load balancers to re-drive the
+   * write (the exact duplicate-insert hazard, same rationale as the DuplicatedKeyException 409 of
+   * issue #4350). Complements the server-module unit test on the catch mapping
+   * (Issue5064CommittedRemotelyHttpStatusTest) by proving the exception reaches that catch RAW
+   * through the real Raft commit path and transaction wrapper.
+   */
+  @Test
+  void postQuorumLocalFailureOverHttpReturns409DoNotRetry() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    final Database leaderDb = getServerDatabase(leaderIndex, getDatabaseName());
+    leaderDb.transaction(() -> {
+      if (!leaderDb.getSchema().existsType(VERTEX_TYPE))
+        leaderDb.getSchema().createVertexType(VERTEX_TYPE, 1);
+    });
+    // Baseline vertex: registers the property name in the dictionary so its INTERNAL transaction does
+    // not consume the single-shot fault below (same pattern as the embedded-API test above).
+    leaderDb.transaction(() -> leaderDb.newVertex(VERTEX_TYPE).set("k", "baseline").save());
+    assertClusterConsistency();
+
+    final AtomicBoolean faultFired = new AtomicBoolean(false);
+    RaftReplicatedDatabase.TEST_PHASE2_COMMIT_FAULT = dbName -> {
+      if (!faultFired.compareAndSet(false, true))
+        return;
+      throw new ConcurrentModificationException("TEST fault injection: simulated post-quorum local failure (#5064)");
+    };
+
+    final int leaderHttpPort = getServer(leaderIndex).getHttpServer().getPort();
+    final HttpURLConnection connection = (HttpURLConnection) new URL(
+        "http://127.0.0.1:" + leaderHttpPort + "/api/v1/command/" + getDatabaseName()).openConnection();
+    try {
+      connection.setRequestMethod("POST");
+      connection.setRequestProperty("Authorization",
+          "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+      connection.setDoOutput(true);
+
+      final JSONObject request = new JSONObject()
+          .put("language", "sql")
+          .put("command", "CREATE VERTEX " + VERTEX_TYPE + " SET k = 'over-http'");
+      try (final PrintWriter pw = new PrintWriter(new OutputStreamWriter(connection.getOutputStream()))) {
+        pw.write(request.toString());
+      }
+
+      final int statusCode = connection.getResponseCode();
+      final String response = readError(connection);
+
+      assertThat(faultFired.get()).as("the phase-2 fault hook must have fired").isTrue();
+      assertThat(statusCode)
+          .as("committed-remotely must surface as 409 Conflict over the wire, got %d (body=%s)", statusCode, response)
+          .isEqualTo(409);
+
+      final JSONObject json = new JSONObject(response);
+      assertThat(json.getString("exception")).isEqualTo(TransactionCommittedRemotelyException.class.getName());
+      assertThat(json.getString("error")).isEqualTo("Transaction committed cluster-wide but the local apply failed - do not retry");
+      assertThat(json.getString("detail")).contains("committed cluster-wide").contains("Do NOT retry");
+    } finally {
+      connection.disconnect();
+    }
+
+    // The write IS durably committed despite the 409: after the fault-triggered step-down, drive the
+    // log forward and verify every node serves both the baseline and the over-http vertex.
+    final int newLeaderIndex = findLeaderIndex();
+    assertThat(newLeaderIndex).as("A leader must be elected after the phase-2 step-down").isGreaterThanOrEqualTo(0);
+    final Database newLeaderDb = getServerDatabase(newLeaderIndex, getDatabaseName());
+    newLeaderDb.transaction(() -> newLeaderDb.newVertex(VERTEX_TYPE).set("k", "post-stepdown").save());
+
+    for (int i = 0; i < getServerCount(); i++)
+      waitForReplicationIsCompleted(i);
+
+    assertClusterConsistency();
+    for (int i = 0; i < getServerCount(); i++) {
+      final Database db = getServerDatabase(i, getDatabaseName());
+      assertThat(db.countType(VERTEX_TYPE, true))
+          .as("Node %d must hold the baseline, the over-http and the post-stepdown vertices", i)
           .isEqualTo(3L);
     }
   }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabaseTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftReplicatedDatabaseTest.java
@@ -28,6 +28,7 @@ import com.arcadedb.exception.LockTimeoutException;
 import com.arcadedb.exception.NeedRetryException;
 import com.arcadedb.exception.QueryNotIdempotentException;
 import com.arcadedb.exception.TimeoutException;
+import com.arcadedb.exception.TransactionCommittedRemotelyException;
 import com.arcadedb.exception.TransactionException;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
@@ -178,6 +179,22 @@ class RaftReplicatedDatabaseTest {
     assertThat(result).isInstanceOf(CommandSQLParsingException.class);
     assertThat(result).isInstanceOf(CommandParsingException.class);
     assertThat(result.getMessage()).isEqualTo("Syntax error near 'SELCT'");
+  }
+
+  @Test
+  void reconstructLeaderExceptionCommittedRemotelyKeepsDoNotRetryContract() {
+    // #5064: a follower forwarding a write must hand the caller the SAME do-not-retry contract the
+    // leader produced - collapsing it to a generic TransactionException (or worse, a retryable type)
+    // would let the client re-drive a transaction the cluster already committed, inserting duplicates.
+    final String body = "{\"error\":\"Transaction committed cluster-wide but the local apply failed - do not retry\","
+        + "\"detail\":\"Transaction TX(1) is committed cluster-wide but the local apply failed. Do NOT retry: reload the records and continue\","
+        + "\"exception\":\"com.arcadedb.exception.TransactionCommittedRemotelyException\"}";
+
+    final RuntimeException result = RaftReplicatedDatabase.reconstructLeaderException(409, body);
+
+    assertThat(result).isInstanceOf(TransactionCommittedRemotelyException.class);
+    assertThat(result).isNotInstanceOf(NeedRetryException.class);
+    assertThat(result.getMessage()).contains("committed cluster-wide").contains("Do NOT retry");
   }
 
   @Test

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -335,6 +335,16 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
         LogManager.instance().log(this, getUserSevereErrorLogLevel(), "Security error on command execution (%s): %s",
                 SecurityException.class.getSimpleName(), realException.getMessage());
         sendErrorResponse(exchange, 403, "Security error", realException, null);
+      } else if (realException instanceof TransactionCommittedRemotelyException committedRemotely) {
+        // Symmetric with the un-wrapped arm (#5064/#5075): a wrapped committed-remotely outcome must keep
+        // its non-retryable 409 - degrading to 500 invites the client retry that inserts duplicates of
+        // records the cluster already committed. Same defense-in-depth as the DuplicatedKeyException
+        // branch below.
+        LogManager.instance()
+                .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
+                        realException.getMessage());
+        sendErrorResponse(exchange, 409, "Transaction committed cluster-wide but the local apply failed - do not retry",
+                committedRemotely, null);
       } else if (realException instanceof DuplicatedKeyException dup) {
         // Symmetric with the un-wrapped DuplicatedKeyException catch arm. Some code paths
         // (e.g. script execution, command planners) wrap DuplicatedKeyException in
@@ -374,6 +384,14 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
                 .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
                         realException.getMessage());
         sendErrorResponse(exchange, 400, "Cannot execute command", realException, null);
+      } else if (realException instanceof TransactionCommittedRemotelyException committedRemotely) {
+        // Same as the un-wrapped committed-remotely arm above (#5064/#5075), reached when the auto-commit
+        // wrapper re-wrapped it: the non-retryable 409 must survive the wrapping.
+        LogManager.instance()
+                .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
+                        realException.getMessage());
+        sendErrorResponse(exchange, 409, "Transaction committed cluster-wide but the local apply failed - do not retry",
+                committedRemotely, null);
       } else if (realException instanceof DuplicatedKeyException dup) {
         // Same as the un-wrapped DuplicatedKeyException arm above, but reached when the
         // exception was thrown inside the auto-commit transaction wrapper in

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -288,6 +288,15 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
       LogManager.instance()
               .log(this, Level.FINE, "Error on command execution (%s): %s", getClass().getSimpleName(), e.getMessage());
       sendErrorResponse(exchange, 503, "Cannot execute command", e, null);
+    } catch (final TransactionCommittedRemotelyException e) {
+      LogManager.instance()
+              .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),
+                      e.getMessage());
+      // 409 Conflict, NOT 5xx (#5064/#5075 review): the transaction IS durably committed cluster-wide -
+      // only the local apply failed. A 5xx would invite HTTP clients and load balancers to RETRY, which
+      // would apply the changes a second time (duplicate inserts) - the exact hazard the distinct
+      // exception type exists to prevent. Same rationale as the DuplicatedKeyException 409 below (#4350).
+      sendErrorResponse(exchange, 409, "Transaction committed cluster-wide but the local apply failed - do not retry", e, null);
     } catch (final DuplicatedKeyException e) {
       LogManager.instance()
               .log(this, getUserSevereErrorLogLevel(), "Error on command execution (%s): %s", getClass().getSimpleName(),

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue5064CommittedRemotelyHttpStatusTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue5064CommittedRemotelyHttpStatusTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.server.http.handler;
 
 import com.arcadedb.ContextConfiguration;
+import com.arcadedb.exception.CommandExecutionException;
 import com.arcadedb.exception.ConcurrentModificationException;
 import com.arcadedb.exception.TransactionCommittedRemotelyException;
 import com.arcadedb.exception.TransactionException;
@@ -75,6 +76,37 @@ class Issue5064CommittedRemotelyHttpStatusTest {
     assertThat(json.getString("error")).isEqualTo("Transaction committed cluster-wide but the local apply failed - do not retry");
     assertThat(json.getString("exception")).isEqualTo(TransactionCommittedRemotelyException.class.getName());
     assertThat(json.getString("detail")).contains("committed cluster-wide").contains("Do NOT retry");
+  }
+
+  @Test
+  void committedRemotelyWrappedInCommandExecutionExceptionKeeps409() {
+    // #5075 round 6 (defense in depth): script execution and command planners wrap exceptions in
+    // CommandExecutionException. The do-not-retry 409 must survive the wrapping - falling through to the
+    // generic 500 would re-invite the duplicate-insert retry the distinct type exists to prevent.
+    final HandledResponse response = handle(new CommandExecutionException("Error on command execution",
+        new TransactionCommittedRemotelyException("Transaction TX(1) is committed cluster-wide but the local apply failed."
+            + " Do NOT retry: reload the records and continue", new IllegalStateException("simulated"))));
+
+    assertThat(response.statusCode)
+        .as("a WRAPPED committed-remotely outcome must keep the non-retryable 409 (body=%s)", response.body)
+        .isEqualTo(409);
+    assertThat(new JSONObject(response.body).getString("exception"))
+        .isEqualTo(TransactionCommittedRemotelyException.class.getName());
+  }
+
+  @Test
+  void committedRemotelyWrappedInTransactionExceptionKeeps409() {
+    // Same guard for the auto-commit wrapper in DatabaseAbstractHandler, which wraps any Exception thrown
+    // by execute() in a plain TransactionException.
+    final HandledResponse response = handle(new TransactionException("Error on transaction commit",
+        new TransactionCommittedRemotelyException("Transaction TX(1) is committed cluster-wide but the local apply failed."
+            + " Do NOT retry: reload the records and continue", new IllegalStateException("simulated"))));
+
+    assertThat(response.statusCode)
+        .as("the auto-commit wrapper must not degrade the committed-remotely 409 (body=%s)", response.body)
+        .isEqualTo(409);
+    assertThat(new JSONObject(response.body).getString("exception"))
+        .isEqualTo(TransactionCommittedRemotelyException.class.getName());
   }
 
   @Test

--- a/server/src/test/java/com/arcadedb/server/http/handler/Issue5064CommittedRemotelyHttpStatusTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/Issue5064CommittedRemotelyHttpStatusTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.exception.ConcurrentModificationException;
+import com.arcadedb.exception.TransactionCommittedRemotelyException;
+import com.arcadedb.exception.TransactionException;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.http.HttpServer;
+import com.arcadedb.server.security.ServerSecurityUser;
+
+import io.micrometer.observation.ObservationRegistry;
+import io.undertow.io.Sender;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HeaderMap;
+import io.undertow.util.Methods;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression test for the wire-facing half of issue #5064 (PR #5075): when a transaction is durably
+ * committed cluster-wide but the LOCAL apply fails, {@link TransactionCommittedRemotelyException} must
+ * surface over HTTP as 409 Conflict with an explicit do-not-retry detail - never as a retryable 5xx.
+ * A 503 (or a load-balancer-retried 500) would invite the client to re-drive the write, inserting
+ * duplicates of records the cluster already committed: the exact hazard the distinct exception type
+ * exists to prevent. Same rationale as the DuplicatedKeyException 409 mapping from issue #4350.
+ * <p>
+ * The exception can only be produced by the Raft HA layer (ha-raft module), which the server module
+ * cannot depend on, so this test drives the REAL {@code handleRequest} catch chain directly with a
+ * handler whose {@code execute()} throws - the same seam the production exception propagates through
+ * (it is thrown from {@code database.commit()} inside the handler's execute path). The full
+ * cluster-side path, including this 409 over a real wire, is covered end-to-end by
+ * {@code Issue5064CommittedRemotelyContractIT} in the ha-raft module.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class Issue5064CommittedRemotelyHttpStatusTest {
+
+  @Test
+  void committedRemotelyMapsTo409WithDoNotRetryDetail() {
+    final HandledResponse response = handle(new TransactionCommittedRemotelyException(
+        "Transaction TX(1) is committed cluster-wide but the local apply failed"
+            + " (local pages reconciled from the replicated payload). Do NOT retry: reload the records and continue",
+        new IllegalStateException("simulated local apply failure")));
+
+    assertThat(response.statusCode)
+        .as("committed-remotely must map to 409 Conflict, not a retry-worthy 5xx (body=%s)", response.body)
+        .isEqualTo(409);
+
+    final JSONObject json = new JSONObject(response.body);
+    assertThat(json.getString("error")).isEqualTo("Transaction committed cluster-wide but the local apply failed - do not retry");
+    assertThat(json.getString("exception")).isEqualTo(TransactionCommittedRemotelyException.class.getName());
+    assertThat(json.getString("detail")).contains("committed cluster-wide").contains("Do NOT retry");
+  }
+
+  @Test
+  void plainTransactionExceptionStillMapsTo500() {
+    // Guards the catch ORDER: the committed-remotely arm precedes the generic TransactionException arm.
+    // If a refactor reordered them, the specific type would fall into this generic 500 mapping instead.
+    final HandledResponse response = handle(new TransactionException("Error on commit"));
+
+    assertThat(response.statusCode).isEqualTo(500);
+    assertThat(new JSONObject(response.body).getString("error")).isEqualTo("Error on transaction commit");
+  }
+
+  @Test
+  void needRetryExceptionStillMapsTo503() {
+    // The retryable/non-retryable split: a NeedRetryException subtype keeps the retry-worthy 503,
+    // while TransactionCommittedRemotelyException (deliberately NOT a NeedRetryException) gets 409.
+    final HandledResponse response = handle(new ConcurrentModificationException("Record modified by another transaction"));
+
+    assertThat(response.statusCode).isEqualTo(503);
+    assertThat(new JSONObject(response.body).getString("error")).isEqualTo("Cannot execute command");
+  }
+
+  private record HandledResponse(int statusCode, String body) {
+  }
+
+  /**
+   * Runs the real {@link AbstractServerHttpHandler#handleRequest} against a handler whose
+   * {@code execute()} throws the given exception, and captures the status code and JSON body the
+   * catch chain produces.
+   */
+  private HandledResponse handle(final RuntimeException toThrow) {
+    final ArcadeDBServer server = mock(ArcadeDBServer.class);
+    when(server.getObservationRegistry()).thenReturn(ObservationRegistry.create());
+    when(server.getConfiguration()).thenReturn(new ContextConfiguration());
+    when(server.getServerName()).thenReturn("test");
+
+    final HttpServer httpServer = mock(HttpServer.class);
+    when(httpServer.getServer()).thenReturn(server);
+
+    final Sender sender = mock(Sender.class);
+    final HttpServerExchange exchange = mock(HttpServerExchange.class);
+    final int[] statusCode = { 200 };
+    when(exchange.setStatusCode(anyInt())).thenAnswer(invocation -> {
+      statusCode[0] = invocation.getArgument(0);
+      return exchange;
+    });
+    when(exchange.getStatusCode()).thenAnswer(invocation -> statusCode[0]);
+    when(exchange.getRequestHeaders()).thenReturn(new HeaderMap());
+    when(exchange.getResponseHeaders()).thenReturn(new HeaderMap());
+    when(exchange.getRequestMethod()).thenReturn(Methods.POST);
+    when(exchange.getRelativePath()).thenReturn("/command/graph");
+    when(exchange.getResponseSender()).thenReturn(sender);
+
+    new ThrowingHandler(httpServer, toThrow).handleRequest(exchange);
+
+    final ArgumentCaptor<String> body = ArgumentCaptor.forClass(String.class);
+    verify(sender).send(body.capture());
+    return new HandledResponse(statusCode[0], body.getValue());
+  }
+
+  /** Handler whose execute() throws, standing in for a command execution that fails at commit time. */
+  private static final class ThrowingHandler extends AbstractServerHttpHandler {
+    private final RuntimeException toThrow;
+
+    private ThrowingHandler(final HttpServer httpServer, final RuntimeException toThrow) {
+      super(httpServer);
+      this.toThrow = toThrow;
+    }
+
+    @Override
+    protected ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user,
+        final JSONObject payload) {
+      throw toThrow;
+    }
+
+    @Override
+    public boolean isRequireAuthentication() {
+      // Skip the Authorization machinery: this test targets the error-mapping catch chain only.
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
Implements option A from the #5064 design discussion.

## The problem
When the Raft quorum durably commits a transaction but the leader's **local** phase-2 apply fails, the application received a generic commit failure - told the commit failed while the data was committed cluster-wide. Worse: an application-level retry of the same records **inserted duplicates**, because the #4940 rollback reset their identities to provisional and the retry re-inserted records the cluster already held.

## The fix
- **`TransactionCommittedRemotelyException`** (engine exception package, catchable without an ha-raft dependency): states the transaction IS committed cluster-wide, whether local pages were reconciled, and that it must NOT be retried. `reconcileLeaderPagesAfterPhase2Failure` now reports its outcome instead of swallowing it.
- **A `remotelyCommitted` durability regime in `TransactionContext`**, set by the HA layer after quorum commit: a local failure past that point releases resources **without** rolling back user-held record identities (they are the identities the cluster committed) and **without** fencing (no orphaned local WAL record exists; the Raft layer reconciles pages from the replicated payload). Slots between the `walAppended` and fence-refused/rollback regimes - #4940/#5053 semantics unchanged for non-replicated databases. The ALL-quorum recovery path gets the same boundary shift.

## Verification
Red-first: `Issue5064CommittedRemotelyContractIT` (3-node cluster, single-shot post-quorum fault) fails on pre-fix behavior (raw exception escapes, identity reset) and passes with the fix - distinct type, actionable message, identity preserved, all nodes converge on the committed data after step-down. HA phase-2 battery green (`Issue4740Phase2ReconcileIT`, `Issue5018Phase2ConflictMessageTest`, `DatabaseReconcilerTest`); engine commit-path battery green (WalCommitOrdering, Issue4940, Issue4959, ExplicitLocking, IsolationContract).

## Conflict risks
`TransactionContext` (one new field + one new regime branch in the finally) - the follow-up fan-out workers do not touch it.