### PR TITLE
test(#4888): un-gate PROTO-002 and OS-guard CONN-003 in Bolt conformance suites

### DIFF
--- a/e2e-csharp/ArcadeDB.E2ETests/BoltE2ETests.cs
+++ b/e2e-csharp/ArcadeDB.E2ETests/BoltE2ETests.cs
@@ -21,6 +21,7 @@
  */
 
 using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Neo4j.Driver;
 using Xunit;
@@ -46,6 +47,15 @@ public class BoltE2ETests
     [Fact(DisplayName = "CONN-003: Connect via neo4j:// routing discovery, single-node deployment")]
     public async Task Conn003_NeoRoutingSingleNode()
     {
+        // neo4j:// routing makes the driver connect to the container IP that
+        // handleRoute advertises. That address is host-routable on Linux CI's
+        // native Docker bridge but not from the host on Docker Desktop
+        // (macOS/Windows), where the driver times out. xUnit 2.x has no runtime
+        // skip, so short-circuit off Linux; bolt:// scenarios use the mapped
+        // host port and are unaffected.
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            return;
+
         await using var driver = GraphDatabase.Driver(
             _fixture.NeoRoutingUri,
             AuthTokens.Basic(ArcadeDbBoltFixture.RootUser, ArcadeDbBoltFixture.RootPassword));
@@ -541,21 +551,20 @@ public class BoltE2ETests
     }
 
     [Fact(DisplayName = "PROTO-002: Version negotiation with a Bolt 5.x-only driver")]
-    public async Task Proto002_Bolt5xNegotiationIsDocumented()
+    public async Task Proto002_Bolt5xNegotiationIsSupported()
     {
-        await KnownGapAssertions.AssertStillFailsAsync(async () =>
-        {
-            await using var session = _fixture.Driver.AsyncSession(o => o.WithDatabase("beer"));
-            var result = await session.RunAsync("RETURN 1 AS value");
-            var summary = await result.ConsumeAsync();
+        // Since #5001 the server advertises Bolt 5.0-5.4, so a 5.x-capable
+        // driver negotiates a 5.x protocol version instead of downgrading to 4.4.
+        await using var session = _fixture.Driver.AsyncSession(o => o.WithDatabase("beer"));
+        var result = await session.RunAsync("RETURN 1 AS value");
+        var summary = await result.ConsumeAsync();
 
-            var protocolVersionString = summary.Server.ProtocolVersion?.ToString()
-                ?? throw new InvalidCastException("ProtocolVersion was null");
-            if (!int.TryParse(protocolVersionString.Split('.')[0], out var majorVersion))
-                throw new InvalidCastException($"ProtocolVersion '{protocolVersionString}' was not in the expected 'major.minor' shape");
-            Assert.True(majorVersion >= 5,
-                $"driver negotiated Bolt {protocolVersionString} instead of a documented Bolt 5.x version");
-        }, "PROTO-002: BoltNetworkExecutor.SUPPORTED_VERSIONS never advertises Bolt 5.x - see #4890");
+        var protocolVersionString = summary.Server.ProtocolVersion?.ToString()
+            ?? throw new InvalidCastException("ProtocolVersion was null");
+        if (!int.TryParse(protocolVersionString.Split('.')[0], out var majorVersion))
+            throw new InvalidCastException($"ProtocolVersion '{protocolVersionString}' was not in the expected 'major.minor' shape");
+        Assert.True(majorVersion >= 5,
+            $"driver negotiated Bolt {protocolVersionString} instead of a 5.x version");
     }
 
     [Fact(DisplayName = "PROTO-003: RESET returns the connection to a clean state mid-stream")]

--- a/e2e-go/bolt_conformance_test.go
+++ b/e2e-go/bolt_conformance_test.go
@@ -20,15 +20,14 @@
 // for cross-language traceability, matching the e2e-python (#4885) and
 // e2e-csharp (#4886) suites.
 //
-// ArcadeDB negotiates Bolt 4.4/4.0/3.0 at most (see PROTO-002 - it never
-// advertises 5.x). This suite depends on the pinned neo4j-go-driver continuing
-// to silently downgrade to 4.4; a future driver major that drops legacy
-// negotiation would break the suite, not just PROTO-002.
+// Since #5001 ArcadeDB advertises Bolt 5.0-5.4 (and still 4.4/4.0/3.0), so the
+// pinned neo4j-go-driver negotiates 5.x (see PROTO-002).
 package e2e_go
 
 import (
 	"errors"
 	"fmt"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -65,10 +64,15 @@ func Test_CONN_001_ConnectBolt(t *testing.T) {
 // 172.17.0.x). On the Linux CI runner the default Docker bridge subnet is
 // routable from the host, so the driver reaches that address and the scenario
 // passes - identical to the e2e-python/e2e-csharp suites. On Docker Desktop
-// (macOS/Windows) container IPs are not host-routable, so this scenario can
-// only be fully verified in CI; bolt:// scenarios are unaffected because they
-// use the mapped host port.
+// (macOS/Windows) container IPs are not host-routable, so the driver times
+// out; the scenario is skipped there and verified only on Linux. bolt://
+// scenarios are unaffected because they use the mapped host port.
 func Test_CONN_003_Neo4jRoutingSingleNode(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("neo4j:// routing needs the advertised container IP to be " +
+			"host-routable, which holds on Linux CI's native Docker bridge " +
+			"but not on Docker Desktop (macOS/Windows)")
+	}
 	d := newDriver(t, boltURI(plainContainer, "neo4j"))
 	require.NoError(t, d.VerifyConnectivity(ctx))
 	rec := runSingle(t, d, "beer", "MATCH (b:Beer) RETURN b.name AS name LIMIT 1", nil)
@@ -620,28 +624,19 @@ func Test_PROTO_001_VersionNegotiationSucceeds(t *testing.T) {
 	require.Equal(t, int64(1), v)
 }
 
-func Test_PROTO_002_Bolt5xNegotiationIsDocumented(t *testing.T) {
+func Test_PROTO_002_Bolt5xNegotiationIsSupported(t *testing.T) {
+	// Since #5001 the server advertises Bolt 5.0-5.4, so a 5.x-capable driver
+	// negotiates a 5.x protocol version instead of downgrading to 4.4.
 	d := newDriver(t, boltURI(plainContainer, "bolt"))
-	assertStillFails(t,
-		"BoltNetworkExecutor.SUPPORTED_VERSIONS never advertises Bolt 5.x; "+
-			"drivers only work by silently downgrading to 4.4; see #4890",
-		func() error {
-			sess := d.NewSession(ctx, neo4j.SessionConfig{DatabaseName: "beer"})
-			defer sess.Close(ctx)
-			res, err := sess.Run(ctx, "RETURN 1 AS value", nil)
-			if err != nil {
-				return err
-			}
-			summary, err := res.Consume(ctx)
-			if err != nil {
-				return err
-			}
-			ver := summary.Server().ProtocolVersion()
-			if ver.Major >= 5 {
-				return nil // gap fixed: 5.x negotiated
-			}
-			return fmt.Errorf("driver negotiated Bolt %d.%d, not 5.x", ver.Major, ver.Minor)
-		})
+	sess := d.NewSession(ctx, neo4j.SessionConfig{DatabaseName: "beer"})
+	t.Cleanup(func() { _ = sess.Close(ctx) })
+	res, err := sess.Run(ctx, "RETURN 1 AS value", nil)
+	require.NoError(t, err)
+	summary, err := res.Consume(ctx)
+	require.NoError(t, err)
+	ver := summary.Server().ProtocolVersion()
+	require.GreaterOrEqualf(t, ver.Major, 5,
+		"driver negotiated Bolt %d.%d, not 5.x", ver.Major, ver.Minor)
 }
 
 func Test_PROTO_003_ResetMidStream(t *testing.T) {

--- a/e2e-js/src/js-bolt-conformance.test.js
+++ b/e2e-js/src/js-bolt-conformance.test.js
@@ -22,10 +22,9 @@
 // official neo4j-driver. Each test name embeds its spec id ([AREA-NNN]) for
 // traceability, per bolt/conformance/README.md.
 //
-// ArcadeDB negotiates Bolt 4.4/4.0/3.0 at most (see PROTO-002 - it never
-// advertises 5.x). This suite depends on neo4j-driver continuing to silently
-// downgrade to 4.4; a future driver major dropping legacy negotiation would
-// break the whole suite, not just PROTO-002.
+// Since #5001 ArcadeDB advertises Bolt 5.0-5.4 (and still 4.4/4.0/3.0), so
+// neo4j-driver negotiates 5.x (see PROTO-002). A future driver major dropping
+// legacy negotiation would not affect this suite as long as 5.x stays offered.
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
@@ -40,6 +39,13 @@ const BASE_JAVA_OPTS =
   " -Darcadedb.server.defaultDatabases=beer[root]{import:https://github.com/ArcadeData/arcadedb-datasets/raw/main/orientdb/OpenBeer.gz}" +
   " -Darcadedb.server.plugins=BoltProtocolPlugin";
 const TLS_STORE_PASSWORD = "changeit";
+// neo4j:// routing (CONN-003) makes the driver connect to the address
+// handleRoute advertises - the server's own bound container IP. That IP is
+// host-routable on the native Docker bridge used by Linux CI, but not from
+// the host on Docker Desktop (macOS/Windows), where it is unreachable and the
+// driver times out. Run the scenario only where the routed address is
+// reachable; bolt:// scenarios use the mapped host port and are unaffected.
+const ROUTING_HOST_REACHABLE = process.platform === "linux";
 
 const TYPE_MATRIX_FIXTURE = path.resolve(
   __dirname,
@@ -260,7 +266,7 @@ describe("Bolt conformance (issue #4888)", () => {
       await driver.verifyConnectivity();
     });
 
-    it("[CONN-003] neo4j:// routing discovery, single-node", async () => {
+    (ROUTING_HOST_REACHABLE ? it : it.skip)("[CONN-003] neo4j:// routing discovery, single-node", async () => {
       const d = neo4j.driver(
         boltUri("neo4j"),
         neo4j.auth.basic("root", ROOT_PASSWORD)
@@ -849,13 +855,9 @@ describe("Bolt conformance (issue #4888)", () => {
       }
     });
 
-    // KNOWN GAP (#4890): the server never advertises any Bolt 5.x version;
-    // 5.x-capable drivers only work by silently downgrading to 4.4, which is
-    // undocumented/untested as a deliberate stance. Under it.failing this body
-    // asserts the Neo4j-correct behavior (negotiated protocol >= 5), so the
-    // test stays green while the gap reproduces (a 4.x version is negotiated)
-    // and flips red (XPASS) the moment the server starts advertising 5.x.
-    it.failing("[PROTO-002] Bolt 5.x negotiation is supported", async () => {
+    // Since #5001 the server advertises Bolt 5.0-5.4, so a 5.x-capable driver
+    // negotiates a 5.x protocol version instead of silently downgrading to 4.4.
+    it("[PROTO-002] Bolt 5.x negotiation is supported", async () => {
       const info = await driver.getServerInfo({ database: "beer" });
       expect(Number(info.protocolVersion)).toBeGreaterThanOrEqual(5);
     });

--- a/e2e-python/tests/test_bolt.py
+++ b/e2e-python/tests/test_bolt.py
@@ -21,14 +21,12 @@ against the official `neo4j` Python driver. Each test function name embeds
 its spec.yaml scenario id (test_<AREA>_<NNN>_<slug>) for traceability, per
 bolt/conformance/README.md's "Traceability convention".
 
-Note: ArcadeDB negotiates Bolt 4.4/4.0/3.0 at most (see PROTO-002 - it
-never advertises 5.x). This entire suite depends on the pinned `neo4j`
-driver continuing to silently downgrade to 4.4 rather than requiring 5.x -
-a future driver major version that drops legacy protocol negotiation would
-break every test here, not just PROTO-002.
+Note: since #5001 ArcadeDB advertises Bolt 5.0-5.4 (and still 4.4/4.0/3.0),
+so the pinned `neo4j` driver negotiates 5.x (see PROTO-002).
 """
 
 import datetime
+import platform
 import shutil
 import subprocess
 import threading
@@ -318,6 +316,13 @@ def test_CONN_002_tls_required(bolt_container_tls_required):
             assert result.single()["name"] is not None
 
 
+@pytest.mark.skipif(
+    platform.system() != "Linux",
+    reason="neo4j:// routing makes the driver connect to the container IP "
+    "handleRoute advertises; that address is host-routable on Linux CI's "
+    "native Docker bridge but not from the host on Docker Desktop "
+    "(macOS/Windows), where it times out - bolt:// scenarios are unaffected",
+)
 def test_CONN_003_neo4j_routing_single_node(bolt_container):
     with GraphDatabase.driver(bolt_uri(bolt_container, scheme="neo4j"), auth=basic_auth("root", ROOT_PASSWORD)) as driver:
         driver.verify_connectivity()
@@ -750,14 +755,9 @@ def test_PROTO_001_version_negotiation_succeeds(bolt_driver):
         assert session.run("RETURN 1 AS value").single()["value"] == 1
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="BoltNetworkExecutor.SUPPORTED_VERSIONS never advertises any "
-    "Bolt 5.x version; drivers that support 5.x only work today by "
-    "silently downgrading to 4.4, which is undocumented and untested as a "
-    "deliberate compatibility stance; see #4890",
-)
-def test_PROTO_002_bolt_5x_negotiation_is_documented(bolt_driver):
+def test_PROTO_002_bolt_5x_negotiation_is_supported(bolt_driver):
+    # Since #5001 the server advertises Bolt 5.0-5.4, so a 5.x-capable driver
+    # negotiates a 5.x protocol version instead of silently downgrading to 4.4.
     with bolt_driver.session(database="beer") as session:
         summary = session.run("RETURN 1 AS value").consume()
         negotiated_version = summary.server.protocol_version


### PR DESCRIPTION
## Summary

Post-#5001 cleanup of the Bolt conformance e2e suites (epic #4882). Two scenarios were failing across the JS/Python/C# (and Go) suites; neither is an engine bug. `bolt/conformance/spec.yaml` already marks both `current_status: passing` - only the per-language test gates were stale.

### PROTO-002 - un-gate (was a strict-xfail tripwire that #5001 tripped)

PROTO-002 was a deliberate "known-gap" tripwire (`it.failing` / `pytest.mark.xfail(strict=True)` / `KnownGapAssertions.AssertStillFailsAsync` / `assertStillFails`) built to fail the build the moment the server advertised Bolt 5.x. #5001 (Bolt 5.0-5.4 negotiation) did exactly that, so the tripwire now XPASSes and reddens all four suites.

This converts PROTO-002 into a plain passing test asserting a negotiated major version `>= 5` in every suite. The C#/Go gap helpers (`KnownGapAssertions`, `assertStillFails`) are left in place as reusable infra for future gaps.

### CONN-003 - OS-guarded skip (Docker Desktop routability, not a regression)

`neo4j://` routing makes the driver connect to the container IP that `handleRoute` advertises (`socket.getLocalAddress()`). That address is host-routable on Linux CI's native Docker bridge - the test passes - but is **not** reachable from the host on Docker Desktop (macOS/Windows), where the driver times out at 30s. This is an environmental limitation the Go suite already documented in a comment; this PR operationalizes it as an actual guard.

CONN-003 now skips off Linux (`process.platform` / `platform.system()` / `RuntimeInformation.IsOSPlatform` / `runtime.GOOS`), so local dev runs on macOS/Windows stay green while Linux CI keeps full coverage. `bolt://` scenarios use the mapped host port and are unaffected. This is not blocked on #5002 (HA-aware ROUTE); single-node routing already works where the advertised address is reachable.

Applied identically across `e2e-js`, `e2e-python`, `e2e-csharp`, and `e2e-go`.

## Verification

- **Compile/parse:** JS `node --check` OK; Python `py_compile` OK; Go `go vet` + `gofmt` clean; C# build 0 errors / 0 warnings.
- **CONN-003 skip:** ran the JS suite on macOS - CONN-003 is skipped as intended.
- **PROTO-002 premise:** `BoltNetworkExecutor.SUPPORTED_VERSIONS` leads with v5.4-v5.0; `BoltVersionNegotiationTest` passes 23/23 on current source, so the un-gated assertion holds against any image built with #5001 (CI builds from source).

## Related

- Closes the e2e fallout of #5001 (Bolt 5.x negotiation)
- Epic #4882, Group B suites (#4885 / #4886 / #4887 / #4888 / #4889)

🤖 Generated with [Claude Code](https://claude.com/claude-code)