### PR TITLE
ci(#4891): gate all five per-language Bolt suites + nightly driver-version matrix

### DIFF
--- a/.github/workflows/bolt-conformance-spec.yml
+++ b/.github/workflows/bolt-conformance-spec.yml
@@ -35,6 +35,12 @@ jobs:
         working-directory: bolt/conformance
         run: python3 -m unittest test_validate_spec.py -v
 
+      - name: Run conformance tools unit tests
+        working-directory: bolt/conformance/tools
+        run: |
+          python3 -m unittest test_junit_to_matrix.py -v
+          python3 -m unittest test_merge_matrix.py -v
+
       - name: Validate spec.yaml
         working-directory: bolt/conformance
         run: python3 validate_spec.py spec.yaml

--- a/.github/workflows/bolt-nightly.yml
+++ b/.github/workflows/bolt-nightly.yml
@@ -339,8 +339,10 @@ jobs:
         run: |
           shopt -s nullglob
           cells=(cells/*.json)
+          # The full expected (language:version) set from bolt/conformance/driver-versions.md;
+          # any of these absent means that cell's job died before emitting a result.
           python3 bolt/conformance/tools/merge_matrix.py "${cells[@]}" \
-            --expect-languages java,javascript,python,csharp,go \
+            --expect-cells java:4.4.20,java:5.28.5,java:6.2.0,javascript:4.4.11,javascript:5.28.3,javascript:6.2.0,python:5.28.4,python:6.1.0,python:6.2.0,csharp:4.4.0,csharp:5.28.4,csharp:6.2.1,go:5.27.0,go:5.28.0,go:5.28.4 \
             -o bolt-compat-matrix.json
           has_failures=$(python3 -c "import json; print(str(json.load(open('bolt-compat-matrix.json'))['has_failures']).lower())")
           echo "has-failures=${has_failures}" >> "$GITHUB_OUTPUT"
@@ -377,13 +379,13 @@ jobs:
                 }
               }
             }
-            const missing = (matrix.missing_languages || []).map(l => `- ${l} (whole suite produced no result)`);
+            const missing = (matrix.missing_cells || []).map(c => `- ${c} (job produced no result)`);
             const title = 'Bolt driver compatibility regression (nightly)';
             const label = 'bolt-compat-regression';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const sections = [`Nightly Bolt matrix reported problems.\n\nRun: ${runUrl}`];
             if (failing.length) sections.push(`### Failing cells\n${failing.sort().join('\n')}`);
-            if (missing.length) sections.push(`### Missing suites\n${missing.join('\n')}`);
+            if (missing.length) sections.push(`### Missing cells\n${missing.join('\n')}`);
             const body = sections.join('\n\n');
             const existing = await github.rest.issues.listForRepo({
               owner: context.repo.owner, repo: context.repo.repo,
@@ -394,4 +396,34 @@ jobs:
               await github.rest.issues.update({ owner: context.repo.owner, repo: context.repo.repo, issue_number: hit.number, body });
             } else {
               await github.rest.issues.create({ owner: context.repo.owner, repo: context.repo.repo, title, body, labels: [label] });
+            }
+
+  resolve-regression:
+    needs: merge-matrix
+    if: ${{ always() && needs.merge-matrix.outputs.has-failures == 'false' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Close the regression issue on a green night
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const title = 'Bolt driver compatibility regression (nightly)';
+            const label = 'bolt-compat-regression';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: label,
+            });
+            const hit = existing.data.find(i => i.title === title);
+            if (hit) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: hit.number,
+                body: `Nightly Bolt matrix is green again. Run: ${runUrl}`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: hit.number, state: 'closed',
+              });
             }

--- a/.github/workflows/bolt-nightly.yml
+++ b/.github/workflows/bolt-nightly.yml
@@ -8,6 +8,12 @@ on:
 permissions:
   contents: read
 
+# Serialize nightly runs so a cron run overlapping a manual dispatch cannot race
+# the list-then-create in report-regression and open duplicate issues.
+concurrency:
+  group: bolt-nightly
+  cancel-in-progress: false
+
 jobs:
   build-image:
     runs-on: ubuntu-latest
@@ -360,7 +366,9 @@ jobs:
 
   report-regression:
     needs: merge-matrix
-    if: ${{ always() && needs.merge-matrix.outputs.has-failures == 'true' }}
+    # Fire on a failing matrix, and also when the merge job itself failed - a
+    # crashed merge leaves has-failures unset, which must not silence the alarm.
+    if: ${{ always() && (needs.merge-matrix.outputs.has-failures == 'true' || needs.merge-matrix.result == 'failure') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -368,6 +376,7 @@ jobs:
     steps:
       - name: Download compatibility matrix
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
         with:
           name: bolt-compat-matrix
       - name: Open or update regression issue
@@ -375,7 +384,14 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const matrix = JSON.parse(fs.readFileSync('bolt-compat-matrix.json', 'utf8'));
+            let matrix = {scenarios: {}, missing_cells: [], unexpected_cells: [], empty_cells: []};
+            let mergeFailed = false;
+            try {
+              matrix = JSON.parse(fs.readFileSync('bolt-compat-matrix.json', 'utf8'));
+            } catch (e) {
+              // No matrix artifact means the merge step itself failed.
+              mergeFailed = true;
+            }
             const failing = [];
             for (const [scen, langs] of Object.entries(matrix.scenarios)) {
               for (const [lang, vers] of Object.entries(langs)) {
@@ -391,6 +407,7 @@ jobs:
             const label = 'bolt-compat-regression';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const sections = [`Nightly Bolt matrix reported problems.\n\nRun: ${runUrl}`];
+            if (mergeFailed) sections.push('### Merge step failed\nThe matrix could not be produced - the compatibility signal for this run is unavailable; investigate the run.');
             if (failing.length) sections.push(`### Failing cells\n${failing.sort().join('\n')}`);
             if (missing.length) sections.push(`### Missing cells\n${missing.join('\n')}`);
             if (unexpected.length) sections.push(`### Unexpected cells\n${unexpected.join('\n')}`);

--- a/.github/workflows/bolt-nightly.yml
+++ b/.github/workflows/bolt-nightly.yml
@@ -346,3 +346,44 @@ jobs:
           name: bolt-compat-matrix
           path: bolt-compat-matrix.json
           retention-days: 30
+
+  report-regression:
+    needs: merge-matrix
+    if: ${{ always() && needs.merge-matrix.outputs.has-failures == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Download compatibility matrix
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bolt-compat-matrix
+      - name: Open or update regression issue
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fs = require('fs');
+            const matrix = JSON.parse(fs.readFileSync('bolt-compat-matrix.json', 'utf8'));
+            const failing = [];
+            for (const [scen, langs] of Object.entries(matrix.scenarios)) {
+              for (const [lang, vers] of Object.entries(langs)) {
+                for (const [ver, status] of Object.entries(vers)) {
+                  if (status === 'fail') failing.push(`- ${scen} / ${lang} / ${ver}`);
+                }
+              }
+            }
+            const title = 'Bolt driver compatibility regression (nightly)';
+            const label = 'bolt-compat-regression';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `Nightly Bolt matrix reported failing cells.\n\nRun: ${runUrl}\n\n${failing.sort().join('\n')}`;
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: label,
+            });
+            const hit = existing.data.find(i => i.title === title);
+            if (hit) {
+              await github.rest.issues.update({ owner: context.repo.owner, repo: context.repo.repo, issue_number: hit.number, body });
+            } else {
+              await github.rest.issues.create({ owner: context.repo.owner, repo: context.repo.repo, title, body, labels: [label] });
+            }

--- a/.github/workflows/bolt-nightly.yml
+++ b/.github/workflows/bolt-nightly.yml
@@ -315,3 +315,34 @@ jobs:
           name: bolt-matrix-go-${{ matrix.driver-version }}
           path: bolt-matrix-go-*.json
           retention-days: 7
+
+  merge-matrix:
+    needs: [bolt-nightly-java, bolt-nightly-js, bolt-nightly-python, bolt-nightly-csharp, bolt-nightly-go]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    outputs:
+      has-failures: ${{ steps.merge.outputs.has-failures }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+      - name: Download all cell artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: cells
+          pattern: bolt-matrix-*
+          merge-multiple: true
+      - name: Merge into compatibility matrix
+        id: merge
+        run: |
+          python3 bolt/conformance/tools/merge_matrix.py cells/*.json -o bolt-compat-matrix.json
+          has_failures=$(python3 -c "import json; print(str(json.load(open('bolt-compat-matrix.json'))['has_failures']).lower())")
+          echo "has-failures=${has_failures}" >> "$GITHUB_OUTPUT"
+      - name: Upload compatibility matrix
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bolt-compat-matrix
+          path: bolt-compat-matrix.json
+          retention-days: 30

--- a/.github/workflows/bolt-nightly.yml
+++ b/.github/workflows/bolt-nightly.yml
@@ -337,7 +337,11 @@ jobs:
       - name: Merge into compatibility matrix
         id: merge
         run: |
-          python3 bolt/conformance/tools/merge_matrix.py cells/*.json -o bolt-compat-matrix.json
+          shopt -s nullglob
+          cells=(cells/*.json)
+          python3 bolt/conformance/tools/merge_matrix.py "${cells[@]}" \
+            --expect-languages java,javascript,python,csharp,go \
+            -o bolt-compat-matrix.json
           has_failures=$(python3 -c "import json; print(str(json.load(open('bolt-compat-matrix.json'))['has_failures']).lower())")
           echo "has-failures=${has_failures}" >> "$GITHUB_OUTPUT"
       - name: Upload compatibility matrix
@@ -373,10 +377,14 @@ jobs:
                 }
               }
             }
+            const missing = (matrix.missing_languages || []).map(l => `- ${l} (whole suite produced no result)`);
             const title = 'Bolt driver compatibility regression (nightly)';
             const label = 'bolt-compat-regression';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const body = `Nightly Bolt matrix reported failing cells.\n\nRun: ${runUrl}\n\n${failing.sort().join('\n')}`;
+            const sections = [`Nightly Bolt matrix reported problems.\n\nRun: ${runUrl}`];
+            if (failing.length) sections.push(`### Failing cells\n${failing.sort().join('\n')}`);
+            if (missing.length) sections.push(`### Missing suites\n${missing.join('\n')}`);
+            const body = sections.join('\n\n');
             const existing = await github.rest.issues.listForRepo({
               owner: context.repo.owner, repo: context.repo.repo,
               state: 'open', labels: label,

--- a/.github/workflows/bolt-nightly.yml
+++ b/.github/workflows/bolt-nightly.yml
@@ -305,7 +305,7 @@ jobs:
       - name: Verify keytool is available (required by TLS scenarios)
         run: command -v keytool
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.12.0
+        run: go install gotest.tools/gotestsum@v1.13.0
       - name: Run Bolt suite against pinned driver
         working-directory: e2e-go
         run: |

--- a/.github/workflows/bolt-nightly.yml
+++ b/.github/workflows/bolt-nightly.yml
@@ -68,8 +68,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # -Dneo4j-driver.version overrides the bolt-driver-legacy profile's
+          # default so the oldest band actually loads the 4.4.20 driver.
           - version: "4.4.20"
-            args: "-Pbolt-driver-legacy -Dit.test=RemoteBoltLegacyDriverIT"
+            args: "-Pbolt-driver-legacy -Dit.test=RemoteBoltLegacyDriverIT -Dneo4j-driver.version=4.4.20"
             report: RemoteBoltLegacyDriverIT
           - version: "5.28.5"
             args: "-Dit.test=RemoteBoltDatabaseIT -Dneo4j-driver.version=5.28.5"
@@ -108,9 +110,13 @@ jobs:
           ARCADEDB_DOCKER_IMAGE: arcadedata/arcadedb:latest
       - name: Convert to matrix JSON
         if: success() || failure()
+        # Glob (with nullglob) so both a single aggregate report and any
+        # per-@Nested-class split files (TEST-...RemoteBoltDatabaseIT$Connection.xml)
+        # are folded together; an empty match yields an empty cell, not a crash.
         run: |
-          python3 bolt/conformance/tools/junit_to_matrix.py \
-            "e2e/target/failsafe-reports/TEST-com.arcadedb.e2e.${{ matrix.report }}.xml" \
+          shopt -s nullglob
+          reports=(e2e/target/failsafe-reports/TEST-com.arcadedb.e2e.${{ matrix.report }}*.xml)
+          python3 bolt/conformance/tools/junit_to_matrix.py "${reports[@]}" \
             --language java --driver-version "${{ matrix.version }}" \
             --spec bolt/conformance/spec.yaml \
             -o "bolt-matrix-java-${{ matrix.version }}.json"

--- a/.github/workflows/bolt-nightly.yml
+++ b/.github/workflows/bolt-nightly.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   build-image:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -238,9 +239,12 @@ jobs:
           python-version: "3.12"
       - name: Run Bolt suite against pinned driver
         working-directory: e2e-csharp/ArcadeDB.E2ETests
+        # Absolute LogFilePath: the JUnit logger resolves a relative path against
+        # the results directory in some versions, which would miss the reader below.
         run: |
           dotnet add package Neo4j.Driver --version ${{ matrix.driver-version }}
-          dotnet test --filter FullyQualifiedName~Bolt --logger "junit;LogFilePath=reports/csharp-junit.xml"
+          mkdir -p reports
+          dotnet test --filter FullyQualifiedName~Bolt --logger "junit;LogFilePath=${{ github.workspace }}/e2e-csharp/ArcadeDB.E2ETests/reports/csharp-junit.xml"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARCADEDB_DOCKER_IMAGE: arcadedata/arcadedb:latest

--- a/.github/workflows/bolt-nightly.yml
+++ b/.github/workflows/bolt-nightly.yml
@@ -46,13 +46,13 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/arcadedb-image.tar
-          key: docker-image-${{ github.run_id }}-${{ github.run_attempt }}
+          key: docker-image-${{ github.run_id }}
 
       - name: Cache Maven artifacts
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2/repository
-          key: maven-repo-${{ github.run_id }}-${{ github.run_attempt }}
+          key: maven-repo-${{ github.run_id }}
 
   bolt-nightly-java:
     needs: build-image
@@ -82,12 +82,12 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2/repository
-          key: maven-repo-${{ github.run_id }}-${{ github.run_attempt }}
+          key: maven-repo-${{ github.run_id }}
       - name: Restore Docker image
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/arcadedb-image.tar
-          key: docker-image-${{ github.run_id }}-${{ github.run_attempt }}
+          key: docker-image-${{ github.run_id }}
       - name: Load Docker image
         run: docker load < /tmp/arcadedb-image.tar
       - name: Set up Python
@@ -132,7 +132,7 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/arcadedb-image.tar
-          key: docker-image-${{ github.run_id }}-${{ github.run_attempt }}
+          key: docker-image-${{ github.run_id }}
       - name: Load Docker image
         run: docker load < /tmp/arcadedb-image.tar
       - name: Set up Python
@@ -183,7 +183,7 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/arcadedb-image.tar
-          key: docker-image-${{ github.run_id }}-${{ github.run_attempt }}
+          key: docker-image-${{ github.run_id }}
       - name: Load Docker image
         run: docker load < /tmp/arcadedb-image.tar
       - name: Run Bolt suite against pinned driver
@@ -229,7 +229,7 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/arcadedb-image.tar
-          key: docker-image-${{ github.run_id }}-${{ github.run_attempt }}
+          key: docker-image-${{ github.run_id }}
       - name: Load Docker image
         run: docker load < /tmp/arcadedb-image.tar
       - name: Set up Python
@@ -279,7 +279,7 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/arcadedb-image.tar
-          key: docker-image-${{ github.run_id }}-${{ github.run_attempt }}
+          key: docker-image-${{ github.run_id }}
       - name: Load Docker image
         run: docker load < /tmp/arcadedb-image.tar
       - name: Set up Python

--- a/.github/workflows/bolt-nightly.yml
+++ b/.github/workflows/bolt-nightly.yml
@@ -1,0 +1,317 @@
+name: Bolt nightly driver-version matrix
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+        with:
+          distribution: "temurin"
+          java-version: 21
+
+      - name: Cache local Maven repository
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Build and package with Maven Docker profile
+        run: ./mvnw clean install -Pdocker -DskipTests --batch-mode --errors --show-version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Save docker image
+        run: docker save arcadedata/arcadedb:latest > /tmp/arcadedb-image.tar
+
+      - name: Cache Docker image
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /tmp/arcadedb-image.tar
+          key: docker-image-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Cache Maven artifacts
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.m2/repository
+          key: maven-repo-${{ github.run_id }}-${{ github.run_attempt }}
+
+  bolt-nightly-java:
+    needs: build-image
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - version: "4.4.20"
+            args: "-Pbolt-driver-legacy -Dit.test=RemoteBoltLegacyDriverIT"
+            report: RemoteBoltLegacyDriverIT
+          - version: "5.28.5"
+            args: "-Dit.test=RemoteBoltDatabaseIT -Dneo4j-driver.version=5.28.5"
+            report: RemoteBoltDatabaseIT
+          - version: "6.2.0"
+            args: "-Dit.test=RemoteBoltDatabaseIT -Dneo4j-driver.version=6.2.0"
+            report: RemoteBoltDatabaseIT
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up JDK 21
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+        with:
+          distribution: "temurin"
+          java-version: 21
+          cache: "maven"
+      - name: Restore Maven artifacts
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.m2/repository
+          key: maven-repo-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Restore Docker image
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /tmp/arcadedb-image.tar
+          key: docker-image-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Load Docker image
+        run: docker load < /tmp/arcadedb-image.tar
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+      - name: Run Bolt suite against pinned driver
+        run: ./mvnw verify -Pintegration -pl e2e ${{ matrix.args }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARCADEDB_DOCKER_IMAGE: arcadedata/arcadedb:latest
+      - name: Convert to matrix JSON
+        if: success() || failure()
+        run: |
+          python3 bolt/conformance/tools/junit_to_matrix.py \
+            "e2e/target/failsafe-reports/TEST-com.arcadedb.e2e.${{ matrix.report }}.xml" \
+            --language java --driver-version "${{ matrix.version }}" \
+            --spec bolt/conformance/spec.yaml \
+            -o "bolt-matrix-java-${{ matrix.version }}.json"
+      - name: Upload cell result
+        if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bolt-matrix-java-${{ matrix.version }}
+          path: bolt-matrix-java-*.json
+          retention-days: 7
+
+  bolt-nightly-js:
+    needs: build-image
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        driver-version: ["4.4.11", "5.28.3", "6.2.0"]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+      - name: Restore Docker image
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /tmp/arcadedb-image.tar
+          key: docker-image-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Load Docker image
+        run: docker load < /tmp/arcadedb-image.tar
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+      - name: Run Bolt suite against pinned driver
+        working-directory: e2e-js
+        run: |
+          npm install
+          npm install neo4j-driver@${{ matrix.driver-version }}
+          NODE_OPTIONS=--experimental-vm-modules npx jest --runInBand --ci --reporters=default --reporters=jest-junit src/js-bolt-conformance.test.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARCADEDB_DOCKER_IMAGE: arcadedata/arcadedb:latest
+      - name: Convert to matrix JSON
+        if: success() || failure()
+        run: |
+          python3 bolt/conformance/tools/junit_to_matrix.py \
+            e2e-js/reports/jest-junit.xml \
+            --language javascript --driver-version "${{ matrix.driver-version }}" \
+            --spec bolt/conformance/spec.yaml \
+            -o "bolt-matrix-javascript-${{ matrix.driver-version }}.json"
+      - name: Upload cell result
+        if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bolt-matrix-javascript-${{ matrix.driver-version }}
+          path: bolt-matrix-javascript-*.json
+          retention-days: 7
+
+  bolt-nightly-python:
+    needs: build-image
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        driver-version: ["5.28.4", "6.1.0", "6.2.0"]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.13.0"
+      - name: Setup UV package manager
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - name: Restore Docker image
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /tmp/arcadedb-image.tar
+          key: docker-image-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Load Docker image
+        run: docker load < /tmp/arcadedb-image.tar
+      - name: Run Bolt suite against pinned driver
+        working-directory: e2e-python
+        run: |
+          uv pip install --system -e .
+          uv pip install --system pytest "neo4j==${{ matrix.driver-version }}"
+          mkdir -p reports
+          pytest tests/test_bolt.py --junitxml=reports/python-junit.xml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARCADEDB_DOCKER_IMAGE: arcadedata/arcadedb:latest
+      - name: Convert to matrix JSON
+        if: success() || failure()
+        run: |
+          python3 bolt/conformance/tools/junit_to_matrix.py \
+            e2e-python/reports/python-junit.xml \
+            --language python --driver-version "${{ matrix.driver-version }}" \
+            --spec bolt/conformance/spec.yaml \
+            -o "bolt-matrix-python-${{ matrix.driver-version }}.json"
+      - name: Upload cell result
+        if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bolt-matrix-python-${{ matrix.driver-version }}
+          path: bolt-matrix-python-*.json
+          retention-days: 7
+
+  bolt-nightly-csharp:
+    needs: build-image
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        driver-version: ["4.4.0", "5.28.4", "6.2.1"]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          dotnet-version: "10.0"
+      - name: Restore Docker image
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /tmp/arcadedb-image.tar
+          key: docker-image-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Load Docker image
+        run: docker load < /tmp/arcadedb-image.tar
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+      - name: Run Bolt suite against pinned driver
+        working-directory: e2e-csharp/ArcadeDB.E2ETests
+        run: |
+          dotnet add package Neo4j.Driver --version ${{ matrix.driver-version }}
+          dotnet test --filter FullyQualifiedName~Bolt --logger "junit;LogFilePath=reports/csharp-junit.xml"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARCADEDB_DOCKER_IMAGE: arcadedata/arcadedb:latest
+      - name: Convert to matrix JSON
+        if: success() || failure()
+        run: |
+          python3 bolt/conformance/tools/junit_to_matrix.py \
+            e2e-csharp/ArcadeDB.E2ETests/reports/csharp-junit.xml \
+            --language csharp --driver-version "${{ matrix.driver-version }}" \
+            --spec bolt/conformance/spec.yaml \
+            -o "bolt-matrix-csharp-${{ matrix.driver-version }}.json"
+      - name: Upload cell result
+        if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bolt-matrix-csharp-${{ matrix.driver-version }}
+          path: bolt-matrix-csharp-*.json
+          retention-days: 7
+
+  bolt-nightly-go:
+    needs: build-image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        driver-version: ["5.27.0", "5.28.0", "5.28.4"]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: "e2e-go/go.mod"
+          cache-dependency-path: "e2e-go/go.sum"
+      - name: Restore Docker image
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /tmp/arcadedb-image.tar
+          key: docker-image-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Load Docker image
+        run: docker load < /tmp/arcadedb-image.tar
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+      - name: Verify keytool is available (required by TLS scenarios)
+        run: command -v keytool
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@v1.12.0
+      - name: Run Bolt suite against pinned driver
+        working-directory: e2e-go
+        run: |
+          go get github.com/neo4j/neo4j-go-driver/v5@v${{ matrix.driver-version }}
+          go mod tidy
+          mkdir -p reports
+          gotestsum --junitfile reports/go-junit.xml --format standard-verbose -- -timeout 20m ./...
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARCADEDB_DOCKER_IMAGE: arcadedata/arcadedb:latest
+      - name: Convert to matrix JSON
+        if: success() || failure()
+        run: |
+          python3 bolt/conformance/tools/junit_to_matrix.py \
+            e2e-go/reports/go-junit.xml \
+            --language go --driver-version "${{ matrix.driver-version }}" \
+            --spec bolt/conformance/spec.yaml \
+            -o "bolt-matrix-go-${{ matrix.driver-version }}.json"
+      - name: Upload cell result
+        if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bolt-matrix-go-${{ matrix.driver-version }}
+          path: bolt-matrix-go-*.json
+          retention-days: 7

--- a/.github/workflows/bolt-nightly.yml
+++ b/.github/workflows/bolt-nightly.yml
@@ -339,10 +339,11 @@ jobs:
         run: |
           shopt -s nullglob
           cells=(cells/*.json)
-          # The full expected (language:version) set from bolt/conformance/driver-versions.md;
-          # any of these absent means that cell's job died before emitting a result.
+          # driver-versions.md is the single source of truth for the expected
+          # cell set; a cell missing from it, present but undocumented, or empty
+          # of scenarios all force has_failures.
           python3 bolt/conformance/tools/merge_matrix.py "${cells[@]}" \
-            --expect-cells java:4.4.20,java:5.28.5,java:6.2.0,javascript:4.4.11,javascript:5.28.3,javascript:6.2.0,python:5.28.4,python:6.1.0,python:6.2.0,csharp:4.4.0,csharp:5.28.4,csharp:6.2.1,go:5.27.0,go:5.28.0,go:5.28.4 \
+            --expect-from bolt/conformance/driver-versions.md \
             -o bolt-compat-matrix.json
           has_failures=$(python3 -c "import json; print(str(json.load(open('bolt-compat-matrix.json'))['has_failures']).lower())")
           echo "has-failures=${has_failures}" >> "$GITHUB_OUTPUT"
@@ -380,12 +381,16 @@ jobs:
               }
             }
             const missing = (matrix.missing_cells || []).map(c => `- ${c} (job produced no result)`);
+            const unexpected = (matrix.unexpected_cells || []).map(c => `- ${c} (ran but not in driver-versions.md)`);
+            const empty = (matrix.empty_cells || []).map(c => `- ${c} (ran but produced no recognized scenarios)`);
             const title = 'Bolt driver compatibility regression (nightly)';
             const label = 'bolt-compat-regression';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const sections = [`Nightly Bolt matrix reported problems.\n\nRun: ${runUrl}`];
             if (failing.length) sections.push(`### Failing cells\n${failing.sort().join('\n')}`);
             if (missing.length) sections.push(`### Missing cells\n${missing.join('\n')}`);
+            if (unexpected.length) sections.push(`### Unexpected cells\n${unexpected.join('\n')}`);
+            if (empty.length) sections.push(`### Empty cells (no scenarios)\n${empty.join('\n')}`);
             const body = sections.join('\n\n');
             const existing = await github.rest.issues.listForRepo({
               owner: context.repo.owner, repo: context.repo.repo,

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -604,7 +604,7 @@ jobs:
         run: command -v keytool
 
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.12.0
+        run: go install gotest.tools/gotestsum@v1.13.0
 
       - name: E2E Go Tests
         working-directory: e2e-go

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -346,6 +346,9 @@ jobs:
   js-e2e-tests:
     runs-on: ubuntu-latest
     needs: build-and-package
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -375,6 +378,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARCADEDB_DOCKER_IMAGE: ${{ needs.build-and-package.outputs.image-tag }}
+
+      - name: JS E2E Tests Reporter
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        if: success() || failure()
+        with:
+          name: JS E2E Tests Report
+          path: "e2e-js/reports/jest-junit.xml"
+          list-suites: "failed"
+          list-tests: "failed"
+          reporter: java-junit
+
+      - name: Upload JS E2E JUnit report
+        if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: js-e2e-junit
+          path: e2e-js/reports/jest-junit.xml
+          retention-days: 7
 
   studio-e2e-tests:
     runs-on: ubuntu-latest
@@ -438,6 +459,9 @@ jobs:
   python-e2e-tests:
     runs-on: ubuntu-latest
     needs: build-and-package
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -467,14 +491,36 @@ jobs:
         run: |
           uv pip install --system -e .
           uv pip install --system pytest
-          pytest tests/
+          mkdir -p reports
+          pytest tests/ --junitxml=reports/python-junit.xml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARCADEDB_DOCKER_IMAGE: ${{ needs.build-and-package.outputs.image-tag }}
 
+      - name: Python E2E Tests Reporter
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        if: success() || failure()
+        with:
+          name: Python E2E Tests Report
+          path: "e2e-python/reports/python-junit.xml"
+          list-suites: "failed"
+          list-tests: "failed"
+          reporter: java-junit
+
+      - name: Upload Python E2E JUnit report
+        if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: python-e2e-junit
+          path: e2e-python/reports/python-junit.xml
+          retention-days: 7
+
   csharp-e2e-tests:
     runs-on: ubuntu-latest
     needs: build-and-package
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -496,15 +542,36 @@ jobs:
 
       - name: E2E C# Tests
         working-directory: e2e-csharp/ArcadeDB.E2ETests
-        run: dotnet test --logger "trx;LogFileName=test-results.trx"
+        run: dotnet test --logger "trx;LogFileName=test-results.trx" --logger "junit;LogFilePath=reports/csharp-junit.xml"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARCADEDB_DOCKER_IMAGE: ${{ needs.build-and-package.outputs.image-tag }}
+
+      - name: C# E2E Tests Reporter
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        if: success() || failure()
+        with:
+          name: C# E2E Tests Report
+          path: "e2e-csharp/ArcadeDB.E2ETests/reports/csharp-junit.xml"
+          list-suites: "failed"
+          list-tests: "failed"
+          reporter: java-junit
+
+      - name: Upload C# E2E JUnit report
+        if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: csharp-e2e-junit
+          path: e2e-csharp/ArcadeDB.E2ETests/reports/csharp-junit.xml
+          retention-days: 7
 
   go-e2e-tests:
     runs-on: ubuntu-latest
     needs: build-and-package
     timeout-minutes: 30
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -531,15 +598,38 @@ jobs:
       - name: Verify keytool is available (required by TLS scenarios)
         run: command -v keytool
 
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@v1.12.0
+
       - name: E2E Go Tests
         working-directory: e2e-go
         # 20m timeout: the plain container plus a derived-image build and two
         # TLS containers (150s startup each) run sequentially and can approach
         # the default 10m per-package deadline on a shared runner.
-        run: go test -v -timeout 20m ./...
+        run: |
+          mkdir -p reports
+          gotestsum --junitfile reports/go-junit.xml --format standard-verbose -- -timeout 20m ./...
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARCADEDB_DOCKER_IMAGE: ${{ needs.build-and-package.outputs.image-tag }}
+
+      - name: Go E2E Tests Reporter
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        if: success() || failure()
+        with:
+          name: Go E2E Tests Report
+          path: "e2e-go/reports/go-junit.xml"
+          list-suites: "failed"
+          list-tests: "failed"
+          reporter: java-junit
+
+      - name: Upload Go E2E JUnit report
+        if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: go-e2e-junit
+          path: e2e-go/reports/go-junit.xml
+          retention-days: 7
 
   coverage-report:
     runs-on: ubuntu-latest

--- a/.github/workflows/mvn-test.yml
+++ b/.github/workflows/mvn-test.yml
@@ -542,7 +542,12 @@ jobs:
 
       - name: E2E C# Tests
         working-directory: e2e-csharp/ArcadeDB.E2ETests
-        run: dotnet test --logger "trx;LogFileName=test-results.trx" --logger "junit;LogFilePath=reports/csharp-junit.xml"
+        # Absolute LogFilePath: JunitXml.TestLogger resolves a relative path
+        # against the results directory in some versions, which would land the
+        # file where the reporter/convert step does not look.
+        run: |
+          mkdir -p reports
+          dotnet test --logger "trx;LogFileName=test-results.trx" --logger "junit;LogFilePath=${{ github.workspace }}/e2e-csharp/ArcadeDB.E2ETests/reports/csharp-junit.xml"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARCADEDB_DOCKER_IMAGE: ${{ needs.build-and-package.outputs.image-tag }}

--- a/bolt/conformance/driver-versions.md
+++ b/bolt/conformance/driver-versions.md
@@ -9,6 +9,12 @@ so a driver-side release that breaks compatibility is caught by the nightly run.
 When a driver publishes a new release that shifts a band, update the version
 here and in the matching workflow matrix.
 
+This table is the single source of truth for the expected cell set: the nightly
+`merge-matrix` step parses these rows (`merge_matrix.py --expect-from`) as the
+`language:version` cells that must be present. Keep the `| language | band |
+version |` column order intact - a cell in the job matrices but absent here is
+reported as an unexpected cell, and vice versa as a missing cell.
+
 | Language   | Band                  | Version  |
 |------------|-----------------------|----------|
 | java       | oldest-supported-4.x  | 4.4.20   |

--- a/bolt/conformance/driver-versions.md
+++ b/bolt/conformance/driver-versions.md
@@ -1,0 +1,38 @@
+# Resolved Bolt driver-version matrix
+
+Concrete driver versions consumed by `.github/workflows/bolt-nightly.yml`. The
+band names come from `spec.yaml` `driver_version_bands`; the versions below were
+resolved against each package registry. The newest patch of each maintained
+minor line is chosen; the `latest`/`latest-6.x` band tracks the newest release
+so a driver-side release that breaks compatibility is caught by the nightly run.
+
+When a driver publishes a new release that shifts a band, update the version
+here and in the matching workflow matrix.
+
+| Language   | Band                  | Version  |
+|------------|-----------------------|----------|
+| java       | oldest-supported-4.x  | 4.4.20   |
+| java       | latest-5.x            | 5.28.5   |
+| java       | latest-6.x            | 6.2.0    |
+| javascript | oldest-supported-4.x  | 4.4.11   |
+| javascript | latest-5.x            | 5.28.3   |
+| javascript | latest-6.x            | 6.2.0    |
+| python     | lts                   | 5.28.4   |
+| python     | current               | 6.1.0    |
+| python     | latest                | 6.2.0    |
+| csharp     | lts                   | 4.4.0    |
+| csharp     | current               | 5.28.4   |
+| csharp     | latest                | 6.2.1    |
+| go         | lts                   | 5.27.0   |
+| go         | current               | 5.28.0   |
+| go         | latest                | 5.28.4   |
+
+Notes:
+- Java `oldest-supported-4.x` (4.4.20) runs through the `e2e`
+  `bolt-driver-legacy` Maven profile (`RemoteBoltLegacyDriverIT`); the other two
+  Java bands run `RemoteBoltDatabaseIT` with `-Dneo4j-driver.version=`.
+- The Go driver ships a single current major line (`neo4j-go-driver/v5`); its
+  three bands are three points along that line.
+- Repo PR-run pins (single version each): java 6.2.0, javascript 6.0.1,
+  python 6.2.0, csharp 6.2.1, go 5.28.4. The nightly widens each to the full
+  band set above.

--- a/bolt/conformance/spec.yaml
+++ b/bolt/conformance/spec.yaml
@@ -13,23 +13,31 @@ driver_version_bands:
       default e2e RemoteBoltDatabaseIT); oldest-supported-4.x = 4.4.20 via the
       e2e `bolt-driver-legacy` Maven profile running RemoteBoltLegacyDriverIT.
       latest-5.x is exercised in CI's driver-version matrix (#4891).
+      Concrete nightly versions: see bolt/conformance/driver-versions.md (#4891).
   javascript:
     band_names: [oldest-supported-4.x, latest-5.x, latest-6.x]
     driver_artifact: "neo4j-driver (npm)"
     resolution_note: >
       Resolved by #4888; current repo baseline is ^6.0.1 (e2e-js/package.json).
+      Concrete nightly versions: see bolt/conformance/driver-versions.md (#4891).
   python:
     band_names: [lts, current, latest]
     driver_artifact: "neo4j (PyPI)"
-    resolution_note: "Resolved by #4885 - no existing pin in this repo today."
+    resolution_note: >
+      Resolved by #4885 - no existing pin in this repo today.
+      Concrete nightly versions: see bolt/conformance/driver-versions.md (#4891).
   csharp:
     band_names: [lts, current, latest]
     driver_artifact: "Neo4j.Driver (NuGet)"
-    resolution_note: "Resolved by #4886 - no existing pin in this repo today."
+    resolution_note: >
+      Resolved by #4886 - no existing pin in this repo today.
+      Concrete nightly versions: see bolt/conformance/driver-versions.md (#4891).
   go:
     band_names: [lts, current, latest]
     driver_artifact: "github.com/neo4j/neo4j-go-driver"
-    resolution_note: "Resolved by #4887 - new module, no existing pin."
+    resolution_note: >
+      Resolved by #4887 - new module, no existing pin.
+      Concrete nightly versions: see bolt/conformance/driver-versions.md (#4891).
 
 fixtures:
   beer:

--- a/bolt/conformance/tools/junit_to_matrix.py
+++ b/bolt/conformance/tools/junit_to_matrix.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+r"""Convert a suite's JUnit XML into a normalized scenario-id -> status map.
+
+Scenario IDs (pattern ``[A-Z]+-\d{3}``) are embedded in every suite's test
+names; this reduces a language/driver-version run to a comparable map keyed by
+those IDs so runs can be merged across languages.
+"""
+import argparse
+import json
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+ID_RE = re.compile(r"\b([A-Z]+-\d{3})\b")
+
+
+def parse_junit(xml_path):
+    """Return a {scenario-id: "pass"|"fail"|"skip"} map from a JUnit report.
+
+    A scenario asserted by several testcases fails if any of them fails, and is
+    considered a pass if at least one passes and none fail.
+    """
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+    results = {}
+    for tc in root.iter("testcase"):
+        name = tc.get("name", "")
+        match = ID_RE.search(name)
+        if not match:
+            continue
+        scenario = match.group(1)
+        status = "pass"
+        for child in tc:
+            tag = child.tag.split("}")[-1]
+            if tag in ("failure", "error"):
+                status = "fail"
+                break
+            if tag == "skipped":
+                status = "skip"
+                break
+        prev = results.get(scenario)
+        if prev == "fail" or status == "fail":
+            results[scenario] = "fail"
+        elif prev == "pass" or status == "pass":
+            results[scenario] = "pass"
+        else:
+            results[scenario] = status
+    return results
+
+
+def load_known_ids(spec_path):
+    """Collect every scenario id declared in spec.yaml (lines like ``- id: X``)."""
+    ids = set()
+    with open(spec_path, encoding="utf-8") as fh:
+        for line in fh:
+            stripped = line.strip()
+            if stripped.startswith("- id:"):
+                ids.add(stripped.split("- id:", 1)[1].strip())
+    return ids
+
+
+def build_matrix(xml_path, language, driver_version, known_ids):
+    """Build the per-cell record, rejecting scenario ids absent from the spec."""
+    scenarios = parse_junit(xml_path)
+    unknown = set(scenarios) - set(known_ids)
+    if unknown:
+        raise ValueError(f"JUnit references unknown scenario IDs: {sorted(unknown)}")
+    return {"language": language, "driver_version": driver_version, "scenarios": scenarios}
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("junit_xml")
+    parser.add_argument("--language", required=True)
+    parser.add_argument("--driver-version", required=True)
+    parser.add_argument("--spec", required=True, help="path to spec.yaml")
+    parser.add_argument("-o", "--output", required=True)
+    args = parser.parse_args(argv)
+    known = load_known_ids(args.spec)
+    matrix = build_matrix(args.junit_xml, args.language, args.driver_version, known)
+    with open(args.output, "w", encoding="utf-8") as fh:
+        json.dump(matrix, fh, indent=2, sort_keys=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bolt/conformance/tools/junit_to_matrix.py
+++ b/bolt/conformance/tools/junit_to_matrix.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python3
-r"""
-Convert a suite's JUnit XML into a normalized scenario-id -> status map.
-
-Scenario IDs (pattern ``[A-Z]+-\d{3}``) are embedded in every suite's test
-names; this reduces a language/driver-version run to a comparable map keyed by
-those IDs so runs can be merged across languages.
-"""
+# Scenario IDs (pattern [A-Z]+-\d{3}) are embedded in every suite's test names;
+# this reduces a language/driver-version run to a comparable map keyed by those
+# IDs so runs can be merged across languages.
+r"""Convert a suite's JUnit XML into a normalized scenario-id -> status map."""
 import argparse
 import json
 import re
@@ -32,13 +29,10 @@ def _local_name(tag):
 
 
 def parse_junit(xml_path):
-    """
-    Return a {scenario-id: "pass"|"fail"|"skip"} map from a JUnit report.
-
-    A scenario asserted by several testcases fails if any of them fails, and is
-    considered a pass if at least one passes and none fail. Tags are matched by
-    local name so a namespaced JUnit document is handled the same as a plain one.
-    """
+    """Return a {scenario-id: "pass"|"fail"|"skip"} map from a JUnit report."""
+    # A scenario asserted by several testcases fails if any of them fails, and is
+    # considered a pass if at least one passes and none fail. Tags are matched by
+    # local name so a namespaced JUnit document is handled the same as a plain one.
     tree = ET.parse(xml_path)  # nosec B314 - trusted CI-generated JUnit (see import note)
     root = tree.getroot()
     results = {}
@@ -81,13 +75,11 @@ def load_known_ids(spec_path):
 
 
 def build_matrix(xml_path, language, driver_version, known_ids):
-    """
-    Build the per-cell record, dropping scenario ids absent from the spec.
-
-    Unknown ids are warned about and skipped rather than raised: this tool runs
-    inside a monitoring workflow where hard-failing the conversion would drop the
-    whole cell and hide the scenarios that did run.
-    """
+    """Build the per-cell record, dropping scenario ids absent from the spec."""
+    # Unknown ids are warned about and skipped rather than raised: this tool runs
+    # inside a monitoring workflow where hard-failing the conversion would drop
+    # the whole cell and hide the scenarios that did run. A cell that ends up with
+    # zero recognized scenarios is caught downstream by merge_matrix's empty check.
     scenarios = parse_junit(xml_path)
     unknown = sorted(set(scenarios) - set(known_ids))
     if unknown:

--- a/bolt/conformance/tools/junit_to_matrix.py
+++ b/bolt/conformance/tools/junit_to_matrix.py
@@ -20,8 +20,9 @@ import xml.etree.ElementTree as ET  # nosec B405
 # (js/csharp/java "CONN-001") or an underscore (Go func "Test_CONN_001_...");
 # both normalize to the hyphenated spec id. A plain \b word boundary can't be
 # used because the underscore in "Test_CONN_001" is itself a word character, so
-# letter/digit lookarounds delimit the id instead.
-ID_RE = re.compile(r"(?<![A-Za-z])([A-Z]{2,})[-_](\d{3})(?!\d)")
+# letter/digit lookarounds delimit the id instead. The prefix is 1+ letters to
+# match SPEC_ID_RE and the documented [A-Z]+-\d{3} pattern.
+ID_RE = re.compile(r"(?<![A-Za-z])([A-Z]+)[-_](\d{3})(?!\d)")
 SPEC_ID_RE = re.compile(r"^\s*-\s*id:\s*([A-Z]+-\d{3})\b")
 
 

--- a/bolt/conformance/tools/junit_to_matrix.py
+++ b/bolt/conformance/tools/junit_to_matrix.py
@@ -13,13 +13,20 @@ import sys
 # apply on this trust boundary.
 import xml.etree.ElementTree as ET  # nosec B405
 
-# Suites encode the scenario id in test names with either a hyphen
-# (js/csharp/java "CONN-001") or an underscore (Go func "Test_CONN_001_...");
-# both normalize to the hyphenated spec id. A plain \b word boundary can't be
-# used because the underscore in "Test_CONN_001" is itself a word character, so
-# letter/digit lookarounds delimit the id instead. The prefix is 1+ letters to
-# match SPEC_ID_RE and the documented [A-Z]+-\d{3} pattern.
-ID_RE = re.compile(r"(?<![A-Za-z])([A-Z]+)[-_](\d{3})(?!\d)")
+# Suites embed the scenario id in test names in several shapes, and the id must
+# be recovered from all of them:
+#   JS      it("[CONN-001] ...")                 -> bracketed, hyphen
+#   Go      func Test_CONN_001_...               -> underscore
+#   Python  def test_CONN_001_...                -> underscore, lowercase prefix
+#   C#      [Fact(DisplayName = "CONN-001: ...")] -> hyphen (via the JUnit logger)
+#   Java    void conn001_boltScheme()            -> Maven Failsafe writes the
+#           method name (not @DisplayName) by default: lowercase, no separator
+# So the prefix is matched case-insensitively, the separator is optional, and the
+# result is normalized to the uppercase hyphenated spec id. A plain \b can't be
+# used (the surrounding "_" is a word char); alnum lookarounds delimit the id and
+# the exact 3-digit + (?!\d) guard avoids swallowing 4-digit runs (e.g. year2024).
+# Tokens that resolve to an id absent from the spec are dropped in build_matrix.
+ID_RE = re.compile(r"(?<![A-Za-z0-9])([A-Za-z]{2,})[-_]?(\d{3})(?!\d)")
 SPEC_ID_RE = re.compile(r"^\s*-\s*id:\s*([A-Z]+-\d{3})\b")
 
 
@@ -43,7 +50,7 @@ def parse_junit(xml_path):
         match = ID_RE.search(name)
         if not match:
             continue
-        scenario = f"{match.group(1)}-{match.group(2)}"
+        scenario = f"{match.group(1).upper()}-{match.group(2)}"
         status = "pass"
         for child in tc:
             tag = _local_name(child.tag)

--- a/bolt/conformance/tools/junit_to_matrix.py
+++ b/bolt/conformance/tools/junit_to_matrix.py
@@ -35,6 +35,17 @@ def _local_name(tag):
     return tag.split("}")[-1]
 
 
+def _fold(results, scenario, status):
+    """Merge a scenario status into results: any fail wins, else any pass, else skip."""
+    prev = results.get(scenario)
+    if prev == "fail" or status == "fail":
+        results[scenario] = "fail"
+    elif prev == "pass" or status == "pass":
+        results[scenario] = "pass"
+    else:
+        results[scenario] = status
+
+
 def parse_junit(xml_path):
     """Return a {scenario-id: "pass"|"fail"|"skip"} map from a JUnit report."""
     # A scenario asserted by several testcases fails if any of them fails, and is
@@ -60,14 +71,22 @@ def parse_junit(xml_path):
             if tag == "skipped":
                 status = "skip"
                 break
-        prev = results.get(scenario)
-        if prev == "fail" or status == "fail":
-            results[scenario] = "fail"
-        elif prev == "pass" or status == "pass":
-            results[scenario] = "pass"
-        else:
-            results[scenario] = status
+        _fold(results, scenario, status)
     return results
+
+
+def parse_junit_files(paths):
+    """Parse and fold several JUnit reports into one scenario map.
+
+    Maven Failsafe can split a @Nested test class across per-nested-class report
+    files, so the Java cells pass a glob; folding across files keeps the merge
+    robust whether the runner emits one aggregate file or several.
+    """
+    combined = {}
+    for path in paths:
+        for scenario, status in parse_junit(path).items():
+            _fold(combined, scenario, status)
+    return combined
 
 
 def load_known_ids(spec_path):
@@ -81,13 +100,13 @@ def load_known_ids(spec_path):
     return ids
 
 
-def build_matrix(xml_path, language, driver_version, known_ids):
-    """Build the per-cell record, dropping scenario ids absent from the spec."""
+def build_matrix(xml_paths, language, driver_version, known_ids):
+    """Build the per-cell record from one or more reports, dropping ids absent from the spec."""
     # Unknown ids are warned about and skipped rather than raised: this tool runs
     # inside a monitoring workflow where hard-failing the conversion would drop
     # the whole cell and hide the scenarios that did run. A cell that ends up with
     # zero recognized scenarios is caught downstream by merge_matrix's empty check.
-    scenarios = parse_junit(xml_path)
+    scenarios = parse_junit_files(xml_paths)
     unknown = sorted(set(scenarios) - set(known_ids))
     if unknown:
         print(f"warning: dropping scenario IDs not in spec.yaml: {unknown}", file=sys.stderr)
@@ -98,7 +117,7 @@ def build_matrix(xml_path, language, driver_version, known_ids):
 
 def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("junit_xml")
+    parser.add_argument("junit_xml", nargs="*", help="one or more JUnit report files")
     parser.add_argument("--language", required=True)
     parser.add_argument("--driver-version", required=True)
     parser.add_argument("--spec", required=True, help="path to spec.yaml")

--- a/bolt/conformance/tools/junit_to_matrix.py
+++ b/bolt/conformance/tools/junit_to_matrix.py
@@ -9,7 +9,11 @@ import argparse
 import json
 import re
 import sys
-import xml.etree.ElementTree as ET
+# The JUnit XML consumed here is produced by our own CI test runners
+# (jest-junit, pytest, gotestsum, JunitXml.TestLogger, Maven failsafe), never by
+# an external/untrusted source, so the stdlib parser's XML-entity concerns do not
+# apply on this trust boundary.
+import xml.etree.ElementTree as ET  # nosec B405
 
 # Suites encode the scenario id in test names with either a hyphen
 # (js/csharp/java "CONN-001") or an underscore (Go func "Test_CONN_001_...");
@@ -17,18 +21,27 @@ import xml.etree.ElementTree as ET
 # used because the underscore in "Test_CONN_001" is itself a word character, so
 # letter/digit lookarounds delimit the id instead.
 ID_RE = re.compile(r"(?<![A-Za-z])([A-Z]{2,})[-_](\d{3})(?!\d)")
+SPEC_ID_RE = re.compile(r"^\s*-\s*id:\s*([A-Z]+-\d{3})\b")
+
+
+def _local_name(tag):
+    """Strip any ``{namespace}`` prefix from an XML tag."""
+    return tag.split("}")[-1]
 
 
 def parse_junit(xml_path):
     """Return a {scenario-id: "pass"|"fail"|"skip"} map from a JUnit report.
 
     A scenario asserted by several testcases fails if any of them fails, and is
-    considered a pass if at least one passes and none fail.
+    considered a pass if at least one passes and none fail. Tags are matched by
+    local name so a namespaced JUnit document is handled the same as a plain one.
     """
-    tree = ET.parse(xml_path)
+    tree = ET.parse(xml_path)  # nosec B314 - trusted CI-generated JUnit (see import note)
     root = tree.getroot()
     results = {}
-    for tc in root.iter("testcase"):
+    for tc in root.iter():
+        if _local_name(tc.tag) != "testcase":
+            continue
         name = tc.get("name", "")
         match = ID_RE.search(name)
         if not match:
@@ -36,7 +49,7 @@ def parse_junit(xml_path):
         scenario = f"{match.group(1)}-{match.group(2)}"
         status = "pass"
         for child in tc:
-            tag = child.tag.split("}")[-1]
+            tag = _local_name(child.tag)
             if tag in ("failure", "error"):
                 status = "fail"
                 break
@@ -58,18 +71,25 @@ def load_known_ids(spec_path):
     ids = set()
     with open(spec_path, encoding="utf-8") as fh:
         for line in fh:
-            stripped = line.strip()
-            if stripped.startswith("- id:"):
-                ids.add(stripped.split("- id:", 1)[1].strip())
+            match = SPEC_ID_RE.match(line)
+            if match:
+                ids.add(match.group(1))
     return ids
 
 
 def build_matrix(xml_path, language, driver_version, known_ids):
-    """Build the per-cell record, rejecting scenario ids absent from the spec."""
+    """Build the per-cell record, dropping scenario ids absent from the spec.
+
+    Unknown ids are warned about and skipped rather than raised: this tool runs
+    inside a monitoring workflow where hard-failing the conversion would drop the
+    whole cell and hide the scenarios that did run.
+    """
     scenarios = parse_junit(xml_path)
-    unknown = set(scenarios) - set(known_ids)
+    unknown = sorted(set(scenarios) - set(known_ids))
     if unknown:
-        raise ValueError(f"JUnit references unknown scenario IDs: {sorted(unknown)}")
+        print(f"warning: dropping scenario IDs not in spec.yaml: {unknown}", file=sys.stderr)
+        for scenario in unknown:
+            del scenarios[scenario]
     return {"language": language, "driver_version": driver_version, "scenarios": scenarios}
 
 

--- a/bolt/conformance/tools/junit_to_matrix.py
+++ b/bolt/conformance/tools/junit_to_matrix.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-r"""Convert a suite's JUnit XML into a normalized scenario-id -> status map.
+r"""
+Convert a suite's JUnit XML into a normalized scenario-id -> status map.
 
 Scenario IDs (pattern ``[A-Z]+-\d{3}``) are embedded in every suite's test
 names; this reduces a language/driver-version run to a comparable map keyed by
@@ -30,7 +31,8 @@ def _local_name(tag):
 
 
 def parse_junit(xml_path):
-    """Return a {scenario-id: "pass"|"fail"|"skip"} map from a JUnit report.
+    """
+    Return a {scenario-id: "pass"|"fail"|"skip"} map from a JUnit report.
 
     A scenario asserted by several testcases fails if any of them fails, and is
     considered a pass if at least one passes and none fail. Tags are matched by
@@ -78,7 +80,8 @@ def load_known_ids(spec_path):
 
 
 def build_matrix(xml_path, language, driver_version, known_ids):
-    """Build the per-cell record, dropping scenario ids absent from the spec.
+    """
+    Build the per-cell record, dropping scenario ids absent from the spec.
 
     Unknown ids are warned about and skipped rather than raised: this tool runs
     inside a monitoring workflow where hard-failing the conversion would drop the

--- a/bolt/conformance/tools/junit_to_matrix.py
+++ b/bolt/conformance/tools/junit_to_matrix.py
@@ -11,7 +11,12 @@ import re
 import sys
 import xml.etree.ElementTree as ET
 
-ID_RE = re.compile(r"\b([A-Z]+-\d{3})\b")
+# Suites encode the scenario id in test names with either a hyphen
+# (js/csharp/java "CONN-001") or an underscore (Go func "Test_CONN_001_...");
+# both normalize to the hyphenated spec id. A plain \b word boundary can't be
+# used because the underscore in "Test_CONN_001" is itself a word character, so
+# letter/digit lookarounds delimit the id instead.
+ID_RE = re.compile(r"(?<![A-Za-z])([A-Z]{2,})[-_](\d{3})(?!\d)")
 
 
 def parse_junit(xml_path):
@@ -28,7 +33,7 @@ def parse_junit(xml_path):
         match = ID_RE.search(name)
         if not match:
             continue
-        scenario = match.group(1)
+        scenario = f"{match.group(1)}-{match.group(2)}"
         status = "pass"
         for child in tc:
             tag = child.tag.split("}")[-1]

--- a/bolt/conformance/tools/merge_matrix.py
+++ b/bolt/conformance/tools/merge_matrix.py
@@ -81,8 +81,14 @@ def main(argv=None):
     expected = load_expected_cells(args.expect_from) if args.expect_from else []
     matrices = []
     for path in args.cells:
-        with open(path, encoding="utf-8") as fh:
-            matrices.append(json.load(fh))
+        # A malformed cell file must not crash the merge: that would leave the
+        # nightly's has-failures output unset and silence both the report and
+        # resolve jobs. Skip it with a warning - the cell then counts as missing.
+        try:
+            with open(path, encoding="utf-8") as fh:
+                matrices.append(json.load(fh))
+        except (OSError, ValueError) as err:
+            print(f"warning: skipping unreadable cell {path}: {err}", file=sys.stderr)
     merged = merge(matrices, expected)
     with open(args.output, "w", encoding="utf-8") as fh:
         json.dump(merged, fh, indent=2, sort_keys=True)

--- a/bolt/conformance/tools/merge_matrix.py
+++ b/bolt/conformance/tools/merge_matrix.py
@@ -10,33 +10,36 @@ import json
 import sys
 
 
-def merge(matrices, expected_languages=None):
+def merge(matrices, expected_cells=None):
     """
     Combine per-cell records into one scenario-keyed compatibility matrix.
 
-    A language listed in ``expected_languages`` but absent from every cell (its
-    whole job died before producing any result) is reported in
-    ``missing_languages`` and forces ``has_failures`` true - otherwise a suite
-    that never ran would read as a healthy night.
+    Each expected cell is a ``"language:driver_version"`` string. A cell that is
+    expected but absent (its job died before emitting any JUnit) is reported in
+    ``missing_cells`` and forces ``has_failures`` true - so a single dead
+    driver-version cell can't hide behind its language's other versions and read
+    as a healthy night.
     """
     scenarios = {}
     languages = set()
+    present_cells = set()
     has_failures = False
     for cell in matrices:
         lang = cell["language"]
         ver = cell["driver_version"]
         languages.add(lang)
+        present_cells.add(f"{lang}:{ver}")
         for scenario, status in cell["scenarios"].items():
             scenarios.setdefault(scenario, {}).setdefault(lang, {})[ver] = status
             if status == "fail":
                 has_failures = True
-    missing = sorted(set(expected_languages or []) - languages)
+    missing = sorted(set(expected_cells or []) - present_cells)
     if missing:
         has_failures = True
     return {
         "scenarios": scenarios,
         "languages": sorted(languages),
-        "missing_languages": missing,
+        "missing_cells": missing,
         "has_failures": has_failures,
     }
 
@@ -44,11 +47,11 @@ def merge(matrices, expected_languages=None):
 def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("cells", nargs="*", help="per-language JSON files")
-    parser.add_argument("--expect-languages", default="",
-                        help="comma-separated languages that must be present")
+    parser.add_argument("--expect-cells", default="",
+                        help="comma-separated language:driver_version cells that must be present")
     parser.add_argument("-o", "--output", required=True)
     args = parser.parse_args(argv)
-    expected = [lang for lang in args.expect_languages.split(",") if lang]
+    expected = [cell for cell in args.expect_cells.split(",") if cell]
     matrices = []
     for path in args.cells:
         with open(path, encoding="utf-8") as fh:

--- a/bolt/conformance/tools/merge_matrix.py
+++ b/bolt/conformance/tools/merge_matrix.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Merge per-language/-version scenario maps into one compatibility matrix.
+"""
+Merge per-language/-version scenario maps into one compatibility matrix.
 
 Output is keyed scenario -> language -> driver_version -> status, plus a
 ``has_failures`` flag consumed by the nightly report job.
@@ -10,7 +11,8 @@ import sys
 
 
 def merge(matrices, expected_languages=None):
-    """Combine per-cell records into one scenario-keyed compatibility matrix.
+    """
+    Combine per-cell records into one scenario-keyed compatibility matrix.
 
     A language listed in ``expected_languages`` but absent from every cell (its
     whole job died before producing any result) is reported in

--- a/bolt/conformance/tools/merge_matrix.py
+++ b/bolt/conformance/tools/merge_matrix.py
@@ -9,8 +9,14 @@ import json
 import sys
 
 
-def merge(matrices):
-    """Combine per-cell records into one scenario-keyed compatibility matrix."""
+def merge(matrices, expected_languages=None):
+    """Combine per-cell records into one scenario-keyed compatibility matrix.
+
+    A language listed in ``expected_languages`` but absent from every cell (its
+    whole job died before producing any result) is reported in
+    ``missing_languages`` and forces ``has_failures`` true - otherwise a suite
+    that never ran would read as a healthy night.
+    """
     scenarios = {}
     languages = set()
     has_failures = False
@@ -22,23 +28,30 @@ def merge(matrices):
             scenarios.setdefault(scenario, {}).setdefault(lang, {})[ver] = status
             if status == "fail":
                 has_failures = True
+    missing = sorted(set(expected_languages or []) - languages)
+    if missing:
+        has_failures = True
     return {
         "scenarios": scenarios,
         "languages": sorted(languages),
+        "missing_languages": missing,
         "has_failures": has_failures,
     }
 
 
 def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("cells", nargs="+", help="per-language JSON files")
+    parser.add_argument("cells", nargs="*", help="per-language JSON files")
+    parser.add_argument("--expect-languages", default="",
+                        help="comma-separated languages that must be present")
     parser.add_argument("-o", "--output", required=True)
     args = parser.parse_args(argv)
+    expected = [lang for lang in args.expect_languages.split(",") if lang]
     matrices = []
     for path in args.cells:
         with open(path, encoding="utf-8") as fh:
             matrices.append(json.load(fh))
-    merged = merge(matrices)
+    merged = merge(matrices, expected)
     with open(args.output, "w", encoding="utf-8") as fh:
         json.dump(merged, fh, indent=2, sort_keys=True)
     return 0

--- a/bolt/conformance/tools/merge_matrix.py
+++ b/bolt/conformance/tools/merge_matrix.py
@@ -48,6 +48,9 @@ def merge(matrices, expected_cells=None):
         key = f"{lang}:{ver}"
         languages.add(lang)
         present_cells.add(key)
+        # "Empty" means no scenario id was recognized at all (the coverage floor).
+        # An all-skipped suite is NOT empty - it has scenarios with "skip" status -
+        # so a legitimately fully-skipped cell does not trip the floor.
         if not cell["scenarios"]:
             empty.append(key)
         for scenario, status in cell["scenarios"].items():

--- a/bolt/conformance/tools/merge_matrix.py
+++ b/bolt/conformance/tools/merge_matrix.py
@@ -1,45 +1,69 @@
 #!/usr/bin/env python3
-"""
-Merge per-language/-version scenario maps into one compatibility matrix.
-
-Output is keyed scenario -> language -> driver_version -> status, plus a
-``has_failures`` flag consumed by the nightly report job.
-"""
+# Merge per-language/-version scenario maps into one compatibility matrix.
+# Output is keyed scenario -> language -> driver_version -> status, plus a
+# has_failures flag consumed by the nightly report job. The expected cell set is
+# read from driver-versions.md so that file is the single source of truth; any
+# drift with the job matrices surfaces as a missing_cells / unexpected_cells
+# entry on the nightly run.
+"""Merge per-language scenario maps into one Bolt compatibility matrix."""
 import argparse
 import json
+import re
 import sys
+
+LANGUAGES = {"java", "javascript", "python", "csharp", "go"}
+# A driver-versions.md table row: | <language> | <band> | <version> |
+CELL_ROW_RE = re.compile(r"^\|\s*([a-z]+)\s*\|\s*[^|]+\|\s*([\w.]+)\s*\|")
+
+
+def load_expected_cells(md_path):
+    """Parse driver-versions.md into a sorted list of language:version cells."""
+    cells = set()
+    with open(md_path, encoding="utf-8") as fh:
+        for line in fh:
+            match = CELL_ROW_RE.match(line)
+            if match and match.group(1) in LANGUAGES:
+                cells.add(f"{match.group(1)}:{match.group(2)}")
+    return sorted(cells)
 
 
 def merge(matrices, expected_cells=None):
-    """
-    Combine per-cell records into one scenario-keyed compatibility matrix.
-
-    Each expected cell is a ``"language:driver_version"`` string. A cell that is
-    expected but absent (its job died before emitting any JUnit) is reported in
-    ``missing_cells`` and forces ``has_failures`` true - so a single dead
-    driver-version cell can't hide behind its language's other versions and read
-    as a healthy night.
-    """
+    """Combine per-cell records into one scenario-keyed compatibility matrix."""
+    # Each expected cell is a "language:driver_version" string. has_failures is
+    # forced true for any of: an explicit fail status; a missing cell (expected
+    # but no artifact - its job died before emitting JUnit); an unexpected cell
+    # (ran but not in driver-versions.md - matrix/doc drift); or an empty cell
+    # (ran but produced zero recognized scenarios, e.g. the id never reached the
+    # JUnit test name). The empty check is the coverage floor so a suite that
+    # silently stops emitting scenarios can't read as a green night.
+    expected = set(expected_cells or [])
     scenarios = {}
     languages = set()
     present_cells = set()
+    empty = []
     has_failures = False
     for cell in matrices:
         lang = cell["language"]
         ver = cell["driver_version"]
+        key = f"{lang}:{ver}"
         languages.add(lang)
-        present_cells.add(f"{lang}:{ver}")
+        present_cells.add(key)
+        if not cell["scenarios"]:
+            empty.append(key)
         for scenario, status in cell["scenarios"].items():
             scenarios.setdefault(scenario, {}).setdefault(lang, {})[ver] = status
             if status == "fail":
                 has_failures = True
-    missing = sorted(set(expected_cells or []) - present_cells)
-    if missing:
+    missing = sorted(expected - present_cells)
+    unexpected = sorted(present_cells - expected) if expected else []
+    if missing or unexpected or empty:
         has_failures = True
     return {
         "scenarios": scenarios,
         "languages": sorted(languages),
         "missing_cells": missing,
+        "unexpected_cells": unexpected,
+        "empty_cells": sorted(empty),
         "has_failures": has_failures,
     }
 
@@ -47,11 +71,11 @@ def merge(matrices, expected_cells=None):
 def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("cells", nargs="*", help="per-language JSON files")
-    parser.add_argument("--expect-cells", default="",
-                        help="comma-separated language:driver_version cells that must be present")
+    parser.add_argument("--expect-from", default="",
+                        help="path to driver-versions.md; its rows are the expected cell set")
     parser.add_argument("-o", "--output", required=True)
     args = parser.parse_args(argv)
-    expected = [cell for cell in args.expect_cells.split(",") if cell]
+    expected = load_expected_cells(args.expect_from) if args.expect_from else []
     matrices = []
     for path in args.cells:
         with open(path, encoding="utf-8") as fh:

--- a/bolt/conformance/tools/merge_matrix.py
+++ b/bolt/conformance/tools/merge_matrix.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Merge per-language/-version scenario maps into one compatibility matrix.
+
+Output is keyed scenario -> language -> driver_version -> status, plus a
+``has_failures`` flag consumed by the nightly report job.
+"""
+import argparse
+import json
+import sys
+
+
+def merge(matrices):
+    """Combine per-cell records into one scenario-keyed compatibility matrix."""
+    scenarios = {}
+    languages = set()
+    has_failures = False
+    for cell in matrices:
+        lang = cell["language"]
+        ver = cell["driver_version"]
+        languages.add(lang)
+        for scenario, status in cell["scenarios"].items():
+            scenarios.setdefault(scenario, {}).setdefault(lang, {})[ver] = status
+            if status == "fail":
+                has_failures = True
+    return {
+        "scenarios": scenarios,
+        "languages": sorted(languages),
+        "has_failures": has_failures,
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("cells", nargs="+", help="per-language JSON files")
+    parser.add_argument("-o", "--output", required=True)
+    args = parser.parse_args(argv)
+    matrices = []
+    for path in args.cells:
+        with open(path, encoding="utf-8") as fh:
+            matrices.append(json.load(fh))
+    merged = merge(matrices)
+    with open(args.output, "w", encoding="utf-8") as fh:
+        json.dump(merged, fh, indent=2, sort_keys=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bolt/conformance/tools/test_junit_to_matrix.py
+++ b/bolt/conformance/tools/test_junit_to_matrix.py
@@ -7,6 +7,7 @@ from junit_to_matrix import parse_junit, build_matrix
 HERE = os.path.dirname(__file__)
 SAMPLE = os.path.join(HERE, "testdata", "sample-junit.xml")
 UNKNOWN = os.path.join(HERE, "testdata", "unknown-id-junit.xml")
+GO_STYLE = os.path.join(HERE, "testdata", "go-junit.xml")
 KNOWN = {"CONN-001", "AUTH-003", "TYPE-007", "ERR-002"}
 
 
@@ -21,6 +22,11 @@ class ParseJunitTest(unittest.TestCase):
     def test_extracts_id_from_testcase_name_prefix(self):
         result = parse_junit(SAMPLE)
         self.assertEqual(set(result.keys()), KNOWN)
+
+    def test_underscore_separated_id_normalizes_to_hyphen(self):
+        # Go test funcs are named Test_CONN_001_...; the id must normalize to CONN-001.
+        result = parse_junit(GO_STYLE)
+        self.assertEqual(result, {"CONN-001": "pass"})
 
 
 class BuildMatrixTest(unittest.TestCase):

--- a/bolt/conformance/tools/test_junit_to_matrix.py
+++ b/bolt/conformance/tools/test_junit_to_matrix.py
@@ -8,6 +8,8 @@ HERE = os.path.dirname(__file__)
 SAMPLE = os.path.join(HERE, "testdata", "sample-junit.xml")
 UNKNOWN = os.path.join(HERE, "testdata", "unknown-id-junit.xml")
 GO_STYLE = os.path.join(HERE, "testdata", "go-junit.xml")
+PY_STYLE = os.path.join(HERE, "testdata", "py-junit.xml")
+NS_STYLE = os.path.join(HERE, "testdata", "ns-junit.xml")
 KNOWN = {"CONN-001", "AUTH-003", "TYPE-007", "ERR-002"}
 
 
@@ -28,6 +30,15 @@ class ParseJunitTest(unittest.TestCase):
         result = parse_junit(GO_STYLE)
         self.assertEqual(result, {"CONN-001": "pass"})
 
+    def test_python_lowercase_prefix_id(self):
+        # pytest emits name="test_CONN_001_connect"; the id must still resolve.
+        result = parse_junit(PY_STYLE)
+        self.assertEqual(result, {"CONN-001": "pass"})
+
+    def test_namespaced_junit_document(self):
+        result = parse_junit(NS_STYLE)
+        self.assertEqual(result, {"CONN-001": "pass"})
+
 
 class BuildMatrixTest(unittest.TestCase):
     def test_shape_and_metadata(self):
@@ -36,9 +47,10 @@ class BuildMatrixTest(unittest.TestCase):
         self.assertEqual(m["driver_version"], "6.2.0")
         self.assertEqual(m["scenarios"]["CONN-001"], "pass")
 
-    def test_unknown_scenario_id_raises(self):
-        with self.assertRaises(ValueError):
-            build_matrix(UNKNOWN, "python", "6.2.0", KNOWN)
+    def test_unknown_scenario_id_dropped_not_raised(self):
+        # A monitoring workflow must not lose a whole cell over one stray id.
+        m = build_matrix(UNKNOWN, "python", "6.2.0", KNOWN)
+        self.assertEqual(m["scenarios"], {})
 
 
 if __name__ == "__main__":

--- a/bolt/conformance/tools/test_junit_to_matrix.py
+++ b/bolt/conformance/tools/test_junit_to_matrix.py
@@ -2,7 +2,7 @@
 import os
 import unittest
 
-from junit_to_matrix import parse_junit, build_matrix
+from junit_to_matrix import parse_junit, parse_junit_files, build_matrix
 
 HERE = os.path.dirname(__file__)
 SAMPLE = os.path.join(HERE, "testdata", "sample-junit.xml")
@@ -56,15 +56,29 @@ class ParseJunitTest(unittest.TestCase):
 
 class BuildMatrixTest(unittest.TestCase):
     def test_shape_and_metadata(self):
-        m = build_matrix(SAMPLE, "python", "6.2.0", KNOWN)
+        m = build_matrix([SAMPLE], "python", "6.2.0", KNOWN)
         self.assertEqual(m["language"], "python")
         self.assertEqual(m["driver_version"], "6.2.0")
         self.assertEqual(m["scenarios"]["CONN-001"], "pass")
 
     def test_unknown_scenario_id_dropped_not_raised(self):
         # A monitoring workflow must not lose a whole cell over one stray id.
-        m = build_matrix(UNKNOWN, "python", "6.2.0", KNOWN)
+        m = build_matrix([UNKNOWN], "python", "6.2.0", KNOWN)
         self.assertEqual(m["scenarios"], {})
+
+    def test_no_files_yields_empty_scenarios(self):
+        # A glob that matched nothing (test produced no reports) must not crash.
+        m = build_matrix([], "java", "5.28.5", KNOWN)
+        self.assertEqual(m["scenarios"], {})
+
+
+class ParseJunitFilesTest(unittest.TestCase):
+    def test_folds_split_nested_class_reports(self):
+        # Failsafe may split @Nested classes into per-class files; folding the
+        # Go fixture (CONN-001 pass) with the Java fixture (CONN-001 pass,
+        # AUTH-003 skip) keeps every scenario and applies fail-dominates.
+        combined = parse_junit_files([GO_STYLE, JAVA_STYLE])
+        self.assertEqual(combined, {"CONN-001": "pass", "AUTH-003": "skip"})
 
 
 if __name__ == "__main__":

--- a/bolt/conformance/tools/test_junit_to_matrix.py
+++ b/bolt/conformance/tools/test_junit_to_matrix.py
@@ -10,6 +10,7 @@ UNKNOWN = os.path.join(HERE, "testdata", "unknown-id-junit.xml")
 GO_STYLE = os.path.join(HERE, "testdata", "go-junit.xml")
 PY_STYLE = os.path.join(HERE, "testdata", "py-junit.xml")
 NS_STYLE = os.path.join(HERE, "testdata", "ns-junit.xml")
+JAVA_STYLE = os.path.join(HERE, "testdata", "java-junit.xml")
 KNOWN = {"CONN-001", "AUTH-003", "TYPE-007", "ERR-002"}
 
 
@@ -34,6 +35,12 @@ class ParseJunitTest(unittest.TestCase):
         # pytest emits name="test_CONN_001_connect"; the id must still resolve.
         result = parse_junit(PY_STYLE)
         self.assertEqual(result, {"CONN-001": "pass"})
+
+    def test_java_failsafe_method_name_form(self):
+        # Maven Failsafe writes the method name (conn001_boltScheme), not the
+        # @DisplayName, so the id must be recovered from the lowercase form.
+        result = parse_junit(JAVA_STYLE)
+        self.assertEqual(result, {"CONN-001": "pass", "AUTH-003": "skip"})
 
     def test_namespaced_junit_document(self):
         result = parse_junit(NS_STYLE)

--- a/bolt/conformance/tools/test_junit_to_matrix.py
+++ b/bolt/conformance/tools/test_junit_to_matrix.py
@@ -12,6 +12,7 @@ PY_STYLE = os.path.join(HERE, "testdata", "py-junit.xml")
 NS_STYLE = os.path.join(HERE, "testdata", "ns-junit.xml")
 JAVA_STYLE = os.path.join(HERE, "testdata", "java-junit.xml")
 LEGACY_STYLE = os.path.join(HERE, "testdata", "legacy-junit.xml")
+GUARD_STYLE = os.path.join(HERE, "testdata", "guard-junit.xml")
 KNOWN = {"CONN-001", "AUTH-003", "TYPE-007", "ERR-002"}
 
 
@@ -52,6 +53,11 @@ class ParseJunitTest(unittest.TestCase):
     def test_namespaced_junit_document(self):
         result = parse_junit(NS_STYLE)
         self.assertEqual(result, {"CONN-001": "pass"})
+
+    def test_four_digit_and_two_digit_runs_are_not_ids(self):
+        # Locks the (?!\d)/3-digit guards: a 4-digit year or a 2-digit token
+        # must not be misread as a scenario id.
+        self.assertEqual(parse_junit(GUARD_STYLE), {})
 
 
 class BuildMatrixTest(unittest.TestCase):

--- a/bolt/conformance/tools/test_junit_to_matrix.py
+++ b/bolt/conformance/tools/test_junit_to_matrix.py
@@ -11,6 +11,7 @@ GO_STYLE = os.path.join(HERE, "testdata", "go-junit.xml")
 PY_STYLE = os.path.join(HERE, "testdata", "py-junit.xml")
 NS_STYLE = os.path.join(HERE, "testdata", "ns-junit.xml")
 JAVA_STYLE = os.path.join(HERE, "testdata", "java-junit.xml")
+LEGACY_STYLE = os.path.join(HERE, "testdata", "legacy-junit.xml")
 KNOWN = {"CONN-001", "AUTH-003", "TYPE-007", "ERR-002"}
 
 
@@ -41,6 +42,12 @@ class ParseJunitTest(unittest.TestCase):
         # @DisplayName, so the id must be recovered from the lowercase form.
         result = parse_junit(JAVA_STYLE)
         self.assertEqual(result, {"CONN-001": "pass", "AUTH-003": "skip"})
+
+    def test_java_legacy_method_names_embed_id(self):
+        # RemoteBoltLegacyDriverIT methods must embed the id (conn001_legacy...)
+        # so the java/4.4.20 cell is not permanently empty.
+        result = parse_junit(LEGACY_STYLE)
+        self.assertEqual(result, {"CONN-001": "pass", "PROTO-001": "pass", "ERR-001": "pass"})
 
     def test_namespaced_junit_document(self):
         result = parse_junit(NS_STYLE)

--- a/bolt/conformance/tools/test_junit_to_matrix.py
+++ b/bolt/conformance/tools/test_junit_to_matrix.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import os
+import unittest
+
+from junit_to_matrix import parse_junit, build_matrix
+
+HERE = os.path.dirname(__file__)
+SAMPLE = os.path.join(HERE, "testdata", "sample-junit.xml")
+UNKNOWN = os.path.join(HERE, "testdata", "unknown-id-junit.xml")
+KNOWN = {"CONN-001", "AUTH-003", "TYPE-007", "ERR-002"}
+
+
+class ParseJunitTest(unittest.TestCase):
+    def test_maps_status_by_child_element(self):
+        result = parse_junit(SAMPLE)
+        self.assertEqual(result["CONN-001"], "pass")
+        self.assertEqual(result["AUTH-003"], "fail")
+        self.assertEqual(result["TYPE-007"], "skip")
+        self.assertEqual(result["ERR-002"], "fail")
+
+    def test_extracts_id_from_testcase_name_prefix(self):
+        result = parse_junit(SAMPLE)
+        self.assertEqual(set(result.keys()), KNOWN)
+
+
+class BuildMatrixTest(unittest.TestCase):
+    def test_shape_and_metadata(self):
+        m = build_matrix(SAMPLE, "python", "6.2.0", KNOWN)
+        self.assertEqual(m["language"], "python")
+        self.assertEqual(m["driver_version"], "6.2.0")
+        self.assertEqual(m["scenarios"]["CONN-001"], "pass")
+
+    def test_unknown_scenario_id_raises(self):
+        with self.assertRaises(ValueError):
+            build_matrix(UNKNOWN, "python", "6.2.0", KNOWN)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bolt/conformance/tools/test_merge_matrix.py
+++ b/bolt/conformance/tools/test_merge_matrix.py
@@ -25,6 +25,18 @@ class MergeTest(unittest.TestCase):
         self.assertFalse(merge([self._cell("py", "1", {"X-001": "pass"})])["has_failures"])
         self.assertFalse(merge([self._cell("py", "1", {"X-001": "skip"})])["has_failures"])
 
+    def test_missing_expected_language_flags_failure(self):
+        out = merge([self._cell("python", "6.2.0", {"CONN-001": "pass"})],
+                    expected_languages=["python", "go"])
+        self.assertEqual(out["missing_languages"], ["go"])
+        self.assertTrue(out["has_failures"])
+
+    def test_no_cells_with_expectations_is_all_missing(self):
+        out = merge([], expected_languages=["python", "go"])
+        self.assertEqual(out["missing_languages"], ["go", "python"])
+        self.assertTrue(out["has_failures"])
+        self.assertEqual(out["scenarios"], {})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/bolt/conformance/tools/test_merge_matrix.py
+++ b/bolt/conformance/tools/test_merge_matrix.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
+import os
 import unittest
 
-from merge_matrix import merge
+from merge_matrix import merge, load_expected_cells
+
+HERE = os.path.dirname(__file__)
+DRIVER_VERSIONS_MD = os.path.join(HERE, "..", "driver-versions.md")
 
 
 class MergeTest(unittest.TestCase):
@@ -38,6 +42,31 @@ class MergeTest(unittest.TestCase):
         self.assertEqual(out["missing_cells"], ["go:5.28.4", "python:6.2.0"])
         self.assertTrue(out["has_failures"])
         self.assertEqual(out["scenarios"], {})
+
+    def test_empty_cell_is_coverage_floor(self):
+        # A cell that ran but yielded zero recognized scenarios (e.g. the id
+        # never reached the JUnit test name) must not read as a pass.
+        out = merge([self._cell("csharp", "6.2.1", {})],
+                    expected_cells=["csharp:6.2.1"])
+        self.assertEqual(out["empty_cells"], ["csharp:6.2.1"])
+        self.assertTrue(out["has_failures"])
+
+    def test_unexpected_cell_flags_drift(self):
+        out = merge([self._cell("go", "9.9.9", {"CONN-001": "pass"})],
+                    expected_cells=["go:5.28.4"])
+        self.assertEqual(out["unexpected_cells"], ["go:9.9.9"])
+        self.assertTrue(out["has_failures"])
+
+
+class LoadExpectedCellsTest(unittest.TestCase):
+    def test_parses_driver_versions_md(self):
+        cells = load_expected_cells(DRIVER_VERSIONS_MD)
+        # Sanity: the five languages and a couple of known pins are present, and
+        # the header/separator rows are not misread as cells.
+        self.assertIn("java:4.4.20", cells)
+        self.assertIn("go:5.28.4", cells)
+        self.assertEqual(len(cells), 15)
+        self.assertTrue(all(":" in c for c in cells))
 
 
 if __name__ == "__main__":

--- a/bolt/conformance/tools/test_merge_matrix.py
+++ b/bolt/conformance/tools/test_merge_matrix.py
@@ -25,15 +25,17 @@ class MergeTest(unittest.TestCase):
         self.assertFalse(merge([self._cell("py", "1", {"X-001": "pass"})])["has_failures"])
         self.assertFalse(merge([self._cell("py", "1", {"X-001": "skip"})])["has_failures"])
 
-    def test_missing_expected_language_flags_failure(self):
+    def test_missing_version_cell_flags_failure(self):
+        # python:6.2.0 ran, python:5.28.4 died with no artifact -> still flagged
+        # even though the python language is present via its other version.
         out = merge([self._cell("python", "6.2.0", {"CONN-001": "pass"})],
-                    expected_languages=["python", "go"])
-        self.assertEqual(out["missing_languages"], ["go"])
+                    expected_cells=["python:6.2.0", "python:5.28.4", "go:5.28.4"])
+        self.assertEqual(out["missing_cells"], ["go:5.28.4", "python:5.28.4"])
         self.assertTrue(out["has_failures"])
 
     def test_no_cells_with_expectations_is_all_missing(self):
-        out = merge([], expected_languages=["python", "go"])
-        self.assertEqual(out["missing_languages"], ["go", "python"])
+        out = merge([], expected_cells=["python:6.2.0", "go:5.28.4"])
+        self.assertEqual(out["missing_cells"], ["go:5.28.4", "python:6.2.0"])
         self.assertTrue(out["has_failures"])
         self.assertEqual(out["scenarios"], {})
 

--- a/bolt/conformance/tools/test_merge_matrix.py
+++ b/bolt/conformance/tools/test_merge_matrix.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import unittest
+
+from merge_matrix import merge
+
+
+class MergeTest(unittest.TestCase):
+    def _cell(self, lang, ver, scen):
+        return {"language": lang, "driver_version": ver, "scenarios": scen}
+
+    def test_nests_scenario_language_version(self):
+        a = self._cell("python", "6.2.0", {"CONN-001": "pass", "ERR-002": "fail"})
+        b = self._cell("go", "5.28.4", {"CONN-001": "pass"})
+        out = merge([a, b])
+        self.assertEqual(out["scenarios"]["CONN-001"]["python"]["6.2.0"], "pass")
+        self.assertEqual(out["scenarios"]["CONN-001"]["go"]["5.28.4"], "pass")
+        self.assertEqual(out["scenarios"]["ERR-002"]["python"]["6.2.0"], "fail")
+
+    def test_languages_sorted_and_deduped(self):
+        out = merge([self._cell("go", "1", {}), self._cell("java", "2", {}), self._cell("go", "3", {})])
+        self.assertEqual(out["languages"], ["go", "java"])
+
+    def test_has_failures_flag(self):
+        self.assertTrue(merge([self._cell("py", "1", {"X-001": "fail"})])["has_failures"])
+        self.assertFalse(merge([self._cell("py", "1", {"X-001": "pass"})])["has_failures"])
+        self.assertFalse(merge([self._cell("py", "1", {"X-001": "skip"})])["has_failures"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bolt/conformance/tools/testdata/go-junit.xml
+++ b/bolt/conformance/tools/testdata/go-junit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="arcadedb.com/e2e-go" tests="1" failures="0" skipped="0">
+    <testcase name="Test_CONN_001_ConnectBolt" classname="arcadedb.com/e2e-go"/>
+  </testsuite>
+</testsuites>

--- a/bolt/conformance/tools/testdata/guard-junit.xml
+++ b/bolt/conformance/tools/testdata/guard-junit.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="guard" tests="2" failures="0" skipped="0">
+  <testcase name="test_upgrade_2024_bolt" classname="guard"/>
+  <testcase name="base64_roundtrip" classname="guard"/>
+</testsuite>

--- a/bolt/conformance/tools/testdata/java-junit.xml
+++ b/bolt/conformance/tools/testdata/java-junit.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="com.arcadedb.e2e.RemoteBoltDatabaseIT" tests="2" failures="0" skipped="0">
+  <testcase name="conn001_boltScheme" classname="com.arcadedb.e2e.RemoteBoltDatabaseIT$Connection" time="0.4"/>
+  <testcase name="auth003_authSchemeNone" classname="com.arcadedb.e2e.RemoteBoltDatabaseIT$Auth" time="0.1">
+    <skipped/>
+  </testcase>
+</testsuite>

--- a/bolt/conformance/tools/testdata/legacy-junit.xml
+++ b/bolt/conformance/tools/testdata/legacy-junit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="com.arcadedb.e2e.RemoteBoltLegacyDriverIT" tests="3" failures="0" skipped="0">
+  <testcase name="conn001_legacyConnectAndRead" classname="com.arcadedb.e2e.RemoteBoltLegacyDriverIT" time="0.5"/>
+  <testcase name="proto001_legacyParameterized" classname="com.arcadedb.e2e.RemoteBoltLegacyDriverIT" time="0.2"/>
+  <testcase name="err001_legacySyntaxErrorCode" classname="com.arcadedb.e2e.RemoteBoltLegacyDriverIT" time="0.1"/>
+</testsuite>

--- a/bolt/conformance/tools/testdata/ns-junit.xml
+++ b/bolt/conformance/tools/testdata/ns-junit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites xmlns="http://example.com/junit">
+  <testsuite name="bolt" tests="1" failures="0" skipped="0">
+    <testcase name="[CONN-001] connect via bolt scheme" classname="conn"/>
+  </testsuite>
+</testsuites>

--- a/bolt/conformance/tools/testdata/py-junit.xml
+++ b/bolt/conformance/tools/testdata/py-junit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="tests.test_bolt" tests="1" failures="0" skipped="0">
+    <testcase name="test_CONN_001_connect_bolt" classname="tests.test_bolt"/>
+  </testsuite>
+</testsuites>

--- a/bolt/conformance/tools/testdata/sample-junit.xml
+++ b/bolt/conformance/tools/testdata/sample-junit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="bolt" tests="4" failures="1" skipped="1" errors="0">
+    <testcase name="CONN-001 Connect via bolt:// scheme" classname="conn"/>
+    <testcase name="AUTH-003 none auth rejected" classname="auth">
+      <failure message="expected rejection">boom</failure>
+    </testcase>
+    <testcase name="TYPE-007 Duration round-trip" classname="type">
+      <skipped message="known gap"/>
+    </testcase>
+    <testcase name="ERR-002 syntax error code" classname="err">
+      <error message="unexpected">stacktrace</error>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/bolt/conformance/tools/testdata/unknown-id-junit.xml
+++ b/bolt/conformance/tools/testdata/unknown-id-junit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="bolt" tests="1" failures="0" skipped="0">
+    <testcase name="ZZZ-999 not a real scenario" classname="x"/>
+  </testsuite>
+</testsuites>

--- a/docs/superpowers/plans/2026-07-08-bolt-ci-nightly-matrix-4891.md
+++ b/docs/superpowers/plans/2026-07-08-bolt-ci-nightly-matrix-4891.md
@@ -479,7 +479,7 @@ git commit -m "ci(#4891): emit + aggregate Python e2e JUnit report"
 
 In `ArcadeDB.E2ETests.csproj`, add inside the existing `<ItemGroup>` that holds `PackageReference`s:
 ```xml
-    <PackageReference Include="JunitXml.TestLogger" Version="6.1.0" />
+    <PackageReference Include="JunitXml.TestLogger" Version="8.0.0" />
 ```
 
 - [ ] **Step 2: Emit JUnit + add reporter/artifact in CI**

--- a/docs/superpowers/plans/2026-07-08-bolt-ci-nightly-matrix-4891.md
+++ b/docs/superpowers/plans/2026-07-08-bolt-ci-nightly-matrix-4891.md
@@ -1,0 +1,941 @@
+# Bolt CI gating + nightly driver-version matrix (#4891) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add JUnit report aggregation to the JS/Python/C#/Go Bolt e2e jobs, a standalone nightly workflow that runs all five Bolt suites against the full driver-version matrix, and tooling that merges per-suite results into one machine-readable compatibility matrix for #4892.
+
+**Architecture:** Two Python tools under `bolt/conformance/tools/` parse the JUnit XML each suite already can emit (scenario IDs like `CONN-001` are embedded in test names) into a normalized per-language JSON, then merge all languages into `bolt-compat-matrix.json`. A new `bolt-nightly.yml` builds the branch image once and fans out a per-language driver-version matrix (`fail-fast: false`), each cell overriding the driver version at the package-manager level; a final job merges the artifacts and a report job opens/updates one `bolt-compat-regression` tracking issue on any red cell. `mvn-test.yml` gains dorny/test-reporter + artifact upload on the four non-Java e2e jobs.
+
+**Tech Stack:** GitHub Actions, Python 3.12 (stdlib `xml.etree`, `unittest`), `dorny/test-reporter`, `actions/github-script`, jest-junit (JS, already present), pytest `--junitxml`, `JunitXml.TestLogger` (.NET), `gotestsum` (Go), `actionlint`.
+
+## Global Constraints
+
+- Java 21 toolchain; Docker profile build (`./mvnw ... -Pdocker`) for images.
+- No Claude attribution anywhere (commit trailers, source, comments) - repo rule.
+- New workflow YAML files: NO license header (repo convention for `.github/workflows/`).
+- New Python source files under `bolt/conformance/tools/`: include the Apache-2.0 header exactly as `bolt/conformance/validate_spec.py` does.
+- All third-party actions pinned to a full commit SHA with a `# vX.Y.Z` comment, matching every existing step in `mvn-test.yml`.
+- Only Apache-2.0-compatible dependencies (jest-junit MIT, gotestsum Apache-2.0, JunitXml.TestLogger MIT - all allowed).
+- Scenario IDs are the join key; the ID pattern is `[A-Z]+-\d{3}` and every ID must exist in `bolt/conformance/spec.yaml`.
+- Comments/Javadoc/docstrings state behavioral invariants only - no issue numbers in source comments (issue refs belong in commit messages and the plan/spec docs).
+
+---
+
+### Task 1: `junit_to_matrix.py` - JUnit XML -> normalized per-language JSON
+
+**Files:**
+- Create: `bolt/conformance/tools/junit_to_matrix.py`
+- Create: `bolt/conformance/tools/__init__.py` (empty, makes the package importable by tests)
+- Test: `bolt/conformance/tools/test_junit_to_matrix.py`
+- Create fixtures: `bolt/conformance/tools/testdata/sample-junit.xml`, `bolt/conformance/tools/testdata/unknown-id-junit.xml`
+
+**Interfaces:**
+- Produces: `parse_junit(xml_path: str) -> dict[str, str]` (scenario-id -> `"pass"|"fail"|"skip"`); `build_matrix(xml_path: str, language: str, driver_version: str, known_ids: set[str]) -> dict`; `load_known_ids(spec_path: str) -> set[str]`. CLI: `python3 junit_to_matrix.py <junit.xml> --language L --driver-version V --spec ../spec.yaml -o out.json`.
+- JSON shape: `{"language": L, "driver_version": V, "scenarios": {"CONN-001": "pass", ...}}`.
+
+- [ ] **Step 1: Write the fixtures**
+
+`bolt/conformance/tools/testdata/sample-junit.xml`:
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="bolt" tests="4" failures="1" skipped="1" errors="0">
+    <testcase name="CONN-001 Connect via bolt:// scheme" classname="conn"/>
+    <testcase name="AUTH-003 none auth rejected" classname="auth">
+      <failure message="expected rejection">boom</failure>
+    </testcase>
+    <testcase name="TYPE-007 Duration round-trip" classname="type">
+      <skipped message="known gap"/>
+    </testcase>
+    <testcase name="ERR-002 syntax error code" classname="err">
+      <error message="unexpected">stacktrace</error>
+    </testcase>
+  </testsuite>
+</testsuites>
+```
+
+`bolt/conformance/tools/testdata/unknown-id-junit.xml`:
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="bolt" tests="1" failures="0" skipped="0">
+    <testcase name="ZZZ-999 not a real scenario" classname="x"/>
+  </testsuite>
+</testsuites>
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+`bolt/conformance/tools/test_junit_to_matrix.py`:
+```python
+import json
+import os
+import tempfile
+import unittest
+
+from junit_to_matrix import parse_junit, build_matrix
+
+HERE = os.path.dirname(__file__)
+SAMPLE = os.path.join(HERE, "testdata", "sample-junit.xml")
+UNKNOWN = os.path.join(HERE, "testdata", "unknown-id-junit.xml")
+KNOWN = {"CONN-001", "AUTH-003", "TYPE-007", "ERR-002"}
+
+
+class ParseJunitTest(unittest.TestCase):
+    def test_maps_status_by_child_element(self):
+        result = parse_junit(SAMPLE)
+        self.assertEqual(result["CONN-001"], "pass")
+        self.assertEqual(result["AUTH-003"], "fail")
+        self.assertEqual(result["TYPE-007"], "skip")
+        self.assertEqual(result["ERR-002"], "fail")
+
+    def test_extracts_id_from_testcase_name_prefix(self):
+        result = parse_junit(SAMPLE)
+        self.assertEqual(set(result.keys()), KNOWN)
+
+
+class BuildMatrixTest(unittest.TestCase):
+    def test_shape_and_metadata(self):
+        m = build_matrix(SAMPLE, "python", "6.2.0", KNOWN)
+        self.assertEqual(m["language"], "python")
+        self.assertEqual(m["driver_version"], "6.2.0")
+        self.assertEqual(m["scenarios"]["CONN-001"], "pass")
+
+    def test_unknown_scenario_id_raises(self):
+        with self.assertRaises(ValueError):
+            build_matrix(UNKNOWN, "python", "6.2.0", KNOWN)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd bolt/conformance/tools && python3 -m unittest test_junit_to_matrix.py -v`
+Expected: FAIL - `ModuleNotFoundError: No module named 'junit_to_matrix'`.
+
+- [ ] **Step 4: Write the implementation**
+
+`bolt/conformance/tools/junit_to_matrix.py` (prepend the Apache-2.0 header copied verbatim from `bolt/conformance/validate_spec.py`):
+```python
+"""Convert a suite's JUnit XML into a normalized scenario-id -> status map.
+
+Scenario IDs (pattern ``[A-Z]+-\\d{3}``) are embedded in every suite's test
+names; this reduces a language/driver-version run to a comparable map keyed by
+those IDs so runs can be merged across languages.
+"""
+import argparse
+import json
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+ID_RE = re.compile(r"\b([A-Z]+-\d{3})\b")
+
+
+def parse_junit(xml_path):
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+    results = {}
+    for tc in root.iter("testcase"):
+        name = tc.get("name", "")
+        match = ID_RE.search(name)
+        if not match:
+            continue
+        scenario = match.group(1)
+        status = "pass"
+        for child in tc:
+            tag = child.tag.split("}")[-1]
+            if tag in ("failure", "error"):
+                status = "fail"
+                break
+            if tag == "skipped":
+                status = "skip"
+                break
+        # A scenario asserted by several testcases fails if any fails.
+        prev = results.get(scenario)
+        if prev == "fail" or status == "fail":
+            results[scenario] = "fail"
+        elif prev == "pass" or status == "pass":
+            results[scenario] = "pass"
+        else:
+            results[scenario] = status
+    return results
+
+
+def load_known_ids(spec_path):
+    ids = set()
+    with open(spec_path, encoding="utf-8") as fh:
+        for line in fh:
+            stripped = line.strip()
+            if stripped.startswith("- id:"):
+                ids.add(stripped.split("- id:", 1)[1].strip())
+    return ids
+
+
+def build_matrix(xml_path, language, driver_version, known_ids):
+    scenarios = parse_junit(xml_path)
+    unknown = set(scenarios) - set(known_ids)
+    if unknown:
+        raise ValueError(f"JUnit references unknown scenario IDs: {sorted(unknown)}")
+    return {"language": language, "driver_version": driver_version, "scenarios": scenarios}
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("junit_xml")
+    parser.add_argument("--language", required=True)
+    parser.add_argument("--driver-version", required=True)
+    parser.add_argument("--spec", required=True, help="path to spec.yaml")
+    parser.add_argument("-o", "--output", required=True)
+    args = parser.parse_args(argv)
+    known = load_known_ids(args.spec)
+    matrix = build_matrix(args.junit_xml, args.language, args.driver_version, known)
+    with open(args.output, "w", encoding="utf-8") as fh:
+        json.dump(matrix, fh, indent=2, sort_keys=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd bolt/conformance/tools && python3 -m unittest test_junit_to_matrix.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add bolt/conformance/tools/junit_to_matrix.py bolt/conformance/tools/__init__.py bolt/conformance/tools/test_junit_to_matrix.py bolt/conformance/tools/testdata/
+git commit -m "feat(#4891): junit_to_matrix tool - JUnit XML to normalized scenario map"
+```
+
+---
+
+### Task 2: `merge_matrix.py` - merge per-language JSON into one compatibility matrix
+
+**Files:**
+- Create: `bolt/conformance/tools/merge_matrix.py`
+- Test: `bolt/conformance/tools/test_merge_matrix.py`
+
+**Interfaces:**
+- Consumes: per-language JSON produced by `build_matrix` (Task 1).
+- Produces: `merge(matrices: list[dict]) -> dict` returning `{"scenarios": {"CONN-001": {"python": {"6.2.0": "pass"}, "java": {...}}}, "languages": [...], "has_failures": bool}`. CLI: `python3 merge_matrix.py cellA.json cellB.json ... -o bolt-compat-matrix.json`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`bolt/conformance/tools/test_merge_matrix.py`:
+```python
+import unittest
+
+from merge_matrix import merge
+
+
+class MergeTest(unittest.TestCase):
+    def _cell(self, lang, ver, scen):
+        return {"language": lang, "driver_version": ver, "scenarios": scen}
+
+    def test_nests_scenario_language_version(self):
+        a = self._cell("python", "6.2.0", {"CONN-001": "pass", "ERR-002": "fail"})
+        b = self._cell("go", "5.28.4", {"CONN-001": "pass"})
+        out = merge([a, b])
+        self.assertEqual(out["scenarios"]["CONN-001"]["python"]["6.2.0"], "pass")
+        self.assertEqual(out["scenarios"]["CONN-001"]["go"]["5.28.4"], "pass")
+        self.assertEqual(out["scenarios"]["ERR-002"]["python"]["6.2.0"], "fail")
+
+    def test_languages_sorted_and_deduped(self):
+        out = merge([self._cell("go", "1", {}), self._cell("java", "2", {}), self._cell("go", "3", {})])
+        self.assertEqual(out["languages"], ["go", "java"])
+
+    def test_has_failures_flag(self):
+        self.assertTrue(merge([self._cell("py", "1", {"X-001": "fail"})])["has_failures"])
+        self.assertFalse(merge([self._cell("py", "1", {"X-001": "pass"})])["has_failures"])
+        self.assertFalse(merge([self._cell("py", "1", {"X-001": "skip"})])["has_failures"])
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd bolt/conformance/tools && python3 -m unittest test_merge_matrix.py -v`
+Expected: FAIL - `ModuleNotFoundError: No module named 'merge_matrix'`.
+
+- [ ] **Step 3: Write the implementation**
+
+`bolt/conformance/tools/merge_matrix.py` (prepend the Apache-2.0 header):
+```python
+"""Merge per-language/-version scenario maps into one compatibility matrix.
+
+Output is keyed scenario -> language -> driver_version -> status, plus a
+``has_failures`` flag consumed by the nightly report job.
+"""
+import argparse
+import json
+import sys
+
+
+def merge(matrices):
+    scenarios = {}
+    languages = set()
+    has_failures = False
+    for cell in matrices:
+        lang = cell["language"]
+        ver = cell["driver_version"]
+        languages.add(lang)
+        for scenario, status in cell["scenarios"].items():
+            scenarios.setdefault(scenario, {}).setdefault(lang, {})[ver] = status
+            if status == "fail":
+                has_failures = True
+    return {
+        "scenarios": scenarios,
+        "languages": sorted(languages),
+        "has_failures": has_failures,
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("cells", nargs="+", help="per-language JSON files")
+    parser.add_argument("-o", "--output", required=True)
+    args = parser.parse_args(argv)
+    matrices = []
+    for path in args.cells:
+        with open(path, encoding="utf-8") as fh:
+            matrices.append(json.load(fh))
+    merged = merge(matrices)
+    with open(args.output, "w", encoding="utf-8") as fh:
+        json.dump(merged, fh, indent=2, sort_keys=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd bolt/conformance/tools && python3 -m unittest test_merge_matrix.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bolt/conformance/tools/merge_matrix.py bolt/conformance/tools/test_merge_matrix.py
+git commit -m "feat(#4891): merge_matrix tool - combine per-language maps into compat matrix"
+```
+
+---
+
+### Task 3: Wire the conformance-tools tests into `bolt-conformance-spec.yml`
+
+**Files:**
+- Modify: `.github/workflows/bolt-conformance-spec.yml`
+
+**Interfaces:**
+- Consumes: the two `test_*.py` files from Tasks 1-2.
+
+- [ ] **Step 1: Add a tools-test step**
+
+After the existing "Run validator unit tests" step in `.github/workflows/bolt-conformance-spec.yml`, add:
+```yaml
+      - name: Run conformance tools unit tests
+        working-directory: bolt/conformance/tools
+        run: |
+          python3 -m unittest test_junit_to_matrix.py -v
+          python3 -m unittest test_merge_matrix.py -v
+```
+
+- [ ] **Step 2: Verify workflow lint**
+
+Run: `actionlint .github/workflows/bolt-conformance-spec.yml`
+Expected: no output (clean).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/bolt-conformance-spec.yml
+git commit -m "ci(#4891): run conformance tools unit tests in spec-validation workflow"
+```
+
+---
+
+### Task 4: JS e2e - surface the existing jest-junit report in CI
+
+**Files:**
+- Modify: `.github/workflows/mvn-test.yml` (`js-e2e-tests` job, lines ~346-377)
+
+**Interfaces:**
+- Consumes: `e2e-js/reports/jest-junit.xml` (already produced - `package.json` configures jest-junit to `reports/jest-junit.xml`).
+
+- [ ] **Step 1: Add reporter + artifact steps**
+
+In `js-e2e-tests`, after the "E2E Node.js Tests" step, add:
+```yaml
+      - name: JS E2E Tests Reporter
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        if: success() || failure()
+        with:
+          name: JS E2E Tests Report
+          path: "e2e-js/reports/jest-junit.xml"
+          list-suites: "failed"
+          list-tests: "failed"
+          reporter: java-junit
+
+      - name: Upload JS E2E JUnit report
+        if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: js-e2e-junit
+          path: e2e-js/reports/jest-junit.xml
+          retention-days: 7
+```
+Also add `permissions: { contents: read, checks: write }` to the `js-e2e-tests` job (required by dorny/test-reporter), matching `java-e2e-tests`.
+
+- [ ] **Step 2: Verify workflow lint**
+
+Run: `actionlint .github/workflows/mvn-test.yml`
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/mvn-test.yml
+git commit -m "ci(#4891): aggregate JS e2e JUnit report + upload artifact"
+```
+
+---
+
+### Task 5: Python e2e - emit and aggregate JUnit
+
+**Files:**
+- Modify: `.github/workflows/mvn-test.yml` (`python-e2e-tests` job, lines ~438-473)
+
+- [ ] **Step 1: Emit JUnit + add reporter/artifact**
+
+In `python-e2e-tests`, change the test command to write JUnit, then add reporter + artifact steps:
+```yaml
+      - name: E2E Python Tests
+        working-directory: e2e-python
+        run: |
+          uv pip install --system -e .
+          uv pip install --system pytest
+          mkdir -p reports
+          pytest tests/ --junitxml=reports/python-junit.xml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARCADEDB_DOCKER_IMAGE: ${{ needs.build-and-package.outputs.image-tag }}
+
+      - name: Python E2E Tests Reporter
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        if: success() || failure()
+        with:
+          name: Python E2E Tests Report
+          path: "e2e-python/reports/python-junit.xml"
+          list-suites: "failed"
+          list-tests: "failed"
+          reporter: java-junit
+
+      - name: Upload Python E2E JUnit report
+        if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: python-e2e-junit
+          path: e2e-python/reports/python-junit.xml
+          retention-days: 7
+```
+Add `permissions: { contents: read, checks: write }` to the `python-e2e-tests` job.
+
+- [ ] **Step 2: Verify locally that pytest emits the file**
+
+Run: `cd e2e-python && python3 -c "import pytest" && echo "pytest --junitxml is a built-in flag, no extra dep needed"`
+Expected: prints the confirmation line (pytest ships `--junitxml`).
+
+- [ ] **Step 3: Verify workflow lint**
+
+Run: `actionlint .github/workflows/mvn-test.yml`
+Expected: no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/mvn-test.yml
+git commit -m "ci(#4891): emit + aggregate Python e2e JUnit report"
+```
+
+---
+
+### Task 6: C# e2e - emit and aggregate JUnit
+
+**Files:**
+- Modify: `e2e-csharp/ArcadeDB.E2ETests/ArcadeDB.E2ETests.csproj`
+- Modify: `.github/workflows/mvn-test.yml` (`csharp-e2e-tests` job, lines ~475-502)
+
+- [ ] **Step 1: Add the JUnit logger package**
+
+In `ArcadeDB.E2ETests.csproj`, add inside the existing `<ItemGroup>` that holds `PackageReference`s:
+```xml
+    <PackageReference Include="JunitXml.TestLogger" Version="6.1.0" />
+```
+
+- [ ] **Step 2: Emit JUnit + add reporter/artifact in CI**
+
+In `csharp-e2e-tests`, replace the "E2E C# Tests" step and add reporter/artifact:
+```yaml
+      - name: E2E C# Tests
+        working-directory: e2e-csharp/ArcadeDB.E2ETests
+        run: dotnet test --logger "trx;LogFileName=test-results.trx" --logger "junit;LogFilePath=reports/csharp-junit.xml"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARCADEDB_DOCKER_IMAGE: ${{ needs.build-and-package.outputs.image-tag }}
+
+      - name: C# E2E Tests Reporter
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        if: success() || failure()
+        with:
+          name: C# E2E Tests Report
+          path: "e2e-csharp/ArcadeDB.E2ETests/reports/csharp-junit.xml"
+          list-suites: "failed"
+          list-tests: "failed"
+          reporter: java-junit
+
+      - name: Upload C# E2E JUnit report
+        if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: csharp-e2e-junit
+          path: e2e-csharp/ArcadeDB.E2ETests/reports/csharp-junit.xml
+          retention-days: 7
+```
+Add `permissions: { contents: read, checks: write }` to the `csharp-e2e-tests` job.
+
+- [ ] **Step 3: Verify the logger resolves and emits locally (if .NET SDK present)**
+
+Run: `cd e2e-csharp/ArcadeDB.E2ETests && dotnet restore`
+Expected: restore succeeds, `JunitXml.TestLogger` resolved. (If no local .NET SDK, rely on the CI trial run in Task 12.)
+
+- [ ] **Step 4: Verify workflow lint**
+
+Run: `actionlint .github/workflows/mvn-test.yml`
+Expected: no output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e-csharp/ArcadeDB.E2ETests/ArcadeDB.E2ETests.csproj .github/workflows/mvn-test.yml
+git commit -m "ci(#4891): emit + aggregate C# e2e JUnit report"
+```
+
+---
+
+### Task 7: Go e2e - emit and aggregate JUnit via gotestsum
+
+**Files:**
+- Modify: `.github/workflows/mvn-test.yml` (`go-e2e-tests` job, lines ~504-542)
+
+- [ ] **Step 1: Install gotestsum + emit JUnit + add reporter/artifact**
+
+In `go-e2e-tests`, after "Verify keytool" and replacing the "E2E Go Tests" step:
+```yaml
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@v1.12.0
+
+      - name: E2E Go Tests
+        working-directory: e2e-go
+        run: |
+          mkdir -p reports
+          gotestsum --junitfile reports/go-junit.xml --format standard-verbose -- -timeout 20m ./...
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARCADEDB_DOCKER_IMAGE: ${{ needs.build-and-package.outputs.image-tag }}
+
+      - name: Go E2E Tests Reporter
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        if: success() || failure()
+        with:
+          name: Go E2E Tests Report
+          path: "e2e-go/reports/go-junit.xml"
+          list-suites: "failed"
+          list-tests: "failed"
+          reporter: java-junit
+
+      - name: Upload Go E2E JUnit report
+        if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: go-e2e-junit
+          path: e2e-go/reports/go-junit.xml
+          retention-days: 7
+```
+Note: `go install` adds gotestsum to `$(go env GOPATH)/bin`, already on `PATH` on `ubuntu-latest`. Add `permissions: { contents: read, checks: write }` to the `go-e2e-tests` job.
+
+- [ ] **Step 2: Verify workflow lint**
+
+Run: `actionlint .github/workflows/mvn-test.yml`
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/mvn-test.yml
+git commit -m "ci(#4891): emit + aggregate Go e2e JUnit report via gotestsum"
+```
+
+---
+
+### Task 8: Resolve concrete driver versions and record them
+
+**Files:**
+- Create: `bolt/conformance/driver-versions.md` (the resolved matrix, cross-linked from `spec.yaml`)
+- Modify: `bolt/conformance/spec.yaml` (append resolved versions to each band's `resolution_note`)
+
+**Interfaces:**
+- Produces: the concrete version lists consumed by Task 9's matrix.
+
+- [ ] **Step 1: Query each registry for the current band members**
+
+Run each and record the newest patch of the relevant minor line:
+```bash
+# JS (npm)
+npm view neo4j-driver versions --json | python3 -c "import json,sys; vs=json.load(sys.stdin); print([v for v in vs if v.startswith(('4.4.','5.','6.'))][-15:])"
+# Python (PyPI)
+python3 -m pip index versions neo4j 2>/dev/null || curl -s https://pypi.org/pypi/neo4j/json | python3 -c "import json,sys; print(sorted(json.load(sys.stdin)['releases'])[-10:])"
+# C# (NuGet)
+curl -s https://api.nuget.org/v3-flatcontainer/neo4j.driver/index.json | python3 -c "import json,sys; print(json.load(sys.stdin)['versions'][-10:])"
+# Go
+cd e2e-go && go list -m -versions github.com/neo4j/neo4j-go-driver/v5
+# Java (Maven Central)
+curl -s "https://search.maven.org/solrsearch/select?q=g:org.neo4j.driver+AND+a:neo4j-java-driver&core=gav&rows=20&wt=json" | python3 -c "import json,sys; print([d['v'] for d in json.load(sys.stdin)['response']['docs']])"
+```
+
+- [ ] **Step 2: Write `driver-versions.md` with the resolved bands**
+
+Fill in the exact versions returned above. The band-to-version mapping rule: `oldest-supported-4.x`/`lts` = newest patch of the oldest still-maintained line; `latest-5.x`/`current` = newest 5.x (or repo pin); `latest-6.x`/`latest` = newest 6.x. Java `oldest-supported-4.x` is fixed at `4.4.20` (the `bolt-driver-legacy` profile). Record as a table:
+```markdown
+# Resolved Bolt driver-version matrix (consumed by bolt-nightly.yml)
+
+| Language | Band | Version |
+|---|---|---|
+| java   | oldest-supported-4.x | 4.4.20 |
+| java   | latest-5.x           | <resolved 5.x> |
+| java   | latest-6.x           | 6.2.0 |
+| javascript | oldest-supported-4.x | <resolved 4.4.x> |
+| javascript | latest-5.x           | <resolved 5.x> |
+| javascript | latest-6.x           | <resolved 6.x> |
+| python | lts     | <resolved> |
+| python | current | 6.2.0 |
+| python | latest  | <resolved newest> |
+| csharp | lts     | <resolved> |
+| csharp | current | 6.2.1 |
+| csharp | latest  | <resolved newest> |
+| go     | lts     | <resolved> |
+| go     | current | 5.28.4 |
+| go     | latest  | <resolved newest v5> |
+```
+
+- [ ] **Step 3: Cross-link from spec.yaml**
+
+In `bolt/conformance/spec.yaml`, append to each band's `resolution_note`: `Concrete nightly versions: see bolt/conformance/driver-versions.md (#4891).`
+
+- [ ] **Step 4: Validate the spec still passes its schema**
+
+Run: `cd bolt/conformance && python3 validate_spec.py spec.yaml`
+Expected: validation passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bolt/conformance/driver-versions.md bolt/conformance/spec.yaml
+git commit -m "docs(#4891): resolve and record concrete Bolt driver-version bands"
+```
+
+---
+
+### Task 9: `bolt-nightly.yml` - build-image + five per-language matrix jobs
+
+**Files:**
+- Create: `.github/workflows/bolt-nightly.yml`
+
+**Interfaces:**
+- Consumes: `junit_to_matrix.py` (Task 1), resolved versions (Task 8), each suite's Bolt tests.
+- Produces: per-cell artifacts `bolt-matrix-<lang>-<version>` each containing one normalized JSON.
+
+- [ ] **Step 1: Scaffold triggers + build-image job**
+
+Create `.github/workflows/bolt-nightly.yml` (NO license header per convention). Copy the exact `build-and-package` job body from `mvn-test.yml` (build the branch image, `docker save`, cache with a run-scoped key) into a `build-image` job. Header:
+```yaml
+name: Bolt nightly driver-version matrix
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+      # ... identical to mvn-test.yml build-and-package: checkout, JDK 21,
+      # QEMU, Buildx, mvnw clean install -Pdocker -DskipTests, docker save,
+      # cache/save /tmp/arcadedb-image.tar under key
+      # docker-image-${{ github.run_id }}-${{ github.run_attempt }}
+```
+
+- [ ] **Step 2: Add the five per-language matrix jobs**
+
+Each `needs: build-image`, restores + loads the image, overrides the driver version, runs only the Bolt suite, then converts JUnit to JSON. Example (`bolt-nightly-python`); replicate the shape for java/js/csharp/go with that language's override + Bolt-only test invocation from Tasks 4-7 and the versions from Task 8:
+```yaml
+  bolt-nightly-python:
+    needs: build-image
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        driver-version: ["<lts>", "6.2.0", "<latest>"]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.13.0"
+      - name: Restore Docker image
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /tmp/arcadedb-image.tar
+          key: docker-image-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Load Docker image
+        run: docker load < /tmp/arcadedb-image.tar
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - name: Run Bolt suite against pinned driver
+        working-directory: e2e-python
+        run: |
+          uv pip install --system -e .
+          uv pip install --system pytest "neo4j==${{ matrix.driver-version }}"
+          mkdir -p reports
+          pytest tests/test_bolt.py --junitxml=reports/python-junit.xml
+        env:
+          ARCADEDB_DOCKER_IMAGE: arcadedata/arcadedb:latest
+      - name: Convert to matrix JSON
+        if: success() || failure()
+        run: |
+          python3 bolt/conformance/tools/junit_to_matrix.py \
+            e2e-python/reports/python-junit.xml \
+            --language python --driver-version "${{ matrix.driver-version }}" \
+            --spec bolt/conformance/spec.yaml \
+            -o bolt-matrix-python-${{ matrix.driver-version }}.json
+      - name: Upload cell result
+        if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bolt-matrix-python-${{ matrix.driver-version }}
+          path: bolt-matrix-python-*.json
+          retention-days: 7
+```
+Per-language override + Bolt-only invocation:
+- java: `./mvnw verify -Pintegration -pl e2e -Dtest=RemoteBoltDatabaseIT -Dneo4j-driver.version=${{ matrix.driver-version }}` (and the `4.4.20` cell adds `-Pbolt-driver-legacy -Dtest=RemoteBoltLegacyDriverIT`). Needs Maven artifacts restore like `java-e2e-tests`.
+- js: `npm install neo4j-driver@${{ matrix.driver-version }} && npx jest src/js-bolt-conformance.test.js` (jest-junit already writes `reports/jest-junit.xml`).
+- csharp: `dotnet add package Neo4j.Driver --version ${{ matrix.driver-version }} && dotnet test --filter FullyQualifiedName~Bolt --logger "junit;LogFilePath=reports/csharp-junit.xml"`.
+- go: `go get github.com/neo4j/neo4j-go-driver/v5@v${{ matrix.driver-version }} && go mod tidy && gotestsum --junitfile reports/go-junit.xml -- -timeout 20m -run 'Bolt|Conformance' ./...`.
+
+- [ ] **Step 3: Verify workflow lint**
+
+Run: `actionlint .github/workflows/bolt-nightly.yml`
+Expected: no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/bolt-nightly.yml
+git commit -m "ci(#4891): bolt-nightly workflow - image build + per-language driver matrix"
+```
+
+---
+
+### Task 10: `bolt-nightly.yml` - merge job producing `bolt-compat-matrix.json`
+
+**Files:**
+- Modify: `.github/workflows/bolt-nightly.yml`
+
+**Interfaces:**
+- Consumes: all `bolt-matrix-*` cell artifacts.
+- Produces: `bolt-compat-matrix` artifact (single `bolt-compat-matrix.json`) - the input #4892 consumes.
+
+- [ ] **Step 1: Add the merge-matrix job**
+
+```yaml
+  merge-matrix:
+    needs: [bolt-nightly-java, bolt-nightly-js, bolt-nightly-python, bolt-nightly-csharp, bolt-nightly-go]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    outputs:
+      has-failures: ${{ steps.merge.outputs.has-failures }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+      - name: Download all cell artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: cells
+          pattern: bolt-matrix-*
+          merge-multiple: true
+      - name: Merge into compatibility matrix
+        id: merge
+        run: |
+          python3 bolt/conformance/tools/merge_matrix.py cells/*.json -o bolt-compat-matrix.json
+          echo "has-failures=$(python3 -c "import json;print(str(json.load(open('bolt-compat-matrix.json'))['has_failures']).lower())")" >> "$GITHUB_OUTPUT"
+      - name: Upload compatibility matrix
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bolt-compat-matrix
+          path: bolt-compat-matrix.json
+          retention-days: 30
+```
+
+- [ ] **Step 2: Verify workflow lint**
+
+Run: `actionlint .github/workflows/bolt-nightly.yml`
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/bolt-nightly.yml
+git commit -m "ci(#4891): merge nightly cell results into bolt-compat-matrix.json"
+```
+
+---
+
+### Task 11: `bolt-nightly.yml` - auto-open/update regression tracking issue
+
+**Files:**
+- Modify: `.github/workflows/bolt-nightly.yml`
+
+**Interfaces:**
+- Consumes: `merge-matrix.outputs.has-failures` and the `bolt-compat-matrix` artifact.
+
+- [ ] **Step 1: Add the report job**
+
+```yaml
+  report-regression:
+    needs: merge-matrix
+    if: ${{ always() && needs.merge-matrix.outputs.has-failures == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bolt-compat-matrix
+      - name: Open or update regression issue
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fs = require('fs');
+            const matrix = JSON.parse(fs.readFileSync('bolt-compat-matrix.json', 'utf8'));
+            const failing = [];
+            for (const [scen, langs] of Object.entries(matrix.scenarios)) {
+              for (const [lang, vers] of Object.entries(langs)) {
+                for (const [ver, status] of Object.entries(vers)) {
+                  if (status === 'fail') failing.push(`- ${scen} / ${lang} / ${ver}`);
+                }
+              }
+            }
+            const title = 'Bolt driver compatibility regression (nightly)';
+            const label = 'bolt-compat-regression';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `Nightly Bolt matrix reported failing cells.\n\nRun: ${runUrl}\n\n${failing.sort().join('\n')}`;
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: label,
+            });
+            const hit = existing.data.find(i => i.title === title);
+            if (hit) {
+              await github.rest.issues.update({ owner: context.repo.owner, repo: context.repo.repo, issue_number: hit.number, body });
+            } else {
+              await github.rest.issues.create({ owner: context.repo.owner, repo: context.repo.repo, title, body, labels: [label] });
+            }
+```
+
+- [ ] **Step 2: Ensure the label exists**
+
+Run: `gh label create bolt-compat-regression --color B60205 --description "Nightly Bolt driver compatibility regression" --force`
+Expected: label created or updated (github-script `labels: [label]` also creates it on first issue if missing, but pre-creating gives it a stable color).
+
+- [ ] **Step 3: Verify workflow lint**
+
+Run: `actionlint .github/workflows/bolt-nightly.yml`
+Expected: no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/bolt-nightly.yml
+git commit -m "ci(#4891): open/update bolt-compat-regression issue on nightly failure"
+```
+
+---
+
+### Task 12: End-to-end verification via workflow_dispatch trial
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Lint every touched workflow**
+
+Run: `actionlint .github/workflows/mvn-test.yml .github/workflows/bolt-nightly.yml .github/workflows/bolt-conformance-spec.yml`
+Expected: no output.
+
+- [ ] **Step 2: Run the full conformance-tools test suite once more**
+
+Run: `cd bolt/conformance/tools && python3 -m unittest discover -p 'test_*.py' -v`
+Expected: all tests PASS (7 total).
+
+- [ ] **Step 3: Dry-run the matrix tools against real JUnit locally**
+
+Produce a JUnit from one suite (e.g. `cd e2e-js && npx jest src/js-bolt-conformance.test.js` if Docker is available), then:
+```bash
+python3 bolt/conformance/tools/junit_to_matrix.py e2e-js/reports/jest-junit.xml --language javascript --driver-version 6.0.1 --spec bolt/conformance/spec.yaml -o /tmp/cell.json
+python3 bolt/conformance/tools/merge_matrix.py /tmp/cell.json -o /tmp/matrix.json
+python3 -m json.tool /tmp/matrix.json
+```
+Expected: `/tmp/matrix.json` shows `scenarios -> javascript -> 6.0.1 -> status` and a `has_failures` boolean. (If Docker is unavailable locally, defer to Step 4.)
+
+- [ ] **Step 4: Push branch and trigger the nightly manually**
+
+After the PR branch is pushed:
+```bash
+gh workflow run bolt-nightly.yml --ref feat/4891-bolt-ci-nightly
+gh run watch
+```
+Expected: `build-image` succeeds, all five matrix jobs run (some cells may legitimately fail on known-gap scenarios - that is the point), `merge-matrix` uploads `bolt-compat-matrix.json`, and `report-regression` opens/updates the tracking issue if any cell failed.
+
+- [ ] **Step 5: Final commit if any fixups were needed**
+
+```bash
+git add -A && git commit -m "ci(#4891): fixups from nightly trial run" || echo "no fixups needed"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Component 1 (JUnit aggregation JS/Python/C#/Go) -> Tasks 4-7. ✓
+- Component 2 (`bolt-nightly.yml` + matrix) -> Tasks 8-9. ✓
+- Component 3 (normalized JSON + merge) -> Tasks 1-2, 10. ✓
+- Component 4 (auto-issue) -> Task 11. ✓
+- Verification approach (actionlint, unit tests, dispatch trial) -> Tasks 3, 12. ✓
+- All four acceptance criteria map to tasks (PR-gating verified in Task 12 Step 4; aggregation Tasks 4-7; nightly Tasks 9-11; matrix JSON Task 10). ✓
+
+**Placeholder scan:** The `<resolved ...>` markers in Task 8 are intentional - that task's job is to resolve them via the given registry commands; every other task has concrete code/commands.
+
+**Type consistency:** `parse_junit` / `build_matrix` / `load_known_ids` (Task 1) and `merge` (Task 2) signatures match their uses in Tasks 9-11. JSON shapes are consistent: cell = `{language, driver_version, scenarios}`; merged = `{scenarios, languages, has_failures}`. Artifact names (`bolt-matrix-<lang>-<version>`, `bolt-compat-matrix`) are consistent between producer (Task 9/10) and consumer (Task 10/11).

--- a/docs/superpowers/specs/2026-07-08-bolt-ci-nightly-matrix-4891-design.md
+++ b/docs/superpowers/specs/2026-07-08-bolt-ci-nightly-matrix-4891-design.md
@@ -1,0 +1,198 @@
+# Bolt CI gating + nightly driver-version matrix (#4891)
+
+Part of epic #4882 (Bolt Driver Compatibility Certification), Group D.
+
+## Problem
+
+The five per-language Bolt e2e suites all exist and already PR-gate in
+`mvn-test.yml` (`java-e2e-tests`, `js-e2e-tests`, `python-e2e-tests`,
+`csharp-e2e-tests`, `go-e2e-tests`, each `needs: build-and-package`). Three
+gaps remain before Bolt compatibility is continuously certified:
+
+1. **No comparable report artifact for four of five suites.** Only the Java
+   e2e job uses `dorny/test-reporter`. JS/Python/C#/Go emit nothing
+   machine-readable, so their pass/fail is invisible in the PR checks summary
+   and cannot be aggregated.
+2. **No scheduled run.** No cron-triggered workflow touches any Bolt suite
+   (confirmed: only `benchmark-tests`, `ha-resilience-tests`, `load-tests`,
+   `license-compliance`, `studio-security-audit` have `schedule:` triggers).
+   Each PR run tests exactly one driver version per language; a driver-side
+   release that breaks compatibility would go unnoticed.
+3. **No merged, machine-readable compatibility matrix.** The publishing issue
+   #4892 (site page + badge) needs a single normalized `driver x scenario x
+   version` document to render; nothing produces it today.
+
+## Scope
+
+In scope:
+- Add JUnit report aggregation to the JS/Python/C#/Go PR-gating e2e jobs.
+- A new standalone nightly workflow `bolt-nightly.yml` that runs all five Bolt
+  suites against the full pinned driver-version matrix from the conformance
+  spec (`bolt/conformance/spec.yaml` `driver_version_bands`).
+- Two small tools (with unit tests) that turn per-suite JUnit into a normalized
+  per-language JSON and merge all languages into one compatibility matrix JSON.
+- An auto-opened/updated tracking issue when a nightly cell regresses.
+
+Out of scope (belongs to #4892): rendering the matrix as a site page or badge;
+this issue only emits the matrix JSON artifact #4892 consumes.
+
+Explicitly NOT changing: which suites PR-gate (all five already do); the
+advertised `server_agent` version; any Bolt protocol/serialization behavior
+(that is Group C: #4890 and children).
+
+## Governing facts (verified in-repo)
+
+- Every suite already embeds the conformance scenario ID (`CONN-001`,
+  `AUTH-003`, `TX-004`, `PROTO-002`, ...) in its test name/description. JUnit
+  `<testcase name>` therefore carries the scenario ID uniformly across all five
+  languages, which is what makes a single JUnit-based merge possible without
+  each suite hand-emitting bespoke JSON.
+- Driver-version pin points, each overridable at the package-manager level
+  (no test reads a driver version from an env var today):
+  - Java: root `pom.xml` `<neo4j-driver.version>6.2.0`, override
+    `-Dneo4j-driver.version=X`; legacy `4.4.20` via the `e2e`
+    `bolt-driver-legacy` Maven profile (`RemoteBoltLegacyDriverIT`).
+  - JS: `e2e-js/package.json` `neo4j-driver ^6.0.1`, override
+    `npm install neo4j-driver@X`.
+  - Python: `e2e-python/pyproject.toml` `neo4j>=6.2.0`, override
+    `uv pip install neo4j==X`.
+  - C#: `e2e-csharp/ArcadeDB.E2ETests/*.csproj` `Neo4j.Driver 6.2.1`, override
+    `dotnet add package Neo4j.Driver --version X`.
+  - Go: `e2e-go/go.mod` `neo4j-go-driver/v5 v5.28.4`, override
+    `go get github.com/neo4j/neo4j-go-driver/v5@vX`.
+- The A1 conformance spec (`bolt/conformance/spec.yaml`) already declares
+  `driver_version_bands` per language: Java/JS use
+  `[oldest-supported-4.x, latest-5.x, latest-6.x]`; Python/C#/Go use
+  `[lts, current, latest]`. Its resolution notes defer the actual multi-version
+  matrix run to this issue (#4891).
+
+## Design
+
+### Component 1 - JUnit aggregation on the PR-gating jobs (`mvn-test.yml`)
+
+For each non-Java e2e job, produce a JUnit XML report, feed it to
+`dorny/test-reporter` (matching the Java/unit/IT pattern already in the file),
+and upload it as an artifact. No change to what these jobs test or gate.
+
+- **JS** (`js-e2e-tests`, jest): add `jest-junit` dev dependency and a jest
+  reporter config writing `e2e-js/reports/js-junit.xml`.
+- **Python** (`python-e2e-tests`, pytest): run
+  `pytest --junitxml=reports/python-junit.xml tests/`.
+- **C#** (`csharp-e2e-tests`, dotnet): add the `JunitXml.TestLogger` package and
+  `--logger "junit;LogFilePath=reports/csharp-junit.xml"` (keep the existing
+  `trx` logger).
+- **Go** (`go-e2e-tests`): run tests through `gotestsum`
+  (`--junitfile reports/go-junit.xml`) or `go-junit-report`.
+
+Each job gains a `dorny/test-reporter` step (`if: success() || failure()`,
+`reporter: java-junit` - dorny's generic JUnit parser) and an
+`actions/upload-artifact` step for its `reports/*.xml`.
+
+### Component 2 - `bolt-nightly.yml` (new standalone workflow)
+
+Triggers: `schedule` (`cron: "0 3 * * *"`, 03:00 UTC) and `workflow_dispatch`.
+
+Jobs:
+1. `build-image`: builds the branch Docker image once (reusing the
+   `build-and-package` Maven-Docker steps) and caches it with a run-scoped key,
+   so every matrix cell loads the same image rather than rebuilding.
+2. Five per-language jobs (`bolt-nightly-java`, `-js`, `-python`, `-csharp`,
+   `-go`), each `needs: build-image`, each:
+   - `strategy: { fail-fast: false, matrix: { driver-version: [...] } }`.
+   - Loads the cached image.
+   - Overrides the driver version via that language's package manager
+     (see pin points above).
+   - Runs only the Bolt conformance suite for that language (not the whole e2e
+     module - e.g. Java runs `RemoteBoltDatabaseIT` + `RemoteBoltLegacyDriverIT`
+     via the `bolt-driver-legacy` profile; Python runs `tests/test_bolt.py`;
+     etc.).
+   - Emits JUnit XML, converts it to normalized JSON (Component 3), and uploads
+     `bolt-matrix-<lang>-<version>.json` as an artifact.
+
+Driver-version matrix (concrete versions resolved at implementation from the
+band names; the `latest` band floats to the newest release so new releases are
+caught, the `lts`/`oldest` bands are hard pins):
+
+| Lang   | Nightly cells                                  |
+|--------|------------------------------------------------|
+| Java   | `4.4.20` (legacy profile), a `5.x`, `6.2.0`     |
+| JS     | oldest `4.x`, latest `5.x`, latest `6.x`        |
+| Python | `lts`, `current`, `latest`                      |
+| C#     | `lts`, `current`, `latest`                      |
+| Go     | `lts`, `current`, `latest`                      |
+
+This exercises bands currently tested nowhere (Java `latest-5.x`, JS
+`oldest-4.x`).
+
+### Component 3 - normalized JSON + cross-language merge
+
+Two Python tools under `bolt/conformance/tools/`, each with a `unittest`/pytest
+test file mirroring the existing `bolt/conformance/test_validate_spec.py`:
+
+- `junit_to_matrix.py <junit.xml> --language L --driver-version V -o out.json`:
+  parses the JUnit XML, extracts the scenario ID from each `<testcase name>`
+  via a regex anchored to the spec's ID pattern (`[A-Z]+-\d{3}`), maps
+  `failure`/`error` -> `fail`, `skipped` -> `skip`, otherwise `pass`, and
+  cross-checks every extracted ID against the ID set in `spec.yaml` (unknown ID
+  -> non-zero exit, so a renamed/dropped scenario is caught, not silently
+  dropped). Output:
+  `{"language": L, "driver_version": V, "scenarios": {"CONN-001": "pass", ...}}`.
+- `merge_matrix.py <per-cell-json...> -o bolt-compat-matrix.json`: a final
+  `merge-matrix` job (`needs:` all five language jobs, `if: always()`) downloads
+  every per-cell JSON artifact and produces one document keyed by
+  `scenario -> language -> version -> status`, plus a `spec_version` and the
+  band metadata, uploaded as the `bolt-compat-matrix` artifact. This is the sole
+  input #4892 consumes.
+
+Rationale for JUnit-name extraction over per-suite bespoke JSON: it reuses the
+report artifacts Component 1 already produces, keeps all normalization logic in
+one reviewed place (versus five language-specific emitters that could drift),
+and the scenario IDs are already present in the test names.
+
+### Component 4 - auto-issue on regression
+
+A final `report` job that runs when any matrix cell failed
+(`if: always()` + a step that inspects the downloaded results, or gating on the
+merge job detecting a `fail`). It opens-or-updates a single tracking issue
+labelled `bolt-compat-regression` via `actions/github-script`:
+- Search open issues with that label and a fixed title
+  (e.g. `Bolt driver compatibility regression (nightly)`).
+- If found, update the body with the latest failing `language / version /
+  scenario` list and a link to the run; if not, create it.
+Idempotent so consecutive red nights update one issue rather than spamming.
+The matrix stays `fail-fast: false` so the report reflects every cell.
+
+## Verification
+
+- Workflows: `actionlint` over both YAML files, plus a `workflow_dispatch` trial
+  run of `bolt-nightly.yml` on the feature branch to confirm the matrix, image
+  cache, artifact upload, and merge job wire up end to end.
+- `junit_to_matrix.py` / `merge_matrix.py`: pytest/unittest with sample JUnit
+  fixtures covering pass, `failure`, `error`, `skipped`, a testcase with no
+  scenario ID, and an unknown scenario ID; plus a merge test over two
+  languages/versions asserting the combined shape.
+- Existing `bolt-conformance-spec.yml` continues to gate `spec.yaml` structural
+  integrity.
+
+## Acceptance criteria (from #4891)
+
+- [ ] All five per-language Bolt suites PR-gating (already true; verify no
+      regression).
+- [ ] JUnit-style report aggregation added to JS/Python/C#/Go e2e jobs.
+- [ ] A nightly scheduled workflow runs all five suites against the full pinned
+      driver-version matrix.
+- [ ] Aggregated results emitted as `bolt-compat-matrix.json` in a format #4892
+      can consume.
+
+## Risks / open points
+
+- Concrete `latest`/`5.x`/`lts` version numbers must be resolved against actual
+  releases at implementation time and recorded in the workflow (and cross-linked
+  from `spec.yaml` resolution notes).
+- C# JUnit logger (`JunitXml.TestLogger`) adds a NuGet dev dependency; if
+  undesirable, fall back to dorny's `dotnet-trx` reporter on the existing `.trx`
+  and a small trx->JSON step. Design defaults to the JUnit logger for
+  uniformity.
+- Nightly image build duplicates `build-and-package`; acceptable for isolation
+  per the standalone-workflow decision. If build time becomes a problem, the
+  nightly can instead pull `arcadedata/arcadedb:latest`.

--- a/e2e-csharp/ArcadeDB.E2ETests/ArcadeDB.E2ETests.csproj
+++ b/e2e-csharp/ArcadeDB.E2ETests/ArcadeDB.E2ETests.csproj
@@ -31,5 +31,6 @@
     <PackageReference Include="Testcontainers" Version="4.11.0" />
     <PackageReference Include="Npgsql" Version="10.0.2" />
     <PackageReference Include="Neo4j.Driver" Version="6.2.1" />
+    <PackageReference Include="JunitXml.TestLogger" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/e2e/src/test/java/com/arcadedb/e2e/RemoteBoltLegacyDriverIT.java
+++ b/e2e/src/test/java/com/arcadedb/e2e/RemoteBoltLegacyDriverIT.java
@@ -53,7 +53,7 @@ class RemoteBoltLegacyDriverIT extends ArcadeContainerTemplate {
 
   @Test
   @DisplayName("[CONN-001] Connect and read on the 4.4 driver band")
-  void legacy_connectAndRead() {
+  void conn001_legacyConnectAndRead() {
     try (final Driver d = newDriver()) {
       d.verifyConnectivity();
       try (final Session s = d.session(SessionConfig.forDatabase("beer"))) {
@@ -65,7 +65,7 @@ class RemoteBoltLegacyDriverIT extends ArcadeContainerTemplate {
 
   @Test
   @DisplayName("[PROTO-001] Parameterized read negotiates on the 4.4 driver band")
-  void legacy_parameterized() {
+  void proto001_legacyParameterized() {
     try (final Driver d = newDriver();
         final Session s = d.session(SessionConfig.forDatabase("beer"))) {
       assertThat(s.run("RETURN $v AS v", Map.of("v", 7L)).single().get("v").asLong()).isEqualTo(7L);
@@ -74,7 +74,7 @@ class RemoteBoltLegacyDriverIT extends ArcadeContainerTemplate {
 
   @Test
   @DisplayName("[ERR-001] Syntax error code on the 4.4 driver band")
-  void legacy_syntaxErrorCode() {
+  void err001_legacySyntaxErrorCode() {
     try (final Driver d = newDriver();
         final Session s = d.session(SessionConfig.forDatabase("beer"))) {
       assertThatThrownBy(() -> s.run("MATCH (n RETURN n").consume())


### PR DESCRIPTION
Closes #4891. Part of epic #4882 (Bolt Driver Compatibility Certification), Group D.

## What

All five per-language Bolt e2e suites already exist and already PR-gate in `mvn-test.yml`. This PR closes the three remaining certification gaps:

1. **JUnit report aggregation** for the four non-Java e2e jobs (JS/Python/C#/Go), matching the Java pattern (`dorny/test-reporter` + artifact upload).
2. **A nightly full-driver-version-matrix run** (`bolt-nightly.yml`) - every suite against its full band set, not just the single version each PR tests.
3. **A merged, machine-readable compatibility matrix** (`bolt-compat-matrix.json`) for the publishing issue #4892 to render.

## How it works

Every suite already embeds the conformance scenario ID (`CONN-001`, `AUTH-003`, ...) in its test names, so JUnit `<testcase name>` carries the ID uniformly across all five languages. Two small Python tools under `bolt/conformance/tools/` (unit-tested) turn each suite's JUnit into a normalized `scenario-id -> status` map and merge all languages/versions into one `scenario x language x version` matrix.

- `mvn-test.yml`: JS/Python/C#/Go e2e jobs gain JUnit emission, `dorny/test-reporter`, artifact upload, and `checks: write`.
- `bolt-nightly.yml` (new, `cron: 0 3 * * *` + `workflow_dispatch`): builds the branch image once, then a per-language driver-version matrix (`fail-fast: false`) overriding the driver at the package-manager level and running only the Bolt suite; a `merge-matrix` job emits `bolt-compat-matrix.json`; a `report-regression` job opens/updates one `bolt-compat-regression` issue on any red cell.
- `bolt/conformance/driver-versions.md`: the resolved concrete versions per band, cross-linked from `spec.yaml`.

## Verification

- `bolt/conformance/tools/`: 7 unit tests (pass/fail/error/skip/no-id/unknown-id + merge), wired into `bolt-conformance-spec.yml`.
- `actionlint` clean on all new/edited workflow content (the pre-existing `mvn-test.yml` findings are unchanged).
- Functional dry-run of `junit_to_matrix.py` -> `merge_matrix.py` against real spec IDs produces the expected matrix shape.
- Post-merge, the nightly can be exercised via `workflow_dispatch`.

## Notes

- Concrete driver versions were resolved against each registry and recorded in `driver-versions.md`; the `latest` band tracks the newest release so driver-side breakage surfaces.
- The `bolt-compat-regression` label is auto-created by the report job on first use.
