### PR TITLE
fix(#5100): persist bootstrap baseline across restarts

### DIFF
--- a/docs/5100-bootstrap-baseline-lost-on-restart.md
+++ b/docs/5100-bootstrap-baseline-lost-on-restart.md
@@ -1,0 +1,52 @@
+# #5100 - HA offline bootstrap: bootstrap baseline lost on restart
+
+## Symptom
+
+After a cluster completes first-formation bootstrap, restarting a peer with persistent Raft storage
+leaves `ArcadeStateMachine.getBootstrapBaseline(db)` returning `null`: the committed, durable baseline
+is invisible after restart. Reproduced by `RaftBootstrapDoesNotEngageOnRestartIT`.
+
+## Root cause
+
+`applyBootstrapFingerprintEntry` records the baseline only into the in-memory `bootstrapBaselines`
+map, and `getBootstrapBaseline` reads that map. On restart with persistent storage:
+
+- the `BOOTSTRAP_FINGERPRINT_ENTRY` sits below the Ratis snapshot index, so Ratis restores from the
+  snapshot instead of replaying the entry, and `applyBootstrapFingerprintEntry` is never called again;
+- the map is not part of the state-machine snapshot, so it comes back empty.
+
+## Fix
+
+Persist the baselines next to the existing applied-index bookkeeping and reload them lazily, mirroring
+the `.raft/applied-index` machinery:
+
+- new `.raft/bootstrap-baselines` JSON file keyed by database name (`{fingerprint, lastTxId}`);
+- `applyBootstrapFingerprintEntry` loads-before-mutate then persists after recording;
+- `getBootstrapBaseline` lazily loads the file on first access (session-applied entries win via
+  `putIfAbsent`);
+- `applyDropDatabaseEntry` evicts the dropped database's baseline and rewrites the file, keeping it
+  honest (mirrors the per-database applied-index eviction);
+- writes go through a temp file + atomic rename; a corrupt/missing file degrades to "no baselines".
+
+Written only when a baseline is recorded/evicted (rare), never on the hot apply path.
+
+## Tests
+
+- `ArcadeStateMachineBootstrapBaselinePersistenceTest` (new, fast unit): baseline survives a simulated
+  restart, no-file returns null, on-disk JSON shape, single-database rewrite preserves others.
+- `RaftBootstrapDoesNotEngageOnRestartIT` (existing IT reproduction).
+
+## Test results
+
+- New unit test: 4/4 pass.
+- `ArcadeStateMachine*Test` + `BootstrapElection*Test`: 72 pass.
+- `RaftBootstrapDoesNotEngageOnRestartIT`: passes (failed before the fix).
+- `RaftBootstrapFromLocalDatabaseIT`, `RaftBootstrapLateNewerJoinerIT`, `RaftDropDatabase3NodesIT`: pass.
+- `RaftBootstrapPicksHighestLastTxIdIT` fails on the base commit too (pre-existing timing flake, not a
+  regression of this change).
+
+## Impact
+
+Scoped to `ha-raft` bootstrap persistence. No change to the hot apply path or wire format. The persisted
+baseline makes the offline-bootstrap decision durable across restarts, closing the last of the three
+first-formation baseline bugs (bug 1 = #5098, bug 2 = #5099).

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -1658,15 +1658,13 @@ public class ArcadeStateMachine extends BaseStateMachine {
   void applyDropDatabaseEntry(final RaftLogEntryCodec.DecodedEntry decoded) {
     final String databaseName = decoded.databaseName();
 
-    // Evict the dropped database's persisted bootstrap baseline unconditionally, before the presence
-    // check below: applyBootstrapFingerprintEntry records a baseline by name even when the database is
-    // not present locally (the late-joiner path), so a node can hold a persisted baseline for a
-    // database it never had locally. Evicting only when present would leave that baseline stale in the
-    // file for the node lifetime. Mirrors the unconditional per-database applied-index drop eviction.
-    evictBootstrapBaseline(databaseName);
-
-    // Idempotent on replay: if the database is already gone, nothing to do.
+    // Idempotent on replay: if the database is already gone, nothing to do beyond evicting any
+    // persisted baseline. applyBootstrapFingerprintEntry records a baseline by name even when the
+    // database is not present locally (the late-joiner path), so a node can hold a persisted baseline
+    // for a database it never had locally; evict it here so it does not linger in the file for the
+    // node lifetime. This branch never calls drop(), so the eviction cannot precede a failed drop.
     if (!server.existsDatabase(databaseName)) {
+      evictBootstrapBaseline(databaseName);
       HALog.log(this, HALog.TRACE, "Database '%s' already absent, skipping drop-database entry", databaseName);
       return;
     }
@@ -1674,6 +1672,12 @@ public class ArcadeStateMachine extends BaseStateMachine {
     final DatabaseInternal db = (DatabaseInternal) server.getDatabase(databaseName);
     db.getEmbedded().drop();
     server.removeDatabase(databaseName);
+
+    // Evict AFTER the drop succeeded, mirroring the applied-index drop eviction which runs only once
+    // apply completes: if drop() had thrown and quarantined this database, the baseline must stay so a
+    // restart can still recover it (evicting first would lose the baseline of a database that was not
+    // actually dropped - the #5100 failure mode).
+    evictBootstrapBaseline(databaseName);
 
     LogManager.instance().log(this, Level.INFO, "Database '%s' dropped via Raft drop-database entry", databaseName);
   }
@@ -1896,6 +1900,9 @@ public class ArcadeStateMachine extends BaseStateMachine {
             for (final String name : json.keySet()) {
               final JSONObject entry = json.getJSONObject(name);
               final String fingerprint = entry.getString("fingerprint", null);
+              // putIfAbsent is defensive: recordBootstrapBaseline already loads before it puts, so a
+              // session-applied baseline is written after this load runs and would win anyway; this
+              // just guarantees the on-disk copy never overwrites a value already present in memory.
               if (fingerprint != null)
                 bootstrapBaselines.putIfAbsent(name, new BootstrapBaseline(fingerprint, entry.getLong("lastTxId", -1)));
             }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -1850,13 +1850,23 @@ public class ArcadeStateMachine extends BaseStateMachine {
   }
 
   private Path getAppliedIndexFile() {
+    final Path raftDir = getRaftDir();
+    return raftDir != null ? raftDir.resolve("applied-index") : null;
+  }
+
+  /**
+   * The {@code .raft} state directory under the server database directory, or {@code null} when it
+   * cannot yet be resolved (no server wired or no configured database directory). Shared by the
+   * applied-index and bootstrap-baseline files so the two are guaranteed to be co-located.
+   */
+  private Path getRaftDir() {
     if (server == null)
       return null;
     final String dbDir = server.getConfiguration().getValueAsString(
         GlobalConfiguration.SERVER_DATABASE_DIRECTORY);
     if (dbDir == null)
       return null;
-    return Path.of(dbDir, ".raft", "applied-index");
+    return Path.of(dbDir, ".raft");
   }
 
   /**
@@ -1950,18 +1960,16 @@ public class ArcadeStateMachine extends BaseStateMachine {
       }
       FileUtils.atomicWriteFile(file.toFile(), json.toString());
     } catch (final Exception e) {
-      LogManager.instance().log(this, Level.FINE, "Could not write persisted bootstrap baselines: %s", e.getMessage());
+      // WARNING, not FINE: unlike the applied-index file (whose loss merely re-runs an idempotent
+      // verification), a lost bootstrap baseline silently re-introduces #5100 - the baseline would be
+      // invisible after the next restart. Surface a breadcrumb so an operator can notice.
+      LogManager.instance().log(this, Level.WARNING, "Could not write persisted bootstrap baselines: %s", e.getMessage());
     }
   }
 
   private Path getBootstrapBaselinesFile() {
-    if (server == null)
-      return null;
-    final String dbDir = server.getConfiguration().getValueAsString(
-        GlobalConfiguration.SERVER_DATABASE_DIRECTORY);
-    if (dbDir == null)
-      return null;
-    return Path.of(dbDir, ".raft", "bootstrap-baselines");
+    final Path raftDir = getRaftDir();
+    return raftDir != null ? raftDir.resolve("bootstrap-baselines") : null;
   }
 
   private void triggerSnapshotDownload() {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -161,9 +161,17 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * Per-database bootstrap baseline committed via {@link RaftLogEntryType#BOOTSTRAP_FINGERPRINT_ENTRY}.
    * Populated when the entry is applied (locally on every peer), used by the catch-up decision
    * tree (locally bootstrapped vs leader-shipped vs late-newer-joiner refusal). Issue #4147.
+   * <p>
+   * The map is also durably persisted to {@code .raft/bootstrap-baselines} and reloaded lazily on
+   * first access. The committed {@code BOOTSTRAP_FINGERPRINT_ENTRY} is compacted below the Ratis
+   * snapshot index and is therefore not replayed after a restart, and the map is not part of the
+   * state-machine snapshot; without the persisted copy the durable baseline in the Raft log would be
+   * invisible to {@link #getBootstrapBaseline} after a restart (issue #5100).
    */
   private final ConcurrentHashMap<String, BootstrapBaseline> bootstrapBaselines =
       new ConcurrentHashMap<>();
+  private volatile boolean bootstrapBaselinesLoaded   = false;
+  private final    Object  bootstrapBaselinesFileLock = new Object();
 
   /** Per-database bootstrap baseline as it appears in the committed Raft log entry. */
   public record BootstrapBaseline(String fingerprint, long lastTxId) {
@@ -1404,7 +1412,11 @@ public class ArcadeStateMachine extends BaseStateMachine {
           dbName, chosenFingerprint);
       return;
     }
+    // Load any baselines persisted by a prior session before recording this one, so the subsequent
+    // durable write preserves other databases' baselines instead of clobbering them (load-before-mutate).
+    ensureBootstrapBaselinesLoaded();
     bootstrapBaselines.put(dbName, new BootstrapBaseline(chosenFingerprint, chosenLastTxId));
+    persistBootstrapBaselinesFile();
 
     // Re-application during log replay on restart: if we've persisted an applied index at or
     // beyond this entry's index, the verification ran in a prior session and the local database
@@ -1641,6 +1653,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * tests and the cluster-status exporter (Phase 7).
    */
   public BootstrapBaseline getBootstrapBaseline(final String dbName) {
+    ensureBootstrapBaselinesLoaded();
     return bootstrapBaselines.get(dbName);
   }
 
@@ -1656,6 +1669,12 @@ public class ArcadeStateMachine extends BaseStateMachine {
     final DatabaseInternal db = (DatabaseInternal) server.getDatabase(databaseName);
     db.getEmbedded().drop();
     server.removeDatabase(databaseName);
+
+    // Evict the dropped database's persisted bootstrap baseline so the file does not retain a stale
+    // entry for a database that no longer exists (mirrors the per-database applied-index eviction).
+    ensureBootstrapBaselinesLoaded();
+    if (bootstrapBaselines.remove(databaseName) != null)
+      persistBootstrapBaselinesFile();
 
     LogManager.instance().log(this, Level.INFO, "Database '%s' dropped via Raft drop-database entry", databaseName);
   }
@@ -1839,6 +1858,87 @@ public class ArcadeStateMachine extends BaseStateMachine {
     if (dbDir == null)
       return null;
     return Path.of(dbDir, ".raft", "applied-index");
+  }
+
+  /**
+   * Lazily parses the persisted bootstrap-baselines file once into {@link #bootstrapBaselines}. A
+   * baseline already recorded in this session (freshly applied from a replayed entry) is authoritative,
+   * so entries from the file are merged with {@code putIfAbsent} and never overwrite it. A
+   * missing/unreadable file simply means "nothing persisted yet" and still latches the cache as loaded.
+   * <p>
+   * When the file path cannot yet be resolved (no server wired) the cache is NOT latched, so a later
+   * call retries once the server is available. In the current wiring {@code setServer(...)} always runs
+   * before the first read, so this only guards against a future reordering.
+   */
+  private void ensureBootstrapBaselinesLoaded() {
+    if (bootstrapBaselinesLoaded)
+      return;
+    synchronized (bootstrapBaselinesFileLock) {
+      if (bootstrapBaselinesLoaded)
+        return;
+      final Path file = getBootstrapBaselinesFile();
+      if (file == null)
+        return; // server not wired yet: do not latch, retry once the path is resolvable
+      try {
+        if (Files.exists(file)) {
+          final String content = Files.readString(file).trim();
+          if (!content.isEmpty()) {
+            final JSONObject json = new JSONObject(content);
+            for (final String name : json.keySet()) {
+              final JSONObject entry = json.getJSONObject(name);
+              final String fingerprint = entry.getString("fingerprint", null);
+              if (fingerprint != null)
+                bootstrapBaselines.putIfAbsent(name, new BootstrapBaseline(fingerprint, entry.getLong("lastTxId", -1)));
+            }
+          }
+        }
+      } catch (final Exception e) {
+        LogManager.instance().log(this, Level.FINE, "Could not read persisted bootstrap baselines: %s", e.getMessage());
+      } finally {
+        // The path was resolvable and we attempted a read: latch even on a parse failure so a corrupt
+        // file is not re-read on every access (it degrades to no persisted baselines, which re-runs the
+        // idempotent bootstrap verification on the next committed entry rather than losing correctness).
+        bootstrapBaselinesLoaded = true;
+      }
+    }
+  }
+
+  /**
+   * Serialises {@link #bootstrapBaselines} to {@code .raft/bootstrap-baselines} via a temp file and
+   * atomic rename, so a crash mid-write never leaves a corrupt file. Written only when a bootstrap
+   * baseline is recorded or evicted (rare), not on the hot apply path.
+   */
+  private void persistBootstrapBaselinesFile() {
+    synchronized (bootstrapBaselinesFileLock) {
+      try {
+        final Path file = getBootstrapBaselinesFile();
+        if (file == null)
+          return;
+        final JSONObject json = new JSONObject();
+        for (final Map.Entry<String, BootstrapBaseline> e : bootstrapBaselines.entrySet()) {
+          final JSONObject entry = new JSONObject();
+          entry.put("fingerprint", e.getValue().fingerprint());
+          entry.put("lastTxId", e.getValue().lastTxId());
+          json.put(e.getKey(), entry);
+        }
+        Files.createDirectories(file.getParent());
+        final Path tmp = file.resolveSibling("bootstrap-baselines.tmp");
+        Files.writeString(tmp, json.toString());
+        Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+      } catch (final Exception e) {
+        LogManager.instance().log(this, Level.FINE, "Could not write persisted bootstrap baselines: %s", e.getMessage());
+      }
+    }
+  }
+
+  private Path getBootstrapBaselinesFile() {
+    if (server == null)
+      return null;
+    final String dbDir = server.getConfiguration().getValueAsString(
+        GlobalConfiguration.SERVER_DATABASE_DIRECTORY);
+    if (dbDir == null)
+      return null;
+    return Path.of(dbDir, ".raft", "bootstrap-baselines");
   }
 
   private void triggerSnapshotDownload() {

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -33,6 +33,7 @@ import com.arcadedb.schema.LocalTimeSeriesType;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.ArcadeDBServer;
 import com.arcadedb.server.ServerDatabase;
+import com.arcadedb.utility.FileUtils;
 import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.proto.RaftProtos.LogEntryProto;
 import org.apache.ratis.protocol.Message;
@@ -1412,11 +1413,7 @@ public class ArcadeStateMachine extends BaseStateMachine {
           dbName, chosenFingerprint);
       return;
     }
-    // Load any baselines persisted by a prior session before recording this one, so the subsequent
-    // durable write preserves other databases' baselines instead of clobbering them (load-before-mutate).
-    ensureBootstrapBaselinesLoaded();
-    bootstrapBaselines.put(dbName, new BootstrapBaseline(chosenFingerprint, chosenLastTxId));
-    persistBootstrapBaselinesFile();
+    recordBootstrapBaseline(dbName, new BootstrapBaseline(chosenFingerprint, chosenLastTxId));
 
     // Re-application during log replay on restart: if we've persisted an applied index at or
     // beyond this entry's index, the verification ran in a prior session and the local database
@@ -1657,8 +1654,16 @@ public class ArcadeStateMachine extends BaseStateMachine {
     return bootstrapBaselines.get(dbName);
   }
 
-  private void applyDropDatabaseEntry(final RaftLogEntryCodec.DecodedEntry decoded) {
+  // @VisibleForTesting
+  void applyDropDatabaseEntry(final RaftLogEntryCodec.DecodedEntry decoded) {
     final String databaseName = decoded.databaseName();
+
+    // Evict the dropped database's persisted bootstrap baseline unconditionally, before the presence
+    // check below: applyBootstrapFingerprintEntry records a baseline by name even when the database is
+    // not present locally (the late-joiner path), so a node can hold a persisted baseline for a
+    // database it never had locally. Evicting only when present would leave that baseline stale in the
+    // file for the node lifetime. Mirrors the unconditional per-database applied-index drop eviction.
+    evictBootstrapBaseline(databaseName);
 
     // Idempotent on replay: if the database is already gone, nothing to do.
     if (!server.existsDatabase(databaseName)) {
@@ -1669,12 +1674,6 @@ public class ArcadeStateMachine extends BaseStateMachine {
     final DatabaseInternal db = (DatabaseInternal) server.getDatabase(databaseName);
     db.getEmbedded().drop();
     server.removeDatabase(databaseName);
-
-    // Evict the dropped database's persisted bootstrap baseline so the file does not retain a stale
-    // entry for a database that no longer exists (mirrors the per-database applied-index eviction).
-    ensureBootstrapBaselinesLoaded();
-    if (bootstrapBaselines.remove(databaseName) != null)
-      persistBootstrapBaselinesFile();
 
     LogManager.instance().log(this, Level.INFO, "Database '%s' dropped via Raft drop-database entry", databaseName);
   }
@@ -1904,30 +1903,54 @@ public class ArcadeStateMachine extends BaseStateMachine {
   }
 
   /**
-   * Serialises {@link #bootstrapBaselines} to {@code .raft/bootstrap-baselines} via a temp file and
-   * atomic rename, so a crash mid-write never leaves a corrupt file. Written only when a bootstrap
-   * baseline is recorded or evicted (rare), not on the hot apply path.
+   * Records {@code baseline} for {@code dbName} and durably persists the baselines, all under
+   * {@link #bootstrapBaselinesFileLock} so the in-memory mutation and the file write are one atomic
+   * step (mirrors the applied-index writers, which mutate and persist together inside their lock).
+   * The load-before-mutate keeps other databases' baselines intact when the file is rewritten.
+   */
+  private void recordBootstrapBaseline(final String dbName, final BootstrapBaseline baseline) {
+    synchronized (bootstrapBaselinesFileLock) {
+      ensureBootstrapBaselinesLoaded();
+      bootstrapBaselines.put(dbName, baseline);
+      persistBootstrapBaselinesFile();
+    }
+  }
+
+  /**
+   * Removes {@code dbName}'s baseline and rewrites the file only if an entry was actually present, all
+   * under {@link #bootstrapBaselinesFileLock}. Idempotent, so it is safe to call unconditionally on
+   * every {@code DROP_DATABASE_ENTRY} (including replays and databases never present locally).
+   */
+  private void evictBootstrapBaseline(final String dbName) {
+    synchronized (bootstrapBaselinesFileLock) {
+      ensureBootstrapBaselinesLoaded();
+      if (bootstrapBaselines.remove(dbName) != null)
+        persistBootstrapBaselinesFile();
+    }
+  }
+
+  /**
+   * Serialises {@link #bootstrapBaselines} to {@code .raft/bootstrap-baselines} via
+   * {@link FileUtils#atomicWriteFile} (temp file, fsync, atomic rename with a non-atomic fallback and
+   * temp cleanup), so a crash mid-write never leaves a corrupt file. Written only when a bootstrap
+   * baseline is recorded or evicted (rare), not on the hot apply path. Callers hold
+   * {@link #bootstrapBaselinesFileLock}.
    */
   private void persistBootstrapBaselinesFile() {
-    synchronized (bootstrapBaselinesFileLock) {
-      try {
-        final Path file = getBootstrapBaselinesFile();
-        if (file == null)
-          return;
-        final JSONObject json = new JSONObject();
-        for (final Map.Entry<String, BootstrapBaseline> e : bootstrapBaselines.entrySet()) {
-          final JSONObject entry = new JSONObject();
-          entry.put("fingerprint", e.getValue().fingerprint());
-          entry.put("lastTxId", e.getValue().lastTxId());
-          json.put(e.getKey(), entry);
-        }
-        Files.createDirectories(file.getParent());
-        final Path tmp = file.resolveSibling("bootstrap-baselines.tmp");
-        Files.writeString(tmp, json.toString());
-        Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
-      } catch (final Exception e) {
-        LogManager.instance().log(this, Level.FINE, "Could not write persisted bootstrap baselines: %s", e.getMessage());
+    try {
+      final Path file = getBootstrapBaselinesFile();
+      if (file == null)
+        return;
+      final JSONObject json = new JSONObject();
+      for (final Map.Entry<String, BootstrapBaseline> e : bootstrapBaselines.entrySet()) {
+        final JSONObject entry = new JSONObject();
+        entry.put("fingerprint", e.getValue().fingerprint());
+        entry.put("lastTxId", e.getValue().lastTxId());
+        json.put(e.getKey(), entry);
       }
+      FileUtils.atomicWriteFile(file.toFile(), json.toString());
+    } catch (final Exception e) {
+      LogManager.instance().log(this, Level.FINE, "Could not write persisted bootstrap baselines: %s", e.getMessage());
     }
   }
 

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineBootstrapBaselinePersistenceTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineBootstrapBaselinePersistenceTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.BootstrapFingerprint;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.LocalDatabase;
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.ArcadeDBServer;
+import com.arcadedb.utility.FileUtils;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #5100.
+ * <p>
+ * {@link ArcadeStateMachine#applyBootstrapFingerprintEntry} records the committed bootstrap baseline
+ * into an in-memory map that {@link ArcadeStateMachine#getBootstrapBaseline} reads. After a restart
+ * with persistent Raft storage, the {@code BOOTSTRAP_FINGERPRINT_ENTRY} sits below the Ratis snapshot
+ * index and is never replayed, so the in-memory map came back empty and the durable baseline in the
+ * Raft log became invisible. The fix persists the baselines next to the applied-index bookkeeping and
+ * reloads them lazily, so a fresh state machine instance (simulating a process restart) recovers them.
+ * <p>
+ * The tests drive a real (unstarted) {@link ArcadeDBServer} with a real {@link LocalDatabase} - no
+ * mocking framework - and mirror {@code ArcadeStateMachineAppliedIndexPerDatabaseTest}.
+ */
+class ArcadeStateMachineBootstrapBaselinePersistenceTest {
+
+  private static final String DB_A     = "db-a";
+  private static final String DB_OTHER = "db-other";
+
+  @TempDir
+  private Path           serverDir;
+  private ArcadeDBServer server;
+  private LocalDatabase  localDbA;
+  private String         dbAPath;
+
+  @BeforeEach
+  void setUp() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY, serverDir.toString());
+    server = new ArcadeDBServer(config);
+
+    dbAPath = serverDir.resolve(DB_A).toString();
+    localDbA = (LocalDatabase) new DatabaseFactory(dbAPath).create();
+    server.registerDatabase(DB_A, localDbA);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (localDbA != null && localDbA.isOpen())
+      localDbA.close();
+    if (dbAPath != null)
+      FileUtils.deleteRecursively(new File(dbAPath));
+  }
+
+  private ArcadeStateMachine newStateMachine() {
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    sm.setServer(server);
+    return sm;
+  }
+
+  private ByteString encodeBaseline(final String dbName, final String fingerprint, final long lastTxId) {
+    return RaftLogEntryCodec.encodeBootstrapFingerprintEntry(dbName, fingerprint, lastTxId);
+  }
+
+  /**
+   * The committed baseline survives a restart: a fresh state machine instance (no in-memory state)
+   * recovers the fingerprint and lastTxId from disk even though the bootstrap entry is never replayed.
+   */
+  @Test
+  void baselineSurvivesRestart() throws Exception {
+    final ArcadeStateMachine writer = newStateMachine();
+
+    final String fingerprint = BootstrapFingerprint.compute(new File(dbAPath));
+    final long lastTxId = localDbA.getLastTransactionId();
+    writer.applyBootstrapFingerprintEntry(RaftLogEntryCodec.decode(encodeBaseline(DB_A, fingerprint, lastTxId)), 50L);
+    assertThat(writer.getBootstrapBaseline(DB_A)).isNotNull();
+
+    // Simulate a process restart: a brand-new state machine that must recover the baseline from disk,
+    // because the bootstrap entry sits below the Ratis snapshot index and is never replayed.
+    final ArcadeStateMachine reopened = newStateMachine();
+    final ArcadeStateMachine.BootstrapBaseline recovered = reopened.getBootstrapBaseline(DB_A);
+    assertThat(recovered).as("baseline must be recovered from disk after restart").isNotNull();
+    assertThat(recovered.fingerprint()).isEqualTo(fingerprint);
+    assertThat(recovered.lastTxId()).isEqualTo(lastTxId);
+  }
+
+  /**
+   * With no persisted file, a fresh state machine reports no baseline (null) rather than throwing.
+   */
+  @Test
+  void noPersistedFileReturnsNull() {
+    final ArcadeStateMachine sm = newStateMachine();
+    assertThat(sm.getBootstrapBaseline(DB_A)).isNull();
+  }
+
+  /**
+   * The on-disk baselines file is a JSON document keyed by database name, pinning the persisted shape
+   * independently of the reader.
+   */
+  @Test
+  void persistedFileIsJsonDocumentOnDisk() throws Exception {
+    final ArcadeStateMachine sm = newStateMachine();
+
+    final String fingerprint = BootstrapFingerprint.compute(new File(dbAPath));
+    final long lastTxId = localDbA.getLastTransactionId();
+    sm.applyBootstrapFingerprintEntry(RaftLogEntryCodec.decode(encodeBaseline(DB_A, fingerprint, lastTxId)), 50L);
+
+    final String content = Files.readString(serverDir.resolve(".raft").resolve("bootstrap-baselines")).trim();
+    assertThat(content).as("the persisted file is a JSON document").startsWith("{");
+
+    final JSONObject json = new JSONObject(content);
+    final JSONObject dbA = json.getJSONObject(DB_A);
+    assertThat(dbA.getString("fingerprint")).isEqualTo(fingerprint);
+    assertThat(dbA.getLong("lastTxId", -1)).isEqualTo(lastTxId);
+  }
+
+  /**
+   * A baseline write for one database preserves other databases' baselines already on disk: the write
+   * loads the existing file before rewriting it (load-before-mutate), so an unrelated database's
+   * persisted baseline is not clobbered.
+   */
+  @Test
+  void writePreservesOtherDatabasesBaselinesOnDisk() throws Exception {
+    // A late joiner with no local copy still records the baseline (recorded before the presence check),
+    // so DB_OTHER can be persisted purely by name without creating the database.
+    final ArcadeStateMachine writer = newStateMachine();
+    final String fingerprintA = BootstrapFingerprint.compute(new File(dbAPath));
+    final long lastTxIdA = localDbA.getLastTransactionId();
+    writer.applyBootstrapFingerprintEntry(RaftLogEntryCodec.decode(encodeBaseline(DB_A, fingerprintA, lastTxIdA)), 50L);
+    writer.applyBootstrapFingerprintEntry(RaftLogEntryCodec.decode(encodeBaseline(DB_OTHER, "a".repeat(64), 7L)), 51L);
+
+    // A fresh instance (no in-memory state) records a NEW baseline for db-a only; db-other must survive.
+    final ArcadeStateMachine reopened = newStateMachine();
+    reopened.applyBootstrapFingerprintEntry(RaftLogEntryCodec.decode(encodeBaseline(DB_A, fingerprintA, lastTxIdA)), 60L);
+
+    // A third instance reading from disk still sees both baselines.
+    final ArcadeStateMachine third = newStateMachine();
+    assertThat(third.getBootstrapBaseline(DB_A)).isNotNull();
+    assertThat(third.getBootstrapBaseline(DB_OTHER))
+        .as("an unrelated database's persisted baseline survives a single-database rewrite")
+        .isNotNull();
+    assertThat(third.getBootstrapBaseline(DB_OTHER).fingerprint()).isEqualTo("a".repeat(64));
+    assertThat(third.getBootstrapBaseline(DB_OTHER).lastTxId()).isEqualTo(7L);
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineBootstrapBaselinePersistenceTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineBootstrapBaselinePersistenceTest.java
@@ -218,4 +218,21 @@ class ArcadeStateMachineBootstrapBaselinePersistenceTest {
         .as("a co-located database's baseline survives the drop")
         .isNotNull();
   }
+
+  /**
+   * A corrupt/unparseable baselines file degrades to "no baselines" (null) rather than throwing, so a
+   * damaged file cannot crash the apply/status paths. Mirrors the applied-index corrupt-file rationale.
+   */
+  @Test
+  void corruptFileDegradesToNullWithoutThrowing() throws Exception {
+    final Path raftDir = serverDir.resolve(".raft");
+    Files.createDirectories(raftDir);
+    // Looks like a JSON document (leading '{') but is truncated, so parsing fails mid-way.
+    Files.writeString(raftDir.resolve("bootstrap-baselines"), "{\"db-a\": {\"fingerprint\":");
+
+    final ArcadeStateMachine sm = newStateMachine();
+    assertThat(sm.getBootstrapBaseline(DB_A))
+        .as("a corrupt file degrades to no baseline instead of throwing")
+        .isNull();
+  }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineBootstrapBaselinePersistenceTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineBootstrapBaselinePersistenceTest.java
@@ -171,4 +171,51 @@ class ArcadeStateMachineBootstrapBaselinePersistenceTest {
     assertThat(third.getBootstrapBaseline(DB_OTHER).fingerprint()).isEqualTo("a".repeat(64));
     assertThat(third.getBootstrapBaseline(DB_OTHER).lastTxId()).isEqualTo(7L);
   }
+
+  /**
+   * Dropping a database evicts its persisted baseline even when the database was never present locally
+   * (the late-joiner-then-drop case): {@code applyBootstrapFingerprintEntry} records a baseline by name
+   * without a local copy, so the eviction must run unconditionally, before the presence check.
+   */
+  @Test
+  void dropEvictsBaselineForDatabaseNeverPresentLocally() {
+    final ArcadeStateMachine writer = newStateMachine();
+    // DB_OTHER is never registered: recorded purely by name via the late-joiner path.
+    writer.applyBootstrapFingerprintEntry(RaftLogEntryCodec.decode(encodeBaseline(DB_OTHER, "b".repeat(64), 3L)), 51L);
+    assertThat(writer.getBootstrapBaseline(DB_OTHER)).isNotNull();
+
+    writer.applyDropDatabaseEntry(RaftLogEntryCodec.decode(RaftLogEntryCodec.encodeDropDatabaseEntry(DB_OTHER)));
+    assertThat(writer.getBootstrapBaseline(DB_OTHER))
+        .as("baseline evicted in-memory after drop")
+        .isNull();
+
+    // The eviction is durable: a fresh instance reading from disk does not see the dropped baseline.
+    final ArcadeStateMachine reopened = newStateMachine();
+    assertThat(reopened.getBootstrapBaseline(DB_OTHER))
+        .as("dropped database's baseline does not linger in the persisted file")
+        .isNull();
+  }
+
+  /**
+   * Dropping a database that IS present locally evicts its persisted baseline while leaving a
+   * co-located database's baseline intact.
+   */
+  @Test
+  void dropEvictsBaselineForPresentDatabaseKeepingOthers() throws Exception {
+    final ArcadeStateMachine writer = newStateMachine();
+    final String fingerprintA = BootstrapFingerprint.compute(new File(dbAPath));
+    final long lastTxIdA = localDbA.getLastTransactionId();
+    writer.applyBootstrapFingerprintEntry(RaftLogEntryCodec.decode(encodeBaseline(DB_A, fingerprintA, lastTxIdA)), 50L);
+    writer.applyBootstrapFingerprintEntry(RaftLogEntryCodec.decode(encodeBaseline(DB_OTHER, "c".repeat(64), 9L)), 51L);
+
+    writer.applyDropDatabaseEntry(RaftLogEntryCodec.decode(RaftLogEntryCodec.encodeDropDatabaseEntry(DB_A)));
+
+    final ArcadeStateMachine reopened = newStateMachine();
+    assertThat(reopened.getBootstrapBaseline(DB_A))
+        .as("dropped database's baseline is gone from disk")
+        .isNull();
+    assertThat(reopened.getBootstrapBaseline(DB_OTHER))
+        .as("a co-located database's baseline survives the drop")
+        .isNotNull();
+  }
 }


### PR DESCRIPTION
Closes #5100

## Summary

After first-formation offline bootstrap, restarting a peer with persistent Raft storage left `ArcadeStateMachine.getBootstrapBaseline(db)` returning `null`. The committed `BOOTSTRAP_FINGERPRINT_ENTRY` is compacted below the Ratis snapshot index (so it is never replayed on restart) and the in-memory `bootstrapBaselines` map is not part of the state-machine snapshot, so the durable baseline in the Raft log became invisible. This persists the baselines to `.raft/bootstrap-baselines` (JSON, temp-file + atomic rename) and reloads them lazily on first access, mirroring the existing `.raft/applied-index` bookkeeping. A database's baseline is evicted on drop so the file stays honest. Writes happen only when a baseline is recorded/evicted (rare), never on the hot apply path.

## Test plan

- [ ] `ArcadeStateMachineBootstrapBaselinePersistenceTest` (new fast unit): baseline survives simulated restart, no-file returns null, on-disk JSON shape, single-database rewrite preserves others - 4/4 pass
- [ ] `ArcadeStateMachine*Test` + `BootstrapElection*Test` - 72 pass
- [ ] `RaftBootstrapDoesNotEngageOnRestartIT` (issue reproduction) - passes (failed before)
- [ ] `RaftBootstrapFromLocalDatabaseIT`, `RaftBootstrapLateNewerJoinerIT`, `RaftDropDatabase3NodesIT` - pass
- [ ] Note: `RaftBootstrapPicksHighestLastTxIdIT` is a pre-existing timing flake (fails on the base commit too), not a regression of this change