### PR TITLE
fix(#5039): gRPC admin RPCs authorize server-admin role before create/drop database

### DIFF
--- a/docs/5039-grpc-admin-authorization.md
+++ b/docs/5039-grpc-admin-authorization.md
@@ -42,3 +42,22 @@ GrpcAuthInterceptorTest = 29 tests) still pass.
 ## Impact
 Closes a critical privilege-escalation + data-destruction vulnerability on the gRPC admin plane.
 No behavior change for root/admin callers.
+
+## Pull request
+https://github.com/ArcadeData/arcadedb/pull/5101
+
+## Review cycles
+- cycle 1: `7b904a0` - initial fix (role gate on createDatabase/dropDatabase, PERMISSION_DENIED).
+  Gemini reviewed with one security-critical suggestion: fail closed if `ServerSecurity.authenticate`
+  returns `null` (defense-in-depth; the current impl throws, but the null path would otherwise map to
+  PERMISSION_DENIED instead of UNAUTHENTICATED and weaken the discarded-return RPCs). Claude bot did
+  not respond within the 15-minute per-iteration timeout.
+- cycle 2: `4f7ccae` - addressed Gemini: `authenticate(...)` now null-checks the returned user and
+  throws `SecurityException` (-> UNAUTHENTICATED), hardening all admin RPCs. All grpcw admin/auth
+  tests pass. Gemini re-posted the same (now already-applied) suggestion; no new actionable items.
+  Claude bot again did not respond within the timeout.
+
+## Final state
+timeout - the Claude bot reviewer never responded within the per-iteration budget across both cycles;
+Gemini's substantive feedback was fully addressed and the working tree is clean. Merge remains the
+developer's responsibility.

--- a/docs/5039-grpc-admin-authorization.md
+++ b/docs/5039-grpc-admin-authorization.md
@@ -1,0 +1,44 @@
+# Issue #5039 - gRPC admin RPCs authenticate but never authorize
+
+## Symptom
+The gRPC admin service (`ArcadeDbGrpcAdminService`) validated the caller's credentials but never
+checked for an administrative (root) role. Any user with a valid server account could
+`CreateDatabase` (resource abuse) or `DropDatabase` on any database (destructive privilege
+escalation), even one they had no rights over.
+
+## Root cause
+`authenticate(DatabaseCredentials)` called `ServerSecurity.authenticate(user, pass, null)`, which
+returns a valid `ServerSecurityUser` for any correct credential pair, then discarded the result.
+`createDatabase` / `dropDatabase` proceeded to `createDatabasePhysical` / `dropDatabasePhysical`
+with no role check. The central `GrpcAuthInterceptor` intentionally enforces authentication only
+(not admin-role authorization), delegating authorization to the handlers.
+
+## Fix
+- `grpcw/.../ArcadeDbGrpcAdminService.java`:
+  - `authenticate(...)` now returns the resolved `ServerSecurityUser`.
+  - Added `requireServerAdmin(ServerSecurityUser)` which throws a dedicated
+    `AdminAuthorizationException` unless the user is `root` (mirrors HTTP
+    `PostServerCommandHandler` / `AbstractServerHttpHandler.checkRootUser`).
+  - `createDatabase` and `dropDatabase` now call `requireServerAdmin(authenticate(...))`.
+  - Both RPCs map `AdminAuthorizationException` to `Status.PERMISSION_DENIED` (distinct from the
+    `UNAUTHENTICATED` used for authentication failures), fail-closed.
+- `grpcw/.../GrpcAuthInterceptor.java`: updated the choke-point comment to state that mutating admin
+  handlers now enforce role authorization.
+
+Scope: only the mutating destructive RPCs (`createDatabase`, `dropDatabase`) are gated, matching the
+acceptance criteria. Read-only info RPCs are left unchanged to avoid altering legitimate non-root
+read behavior.
+
+## Tests
+`grpcw/src/test/java/com/arcadedb/server/grpc/Issue5039GrpcAdminAuthorizationIT.java`:
+- `nonAdminCreateDatabaseIsDenied` - non-admin `CreateDatabase` -> `PERMISSION_DENIED`, db not created.
+- `nonAdminDropDatabaseIsDenied` - non-admin `DropDatabase` on existing db -> `PERMISSION_DENIED`, db preserved.
+- `adminCreateAndDropDatabaseStillSucceeds` - positive control, root still succeeds.
+
+TDD confirmed: both denial tests fail before the fix, pass after. All existing gRPC admin/auth
+tests (GrpcAdminServiceIT, GrpcAdminAuthInterceptorIT, Issue4794GrpcPerDbAuthorizationIT,
+GrpcAuthInterceptorTest = 29 tests) still pass.
+
+## Impact
+Closes a critical privilege-escalation + data-destruction vulnerability on the gRPC admin plane.
+No behavior change for root/admin callers.

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
@@ -319,9 +319,13 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
     // Validate format first
     credentialsValidator.validateCredentials(user, pass);
 
-    // Then authenticate against server security
+    // Then authenticate against server security. Fail closed: treat a null result the same as an
+    // authentication failure so callers never proceed (or reach the role check) unauthenticated.
     try {
-      return server.getSecurity().authenticate(user, pass, null);
+      final ServerSecurityUser authenticatedUser = server.getSecurity().authenticate(user, pass, null);
+      if (authenticatedUser == null)
+        throw new SecurityException("Invalid credentials");
+      return authenticatedUser;
     } catch (ServerSecurityException e) {
       throw new SecurityException("Invalid credentials");
     }

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcAdminService.java
@@ -30,6 +30,7 @@ import com.arcadedb.server.ServerDatabase;
 import com.arcadedb.server.ServerPlugin;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.security.ServerSecurityException;
+import com.arcadedb.server.security.ServerSecurityUser;
 import com.arcadedb.server.security.credential.CredentialsValidator;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
@@ -147,7 +148,7 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
   public void createDatabase(CreateDatabaseRequest req, StreamObserver<CreateDatabaseResponse> resp) {
 
     try {
-      authenticate(req.getCredentials());
+      requireServerAdmin(authenticate(req.getCredentials()));
 
       final String name = req.getName(); // DB name in proto
       final String type = req.getType(); // "graph" or "document" (logical)
@@ -176,6 +177,8 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
       }
       resp.onNext(CreateDatabaseResponse.newBuilder().build());
       resp.onCompleted();
+    } catch (AdminAuthorizationException ae) {
+      resp.onError(Status.PERMISSION_DENIED.withDescription(ae.getMessage()).asException());
     } catch (SecurityException se) {
       resp.onError(Status.UNAUTHENTICATED.withDescription(se.getMessage()).asException());
     } catch (Exception e) {
@@ -188,7 +191,7 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
 
     try {
 
-      authenticate(req.getCredentials());
+      requireServerAdmin(authenticate(req.getCredentials()));
 
       final String name = req.getName();
 
@@ -202,6 +205,8 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
 
       resp.onNext(DropDatabaseResponse.newBuilder().build());
       resp.onCompleted();
+    } catch (AdminAuthorizationException ae) {
+      resp.onError(Status.PERMISSION_DENIED.withDescription(ae.getMessage()).asException());
     } catch (SecurityException se) {
       resp.onError(Status.UNAUTHENTICATED.withDescription(se.getMessage()).asException());
     } catch (Exception e) {
@@ -301,7 +306,7 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
   // before the call reaches this handler. This handler-side check is intentionally kept (do not
   // remove it assuming the interceptor covers it) so the service stays safe even if the central
   // gate is ever bypassed or reconfigured.
-  private void authenticate(DatabaseCredentials creds) {
+  private ServerSecurityUser authenticate(DatabaseCredentials creds) {
 
     if (creds == null)
       throw new SecurityException("Authentication required");
@@ -316,9 +321,31 @@ public class ArcadeDbGrpcAdminService extends ArcadeDbAdminServiceGrpc.ArcadeDbA
 
     // Then authenticate against server security
     try {
-      server.getSecurity().authenticate(user, pass, null);
+      return server.getSecurity().authenticate(user, pass, null);
     } catch (ServerSecurityException e) {
       throw new SecurityException("Invalid credentials");
+    }
+  }
+
+  /**
+   * Ensures the authenticated caller holds the server-admin (root) role before running a mutating
+   * admin operation such as creating or dropping a database. Authentication (via {@link #authenticate})
+   * proves identity only; without this gate any valid account could create or drop any database.
+   * Mirrors the HTTP {@code PostServerCommandHandler} which restricts server administration to root.
+   */
+  private void requireServerAdmin(final ServerSecurityUser user) {
+    if (user == null || !"root".equals(user.getName()))
+      throw new AdminAuthorizationException("User is not authorized to execute server administration commands");
+  }
+
+  /**
+   * Raised when an authenticated caller lacks the server-admin role. Mapped to
+   * {@code Status.PERMISSION_DENIED} (the caller is authenticated but not authorized), distinct from
+   * the {@code UNAUTHENTICATED} used for authentication failures.
+   */
+  private static final class AdminAuthorizationException extends RuntimeException {
+    AdminAuthorizationException(final String message) {
+      super(message);
     }
   }
 

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/GrpcAuthInterceptor.java
@@ -82,8 +82,8 @@ class GrpcAuthInterceptor implements ServerInterceptor {
     // trusting every RPC to authenticate itself. This is the central authentication choke point: a
     // missing, malformed or invalid credential closes the call before the request reaches the
     // handler, so an admin method that forgets its own authenticate() call cannot expose a side
-    // effect. Note this enforces authentication only, not admin-role authorization (the handlers
-    // behave the same way today).
+    // effect. This choke point enforces authentication only; admin-role authorization for mutating
+    // operations (create/drop database) is enforced by the handlers themselves.
     if (methodName.startsWith("com.arcadedb.grpc.ArcadeDbAdminService/")) {
       // If security is not enabled, allow all requests (consistent with the data-plane methods below)
       if (!securityEnabled)

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue5039GrpcAdminAuthorizationIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue5039GrpcAdminAuthorizationIT.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.security.ServerSecurity;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #5039.
+ * <p>
+ * The gRPC admin service authenticates the caller's credentials but never checks that the caller
+ * holds an administrative (root) role. Any user who owns a valid server account could therefore
+ * create or drop any database on the server - a privilege escalation that is also destructive.
+ * <p>
+ * This test creates a non-admin user (authorized only for a dedicated database) and asserts that
+ * mutating admin RPCs ({@code CreateDatabase}, {@code DropDatabase}) are rejected with
+ * {@code PERMISSION_DENIED}. A positive control confirms the {@code root} user still succeeds.
+ */
+public class Issue5039GrpcAdminAuthorizationIT extends BaseGraphServerTest {
+
+  private static final int    GRPC_PORT    = 50051;
+  private static final String ALLOWED_DB   = "allowed5039db";
+  private static final String LIMITED_USER = "limited5039";
+  private static final String LIMITED_PASS = "limited5039pass";
+
+  private ManagedChannel channel;
+  private ArcadeDbAdminServiceGrpc.ArcadeDbAdminServiceBlockingStub adminStub;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void setupUserAndChannel() {
+    final ServerSecurity security = getServer(0).getSecurity();
+
+    // The database the limited user IS authorized for (still no server-admin role).
+    getServer(0).getOrCreateDatabase(ALLOWED_DB);
+
+    if (!security.existsUser(LIMITED_USER)) {
+      final JSONObject config = new JSONObject();
+      config.put("name", LIMITED_USER);
+      config.put("password", security.encodePassword(LIMITED_PASS));
+      config.put("databases", new JSONObject().put(ALLOWED_DB, new JSONArray().put("admin")));
+      security.createUser(config);
+    }
+
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+    adminStub = ArcadeDbAdminServiceGrpc.newBlockingStub(channel);
+  }
+
+  @AfterEach
+  void teardown() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private DatabaseCredentials limitedCredentials() {
+    return DatabaseCredentials.newBuilder().setUsername(LIMITED_USER).setPassword(LIMITED_PASS).build();
+  }
+
+  private DatabaseCredentials rootCredentials() {
+    return DatabaseCredentials.newBuilder().setUsername("root").setPassword(DEFAULT_PASSWORD_FOR_TESTS).build();
+  }
+
+  @Test
+  void nonAdminCreateDatabaseIsDenied() {
+    final String newDb = "grpc_5039_should_not_exist_" + System.currentTimeMillis();
+
+    final CreateDatabaseRequest request = CreateDatabaseRequest.newBuilder()
+        .setCredentials(limitedCredentials())
+        .setName(newDb)
+        .setType("graph")
+        .build();
+
+    assertThatThrownBy(() -> adminStub.createDatabase(request))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("PERMISSION_DENIED");
+
+    // The database must NOT have been created by the unauthorized caller.
+    assertThat(getServer(0).existsDatabase(newDb)).isFalse();
+  }
+
+  @Test
+  void nonAdminDropDatabaseIsDenied() {
+    // Target an existing database the limited user must never be able to destroy.
+    final String targetDb = getDatabaseName();
+    assertThat(getServer(0).existsDatabase(targetDb)).isTrue();
+
+    final DropDatabaseRequest request = DropDatabaseRequest.newBuilder()
+        .setCredentials(limitedCredentials())
+        .setName(targetDb)
+        .build();
+
+    assertThatThrownBy(() -> adminStub.dropDatabase(request))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("PERMISSION_DENIED");
+
+    // The database must still exist after the denied drop.
+    assertThat(getServer(0).existsDatabase(targetDb)).isTrue();
+  }
+
+  @Test
+  void adminCreateAndDropDatabaseStillSucceeds() {
+    final String newDb = "grpc_5039_admin_db_" + System.currentTimeMillis();
+
+    final CreateDatabaseRequest createRequest = CreateDatabaseRequest.newBuilder()
+        .setCredentials(rootCredentials())
+        .setName(newDb)
+        .setType("document")
+        .build();
+
+    adminStub.createDatabase(createRequest);
+    assertThat(getServer(0).existsDatabase(newDb)).isTrue();
+
+    final DropDatabaseRequest dropRequest = DropDatabaseRequest.newBuilder()
+        .setCredentials(rootCredentials())
+        .setName(newDb)
+        .build();
+
+    adminStub.dropDatabase(dropRequest);
+    assertThat(getServer(0).existsDatabase(newDb)).isFalse();
+  }
+}


### PR DESCRIPTION
Closes #5039

## Summary
The gRPC admin service (`ArcadeDbGrpcAdminService`) validated the caller's credentials but never checked for an administrative (root) role, so any user with a valid server account could `CreateDatabase` (resource abuse) or `DropDatabase` on any database (destructive privilege escalation). The central `GrpcAuthInterceptor` intentionally enforces authentication only and delegates role authorization to the handlers, which never performed it.

This change gates the mutating admin RPCs (`createDatabase`, `dropDatabase`) on a root-role check, mirroring the HTTP `PostServerCommandHandler` / `AbstractServerHttpHandler.checkRootUser`. `authenticate(...)` now returns the resolved `ServerSecurityUser`; a non-admin caller receives `Status.PERMISSION_DENIED` (distinct from the `UNAUTHENTICATED` used for authentication failures), fail-closed. Read-only info RPCs are left unchanged to avoid altering legitimate non-root read behavior.

## Test plan
- [ ] `Issue5039GrpcAdminAuthorizationIT#nonAdminCreateDatabaseIsDenied` - non-admin `CreateDatabase` returns `PERMISSION_DENIED` and the database is not created.
- [ ] `Issue5039GrpcAdminAuthorizationIT#nonAdminDropDatabaseIsDenied` - non-admin `DropDatabase` on an existing db returns `PERMISSION_DENIED` and the database is preserved.
- [ ] `Issue5039GrpcAdminAuthorizationIT#adminCreateAndDropDatabaseStillSucceeds` - positive control: root create/drop still succeed.
- [ ] Existing gRPC admin/auth tests unaffected: `GrpcAdminServiceIT`, `GrpcAdminAuthInterceptorIT`, `Issue4794GrpcPerDbAuthorizationIT`, `GrpcAuthInterceptorTest` (29 tests, all pass).
- [ ] TDD confirmed: both denial tests fail before the fix, pass after.

Run: `mvn -pl grpcw test -Dtest='Issue5039GrpcAdminAuthorizationIT'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)