### PR TITLE
feat(#5054): per-page CRC32C checksums close the multi-version torn-write recovery gap

### DIFF
--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -216,12 +216,26 @@ that could starve the very snapshot resync meant to heal the node.
   skip declared such a page "already applied" and left it silently corrupt despite an intact WAL,
   [#4926](https://github.com/ArcadeData/arcadedb/issues/4926); known limitation: async flush can coalesce
   several committed versions into one physical write, and only the newest version's region is repaired -
-  fully closing the multi-version case needs per-page checksums to detect which pages are torn, tracked in
+  fully closing the multi-version case needs per-page checksums to detect which pages are torn - now done,
+  see the per-page checksums entry below,
   [#5054](https://github.com/ArcadeData/arcadedb/issues/5054)). A clean close whose data fsync failed now
   preserves the WAL and the lock file for recovery instead of deleting them (after a failed fsync the OS
   may have dropped the dirty pages, so the WAL held the only durable copy;
   [#4934](https://github.com/ArcadeData/arcadedb/issues/4934) - the runtime WAL rotation also skips its
   drop pass when the pre-drop fsync fails).
+- **Per-page checksums close the multi-version torn-write gap (2026-07 audit follow-up).** Every page flush
+  now also maintains an 8-byte slot (page version + CRC32C of the raw page bytes, hardware-accelerated) in a
+  `.pcrc` sidecar file next to each data file, written before the page itself and covered by the same fsync
+  barrier. Crash recovery uses it to detect what the page version header alone cannot reveal: async flush
+  coalesces several committed versions into one physical write, so a torn write can persist the newest
+  version header while regions changed by the coalesced OLDER versions still hold stale bytes - the #4926
+  equal-version re-apply repaired only the newest version's delta region. A page that fails verification now
+  gets its FULL retained WAL delta chain replayed in transaction order (safe by the fsync-before-WAL-drop
+  barrier: dropped entries are always durably contained in the on-disk page), guarded so a stale checksum
+  can never trigger a replay ending below the version already on disk. No data-file format change: the
+  sidecar is ignored by directory scans (old and new versions alike), databases without one recover exactly
+  as before, and the slots fill in as pages flush. Disable with `arcadedb.pageChecksum=false`
+  ([#5054](https://github.com/ArcadeData/arcadedb/issues/5054)).
 
 - **LSM index hardening (2026-07 audit).** A failed compaction is now atomic: the in-RAM page count is
   rolled back (after draining in-flight flushes) so the orphaned leaf pages a mid-merge failure leaves on

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -364,6 +364,16 @@ public enum GlobalConfiguration {
 
   PAGE_FLUSH_QUEUE("arcadedb.pageFlushQueue", SCOPE.DATABASE, "Size of the asynchronous page flush queue", Integer.class, 512),
 
+  PAGE_CHECKSUM("arcadedb.pageChecksum", SCOPE.JVM,
+      """
+      Maintains a per-page CRC32C checksum in a '.pcrc' sidecar file next to each data file, updated on every \
+      page flush. Crash recovery uses it to detect torn page writes that the page version header alone cannot \
+      reveal (issue #5054: async flush coalesces several committed versions into one physical write, and a torn \
+      write can persist the newest version header over stale data sectors) and repairs the damaged page by \
+      replaying its full retained WAL delta chain. Databases without sidecar files (created by older versions, \
+      or with the flag disabled) recover exactly as before: verification is skipped.""",
+      Boolean.class, true),
+
   FLUSH_SUSPEND_MAX_DEFERRED_RAM("arcadedb.flushSuspendMaxDeferredRAM", SCOPE.DATABASE,
       """
       Maximum amount of RAM (in MB) of dirty pages the page-flush thread may defer in memory while flushing \

--- a/engine/src/main/java/com/arcadedb/engine/PaginatedComponentFile.java
+++ b/engine/src/main/java/com/arcadedb/engine/PaginatedComponentFile.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.engine;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.log.LogManager;
 
 import java.io.File;
@@ -37,12 +38,25 @@ import java.nio.file.StandardCopyOption;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
 import java.util.zip.CRC32;
+import java.util.zip.CRC32C;
 
 public class PaginatedComponentFile extends ComponentFile {
+  /**
+   * Extension of the per-page checksum sidecar file (issue #5054): one fixed 8-byte slot per page at offset
+   * {@code pageNumber * 8}, holding the page version (int) followed by the CRC32C of the raw page bytes (int).
+   * The slot is written BEFORE the page bytes on every {@link #write(MutablePage)}, so a persisted slot always
+   * describes the newest attempted write. The extension is NOT in the FileManager whitelist, so both this and
+   * older versions ignore the sidecar when scanning the database directory; a missing or stale sidecar only
+   * disables verification, never breaks anything (see {@code TransactionManager} recovery).
+   */
+  public static final String CHECKSUM_FILE_EXT  = ".pcrc";
+  private static final int   CHECKSUM_SLOT_SIZE = 8;
 
   private                 RandomAccessFile file;
   private                 FileChannel      channel;
   private                 int              pageSize;
+  private volatile        RandomAccessFile checksumFile;
+  private volatile        FileChannel      checksumChannel;
   private static volatile boolean          warningPrinted = false;
 
   /**
@@ -125,6 +139,17 @@ public class PaginatedComponentFile extends ComponentFile {
             Thread.currentThread().interrupt();
         }
       }
+
+      // Make the checksum sidecar durable under the same fsync barrier as the data file (issue #5054): the
+      // WAL-drop path relies on syncFiles() making everything the WAL protects durable, and a stale slot
+      // would otherwise survive the barrier and later look like a torn write to recovery. A failure here is
+      // contained: checksums are advisory (a stale slot degrades to a guarded repair replay at recovery),
+      // and it must not veto the caller's fsync verdict on the DATA file.
+      try {
+        forceChecksumChannel(metaData);
+      } catch (final IOException e) {
+        LogManager.instance().log(this, Level.WARNING, "Error on syncing checksum sidecar of file '%s'", e, fileName);
+      }
     } finally {
       channelLock.readLock().unlock();
     }
@@ -146,12 +171,25 @@ public class PaginatedComponentFile extends ComponentFile {
         file = null;
       }
 
+      closeChecksumFile();
+
     } catch (final IOException e) {
       LogManager.instance().log(this, Level.SEVERE, "Error on closing file %s (id=%d)", e, filePath, fileId);
     } finally {
       this.open = false;
       channelLock.writeLock().unlock();
     }
+  }
+
+  @Override
+  public void drop() throws IOException {
+    super.drop();
+    // Best-effort removal of the checksum sidecar: an orphan sidecar is harmless (nothing scans for it),
+    // but deleting it keeps the database directory clean and avoids a stale sidecar being adopted if a
+    // future file re-uses the exact same name.
+    final File sidecar = new File(filePath + CHECKSUM_FILE_EXT);
+    if (sidecar.exists() && !sidecar.delete())
+      LogManager.instance().log(this, Level.WARNING, "Error on deleting checksum sidecar file '%s'", null, sidecar);
   }
 
   public void rename(final String newFileName) throws IOException {
@@ -177,6 +215,19 @@ public class PaginatedComponentFile extends ComponentFile {
       }
       try {
         Files.move(osFile.getAbsoluteFile().toPath(), newFile.getAbsoluteFile().toPath(), StandardCopyOption.ATOMIC_MOVE);
+
+        // Carry the checksum sidecar along (issue #5054). Best-effort: on failure the old sidecar is removed
+        // so a stale one can never be matched against the renamed file's future content.
+        final File oldSidecar = new File(filePath + CHECKSUM_FILE_EXT);
+        if (oldSidecar.exists())
+          try {
+            Files.move(oldSidecar.toPath(), new File(newFile.getAbsolutePath() + CHECKSUM_FILE_EXT).toPath(),
+                StandardCopyOption.REPLACE_EXISTING);
+          } catch (final IOException e) {
+            LogManager.instance().log(this, Level.WARNING, "Error on renaming checksum sidecar file '%s'", e, oldSidecar);
+            oldSidecar.delete();
+          }
+
         open(newFile.getAbsolutePath(), mode);
       } catch (Exception e) {
         open(filePath, mode);
@@ -256,6 +307,23 @@ public class PaginatedComponentFile extends ComponentFile {
 
       // NO NEED TO SYNCHRONIZE THE BUFFER BECAUSE MUTABLE PAGES ARE NOT SHARED
       buffer.clear();
+
+      // Write the checksum slot BEFORE the page bytes (issue #5054): a persisted slot always describes the
+      // newest attempted write, so recovery can tell a torn page (slot version <= disk version, CRC mismatch)
+      // from an intact one. A failure here must never fail the flush: checksums are advisory, and a stale slot
+      // degrades to a guarded repair replay at recovery, never to data loss.
+      if (mode == MODE.READ_WRITE && GlobalConfiguration.PAGE_CHECKSUM.getValueAsBoolean())
+        try {
+          final CRC32C crc = new CRC32C();
+          crc.update(buffer);
+          buffer.clear();
+          writeChecksumSlot(pageNumber, buffer.getInt(0), (int) crc.getValue());
+        } catch (final IOException e) {
+          LogManager.instance()
+              .log(this, Level.WARNING, "Error on writing checksum slot for page %d of file '%s'", e, pageNumber, fileName);
+          buffer.clear();
+        }
+
       try {
         long pos = page.getPhysicalSize() * (long) pageNumber;
         while (buffer.hasRemaining())
@@ -364,6 +432,113 @@ public class PaginatedComponentFile extends ComponentFile {
       }
     } finally {
       channelLock.readLock().unlock();
+    }
+  }
+
+  /**
+   * Reads the checksum slot of a page from the sidecar file (issue #5054).
+   *
+   * @return {@code -1} when no slot is available (sidecar missing, shorter than the slot offset, or the slot
+   *     was never written); otherwise the page version in the high 32 bits and the CRC32C in the low 32 bits.
+   */
+  public long readPageChecksum(final int pageNumber) throws IOException {
+    final FileChannel c = getChecksumChannel(false);
+    if (c == null)
+      return -1L;
+
+    final long pos = (long) pageNumber * CHECKSUM_SLOT_SIZE;
+    if (pos + CHECKSUM_SLOT_SIZE > c.size())
+      return -1L;
+
+    final ByteBuffer slot = ByteBuffer.allocate(CHECKSUM_SLOT_SIZE);
+    long readPos = pos;
+    while (slot.hasRemaining()) {
+      final int r = c.read(slot, readPos);
+      if (r < 0)
+        return -1L;
+      readPos += r;
+    }
+
+    final int version = slot.getInt(0);
+    if (version <= 0)
+      // NEVER-WRITTEN SLOT (SPARSE ZEROS) OR INVALID: FLUSHED PAGES ALWAYS HAVE VERSION >= 1
+      return -1L;
+
+    return ((long) version << 32) | (slot.getInt(4) & 0xffffffffL);
+  }
+
+  private void writeChecksumSlot(final int pageNumber, final int version, final int crc) throws IOException {
+    final FileChannel c = getChecksumChannel(true);
+    final ByteBuffer slot = ByteBuffer.allocate(CHECKSUM_SLOT_SIZE);
+    slot.putInt(version);
+    slot.putInt(crc);
+    slot.flip();
+    long pos = (long) pageNumber * CHECKSUM_SLOT_SIZE;
+    while (slot.hasRemaining())
+      pos += c.write(slot, pos);
+  }
+
+  /**
+   * Lazily opens the checksum sidecar channel. Lazy on purpose: it doubles the file-descriptor count only for
+   * files that are actually written (or verified during recovery), not for every component file at startup.
+   */
+  private FileChannel getChecksumChannel(final boolean createIfAbsent) throws IOException {
+    final FileChannel c = checksumChannel;
+    if (c != null && c.isOpen())
+      return c;
+
+    synchronized (this) {
+      if (checksumChannel != null && checksumChannel.isOpen())
+        return checksumChannel;
+
+      final File sidecar = new File(filePath + CHECKSUM_FILE_EXT);
+      if (!createIfAbsent && !sidecar.exists())
+        return null;
+
+      checksumFile = new RandomAccessFile(sidecar, mode == MODE.READ_WRITE ? "rw" : "r");
+      checksumChannel = checksumFile.getChannel();
+      // Same interrupt shielding as the main channel: a thread interrupt during a slot write/force must not
+      // close the shared sidecar channel under the other pages.
+      doNotCloseOnInterrupt(checksumChannel);
+      return checksumChannel;
+    }
+  }
+
+  /**
+   * Fsyncs the checksum sidecar, tolerating a thread interrupt: the flag is cleared for the duration (an
+   * interruptible channel would otherwise close itself and throw {@link ClosedChannelException} immediately,
+   * e.g. right after the main channel's own interrupt-retry restored the flag) and restored on exit. A channel
+   * closed by a concurrent interrupt is reopened once and the force retried.
+   */
+  private void forceChecksumChannel(final boolean metaData) throws IOException {
+    FileChannel cc = checksumChannel;
+    if (cc == null)
+      return;
+
+    final boolean wasInterrupted = Thread.interrupted();
+    try {
+      try {
+        cc.force(metaData);
+      } catch (final ClosedChannelException e) {
+        closeChecksumFile();
+        cc = getChecksumChannel(false);
+        if (cc != null)
+          cc.force(metaData);
+      }
+    } finally {
+      if (wasInterrupted)
+        Thread.currentThread().interrupt();
+    }
+  }
+
+  private synchronized void closeChecksumFile() throws IOException {
+    if (checksumChannel != null) {
+      checksumChannel.close();
+      checksumChannel = null;
+    }
+    if (checksumFile != null) {
+      checksumFile.close();
+      checksumFile = null;
     }
   }
 

--- a/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/TransactionManager.java
@@ -32,6 +32,7 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.utility.LockManager;
 
 import java.io.*;
+import java.nio.ByteBuffer;
 import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.file.Files;
@@ -41,6 +42,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.stream.Stream;
+import java.util.zip.CRC32C;
 
 public class TransactionManager {
   private static final long MAX_LOG_FILE_SIZE = 64 * 1024 * 1024;
@@ -299,6 +301,11 @@ public class TransactionManager {
         long lastTxId = -1;
         boolean walGapDetected = false;
 
+        // #5054: pre-scan the WAL files to know, per page, the HIGHEST version any retained entry carries.
+        // The torn-page verifier only enters repair mode when that maximum reaches the on-disk version, so a
+        // stale checksum can never cause a replay that would end BELOW the version already on disk.
+        final RecoveryPageVerifier verifier = new RecoveryPageVerifier(collectMaxWalVersions());
+
         final WALFile.WALTransaction[] walPositions = new WALFile.WALTransaction[activeWALFilePool.length];
         for (int i = 0; i < activeWALFilePool.length; ++i) {
           final WALFile file = activeWALFilePool[i];
@@ -332,7 +339,7 @@ public class TransactionManager {
             break;
 
           try {
-            applyChanges(walPositions[lowerTx], Collections.emptyMap(), false);
+            applyChanges(walPositions[lowerTx], Collections.emptyMap(), false, verifier);
             // Only advance lastTxId after a successful apply, otherwise a failed transaction
             // would wrongly increment the next-tx counter past data that was never written.
             lastTxId = lowerTxId;
@@ -447,6 +454,20 @@ public class TransactionManager {
 
   public boolean applyChanges(final WALFile.WALTransaction tx, final Map<Integer, Integer> bucketRecordDelta,
       final boolean ignoreErrors) {
+    return applyChanges(tx, bucketRecordDelta, ignoreErrors, null);
+  }
+
+  /**
+   * @param verifier torn-page detector active ONLY during crash recovery ({@link #checkIntegrity()}), {@code null}
+   *                 on every other path (HA/Raft replay). For a page the verifier flags as torn (issue #5054) the
+   *                 strictly-older skip and the version-gap abort are bypassed, so the page's FULL retained WAL
+   *                 delta chain is replayed in transaction order. Correctness rests on the fsync-before-WAL-drop
+   *                 barrier: any entry already dropped from the WAL is durably contained in the on-disk page, so
+   *                 replaying every retained entry in order over the disk bytes reconstructs exactly the newest
+   *                 committed state.
+   */
+  public boolean applyChanges(final WALFile.WALTransaction tx, final Map<Integer, Integer> bucketRecordDelta,
+      final boolean ignoreErrors, final RecoveryPageVerifier verifier) {
     boolean changed = false;
     boolean involveDictionary = false;
 
@@ -491,7 +512,14 @@ public class TransactionManager {
             .log(this, Level.FINE, "-- checking page %s versionInLog=%d versionInDB=%d", null, pageId, txPage.currentPageVersion,
                 page.getVersion());
 
-        if (txPage.currentPageVersion < page.getVersion()) {
+        // #5054: during recovery, pages whose checksum reveals a torn write bypass BOTH the strictly-older
+        // skip and the version-gap abort below, so their full retained delta chain is replayed in order.
+        final boolean repairTornPage = verifier != null && verifier.isSuspect(file, txPage.pageNumber);
+        if (repairTornPage)
+          LogManager.instance().log(this, Level.INFO, "Replaying delta v.%d for torn page %s (db v.%d, txId=%d)", null,
+              txPage.currentPageVersion, pageId, page.getVersion(), tx.txId);
+
+        if (!repairTornPage && txPage.currentPageVersion < page.getVersion()) {
           // Always skip OLDER pages instead of aborting the entire transaction. During Raft state machine
           // replay or crash recovery, a partial apply may have written some pages but not others. Skipping
           // only the superseded pages (instead of throwing ConcurrentModificationException and aborting the
@@ -507,23 +535,21 @@ public class TransactionManager {
           // WAL delta carries absolute bytes for exactly this version) and repairs the torn state; skipping
           // a STRICTLY older entry remains required, because its delta would overwrite newer content.
           //
-          // KNOWN LIMITATION (multi-version accumulation): async flush coalesces several committed versions
-          // into a single physical page write, so a page can jump v1(on-disk) -> v2 -> v3 -> v4 with only the
-          // v4 flush hitting the platter. If THAT flush tears, only v4's delta region is repaired here; the
-          // regions changed by v2/v3 (skipped as strictly-older) can stay torn. The version header alone
-          // cannot tell a torn page from an intact one, so detecting which pages need the older deltas
-          // re-applied needs a per-page checksum (the longer-term fix noted in #4926, tracked in #5054); an
-          // unconditional
-          // in-order replay of every entry <= disk version would repair it but changes the recovery
-          // semantics that also govern the version-gap/forceApply paths, out of scope here. This fix still
-          // strictly improves on `<=` (which repaired nothing) and fully covers the single-flush case.
+          // MULTI-VERSION accumulation (#5054): async flush coalesces several committed versions into a
+          // single physical page write, so a page can jump v1(on-disk) -> v2 -> v3 -> v4 with only the v4
+          // flush hitting the platter. If THAT flush tears, re-applying v4's delta alone leaves the regions
+          // changed by v2/v3 torn. The version header alone cannot tell a torn page from an intact one, so
+          // the per-page CRC32C sidecar (see PaginatedComponentFile.CHECKSUM_FILE_EXT) provides the missing
+          // evidence: during recovery the RecoveryPageVerifier flags such pages and the repairTornPage flag
+          // above bypasses this skip, replaying the full retained delta chain in order. Outside recovery
+          // (verifier == null) and for pages the checksum proves intact, the strictly-older skip stands.
           LogManager.instance().log(this, Level.FINE,
               "Skipping superseded page %s (log v.%d < db v.%d)", null,
               pageId, txPage.currentPageVersion, page.getVersion());
           continue;
         }
 
-        if (txPage.currentPageVersion > page.getVersion() + 1) {
+        if (!repairTornPage && txPage.currentPageVersion > page.getVersion() + 1) {
           if (!tx.forceApply) {
             LogManager.instance().log(this, Level.WARNING,
                 "Cannot apply changes to the database because modified page %s version in WAL (%d) does not match with existent version (%d) fileId=%d",
@@ -950,6 +976,122 @@ public class TransactionManager {
     }
 
     return inactiveWALFilePool.isEmpty();
+  }
+
+  /**
+   * Scans every WAL file collecting, per page, the highest version any retained entry carries. Feeds the
+   * {@link RecoveryPageVerifier} guard: a torn-page repair replay must end AT or ABOVE the version the disk
+   * already claims, or it would downgrade an intact page (possible only with a stale checksum, e.g. a sidecar
+   * restored from a backup, since the fsync-before-WAL-drop barrier keeps a genuinely torn page's newest
+   * entry retained). Recovery-only cost: one extra sequential pass over the WAL files.
+   */
+  private Map<Long, Integer> collectMaxWalVersions() {
+    final Map<Long, Integer> maxVersions = new HashMap<>();
+    for (final WALFile file : activeWALFilePool) {
+      if (file == null)
+        continue;
+      WALFile.WALTransaction tx = file.getFirstTransaction();
+      while (tx != null) {
+        for (final WALFile.WALPage page : tx.pages) {
+          final long key = pageKey(page.fileId, page.pageNumber);
+          final Integer prev = maxVersions.get(key);
+          if (prev == null || page.currentPageVersion > prev)
+            maxVersions.put(key, page.currentPageVersion);
+        }
+        tx = file.getTransaction(tx.endPositionInLog);
+      }
+    }
+    return maxVersions;
+  }
+
+  private static long pageKey(final int fileId, final int pageNumber) {
+    return ((long) fileId << 32) | (pageNumber & 0xffffffffL);
+  }
+
+  /**
+   * Recovery-only torn-page detector (issue #5054). For every page referenced by the WAL it compares the raw
+   * on-disk bytes against the CRC32C slot maintained in the {@code .pcrc} sidecar file (see
+   * {@link PaginatedComponentFile#CHECKSUM_FILE_EXT}, written BEFORE the page bytes on every flush):
+   * <ul>
+   *   <li>no slot available (pre-checksum database, disabled flag, never-flushed page): unverifiable, the
+   *   standard recovery rules apply - the migration story for existing databases;</li>
+   *   <li>slot version > disk version: the interrupted flush kept the OLD version header, so every newer WAL
+   *   delta applies under the standard rules, which provably reconstruct the page;</li>
+   *   <li>slot version == disk version and the CRC matches: the page is verified intact;</li>
+   *   <li>otherwise (equal-version CRC mismatch, or a slot older than the disk version - the sidecar update
+   *   did not persist while the possibly-torn page write did): the page is flagged TORN, provided the WAL
+   *   still retains an entry at the disk version or newer (the {@code maxWalVersions} guard above).</li>
+   * </ul>
+   * Verdicts are memoized for the whole recovery run: the repair replay itself rewrites the page (and its
+   * checksum slot) through the normal write path, and later entries of the chain must keep seeing the page
+   * as under repair.
+   */
+  static class RecoveryPageVerifier {
+    private final Map<Long, Integer> maxWalVersions;
+    private final Map<Long, Boolean> verdicts = new HashMap<>();
+
+    RecoveryPageVerifier(final Map<Long, Integer> maxWalVersions) {
+      this.maxWalVersions = maxWalVersions;
+    }
+
+    boolean isSuspect(final PaginatedComponentFile file, final int pageNumber) {
+      final long key = pageKey(file.getFileId(), pageNumber);
+      final Boolean cached = verdicts.get(key);
+      if (cached != null)
+        return cached;
+
+      boolean suspect = false;
+      try {
+        suspect = verify(file, pageNumber, key);
+      } catch (final IOException e) {
+        LogManager.instance()
+            .log(this, Level.WARNING, "Error on verifying the checksum of page %d of file '%s'", e, pageNumber,
+                file.getFileName());
+      }
+      verdicts.put(key, suspect);
+      return suspect;
+    }
+
+    private boolean verify(final PaginatedComponentFile file, final int pageNumber, final long key) throws IOException {
+      final long slot = file.readPageChecksum(pageNumber);
+      if (slot == -1L)
+        return false;
+
+      final int pageSize = file.getPageSize();
+      if ((pageNumber + 1L) * pageSize > file.getSize())
+        // THE PAGE IS (PARTIALLY) BEYOND THE PHYSICAL FILE: NOTHING TO VERIFY
+        return false;
+
+      final ByteBuffer raw = ByteBuffer.allocate(pageSize);
+      file.readPage(pageNumber, raw);
+      final int diskVersion = raw.getInt(0);
+
+      final int slotVersion = (int) (slot >>> 32);
+      if (slotVersion > diskVersion)
+        return false;
+
+      if (slotVersion == diskVersion) {
+        final CRC32C crc = new CRC32C();
+        raw.rewind();
+        crc.update(raw);
+        if ((int) crc.getValue() == (int) slot)
+          // VERIFIED INTACT
+          return false;
+      }
+
+      final Integer maxWalVersion = maxWalVersions.get(key);
+      if (maxWalVersion == null || maxWalVersion < diskVersion) {
+        LogManager.instance().log(this, Level.SEVERE,
+            "Page %d of file '%s' fails its checksum (disk v.%d, checksum v.%d) but the WAL retains no entry at that version or newer: the checksum is considered stale and the page is recovered with the standard rules",
+            null, pageNumber, file.getFileName(), diskVersion, slotVersion);
+        return false;
+      }
+
+      LogManager.instance().log(this, Level.WARNING,
+          "Torn write detected on page %d of file '%s' (disk v.%d, checksum v.%d): replaying the full WAL delta chain for the page",
+          null, pageNumber, file.getFileName(), diskVersion, slotVersion);
+      return true;
+    }
   }
 
   @Override

--- a/engine/src/test/java/com/arcadedb/engine/Issue4510ForceApplyPartialDeltaTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue4510ForceApplyPartialDeltaTest.java
@@ -62,6 +62,10 @@ class Issue4510ForceApplyPartialDeltaTest extends TestHelper {
       for (int i = 0; i < 10; i++)
         db.newDocument("TestType").set("name", "record-" + i).save();
     });
+    // Drain the async flush of the setup transaction: its in-flight I/O uses the same per-page interlock
+    // (concurrentPageAccess) this test then manipulates, and the winner's finally-remove would otherwise
+    // race the fake entry planted below / leave the stale setup page in the flush-queue index.
+    db.getPageManager().waitAllPagesOfDatabaseAreFlushed(db);
 
     final int fileId = db.getSchema().getType("TestType").getBuckets(false).get(0).getFileId();
     final PaginatedComponentFile file = (PaginatedComponentFile) db.getFileManager().getFile(fileId);
@@ -122,6 +126,10 @@ class Issue4510ForceApplyPartialDeltaTest extends TestHelper {
       for (int i = 0; i < 10; i++)
         db.newDocument("TestType").set("name", "record-" + i).save();
     });
+    // Drain the async flush of the setup transaction: its in-flight I/O uses the same per-page interlock
+    // (concurrentPageAccess) this test then manipulates, and the winner's finally-remove would otherwise
+    // race the fake entry planted below / leave the stale setup page in the flush-queue index.
+    db.getPageManager().waitAllPagesOfDatabaseAreFlushed(db);
 
     final int fileId = db.getSchema().getType("TestType").getBuckets(false).get(0).getFileId();
     final PaginatedComponentFile file = (PaginatedComponentFile) db.getFileManager().getFile(fileId);

--- a/engine/src/test/java/com/arcadedb/engine/Issue4712ReplicatedWriteLockTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/Issue4712ReplicatedWriteLockTest.java
@@ -60,6 +60,10 @@ class Issue4712ReplicatedWriteLockTest extends TestHelper {
       for (int i = 0; i < 10; i++)
         db.newDocument("TestType").set("name", "record-" + i).save();
     });
+    // Drain the async flush of the setup transaction: its in-flight I/O uses the same per-page interlock
+    // (concurrentPageAccess) this test then manipulates, and the winner's finally-remove would otherwise
+    // race the fake entry planted below / leave the stale setup page in the flush-queue index.
+    db.getPageManager().waitAllPagesOfDatabaseAreFlushed(db);
 
     final int fileId = db.getSchema().getType("TestType").getBuckets(false).get(0).getFileId();
     final PaginatedComponentFile file = (PaginatedComponentFile) db.getFileManager().getFile(fileId);
@@ -136,6 +140,10 @@ class Issue4712ReplicatedWriteLockTest extends TestHelper {
       for (int i = 0; i < 10; i++)
         db.newDocument("TestType").set("name", "record-" + i).save();
     });
+    // Drain the async flush of the setup transaction: its in-flight I/O uses the same per-page interlock
+    // (concurrentPageAccess) this test then manipulates, and the winner's finally-remove would otherwise
+    // race the fake entry planted below / leave the stale setup page in the flush-queue index.
+    db.getPageManager().waitAllPagesOfDatabaseAreFlushed(db);
 
     final int fileId = db.getSchema().getType("TestType").getBuckets(false).get(0).getFileId();
     final PaginatedComponentFile file = (PaginatedComponentFile) db.getFileManager().getFile(fileId);

--- a/engine/src/test/java/com/arcadedb/engine/PageChecksumRecoveryTest.java
+++ b/engine/src/test/java/com/arcadedb/engine/PageChecksumRecoveryTest.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.engine;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.zip.CRC32C;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Per-page checksum tests (#5054, follow-up to #4926/#5052).
+ * <p>
+ * Async flush coalesces several committed versions into a single physical page write, so a page can go
+ * v1(on-disk) -> v2 -> v3 -> v4 with only the v4 flush reaching the platter. If that flush tears (the
+ * version header sector persists, the data sectors do not), the #5052 equal-version re-apply repairs only
+ * v4's delta region; the regions changed by v2/v3 are skipped as strictly-older and stay silently torn.
+ * The version header alone cannot tell a torn page from an intact one: a per-page CRC32C, maintained in a
+ * {@code .pcrc} sidecar file on every flush, gives recovery the missing evidence, and on mismatch the FULL
+ * retained WAL delta chain for that page is replayed in transaction order.
+ */
+class PageChecksumRecoveryTest {
+
+  private static final String DB_PATH = "target/databases/PageChecksumRecoveryTest";
+
+  @AfterEach
+  void cleanup() {
+    final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
+    try {
+      if (factory.exists())
+        factory.open().drop();
+    } catch (final Exception e) {
+      // A test may deliberately leave the database unreopenable: remove it on disk below.
+    }
+    factory.close();
+    FileUtils.deleteRecursively(new File(DB_PATH));
+  }
+
+  /**
+   * The #5054 case: three committed versions coalesced into one torn flush. Doc1 changed at v2, doc2 at v3,
+   * doc3 at v4 - disjoint byte regions of the SAME page. The forged tear persists the v4 version header
+   * while every data sector still holds the v1 content. The old recovery skipped v2/v3 as strictly-older
+   * and re-applied only v4, leaving doc1/doc2 silently stale; the checksum-driven repair must replay the
+   * full chain.
+   */
+  @Test
+  void multiVersionTornWriteIsRepairedByFullChainReplay() throws Exception {
+    final String bucketFilePath = prepareTornMultiVersionScenario();
+
+    // Forge the TORN write: the disk page still holds the v1 content, but the version header (bytes 0-3,
+    // the first sector a torn flush can persist alone) claims v4. The sidecar still describes v1: a torn
+    // flush that persisted the header sector but not the (earlier-issued) sidecar slot looks exactly
+    // like this.
+    try (final RandomAccessFile raf = new RandomAccessFile(bucketFilePath, "rw")) {
+      raf.seek(0);
+      assertThat(raf.readInt()).as("the updates' page must not have reached the disk").isEqualTo(1);
+      raf.seek(0);
+      raf.writeInt(4);
+    }
+
+    reopenAndExpectAllRepaired();
+  }
+
+  /**
+   * Same tear, but the sidecar slot persisted too (slot version == disk version, CRC of the OLD bytes):
+   * the equal-version CRC mismatch is the direct positive evidence of the tear.
+   */
+  @Test
+  void tornWriteWithPersistedChecksumSlotIsRepaired() throws Exception {
+    final String bucketFilePath = prepareTornMultiVersionScenario();
+
+    try (final RandomAccessFile raf = new RandomAccessFile(bucketFilePath, "rw")) {
+      raf.seek(0);
+      assertThat(raf.readInt()).as("the updates' page must not have reached the disk").isEqualTo(1);
+      raf.seek(0);
+      raf.writeInt(4);
+    }
+
+    // Forge the sidecar slot version to match the torn header (the CRC stays the one of the v1 bytes, so
+    // it can no longer match the forged page: equal version + CRC mismatch = torn page).
+    final File sidecar = new File(bucketFilePath + PaginatedComponentFile.CHECKSUM_FILE_EXT);
+    assertThat(sidecar).as("the checksum sidecar must have been written by the v1 flush").exists();
+    try (final RandomAccessFile raf = new RandomAccessFile(sidecar, "rw")) {
+      raf.seek(0);
+      raf.writeInt(4);
+    }
+
+    reopenAndExpectAllRepaired();
+  }
+
+  /**
+   * Migration story: a database without a sidecar (pre-checksum files, or a sidecar lost by a file copy)
+   * must recover exactly as before - no verification, no repair, no failure.
+   */
+  @Test
+  void missingSidecarSkipsVerificationAndRecoversNormally() throws Exception {
+    final String bucketFilePath = prepareTornMultiVersionScenario();
+
+    final File sidecar = new File(bucketFilePath + PaginatedComponentFile.CHECKSUM_FILE_EXT);
+    if (sidecar.exists())
+      assertThat(sidecar.delete()).isTrue();
+
+    // No forged tear here: the disk page is intact at v1, so normal recovery applies v2/v3/v4 in order.
+    reopenAndExpectAllRepaired();
+  }
+
+  /** Contract: every flushed page carries a sidecar slot with its version and the CRC32C of its raw bytes. */
+  @Test
+  void flushWritesMatchingChecksumSlot() throws Exception {
+    final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
+    if (factory.exists())
+      factory.open().drop();
+
+    final DatabaseInternal db = (DatabaseInternal) factory.create();
+    try {
+      db.getSchema().createDocumentType("Doc");
+      db.transaction(() -> db.newDocument("Doc").set("v", "A").save());
+      db.getPageManager().waitAllPagesOfDatabaseAreFlushed(db);
+
+      final PaginatedComponent bucket = (PaginatedComponent) db.getSchema().getType("Doc").getBuckets(false).getFirst();
+      final PaginatedComponentFile file = (PaginatedComponentFile) db.getFileManager().getFile(bucket.getFileId());
+
+      final long slot = file.readPageChecksum(0);
+      assertThat(slot).as("the flush must have written a checksum slot for page 0").isNotEqualTo(-1L);
+
+      final ByteBuffer raw = ByteBuffer.allocate(file.getPageSize());
+      file.readPage(0, raw);
+      final int diskVersion = raw.getInt(0);
+      final CRC32C crc = new CRC32C();
+      raw.rewind();
+      crc.update(raw);
+
+      assertThat((int) (slot >>> 32)).as("slot version must match the on-disk page version").isEqualTo(diskVersion);
+      assertThat((int) slot).as("slot CRC must match the CRC32C of the raw on-disk page").isEqualTo((int) crc.getValue());
+    } finally {
+      db.drop();
+      factory.close();
+    }
+  }
+
+  /** A corrupted sidecar on a cleanly-closed database (no WAL) must not affect normal opens: verification is recovery-only. */
+  @Test
+  void corruptedSidecarOnCleanDatabaseIsIgnoredOutsideRecovery() throws Exception {
+    final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
+    if (factory.exists())
+      factory.open().drop();
+
+    String bucketFilePath;
+    {
+      final DatabaseInternal db = (DatabaseInternal) factory.create();
+      db.getSchema().createDocumentType("Doc");
+      db.transaction(() -> db.newDocument("Doc").set("v", "A").save());
+      final PaginatedComponent bucket = (PaginatedComponent) db.getSchema().getType("Doc").getBuckets(false).getFirst();
+      bucketFilePath = db.getFileManager().getFile(bucket.getFileId()).getFilePath();
+      db.close();
+    }
+
+    final File sidecar = new File(bucketFilePath + PaginatedComponentFile.CHECKSUM_FILE_EXT);
+    assertThat(sidecar).exists();
+    try (final RandomAccessFile raf = new RandomAccessFile(sidecar, "rw")) {
+      raf.seek(4);
+      raf.writeInt(0xDEADBEEF);
+    }
+
+    final Database reopened = factory.open();
+    try {
+      assertThat(reopened.query("sql", "SELECT v FROM Doc").next().<String>getProperty("v")).isEqualTo("A");
+    } finally {
+      reopened.close();
+      factory.close();
+    }
+  }
+
+  /**
+   * Creates three documents in the same page (v1, flushed and durable), then commits three more
+   * transactions - each updating ONE of the documents (v2, v3, v4) - with flushing suspended, and kills
+   * the database. The WAL holds the v2/v3/v4 deltas; the data page on disk is still at v1.
+   *
+   * @return the bucket file path
+   */
+  private String prepareTornMultiVersionScenario() throws Exception {
+    final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
+    if (factory.exists())
+      factory.open().drop();
+
+    final String bucketFilePath;
+    final DatabaseInternal db = (DatabaseInternal) factory.create();
+    db.getSchema().createDocumentType("Doc");
+    db.transaction(() -> {
+      db.newDocument("Doc").set("id", 1, "v", "A1").save();
+      db.newDocument("Doc").set("id", 2, "v", "A2").save();
+      db.newDocument("Doc").set("id", 3, "v", "A3").save();
+    });
+    db.getPageManager().waitAllPagesOfDatabaseAreFlushed(db);
+
+    final PaginatedComponent bucket = (PaginatedComponent) db.getSchema().getType("Doc").getBuckets(false).getFirst();
+    bucketFilePath = db.getFileManager().getFile(bucket.getFileId()).getFilePath();
+
+    assertThat(PageManager.INSTANCE.getFlushThread().setSuspended(db, true))
+        .as("flush suspension must engage or the pages could reach disk, invalidating the test").isTrue();
+
+    // Three transactions, each rewriting only its own record's byte region: v2 (doc1), v3 (doc2), v4 (doc3).
+    // The new values keep the same serialized size so the update happens in place.
+    for (int i = 1; i <= 3; i++) {
+      final int id = i;
+      db.transaction(() -> db.query("sql", "SELECT FROM Doc WHERE id = " + id).next().getRecord().get().asDocument()
+          .modify().set("v", "B" + id).save());
+    }
+
+    ((LocalDatabase) db).kill();
+    db.close();
+
+    return bucketFilePath;
+  }
+
+  private void reopenAndExpectAllRepaired() {
+    final DatabaseFactory factory = new DatabaseFactory(DB_PATH);
+    final Database reopened = factory.open();
+    try {
+      final Map<Integer, String> values = new HashMap<>();
+      try (final ResultSet rs = reopened.query("sql", "SELECT id, v FROM Doc")) {
+        while (rs.hasNext()) {
+          final Result r = rs.next();
+          values.put(r.getProperty("id"), r.getProperty("v"));
+        }
+      }
+      assertThat(values).as("recovery must replay the FULL WAL delta chain for the torn page (#5054)")
+          .containsEntry(1, "B1").containsEntry(2, "B2").containsEntry(3, "B3");
+    } finally {
+      reopened.close();
+      factory.close();
+    }
+  }
+}


### PR DESCRIPTION
Follow-up to #4926 / #5052 from the 2026-07 audit backlog. Closes #5054.

## What does this PR do?

**#5054 (implemented, red-first).** Async flush coalesces several committed versions into a single physical page write, so a page can go v1(on-disk) -> v2 -> v3 -> v4 with only the v4 flush reaching the platter. If that flush tears, the #5052 equal-version re-apply repairs only v4's delta region: v2/v3 entries are skipped as strictly-older and their byte regions stay silently torn. The version header alone cannot distinguish this page from an intact one.

Every page flush now also maintains an 8-byte slot (page version + CRC32C of the raw page bytes) in a `.pcrc` sidecar file next to each data file, written BEFORE the page bytes and fsynced under the same `force()` barrier. During crash recovery a pre-scan collects the per-page maximum retained WAL version, and each WAL-referenced page is verified once: a page whose checksum reveals a torn write gets its FULL retained WAL delta chain replayed in transaction order (the strictly-older skip and the version-gap abort are bypassed for that page only). Correctness rests on the fsync-before-WAL-drop barrier (#4509/#4934): a dropped entry is always durably contained in the on-disk page, so in-order application of every retained entry reconstructs exactly the newest committed state. A guard refuses the repair when the WAL retains no entry at or above the disk version, so a stale checksum (e.g. a sidecar restored from a backup) can never downgrade an intact page.

Red-first evidence (`PageChecksumRecoveryTest`): three documents in one page updated by three separate transactions (v2/v3/v4, disjoint byte regions) with flushing suspended, kill, version header forged to v4 over the v1 content. Before the fix recovery produced `{doc1=A1, doc2=A2, doc3=B3}` - the exact #5054 silent corruption; after, the full chain replay restores `{B1, B2, B3}`. Also covered: the tear with a persisted equal-version slot (CRC mismatch as direct positive evidence), the missing-sidecar migration path, the slot-matches-disk flush contract, and a corrupted sidecar on a cleanly-closed database (verification is recovery-only).

## Design decisions (design-first item)

- **Where the checksum lives.** A `.pcrc` sidecar per data file (8 bytes per page at `pageNumber * 8`), NOT a page-header extension. The header extension was analyzed and rejected: component file versions carry per-component semantics (`LocalBucket.purposeForVersion` treats v>=1 as EXTERNAL_PROPERTY and `maxRecordsInPageForVersion` keys the slot table on the same integer), so a cross-cutting "has checksum" gate cannot ride that version without redesigning component versioning across every component type; `PAGE_HEADER_SIZE` is additionally a static constant compiled into 17+ classes including the just-stabilized commit path, and the WAL/replication deltas carry absolute in-page offsets. The sidecar needs no version gating at all.
- **Algorithm.** `java.util.zip.CRC32C` (hardware-accelerated) over the full raw page bytes exactly as written, version stored alongside so a slot can be matched to the page state it describes.
- **When written.** Inside `PaginatedComponentFile.write()` - every write site (flush thread, sync flush, recovery/replicated `writePageWithLock`) is covered automatically - BEFORE the page bytes, so a persisted slot always describes the newest attempted write. Cost is on the flush thread, not commit latency. Gated by `arcadedb.pageChecksum` (default true). A sidecar write/fsync failure is contained as a WARNING: checksums are advisory and must never veto the data file's fsync verdict.
- **When verified.** Recovery only (`TransactionManager.checkIntegrity` passes a `RecoveryPageVerifier` into `applyChanges`; the HA/Raft replay callers pass null and are untouched). Read-path verification behind a config flag was deliberately left out to keep the hot read path unchanged; it can be added later (noted below).
- **Mismatch handling.** Torn page -> replay the full retained WAL chain in tx order for that page, guarded by the pre-scanned per-page max WAL version (a replay can never end below the version the disk already claims).
- **Migration.** None needed, in both directions. Old databases have no sidecar -> verification is skipped and slots fill in as pages flush. `FileManager` scans the directory by extension whitelist, so old and NEW versions alike ignore `.pcrc` (downgrade-safe). `drop()` deletes the sidecar; `rename()` (LSM compaction temp-suffix removal) carries it along; HA file transfers that omit it only lose verification, never data.

## Per-issue verdict

- **#5054: implemented.** Red-first TDD; the forged multi-version torn write reproduces the exact silent corruption on main and is repaired with the fix.

## Test evidence

- `PageChecksumRecoveryTest` (new, 5 tests): red-first on main for the two torn-write cases (`{A1, A2, B3}` observed pre-fix), green with the fix.
- Full engine+database battery (`com.arcadedb.engine.**` + `com.arcadedb.database.**`): **624 tests, 0 failures, 0 errors** (1 pre-existing skip).
- LSM compaction/drop suites (`LSMTreeIndexCompactionTest`, `LSMTreeCompactionCorrectnessTest`, `DropIndexTest`, `Issue4960LSMReloadCompactionCounterTest`): green - exercises the sidecar rename/drop lifecycle.
- Recovery suites (`WalRecoveryCorrectnessTest`, `WALVersionGapRecoveryTest`, `Issue4508TornWALRecoveryTest`, `Issue4510ForceApplyPartialDeltaTest`, `ACIDTransactionTest`): green.
- Earlier battery rounds surfaced two real issues, both resolved in this PR: the sidecar fsync initially threw `ClosedByInterruptException` when the main channel's interrupt retry restored the flag first (now interrupt-shielded like the main channel), and the sidecar-creation latency inside the per-page interlock made a latent race in `Issue4712ReplicatedWriteLockTest` / `Issue4510ForceApplyPartialDeltaTest` frequent - their fake-interlock/reload setup raced the async flush of their own setup transaction (`LocalDatabase.equals` is path-based, so the race spans helper database instances). Fixed by draining the flush pipeline after setup (second commit); verified 8/8 green isolated runs.

## Conflict-risk notes

- `docs/release-26.7.2.md`: expected to conflict with sibling audit PRs (append-style entries); trivial to resolve.
- `TransactionManager.applyChanges`: touched by #5052 recently; this PR builds directly on that code (comment block updated in place). Sibling PRs touching recovery would conflict here.
- `PaginatedComponentFile`: new sidecar members and `write()`/`force()`/`close()`/`rename()`/`drop()` additions; low conflict risk.

## Follow-up candidates (not in scope)

- Optional checksum verification on normal page reads behind a config flag (default off), and a CHECK DATABASE integration that validates every slot offline.
- Sparse/vector bulk writers that bypass `PaginatedComponentFile.write()` leave no slots for their pages (verification simply skips them); wiring them in would extend coverage.

## Checklist

- [x] I have run the build using `mvn clean package` command (engine module + full engine/database battery)
- [x] My unit tests cover both failure and success scenarios
