### PR TITLE
refactor(#5082): make writeTo() the sole header authority in PackStreamStructure

### DIFF
--- a/bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamStructure.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamStructure.java
@@ -26,17 +26,9 @@ import java.io.IOException;
 public interface PackStreamStructure {
 
   /**
-   * Get the structure signature byte.
-   */
-  byte getSignature();
-
-  /**
-   * Get the number of fields in this structure.
-   */
-  int getFieldCount();
-
-  /**
-   * Write this structure to a PackStream writer.
+   * Write this structure to a PackStream writer. This is the sole authority for the structure's wire
+   * header (marker + signature) and body; there is no separate accessor for signature or field count,
+   * because the header can be version-dependent and only the writer carries the negotiated Bolt version.
    */
   void writeTo(PackStreamWriter writer) throws IOException;
 }

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltDateTimeStructure.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltDateTimeStructure.java
@@ -63,17 +63,6 @@ public class BoltDateTimeStructure implements PackStreamStructure {
   }
 
   @Override
-  public byte getSignature() {
-    // Legacy (Bolt 4.x) signature; writeTo is authoritative and emits the UTC signature ('I'/'i') when the writer negotiated Bolt >= 5.
-    return zoneId ? SIG_ZONEID_LEGACY : SIG_OFFSET_LEGACY;
-  }
-
-  @Override
-  public int getFieldCount() {
-    return 3;
-  }
-
-  @Override
   public void writeTo(final PackStreamWriter writer) throws IOException {
     final boolean utc = writer.getBoltMajorVersion() >= 5;
     final long seconds = utc ? utcEpochSeconds : localEpochSeconds;

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltNode.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltNode.java
@@ -47,17 +47,6 @@ public class BoltNode implements PackStreamStructure {
   }
 
   @Override
-  public byte getSignature() {
-    return SIGNATURE;
-  }
-
-  @Override
-  public int getFieldCount() {
-    // v4.x base count; writeTo is authoritative and emits 4 fields (adds element_id) when the writer negotiated Bolt >= 5.
-    return 3;
-  }
-
-  @Override
   public void writeTo(final PackStreamWriter writer) throws IOException {
     if (writer.getBoltMajorVersion() >= 5) {
       writer.writeStructureHeader(SIGNATURE, 4);

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltPath.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltPath.java
@@ -47,16 +47,6 @@ public class BoltPath implements PackStreamStructure {
   }
 
   @Override
-  public byte getSignature() {
-    return SIGNATURE;
-  }
-
-  @Override
-  public int getFieldCount() {
-    return 3;
-  }
-
-  @Override
   public void writeTo(final PackStreamWriter writer) throws IOException {
     writer.writeStructureHeader(SIGNATURE, 3);
 

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltPointStructure.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltPointStructure.java
@@ -48,18 +48,10 @@ public class BoltPointStructure implements PackStreamStructure {
   }
 
   @Override
-  public byte getSignature() {
-    return z == null ? SIGNATURE_2D : SIGNATURE_3D;
-  }
-
-  @Override
-  public int getFieldCount() {
-    return z == null ? 3 : 4;
-  }
-
-  @Override
   public void writeTo(final PackStreamWriter writer) throws IOException {
-    writer.writeStructureHeader(getSignature(), getFieldCount());
+    final byte signature = z == null ? SIGNATURE_2D : SIGNATURE_3D;
+    final int fieldCount = z == null ? 3 : 4;
+    writer.writeStructureHeader(signature, fieldCount);
     writer.writeValue((long) srid);
     writer.writeValue(x);
     writer.writeValue(y);

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltRelationship.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltRelationship.java
@@ -56,17 +56,6 @@ public class BoltRelationship implements PackStreamStructure {
   }
 
   @Override
-  public byte getSignature() {
-    return SIGNATURE;
-  }
-
-  @Override
-  public int getFieldCount() {
-    // v4.x base count; writeTo is authoritative and emits 8 fields (adds element_id + start/end element ids) when the writer negotiated Bolt >= 5.
-    return 5;
-  }
-
-  @Override
   public void writeTo(final PackStreamWriter writer) throws IOException {
     if (writer.getBoltMajorVersion() >= 5) {
       writer.writeStructureHeader(SIGNATURE, 8);

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltTemporalStructure.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltTemporalStructure.java
@@ -43,16 +43,6 @@ public class BoltTemporalStructure implements PackStreamStructure {
   }
 
   @Override
-  public byte getSignature() {
-    return signature;
-  }
-
-  @Override
-  public int getFieldCount() {
-    return fields.length;
-  }
-
-  @Override
   public void writeTo(final PackStreamWriter writer) throws IOException {
     writer.writeStructureHeader(signature, fields.length);
     for (final Object field : fields)

--- a/bolt/src/main/java/com/arcadedb/bolt/structure/BoltUnboundRelationship.java
+++ b/bolt/src/main/java/com/arcadedb/bolt/structure/BoltUnboundRelationship.java
@@ -47,17 +47,6 @@ public class BoltUnboundRelationship implements PackStreamStructure {
   }
 
   @Override
-  public byte getSignature() {
-    return SIGNATURE;
-  }
-
-  @Override
-  public int getFieldCount() {
-    // v4.x base count; writeTo is authoritative and emits 4 fields (adds element_id) when the writer negotiated Bolt >= 5.
-    return 3;
-  }
-
-  @Override
   public void writeTo(final PackStreamWriter writer) throws IOException {
     if (writer.getBoltMajorVersion() >= 5) {
       writer.writeStructureHeader(SIGNATURE, 4);

--- a/bolt/src/test/java/com/arcadedb/bolt/Bolt4998PathMappingTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/Bolt4998PathMappingTest.java
@@ -117,7 +117,7 @@ class Bolt4998PathMappingTest {
     final Object out = BoltStructureMapper.toPackStreamValue(p);
     assertThat(out).isInstanceOf(BoltPointStructure.class);
     final BoltPointStructure pt = (BoltPointStructure) out;
-    assertThat(pt.getSignature()).isEqualTo((byte) 0x58);
+    assertThat(pt.getZ()).isNull(); // z absent -> writeTo emits the Point2D (0x58) signature
     assertThat(pt.getSrid()).isEqualTo(7203);
     assertThat(pt.getX()).isEqualTo(12.34);
     assertThat(pt.getY()).isEqualTo(56.78);

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltStructureTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltStructureTest.java
@@ -19,6 +19,7 @@
 package com.arcadedb.bolt;
 
 import com.arcadedb.bolt.packstream.PackStreamReader;
+import com.arcadedb.bolt.packstream.PackStreamStructure;
 import com.arcadedb.bolt.packstream.PackStreamWriter;
 import com.arcadedb.bolt.structure.BoltNode;
 import com.arcadedb.bolt.structure.BoltPath;
@@ -30,6 +31,7 @@ import com.arcadedb.database.RID;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
@@ -50,14 +52,23 @@ import static org.assertj.core.api.Assertions.*;
  */
 class BoltStructureTest {
 
+  // Serializes a structure at the default (Bolt 4.x) negotiated version and returns the raw PackStream
+  // bytes. The first byte is the TINY_STRUCT marker (0xB0 | fieldCount); the second is the signature.
+  private static byte[] wireHeader(final PackStreamStructure s) throws IOException {
+    final PackStreamWriter writer = new PackStreamWriter();
+    s.writeTo(writer);
+    return writer.toByteArray();
+  }
+
   // ============ BoltNode tests ============
 
   @Test
-  void boltNodeCreation() {
+  void boltNodeCreation() throws IOException {
     final BoltNode node = new BoltNode(123L, List.of("Person", "Employee"), Map.of("name", "Alice"), "#1:0");
 
-    assertThat(node.getSignature()).isEqualTo(BoltNode.SIGNATURE);
-    assertThat(node.getFieldCount()).isEqualTo(3);
+    final byte[] header = wireHeader(node);
+    assertThat(header[0]).isEqualTo((byte) (0xB0 | 3)); // TINY_STRUCT, 3 fields (Bolt 4.x)
+    assertThat(header[1]).isEqualTo(BoltNode.SIGNATURE);
     assertThat(node.getId()).isEqualTo(123L);
     assertThat(node.getLabels()).containsExactly("Person", "Employee");
     assertThat(node.getProperties()).containsEntry("name", "Alice");
@@ -96,13 +107,14 @@ class BoltStructureTest {
   // ============ BoltRelationship tests ============
 
   @Test
-  void boltRelationshipCreation() {
+  void boltRelationshipCreation() throws IOException {
     final BoltRelationship rel = new BoltRelationship(
         100L, 1L, 2L, "KNOWS", Map.of("since", 2020), "#10:0", "#1:0", "#2:0"
     );
 
-    assertThat(rel.getSignature()).isEqualTo(BoltRelationship.SIGNATURE);
-    assertThat(rel.getFieldCount()).isEqualTo(5);
+    final byte[] header = wireHeader(rel);
+    assertThat(header[0]).isEqualTo((byte) (0xB0 | 5)); // TINY_STRUCT, 5 fields (Bolt 4.x)
+    assertThat(header[1]).isEqualTo(BoltRelationship.SIGNATURE);
     assertThat(rel.getId()).isEqualTo(100L);
     assertThat(rel.getStartNodeId()).isEqualTo(1L);
     assertThat(rel.getEndNodeId()).isEqualTo(2L);
@@ -146,11 +158,12 @@ class BoltStructureTest {
   // ============ BoltUnboundRelationship tests ============
 
   @Test
-  void boltUnboundRelationshipCreation() {
+  void boltUnboundRelationshipCreation() throws IOException {
     final BoltUnboundRelationship rel = new BoltUnboundRelationship(1L, "FRIEND", Map.of("weight", 0.5), "#1:0");
 
-    assertThat(rel.getSignature()).isEqualTo(BoltUnboundRelationship.SIGNATURE);
-    assertThat(rel.getFieldCount()).isEqualTo(3);
+    final byte[] header = wireHeader(rel);
+    assertThat(header[0]).isEqualTo((byte) (0xB0 | 3)); // TINY_STRUCT, 3 fields (Bolt 4.x)
+    assertThat(header[1]).isEqualTo(BoltUnboundRelationship.SIGNATURE);
     assertThat(rel.getId()).isEqualTo(1L);
     assertThat(rel.getType()).isEqualTo("FRIEND");
     assertThat(rel.getProperties()).containsEntry("weight", 0.5);
@@ -187,7 +200,7 @@ class BoltStructureTest {
   // ============ BoltPath tests ============
 
   @Test
-  void boltPathCreation() {
+  void boltPathCreation() throws IOException {
     final List<BoltNode> nodes = List.of(
         new BoltNode(1L, List.of("A"), Map.of(), "#1:0"),
         new BoltNode(2L, List.of("B"), Map.of(), "#2:0")
@@ -199,8 +212,9 @@ class BoltStructureTest {
 
     final BoltPath path = new BoltPath(nodes, rels, indices);
 
-    assertThat(path.getSignature()).isEqualTo(BoltPath.SIGNATURE);
-    assertThat(path.getFieldCount()).isEqualTo(3);
+    final byte[] header = wireHeader(path);
+    assertThat(header[0]).isEqualTo((byte) (0xB0 | 3)); // TINY_STRUCT, 3 fields
+    assertThat(header[1]).isEqualTo(BoltPath.SIGNATURE);
     assertThat(path.getNodes()).hasSize(2);
     assertThat(path.getRelationships()).hasSize(1);
     assertThat(path.getIndices()).containsExactly(1L, 1L);

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltStructureTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltStructureTest.java
@@ -55,7 +55,12 @@ class BoltStructureTest {
   // Serializes a structure at the default (Bolt 4.x) negotiated version and returns the raw PackStream
   // bytes. The first byte is the TINY_STRUCT marker (0xB0 | fieldCount); the second is the signature.
   private static byte[] wireHeader(final PackStreamStructure s) throws IOException {
-    final PackStreamWriter writer = new PackStreamWriter();
+    return wireHeader(s, 4);
+  }
+
+  // Serializes a structure at the given negotiated Bolt major version.
+  private static byte[] wireHeader(final PackStreamStructure s, final int boltMajorVersion) throws IOException {
+    final PackStreamWriter writer = new PackStreamWriter().boltMajorVersion(boltMajorVersion);
     s.writeTo(writer);
     return writer.toByteArray();
   }
@@ -218,6 +223,26 @@ class BoltStructureTest {
     assertThat(path.getNodes()).hasSize(2);
     assertThat(path.getRelationships()).hasSize(1);
     assertThat(path.getIndices()).containsExactly(1L, 1L);
+  }
+
+  @Test
+  void versionGatedStructuresEmitBolt5HeaderShape() throws IOException {
+    // On Bolt >= 5 the version-gated structs append element_id fields, so writeTo() must emit a wider
+    // header than the 4.x base: Node 3 -> 4, Relationship 5 -> 8, UnboundRelationship 3 -> 4. This is
+    // the exact case the removed accessors got wrong (they returned the 4.x count on a 5.x connection);
+    // pin the 5.x header shape at the unit level so a regression in the version gate fails fast here.
+    final byte[] node = wireHeader(new BoltNode(1L, List.of("Label"), Map.of("k", "v"), "#1:0"), 5);
+    assertThat(node[0]).isEqualTo((byte) (0xB0 | 4)); // TINY_STRUCT, 4 fields (adds element_id)
+    assertThat(node[1]).isEqualTo(BoltNode.SIGNATURE);
+
+    final byte[] rel = wireHeader(
+        new BoltRelationship(10L, 1L, 2L, "KNOWS", Map.of(), "#10:0", "#1:0", "#2:0"), 5);
+    assertThat(rel[0]).isEqualTo((byte) (0xB0 | 8)); // TINY_STRUCT, 8 fields (adds element ids)
+    assertThat(rel[1]).isEqualTo(BoltRelationship.SIGNATURE);
+
+    final byte[] unbound = wireHeader(new BoltUnboundRelationship(5L, "REL", Map.of(), "#5:0"), 5);
+    assertThat(unbound[0]).isEqualTo((byte) (0xB0 | 4)); // TINY_STRUCT, 4 fields (adds element_id)
+    assertThat(unbound[1]).isEqualTo(BoltUnboundRelationship.SIGNATURE);
   }
 
   @Test

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltTypeRoundTripTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltTypeRoundTripTest.java
@@ -102,7 +102,7 @@ class BoltTypeRoundTripTest {
 
   @Test
   @DisplayName("[TYPE-012] cartesian Point serializes as a native Bolt Point2D structure")
-  void type012_cartesianPointNative() {
+  void type012_cartesianPointNative() throws IOException {
     final Map<String, Object> point = new LinkedHashMap<>();
     point.put("x", 12.34);
     point.put("y", 56.78);
@@ -113,12 +113,19 @@ class BoltTypeRoundTripTest {
     assertThat(p.getSrid()).isEqualTo(7203);
     assertThat(p.getX()).isEqualTo(12.34);
     assertThat(p.getY()).isEqualTo(56.78);
-    assertThat(p.getZ()).isNull(); // z absent -> writeTo emits the Point2D (0x58) signature
+    assertThat(p.getZ()).isNull();
+
+    // Pin the header the inlined BoltPointStructure.writeTo emits for a 2D point (z absent).
+    final PackStreamWriter writer = new PackStreamWriter();
+    p.writeTo(writer);
+    final byte[] bytes = writer.toByteArray();
+    assertThat(bytes[0]).isEqualTo((byte) (0xB0 | 3)); // TINY_STRUCT, 3 fields
+    assertThat(bytes[1]).isEqualTo(BoltPointStructure.SIGNATURE_2D);
   }
 
   @Test
   @DisplayName("[TYPE-012] WGS-84 3D Point serializes as a native Bolt Point3D structure")
-  void type012_wgs84Point3DNative() {
+  void type012_wgs84Point3DNative() throws IOException {
     final Map<String, Object> point = new LinkedHashMap<>();
     point.put("longitude", 12.34);
     point.put("latitude", 56.78);
@@ -129,7 +136,14 @@ class BoltTypeRoundTripTest {
     assertThat(p.getSrid()).isEqualTo(4979);
     assertThat(p.getX()).isEqualTo(12.34);
     assertThat(p.getY()).isEqualTo(56.78);
-    assertThat(p.getZ()).isEqualTo(100.0); // z present -> writeTo emits the Point3D (0x59) signature
+    assertThat(p.getZ()).isEqualTo(100.0);
+
+    // Pin the header the inlined BoltPointStructure.writeTo emits for a 3D point (z present).
+    final PackStreamWriter writer = new PackStreamWriter();
+    p.writeTo(writer);
+    final byte[] bytes = writer.toByteArray();
+    assertThat(bytes[0]).isEqualTo((byte) (0xB0 | 4)); // TINY_STRUCT, 4 fields
+    assertThat(bytes[1]).isEqualTo(BoltPointStructure.SIGNATURE_3D);
   }
 
   @Test

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltTypeRoundTripTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltTypeRoundTripTest.java
@@ -90,8 +90,6 @@ class BoltTypeRoundTripTest {
     final Object out = BoltStructureMapper.toPackStreamValue(d);
     assertThat(out).isInstanceOf(BoltTemporalStructure.class);
     final BoltTemporalStructure s = (BoltTemporalStructure) out;
-    assertThat(s.getSignature()).isEqualTo((byte) 0x45);
-    assertThat(s.getFieldCount()).isEqualTo(4);
 
     // BoltTemporalStructure has no field getter by design; round-trip through the wire to pin the
     // field ORDER and VALUES, not just the structure shape.
@@ -112,7 +110,7 @@ class BoltTypeRoundTripTest {
     final Object out = BoltStructureMapper.toPackStreamValue(point);
     assertThat(out).isInstanceOf(BoltPointStructure.class);
     final BoltPointStructure p = (BoltPointStructure) out;
-    assertThat(p.getSignature()).isEqualTo((byte) 0x58);
+    assertThat(p.getZ()).isNull(); // z absent -> writeTo emits the Point2D (0x58) signature
     assertThat(p.getSrid()).isEqualTo(7203);
     assertThat(p.getX()).isEqualTo(12.34);
     assertThat(p.getY()).isEqualTo(56.78);
@@ -129,7 +127,7 @@ class BoltTypeRoundTripTest {
     point.put("crs", "WGS-84-3D");
     point.put("srid", 4979);
     final BoltPointStructure p = (BoltPointStructure) BoltStructureMapper.toPackStreamValue(point);
-    assertThat(p.getSignature()).isEqualTo((byte) 0x59);
+    assertThat(p.getZ()).isNotNull(); // z present -> writeTo emits the Point3D (0x59) signature
     assertThat(p.getSrid()).isEqualTo(4979);
     assertThat(p.getX()).isEqualTo(12.34);
     assertThat(p.getY()).isEqualTo(56.78);

--- a/bolt/src/test/java/com/arcadedb/bolt/BoltTypeRoundTripTest.java
+++ b/bolt/src/test/java/com/arcadedb/bolt/BoltTypeRoundTripTest.java
@@ -110,11 +110,10 @@ class BoltTypeRoundTripTest {
     final Object out = BoltStructureMapper.toPackStreamValue(point);
     assertThat(out).isInstanceOf(BoltPointStructure.class);
     final BoltPointStructure p = (BoltPointStructure) out;
-    assertThat(p.getZ()).isNull(); // z absent -> writeTo emits the Point2D (0x58) signature
     assertThat(p.getSrid()).isEqualTo(7203);
     assertThat(p.getX()).isEqualTo(12.34);
     assertThat(p.getY()).isEqualTo(56.78);
-    assertThat(p.getZ()).isNull();
+    assertThat(p.getZ()).isNull(); // z absent -> writeTo emits the Point2D (0x58) signature
   }
 
   @Test
@@ -127,11 +126,10 @@ class BoltTypeRoundTripTest {
     point.put("crs", "WGS-84-3D");
     point.put("srid", 4979);
     final BoltPointStructure p = (BoltPointStructure) BoltStructureMapper.toPackStreamValue(point);
-    assertThat(p.getZ()).isNotNull(); // z present -> writeTo emits the Point3D (0x59) signature
     assertThat(p.getSrid()).isEqualTo(4979);
     assertThat(p.getX()).isEqualTo(12.34);
     assertThat(p.getY()).isEqualTo(56.78);
-    assertThat(p.getZ()).isEqualTo(100.0);
+    assertThat(p.getZ()).isEqualTo(100.0); // z present -> writeTo emits the Point3D (0x59) signature
   }
 
   @Test

--- a/docs/superpowers/plans/2026-07-08-bolt-writeto-header-authority.md
+++ b/docs/superpowers/plans/2026-07-08-bolt-writeto-header-authority.md
@@ -1,0 +1,331 @@
+# Bolt writeTo() Sole Header Authority Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove `getSignature()` and `getFieldCount()` from the `PackStreamStructure` interface and all seven implementers, making `writeTo()` the sole authority for Bolt structure-header emission, with zero wire-behavior change on any negotiated Bolt version (3.0-5.4).
+
+**Architecture:** Two-phase refactor. Phase 1 converts the three test files that assert on the *interface* accessors over to wire-byte / value-getter assertions - these new assertions pass against current behavior and act as characterization guards. Phase 2 deletes the accessors (inlining the one internal consumer, `BoltPointStructure.writeTo`), guarded green by the Phase-1 assertions plus the existing real-driver ITs.
+
+**Tech Stack:** Java 21, Maven, JUnit 5 (Jupiter), AssertJ. Module: `bolt`.
+
+## Global Constraints
+
+- Java 21+ (main branch).
+- Do NOT commit on the user's behalf beyond the commits this plan specifies on the feature branch; the user reviews before any push/merge.
+- `final` on variables and parameters where the surrounding code does.
+- Single-child `if` needs no braces (match existing style).
+- No new dependencies.
+- No `System.out` debug left behind.
+- No issue-number references in code comments (behavioral invariants only).
+- No `@author` / Claude attribution in source.
+- Working directory / worktree: `.worktrees/feat/5082-bolt-writeto-header-authority` on branch `feat/5082-bolt-writeto-header-authority`.
+
+---
+
+## File Structure
+
+**Production (Phase 2):**
+- `bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamStructure.java` - drop two method declarations; becomes single-method contract.
+- `bolt/src/main/java/com/arcadedb/bolt/structure/BoltPointStructure.java` - inline signature + field count into `writeTo()`; delete two accessors.
+- `bolt/src/main/java/com/arcadedb/bolt/structure/BoltNode.java` - delete two accessors.
+- `bolt/src/main/java/com/arcadedb/bolt/structure/BoltRelationship.java` - delete two accessors.
+- `bolt/src/main/java/com/arcadedb/bolt/structure/BoltUnboundRelationship.java` - delete two accessors.
+- `bolt/src/main/java/com/arcadedb/bolt/structure/BoltPath.java` - delete two accessors.
+- `bolt/src/main/java/com/arcadedb/bolt/structure/BoltTemporalStructure.java` - delete two accessors.
+- `bolt/src/main/java/com/arcadedb/bolt/structure/BoltDateTimeStructure.java` - delete two accessors.
+
+**Tests (Phase 1):**
+- `bolt/src/test/java/com/arcadedb/bolt/BoltStructureTest.java` - 4 creation tests → wire-byte header assertions.
+- `bolt/src/test/java/com/arcadedb/bolt/BoltTypeRoundTripTest.java` - TYPE-011 drop pre-wire accessor asserts; TYPE-012 (x2) signature assert → `getZ()`.
+- `bolt/src/test/java/com/arcadedb/bolt/Bolt4998PathMappingTest.java` - TYPE-012 point signature assert → `getZ()`.
+
+**Untouched (verified different types / safe):** `BoltDateTimeStructureTest` (all `getSignature()` on `PackStreamReader.StructureValue` via its `roundTrip`/`mapperRoundTrip` helpers), `PackStreamTest` (`StructureValue`), `BoltMessageTest` (`BoltMessage`), and `BoltStructureMapper` / `BoltMessage` / `PackStreamReader.StructureValue` production code.
+
+---
+
+### Task 1: Convert test assertions off the interface accessors (characterization guard)
+
+Rewrite every assertion that reads `PackStreamStructure.getSignature()` / `getFieldCount()` on an *interface implementer* so it instead asserts the serialized wire header (Node/Rel/UnboundRel/Path) or the z-coordinate that solely determines a Point's signature (Point). These assertions must PASS against current, unchanged production code - they are the guard that Task 2's removal is behavior-preserving.
+
+**Files:**
+- Modify: `bolt/src/test/java/com/arcadedb/bolt/BoltStructureTest.java`
+- Modify: `bolt/src/test/java/com/arcadedb/bolt/BoltTypeRoundTripTest.java`
+- Modify: `bolt/src/test/java/com/arcadedb/bolt/Bolt4998PathMappingTest.java`
+
+**Interfaces:**
+- Consumes: `PackStreamStructure.writeTo(PackStreamWriter)` (unchanged), `PackStreamWriter.toByteArray()`, `BoltPointStructure.getZ()`.
+- Produces: nothing for later tasks; this task only de-couples tests from the soon-to-be-removed accessors.
+
+- [ ] **Step 1: Add imports + a wire helper to `BoltStructureTest`**
+
+Add to the import block (after the existing `com.arcadedb.bolt.packstream.PackStreamWriter` import and in the `java.io` group):
+
+```java
+import com.arcadedb.bolt.packstream.PackStreamStructure;
+```
+```java
+import java.io.IOException;
+```
+
+Add this private helper inside the `BoltStructureTest` class (near the top, before the first `@Test`):
+
+```java
+  // Serializes a structure at the default (Bolt 4.x) negotiated version and returns the raw PackStream
+  // bytes. The first byte is the TINY_STRUCT marker (0xB0 | fieldCount); the second is the signature.
+  private static byte[] wireHeader(final PackStreamStructure s) throws IOException {
+    final PackStreamWriter writer = new PackStreamWriter();
+    s.writeTo(writer);
+    return writer.toByteArray();
+  }
+```
+
+- [ ] **Step 2: Rewrite the 4 creation tests in `BoltStructureTest`**
+
+In `boltNodeCreation`, change the signature to `throws IOException` and replace:
+
+```java
+    assertThat(node.getSignature()).isEqualTo(BoltNode.SIGNATURE);
+    assertThat(node.getFieldCount()).isEqualTo(3);
+```
+with:
+```java
+    final byte[] header = wireHeader(node);
+    assertThat(header[0]).isEqualTo((byte) (0xB0 | 3)); // TINY_STRUCT, 3 fields (Bolt 4.x)
+    assertThat(header[1]).isEqualTo(BoltNode.SIGNATURE);
+```
+
+In `boltRelationshipCreation` (`throws IOException`), replace:
+```java
+    assertThat(rel.getSignature()).isEqualTo(BoltRelationship.SIGNATURE);
+    assertThat(rel.getFieldCount()).isEqualTo(5);
+```
+with:
+```java
+    final byte[] header = wireHeader(rel);
+    assertThat(header[0]).isEqualTo((byte) (0xB0 | 5)); // TINY_STRUCT, 5 fields (Bolt 4.x)
+    assertThat(header[1]).isEqualTo(BoltRelationship.SIGNATURE);
+```
+
+In `boltUnboundRelationshipCreation` (`throws IOException`), replace:
+```java
+    assertThat(rel.getSignature()).isEqualTo(BoltUnboundRelationship.SIGNATURE);
+    assertThat(rel.getFieldCount()).isEqualTo(3);
+```
+with:
+```java
+    final byte[] header = wireHeader(rel);
+    assertThat(header[0]).isEqualTo((byte) (0xB0 | 3)); // TINY_STRUCT, 3 fields (Bolt 4.x)
+    assertThat(header[1]).isEqualTo(BoltUnboundRelationship.SIGNATURE);
+```
+
+In `boltPathCreation` (`throws IOException`), replace:
+```java
+    assertThat(path.getSignature()).isEqualTo(BoltPath.SIGNATURE);
+    assertThat(path.getFieldCount()).isEqualTo(3);
+```
+with:
+```java
+    final byte[] header = wireHeader(path);
+    assertThat(header[0]).isEqualTo((byte) (0xB0 | 3)); // TINY_STRUCT, 3 fields
+    assertThat(header[1]).isEqualTo(BoltPath.SIGNATURE);
+```
+
+- [ ] **Step 3: Rewrite the TYPE-011 and TYPE-012 assertions in `BoltTypeRoundTripTest`**
+
+In `type011_durationNative` (already `throws IOException`), delete these two now-redundant pre-wire lines (the code just below already round-trips through the wire and asserts `wire.getSignature()` == `0x45` and the exact field values):
+
+```java
+    assertThat(s.getSignature()).isEqualTo((byte) 0x45);
+    assertThat(s.getFieldCount()).isEqualTo(4);
+```
+
+Keep the surrounding `final BoltTemporalStructure s = (BoltTemporalStructure) out;` line and everything after it - `s` is still written to the wire below.
+
+In `type012_cartesianPointNative`, replace:
+```java
+    assertThat(p.getSignature()).isEqualTo((byte) 0x58);
+```
+with (a 2D point is exactly the case where `writeTo` emits the `0x58` Point2D signature - i.e. `z == null`):
+```java
+    assertThat(p.getZ()).isNull(); // z absent -> writeTo emits the Point2D (0x58) signature
+```
+
+In `type012_wgs84Point3DNative`, replace:
+```java
+    assertThat(p.getSignature()).isEqualTo((byte) 0x59);
+```
+with:
+```java
+    assertThat(p.getZ()).isNotNull(); // z present -> writeTo emits the Point3D (0x59) signature
+```
+
+(The `assertThat(p.getZ()).isEqualTo(100.0);` line further down remains and pins the actual value.)
+
+- [ ] **Step 4: Rewrite the TYPE-012 point assertion in `Bolt4998PathMappingTest`**
+
+In `type012_enginePointOutbound`, replace:
+```java
+    assertThat(pt.getSignature()).isEqualTo((byte) 0x58);
+```
+with:
+```java
+    assertThat(pt.getZ()).isNull(); // z absent -> writeTo emits the Point2D (0x58) signature
+```
+
+- [ ] **Step 5: Run the three converted test classes and verify they PASS against unchanged production code**
+
+Run:
+```bash
+cd .worktrees/feat/5082-bolt-writeto-header-authority
+mvn -q -pl bolt test -Dtest='BoltStructureTest,BoltTypeRoundTripTest,Bolt4998PathMappingTest'
+```
+Expected: BUILD SUCCESS, all three classes green. (Proves the new assertions correctly characterize current wire behavior before any accessor is removed.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add bolt/src/test/java/com/arcadedb/bolt/BoltStructureTest.java \
+        bolt/src/test/java/com/arcadedb/bolt/BoltTypeRoundTripTest.java \
+        bolt/src/test/java/com/arcadedb/bolt/Bolt4998PathMappingTest.java
+git commit -m "test(#5082): assert Bolt structure headers on the wire, not via getSignature/getFieldCount"
+```
+
+---
+
+### Task 2: Remove `getSignature()` / `getFieldCount()` from the interface and all implementers
+
+Delete the two accessors from `PackStreamStructure` and all seven implementers. The only internal consumer, `BoltPointStructure.writeTo`, is rewritten to inline its own signature + field count. This is an atomic change: an `@Override` accessor left behind after the interface method is removed is a compile error, so interface + implementers change together in one commit.
+
+**Files:**
+- Modify: `bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamStructure.java`
+- Modify: `bolt/src/main/java/com/arcadedb/bolt/structure/BoltPointStructure.java`
+- Modify: `bolt/src/main/java/com/arcadedb/bolt/structure/BoltNode.java`
+- Modify: `bolt/src/main/java/com/arcadedb/bolt/structure/BoltRelationship.java`
+- Modify: `bolt/src/main/java/com/arcadedb/bolt/structure/BoltUnboundRelationship.java`
+- Modify: `bolt/src/main/java/com/arcadedb/bolt/structure/BoltPath.java`
+- Modify: `bolt/src/main/java/com/arcadedb/bolt/structure/BoltTemporalStructure.java`
+- Modify: `bolt/src/main/java/com/arcadedb/bolt/structure/BoltDateTimeStructure.java`
+
+**Interfaces:**
+- Consumes: the Task-1 wire-header assertions (guard), the existing `bolt` ITs (`RemoteBoltDatabaseIT`, `BoltProtocolIT`, Bolt-version-negotiation ITs).
+- Produces: `PackStreamStructure` reduced to `void writeTo(PackStreamWriter) throws IOException`. No new symbols other code depends on.
+
+- [ ] **Step 1: Reduce the `PackStreamStructure` interface to a single method**
+
+Replace the body of `PackStreamStructure.java` (the interface declaration through its methods) so only `writeTo` remains:
+
+```java
+public interface PackStreamStructure {
+
+  /**
+   * Write this structure to a PackStream writer. This is the sole authority for the structure's wire
+   * header (marker + signature) and body; there is no separate accessor for signature or field count,
+   * because the header can be version-dependent and only the writer carries the negotiated Bolt version.
+   */
+  void writeTo(PackStreamWriter writer) throws IOException;
+}
+```
+
+Leave the license header, package statement, and `import java.io.IOException;` intact.
+
+- [ ] **Step 2: Inline the header in `BoltPointStructure.writeTo` and delete its accessors**
+
+Replace the `getSignature()`, `getFieldCount()`, and `writeTo()` members with:
+
+```java
+  @Override
+  public void writeTo(final PackStreamWriter writer) throws IOException {
+    final byte signature = z == null ? SIGNATURE_2D : SIGNATURE_3D;
+    final int fieldCount = z == null ? 3 : 4;
+    writer.writeStructureHeader(signature, fieldCount);
+    writer.writeValue((long) srid);
+    writer.writeValue(x);
+    writer.writeValue(y);
+    if (z != null)
+      writer.writeValue(z);
+  }
+```
+
+Keep the `SIGNATURE_2D` / `SIGNATURE_3D` constants and the `getSrid`/`getX`/`getY`/`getZ` getters.
+
+- [ ] **Step 3: Delete the two accessors from the remaining six implementers**
+
+In each of `BoltNode`, `BoltRelationship`, `BoltUnboundRelationship`, `BoltPath`, `BoltTemporalStructure`, `BoltDateTimeStructure`, delete the entire `@Override public byte getSignature() { ... }` and `@Override public int getFieldCount() { ... }` methods, including their preceding comment lines (e.g. the `// v4.x base count; writeTo is authoritative ...` fragments). Do NOT touch each class's `writeTo()` body, its `SIGNATURE` constant, or its value getters.
+
+For example, in `BoltNode.java` remove exactly:
+
+```java
+  @Override
+  public byte getSignature() {
+    return SIGNATURE;
+  }
+
+  @Override
+  public int getFieldCount() {
+    // v4.x base count; writeTo is authoritative and emits 4 fields (adds element_id) when the writer negotiated Bolt >= 5.
+    return 3;
+  }
+```
+
+Apply the analogous deletion in the other five classes.
+
+- [ ] **Step 4: Compile the module**
+
+Run:
+```bash
+mvn -q -pl bolt -am test-compile
+```
+Expected: BUILD SUCCESS with no `method does not override a method from its superclass` and no `cannot find symbol` errors.
+
+- [ ] **Step 5: Full module verify (unit tests + real-driver ITs across Bolt 3.0-5.4)**
+
+Run:
+```bash
+mvn -q -pl bolt verify
+```
+Expected: BUILD SUCCESS. This is the guard that no wire behavior changed for any negotiated version - `BoltStructureTest`, `BoltDateTimeStructureTest`, `BoltTypeRoundTripTest`, `BoltProtocolIT`, `RemoteBoltDatabaseIT`, and the version-negotiation ITs all pass.
+
+- [ ] **Step 6: Confirm no stray references to the removed accessors remain**
+
+Run:
+```bash
+grep -rn 'getFieldCount\|getSignature' bolt/src/main/java/com/arcadedb/bolt/structure/ bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamStructure.java
+```
+Expected: no matches in `structure/*.java` and none in `PackStreamStructure.java`. (Matches elsewhere - `PackStreamReader.StructureValue`, `BoltMessage` - are the untouched different types and are fine.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add bolt/src/main/java/com/arcadedb/bolt/packstream/PackStreamStructure.java \
+        bolt/src/main/java/com/arcadedb/bolt/structure/BoltPointStructure.java \
+        bolt/src/main/java/com/arcadedb/bolt/structure/BoltNode.java \
+        bolt/src/main/java/com/arcadedb/bolt/structure/BoltRelationship.java \
+        bolt/src/main/java/com/arcadedb/bolt/structure/BoltUnboundRelationship.java \
+        bolt/src/main/java/com/arcadedb/bolt/structure/BoltPath.java \
+        bolt/src/main/java/com/arcadedb/bolt/structure/BoltTemporalStructure.java \
+        bolt/src/main/java/com/arcadedb/bolt/structure/BoltDateTimeStructure.java
+git commit -m "refactor(#5082): make writeTo() the sole header authority in PackStreamStructure
+
+Remove getSignature()/getFieldCount() from the PackStreamStructure interface and
+all seven implementers; inline the header write in BoltPointStructure.writeTo (its
+only internal consumer). writeTo() is now the single source of truth for structure
+headers, which the version-gated structs already require since only the writer
+carries the negotiated Bolt version. No wire change on any version (3.0-5.4)."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- AC "interface no longer exposes accessors" → Task 2 Step 1.
+- AC "no @Override accessor remains on any implementer" → Task 2 Steps 2-3, verified Step 6.
+- AC "no wire behavioral change 3.0-5.4" → Task 1 guard assertions + Task 2 Step 5 (`mvn -pl bolt verify`).
+- AC "three affected test files compile and pass" → Task 1 Steps 2-5.
+- AC "`mvn -pl bolt verify` green" → Task 2 Step 5.
+- Spec's `BoltPointStructure` inline requirement → Task 2 Step 2.
+- Spec's "untouched: BoltDateTimeStructureTest / decode path" → honored (not in any task's file list).
+
+**Placeholder scan:** No TBD/TODO; every code step shows exact before/after code and exact commands with expected output.
+
+**Type consistency:** `wireHeader(PackStreamStructure)` helper is defined in Task 1 Step 1 and used in Step 2. Marker byte `(byte)(0xB0 | n)` matches `PackStreamWriter.writeStructureHeader` (`TINY_STRUCT | fieldCount`, `TINY_STRUCT = 0xB0`). `SIGNATURE_2D`/`SIGNATURE_3D`, `getZ()`, per-class `SIGNATURE` constants all exist in the current source. Field counts (Node 3, Rel 5, UnboundRel 3, Path 3 at Bolt 4.x default) match each `writeTo()`'s else-branch literal.

--- a/docs/superpowers/specs/2026-07-08-bolt-writeto-header-authority-design.md
+++ b/docs/superpowers/specs/2026-07-08-bolt-writeto-header-authority-design.md
@@ -1,0 +1,177 @@
+# Bolt: make writeTo() the sole header authority in PackStreamStructure
+
+Issue: [#5082](https://github.com/ArcadeData/arcadedb/issues/5082)
+Epic: [#4882](https://github.com/ArcadeData/arcadedb/issues/4882) - Bolt Driver Compatibility Certification
+Tracking: [#4890](https://github.com/ArcadeData/arcadedb/issues/4890) - protocol/type-fidelity gaps
+Follow-up to: [#5001](https://github.com/ArcadeData/arcadedb/issues/5001) (PR #5059, Bolt 5.x version-gated wire encoding)
+
+## Motivation
+
+After #5001 added Bolt 5.x version-gated wire encoding, the `PackStreamStructure`
+accessors `getSignature()` and `getFieldCount()` became inconsistent with
+`writeTo()` on the version-gated structures:
+
+- `BoltNode` / `BoltRelationship` / `BoltUnboundRelationship`: `getFieldCount()`
+  returns the Bolt 4.x base count (3 / 5 / 3) while `writeTo()` emits 4 / 8 / 4
+  when the negotiated major is >= 5 (adding `element_id` fields).
+- `BoltDateTimeStructure`: `getSignature()` returns the legacy `'F'` / `'f'`
+  signature while `writeTo()` emits the UTC `'I'` / `'i'` signature on Bolt 5.0+.
+
+This is **inert today** and was verified during review of this design:
+`PackStreamWriter` serializes structures exclusively through `writeTo()` (the
+`writeValue` dispatch at `PackStreamWriter.java` calls `((PackStreamStructure)
+value).writeTo(this)` and never consults the accessors). The only main-source
+consumer of the `writeStructureHeader(getSignature(), getFieldCount())` idiom is
+`BoltPointStructure.writeTo` - a version-invariant struct.
+
+It remains a latent footgun: any future serialization path that calls
+`writeStructureHeader(getSignature(), getFieldCount())` for a version-gated struct
+would emit a header/body mismatch on a 5.x connection and corrupt the stream. The
+accessors cannot be made version-correct because they are no-arg interface methods
+with no access to the negotiated version (only `writeTo()` has it, via the writer).
+Raised repeatedly by Claude and Gemini reviews on PR #5059; deferred out of that PR
+because it is a serialization-layer refactor, not a protocol-negotiation change.
+
+## Scope verification (done up front against the code)
+
+The interface `com.arcadedb.bolt.packstream.PackStreamStructure` declares three
+methods: `getSignature()`, `getFieldCount()`, `writeTo()`. Seven classes implement
+it:
+
+| Class | version-gated? | `writeTo()` header today | accessors consumed by `writeTo()`? |
+|---|---|---|---|
+| `BoltNode` | yes (>=5 adds `element_id`) | inline literals `3`/`4` | no |
+| `BoltRelationship` | yes (>=5 adds element ids) | inline literals `5`/`8` | no |
+| `BoltUnboundRelationship` | yes (>=5 adds `element_id`) | inline literals `3`/`4` | no |
+| `BoltDateTimeStructure` | yes (>=5 UTC signature) | inline `SIG_*`, count `3` | no |
+| `BoltPath` | no | inline `SIGNATURE`, `3` | no |
+| `BoltTemporalStructure` | no | inline `signature`, `fields.length` | no |
+| `BoltPointStructure` | no | **`writeStructureHeader(getSignature(), getFieldCount())`** | **yes** |
+
+**Callers that look like consumers but are not** (different types, each keeps its
+own methods - untouched by this change):
+
+- `BoltStructureMapper.fromInboundStructure` calls `structure.getSignature()` where
+  `structure` is a `PackStreamReader.StructureValue` (inbound decode holder).
+- `BoltMessage.parse` calls `structure.getSignature()` on a `StructureValue`, and
+  `BoltMessage` has its own `getSignature()`.
+- `PackStreamReader.StructureValue` defines its own `getSignature()` /
+  `getFieldCount()`.
+
+**Correction to the issue text:** #5082 names only `BoltStructureTest` for test
+updates. The *interface* accessors are actually asserted in **three** test files:
+`BoltStructureTest` (Node/Rel/UnboundRel/Path), `BoltTypeRoundTripTest`
+(`BoltTemporalStructure` + `BoltPointStructure`), and `Bolt4998PathMappingTest`
+(`BoltPointStructure`). Assertions that *look* affected but are not, because their
+receiver is a `PackStreamReader.StructureValue` / `BoltMessage` (different types
+that keep their own methods), and therefore stay unchanged:
+
+- `BoltDateTimeStructureTest` - all 8 `getSignature()` calls are on the
+  `StructureValue` returned by its `roundTrip()` / `mapperRoundTrip()` helpers,
+  which already serialize through `writeTo()`. **No change needed.**
+- `PackStreamTest` (`struct` is a `StructureValue`) and `BoltMessageTest`
+  (`msg` is a `BoltMessage`). **No change needed.**
+- In `BoltTypeRoundTripTest` the `wire.getSignature()` assertion (TYPE-011) is on a
+  `StructureValue` and stays; only the pre-wire `s.*` / `p.*` accessor assertions go.
+
+## Design decision
+
+**Full removal** (the issue's literal design): drop `getSignature()` and
+`getFieldCount()` from the interface *and* from all seven implementers, inlining
+the signature + field count directly into every `writeTo()`. `writeTo()` / the
+serialized wire bytes become the single source of truth for structure-header shape.
+The version-invariant structs (Point, Path, Temporal) lose their accessors too,
+even though only the version-gated ones are footguns - chosen for a uniform
+single-method contract that matches the acceptance criteria exactly, over a split
+API that keeps plain getters on some structs.
+
+## Proposed design
+
+### 1. Interface `PackStreamStructure`
+
+Remove the `getSignature()` and `getFieldCount()` declarations and their Javadoc.
+The interface becomes a single-method contract:
+
+```java
+public interface PackStreamStructure {
+  /** Write this structure to a PackStream writer. */
+  void writeTo(PackStreamWriter writer) throws IOException;
+}
+```
+
+### 2. Implementers
+
+- **`BoltPointStructure`** (only class using the idiom): inline the header write in
+  `writeTo()`. The signature (`z == null ? SIGNATURE_2D : SIGNATURE_3D`) and field
+  count (`z == null ? 3 : 4`) are computed locally at the `writeStructureHeader`
+  call. Remove the two `@Override` accessors. `SIGNATURE_2D` / `SIGNATURE_3D`
+  constants and the value getters (`getSrid`/`getX`/`getY`/`getZ`) stay.
+- **`BoltNode`, `BoltRelationship`, `BoltUnboundRelationship`,
+  `BoltDateTimeStructure`, `BoltPath`, `BoltTemporalStructure`**: delete the two
+  now-unused override methods. Their `writeTo()` bodies already write the header
+  with inline literals and are unchanged. Remove the stale "writeTo is
+  authoritative" comment fragments on the deleted accessors. `SIGNATURE` constants
+  and value getters stay.
+
+No `writeTo()` body logic changes for any class - this is dead-accessor removal,
+not a re-encode.
+
+### 3. Tests
+
+Convert accessor assertions to serialize-then-assert-on-wire-bytes, which is
+strictly stronger (it pins the actual emitted header, the thing that matters):
+
+- **`BoltStructureTest`** - `boltNodeCreation` / `boltRelationshipCreation` /
+  `boltUnboundRelationshipCreation` / `boltPathCreation` assert
+  `getSignature()`/`getFieldCount()` as a construction smoke-check. Replace each
+  with a `writeTo` + assert on the struct-marker byte (`0xB0 | fieldCount`) and the
+  following signature byte. The existing `...WriteTo` tests already serialize, so
+  this extends an established pattern.
+- **`BoltTypeRoundTripTest`** - TYPE-011 already round-trips `BoltTemporalStructure`
+  through the wire and asserts `wire.getSignature()` on a `StructureValue` (safe -
+  stays). Drop the redundant pre-wire `s.getSignature()` / `s.getFieldCount()`.
+  TYPE-012 Point: replace `p.getSignature()` with a wire-byte assertion (or the
+  already-present `getZ()` null / non-null check that distinguishes 2D from 3D).
+- **`Bolt4998PathMappingTest`** - one Point `getSignature()` assertion → wire-byte
+  or `getZ()` check.
+
+## Acceptance criteria
+
+- [ ] `PackStreamStructure` no longer exposes `getSignature()` / `getFieldCount()`;
+      `writeTo()` is the only header contract.
+- [ ] No `@Override getSignature()` / `getFieldCount()` remains on any of the seven
+      implementers.
+- [ ] No behavioral change on the wire for any negotiated Bolt version (3.0-5.4),
+      guarded by the existing `bolt` unit tests + real-driver ITs.
+- [ ] All three affected test files (`BoltStructureTest`, `BoltTypeRoundTripTest`,
+      `Bolt4998PathMappingTest`) compile and pass with wire-byte / value-getter
+      assertions replacing the removed accessor assertions.
+- [ ] `mvn -pl bolt verify` green.
+
+## Testing / verification
+
+`mvn -pl bolt verify` runs the `bolt` unit tests plus the real-driver integration
+tests (`RemoteBoltDatabaseIT`, `BoltProtocolIT`, and the Bolt 5.x negotiation ITs)
+that exercise the actual `neo4j-java-driver` against a live server across
+negotiated versions 3.0 through 5.4. Green there is the guard that proves no wire
+drift. Because no `writeTo()` body changes, the refactor is behavior-preserving by
+construction; compile-time safety catches any missed interface caller.
+
+## Risk
+
+Essentially nil. The removed methods have exactly one main-source consumer
+(`BoltPointStructure.writeTo`), which is rewritten in the same change. Any missed
+caller is a compile error, not a runtime surprise. The ITs catch any accidental
+wire divergence.
+
+## Non-goals
+
+- No change to `writeTo()` encoding for any version.
+- No change to inbound decode (`PackStreamReader.StructureValue`,
+  `BoltStructureMapper.fromInboundStructure`, `BoltMessage.parse`).
+- No change to `BoltMessage`'s own `getSignature()`.
+- No change to the advertised server identity or negotiated version set.
+
+## Effort
+
+**S** (per the issue).


### PR DESCRIPTION
## Summary

Closes #5082. Follow-up to #5001 (PR #5059). Part of the Bolt certification epic #4882 / tracking issue #4890.

Removes `getSignature()` and `getFieldCount()` from the `PackStreamStructure` interface and all seven implementers, making `writeTo()` the **sole authority** for Bolt structure-header emission. After #5001 added Bolt 5.x version-gated encoding, these no-arg accessors became inconsistent with `writeTo()` on version-gated structs (they cannot see the negotiated version - only the writer carries it), leaving a latent footgun: any future `writeStructureHeader(getSignature(), getFieldCount())` call site would emit a header/body mismatch and corrupt the stream on a 5.x connection.

**No wire-behavior change on any negotiated Bolt version (3.0-5.4)** - this is dead-accessor removal, not a re-encode. No `writeTo()` body logic changed.

## Changes

**Production**
- `PackStreamStructure` reduced to a single-method contract: `void writeTo(PackStreamWriter)`.
- `BoltPointStructure.writeTo` (the only internal consumer of the `writeStructureHeader(getSignature(), getFieldCount())` idiom) now inlines its version-invariant signature (`z == null ? 0x58 : 0x59`) and field count (`3`/`4`) locally.
- `BoltNode`, `BoltRelationship`, `BoltUnboundRelationship`, `BoltPath`, `BoltTemporalStructure`, `BoltDateTimeStructure` drop the two now-unused overrides; their `writeTo()` bodies already wrote headers with inline literals and are untouched.

**Not touched** (verified different types, each keeps its own methods): `PackStreamReader.StructureValue` and `BoltMessage` (the inbound-decode + message paths in `BoltStructureMapper.fromInboundStructure` / `BoltMessage.parse`).

**Tests** - accessor assertions on interface implementers converted to stronger, wire-truth assertions:
- `BoltStructureTest` (Node/Rel/UnboundRel/Path): assert the serialized `TINY_STRUCT` marker + signature bytes.
- `BoltTypeRoundTripTest`: TYPE-011 relies on the existing wire round-trip (drops redundant pre-wire asserts); TYPE-012 Point uses `getZ()` null-ness (the sole determinant of the 2D/3D signature).
- `Bolt4998PathMappingTest`: TYPE-012 Point → `getZ()`.
- `BoltDateTimeStructureTest` needed **no change** - all its `getSignature()` calls are on the `PackStreamReader.StructureValue` returned by its `roundTrip()`/`mapperRoundTrip()` helpers, which already serialize through `writeTo()`.

## Verification

- `mvn -pl bolt verify` - **BUILD SUCCESS**, 275 unit tests pass.
- `mvn -pl bolt verify -DskipITs=false` - real-driver ITs (`neo4j-java-driver` against a live server across negotiated Bolt 3.0-5.4, incl. `BoltProtocolIT`, `RemoteBoltDatabaseIT`, `BoltVersionNegotiationTest`, temporal/point/path/counters ITs) all pass. The one flake observed - `BoltProtocolIT.concurrentSessions` failing with `User 'root' is not allowed to update schema` - is a pre-existing concurrent-schema-creation race unrelated to serialization; it passed on isolated re-run.
- Confirmed no residual `getSignature()`/`getFieldCount()` references remain in `structure/` or the interface.

## Acceptance criteria

- [x] `PackStreamStructure` no longer exposes `getSignature()` / `getFieldCount()`; `writeTo()` is the only header contract.
- [x] No `@Override` accessor remains on any of the seven implementers.
- [x] No behavioral change on the wire for any negotiated Bolt version (3.0-5.4).
- [x] `mvn -pl bolt verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)