### PR TITLE
fix(#5080): bound the async drain on close()/drop() so a wedged worker cannot hang shutdown

### DIFF
--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -371,6 +371,12 @@ that could starve the very snapshot resync meant to heal the node.
   its waiter blocked forever, and `QueryEngineManager.register()` publishes a copy-on-write map so a
   post-construction registration cannot corrupt concurrent readers
   ([#4961](https://github.com/ArcadeData/arcadedb/issues/4961)).
+- **`close()`/`drop()` no longer hang on a wedged async worker.** The graceful drain of in-flight
+  asynchronous tasks on database close/drop used an UNBOUNDED wait, so a worker stuck inside a user task
+  or callback blocked shutdown forever. It now waits at most `arcadedb.asyncCloseTimeout` ms (default
+  60000, 0 = wait forever) before logging a WARNING and forcing the async workers down; the forced
+  shutdown is itself bounded (interrupt + 1s join per worker) and notifies completion of the leftover
+  tasks ([#5080](https://github.com/ArcadeData/arcadedb/issues/5080)).
 - **PageManager lifecycle is refcounted.** The JVM-wide page manager was started and stopped on a racy
   "is the active-database map empty" check-then-act spanning factory instances: closing the last instance
   of one database could null the shared flush thread under a database whose open was still in flight

--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -375,7 +375,8 @@ that could starve the very snapshot resync meant to heal the node.
   asynchronous tasks on database close/drop used an UNBOUNDED wait, so a worker stuck inside a user task
   or callback blocked shutdown forever. It now waits at most `arcadedb.asyncCloseTimeout` ms (default
   60000, 0 = wait forever) before logging a WARNING and forcing the async workers down; the forced
-  shutdown is itself bounded (interrupt + 1s join per worker) and notifies completion of the leftover
+  shutdown is itself bounded (FORCE_EXIT offer + interrupt + a ~10s join per worker, escalated to a
+  second interrupt and join) and notifies completion of the leftover
   tasks ([#5080](https://github.com/ArcadeData/arcadedb/issues/5080)).
 - **PageManager lifecycle is refcounted.** The JVM-wide page manager was started and stopped on a racy
   "is the active-database map empty" check-then-act spanning factory instances: closing the last instance

--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -377,7 +377,11 @@ that could starve the very snapshot resync meant to heal the node.
   60000, 0 = wait forever) before logging a WARNING and forcing the async workers down; the forced
   shutdown is itself bounded (FORCE_EXIT offer + interrupt + a ~10s join per worker, escalated to a
   second interrupt and join) and notifies completion of the leftover
-  tasks ([#5080](https://github.com/ArcadeData/arcadedb/issues/5080)).
+  tasks ([#5080](https://github.com/ArcadeData/arcadedb/issues/5080)). Note for operators tuning a fast
+  shutdown: in the worst case these bounded stages run SEQUENTIALLY - the async drain
+  (`arcadedb.asyncCloseTimeout`), then the force-shutdown join, then the page-flush wait
+  (`arcadedb.flushAllPagesTimeout`) - so a pathological close can take the sum. Each stage is individually
+  bounded (shutdown always makes progress); lower the two timeouts if a tighter cap is needed.
 - **PageManager lifecycle is refcounted.** The JVM-wide page manager was started and stopped on a racy
   "is the active-database map empty" check-then-act spanning factory instances: closing the last instance
   of one database could null the shared flush thread under a database whose open was still in flight

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -272,6 +272,15 @@ public enum GlobalConfiguration {
       (pre-26.7.2 behavior)""",
       Long.class, 60_000L),
 
+  ASYNC_CLOSE_TIMEOUT("arcadedb.asyncCloseTimeout", SCOPE.DATABASE,
+      """
+      Milliseconds to wait for in-flight asynchronous tasks to drain when closing or dropping a database \
+      before giving up with a WARNING and forcing the async workers down. Without a bound, a worker wedged \
+      inside a user task or callback made close()/drop() hang forever (#5080). Giving up here is safe: the \
+      forced shutdown interrupts the workers and notifies completion, and any task that never ran is simply \
+      not applied. 0 waits forever (pre-26.7.2 behavior)""",
+      Long.class, 60_000L),
+
   PARALLEL_SCAN_ABANDONED_TIMEOUT("arcadedb.parallelScanAbandonedTimeout", SCOPE.DATABASE,
       """
       Milliseconds a parallel-scan producer keeps waiting on a full result queue with NO consumer \

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -2043,8 +2043,9 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
       try {
         // EXECUTE OUTSIDE LOCK
         // #5080: bound the graceful drain so a worker wedged inside a user task or callback cannot make
-        // close()/drop() hang forever. On expiry, fall through to async.close(), which is itself already
-        // bounded (interrupt + 1s join per worker) and notifies completion of the leftover tasks.
+        // close()/drop() hang forever. On expiry, fall through to async.close(), which is itself bounded
+        // (FORCE_EXIT offer + interrupt + a ~10s join per worker, escalated to a second interrupt+join)
+        // and notifies completion of the leftover tasks.
         final long asyncCloseTimeout = configuration.getValueAsLong(GlobalConfiguration.ASYNC_CLOSE_TIMEOUT);
         if (!async.waitCompletion(asyncCloseTimeout)) {
           // #5105 review: waitCompletion also returns false when the caller thread is interrupted (it
@@ -2059,7 +2060,17 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
                 Asynchronous tasks of database '%s' did not drain within %d ms on close: forcing the async \
                 workers down. A task blocked inside user code may not have completed""", name, asyncCloseTimeout);
         }
-        async.close();
+        // #5105 review: async.close()'s shutdown uses INTERRUPTIBLE steps (bounded FORCE_EXIT offer, join)
+        // - if the caller thread's interrupt flag is still set (waitCompletion re-set it above), those
+        // steps throw immediately and the wedged worker is never actually interrupted/joined. Clear the
+        // flag across the force-shutdown so it can do its job, then restore it for the caller.
+        final boolean wasInterrupted = Thread.interrupted();
+        try {
+          async.close();
+        } finally {
+          if (wasInterrupted)
+            Thread.currentThread().interrupt();
+        }
       } catch (final Throwable e) {
         LogManager.instance()
             .log(this, Level.WARNING, """

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -2039,40 +2039,55 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
   }
 
   private void closeInternal(final boolean drop) {
-    // #5105 review: the caller's interrupt flag is cleared for the durable part of the close and restored
-    // only at the very END (finally below). async.close()'s shutdown AND the page flush in
-    // executeInWriteLock use INTERRUPTIBLE steps (bounded FORCE_EXIT offer/join; PageManager throws
-    // InterruptedIOException on a set flag), so leaving the flag set would both skip interrupting the
-    // wedged worker and truncate the durable flush into a needless crash-equivalent close. The flag is
-    // cleared AFTER the graceful async drain below, so an interrupted caller still bails that wait fast.
-    boolean callerWasInterrupted = false;
+    // Graceful async drain FIRST, with the caller's interrupt flag INTACT so an interrupted caller bails
+    // this wait fast; the warning distinguishes an interrupt from a real timeout.
+    if (async != null) {
+      try {
+        // EXECUTE OUTSIDE LOCK
+        // #5080: bound the graceful drain so a worker wedged inside a user task or callback cannot make
+        // close()/drop() hang forever. On expiry, closeDurableParts() below force-shuts the workers (that
+        // path is itself bounded: FORCE_EXIT offer + interrupt + a ~10s join, escalated to a second one).
+        final long asyncCloseTimeout = configuration.getValueAsLong(GlobalConfiguration.ASYNC_CLOSE_TIMEOUT);
+        if (!async.waitCompletion(asyncCloseTimeout)) {
+          // waitCompletion also returns false when the caller thread is interrupted (it re-sets the flag
+          // and returns), not only on timeout - distinguish the two so the message is accurate and never
+          // prints "within 0 ms" for the wait-forever (interrupt) case.
+          if (Thread.currentThread().isInterrupted())
+            LogManager.instance().log(this, Level.WARNING, """
+                Interrupted while draining the asynchronous tasks of database '%s' on close: forcing the \
+                async workers down. A task blocked inside user code may not have completed""", name);
+          else
+            LogManager.instance().log(this, Level.WARNING, """
+                Asynchronous tasks of database '%s' did not drain within %d ms on close: forcing the async \
+                workers down. A task blocked inside user code may not have completed""", name, asyncCloseTimeout);
+        }
+      } catch (final Throwable e) {
+        LogManager.instance()
+            .log(this, Level.WARNING, """
+                Error while draining the asynchronous manager during closing operation for database \
+                '%s'""", e, name);
+      }
+    }
+
+    // #5105 review: the DURABLE part of the close (async force-shutdown + the page flush in
+    // executeInWriteLock) uses INTERRUPTIBLE steps - the bounded FORCE_EXIT offer/join, and PageManager
+    // throws InterruptedIOException on a set flag. A set interrupt would therefore skip interrupting a
+    // wedged worker AND truncate the flush into a needless crash-equivalent close. Run it all with the
+    // flag CLEARED (unconditionally, so async == null is covered too) and restore it for the caller after.
+    final boolean callerWasInterrupted = Thread.interrupted();
     try {
-      if (async != null) {
-        try {
-          // EXECUTE OUTSIDE LOCK
-          // #5080: bound the graceful drain so a worker wedged inside a user task or callback cannot make
-          // close()/drop() hang forever. On expiry, fall through to async.close(), which is itself bounded
-          // (FORCE_EXIT offer + interrupt + a ~10s join per worker, escalated to a second interrupt+join)
-          // and notifies completion of the leftover tasks.
-          final long asyncCloseTimeout = configuration.getValueAsLong(GlobalConfiguration.ASYNC_CLOSE_TIMEOUT);
-          if (!async.waitCompletion(asyncCloseTimeout)) {
-            // #5105 review: waitCompletion also returns false when the caller thread is interrupted (it
-            // re-sets the flag and returns), not only on timeout - distinguish the two so the message is
-            // accurate and never prints "within 0 ms" for the wait-forever (interrupt) case.
-            if (Thread.currentThread().isInterrupted())
-              LogManager.instance().log(this, Level.WARNING, """
-                  Interrupted while draining the asynchronous tasks of database '%s' on close: forcing the \
-                  async workers down. A task blocked inside user code may not have completed""", name);
-            else
-              LogManager.instance().log(this, Level.WARNING, """
-                  Asynchronous tasks of database '%s' did not drain within %d ms on close: forcing the async \
-                  workers down. A task blocked inside user code may not have completed""", name, asyncCloseTimeout);
-          }
-          // Clear the flag here (see the method-level note): from now to the end of closeInternal the
-          // force-shutdown and the durable flush must run uninterrupted.
-          callerWasInterrupted = Thread.interrupted();
-          async.close();
-        } catch (final Throwable e) {
+      closeDurableParts(drop);
+    } finally {
+      if (callerWasInterrupted)
+        Thread.currentThread().interrupt();
+    }
+  }
+
+  private void closeDurableParts(final boolean drop) {
+    if (async != null) {
+      try {
+        async.close();
+      } catch (final Throwable e) {
         LogManager.instance()
             .log(this, Level.WARNING, """
                 Error on stopping asynchronous manager during closing operation for database \
@@ -2245,12 +2260,6 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     // closes a same-path open race loser, the factory's catch sees the flag and does not release again.
     if (pageManagerReferenceReleased.compareAndSet(false, true))
       PageManager.INSTANCE.release();
-    } finally {
-      // #5105 review: restore the caller's interrupt now that the whole close (force-shutdown + durable
-      // flush) is done, so the interrupt is not lost but also never truncated the durable work above.
-      if (callerWasInterrupted)
-        Thread.currentThread().interrupt();
-    }
   }
 
   /** #4927/#5070: whether this instance already consumed its PageManager lifecycle reference (see closeInternal). */

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -2042,7 +2042,14 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     if (async != null) {
       try {
         // EXECUTE OUTSIDE LOCK
-        async.waitCompletion();
+        // #5080: bound the graceful drain so a worker wedged inside a user task or callback cannot make
+        // close()/drop() hang forever. On expiry, fall through to async.close(), which is itself already
+        // bounded (interrupt + 1s join per worker) and notifies completion of the leftover tasks.
+        final long asyncCloseTimeout = configuration.getValueAsLong(GlobalConfiguration.ASYNC_CLOSE_TIMEOUT);
+        if (!async.waitCompletion(asyncCloseTimeout))
+          LogManager.instance().log(this, Level.WARNING, """
+              Asynchronous tasks of database '%s' did not drain within %d ms on close: forcing the async \
+              workers down. A task blocked inside user code may not have completed""", name, asyncCloseTimeout);
         async.close();
       } catch (final Throwable e) {
         LogManager.instance()

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -2046,10 +2046,19 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
         // close()/drop() hang forever. On expiry, fall through to async.close(), which is itself already
         // bounded (interrupt + 1s join per worker) and notifies completion of the leftover tasks.
         final long asyncCloseTimeout = configuration.getValueAsLong(GlobalConfiguration.ASYNC_CLOSE_TIMEOUT);
-        if (!async.waitCompletion(asyncCloseTimeout))
-          LogManager.instance().log(this, Level.WARNING, """
-              Asynchronous tasks of database '%s' did not drain within %d ms on close: forcing the async \
-              workers down. A task blocked inside user code may not have completed""", name, asyncCloseTimeout);
+        if (!async.waitCompletion(asyncCloseTimeout)) {
+          // #5105 review: waitCompletion also returns false when the caller thread is interrupted (it
+          // re-sets the flag and returns), not only on timeout - distinguish the two so the message is
+          // accurate and never prints "within 0 ms" for the wait-forever (interrupt) case.
+          if (Thread.currentThread().isInterrupted())
+            LogManager.instance().log(this, Level.WARNING, """
+                Interrupted while draining the asynchronous tasks of database '%s' on close: forcing the \
+                async workers down. A task blocked inside user code may not have completed""", name);
+          else
+            LogManager.instance().log(this, Level.WARNING, """
+                Asynchronous tasks of database '%s' did not drain within %d ms on close: forcing the async \
+                workers down. A task blocked inside user code may not have completed""", name, asyncCloseTimeout);
+        }
         async.close();
       } catch (final Throwable e) {
         LogManager.instance()

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -2039,39 +2039,40 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
   }
 
   private void closeInternal(final boolean drop) {
-    if (async != null) {
-      try {
-        // EXECUTE OUTSIDE LOCK
-        // #5080: bound the graceful drain so a worker wedged inside a user task or callback cannot make
-        // close()/drop() hang forever. On expiry, fall through to async.close(), which is itself bounded
-        // (FORCE_EXIT offer + interrupt + a ~10s join per worker, escalated to a second interrupt+join)
-        // and notifies completion of the leftover tasks.
-        final long asyncCloseTimeout = configuration.getValueAsLong(GlobalConfiguration.ASYNC_CLOSE_TIMEOUT);
-        if (!async.waitCompletion(asyncCloseTimeout)) {
-          // #5105 review: waitCompletion also returns false when the caller thread is interrupted (it
-          // re-sets the flag and returns), not only on timeout - distinguish the two so the message is
-          // accurate and never prints "within 0 ms" for the wait-forever (interrupt) case.
-          if (Thread.currentThread().isInterrupted())
-            LogManager.instance().log(this, Level.WARNING, """
-                Interrupted while draining the asynchronous tasks of database '%s' on close: forcing the \
-                async workers down. A task blocked inside user code may not have completed""", name);
-          else
-            LogManager.instance().log(this, Level.WARNING, """
-                Asynchronous tasks of database '%s' did not drain within %d ms on close: forcing the async \
-                workers down. A task blocked inside user code may not have completed""", name, asyncCloseTimeout);
-        }
-        // #5105 review: async.close()'s shutdown uses INTERRUPTIBLE steps (bounded FORCE_EXIT offer, join)
-        // - if the caller thread's interrupt flag is still set (waitCompletion re-set it above), those
-        // steps throw immediately and the wedged worker is never actually interrupted/joined. Clear the
-        // flag across the force-shutdown so it can do its job, then restore it for the caller.
-        final boolean wasInterrupted = Thread.interrupted();
+    // #5105 review: the caller's interrupt flag is cleared for the durable part of the close and restored
+    // only at the very END (finally below). async.close()'s shutdown AND the page flush in
+    // executeInWriteLock use INTERRUPTIBLE steps (bounded FORCE_EXIT offer/join; PageManager throws
+    // InterruptedIOException on a set flag), so leaving the flag set would both skip interrupting the
+    // wedged worker and truncate the durable flush into a needless crash-equivalent close. The flag is
+    // cleared AFTER the graceful async drain below, so an interrupted caller still bails that wait fast.
+    boolean callerWasInterrupted = false;
+    try {
+      if (async != null) {
         try {
+          // EXECUTE OUTSIDE LOCK
+          // #5080: bound the graceful drain so a worker wedged inside a user task or callback cannot make
+          // close()/drop() hang forever. On expiry, fall through to async.close(), which is itself bounded
+          // (FORCE_EXIT offer + interrupt + a ~10s join per worker, escalated to a second interrupt+join)
+          // and notifies completion of the leftover tasks.
+          final long asyncCloseTimeout = configuration.getValueAsLong(GlobalConfiguration.ASYNC_CLOSE_TIMEOUT);
+          if (!async.waitCompletion(asyncCloseTimeout)) {
+            // #5105 review: waitCompletion also returns false when the caller thread is interrupted (it
+            // re-sets the flag and returns), not only on timeout - distinguish the two so the message is
+            // accurate and never prints "within 0 ms" for the wait-forever (interrupt) case.
+            if (Thread.currentThread().isInterrupted())
+              LogManager.instance().log(this, Level.WARNING, """
+                  Interrupted while draining the asynchronous tasks of database '%s' on close: forcing the \
+                  async workers down. A task blocked inside user code may not have completed""", name);
+            else
+              LogManager.instance().log(this, Level.WARNING, """
+                  Asynchronous tasks of database '%s' did not drain within %d ms on close: forcing the async \
+                  workers down. A task blocked inside user code may not have completed""", name, asyncCloseTimeout);
+          }
+          // Clear the flag here (see the method-level note): from now to the end of closeInternal the
+          // force-shutdown and the durable flush must run uninterrupted.
+          callerWasInterrupted = Thread.interrupted();
           async.close();
-        } finally {
-          if (wasInterrupted)
-            Thread.currentThread().interrupt();
-        }
-      } catch (final Throwable e) {
+        } catch (final Throwable e) {
         LogManager.instance()
             .log(this, Level.WARNING, """
                 Error on stopping asynchronous manager during closing operation for database \
@@ -2244,6 +2245,12 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
     // closes a same-path open race loser, the factory's catch sees the flag and does not release again.
     if (pageManagerReferenceReleased.compareAndSet(false, true))
       PageManager.INSTANCE.release();
+    } finally {
+      // #5105 review: restore the caller's interrupt now that the whole close (force-shutdown + durable
+      // flush) is done, so the interrupt is not lost but also never truncated the durable work above.
+      if (callerWasInterrupted)
+        Thread.currentThread().interrupt();
+    }
   }
 
   /** #4927/#5070: whether this instance already consumed its PageManager lifecycle reference (see closeInternal). */

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownDrainTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownDrainTest.java
@@ -112,27 +112,35 @@ class AsyncShutdownDrainTest extends TestHelper {
       factory.open().drop();
 
     final DatabaseInternal db = (DatabaseInternal) factory.create();
-    db.getConfiguration().setValue(GlobalConfiguration.ASYNC_CLOSE_TIMEOUT, 1_000L);
-    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
-    async.setParallelLevel(1);
-    // Force thread re-creation so the parallel level above is picked up.
-    async.setTransactionUseWAL(true);
+    try {
+      db.getConfiguration().setValue(GlobalConfiguration.ASYNC_CLOSE_TIMEOUT, 1_000L);
+      final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
+      async.setParallelLevel(1);
+      // Force thread re-creation so the parallel level above is picked up.
+      async.setTransactionUseWAL(true);
 
-    final CountDownLatch blockerStarted = new CountDownLatch(1);
-    // Wedged far longer than both the 1s close timeout and the 30s test timeout: pre-fix, the unbounded
-    // waitCompletion() would block close() until it finished (~60s), tripping @Timeout.
-    async.scheduleTask(0, blockerTask(blockerStarted, 60_000), true, 0);
-    assertThat(blockerStarted.await(5, TimeUnit.SECONDS)).isTrue();
+      final CountDownLatch blockerStarted = new CountDownLatch(1);
+      // Wedged far longer than both the 1s close timeout and the 30s test timeout: pre-fix, the unbounded
+      // waitCompletion() would block close() until it finished (~60s), tripping @Timeout.
+      async.scheduleTask(0, blockerTask(blockerStarted, 60_000), true, 0);
+      assertThat(blockerStarted.await(5, TimeUnit.SECONDS)).isTrue();
 
-    final long begin = System.currentTimeMillis();
-    db.close();
-    final long elapsed = System.currentTimeMillis() - begin;
+      final long begin = System.currentTimeMillis();
+      db.close();
+      final long elapsed = System.currentTimeMillis() - begin;
 
-    assertThat(elapsed)
-        .as("close() must give up the async drain after ASYNC_CLOSE_TIMEOUT instead of hanging on a wedged worker")
-        .isLessThan(15_000L);
-
-    new DatabaseFactory(dbPath).open().drop();
+      assertThat(elapsed)
+          .as("close() must give up the async drain after ASYNC_CLOSE_TIMEOUT instead of hanging on a wedged worker")
+          .isLessThan(15_000L);
+    } finally {
+      // #5105 review: drop even if the assertion failed, so a failure does not leak the wedged worker's
+      // 60s thread or the DB directory. The bounded close config above keeps this final close bounded too.
+      if (db.isOpen())
+        db.close();
+      final DatabaseFactory cleanup = new DatabaseFactory(dbPath);
+      if (cleanup.exists())
+        cleanup.open().drop();
+    }
   }
 
   private static DatabaseAsyncTask blockerTask(final CountDownLatch started, final long sleepMs) {

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownDrainTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownDrainTest.java
@@ -116,6 +116,9 @@ class AsyncShutdownDrainTest extends TestHelper {
       db.getConfiguration().setValue(GlobalConfiguration.ASYNC_CLOSE_TIMEOUT, 1_000L);
       final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
       async.setParallelLevel(1);
+      // #5105 review: pin the join timeout small so the <15s bound is self-contained (not coupled to the
+      // 10s shutdownJoinTimeoutMs default) - the force-shutdown here is offer -> join -> interrupt -> join.
+      async.shutdownJoinTimeoutMs = 2_000;
       // Force thread re-creation so the parallel level above is picked up.
       async.setTransactionUseWAL(true);
 
@@ -160,6 +163,8 @@ class AsyncShutdownDrainTest extends TestHelper {
       db.getConfiguration().setValue(GlobalConfiguration.ASYNC_CLOSE_TIMEOUT, 1_000L);
       final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
       async.setParallelLevel(1);
+      // #5105 review: pin the join timeout small so the assertion is not coupled to the 10s default.
+      async.shutdownJoinTimeoutMs = 2_000;
       async.setTransactionUseWAL(true);
 
       final CountDownLatch blockerStarted = new CountDownLatch(1);

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownDrainTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownDrainTest.java
@@ -143,6 +143,73 @@ class AsyncShutdownDrainTest extends TestHelper {
     }
   }
 
+  @Test
+  @Timeout(30)
+  void forceShutdownStillInterruptsWorkerWhenCallerThreadIsInterrupted() throws Exception {
+    // #5105 review (finding 1): when close() drains from an already-interrupted thread, waitCompletion
+    // returns false and re-sets the interrupt flag. async.close()'s shutdown uses interruptible steps, so
+    // leaving the flag set makes them throw immediately and the wedged worker is never interrupted - it
+    // keeps running behind a returned close(). The fix clears the flag across the force-shutdown.
+    final String dbPath = "target/databases/AsyncCloseInterruptTest";
+    DatabaseFactory factory = new DatabaseFactory(dbPath);
+    if (factory.exists())
+      factory.open().drop();
+
+    final DatabaseInternal db = (DatabaseInternal) factory.create();
+    try {
+      db.getConfiguration().setValue(GlobalConfiguration.ASYNC_CLOSE_TIMEOUT, 1_000L);
+      final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
+      async.setParallelLevel(1);
+      async.setTransactionUseWAL(true);
+
+      final CountDownLatch blockerStarted = new CountDownLatch(1);
+      // Signals iff the worker actually receives an interrupt: on the pre-fix code the caller's set flag
+      // neuters the force-shutdown, this latch never fires, and the test times out.
+      final CountDownLatch workerInterrupted = new CountDownLatch(1);
+      async.scheduleTask(0, interruptSignallingBlockerTask(blockerStarted, workerInterrupted), true, 0);
+      assertThat(blockerStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+      // Close from an INTERRUPTED thread - the scenario finding 1 covers.
+      Thread.currentThread().interrupt();
+      db.close();
+      // close() restores the caller's interrupt flag; consume it so it does not leak into the assertions
+      // (and JUnit's own waits) below.
+      assertThat(Thread.interrupted()).as("close() must restore the caller's interrupt flag").isTrue();
+
+      assertThat(workerInterrupted.await(10, TimeUnit.SECONDS))
+          .as("the wedged worker must be interrupted by the force-shutdown even when close()'s caller was interrupted")
+          .isTrue();
+    } finally {
+      Thread.interrupted();
+      if (db.isOpen())
+        db.close();
+      final DatabaseFactory cleanup = new DatabaseFactory(dbPath);
+      if (cleanup.exists())
+        cleanup.open().drop();
+    }
+  }
+
+  private static DatabaseAsyncTask interruptSignallingBlockerTask(final CountDownLatch started,
+      final CountDownLatch interrupted) {
+    return new DatabaseAsyncTask() {
+      @Override
+      public void execute(final DatabaseAsyncExecutorImpl.AsyncThread asyncThread, final DatabaseInternal database) {
+        started.countDown();
+        try {
+          Thread.sleep(60_000);
+        } catch (final InterruptedException e) {
+          interrupted.countDown();
+          Thread.currentThread().interrupt();
+        }
+      }
+
+      @Override
+      public boolean requiresActiveTx() {
+        return false;
+      }
+    };
+  }
+
   private static DatabaseAsyncTask blockerTask(final CountDownLatch started, final long sleepMs) {
     return new DatabaseAsyncTask() {
       @Override

--- a/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownDrainTest.java
+++ b/engine/src/test/java/com/arcadedb/database/async/AsyncShutdownDrainTest.java
@@ -20,8 +20,10 @@ package com.arcadedb.database.async;
 
 import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseFactory;
 import com.arcadedb.database.DatabaseInternal;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -96,6 +98,41 @@ class AsyncShutdownDrainTest extends TestHelper {
         .as("queued tasks must be executed or completed() during shutdown")
         .isTrue();
     closer.join(5_000);
+  }
+
+  @Test
+  @Timeout(30)
+  void closeDoesNotHangOnAWedgedAsyncWorker() throws Exception {
+    // #5080: database.close()/drop() drained the async executor via an UNBOUNDED waitCompletion(), so a
+    // worker wedged inside a user task (here a 60s sleep, standing in for an infinite loop or stuck I/O)
+    // made close() hang. With ASYNC_CLOSE_TIMEOUT the graceful drain gives up and force-shuts the workers.
+    final String dbPath = "target/databases/AsyncCloseTimeoutTest";
+    DatabaseFactory factory = new DatabaseFactory(dbPath);
+    if (factory.exists())
+      factory.open().drop();
+
+    final DatabaseInternal db = (DatabaseInternal) factory.create();
+    db.getConfiguration().setValue(GlobalConfiguration.ASYNC_CLOSE_TIMEOUT, 1_000L);
+    final DatabaseAsyncExecutorImpl async = (DatabaseAsyncExecutorImpl) db.async();
+    async.setParallelLevel(1);
+    // Force thread re-creation so the parallel level above is picked up.
+    async.setTransactionUseWAL(true);
+
+    final CountDownLatch blockerStarted = new CountDownLatch(1);
+    // Wedged far longer than both the 1s close timeout and the 30s test timeout: pre-fix, the unbounded
+    // waitCompletion() would block close() until it finished (~60s), tripping @Timeout.
+    async.scheduleTask(0, blockerTask(blockerStarted, 60_000), true, 0);
+    assertThat(blockerStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+    final long begin = System.currentTimeMillis();
+    db.close();
+    final long elapsed = System.currentTimeMillis() - begin;
+
+    assertThat(elapsed)
+        .as("close() must give up the async drain after ASYNC_CLOSE_TIMEOUT instead of hanging on a wedged worker")
+        .isLessThan(15_000L);
+
+    new DatabaseFactory(dbPath).open().drop();
   }
 
   private static DatabaseAsyncTask blockerTask(final CountDownLatch started, final long sleepMs) {


### PR DESCRIPTION
## The problem
`LocalDatabase.closeInternal` drained the async executor via an **unbounded** `async.waitCompletion()`, so a worker wedged inside a user task or callback (infinite loop, stuck I/O) made `close()`/`drop()` hang forever. The specific trigger that first surfaced this - the #5065 `SelectParallelIterator` busy-spin - is already fixed in #5077, but the unbounded wait remained a latent hazard for any wedged worker.

## The fix
Mirrors the existing `FLUSH_ALL_PAGES_TIMEOUT` precedent for "give up instead of hanging":
- New `arcadedb.asyncCloseTimeout` (default **60000 ms**, `0` = wait forever = pre-26.7.2 behavior) bounds the graceful drain.
- On expiry, `closeInternal` logs a WARNING and falls through to `async.close()`, which is **already bounded** (interrupt + 1s join per worker, WARNING on a holdout) and notifies completion of leftover tasks - so shutdown always makes progress.

Single behavioral line changed; `async.close()` itself was already safe.

## Verification
Red-first: `AsyncShutdownDrainTest#closeDoesNotHangOnAWedgedAsyncWorker` wedges a worker for 60s and times `database.close()` under `@Timeout(30)`. On the pre-fix unbounded wait `close()` blocks ~60s and trips the timeout (**verified red**); with the bound it gives up at 1s, force-interrupts the worker, and returns in well under 15s. Async battery green (`AsyncShutdownDrainTest`, `AsyncFastQueueShutdownUndoTest`, `AsyncWaitCompletionTimeoutTest`, `DatabaseAsyncExecutorLifecycleRaceTest`).

Closes #5080.