### PR TITLE
feat(#5015): extend Cypher write-counter surfacing (HTTP/gRPC + UNION/CALL aggregation)

### DIFF
--- a/bolt/src/test/java/com/arcadedb/bolt/Bolt5000ResultCountersIT.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Bolt5000ResultCountersIT.java
@@ -94,4 +94,29 @@ public class Bolt5000ResultCountersIT extends BaseGraphServerTest {
       assertThat(counters.containsUpdates()).isTrue();
     }
   }
+
+  @Test
+  void callSubqueryWriteReportsCountersOverBolt() {
+    try (final Driver driver = getDriver();
+         final Session session = driver.session(SessionConfig.forDatabase(getDatabaseName()))) {
+      final SummaryCounters counters = session.run(
+          "UNWIND [1,2] AS x CALL { WITH x CREATE (:BoltCall {v:x}) } RETURN x").consume().counters();
+      assertThat(counters.nodesCreated()).isEqualTo(2);
+      assertThat(counters.propertiesSet()).isEqualTo(2);
+      assertThat(counters.containsUpdates()).isTrue();
+    }
+  }
+
+  @Test
+  void unionWriteReportsSummedCountersOverBolt() {
+    try (final Driver driver = getDriver();
+         final Session session = driver.session(SessionConfig.forDatabase(getDatabaseName()))) {
+      final SummaryCounters counters = session.run(
+          "CREATE (:BoltUnionA {n:1}) RETURN 1 AS r UNION ALL CREATE (:BoltUnionB {n:2}) RETURN 2 AS r")
+          .consume().counters();
+      assertThat(counters.nodesCreated()).isEqualTo(2);
+      assertThat(counters.propertiesSet()).isEqualTo(2);
+      assertThat(counters.containsUpdates()).isTrue();
+    }
+  }
 }

--- a/docs/superpowers/plans/2026-07-07-cypher-write-counter-surfacing.md
+++ b/docs/superpowers/plans/2026-07-07-cypher-write-counter-surfacing.md
@@ -1,0 +1,965 @@
+# Cypher Write-Counter Surfacing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface Cypher write counters (`QueryStatistics`) over HTTP `POST /command` and gRPC, aggregate them across top-level `UNION` writes and `CALL { ... }` write subqueries, and close two counter-fidelity correctness bugs plus missing constraint-kind coverage.
+
+**Architecture:** Builds on the `QueryStatistics` / `ResultSet.getStatistics()` infrastructure merged in #5016. A new `QueryStatistics.add()` merge and a `CommandContext.setStatistics()` instance-share close the UNION/CALL aggregation gap in the engine; HTTP and gRPC read the already-attached accumulator off the `ResultSet` and serialize it (camelCase JSON / a new proto message). Three engine fidelity fixes are folded in.
+
+**Tech Stack:** Java 21, Maven multi-module, JUnit 5 + AssertJ, ArcadeDB `com.arcadedb.serializer.json.JSONObject`, protobuf3 (grpc module), neo4j-java-driver (Bolt IT).
+
+## Global Constraints
+
+- Java 21+; match existing code style (final on locals/params; no curly braces for single-statement `if`; import classes, no FQNs).
+- Use `com.arcadedb.serializer.json.JSONObject` for JSON, not org.json.
+- No new dependencies. Apache-2.0 compatible only.
+- Do not add Claude as author. No issue numbers in Javadoc/comments (state behavioral invariants only).
+- Every backend change compiles before moving on; run the affected module tests, not the whole suite.
+- Test tags: none needed here (these are fast functional tests) except the Bolt/gRPC ITs which already follow the `IT` server-boot pattern.
+- Commit after each task's tests pass. Commit message format `feat(#5015): <subject>` (or `test(#5015):`/`fix(#5015):`). End body with the Co-Authored-By trailer only if the repo convention requires it - here, do NOT add Claude as author.
+
+---
+
+### Task 1: `QueryStatistics.add()` merge + camelCase `toJSON()`
+
+**Files:**
+- Modify: `engine/src/main/java/com/arcadedb/query/sql/executor/QueryStatistics.java`
+- Test: `engine/src/test/java/com/arcadedb/query/sql/executor/QueryStatisticsTest.java`
+
+**Interfaces:**
+- Produces: `void QueryStatistics.add(QueryStatistics other)` (null `other` is a no-op); `com.arcadedb.serializer.json.JSONObject QueryStatistics.toJSON()` (camelCase keys, always includes all 11 counters + `containsUpdates`).
+
+- [ ] **Step 1: Write the failing test** — append to `QueryStatisticsTest`:
+
+```java
+  @Test
+  void addMergesCountersFieldWise() {
+    final QueryStatistics a = new QueryStatistics();
+    a.incNodesCreated();
+    a.addPropertiesSet(2);
+    final QueryStatistics b = new QueryStatistics();
+    b.incNodesCreated();
+    b.incRelationshipsCreated();
+    b.addPropertiesSet(3);
+    a.add(b);
+    assertThat(a.getNodesCreated()).isEqualTo(2);
+    assertThat(a.getRelationshipsCreated()).isEqualTo(1);
+    assertThat(a.getPropertiesSet()).isEqualTo(5);
+    assertThat(a.containsUpdates()).isTrue();
+  }
+
+  @Test
+  void addNullIsNoOp() {
+    final QueryStatistics a = new QueryStatistics();
+    a.incNodesCreated();
+    a.add(null);
+    assertThat(a.getNodesCreated()).isEqualTo(1);
+  }
+
+  @Test
+  void toJSONEmitsAllCamelCaseCountersAndContainsUpdates() {
+    final QueryStatistics s = new QueryStatistics();
+    s.incNodesCreated();
+    s.addPropertiesSet(2);
+    final JSONObject json = s.toJSON();
+    assertThat(json.getInt("nodesCreated")).isEqualTo(1);
+    assertThat(json.getInt("propertiesSet")).isEqualTo(2);
+    assertThat(json.getInt("relationshipsCreated")).isEqualTo(0);
+    assertThat(json.getBoolean("containsUpdates")).isTrue();
+  }
+```
+
+Add imports to the test if missing: `import com.arcadedb.serializer.json.JSONObject;` and `import static org.assertj.core.api.Assertions.assertThat;`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd engine && mvn -q -Dtest=QueryStatisticsTest test`
+Expected: compile failure / FAIL — `add(...)` and `toJSON()` do not exist.
+
+- [ ] **Step 3: Implement `add()` and `toJSON()`** in `QueryStatistics.java` (add import `com.arcadedb.serializer.json.JSONObject`), after `restore(...)`:
+
+```java
+  /**
+   * Adds every counter from {@code other} into this accumulator. A {@code null} argument is a no-op.
+   * Used to aggregate the statistics of UNION branches and CALL subqueries into the outer result.
+   */
+  public void add(final QueryStatistics other) {
+    if (other == null)
+      return;
+    nodesCreated += other.nodesCreated;
+    nodesDeleted += other.nodesDeleted;
+    relationshipsCreated += other.relationshipsCreated;
+    relationshipsDeleted += other.relationshipsDeleted;
+    propertiesSet += other.propertiesSet;
+    labelsAdded += other.labelsAdded;
+    labelsRemoved += other.labelsRemoved;
+    indexesAdded += other.indexesAdded;
+    indexesRemoved += other.indexesRemoved;
+    constraintsAdded += other.constraintsAdded;
+    constraintsRemoved += other.constraintsRemoved;
+  }
+
+  /**
+   * Serializes the counters into an ArcadeDB-native camelCase JSON object. All eleven counters are
+   * always present (zero when unset) plus a {@code containsUpdates} flag, giving a stable shape.
+   */
+  public JSONObject toJSON() {
+    final JSONObject json = new JSONObject();
+    json.put("nodesCreated", nodesCreated);
+    json.put("nodesDeleted", nodesDeleted);
+    json.put("relationshipsCreated", relationshipsCreated);
+    json.put("relationshipsDeleted", relationshipsDeleted);
+    json.put("propertiesSet", propertiesSet);
+    json.put("labelsAdded", labelsAdded);
+    json.put("labelsRemoved", labelsRemoved);
+    json.put("indexesAdded", indexesAdded);
+    json.put("indexesRemoved", indexesRemoved);
+    json.put("constraintsAdded", constraintsAdded);
+    json.put("constraintsRemoved", constraintsRemoved);
+    json.put("containsUpdates", containsUpdates());
+    return json;
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd engine && mvn -q -Dtest=QueryStatisticsTest test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add engine/src/main/java/com/arcadedb/query/sql/executor/QueryStatistics.java engine/src/test/java/com/arcadedb/query/sql/executor/QueryStatisticsTest.java
+git commit -m "feat(#5015): add QueryStatistics.add() merge and camelCase toJSON()"
+```
+
+---
+
+### Task 2: Aggregate counters across CALL subqueries and top-level UNION
+
+**Files:**
+- Modify: `engine/src/main/java/com/arcadedb/query/sql/executor/CommandContext.java` (add `setStatistics`)
+- Modify: `engine/src/main/java/com/arcadedb/query/sql/executor/BasicCommandContext.java` (impl `setStatistics`)
+- Modify: `engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java` (`executeWithSeedRow` signature + share stats; `executeUnion` write aggregation)
+- Modify: `engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SubqueryStep.java` (pass outer context)
+- Modify: `engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/UnionStep.java` (aggregate branch stats)
+- Test: `engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java`
+
+**Interfaces:**
+- Consumes: `QueryStatistics.add(...)` from Task 1.
+- Produces: `void CommandContext.setStatistics(QueryStatistics)`; `ResultSet CypherExecutionPlan.executeWithSeedRow(Result seedRow, CommandContext outerContext)` (new second param); `QueryStatistics UnionStep.getAggregatedStatistics()`.
+
+- [ ] **Step 1: Write the failing tests** — append to `CypherQueryStatisticsTest`:
+
+```java
+  @Test
+  void callSubqueryWriteCountsPropagateToOuter() {
+    database.transaction(() -> {
+      final QueryStatistics s = statsOf(database,
+          "UNWIND [1,2] AS x CALL { WITH x CREATE (:CallNode {v:x}) } RETURN x");
+      assertThat(s.getNodesCreated()).isEqualTo(2);
+      assertThat(s.getPropertiesSet()).isEqualTo(2);
+      assertThat(s.getLabelsAdded()).isEqualTo(2);
+      assertThat(s.containsUpdates()).isTrue();
+    });
+  }
+
+  @Test
+  void topLevelUnionWriteCountsAreSummed() {
+    database.transaction(() -> {
+      final QueryStatistics s = statsOf(database,
+          "CREATE (:UnionA {n:1}) RETURN 1 AS r UNION ALL CREATE (:UnionB {n:2}) RETURN 2 AS r");
+      assertThat(s.getNodesCreated()).isEqualTo(2);
+      assertThat(s.getPropertiesSet()).isEqualTo(2);
+      assertThat(s.getLabelsAdded()).isEqualTo(2);
+      assertThat(s.containsUpdates()).isTrue();
+    });
+  }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd engine && mvn -q -Dtest=CypherQueryStatisticsTest#callSubqueryWriteCountsPropagateToOuter+topLevelUnionWriteCountsAreSummed test`
+Expected: FAIL — counters are 0 (CALL/UNION not aggregated).
+
+- [ ] **Step 3a: Add `setStatistics` to the context interface + impl.**
+
+In `CommandContext.java`, next to `QueryStatistics getStatistics();`:
+
+```java
+  void setStatistics(QueryStatistics statistics);
+```
+
+In `BasicCommandContext.java`, right after `getStatistics()`:
+
+```java
+  @Override
+  public void setStatistics(final QueryStatistics statistics) {
+    this.statistics = statistics;
+  }
+```
+
+If any other `CommandContext` implementation exists that does not extend `BasicCommandContext`, add a no-op or field-backed `setStatistics`. Verify with:
+`grep -rln "implements CommandContext" engine/src/main/java` — as of this writing only `BasicCommandContext` implements it directly.
+
+- [ ] **Step 3b: Share the outer accumulator into CALL subqueries.**
+
+In `CypherExecutionPlan.java`, change the `executeWithSeedRow` signature and share stats. Replace the method header and the two inner-context creations:
+
+Header (line ~311):
+```java
+  public ResultSet executeWithSeedRow(final Result seedRow, final CommandContext outerContext) {
+```
+
+In the UNION-in-CALL branch, after `setupFunctionResolver(ctx);` (the `ctx` created ~line 323) add:
+```java
+      if (outerContext != null)
+        ctx.setStatistics(outerContext.getStatistics());
+```
+and change the recursive branch call from `branchPlan.executeWithSeedRow(seedRow)` to:
+```java
+        final ResultSet rs = branchPlan.executeWithSeedRow(seedRow, outerContext);
+```
+
+In the non-UNION path, after `setupFunctionResolver(context);` (the `context` created ~line 349) add:
+```java
+    if (outerContext != null)
+      context.setStatistics(outerContext.getStatistics());
+```
+
+Delete the now-stale limitation comment at the top of `executeWithSeedRow` (the `// Limitation: each branch/inner plan runs with its own BasicCommandContext ...` block).
+
+- [ ] **Step 3c: Update the CALL caller to pass the outer context.**
+
+In `SubqueryStep.java` line ~424, change:
+```java
+    final ResultSet resultSet = innerPlan.executeWithSeedRow(filterSeedRow(outerRow), context);
+```
+
+- [ ] **Step 3d: Aggregate branch stats in `UnionStep`.**
+
+In `UnionStep.java`: add a field and a getter, and accumulate when a branch is exhausted. Add near the other fields:
+```java
+  private final QueryStatistics aggregatedStatistics = new QueryStatistics();
+```
+Add import `import com.arcadedb.query.sql.executor.QueryStatistics;` if absent.
+
+In `syncPull`, at the point where the current branch's result set is exhausted and the step advances to the next branch (right before incrementing `currentQueryIndex` past a finished `currentResultSet`), fold its stats in exactly once:
+```java
+        if (currentResultSet != null)
+          aggregatedStatistics.add(currentResultSet.getStatistics().orElse(null));
+```
+Place this so it runs once per branch as that branch completes (i.e. immediately before the code moves `currentResultSet` to the next branch's `execute()`). If the loop structure makes "just exhausted" hard to pinpoint, accumulate right after the `while(currentResultSet.hasNext())` for a branch drains and before loading the next.
+
+Add the getter:
+```java
+  public QueryStatistics getAggregatedStatistics() {
+    return aggregatedStatistics;
+  }
+```
+
+- [ ] **Step 3e: Attach the aggregate for write UNIONs in `executeUnion`.**
+
+Replace the body of `executeUnion()` (keeping the read path lazy):
+```java
+  private ResultSet executeUnion() {
+    final BasicCommandContext context = new BasicCommandContext();
+    context.setDatabase(database);
+    context.setInputParameters(parameters);
+    setupFunctionResolver(context);
+
+    final UnionStep unionStep = new UnionStep(unionSubqueryPlans, unionRemoveDuplicates, context);
+
+    // Read UNION: stay lazy/streaming, no statistics to surface.
+    if (statement.isReadOnly())
+      return unionStep.syncPull(context, 100);
+
+    // Write UNION: materialize to force each branch's mutation steps to execute (mirroring the
+    // non-union write path), then surface the summed per-branch statistics.
+    final ResultSet rs = unionStep.syncPull(context, 100);
+    final List<Result> rows = new ArrayList<>();
+    while (rs.hasNext())
+      rows.add(rs.next());
+    final IteratorResultSet out = new IteratorResultSet(rows.iterator());
+    final QueryStatistics aggregated = unionStep.getAggregatedStatistics();
+    if (aggregated.containsUpdates())
+      out.setStatistics(aggregated);
+    return out;
+  }
+```
+Ensure imports exist in `CypherExecutionPlan.java`: `java.util.List`, `java.util.ArrayList`, `com.arcadedb.query.sql.executor.Result`, `IteratorResultSet`, `QueryStatistics` (most already imported; add any missing). Remove the stale `// Limitation:` comment block at the top of `executeUnion`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd engine && mvn -q -Dtest=CypherQueryStatisticsTest test`
+Expected: PASS (new + existing cases).
+
+- [ ] **Step 5: Run the wider Cypher regression subset to catch UNION/CALL behavior changes**
+
+Run: `cd engine && mvn -q -Dtest="com.arcadedb.query.opencypher.**" test`
+Expected: PASS. If a UNION/CALL row-count test regresses, the materialization change in `executeUnion` is the suspect — confirm the read path (`statement.isReadOnly()`) still returns the lazy `unionStep.syncPull(...)`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add engine/src/main/java/com/arcadedb/query/sql/executor/CommandContext.java engine/src/main/java/com/arcadedb/query/sql/executor/BasicCommandContext.java engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SubqueryStep.java engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/UnionStep.java engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
+git commit -m "feat(#5015): aggregate write counters across CALL subqueries and UNION"
+```
+
+---
+
+### Task 3: Fix constraint-vs-plain-index miscount + constraint-kind coverage
+
+**Files:**
+- Modify: `engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java`
+- Test: `engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java`
+
+**Interfaces:**
+- Produces: internal helper `uniqueIndexExistsOnProperties(Schema, String, String[])`; no public API change.
+
+- [ ] **Step 1: Write the failing tests** — append to `CypherQueryStatisticsTest`:
+
+```java
+  @Test
+  void notNullConstraintCountsAsConstraintAdded() {
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:NnLabel {p:1})");
+      final QueryStatistics s = statsOf(database,
+          "CREATE CONSTRAINT FOR (n:NnLabel) REQUIRE n.p IS NOT NULL");
+      assertThat(s.getConstraintsAdded()).isEqualTo(1);
+    });
+  }
+
+  @Test
+  void nodeKeyConstraintCountsAsConstraintAdded() {
+    database.transaction(() -> {
+      final QueryStatistics s = statsOf(database,
+          "CREATE CONSTRAINT FOR (n:KeyLabel) REQUIRE (n.k) IS NODE KEY");
+      assertThat(s.getConstraintsAdded()).isEqualTo(1);
+    });
+  }
+
+  @Test
+  void typedConstraintCountsAsConstraintAdded() {
+    database.transaction(() -> {
+      final QueryStatistics s = statsOf(database,
+          "CREATE CONSTRAINT FOR (n:TypedLabel) REQUIRE n.age IS :: INTEGER");
+      assertThat(s.getConstraintsAdded()).isEqualTo(1);
+    });
+  }
+
+  @Test
+  void uniqueConstraintOverPlainIndexStillCountsAsConstraintAdded() {
+    database.transaction(() -> {
+      // A non-unique index already covers the property; adding a UNIQUE constraint is a genuine
+      // schema change and must be counted even though an index existed.
+      database.command("sql", "CREATE VERTEX TYPE CoveredLabel");
+      database.command("sql", "CREATE PROPERTY CoveredLabel.email STRING");
+      database.command("sql", "CREATE INDEX ON CoveredLabel (email) NOTUNIQUE");
+      final QueryStatistics s = statsOf(database,
+          "CREATE CONSTRAINT FOR (n:CoveredLabel) REQUIRE n.email IS UNIQUE");
+      assertThat(s.getConstraintsAdded()).isEqualTo(1);
+    });
+  }
+```
+
+Note: verify the exact Cypher DDL surface for NODE KEY / IS TYPED against existing tests in `engine/src/test/java/com/arcadedb/query/opencypher/` (search for `IS NODE KEY`, `IS ::`, `REQUIRE`); adjust the constraint syntax in the tests above to the dialect the parser accepts if it differs. The `constraintsAdded == 1` assertions are the invariant.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd engine && mvn -q -Dtest=CypherQueryStatisticsTest#uniqueConstraintOverPlainIndexStillCountsAsConstraintAdded test`
+Expected: FAIL — `constraintsAdded` is 0 because `indexExistsOnProperties` returns true for the plain index. (The NOT_NULL/KEY/TYPED tests may already pass; they are added coverage and guard against regression.)
+
+- [ ] **Step 3: Narrow the pre-existence check to unique indexes.** In `OpenCypherQueryEngine.java`, add a helper next to `indexExistsOnProperties`:
+
+```java
+  /**
+   * Like {@link #indexExistsOnProperties} but only reports a pre-existing UNIQUE index. A non-unique
+   * index over the same properties does not satisfy a UNIQUE/KEY constraint, so adding the constraint
+   * is a genuine schema change that must be counted.
+   */
+  private static boolean uniqueIndexExistsOnProperties(final Schema schema, final String typeName, final String[] propertyNames) {
+    if (!schema.existsType(typeName))
+      return false;
+    final DocumentType type = schema.getType(typeName);
+    final com.arcadedb.index.Index own = type.getIndexByProperties(propertyNames);
+    if (own != null && own.isUnique())
+      return true;
+    final com.arcadedb.index.Index poly = type.getPolymorphicIndexByProperties(propertyNames);
+    return poly != null && poly.isUnique();
+  }
+```
+
+(Prefer importing `com.arcadedb.index.Index` at the top and using the short name, matching the file's style; the FQN above is only for clarity. Verify `Index.isUnique()` exists — it is the standard ArcadeDB index API.)
+
+Change the UNIQUE branch (line ~393) and the KEY branch (line ~428) to use the new helper:
+```java
+      final boolean existedBefore = uniqueIndexExistsOnProperties(schema, typeName, propertyNames);
+```
+Leave `indexExistsOnProperties` in place for the plain `CREATE INDEX` paths.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd engine && mvn -q -Dtest=CypherQueryStatisticsTest test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
+git commit -m "fix(#5015): count UNIQUE/KEY constraint added over a pre-existing plain index"
+```
+
+---
+
+### Task 4: Fix DETACH DELETE + explicit-edge-delete double-count
+
+**Files:**
+- Modify: `engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/DeleteStep.java`
+- Test: `engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java`
+
+**Interfaces:**
+- Produces: `deleteVertex`/`deleteAllEdges`/`deleteEdge` now thread and consult the shared `Set<Object> deleted` set, so a relationship removed via DETACH and via an explicit match is counted once.
+
+- [ ] **Step 1: Write the failing test** — append to `CypherQueryStatisticsTest`:
+
+```java
+  @Test
+  void detachDeleteWithExplicitEdgeCountsRelationshipOnce() {
+    database.transaction(() -> {
+      database.command("opencypher",
+          "CREATE (a:Dd {n:'a'})-[:LINK]->(b:Dd {n:'b'})");
+      final QueryStatistics s = statsOf(database,
+          "MATCH (a:Dd {n:'a'})-[r:LINK]->(b:Dd {n:'b'}) DETACH DELETE r, a, b");
+      assertThat(s.getRelationshipsDeleted()).isEqualTo(1);
+      assertThat(s.getNodesDeleted()).isEqualTo(2);
+    });
+  }
+```
+
+- [ ] **Step 2: Run test to verify it fails (or passes as a guard)**
+
+Run: `cd engine && mvn -q -Dtest=CypherQueryStatisticsTest#detachDeleteWithExplicitEdgeCountsRelationshipOnce test`
+Expected: ideally FAIL with `relationshipsDeleted == 2`. If it already passes (the current `RecordNotFoundException` guard happens to mask the double count for this shape), keep the test as a regression guard and still apply Step 3 so the dedup is deterministic rather than exception-timing-dependent. Note the observed result in the commit body.
+
+- [ ] **Step 3: Consult the shared `deleted` set in the vertex/edge delete helpers.**
+
+In `DeleteStep.java`, thread the `deleted` set through the instance delete methods so DETACH edge removal dedups against explicitly-deleted edges:
+
+Change `deleteObject` (line ~433/440) call sites to pass the set:
+```java
+      try {
+        deleteVertex((Vertex) obj, deleted);
+      } catch (final RecordNotFoundException e) {
+        // Already deleted - skip
+      }
+```
+```java
+      try {
+        deleteEdge((Edge) obj, deleted);
+      } catch (final RecordNotFoundException e) {
+        // Already deleted - skip
+      }
+```
+
+Change `deleteVertex` (line ~479) signature and its `deleteAllEdges` call:
+```java
+  private void deleteVertex(final Vertex vertex, final Set<Object> deleted) {
+    if (deleteClause.isDetach()) {
+      deleteAllEdges(vertex, deleted);
+    } else {
+      if (vertex.getEdges(Vertex.DIRECTION.OUT).iterator().hasNext() ||
+          vertex.getEdges(Vertex.DIRECTION.IN).iterator().hasNext())
+        throw new CommandExecutionException("DeleteConnectedNode: Cannot delete node " + vertex.getIdentity() +
+            " because it still has relationships. To delete this node, you must first delete its relationships, or use DETACH DELETE");
+    }
+
+    vertex.delete();
+    context.getStatistics().incNodesDeleted();
+  }
+```
+
+Change `deleteAllEdges` (line ~500) to skip and record edges already in the set:
+```java
+  private void deleteAllEdges(final Vertex vertex, final Set<Object> deleted) {
+    // Collect connected edges in both directions, de-duplicating self-loops (which appear in both
+    // OUT and IN) so a self-loop relationship is deleted and counted exactly once.
+    final List<Edge> edgesToDelete = new ArrayList<>();
+    final Set<RID> seen = new HashSet<>();
+    for (final Edge edge : vertex.getEdges(Vertex.DIRECTION.OUT))
+      if (seen.add(edge.getIdentity()))
+        edgesToDelete.add(edge);
+    for (final Edge edge : vertex.getEdges(Vertex.DIRECTION.IN))
+      if (seen.add(edge.getIdentity()))
+        edgesToDelete.add(edge);
+
+    final QueryStatistics stats = context.getStatistics();
+    for (final Edge edge : edgesToDelete) {
+      // Skip any relationship already removed and counted by an explicit DELETE in the same statement.
+      if (deleted.contains(edge))
+        continue;
+      try {
+        edge.delete();
+        stats.incRelationshipsDeleted();
+        deleted.add(edge);
+      } catch (final RecordNotFoundException ignored) {
+        deleted.add(edge);
+      }
+    }
+  }
+```
+
+Change `deleteEdge` (line ~528) to record the edge in the set:
+```java
+  private void deleteEdge(final Edge edge, final Set<Object> deleted) {
+    edge.delete();
+    context.getStatistics().incRelationshipsDeleted();
+    deleted.add(edge);
+  }
+```
+
+Verify no other caller of `deleteVertex`/`deleteEdge`/`deleteAllEdges` remains with the old arity:
+`grep -n "deleteVertex(\|deleteEdge(\|deleteAllEdges(" engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/DeleteStep.java`
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd engine && mvn -q -Dtest=CypherQueryStatisticsTest test`
+Expected: PASS. Then run the delete regression subset:
+Run: `cd engine && mvn -q -Dtest="*Delete*" -pl engine test` (or `-Dtest=CypherDeleteTest` if that is the concrete class name — confirm via `ls engine/src/test/java/com/arcadedb/query/opencypher | grep -i delete`).
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/DeleteStep.java engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
+git commit -m "fix(#5015): dedup relationships-deleted across DETACH DELETE and explicit edge delete"
+```
+
+---
+
+### Task 5: Single-source the replace-map removed-property counting rule
+
+**Files:**
+- Create: `engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CypherStatisticsHelper.java`
+- Modify: `engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java`
+- Modify: `engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java`
+- Test: `engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/CypherStatisticsHelperTest.java`
+
+**Interfaces:**
+- Produces: `static int CypherStatisticsHelper.countRemovedProperties(Set<String> existingProps, Map<String,Object> replacementMap)` — number of non-internal pre-existing properties not re-set by the replacement map.
+
+- [ ] **Step 1: Write the failing test** — create `CypherStatisticsHelperTest.java`:
+
+```java
+package com.arcadedb.query.opencypher.executor.steps;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CypherStatisticsHelperTest {
+
+  @Test
+  void countsPreExistingPropertiesNotReSetAndSkipsInternal() {
+    final Set<String> existing = new LinkedHashSet<>();
+    existing.add("a");
+    existing.add("b");
+    existing.add("@type"); // internal - never counted
+    final Map<String, Object> replacement = new HashMap<>();
+    replacement.put("a", 1); // re-set, not a removal
+    // b is removed (absent from replacement) -> counts 1
+    assertThat(CypherStatisticsHelper.countRemovedProperties(existing, replacement)).isEqualTo(1);
+  }
+
+  @Test
+  void nullValuedReplacementIsARemoval() {
+    final Set<String> existing = new LinkedHashSet<>();
+    existing.add("a");
+    final Map<String, Object> replacement = new HashMap<>();
+    replacement.put("a", null); // map.get("a") == null -> counts as removed
+    assertThat(CypherStatisticsHelper.countRemovedProperties(existing, replacement)).isEqualTo(1);
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd engine && mvn -q -Dtest=CypherStatisticsHelperTest test`
+Expected: compile failure — `CypherStatisticsHelper` does not exist.
+
+- [ ] **Step 3: Create the helper** `CypherStatisticsHelper.java` (include the standard Apache license header copied from a sibling file in the same package):
+
+```java
+package com.arcadedb.query.opencypher.executor.steps;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Shared counting rules for Cypher mutation statistics, single-sourced so the subtle semantics do
+ * not drift between the SET and MERGE step implementations.
+ */
+public final class CypherStatisticsHelper {
+  private CypherStatisticsHelper() {
+  }
+
+  /**
+   * Counts pre-existing, non-internal properties that a replace-map (SET n = {..} / MERGE ... = {..})
+   * does not re-set with a non-null value. Neo4j counts these removals toward properties-set.
+   */
+  public static int countRemovedProperties(final Set<String> existingProps, final Map<String, Object> replacementMap) {
+    int removed = 0;
+    for (final String prop : existingProps)
+      if (!prop.startsWith("@") && replacementMap.get(prop) == null)
+        removed++;
+    return removed;
+  }
+}
+```
+
+- [ ] **Step 4: Route both call sites through the helper.**
+
+In `SetStep.applyReplaceMap` replace the loop (lines ~281-283):
+```java
+    propertiesSet += CypherStatisticsHelper.countRemovedProperties(existingProps, map);
+```
+
+In `MergeStep` REPLACE_MAP branch replace the loop (lines ~1362-1364):
+```java
+          propertiesSet += CypherStatisticsHelper.countRemovedProperties(existingProps, map);
+```
+
+(Both files are in the same package, so no import is needed.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd engine && mvn -q -Dtest="CypherStatisticsHelperTest,CypherQueryStatisticsTest" test`
+Expected: PASS (helper unit + existing REPLACE-map stat assertions unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CypherStatisticsHelper.java engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/CypherStatisticsHelperTest.java
+git commit -m "refactor(#5015): single-source the replace-map removed-property counting rule"
+```
+
+---
+
+### Task 6: Surface write counters over HTTP `POST /command`
+
+**Files:**
+- Modify: `server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java`
+- Test: `server/src/test/java/com/arcadedb/server/http/handler/PostCommandStatisticsIT.java` (new)
+
+**Interfaces:**
+- Consumes: `ResultSet.getStatistics()` (already attached by the engine); `QueryStatistics.toJSON()` from Task 1.
+- Produces: HTTP `POST /command` JSON response contains a `stats` object (camelCase) for write queries; absent for reads.
+
+- [ ] **Step 1: Write the failing test** — create `PostCommandStatisticsIT.java` (mirror `PostCommandHandlerProfileIT`'s HTTP helpers):
+
+```java
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PostCommandStatisticsIT extends BaseGraphServerTest {
+
+  @Test
+  void writeCommandReturnsCamelCaseStats() throws Exception {
+    final JSONObject response = command("opencypher",
+        "CREATE (:HttpStat {name:'x'})-[:REL]->(:HttpStat2 {name:'y'})");
+    assertThat(response.has("stats")).isTrue();
+    final JSONObject stats = response.getJSONObject("stats");
+    assertThat(stats.getInt("nodesCreated")).isEqualTo(2);
+    assertThat(stats.getInt("relationshipsCreated")).isEqualTo(1);
+    assertThat(stats.getInt("propertiesSet")).isEqualTo(2);
+    assertThat(stats.getBoolean("containsUpdates")).isTrue();
+  }
+
+  @Test
+  void readCommandOmitsStats() throws Exception {
+    command("opencypher", "CREATE (:HttpStatRead {id:1})");
+    final JSONObject response = command("opencypher", "MATCH (n:HttpStatRead) RETURN n");
+    assertThat(response.has("stats")).isFalse();
+  }
+
+  private JSONObject command(final String language, final String cmd) throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URI(
+        "http://127.0.0.1:2480/api/v1/command/graph").toURL().openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization",
+        "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+    final JSONObject payload = new JSONObject();
+    payload.put("language", language);
+    payload.put("command", cmd);
+    payload.put("serializer", "studio");
+    formatPayload(connection, payload);
+    connection.connect();
+    try {
+      final String response = readResponse(connection);
+      assertThat(connection.getResponseCode()).isEqualTo(200);
+      return new JSONObject(response);
+    } finally {
+      connection.disconnect();
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && mvn -q -Dtest=PostCommandStatisticsIT test`
+Expected: FAIL — `stats` is absent on the write response.
+
+- [ ] **Step 3: Emit `stats` in `PostCommandHandler`.**
+
+In `PostCommandHandler.java`, in the non-EXPLAIN `else` block, after `serializeResultSet(database, serializer, limit, response, qResult);` (line ~192) and before the profile/explain block, add:
+
+```java
+          if (qResult != null) {
+            final var qStats = qResult.getStatistics();
+            if (qStats.isPresent() && qStats.get().containsUpdates())
+              response.put("stats", qStats.get().toJSON());
+          }
+```
+
+`getStatistics()` reads the accumulator already attached to the result set during engine execution; it does not require re-iterating and is safe to call after `serializeResultSet` (which consumes rows but leaves the attached statistics intact) and before the `finally` closes the result set. Add an import for `QueryStatistics` only if referenced explicitly; the `var` above avoids it.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && mvn -q -Dtest=PostCommandStatisticsIT test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java server/src/test/java/com/arcadedb/server/http/handler/PostCommandStatisticsIT.java
+git commit -m "feat(#5015): surface Cypher write counters as camelCase stats over HTTP /command"
+```
+
+---
+
+### Task 7: Surface write counters over gRPC
+
+**Files:**
+- Modify: `grpc/src/main/proto/arcadedb-server.proto`
+- Modify: `grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java`
+- Test: `grpcw/src/test/java/com/arcadedb/server/grpc/GrpcWriteStatisticsIT.java` (new)
+
+**Interfaces:**
+- Consumes: `ResultSet.getStatistics()`.
+- Produces: proto message `QueryUpdateStats` + `ExecuteCommandResponse.stats` field, populated for writes, absent for reads.
+
+- [ ] **Step 1: Add the proto message and field.**
+
+In `arcadedb-server.proto`, add the message (near `ExecuteCommandResponse`):
+```proto
+message QueryUpdateStats {
+  int32 nodes_created = 1;
+  int32 nodes_deleted = 2;
+  int32 relationships_created = 3;
+  int32 relationships_deleted = 4;
+  int32 properties_set = 5;
+  int32 labels_added = 6;
+  int32 labels_removed = 7;
+  int32 indexes_added = 8;
+  int32 indexes_removed = 9;
+  int32 constraints_added = 10;
+  int32 constraints_removed = 11;
+  bool contains_updates = 12;
+}
+```
+Add a field to `ExecuteCommandResponse` (next free number is 6):
+```proto
+  QueryUpdateStats stats = 6; // present only for write commands that mutated data
+```
+
+- [ ] **Step 2: Regenerate + write the failing test.** Regenerate proto stubs by building the grpc module:
+
+Run: `cd grpc && mvn -q -DskipTests install`
+Expected: BUILD SUCCESS; `QueryUpdateStats` and `ExecuteCommandResponse.getStats()`/`hasStats()` now exist.
+
+Create `GrpcWriteStatisticsIT.java`. Mirror an existing command-executing IT (e.g. `GrpcServerIT` / `ArcadeDbGrpcServiceExtendedTest`) for channel/stub setup; assert on the response:
+
+```java
+// Pseudocode skeleton — copy the concrete stub/channel bootstrap from an existing grpcw IT
+// (e.g. GrpcServerIT): build a managed channel to the running gRPC server, obtain the blocking
+// stub, then:
+
+ExecuteCommandResponse write = stub.executeCommand(ExecuteCommandRequest.newBuilder()
+    .setDatabase(dbName)
+    .setLanguage("opencypher")
+    .setCommand("CREATE (:GrpcStat {name:'x'})-[:REL]->(:GrpcStat2 {name:'y'})")
+    .setCredentials(creds)
+    .build());
+assertThat(write.hasStats()).isTrue();
+assertThat(write.getStats().getNodesCreated()).isEqualTo(2);
+assertThat(write.getStats().getRelationshipsCreated()).isEqualTo(1);
+assertThat(write.getStats().getPropertiesSet()).isEqualTo(2);
+assertThat(write.getStats().getContainsUpdates()).isTrue();
+
+ExecuteCommandResponse read = stub.executeCommand(ExecuteCommandRequest.newBuilder()
+    .setDatabase(dbName)
+    .setLanguage("opencypher")
+    .setCommand("MATCH (n:GrpcStat) RETURN n")
+    .setCredentials(creds)
+    .build());
+assertThat(read.hasStats()).isFalse();
+```
+
+Fill the skeleton with the concrete bootstrap used by the sibling IT so it compiles and boots a real server.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd grpcw && mvn -q -Dtest=GrpcWriteStatisticsIT test`
+Expected: FAIL — `hasStats()` is false for the write (service never sets it).
+
+- [ ] **Step 4: Populate `stats` in the service.**
+
+In `ArcadeDbGrpcService.executeCommandInternal`, capture the statistics before the try-with-resources closes the `ResultSet`. Add a local before the `try (ResultSet rs = ...)`:
+```java
+      QueryStatistics writeStats = null;
+```
+Inside the try, after both drain branches (right before the closing brace of the `if (rs != null)` block, i.e. after line ~531), add:
+```java
+          writeStats = rs.getStatistics().orElse(null);
+```
+After `out.setAffectedRecords(affected).setExecutionTimeMs(ms);` (line ~575) and before `out.build()`, add:
+```java
+      if (writeStats != null && writeStats.containsUpdates())
+        out.setStats(QueryUpdateStats.newBuilder()
+            .setNodesCreated(writeStats.getNodesCreated())
+            .setNodesDeleted(writeStats.getNodesDeleted())
+            .setRelationshipsCreated(writeStats.getRelationshipsCreated())
+            .setRelationshipsDeleted(writeStats.getRelationshipsDeleted())
+            .setPropertiesSet(writeStats.getPropertiesSet())
+            .setLabelsAdded(writeStats.getLabelsAdded())
+            .setLabelsRemoved(writeStats.getLabelsRemoved())
+            .setIndexesAdded(writeStats.getIndexesAdded())
+            .setIndexesRemoved(writeStats.getIndexesRemoved())
+            .setConstraintsAdded(writeStats.getConstraintsAdded())
+            .setConstraintsRemoved(writeStats.getConstraintsRemoved())
+            .setContainsUpdates(true)
+            .build());
+```
+Add imports: `import com.arcadedb.query.sql.executor.QueryStatistics;` and the generated `QueryUpdateStats` (same generated package as `ExecuteCommandResponse`, e.g. `import com.arcadedb.server.grpc.QueryUpdateStats;` — confirm the concrete package from an existing generated-type import in the file).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd grpcw && mvn -q -Dtest=GrpcWriteStatisticsIT test`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add grpc/src/main/proto/arcadedb-server.proto grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java grpcw/src/test/java/com/arcadedb/server/grpc/GrpcWriteStatisticsIT.java
+git commit -m "feat(#5015): carry Cypher write counters in gRPC ExecuteCommandResponse"
+```
+
+---
+
+### Task 8: Extend the Bolt IT for CALL / UNION write counters over the wire
+
+**Files:**
+- Modify: `bolt/src/test/java/com/arcadedb/bolt/Bolt5000ResultCountersIT.java`
+
+**Interfaces:**
+- Consumes: the Task 2 engine aggregation, surfaced through the existing Bolt `stats` path.
+
+- [ ] **Step 1: Add the failing wire tests** — append to `Bolt5000ResultCountersIT`:
+
+```java
+  @Test
+  void callSubqueryWriteReportsCountersOverBolt() {
+    try (final Driver driver = getDriver();
+         final Session session = driver.session(SessionConfig.forDatabase(getDatabaseName()))) {
+      final SummaryCounters counters = session.run(
+          "UNWIND [1,2] AS x CALL { WITH x CREATE (:BoltCall {v:x}) } RETURN x").consume().counters();
+      assertThat(counters.nodesCreated()).isEqualTo(2);
+      assertThat(counters.propertiesSet()).isEqualTo(2);
+      assertThat(counters.containsUpdates()).isTrue();
+    }
+  }
+
+  @Test
+  void unionWriteReportsSummedCountersOverBolt() {
+    try (final Driver driver = getDriver();
+         final Session session = driver.session(SessionConfig.forDatabase(getDatabaseName()))) {
+      final SummaryCounters counters = session.run(
+          "CREATE (:BoltUnionA {n:1}) RETURN 1 AS r UNION ALL CREATE (:BoltUnionB {n:2}) RETURN 2 AS r")
+          .consume().counters();
+      assertThat(counters.nodesCreated()).isEqualTo(2);
+      assertThat(counters.propertiesSet()).isEqualTo(2);
+      assertThat(counters.containsUpdates()).isTrue();
+    }
+  }
+```
+
+- [ ] **Step 2: Run to verify (should pass on top of Task 2)**
+
+Run: `cd bolt && mvn -q -Dtest=Bolt5000ResultCountersIT test`
+Expected: PASS (the engine aggregation from Task 2 flows through the unchanged Bolt `stats` path). If these were run before Task 2 they would FAIL with zero counters — Task 2 is the dependency.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add bolt/src/test/java/com/arcadedb/bolt/Bolt5000ResultCountersIT.java
+git commit -m "test(#5015): assert CALL and UNION write counters over Bolt wire"
+```
+
+---
+
+### Task 9: Full affected-module verification
+
+- [ ] **Step 1: Compile everything touched**
+
+Run: `mvn -q -pl engine,server,grpc,grpcw,bolt -am -DskipTests install`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 2: Run the affected test classes together**
+
+Run:
+```bash
+cd engine && mvn -q -Dtest="QueryStatisticsTest,CypherQueryStatisticsTest,CypherStatisticsHelperTest" test
+cd ../server && mvn -q -Dtest=PostCommandStatisticsIT test
+cd ../grpcw && mvn -q -Dtest=GrpcWriteStatisticsIT test
+cd ../bolt && mvn -q -Dtest=Bolt5000ResultCountersIT test
+```
+Expected: all PASS.
+
+- [ ] **Step 3: Run the broader Cypher + delete regression subsets** (guards the executeUnion/DeleteStep changes)
+
+Run: `cd engine && mvn -q -Dtest="com.arcadedb.query.opencypher.**" test`
+Expected: PASS.
+
+- [ ] **Step 4: Commit any final fixups, then open the PR** (handled by the outer workflow).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Item 1 (HTTP surfacing) -> Task 6. Item 1 (gRPC surfacing) -> Task 7.
+- Item 2 (UNION + CALL aggregation) -> Task 2, verified over Bolt in Task 8.
+- Constraint-kind coverage + constraint-vs-plain-index miscount -> Task 3.
+- DETACH DELETE dedup -> Task 4.
+- Single-source replace-map rule -> Task 5.
+- `QueryStatistics.add()` + camelCase `toJSON()` prerequisites -> Task 1.
+- Testing across engine/HTTP/gRPC/Bolt -> Tasks 1-8, consolidated in Task 9.
+
+**Type consistency:** `QueryStatistics.add(QueryStatistics)`, `QueryStatistics.toJSON()`, `CommandContext.setStatistics(QueryStatistics)`, `CypherExecutionPlan.executeWithSeedRow(Result, CommandContext)`, `UnionStep.getAggregatedStatistics()`, `CypherStatisticsHelper.countRemovedProperties(Set<String>, Map<String,Object>)` — used consistently across tasks. proto `QueryUpdateStats` snake_case fields map to `getNodesCreated()` etc. in generated Java.
+
+**Known implementation-time confirmations flagged inline:** exact Cypher DDL dialect for NODE KEY / IS TYPED (Task 3 Step 1), `Index.isUnique()` name (Task 3 Step 3), the concrete grpcw IT channel bootstrap (Task 7 Step 2), and the generated `QueryUpdateStats` package (Task 7 Step 4). Each has a grep/verify note.

--- a/docs/superpowers/specs/2026-07-07-cypher-write-counter-surfacing-design.md
+++ b/docs/superpowers/specs/2026-07-07-cypher-write-counter-surfacing-design.md
@@ -1,0 +1,124 @@
+# Design: Extend Cypher write-counter (QueryStatistics) surfacing
+
+Issue: [#5015](https://github.com/ArcadeData/arcadedb/issues/5015)
+Part of [#4890](https://github.com/ArcadeData/arcadedb/issues/4890) / epic [#4882](https://github.com/ArcadeData/arcadedb/issues/4882).
+Builds on the `QueryStatistics` / `ResultSet.getStatistics()` infrastructure merged in [#5016](https://github.com/ArcadeData/arcadedb/pull/5016) (closes #5000).
+
+## Problem
+
+PR #5016 added a reusable engine capability: a `QueryStatistics` accumulator on `CommandContext`, surfaced through `ResultSet.getStatistics()` and consumed by the Bolt layer, which emits a Neo4j-hyphenated `stats` map on the terminal SUCCESS for write queries. Three extensions were deliberately left out to keep that PR's blast radius contained:
+
+1. The counters are surfaced only over Bolt. HTTP `POST /command` and the gRPC service both hold a `ResultSet` and can surface the same counters cheaply, but do not.
+2. `CypherExecutionPlan` attaches the accumulator for top-level mutation steps only. Two shapes execute their writes correctly but return zero counters, and worse, misreport `containsUpdates() == false` (`type: "w"` yet no updates), a misreport rather than merely a zero:
+   - **Top-level UNION writes** (`executeUnion()`): each branch runs its own step chain; counts are not summed into the returned result set.
+   - **`CALL { ... }` write subqueries** (`executeWithSeedRow()`): the inner query builds its own `CommandContext`; its counts are not propagated to the outer context.
+3. Constraint-kind counting (`NOT_NULL` / `KEY` / `TYPED`) is implemented but only `UNIQUE` is test-covered. Two additional constraint/delete counter-fidelity bugs surfaced in review (see below).
+
+## Goals
+
+- Surface write counters over HTTP `POST /command` (ArcadeDB-native camelCase shape) and over gRPC (`grpcw` result), omitting them for read queries.
+- Aggregate write counters across top-level `UNION` writes and `CALL { ... }` write subqueries so `CALL { CREATE ... }` and `CREATE ... UNION CREATE ...` report accurate, non-zero counters (and correct `containsUpdates()`) over every surface.
+- Close two counter-fidelity correctness bugs and add missing constraint-kind test coverage.
+- Single-source the duplicated replace-map removed-property counting rule.
+
+## Non-goals
+
+- No change to the Bolt `stats` shape or the engine accumulator's counter set (both established by #5016).
+- No new counters beyond the existing eleven.
+- No change to SQL-engine semantics (SQL never populates `QueryStatistics`).
+
+## Current state (verified against `main`)
+
+- `QueryStatistics` (`engine/.../query/sql/executor/QueryStatistics.java`) - eleven primitive `int` counters + `containsUpdates()`, `copy()`, `restore()`. No merge/aggregate method.
+- `BasicCommandContext.getStatistics()` - lazily allocates a **local** accumulator; does **not** delegate to `parent` (unlike `getDatabase()` / `getInputParameters()` / `getVariableFromParentHierarchy()`, which do). `copy()` shares the same `statistics` reference.
+- `ResultSet.getStatistics()` - `default Optional.empty()`; `IteratorResultSet` / `InternalResultSet` store and return it. `CypherExecutionPlan.execute()` and `OpenCypherQueryEngine.executeDDL()` attach it.
+- `CypherExecutionPlan.executeUnion()` and `executeWithSeedRow()` build fresh child contexts and never attach/aggregate stats (documented in-code limitations).
+- Bolt: `BoltNetworkExecutor.handlePull/handleDiscard` read `getStatistics()` and emit `BoltResultStats.toStatsMap(...)` (Neo4j hyphenated keys) when `containsUpdates()`.
+- HTTP: `PostCommandHandler` -> `AbstractQueryHandler.serializeResultSet(...)` consumes and closes the `ResultSet`; no `getStatistics()` call anywhere in HTTP handlers.
+- gRPC: `arcadedb-server.proto` `ExecuteCommandResponse` has no stats field; `ArcadeDbGrpcService.executeCommandInternal` drains the `ResultSet` for an affected-count but never reads `getStatistics()`.
+- Duplicated idiom: `!prop.startsWith("@") && map.get(prop) == null` in `SetStep.applyReplaceMap` and the `MergeStep` REPLACE_MAP branch.
+
+## Design
+
+### 1. UNION / CALL aggregation (engine)
+
+Add `QueryStatistics.add(QueryStatistics other)` - a field-wise sum used to merge branch/subquery accumulators.
+
+**CALL subqueries** (`executeWithSeedRow`): make `BasicCommandContext.getStatistics()` delegate to `parent` when a parent is present, so the root context owns the single accumulator and nested contexts write straight into it. This matches the parent-delegation pattern already used by several accessors on `BasicCommandContext`. Ensure the CALL subquery context is wired with the outer context as its parent (verify; set if missing). Because read queries never call `getStatistics()`, the "read query allocates nothing" regression from #5016 still holds. `restore()` / `copy()` continue to operate on the single root instance, so transaction-retry rollback of counts is unaffected.
+
+**Top-level UNION** (`executeUnion`): each branch runs as an independent *root* context with no parent, so delegation cannot reach it. Sum each branch's `QueryStatistics` into a combined accumulator via `add(...)` and attach it to the returned union `ResultSet` via `setStatistics(...)`.
+
+Rationale for the hybrid: delegation is idiomatic to `BasicCommandContext` and was the mechanism suggested in issue review; explicit merge is structurally unavoidable for UNION's fresh-root branches. Blast radius of the `getStatistics()` change is bounded: only Cypher mutation steps populate the accumulator, and only Bolt/HTTP/gRPC read it back off a `ResultSet`; SQL result sets never carry statistics.
+
+### 2. HTTP `POST /command` surfacing
+
+Add a `QueryStatistics.toJSON()` helper (engine, `com.arcadedb.serializer.json.JSONObject`) producing the ArcadeDB-native camelCase shape:
+
+```json
+"stats": {
+  "nodesCreated": 1,
+  "relationshipsCreated": 1,
+  "propertiesSet": 2,
+  "nodesDeleted": 0,
+  "relationshipsDeleted": 0,
+  "labelsAdded": 0,
+  "labelsRemoved": 0,
+  "indexesAdded": 0,
+  "indexesRemoved": 0,
+  "constraintsAdded": 0,
+  "constraintsRemoved": 0,
+  "containsUpdates": true
+}
+```
+
+In `PostCommandHandler`, read `qResult.getStatistics()` **before** `serializeResultSet(...)` consumes/closes the result set (Cypher writes are materialized during `execute()`, so the accumulator is already populated). When present and `containsUpdates()`, put `stats` on the response `JSONObject`. Reads omit it. Zero-valued counters are included for a stable object shape when updates occurred; `containsUpdates` disambiguates.
+
+### 3. gRPC surfacing
+
+Add to `grpc/src/main/proto/arcadedb-server.proto`:
+
+```proto
+message QueryUpdateStats {
+  int32 nodes_created = 1;
+  int32 nodes_deleted = 2;
+  int32 relationships_created = 3;
+  int32 relationships_deleted = 4;
+  int32 properties_set = 5;
+  int32 labels_added = 6;
+  int32 labels_removed = 7;
+  int32 indexes_added = 8;
+  int32 indexes_removed = 9;
+  int32 constraints_added = 10;
+  int32 constraints_removed = 11;
+  bool contains_updates = 12;
+}
+```
+
+Add an optional `QueryUpdateStats stats = <next free field number>;` to `ExecuteCommandResponse`. In `ArcadeDbGrpcService.executeCommandInternal`, after the drain loop read `rs.getStatistics()` and set the message only when `containsUpdates()`. proto3 message has-semantics mean the field is absent for reads.
+
+### 4. Fidelity fixes
+
+- **Constraint-vs-plain-index miscount** - in `OpenCypherQueryEngine.executeCreateConstraint` (UNIQUE / KEY), `existedBefore` derives from `indexExistsOnProperties(...)`, which is true for *any* index. Adding a UNIQUE/KEY constraint over properties already covered by a **non-unique** index therefore fails to increment `constraints-added`. Narrow the pre-existence check to unique-index / constraint existence so a genuine constraint addition is counted.
+- **DETACH DELETE dedup** - `deleteAllEdges()` / `deleteVertex()` do not consult the batch `deleted` set that `deleteObjectStatic()` uses, so an edge removed both by `DETACH DELETE` and by a separate explicit match/delete can be counted twice, where Neo4j dedups. Consult the shared `deleted` set before incrementing `relationshipsDeleted`.
+- **Single-source the replace-map rule** - extract the `!prop.startsWith("@") && map.get(prop) == null` removed-property count into one shared static helper used by both `SetStep.applyReplaceMap` and the `MergeStep` REPLACE_MAP branch, so the subtle semantics cannot drift.
+
+## Testing
+
+- **Engine unit** - `QueryStatistics.add()` merge; extend `CypherQueryStatisticsTest`:
+  - `CALL { CREATE ... }` reports non-zero counters and `containsUpdates()`.
+  - `CREATE ... UNION CREATE ...` sums both branches.
+  - `DETACH DELETE` + explicit edge delete counts the shared edge once.
+  - Constraint kinds `NOT_NULL` / `KEY` / `TYPED` each increment `constraintsAdded`.
+  - UNIQUE/KEY constraint over properties already covered by a plain index increments `constraintsAdded`.
+- **HTTP** - new handler test: `POST /command` write returns the camelCase `stats` object with correct values; a read query omits `stats`.
+- **gRPC** - new `grpcw` test: `ExecuteCommandResponse.stats` populated and correct for a write; absent for a read.
+- **Bolt** - extend `Bolt5000ResultCountersIT` (or a sibling IT) to assert non-zero, correct `summary.counters()` for `CALL { CREATE ... }` and a UNION write over the real `neo4j-java-driver`.
+
+## Rollout
+
+Single PR on branch `feat/5015-cypher-write-counter-surfacing`. TDD: failing tests first per component, then implementation, compile and run affected engine/server/grpcw/bolt tests until green. After the PR is opened, run the code-review response loop (Claude + Gemini) for at least four rounds, answering each via the `receiving-code-review` skill.
+
+## Open risks
+
+- Making `getStatistics()` delegate to `parent` is a change to a widely-called method. Mitigation: audit confirms only Cypher writes populate it and only Bolt/HTTP/gRPC read it off result sets; a read-allocates-nothing regression test guards the hot path.
+- Proto field additions are backward compatible (new field numbers only); no existing field is renumbered.

--- a/docs/superpowers/specs/2026-07-07-cypher-write-counter-surfacing-design.md
+++ b/docs/superpowers/specs/2026-07-07-cypher-write-counter-surfacing-design.md
@@ -42,13 +42,13 @@ PR #5016 added a reusable engine capability: a `QueryStatistics` accumulator on 
 
 ### 1. UNION / CALL aggregation (engine)
 
-Add `QueryStatistics.add(QueryStatistics other)` - a field-wise sum used to merge branch/subquery accumulators.
+Add `QueryStatistics.add(QueryStatistics other)` - a null-safe field-wise sum used to merge branch/subquery accumulators. `getStatistics()` semantics are left unchanged (lower blast radius than the parent-delegation idea originally sketched; code inspection showed the CALL subquery context has no link to the outer context and top-level UNION branches run as independent root plans, so delegation would require threading anyway).
 
-**CALL subqueries** (`executeWithSeedRow`): make `BasicCommandContext.getStatistics()` delegate to `parent` when a parent is present, so the root context owns the single accumulator and nested contexts write straight into it. This matches the parent-delegation pattern already used by several accessors on `BasicCommandContext`. Ensure the CALL subquery context is wired with the outer context as its parent (verify; set if missing). Because read queries never call `getStatistics()`, the "read query allocates nothing" regression from #5016 still holds. `restore()` / `copy()` continue to operate on the single root instance, so transaction-retry rollback of counts is unaffected.
+**CALL subqueries** (`executeWithSeedRow` / `SubqueryStep.executeInnerQuery`): thread the outer `CommandContext` into `executeWithSeedRow(...)` and have the inner context **share the outer's `QueryStatistics` instance** via a new `CommandContext.setStatistics(QueryStatistics)`. Inner mutation steps then accumulate directly into the outer accumulator - the same instance-sharing rationale `BasicCommandContext.copy()` already documents. No post-hoc merge, no wrapper, no change to `getStatistics()`. The "read query allocates nothing" regression from #5016 still holds because sharing only happens once the outer context has already allocated its accumulator for a write, and a pure-read CALL never triggers a mutation step.
 
-**Top-level UNION** (`executeUnion`): each branch runs as an independent *root* context with no parent, so delegation cannot reach it. Sum each branch's `QueryStatistics` into a combined accumulator via `add(...)` and attach it to the returned union `ResultSet` via `setStatistics(...)`.
+**Top-level UNION** (`executeUnion` / `UnionStep`): each branch runs as an independent root `CypherExecutionPlan.execute()` whose stats are attached to its own `ResultSet`. `UnionStep` accumulates each exhausted branch's `getStatistics()` into an internal aggregate via `add(...)` and exposes it (`getAggregatedStatistics()`). The read path stays lazy and unchanged; for a write UNION (`!statement.isReadOnly()`), `executeUnion()` materializes the union result (mirroring the non-union write path), then attaches the aggregate to the returned `IteratorResultSet` only when `containsUpdates()`.
 
-Rationale for the hybrid: delegation is idiomatic to `BasicCommandContext` and was the mechanism suggested in issue review; explicit merge is structurally unavoidable for UNION's fresh-root branches. Blast radius of the `getStatistics()` change is bounded: only Cypher mutation steps populate the accumulator, and only Bolt/HTTP/gRPC read it back off a `ResultSet`; SQL result sets never carry statistics.
+Blast radius is bounded: only Cypher mutation steps populate the accumulator, and only Bolt/HTTP/gRPC read it back off a `ResultSet`; SQL result sets never carry statistics.
 
 ### 2. HTTP `POST /command` surfacing
 
@@ -120,5 +120,6 @@ Single PR on branch `feat/5015-cypher-write-counter-surfacing`. TDD: failing tes
 
 ## Open risks
 
-- Making `getStatistics()` delegate to `parent` is a change to a widely-called method. Mitigation: audit confirms only Cypher writes populate it and only Bolt/HTTP/gRPC read it off result sets; a read-allocates-nothing regression test guards the hot path.
+- `getStatistics()` is left unchanged; the only new context API is `setStatistics(...)`, used solely to share the outer accumulator into a CALL subquery context. A read-allocates-nothing regression test guards the hot path.
+- Making `executeUnion()` materialize the union result for **write** UNIONs (to force branch writes and aggregate counters) changes read behavior for none - the read path stays lazy. Large write-UNION result sets are materialized, matching the existing non-union write path.
 - Proto field additions are backward compatible (new field numbers only); no existing field is renumbered.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -323,8 +323,6 @@ public class CypherExecutionPlan {
       ctx.setDatabase(database);
       ctx.setInputParameters(parameters);
       setupFunctionResolver(ctx);
-      if (outerContext != null)
-        ctx.setStatistics(outerContext.getStatistics());
 
       // Execute each branch with the seed row, collect all results
       final List<ResultInternal> allResults = new ArrayList<>();
@@ -351,7 +349,10 @@ public class CypherExecutionPlan {
     context.setDatabase(database);
     context.setInputParameters(parameters);
     setupFunctionResolver(context);
-    if (outerContext != null)
+    // Only share the outer statistics accumulator for a write CALL body: getStatistics() lazily
+    // allocates, so sharing it unconditionally would allocate a QueryStatistics even for a
+    // fully read-only CALL, violating the "read queries allocate nothing" constraint.
+    if (outerContext != null && !statement.isReadOnly())
       context.setStatistics(outerContext.getStatistics());
 
     // Create a seed step that returns the seed row
@@ -427,9 +428,10 @@ public class CypherExecutionPlan {
     while (rs.hasNext())
       rows.add(rs.next());
     final IteratorResultSet out = new IteratorResultSet(rows.iterator());
-    final QueryStatistics aggregated = unionStep.getAggregatedStatistics();
-    if (aggregated.containsUpdates())
-      out.setStatistics(aggregated);
+    // Always attach the accumulator for a write UNION, even when no branch actually mutated
+    // anything (aggregated.containsUpdates() false then): presence signals "this was a write",
+    // mirroring the non-union write path above.
+    out.setStatistics(unionStep.getAggregatedStatistics());
     return out;
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -593,8 +593,10 @@ public class CypherExecutionPlan {
 
     results.setPlan(new OpenCypherExplainExecutionPlan(profileOutput.toString(), executionSteps, endTime - startTime));
     // Surface the CRUD-count accumulator built up by the mutation steps during the profiled run,
-    // mirroring execute()'s write path so a profiled write still reports its counters.
-    results.setStatistics(context.getStatistics());
+    // mirroring execute()'s write path so a profiled write still reports its counters. Read-only
+    // statements never attach a statistics accumulator, matching execute()'s read path.
+    if (!statement.isReadOnly())
+      results.setStatistics(context.getStatistics());
     return results;
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -304,15 +304,14 @@ public class CypherExecutionPlan {
    * Used by CALL subqueries to inject outer scope variables into the inner query.
    * The seed row provides variables that the inner query's WITH clause can import.
    *
-   * @param seedRow the initial row providing outer scope variables
+   * @param seedRow      the initial row providing outer scope variables
+   * @param outerContext the outer command context whose QueryStatistics accumulator is shared
+   *                     with the inner query's context, so writes performed inside the CALL
+   *                     subquery are folded into the outer plan's statistics. May be {@code null}.
    *
    * @return result set from the inner query execution
    */
-  public ResultSet executeWithSeedRow(final Result seedRow) {
-    // Limitation: each branch/inner plan runs with its own BasicCommandContext, so QueryStatistics
-    // from writes performed inside this CALL subquery are not aggregated into the outer plan's
-    // statistics. The ResultSet returned to the caller only reflects top-level mutation steps.
-
+  public ResultSet executeWithSeedRow(final Result seedRow, final CommandContext outerContext) {
     // Handle UNION inside CALL subqueries: execute each branch with the seed row
     if (statement instanceof UnionStatement unionStmt) {
       final List<CypherExecutionPlan> branchPlans = new ArrayList<>();
@@ -324,12 +323,14 @@ public class CypherExecutionPlan {
       ctx.setDatabase(database);
       ctx.setInputParameters(parameters);
       setupFunctionResolver(ctx);
+      if (outerContext != null)
+        ctx.setStatistics(outerContext.getStatistics());
 
       // Execute each branch with the seed row, collect all results
       final List<ResultInternal> allResults = new ArrayList<>();
       final Set<String> seen = removeDuplicates ? new HashSet<>() : null;
       for (final CypherExecutionPlan branchPlan : branchPlans) {
-        final ResultSet rs = branchPlan.executeWithSeedRow(seedRow);
+        final ResultSet rs = branchPlan.executeWithSeedRow(seedRow, outerContext);
         while (rs.hasNext()) {
           final Result row = rs.next();
           if (removeDuplicates) {
@@ -350,6 +351,8 @@ public class CypherExecutionPlan {
     context.setDatabase(database);
     context.setInputParameters(parameters);
     setupFunctionResolver(context);
+    if (outerContext != null)
+      context.setStatistics(outerContext.getStatistics());
 
     // Create a seed step that returns the seed row
     final AbstractExecutionStep seedStep = new AbstractExecutionStep(context) {
@@ -404,10 +407,6 @@ public class CypherExecutionPlan {
    * @return combined result set
    */
   private ResultSet executeUnion() {
-    // Limitation: each UNION branch executes as its own sub-plan with its own QueryStatistics, so
-    // write statistics from inside a branch are not aggregated into the combined ResultSet's
-    // statistics; only top-level mutation steps outside the UNION are reflected there.
-
     // Use UnionStep to combine results from all subqueries
     final BasicCommandContext context = new BasicCommandContext();
     context.setDatabase(database);
@@ -417,7 +416,21 @@ public class CypherExecutionPlan {
     final UnionStep unionStep =
         new UnionStep(unionSubqueryPlans, unionRemoveDuplicates, context);
 
-    return unionStep.syncPull(context, 100);
+    // Read UNION: stay lazy/streaming, no statistics to surface.
+    if (statement.isReadOnly())
+      return unionStep.syncPull(context, 100);
+
+    // Write UNION: materialize to force each branch's mutation steps to execute (mirroring the
+    // non-union write path), then surface the summed per-branch statistics.
+    final ResultSet rs = unionStep.syncPull(context, 100);
+    final List<Result> rows = new ArrayList<>();
+    while (rs.hasNext())
+      rows.add(rs.next());
+    final IteratorResultSet out = new IteratorResultSet(rows.iterator());
+    final QueryStatistics aggregated = unionStep.getAggregatedStatistics();
+    if (aggregated.containsUpdates())
+      out.setStatistics(aggregated);
+    return out;
   }
 
   /**

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -425,8 +425,12 @@ public class CypherExecutionPlan {
     // non-union write path), then surface the summed per-branch statistics.
     final ResultSet rs = unionStep.syncPull(context, 100);
     final List<Result> rows = new ArrayList<>();
-    while (rs.hasNext())
-      rows.add(rs.next());
+    try {
+      while (rs.hasNext())
+        rows.add(rs.next());
+    } finally {
+      rs.close();
+    }
     final IteratorResultSet out = new IteratorResultSet(rows.iterator());
     // Always attach the accumulator for a write UNION, even when no branch actually mutated
     // anything (aggregated.containsUpdates() false then): presence signals "this was a write",

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/CypherExecutionPlan.java
@@ -592,6 +592,9 @@ public class CypherExecutionPlan {
     }
 
     results.setPlan(new OpenCypherExplainExecutionPlan(profileOutput.toString(), executionSteps, endTime - startTime));
+    // Surface the CRUD-count accumulator built up by the mutation steps during the profiled run,
+    // mirroring execute()'s write path so a profiled write still reports its counters.
+    results.setStatistics(context.getStatistics());
     return results;
   }
 

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CypherStatisticsHelper.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/CypherStatisticsHelper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.query.opencypher.executor.steps;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Shared counting rules for Cypher mutation statistics, single-sourced so the subtle semantics do
+ * not drift between the SET and MERGE step implementations.
+ */
+public final class CypherStatisticsHelper {
+  private CypherStatisticsHelper() {
+  }
+
+  /**
+   * Counts pre-existing, non-internal properties that a replace-map (SET n = {..} / MERGE ... = {..})
+   * does not re-set with a non-null value. Neo4j counts these removals toward properties-set.
+   */
+  public static int countRemovedProperties(final Set<String> existingProps, final Map<String, Object> replacementMap) {
+    int removed = 0;
+    for (final String prop : existingProps)
+      if (!prop.startsWith("@") && replacementMap.get(prop) == null)
+        removed++;
+    return removed;
+  }
+}

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/DeleteStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/DeleteStep.java
@@ -498,8 +498,9 @@ public class DeleteStep extends AbstractExecutionStep {
    * Deletes all edges connected to a vertex.
    *
    * @param vertex  vertex whose edges should be deleted
-   * @param deleted shared set of already-deleted objects; edges already removed and counted by an
-   *                explicit DELETE elsewhere in the same statement are skipped here
+   * @param deleted shared set of already-deleted objects; edges already removed and counted earlier
+   *                in the same statement (by an explicit DELETE or another vertex's DETACH pass) are
+   *                skipped here
    */
   private void deleteAllEdges(final Vertex vertex, final Set<Object> deleted) {
     // Collect connected edges in both directions, de-duplicating self-loops (which appear in both

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/DeleteStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/DeleteStep.java
@@ -430,14 +430,14 @@ public class DeleteStep extends AbstractExecutionStep {
     if (obj instanceof Vertex) {
       deleted.add(obj);
       try {
-        deleteVertex((Vertex) obj);
+        deleteVertex((Vertex) obj, deleted);
       } catch (final RecordNotFoundException e) {
         // Already deleted - skip
       }
     } else if (obj instanceof Edge) {
       deleted.add(obj);
       try {
-        deleteEdge((Edge) obj);
+        deleteEdge((Edge) obj, deleted);
       } catch (final RecordNotFoundException e) {
         // Already deleted - skip
       }
@@ -474,12 +474,14 @@ public class DeleteStep extends AbstractExecutionStep {
    * Deletes a vertex from the graph.
    * If detach is true, deletes all connected relationships first.
    *
-   * @param vertex vertex to delete
+   * @param vertex  vertex to delete
+   * @param deleted shared set of already-deleted objects, so a relationship removed both by DETACH
+   *                and by an explicit edge delete in the same statement is counted only once
    */
-  private void deleteVertex(final Vertex vertex) {
+  private void deleteVertex(final Vertex vertex, final Set<Object> deleted) {
     if (deleteClause.isDetach()) {
       // DETACH DELETE: Remove all connected relationships first
-      deleteAllEdges(vertex);
+      deleteAllEdges(vertex, deleted);
     } else {
       // Non-DETACH DELETE: check for connected edges
       if (vertex.getEdges(Vertex.DIRECTION.OUT).iterator().hasNext() ||
@@ -495,9 +497,11 @@ public class DeleteStep extends AbstractExecutionStep {
   /**
    * Deletes all edges connected to a vertex.
    *
-   * @param vertex vertex whose edges should be deleted
+   * @param vertex  vertex whose edges should be deleted
+   * @param deleted shared set of already-deleted objects; edges already removed and counted by an
+   *                explicit DELETE elsewhere in the same statement are skipped here
    */
-  private void deleteAllEdges(final Vertex vertex) {
+  private void deleteAllEdges(final Vertex vertex, final Set<Object> deleted) {
     // Collect connected edges in both directions, de-duplicating self-loops (which appear in both
     // OUT and IN) so a self-loop relationship is deleted and counted exactly once.
     final List<Edge> edgesToDelete = new ArrayList<>();
@@ -511,11 +515,16 @@ public class DeleteStep extends AbstractExecutionStep {
 
     final QueryStatistics stats = context.getStatistics();
     for (final Edge edge : edgesToDelete) {
+      // Skip any relationship already removed and counted by an explicit DELETE in the same statement.
+      if (deleted.contains(edge))
+        continue;
       try {
         edge.delete();
         stats.incRelationshipsDeleted();
+        deleted.add(edge);
       } catch (final RecordNotFoundException ignored) {
         // already removed (e.g. a shared edge deleted when the other endpoint was detached) - do not count again
+        deleted.add(edge);
       }
     }
   }
@@ -523,11 +532,14 @@ public class DeleteStep extends AbstractExecutionStep {
   /**
    * Deletes an edge from the graph.
    *
-   * @param edge edge to delete
+   * @param edge    edge to delete
+   * @param deleted shared set of already-deleted objects, updated so a later DETACH pass does not
+   *                recount this edge
    */
-  private void deleteEdge(final Edge edge) {
+  private void deleteEdge(final Edge edge, final Set<Object> deleted) {
     edge.delete();
     context.getStatistics().incRelationshipsDeleted();
+    deleted.add(edge);
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/MergeStep.java
@@ -1359,9 +1359,7 @@ public class MergeStep extends AbstractExecutionStep {
           // Neo4j counts both the properties written and the pre-existing properties removed by
           // the replace (i.e. not re-set with a non-null value), matching the PROPERTY/MERGE_MAP
           // branches above.
-          for (final String prop : existingProps)
-            if (!prop.startsWith("@") && map.get(prop) == null)
-              propertiesSet++;
+          propertiesSet += CypherStatisticsHelper.countRemovedProperties(existingProps, map);
           mutableDoc.save();
           context.getStatistics().addPropertiesSet(propertiesSet);
           ((ResultInternal) result).setProperty(variable, mutableDoc);

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SetStep.java
@@ -278,9 +278,7 @@ public class SetStep extends AbstractExecutionStep {
 
     // Neo4j counts both the properties written and the pre-existing properties removed by the
     // replace (i.e. not re-set with a non-null value), matching applyPropertySet/applyMergeMap.
-    for (final String prop : existingProps)
-      if (!prop.startsWith("@") && map.get(prop) == null)
-        propertiesSet++;
+    propertiesSet += CypherStatisticsHelper.countRemovedProperties(existingProps, map);
 
     mutableDoc.save();
     final QueryStatistics stats = context.getStatistics();

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SubqueryStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/SubqueryStep.java
@@ -421,7 +421,7 @@ public class SubqueryStep extends AbstractExecutionStep {
     final CypherExecutionPlan innerPlan = new CypherExecutionPlan(
         database, innerStatement, parameters, database.getConfiguration(), null, expressionEvaluator);
 
-    final ResultSet resultSet = innerPlan.executeWithSeedRow(filterSeedRow(outerRow));
+    final ResultSet resultSet = innerPlan.executeWithSeedRow(filterSeedRow(outerRow), context);
 
     try {
       // Unit subquery: no RETURN clause — consume all inner rows for side effects only.

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/UnionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/UnionStep.java
@@ -169,6 +169,8 @@ public class UnionStep extends AbstractExecutionStep {
 
   /**
    * Returns the write statistics summed across every branch that has completed execution so far.
+   * The accumulator fills in incrementally as branches are pulled, so the sum is only complete
+   * once the caller has fully drained the ResultSet returned by {@link #syncPull}.
    */
   public QueryStatistics getAggregatedStatistics() {
     return aggregatedStatistics;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/UnionStep.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/executor/steps/UnionStep.java
@@ -22,6 +22,7 @@ import com.arcadedb.exception.TimeoutException;
 import com.arcadedb.query.opencypher.executor.CypherExecutionPlan;
 import com.arcadedb.query.sql.executor.AbstractExecutionStep;
 import com.arcadedb.query.sql.executor.CommandContext;
+import com.arcadedb.query.sql.executor.QueryStatistics;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 
@@ -50,6 +51,7 @@ import java.util.Set;
 public class UnionStep extends AbstractExecutionStep {
   private final List<CypherExecutionPlan> queryPlans;
   private final boolean removeDuplicates;
+  private final QueryStatistics aggregatedStatistics = new QueryStatistics();
 
   /**
    * Creates a UnionStep.
@@ -102,6 +104,7 @@ public class UnionStep extends AbstractExecutionStep {
           // Initialize or advance to next query's result set
           if (currentResultSet == null || !currentResultSet.hasNext()) {
             if (currentResultSet != null) {
+              aggregatedStatistics.add(currentResultSet.getStatistics().orElse(null));
               currentResultSet.close();
             }
 
@@ -162,6 +165,13 @@ public class UnionStep extends AbstractExecutionStep {
           currentResultSet.close();
       }
     };
+  }
+
+  /**
+   * Returns the write statistics summed across every branch that has completed execution so far.
+   */
+  public QueryStatistics getAggregatedStatistics() {
+    return aggregatedStatistics;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
@@ -46,7 +46,6 @@ import com.arcadedb.query.sql.executor.QueryStatistics;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.utility.CollectionUtils;
-import com.arcadedb.index.Index;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Property;
 import com.arcadedb.schema.Schema;
@@ -55,6 +54,7 @@ import com.arcadedb.schema.TypeIndexBuilder;
 import com.arcadedb.security.SecurityDatabaseUser;
 import com.arcadedb.security.SecurityManager;
 import com.arcadedb.function.sql.DefaultSQLFunctionFactory;
+import com.arcadedb.index.Index;
 
 import java.util.EnumSet;
 import java.util.HashMap;

--- a/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
+++ b/engine/src/main/java/com/arcadedb/query/opencypher/query/OpenCypherQueryEngine.java
@@ -46,6 +46,7 @@ import com.arcadedb.query.sql.executor.QueryStatistics;
 import com.arcadedb.query.sql.executor.ResultInternal;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.utility.CollectionUtils;
+import com.arcadedb.index.Index;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.Property;
 import com.arcadedb.schema.Schema;
@@ -342,6 +343,22 @@ public class OpenCypherQueryEngine implements QueryEngine {
     return type.getIndexByProperties(propertyNames) != null || type.getPolymorphicIndexByProperties(propertyNames) != null;
   }
 
+  /**
+   * Like {@link #indexExistsOnProperties} but only reports a pre-existing UNIQUE index. A non-unique
+   * index over the same properties does not satisfy a UNIQUE/KEY constraint, so adding the constraint
+   * is a genuine schema change that must be counted.
+   */
+  private static boolean uniqueIndexExistsOnProperties(final Schema schema, final String typeName, final String[] propertyNames) {
+    if (!schema.existsType(typeName))
+      return false;
+    final DocumentType type = schema.getType(typeName);
+    final Index own = type.getIndexByProperties(propertyNames);
+    if (own != null && own.isUnique())
+      return true;
+    final Index poly = type.getPolymorphicIndexByProperties(propertyNames);
+    return poly != null && poly.isUnique();
+  }
+
   private void executeCreateConstraint(final CypherDDLStatement ddl, final Schema schema, final QueryStatistics stats) {
     final String typeName = ddl.getLabelName();
     final String[] propertyNames = ddl.getPropertyNames().toArray(new String[0]);
@@ -390,7 +407,7 @@ public class OpenCypherQueryEngine implements QueryEngine {
 
     switch (ddl.getConstraintKind()) {
     case UNIQUE: {
-      final boolean existedBefore = indexExistsOnProperties(schema, typeName, propertyNames);
+      final boolean existedBefore = uniqueIndexExistsOnProperties(schema, typeName, propertyNames);
       final TypeIndexBuilder b = schema.buildTypeIndex(typeName, propertyNames);
       b.withType(Schema.INDEX_TYPE.LSM_TREE);
       b.withUnique(true);
@@ -425,7 +442,7 @@ public class OpenCypherQueryEngine implements QueryEngine {
 
     case KEY: {
       // NODE KEY = unique index + mandatory properties
-      final boolean existedBefore = indexExistsOnProperties(schema, typeName, propertyNames);
+      final boolean existedBefore = uniqueIndexExistsOnProperties(schema, typeName, propertyNames);
       final TypeIndexBuilder b = schema.buildTypeIndex(typeName, propertyNames);
       b.withType(Schema.INDEX_TYPE.LSM_TREE);
       b.withUnique(true);

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/BasicCommandContext.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/BasicCommandContext.java
@@ -460,6 +460,11 @@ public class BasicCommandContext implements CommandContext {
     return statistics;
   }
 
+  @Override
+  public void setStatistics(final QueryStatistics statistics) {
+    this.statistics = statistics;
+  }
+
   public CommandContext setDatabase(final Database database) {
     this.database = (DatabaseInternal) database;
     return this;

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/CommandContext.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/CommandContext.java
@@ -80,6 +80,8 @@ public interface CommandContext {
 
   QueryStatistics getStatistics();
 
+  void setStatistics(QueryStatistics statistics);
+
   void declareScriptVariable(String varName);
 
   boolean isScriptVariableDeclared(String varName);

--- a/engine/src/main/java/com/arcadedb/query/sql/executor/QueryStatistics.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/QueryStatistics.java
@@ -18,6 +18,8 @@
  */
 package com.arcadedb.query.sql.executor;
 
+import com.arcadedb.serializer.json.JSONObject;
+
 /**
  * Mutable, allocation-light accumulator of CRUD and schema mutation counts produced while executing
  * a single command. Held on the {@link CommandContext} and read once when the result set is
@@ -103,5 +105,46 @@ public class QueryStatistics {
     indexesRemoved = snapshot.indexesRemoved;
     constraintsAdded = snapshot.constraintsAdded;
     constraintsRemoved = snapshot.constraintsRemoved;
+  }
+
+  /**
+   * Adds every counter from {@code other} into this accumulator. A {@code null} argument is a no-op.
+   * Used to aggregate the statistics of UNION branches and CALL subqueries into the outer result.
+   */
+  public void add(final QueryStatistics other) {
+    if (other == null)
+      return;
+    nodesCreated += other.nodesCreated;
+    nodesDeleted += other.nodesDeleted;
+    relationshipsCreated += other.relationshipsCreated;
+    relationshipsDeleted += other.relationshipsDeleted;
+    propertiesSet += other.propertiesSet;
+    labelsAdded += other.labelsAdded;
+    labelsRemoved += other.labelsRemoved;
+    indexesAdded += other.indexesAdded;
+    indexesRemoved += other.indexesRemoved;
+    constraintsAdded += other.constraintsAdded;
+    constraintsRemoved += other.constraintsRemoved;
+  }
+
+  /**
+   * Serializes the counters into an ArcadeDB-native camelCase JSON object. All eleven counters are
+   * always present (zero when unset) plus a {@code containsUpdates} flag, giving a stable shape.
+   */
+  public JSONObject toJSON() {
+    final JSONObject json = new JSONObject();
+    json.put("nodesCreated", nodesCreated);
+    json.put("nodesDeleted", nodesDeleted);
+    json.put("relationshipsCreated", relationshipsCreated);
+    json.put("relationshipsDeleted", relationshipsDeleted);
+    json.put("propertiesSet", propertiesSet);
+    json.put("labelsAdded", labelsAdded);
+    json.put("labelsRemoved", labelsRemoved);
+    json.put("indexesAdded", indexesAdded);
+    json.put("indexesRemoved", indexesRemoved);
+    json.put("constraintsAdded", constraintsAdded);
+    json.put("constraintsRemoved", constraintsRemoved);
+    json.put("containsUpdates", containsUpdates());
+    return json;
   }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
@@ -329,4 +329,28 @@ class CypherQueryStatisticsTest extends TestHelper {
       assertThat(s.getRelationshipsDeleted()).isEqualTo(1);
     });
   }
+
+  @Test
+  void callSubqueryWriteCountsPropagateToOuter() {
+    database.transaction(() -> {
+      final QueryStatistics s = statsOf(database,
+          "UNWIND [1,2] AS x CALL { WITH x CREATE (:CallNode {v:x}) } RETURN x");
+      assertThat(s.getNodesCreated()).isEqualTo(2);
+      assertThat(s.getPropertiesSet()).isEqualTo(2);
+      assertThat(s.getLabelsAdded()).isEqualTo(2);
+      assertThat(s.containsUpdates()).isTrue();
+    });
+  }
+
+  @Test
+  void topLevelUnionWriteCountsAreSummed() {
+    database.transaction(() -> {
+      final QueryStatistics s = statsOf(database,
+          "CREATE (:UnionA {n:1}) RETURN 1 AS r UNION ALL CREATE (:UnionB {n:2}) RETURN 2 AS r");
+      assertThat(s.getNodesCreated()).isEqualTo(2);
+      assertThat(s.getPropertiesSet()).isEqualTo(2);
+      assertThat(s.getLabelsAdded()).isEqualTo(2);
+      assertThat(s.containsUpdates()).isTrue();
+    });
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
@@ -371,4 +371,36 @@ class CypherQueryStatisticsTest extends TestHelper {
       assertThat(rs.getStatistics().get().containsUpdates()).isFalse();
     });
   }
+
+  @Test
+  void notNullConstraintCountsAsConstraintAdded() {
+    database.command("opencypher", "CREATE (:NnLabel {p:1})");
+    final QueryStatistics s = statsOf(database, "CREATE CONSTRAINT FOR (n:NnLabel) REQUIRE n.p IS NOT NULL");
+    assertThat(s.getConstraintsAdded()).isEqualTo(1);
+  }
+
+  @Test
+  void nodeKeyConstraintCountsAsConstraintAdded() {
+    final QueryStatistics s = statsOf(database, "CREATE CONSTRAINT FOR (n:KeyLabel) REQUIRE n.k IS NODE KEY");
+    assertThat(s.getConstraintsAdded()).isEqualTo(1);
+  }
+
+  @Test
+  void typedConstraintCountsAsConstraintAdded() {
+    final QueryStatistics s = statsOf(database, "CREATE CONSTRAINT FOR (n:TypedLabel) REQUIRE n.age IS TYPED INTEGER");
+    assertThat(s.getConstraintsAdded()).isEqualTo(1);
+  }
+
+  @Test
+  void uniqueConstraintOverPlainIndexStillCountsAsConstraintAdded() {
+    // A non-unique index already covers the property. TypeIndexBuilder.create() only tolerates a
+    // pre-existing index with a different uniqueness when IF NOT EXISTS is used - it then drops the
+    // plain index and creates the unique one. That is a genuine schema change and must be counted
+    // even though indexExistsOnProperties(...) sees an index there both before and after.
+    database.command("sql", "CREATE VERTEX TYPE CoveredLabel");
+    database.command("sql", "CREATE PROPERTY CoveredLabel.email STRING");
+    database.command("sql", "CREATE INDEX ON CoveredLabel (email) NOTUNIQUE");
+    final QueryStatistics s = statsOf(database, "CREATE CONSTRAINT IF NOT EXISTS FOR (n:CoveredLabel) REQUIRE n.email IS UNIQUE");
+    assertThat(s.getConstraintsAdded()).isEqualTo(1);
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
@@ -353,4 +353,22 @@ class CypherQueryStatisticsTest extends TestHelper {
       assertThat(s.containsUpdates()).isTrue();
     });
   }
+
+  @Test
+  void zeroNetEffectWriteUnionStillReportsStatisticsPresent() {
+    // Presence of statistics on the result set signals "this was a write statement", independent
+    // of whether the write actually mutated anything. Both UNION branches are MERGE clauses that
+    // match the pre-existing node, so containsUpdates() is false, but getStatistics() must still
+    // be present.
+    database.transaction(() -> {
+      database.command("opencypher", "CREATE (:UnionMergeTarget {id:1})");
+      final ResultSet rs = database.command("opencypher",
+          "MERGE (n:UnionMergeTarget {id:1}) RETURN n.id AS r UNION ALL "
+              + "MERGE (n:UnionMergeTarget {id:1}) RETURN n.id AS r");
+      while (rs.hasNext())
+        rs.next();
+      assertThat(rs.getStatistics()).isPresent();
+      assertThat(rs.getStatistics().get().containsUpdates()).isFalse();
+    });
+  }
 }

--- a/engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/CypherQueryStatisticsTest.java
@@ -331,6 +331,18 @@ class CypherQueryStatisticsTest extends TestHelper {
   }
 
   @Test
+  void detachDeleteWithExplicitEdgeCountsRelationshipOnce() {
+    database.transaction(() -> {
+      database.command("opencypher",
+          "CREATE (a:Dd {n:'a'})-[:LINK]->(b:Dd {n:'b'})");
+      final QueryStatistics s = statsOf(database,
+          "MATCH (a:Dd {n:'a'})-[r:LINK]->(b:Dd {n:'b'}) DETACH DELETE r, a, b");
+      assertThat(s.getRelationshipsDeleted()).isEqualTo(1);
+      assertThat(s.getNodesDeleted()).isEqualTo(2);
+    });
+  }
+
+  @Test
   void callSubqueryWriteCountsPropagateToOuter() {
     database.transaction(() -> {
       final QueryStatistics s = statsOf(database,

--- a/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/CypherStatisticsHelperTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/CypherStatisticsHelperTest.java
@@ -1,0 +1,34 @@
+package com.arcadedb.query.opencypher.executor.steps;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CypherStatisticsHelperTest {
+
+  @Test
+  void countsPreExistingPropertiesNotReSetAndSkipsInternal() {
+    final Set<String> existing = new LinkedHashSet<>();
+    existing.add("a");
+    existing.add("b");
+    existing.add("@type"); // internal - never counted
+    final Map<String, Object> replacement = new HashMap<>();
+    replacement.put("a", 1); // re-set, not a removal
+    // b is removed (absent from replacement) -> counts 1
+    assertThat(CypherStatisticsHelper.countRemovedProperties(existing, replacement)).isEqualTo(1);
+  }
+
+  @Test
+  void nullValuedReplacementIsARemoval() {
+    final Set<String> existing = new LinkedHashSet<>();
+    existing.add("a");
+    final Map<String, Object> replacement = new HashMap<>();
+    replacement.put("a", null); // map.get("a") == null -> counts as removed
+    assertThat(CypherStatisticsHelper.countRemovedProperties(existing, replacement)).isEqualTo(1);
+  }
+}

--- a/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/CypherStatisticsHelperTest.java
+++ b/engine/src/test/java/com/arcadedb/query/opencypher/executor/steps/CypherStatisticsHelperTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.arcadedb.query.opencypher.executor.steps;
 
 import org.junit.jupiter.api.Test;

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/QueryStatisticsTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/QueryStatisticsTest.java
@@ -18,6 +18,7 @@
  */
 package com.arcadedb.query.sql.executor;
 
+import com.arcadedb.serializer.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -83,5 +84,41 @@ class QueryStatisticsTest {
     copy.getStatistics().incNodesCreated();
     assertThat(copy.getStatistics()).isSameAs(ctx.getStatistics());
     assertThat(ctx.getStatistics().getNodesCreated()).isEqualTo(2);
+  }
+
+  @Test
+  void addMergesCountersFieldWise() {
+    final QueryStatistics a = new QueryStatistics();
+    a.incNodesCreated();
+    a.addPropertiesSet(2);
+    final QueryStatistics b = new QueryStatistics();
+    b.incNodesCreated();
+    b.incRelationshipsCreated();
+    b.addPropertiesSet(3);
+    a.add(b);
+    assertThat(a.getNodesCreated()).isEqualTo(2);
+    assertThat(a.getRelationshipsCreated()).isEqualTo(1);
+    assertThat(a.getPropertiesSet()).isEqualTo(5);
+    assertThat(a.containsUpdates()).isTrue();
+  }
+
+  @Test
+  void addNullIsNoOp() {
+    final QueryStatistics a = new QueryStatistics();
+    a.incNodesCreated();
+    a.add(null);
+    assertThat(a.getNodesCreated()).isEqualTo(1);
+  }
+
+  @Test
+  void toJSONEmitsAllCamelCaseCountersAndContainsUpdates() {
+    final QueryStatistics s = new QueryStatistics();
+    s.incNodesCreated();
+    s.addPropertiesSet(2);
+    final JSONObject json = s.toJSON();
+    assertThat(json.getInt("nodesCreated")).isEqualTo(1);
+    assertThat(json.getInt("propertiesSet")).isEqualTo(2);
+    assertThat(json.getInt("relationshipsCreated")).isEqualTo(0);
+    assertThat(json.getBoolean("containsUpdates")).isTrue();
   }
 }

--- a/grpc/src/main/proto/arcadedb-server.proto
+++ b/grpc/src/main/proto/arcadedb-server.proto
@@ -272,6 +272,23 @@ message ExecuteCommandResponse {
   int64 execution_time_ms = 4;
 
   repeated GrpcRecord records = 5; // optional row payload if return_rows=true
+
+  QueryUpdateStats stats = 6; // present only for write commands that mutated data
+}
+
+message QueryUpdateStats {
+  int32 nodes_created = 1;
+  int32 nodes_deleted = 2;
+  int32 relationships_created = 3;
+  int32 relationships_deleted = 4;
+  int32 properties_set = 5;
+  int32 labels_added = 6;
+  int32 labels_removed = 7;
+  int32 indexes_added = 8;
+  int32 indexes_removed = 9;
+  int32 constraints_added = 10;
+  int32 constraints_removed = 11;
+  bool contains_updates = 12;
 }
 
 // -----------------------------------------------------------------------------

--- a/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
+++ b/grpcw/src/main/java/com/arcadedb/server/grpc/ArcadeDbGrpcService.java
@@ -40,6 +40,7 @@ import com.arcadedb.graph.MutableEdge;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.log.LogManager;
+import com.arcadedb.query.sql.executor.QueryStatistics;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.DocumentType;
@@ -469,6 +470,7 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
 
       long serializationAccum = 0L;
       final long engineStart = System.nanoTime();
+      QueryStatistics writeStats = null;
 
       try (ResultSet rs = db.command(language, req.getCommand(), params)) {
 
@@ -528,6 +530,8 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
               }
             }
           }
+
+          writeStats = rs.getStatistics().orElse(null);
         }
       }
 
@@ -573,6 +577,21 @@ public class ArcadeDbGrpcService extends ArcadeDbServiceGrpc.ArcadeDbServiceImpl
       final long ms = (System.nanoTime() - t0) / 1_000_000L;
       final long serFinalStart = System.nanoTime();
       out.setAffectedRecords(affected).setExecutionTimeMs(ms);
+      if (writeStats != null && writeStats.containsUpdates())
+        out.setStats(QueryUpdateStats.newBuilder()
+            .setNodesCreated(writeStats.getNodesCreated())
+            .setNodesDeleted(writeStats.getNodesDeleted())
+            .setRelationshipsCreated(writeStats.getRelationshipsCreated())
+            .setRelationshipsDeleted(writeStats.getRelationshipsDeleted())
+            .setPropertiesSet(writeStats.getPropertiesSet())
+            .setLabelsAdded(writeStats.getLabelsAdded())
+            .setLabelsRemoved(writeStats.getLabelsRemoved())
+            .setIndexesAdded(writeStats.getIndexesAdded())
+            .setIndexesRemoved(writeStats.getIndexesRemoved())
+            .setConstraintsAdded(writeStats.getConstraintsAdded())
+            .setConstraintsRemoved(writeStats.getConstraintsRemoved())
+            .setContainsUpdates(true)
+            .build());
       final ExecuteCommandResponse response = out.build();
       profile.addSerializationNanos(System.nanoTime() - serFinalStart);
       return response;

--- a/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcWriteStatisticsIT.java
+++ b/grpcw/src/test/java/com/arcadedb/server/grpc/GrpcWriteStatisticsIT.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.grpc;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.BaseGraphServerTest;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@code ExecuteCommandResponse.stats} carries Cypher write counters for mutating
+ * commands and is absent for read-only commands.
+ */
+public class GrpcWriteStatisticsIT extends BaseGraphServerTest {
+
+  private static final int GRPC_PORT = 50051;
+
+  private static final Metadata.Key<String> USER_HEADER =
+      Metadata.Key.of("x-arcade-user", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> PASSWORD_HEADER =
+      Metadata.Key.of("x-arcade-password", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Metadata.Key<String> DATABASE_HEADER =
+      Metadata.Key.of("x-arcade-database", Metadata.ASCII_STRING_MARSHALLER);
+
+  private ManagedChannel channel;
+  private ArcadeDbServiceGrpc.ArcadeDbServiceBlockingStub authenticatedStub;
+
+  @Override
+  public void setTestConfiguration() {
+    super.setTestConfiguration();
+    GlobalConfiguration.SERVER_PLUGINS.setValue(
+        "GrpcServer:com.arcadedb.server.grpc.GrpcServerPlugin");
+  }
+
+  @BeforeEach
+  void setupGrpcClient() {
+    channel = ManagedChannelBuilder.forAddress("localhost", GRPC_PORT)
+        .usePlaintext()
+        .build();
+    final Channel authenticatedChannel = ClientInterceptors.intercept(channel, new AuthClientInterceptor());
+    authenticatedStub = ArcadeDbServiceGrpc.newBlockingStub(authenticatedChannel);
+  }
+
+  @AfterEach
+  void teardownGrpcClient() throws InterruptedException {
+    if (channel != null) {
+      channel.shutdown();
+      channel.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private class AuthClientInterceptor implements ClientInterceptor {
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        final MethodDescriptor<ReqT, RespT> method, final CallOptions callOptions, final Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+          next.newCall(method, callOptions)) {
+        @Override
+        public void start(final Listener<RespT> responseListener, final Metadata headers) {
+          headers.put(USER_HEADER, "root");
+          headers.put(PASSWORD_HEADER, DEFAULT_PASSWORD_FOR_TESTS);
+          headers.put(DATABASE_HEADER, getDatabaseName());
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+
+  @Test
+  void writeCommandCarriesStatsInResponse() {
+    final ExecuteCommandRequest writeRequest = ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(DatabaseCredentials.newBuilder()
+            .setUsername("root")
+            .setPassword(DEFAULT_PASSWORD_FOR_TESTS)
+            .build())
+        .setLanguage("opencypher")
+        .setCommand("CREATE (:GrpcStat {name:'x'})-[:REL]->(:GrpcStat2 {name:'y'})")
+        .build();
+
+    final ExecuteCommandResponse write = authenticatedStub.executeCommand(writeRequest);
+
+    assertThat(write.hasStats()).isTrue();
+    assertThat(write.getStats().getNodesCreated()).isEqualTo(2);
+    assertThat(write.getStats().getRelationshipsCreated()).isEqualTo(1);
+    assertThat(write.getStats().getPropertiesSet()).isEqualTo(2);
+    assertThat(write.getStats().getContainsUpdates()).isTrue();
+  }
+
+  @Test
+  void readCommandHasNoStatsInResponse() {
+    final ExecuteCommandRequest seedRequest = ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(DatabaseCredentials.newBuilder()
+            .setUsername("root")
+            .setPassword(DEFAULT_PASSWORD_FOR_TESTS)
+            .build())
+        .setLanguage("opencypher")
+        .setCommand("CREATE (:GrpcStat {name:'x'})")
+        .build();
+    authenticatedStub.executeCommand(seedRequest);
+
+    final ExecuteCommandRequest readRequest = ExecuteCommandRequest.newBuilder()
+        .setDatabase(getDatabaseName())
+        .setCredentials(DatabaseCredentials.newBuilder()
+            .setUsername("root")
+            .setPassword(DEFAULT_PASSWORD_FOR_TESTS)
+            .build())
+        .setLanguage("opencypher")
+        .setCommand("MATCH (n:GrpcStat) RETURN n")
+        .build();
+
+    final ExecuteCommandResponse read = authenticatedStub.executeCommand(readRequest);
+
+    assertThat(read.hasStats()).isFalse();
+  }
+}

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
@@ -191,6 +191,12 @@ public class PostCommandHandler extends AbstractQueryHandler {
           final long serializationStart = System.nanoTime();
           serializeResultSet(database, serializer, limit, response, qResult);
 
+          if (qResult != null) {
+            final var qStats = qResult.getStatistics();
+            if (qStats.isPresent() && qStats.get().containsUpdates())
+              response.put("stats", qStats.get().toJSON());
+          }
+
           if (qResult != null && qResult.getExecutionPlan().isPresent() &&
               (profileExecution != null ||
                   command.toUpperCase(Locale.ENGLISH).startsWith("PROFILE "))) {

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
@@ -23,6 +23,7 @@ import com.arcadedb.database.async.AsyncResultsetCallback;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.query.sql.executor.ExecutionPlan;
 import com.arcadedb.query.sql.executor.IteratorResultSet;
+import com.arcadedb.query.sql.executor.QueryStatistics;
 import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.query.sql.parser.ExplainResultSet;
@@ -265,12 +266,15 @@ public class PostCommandHandler extends AbstractQueryHandler {
         rows.add(source.next());
 
       final Optional<ExecutionPlan> plan = source.getExecutionPlan();
-      return new IteratorResultSet(rows.iterator()) {
+      final Optional<QueryStatistics> stats = source.getStatistics();
+      final IteratorResultSet materialized = new IteratorResultSet(rows.iterator()) {
         @Override
         public Optional<ExecutionPlan> getExecutionPlan() {
           return plan;
         }
       };
+      stats.ifPresent(materialized::setStatistics);
+      return materialized;
     } finally {
       source.close();
     }

--- a/server/src/test/java/com/arcadedb/server/http/handler/PostCommandStatisticsIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/PostCommandStatisticsIT.java
@@ -49,7 +49,23 @@ class PostCommandStatisticsIT extends BaseGraphServerTest {
     assertThat(response.has("stats")).isFalse();
   }
 
+  @Test
+  void writeCommandWithDetailedProfileStillReturnsStats() throws Exception {
+    final JSONObject response = command("opencypher",
+        "CREATE (:HttpStatProfiled {name:'x'})-[:REL]->(:HttpStatProfiled2 {name:'y'})", true);
+    assertThat(response.has("stats")).isTrue();
+    final JSONObject stats = response.getJSONObject("stats");
+    assertThat(stats.getInt("nodesCreated")).isEqualTo(2);
+    assertThat(stats.getInt("relationshipsCreated")).isEqualTo(1);
+    assertThat(stats.getInt("propertiesSet")).isEqualTo(2);
+    assertThat(stats.getBoolean("containsUpdates")).isTrue();
+  }
+
   private JSONObject command(final String language, final String cmd) throws Exception {
+    return command(language, cmd, false);
+  }
+
+  private JSONObject command(final String language, final String cmd, final boolean detailedProfile) throws Exception {
     final HttpURLConnection connection = (HttpURLConnection) new URI(
         "http://127.0.0.1:2480/api/v1/command/graph").toURL().openConnection();
     connection.setRequestMethod("POST");
@@ -59,6 +75,8 @@ class PostCommandStatisticsIT extends BaseGraphServerTest {
     payload.put("language", language);
     payload.put("command", cmd);
     payload.put("serializer", "studio");
+    if (detailedProfile)
+      payload.put("profileExecution", "detailed");
     formatPayload(connection, payload);
     connection.connect();
     try {

--- a/server/src/test/java/com/arcadedb/server/http/handler/PostCommandStatisticsIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/PostCommandStatisticsIT.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.BaseGraphServerTest;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PostCommandStatisticsIT extends BaseGraphServerTest {
+
+  @Test
+  void writeCommandReturnsCamelCaseStats() throws Exception {
+    final JSONObject response = command("opencypher",
+        "CREATE (:HttpStat {name:'x'})-[:REL]->(:HttpStat2 {name:'y'})");
+    assertThat(response.has("stats")).isTrue();
+    final JSONObject stats = response.getJSONObject("stats");
+    assertThat(stats.getInt("nodesCreated")).isEqualTo(2);
+    assertThat(stats.getInt("relationshipsCreated")).isEqualTo(1);
+    assertThat(stats.getInt("propertiesSet")).isEqualTo(2);
+    assertThat(stats.getBoolean("containsUpdates")).isTrue();
+  }
+
+  @Test
+  void readCommandOmitsStats() throws Exception {
+    command("opencypher", "CREATE (:HttpStatRead {id:1})");
+    final JSONObject response = command("opencypher", "MATCH (n:HttpStatRead) RETURN n");
+    assertThat(response.has("stats")).isFalse();
+  }
+
+  private JSONObject command(final String language, final String cmd) throws Exception {
+    final HttpURLConnection connection = (HttpURLConnection) new URI(
+        "http://127.0.0.1:2480/api/v1/command/graph").toURL().openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Authorization",
+        "Basic " + Base64.getEncoder().encodeToString(("root:" + DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
+    final JSONObject payload = new JSONObject();
+    payload.put("language", language);
+    payload.put("command", cmd);
+    payload.put("serializer", "studio");
+    formatPayload(connection, payload);
+    connection.connect();
+    try {
+      final String response = readResponse(connection);
+      assertThat(connection.getResponseCode()).isEqualTo(200);
+      return new JSONObject(response);
+    } finally {
+      connection.disconnect();
+    }
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/PostCommandStatisticsIT.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/PostCommandStatisticsIT.java
@@ -61,6 +61,13 @@ class PostCommandStatisticsIT extends BaseGraphServerTest {
     assertThat(stats.getBoolean("containsUpdates")).isTrue();
   }
 
+  @Test
+  void readCommandWithDetailedProfileOmitsStats() throws Exception {
+    command("opencypher", "CREATE (:HttpStatReadProfiled {id:1})");
+    final JSONObject response = command("opencypher", "MATCH (n:HttpStatReadProfiled) RETURN n", true);
+    assertThat(response.has("stats")).isFalse();
+  }
+
   private JSONObject command(final String language, final String cmd) throws Exception {
     return command(language, cmd, false);
   }


### PR DESCRIPTION
Closes #5015. Part of #4890 (Group C protocol/type-fidelity gaps), epic #4882 (Bolt Driver Compatibility Certification). Builds on the `QueryStatistics` / `ResultSet.getStatistics()` infrastructure merged in #5016.

## Problem
#5016 added a `QueryStatistics` accumulator on `CommandContext`, surfaced via `ResultSet.getStatistics()` and consumed by Bolt only. Three extensions were deliberately deferred to #5015:
1. HTTP `POST /command` and gRPC hold a `ResultSet` but never surfaced the counters.
2. `CypherExecutionPlan` attached the accumulator for top-level mutation steps only, so `CALL { CREATE ... }` and `CREATE ... UNION CREATE ...` returned zero counters and even misreported `containsUpdates() == false` (a `type:"w"` write reporting no updates).
3. Constraint-kind counting (`NOT_NULL`/`KEY`/`TYPED`) was implemented but only `UNIQUE` was test-covered, plus two counter-fidelity bugs surfaced in review.

## Approach
**Aggregation (engine)**
- `QueryStatistics.add(QueryStatistics)` - null-safe field-wise merge; `QueryStatistics.toJSON()` - ArcadeDB-native camelCase shape.
- **CALL subqueries**: thread the outer `CommandContext` into `executeWithSeedRow(...)` and share the outer's accumulator instance via a new `CommandContext.setStatistics(...)`, gated on `!statement.isReadOnly()` so read-only CALL bodies allocate nothing. Inner mutation steps accumulate directly into the outer accumulator (no post-hoc merge, matching the sharing rationale `copy()` already documents).
- **Top-level UNION**: `UnionStep` sums each exhausted branch's stats (`getAggregatedStatistics()`); the read path stays lazy/streaming, the write path materializes (mirroring the non-union write path) and always attaches the aggregate (presence signals "write", `containsUpdates()` signals "mutated").

**Surfacing**
- **HTTP**: `PostCommandHandler` adds a camelCase `stats` object (`nodesCreated`, `relationshipsCreated`, `propertiesSet`, ..., `containsUpdates`) for writes; omitted for reads. Also fixed the detailed-profile path (`CypherExecutionPlan.profile()` + `materializeResultSet`) which previously dropped the counters.
- **gRPC**: new additive `QueryUpdateStats` proto message on `ExecuteCommandResponse` (11 counters + `contains_updates`), populated for writes, absent for reads (proto3 has-semantics).

**Fidelity fixes**
- UNIQUE/KEY constraint added over a pre-existing **non-unique** index now counts as `constraints-added` (`uniqueIndexExistsOnProperties`), plus new `NOT_NULL`/`KEY`/`TYPED` coverage.
- `DETACH DELETE` + explicit edge delete dedups `relationships-deleted` via the shared `deleted` set threaded through `DeleteStep` (deterministic, no longer reliant on `RecordNotFoundException` timing).
- Single-sourced the replace-map removed-property counting rule into `CypherStatisticsHelper` (was duplicated verbatim in `SetStep` and `MergeStep`).

## Testing
- Engine: `QueryStatisticsTest` (add/toJSON), `CypherStatisticsHelperTest`, and `CypherQueryStatisticsTest` extended with CALL, UNION (incl. zero-net-effect write UNION presence), DETACH-DELETE dedup, and constraint-kind/plain-index cases.
- HTTP: `PostCommandStatisticsIT` - write returns camelCase `stats`, read omits it, detailed-profile write returns stats, detailed-profile read omits stats.
- gRPC: `GrpcWriteStatisticsIT` - `ExecuteCommandResponse.stats` populated for a write, absent for a read.
- Bolt: `Bolt5000ResultCountersIT` extended with `CALL { CREATE }` and UNION write counters over the real `neo4j-java-driver`.
- Cross-module `mvn -pl engine,server,grpc,grpcw,bolt -am -DskipTests install` green; full `com.arcadedb.query.opencypher` package regression green.

## Compatibility
Proto change is additive (new field numbers only). `CommandContext.setStatistics(...)` is a new interface method; `BasicCommandContext` is the only implementer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)