### PR TITLE
fix(#5002): HA-aware Bolt ROUTE response with multi-server routing table

### DIFF
--- a/bolt/conformance/spec.yaml
+++ b/bolt/conformance/spec.yaml
@@ -110,12 +110,13 @@ scenarios:
       - "When the driver connects to neo4j://<any-node>:7687 and requests a routing table"
       - "Then the routing table should list the true leader as writer and the true followers as readers"
     applicable_driver_versions: all
-    current_status: expected-fail
+    current_status: passing
     known_limitation: >
-      BoltNetworkExecutor.handleRoute (bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java:903-939)
-      always returns the local node's own address as WRITE, READ, and ROUTE
-      roles, regardless of actual cluster topology - single-node only.
-    tracking_issue: "#4890"
+      For clusters with heterogeneous Bolt ports, each node's client-reachable
+      Bolt address must be declared with the object-form 'bolt:' field in
+      HA_SERVER_LIST (host:{raft:..,http:..,bolt:..}). When omitted, the address
+      is derived from each peer's Raft host plus this node's Bolt port, which is
+      correct only for homogeneous deployments (e.g. a Kubernetes StatefulSet).
   - id: CONN-005
     area: connection
     title: "TLS OPTIONAL mode falls back to plaintext bolt://"

--- a/bolt/conformance/test_validate_spec.py
+++ b/bolt/conformance/test_validate_spec.py
@@ -84,12 +84,18 @@ class ValidateSpecTest(unittest.TestCase):
         self.assertTrue(any("tracking_issue" in e for e in errors), errors)
 
     def test_missing_gap_tracking_area_is_flagged(self):
-        spec = minimal_valid_spec()
-        spec["scenarios"] = [s for s in spec["scenarios"] if s["id"] != "CONN-900"]
-        errors = validate(spec)
-        self.assertTrue(
-            any("connection" in e for e in errors), errors
-        )
+        # REQUIRED_GAP_AREAS is empty once every #4890-tracked gap is closed, so the missing-gap
+        # mechanism is exercised against a temporarily required area rather than the live config.
+        import validate_spec
+        original = validate_spec.REQUIRED_GAP_AREAS
+        validate_spec.REQUIRED_GAP_AREAS = {"connection"}
+        try:
+            spec = minimal_valid_spec()
+            spec["scenarios"] = [s for s in spec["scenarios"] if s["id"] != "CONN-900"]
+            errors = validate(spec)
+            self.assertTrue(any("connection" in e for e in errors), errors)
+        finally:
+            validate_spec.REQUIRED_GAP_AREAS = original
 
     def test_missing_driver_language_is_flagged(self):
         spec = minimal_valid_spec()

--- a/bolt/conformance/validate_spec.py
+++ b/bolt/conformance/validate_spec.py
@@ -24,13 +24,12 @@ REQUIRED_AREAS = {
 VALID_STATUSES = {"passing", "expected-fail", "not-applicable", "unverified"}
 REQUIRED_LANGUAGES = {"java", "javascript", "python", "csharp", "go"}
 KNOWN_GAP_TRACKING_ISSUE = "#4890"
-# Areas that must each carry at least one #4890-tracked expected-fail scenario:
-# connection (single-node-only ROUTE).
-# errors, type-roundtrip, and protocol previously appeared here too (ERR-002,
-# TYPE-003/011/012, and PROTO-002 respectively), but those were the only
-# #4890-tracked gaps in their areas and all are now closed and flipped to
-# passing.
-REQUIRED_GAP_AREAS = {"connection"}
+# Areas that must each carry at least one #4890-tracked expected-fail scenario.
+# All #4890-tracked gaps are now closed and flipped to passing: connection
+# (CONN-004, HA-aware ROUTE), errors (ERR-002), type-roundtrip (TYPE-003/011/012),
+# and protocol (PROTO-002) each previously appeared here as the only #4890-tracked
+# gap in their area. None remain, so this set is empty.
+REQUIRED_GAP_AREAS = set()
 # Canonical AREA-NNN id prefix per area - not derivable from the area string
 # (e.g. transactions -> TX, multi-database -> MDB, causal-consistency ->
 # CAUSAL), so scenario ids are checked against this table rather than a

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -929,6 +929,15 @@ public class BoltNetworkExecutor extends Thread {
       return;
     }
 
+    if (state != State.READY) {
+      // ROUTE enumerates every peer's Bolt endpoint, so it must not run for an unauthenticated caller.
+      // Require an authenticated (READY) session, matching the other request handlers. A Bolt driver
+      // always sends ROUTE after HELLO/LOGON, so this does not affect legitimate routing.
+      sendFailure(BoltException.PROTOCOL_ERROR, "ROUTE not expected in state: " + state);
+      state = State.FAILED;
+      return;
+    }
+
     final Map<String, Object> rt = new LinkedHashMap<>();
     rt.put("ttl", GlobalConfiguration.BOLT_ROUTING_TTL.getValueAsLong());
     rt.put("db", message.getDatabase() != null ? message.getDatabase() : databaseName);

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -56,6 +56,7 @@ import com.arcadedb.schema.Property;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.schema.VertexType;
 import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.HAServerPlugin;
 import com.arcadedb.server.security.ServerSecurityException;
 import com.arcadedb.server.security.ServerSecurityUser;
 import com.arcadedb.utility.CollectionUtils;
@@ -928,36 +929,55 @@ public class BoltNetworkExecutor extends Thread {
       return;
     }
 
-    // For single-server setup, return this server as the only endpoint
-    final String address = getBoltAddress(GlobalConfiguration.BOLT_PORT.getValueAsInteger());
-
     final Map<String, Object> rt = new LinkedHashMap<>();
     rt.put("ttl", GlobalConfiguration.BOLT_ROUTING_TTL.getValueAsLong());
     rt.put("db", message.getDatabase() != null ? message.getDatabase() : databaseName);
 
     final List<Map<String, Object>> servers = new ArrayList<>();
 
-    // Writer server
-    final Map<String, Object> writer = new LinkedHashMap<>();
-    writer.put("addresses", List.of(address));
-    writer.put("role", "WRITE");
-    servers.add(writer);
+    final HAServerPlugin ha = server.getHA();
+    final String leaderBolt = ha != null ? ha.getLeaderBoltAddress() : null;
 
-    // Reader server (same as writer for single-server)
-    final Map<String, Object> reader = new LinkedHashMap<>();
-    reader.put("addresses", List.of(address));
-    reader.put("role", "READ");
-    servers.add(reader);
+    if (leaderBolt != null) {
+      // HA cluster: the leader is the writer and a router, followers are readers and routers.
+      final List<String> readers = new ArrayList<>();
+      final String replicaCsv = ha.getReplicaBoltAddresses();
+      if (replicaCsv != null && !replicaCsv.isEmpty())
+        for (final String addr : replicaCsv.split(","))
+          if (!addr.isBlank())
+            readers.add(addr.trim());
 
-    // Route server
-    final Map<String, Object> router = new LinkedHashMap<>();
-    router.put("addresses", List.of(address));
-    router.put("role", "ROUTE");
-    servers.add(router);
+      final List<String> routers = new ArrayList<>();
+      routers.add(leaderBolt);
+      routers.addAll(readers);
+
+      servers.add(roleEntry(List.of(leaderBolt), "WRITE"));
+      servers.add(roleEntry(readers.isEmpty() ? List.of(leaderBolt) : readers, "READ"));
+      servers.add(roleEntry(routers, "ROUTE"));
+    } else {
+      // Single-server (or HA leader not yet known): advertise this node for every role, using the
+      // actual bound Bolt port of this connection rather than the global default. A driver hitting the
+      // transient HA case retries after the TTL and receives the full topology once the leader is known.
+      final String address = getBoltAddress(socket.getLocalPort());
+      servers.add(roleEntry(List.of(address), "WRITE"));
+      servers.add(roleEntry(List.of(address), "READ"));
+      servers.add(roleEntry(List.of(address), "ROUTE"));
+    }
 
     rt.put("servers", servers);
 
     sendSuccess(CollectionUtils.singletonMap("rt", rt));
+  }
+
+  /**
+   * Builds a single ROUTE routing-table server entry pairing a list of client-reachable addresses with
+   * a Bolt routing role (WRITE, READ, or ROUTE).
+   */
+  private static Map<String, Object> roleEntry(final List<String> addresses, final String role) {
+    final Map<String, Object> entry = new LinkedHashMap<>();
+    entry.put("addresses", addresses);
+    entry.put("role", role);
+    return entry;
   }
 
   /**

--- a/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java
@@ -936,32 +936,38 @@ public class BoltNetworkExecutor extends Thread {
     final List<Map<String, Object>> servers = new ArrayList<>();
 
     final HAServerPlugin ha = server.getHA();
-    final String leaderBolt = ha != null ? ha.getLeaderBoltAddress() : null;
+    final HAServerPlugin.BoltRoutingTable table = ha != null ? ha.getBoltRoutingTable() : null;
 
-    if (leaderBolt != null) {
-      // HA cluster: the leader is the writer and a router, followers are readers and routers.
-      final List<String> readers = new ArrayList<>();
-      final String replicaCsv = ha.getReplicaBoltAddresses();
-      if (replicaCsv != null && !replicaCsv.isEmpty())
-        for (final String addr : replicaCsv.split(","))
-          if (!addr.isBlank())
-            readers.add(addr.trim());
+    if (table != null) {
+      // HA cluster with a known leader: the leader is the writer and a router, followers are readers and
+      // routers. Writer and readers come from one leader snapshot, so they cannot disagree about the leader.
+      final String writer = table.writer();
+      final List<String> readers = table.readers();
 
       final List<String> routers = new ArrayList<>();
-      routers.add(leaderBolt);
+      routers.add(writer);
       routers.addAll(readers);
 
-      servers.add(roleEntry(List.of(leaderBolt), "WRITE"));
-      servers.add(roleEntry(readers.isEmpty() ? List.of(leaderBolt) : readers, "READ"));
+      servers.add(roleEntry(List.of(writer), "WRITE"));
+      servers.add(roleEntry(readers.isEmpty() ? List.of(writer) : readers, "READ"));
       servers.add(roleEntry(routers, "ROUTE"));
     } else {
-      // Single-server (or HA leader not yet known): advertise this node for every role, using the
-      // actual bound Bolt port of this connection rather than the global default. A driver hitting the
-      // transient HA case retries after the TTL and receives the full topology once the leader is known.
+      // No known leader. Advertise this node using the actual bound Bolt port of this connection rather
+      // than the global default.
       final String address = getBoltAddress(socket.getLocalPort());
-      servers.add(roleEntry(List.of(address), "WRITE"));
-      servers.add(roleEntry(List.of(address), "READ"));
-      servers.add(roleEntry(List.of(address), "ROUTE"));
+      if (ha != null) {
+        // HA is active but the leader is not known yet (e.g. mid-election): advertise this node as reader
+        // and router only - never writer, since it may be a follower. The driver keeps reading and
+        // re-routes after the TTL, receiving a writer once the leader is known, instead of sending a write
+        // to a follower and getting an error.
+        servers.add(roleEntry(List.of(address), "READ"));
+        servers.add(roleEntry(List.of(address), "ROUTE"));
+      } else {
+        // True single-node deployment: this node is writer, reader, and router.
+        servers.add(roleEntry(List.of(address), "WRITE"));
+        servers.add(roleEntry(List.of(address), "READ"));
+        servers.add(roleEntry(List.of(address), "ROUTE"));
+      }
     }
 
     rt.put("servers", servers);

--- a/bolt/src/test/java/com/arcadedb/bolt/Bolt5002RoutingTableIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Bolt5002RoutingTableIT.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.bolt.message.BoltMessage;
+import com.arcadedb.bolt.packstream.PackStreamReader;
+import com.arcadedb.bolt.packstream.PackStreamWriter;
+import com.arcadedb.server.ha.raft.BaseRaftHATest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Config;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
+
+import java.io.DataInputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Certifies that the Bolt ROUTE response reflects real HA topology: the true leader is advertised as the
+ * writer and the followers as readers, and a neo4j:// driver can route reads and writes accordingly.
+ * Covers conformance scenario CONN-004.
+ */
+@Tag("slow")
+class Bolt5002RoutingTableIT extends BaseRaftHATest {
+
+  private static final int    BASE_BOLT_PORT = 57697;
+  private static final String VERTEX_TYPE    = "Bolt5002Route";
+
+  private Driver driver;
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Override
+  protected String getServerAddresses() {
+    // Object form so each node declares its own Bolt port (nodes share localhost, differ only by port).
+    final StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < getServerCount(); i++) {
+      if (i > 0)
+        sb.append(",");
+      sb.append("localhost:{raft:").append(2434 + i)
+          .append(",http:").append(2480 + i)
+          .append(",bolt:").append(BASE_BOLT_PORT + i).append("}");
+    }
+    return sb.toString();
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    final String serverName = config.getValueAsString(GlobalConfiguration.SERVER_NAME);
+    final int index = Integer.parseInt(serverName.substring(serverName.lastIndexOf('_') + 1));
+    config.setValue(GlobalConfiguration.SERVER_PLUGINS.getKey(), "Bolt:com.arcadedb.bolt.BoltProtocolPlugin");
+    config.setValue(GlobalConfiguration.BOLT_PORT.getKey(), String.valueOf(BASE_BOLT_PORT + index));
+  }
+
+  @AfterEach
+  void closeDriver() {
+    if (driver != null) {
+      driver.close();
+      driver = null;
+    }
+  }
+
+  @Test
+  void routeTableReflectsLeaderAndFollowers() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+    waitForAllServers();
+
+    final String leaderBolt = "localhost:" + (BASE_BOLT_PORT + leaderIndex);
+    final List<String> followerBolt = new ArrayList<>();
+    for (int i = 0; i < getServerCount(); i++)
+      if (i != leaderIndex)
+        followerBolt.add("localhost:" + (BASE_BOLT_PORT + i));
+
+    // Ask a follower (not the leader) for its routing table to prove routing is not leader-local. Poll
+    // until the follower has learned the leader (a freshly-connected follower may briefly not know it).
+    final int askIndex = (leaderIndex + 1) % getServerCount();
+    final Map<String, Object> rt = awaitRoutingTable(BASE_BOLT_PORT + askIndex, leaderBolt);
+
+    assertThat(addressesForRole(rt, "WRITE")).containsExactly(leaderBolt);
+    assertThat(addressesForRole(rt, "READ")).containsExactlyInAnyOrderElementsOf(followerBolt);
+    assertThat(addressesForRole(rt, "ROUTE")).contains(leaderBolt).containsAll(followerBolt);
+  }
+
+  @Test
+  void neo4jSchemeRoutesReadsAndWrites() {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).isGreaterThanOrEqualTo(0);
+
+    driver = GraphDatabase.driver(
+        "neo4j://localhost:" + (BASE_BOLT_PORT + leaderIndex),
+        AuthTokens.basic("root", DEFAULT_PASSWORD_FOR_TESTS),
+        Config.builder().withoutEncryption().build());
+    driver.verifyConnectivity();
+
+    try (Session session = driver.session(SessionConfig.builder().withDatabase(getDatabaseName()).build())) {
+      session.executeWrite(tx -> {
+        tx.run("CREATE (n:" + VERTEX_TYPE + " {name: 'routed'})").consume();
+        return null;
+      });
+    }
+    waitForAllServers();
+
+    try (Session session = driver.session(SessionConfig.builder().withDatabase(getDatabaseName()).build())) {
+      final long count = session.executeRead(tx ->
+          tx.run("MATCH (n:" + VERTEX_TYPE + ") RETURN count(n) AS c").single().get("c").asLong());
+      assertThat(count).isEqualTo(1L);
+    }
+  }
+
+  @Test
+  void writerClassificationTracksLeaderChange() throws Exception {
+    final int firstLeader = findLeaderIndex();
+    assertThat(firstLeader).isGreaterThanOrEqualTo(0);
+
+    // Stop the current leader and wait for the surviving nodes to elect a new one.
+    getServer(firstLeader).stop();
+
+    int newLeader = -1;
+    for (int attempt = 0; attempt < 60 && newLeader < 0; attempt++) {
+      final int candidate = findLeaderIndex();
+      if (candidate >= 0 && candidate != firstLeader)
+        newLeader = candidate;
+      else
+        Thread.sleep(500);
+    }
+    assertThat(newLeader).as("A new leader must be elected after the old one stops").isGreaterThanOrEqualTo(0);
+
+    final String newLeaderBolt = "localhost:" + (BASE_BOLT_PORT + newLeader);
+    final Map<String, Object> rt = awaitRoutingTable(BASE_BOLT_PORT + newLeader, newLeaderBolt);
+    assertThat(addressesForRole(rt, "WRITE")).containsExactly(newLeaderBolt);
+  }
+
+  // --- raw Bolt ROUTE helper -------------------------------------------------
+
+  /**
+   * Polls the routing table on {@code boltPort} until its WRITE role advertises {@code expectedWriter},
+   * tolerating the brief window in which a freshly-queried node has not yet learned the current leader.
+   */
+  private Map<String, Object> awaitRoutingTable(final int boltPort, final String expectedWriter) throws Exception {
+    Map<String, Object> rt = null;
+    for (int attempt = 0; attempt < 40; attempt++) {
+      rt = fetchRoutingTable(boltPort);
+      if (List.of(expectedWriter).equals(addressesForRole(rt, "WRITE")))
+        return rt;
+      Thread.sleep(250);
+    }
+    return rt;
+  }
+
+  private Map<String, Object> fetchRoutingTable(final int boltPort) throws Exception {
+    try (Socket socket = new Socket("localhost", boltPort)) {
+      final OutputStream rawOut = socket.getOutputStream();
+      final ByteBuffer handshake = ByteBuffer.allocate(20);
+      handshake.put((byte) 0x60).put((byte) 0x60).put((byte) 0xB0).put((byte) 0x17);
+      handshake.putInt(0x00020404);
+      handshake.putInt(0x00000004);
+      handshake.putInt(0x00000003);
+      handshake.putInt(0x00000000);
+      handshake.flip();
+      rawOut.write(handshake.array());
+      rawOut.flush();
+
+      final DataInputStream rawIn = new DataInputStream(socket.getInputStream());
+      final byte[] negotiated = new byte[4];
+      rawIn.readFully(negotiated);
+
+      final BoltChunkedOutput out = new BoltChunkedOutput(rawOut);
+      final BoltChunkedInput in = new BoltChunkedInput(socket.getInputStream());
+
+      final PackStreamWriter hello = new PackStreamWriter();
+      hello.writeStructureHeader(BoltMessage.HELLO, 1);
+      hello.writeMap(Map.of("user_agent", "bolt5002/1.0", "scheme", "basic",
+          "principal", "root", "credentials", DEFAULT_PASSWORD_FOR_TESTS));
+      out.writeMessage(hello.toByteArray());
+      in.readMessage();
+
+      final PackStreamWriter route = new PackStreamWriter();
+      route.writeStructureHeader(BoltMessage.ROUTE, 3);
+      route.writeMap(Map.of());
+      route.writeList(List.of());
+      route.writeMap(Map.of("db", getDatabaseName()));
+      out.writeMessage(route.toByteArray());
+
+      final byte[] response = in.readMessage();
+      assertThat(response[1]).as("ROUTE must succeed").isEqualTo(BoltMessage.SUCCESS);
+      return readRoutingTable(response);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> readRoutingTable(final byte[] successResponse) throws java.io.IOException {
+    // SUCCESS is a single-field structure: [struct marker][signature][metadata map]. Skip the two
+    // header bytes and read the metadata map, then pull out the "rt" routing table.
+    final PackStreamReader reader = new PackStreamReader(successResponse);
+    reader.readRawByte();
+    reader.readRawByte();
+    final Map<String, Object> metadata = (Map<String, Object>) reader.readValue();
+    return (Map<String, Object>) metadata.get("rt");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<String> addressesForRole(final Map<String, Object> rt, final String role) {
+    final List<Map<String, Object>> servers = (List<Map<String, Object>>) rt.get("servers");
+    for (final Map<String, Object> s : servers)
+      if (role.equals(s.get("role")))
+        return (List<String>) s.get("addresses");
+    return List.of();
+  }
+}

--- a/bolt/src/test/java/com/arcadedb/bolt/Bolt5002RoutingTableIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Bolt5002RoutingTableIT.java
@@ -21,7 +21,6 @@ package com.arcadedb.bolt;
 import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.bolt.message.BoltMessage;
-import com.arcadedb.bolt.packstream.PackStreamReader;
 import com.arcadedb.bolt.packstream.PackStreamWriter;
 import com.arcadedb.server.ha.raft.BaseRaftHATest;
 import org.junit.jupiter.api.AfterEach;
@@ -110,9 +109,9 @@ class Bolt5002RoutingTableIT extends BaseRaftHATest {
     final int askIndex = (leaderIndex + 1) % getServerCount();
     final Map<String, Object> rt = awaitRoutingTable(BASE_BOLT_PORT + askIndex, leaderBolt);
 
-    assertThat(addressesForRole(rt, "WRITE")).containsExactly(leaderBolt);
-    assertThat(addressesForRole(rt, "READ")).containsExactlyInAnyOrderElementsOf(followerBolt);
-    assertThat(addressesForRole(rt, "ROUTE")).contains(leaderBolt).containsAll(followerBolt);
+    assertThat(BoltRouteTestSupport.addressesForRole(rt, "WRITE")).containsExactly(leaderBolt);
+    assertThat(BoltRouteTestSupport.addressesForRole(rt, "READ")).containsExactlyInAnyOrderElementsOf(followerBolt);
+    assertThat(BoltRouteTestSupport.addressesForRole(rt, "ROUTE")).contains(leaderBolt).containsAll(followerBolt);
   }
 
   @Test
@@ -161,7 +160,7 @@ class Bolt5002RoutingTableIT extends BaseRaftHATest {
 
     final String newLeaderBolt = "localhost:" + (BASE_BOLT_PORT + newLeader);
     final Map<String, Object> rt = awaitRoutingTable(BASE_BOLT_PORT + newLeader, newLeaderBolt);
-    assertThat(addressesForRole(rt, "WRITE")).containsExactly(newLeaderBolt);
+    assertThat(BoltRouteTestSupport.addressesForRole(rt, "WRITE")).containsExactly(newLeaderBolt);
   }
 
   // --- raw Bolt ROUTE helper -------------------------------------------------
@@ -175,13 +174,16 @@ class Bolt5002RoutingTableIT extends BaseRaftHATest {
     for (int attempt = 0; attempt < 40; attempt++) {
       try {
         rt = fetchRoutingTable(boltPort);
-        if (List.of(expectedWriter).equals(addressesForRole(rt, "WRITE")))
+        if (List.of(expectedWriter).equals(BoltRouteTestSupport.addressesForRole(rt, "WRITE")))
           return rt;
       } catch (final Exception e) {
         // A node contacted mid-failover may reset the connection; retry until it settles.
       }
       Thread.sleep(250);
     }
+    assertThat(rt)
+        .as("no routing table advertising writer %s obtained from bolt port %d after retries", expectedWriter, boltPort)
+        .isNotNull();
     return rt;
   }
 
@@ -221,27 +223,7 @@ class Bolt5002RoutingTableIT extends BaseRaftHATest {
 
       final byte[] response = in.readMessage();
       assertThat(response[1]).as("ROUTE must succeed").isEqualTo(BoltMessage.SUCCESS);
-      return readRoutingTable(response);
+      return BoltRouteTestSupport.readRoutingTable(response);
     }
-  }
-
-  @SuppressWarnings("unchecked")
-  private static Map<String, Object> readRoutingTable(final byte[] successResponse) throws java.io.IOException {
-    // SUCCESS is a single-field structure: [struct marker][signature][metadata map]. Skip the two
-    // header bytes and read the metadata map, then pull out the "rt" routing table.
-    final PackStreamReader reader = new PackStreamReader(successResponse);
-    reader.readRawByte();
-    reader.readRawByte();
-    final Map<String, Object> metadata = (Map<String, Object>) reader.readValue();
-    return (Map<String, Object>) metadata.get("rt");
-  }
-
-  @SuppressWarnings("unchecked")
-  private static List<String> addressesForRole(final Map<String, Object> rt, final String role) {
-    final List<Map<String, Object>> servers = (List<Map<String, Object>>) rt.get("servers");
-    for (final Map<String, Object> s : servers)
-      if (role.equals(s.get("role")))
-        return (List<String>) s.get("addresses");
-    return List.of();
   }
 }

--- a/bolt/src/test/java/com/arcadedb/bolt/Bolt5002RoutingTableIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Bolt5002RoutingTableIT.java
@@ -34,6 +34,7 @@ import org.neo4j.driver.Session;
 import org.neo4j.driver.SessionConfig;
 
 import java.io.DataInputStream;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.net.Socket;
 import java.nio.ByteBuffer;
@@ -222,7 +223,10 @@ class Bolt5002RoutingTableIT extends BaseRaftHATest {
       out.writeMessage(route.toByteArray());
 
       final byte[] response = in.readMessage();
-      assertThat(response[1]).as("ROUTE must succeed").isEqualTo(BoltMessage.SUCCESS);
+      // Throw (rather than assert) on a non-SUCCESS ROUTE so awaitRoutingTable's retry loop, which
+      // catches Exception, keeps polling through a failover window instead of failing on an AssertionError.
+      if (response[1] != BoltMessage.SUCCESS)
+        throw new IOException("ROUTE did not return SUCCESS (signature 0x" + Integer.toHexString(response[1] & 0xFF) + ")");
       return BoltRouteTestSupport.readRoutingTable(response);
     }
   }

--- a/bolt/src/test/java/com/arcadedb/bolt/Bolt5002RoutingTableIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Bolt5002RoutingTableIT.java
@@ -173,9 +173,13 @@ class Bolt5002RoutingTableIT extends BaseRaftHATest {
   private Map<String, Object> awaitRoutingTable(final int boltPort, final String expectedWriter) throws Exception {
     Map<String, Object> rt = null;
     for (int attempt = 0; attempt < 40; attempt++) {
-      rt = fetchRoutingTable(boltPort);
-      if (List.of(expectedWriter).equals(addressesForRole(rt, "WRITE")))
-        return rt;
+      try {
+        rt = fetchRoutingTable(boltPort);
+        if (List.of(expectedWriter).equals(addressesForRole(rt, "WRITE")))
+          return rt;
+      } catch (final Exception e) {
+        // A node contacted mid-failover may reset the connection; retry until it settles.
+      }
       Thread.sleep(250);
     }
     return rt;

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltProtocolIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltProtocolIT.java
@@ -20,7 +20,6 @@ package com.arcadedb.bolt;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.bolt.message.BoltMessage;
-import com.arcadedb.bolt.packstream.PackStreamReader;
 import com.arcadedb.bolt.packstream.PackStreamWriter;
 import com.arcadedb.database.Database;
 import com.arcadedb.schema.Schema;
@@ -200,11 +199,13 @@ public class BoltProtocolIT extends BaseGraphServerTest {
       final byte[] response = chunkedIn.readMessage();
       assertThat(response[1]).as("ROUTE must succeed").isEqualTo(BoltMessage.SUCCESS);
 
-      final Map<String, Object> rt = readRoutingTable(response);
-      final String self = addressForRole(rt, "WRITE");
+      final Map<String, Object> rt = BoltRouteTestSupport.readRoutingTable(response);
+      final List<String> writers = BoltRouteTestSupport.addressesForRole(rt, "WRITE");
+      assertThat(writers).hasSize(1);
+      final String self = writers.get(0);
       assertThat(self).isNotBlank();
-      assertThat(addressForRole(rt, "READ")).isEqualTo(self);
-      assertThat(addressForRole(rt, "ROUTE")).isEqualTo(self);
+      assertThat(BoltRouteTestSupport.addressesForRole(rt, "READ")).containsExactly(self);
+      assertThat(BoltRouteTestSupport.addressesForRole(rt, "ROUTE")).containsExactly(self);
     }
   }
 
@@ -252,28 +253,6 @@ public class BoltProtocolIT extends BaseGraphServerTest {
     }
   }
 
-  @SuppressWarnings("unchecked")
-  private static Map<String, Object> readRoutingTable(final byte[] successResponse) throws java.io.IOException {
-    // SUCCESS is a single-field structure: [struct marker][signature][metadata map]. Skip the two
-    // header bytes and read the metadata map, then pull out the "rt" routing table.
-    final PackStreamReader reader = new PackStreamReader(successResponse);
-    reader.readRawByte();
-    reader.readRawByte();
-    final Map<String, Object> metadata = (Map<String, Object>) reader.readValue();
-    return (Map<String, Object>) metadata.get("rt");
-  }
-
-  @SuppressWarnings("unchecked")
-  private static String addressForRole(final Map<String, Object> rt, final String role) {
-    final List<Map<String, Object>> servers = (List<Map<String, Object>>) rt.get("servers");
-    for (final Map<String, Object> s : servers) {
-      if (role.equals(s.get("role"))) {
-        final List<String> addrs = (List<String>) s.get("addresses");
-        return addrs.isEmpty() ? null : addrs.get(0);
-      }
-    }
-    return null;
-  }
 
   @Test
   void simpleQuery() {

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltProtocolIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltProtocolIT.java
@@ -20,6 +20,7 @@ package com.arcadedb.bolt;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.bolt.message.BoltMessage;
+import com.arcadedb.bolt.packstream.PackStreamReader;
 import com.arcadedb.bolt.packstream.PackStreamWriter;
 import com.arcadedb.database.Database;
 import com.arcadedb.schema.Schema;
@@ -156,6 +157,78 @@ public class BoltProtocolIT extends BaseGraphServerTest {
         assertThat(result.next().get("value").asLong()).isEqualTo(1L);
       }
     }
+  }
+
+  // Single-node (non-HA) ROUTE must keep advertising this node for every role. Guards the fallback
+  // branch so the HA-aware routing table never regresses standalone deployments.
+  @Test
+  void routeTableSingleNodeReturnsSelfForAllRoles() throws Exception {
+    try (Socket socket = new Socket("localhost", 7687)) {
+      final OutputStream rawOut = socket.getOutputStream();
+
+      final ByteBuffer handshake = ByteBuffer.allocate(20);
+      handshake.put((byte) 0x60).put((byte) 0x60).put((byte) 0xB0).put((byte) 0x17);
+      handshake.putInt(0x00020404);
+      handshake.putInt(0x00000004);
+      handshake.putInt(0x00000003);
+      handshake.putInt(0x00000000);
+      handshake.flip();
+      rawOut.write(handshake.array());
+      rawOut.flush();
+
+      final DataInputStream rawIn = new DataInputStream(socket.getInputStream());
+      final byte[] negotiatedVersion = new byte[4];
+      rawIn.readFully(negotiatedVersion);
+
+      final BoltChunkedOutput chunkedOut = new BoltChunkedOutput(rawOut);
+      final BoltChunkedInput chunkedIn = new BoltChunkedInput(socket.getInputStream());
+
+      final PackStreamWriter hello = new PackStreamWriter();
+      hello.writeStructureHeader(BoltMessage.HELLO, 1);
+      hello.writeMap(Map.of("user_agent", "route-regression/1.0", "scheme", "basic",
+          "principal", "root", "credentials", DEFAULT_PASSWORD_FOR_TESTS));
+      chunkedOut.writeMessage(hello.toByteArray());
+      chunkedIn.readMessage();
+
+      final PackStreamWriter route = new PackStreamWriter();
+      route.writeStructureHeader(BoltMessage.ROUTE, 3);
+      route.writeMap(Map.of());
+      route.writeList(List.of());
+      route.writeMap(Map.of("db", getDatabaseName()));
+      chunkedOut.writeMessage(route.toByteArray());
+
+      final byte[] response = chunkedIn.readMessage();
+      assertThat(response[1]).as("ROUTE must succeed").isEqualTo(BoltMessage.SUCCESS);
+
+      final Map<String, Object> rt = readRoutingTable(response);
+      final String self = addressForRole(rt, "WRITE");
+      assertThat(self).isNotBlank();
+      assertThat(addressForRole(rt, "READ")).isEqualTo(self);
+      assertThat(addressForRole(rt, "ROUTE")).isEqualTo(self);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> readRoutingTable(final byte[] successResponse) throws java.io.IOException {
+    // SUCCESS is a single-field structure: [struct marker][signature][metadata map]. Skip the two
+    // header bytes and read the metadata map, then pull out the "rt" routing table.
+    final PackStreamReader reader = new PackStreamReader(successResponse);
+    reader.readRawByte();
+    reader.readRawByte();
+    final Map<String, Object> metadata = (Map<String, Object>) reader.readValue();
+    return (Map<String, Object>) metadata.get("rt");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static String addressForRole(final Map<String, Object> rt, final String role) {
+    final List<Map<String, Object>> servers = (List<Map<String, Object>>) rt.get("servers");
+    for (final Map<String, Object> s : servers) {
+      if (role.equals(s.get("role"))) {
+        final List<String> addrs = (List<String>) s.get("addresses");
+        return addrs.isEmpty() ? null : addrs.get(0);
+      }
+    }
+    return null;
   }
 
   @Test

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltProtocolIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltProtocolIT.java
@@ -208,6 +208,50 @@ public class BoltProtocolIT extends BaseGraphServerTest {
     }
   }
 
+  // ROUTE enumerates the cluster's Bolt endpoints, so it must require an authenticated session. Bolt 5.1+
+  // defers auth to LOGON: after a HELLO with no credentials the session is not yet authenticated, and a
+  // ROUTE sent before LOGON must be refused rather than disclosing the topology.
+  @Test
+  void routeBeforeLogonIsRejected() throws Exception {
+    try (Socket socket = new Socket("localhost", 7687)) {
+      final OutputStream rawOut = socket.getOutputStream();
+
+      final ByteBuffer handshake = ByteBuffer.allocate(20);
+      handshake.put((byte) 0x60).put((byte) 0x60).put((byte) 0xB0).put((byte) 0x17);
+      handshake.putInt(0x00000405); // v5.4
+      handshake.putInt(0x00000404); // v4.4
+      handshake.putInt(0x00000003); // v3.0
+      handshake.putInt(0x00000000);
+      handshake.flip();
+      rawOut.write(handshake.array());
+      rawOut.flush();
+
+      final DataInputStream rawIn = new DataInputStream(socket.getInputStream());
+      final byte[] negotiated = new byte[4];
+      rawIn.readFully(negotiated);
+      assertThat(negotiated[3]).as("server must negotiate Bolt 5.x for the deferred-auth path").isEqualTo((byte) 5);
+
+      final BoltChunkedOutput chunkedOut = new BoltChunkedOutput(rawOut);
+      final BoltChunkedInput chunkedIn = new BoltChunkedInput(socket.getInputStream());
+
+      // HELLO with no auth fields: Bolt 5.1+ accepts it and awaits LOGON (session not yet authenticated).
+      final PackStreamWriter hello = new PackStreamWriter();
+      hello.writeStructureHeader(BoltMessage.HELLO, 1);
+      hello.writeMap(Map.of("user_agent", "route-auth-gate/1.0"));
+      chunkedOut.writeMessage(hello.toByteArray());
+      assertThat(chunkedIn.readMessage()[1]).as("HELLO accepted under deferred auth").isEqualTo(BoltMessage.SUCCESS);
+
+      // ROUTE before LOGON must be rejected.
+      final PackStreamWriter route = new PackStreamWriter();
+      route.writeStructureHeader(BoltMessage.ROUTE, 3);
+      route.writeMap(Map.of());
+      route.writeList(List.of());
+      route.writeMap(Map.of("db", getDatabaseName()));
+      chunkedOut.writeMessage(route.toByteArray());
+      assertThat(chunkedIn.readMessage()[1]).as("ROUTE before LOGON must be rejected").isEqualTo(BoltMessage.FAILURE);
+    }
+  }
+
   @SuppressWarnings("unchecked")
   private static Map<String, Object> readRoutingTable(final byte[] successResponse) throws java.io.IOException {
     // SUCCESS is a single-field structure: [struct marker][signature][metadata map]. Skip the two

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltRouteTestSupport.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltRouteTestSupport.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.bolt;
+
+import com.arcadedb.bolt.packstream.PackStreamReader;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Shared helpers for decoding a Bolt ROUTE SUCCESS response into its routing table, used by the ROUTE
+ * tests so the SUCCESS/{@code rt} wire shape is parsed in a single place.
+ */
+final class BoltRouteTestSupport {
+
+  private BoltRouteTestSupport() {
+  }
+
+  /**
+   * Extracts the {@code rt} routing table from a ROUTE SUCCESS message. SUCCESS is a single-field
+   * structure: [struct marker][signature][metadata map]. Skips the two header bytes, reads the metadata
+   * map, then returns its {@code rt} entry.
+   */
+  @SuppressWarnings("unchecked")
+  static Map<String, Object> readRoutingTable(final byte[] successResponse) throws IOException {
+    final PackStreamReader reader = new PackStreamReader(successResponse);
+    reader.readRawByte();
+    reader.readRawByte();
+    final Map<String, Object> metadata = (Map<String, Object>) reader.readValue();
+    return (Map<String, Object>) metadata.get("rt");
+  }
+
+  /**
+   * Returns the advertised addresses for a routing role (WRITE, READ, or ROUTE), or an empty list when
+   * the role is absent.
+   */
+  @SuppressWarnings("unchecked")
+  static List<String> addressesForRole(final Map<String, Object> rt, final String role) {
+    final List<Map<String, Object>> servers = (List<Map<String, Object>>) rt.get("servers");
+    for (final Map<String, Object> server : servers)
+      if (role.equals(server.get("role")))
+        return (List<String>) server.get("addresses");
+    return List.of();
+  }
+}

--- a/docs/superpowers/plans/2026-07-07-bolt-ha-aware-route-5002.md
+++ b/docs/superpowers/plans/2026-07-07-bolt-ha-aware-route-5002.md
@@ -1,0 +1,899 @@
+# Bolt HA-aware ROUTE response Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Bolt `ROUTE` response reflect real HA cluster topology - advertise the leader as the writer and followers as readers - so `neo4j://` drivers can discover and route against an ArcadeDB cluster.
+
+**Architecture:** The `bolt` module reaches the cluster only through the `HAServerPlugin` interface (server module). We add per-node Bolt address knowledge to HA membership by extending the `HA_SERVER_LIST` object form with an optional `bolt:<port>` field, resolve it in `RaftHAServer` (with a homogeneous-cluster fallback mirroring the existing HTTP handling), surface it via two new `HAServerPlugin` methods, and rebuild the routing table from live membership in `BoltNetworkExecutor.handleRoute`. Single-node behavior is preserved as the fallback.
+
+**Tech Stack:** Java 21, Maven multi-module, Apache Ratis (Raft), JUnit 5 + AssertJ, neo4j-java-driver (test), custom PackStream Bolt codec.
+
+## Global Constraints
+
+- Java 21+; import classes, do not use fully-qualified names inline.
+- Use `final` on variables and parameters; single-statement `if` needs no braces.
+- No new dependencies. No Claude authorship in source. Remove any debug `System.out`.
+- Never use the em dash character in code, comments, or docs.
+- Comments state behavioral invariants only - no issue numbers in Javadoc/comments.
+- New/changed backend code must have a test; compile the touched modules before declaring done.
+- Cluster ITs are slow: annotate `@Tag("slow")` at class level.
+- The bolt module must NOT reference any `ha-raft` class in `src/main/java` (ha-raft is test-scope only there); production Bolt code uses only `com.arcadedb.server.HAServerPlugin`.
+- `neo4j+s`/TLS reuse existing `BoltSslHelper`; no new TLS work. No change to advertised server identity (`Neo4j/5.26.0 compatible ...`).
+
+## File Structure
+
+- Modify `ha-raft/.../raft/RaftPeerAddressResolver.java` - parse optional object-form `bolt:` field; add `boltAddresses` to `ParsedPeerList`.
+- Modify `ha-raft/.../raft/RaftHAServer.java` - store `boltAddresses`; add `deriveBoltAddress`, `resolveBoltAddress`, `getLeaderBoltAddress`, `getReplicaBoltAddresses`, `boltFallbackWarned`.
+- Modify `server/.../server/HAServerPlugin.java` - two new default methods.
+- Modify `ha-raft/.../raft/RaftHAPlugin.java` - override the two new methods.
+- Modify `bolt/.../bolt/BoltNetworkExecutor.java` - HA-aware `handleRoute` with single-node fallback.
+- Create `bolt/src/test/java/com/arcadedb/bolt/Bolt5002RoutingTableIT.java` - 3-node cluster IT.
+- Modify `ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAServerAddressParsingTest.java` - `bolt:` parsing unit tests.
+- Modify `bolt/src/test/java/com/arcadedb/bolt/BoltProtocolIT.java` - single-node ROUTE regression assertion.
+- Modify `bolt/conformance/spec.yaml` - flip `CONN-004` to `passing`.
+
+---
+
+### Task 1: Parse optional `bolt:` field in HA_SERVER_LIST object form
+
+**Files:**
+- Modify: `ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftPeerAddressResolver.java`
+- Test: `ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAServerAddressParsingTest.java`
+
+**Interfaces:**
+- Produces: `ParsedPeerList` record now has a 5th component `Map<RaftPeerId,String> boltAddresses()`, populated only when an object-form entry declares `bolt:<port>`. Constructor arity becomes 5.
+
+- [ ] **Step 1: Write the failing tests** (append to `RaftHAServerAddressParsingTest`)
+
+```java
+  @Test
+  void objectFormParsesBoltPort() {
+    final var parsed = RaftPeerAddressResolver.parsePeerList("myhost:{raft:2434,http:2480,bolt:7687}", 2434);
+    final var peerId = parsed.peers().get(0).getId();
+    assertThat(parsed.boltAddresses()).containsEntry(peerId, "myhost:7687");
+    assertThat(parsed.httpAddresses()).containsEntry(peerId, "myhost:2480");
+  }
+
+  @Test
+  void objectFormWithoutBoltLeavesBoltAddressesEmpty() {
+    final var parsed = RaftPeerAddressResolver.parsePeerList("myhost:{raft:2434,http:2480}", 2434);
+    assertThat(parsed.boltAddresses()).isEmpty();
+  }
+
+  @Test
+  void positionalFormNeverPopulatesBoltAddresses() {
+    final var parsed = RaftPeerAddressResolver.parsePeerList("myhost:2434:2480:7:2490", 2434);
+    assertThat(parsed.boltAddresses()).isEmpty();
+  }
+
+  @Test
+  void namedObjectFormParsesBoltPort() {
+    final var parsed = RaftPeerAddressResolver.parsePeerList("alpha@myhost:{raft:2434,bolt:7690}", 2434);
+    final var peerId = parsed.peers().get(0).getId();
+    assertThat(parsed.boltAddresses()).containsEntry(peerId, "myhost:7690");
+    assertThat(parsed.peerNames()).containsEntry(peerId, "alpha");
+  }
+
+  @Test
+  void unknownObjectKeyStillThrows() {
+    assertThatThrownBy(() -> RaftPeerAddressResolver.parsePeerList("myhost:{raft:2434,ftp:21}", 2434))
+        .isInstanceOf(ServerException.class);
+  }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `mvn -q -pl ha-raft test -Dtest=RaftHAServerAddressParsingTest`
+Expected: FAIL - `boltAddresses()` method does not exist on `ParsedPeerList` (compile error).
+
+- [ ] **Step 3: Implement the parser changes**
+
+In `ParsedPeerList` record, add the 5th component and update its Javadoc:
+
+```java
+  public record ParsedPeerList(List<RaftPeer> peers, Map<RaftPeerId, String> httpAddresses,
+                               Map<RaftPeerId, String> httpsAddresses, Map<RaftPeerId, String> peerNames,
+                               Map<RaftPeerId, String> boltAddresses) {
+  }
+```
+
+In `parsePeerList`, add the map and populate it. Near the other maps:
+
+```java
+    final Map<RaftPeerId, String> boltAddresses = new HashMap<>(entries.size());
+```
+
+Add a local `String boltAddress = null;` beside `httpAddress`/`httpsAddress`, set it in the object-form branch:
+
+```java
+      final int braceIdx = entry.indexOf('{');
+      if (braceIdx >= 0) {
+        final PeerSpec spec = parseObjectForm(entry, braceIdx, defaultPort);
+        final String host = applyDnsSuffix(spec.host, k8sDnsSuffix);
+        raftAddress = host + ":" + spec.raftPort;
+        if (spec.httpPort != null)
+          httpAddress = host + ":" + spec.httpPort;
+        if (spec.httpsPort != null)
+          httpsAddress = host + ":" + spec.httpsPort;
+        if (spec.boltPort != null)
+          boltAddress = host + ":" + spec.boltPort;
+        priority = spec.priority;
+      } else {
+```
+
+After the existing `httpsAddresses.put(...)` / `peerNames.put(...)` block:
+
+```java
+      if (boltAddress != null)
+        boltAddresses.put(peer.getId(), boltAddress);
+```
+
+Update the `return new ParsedPeerList(...)` to pass the new map:
+
+```java
+    return new ParsedPeerList(
+        Collections.unmodifiableList(peers),
+        Collections.unmodifiableMap(httpAddresses),
+        Collections.unmodifiableMap(httpsAddresses),
+        Collections.unmodifiableMap(peerNames),
+        Collections.unmodifiableMap(boltAddresses));
+```
+
+Extend `PeerSpec` with a nullable `boltPort`:
+
+```java
+  private static final class PeerSpec {
+    final String  host;
+    final int     raftPort;
+    final Integer httpPort;
+    final Integer httpsPort;
+    final Integer boltPort; // null when not specified
+    final int     priority;
+
+    PeerSpec(final String host, final int raftPort, final Integer httpPort, final Integer httpsPort,
+        final Integer boltPort, final int priority) {
+      this.host = host;
+      this.raftPort = raftPort;
+      this.httpPort = httpPort;
+      this.httpsPort = httpsPort;
+      this.boltPort = boltPort;
+      this.priority = priority;
+    }
+  }
+```
+
+In `parseObjectForm`, add `Integer boltPort = null;` beside the others, a `case "bolt"` branch, update the `default` message, and pass `boltPort` to the constructor:
+
+```java
+    int raftPort = defaultPort;
+    Integer httpPort = null;
+    Integer httpsPort = null;
+    Integer boltPort = null;
+    int priority = 0;
+```
+
+```java
+        switch (key) {
+        case "raft" -> raftPort = parseIntField(value, "raft", entry);
+        case "http" -> httpPort = parseIntField(value, "http", entry);
+        case "https" -> httpsPort = parseIntField(value, "https", entry);
+        case "bolt" -> boltPort = parseIntField(value, "bolt", entry);
+        case "priority" -> priority = parseIntField(value, "priority", entry);
+        default -> throw new ServerException(
+            "Unknown key '" + key + "' in peer address '" + entry + "'. Supported keys: raft, http, https, bolt, priority");
+        }
+```
+
+```java
+    return new PeerSpec(host, raftPort, httpPort, httpsPort, boltPort, priority);
+```
+
+Update the `parsePeerList` class Javadoc: document that the object form accepts an optional `bolt:` field (`host:{raft:2434,http:2480,bolt:7687}`), that the `boltAddresses` map is populated only when `bolt:` is present, and that `bolt:` is object-form only (the positional colon form has no Bolt field).
+
+- [ ] **Step 4: Fix the other `ParsedPeerList` consumer**
+
+`RaftHAServer` reads `parsed.httpAddresses()` etc. Adding a record component is additive for existing reads, but confirm no other `new ParsedPeerList(` construction exists:
+
+Run: `rg -n "new ParsedPeerList\(" ha-raft/src`
+Expected: exactly one call site (inside `parsePeerList`). If any other exists, update its arity.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `mvn -q -pl ha-raft test -Dtest=RaftHAServerAddressParsingTest`
+Expected: PASS (all methods, including the pre-existing ones).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftPeerAddressResolver.java \
+        ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAServerAddressParsingTest.java
+git commit -m "feat(#5002): parse optional bolt: field in HA_SERVER_LIST object form"
+```
+
+---
+
+### Task 2: Resolve per-peer Bolt addresses in RaftHAServer
+
+**Files:**
+- Modify: `ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java`
+- Test: `ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAServerAddressParsingTest.java` (for the static helper)
+
+**Interfaces:**
+- Consumes: `ParsedPeerList.boltAddresses()` (Task 1); existing `getLeaderId()`, `localPeerId`, `raftGroup.getPeers()`, `peerRaftAddress(RaftPeerId)`, `extractHost(String)`, `configuration`.
+- Produces:
+  - `static String deriveBoltAddress(String raftAddress, int boltPort)` - `host:boltPort` or `null` when `boltPort <= 0` / host unresolvable.
+  - `String getLeaderBoltAddress()` - resolved leader Bolt address or `null`.
+  - `String getReplicaBoltAddresses()` - comma-separated non-leader Bolt addresses, or `""`.
+
+- [ ] **Step 1: Write the failing test for the static helper** (append to `RaftHAServerAddressParsingTest`)
+
+```java
+  @Test
+  void deriveBoltAddressCombinesRaftHostWithBoltPort() {
+    assertThat(RaftHAServer.deriveBoltAddress("db1:2434", 7687)).isEqualTo("db1:7687");
+  }
+
+  @Test
+  void deriveBoltAddressReturnsNullForNonPositivePort() {
+    assertThat(RaftHAServer.deriveBoltAddress("db1:2434", 0)).isNull();
+    assertThat(RaftHAServer.deriveBoltAddress("db1:2434", -1)).isNull();
+  }
+
+  @Test
+  void deriveBoltAddressHandlesIpv6Literal() {
+    assertThat(RaftHAServer.deriveBoltAddress("[::1]:2434", 7687)).isEqualTo("[::1]:7687");
+  }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn -q -pl ha-raft test -Dtest=RaftHAServerAddressParsingTest#deriveBoltAddressCombinesRaftHostWithBoltPort`
+Expected: FAIL - `deriveBoltAddress` does not exist (compile error).
+
+- [ ] **Step 3: Implement RaftHAServer changes**
+
+Add the field beside `httpFallbackWarned` (around line 118):
+
+```java
+  private final    Map<RaftPeerId, String> boltAddresses      = new HashMap<>();
+  // Logged at most once: warns operators that Bolt routing addresses are derived (not explicitly configured).
+  private final    AtomicBoolean           boltFallbackWarned = new AtomicBoolean(false);
+```
+
+In the constructor, after `this.httpsAddresses.putAll(parsed.httpsAddresses());` (around line 181):
+
+```java
+    this.boltAddresses.putAll(parsed.boltAddresses());
+```
+
+Add the static helper next to `deriveHttpAddress` (around line 1270):
+
+```java
+  /**
+   * Derives a Bolt address (host:boltPort) by combining a peer's Raft host with the given Bolt port.
+   * Returns {@code null} when the port is not positive or the host cannot be extracted. Package-private
+   * for testing.
+   */
+  static String deriveBoltAddress(final String raftAddress, final int boltPort) {
+    if (boltPort <= 0)
+      return null;
+    final String host = extractHost(raftAddress);
+    return host != null ? host + ":" + boltPort : null;
+  }
+```
+
+Add the resolver mirroring `resolveHttpAddress` (place near `resolveHttpAddress`, around line 1200):
+
+```java
+  /**
+   * Resolves the client-reachable Bolt address (host:boltPort) of a peer. Returns the address declared
+   * with the object-form {@code bolt:} field when present; otherwise derives it from the peer's Raft host
+   * plus this node's local Bolt port. The fallback is correct only for homogeneous deployments where every
+   * node listens on the same Bolt port (e.g. a Kubernetes StatefulSet); a one-time WARNING is logged so
+   * operators declare explicit Bolt ports for heterogeneous clusters. Returns {@code null} when the peer is
+   * unknown or the local Bolt port is unavailable.
+   */
+  private String resolveBoltAddress(final RaftPeerId peerId) {
+    if (peerId == null)
+      return null;
+    final String configured = boltAddresses.get(peerId);
+    if (configured != null)
+      return configured;
+    final int localBoltPort = configuration.getValueAsInteger(GlobalConfiguration.BOLT_PORT);
+    final String derived = deriveBoltAddress(peerRaftAddress(peerId), localBoltPort);
+    if (derived != null && boltFallbackWarned.compareAndSet(false, true))
+      LogManager.instance().log(this, Level.WARNING,
+          "HA Bolt routing addresses are not configured in '%s': deriving peer Bolt endpoints from each peer's Raft host plus this node's Bolt port (%d). "
+              + "This is correct only when every node listens on the same Bolt port (e.g. a Kubernetes StatefulSet). For clusters with heterogeneous "
+              + "Bolt ports, declare them explicitly using the 'host:{raft:..,bolt:..}' object syntax in %s.",
+          GlobalConfiguration.HA_SERVER_LIST.getKey(), localBoltPort, GlobalConfiguration.HA_SERVER_LIST.getKey());
+    return derived;
+  }
+```
+
+Add the two public methods (near `getLeaderHttpAddress` / `getReplicaAddresses`):
+
+```java
+  public String getLeaderBoltAddress() {
+    return resolveBoltAddress(getLeaderId());
+  }
+
+  public String getReplicaBoltAddresses() {
+    final RaftPeerId leaderId = getLeaderId();
+    final RaftPeerId excludeId = leaderId != null ? leaderId : localPeerId;
+    final StringBuilder sb = new StringBuilder();
+    for (final RaftPeer peer : raftGroup.getPeers()) {
+      if (!peer.getId().equals(excludeId)) {
+        final String boltAddr = resolveBoltAddress(peer.getId());
+        if (boltAddr != null) {
+          if (!sb.isEmpty())
+            sb.append(",");
+          sb.append(boltAddr);
+        }
+      }
+    }
+    return sb.toString();
+  }
+```
+
+Confirm `GlobalConfiguration` is already imported in `RaftHAServer` (it is, used elsewhere).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mvn -q -pl ha-raft test -Dtest=RaftHAServerAddressParsingTest`
+Expected: PASS.
+
+- [ ] **Step 5: Compile the module**
+
+Run: `mvn -q -pl ha-raft -am -DskipTests install`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java \
+        ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAServerAddressParsingTest.java
+git commit -m "feat(#5002): resolve per-peer Bolt addresses with homogeneous fallback"
+```
+
+---
+
+### Task 3: Expose Bolt addresses on HAServerPlugin
+
+**Files:**
+- Modify: `server/src/main/java/com/arcadedb/server/HAServerPlugin.java`
+- Modify: `ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java`
+
+**Interfaces:**
+- Consumes: `RaftHAServer.getLeaderBoltAddress()`, `getReplicaBoltAddresses()` (Task 2).
+- Produces: `HAServerPlugin.getLeaderBoltAddress()` (default `null`), `HAServerPlugin.getReplicaBoltAddresses()` (default `""`), consumed by `BoltNetworkExecutor` (Task 4).
+
+- [ ] **Step 1: Add default methods to the interface**
+
+In `HAServerPlugin.java`, after `getReplicaAddresses()` (around line 112):
+
+```java
+  /**
+   * Returns the client-reachable Bolt address (host:port) of the current leader, or null when unknown
+   * or HA is not active. Used to build the writer entry of the Bolt ROUTE routing table.
+   */
+  default String getLeaderBoltAddress() {
+    return null;
+  }
+
+  /**
+   * Returns a comma-separated list of client-reachable Bolt addresses for the non-leader replicas,
+   * or an empty string when none. Used to build the reader entries of the Bolt ROUTE routing table.
+   */
+  default String getReplicaBoltAddresses() {
+    return "";
+  }
+```
+
+- [ ] **Step 2: Override in RaftHAPlugin**
+
+In `RaftHAPlugin.java`, after the `getReplicaAddresses()` override (around line 262):
+
+```java
+  @Override
+  public String getLeaderBoltAddress() {
+    return raftHAServer != null ? raftHAServer.getLeaderBoltAddress() : null;
+  }
+
+  @Override
+  public String getReplicaBoltAddresses() {
+    return raftHAServer != null ? raftHAServer.getReplicaBoltAddresses() : "";
+  }
+```
+
+- [ ] **Step 3: Compile server + ha-raft**
+
+Run: `mvn -q -pl server,ha-raft -am -DskipTests install`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/src/main/java/com/arcadedb/server/HAServerPlugin.java \
+        ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+git commit -m "feat(#5002): expose leader/replica Bolt addresses on HAServerPlugin"
+```
+
+---
+
+### Task 4: Build the HA-aware routing table in handleRoute
+
+**Files:**
+- Modify: `bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java` (`handleRoute`, around line 927)
+- Test: `bolt/src/test/java/com/arcadedb/bolt/BoltProtocolIT.java`
+
+**Interfaces:**
+- Consumes: `server.getHA()` returning `HAServerPlugin` with `getLeaderBoltAddress()` / `getReplicaBoltAddresses()` (Task 3).
+- Produces: ROUTE `SUCCESS` whose `rt.servers` lists leader as `WRITE`+`ROUTE` and each replica as `READ`+`ROUTE`, or the single-node self table when HA is absent/leaderless.
+
+- [ ] **Step 1: Write the single-node ROUTE regression test** (append to `BoltProtocolIT`, reuse the raw-socket pattern already in this file)
+
+```java
+  @Test
+  void routeTableSingleNodeReturnsSelfForAllRoles() throws Exception {
+    try (Socket socket = new Socket("localhost", 7687)) {
+      final OutputStream rawOut = socket.getOutputStream();
+
+      final ByteBuffer handshake = ByteBuffer.allocate(20);
+      handshake.put((byte) 0x60).put((byte) 0x60).put((byte) 0xB0).put((byte) 0x17);
+      handshake.putInt(0x00020404);
+      handshake.putInt(0x00000004);
+      handshake.putInt(0x00000003);
+      handshake.putInt(0x00000000);
+      handshake.flip();
+      rawOut.write(handshake.array());
+      rawOut.flush();
+
+      final DataInputStream rawIn = new DataInputStream(socket.getInputStream());
+      final byte[] negotiatedVersion = new byte[4];
+      rawIn.readFully(negotiatedVersion);
+
+      final BoltChunkedOutput chunkedOut = new BoltChunkedOutput(rawOut);
+      final BoltChunkedInput chunkedIn = new BoltChunkedInput(socket.getInputStream());
+
+      // HELLO
+      PackStreamWriter hello = new PackStreamWriter();
+      hello.writeStructureHeader(BoltMessage.HELLO, 1);
+      hello.writeMap(Map.of("user_agent", "route-regression/1.0", "scheme", "basic",
+          "principal", "root", "credentials", DEFAULT_PASSWORD_FOR_TESTS));
+      chunkedOut.writeMessage(hello.toByteArray());
+      chunkedIn.readMessage(); // HELLO SUCCESS
+
+      // ROUTE (routing map, bookmarks, extra{db})
+      PackStreamWriter route = new PackStreamWriter();
+      route.writeStructureHeader(BoltMessage.ROUTE, 3);
+      route.writeMap(Map.of());
+      route.writeList(List.of());
+      route.writeMap(Map.of("db", getDatabaseName()));
+      chunkedOut.writeMessage(route.toByteArray());
+
+      final byte[] response = chunkedIn.readMessage();
+      assertThat(response[1]).as("ROUTE must succeed").isEqualTo(BoltMessage.SUCCESS);
+
+      final Map<String, Object> body = new PackStreamReader(response).readSuccessMetadata();
+      @SuppressWarnings("unchecked")
+      final Map<String, Object> rt = (Map<String, Object>) body.get("rt");
+      @SuppressWarnings("unchecked")
+      final List<Map<String, Object>> servers = (List<Map<String, Object>>) rt.get("servers");
+
+      // Single-node: the same self address appears under WRITE, READ and ROUTE.
+      final String self = addressForRole(servers, "WRITE");
+      assertThat(self).isNotBlank();
+      assertThat(addressForRole(servers, "READ")).isEqualTo(self);
+      assertThat(addressForRole(servers, "ROUTE")).isEqualTo(self);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static String addressForRole(final List<Map<String, Object>> servers, final String role) {
+    for (final Map<String, Object> s : servers) {
+      if (role.equals(s.get("role"))) {
+        final List<String> addrs = (List<String>) s.get("addresses");
+        return addrs.isEmpty() ? null : addrs.get(0);
+      }
+    }
+    return null;
+  }
+```
+
+Add any missing imports to `BoltProtocolIT`: `com.arcadedb.bolt.packstream.PackStreamReader`, `com.arcadedb.bolt.packstream.PackStreamWriter`, `com.arcadedb.bolt.message.BoltMessage`, `com.arcadedb.bolt.BoltChunkedInput`, `com.arcadedb.bolt.BoltChunkedOutput`, `java.util.List`. First confirm `PackStreamReader.readSuccessMetadata()` exists; if the accessor differs, use the actual method name (run `rg -n "readSuccessMetadata|public Map.*read.*[Mm]etadata|Map<String, Object> read" bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamReader.java`). If no map-returning reader exists, parse via the existing reader entrypoint used elsewhere in `BoltProtocolIT` for SUCCESS bodies.
+
+- [ ] **Step 2: Run the regression test against current (single-node) code**
+
+Run: `mvn -q -pl bolt test -Dtest=BoltProtocolIT#routeTableSingleNodeReturnsSelfForAllRoles`
+Expected: PASS - current `handleRoute` already returns self for all roles. This test guards the fallback so the Task-4 change must not regress it.
+
+- [ ] **Step 3: Rewrite `handleRoute` with the HA-aware branch**
+
+Replace the body of `handleRoute` (keep the FAILED guard and the response send) with:
+
+```java
+  private void handleRoute(final RouteMessage message) throws IOException {
+    if (state == State.FAILED) {
+      sendIgnored();
+      return;
+    }
+
+    final Map<String, Object> rt = new LinkedHashMap<>();
+    rt.put("ttl", GlobalConfiguration.BOLT_ROUTING_TTL.getValueAsLong());
+    rt.put("db", message.getDatabase() != null ? message.getDatabase() : databaseName);
+
+    final List<Map<String, Object>> servers = new ArrayList<>();
+
+    final HAServerPlugin ha = server.getHA();
+    final String leaderBolt = ha != null ? ha.getLeaderBoltAddress() : null;
+
+    if (leaderBolt != null) {
+      // HA cluster: leader is the writer + router, followers are readers + routers.
+      final List<String> readers = new ArrayList<>();
+      final String replicaCsv = ha.getReplicaBoltAddresses();
+      if (replicaCsv != null && !replicaCsv.isEmpty())
+        for (final String addr : replicaCsv.split(","))
+          if (!addr.isBlank())
+            readers.add(addr.trim());
+
+      final List<String> routers = new ArrayList<>();
+      routers.add(leaderBolt);
+      routers.addAll(readers);
+
+      servers.add(roleEntry(List.of(leaderBolt), "WRITE"));
+      servers.add(roleEntry(readers.isEmpty() ? List.of(leaderBolt) : readers, "READ"));
+      servers.add(roleEntry(routers, "ROUTE"));
+    } else {
+      // Single-node (or HA not ready): advertise this node for every role.
+      final String address = getBoltAddress(GlobalConfiguration.BOLT_PORT.getValueAsInteger());
+      servers.add(roleEntry(List.of(address), "WRITE"));
+      servers.add(roleEntry(List.of(address), "READ"));
+      servers.add(roleEntry(List.of(address), "ROUTE"));
+    }
+
+    rt.put("servers", servers);
+    sendSuccess(CollectionUtils.singletonMap("rt", rt));
+  }
+
+  private static Map<String, Object> roleEntry(final List<String> addresses, final String role) {
+    final Map<String, Object> entry = new LinkedHashMap<>();
+    entry.put("addresses", addresses);
+    entry.put("role", role);
+    return entry;
+  }
+```
+
+Add the import `com.arcadedb.server.HAServerPlugin` if not already present. Confirm `server` field type exposes `getHA()` returning `HAServerPlugin` (`rg -n "public HAServerPlugin getHA" server/src/main/java/com/arcadedb/server/ArcadeDBServer.java`).
+
+- [ ] **Step 4: Run the single-node regression again**
+
+Run: `mvn -q -pl bolt test -Dtest=BoltProtocolIT#routeTableSingleNodeReturnsSelfForAllRoles`
+Expected: PASS - fallback path unchanged in behavior (still self for all roles).
+
+- [ ] **Step 5: Run the existing routing test to confirm no regression**
+
+Run: `mvn -q -pl bolt test -Dtest=BoltProtocolIT#routingConnection`
+Expected: PASS.
+
+- [ ] **Step 6: Compile the bolt module**
+
+Run: `mvn -q -pl bolt -am -DskipTests install`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add bolt/src/main/java/com/arcadedb/bolt/BoltNetworkExecutor.java \
+        bolt/src/test/java/com/arcadedb/bolt/BoltProtocolIT.java
+git commit -m "feat(#5002): build HA-aware Bolt ROUTE table from live cluster membership"
+```
+
+---
+
+### Task 5: Multi-node cluster IT (CONN-004 acceptance)
+
+**Files:**
+- Create: `bolt/src/test/java/com/arcadedb/bolt/Bolt5002RoutingTableIT.java`
+
+**Interfaces:**
+- Consumes: `BaseRaftHATest` harness (`findLeaderIndex()`, `getServerDatabase(int,String)`, `waitForAllServers()`, `getServerCount()`, `getDatabaseName()`, `DEFAULT_PASSWORD_FOR_TESTS`, `restartServer`/`stopServer` as available); the full Task 1-4 chain.
+- Produces: the acceptance test proving CONN-004.
+
+- [ ] **Step 1: Write the IT**
+
+```java
+package com.arcadedb.bolt;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.ha.raft.BaseRaftHATest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Config;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
+
+import java.io.DataInputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.arcadedb.bolt.message.BoltMessage;
+import com.arcadedb.bolt.packstream.PackStreamReader;
+import com.arcadedb.bolt.packstream.PackStreamWriter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Certifies that the Bolt ROUTE response reflects real HA topology: the true leader is advertised as
+ * the writer and the followers as readers, and a neo4j:// driver can route reads and writes accordingly.
+ */
+@Tag("slow")
+class Bolt5002RoutingTableIT extends BaseRaftHATest {
+
+  private static final int    BASE_BOLT_PORT = 57697;
+  private static final String VERTEX_TYPE    = "Bolt5002Route";
+
+  private Driver driver;
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Override
+  protected String getServerAddresses() {
+    // Object form so each node declares its own Bolt port (nodes share localhost, differ by port).
+    final StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < getServerCount(); i++) {
+      if (i > 0)
+        sb.append(",");
+      sb.append("localhost:{raft:").append(2434 + i)
+        .append(",http:").append(2480 + i)
+        .append(",bolt:").append(BASE_BOLT_PORT + i).append("}");
+    }
+    return sb.toString();
+  }
+
+  @Override
+  protected void onServerConfiguration(final ContextConfiguration config) {
+    super.onServerConfiguration(config);
+    final String serverName = config.getValueAsString(GlobalConfiguration.SERVER_NAME);
+    final int index = Integer.parseInt(serverName.substring(serverName.lastIndexOf('_') + 1));
+    config.setValue(GlobalConfiguration.SERVER_PLUGINS.getKey(), "Bolt:com.arcadedb.bolt.BoltProtocolPlugin");
+    config.setValue(GlobalConfiguration.BOLT_PORT.getKey(), String.valueOf(BASE_BOLT_PORT + index));
+  }
+
+  @AfterEach
+  void closeDriver() {
+    if (driver != null) {
+      driver.close();
+      driver = null;
+    }
+  }
+
+  @Test
+  void routeTableReflectsLeaderAndFollowers() throws Exception {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).as("A Raft leader must be elected").isGreaterThanOrEqualTo(0);
+
+    final String leaderBolt = "localhost:" + (BASE_BOLT_PORT + leaderIndex);
+    final List<String> followerBolt = new ArrayList<>();
+    for (int i = 0; i < getServerCount(); i++)
+      if (i != leaderIndex)
+        followerBolt.add("localhost:" + (BASE_BOLT_PORT + i));
+
+    // Ask any node (a follower, to prove routing is not leader-local) for its routing table.
+    final int askIndex = (leaderIndex + 1) % getServerCount();
+    final Map<String, Object> rt = fetchRoutingTable(BASE_BOLT_PORT + askIndex);
+
+    assertThat(addressesForRole(rt, "WRITE")).containsExactly(leaderBolt);
+    assertThat(addressesForRole(rt, "READ")).containsExactlyInAnyOrderElementsOf(followerBolt);
+    assertThat(addressesForRole(rt, "ROUTE")).contains(leaderBolt).containsAll(followerBolt);
+  }
+
+  @Test
+  void neo4jSchemeRoutesReadsAndWrites() {
+    final int leaderIndex = findLeaderIndex();
+    assertThat(leaderIndex).isGreaterThanOrEqualTo(0);
+
+    driver = GraphDatabase.driver(
+        "neo4j://localhost:" + (BASE_BOLT_PORT + leaderIndex),
+        AuthTokens.basic("root", DEFAULT_PASSWORD_FOR_TESTS),
+        Config.builder().withoutEncryption().build());
+    driver.verifyConnectivity();
+
+    try (Session session = driver.session(SessionConfig.builder().withDatabase(getDatabaseName()).build())) {
+      session.executeWrite(tx -> {
+        tx.run("CREATE (n:" + VERTEX_TYPE + " {name: 'routed'})").consume();
+        return null;
+      });
+    }
+    waitForAllServers();
+
+    try (Session session = driver.session(SessionConfig.builder().withDatabase(getDatabaseName()).build())) {
+      final long count = session.executeRead(tx ->
+          tx.run("MATCH (n:" + VERTEX_TYPE + ") RETURN count(n) AS c").single().get("c").asLong());
+      assertThat(count).isEqualTo(1L);
+    }
+  }
+
+  @Test
+  void writerClassificationTracksLeaderChange() throws Exception {
+    final int firstLeader = findLeaderIndex();
+    assertThat(firstLeader).isGreaterThanOrEqualTo(0);
+
+    // Stop the current leader and wait for a new election.
+    stopServer(firstLeader);
+    int newLeader = -1;
+    for (int attempt = 0; attempt < 60 && newLeader < 0; attempt++) {
+      final int candidate = findLeaderIndex();
+      if (candidate >= 0 && candidate != firstLeader)
+        newLeader = candidate;
+      else
+        Thread.sleep(500);
+    }
+    assertThat(newLeader).as("A new leader must be elected after the old one stops").isGreaterThanOrEqualTo(0);
+
+    final int askIndex = newLeader; // ask a surviving node
+    final Map<String, Object> rt = fetchRoutingTable(BASE_BOLT_PORT + askIndex);
+    assertThat(addressesForRole(rt, "WRITE"))
+        .containsExactly("localhost:" + (BASE_BOLT_PORT + newLeader));
+  }
+
+  // --- raw Bolt ROUTE helper -------------------------------------------------
+
+  private Map<String, Object> fetchRoutingTable(final int boltPort) throws Exception {
+    try (Socket socket = new Socket("localhost", boltPort)) {
+      final OutputStream rawOut = socket.getOutputStream();
+      final ByteBuffer handshake = ByteBuffer.allocate(20);
+      handshake.put((byte) 0x60).put((byte) 0x60).put((byte) 0xB0).put((byte) 0x17);
+      handshake.putInt(0x00020404);
+      handshake.putInt(0x00000004);
+      handshake.putInt(0x00000003);
+      handshake.putInt(0x00000000);
+      handshake.flip();
+      rawOut.write(handshake.array());
+      rawOut.flush();
+
+      final DataInputStream rawIn = new DataInputStream(socket.getInputStream());
+      final byte[] negotiated = new byte[4];
+      rawIn.readFully(negotiated);
+
+      final BoltChunkedOutput out = new BoltChunkedOutput(rawOut);
+      final BoltChunkedInput in = new BoltChunkedInput(socket.getInputStream());
+
+      final PackStreamWriter hello = new PackStreamWriter();
+      hello.writeStructureHeader(BoltMessage.HELLO, 1);
+      hello.writeMap(Map.of("user_agent", "bolt5002/1.0", "scheme", "basic",
+          "principal", "root", "credentials", DEFAULT_PASSWORD_FOR_TESTS));
+      out.writeMessage(hello.toByteArray());
+      in.readMessage();
+
+      final PackStreamWriter route = new PackStreamWriter();
+      route.writeStructureHeader(BoltMessage.ROUTE, 3);
+      route.writeMap(Map.of());
+      route.writeList(List.of());
+      route.writeMap(Map.of("db", getDatabaseName()));
+      out.writeMessage(route.toByteArray());
+
+      final byte[] response = in.readMessage();
+      assertThat(response[1]).as("ROUTE must succeed").isEqualTo(BoltMessage.SUCCESS);
+      final Map<String, Object> body = new PackStreamReader(response).readSuccessMetadata();
+      @SuppressWarnings("unchecked")
+      final Map<String, Object> rt = (Map<String, Object>) body.get("rt");
+      return rt;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<String> addressesForRole(final Map<String, Object> rt, final String role) {
+    final List<Map<String, Object>> servers = (List<Map<String, Object>>) rt.get("servers");
+    for (final Map<String, Object> s : servers)
+      if (role.equals(s.get("role")))
+        return (List<String>) s.get("addresses");
+    return List.of();
+  }
+}
+```
+
+- [ ] **Step 2: Reconcile harness method names**
+
+Confirm the exact `BaseRaftHATest`/`BaseGraphServerTest` API the test uses. Run:
+
+```bash
+rg -n "protected .*findLeaderIndex|void stopServer|void restartServer|getServerDatabase|waitForAllServers|DEFAULT_PASSWORD_FOR_TESTS|getServerAddresses" \
+  ha-raft/src/test/java/com/arcadedb/server/ha/raft/BaseRaftHATest.java \
+  server/src/test/java/com/arcadedb/server/BaseGraphServerTest.java
+```
+
+Adjust the test to the real signatures: if `stopServer(int)` is absent, use the actual stop/kill API (e.g. `getServer(i).stop()` plus the harness's server-stop bookkeeping) exactly as other HA leader-change ITs do - locate one with `rg -ln "new leader|stopServer|getServer\(.*\)\.stop" ha-raft/src/test`. Also verify `PackStreamReader.readSuccessMetadata()` (Task 4, Step 1); use the real accessor name if different.
+
+- [ ] **Step 3: Run the IT**
+
+Run: `mvn -q -pl bolt test -Dtest=Bolt5002RoutingTableIT`
+Expected: PASS (all three methods). Cluster ITs are slow; allow several minutes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bolt/src/test/java/com/arcadedb/bolt/Bolt5002RoutingTableIT.java
+git commit -m "test(#5002): certify HA-aware Bolt ROUTE against a 3-node cluster"
+```
+
+---
+
+### Task 6: Flip CONN-004 to passing in the conformance spec
+
+**Files:**
+- Modify: `bolt/conformance/spec.yaml` (`CONN-004`, around line 99-115)
+
+**Interfaces:**
+- Consumes: nothing. Produces: authoritative conformance status.
+
+- [ ] **Step 1: Update the CONN-004 entry**
+
+Change `current_status: expected-fail` to `current_status: passing`. Remove the `known_limitation:` block and the `tracking_issue: "#4890"` line (both no longer apply). If a residual limitation must be recorded, replace `known_limitation` with a short note that heterogeneous Bolt ports require the `host:{raft:..,bolt:..}` object syntax in `HA_SERVER_LIST`; otherwise remove it entirely. Keep the `steps`, `description`, and `applicable_driver_versions` fields intact.
+
+- [ ] **Step 2: Sanity-check the YAML**
+
+Run: `rg -n "CONN-004" -A15 bolt/conformance/spec.yaml`
+Expected: shows `current_status: passing` and no dangling `known_limitation`/`tracking_issue` keys under CONN-004.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add bolt/conformance/spec.yaml
+git commit -m "docs(#5002): mark CONN-004 passing in the Bolt conformance spec"
+```
+
+---
+
+### Task 7: Full verification and cross-module regression
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Compile the whole reactor for touched modules**
+
+Run: `mvn -q -pl engine,server,ha-raft,bolt -am -DskipTests install`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 2: Run the focused regression set**
+
+Run:
+```bash
+mvn -q -pl ha-raft test -Dtest=RaftHAServerAddressParsingTest
+mvn -q -pl bolt test -Dtest=BoltProtocolIT#routingConnection+routeTableSingleNodeReturnsSelfForAllRoles
+mvn -q -pl bolt test -Dtest=BoltFollowerForwardingIT
+mvn -q -pl bolt test -Dtest=Bolt5002RoutingTableIT
+```
+Expected: all PASS.
+
+- [ ] **Step 3: Confirm no stray debug output or fully-qualified names were introduced**
+
+Run: `git diff main --stat && rg -n "System.out" $(git diff --name-only main -- '*.java')`
+Expected: no `System.out` in changed files.
+
+- [ ] **Step 4: Final commit if any cleanup was needed**
+
+```bash
+git add -A && git commit -m "chore(#5002): verification cleanup" || echo "nothing to clean up"
+```
+
+---
+
+## Self-Review notes
+
+- Spec coverage: Address resolution (Task 1-2), interface bridge (Task 3), ROUTE handler + fallback (Task 4), multi-node acceptance incl. leader-change (Task 5), single-node regression (Task 4 Step 1), conformance flip (Task 6), whole-reactor verification (Task 7). All spec sections mapped.
+- Homogeneous fallback + one-time WARNING mirrors the established `resolveHttpAddress` pattern (spec constraint).
+- `bolt:` is object-form only; positional form untouched (Task 1 tests assert this).
+- Type consistency: `getLeaderBoltAddress()`/`getReplicaBoltAddresses()` names identical across RaftHAServer, HAServerPlugin, RaftHAPlugin, and BoltNetworkExecutor. `roleEntry`/`addressesForRole`/`fetchRoutingTable` helper names consistent within their files.
+- Open reconciliations flagged inline for the implementer: `PackStreamReader.readSuccessMetadata()` accessor name (Task 4/5) and the harness stop-server API (Task 5 Step 2). These are verify-then-adapt steps, not placeholders.

--- a/docs/superpowers/plans/2026-07-07-bolt-ha-aware-route-5002.md
+++ b/docs/superpowers/plans/2026-07-07-bolt-ha-aware-route-5002.md
@@ -8,6 +8,15 @@
 
 **Tech Stack:** Java 21, Maven multi-module, Apache Ratis (Raft), JUnit 5 + AssertJ, neo4j-java-driver (test), custom PackStream Bolt codec.
 
+> **Post-review deltas (final code differs from the task steps below):** code review reshaped three points.
+> (1) The two-method interface (`getLeaderBoltAddress()` + `getReplicaBoltAddresses()`) was collapsed into a
+> single `HAServerPlugin.BoltRoutingTable getBoltRoutingTable()` computed from one `getLeaderId()` read, to
+> remove the writer/reader leader-disagreement window; `readers` is an immutable `List.copyOf`. (2)
+> `handleRoute` is gated behind an authenticated session (`state == READY`) because ROUTE enumerates cluster
+> Bolt endpoints. (3) The fallback distinguishes HA-active-but-leaderless (advertise `READ` + `ROUTE` only,
+> never `WRITE`) from true single-node (`WRITE`/`READ`/`ROUTE`), and uses `socket.getLocalPort()` for the
+> self address. The task steps below capture the original plan; the spec's section 2/3 reflect the final design.
+
 ## Global Constraints
 
 - Java 21+; import classes, do not use fully-qualified names inline.

--- a/docs/superpowers/specs/2026-07-07-bolt-ha-aware-route-5002-design.md
+++ b/docs/superpowers/specs/2026-07-07-bolt-ha-aware-route-5002-design.md
@@ -1,0 +1,149 @@
+# Bolt: HA-aware ROUTE response with multi-server routing table (#5002)
+
+- Issue: https://github.com/ArcadeData/arcadedb/issues/5002
+- Tracking: #4890 (Group C protocol/type-fidelity gaps)
+- Epic: #4882 (Bolt Driver Compatibility Certification)
+- Conformance scenario: `CONN-004` in `bolt/conformance/spec.yaml` (currently `expected-fail`)
+
+## Problem
+
+`BoltNetworkExecutor.handleRoute` returns **this node's own address** as the `WRITE`,
+`READ`, and `ROUTE` server, regardless of cluster topology. Against a real HA cluster a
+`neo4j://` driver therefore cannot discover the leader/followers or route reads versus
+writes: routing/discovery is unproven, and the ROUTE table lies about the topology.
+
+The `neo4j://` driver does not merely read the routing table; it **connects** to the
+advertised addresses and routes subsequent work to them. Any address the ROUTE table
+returns must be genuinely reachable on the Bolt port.
+
+## Constraints discovered
+
+- The `bolt` module depends on `arcadedb-server` in `provided` scope and on `arcadedb-ha-raft`
+  in `test` scope only. Production Bolt code can reach the cluster **only** through the
+  `HAServerPlugin` interface (package `com.arcadedb.server`). It cannot reference any ha-raft
+  class at compile time.
+- `HAServerPlugin` today exposes `isLeader()`, `getLeaderName()`, `getLeaderAddress()` and
+  `getReplicaAddresses()` - but the two address methods return **HTTP** addresses
+  (`host:httpPort`), not Bolt addresses.
+- HA membership (`HA_SERVER_LIST`) records each peer's host plus Raft/HTTP/HTTPS ports and a
+  leader-election priority. It records **no Bolt port**. `RaftPeerAddressResolver` already
+  supports an extensible **object form** `host:{raft:2434,http:2480,https:2490,priority:10}`
+  and a positional colon form (max 5 fields), plus an optional `name@` prefix.
+- `RaftHAServer.resolveHttpAddress` already establishes the pattern: use the explicitly
+  declared `host:port` if present, otherwise derive `peerHost:localPort` (homogeneous-cluster
+  assumption) and log a throttled one-time WARNING telling operators to declare ports
+  explicitly for heterogeneous clusters.
+- Test harness `BaseRaftHATest` runs an in-process N-node cluster on `localhost` with distinct
+  ports per node. `BoltFollowerForwardingIT` already drives a 3-node cluster over Bolt using
+  `BASE_BOLT_PORT + index`. This means the "peer host + my own Bolt port" shortcut is wrong in
+  the test harness (all nodes share `localhost`, differ only by port) - the per-node Bolt port
+  must be knowable.
+
+## Design
+
+### 1. Address resolution (ha-raft module)
+
+**`RaftPeerAddressResolver`**
+- Extend the object-form peer spec to accept an optional `bolt:<port>` field:
+  `host:{raft:2434,http:2480,bolt:7687}`.
+- `PeerSpec` gains a nullable `boltPort`; `parseObjectForm` reads `bolt:`.
+- `ParsedPeerList` gains `Map<RaftPeerId,String> boltAddresses`, populated only when `bolt:`
+  is declared, keyed by `RaftPeerId` exactly like `httpAddresses`/`httpsAddresses`.
+- The positional colon form is left at its current 5-field maximum. A 6th positional field
+  would be unreadable; `bolt:` is **object-form only** and documented as such in the Javadoc.
+
+**`RaftHAServer`**
+- Store `boltAddresses` from the parsed list (new final `Map<RaftPeerId,String>`).
+- `resolveBoltAddress(RaftPeerId)` mirrors `resolveHttpAddress`: return the declared
+  `host:boltPort` if present; otherwise derive `peerRaftHost:localBoltPort` where
+  `localBoltPort = configuration.getValueAsInteger(GlobalConfiguration.BOLT_PORT)`, logging a
+  throttled one-time WARNING (same contract as HTTP). Returns `null` when the peer is unknown.
+- `getLeaderBoltAddress()` returns the leader's resolved Bolt address (or `null`).
+- `getReplicaBoltAddresses()` returns a comma-separated list of resolved Bolt addresses for
+  every peer except the leader (or this node when the leader is unknown), skipping any that
+  resolve to `null` - an exact parallel of `getReplicaAddresses()`.
+
+### 2. Interface (server module)
+
+**`HAServerPlugin`** gains two methods with safe defaults so non-Raft or absent
+implementations need no change:
+```java
+default String getLeaderBoltAddress()   { return null; }
+default String getReplicaBoltAddresses() { return ""; }
+```
+**`RaftHAPlugin`** overrides both, delegating to `RaftHAServer`.
+
+### 3. ROUTE handler (bolt module)
+
+**`BoltNetworkExecutor.handleRoute`**: obtain `server.getHA()`. When it is non-null and a
+leader is resolvable (`getLeaderBoltAddress() != null`), build the routing table from live
+membership:
+- leader Bolt address -> `WRITE` and `ROUTE`
+- each replica Bolt address -> `READ` and `ROUTE`
+- `ttl` from `BOLT_ROUTING_TTL`, `db` from the message/session (unchanged).
+
+When HA is null or no leader is resolvable yet, fall back to the **current single-node table**
+(self as `WRITE`/`READ`/`ROUTE`) - unchanged behavior.
+
+Because the table is rebuilt on every ROUTE call and the leader/replica split is taken from
+live membership, **reader/writer classification tracks leader changes automatically**: after
+the TTL expires (or on a connection failure) the driver re-issues ROUTE and receives the new
+topology.
+
+Roles are emitted as three separate server entries (`WRITE`, `READ`, `ROUTE`) consistent with
+the existing single-node shape and the Neo4j routing-table contract. When a node holds two
+roles (leader is both writer and router) its address appears in both the `WRITE` and `ROUTE`
+entries.
+
+### 4. Tests
+
+- **`Bolt5002RoutingTableIT extends BaseRaftHATest`** (`@Tag("slow")`), `getServerCount() == 3`.
+  - Override `getServerAddresses()` to emit the object form with a per-node `bolt:<port>`
+    (e.g. `localhost:{raft:2434,http:2480,bolt:57687}`), and `onServerConfiguration` to bind
+    those same Bolt ports (mirrors `BoltFollowerForwardingIT`).
+  - Discover the true leader via `findLeaderIndex()`.
+  - Connect a `neo4j://localhost:<anyNodeBoltPort>` driver and request the routing table
+    (drive `getServerAddresses()`/`SHOW ...` via the driver, or assert on a routed session):
+    assert the `WRITE` entry is the true leader's Bolt address and the `READ` entries are the
+    two followers' Bolt addresses.
+  - Run a routed **write** and a routed **read** through the `neo4j://` session to prove the
+    advertised addresses are actually reachable and routable end to end.
+  - Leader-change check: stop the current leader, wait for re-election, re-request the routing
+    table, assert the new leader is now classified `WRITE`.
+- **`RaftPeerAddressResolver` unit test**: `bolt:` present in object form populates
+  `boltAddresses`; absent leaves it empty; object + positional entries mix correctly; `name@`
+  prefix still works alongside `bolt:`.
+- **Single-node regression**: assert non-HA ROUTE is unchanged (self as `WRITE`/`READ`/`ROUTE`).
+  Extend or add alongside the existing ROUTE coverage in `BoltProtocolIT`.
+
+### 5. Conformance spec
+
+Flip `CONN-004` in `bolt/conformance/spec.yaml` from `current_status: expected-fail` to the
+passing status used by the other closed Group C gaps, and remove the `known_limitation` block
+(or restate any residual limitation - e.g. `bolt:` must be declared for heterogeneous Bolt
+ports - as an accepted, documented note rather than a failure).
+
+## Scope guardrails (YAGNI)
+
+- No changes to the positional colon syntax (no 6th positional field).
+- No new standalone advertised-address config key; no gossip/registry.
+- No Bolt-side load balancing beyond writer/reader/router classification.
+- `neo4j+s` routing over TLS reuses the existing `BoltSslHelper`; no new TLS work.
+- No change to the advertised server identity (`Neo4j/5.26.0 compatible ...`).
+
+## Verification
+
+- `mvn -q -pl ha-raft -am test -Dtest=RaftPeerAddressResolver*` for the parser unit test.
+- `mvn -q -pl bolt -am test -Dtest=Bolt5002RoutingTableIT` for the cluster IT (`slow` tag,
+  run explicitly).
+- Re-run `BoltFollowerForwardingIT` and `BoltProtocolIT` ROUTE coverage to confirm no
+  regression in existing Bolt behavior.
+- Compile the whole reactor (`mvn -q -DskipTests install` on the touched modules) before
+  declaring done.
+
+## Acceptance criteria (from #5002)
+
+- [ ] `CONN-004` passes against a multi-node cluster: a `neo4j://` driver discovers writer +
+  reader(s) and routes accordingly (scenario re-enabled).
+- [ ] Single-node (non-HA) ROUTE behavior unchanged.
+- [ ] Reader/writer classification tracks leader changes.

--- a/docs/superpowers/specs/2026-07-07-bolt-ha-aware-route-5002-design.md
+++ b/docs/superpowers/specs/2026-07-07-bolt-ha-aware-route-5002-design.md
@@ -65,25 +65,39 @@ returns must be genuinely reachable on the Bolt port.
 
 ### 2. Interface (server module)
 
-**`HAServerPlugin`** gains two methods with safe defaults so non-Raft or absent
+**`HAServerPlugin`** gains a single snapshot method with a safe default so non-Raft or absent
 implementations need no change:
 ```java
-default String getLeaderBoltAddress()   { return null; }
-default String getReplicaBoltAddresses() { return ""; }
+record BoltRoutingTable(String writer, List<String> readers) {}
+default BoltRoutingTable getBoltRoutingTable() { return null; }
 ```
-**`RaftHAPlugin`** overrides both, delegating to `RaftHAServer`.
+**`RaftHAPlugin`** overrides it, delegating to `RaftHAServer`, which derives the writer and readers from
+a single `getLeaderId()` read and returns `readers` as an immutable `List.copyOf`.
+
+> Implementation note (post-review): an earlier draft exposed two methods
+> (`getLeaderBoltAddress()` + `getReplicaBoltAddresses()`). Code review flagged that reading the leader
+> twice opens a window where the writer and reader sets can disagree about who the leader is, so the
+> final design collapses them into one snapshot method.
 
 ### 3. ROUTE handler (bolt module)
 
-**`BoltNetworkExecutor.handleRoute`**: obtain `server.getHA()`. When it is non-null and a
-leader is resolvable (`getLeaderBoltAddress() != null`), build the routing table from live
-membership:
-- leader Bolt address -> `WRITE` and `ROUTE`
-- each replica Bolt address -> `READ` and `ROUTE`
+**`BoltNetworkExecutor.handleRoute`**: ROUTE enumerates every peer's Bolt endpoint, so it is gated
+behind an authenticated session (`state == READY`), matching the other request handlers - a ROUTE sent
+before HELLO/LOGON completes is refused. When authenticated, obtain `server.getHA()` and its
+`getBoltRoutingTable()` snapshot. When the snapshot is non-null (HA active with a known leader), build the
+routing table:
+- leader (writer) Bolt address -> `WRITE` and `ROUTE`
+- each replica (reader) Bolt address -> `READ` and `ROUTE`
 - `ttl` from `BOLT_ROUTING_TTL`, `db` from the message/session (unchanged).
 
-When HA is null or no leader is resolvable yet, fall back to the **current single-node table**
-(self as `WRITE`/`READ`/`ROUTE`) - unchanged behavior.
+When the snapshot is null, fall back by HA state:
+- **HA active but no leader known yet** (mid-election): advertise this node as `READ` + `ROUTE` only -
+  never `WRITE`, since it may be a follower - so a driver keeps reading and re-routes after the TTL
+  instead of writing to a follower.
+- **No HA** (true single-node): advertise this node as `WRITE`/`READ`/`ROUTE` (unchanged).
+
+The self address uses the connection's actual bound Bolt port (`socket.getLocalPort()`), not the global
+default, so a non-default listener port is advertised correctly.
 
 Because the table is rebuilt on every ROUTE call and the leader/replica split is taken from
 live membership, **reader/writer classification tracks leader changes automatically**: after

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
@@ -262,13 +262,8 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
   }
 
   @Override
-  public String getLeaderBoltAddress() {
-    return raftHAServer != null ? raftHAServer.getLeaderBoltAddress() : null;
-  }
-
-  @Override
-  public String getReplicaBoltAddresses() {
-    return raftHAServer != null ? raftHAServer.getReplicaBoltAddresses() : "";
+  public BoltRoutingTable getBoltRoutingTable() {
+    return raftHAServer != null ? raftHAServer.getBoltRoutingTable() : null;
   }
 
   @Override

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAPlugin.java
@@ -262,6 +262,16 @@ public class RaftHAPlugin implements HAServerPlugin, HAReplicationStatsProvider 
   }
 
   @Override
+  public String getLeaderBoltAddress() {
+    return raftHAServer != null ? raftHAServer.getLeaderBoltAddress() : null;
+  }
+
+  @Override
+  public String getReplicaBoltAddresses() {
+    return raftHAServer != null ? raftHAServer.getReplicaBoltAddresses() : "";
+  }
+
+  @Override
   public void shutdownRemoteServer(final String serverName) {
     if (raftHAServer == null)
       throw new RuntimeException("Raft HA server not started");

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -22,6 +22,7 @@ import com.arcadedb.ContextConfiguration;
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.server.HAServerPlugin;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.monitor.HAReplicationStatsProvider;
 import org.apache.ratis.client.RaftClient;
@@ -1249,33 +1250,28 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   }
 
   /**
-   * Returns the client-reachable Bolt address (host:boltPort) of the current leader for the Bolt ROUTE
-   * routing table, or {@code null} when the leader is unknown or no Bolt address can be resolved.
+   * Builds a single-snapshot Bolt routing table (leader as writer, followers as readers) from one
+   * {@link #getLeaderId()} read, so a concurrent leader change cannot make the writer and reader sets
+   * mutually inconsistent. Returns {@code null} when no leader is known or the leader has no resolvable
+   * Bolt address. Readers reflect the configured cluster membership, matching {@link #getReplicaAddresses()};
+   * peers whose Bolt address cannot be resolved are skipped.
    */
-  public String getLeaderBoltAddress() {
-    return resolveBoltAddress(getLeaderId());
-  }
-
-  /**
-   * Returns a comma-separated list of client-reachable Bolt addresses for every peer except the leader
-   * (or except this node when the leader is unknown), for the reader entries of the Bolt ROUTE routing
-   * table. Peers whose Bolt address cannot be resolved are skipped. Returns an empty string when none.
-   */
-  public String getReplicaBoltAddresses() {
+  public HAServerPlugin.BoltRoutingTable getBoltRoutingTable() {
     final RaftPeerId leaderId = getLeaderId();
-    final RaftPeerId excludeId = leaderId != null ? leaderId : localPeerId;
-    final StringBuilder sb = new StringBuilder();
+    if (leaderId == null)
+      return null;
+    final String writer = resolveBoltAddress(leaderId);
+    if (writer == null)
+      return null;
+    final List<String> readers = new ArrayList<>();
     for (final RaftPeer peer : raftGroup.getPeers()) {
-      if (!peer.getId().equals(excludeId)) {
-        final String boltAddr = resolveBoltAddress(peer.getId());
-        if (boltAddr != null) {
-          if (!sb.isEmpty())
-            sb.append(",");
-          sb.append(boltAddr);
-        }
+      if (!peer.getId().equals(leaderId)) {
+        final String reader = resolveBoltAddress(peer.getId());
+        if (reader != null)
+          readers.add(reader);
       }
     }
-    return sb.toString();
+    return new HAServerPlugin.BoltRoutingTable(writer, readers);
   }
 
   /**
@@ -1336,7 +1332,7 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
    * for testing.
    */
   static String deriveBoltAddress(final String raftAddress, final int boltPort) {
-    if (boltPort <= 0)
+    if (raftAddress == null || boltPort <= 0)
       return null;
     final String host = extractHost(raftAddress);
     return host != null ? host + ":" + boltPort : null;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -120,6 +120,11 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   private final    AtomicBoolean           httpFallbackWarned = new AtomicBoolean(false);
   // Logged at most once: notes that peer HTTPS endpoints are derived from this node's local HTTPS port.
   private final    AtomicBoolean           httpsFallbackWarned = new AtomicBoolean(false);
+  // Client-reachable Bolt endpoints (optional object-form 'bolt' field in HA_SERVER_LIST). Advertised
+  // in the Bolt ROUTE routing table so neo4j:// drivers can discover leader/followers.
+  private final    Map<RaftPeerId, String> boltAddresses      = new HashMap<>();
+  // Logged at most once: warns operators that Bolt routing addresses are derived (not explicitly configured).
+  private final    AtomicBoolean           boltFallbackWarned = new AtomicBoolean(false);
   private final    Map<RaftPeerId, String> peerDisplayNames   = new ConcurrentHashMap<>();
   private final    String                  clusterName;
 
@@ -181,6 +186,7 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
 
     this.httpAddresses.putAll(parsed.httpAddresses());
     this.httpsAddresses.putAll(parsed.httpsAddresses());
+    this.boltAddresses.putAll(parsed.boltAddresses());
 
     RaftPeerId resolvedLocalPeerId;
     try {
@@ -1243,6 +1249,36 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
   }
 
   /**
+   * Returns the client-reachable Bolt address (host:boltPort) of the current leader for the Bolt ROUTE
+   * routing table, or {@code null} when the leader is unknown or no Bolt address can be resolved.
+   */
+  public String getLeaderBoltAddress() {
+    return resolveBoltAddress(getLeaderId());
+  }
+
+  /**
+   * Returns a comma-separated list of client-reachable Bolt addresses for every peer except the leader
+   * (or except this node when the leader is unknown), for the reader entries of the Bolt ROUTE routing
+   * table. Peers whose Bolt address cannot be resolved are skipped. Returns an empty string when none.
+   */
+  public String getReplicaBoltAddresses() {
+    final RaftPeerId leaderId = getLeaderId();
+    final RaftPeerId excludeId = leaderId != null ? leaderId : localPeerId;
+    final StringBuilder sb = new StringBuilder();
+    for (final RaftPeer peer : raftGroup.getPeers()) {
+      if (!peer.getId().equals(excludeId)) {
+        final String boltAddr = resolveBoltAddress(peer.getId());
+        if (boltAddr != null) {
+          if (!sb.isEmpty())
+            sb.append(",");
+          sb.append(boltAddr);
+        }
+      }
+    }
+    return sb.toString();
+  }
+
+  /**
    * Resolves the HTTP address (host:port) of a peer. When the peer's HTTP port was declared
    * explicitly in {@link GlobalConfiguration#HA_SERVER_LIST} (the {@code host:raftPort:httpPort}
    * syntax) that value is returned. Otherwise a best-effort address is synthesized by combining the
@@ -1267,6 +1303,43 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
     if (configured != null)
       return configured;
     return deriveHttpAddressWithWarning(peer.getAddress());
+  }
+
+  /**
+   * Resolves the client-reachable Bolt address (host:boltPort) of a peer. Returns the address declared
+   * with the object-form {@code bolt:} field when present; otherwise derives it from the peer's Raft host
+   * plus this node's local Bolt port. The fallback is correct only for homogeneous deployments where every
+   * node listens on the same Bolt port (e.g. a Kubernetes StatefulSet); a one-time WARNING is logged so
+   * operators declare explicit Bolt ports for heterogeneous clusters. Returns {@code null} when the peer is
+   * unknown or the local Bolt port is unavailable.
+   */
+  private String resolveBoltAddress(final RaftPeerId peerId) {
+    if (peerId == null)
+      return null;
+    final String configured = boltAddresses.get(peerId);
+    if (configured != null)
+      return configured;
+    final int localBoltPort = configuration.getValueAsInteger(GlobalConfiguration.BOLT_PORT);
+    final String derived = deriveBoltAddress(peerRaftAddress(peerId), localBoltPort);
+    if (derived != null && boltFallbackWarned.compareAndSet(false, true))
+      LogManager.instance().log(this, Level.WARNING,
+          "HA Bolt routing addresses are not configured in '%s': deriving peer Bolt endpoints from each peer's Raft host plus this node's Bolt port (%d). "
+              + "This is correct only when every node listens on the same Bolt port (e.g. a Kubernetes StatefulSet). For clusters with heterogeneous "
+              + "Bolt ports, declare them explicitly using the 'host:{raft:..,bolt:..}' object syntax in %s.",
+          GlobalConfiguration.HA_SERVER_LIST.getKey(), localBoltPort, GlobalConfiguration.HA_SERVER_LIST.getKey());
+    return derived;
+  }
+
+  /**
+   * Derives a Bolt address (host:boltPort) by combining a peer's Raft host with the given Bolt port.
+   * Returns {@code null} when the port is not positive or the host cannot be extracted. Package-private
+   * for testing.
+   */
+  static String deriveBoltAddress(final String raftAddress, final int boltPort) {
+    if (boltPort <= 0)
+      return null;
+    final String host = extractHost(raftAddress);
+    return host != null ? host + ":" + boltPort : null;
   }
 
   private String deriveHttpAddressWithWarning(final String raftAddress) {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftHAServer.java
@@ -1271,7 +1271,7 @@ public class RaftHAServer implements HealthMonitor.HealthTarget {
           readers.add(reader);
       }
     }
-    return new HAServerPlugin.BoltRoutingTable(writer, readers);
+    return new HAServerPlugin.BoltRoutingTable(writer, List.copyOf(readers));
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftPeerAddressResolver.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/RaftPeerAddressResolver.java
@@ -43,9 +43,12 @@ final class RaftPeerAddressResolver {
    * it is used for encrypted peer-to-peer transfers (e.g. snapshot download) when SSL is enabled.
    * The {@code peerNames} map contains user-provided peer names from the optional {@code name@}
    * prefix and is empty when no entry uses that syntax.
+   * The {@code boltAddresses} map is empty when no entry declares the object-form {@code bolt} field;
+   * it holds the client-reachable Bolt address advertised in the ROUTE routing table.
    */
   public record ParsedPeerList(List<RaftPeer> peers, Map<RaftPeerId, String> httpAddresses,
-                               Map<RaftPeerId, String> httpsAddresses, Map<RaftPeerId, String> peerNames) {
+                               Map<RaftPeerId, String> httpsAddresses, Map<RaftPeerId, String> peerNames,
+                               Map<RaftPeerId, String> boltAddresses) {
   }
 
   private RaftPeerAddressResolver() {
@@ -56,11 +59,13 @@ final class RaftPeerAddressResolver {
    * <p>
    * Each entry supports two interchangeable syntaxes.
    * <p>
-   * <b>1. Object form</b> (recommended for readability): {@code host:{raft:2434,http:2480,https:2490,priority:10}}.
+   * <b>1. Object form</b> (recommended for readability): {@code host:{raft:2434,http:2480,https:2490,bolt:7687,priority:10}}.
    * The fields are unordered and all optional except that {@code raft} defaults to {@code defaultPort}
-   * when omitted ({@code http}/{@code https} are simply not stored when absent, {@code priority} defaults
-   * to 0). This avoids the positional ambiguity of the colon form. Example:
-   * {@code frankfurt@db1:{raft:2434,http:2480,https:2490}}.
+   * when omitted ({@code http}/{@code https}/{@code bolt} are simply not stored when absent, {@code priority}
+   * defaults to 0). This avoids the positional ambiguity of the colon form. Example:
+   * {@code frankfurt@db1:{raft:2434,http:2480,https:2490,bolt:7687}}. The {@code bolt} field is the
+   * client-reachable Bolt address advertised in the ROUTE routing table and is available only in the object
+   * form (the positional colon form has no Bolt field).
    * <p>
    * <b>2. Positional (colon) form</b>:
    * <ul>
@@ -107,6 +112,7 @@ final class RaftPeerAddressResolver {
     final List<RaftPeer> peers = new ArrayList<>(entries.size());
     final Map<RaftPeerId, String> httpAddresses = new HashMap<>(entries.size());
     final Map<RaftPeerId, String> httpsAddresses = new HashMap<>(entries.size());
+    final Map<RaftPeerId, String> boltAddresses = new HashMap<>(entries.size());
     final Map<RaftPeerId, String> peerNames = new HashMap<>(entries.size());
     final Map<String, String> nameToEntry = new HashMap<>(entries.size());
 
@@ -131,6 +137,7 @@ final class RaftPeerAddressResolver {
       final String raftAddress;
       String httpAddress = null;
       String httpsAddress = null;
+      String boltAddress = null;
       int priority = 0;
 
       final int braceIdx = entry.indexOf('{');
@@ -143,6 +150,8 @@ final class RaftPeerAddressResolver {
           httpAddress = host + ":" + spec.httpPort;
         if (spec.httpsPort != null)
           httpsAddress = host + ":" + spec.httpsPort;
+        if (spec.boltPort != null)
+          boltAddress = host + ":" + spec.boltPort;
         priority = spec.priority;
       } else {
         final String[] parts = entry.split(":");
@@ -192,6 +201,8 @@ final class RaftPeerAddressResolver {
         httpAddresses.put(peer.getId(), httpAddress);
       if (httpsAddress != null)
         httpsAddresses.put(peer.getId(), httpsAddress);
+      if (boltAddress != null)
+        boltAddresses.put(peer.getId(), boltAddress);
       if (peerName != null)
         peerNames.put(peer.getId(), peerName);
     }
@@ -216,7 +227,8 @@ final class RaftPeerAddressResolver {
         Collections.unmodifiableList(peers),
         Collections.unmodifiableMap(httpAddresses),
         Collections.unmodifiableMap(httpsAddresses),
-        Collections.unmodifiableMap(peerNames));
+        Collections.unmodifiableMap(peerNames),
+        Collections.unmodifiableMap(boltAddresses));
   }
 
   /** Resolved ports for a single peer entry, regardless of the syntax it was written in. */
@@ -225,19 +237,22 @@ final class RaftPeerAddressResolver {
     final int     raftPort;
     final Integer httpPort;  // null when not specified
     final Integer httpsPort; // null when not specified
+    final Integer boltPort;  // null when not specified
     final int     priority;
 
-    PeerSpec(final String host, final int raftPort, final Integer httpPort, final Integer httpsPort, final int priority) {
+    PeerSpec(final String host, final int raftPort, final Integer httpPort, final Integer httpsPort, final Integer boltPort,
+        final int priority) {
       this.host = host;
       this.raftPort = raftPort;
       this.httpPort = httpPort;
       this.httpsPort = httpsPort;
+      this.boltPort = boltPort;
       this.priority = priority;
     }
   }
 
   /**
-   * Parses the object form {@code host:{raft:..,http:..,https:..,priority:..}} into a {@link PeerSpec}.
+   * Parses the object form {@code host:{raft:..,http:..,https:..,bolt:..,priority:..}} into a {@link PeerSpec}.
    * Fields are unordered and all optional; {@code raft} defaults to {@code defaultPort}. Unknown or
    * duplicated keys throw {@link ServerException}.
    */
@@ -256,6 +271,7 @@ final class RaftPeerAddressResolver {
     int raftPort = defaultPort;
     Integer httpPort = null;
     Integer httpsPort = null;
+    Integer boltPort = null;
     int priority = 0;
     final Map<String, String> seen = new HashMap<>();
 
@@ -276,13 +292,14 @@ final class RaftPeerAddressResolver {
         case "raft" -> raftPort = parseIntField(value, "raft", entry);
         case "http" -> httpPort = parseIntField(value, "http", entry);
         case "https" -> httpsPort = parseIntField(value, "https", entry);
+        case "bolt" -> boltPort = parseIntField(value, "bolt", entry);
         case "priority" -> priority = parseIntField(value, "priority", entry);
         default -> throw new ServerException(
-            "Unknown key '" + key + "' in peer address '" + entry + "'. Supported keys: raft, http, https, priority");
+            "Unknown key '" + key + "' in peer address '" + entry + "'. Supported keys: raft, http, https, bolt, priority");
         }
       }
     }
-    return new PeerSpec(host, raftPort, httpPort, httpsPort, priority);
+    return new PeerSpec(host, raftPort, httpPort, httpsPort, boltPort, priority);
   }
 
   /**

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAServerAddressParsingTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/RaftHAServerAddressParsingTest.java
@@ -346,4 +346,54 @@ class RaftHAServerAddressParsingTest {
     final var parsed = RaftPeerAddressResolver.parsePeerList("arcadedb-0:2434:2480", 2434);
     assertThat(parsed.peers().get(0).getAddress()).isEqualTo("arcadedb-0:2434");
   }
+
+  @Test
+  void objectFormParsesBoltPort() {
+    final var parsed = RaftPeerAddressResolver.parsePeerList("myhost:{raft:2434,http:2480,bolt:7687}", 2434);
+    final var peerId = parsed.peers().get(0).getId();
+    assertThat(parsed.boltAddresses()).containsEntry(peerId, "myhost:7687");
+    assertThat(parsed.httpAddresses()).containsEntry(peerId, "myhost:2480");
+  }
+
+  @Test
+  void objectFormWithoutBoltLeavesBoltAddressesEmpty() {
+    final var parsed = RaftPeerAddressResolver.parsePeerList("myhost:{raft:2434,http:2480}", 2434);
+    assertThat(parsed.boltAddresses()).isEmpty();
+  }
+
+  @Test
+  void positionalFormNeverPopulatesBoltAddresses() {
+    final var parsed = RaftPeerAddressResolver.parsePeerList("myhost:2434:2480:7:2490", 2434);
+    assertThat(parsed.boltAddresses()).isEmpty();
+  }
+
+  @Test
+  void namedObjectFormParsesBoltPort() {
+    final var parsed = RaftPeerAddressResolver.parsePeerList("alpha@myhost:{raft:2434,bolt:7690}", 2434);
+    final var peerId = parsed.peers().get(0).getId();
+    assertThat(parsed.boltAddresses()).containsEntry(peerId, "myhost:7690");
+    assertThat(parsed.peerNames()).containsEntry(peerId, "alpha");
+  }
+
+  @Test
+  void unknownObjectKeyStillThrows() {
+    assertThatThrownBy(() -> RaftPeerAddressResolver.parsePeerList("myhost:{raft:2434,ftp:21}", 2434))
+        .isInstanceOf(ServerException.class);
+  }
+
+  @Test
+  void deriveBoltAddressCombinesRaftHostWithBoltPort() {
+    assertThat(RaftHAServer.deriveBoltAddress("db1:2434", 7687)).isEqualTo("db1:7687");
+  }
+
+  @Test
+  void deriveBoltAddressReturnsNullForNonPositivePort() {
+    assertThat(RaftHAServer.deriveBoltAddress("db1:2434", 0)).isNull();
+    assertThat(RaftHAServer.deriveBoltAddress("db1:2434", -1)).isNull();
+  }
+
+  @Test
+  void deriveBoltAddressHandlesIpv6Literal() {
+    assertThat(RaftHAServer.deriveBoltAddress("[::1]:2434", 7687)).isEqualTo("[::1]:7687");
+  }
 }

--- a/server/src/main/java/com/arcadedb/server/HAServerPlugin.java
+++ b/server/src/main/java/com/arcadedb/server/HAServerPlugin.java
@@ -121,10 +121,11 @@ public interface HAServerPlugin extends ServerPlugin {
   }
 
   /**
-   * Returns a single-snapshot Bolt routing table for the ROUTE response, or null when HA is inactive or
-   * no leader is currently known. Readers reflect the configured cluster membership (parity with
-   * {@link #getReplicaAddresses()}); a down or partitioned follower is still advertised until it leaves
-   * the group, and the driver fails over. Used to build the Bolt ROUTE routing table.
+   * Returns a single-snapshot Bolt routing table for the ROUTE response, or null when HA is inactive,
+   * no leader is currently known, or the leader has no resolvable Bolt address. Readers reflect the
+   * configured cluster membership (parity with {@link #getReplicaAddresses()}); a down or partitioned
+   * follower is still advertised until it leaves the group, and the driver fails over. Used to build the
+   * Bolt ROUTE routing table.
    */
   default BoltRoutingTable getBoltRoutingTable() {
     return null;

--- a/server/src/main/java/com/arcadedb/server/HAServerPlugin.java
+++ b/server/src/main/java/com/arcadedb/server/HAServerPlugin.java
@@ -112,6 +112,22 @@ public interface HAServerPlugin extends ServerPlugin {
   String getReplicaAddresses();
 
   /**
+   * Returns the client-reachable Bolt address (host:port) of the current leader, or null when unknown
+   * or HA is not active. Used to build the writer entry of the Bolt ROUTE routing table.
+   */
+  default String getLeaderBoltAddress() {
+    return null;
+  }
+
+  /**
+   * Returns a comma-separated list of client-reachable Bolt addresses for the non-leader replicas,
+   * or an empty string when none. Used to build the reader entries of the Bolt ROUTE routing table.
+   */
+  default String getReplicaBoltAddresses() {
+    return "";
+  }
+
+  /**
    * Sends a shutdown command to a remote server in the cluster.
    */
   void shutdownRemoteServer(String serverName);

--- a/server/src/main/java/com/arcadedb/server/HAServerPlugin.java
+++ b/server/src/main/java/com/arcadedb/server/HAServerPlugin.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.server;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -112,19 +113,21 @@ public interface HAServerPlugin extends ServerPlugin {
   String getReplicaAddresses();
 
   /**
-   * Returns the client-reachable Bolt address (host:port) of the current leader, or null when unknown
-   * or HA is not active. Used to build the writer entry of the Bolt ROUTE routing table.
+   * Immutable snapshot of the Bolt routing topology: the current leader's client-reachable Bolt address
+   * (writer) and the non-leader replicas' Bolt addresses (readers). Both sets are derived from a single
+   * leader read so a concurrent leader change cannot make them mutually inconsistent.
    */
-  default String getLeaderBoltAddress() {
-    return null;
+  record BoltRoutingTable(String writer, List<String> readers) {
   }
 
   /**
-   * Returns a comma-separated list of client-reachable Bolt addresses for the non-leader replicas,
-   * or an empty string when none. Used to build the reader entries of the Bolt ROUTE routing table.
+   * Returns a single-snapshot Bolt routing table for the ROUTE response, or null when HA is inactive or
+   * no leader is currently known. Readers reflect the configured cluster membership (parity with
+   * {@link #getReplicaAddresses()}); a down or partitioned follower is still advertised until it leaves
+   * the group, and the driver fails over. Used to build the Bolt ROUTE routing table.
    */
-  default String getReplicaBoltAddresses() {
-    return "";
+  default BoltRoutingTable getBoltRoutingTable() {
+    return null;
   }
 
   /**


### PR DESCRIPTION
Closes #5002. Part of #4890 (Group C protocol/type-fidelity gaps), epic #4882 (Bolt Driver Compatibility Certification). Certifies conformance scenario `CONN-004`.

## Problem
`BoltNetworkExecutor.handleRoute` always returned this node's own address as `WRITE`, `READ`, and `ROUTE`, regardless of cluster topology. Against a real HA cluster a `neo4j://` driver could not discover the leader/followers or route reads vs writes; routing/discovery was unproven.

## Approach
The `bolt` module reaches the cluster only through the `HAServerPlugin` interface (ha-raft is test-scope there). The HA layer knew each peer's host plus Raft/HTTP/HTTPS ports, but no Bolt port - and the `neo4j://` driver actually *connects* to whatever addresses ROUTE returns, so they must be genuinely reachable on the Bolt port.

- **Per-peer Bolt address**: extend the existing `HA_SERVER_LIST` object form with an optional `bolt:<port>` field (`host:{raft:2434,http:2480,bolt:7687}`), parsed into a `boltAddresses` map. When a peer omits it, derive `peerHost:localBoltPort` (homogeneous-cluster assumption) with a one-time WARNING - exactly mirroring the established `resolveHttpAddress` pattern.
- **Interface bridge**: `HAServerPlugin` gains a single `getBoltRoutingTable()` returning an immutable `BoltRoutingTable(writer, readers)` snapshot computed from one `getLeaderId()` read (so writer and readers cannot disagree about the leader), implemented by `RaftHAPlugin` -> `RaftHAServer`. Readers reflect the **configured cluster membership** (parity with `getReplicaAddresses()`).
- **ROUTE handler**: `handleRoute` requires an authenticated (`READY`) session - ROUTE enumerates every peer's Bolt endpoint, so it is not served to an unauthenticated caller. When authenticated, it advertises the leader as `WRITE`+`ROUTE` and each follower as `READ`+`ROUTE`. The table is rebuilt on every ROUTE call, so **reader/writer classification tracks leader changes** automatically. Fallbacks: HA-active-but-leaderless advertises `READ`+`ROUTE` only (never write to a possible follower); true single-node advertises all three roles - both using the connection's actual bound Bolt port.

## Tests
- `Bolt5002RoutingTableIT` (3-node `BaseRaftHATest`, `@Tag("slow")`): asserts the routing table classifies the true leader as writer and followers as readers, that a `neo4j://` driver routes reads and writes end to end, and that writer classification tracks a leader change (stops the leader, waits for re-election, re-checks the table). Polls the queried follower to tolerate the brief leader-unknown window after connect.
- `RaftHAServerAddressParsingTest`: `bolt:` parsing (present/absent, named, positional-form has no Bolt field) and the `deriveBoltAddress` helper.
- `BoltProtocolIT#routeTableSingleNodeReturnsSelfForAllRoles`: single-node (non-HA) ROUTE is unchanged.
- `BoltProtocolIT#routeBeforeLogonIsRejected`: ROUTE on a Bolt 5.x deferred-auth session before LOGON is refused.

## Conformance
Flips `CONN-004` in `bolt/conformance/spec.yaml` from `expected-fail` to `passing`; the residual note documents that heterogeneous Bolt ports require the object-form `bolt:` field.

## Acceptance criteria (#5002)
- [x] `CONN-004` passes against a multi-node cluster; a `neo4j://` driver discovers writer + reader(s) and routes accordingly.
- [x] Single-node (non-HA) ROUTE behavior unchanged.
- [x] Reader/writer classification tracks leader changes.

Design and plan committed under `docs/superpowers/specs` and `docs/superpowers/plans`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)