### PR TITLE
fix(ha): offline bootstrap skipped on transient -1 commit index at first formation

### DIFF
--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -850,9 +850,12 @@ public class ArcadeStateMachine extends BaseStateMachine {
       reconciler.clearFollowerReconcileStatesOnBecomeLeader();
 
       // Issue #4147: drive offline cluster bootstrap if conditions match (commit index still 0,
-      // arcadedb.ha.bootstrapFromLocalDatabase=true). Runs on a background thread to keep the
-      // notifyLeaderChanged callback non-blocking; a slow peer or a bootstrap-state RPC timeout
-      // must not stall Raft's normal leader-change processing on this node.
+      // arcadedb.ha.bootstrapFromLocalDatabase=true). Runs on a background thread so a slow peer or a
+      // bootstrap-state RPC timeout does not stall Raft's normal leader-change processing on this node.
+      // Note: the background pass itself may park this single-threaded lifecycleExecutor briefly - it
+      // waits for the freshly-elected leader's Raft division to expose a readable commit index (~100 ms
+      // typically, up to commitIndexReadinessTimeoutMs on a broken read) - so tasks submitted afterward
+      // (e.g. the snapshot download below) queue behind it in that rare worst case.
       lifecycleExecutor.submit(() -> {
         try {
           raftHAServer.runBootstrapIfEligible();

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/BootstrapElection.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/BootstrapElection.java
@@ -113,11 +113,20 @@ class BootstrapElection {
       .connectTimeout(Duration.ofSeconds(5))
       .build();
 
+  // Poll interval while waiting for the freshly-elected leader's Raft division to become readable.
+  private static final long             COMMIT_INDEX_READINESS_POLL_MS = 100L;
+
   private final RaftHAServer            haServer;
   private final ArcadeDBServer          server;
   // Tracks per-database whether the bootstrap protocol has been attempted in this leader's
   // lifetime. Used to short-circuit on repeated notifyLeaderChanged callbacks for the same term.
   private final Set<String>             attemptedThisTerm = ConcurrentHashMap.newKeySet();
+  // Maximum time to wait for getCommitIndex() to return a definitive (non-negative) value right after
+  // this node becomes leader. The notifyLeaderChanged callback fires before the Raft division's log is
+  // queryable, so the very first read returns the -1 UNKNOWN sentinel for a brief window (~100 ms in
+  // practice); without waiting, the once-per-term bootstrap pass would skip on that transient -1 and
+  // never re-run. Package-private and non-final so tests can shorten it. See awaitReadableCommitIndex.
+  long                                  commitIndexReadinessTimeoutMs = 10_000L;
 
   BootstrapElection(final RaftHAServer haServer, final ArcadeDBServer server) {
     this.haServer = haServer;
@@ -151,7 +160,15 @@ class BootstrapElection {
     // ("Gating") in #4147. A negative value means the index is UNKNOWN (the Raft division is not
     // ready, or getCommitIndex() hit a transient IOException) and must NOT be mistaken for an empty
     // log - see isConfirmedFirstFormation and issue #4800.
-    final long commitIndex = haServer.getCommitIndex();
+    //
+    // The notifyLeaderChanged callback that drives this runs before the freshly-elected leader's Raft
+    // division exposes its committed index, so the very first read returns the -1 UNKNOWN sentinel for
+    // a brief window. Since bootstrap runs at most once per term, skipping on that transient -1 would
+    // leave the baseline uncommitted forever. Wait a bounded time for a definitive reading: on genuine
+    // first formation it resolves to 0 and the gate opens; on an already-running cluster it resolves
+    // to a positive index and the gate stays closed; if it never resolves (persistent read failure) we
+    // conservatively skip, exactly as issue #4800 requires.
+    final long commitIndex = awaitReadableCommitIndex();
     if (!isConfirmedFirstFormation(commitIndex))
       return Outcome.SKIPPED_NOT_FIRST_FORMATION;
 
@@ -190,6 +207,31 @@ class BootstrapElection {
    */
   static boolean isConfirmedFirstFormation(final long commitIndex) {
     return commitIndex == 0L;
+  }
+
+  /**
+   * Poll {@link RaftHAServer#getCommitIndex()} until it returns a definitive (non-negative) value or
+   * {@link #commitIndexReadinessTimeoutMs} elapses, then return the last reading. Right after a leader
+   * change the division briefly reports -1 (log not yet queryable); this absorbs that startup window
+   * so the gate sees the real first-formation index (0) instead of the transient -1. A non-negative
+   * reading is returned immediately (no wait for a running cluster or a confirmed empty log). If this
+   * node stops being the leader while waiting, we stop early and return the last reading so the gate
+   * can skip. A persistent -1 (genuine read failure) is returned unchanged after the budget, keeping
+   * the issue #4800 "never bootstrap on an unconfirmed index" guarantee.
+   */
+  private long awaitReadableCommitIndex() {
+    final long deadline = System.currentTimeMillis() + commitIndexReadinessTimeoutMs;
+    long commitIndex = haServer.getCommitIndex();
+    while (commitIndex < 0 && System.currentTimeMillis() < deadline && haServer.isLeader()) {
+      try {
+        Thread.sleep(COMMIT_INDEX_READINESS_POLL_MS);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        break;
+      }
+      commitIndex = haServer.getCommitIndex();
+    }
+    return commitIndex;
   }
 
   /**

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/BootstrapElection.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/BootstrapElection.java
@@ -113,9 +113,6 @@ class BootstrapElection {
       .connectTimeout(Duration.ofSeconds(5))
       .build();
 
-  // Poll interval while waiting for the freshly-elected leader's Raft division to become readable.
-  private static final long             COMMIT_INDEX_READINESS_POLL_MS = 100L;
-
   private final RaftHAServer            haServer;
   private final ArcadeDBServer          server;
   // Tracks per-database whether the bootstrap protocol has been attempted in this leader's
@@ -125,8 +122,14 @@ class BootstrapElection {
   // this node becomes leader. The notifyLeaderChanged callback fires before the Raft division's log is
   // queryable, so the very first read returns the -1 UNKNOWN sentinel for a brief window (~100 ms in
   // practice); without waiting, the once-per-term bootstrap pass would skip on that transient -1 and
-  // never re-run. Package-private and non-final so tests can shorten it. See awaitReadableCommitIndex.
+  // never re-run. 10 s is deliberately generous versus the observed ~100 ms readiness gap: the wait
+  // ends as soon as the index resolves (or leadership is lost), so the full budget is only ever spent
+  // on a genuinely broken read - a rare case that does not warrant an operator-facing config knob.
+  // Package-private and non-final so tests can shorten it. See awaitReadableCommitIndex.
   long                                  commitIndexReadinessTimeoutMs = 10_000L;
+  // Poll interval while waiting for the division to become readable. Package-private and non-final so
+  // tests can set it to 0 and spin without sleeping.
+  long                                  commitIndexReadinessPollMs    = 100L;
 
   BootstrapElection(final RaftHAServer haServer, final ArcadeDBServer server) {
     this.haServer = haServer;
@@ -220,11 +223,14 @@ class BootstrapElection {
    * the issue #4800 "never bootstrap on an unconfirmed index" guarantee.
    */
   private long awaitReadableCommitIndex() {
-    final long deadline = System.currentTimeMillis() + commitIndexReadinessTimeoutMs;
+    // Monotonic deadline: nanoTime is immune to wall-clock steps/NTP adjustments and the
+    // (now - start) form is overflow-safe, unlike a currentTimeMillis-based absolute deadline.
+    final long start = System.nanoTime();
+    final long timeoutNanos = TimeUnit.MILLISECONDS.toNanos(commitIndexReadinessTimeoutMs);
     long commitIndex = haServer.getCommitIndex();
-    while (commitIndex < 0 && System.currentTimeMillis() < deadline && haServer.isLeader()) {
+    while (commitIndex < 0 && (System.nanoTime() - start) < timeoutNanos && haServer.isLeader()) {
       try {
-        Thread.sleep(COMMIT_INDEX_READINESS_POLL_MS);
+        Thread.sleep(commitIndexReadinessPollMs);
       } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();
         break;

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BootstrapElectionGateTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BootstrapElectionGateTest.java
@@ -81,14 +81,44 @@ class BootstrapElectionGateTest {
 
     final RaftHAServer mockHa = mock(RaftHAServer.class);
     when(mockHa.isLeader()).thenReturn(true);
-    when(mockHa.getCommitIndex()).thenReturn(-1L); // transient IOException / division not ready
+    when(mockHa.getCommitIndex()).thenReturn(-1L); // persistent IOException / division never ready
 
     final BootstrapElection election = new BootstrapElection(mockHa, mockServer);
+    election.commitIndexReadinessTimeoutMs = 0L; // a persistent -1 must skip without a real wait
     final BootstrapElection.Outcome outcome = election.runIfEligible();
 
     assertThat(outcome).isEqualTo(BootstrapElection.Outcome.SKIPPED_NOT_FIRST_FORMATION);
     // The gate must short-circuit before any data is collected: no database enumeration happened.
     verify(mockServer, never()).getDatabaseNames();
+  }
+
+  /**
+   * The regression case: the {@code notifyLeaderChanged} callback runs the bootstrap pass before the
+   * freshly-elected leader's Raft division is queryable, so {@code getCommitIndex()} returns the -1
+   * UNKNOWN sentinel for a brief window before resolving to the genuine first-formation index 0. Since
+   * bootstrap runs at most once per term, an instant skip on that transient -1 would leave the baseline
+   * uncommitted forever. The gate must absorb the startup window and open once the index resolves to 0.
+   */
+  @Test
+  void transientUnknownCommitIndexThatResolvesToZeroEngagesBootstrap() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_BOOTSTRAP_FROM_LOCAL_DATABASE, true);
+
+    final ArcadeDBServer mockServer = mock(ArcadeDBServer.class);
+    when(mockServer.getConfiguration()).thenReturn(config);
+    when(mockServer.getDatabaseNames()).thenReturn(Set.of());
+
+    final RaftHAServer mockHa = mock(RaftHAServer.class);
+    when(mockHa.isLeader()).thenReturn(true);
+    // -1 (division not ready) on the first read, then the real first-formation index 0.
+    when(mockHa.getCommitIndex()).thenReturn(-1L, -1L, 0L);
+
+    final BootstrapElection election = new BootstrapElection(mockHa, mockServer);
+    final BootstrapElection.Outcome outcome = election.runIfEligible();
+
+    // Past the gate once the index resolved to 0: it tried to collect databases and found none.
+    assertThat(outcome).isEqualTo(BootstrapElection.Outcome.SKIPPED_NO_DATABASES);
+    verify(mockServer).getDatabaseNames();
   }
 
   /**

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BootstrapElectionGateTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BootstrapElectionGateTest.java
@@ -114,11 +114,38 @@ class BootstrapElectionGateTest {
     when(mockHa.getCommitIndex()).thenReturn(-1L, -1L, 0L);
 
     final BootstrapElection election = new BootstrapElection(mockHa, mockServer);
+    election.commitIndexReadinessPollMs = 0L; // spin without sleeping
     final BootstrapElection.Outcome outcome = election.runIfEligible();
 
     // Past the gate once the index resolved to 0: it tried to collect databases and found none.
     assertThat(outcome).isEqualTo(BootstrapElection.Outcome.SKIPPED_NO_DATABASES);
     verify(mockServer).getDatabaseNames();
+  }
+
+  /**
+   * The wait loop's third exit condition: if this node stops being the leader while the commit index
+   * is still unresolved (-1), the wait must break rather than spin out the full readiness budget, and
+   * the gate must skip. Proves the {@code haServer.isLeader()} guard inside the loop works.
+   */
+  @Test
+  void losingLeadershipWhileWaitingStopsTheWaitAndSkips() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_BOOTSTRAP_FROM_LOCAL_DATABASE, true);
+
+    final ArcadeDBServer mockServer = mock(ArcadeDBServer.class);
+    when(mockServer.getConfiguration()).thenReturn(config);
+    lenient().when(mockServer.getDatabaseNames()).thenReturn(Set.of("alpha"));
+
+    final RaftHAServer mockHa = mock(RaftHAServer.class);
+    // Leader at the entry guard and on the first loop check, then leadership is lost.
+    when(mockHa.isLeader()).thenReturn(true, true, false);
+    when(mockHa.getCommitIndex()).thenReturn(-1L); // never resolves
+
+    final BootstrapElection election = new BootstrapElection(mockHa, mockServer);
+    election.commitIndexReadinessPollMs = 0L; // spin without sleeping
+
+    assertThat(election.runIfEligible()).isEqualTo(BootstrapElection.Outcome.SKIPPED_NOT_FIRST_FORMATION);
+    verify(mockServer, never()).getDatabaseNames();
   }
 
   /**


### PR DESCRIPTION
## Problem

`RaftBootstrapFromLocalDatabaseIT` (and every other first-formation bootstrap IT) times out waiting for a bootstrap baseline that never arrives: `getBootstrapBaseline(db)` stays `null`.

**Root cause.** The Raft leader-change callback submits `BootstrapElection.runIfEligible` on a background thread immediately after this node becomes leader - **before** the freshly-elected leader's Raft division exposes its committed index. `getCommitIndex()` therefore returns the `-1` UNKNOWN sentinel for a brief window (~100 ms observed in the logs):

```
DIAG poll[0] commitIndex=-1   ← bootstrap runs ~7ms after election
DIAG poll[1] commitIndex=0    ← ~100ms later the division is readable
```

Since #4800 (commit `3a843ef8f`) tightened the first-formation gate from `commitIndex > 0` to exactly `commitIndex == 0` (deliberately rejecting `-1`), and bootstrap runs **at most once per term with no retry**, that transient `-1` makes the pass skip permanently. The `BOOTSTRAP_FINGERPRINT_ENTRY` is never committed and the baseline stays `null` forever.

## Fix

Before applying the gate, poll `getCommitIndex()` for a bounded window (10s, 100ms interval) until it returns a definitive non-negative value, so the gate sees the real first-formation index (`0`) instead of the startup `-1`.

This **strictly preserves the #4800 guarantee**:
- a running cluster's committed index is permanently `> 0` (it can never read `0`), so it still skips;
- a non-negative first read returns immediately (no wait for a running cluster or a confirmed empty log);
- a *persistent* `-1` (genuine read failure) is returned unchanged after the budget and still skips.

Adds a unit regression test for the transient `-1 → 0` resolution and keeps the existing persistent-`-1` test fast via an injectable timeout field.

## Verification

- `RaftBootstrapFromLocalDatabaseIT` now passes (~15s, previously a 49s timeout).
- Full bootstrap suite: **10 of 12 classes / 27 of 29 methods pass** (up from first-formation being broken everywhere).
- `BootstrapElectionGateTest`: 7/7 pass.

## Out of scope (pre-existing, tracked separately)

Two bootstrap ITs still fail after this fix - both confirmed failing on pristine `main` (not regressions from this PR), and both are design-level:

1. **`RaftBootstrapLeadershipTransferIT`** (#5099) - after leadership transfers to the elected source, the new leader reads `commitIndex=2` (the transfer/term-2 election commits Ratis no-op/config entries), so the `== 0` gate never opens. Needs a first-formation signal that survives an internal term bump.
2. **`RaftBootstrapDoesNotEngageOnRestartIT`** (#5100) - the in-memory `bootstrapBaselines` map is not part of the state-machine snapshot, so a follower restart with persistent Raft storage loses the baseline (the entry is below the snapshot index and isn't replayed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)