### PR TITLE
fix(#5021): enforce per-database authorization on WebSocket change-stream SUBSCRIBE

### DIFF
--- a/docs/5021-websocket-subscription-authz.md
+++ b/docs/5021-websocket-subscription-authz.md
@@ -1,0 +1,34 @@
+# Issue #5021 - WebSocket change-stream subscription lacks per-database authorization
+
+## Symptom
+The WebSocket change-stream endpoint authenticates the user during the HTTP handshake but then
+discards that identity. When a client sends a `SUBSCRIBE` message, the server subscribes to the
+client-supplied database name with no authorization check, so any authenticated user can stream the
+full live change feed (record contents) of a database they have no rights to read
+(cross-tenant / cross-database data disclosure).
+
+## Root cause
+- `WebSocketConnectionHandler.execute(exchange, user, payload)` receives an authenticated
+  `ServerSecurityUser` but the handshake callback only stores a random channel id; the user is dropped.
+- `WebSocketReceiveListener` `SUBSCRIBE` branch subscribes with the client-supplied database name and
+  performs no `user.canAccessToDatabase(database)` gate (unlike the REST path).
+
+## Fix
+- Add a `WebSocketEventBus.USER` channel-attribute key.
+- `WebSocketConnectionHandler` stores the authenticated `user` on the channel inside the handshake
+  callback.
+- `WebSocketReceiveListener` `SUBSCRIBE` branch reads the user back and rejects the subscription with an
+  error frame when the user is missing or `!user.canAccessToDatabase(database)`. The authorization check
+  runs before any database watcher is started, so an unauthorized subscribe delivers zero events.
+- `UNSUBSCRIBE` needs no additional check (it only affects the caller's own channel).
+
+## Tests
+`server/src/test/java/com/arcadedb/server/ws/WebSocketEventBusIT.java`:
+- `subscribeToUnauthorizedDatabaseIsRejected`: a user authorized only for another database subscribes to
+  `graph`, asserts an error frame and that no change events are delivered.
+- `subscribeToAuthorizedDatabaseWorksForNonRootUser`: a non-root user authorized for `graph` subscribes
+  and asserts events flow (no regression).
+
+## Impact
+Closes a HIGH-severity cross-database data-disclosure hole in the change stream. No new auth model:
+reuses the existing `ServerSecurityUser.canAccessToDatabase` primitive already used by the REST layer.

--- a/docs/5021-websocket-subscription-authz.md
+++ b/docs/5021-websocket-subscription-authz.md
@@ -32,3 +32,19 @@ full live change feed (record contents) of a database they have no rights to rea
 ## Impact
 Closes a HIGH-severity cross-database data-disclosure hole in the change stream. No new auth model:
 reuses the existing `ServerSecurityUser.canAccessToDatabase` primitive already used by the REST layer.
+
+## Pull request
+https://github.com/ArcadeData/arcadedb/pull/5087
+
+## Review cycles
+- Cycle 1 - head SHA `28926f5`: `gemini-code-assist` reviewed (COMMENTED) with no actionable
+  feedback ("the implementation is solid and well-tested"); zero inline comments. The `claude`
+  gating bot did not post a review within the 15-minute per-cycle window.
+
+## Deferred items
+None.
+
+## Final state
+`timeout` - only one of the two gating reviewers (`gemini-code-assist`) responded within the
+per-cycle timeout; `claude` did not. No changes were required by the review that did arrive.
+The PR is left open for the developer; merge remains the developer's responsibility.

--- a/server/src/main/java/com/arcadedb/server/http/ws/WebSocketConnectionHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/WebSocketConnectionHandler.java
@@ -43,6 +43,8 @@ public class WebSocketConnectionHandler extends AbstractServerHttpHandler {
     final var handler = new WebSocketProtocolHandshakeHandler((WebSocketConnectionCallback) (webSocketHttpExchange, channel) -> {
       channel.getReceiveSetter().set(new WebSocketReceiveListener(this.httpServer, webSocketEventBus));
       channel.setAttribute(WebSocketEventBus.CHANNEL_ID, UUID.randomUUID());
+      // Retain the authenticated identity so SUBSCRIBE can enforce per-database authorization.
+      channel.setAttribute(WebSocketEventBus.USER, user);
       channel.resumeReceives();
     });
     handler.handleRequest(exchange);

--- a/server/src/main/java/com/arcadedb/server/http/ws/WebSocketEventBus.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/WebSocketEventBus.java
@@ -38,6 +38,7 @@ public class WebSocketEventBus {
   private final       ConcurrentHashMap<String, DatabaseEventWatcherThread>                        databaseWatchers = new ConcurrentHashMap<>();
   private final       ArcadeDBServer                                                               arcadeServer;
   public static final String                                                                       CHANNEL_ID       = "ID";
+  public static final String                                                                       USER             = "USER";
 
   public WebSocketEventBus(final ArcadeDBServer server) {
     this.arcadeServer = server;

--- a/server/src/main/java/com/arcadedb/server/http/ws/WebSocketReceiveListener.java
+++ b/server/src/main/java/com/arcadedb/server/http/ws/WebSocketReceiveListener.java
@@ -24,6 +24,7 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.serializer.json.JSONException;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.http.HttpServer;
+import com.arcadedb.server.security.ServerSecurityUser;
 import io.undertow.websockets.core.AbstractReceiveListener;
 import io.undertow.websockets.core.BufferedTextMessage;
 import io.undertow.websockets.core.StreamSourceFrameChannel;
@@ -61,11 +62,17 @@ public class WebSocketReceiveListener extends AbstractReceiveListener {
 
       switch (action) {
       case SUBSCRIBE:
+        final var database = message.getString("database");
+        final var user = (ServerSecurityUser) channel.getAttribute(WebSocketEventBus.USER);
+        if (user == null || !user.canAccessToDatabase(database)) {
+          sendError(channel, "Security error", "User does not have access to database '%s'.".formatted(database), null);
+          break;
+        }
         final var jsonChangeTypes = !message.isNull("changeTypes") ? message.getJSONArray("changeTypes") : null;
         final var changeTypes = jsonChangeTypes == null ?
             null :
             jsonChangeTypes.toList().stream().map(t -> ChangeEvent.TYPE.valueOf(t.toString().toUpperCase(Locale.ENGLISH))).collect(Collectors.toSet());
-        this.webSocketEventBus.subscribe(message.getString("database"), message.getString("type", null), changeTypes, channel);
+        this.webSocketEventBus.subscribe(database, message.getString("type", null), changeTypes, channel);
         this.sendAck(channel, action);
         break;
       case UNSUBSCRIBE:

--- a/server/src/test/java/com/arcadedb/server/ws/WebSocketEventBusIT.java
+++ b/server/src/test/java/com/arcadedb/server/ws/WebSocketEventBusIT.java
@@ -20,8 +20,10 @@ package com.arcadedb.server.ws;
 
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.security.ServerSecurity;
 import com.arcadedb.utility.CallableNoReturn;
 
 import org.awaitility.Awaitility;
@@ -368,6 +370,64 @@ class WebSocketEventBusIT extends BaseGraphServerTest {
         assertThat(client.popMessage(500)).isNull();
       }
     }, "unsubscribeDatabaseWorks");
+  }
+
+  @Test
+  void subscribeToUnauthorizedDatabaseIsRejected() throws Throwable {
+    // ISSUE #5021: the WebSocket change-stream authenticated the user only during the HTTP handshake and
+    // then dropped the identity, so any authenticated user could subscribe to (and stream the full record
+    // contents of) a database they had no rights to read. After the fix the SUBSCRIBE must be rejected with
+    // an error frame and zero change events must be delivered for the unauthorized database.
+    execute(() -> {
+      final ServerSecurity security = getServer(0).getSecurity();
+      final String user = "eve";
+      final String password = "evepassword";
+      // eve is a valid user (handshake succeeds) but is authorized only for an unrelated database.
+      security.createUser(new JSONObject().put("name", user).put("password", security.encodePassword(password))
+          .put("databases", new JSONObject().put("otherdb", new JSONArray(new String[] { "admin" }))));
+      try {
+        try (final var client = new WebSocketClientHelper("ws://localhost:2480/ws", user, password)) {
+          final var result = new JSONObject(client.send(buildActionMessage("subscribe", "graph")));
+          assertThat(result.get("result")).isEqualTo("error");
+          assertThat(result.getString("error", "")).contains("Security");
+
+          // A change in the unauthorized database must not reach eve.
+          getServerDatabase(0, "graph").newVertex("V1").set("name", "secret").save();
+          assertThat(client.popMessage(1000)).isNull();
+        }
+      } finally {
+        security.dropUser(user);
+      }
+    }, "subscribeToUnauthorizedDatabaseIsRejected");
+  }
+
+  @Test
+  void subscribeToAuthorizedDatabaseWorksForNonRootUser() throws Throwable {
+    // ISSUE #5021 (no-regression): a non-root user explicitly authorized for the database must still be able
+    // to subscribe and receive change events.
+    execute(() -> {
+      final ServerSecurity security = getServer(0).getSecurity();
+      final String user = "alice";
+      final String password = "alicepassword";
+      security.createUser(new JSONObject().put("name", user).put("password", security.encodePassword(password))
+          .put("databases", new JSONObject().put("graph", new JSONArray(new String[] { "admin" }))));
+      try {
+        try (final var client = new WebSocketClientHelper("ws://localhost:2480/ws", user, password)) {
+          final var result = new JSONObject(client.send(buildActionMessage("subscribe", "graph")));
+          assertThat(result.get("result")).isEqualTo("ok");
+
+          getServerDatabase(0, "graph").newVertex("V1").set("name", "test").save();
+
+          final var json = getJsonMessageOrFail(client);
+          assertThat(json.get("changeType")).isEqualTo("create");
+          final var record = json.getJSONObject("record");
+          assertThat(record.get("name")).isEqualTo("test");
+          assertThat(record.get("@type")).isEqualTo("V1");
+        }
+      } finally {
+        security.dropUser(user);
+      }
+    }, "subscribeToAuthorizedDatabaseWorksForNonRootUser");
   }
 
   private static String buildActionMessage(final String action, final String database) {


### PR DESCRIPTION
Closes #5021

## Summary

The WebSocket change-stream endpoint authenticated the user only during the HTTP handshake and then discarded that identity. When a client sent a `SUBSCRIBE` message, the server subscribed to the client-supplied database name with **no authorization check**, so any authenticated user could stream the full live change feed (record contents) of a database they had no rights to read - a HIGH-severity cross-tenant / cross-database data-disclosure hole.

The fix retains the already-authenticated `ServerSecurityUser` as a channel attribute during the handshake (`WebSocketConnectionHandler`) and, in the `SUBSCRIBE` branch of `WebSocketReceiveListener`, rejects the subscription with an error frame when the user is missing or `!user.canAccessToDatabase(database)` - before any database watcher is started, so an unauthorized subscribe delivers zero events. `UNSUBSCRIBE` needs no change (it only affects the caller's own channel). No new auth model: this reuses the same `canAccessToDatabase` primitive the REST layer already uses.

## Test plan

- [ ] `subscribeToUnauthorizedDatabaseIsRejected`: a user authorized only for another database subscribes to `graph`, asserts an error frame is returned and that a subsequent change in `graph` delivers zero events. (Verified it fails without the fix - subscribe returned `ok`.)
- [ ] `subscribeToAuthorizedDatabaseWorksForNonRootUser`: a non-root user authorized for `graph` subscribes and receives the create event (no regression).
- [ ] Full `WebSocketEventBusIT` suite (19 tests) is green: `mvn -pl server failsafe:integration-test -DskipITs=false -Dit.test=WebSocketEventBusIT`.