### PR TITLE
fix(#5065): bound the parallel select producer offer, stop the 100% CPU spin

### DIFF
--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -392,8 +392,6 @@ that could starve the very snapshot resync meant to heal the node.
   conflict-heavy file) and the descending duplicate-run cursor rescan (perf-only); the `createNewPage`
   rollback counter drift was subsequently fixed in
   [#5067](https://github.com/ArcadeData/arcadedb/issues/5067).
-  conflict-heavy file), the `createNewPage` rollback counter drift and the descending duplicate-run
-  cursor rescan (perf-only).
 - **Storage: flush suspension is refcounted - overlapping backup/verify/snapshot each own their window
   (2026-07 audit follow-up).** `suspendFlushAndExecute` ownership was first-caller-wins: with two
   concurrent suspenders on the same database (SQL `BACKUP DATABASE`, the HA verify endpoint, HA snapshot
@@ -446,8 +444,14 @@ that could starve the very snapshot resync meant to heal the node.
   receive fewer records than requested (down to zero on a fast producer); `skip` crashed with a
   `NullPointerException` (the base constructor consumed the skipped records before the parallel machinery
   existed); and a record published between the consumer's last poll and the final producer's countdown
-  could be silently dropped at end of stream
-  ([#5065](https://github.com/ArcadeData/arcadedb/issues/5065)).
+  could be silently dropped at end of stream. Review follow-ups on the same PR: the select `timeout` is
+  enforced on every fetch, including when records are immediately available (it was previously only
+  checked on an empty queue, so a slow consumer of an always-full queue could run unbounded past its
+  timeout); the consumer got the same spin-then-park backoff as the producers, so a slow producer (e.g. a
+  heavy WHERE scanning many non-matching rows) no longer pins the caller thread at 100% CPU; and
+  `skip(s).limit(n)` together now returns `n` records after the `s` skipped ones (standard semantics, like
+  the ORDER BY path) instead of `n - s` - this last fix is in the shared base iterator, so it corrects the
+  serial non-ordered path too ([#5065](https://github.com/ArcadeData/arcadedb/issues/5065)).
 - **Low-severity audit residuals (2026-07 audit).** Four small residuals collected from the audit
   follow-up PRs ([#5067](https://github.com/ArcadeData/arcadedb/issues/5067)):
   `TransactionContext.kill()` (test-only API) now releases the file locks acquired by a commit's 1st

--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -383,6 +383,26 @@ that could starve the very snapshot resync meant to heal the node.
   page-level MVCC isolation contract (no read-set validation: write skew and phantoms possible under both
   levels, unbounded per-transaction page cache under `REPEATABLE_READ`) is now documented on
   `Database.TRANSACTION_ISOLATION_LEVEL` and pinned by tests.
+- **Parallel select no longer pins async workers at 100% CPU when the consumer stops draining (2026-07
+  audit follow-up).** The native-query `select().parallel()` iterator hands records from its per-bucket
+  async browse tasks to the consumer through a fixed 4,096-slot queue, and the producers offered into it
+  with an unbounded busy-spin: a consumer that stopped fetching (an exception in user code, an early
+  return, or plain abandonment) left one async worker per bucket spinning at 100% CPU forever, and the
+  next `Database.close()`/`drop()` hung indefinitely behind the async executor's unbounded
+  `waitCompletion()`. The offer is now bounded: producers park briefly between attempts and give up
+  cleanly - through the regular task-completion path, preserving the async executor contracts hardened
+  with #5062 - when the iterator is closed, the worker is interrupted (executor shutdown), the limit is
+  already satisfied, or the consumer makes no progress for the whole stall bound (the select timeout when
+  set, otherwise 60s, matching the async executor's zero-progress backstop). A consumer still alive after
+  the producers stall out gets a `TimeoutException` instead of a silently truncated result set (unless it
+  opted into truncation with a non-throwing timeout), and `SelectIterator` is now `AutoCloseable` so an
+  early-terminating consumer can release the producers deterministically. The rework also fixes three
+  latent defects in the parallel path: `limit` was accounted on the producer side, so the consumer could
+  receive fewer records than requested (down to zero on a fast producer); `skip` crashed with a
+  `NullPointerException` (the base constructor consumed the skipped records before the parallel machinery
+  existed); and a record published between the consumer's last poll and the final producer's countdown
+  could be silently dropped at end of stream
+  ([#5065](https://github.com/ArcadeData/arcadedb/issues/5065)).
 
 ### Improvements
 

--- a/engine/src/main/java/com/arcadedb/query/select/SelectIterator.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectIterator.java
@@ -82,7 +82,10 @@ public class SelectIterator<T extends Document> implements Iterator<T>, AutoClos
       return more;
     }
 
-    if (executor.select.limit > -1 && returned >= executor.select.limit)
+    // THE LIMIT COUNTS THE RECORDS RETURNED AFTER THE SKIPPED ONES (STANDARD SKIP/LIMIT SEMANTICS). `returned` IS
+    // ALREADY AT `skip` WHEN THE STREAMING STARTS BECAUSE THE CONSTRUCTOR CONSUMES THE SKIPPED RECORDS THROUGH
+    // hasNext()/next(), SO THE CAP IS skip + limit (THE ORDER BY PATH APPLIES THE SAME CAP ON THE SORTED RESULT SET)
+    if (executor.select.limit > -1 && returned >= (long) executor.select.limit + executor.select.skip)
       return false;
     if (next != null)
       return true;

--- a/engine/src/main/java/com/arcadedb/query/select/SelectIterator.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectIterator.java
@@ -40,7 +40,7 @@ import java.util.stream.StreamSupport;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-public class SelectIterator<T extends Document> implements Iterator<T> {
+public class SelectIterator<T extends Document> implements Iterator<T>, AutoCloseable {
   protected final SelectExecutor                   executor;
   protected final Iterator<? extends Identifiable> iterator;
   protected final Set<RID>                         filterOutRecords;
@@ -132,6 +132,16 @@ public class SelectIterator<T extends Document> implements Iterator<T> {
 
   public T nextOrNull() {
     return hasNext() ? next() : null;
+  }
+
+  /**
+   * Releases the resources associated to the iterator. The serial implementation has nothing to release; the parallel
+   * implementation ({@link SelectParallelIterator}) overrides this method to stop the background producers, so an early
+   * close does not leave async workers running (#5065). Closing an iterator is optional when it is fully consumed.
+   */
+  @Override
+  public void close() {
+    // NOTHING TO RELEASE IN THE SERIAL IMPLEMENTATION
   }
 
   public List<T> toList() {

--- a/engine/src/main/java/com/arcadedb/query/select/SelectParallelIterator.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectParallelIterator.java
@@ -52,15 +52,22 @@ import java.util.concurrent.locks.LockSupport;
  * gives up ends its task through the regular completion path, so the async executor contracts (completed() notification,
  * batch commit) are preserved.</p>
  *
+ * <p>
+ * The consumer mirrors the cooperative backoff: on an empty queue it spins briefly for low hand-off latency, then parks
+ * between polls. The select timeout is enforced on every fetch, including when records are immediately available, matching
+ * the serial path semantics.</p>
+ *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class SelectParallelIterator<T extends Document> extends SelectIterator<T> {
   // HOW LONG A PRODUCER WAITS ON A FULL QUEUE WITH ZERO CONSUMER PROGRESS BEFORE CONCLUDING THE CONSUMER IS GONE
   // (#5065). ALIGNED WITH THE ASYNC EXECUTOR ZERO-PROGRESS BACKSTOP INTRODUCED WITH #5062 (60 SECONDS BY DEFAULT).
   // A CONSUMER THAT POLLS NOTHING FOR THE WHOLE BOUND WHILE THE QUEUE IS FULL IS INDISTINGUISHABLE FROM A DEAD ONE
-  private static final long DEFAULT_STALL_TIMEOUT_MS = 60_000;
+  private static final long DEFAULT_STALL_TIMEOUT_MS   = 60_000;
   // PAUSE BETWEEN OFFER ATTEMPTS ON A FULL QUEUE: 0.1 MS KEEPS THE HAND-OFF LATENCY NEGLIGIBLE WITHOUT BURNING CPU
-  private static final long OFFER_PARK_NANOS         = 100_000;
+  private static final long OFFER_PARK_NANOS           = 100_000;
+  // EMPTY-QUEUE POLLS BEFORE THE CONSUMER SWITCHES FROM SPINNING TO PARKING (SEE fetchNext())
+  private static final int  CONSUMER_SPINS_BEFORE_PARK = 64;
 
   private final    CountDownLatch                       semaphore;
   private final    MultithreadConcurrentQueue<Document> queue;
@@ -103,25 +110,28 @@ public class SelectParallelIterator<T extends Document> extends SelectIterator<T
             return true;
 
           if (executor.select.rootTreeElement == null || executor.evaluateWhere(record)) {
-            if (filterOutRecords != null)
-              filterOutRecords.add(record.getIdentity());
-
             if (limit > -1 && produced.incrementAndGet() > limit)
               // ENOUGH RECORDS PRODUCED TO SATISFY THE LIMIT: THE CONSUMER CANNOT TAKE MORE, STOP THIS PRODUCER
+              // (BEFORE REGISTERING THE RECORD AMONG THE RETURNED ONES, SINCE IT IS NEVER HANDED OVER)
               return false;
+
+            if (filterOutRecords != null)
+              filterOutRecords.add(record.getIdentity());
 
             // BOUNDED OFFER (#5065): THE FORMER UNBOUNDED while(true) BUSY-SPIN PINNED AN ASYNC WORKER AT 100% CPU
             // FOREVER (AND HUNG Database.close() BEHIND ITS UNBOUNDED waitCompletion()) WHEN THE CONSUMER STOPPED
             // DRAINING BECAUSE OF AN EXCEPTION, AN EARLY CLOSE OR A SATISFIED LIMIT
+            boolean waiting = false;
             long waitStart = 0L;
             while (!queue.offer(record)) {
               if (closed || Thread.currentThread().isInterrupted())
                 return false;
 
               final long now = System.nanoTime();
-              if (waitStart == 0L)
+              if (!waiting) {
+                waiting = true;
                 waitStart = now;
-              else if (now - waitStart >= stallTimeoutNanos) {
+              } else if (now - waitStart >= stallTimeoutNanos) {
                 // THE CONSUMER MADE NO PROGRESS FOR THE WHOLE BOUND: GIVE UP INSTEAD OF SPINNING FOREVER. A CONSUMER
                 // STILL ALIVE IS TOLD THE RESULT SET WOULD BE INCOMPLETE (SEE fetchNext())
                 producerStalled = true;
@@ -155,12 +165,28 @@ public class SelectParallelIterator<T extends Document> extends SelectIterator<T
 
     final MultiIterator<? extends Identifiable> it = (MultiIterator<? extends Identifiable>) iterator;
 
+    int emptyPolls = 0;
     while (true) {
       if (producerStalled)
         return onProducerStalled();
 
       if (closed)
         return null;
+
+      // ENFORCE THE SELECT TIMEOUT ON EVERY FETCH, INCLUDING WHEN A RECORD IS IMMEDIATELY AVAILABLE: THE SERIAL PATH
+      // ALWAYS CHECKED IT AT THE TOP OF fetchNext(), SO A SLOW CONSUMER OF AN ALWAYS-READY QUEUE MUST STILL TIME OUT.
+      // THE CHECK IS A SHORT-CIRCUITED COMPARISON WHEN NO TIMEOUT IS SET, NEGLIGIBLE PER RECORD OTHERWISE
+      try {
+        if (it.checkForTimeout()) {
+          // TIMEOUT WITHOUT EXCEPTION REQUESTED: STOP THE PRODUCERS AND RETURN WHAT WAS FETCHED SO FAR
+          closed = true;
+          return null;
+        }
+      } catch (final TimeoutException e) {
+        // STOP THE PRODUCERS BEFORE SURFACING THE TIMEOUT TO THE CALLER
+        closed = true;
+        throw e;
+      }
 
       final T record = (T) queue.poll();
       if (record != null) {
@@ -179,19 +205,13 @@ public class SelectParallelIterator<T extends Document> extends SelectIterator<T
         return producerStalled ? onProducerStalled() : null;
       }
 
-      try {
-        if (it.checkForTimeout()) {
-          // TIMEOUT WITHOUT EXCEPTION REQUESTED: STOP THE PRODUCERS AND RETURN WHAT WAS FETCHED SO FAR
-          closed = true;
-          return null;
-        }
-      } catch (final TimeoutException e) {
-        // STOP THE PRODUCERS BEFORE SURFACING THE TIMEOUT TO THE CALLER
-        closed = true;
-        throw e;
-      }
-
-      Thread.onSpinWait();
+      // COOPERATIVE BACKOFF ON THE EMPTY QUEUE, MIRRORING THE PRODUCER SIDE: SPIN BRIEFLY TO KEEP THE HAND-OFF LATENCY
+      // LOW ON A TRANSIENT GAP, THEN PARK BETWEEN POLLS SO A SLOW PRODUCER (E.G. A HEAVY WHERE SCANNING MANY
+      // NON-MATCHING ROWS) DOES NOT PIN THE CALLER THREAD AT 100% CPU
+      if (++emptyPolls <= CONSUMER_SPINS_BEFORE_PARK)
+        Thread.onSpinWait();
+      else
+        LockSupport.parkNanos(OFFER_PARK_NANOS);
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/query/select/SelectParallelIterator.java
+++ b/engine/src/main/java/com/arcadedb/query/select/SelectParallelIterator.java
@@ -23,12 +23,16 @@ import com.arcadedb.database.Document;
 import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.async.DatabaseAsyncBrowseIterator;
 import com.arcadedb.database.async.DatabaseAsyncExecutorImpl;
+import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.utility.MultiIterator;
 import com.conversantmedia.util.concurrent.MultithreadConcurrentQueue;
 
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.LockSupport;
 
 /**
  * Query iterator returned from queries. Extends the base Java iterator with convenient methods.
@@ -40,16 +44,31 @@ import java.util.concurrent.CountDownLatch;
  * `filterOutRecords` keeps track of the returning RIDs to avoid returning duplicates.</p>
  *
  * <p>
- * This iterator creates
- * one task per bucket and execute the fetching in parallel. The fetched records are kept in memory in a list. The list
- * has a pointer to the last element fetched. Once fetched, the element is removed from the list, but the list is not shrunk
- * to avoid wasting CPU to save a few KB.</p>
+ * This iterator creates one task per bucket and executes the fetching in parallel on the database async workers. The
+ * fetched records are handed to the consumer through a fixed-size concurrent queue. A producer facing a full queue waits
+ * with a bounded park instead of busy-spinning (#5065): it gives up as soon as the iterator is closed, the worker is
+ * interrupted (executor shutdown), enough records were produced to satisfy the limit, or the consumer made no progress
+ * for the whole stall bound (the select timeout when set, otherwise {@link #DEFAULT_STALL_TIMEOUT_MS}). A producer that
+ * gives up ends its task through the regular completion path, so the async executor contracts (completed() notification,
+ * batch commit) are preserved.</p>
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class SelectParallelIterator<T extends Document> extends SelectIterator<T> {
-  private final CountDownLatch                   semaphore;
-  private final MultithreadConcurrentQueue<Document> queue;
+  // HOW LONG A PRODUCER WAITS ON A FULL QUEUE WITH ZERO CONSUMER PROGRESS BEFORE CONCLUDING THE CONSUMER IS GONE
+  // (#5065). ALIGNED WITH THE ASYNC EXECUTOR ZERO-PROGRESS BACKSTOP INTRODUCED WITH #5062 (60 SECONDS BY DEFAULT).
+  // A CONSUMER THAT POLLS NOTHING FOR THE WHOLE BOUND WHILE THE QUEUE IS FULL IS INDISTINGUISHABLE FROM A DEAD ONE
+  private static final long DEFAULT_STALL_TIMEOUT_MS = 60_000;
+  // PAUSE BETWEEN OFFER ATTEMPTS ON A FULL QUEUE: 0.1 MS KEEPS THE HAND-OFF LATENCY NEGLIGIBLE WITHOUT BURNING CPU
+  private static final long OFFER_PARK_NANOS         = 100_000;
+
+  private final    CountDownLatch                       semaphore;
+  private final    MultithreadConcurrentQueue<Document> queue;
+  // COUNTS THE RECORDS ENQUEUED BY THE PRODUCERS (POST WHERE/DEDUPLICATION), USED TO STOP THEM AT THE LIMIT. THE
+  // INHERITED `returned` FIELD COUNTS THE RECORDS HANDED TO THE CONSUMER, MATCHING THE SERIAL SEMANTICS (SEE hasNext())
+  private final    AtomicLong                           produced = new AtomicLong();
+  private volatile boolean                              closed   = false;
+  private volatile boolean                              producerStalled;
 
   protected SelectParallelIterator(final SelectExecutor executor, final Iterator<? extends Identifiable> iterator,
       final boolean enforceUniqueReturn) {
@@ -64,27 +83,53 @@ public class SelectParallelIterator<T extends Document> extends SelectIterator<T
       final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) database.async();
       final int backPressurePercentage = database.getConfiguration().getValueAsInteger(GlobalConfiguration.ASYNC_BACK_PRESSURE);
 
+      final int limit = executor.select.limit;
+      final long stallTimeoutNanos = TimeUnit.MILLISECONDS.toNanos(
+          executor.select.timeoutInMs > 0 ? executor.select.timeoutInMs : DEFAULT_STALL_TIMEOUT_MS);
+
       semaphore = new CountDownLatch(sources.size());
 
       for (int i = 0; i < sources.size(); i++) {
         final Iterator<? extends Identifiable> source = (Iterator<? extends Identifiable>) sources.get(i);
 
-        //System.out.printf("Iterator %d on %s\n", i, source);
-
         async.scheduleTask(-1, new DatabaseAsyncBrowseIterator(semaphore, record -> {
+          if (closed)
+            // THE CONSUMER CLOSED THE ITERATOR OR GAVE UP: STOP BROWSING. RETURNING FALSE ENDS THE TASK THROUGH THE
+            // REGULAR COMPLETION PATH (completed() + SEMAPHORE COUNTDOWN), WITHOUT THROWING THROUGH THE ASYNC WORKER
+            return false;
+
           if (filterOutRecords != null && filterOutRecords.contains(record.getIdentity()))
             // ALREADY RETURNED, AVOID DUPLICATES IN THE RESULT SET
             return true;
 
           if (executor.select.rootTreeElement == null || executor.evaluateWhere(record)) {
-            ++returned;
-
             if (filterOutRecords != null)
               filterOutRecords.add(record.getIdentity());
 
-            while (true) {
-              if (queue.offer(record))
-                break;
+            if (limit > -1 && produced.incrementAndGet() > limit)
+              // ENOUGH RECORDS PRODUCED TO SATISFY THE LIMIT: THE CONSUMER CANNOT TAKE MORE, STOP THIS PRODUCER
+              return false;
+
+            // BOUNDED OFFER (#5065): THE FORMER UNBOUNDED while(true) BUSY-SPIN PINNED AN ASYNC WORKER AT 100% CPU
+            // FOREVER (AND HUNG Database.close() BEHIND ITS UNBOUNDED waitCompletion()) WHEN THE CONSUMER STOPPED
+            // DRAINING BECAUSE OF AN EXCEPTION, AN EARLY CLOSE OR A SATISFIED LIMIT
+            long waitStart = 0L;
+            while (!queue.offer(record)) {
+              if (closed || Thread.currentThread().isInterrupted())
+                return false;
+
+              final long now = System.nanoTime();
+              if (waitStart == 0L)
+                waitStart = now;
+              else if (now - waitStart >= stallTimeoutNanos) {
+                // THE CONSUMER MADE NO PROGRESS FOR THE WHOLE BOUND: GIVE UP INSTEAD OF SPINNING FOREVER. A CONSUMER
+                // STILL ALIVE IS TOLD THE RESULT SET WOULD BE INCOMPLETE (SEE fetchNext())
+                producerStalled = true;
+                closed = true;
+                return false;
+              }
+
+              LockSupport.parkNanos(OFFER_PARK_NANOS);
             }
           }
           return true;
@@ -102,16 +147,71 @@ public class SelectParallelIterator<T extends Document> extends SelectIterator<T
     if (!(iterator instanceof MultiIterator))
       // NO CHANCE TO GO IN PARALLEL, FALL BACK TO THE SERIAL IMPLEMENTATION
       return super.fetchNext();
-    else
-      ((MultiIterator<? extends Identifiable>) iterator).checkForTimeout();
 
-    while (!queue.isEmpty() || semaphore.getCount() > 0) {
+    if (queue == null)
+      // INVOKED BY THE BASE CLASS CONSTRUCTOR (SKIP CONSUMPTION) BEFORE THE PARALLEL MACHINERY IS INITIALIZED AND THE
+      // PRODUCERS ARE SCHEDULED: CONSUME SERIALLY FROM THE UNDERLYING ITERATOR
+      return super.fetchNext();
+
+    final MultiIterator<? extends Identifiable> it = (MultiIterator<? extends Identifiable>) iterator;
+
+    while (true) {
+      if (producerStalled)
+        return onProducerStalled();
+
+      if (closed)
+        return null;
+
       final T record = (T) queue.poll();
-      if (record != null)
+      if (record != null) {
+        ++returned;
         return record;
-    }
+      }
 
-    // NOT FOUND
-    return null;
+      if (semaphore.getCount() == 0) {
+        // ALL THE PRODUCERS ARE DONE. EVERY OFFER HAPPENS BEFORE THE PRODUCER'S COUNTDOWN, SO ONE LAST POLL DRAINS A
+        // RECORD PUBLISHED BETWEEN THE POLL ABOVE AND THE LAST COUNTDOWN
+        final T last = (T) queue.poll();
+        if (last != null) {
+          ++returned;
+          return last;
+        }
+        return producerStalled ? onProducerStalled() : null;
+      }
+
+      try {
+        if (it.checkForTimeout()) {
+          // TIMEOUT WITHOUT EXCEPTION REQUESTED: STOP THE PRODUCERS AND RETURN WHAT WAS FETCHED SO FAR
+          closed = true;
+          return null;
+        }
+      } catch (final TimeoutException e) {
+        // STOP THE PRODUCERS BEFORE SURFACING THE TIMEOUT TO THE CALLER
+        closed = true;
+        throw e;
+      }
+
+      Thread.onSpinWait();
+    }
+  }
+
+  /**
+   * Stops the background producers. Each producer ends its async task through the regular completion path, releasing
+   * the worker within one park cycle. Idempotent and safe to call from any thread.
+   */
+  @Override
+  public void close() {
+    closed = true;
+  }
+
+  private T onProducerStalled() {
+    // A PRODUCER GAVE UP AFTER WAITING THE WHOLE STALL BOUND ON THE FULL QUEUE, SO THE RESULT SET WOULD BE INCOMPLETE.
+    // WITH AN EXPLICIT NON-THROWING TIMEOUT THE TRUNCATION IS WHAT THE CALLER ASKED FOR, OTHERWISE FAIL LOUD
+    if (executor.select.timeoutInMs > 0 && !executor.select.exceptionOnTimeout)
+      return null;
+    throw new TimeoutException(
+        "Timeout on parallel select: the producers waited more than " + (executor.select.timeoutInMs > 0 ?
+            executor.select.timeoutInMs :
+            DEFAULT_STALL_TIMEOUT_MS) + " ms for the consumer to fetch records, the result set would be incomplete");
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/select/SelectParallelIteratorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectParallelIteratorTest.java
@@ -18,6 +18,7 @@ package com.arcadedb.query.select;/*
  */
 
 import com.arcadedb.TestHelper;
+import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.graph.Vertex;
 
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Regression tests for #5065: the parallel select producers (async workers browsing one bucket each) must never
@@ -37,6 +39,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class SelectParallelIteratorTest extends TestHelper {
   private static final int TOTAL_RECORDS = 10_000;
+  // FITS ENTIRELY IN THE 4,096-SLOT HAND-OFF QUEUE, SO THE PRODUCERS COMPLETE WITHOUT EVER STALLING ON A FULL QUEUE
+  // AND THE TIMEOUT TESTS EXERCISE THE STREAMING (NON-EMPTY QUEUE) PATH ONLY
+  private static final int SMALL_RECORDS = 1_000;
   private static final int BUCKETS       = 8;
 
   public SelectParallelIteratorTest() {
@@ -46,9 +51,12 @@ public class SelectParallelIteratorTest extends TestHelper {
   @Override
   protected void beginTest() {
     database.getSchema().createVertexType("Big", BUCKETS);
+    database.getSchema().createVertexType("Small", BUCKETS);
     database.transaction(() -> {
       for (int i = 0; i < TOTAL_RECORDS; i++)
         database.newVertex("Big").set("id", i).save();
+      for (int i = 0; i < SMALL_RECORDS; i++)
+        database.newVertex("Small").set("id", i).save();
     });
   }
 
@@ -102,6 +110,76 @@ public class SelectParallelIteratorTest extends TestHelper {
   void skipIsAppliedOnParallelScan() {
     final List<Vertex> result = database.select().fromType("Big").skip(100).compile().parallel().<Vertex>vertices().toList();
     assertThat(result).hasSize(TOTAL_RECORDS - 100);
+    assertThat(database.async().waitCompletion(15_000)).isTrue();
+  }
+
+  @Test
+  void skipAndLimitTogetherReturnLimitRecordsOnParallelScan() {
+    // STANDARD SEMANTICS: SKIP s RECORDS, THEN RETURN UP TO n. A LIMIT SMALLER THAN THE SKIP MUST NOT TRUNCATE THE
+    // RESULT (THE INHERITED `returned` COUNTER ALREADY CONTAINS THE SKIPPED RECORDS WHEN THE STREAMING STARTS)
+    final List<Vertex> result = database.select().fromType("Big").skip(100).limit(50).compile().parallel().<Vertex>vertices()
+        .toList();
+    assertThat(result).hasSize(50);
+    assertThat(database.async().waitCompletion(15_000)).isTrue();
+
+    final List<Vertex> result2 = database.select().fromType("Big").skip(10).limit(50).compile().parallel().<Vertex>vertices()
+        .toList();
+    assertThat(result2).hasSize(50);
+    assertThat(database.async().waitCompletion(15_000)).isTrue();
+  }
+
+  @Test
+  void skipAndLimitTogetherReturnLimitRecordsOnSerialScan() {
+    // SAME SEMANTICS ON THE SERIAL PATH: THE LIMIT COUNTS THE RECORDS RETURNED AFTER THE SKIPPED ONES
+    final List<Vertex> result = database.select().fromType("Big").skip(100).limit(50).compile().<Vertex>vertices().toList();
+    assertThat(result).hasSize(50);
+
+    final List<Vertex> result2 = database.select().fromType("Big").skip(10).limit(50).compile().<Vertex>vertices().toList();
+    assertThat(result2).hasSize(50);
+  }
+
+  @Test
+  void timeoutIsEnforcedWhileStreaming() throws InterruptedException {
+    // THE DATASET FITS IN THE HAND-OFF QUEUE: THE PRODUCERS COMPLETE QUICKLY AND NEVER STALL, SO THE ONLY WAY THE
+    // TIMEOUT CAN FIRE IS THE PER-FETCH CHECK ON THE STREAMING PATH (REGRESSION: THE CHECK WAS ONLY REACHED WHEN THE
+    // QUEUE WAS EMPTY, SO A SLOW CONSUMER OF AN ALWAYS-READY QUEUE COULD RUN UNBOUNDED PAST ITS timeout())
+    final SelectIterator<Vertex> iterator = database.select().fromType("Small")//
+        .timeout(100, TimeUnit.MILLISECONDS, true)//
+        .compile().parallel().vertices();
+
+    assertThat(iterator.hasNext()).isTrue();
+    assertThat(iterator.next()).isNotNull();
+
+    // LET THE TIMEOUT EXPIRE WHILE THE QUEUE IS STILL FULL OF RECORDS
+    Thread.sleep(400);
+
+    assertThatThrownBy(() -> {
+      while (iterator.hasNext())
+        iterator.next();
+    }).isInstanceOf(TimeoutException.class);
+
+    assertThat(database.async().waitCompletion(15_000)).isTrue();
+  }
+
+  @Test
+  void nonThrowingTimeoutTruncatesWhileStreaming() throws InterruptedException {
+    // SAME SCENARIO WITH exceptionOnTimeout=false: THE ITERATION MUST END EARLY RETURNING WHAT WAS FETCHED SO FAR
+    final SelectIterator<Vertex> iterator = database.select().fromType("Small")//
+        .timeout(100, TimeUnit.MILLISECONDS, false)//
+        .compile().parallel().vertices();
+
+    assertThat(iterator.hasNext()).isTrue();
+    assertThat(iterator.next()).isNotNull();
+
+    Thread.sleep(400);
+
+    int fetchedAfterTimeout = 0;
+    while (iterator.hasNext()) {
+      iterator.next();
+      ++fetchedAfterTimeout;
+    }
+
+    assertThat(fetchedAfterTimeout).isZero();
     assertThat(database.async().waitCompletion(15_000)).isTrue();
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/select/SelectParallelIteratorTest.java
+++ b/engine/src/test/java/com/arcadedb/query/select/SelectParallelIteratorTest.java
@@ -1,0 +1,107 @@
+package com.arcadedb.query.select;/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import com.arcadedb.TestHelper;
+import com.arcadedb.graph.Vertex;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for #5065: the parallel select producers (async workers browsing one bucket each) must never
+ * busy-spin forever when the consumer stops draining the hand-off queue (limit reached, early close, exception or
+ * plain abandonment). The dataset is larger than the 4,096-slot hand-off queue on purpose, so the producers are
+ * guaranteed to hit a full queue when the consumer stops.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+public class SelectParallelIteratorTest extends TestHelper {
+  private static final int TOTAL_RECORDS = 10_000;
+  private static final int BUCKETS       = 8;
+
+  public SelectParallelIteratorTest() {
+    autoStartTx = false;
+  }
+
+  @Override
+  protected void beginTest() {
+    database.getSchema().createVertexType("Big", BUCKETS);
+    database.transaction(() -> {
+      for (int i = 0; i < TOTAL_RECORDS; i++)
+        database.newVertex("Big").set("id", i).save();
+    });
+  }
+
+  @Test
+  void fullParallelScanReturnsAllRecords() {
+    final List<Vertex> result = database.select().fromType("Big").compile().parallel().<Vertex>vertices().toList();
+    assertThat(result).hasSize(TOTAL_RECORDS);
+    assertThat(database.async().waitCompletion(15_000)).isTrue();
+  }
+
+  @Test
+  void limitStopsProducersAndReturnsExactRecords() {
+    final List<Vertex> result = database.select().fromType("Big").limit(10).compile().parallel().<Vertex>vertices().toList();
+
+    // THE PRODUCERS MUST STOP ONCE THE LIMIT IS SATISFIED INSTEAD OF SPINNING FOREVER ON THE FULL QUEUE (#5065)
+    assertThat(database.async().waitCompletion(15_000)).isTrue();
+    assertThat(result).hasSize(10);
+  }
+
+  @Test
+  void abandonedConsumerReleasesWorkersWithinStallBound() {
+    final SelectIterator<Vertex> iterator = database.select().fromType("Big")//
+        .timeout(1, TimeUnit.SECONDS, false)//
+        .compile().parallel().vertices();
+
+    assertThat(iterator.hasNext()).isTrue();
+    assertThat(iterator.next()).isNotNull();
+
+    // THE CONSUMER STOPS DRAINING WITHOUT CLOSING (E.G. AN EXCEPTION IN USER CODE): THE PRODUCERS MUST GIVE UP
+    // WITHIN THE STALL BOUND (THE SELECT TIMEOUT HERE) INSTEAD OF PINNING THE ASYNC WORKERS AT 100% CPU (#5065)
+    assertThat(database.async().waitCompletion(15_000)).isTrue();
+  }
+
+  @Test
+  void earlyCloseReleasesAsyncWorkers() {
+    final SelectIterator<Vertex> iterator = database.select().fromType("Big").compile().parallel().vertices();
+
+    for (int i = 0; i < 3; i++) {
+      assertThat(iterator.hasNext()).isTrue();
+      assertThat(iterator.next()).isNotNull();
+    }
+
+    // CLOSE WHILE THE PRODUCERS ARE STILL STREAMING: THE ASYNC WORKERS MUST RETURN WITHIN A BOUND (#5065)
+    iterator.close();
+
+    assertThat(database.async().waitCompletion(15_000)).isTrue();
+    assertThat(iterator.hasNext()).isFalse();
+  }
+
+  @Test
+  void skipIsAppliedOnParallelScan() {
+    final List<Vertex> result = database.select().fromType("Big").skip(100).compile().parallel().<Vertex>vertices().toList();
+    assertThat(result).hasSize(TOTAL_RECORDS - 100);
+    assertThat(database.async().waitCompletion(15_000)).isTrue();
+  }
+}


### PR DESCRIPTION
Fixes #5065 (2026-07 audit follow-up, #4962; outside PR #5062's footprint).

## Verdicts

| Issue | Verdict | Detail |
|---|---|---|
| #5065 | fixed | Reproduced on current main, red-first, fixed with a bounded cooperative offer. Worse than filed: besides pinning one async worker per bucket at 100% CPU, the spin also hung the next `Database.close()`/`drop()` forever behind the executor's unbounded `waitCompletion()`. |

## Red evidence (unmodified main)

Running the new `SelectParallelIteratorTest` against main wedged the JVM permanently. `jstack` showed 4 `AsyncExecutor` workers RUNNABLE at `SelectParallelIterator.java:86` (the `while (true) { offer }` loop) with ~706,000 ms CPU each on a 712 s old JVM, and the JUnit main thread parked forever in `LocalDatabase.closeInternal -> DatabaseAsyncExecutorImpl.waitCompletion` during teardown. The run had to be killed.

## Fix

A producer facing a full hand-off queue now parks 0.1 ms between offer attempts (no CPU burn even while legitimately waiting) and gives up when:

- the iterator was closed (`SelectIterator` is now `AutoCloseable`; the parallel `close()` signals the producers, the serial one is a no-op);
- the worker was interrupted (executor shutdown escalation, #4954);
- enough records were produced to satisfy the limit; or
- the consumer made no progress for the whole stall bound: the select timeout when set, otherwise 60 s (matching the #5062 zero-progress backstop).

Async executor contracts from #5062 are preserved: a producer that gives up returns `false` from the browse callback, so the task ends through the regular completion path (`completed()`, batch commit, semaphore countdown); nothing is thrown through the worker and no in-flight commit batch is rolled back. A consumer still alive after a producer stall gets a `TimeoutException` instead of a silently truncated result set (unless it opted into truncation with a non-throwing timeout).

Three latent defects in the same code path fixed by the rework (details in the commit message):

1. `limit` was accounted producer-side with racy increments of `returned`, so the consumer could receive fewer than `limit` records (down to zero);
2. `skip > 0` on the parallel path crashed with an NPE (base constructor consumed skip via the override before the queue existed);
3. a record published between the consumer's last poll and the final producer's `countDown()` could be lost at end of stream (non-atomic queue-empty + latch check).

## Tests

- New `SelectParallelIteratorTest` (10,000 records / 8 buckets, dataset deliberately larger than the 4,096-slot queue): full-scan sanity, limit exact + workers released, early close releases workers, abandoned consumer releases workers within the stall bound, skip works. All red on main; all green in 1.5 s with the fix.
- Full `com.arcadedb.query.select.*` + `com.arcadedb.database.async.*` + `AsyncTest` suites: 97 tests, 0 failures (includes the pre-existing 1M-record `okParallel` and every #5062 executor-contract regression test).

## Conflict risk

- `docs/release-26.7.2.md`: appended one bullet at the end of Fixes; expected to conflict trivially with sibling audit PRs.
- Engine changes are confined to `query/select` (`SelectParallelIterator` rewrite, 12-line `SelectIterator` addition); no touch of the async executor, TransactionContext or PageManager.