### PR TITLE
fix(#5099): HA bootstrap first-formation survives leadership transfer

### DIFF
--- a/docs/5099-ha-offline-bootstrap-leadership-transfer.md
+++ b/docs/5099-ha-offline-bootstrap-leadership-transfer.md
@@ -57,6 +57,29 @@ an election" window is bounded by Raft's election restriction (a lagging node ca
 until its log is up to date) and backstopped by the existing `localLastTxId > baseline`
 refusing-to-overwrite guard.
 
+## PR
+https://github.com/ArcadeData/arcadedb/pull/5113
+
+## Review cycles
+- **Cycle 1** (`3f558b8`) - both bots flagged the same failure mode: a degraded/corrupt read of the
+  persisted `.raft/applied-index` file degrading to `-1` could re-open bootstrap on a running
+  cluster. Applied the file-existence guard (`8fba97a0`): the file exists only after an application
+  entry is applied, so its presence proves the node is not fresh regardless of parse result. Added
+  `presentButCorruptAppliedIndexFileKeepsTheSignalClosed`. Declined the alternative
+  `lastAppliedIndex >= commitIndex` guard (infeasible: internal entries advance commit but never
+  applied).
+- **Cycle 2** (`8fba97a0`) - claude LGTM; applied its clarifying comment on the fallthrough line
+  (`b723394e`). Gemini re-posted its already-applied suggestion.
+- **Cycle 3** (`b723394e`) - claude LGTM; applied all three polish items (`167a5be3`): residual-window
+  reasoning moved into the `isFirstFormation` code comment, `unwiredStateMachineReportsFirstFormation`
+  null-path test, and narrowed `hasNeverAppliedApplicationEntry()` to package-private. Gemini re-posted
+  the already-applied suggestion again.
+- **Cycle 4** (`167a5be3`) - claude verdict "looks good to merge"; all observations non-blocking and
+  already covered, no code changes. Gemini did not re-review this head.
+
+**Final state:** clean-approval (claude LGTM, no actionable items outstanding; working tree clean).
+Merge is the maintainer's decision - this workflow does not merge.
+
 ## Related
 - #4147 (offline bootstrap protocol), #4800 (first-formation gate), #5098 (transient `-1` fix,
   prerequisite), #5100/#5104 (restart baseline persistence).

--- a/docs/5099-ha-offline-bootstrap-leadership-transfer.md
+++ b/docs/5099-ha-offline-bootstrap-leadership-transfer.md
@@ -40,6 +40,23 @@ negative (unready/failed) commit index still never opens the gate (#4800 preserv
   machine it skips.
 - `RaftBootstrapLeadershipTransferIT` (existing IT) - end-to-end reproduction, now passes.
 
+## Review hardening (cycle 1)
+Both bot reviewers flagged the same failure mode: `hasNeverAppliedApplicationEntry()` could falsely
+report first formation on a running cluster if the persisted `.raft/applied-index` read degrades to
+`-1` (a transient I/O error or corrupt file). Added a defense-in-depth guard: the file is created
+only after an application entry is applied, so its mere presence proves the node is not fresh -
+`hasNeverAppliedApplicationEntry()` now returns `false` when the file exists, regardless of whether
+its contents parse. New unit case
+`ArcadeStateMachineFirstFormationSignalTest.presentButCorruptAppliedIndexFileKeepsTheSignalClosed`.
+
+The reviewer's alternative "require `lastAppliedIndex >= commitIndex`" is infeasible: internal
+no-op/config entries advance the commit index but never flow through `applyTransaction`, so applied
+can never catch up to commit in the transfer case (that is the whole reason the exact-`0` gate had to
+be replaced). The residual "never-applied node with committed-but-unapplied application entries wins
+an election" window is bounded by Raft's election restriction (a lagging node cannot win leadership
+until its log is up to date) and backstopped by the existing `localLastTxId > baseline`
+refusing-to-overwrite guard.
+
 ## Related
 - #4147 (offline bootstrap protocol), #4800 (first-formation gate), #5098 (transient `-1` fix,
   prerequisite), #5100/#5104 (restart baseline persistence).

--- a/docs/5099-ha-offline-bootstrap-leadership-transfer.md
+++ b/docs/5099-ha-offline-bootstrap-leadership-transfer.md
@@ -1,0 +1,45 @@
+# #5099 - HA offline bootstrap: leadership-transfer path never commits baseline
+
+## Symptom
+`RaftBootstrapLeadershipTransferIT.leadershipTransfersToTheFresherPeerBeforeBootstrapCommit`
+times out: after the offline-bootstrap protocol transfers Raft leadership to the elected source
+peer, that new leader never commits the `BOOTSTRAP_FINGERPRINT_ENTRY`, so
+`getBootstrapBaseline(db)` stays `null` on every peer.
+
+## Root cause
+`BootstrapElection`'s first-formation gate was `commitIndex == 0`
+(`isConfirmedFirstFormation`). The leadership transfer plus the term-2 leader election make Ratis
+append and commit internal no-op / configuration entries, so the new leader (the elected source)
+reads `commitIndex = 2`, not `0`. The exact-`0` gate (tightened in #4800 to reject a running
+cluster) therefore rejects the post-transfer leader and the baseline is never committed.
+
+The gate cannot simply be loosened to `<= 2`: #4800 keys first-formation on an exact `0` to stop
+bootstrap re-triggering on an already-running cluster (which would risk overwriting live data).
+
+## Fix
+Add a durable first-formation signal that survives an internal term bump but still cannot fire once
+any application data has committed:
+`ArcadeStateMachine.hasNeverAppliedApplicationEntry()`.
+
+Ratis internal no-op/config entries never flow through `applyTransaction`, so they advance neither
+the in-memory `lastAppliedIndex` nor the persisted applied index - while every real mutation
+(TX/SCHEMA/INSTALL/DROP/SECURITY/BOOTSTRAP entry) advances both. The signal checks both the
+in-memory and the persisted index so a restarted, already-bootstrapped cluster (log compacted below
+the Ratis snapshot) is never mistaken for a fresh one.
+
+`BootstrapElection` gate is widened: it opens on either the exact-`0` empty log (no-transfer path,
+unchanged) OR, when commitIndex > 0, on the "no application entry has ever been applied" signal. A
+negative (unready/failed) commit index still never opens the gate (#4800 preserved). The static
+`isConfirmedFirstFormation(long)` is left unchanged.
+
+## Tests
+- `ArcadeStateMachineFirstFormationSignalTest` (new, unit) - the durable signal: fresh SM true;
+  false once a persisted applied index exists; false across a simulated restart.
+- `BootstrapElectionTransferGateTest` (new, unit) - the widened gate: post-transfer leader
+  (commitIndex 2) with no application data engages bootstrap; with committed data or a null state
+  machine it skips.
+- `RaftBootstrapLeadershipTransferIT` (existing IT) - end-to-end reproduction, now passes.
+
+## Related
+- #4147 (offline bootstrap protocol), #4800 (first-formation gate), #5098 (transient `-1` fix,
+  prerequisite), #5100/#5104 (restart baseline persistence).

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -1688,6 +1688,9 @@ public class ArcadeStateMachine extends BaseStateMachine {
     final Path appliedIndexFile = getAppliedIndexFile();
     if (appliedIndexFile != null && Files.exists(appliedIndexFile))
       return false;
+    // Reached only when the file path is unresolvable (server not wired yet, getAppliedIndexFile()
+    // == null) or the file did not exist at the check above: read the persisted value as the final
+    // signal. It is -1 for a genuinely fresh node.
     return readPersistedAppliedIndex() < 0;
   }
 

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -1672,9 +1672,21 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * Both indices are consulted: the in-memory one for the current session, and the persisted one so
    * a restarted, already-bootstrapped cluster - whose {@code BOOTSTRAP_FINGERPRINT_ENTRY} has been
    * compacted below the Ratis snapshot and is not replayed - is never mistaken for a fresh one.
+   * <p>
+   * Defense in depth against a degraded read: the persisted {@code .raft/applied-index} file is
+   * created only after at least one application entry has been applied (see
+   * {@link #writePersistedAppliedIndex} and the snapshot-install path), so its mere presence proves
+   * this node is not fresh. {@link #readPersistedAppliedIndex()} degrades a momentarily-unreadable or
+   * corrupt file to {@code -1}; keying solely on that value could re-open the gate on a running
+   * cluster whose file is transiently unreadable. We therefore treat an existing file as "already
+   * applied" regardless of whether its contents parse, so a transient I/O error can never re-trigger
+   * bootstrap on a cluster that already holds data.
    */
   public boolean hasNeverAppliedApplicationEntry() {
     if (lastAppliedIndex.get() >= 0)
+      return false;
+    final Path appliedIndexFile = getAppliedIndexFile();
+    if (appliedIndexFile != null && Files.exists(appliedIndexFile))
       return false;
     return readPersistedAppliedIndex() < 0;
   }

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -1681,8 +1681,10 @@ public class ArcadeStateMachine extends BaseStateMachine {
    * cluster whose file is transiently unreadable. We therefore treat an existing file as "already
    * applied" regardless of whether its contents parse, so a transient I/O error can never re-trigger
    * bootstrap on a cluster that already holds data.
+   * <p>
+   * Package-private: the sole caller is {@link BootstrapElection} in this package.
    */
-  public boolean hasNeverAppliedApplicationEntry() {
+  boolean hasNeverAppliedApplicationEntry() {
     if (lastAppliedIndex.get() >= 0)
       return false;
     final Path appliedIndexFile = getAppliedIndexFile();

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/ArcadeStateMachine.java
@@ -1654,6 +1654,31 @@ public class ArcadeStateMachine extends BaseStateMachine {
     return bootstrapBaselines.get(dbName);
   }
 
+  /**
+   * True iff this state machine has never applied an application-level Raft log entry - in this
+   * session or any prior one. This is the durable first-formation signal used by the offline
+   * bootstrap protocol (issue #5099).
+   * <p>
+   * The raw Ratis commit index is not a reliable first-formation signal on its own: a leadership
+   * transfer during bootstrap makes the new leader append internal no-op / configuration entries
+   * that push its commit index above {@code 0} without committing any application data. Those
+   * internal entries never flow through {@link #applyTransaction}, so neither the in-memory
+   * {@link #lastAppliedIndex} nor the persisted applied index advances for them - while every real
+   * mutation (TX / SCHEMA / INSTALL / DROP / SECURITY / BOOTSTRAP entry) advances both. The signal
+   * therefore survives the internal term bump yet still turns {@code false} the instant any
+   * application entry commits, preserving the issue #4800 guarantee that bootstrap can never
+   * re-engage on a cluster that already holds data.
+   * <p>
+   * Both indices are consulted: the in-memory one for the current session, and the persisted one so
+   * a restarted, already-bootstrapped cluster - whose {@code BOOTSTRAP_FINGERPRINT_ENTRY} has been
+   * compacted below the Ratis snapshot and is not replayed - is never mistaken for a fresh one.
+   */
+  public boolean hasNeverAppliedApplicationEntry() {
+    if (lastAppliedIndex.get() >= 0)
+      return false;
+    return readPersistedAppliedIndex() < 0;
+  }
+
   // @VisibleForTesting
   void applyDropDatabaseEntry(final RaftLogEntryCodec.DecodedEntry decoded) {
     final String databaseName = decoded.databaseName();

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/BootstrapElection.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/BootstrapElection.java
@@ -70,22 +70,27 @@ import java.util.logging.Level;
  *   <li>If the elected source is the local peer, commit one
  *       {@link RaftLogEntryType#BOOTSTRAP_FINGERPRINT_ENTRY} per database via the existing
  *       transaction broker, all from the local copies. If the elected source is a different peer,
- *       transfer Raft leadership to that peer <em>without committing anything</em> (so the cluster
- *       commit index stays 0); the new leader re-enters this protocol on its own
- *       {@code notifyLeaderChanged} callback, elects itself, and commits every database then.</li>
+ *       transfer Raft leadership to that peer <em>without committing anything</em>; the new leader
+ *       re-enters this protocol on its own {@code notifyLeaderChanged} callback, elects itself, and
+ *       commits every database then.</li>
  * </ol>
  * <p>
- * Because the protocol never commits a baseline before transferring leadership, the single
- * transfer-then-commit-all sequence keeps the {@code commitIndex == 0} first-formation gate valid
- * and converges in at most one leadership move. A database whose freshest copy happens to live on a
+ * The protocol never commits a baseline before transferring leadership, so no <em>application</em>
+ * entry is committed until the elected source commits the whole cluster's fingerprints. The
+ * leadership transfer itself, however, makes Ratis append internal no-op / configuration entries, so
+ * the new leader's raw commit index is <em>not</em> 0 by the time it re-runs (issue #5099). The
+ * first-formation gate therefore keys on "the state machine has never applied an application entry"
+ * rather than an exact {@code commitIndex == 0}: that signal survives the transfer's internal term
+ * bump yet still closes the instant any real data commits, converging in at most one leadership
+ * move. See {@link #isFirstFormation(long)}. A database whose freshest copy happens to live on a
  * node <em>other</em> than the elected source (only reachable by an operator manually staging
  * mismatched backups, never by normal single-leader replication) is protected by the
  * {@code localLastTxId > baseline} "refusing to overwrite" guard in
  * {@code ArcadeStateMachine.applyBootstrapFingerprintEntry}, which surfaces a SEVERE for the
  * operator instead of silently discarding the fresher data.
  * <p>
- * The protocol is idempotent across leader changes: each newly-elected leader checks whether the
- * cluster's commit index is still 0 and, if so, re-runs. A leader transfer triggered by a previous
+ * The protocol is idempotent across leader changes: each newly-elected leader re-checks the
+ * first-formation gate and, if it still holds, re-runs. A leader transfer triggered by a previous
  * bootstrap pass is therefore safe even if the new leader doesn't know it was selected as the
  * source - it picks itself again from its own state.
  * <p>
@@ -101,7 +106,7 @@ class BootstrapElection {
    */
   enum Outcome {
     SKIPPED_DISABLED,           // bootstrapFromLocalDatabase=false
-    SKIPPED_NOT_FIRST_FORMATION,// commit index not a confirmed 0 (cluster running, or index unknown)
+    SKIPPED_NOT_FIRST_FORMATION,// not first formation (application data already committed, or index unknown)
     SKIPPED_NO_DATABASES,       // nothing to bootstrap
     NOT_LEADER,                 // we're not the leader anymore by the time we ran
     TRANSFERRED,                // leadership transferred to the source peer; new leader will retry
@@ -157,22 +162,24 @@ class BootstrapElection {
     if (!haServer.isLeader())
       return Outcome.NOT_LEADER;
 
-    // The bootstrap path is gated on first cluster formation: every peer's Raft log empty, i.e. a
-    // commit index of exactly 0. The leader's commit index is the only piece of cluster-wide state
-    // we have to check; once any entry has been committed, we never re-engage. See section 8
-    // ("Gating") in #4147. A negative value means the index is UNKNOWN (the Raft division is not
-    // ready, or getCommitIndex() hit a transient IOException) and must NOT be mistaken for an empty
-    // log - see isConfirmedFirstFormation and issue #4800.
+    // The bootstrap path is gated on first cluster formation: the cluster has never committed any
+    // application data. See section 8 ("Gating") in #4147. A commit index of exactly 0 is the fast,
+    // unambiguous case (empty Raft log, no leadership transfer). But a bootstrap that transfers
+    // leadership to the elected source makes Ratis append internal no-op / configuration entries, so
+    // the new leader's commit index is above 0 even though no application entry has committed (issue
+    // #5099); the exact-0 test alone would wrongly reject it. isFirstFormation therefore also accepts
+    // a positive commit index when the state machine has never applied an application entry - a signal
+    // that survives the internal term bump yet still closes the instant any real data commits, keeping
+    // the issue #4800 guarantee that bootstrap never re-engages on a running cluster.
     //
     // The notifyLeaderChanged callback that drives this runs before the freshly-elected leader's Raft
     // division exposes its committed index, so the very first read returns the -1 UNKNOWN sentinel for
     // a brief window. Since bootstrap runs at most once per term, skipping on that transient -1 would
-    // leave the baseline uncommitted forever. Wait a bounded time for a definitive reading: on genuine
-    // first formation it resolves to 0 and the gate opens; on an already-running cluster it resolves
-    // to a positive index and the gate stays closed; if it never resolves (persistent read failure) we
-    // conservatively skip, exactly as issue #4800 requires.
+    // leave the baseline uncommitted forever. Wait a bounded time for a definitive reading: a negative
+    // value never opens the gate (division not ready / transient IOException, exactly as #4800
+    // requires); a non-negative value is then judged by isFirstFormation.
     final long commitIndex = awaitReadableCommitIndex();
-    if (!isConfirmedFirstFormation(commitIndex))
+    if (!isFirstFormation(commitIndex))
       return Outcome.SKIPPED_NOT_FIRST_FORMATION;
 
     final List<String> dbNames = collectLocalDatabaseNames();
@@ -200,13 +207,39 @@ class BootstrapElection {
   }
 
   /**
-   * The first-formation gate. Bootstrap may only engage on a positively-confirmed empty cluster,
-   * i.e. a commit index of exactly {@code 0}. A negative value means the commit index is UNKNOWN -
-   * {@link RaftHAServer#getCommitIndex()} returns {@code -1} when the Raft division is not ready yet
-   * or a transient {@code IOException} is thrown while reading it - and MUST be treated as "skip" so
-   * a transient read failure during a leader-change callback can never re-trigger bootstrap on a
-   * live cluster (issue #4800). Any positive value means the cluster has already committed entries
-   * and the first-formation window is long past.
+   * The first-formation gate. Bootstrap may only engage on a cluster that has never committed any
+   * application data, evaluated in two steps:
+   * <ol>
+   *   <li>A commit index of exactly {@code 0} - a positively-confirmed empty Raft log - opens the
+   *       gate immediately. This is the no-transfer path and is unchanged from #4800
+   *       (see {@link #isConfirmedFirstFormation}).</li>
+   *   <li>A positive commit index opens the gate only when the state machine reports it has never
+   *       applied an application entry ({@link ArcadeStateMachine#hasNeverAppliedApplicationEntry()}).
+   *       This is the leadership-transfer path (issue #5099): the transfer appends internal
+   *       no-op / configuration entries that raise the commit index above {@code 0} without
+   *       committing any application data. The durable no-application-entry signal survives that
+   *       internal term bump yet still closes the instant any real mutation commits, so #4800's
+   *       "never re-engage on a running cluster" guarantee is preserved.</li>
+   * </ol>
+   * A negative commit index means the index is UNKNOWN - {@link RaftHAServer#getCommitIndex()}
+   * returns {@code -1} when the Raft division is not ready yet or a transient {@code IOException} is
+   * thrown while reading it - and MUST be treated as "skip" so a transient read failure during a
+   * leader-change callback can never re-trigger bootstrap on a live cluster (issue #4800).
+   */
+  private boolean isFirstFormation(final long commitIndex) {
+    if (isConfirmedFirstFormation(commitIndex))
+      return true;
+    if (commitIndex < 0L)
+      return false; // division not ready / transient read failure: never treat as an empty log (#4800)
+    final ArcadeStateMachine stateMachine = haServer.getStateMachine();
+    return stateMachine != null && stateMachine.hasNeverAppliedApplicationEntry();
+  }
+
+  /**
+   * The exact-{@code 0} empty-log test: {@code true} only for a positively-confirmed empty Raft log.
+   * Kept as a distinct static helper (issue #4800) that {@link #isFirstFormation(long)} layers the
+   * leadership-transfer signal on top of; a negative or positive commit index both return
+   * {@code false} here.
    */
   static boolean isConfirmedFirstFormation(final long commitIndex) {
     return commitIndex == 0L;

--- a/ha-raft/src/main/java/com/arcadedb/server/ha/raft/BootstrapElection.java
+++ b/ha-raft/src/main/java/com/arcadedb/server/ha/raft/BootstrapElection.java
@@ -225,6 +225,17 @@ class BootstrapElection {
    * returns {@code -1} when the Raft division is not ready yet or a transient {@code IOException} is
    * thrown while reading it - and MUST be treated as "skip" so a transient read failure during a
    * leader-change callback can never re-trigger bootstrap on a live cluster (issue #4800).
+   * <p>
+   * <b>Residual window (do not weaken the backstops without accounting for it):</b> the
+   * no-application-entry signal is strictly weaker than the exact-{@code 0} test in one narrow case -
+   * a node whose Raft log holds application entries that are committed but not yet run through
+   * {@code applyTransaction} reads no applied index and no persisted file, so it reports first
+   * formation. That state is essentially unreachable after normal operation (any prior apply writes
+   * the {@code .raft/applied-index} file, and Raft's election restriction stops a node from winning
+   * leadership until its log is up to date), and if it were ever hit, the elected source's commit is
+   * still refused by the {@code localLastTxId > baseline} overwrite guard in
+   * {@code ArcadeStateMachine.applyBootstrapFingerprintEntry} - so the worst case is a spurious,
+   * refused bootstrap attempt, never data loss.
    */
   private boolean isFirstFormation(final long commitIndex) {
     if (isConfirmedFirstFormation(commitIndex))

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineFirstFormationSignalTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineFirstFormationSignalTest.java
@@ -24,6 +24,7 @@ import com.arcadedb.server.ArcadeDBServer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -99,6 +100,29 @@ class ArcadeStateMachineFirstFormationSignalTest {
     final ArcadeStateMachine reopened = newStateMachine();
     assertThat(reopened.hasNeverAppliedApplicationEntry())
         .as("a persisted applied index survives a restart and keeps the gate closed")
+        .isFalse();
+  }
+
+  /**
+   * Defense in depth: a present-but-corrupt {@code .raft/applied-index} file (a transient read
+   * failure would degrade {@code readPersistedAppliedIndex()} to -1) must still keep the gate closed.
+   * The file exists only after an application entry was applied, so its presence alone proves the node
+   * is not fresh - a degraded read must never re-open bootstrap on a running cluster.
+   */
+  @Test
+  void presentButCorruptAppliedIndexFileKeepsTheSignalClosed() throws Exception {
+    final Path raftDir = serverDir.resolve(".raft");
+    Files.createDirectories(raftDir);
+    // Leading '{' looks like the JSON document but is truncated, so parsing fails and the read
+    // degrades to -1 (mirrors ArcadeStateMachineAppliedIndexPerDatabaseTest.corruptFileDegradesToMinusOne).
+    Files.writeString(raftDir.resolve("applied-index"), "{\"global\": 42, \"db\": {\"db-a\":");
+
+    final ArcadeStateMachine sm = newStateMachine();
+    assertThat(sm.readPersistedAppliedIndex())
+        .as("the corrupt file degrades the persisted read to -1")
+        .isEqualTo(-1L);
+    assertThat(sm.hasNeverAppliedApplicationEntry())
+        .as("but the file's existence keeps the gate closed despite the degraded read")
         .isFalse();
   }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineFirstFormationSignalTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineFirstFormationSignalTest.java
@@ -125,4 +125,19 @@ class ArcadeStateMachineFirstFormationSignalTest {
         .as("but the file's existence keeps the gate closed despite the degraded read")
         .isFalse();
   }
+
+  /**
+   * The unwired fallthrough: a state machine whose server (and hence applied-index file path) is not
+   * resolvable falls through the file-existence guard to {@code readPersistedAppliedIndex() < 0},
+   * which returns {@code -1}, so the node reports first formation. In production
+   * {@code BootstrapElection.isFirstFormation} only reaches this method with a non-null state machine
+   * and a readable commit index (the server is wired by then), but this pins the null-path branch.
+   */
+  @Test
+  void unwiredStateMachineReportsFirstFormation() {
+    final ArcadeStateMachine sm = new ArcadeStateMachine(); // no setServer(): path is unresolvable
+    assertThat(sm.hasNeverAppliedApplicationEntry())
+        .as("an unwired state machine has no applied index and reports first formation")
+        .isTrue();
+  }
 }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineFirstFormationSignalTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/ArcadeStateMachineFirstFormationSignalTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.ArcadeDBServer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the durable first-formation signal {@link ArcadeStateMachine#hasNeverAppliedApplicationEntry()}
+ * (issue #5099).
+ * <p>
+ * The offline-bootstrap gate cannot rely on the raw Ratis commit index alone: a bootstrap leadership
+ * transfer appends internal no-op / configuration entries that push the new leader's commit index
+ * above {@code 0} without committing any application data. The state machine advances neither its
+ * in-memory nor its persisted applied index for those internal entries (they never flow through
+ * {@code applyTransaction}), so "no application entry has ever been applied" is a first-formation
+ * signal that survives the internal term bump but still turns false the instant real data commits -
+ * preserving the issue #4800 guarantee.
+ * <p>
+ * The tests drive a real (unstarted) {@link ArcadeDBServer} pointed at a temp directory so the
+ * persisted {@code .raft/applied-index} file is exercised for real - no mocking framework.
+ */
+class ArcadeStateMachineFirstFormationSignalTest {
+
+  private static final String DB = "db-a";
+
+  @TempDir
+  private Path serverDir;
+
+  private ArcadeStateMachine newStateMachine() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY, serverDir.toString());
+    final ArcadeStateMachine sm = new ArcadeStateMachine();
+    sm.setServer(new ArcadeDBServer(config));
+    return sm;
+  }
+
+  /**
+   * A brand-new state machine with no persisted applied index and nothing applied in memory reports
+   * first formation: this is exactly the state of the elected source right after a bootstrap
+   * leadership transfer (only Ratis-internal entries committed, none applied).
+   */
+  @Test
+  void freshStateMachineHasNeverAppliedApplicationEntry() {
+    final ArcadeStateMachine sm = newStateMachine();
+    assertThat(sm.hasNeverAppliedApplicationEntry())
+        .as("a fresh state machine with no applied entries is first formation")
+        .isTrue();
+  }
+
+  /**
+   * Once any application entry has been persisted (its applied index recorded), the signal turns
+   * false: a cluster that has committed data must never be mistaken for a fresh one (issue #4800).
+   */
+  @Test
+  void persistedAppliedIndexClosesTheSignal() {
+    final ArcadeStateMachine sm = newStateMachine();
+    sm.writePersistedAppliedIndex(5L, DB);
+
+    assertThat(sm.hasNeverAppliedApplicationEntry())
+        .as("a persisted applied index means application data committed; not first formation")
+        .isFalse();
+  }
+
+  /**
+   * The signal is durable across a restart: a persisted applied index written by one instance is
+   * honoured by a fresh instance (whose in-memory applied index starts at -1). This is what stops an
+   * already-bootstrapped cluster - whose bootstrap entry has been compacted below the Ratis snapshot
+   * and is not replayed - from re-engaging bootstrap after a restart.
+   */
+  @Test
+  void signalIsDurableAcrossRestart() {
+    final ArcadeStateMachine writer = newStateMachine();
+    writer.writePersistedAppliedIndex(42L, DB);
+
+    final ArcadeStateMachine reopened = newStateMachine();
+    assertThat(reopened.hasNeverAppliedApplicationEntry())
+        .as("a persisted applied index survives a restart and keeps the gate closed")
+        .isFalse();
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BootstrapElectionTransferGateTest.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/BootstrapElectionTransferGateTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.server.ArcadeDBServer;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for the leadership-transfer branch of the first-formation gate in
+ * {@link BootstrapElection} (issue #5099).
+ * <p>
+ * When the offline-bootstrap protocol transfers Raft leadership to the elected source, the transfer
+ * and the ensuing term bump make Ratis commit internal no-op / configuration entries, so the new
+ * leader reads a commit index above {@code 0} (empirically 2) even though no application entry has
+ * committed. The exact-{@code 0} gate ({@link BootstrapElection#isConfirmedFirstFormation}) rejected
+ * that post-transfer leader and the baseline was never committed. The widened gate accepts a positive
+ * commit index when the state machine reports it has never applied an application entry, while still
+ * rejecting a genuinely running cluster (issue #4800 preserved).
+ */
+class BootstrapElectionTransferGateTest {
+
+  /**
+   * The core #5099 fix: post-transfer leader with commit index 2 (internal entries only) and a state
+   * machine that has never applied an application entry. The gate must OPEN - the protocol moves past
+   * it and, with no local databases, reports {@code SKIPPED_NO_DATABASES} rather than the gate outcome.
+   */
+  @Test
+  void postTransferLeaderWithOnlyInternalEntriesEngagesBootstrap() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_BOOTSTRAP_FROM_LOCAL_DATABASE, true);
+
+    final ArcadeDBServer mockServer = mock(ArcadeDBServer.class);
+    when(mockServer.getConfiguration()).thenReturn(config);
+    when(mockServer.getDatabaseNames()).thenReturn(Set.of());
+
+    final ArcadeStateMachine mockSm = mock(ArcadeStateMachine.class);
+    when(mockSm.hasNeverAppliedApplicationEntry()).thenReturn(true);
+
+    final RaftHAServer mockHa = mock(RaftHAServer.class);
+    when(mockHa.isLeader()).thenReturn(true);
+    when(mockHa.getCommitIndex()).thenReturn(2L); // post-transfer: internal no-op/config entries
+    when(mockHa.getStateMachine()).thenReturn(mockSm);
+
+    final BootstrapElection election = new BootstrapElection(mockHa, mockServer);
+
+    assertThat(election.runIfEligible()).isEqualTo(BootstrapElection.Outcome.SKIPPED_NO_DATABASES);
+    verify(mockServer).getDatabaseNames();
+  }
+
+  /**
+   * A genuinely running cluster: commit index above {@code 0} AND the state machine has applied
+   * application entries. The gate must stay CLOSED so bootstrap never overwrites live data (#4800).
+   */
+  @Test
+  void positiveCommitIndexWithCommittedDataIsSkipped() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_BOOTSTRAP_FROM_LOCAL_DATABASE, true);
+
+    final ArcadeDBServer mockServer = mock(ArcadeDBServer.class);
+    when(mockServer.getConfiguration()).thenReturn(config);
+    lenient().when(mockServer.getDatabaseNames()).thenReturn(Set.of("alpha"));
+
+    final ArcadeStateMachine mockSm = mock(ArcadeStateMachine.class);
+    when(mockSm.hasNeverAppliedApplicationEntry()).thenReturn(false);
+
+    final RaftHAServer mockHa = mock(RaftHAServer.class);
+    when(mockHa.isLeader()).thenReturn(true);
+    when(mockHa.getCommitIndex()).thenReturn(2L);
+    when(mockHa.getStateMachine()).thenReturn(mockSm);
+
+    final BootstrapElection election = new BootstrapElection(mockHa, mockServer);
+
+    assertThat(election.runIfEligible()).isEqualTo(BootstrapElection.Outcome.SKIPPED_NOT_FIRST_FORMATION);
+    verify(mockServer, never()).getDatabaseNames();
+  }
+
+  /**
+   * Defensive: a positive commit index with no reachable state machine (the query cannot be answered)
+   * must skip rather than assume first formation.
+   */
+  @Test
+  void positiveCommitIndexWithNoStateMachineIsSkipped() {
+    final ContextConfiguration config = new ContextConfiguration();
+    config.setValue(GlobalConfiguration.HA_BOOTSTRAP_FROM_LOCAL_DATABASE, true);
+
+    final ArcadeDBServer mockServer = mock(ArcadeDBServer.class);
+    when(mockServer.getConfiguration()).thenReturn(config);
+    lenient().when(mockServer.getDatabaseNames()).thenReturn(Set.of("alpha"));
+
+    final RaftHAServer mockHa = mock(RaftHAServer.class);
+    when(mockHa.isLeader()).thenReturn(true);
+    when(mockHa.getCommitIndex()).thenReturn(2L);
+    when(mockHa.getStateMachine()).thenReturn(null); // state machine not wired yet
+
+    final BootstrapElection election = new BootstrapElection(mockHa, mockServer);
+
+    assertThat(election.runIfEligible()).isEqualTo(BootstrapElection.Outcome.SKIPPED_NOT_FIRST_FORMATION);
+    verify(mockServer, never()).getDatabaseNames();
+  }
+}


### PR DESCRIPTION
Closes #5099

## Summary
The offline-bootstrap first-formation gate keyed on `commitIndex == 0`. When the protocol transfers Raft leadership to the elected source peer, the transfer plus the term-2 leader election make Ratis append and commit internal no-op / configuration entries, so the new leader reads `commitIndex = 2`, not `0`. The exact-`0` gate (tightened in #4800 to reject a running cluster) therefore rejected the post-transfer leader and the `BOOTSTRAP_FINGERPRINT_ENTRY` was never committed - `getBootstrapBaseline(db)` stayed `null` on every peer.

The gate cannot simply be loosened to `<= 2`: #4800 keys first-formation on an exact `0` to stop bootstrap re-triggering on an already-running cluster (which would risk overwriting live data).

The fix adds a durable first-formation signal, `ArcadeStateMachine.hasNeverAppliedApplicationEntry()`. Ratis internal no-op/config entries never flow through `applyTransaction`, so they advance neither the in-memory `lastAppliedIndex` nor the persisted applied index - while every real mutation (TX/SCHEMA/INSTALL/DROP/SECURITY/BOOTSTRAP entry) advances both. The signal consults both indices so a restarted, already-bootstrapped cluster (bootstrap entry compacted below the Ratis snapshot) is never mistaken for a fresh one. The `BootstrapElection` gate is widened to open on either the exact-`0` empty log (no-transfer path, unchanged) OR, for a positive commit index, on the no-application-entry signal. A negative (unready/failed) commit index still never opens the gate, so #4800 is preserved. The static `isConfirmedFirstFormation(long)` is left unchanged.

## Test plan
- [x] `ArcadeStateMachineFirstFormationSignalTest` (new, unit) - fresh SM is first formation; a persisted applied index closes the signal; the signal is durable across a simulated restart.
- [x] `BootstrapElectionTransferGateTest` (new, unit) - post-transfer leader (commitIndex 2, no application data) engages bootstrap; committed data or a null state machine skips.
- [x] `BootstrapElectionGateTest` (existing, unchanged) - all 8 first-formation gate cases still pass.
- [x] `RaftBootstrapLeadershipTransferIT` (existing IT) - end-to-end reproduction now passes (was timing out).
- [x] `RaftBootstrapDoesNotEngageOnRestartIT`, `RaftBootstrapFromLocalDatabaseIT`, `RaftBootstrapLateNewerJoinerIT` - no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)