### PR TITLE
fix(#5040): gRPC transaction hijack - unpredictable tx ids + authz on tx-scoped RPCs

### DIFF
--- a/docs/5040-grpc-tx-hijack-authz.md
+++ b/docs/5040-grpc-tx-hijack-authz.md
@@ -1,0 +1,40 @@
+# Issue #5040 - gRPC transaction hijack: predictable/colliding tx IDs + tx-scoped RPCs skip authorization
+
+## Symptom
+Server-side gRPC transactions use a predictable, monotonic id (`"tx_" + System.nanoTime()`) and every
+transaction-scoped RPC acts on the transaction found by that id without re-checking per-database
+authorization or transaction ownership. An authenticated user can hijack another user's in-flight
+transaction on a database they have no rights to. The weak id scheme also allows silent id collisions
+between two concurrent `beginTransaction` calls (`activeTransactions.put` overwrites).
+
+## Root cause
+1. `generateTransactionId()` returns `"tx_" + System.nanoTime()` (low entropy, enumerable, collidable).
+2. The transaction-scoped handlers resolve `TransactionContext` by id and run against `txCtx.db`
+   directly, skipping the `getDatabase()` -> `validateCredentials()` authn/per-db-authz gate used on the
+   non-transactional path. The context is not bound to the authenticating principal.
+3. `activeTransactions.put(id, ctx)` silently overwrites on id collision.
+
+## Fix (grpcw `ArcadeDbGrpcService`)
+- `generateTransactionId()` now returns `"tx_" + UUID.randomUUID()` (CSPRNG-backed, collision-free).
+- `TransactionContext` gains an immutable `owner` field, bound to the authenticated principal at
+  `beginTransaction` (`resolvedUsername(credentials)`).
+- `beginTransaction` registers with `putIfAbsent`; a non-null return (impossible with UUIDs) is treated
+  as an internal error, rolling back the just-started transaction instead of silently overwriting.
+- New `authorizeTransactionAccess(txCtx, credentials)` re-runs `validateCredentials` against the
+  transaction's REAL database (`txCtx.db.getName()`, never a request-supplied name) and enforces that
+  the caller is the transaction owner; otherwise `PERMISSION_DENIED`.
+- New `resolveAuthorizedTransaction(txId, credentials)` = lookup + authorize; used by `executeCommand`,
+  `createRecord`, `lookupByRid`, `updateRecord`, `deleteRecord`, `executeQuery`.
+- `commitTransaction` / `rollbackTransaction` peek (not remove) first, authorize, then atomically
+  `remove(key, value)` so the double-commit race protection and the idempotent no-op for unknown ids are
+  preserved and a denied caller cannot evict the real owner's transaction.
+
+## Tests
+- New IT `Issue5040GrpcTransactionHijackIT`: cross-tenant commit/rollback/executeCommand denied; an
+  authorized-but-non-owner user denied ("owned by another user"); owner still succeeds; tx ids are
+  `tx_<uuid>` and unique.
+
+## Impact
+Closes the cross-tenant hijack and the id-collision data-integrity race on the gRPC transaction path.
+No change to the non-transactional path or to public API. Fail-closed: unknown owner (open/no-security
+mode) leaves ownership unenforced, matching the interceptor's existing `securityEnabled` gate.

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -135,12 +135,17 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     final Database        db;
     final ExecutorService executor;
     final String          txId;
+    // Principal that opened this transaction. Bound at beginTransaction so a transaction-scoped RPC can
+    // reject any caller other than the owner. Null only when the transaction was opened on a server with
+    // security disabled (open mode), where there is no authenticated identity to bind to.
+    final String          owner;
     final long            createdAtMs;
     volatile long         lastAccessMs;
 
-    TransactionContext(Database db, String txId) {
+    TransactionContext(Database db, String txId, String owner) {
       this.db = db;
       this.txId = txId;
+      this.owner = owner;
       this.createdAtMs = System.currentTimeMillis();
       this.lastAccessMs = this.createdAtMs;
       // Single-thread executor ensures all tx operations happen on the same thread
@@ -241,6 +246,38 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     if (ctx != null)
       ctx.touch();
     return ctx;
+  }
+
+  /**
+   * Resolves an active transaction for a transaction-scoped RPC and enforces that the caller is allowed to
+   * drive it. Returns {@code null} when no transaction id was supplied (or none is registered) so the
+   * caller falls back to the non-transactional path. When a transaction IS found the caller must pass the
+   * same authentication + per-database authorization enforced by {@link #getDatabase} and be the principal
+   * that opened it; otherwise a gRPC {@code PERMISSION_DENIED} (or {@code UNAUTHENTICATED}) is thrown. This
+   * closes the transaction-hijack where a caller guessing another user's transaction id could drive it on a
+   * database it cannot otherwise access.
+   */
+  private TransactionContext resolveAuthorizedTransaction(final String txId, final DatabaseCredentials credentials) {
+    final TransactionContext txCtx = lookupActiveTransaction(txId);
+    if (txCtx == null)
+      return null;
+    authorizeTransactionAccess(txCtx, credentials);
+    return txCtx;
+  }
+
+  /**
+   * Authenticates the caller and authorizes them for the transaction's REAL database (never a
+   * request-supplied database name), mirroring {@link #getDatabase}'s gate, then enforces transaction
+   * ownership: only the principal that opened the transaction may drive it. Throws a gRPC status exception
+   * (fail-closed) on any mismatch.
+   */
+  private void authorizeTransactionAccess(final TransactionContext txCtx, final DatabaseCredentials credentials) {
+    // Authorize against the transaction's actual database so a caller cannot lie about the database name.
+    validateCredentials(credentials, txCtx.db.getName());
+
+    final String caller = resolvedUsername(credentials);
+    if (txCtx.owner != null && !txCtx.owner.equals(caller))
+      throw Status.PERMISSION_DENIED.withDescription("Transaction is owned by another user").asRuntimeException();
   }
 
   /**
@@ -360,7 +397,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       final boolean hasTx = req.hasTransaction();
       final var tx = hasTx ? req.getTransaction() : null;
       final String incomingTxId = hasTx && tx != null ? tx.getTransactionId() : null;
-      final TransactionContext txCtx = lookupActiveTransaction(incomingTxId);
+      final TransactionContext txCtx = resolveAuthorizedTransaction(incomingTxId, req.getCredentials());
 
       if (txCtx != null) {
         // External transaction - execute command on the transaction's dedicated thread
@@ -628,7 +665,13 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   public void createRecord(CreateRecordRequest req, StreamObserver<CreateRecordResponse> resp) {
     // Check for external transaction
     final String incomingTxId = req.hasTransaction() ? req.getTransaction().getTransactionId() : null;
-    final TransactionContext txCtx = lookupActiveTransaction(incomingTxId);
+    final TransactionContext txCtx;
+    try {
+      txCtx = resolveAuthorizedTransaction(incomingTxId, req.getCredentials());
+    } catch (final StatusRuntimeException e) {
+      resp.onError(e);
+      return;
+    }
 
     if (txCtx != null) {
       // External transaction — execute on its dedicated thread to maintain thread-local state
@@ -749,7 +792,13 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
     // record version is tracked in that transaction. Under REPEATABLE_READ this is what lets a later write detect a
     // concurrent modification on commit, mirroring the HTTP behavior (issue #4533).
     final String incomingTxId = req.hasTransaction() ? req.getTransaction().getTransactionId() : null;
-    final TransactionContext txCtx = lookupActiveTransaction(incomingTxId);
+    final TransactionContext txCtx;
+    try {
+      txCtx = resolveAuthorizedTransaction(incomingTxId, req.getCredentials());
+    } catch (final StatusRuntimeException e) {
+      resp.onError(e);
+      return;
+    }
 
     if (txCtx != null) {
       try {
@@ -791,7 +840,13 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   public void updateRecord(final UpdateRecordRequest req, final StreamObserver<UpdateRecordResponse> resp) {
     // Check for external transaction
     final String incomingTxId = req.hasTransaction() ? req.getTransaction().getTransactionId() : null;
-    final TransactionContext txCtx = lookupActiveTransaction(incomingTxId);
+    final TransactionContext txCtx;
+    try {
+      txCtx = resolveAuthorizedTransaction(incomingTxId, req.getCredentials());
+    } catch (final StatusRuntimeException e) {
+      resp.onError(e);
+      return;
+    }
 
     if (txCtx != null) {
       // External transaction — execute on its dedicated thread to maintain thread-local state
@@ -954,7 +1009,13 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   public void deleteRecord(DeleteRecordRequest req, StreamObserver<DeleteRecordResponse> resp) {
     // Check for external transaction
     final String incomingTxId = req.hasTransaction() ? req.getTransaction().getTransactionId() : null;
-    final TransactionContext txCtx = lookupActiveTransaction(incomingTxId);
+    final TransactionContext txCtx;
+    try {
+      txCtx = resolveAuthorizedTransaction(incomingTxId, req.getCredentials());
+    } catch (final StatusRuntimeException e) {
+      resp.onError(e);
+      return;
+    }
 
     if (txCtx != null) {
       // External transaction — execute on its dedicated thread to maintain thread-local state
@@ -1041,7 +1102,14 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       final String incomingTxId = request.getTransaction().getTransactionId();
       LogManager.instance().log(this, Level.FINE, "executeQuery(): has Tx %s", incomingTxId);
 
-      final TransactionContext txCtx = lookupActiveTransaction(incomingTxId);
+      final TransactionContext txCtx;
+      try {
+        txCtx = resolveAuthorizedTransaction(incomingTxId, request.getCredentials());
+      } catch (final StatusRuntimeException e) {
+        // Preserve the authz/authn status (PERMISSION_DENIED/UNAUTHENTICATED) instead of masking it.
+        responseObserver.onError(e);
+        return;
+      }
       if (txCtx == null) {
         responseObserver.onError(Status.INTERNAL
             .withDescription("Query execution failed: Invalid transaction ID").asException());
@@ -1262,8 +1330,12 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       // Generate transaction ID first so we can create the context
       final String transactionId = generateTransactionId();
 
+      // Bind the transaction to the authenticated principal so a transaction-scoped RPC can later reject
+      // any caller other than the owner (getDatabase() above already authenticated/authorized this user).
+      final String owner = resolvedUsername(request.getCredentials());
+
       // Create transaction context with dedicated executor thread
-      txCtx = new TransactionContext(database, transactionId);
+      txCtx = new TransactionContext(database, transactionId, owner);
 
       LogManager.instance().log(this, Level.FINE, """
           beginTransaction(): calling database.begin() on dedicated thread \
@@ -1283,8 +1355,21 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       });
       beginFuture.get(); // Wait for begin to complete
 
-      // Register the transaction context
-      activeTransactions.put(transactionId, txCtx);
+      // Register the transaction context. putIfAbsent (never plain put) so two concurrent begins can never
+      // silently overwrite one another's context; with UUID ids a collision is effectively impossible, so a
+      // non-null return is treated as an internal error. Roll back the transaction we just started on its
+      // own thread before failing so it does not leak.
+      final TransactionContext registered = txCtx;
+      final TransactionContext existing = activeTransactions.putIfAbsent(transactionId, registered);
+      if (existing != null) {
+        try {
+          registered.executor.submit(() -> database.rollback()).get();
+        } catch (final Exception rollbackError) {
+          LogManager.instance().log(this, Level.WARNING,
+              "Failed to roll back transaction after id collision for txId=%s", rollbackError, transactionId);
+        }
+        throw new IllegalStateException("Transaction id collision for id=" + transactionId);
+      }
 
       LogManager.instance()
           .log(this, Level.FINE, "beginTransaction(): started txId=%s for db=%s activeTxCount(after)=%s", transactionId,
@@ -1322,18 +1407,34 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       return;
     }
 
-    // remove atomically to avoid double-commit races
-    final TransactionContext txCtx = activeTransactions.remove(txId);
-
-    LogManager.instance()
-        .log(this, Level.FINE, "commitTransaction(): removed txId=%s, presentPreviously=%s, remainingActiveTx=%s", txId,
-            txCtx != null,
-            activeTransactions.size());
+    // Peek (do NOT remove yet) so an unauthorized caller cannot evict the real owner's transaction.
+    final TransactionContext txCtx = lookupActiveTransaction(txId);
 
     if (txCtx == null) {
       // Idempotent no-op
       LogManager.instance()
           .log(this, Level.FINE, "commitTransaction(): no active tx for id=%s, responding committed=false", txId);
+      rsp.onNext(CommitTransactionResponse.newBuilder().setSuccess(true).setCommitted(false)
+          .setMessage("No active transaction for id=" + txId + " (already committed/rolled back?)").build());
+      rsp.onCompleted();
+      return;
+    }
+
+    // Enforce ownership + per-database authorization before mutating anything. A denied caller must not be
+    // able to commit (or, via the removal, disrupt) another user's transaction.
+    try {
+      authorizeTransactionAccess(txCtx, req.getCredentials());
+    } catch (final StatusRuntimeException e) {
+      rsp.onError(e);
+      return;
+    }
+
+    // Now atomically claim the transaction. remove(key, value) avoids double-commit races: if a concurrent
+    // commit/rollback/reaper already took it, treat this as the same idempotent no-op as an unknown id.
+    if (!activeTransactions.remove(txId, txCtx)) {
+      LogManager.instance()
+          .log(this, Level.FINE, "commitTransaction(): tx id=%s already claimed concurrently, responding committed=false",
+              txId);
       rsp.onNext(CommitTransactionResponse.newBuilder().setSuccess(true).setCommitted(false)
           .setMessage("No active transaction for id=" + txId + " (already committed/rolled back?)").build());
       rsp.onCompleted();
@@ -1378,17 +1479,32 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       return;
     }
 
-    final TransactionContext txCtx = activeTransactions.remove(txId);
-
-    LogManager.instance()
-        .log(this, Level.FINE, "rollbackTransaction(): removed txId=%s, presentPreviously=%s, remainingActiveTx=%s",
-            txId,
-            txCtx != null,
-            activeTransactions.size());
+    // Peek (do NOT remove yet) so an unauthorized caller cannot evict the real owner's transaction.
+    final TransactionContext txCtx = lookupActiveTransaction(txId);
 
     if (txCtx == null) {
       LogManager.instance()
           .log(this, Level.FINE, "rollbackTransaction(): no active tx for id=%s, responding rolledBack=false", txId);
+      rsp.onNext(RollbackTransactionResponse.newBuilder().setSuccess(true).setRolledBack(false)
+          .setMessage("No active transaction for id=" + txId + " (already committed/rolled back?)").build());
+      rsp.onCompleted();
+      return;
+    }
+
+    // Enforce ownership + per-database authorization before mutating anything.
+    try {
+      authorizeTransactionAccess(txCtx, req.getCredentials());
+    } catch (final StatusRuntimeException e) {
+      rsp.onError(e);
+      return;
+    }
+
+    // Atomically claim the transaction; if a concurrent commit/rollback/reaper already took it, treat this
+    // as the same idempotent no-op as an unknown id.
+    if (!activeTransactions.remove(txId, txCtx)) {
+      LogManager.instance()
+          .log(this, Level.FINE, "rollbackTransaction(): tx id=%s already claimed concurrently, responding rolledBack=false",
+              txId);
       rsp.onNext(RollbackTransactionResponse.newBuilder().setSuccess(true).setRolledBack(false)
           .setMessage("No active transaction for id=" + txId + " (already committed/rolled back?)").build());
       rsp.onCompleted();
@@ -4150,7 +4266,10 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
   }
 
   private String generateTransactionId() {
-    return "tx_" + System.nanoTime();
+    // UUID (CSPRNG-backed) instead of System.nanoTime(): high-entropy so it cannot be enumerated by an
+    // attacker guessing values around a known point in time, and collision-free so two concurrent begins
+    // can never map to the same id and drive one another's server-side transaction.
+    return "tx_" + UUID.randomUUID();
   }
 
   private static String langOrDefault(String language) {

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/Issue5040GrpcTransactionHijackIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/Issue5040GrpcTransactionHijackIT.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.serializer.json.JSONArray;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import com.arcadedb.server.security.ServerSecurity;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for issue #5040.
+ * <p>
+ * Server-side gRPC transactions were identified by a predictable, monotonic id
+ * ({@code "tx_" + System.nanoTime()}) and every transaction-scoped RPC acted on the transaction
+ * found by that id without re-checking per-database authorization or transaction ownership. Together
+ * these allowed an authenticated user to hijack another user's in-flight transaction on a database
+ * they have no rights to.
+ * <p>
+ * These tests set up an owner authorized only for the owner's database and an attacker authorized
+ * only for a different database. The attacker guesses the owner's transaction id and tries to drive
+ * it via {@code commitTransaction}, {@code rollbackTransaction} and {@code executeCommand}; every
+ * attempt must be denied while the owner's own operations still succeed. A third user, authorized for
+ * the owner's database but NOT the transaction owner, is also denied, proving the ownership binding is
+ * enforced independently of per-database authorization. Finally, transaction ids must be UUID-based
+ * (high-entropy, collision-free).
+ */
+public class Issue5040GrpcTransactionHijackIT extends BaseGraphServerTest {
+
+  private static final int    GRPC_PORT     = 50051;
+  private static final String OWNER_DB      = "hijackowner5040db";
+  private static final String ATTACKER_DB   = "hijackattacker5040db";
+  private static final String OWNER_USER    = "owner5040";
+  private static final String OWNER_PASS    = "owner5040pass";
+  private static final String ATTACKER_USER = "attacker5040";
+  private static final String ATTACKER_PASS = "attacker5040pass";
+  private static final String NONOWNER_USER = "nonowner5040";
+  private static final String NONOWNER_PASS = "nonowner5040pass";
+
+  private static final Pattern TX_ID_PATTERN =
+      Pattern.compile("tx_[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}");
+
+  private static final Metadata.Key<String> USER_HEADER     =
+      Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER =
+      Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER =
+      Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  private ManagedChannel channel;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue("GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void setup() {
+    final ServerSecurity security = getServer(0).getSecurity();
+
+    getServer(0).getOrCreateDatabase(OWNER_DB);
+    getServer(0).getOrCreateDatabase(ATTACKER_DB);
+
+    createUserIfMissing(security, OWNER_USER, OWNER_PASS, OWNER_DB);
+    createUserIfMissing(security, ATTACKER_USER, ATTACKER_PASS, ATTACKER_DB);
+    createUserIfMissing(security, NONOWNER_USER, NONOWNER_PASS, OWNER_DB);
+
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT).usePlaintext().build();
+
+    // Ensure a target type exists in the owner's database for the in-transaction inserts.
+    final ExecuteCommandResponse createType = ownerStub().executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(OWNER_DB)
+        .setCredentials(creds(OWNER_USER, OWNER_PASS))
+        .setCommand("CREATE DOCUMENT TYPE Doc5040 IF NOT EXISTS")
+        .build());
+    assertThat(createType.getSuccess()).isTrue();
+  }
+
+  @AfterEach
+  void teardown() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private void createUserIfMissing(final ServerSecurity security, final String user, final String pass,
+      final String db) {
+    if (!security.existsUser(user)) {
+      final JSONObject config = new JSONObject();
+      config.put("name", user);
+      config.put("password", security.encodePassword(pass));
+      config.put("databases", new JSONObject().put(db, new JSONArray().put("admin")));
+      security.createUser(config);
+    }
+  }
+
+  private DatabaseCredentials creds(final String user, final String pass) {
+    return DatabaseCredentials.newBuilder().setUsername(user).setPassword(pass).build();
+  }
+
+  /**
+   * Builds a stub whose metadata carries {@code user}/{@code pass} basic-auth credentials and names
+   * {@code headerDb} (a database the user is authorized for, so the auth interceptor lets the call
+   * through and the service-layer authorization is what is under test).
+   */
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub stub(final String user, final String pass,
+      final String headerDb) {
+    final Channel authenticated = ClientInterceptors.intercept(channel, new ClientInterceptor() {
+      @Override
+      public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(final MethodDescriptor<ReqT, RespT> method,
+          final CallOptions callOptions, final Channel next) {
+        return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+          @Override
+          public void start(final Listener<RespT> responseListener, final Metadata headers) {
+            headers.put(USER_HEADER, user);
+            headers.put(PASSWORD_HEADER, pass);
+            headers.put(DATABASE_HEADER, headerDb);
+            super.start(responseListener, headers);
+          }
+        };
+      }
+    });
+    return ArcadeDbServiceGrpc.newBlockingStub(authenticated);
+  }
+
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub ownerStub() {
+    return stub(OWNER_USER, OWNER_PASS, OWNER_DB);
+  }
+
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub attackerStub() {
+    return stub(ATTACKER_USER, ATTACKER_PASS, ATTACKER_DB);
+  }
+
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub nonOwnerStub() {
+    return stub(NONOWNER_USER, NONOWNER_PASS, OWNER_DB);
+  }
+
+  private String beginOwnerTransaction() {
+    final BeginTransactionResponse begin = ownerStub().beginTransaction(BeginTransactionRequest.newBuilder()
+        .setDatabase(OWNER_DB)
+        .setCredentials(creds(OWNER_USER, OWNER_PASS))
+        .build());
+    assertThat(begin.getTransactionId()).isNotEmpty();
+    return begin.getTransactionId();
+  }
+
+  private CommitTransactionRequest commitAs(final String txId, final String user, final String pass) {
+    return CommitTransactionRequest.newBuilder()
+        .setCredentials(creds(user, pass))
+        .setTransaction(TransactionContext.newBuilder().setTransactionId(txId).setDatabase(OWNER_DB).build())
+        .build();
+  }
+
+  private RollbackTransactionRequest rollbackAs(final String txId, final String user, final String pass) {
+    return RollbackTransactionRequest.newBuilder()
+        .setCredentials(creds(user, pass))
+        .setTransaction(TransactionContext.newBuilder().setTransactionId(txId).setDatabase(OWNER_DB).build())
+        .build();
+  }
+
+  @Test
+  void crossTenantCommitIsDeniedAndOwnerStillSucceeds() {
+    final String txId = beginOwnerTransaction();
+
+    // Attacker (authorized only for ATTACKER_DB) guesses the owner's tx id and tries to commit it.
+    final CommitTransactionRequest attackerCommit = commitAs(txId, ATTACKER_USER, ATTACKER_PASS);
+    assertThatThrownBy(() -> attackerStub().commitTransaction(attackerCommit))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("PERMISSION_DENIED");
+
+    // The owner's transaction must be untouched: the owner can still commit it.
+    final CommitTransactionResponse ownerCommit = ownerStub().commitTransaction(commitAs(txId, OWNER_USER, OWNER_PASS));
+    assertThat(ownerCommit.getSuccess()).isTrue();
+    assertThat(ownerCommit.getCommitted()).isTrue();
+  }
+
+  @Test
+  void crossTenantRollbackIsDeniedAndOwnerStillSucceeds() {
+    final String txId = beginOwnerTransaction();
+
+    final RollbackTransactionRequest attackerRollback = rollbackAs(txId, ATTACKER_USER, ATTACKER_PASS);
+    assertThatThrownBy(() -> attackerStub().rollbackTransaction(attackerRollback))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("PERMISSION_DENIED");
+
+    // Owner's transaction is intact and can be rolled back by the owner.
+    final RollbackTransactionResponse ownerRollback =
+        ownerStub().rollbackTransaction(rollbackAs(txId, OWNER_USER, OWNER_PASS));
+    assertThat(ownerRollback.getSuccess()).isTrue();
+    assertThat(ownerRollback.getRolledBack()).isTrue();
+  }
+
+  @Test
+  void crossTenantExecuteCommandIsDenied() {
+    final String txId = beginOwnerTransaction();
+
+    // executeCommand surfaces execution/authorization errors in-band (success=false) rather than a gRPC
+    // error status. The denial must come from the transaction-scoped authorization gate.
+    final ExecuteCommandResponse response = attackerStub().executeCommand(ExecuteCommandRequest.newBuilder()
+        .setDatabase(OWNER_DB)
+        .setCredentials(creds(ATTACKER_USER, ATTACKER_PASS))
+        .setCommand("INSERT INTO Doc5040 SET name = 'intruder'")
+        .setTransaction(TransactionContext.newBuilder().setTransactionId(txId).build())
+        .build());
+
+    assertThat(response.getSuccess()).isFalse();
+    assertThat(response.getMessage()).contains("has not access to database '" + OWNER_DB + "'");
+
+    // Nothing was written into the owner's transaction; the owner can still roll back cleanly.
+    final RollbackTransactionResponse ownerRollback =
+        ownerStub().rollbackTransaction(rollbackAs(txId, OWNER_USER, OWNER_PASS));
+    assertThat(ownerRollback.getRolledBack()).isTrue();
+  }
+
+  @Test
+  void authorizedNonOwnerCannotDriveTransaction() {
+    final String txId = beginOwnerTransaction();
+
+    // nonOwner IS authorized for OWNER_DB but did not open this transaction: the ownership binding must
+    // still reject the commit, independently of the per-database authorization check.
+    final CommitTransactionRequest nonOwnerCommit = commitAs(txId, NONOWNER_USER, NONOWNER_PASS);
+    assertThatThrownBy(() -> nonOwnerStub().commitTransaction(nonOwnerCommit))
+        .isInstanceOf(StatusRuntimeException.class)
+        .hasMessageContaining("owned by another user");
+
+    // The owner can still commit its own transaction.
+    final CommitTransactionResponse ownerCommit = ownerStub().commitTransaction(commitAs(txId, OWNER_USER, OWNER_PASS));
+    assertThat(ownerCommit.getCommitted()).isTrue();
+  }
+
+  @Test
+  void transactionIdsAreUuidBasedAndUnique() {
+    final Set<String> ids = new HashSet<>();
+    for (int i = 0; i < 5; i++) {
+      final String txId = beginOwnerTransaction();
+      assertThat(TX_ID_PATTERN.matcher(txId).matches())
+          .as("transaction id must be UUID-based: %s", txId)
+          .isTrue();
+      ids.add(txId);
+    }
+    assertThat(ids).hasSize(5);
+
+    // Clean up the open transactions.
+    for (final String txId : ids)
+      ownerStub().rollbackTransaction(rollbackAs(txId, OWNER_USER, OWNER_PASS));
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #5040. Closes a critical gRPC security hole: server-side transactions were identified by a predictable, monotonic id (`"tx_" + System.nanoTime()`) and every transaction-scoped RPC acted on the transaction found by that id **without** re-checking per-database authorization or transaction ownership. Together these let an authenticated user hijack another user's in-flight transaction on a database they have no rights to. The weak id scheme also allowed silent id collisions between two concurrent `beginTransaction` calls (`activeTransactions.put` overwrote).

## Changes (`grpcw` `ArcadeDbGrpcService`)

- **Unpredictable ids**: `generateTransactionId()` now returns `"tx_" + UUID.randomUUID()` (CSPRNG-backed, non-enumerable, collision-free).
- **Ownership binding**: `TransactionContext` gains an immutable `owner`, bound to the authenticated principal at `beginTransaction`.
- **No silent overwrite**: `beginTransaction` registers with `putIfAbsent`; a non-null return (impossible with UUIDs) is treated as an internal error and rolls back the just-started transaction instead of stranding another client's context.
- **Re-auth on the tx path**: new `authorizeTransactionAccess(txCtx, credentials)` re-runs `validateCredentials` against the transaction's **real** database (`txCtx.db.getName()`, never a request-supplied name) and enforces caller == owner, otherwise `PERMISSION_DENIED`.
- The data-plane handlers (`executeCommand`, `executeQuery`, `createRecord`, `updateRecord`, `deleteRecord`, `lookupByRid`) resolve the transaction through the new authorized gate.
- `commitTransaction` / `rollbackTransaction` now **peek + authorize before** atomically claiming the transaction (`remove(key, value)`), so a denied caller cannot evict the real owner's transaction. The idempotent no-op for unknown ids and the double-commit race protection are preserved.

Fail-closed: a null owner (server with security disabled / open mode) leaves ownership unenforced, matching the auth interceptor's existing `securityEnabled` gate. No change to the non-transactional path or public API.

## Tests

New `Issue5040GrpcTransactionHijackIT` (5 cases):
- cross-tenant `commitTransaction` / `rollbackTransaction` denied; owner still succeeds
- cross-tenant `executeCommand` denied (in-band, with the authorization message)
- authorized-but-non-owner user denied ("owned by another user"), proving ownership is enforced independently of per-db authz
- transaction ids are `tx_<uuid>` and unique

TDD verified: all 5 fail on the pre-fix code, all 5 pass after. Existing gRPC transaction/authorization ITs (`GrpcServerIT`, `ArcadeDbGrpcServiceCoverageIT`, `Issue4794GrpcPerDbAuthorizationIT`, `Issue4793GrpcGetDatabaseSecurityIT`, `GrpcTransactionReaperIT` = 76 tests) still pass.

## Acceptance criteria

- [x] Tx ids are UUIDs; no two concurrent begins can collide
- [x] A non-owner (or a caller not authorized for the tx's database) is rejected on commit/rollback/execute with `PERMISSION_DENIED`
- [x] New IT: cross-tenant hijack denied; owner still succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)