### PR TITLE
fix(#5066): map the 'fast' async queue to the MPMC DisruptorBlockingQueue

### DIFF
--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -310,7 +310,9 @@ that could starve the very snapshot resync meant to heal the node.
   producers: a reproduction test showed concurrent offers silently LOSING tasks in normal
   operation, and its missing `remove(Object)` degraded the post-shutdown scheduling undo to a
   logged best-effort. The multi-producer replacement comes from the same library and jar, keeps the
-  lock-free fast path (CAS-claimed sequences), supports `remove(Object)` (the shutdown undo now
+  lock-free fast path (CAS-claimed sequences; note `fast` trades CPU for latency - the Disruptor
+  queue busy-spins before parking, so idle workers cost more CPU than `standard`, same as the
+  previous `fast` implementation), supports `remove(Object)` (the shutdown undo now
   works identically on both impls) and rounds capacities up to the next power of two. Shutdown no
   longer strands completion waiters: an interrupted or exiting worker now notifies `completed()` on every
   task left in its queue instead of `queue.clear()`-ing them (threads blocked in `scanType()` /

--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -313,7 +313,10 @@ that could starve the very snapshot resync meant to heal the node.
   lock-free fast path (CAS-claimed sequences; note `fast` trades CPU for latency - the Disruptor
   queue busy-spins before parking, so idle workers cost more CPU than `standard`, same as the
   previous `fast` implementation), supports `remove(Object)` (the shutdown undo now
-  works identically on both impls) and rounds capacities up to the next power of two. Shutdown no
+  works identically on both impls) and rounds capacities up to the next power of two (so for a
+  non-power-of-two configured `ASYNC_OPERATIONS_QUEUE_SIZE / parallelLevel`, `fast` applies
+  back-pressure at a slightly different real fill level than `standard`, which uses the exact size).
+  Shutdown no
   longer strands completion waiters: an interrupted or exiting worker now notifies `completed()` on every
   task left in its queue instead of `queue.clear()`-ing them (threads blocked in `scanType()` /
   `waitCompletion()` hung forever), and `close()` no longer blocks unbounded on `queue.put(FORCE_EXIT)`

--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -302,11 +302,16 @@ that could starve the very snapshot resync meant to heal the node.
   your tasks legitimately run that long. Operators
   running scheduling chains deeper than two workers with individual tasks slower than 15s should
   raise `checkForStalledQueuesMaxDelay` (only the window duration is tunable, the counts are fixed),
-  or the cross-slot detector can fire on a chain that would have resolved. Known residual
-  gap: with the opt-in
-  `arcadedb.asyncOperationsQueueImpl=fast` queue, a task whose enqueue races the target worker's
-  exit cannot be removed (`remove(Object)` unsupported) and its completion is never notified; a
-  WARNING is logged when this happens, and the default `standard` queue is not affected. Shutdown no
+  or the cross-slot detector can fire on a chain that would have resolved. The formerly documented
+  `fast`-queue residual gap is fixed ([#5066](https://github.com/ArcadeData/arcadedb/issues/5066)):
+  `arcadedb.asyncOperationsQueueImpl=fast` (also selected by the `high-performance` profile) now maps
+  to Conversant's `DisruptorBlockingQueue` instead of `PushPullBlockingQueue`. The old class is an
+  explicit single-producer/single-consumer design, while every async worker queue has many
+  producers: a reproduction test showed concurrent offers silently LOSING tasks in normal
+  operation, and its missing `remove(Object)` degraded the post-shutdown scheduling undo to a
+  logged best-effort. The multi-producer replacement comes from the same library and jar, keeps the
+  lock-free fast path (CAS-claimed sequences), supports `remove(Object)` (the shutdown undo now
+  works identically on both impls) and rounds capacities up to the next power of two. Shutdown no
   longer strands completion waiters: an interrupted or exiting worker now notifies `completed()` on every
   task left in its queue instead of `queue.clear()`-ing them (threads blocked in `scanType()` /
   `waitCompletion()` hung forever), and `close()` no longer blocks unbounded on `queue.put(FORCE_EXIT)`

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -1010,7 +1010,7 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       final BlockingQueue<DatabaseAsyncTask> queue = target.queue;
 
       if (applyBackPressureOnPercentage > 0) {
-        final int queueFullAt = 100 - (queue.remainingCapacity() * 100 / (queue.remainingCapacity() + queue.size()));
+        final int queueFullAt = queueFullPercentage(queue);
 
         if (queueFullAt >= applyBackPressureOnPercentage)
           // TODO: VARIABLE SLEEP TIME BASED ON HOW MUCH THE QUEUE IS FULL
@@ -1067,6 +1067,23 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
                   + "to close this window", task);
       return false;
     }
+  }
+
+  /**
+   * Back-pressure gauge: how full the queue is, as a 0-100 percentage.
+   * <p>
+   * #5081 review: {@code remainingCapacity()} and {@code size()} are read ONCE each into locals so the
+   * numerator and denominator are computed from the same pair - the previous inline form called each twice,
+   * and on the 'fast' {@link com.conversantmedia.util.concurrent.DisruptorBlockingQueue} the two are
+   * weakly-consistent estimates, so a full-then-drained race between the calls could yield a zero
+   * denominator ({@code ArithmeticException}). {@code Math.max(1, ...)} guards the divide regardless.
+   */
+  // Package-visible for AsyncFastQueueShutdownUndoTest, which feeds a fake queue reporting the racy 0/0
+  // snapshot the real TOCTOU cannot be forced to produce deterministically.
+  static int queueFullPercentage(final BlockingQueue<DatabaseAsyncTask> queue) {
+    final int remaining = queue.remainingCapacity();
+    final int size = queue.size();
+    return 100 - (remaining * 100 / Math.max(1, remaining + size));
   }
 
   /**
@@ -1141,8 +1158,7 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
         }
 
         if (applyBackPressureOnPercentage > 0) {
-          final int queueFullAt =
-              100 - (queue.remainingCapacity() * 100 / (queue.remainingCapacity() + queue.size()));
+          final int queueFullAt = queueFullPercentage(queue);
           Thread.sleep(100 + (4L * queueFullAt));
         }
       }

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -1027,6 +1027,9 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
         scheduled = false;
 
       if (scheduled) {
+        // NOTE (#5081 review): remove(Object) on the Disruptor queue is an O(n) whole-queue-locking scan.
+        // Acceptable ONLY because this undo runs on the rare dead-worker post-shutdown race - it must never
+        // migrate onto the steady-state scheduling path.
         if (!target.isAlive() && removeQuietly(queue, task))
           // The worker exited (shutdown) after its final queue drain but before this offer landed:
           // the task would sit unexecuted forever. Undo the offer and fail like any post-shutdown

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -1077,6 +1077,9 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
    * and on the 'fast' {@link com.conversantmedia.util.concurrent.DisruptorBlockingQueue} the two are
    * weakly-consistent estimates, so a full-then-drained race between the calls could yield a zero
    * denominator ({@code ArithmeticException}). {@code Math.max(1, ...)} guards the divide regardless.
+   * <p>
+   * On the guarded {@code remaining=0, size=0} snapshot this returns 100 ("full"), not 0: an ambiguous
+   * estimate biases toward MORE back-pressure for that one iteration, self-correcting on the next re-read.
    */
   // Package-visible for AsyncFastQueueShutdownUndoTest, which feeds a fake queue reporting the racy 0/0
   // snapshot the real TOCTOU cannot be forced to produce deterministically.

--- a/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
+++ b/engine/src/main/java/com/arcadedb/database/async/DatabaseAsyncExecutorImpl.java
@@ -39,7 +39,7 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.EdgeType;
 import com.arcadedb.schema.LocalTimeSeriesType;
-import com.conversantmedia.util.concurrent.PushPullBlockingQueue;
+import com.conversantmedia.util.concurrent.DisruptorBlockingQueue;
 
 import java.util.ArrayDeque;
 import java.util.Arrays;
@@ -156,7 +156,13 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
       final String cfgQueueImpl =
           database.getConfiguration().getValueAsString(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_IMPL);
       if ("fast".equalsIgnoreCase(cfgQueueImpl))
-        this.queue = new PushPullBlockingQueue<>(queueSize);
+        // #5066: DisruptorBlockingQueue (MPMC, lock-free CAS-claimed sequences) instead of
+        // PushPullBlockingQueue: the latter is an explicit single-producer/single-consumer design
+        // with no CAS on the tail, while this queue has many producers (any application thread,
+        // cross-scheduling workers, completion markers, the closing thread), so concurrent offers
+        // could silently lose tasks; it also lacks remove(Object), which scheduleTask's
+        // post-shutdown undo relies on. Same library, same jar, capacity rounded up to a power of 2.
+        this.queue = new DisruptorBlockingQueue<>(queueSize);
       else if ("standard".equalsIgnoreCase(cfgQueueImpl))
         this.queue = new ArrayBlockingQueue<>(queueSize);
       else {
@@ -1046,11 +1052,11 @@ public class DatabaseAsyncExecutorImpl implements DatabaseAsyncExecutor {
     try {
       return queue.remove(task);
     } catch (final UnsupportedOperationException e) {
-      // THE "fast" QUEUE (PushPullBlockingQueue) DOES NOT SUPPORT remove(Object): the offer cannot
-      // be undone, so a task that landed right after a dead worker's final drain stays queued and
-      // its completed() never fires (#5062 review, point 4). Known gap, accepted: the impl is
-      // opt-in and the window (an offer racing the worker's exit) is a few instructions wide. The
-      // WARNING below gives operators the reason should a scanType()/waitCompletion() waiter hang.
+      // #5066: DEFENSIVE ONLY - both shipped queue impls ('standard' ArrayBlockingQueue and 'fast'
+      // DisruptorBlockingQueue) support remove(Object) now that 'fast' no longer maps to
+      // PushPullBlockingQueue. If a future impl lacks remove, the offer cannot be undone: a task
+      // that landed right after a dead worker's final drain stays queued with completed() never
+      // fired, and the WARNING below gives operators the reason should a waiter hang.
       LogManager.instance()
           .log(DatabaseAsyncExecutorImpl.class, Level.WARNING,
               "Asynchronous task %s was scheduled on a worker that already shut down and cannot be removed from its "

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncFastQueueShutdownUndoTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncFastQueueShutdownUndoTest.java
@@ -120,12 +120,6 @@ class AsyncFastQueueShutdownUndoTest extends TestHelper {
     assertThat(async.waitCompletion(10_000)).isTrue();
   }
 
-  private static DatabaseAsyncExecutorImpl.AsyncThread findWorkerThread(final DatabaseInternal db, final int slot) {
-    final String name = "AsyncExecutor-" + db.getName() + "-" + slot;
-    return (DatabaseAsyncExecutorImpl.AsyncThread) Thread.getAllStackTraces().keySet().stream()
-        .filter(t -> t.getName().equals(name)).findFirst()
-        .orElseThrow(() -> new IllegalStateException("Worker thread " + name + " not found"));
-  }
   @Test
   @Timeout(60)
   void fastQueueSupportsEffectiveCapacityOne() throws Exception {
@@ -160,6 +154,13 @@ class AsyncFastQueueShutdownUndoTest extends TestHelper {
     }
 
     assertThat(async.waitCompletion(10_000)).isTrue();
+  }
+
+  private static DatabaseAsyncExecutorImpl.AsyncThread findWorkerThread(final DatabaseInternal db, final int slot) {
+    final String name = "AsyncExecutor-" + db.getName() + "-" + slot;
+    return (DatabaseAsyncExecutorImpl.AsyncThread) Thread.getAllStackTraces().keySet().stream()
+        .filter(t -> t.getName().equals(name)).findFirst()
+        .orElseThrow(() -> new IllegalStateException("Worker thread " + name + " not found"));
   }
 
 }

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncFastQueueShutdownUndoTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncFastQueueShutdownUndoTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import static com.arcadedb.database.async.AsyncTestTasks.awaitTask;
@@ -115,7 +116,7 @@ class AsyncFastQueueShutdownUndoTest extends TestHelper {
       t.join(30_000);
 
     assertThat(executed.await(30, TimeUnit.SECONDS))
-        .as("every task offered by concurrent producers must execute exactly once")
+        .as("every task offered by concurrent producers must all execute (the SPSC impl silently lost tasks)")
         .isTrue();
     assertThat(async.waitCompletion(10_000)).isTrue();
   }
@@ -156,11 +157,47 @@ class AsyncFastQueueShutdownUndoTest extends TestHelper {
     assertThat(async.waitCompletion(10_000)).isTrue();
   }
 
+  @Test
+  void backPressureGaugeSurvivesTheRacyZeroDenominatorSnapshot() {
+    // #5081 review point 2: remainingCapacity() and size() are separate reads, and on the 'fast'
+    // DisruptorBlockingQueue they are weakly-consistent estimates - a full-then-drained race between the
+    // two can present as remaining=0, size=0. Without the Math.max(1, ...) guard that is a divide by zero.
+    // The real race cannot be forced deterministically, so drive the gauge with a fake queue that reports
+    // exactly that snapshot; the guard must yield a sane 0-100 value instead of throwing.
+    assertThat(DatabaseAsyncExecutorImpl.queueFullPercentage(new FixedSnapshotQueue(0, 0)))
+        .as("a 0/0 estimate must not divide by zero").isBetween(0, 100);
+    // A normal half-full snapshot still reports ~50.
+    assertThat(DatabaseAsyncExecutorImpl.queueFullPercentage(new FixedSnapshotQueue(50, 50))).isEqualTo(50);
+    // A full queue reports 100.
+    assertThat(DatabaseAsyncExecutorImpl.queueFullPercentage(new FixedSnapshotQueue(0, 100))).isEqualTo(100);
+  }
+
   private static DatabaseAsyncExecutorImpl.AsyncThread findWorkerThread(final DatabaseInternal db, final int slot) {
     final String name = "AsyncExecutor-" + db.getName() + "-" + slot;
     return (DatabaseAsyncExecutorImpl.AsyncThread) Thread.getAllStackTraces().keySet().stream()
         .filter(t -> t.getName().equals(name)).findFirst()
         .orElseThrow(() -> new IllegalStateException("Worker thread " + name + " not found"));
+  }
+
+  /** A queue that reports a fixed (remainingCapacity, size) snapshot, standing in for the weakly-consistent estimates. */
+  private static final class FixedSnapshotQueue extends LinkedBlockingQueue<DatabaseAsyncTask> {
+    private final int remaining;
+    private final int size;
+
+    private FixedSnapshotQueue(final int remaining, final int size) {
+      this.remaining = remaining;
+      this.size = size;
+    }
+
+    @Override
+    public int remainingCapacity() {
+      return remaining;
+    }
+
+    @Override
+    public int size() {
+      return size;
+    }
   }
 
 }

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncFastQueueShutdownUndoTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncFastQueueShutdownUndoTest.java
@@ -173,6 +173,8 @@ class AsyncFastQueueShutdownUndoTest extends TestHelper {
   }
 
   private static DatabaseAsyncExecutorImpl.AsyncThread findWorkerThread(final DatabaseInternal db, final int slot) {
+    // Couples to the worker thread name set in the AsyncThread constructor ("AsyncExecutor-<db>-<slot>");
+    // if that format changes these tests fail here rather than obscurely.
     final String name = "AsyncExecutor-" + db.getName() + "-" + slot;
     return (DatabaseAsyncExecutorImpl.AsyncThread) Thread.getAllStackTraces().keySet().stream()
         .filter(t -> t.getName().equals(name)).findFirst()

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncFastQueueShutdownUndoTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncFastQueueShutdownUndoTest.java
@@ -126,4 +126,40 @@ class AsyncFastQueueShutdownUndoTest extends TestHelper {
         .filter(t -> t.getName().equals(name)).findFirst()
         .orElseThrow(() -> new IllegalStateException("Worker thread " + name + " not found"));
   }
+  @Test
+  @Timeout(60)
+  void fastQueueSupportsEffectiveCapacityOne() throws Exception {
+    // #5081 review: queueSize = ASYNC_OPERATIONS_QUEUE_SIZE / parallelLevel floors to 1 on large pools, so
+    // capacity 1 is production-reachable - and the Conversant ring's minimum-size rounding is
+    // library-version-specific. Pin the guarantee: offer/remove/reuse must behave on a 1-slot Disruptor
+    // queue so a future library bump cannot silently regress it.
+    final DatabaseInternal db = (DatabaseInternal) database;
+    db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_IMPL, "fast");
+    db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 1);
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
+    async.setParallelLevel(1);
+    async.recreateThreadsForTests();
+
+    final CountDownLatch blockerStarted = new CountDownLatch(1);
+    final CountDownLatch release = new CountDownLatch(1);
+    try {
+      // Park the worker so the queue keeps exactly its 1 slot for the probes below.
+      async.scheduleTask(0, awaitTask(blockerStarted, release), true, 0);
+      assertThat(blockerStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+      final DatabaseAsyncExecutorImpl.AsyncThread worker = findWorkerThread(db, 0);
+      final DatabaseAsyncTask first = noOpTask();
+      final DatabaseAsyncTask second = noOpTask();
+      assertThat(worker.queue.offer(first)).as("a 1-slot queue accepts the first task").isTrue();
+      assertThat(worker.queue.offer(second)).as("a full 1-slot queue rejects (not blocks/throws) the second").isFalse();
+      assertThat(worker.queue.remove(first))
+          .as("remove(Object) works at capacity 1 - the post-shutdown undo primitive").isTrue();
+      assertThat(worker.queue.offer(second)).as("the slot freed by remove is reusable").isTrue();
+    } finally {
+      release.countDown();
+    }
+
+    assertThat(async.waitCompletion(10_000)).isTrue();
+  }
+
 }

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncFastQueueShutdownUndoTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncFastQueueShutdownUndoTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.database.async;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static com.arcadedb.database.async.AsyncTestTasks.awaitTask;
+import static com.arcadedb.database.async.AsyncTestTasks.countingTask;
+import static com.arcadedb.database.async.AsyncTestTasks.noOpTask;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for #5066: with {@code arcadedb.asyncOperationsQueueImpl=fast} (also enabled by
+ * the {@code high-performance} profile) the worker queue was Conversant's
+ * {@code PushPullBlockingQueue}, whose {@code remove(Object)} throws
+ * {@code UnsupportedOperationException}. That degraded {@code scheduleTask}'s post-shutdown undo
+ * (remove the task offered after the dead worker's final drain, then throw) to a silent no-op: the
+ * orphaned task's {@code completed()} never fired and waiters hung. Worse, that queue is an
+ * explicit single-producer/single-consumer design ("Transfers from a single thread writer to a
+ * single thread reader") with no CAS on the tail sequence, while every worker queue here has many
+ * producers (any application thread, cross-scheduling workers, completion markers, the closing
+ * thread), so concurrent offers could silently lose tasks in normal operation. The 'fast' setting
+ * now maps to {@code DisruptorBlockingQueue}, the multi-producer variant from the same library,
+ * which both honors the multi-producer contract and implements {@code remove(Object)}.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class AsyncFastQueueShutdownUndoTest extends TestHelper {
+
+  @Test
+  @Timeout(60)
+  void fastQueueMustSupportRemoveForThePostShutdownUndo() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_IMPL, "fast");
+    db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 4);
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
+    async.setParallelLevel(1);
+    // Rebuild the pool so the settings above are picked up.
+    async.recreateThreadsForTests();
+
+    final CountDownLatch blockerStarted = new CountDownLatch(1);
+    final CountDownLatch release = new CountDownLatch(1);
+    try {
+      // Park the worker so the probe below stays in the queue while we exercise remove().
+      async.scheduleTask(0, awaitTask(blockerStarted, release), true, 0);
+      assertThat(blockerStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+      final DatabaseAsyncTask probe = noOpTask();
+      assertThat(async.scheduleTask(0, probe, false, 0)).isTrue();
+
+      // The exact operation the post-shutdown undo depends on: on the old PushPullBlockingQueue it
+      // threw UnsupportedOperationException, leaving the orphaned task enqueued forever.
+      final DatabaseAsyncExecutorImpl.AsyncThread worker = findWorkerThread(db, 0);
+      assertThat(worker.queue.remove(probe))
+          .as("the 'fast' queue impl must support remove(Object): scheduleTask's post-shutdown undo relies on it")
+          .isTrue();
+      assertThat(worker.queue.remove(probe)).as("the probe must be gone after removal").isFalse();
+    } finally {
+      release.countDown();
+    }
+
+    assertThat(async.waitCompletion(10_000)).isTrue();
+  }
+
+  @Test
+  @Timeout(60)
+  void fastQueueMustNotLoseTasksUnderConcurrentProducers() throws Exception {
+    final DatabaseInternal db = (DatabaseInternal) database;
+    db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_IMPL, "fast");
+    db.getConfiguration().setValue(GlobalConfiguration.ASYNC_OPERATIONS_QUEUE_SIZE, 64);
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
+    async.setParallelLevel(2);
+    // Rebuild the pool so the settings above are picked up.
+    async.recreateThreadsForTests();
+
+    // Integrity guard for the multi-producer contract: the SPSC impl the 'fast' setting used to
+    // select has no CAS on its tail sequence, so racing producers could overwrite each other's
+    // slot and silently lose tasks. Deterministically green on a compliant MPMC impl.
+    final int producers = 8;
+    final int tasksPerProducer = 250;
+    final CountDownLatch executed = new CountDownLatch(producers * tasksPerProducer);
+    final Thread[] threads = new Thread[producers];
+    for (int p = 0; p < producers; p++) {
+      final int slotSeed = p;
+      threads[p] = new Thread(() -> {
+        for (int i = 0; i < tasksPerProducer; i++)
+          async.scheduleTask((slotSeed + i) % 2, countingTask(executed), true, 0);
+      }, getClass().getSimpleName() + "-producer-" + p);
+      threads[p].start();
+    }
+    for (final Thread t : threads)
+      t.join(30_000);
+
+    assertThat(executed.await(30, TimeUnit.SECONDS))
+        .as("every task offered by concurrent producers must execute exactly once")
+        .isTrue();
+    assertThat(async.waitCompletion(10_000)).isTrue();
+  }
+
+  private static DatabaseAsyncExecutorImpl.AsyncThread findWorkerThread(final DatabaseInternal db, final int slot) {
+    final String name = "AsyncExecutor-" + db.getName() + "-" + slot;
+    return (DatabaseAsyncExecutorImpl.AsyncThread) Thread.getAllStackTraces().keySet().stream()
+        .filter(t -> t.getName().equals(name)).findFirst()
+        .orElseThrow(() -> new IllegalStateException("Worker thread " + name + " not found"));
+  }
+}


### PR DESCRIPTION
Fixes #5066.

## Verdict per option in the issue

The issue offered two shapes: a second drain pass on shutdown, or documenting the limitation. Investigation found the real defect one level deeper, which makes both options the wrong fix:

- **The `fast` impl violated its own concurrency contract in normal operation.** `PushPullBlockingQueue` is an explicit single-producer/single-consumer design ("Transfers from a single thread writer to a single thread reader", no CAS on the tail sequence). Every async worker queue here has MANY producers: any application thread calling `scheduleTask`, cross-scheduling workers, `waitCompletion` markers, the closing thread. This is not theoretical - the new multi-producer regression test **demonstrated lost tasks empirically** on the old impl (8 producers x 250 no-op tasks, completion latch never reached zero). Note the `high-performance` profile selects `fast`, so this was not an obscure opt-in corner.
- **A second drain pass cannot be made total.** A producer that snapshotted `executorThreads` before shutdown can offer arbitrarily late, so no finite number of drain passes closes the window; the producer-side remove-undo is the only shape that works regardless of timing - and it needs `remove(Object)`.

## The fix

`arcadedb.asyncOperationsQueueImpl=fast` now maps to **`DisruptorBlockingQueue`**, the flagship MPMC variant from the same Conversant jar (no new dependency, same Apache 2.0 artifact):

- lock-free CAS-claimed sequences honor the multi-producer contract;
- `remove(Object)` is implemented (cursor-blocked scan-and-shift), so `scheduleTask`'s post-shutdown undo now works identically on both queue impls - the #5062-documented residual gap is gone;
- capacity 1 is explicitly supported (`Capacity.getCapacity`), matching small test configs; capacities round up to the next power of two, as the old ring already did.

`removeQuietly`'s `UnsupportedOperationException` catch is kept as defensive-only for hypothetical future impls, with its comment and operator WARNING updated.

## Red-first evidence

`AsyncFastQueueShutdownUndoTest` (both red on the old impl, green after the swap):
- `fastQueueMustSupportRemoveForThePostShutdownUndo`: the exact primitive the undo depends on - threw `UnsupportedOperationException` before.
- `fastQueueMustNotLoseTasksUnderConcurrentProducers`: timed out with lost tasks before; deterministically green on a compliant MPMC impl.

## Verification

`mvn -pl engine compile`; the full `com.arcadedb.database.async` battery plus `AsyncTest` run **twice**: default config (36 tests) and the fast-queue variant via `-Darcadedb.asyncOperationsQueueImpl=fast` (36 tests) - all green, so every existing shutdown/drain/stall/helping regression also passes on the Disruptor queue. Release notes updated to record that the formerly documented fast-queue gap is fixed.