### PR TITLE
fix(#5067): low-severity audit residuals (kill() lock symmetry, page-stats math, LSM counter drift, context prune)

### DIFF
--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -361,8 +361,9 @@ that could starve the very snapshot resync meant to heal the node.
   instead of hardcoding 1, so auto-compaction is no longer deferred by up to a full threshold of new
   pages after every restart. Items deliberately left open on #4958/#4960 with reasoning on the issues:
   the `activeWALFilePool` element publication (needs an `AtomicReferenceArray` refactor of a
-  conflict-heavy file), the `createNewPage` rollback counter drift and the descending duplicate-run
-  cursor rescan (perf-only).
+  conflict-heavy file) and the descending duplicate-run cursor rescan (perf-only); the `createNewPage`
+  rollback counter drift was subsequently fixed in
+  [#5067](https://github.com/ArcadeData/arcadedb/issues/5067).
 - **Transaction commit cleanups (2026-07 audit).** A phase-2 commit failure that happens BEFORE the
   transaction reaches the WAL now restores user-held record state like a phase-1 failure does (rollback):
   records created in the failed transaction get their optimistically-assigned RID reset to provisional and
@@ -383,6 +384,20 @@ that could starve the very snapshot resync meant to heal the node.
   page-level MVCC isolation contract (no read-set validation: write skew and phantoms possible under both
   levels, unbounded per-transaction page cache under `REPEATABLE_READ`) is now documented on
   `Database.TRANSACTION_ISOLATION_LEVEL` and pinned by tests.
+- **Low-severity audit residuals (2026-07 audit).** Four small residuals collected from the audit
+  follow-up PRs ([#5067](https://github.com/ArcadeData/arcadedb/issues/5067)):
+  `TransactionContext.kill()` (test-only API) now releases the file locks acquired by a commit's 1st
+  phase instead of leaking the `LockManager` entries until the whole lock manager is torn down (symmetry
+  with `reset()`); `LocalBucket.updatePageStatistics` now measures free space against the usable page
+  content region like `gatherPageStatistics` does (#4958), instead of the physical page size that
+  overstated every page by the page header and skewed the reuse-space threshold; the LSM mutable index
+  re-aligns its uncompacted-pages counter with the real page count at commit time, so page creations
+  discarded by a rolled-back transaction can no longer inflate the counter and schedule auto-compaction
+  early; and the periodic thread-context sweep now opportunistically drops the empty per-thread entries a
+  foreign database close leaves behind (a claim/re-check protocol closes the #4939 re-registration race),
+  so open/close churn on large long-lived thread pools no longer accumulates them. A file-enumeration
+  audit of backup, snapshot and resync paths against the `.wal.corrupt` evidence files confirmed all
+  sites use extension allowlists (report on the issue); no changes needed.
 
 ### Improvements
 

--- a/engine/src/main/java/com/arcadedb/database/DatabaseContext.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseContext.java
@@ -163,8 +163,9 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
       // DO NOT PRUNE THE CONTEXTS ENTRY HERE EVEN WHEN THE MAP BECAME EMPTY: THIS RUNS ON THE CLOSING THREAD AND
       // WOULD RACE THE OWNER THREAD'S init() RE-REGISTRATION, UNREGISTERING A LIVE CONTEXT (ISSUE #4939). AN
       // EMPTY ENTRY LINGERS UNTIL ITS OWNER NEXT TOUCHES THE CONTEXT API (removeContext/
-      // removeCurrentThreadContexts) OR DIES (DEAD-THREAD SWEEP): AN IDLE LIVE THREAD KEEPS A TINY EMPTY-MAP
-      // ENTRY MEANWHILE, BOUNDED BY THE LIVE-THREAD COUNT
+      // removeCurrentThreadContexts), DIES (DEAD-THREAD SWEEP) OR THE PERIODIC SWEEP OPPORTUNISTICALLY DROPS
+      // IT WITH ITS CLAIM/RE-CHECK PROTOCOL (#5067): AN IDLE LIVE THREAD KEEPS A TINY EMPTY-MAP ENTRY
+      // MEANWHILE, BOUNDED BY THE LIVE-THREAD COUNT
     }
     return result;
   }
@@ -228,7 +229,9 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
 
   /**
    * Scans CONTEXTS and removes the entries whose owning thread is no longer alive, rolling back any transaction
-   * they abandoned. Called periodically as a safety net. Liveness is checked per entry via the thread weak
+   * they abandoned. Also opportunistically drops the empty entries of LIVE threads left behind by a foreign
+   * database close ({@code removeAllContexts} cannot prune them without racing the owner, see #4939/#5067);
+   * that prune is allocation-free and never rolls anything back. Called periodically as a safety net. Liveness is checked per entry via the thread weak
    * reference ({@link ThreadContexts}), which is virtual-thread-correct and safepoint-free (issue #4956).
    * Rolling back the abandoned transactions releases their file locks: before this, the sweep dropped the map
    * entries only, so the {@code LockManager} files locked by a thread that died with an open transaction (for
@@ -296,6 +299,21 @@ public class DatabaseContext extends ThreadLocal<Map<String, DatabaseContext.Dat
                     .append("' transactions=").append(rolled);
               }
             }
+      } else if (threadContexts.contexts.isEmpty()) {
+        // #5067: A LIVE THREAD'S ENTRY WHOSE PER-DATABASE MAP IS NOW EMPTY, LEFT BEHIND BY A FOREIGN CLOSE
+        // (removeAllContexts DELIBERATELY DOES NOT PRUNE, SEE THE #4939 NOTE THERE). DROP IT SO OPEN/CLOSE
+        // CHURN ON LARGE LONG-LIVED POOLS (E.G. THE ~500 UNDERTOW WORKERS) DOES NOT ACCUMULATE EMPTY
+        // ENTRIES. THE HAZARD IS THE #4939 RACE: THE OWNER'S init() MAY HAVE JUST REPOPULATED THE MAP AND
+        // SKIPPED ITS RE-PUT ON THE IDENTITY FAST-PATH, SO A BARE REMOVE COULD UNREGISTER A LIVE CONTEXT.
+        // THE CLAIM/RE-CHECK PROTOCOL CLOSES IT: CLAIM THE EXACT ENTRY (VALUE-KEYED REMOVE), RE-CHECK
+        // EMPTINESS, AND RESTORE THE SAME ENTRY IF THE OWNER REPOPULATED MEANWHILE. ORDERING ARGUMENT: IN
+        // init() THE OWNER'S map.put ALWAYS PRECEDES ITS CONTEXTS REGISTRATION CHECK. IF THAT map.put
+        // LINEARIZES BEFORE THE RE-CHECK, THE RE-CHECK SEES NON-EMPTY AND RESTORES (putIfAbsent, SO A
+        // REGISTRATION THE OWNER ALREADY REFRESHED WINS); IF AFTER, THE OWNER'S SUBSEQUENT CHECK SEES THE
+        // ENTRY GONE AND RE-REGISTERS ITSELF. EITHER WAY NO LIVE REGISTRATION IS LOST. NO ROLLBACKS RUN
+        // HERE (THE MAP IS EMPTY), SO THE TWO-LEVEL CLAIM DISCIPLINE ABOVE IS UNTOUCHED; ALLOCATION-FREE
+        if (CONTEXTS.remove(entry.getKey(), threadContexts) && !threadContexts.contexts.isEmpty())
+          CONTEXTS.putIfAbsent(entry.getKey(), threadContexts);
       }
     }
 

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -558,7 +558,13 @@ public class TransactionContext implements Transaction {
       database.getTransactionManager().unlockFilesInOrder(explicitLockedFiles, getRequester());
       explicitLockedFiles = null;
     }
-    lockedFiles = null;
+    // #5067: SAME RELEASE SYMMETRY AS reset(). NULLING THE FIELD WITHOUT UNLOCKING LEAKED THE LockManager
+    // ENTRIES OF A TRANSACTION KILLED IN COMMIT_1ST_PHASE (WHERE lockFilesInOrder POPULATED lockedFiles)
+    // UNTIL TransactionManager.kill() CLOSED THE WHOLE LOCK MANAGER
+    if (lockedFiles != null) {
+      database.getTransactionManager().unlockFilesInOrder(lockedFiles, getRequester());
+      lockedFiles = null;
+    }
     modifiedPages = null;
     newPages = null;
     updatedRecords = null;

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -2114,7 +2114,10 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
       if (availableSpace + delta == 0)
         freeSpaceInPages.remove(pageId, -1);
       else {
-        final int usableSpaceInPage = getPageSize() - contentHeaderSize;
+        // #5067: same usable-space base as gatherPageStatistics() (#4958): measure against the usable
+        // content region (physical page size minus the page header), not the physical page size, which
+        // overstated the space of every page and skewed the GATHER_STATS_MIN_SPACE_PERC threshold
+        final int usableSpaceInPage = getPageSize() - BasePage.PAGE_HEADER_SIZE - contentHeaderSize;
 
         final boolean hasEntry = freeSpaceInPages.containsKey(pageId);
         final int existingFreeSpace = hasEntry ? freeSpaceInPages.get(pageId, 0) : 0;

--- a/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
+++ b/engine/src/main/java/com/arcadedb/index/lsm/LSMTreeIndexMutable.java
@@ -144,6 +144,16 @@ public class LSMTreeIndexMutable extends LSMTreeIndexAbstract {
 
   @Override
   public void onAfterCommit() {
+    // #5067: createNewPage() increments currentMutablePages eagerly inside the transaction, so a rolled
+    // back transaction (e.g. a commit that failed in 1st phase after applying some index changes) discards
+    // the pages but not the increments, and the counter drifts above the real page count until the next
+    // reload (#5063's onAfterLoad re-derivation). The transaction's page counters are already published at
+    // this point of the commit, so clamp to the real total to keep the drift from scheduling a compaction
+    // early.
+    final int totalPages = getTotalPages();
+    if (currentMutablePages > totalPages)
+      currentMutablePages = totalPages;
+
     if (minPagesToScheduleACompaction > 1 && currentMutablePages >= minPagesToScheduleACompaction) {
       LogManager.instance()
           .log(this, Level.FINE, "Scheduled compaction of index '%s' (currentMutablePages=%d totalPages=%d)", null, componentName,

--- a/engine/src/test/java/com/arcadedb/database/DatabaseContextLifecycleTest.java
+++ b/engine/src/test/java/com/arcadedb/database/DatabaseContextLifecycleTest.java
@@ -148,6 +148,67 @@ class DatabaseContextLifecycleTest extends TestHelper {
   }
 
   @Test
+  void sweepPrunesEmptyEntryOfLiveThreadAfterForeignClose() throws Exception {
+    final CountDownLatch registered = new CountDownLatch(1);
+    final CountDownLatch pruned = new CountDownLatch(1);
+    final CountDownLatch reinitDone = new CountDownLatch(1);
+    final CountDownLatch release = new CountDownLatch(1);
+    final AtomicReference<Throwable> workerError = new AtomicReference<>();
+
+    final Thread worker = new Thread(() -> {
+      try {
+        database.begin();
+        database.rollback();
+        registered.countDown();
+        // STAYS ALIVE AND IDLE, LIKE A LONG-LIVED POOL THREAD THAT OPENED AND CLOSED A DATABASE
+        if (!pruned.await(10, TimeUnit.SECONDS))
+          throw new IllegalStateException("prune signal not received");
+        // AFTER THE PRUNE, THE OWNER'S NEXT init() MUST RE-REGISTER CLEANLY
+        database.begin();
+        database.rollback();
+        reinitDone.countDown();
+        release.await(10, TimeUnit.SECONDS);
+      } catch (final Throwable e) {
+        workerError.set(e);
+      } finally {
+        DatabaseContext.INSTANCE.removeCurrentThreadContexts();
+      }
+    }, "ctx-lifecycle-live-empty");
+    worker.start();
+
+    assertThat(registered.await(10, TimeUnit.SECONDS)).isTrue();
+    try {
+      assertThat(DatabaseContext.isThreadRegistered(worker.threadId())).isTrue();
+
+      // A FOREIGN CLOSE (removeAllContexts ON THIS THREAD) EMPTIES THE WORKER'S PER-DATABASE MAP BUT
+      // DELIBERATELY DOES NOT PRUNE ITS CONTEXTS ENTRY (#4939): THE EMPTY ENTRY LINGERS WHILE THE WORKER
+      // IS ALIVE
+      DatabaseContext.INSTANCE.removeAllContexts(database.getDatabasePath());
+      assertThat(DatabaseContext.isThreadRegistered(worker.threadId())).isTrue();
+
+      // #5067: THE PERIODIC SWEEP MUST OPPORTUNISTICALLY DROP THE NOW-EMPTY ENTRY EVEN THOUGH ITS OWNER IS
+      // STILL ALIVE, SO OPEN/CLOSE CHURN ON LARGE LONG-LIVED THREAD POOLS DOES NOT ACCUMULATE EMPTY ENTRIES
+      DatabaseContext.cleanupDeadThreads();
+      assertThat(DatabaseContext.isThreadRegistered(worker.threadId()))
+          .as("the sweep must prune a live thread's empty context entry")
+          .isFalse();
+
+      // THE PRUNED OWNER RE-REGISTERS ON ITS NEXT init()
+      pruned.countDown();
+      assertThat(reinitDone.await(10, TimeUnit.SECONDS)).isTrue();
+      assertThat(DatabaseContext.isThreadRegistered(worker.threadId())).isTrue();
+    } finally {
+      pruned.countDown();
+      release.countDown();
+    }
+
+    worker.join(10_000);
+    assertThat(worker.isAlive()).isFalse();
+    assertThat(workerError.get()).isNull();
+    assertThat(DatabaseContext.isThreadRegistered(worker.threadId())).isFalse();
+  }
+
+  @Test
   void gavAsyncBuildUnregistersWorkerContext() {
     database.getSchema().getOrCreateVertexType("Person");
     database.getSchema().getOrCreateEdgeType("Knows");

--- a/engine/src/test/java/com/arcadedb/database/DatabaseContextLifecycleTest.java
+++ b/engine/src/test/java/com/arcadedb/database/DatabaseContextLifecycleTest.java
@@ -183,6 +183,9 @@ class DatabaseContextLifecycleTest extends TestHelper {
       // A FOREIGN CLOSE (removeAllContexts ON THIS THREAD) EMPTIES THE WORKER'S PER-DATABASE MAP BUT
       // DELIBERATELY DOES NOT PRUNE ITS CONTEXTS ENTRY (#4939): THE EMPTY ENTRY LINGERS WHILE THE WORKER
       // IS ALIVE
+      // NOTE (#5076 review): this empties the per-db map for EVERY thread that had the db open, including
+      // THIS main test thread - the sweep may prune the main thread's now-empty entry too. Harmless: the
+      // next context-API touch (teardown's init()) re-registers it; the assertions below key on the worker.
       DatabaseContext.INSTANCE.removeAllContexts(database.getDatabasePath());
       assertThat(DatabaseContext.isThreadRegistered(worker.threadId())).isTrue();
 

--- a/engine/src/test/java/com/arcadedb/database/Issue5067KillLockSymmetryTest.java
+++ b/engine/src/test/java/com/arcadedb/database/Issue5067KillLockSymmetryTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.engine.TransactionManager;
+import com.arcadedb.utility.LockManager;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5067 (item 1): {@code TransactionContext.kill()} released the explicit lock
+ * set but nulled {@code lockedFiles} WITHOUT unlocking, so killing a transaction caught in
+ * COMMIT_1ST_PHASE (its file locks acquired by {@code commit1stPhase}) leaked the {@code LockManager}
+ * entries until {@code TransactionManager.kill()} closed the whole lock manager. Test-only API, but the
+ * release must be symmetric with {@code reset()}.
+ */
+class Issue5067KillLockSymmetryTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    database.getSchema().createDocumentType("Issue5067Type");
+  }
+
+  @Test
+  void killAfterCommit1stPhaseReleasesFileLocks() {
+    database.begin();
+    database.newDocument("Issue5067Type").set("k", 1).save();
+
+    final TransactionContext tx = ((DatabaseInternal) database).getTransaction();
+
+    // Bring the transaction into COMMIT_1ST_PHASE: this is where lockFilesInOrder populates lockedFiles.
+    assertThat(tx.commit1stPhase(true)).isNotNull();
+
+    tx.kill();
+    // Leave the killed context inactive so the teardown close does not try to roll back its nulled state.
+    tx.setStatus(TransactionContext.STATUS.INACTIVE);
+
+    // The file locks acquired by commit1stPhase must have been released by kill(): a foreign requester
+    // must be able to lock the same bucket file within the (short) timeout instead of timing out on a
+    // lock still keyed to the killed transaction's requester.
+    final int bucketFileId = database.getSchema().getType("Issue5067Type").getBuckets(false).getFirst().getFileId();
+    final TransactionManager transactionManager = ((DatabaseInternal) database).getTransactionManager();
+    final Object foreignRequester = new Object();
+
+    final LockManager.LOCK_STATUS status = transactionManager.tryLockFile(bucketFileId, 1_000L, foreignRequester);
+    assertThat(status).as("kill() must release the COMMIT_1ST_PHASE file locks (symmetry with reset())")
+        .isEqualTo(LockManager.LOCK_STATUS.YES);
+
+    transactionManager.unlockFile(bucketFileId, foreignRequester);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/index/Issue5067MutablePagesCounterDriftTest.java
+++ b/engine/src/test/java/com/arcadedb/index/Issue5067MutablePagesCounterDriftTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.index;
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.index.lsm.LSMTreeIndex;
+import com.arcadedb.index.lsm.LSMTreeIndexMutable;
+import com.arcadedb.schema.DocumentType;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #5067 (item 3): {@code LSMTreeIndexMutable.createNewPage()} increments
+ * {@code currentMutablePages} eagerly inside the transaction, so a rollback discards the pages but not
+ * the increments. The counter drifted above the real page count for the rest of the run (it only
+ * self-corrected on reload after #5063's onAfterLoad fix), inflating the auto-compaction scheduling
+ * check in {@code onAfterCommit}. The fix clamps the counter to the real page count at commit time.
+ */
+class Issue5067MutablePagesCounterDriftTest extends TestHelper {
+
+  @Override
+  protected void beginTest() {
+    final DocumentType type = database.getSchema().createDocumentType("Issue5067Doc");
+    type.createProperty("id", Type.STRING);
+    database.getSchema().buildTypeIndex("Issue5067Doc", new String[] { "id" }).withType(Schema.INDEX_TYPE.LSM_TREE)
+        .withUnique(false).withPageSize(4_096).create();
+  }
+
+  @Test
+  void rolledBackPageCreationsDoNotDriftTheMutablePagesCounter() {
+    final TypeIndex typeIndex = database.getSchema().getType("Issue5067Doc").getAllIndexes(false).iterator().next();
+    final LSMTreeIndex lsmIndex = (LSMTreeIndex) typeIndex.getIndexesOnBuckets()[0];
+    final LSMTreeIndexMutable mutable = lsmIndex.getMutableIndex();
+    final int bucketFileId = database.getSchema().getType("Issue5067Doc").getBuckets(false).getFirst().getFileId();
+
+    // Create index pages inside a transaction that rolls back: put directly on the mutable index (the
+    // regular record path defers index writes to commit) so createNewPage runs, then discard everything.
+    database.begin();
+    try {
+      for (int i = 0; i < 2_000; i++)
+        mutable.put(new Object[] { "key-" + i }, new RID[] { new RID(bucketFileId, i) });
+    } finally {
+      database.rollback();
+    }
+
+    // Precondition documenting the drift: the rolled-back page creations left the counter above the
+    // real (persistent) page count.
+    assertThat(mutable.getCurrentMutablePages())
+        .as("rolled-back page creations must have drifted the counter for this test to be meaningful")
+        .isGreaterThan(mutable.getTotalPages());
+
+    // A committed write to the index triggers onAfterCommit, which must re-align the counter with the
+    // real page count instead of feeding the drifted value to the compaction scheduling check.
+    database.transaction(() -> database.newDocument("Issue5067Doc").set("id", "committed").save());
+
+    assertThat(mutable.getCurrentMutablePages())
+        .as("after a commit the counter must not exceed the real page count")
+        .isLessThanOrEqualTo(mutable.getTotalPages());
+  }
+}


### PR DESCRIPTION
Closes #5067. Part of the 2026-07 audit follow-up (#4962). All five items re-verified against current main before touching anything.

## Per-item verdicts

| # | Item | Verdict |
|---|------|---------|
| 1 | `TransactionContext.kill()` lock asymmetry | **Fixed.** Reproduced on main: kill() nulled `lockedFiles` without unlocking, leaking the LockManager entries of a tx killed in COMMIT_1ST_PHASE until `TransactionManager.kill()`. Now mirrors `reset()`'s release block (pure `getRequester()`, same as every release path). |
| 2 | `LocalBucket.updatePageStatistics` free-space math | **Fixed.** Reproduced on main: threshold denominator was `getPageSize() - contentHeaderSize`, the same header overstatement #4958 fixed in `gatherPageStatistics`. Unified on the usable content region (`- BasePage.PAGE_HEADER_SIZE`). 8-byte threshold shift only; no deterministic public observation point, so no dedicated test (honest label), covered by existing bucket/stats suites. |
| 3 | `LSMTreeIndexMutable.createNewPage` counter drift on rollback | **Fixed.** Reproduced on main (counter 9 vs 1 real page after a rolled-back page-creating tx). Minimal fix: `onAfterCommit` clamps `currentMutablePages` to `getTotalPages()` (page counters already published at that point), so drift can no longer schedule compaction early. Deliberately did NOT add a rollback callback to the commit path (just stabilized through ~50 review rounds); the clamp bounds the drift exactly where it matters. |
| 4 | Node-local file-enumeration audit (`.wal.corrupt` evidence files) | **Report-only, no changes needed.** See audit below. |
| 5 | Empty ThreadContexts retention (appended in issue comment) | **Implemented.** The periodic sweep (invoked from `init()` every 1000th call) now opportunistically drops live threads' empty entries via a claim/re-check protocol (value-keyed remove, re-check emptiness, `putIfAbsent` the same entry back if the owner repopulated). Allocation-free, no rollbacks, two-level claim discipline untouched; the #4939 ordering argument is documented inline (owner's `map.put` always precedes its CONTEXTS registration check). |

## Item 4: file-enumeration audit (sites checked, verdict each)

The `.wal.corrupt` evidence files (#4958) required a skip-list extension in ha-raft `SnapshotManager.computeFileChecksums` - audited every other enumeration site for the same "only `*.wal` is node-local" assumption:

- `FileManager.scanDirectoryForComponentFiles` - **safe**: extension allowlist (`supportedFileExt`); `corrupt` is not a registered extension, evidence files are never adopted as components.
- `TransactionManager` WAL adoption (lines 211/271/846) - **safe**: `endsWith(".wal")` cannot match `foo.wal.corrupt`; that non-adoption is exactly the #4958 design.
- Full backup (`FullBackupFormat`) - **safe**: backs up registered `ComponentFile`s + config + schema only; never enumerates the directory, WAL and evidence files never enter a backup.
- Snapshot serving (`SnapshotHttpHandler`) - **safe**: registered components + config + schema + explicit `.ts.sealed` allowlist; `.wal`/`.corrupt` never shipped.
- Snapshot install (`SnapshotInstaller` clearLive/atomicSwap/restoreBackup/cleanupWal) - **safe by design**: wholesale directory replacement moves/deletes everything non-`.snapshot*`, so evidence files from the replaced generation go with the data they belong to; `cleanupWalFiles` deletes only `*.wal` and leaves evidence alone.
- `BootstrapFingerprint` - **safe**: suffix allowlist (`.bucket`, index/vector extensions, schema, config); `.corrupt` files never absorbed, so fingerprints cannot diverge on evidence presence.
- ha-raft `SnapshotManager.computeFileChecksums` - **already fixed** in #4958 (skips `.wal`, `.prev.json`, `.lock`, `.corrupt`).
- Cosmetic notes (not defects, no action): `LocalDatabase.getSize()` walks the whole directory and includes evidence files in the reported size; legacy network-HA resync no longer exists (replaced by ha-raft).

## Tests

- New (red-first, failure evidence in commit message): `Issue5067KillLockSymmetryTest` (lock was NO on timeout before, YES after), `Issue5067MutablePagesCounterDriftTest` (counter 9 vs 1 before), `DatabaseContextLifecycleTest#sweepPrunesEmptyEntryOfLiveThreadAfterForeignClose` (entry lingered before; also asserts owner re-registration after the prune).
- Connected suites, all green: ACIDTransactionTest (11, includes the db.kill() crash-simulation paths), ExplicitLockingTransactionTest, LockTimeoutRetryTest, DatabaseContextLifecycleTest (9/9), Issue4511OpenFailureLockLeakTest, Issue4547ReadOnlyRecoveryLockLeakTest, TransactionContextRemoveFileTest, ProtocolContextTest, Issue4958StorageStatsTest, LocalBucketRecordPositionTest, Issue4960LSMReloadCompactionCounterTest, Issue4960LSMCloseDuringCompactionTest, ConcurrentCompactionTest, MultipleDatabasesTest.

## Conflict risks

- `docs/release-26.7.2.md`: appended a bullet and amended the #4960 "left open" list (the counter-drift item is now fixed here) - expected to conflict with sibling audit PRs, trivial to resolve.
- `DatabaseContext.java` / `DatabaseContextLifecycleTest.java`: touches the #5060 sweep - any sibling touching the context lifecycle will conflict textually (comments/branch added inside `cleanupDeadThreads`).
- `TransactionContext.java`: 7-line addition inside `kill()` only; no commit-path logic touched.