### PR TITLE
fix(#5022): thread-safe users map + atomic security-store persistence

### DIFF
--- a/docs/5022-security-store-thread-safety.md
+++ b/docs/5022-security-store-thread-safety.md
@@ -1,0 +1,42 @@
+# Issue #5022 - User/group security store: thread-unsafe users map + non-atomic persistence
+
+## Symptom
+- `ServerSecurity.users` was a plain `HashMap` read unsynchronized on every request and mutated by
+  three threads (HTTP handlers, config-reload timer, Raft apply). Reads landing in the
+  `clear()`->repopulate window returned `null` -> spurious `User/Password not valid`; concurrent
+  structural mutation could corrupt the map or lose entries.
+- `SecurityUserFileRepository.save()` / `SecurityGroupFileRepository.save()` truncated and rewrote
+  the live file in place (plain `FileWriter`, no temp file, no fsync, no rename). A crash mid-write
+  left a truncated/empty file, and on restart the parse failure fell back to `createDefault()` -
+  losing all users/hashes/grants (root reset) or resetting group policy to the permissive default.
+- `ServerSecurity.saveUsers()` swallowed `IOException`, so an HTTP `create user` could return 200
+  while the user was never persisted.
+- Concurrent writers (synchronized local mutations vs. non-synchronized Raft apply) could interleave
+  `FileWriter` output and corrupt the JSONL.
+
+## Root cause
+Shared mutable state without a publish-safe data structure, plus non-atomic single-file rewrites.
+
+## Fix
+- `ServerSecurity.users` is now a `volatile Map` holding a `ConcurrentHashMap`. `loadUsers()` and
+  `applyReplicatedUsers()` build a fresh map and publish it in one atomic reference swap instead of
+  `clear()`+repopulate, so readers never observe an empty/torn window.
+- `SecurityUserFileRepository.save()` and `SecurityGroupFileRepository.save()` write to a sibling
+  temp file, `FileChannel.force(true)`, then `Files.move(..., ATOMIC_MOVE, REPLACE_EXISTING)` with a
+  plain-move fallback. Both serialize writers via an internal lock. The users file is written with
+  POSIX owner-only (600) permissions, matching `ApiTokenConfiguration`.
+- `ServerSecurity.saveUsers()` now propagates a failed save as a `ServerSecurityException` so the
+  HTTP caller sees an error instead of a false 200.
+- `SecurityGroupFileRepository.getGroups()` lazy-init uses double-checked locking on the volatile
+  field.
+
+## Tests
+- `SecurityUserFileRepositoryTest` - round-trip, no leftover temp files, POSIX 600 perms, concurrent
+  saves always yield a complete parseable file.
+- `SecurityGroupFileRepositoryTest` - atomic round-trip + concurrent saves stay valid.
+- `ServerSecurityUsersConcurrencyTest` - authenticate() never spuriously fails while
+  applyReplicatedUsers() rebuilds the map; failed save propagates to the caller.
+
+## Impact
+Server security module only. No API signature changes except `saveUsers()` now throwing a runtime
+exception on persistence failure (previously swallowed).

--- a/server/src/main/java/com/arcadedb/server/security/SecurityGroupFileRepository.java
+++ b/server/src/main/java/com/arcadedb/server/security/SecurityGroupFileRepository.java
@@ -30,6 +30,13 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.logging.Level;
@@ -58,13 +65,31 @@ public class SecurityGroupFileRepository {
   }
 
   public synchronized void save(final JSONObject configuration) throws IOException {
-    if (!file.exists())
-      file.getParentFile().mkdirs();
+    final File dir = file.getParentFile();
+    if (dir != null && !dir.exists())
+      dir.mkdirs();
 
-    try (final FileWriter writer = new FileWriter(file, DatabaseFactory.getDefaultCharset())) {
-      writer.write(configuration.toString(2));
-      latestGroupConfiguration = configuration;
+    final byte[] bytes = configuration.toString(2).getBytes(DatabaseFactory.getDefaultCharset());
+    final Path target = file.toPath();
+    // Write to a sibling temp file, fsync it, then atomically rename over the target so a crash mid-write
+    // can only damage the throwaway temp file. The live group file stays the previous complete version and
+    // restart never falls back to createDefault(), which would silently widen permissions to the default.
+    final Path tmp = Files.createTempFile(target.getParent(), FILE_NAME, ".tmp");
+    try {
+      try (final FileChannel channel = FileChannel.open(tmp, StandardOpenOption.WRITE)) {
+        channel.write(ByteBuffer.wrap(bytes));
+        channel.force(true);
+      }
+      try {
+        Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+      } catch (final AtomicMoveNotSupportedException e) {
+        Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
+      }
+    } finally {
+      Files.deleteIfExists(tmp);
     }
+
+    latestGroupConfiguration = configuration;
   }
 
   public synchronized void saveInError(final Exception e) {
@@ -93,16 +118,25 @@ public class SecurityGroupFileRepository {
   }
 
   public JSONObject getGroups() {
-    if (latestGroupConfiguration == null) {
-      try {
-        load();
-      } catch (final Exception e) {
-        LogManager.instance().log(this, Level.SEVERE, "Error on loading file '%s', using default configuration", e, FILE_NAME);
-        saveInError(e);
-        latestGroupConfiguration = createDefault();
+    // Double-checked locking on the volatile field: the hot read path stays lock-free, while a concurrent
+    // first-time lazy init cannot race two threads both running load()/createDefault().
+    JSONObject cfg = latestGroupConfiguration;
+    if (cfg == null) {
+      synchronized (this) {
+        cfg = latestGroupConfiguration;
+        if (cfg == null) {
+          try {
+            load();
+          } catch (final Exception e) {
+            LogManager.instance().log(this, Level.SEVERE, "Error on loading file '%s', using default configuration", e, FILE_NAME);
+            saveInError(e);
+            latestGroupConfiguration = createDefault();
+          }
+          cfg = latestGroupConfiguration;
+        }
       }
     }
-    return latestGroupConfiguration;
+    return cfg;
   }
 
   protected synchronized JSONObject load() throws IOException {

--- a/server/src/main/java/com/arcadedb/server/security/SecurityUserFileRepository.java
+++ b/server/src/main/java/com/arcadedb/server/security/SecurityUserFileRepository.java
@@ -25,15 +25,27 @@ import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 
 import java.io.*;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 
 public class SecurityUserFileRepository {
   public static final  String FILE_NAME        = "server-users.jsonl";
   private static final int    BUFFER_SIZE      = 65536 * 10;
   private final        String securityConfPath;
-  private              long   fileLastModified = -1;
+  // Serializes all writers (local mutations, config reload, Raft apply) so their output never interleaves.
+  private final        Object saveLock         = new Object();
+  private volatile     long   fileLastModified = -1;
 
   public SecurityUserFileRepository(String securityConfPath) {
     if (!securityConfPath.endsWith(File.separator))
@@ -43,15 +55,53 @@ public class SecurityUserFileRepository {
 
   public void save(final List<JSONObject> configuration) throws IOException {
     final File file = new File(securityConfPath, FILE_NAME);
-    if (!file.exists())
-      file.getParentFile().mkdirs();
 
-    try (final FileWriter writer = new FileWriter(file, DatabaseFactory.getDefaultCharset())) {
-      for (final JSONObject line : configuration)
-        writer.write(line.toString() + "\n");
+    final StringBuilder sb = new StringBuilder();
+    for (final JSONObject line : configuration)
+      sb.append(line.toString()).append("\n");
+    final byte[] bytes = sb.toString().getBytes(DatabaseFactory.getDefaultCharset());
+
+    synchronized (saveLock) {
+      final File dir = file.getParentFile();
+      if (dir != null && !dir.exists())
+        dir.mkdirs();
+
+      final Path target = file.toPath();
+      // Write to a sibling temp file, fsync it, then atomically rename over the target. A crash or power
+      // loss mid-write can only ever damage the throwaway temp file: the live users file remains the
+      // previous complete version, so restart never falls back to createDefault() and resets all users.
+      final Path tmp = Files.createTempFile(target.getParent(), FILE_NAME, ".tmp");
+      try {
+        try (final FileChannel channel = FileChannel.open(tmp, StandardOpenOption.WRITE)) {
+          channel.write(ByteBuffer.wrap(bytes));
+          channel.force(true);
+        }
+
+        // Restrict to owner-only (mode 600) before publishing, matching ApiTokenConfiguration, so the
+        // password-hash file is never world-readable.
+        applyOwnerOnlyPermissions(tmp);
+
+        try {
+          Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } catch (final AtomicMoveNotSupportedException e) {
+          Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
+        }
+      } finally {
+        Files.deleteIfExists(tmp);
+      }
+
+      fileLastModified = file.lastModified();
     }
+  }
 
-    fileLastModified = file.lastModified();
+  private static void applyOwnerOnlyPermissions(final Path path) {
+    try {
+      final PosixFileAttributeView posixView = Files.getFileAttributeView(path, PosixFileAttributeView.class);
+      if (posixView != null)
+        posixView.setPermissions(Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
+    } catch (final IOException | UnsupportedOperationException e) {
+      // Non-POSIX system (e.g. Windows): skip
+    }
   }
 
   public List<JSONObject> getUsers() {

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -66,7 +66,10 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
   private final        SecretKeyFactory                secretKeyFactory;
   private final        ConcurrentSaltCache             saltCache;
   private final        int                             saltIteration;
-  private final        Map<String, ServerSecurityUser> users                = new HashMap<>();
+  // Volatile reference to an immutable-by-convention snapshot: readers (authenticate on Undertow worker
+  // threads) grab the current map lock-free, while loadUsers/applyReplicatedUsers build a fresh map and
+  // publish it in one atomic reference swap so a read never observes a clear()->repopulate empty window.
+  private volatile     Map<String, ServerSecurityUser> users                = new ConcurrentHashMap<>();
   private final        int                             checkConfigReloadEveryMs;
   private              CredentialsValidator            credentialsValidator = new DefaultCredentialsValidator();
   private static final SecureRandom                    RANDOM               = new SecureRandom();
@@ -127,22 +130,26 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
 
   public void loadUsers() {
     try {
-      users.clear();
+      final Map<String, ServerSecurityUser> newUsers = new ConcurrentHashMap<>();
 
       try {
         for (final JSONObject userJson : usersRepository.getUsers()) {
           final ServerSecurityUser user = new ServerSecurityUser(server, userJson);
-          users.put(user.getName(), user);
+          newUsers.put(user.getName(), user);
         }
       } catch (final JSONException e) {
         groupRepository.saveInError(e);
         for (final JSONObject userJson : SecurityUserFileRepository.createDefault()) {
           final ServerSecurityUser user = new ServerSecurityUser(server, userJson);
-          users.put(user.getName(), user);
+          newUsers.put(user.getName(), user);
         }
       }
 
-      if (users.isEmpty() || (users.containsKey("root") && users.get("root").getPassword() == null))
+      // Publish the freshly-built map in a single atomic reference swap: concurrent readers see either the
+      // previous complete map or this one, never an empty intermediate state.
+      this.users = newUsers;
+
+      if (newUsers.isEmpty() || (newUsers.containsKey("root") && newUsers.get("root").getPassword() == null))
         askForRootPassword();
 
       apiTokenConfig.load();
@@ -187,7 +194,7 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
       tokenFailureCleanupTimer = null;
     }
 
-    users.clear();
+    users = new ConcurrentHashMap<>();
     if (groupRepository != null)
       groupRepository.stop();
   }
@@ -431,6 +438,10 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
     } catch (final IOException e) {
       LogManager.instance()
           .log(this, Level.SEVERE, "Error on saving security configuration to file '%s'", e, SecurityUserFileRepository.FILE_NAME);
+      // Propagate so an HTTP create/update/drop user request fails instead of falsely returning success
+      // while nothing was persisted (the change would silently vanish on restart).
+      throw new ServerSecurityException(
+          "Error on saving security configuration to file '" + SecurityUserFileRepository.FILE_NAME + "'", e);
     }
   }
 
@@ -483,10 +494,12 @@ public class ServerSecurity implements ServerPlugin, SecurityManager {
       throw new ServerException("Failed to save replicated users file", e);
     }
 
-    // Build in-memory map from the authoritative Raft payload, not from the file.
-    users.clear();
+    // Build in-memory map from the authoritative Raft payload, not from the file, and publish it in a
+    // single atomic reference swap so concurrent readers never observe an empty/torn window.
+    final Map<String, ServerSecurityUser> newUsers = new ConcurrentHashMap<>();
     for (final JSONObject userJson : list)
-      users.put(userJson.getString("name"), new ServerSecurityUser(server, userJson));
+      newUsers.put(userJson.getString("name"), new ServerSecurityUser(server, userJson));
+    this.users = newUsers;
   }
 
   public void saveGroups() {

--- a/server/src/test/java/com/arcadedb/server/security/SecurityGroupFileRepositoryTest.java
+++ b/server/src/test/java/com/arcadedb/server/security/SecurityGroupFileRepositoryTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.security;
+
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SecurityGroupFileRepositoryTest {
+  private static final String TEST_CONFIG_PATH = "target/test-security-groups";
+
+  @BeforeEach
+  void setUp() {
+    final File dir = new File(TEST_CONFIG_PATH);
+    if (dir.exists())
+      FileUtils.deleteRecursively(dir);
+    dir.mkdirs();
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(TEST_CONFIG_PATH));
+  }
+
+  private static JSONObject groups(final int marker) {
+    return new JSONObject()
+        .put("version", ServerSecurity.LATEST_VERSION)
+        .put("databases", new JSONObject().put("*", new JSONObject()
+            .put("groups", new JSONObject().put("admin", new JSONObject()
+                .put("marker", marker)
+                .put("access", new JSONArray().put("updateSecurity"))))));
+  }
+
+  @Test
+  void saveRoundTrips() throws Exception {
+    final SecurityGroupFileRepository repo = new SecurityGroupFileRepository(TEST_CONFIG_PATH, 1_000_000);
+    repo.save(groups(42));
+
+    final SecurityGroupFileRepository repo2 = new SecurityGroupFileRepository(TEST_CONFIG_PATH, 1_000_000);
+    final JSONObject loaded = repo2.getGroups();
+    assertThat(loaded.getJSONObject("databases").getJSONObject("*").getJSONObject("groups")
+        .getJSONObject("admin").getInt("marker")).isEqualTo(42);
+    repo.stop();
+    repo2.stop();
+  }
+
+  @Test
+  void saveLeavesNoTempFilesBehind() throws Exception {
+    final SecurityGroupFileRepository repo = new SecurityGroupFileRepository(TEST_CONFIG_PATH, 1_000_000);
+    repo.save(groups(1));
+
+    final File[] files = new File(TEST_CONFIG_PATH).listFiles();
+    assertThat(files).isNotNull();
+    for (final File f : files)
+      assertThat(f.getName()).isEqualTo(SecurityGroupFileRepository.FILE_NAME);
+    repo.stop();
+  }
+
+  @Test
+  void concurrentSavesNeverProduceCorruptFile() throws Exception {
+    final SecurityGroupFileRepository repo = new SecurityGroupFileRepository(TEST_CONFIG_PATH, 1_000_000);
+    repo.save(groups(0));
+
+    final int writers = 6;
+    final int readers = 6;
+    final int iterations = 300;
+    final ExecutorService pool = Executors.newFixedThreadPool(writers + readers);
+    final CountDownLatch start = new CountDownLatch(1);
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+
+    for (int w = 0; w < writers; w++) {
+      final int marker = w;
+      pool.submit(() -> {
+        try {
+          start.await();
+          for (int i = 0; i < iterations && failure.get() == null; i++)
+            repo.save(groups(marker));
+        } catch (final Throwable t) {
+          failure.compareAndSet(null, t);
+        }
+      });
+    }
+
+    for (int r = 0; r < readers; r++) {
+      pool.submit(() -> {
+        try {
+          start.await();
+          for (int i = 0; i < iterations && failure.get() == null; i++) {
+            final SecurityGroupFileRepository reader = new SecurityGroupFileRepository(TEST_CONFIG_PATH, 1_000_000);
+            final JSONObject loaded = reader.getGroups();
+            // must always be a complete, parseable config with the expected structure
+            assertThat(loaded.getJSONObject("databases").getJSONObject("*").has("groups")).isTrue();
+            reader.stop();
+          }
+        } catch (final Throwable t) {
+          failure.compareAndSet(null, t);
+        }
+      });
+    }
+
+    start.countDown();
+    pool.shutdown();
+    assertThat(pool.awaitTermination(60, SECONDS)).isTrue();
+    repo.stop();
+    if (failure.get() != null)
+      throw new AssertionError("Concurrent save/load observed a corrupt group file", failure.get());
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/security/SecurityUserFileRepositoryTest.java
+++ b/server/src/test/java/com/arcadedb/server/security/SecurityUserFileRepositoryTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.security;
+
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SecurityUserFileRepositoryTest {
+  private static final String TEST_CONFIG_PATH = "target/test-security-users";
+
+  @BeforeEach
+  void setUp() {
+    final File dir = new File(TEST_CONFIG_PATH);
+    if (dir.exists())
+      FileUtils.deleteRecursively(dir);
+    dir.mkdirs();
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteRecursively(new File(TEST_CONFIG_PATH));
+  }
+
+  private static List<JSONObject> users(final int count) {
+    final List<JSONObject> list = new ArrayList<>(count);
+    for (int i = 0; i < count; i++)
+      list.add(new JSONObject().put("name", "user" + i)
+          .put("password", "secret-hash-" + i)
+          .put("databases", new JSONObject().put("*", new JSONArray().put("admin"))));
+    return list;
+  }
+
+  @Test
+  void saveRoundTripsAllLines() throws Exception {
+    final SecurityUserFileRepository repo = new SecurityUserFileRepository(TEST_CONFIG_PATH);
+    repo.save(users(5));
+
+    final List<JSONObject> reloaded = new SecurityUserFileRepository(TEST_CONFIG_PATH).getUsers();
+    assertThat(reloaded).hasSize(5);
+    assertThat(reloaded.get(0).getString("name")).isEqualTo("user0");
+    assertThat(reloaded.get(4).getString("name")).isEqualTo("user4");
+  }
+
+  @Test
+  void saveLeavesNoTempFilesBehind() throws Exception {
+    final SecurityUserFileRepository repo = new SecurityUserFileRepository(TEST_CONFIG_PATH);
+    repo.save(users(3));
+
+    final File[] files = new File(TEST_CONFIG_PATH).listFiles();
+    assertThat(files).isNotNull();
+    for (final File f : files)
+      assertThat(f.getName()).endsWith(SecurityUserFileRepository.FILE_NAME);
+  }
+
+  @Test
+  void saveSetsOwnerOnlyPermissionsOnPosix() throws Exception {
+    final SecurityUserFileRepository repo = new SecurityUserFileRepository(TEST_CONFIG_PATH);
+    repo.save(users(2));
+
+    final Path file = new File(TEST_CONFIG_PATH, SecurityUserFileRepository.FILE_NAME).toPath();
+    final PosixFileAttributeView view = Files.getFileAttributeView(file, PosixFileAttributeView.class);
+    if (view == null)
+      return; // non-POSIX filesystem (e.g. Windows): nothing to assert
+
+    final Set<PosixFilePermission> perms = view.readAttributes().permissions();
+    assertThat(perms).containsExactlyInAnyOrder(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE);
+  }
+
+  @Test
+  void concurrentSavesNeverProducePartialFile() throws Exception {
+    final SecurityUserFileRepository repo = new SecurityUserFileRepository(TEST_CONFIG_PATH);
+    // seed a valid file so readers always have something to read
+    repo.save(users(10));
+
+    final int writers = 6;
+    final int readers = 6;
+    final int iterations = 300;
+    final ExecutorService pool = Executors.newFixedThreadPool(writers + readers);
+    final CountDownLatch start = new CountDownLatch(1);
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+
+    for (int w = 0; w < writers; w++) {
+      final int size = 5 + w; // distinct, always-valid payloads
+      pool.submit(() -> {
+        try {
+          start.await();
+          for (int i = 0; i < iterations && failure.get() == null; i++)
+            repo.save(users(size));
+        } catch (final Throwable t) {
+          failure.compareAndSet(null, t);
+        }
+      });
+    }
+
+    for (int r = 0; r < readers; r++) {
+      pool.submit(() -> {
+        try {
+          start.await();
+          for (int i = 0; i < iterations && failure.get() == null; i++) {
+            final List<JSONObject> loaded = new SecurityUserFileRepository(TEST_CONFIG_PATH).getUsers();
+            // every observed snapshot must be a complete, parseable, non-empty file
+            assertThat(loaded).isNotEmpty();
+            for (final JSONObject u : loaded)
+              assertThat(u.getString("name")).startsWith("user");
+          }
+        } catch (final Throwable t) {
+          failure.compareAndSet(null, t);
+        }
+      });
+    }
+
+    start.countDown();
+    pool.shutdown();
+    assertThat(pool.awaitTermination(60, SECONDS)).isTrue();
+    if (failure.get() != null)
+      throw new AssertionError("Concurrent save/load observed a corrupt or partial file", failure.get());
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/security/ServerSecurityUsersConcurrencyTest.java
+++ b/server/src/test/java/com/arcadedb/server/security/ServerSecurityUsersConcurrencyTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.security;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.utility.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class ServerSecurityUsersConcurrencyTest {
+  private static final String TEST_CONFIG_PATH = "target/test-security-store";
+  private static final int    USER_COUNT       = 8;
+
+  @BeforeEach
+  void setUp() {
+    GlobalConfiguration.SERVER_SECURITY_SALT_ITERATIONS.setValue(1000);
+    GlobalConfiguration.SERVER_SECURITY_SALT_CACHE_SIZE.setValue(256);
+    final File dir = new File(TEST_CONFIG_PATH);
+    if (dir.exists())
+      FileUtils.deleteRecursively(dir);
+    dir.mkdirs();
+  }
+
+  @AfterEach
+  void tearDown() {
+    GlobalConfiguration.SERVER_SECURITY_SALT_ITERATIONS.reset();
+    GlobalConfiguration.SERVER_SECURITY_SALT_CACHE_SIZE.reset();
+    FileUtils.deleteRecursively(new File(TEST_CONFIG_PATH));
+  }
+
+  private static String plainPassword(final int i) {
+    return "pwd-" + i + "-secret";
+  }
+
+  private String buildPayload(final ServerSecurity security) {
+    final JSONArray payload = new JSONArray();
+    for (int i = 0; i < USER_COUNT; i++)
+      payload.put(new JSONObject()
+          .put("name", "user" + i)
+          .put("password", security.encodePassword(plainPassword(i)))
+          .put("databases", new JSONObject().put("*", new JSONArray().put("admin"))));
+    return payload.toString();
+  }
+
+  @Test
+  void authenticateNeverSpuriouslyFailsWhileUsersMapIsRebuilt() throws Exception {
+    final ServerSecurity security = new ServerSecurity(null, new ContextConfiguration(), TEST_CONFIG_PATH);
+    final String payload = buildPayload(security);
+    security.applyReplicatedUsers(payload); // prime the in-memory map
+
+    final int readers = 8;
+    final int writers = 3;
+    final int readerIterations = 3000;
+    final int writerIterations = 300;
+
+    final ExecutorService pool = Executors.newFixedThreadPool(readers + writers);
+    final CountDownLatch start = new CountDownLatch(1);
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+
+    for (int r = 0; r < readers; r++) {
+      pool.submit(() -> {
+        try {
+          start.await();
+          for (int i = 0; i < readerIterations && failure.get() == null; i++) {
+            final int k = i % USER_COUNT;
+            // authenticate against the in-memory map while writers rebuild it; must never see a
+            // torn/empty snapshot (which would surface as ServerSecurityException "User/Password not valid")
+            final ServerSecurityUser u = security.authenticate("user" + k, plainPassword(k), null);
+            assertThat(u.getName()).isEqualTo("user" + k);
+          }
+        } catch (final Throwable t) {
+          failure.compareAndSet(null, t);
+        }
+      });
+    }
+
+    for (int w = 0; w < writers; w++) {
+      pool.submit(() -> {
+        try {
+          start.await();
+          for (int i = 0; i < writerIterations && failure.get() == null; i++)
+            security.applyReplicatedUsers(payload); // full rebuild + atomic publish
+        } catch (final Throwable t) {
+          failure.compareAndSet(null, t);
+        }
+      });
+    }
+
+    start.countDown();
+    pool.shutdown();
+    assertThat(pool.awaitTermination(90, SECONDS)).isTrue();
+    if (failure.get() != null)
+      throw new AssertionError("Spurious auth failure or lost user during concurrent rebuild", failure.get());
+
+    // all users survived the churn
+    assertThat(security.getUsers()).hasSize(USER_COUNT);
+  }
+
+  @Test
+  void failedSaveSurfacesToCallerInsteadOfFalseSuccess() throws Exception {
+    final ServerSecurity security = new ServerSecurity(null, new ContextConfiguration(), TEST_CONFIG_PATH);
+
+    // Obstruct the target file with a non-empty directory of the same name so the atomic rename fails.
+    final File obstruction = new File(TEST_CONFIG_PATH, SecurityUserFileRepository.FILE_NAME);
+    assertThat(obstruction.mkdirs()).isTrue();
+    assertThat(new File(obstruction, "keep").createNewFile()).isTrue();
+
+    final JSONObject config = new JSONObject()
+        .put("name", "alice")
+        .put("password", security.encodePassword("alice-pwd"))
+        .put("databases", new JSONObject().put("*", new JSONArray().put("admin")));
+
+    // The swallowed-IOException bug returned success even though nothing was persisted; the fix must
+    // propagate the failure to the caller.
+    assertThatExceptionOfType(ServerSecurityException.class).isThrownBy(() -> security.createUser(config));
+  }
+}


### PR DESCRIPTION
Closes #5022

## Summary
The server security store had two classes of concurrency/durability defects that could silently reset all security state. `ServerSecurity.users` was a plain `HashMap` read unsynchronized on every authentication request while being mutated by three threads (Undertow HTTP workers, the config-reload timer, and the Raft state-machine apply thread) via `clear()`+repopulate, so a read landing in the empty window returned `null` and produced spurious `User/Password not valid` failures, and concurrent structural mutation could corrupt the map or lose entries. Both `server-users.jsonl` and `server-groups.json` were rewritten in place with a plain `FileWriter` (no temp file, no fsync, no rename), so a crash mid-write left a truncated/empty file that on restart fell back to `createDefault()` - wiping all users/hashes/grants (root reset) or resetting the group policy to the permissive default. `saveUsers()` also swallowed `IOException`, letting an HTTP create-user return 200 while nothing was persisted.

This change:
- Makes `ServerSecurity.users` a `volatile ConcurrentHashMap`; `loadUsers()` and `applyReplicatedUsers()` build a fresh map and publish it in a single atomic reference swap, so readers see either the previous complete map or the new one - never an empty/torn window.
- Rewrites `SecurityUserFileRepository.save()` and `SecurityGroupFileRepository.save()` to write a sibling temp file, `FileChannel.force(true)`, then `Files.move(..., ATOMIC_MOVE, REPLACE_EXISTING)` (plain-move fallback), each serialized by an internal lock. The users file is written with POSIX owner-only (600) permissions, matching `ApiTokenConfiguration`.
- Makes `ServerSecurity.saveUsers()` propagate a persistence failure as a `ServerSecurityException` so the HTTP caller sees an error instead of a false success.
- Converts `SecurityGroupFileRepository.getGroups()` lazy-init to double-checked locking on the volatile field.

No public API signatures change; the only behavioral change is that `saveUsers()` now throws on a persistence failure instead of swallowing it.

## Test plan
- [x] `ServerSecurityUsersConcurrencyTest` - 8 reader threads calling `authenticate()` x3000 while 3 writers rebuild the map via `applyReplicatedUsers()` observe zero spurious auth failures and lose no users; a save failure surfaces to the caller as `ServerSecurityException` instead of a false success.
- [x] `SecurityUserFileRepositoryTest` - save round-trips all lines, leaves no temp files, sets POSIX 600 perms, and concurrent writers/readers never observe a partial/corrupt file.
- [x] `SecurityGroupFileRepositoryTest` - atomic round-trip, no temp-file leftovers, and concurrent save/load never yields a corrupt group file.
- [x] Existing regressions green: `ServerSecurityIT`, `SecurityGroupMigrationIT`, `GroupManagementIT`, `UserManagementIT`, `ServerSecuritySaltCacheTest`, `ApiTokenConfigurationTest`, `ConcurrentSaltCacheTest`.

Verify: `cd server && mvn -o surefire:test -Dtest='SecurityUserFileRepositoryTest,SecurityGroupFileRepositoryTest,ServerSecurityUsersConcurrencyTest'`