### PR TITLE
Supernode - merge append of edges

### DIFF
--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -631,6 +631,22 @@ that could starve the very snapshot resync meant to heal the node.
   own quantization code), so already-built indexes are unaffected. The Java API exposes the same knob
   via `TypeLSMSparseVectorIndexBuilder.withWeightQuantization(...)`.
 
+- **Graph: concurrent edge insertion into a "super-node" (hot vertex) no longer triggers a retry storm.**
+  When many transactions append edges to the SAME vertex at once - a payments graph funnelling every
+  transaction into a central account, a popular product, a star-schema hub - they all collide on that
+  vertex's single edge-list head chunk under ArcadeDB's page-level MVCC. Previously each collision aborted
+  the whole transaction with a `ConcurrentModificationException` and retried it; under HA every retry re-ran
+  the entire Raft replication round, so contention piled up into multi-second (occasionally over a minute)
+  leader latencies that could breach application timeouts. Because appends to an edge list commute (order is
+  irrelevant), the engine now replays the conflicting appends on top of the newer committed page instead of
+  failing the transaction. In a 3-node HA benchmark this cut the worst-case commit latency from ~67s to
+  ~0.4s and full-transaction retries from ~350% to ~0.7% of commits for the same workload, with 4x less
+  leader/replication work. The optimization is on by default and transparent (all edges still land; the
+  leader replicates the merged result, so replicas stay identical). It adds ~0.7% allocation overhead on the
+  non-contended path and can be disabled with `arcadedb.graph.edgeAppendMerge=false`. Raw write throughput on
+  a single hot vertex is unchanged (a follow-up shards the edge list itself); this release removes the retry
+  cascade and the latency spikes.
+
 ## Breaking Changes (migration notes)
 
 ### 1. `raftPersistStorage` now defaults to `true` (durable Raft storage)

--- a/docs/release-26.7.2.md
+++ b/docs/release-26.7.2.md
@@ -10,6 +10,18 @@ that could starve the very snapshot resync meant to heal the node.
 
 ### Fixes
 
+- **Graph: concurrent edge insertion into the same super-node (hot) vertex no longer silently drops edges.**
+  Under many transactions appending edges to one vertex at once, an edge record could commit with **no
+  back-reference** in the target vertex's edge list - the edge count came up short and `CHECK DATABASE` reported
+  `missingReferenceBack` ([#5147](https://github.com/ArcadeData/arcadedb/issues/5147)). Root cause was a
+  deferred-update MVCC gap: the edge-list head chunk was read via an immutable lookup that (under
+  `READ_COMMITTED`) did not retain the page in the transaction, and the page was only captured later by the
+  deferred record update - at the newer version if a concurrent append committed in between. The commit-time
+  page-version check then compared the newer version against itself, found no conflict, and the stale chunk
+  buffer overwrote the concurrent append (a lost update). The head chunk's page is now anchored in the
+  transaction at read time, so a concurrent commit is detected and the transaction retries. Pre-existing and
+  independent of the new edge-append merge (it reproduced with that feature disabled).
+
 - **Cypher: `COUNT { ... }` (and other block subqueries) inside a pattern-comprehension `WHERE` no longer swallow a
   trailing comparison.** A filter such as `[(a)-[:E]->(b) WHERE COUNT { MATCH (b)-[:E]->() } = 0 | b.name]` was parsed
   as just the `COUNT { ... }` block, dropping the `= 0`, so the predicate evaluated to a non-boolean count and every

--- a/docs/supernode.md
+++ b/docs/supernode.md
@@ -163,17 +163,33 @@ Design guidance (from the initial review):
 
 ---
 
-## 5. Related pre-existing bug (separate)
+## 5. Related pre-existing bug: #5147 (FIXED, in this PR)
 
-**Issue #5147** - concurrent edge insertion into one super-node can **drop edges**
-and occasionally orphan an edge-list chunk (`inEdgesHeadChunk not found` SEVERE at
-`GraphEngine.createInEdgeChunk`). It reproduces with the append-merge **disabled**,
-so it is pre-existing and independent; the merge actually *mitigates* it (fewer
-retries = smaller race window). Hypothesis: the concurrent chunk-full transition
-(new chunk + `previous` relink + vertex head-pointer update in
-`EdgeLinkedList.add`) is not serialised as one MVCC unit. Needs its own fix. The
-benchmarks below tolerate this with lenient assertions; the merge's own
-correctness is gated by the deterministic `ConcurrentEdgeAppendMergeTest`.
+**Issue #5147** - concurrent edge insertion into one super-node could **drop
+edges**: an edge record committed with no back-reference from the target's edge
+list (`check database` -> `missingReferenceBack`; the edge count came up short).
+Pre-existing and independent of the merge (reproduces with the merge **disabled**;
+the merge only *masked* it by re-reading and re-applying at commit).
+
+**Root cause** (not the original chunk-full hypothesis): a deferred-update MVCC
+gap. The head chunk was read via an immutable `lookupByRID` which, under
+READ_COMMITTED, does not retain the page in the transaction. The page was only
+captured later by the deferred `updateRecord` - at the NEWER version if a
+concurrent append committed in between. The commit-time version check then
+compared the newer version against itself, found no conflict, and the stale chunk
+buffer overwrote the concurrent append (a lost update).
+
+**Fix**: `GraphEngine.createInEdgeChunk`/`createOutEdgeChunk` now anchor the head
+chunk's page in the transaction at read time (`fetchPageInTransaction`), so the
+append is bound to that version; a concurrent commit is caught by the MVCC check
+and the transaction retries and re-reads the current chunk. Regression:
+`Issue5147SuperNodeChunkRaceTest` (8 threads x 4000 edges into one vertex) - was
+losing ~130-160 edges/run, now 32000/32000 with a clean integrity check. This
+fixes the root cause so it is correct with the merge off too.
+
+**Follow-up**: the edge-**removal** path (`deleteEdge`/`removeVertex` via
+`getEdgeHeadChunk`) shares the same unanchored-read pattern (lower impact;
+full protection needs anchoring the whole chunk chain).
 
 ---
 
@@ -240,8 +256,9 @@ Reading the HA numbers:
 |---|---|
 | Commutative edge-append merge (engine) | ✅ implemented, tested, benchmarked |
 | Embedded + HA benchmarks | ✅ in `@Tag("benchmark")` tests |
-| Issue #5147 (chunk-allocation race) | 🐞 filed, not started |
+| Issue #5147 (lost-update edge drop) | ✅ fixed (root cause: deferred-update MVCC gap) in this PR |
 | Adaptive striped edge list (throughput) | ⏳ designed, not started |
+| Edge-removal path anchoring (#5147 follow-up) | ⏳ noted, not started |
 
 ## 8. Next steps
 
@@ -266,3 +283,7 @@ Reading the HA numbers:
   lazy `PageId`). Per-append overhead dropped from ~+504 to **+39 bytes/edge**;
   merge behaviour and correctness unchanged. Added the single-threaded overhead
   micro-benchmark.
+- **2026-07-08** - Fixed **#5147** (root-caused as a deferred-update MVCC gap, not
+  a chunk-allocation race): head-chunk page now anchored in the tx at read time in
+  `GraphEngine.createIn/OutEdgeChunk`. Added `Issue5147SuperNodeChunkRaceTest`.
+  Folded into this PR.

--- a/docs/supernode.md
+++ b/docs/supernode.md
@@ -109,6 +109,24 @@ modification in this transaction was a tracked in-chunk edge append, the page is
   `EdgeLinkedList.add` chunk-full branch in one place.
 - Tracking is lazy (only allocated when the feature is on and an append happens)
   and cleared on `reset()`/`kill()`.
+- **Bulk import (`GraphBatch.addManyAtEndDirect`) neither tracks nor poisons**, and
+  that is safe because of an implicit invariant: a `GraphBatch` transaction builds
+  edge chunks through its own path and never also drives `EdgeLinkedList.add` on the
+  same page, so a bulk-written (untracked, unpoisoned) chunk page can never coexist
+  with a tracked append in one transaction - which is the only thing that could make
+  a poisoned-but-untracked page wrongly rebasable. `GraphBatch` is also
+  single-threaded per its own contract. Any future change that mixes the bulk and
+  the `EdgeLinkedList.add` paths in one transaction must poison the bulk pages.
+- **Slot reuse during rebase.** `rebaseEdgeAppends` reloads the chunk by segment RID
+  and handles a concurrent delete via `RecordNotFoundException` -> retry. The only
+  way an appended-to HEAD chunk is deleted is a concurrent deletion of the vertex
+  itself (`deleteAll`); the head is never empty-collapsed (`updateSegment` only
+  drops non-head empty chunks). Appending edges to a vertex being concurrently
+  deleted is an application-level conflict with already-undefined semantics; the
+  common case is covered by the `RecordNotFoundException` fallback. The residual
+  theoretical case - the freed head-chunk slot being recycled by another chunk
+  before this commit acquires the lock - is not currently guarded beyond that, and
+  is noted here rather than claimed impossible.
 - **Allocation-free hot path.** Appends are keyed by *segment* RID (a super-node
   is one segment however many edges it receives) with the (edge, vertex) pairs
   packed into growable primitive arrays (`EdgeAppendBuffer`), not one object per

--- a/docs/supernode.md
+++ b/docs/supernode.md
@@ -187,9 +187,12 @@ and the transaction retries and re-reads the current chunk. Regression:
 losing ~130-160 edges/run, now 32000/32000 with a clean integrity check. This
 fixes the root cause so it is correct with the merge off too.
 
-**Follow-up**: the edge-**removal** path (`deleteEdge`/`removeVertex` via
-`getEdgeHeadChunk`) shares the same unanchored-read pattern (lower impact;
-full protection needs anchoring the whole chunk chain).
+**Follow-up ([#5153](https://github.com/ArcadeData/arcadedb/issues/5153))**: the
+edge-**removal** path (`deleteEdge`/`removeVertex` via `getEdgeHeadChunk`) shares
+the same unanchored-read pattern - concurrent removals on one hot vertex can lose
+a removal (reproduces with the merge on and off, so independent of it). Full
+protection needs anchoring the chunk actually modified during the remove
+chain-walk; kept out of this PR to stay focused.
 
 ---
 
@@ -258,7 +261,7 @@ Reading the HA numbers:
 | Embedded + HA benchmarks | ✅ in `@Tag("benchmark")` tests |
 | Issue #5147 (lost-update edge drop) | ✅ fixed (root cause: deferred-update MVCC gap) in this PR |
 | Adaptive striped edge list (throughput) | ⏳ designed, not started |
-| Edge-removal path anchoring (#5147 follow-up) | ⏳ noted, not started |
+| Edge-removal path lost-update (#5153) | 🐞 filed (removal twin of #5147), not started |
 
 ## 8. Next steps
 

--- a/docs/supernode.md
+++ b/docs/supernode.md
@@ -187,12 +187,16 @@ and the transaction retries and re-reads the current chunk. Regression:
 losing ~130-160 edges/run, now 32000/32000 with a clean integrity check. This
 fixes the root cause so it is correct with the merge off too.
 
-**Follow-up ([#5153](https://github.com/ArcadeData/arcadedb/issues/5153))**: the
-edge-**removal** path (`deleteEdge`/`removeVertex` via `getEdgeHeadChunk`) shares
-the same unanchored-read pattern - concurrent removals on one hot vertex can lose
-a removal (reproduces with the merge on and off, so independent of it). Full
-protection needs anchoring the chunk actually modified during the remove
-chain-walk; kept out of this PR to stay focused.
+**Also fixed ([#5153](https://github.com/ArcadeData/arcadedb/issues/5153))**: the
+edge-**removal** path (`deleteEdge`/`removeVertex` via `getEdgeHeadChunk`) shared
+the same unanchored-read pattern - concurrent removals on one hot vertex could
+lose a removal (reproduced with the merge on and off, so independent of it).
+`EdgeLinkedList` now loads each chunk it will modify during the remove chain-walk
+through `loadChunkForWrite` (anchors the page at read time, reads content from it,
+via the new `EdgeSegment.getPreviousRID()` to walk without a stray load), so a
+concurrent modification of the same chunk is caught by the MVCC check. Regression:
+`ConcurrentEdgeAppendMergeTest.concurrentAppendsAndRemovesStayConsistent` (mixed
+concurrent append+delete on one hub, net-zero degree, integrity clean).
 
 ---
 
@@ -261,7 +265,8 @@ Reading the HA numbers:
 | Embedded + HA benchmarks | ✅ in `@Tag("benchmark")` tests |
 | Issue #5147 (lost-update edge drop) | ✅ fixed (root cause: deferred-update MVCC gap) in this PR |
 | Adaptive striped edge list (throughput) | ⏳ designed, not started |
-| Edge-removal path lost-update (#5153) | 🐞 filed (removal twin of #5147), not started |
+| Edge-removal path lost-update (#5153) | ✅ fixed (removal twin of #5147) in this PR |
+| Deterministic 3-node HA correctness gate | ✅ added (`SuperNodeAppendHAConsistencyIT`) |
 
 ## 8. Next steps
 
@@ -290,3 +295,10 @@ Reading the HA numbers:
   a chunk-allocation race): head-chunk page now anchored in the tx at read time in
   `GraphEngine.createIn/OutEdgeChunk`. Added `Issue5147SuperNodeChunkRaceTest`.
   Folded into this PR.
+- **2026-07-08** - Code-review round: hardened the rebase (retryable on missing
+  segment/bucket), `@Tag("slow")` on the correctness test, tightened both
+  benchmarks to strict counts now that #5147 is fixed, benchmark imports cleanup.
+  Fixed the removal-direction twin **#5153** (`EdgeLinkedList` now anchors each
+  chunk it modifies during the remove walk via `loadChunkForWrite` +
+  `EdgeSegment.getPreviousRID()`); regression = the mixed append+delete test. Added
+  the deterministic 3-node HA correctness gate `SuperNodeAppendHAConsistencyIT`.

--- a/docs/supernode.md
+++ b/docs/supernode.md
@@ -154,8 +154,14 @@ Design guidance (from the initial review):
   unchanged.
 - **Per-bucket granularity** because MVCC conflicts are page-level: stripe across
   distinct files/pages so appends never false-share.
-- **Deterministic hash by edge RID** so delete/lookup goes straight to the owning
-  stripe.
+- **Deterministic hash by the NEIGHBOUR vertex RID** (the second element of each
+  `(edgeRID, vertexRID)` entry), NOT the edge RID. The connectivity/existence/
+  remove operations (`isConnectedTo`, `containsVertex`, `getFirstEdgeConnectedToVertex`,
+  `removeVertex`) all key on the neighbour vertex, so hashing by it localises them
+  to one stripe (O(degree/N)); appends still spread because a hub's edges come from
+  many distinct neighbours; and `deleteEdge` still resolves the stripe from the
+  edge's endpoints. Hashing by edge RID would give zero read benefit on those hot
+  paths. (Only a bare `containsEdge(edgeRID)` can't localise - uncommon.)
 - Read order changes (per-stripe order, merged) - confirm nothing guarantees edge
   iteration order and doc the change.
 - Composes with the merge: merge kills the retry storm today; striping unlocks
@@ -271,10 +277,16 @@ Reading the HA numbers:
 ## 8. Next steps
 
 1. Prototype the **adaptive striped edge list** (promote-on-hot, per-bucket
-   stripes, hash by edge RID) and re-run the HA benchmark to measure the
-   throughput half.
-2. Fix **#5147** (serialise the concurrent chunk-full transition; replace the
-   silent "chunk not found → create new" fallback with fail-loud/retry).
+   stripes, hash by the neighbour vertex RID - see §4) and re-run the HA benchmark
+   to measure the throughput half. This is the remaining super-node lever now that
+   the retry storm and the two lost-update races are closed.
+2. **Remove-path anchoring cost** (from code review): `loadChunkForWrite`
+   materialises a mutable page for every chunk the remove walk visits, including
+   read-only ones (bounded - a 32k-edge hub is ~8 pages - and unmodified pages are
+   dropped at commit, so not a correctness issue). `removeVertex` genuinely
+   modifies many chunks, but `removeEdge`/`removeEdgeRID` modify only one; a
+   possible optimisation is to traverse read-only and anchor just the chunk about
+   to be modified. Measure on a large super-node before optimising.
 3. Consider group-committing multiple pending hub appends into one replicated
    round (reduces the per-commit HA cost further).
 

--- a/docs/supernode.md
+++ b/docs/supernode.md
@@ -3,7 +3,7 @@
 Living design + development log for improving ArcadeDB's behaviour when many
 transactions concurrently write edges into the **same hot vertex** (a
 "super-node": a treasury/float account, a popular product, a hub in a
-star schema). Target release: **26.8.1**.
+star schema). Target release: **26.7.2** (edge-append merge; striping + #5147 follow-ups target a later release).
 
 Keep this document updated as the work progresses (design decisions, benchmarks,
 follow-ups). Sections at the bottom track status and next steps.
@@ -120,7 +120,7 @@ modification in this transaction was a tracked in-chunk edge append, the page is
   overhead on a single-threaded 200k-edge insert: **+39 bytes/edge** vs
   feature-off (~0.7% on top of the ~5.3 KB/edge that edge creation already
   allocates), throughput within noise. This makes always-on cheap; the flag is
-  kept for 26.8.1 purely as an operational kill-switch for new commit-path code.
+  kept purely as an operational kill-switch for new commit-path code.
 
 ### Touched files
 

--- a/docs/supernode.md
+++ b/docs/supernode.md
@@ -1,0 +1,251 @@
+# Super-node write contention
+
+Living design + development log for improving ArcadeDB's behaviour when many
+transactions concurrently write edges into the **same hot vertex** (a
+"super-node": a treasury/float account, a popular product, a hub in a
+star schema). Target release: **26.8.1**.
+
+Keep this document updated as the work progresses (design decisions, benchmarks,
+follow-ups). Sections at the bottom track status and next steps.
+
+---
+
+## 1. Problem
+
+In a graph with a power-law degree distribution a handful of vertices accumulate
+a huge fraction of the edges. Every edge pointing at such a hub is prepended to
+the hub's edge-list **head chunk** - a single record on a single page. Under
+ArcadeDB's **page-level MVCC**, two transactions that append to that head chunk
+concurrently collide: one commits, the other gets a
+`ConcurrentModificationException` and retries the **whole transaction**.
+
+Symptoms (reported from the field, payments workload, 3-node HA cluster):
+
+- Leader-side processing time jumping from ~20-40 ms to **over a minute**,
+  breaching a 1-minute application timeout.
+- Followers healthy; the pathology is on the leader, where each retry re-runs the
+  **entire Raft replication round**, so retries pile up into a latency cascade.
+
+The contention scales with data growth: as the hub's edge list grows and hot
+accounts get hotter, the collision probability per operation rises, so a workload
+that was fine yesterday degrades today with no code change.
+
+### Where it lives in the engine
+
+- `EdgeLinkedList.add()` - prepends to `lastSegment` (the head chunk). O(1), but
+  every concurrent appender hits the **same page**.
+- MVCC conflict detection is **page-level** (`TransactionManager` /
+  `TransactionContext.commit1stPhase` compare `currentPageVersion` vs
+  `page.getVersion()`), so two appends to the same head-chunk page conflict even
+  though they are logically independent.
+- `ConcurrentModificationException extends NeedRetryException`, so
+  `LocalDatabase.transaction(...)` retries the whole block.
+
+---
+
+## 2. Two independent levers
+
+Contention on a super-node has two distinct costs, and they need two distinct
+fixes:
+
+1. **Wasted work / latency tail** - the retry storm. Each conflict throws away a
+   whole transaction (and under HA a whole replication round) and redoes it.
+   → Fixed by the **commutative edge-append merge** (this release).
+2. **Throughput ceiling** - even with zero retries, a single hot chunk is a
+   one-at-a-time version chain: every append must build on the latest committed
+   version of that one page, so hub commits serialise.
+   → Needs a **structural fix**: striped/sharded edge lists (follow-up).
+
+The benchmarks in §6 quantify both: the merge collapses the retry storm and the
+66-second latency tail, but raw super-node throughput stays ~45% below a
+non-contended workload until the edge list itself is sharded.
+
+---
+
+## 3. Delivered: commutative edge-append merge
+
+### Idea
+
+Appends to an edge-list chunk **commute** - the order of two edges in a vertex's
+edge list carries no semantics. So a commit-time page-version conflict whose
+**only** cause is concurrent in-chunk appends can be resolved by **replaying this
+transaction's appends on top of the newer committed page**, instead of failing
+the whole transaction. This is the edge-list analogue of a striped/`LongAdder`
+merge, applied at commit time.
+
+### Config
+
+`arcadedb.graph.edgeAppendMerge` (`GlobalConfiguration.GRAPH_EDGE_APPEND_MERGE`,
+`SCOPE.DATABASE`, default **true**).
+
+### How it works
+
+At `TransactionContext.commit1stPhase` (leader / embedded only), the page-version
+check loop is wrapped: when `checkPageVersion` fails for a page whose every
+modification in this transaction was a tracked in-chunk edge append, the page is
+**rebased** instead of aborting:
+
+1. Evict the stale page copy so the reload observes the current committed version.
+2. Reload the chunk fresh from the bucket (bypassing the tx record cache, which
+   still holds the stale, already-appended instance).
+3. Re-apply this transaction's appends via `MutableEdgeSegment.add(...)`; if a
+   chunk filled up in the meantime, fall back to a normal full retry.
+4. Write the merged chunk back (`updateRecordNoLock`), re-check the version, and
+   continue the commit. The merged page is what gets written to the WAL and
+   replicated - so followers apply the merged bytes verbatim.
+
+### Correctness guards
+
+- **Leader / embedded only** (`commit1stPhase(isLeader)`). Followers apply the
+  leader's already-merged WAL verbatim; they never rebase, so no HA divergence.
+  The leader merges, then replicates the merged result.
+- **Only pure-append pages are eligible.** Any non-commutative write **poisons**
+  the page (excludes it): edge removal / relink (`EdgeLinkedList.updateSegment`),
+  bulk `addAll`, and - crucially - **new-chunk allocation**. A brand-new chunk's
+  page has no committed version containing that chunk, so rebasing it would target
+  the wrong bytes; new-chunk poison is centralised in
+  `LocalDatabase.createRecordNoLock` for any `MutableEdgeSegment`, covering
+  `GraphEngine.createInEdgeChunk`/`createOutEdgeChunk` and the
+  `EdgeLinkedList.add` chunk-full branch in one place.
+- Tracking is lazy (only allocated when the feature is on and an append happens)
+  and cleared on `reset()`/`kill()`.
+
+### Touched files
+
+| File | Change |
+|---|---|
+| `GlobalConfiguration` | `GRAPH_EDGE_APPEND_MERGE` flag |
+| `TransactionContext` | append tracking + poison + `rebaseEdgeAppends` + commit-loop hook |
+| `LocalDatabase` | central new-chunk poison in `createRecordNoLock` |
+| `EdgeLinkedList` | register in-place appends; poison remove/bulk paths |
+| `PageManager` | `edgeAppendMerges` stat |
+
+---
+
+## 4. Deferred: striped / sharded edge list (throughput)
+
+To let concurrent appends to one hub run in parallel, a hub's edge list must span
+**multiple pages/files** so writers don't all serialise on one head-chunk page.
+ArcadeDB already keys edge buckets per vertex bucket (`getEdgesBucketName`), so
+the files exist; the change is to let a *single hot vertex* keep a head chunk in
+several of them and hash appends across the stripes.
+
+Design guidance (from the initial review):
+
+- **Adaptive, not blanket.** Degree is power-law: the vast majority of vertices
+  have a handful of edges. Striping every vertex bloats the vertex header
+  (2 → 2N pointers), scatters tiny chunks, and regresses the hottest read path
+  (`out()`/`in()`/degree/`isConnectedTo` open N stripe iterators). Instead,
+  **promote a vertex to a striped representation only when it crosses a degree
+  threshold** (ConcurrentHashMap-treeify style) via a small "stripe directory"
+  record; small vertices and old databases keep the current single-list format
+  unchanged.
+- **Per-bucket granularity** because MVCC conflicts are page-level: stripe across
+  distinct files/pages so appends never false-share.
+- **Deterministic hash by edge RID** so delete/lookup goes straight to the owning
+  stripe.
+- Read order changes (per-stripe order, merged) - confirm nothing guarantees edge
+  iteration order and doc the change.
+- Composes with the merge: merge kills the retry storm today; striping unlocks
+  throughput.
+
+---
+
+## 5. Related pre-existing bug (separate)
+
+**Issue #5147** - concurrent edge insertion into one super-node can **drop edges**
+and occasionally orphan an edge-list chunk (`inEdgesHeadChunk not found` SEVERE at
+`GraphEngine.createInEdgeChunk`). It reproduces with the append-merge **disabled**,
+so it is pre-existing and independent; the merge actually *mitigates* it (fewer
+retries = smaller race window). Hypothesis: the concurrent chunk-full transition
+(new chunk + `previous` relink + vertex head-pointer update in
+`EdgeLinkedList.add`) is not serialised as one MVCC unit. Needs its own fix. The
+benchmarks below tolerate this with lenient assertions; the merge's own
+correctness is gated by the deterministic `ConcurrentEdgeAppendMergeTest`.
+
+---
+
+## 6. Benchmarks
+
+All numbers: 8 threads, tiny `txRetryDelay`, macOS dev box. Reproduce:
+
+```
+# Embedded (engine):
+mvn -pl engine test -Dtest=SuperNodeConcurrentAppendBenchmark -DexcludedGroups=
+mvn -pl engine test -Dtest=SuperNodeConcurrentAppendBenchmark -DexcludedGroups= -Darcadedb.graph.edgeAppendMerge=false
+
+# 3-node HA (ha-raft):
+mvn -pl ha-raft test -Dtest=SuperNodeConcurrentAppendHABenchmark -DexcludedGroups=
+mvn -pl ha-raft test -Dtest=SuperNodeConcurrentAppendHABenchmark -DexcludedGroups= -DedgeAppendMerge=false
+mvn -pl ha-raft test -Dtest=SuperNodeConcurrentAppendHABenchmark -DexcludedGroups= -DsuperNode=false   # control
+```
+
+### Embedded, 32,000 edges into one hub
+
+| | full-tx retries | append merges | throughput |
+|---|---|---|---|
+| append-merge OFF | 11,298 (35.3%) | 0 | 9,898 edges/s |
+| append-merge ON | **226 (0.7%)** | 31,446 | 11,038 edges/s |
+
+Full-transaction retries collapse ~50×.
+
+### 3-node HA (Raft), 4,000 edges into one hub
+
+| Workload (ON unless noted) | throughput | full-tx retries | max commit latency | leader merges |
+|---|---|---|---|---|
+| Super-node | 52 edges/s | 135 (3.4%) | **408 ms** | 3,978 |
+| Super-node, **OFF** | 52 edges/s | 14,002 (350%) | **66,697 ms** | 0 |
+| Control (distinct targets) | **94 edges/s** | 2,950 (74%) | 489 ms | 0 |
+
+Reading the HA numbers:
+
+- **Latency tail:** OFF's worst commit takes **66.7 s** (a single edge insertion
+  breaching a 1-minute timeout - exactly the field symptom). ON's worst is
+  **408 ms**. This is the headline win.
+- **Cluster load:** OFF pushed **18,002** attempts through the leader for 4,000
+  successful commits; ON pushed **4,135**. Same 4,000 replicated, but **4.3× less**
+  leader CPU / network / fsync.
+- **Throughput is unchanged by the merge (52 → 52)** because a single hot chunk is
+  a serialised version chain: each append rebases onto the latest version, so hub
+  commits advance one at a time regardless of retries. The distinct-target
+  **control hits 94 edges/s** on the same cluster, proving 52/s is a
+  *super-node* ceiling, not an HA-replication ceiling. Closing that gap needs the
+  striped edge list (§4).
+
+### Verification
+
+- `ConcurrentEdgeAppendMergeTest` (engine): correctness gate, deterministically
+  clean at 32k concurrent edges (`check database` clean, no lost/duplicated).
+- No regressions: MVCCTest, ConcurrentWriteTest, BasicGraphTest,
+  DanglingEdgeIteratorTest, ACIDTransactionTest, Issue4940/4959,
+  LocalTransactionCommitLockRetryTest.
+
+---
+
+## 7. Status
+
+| Item | Status |
+|---|---|
+| Commutative edge-append merge (engine) | ✅ implemented, tested, benchmarked |
+| Embedded + HA benchmarks | ✅ in `@Tag("benchmark")` tests |
+| Issue #5147 (chunk-allocation race) | 🐞 filed, not started |
+| Adaptive striped edge list (throughput) | ⏳ designed, not started |
+
+## 8. Next steps
+
+1. Prototype the **adaptive striped edge list** (promote-on-hot, per-bucket
+   stripes, hash by edge RID) and re-run the HA benchmark to measure the
+   throughput half.
+2. Fix **#5147** (serialise the concurrent chunk-full transition; replace the
+   silent "chunk not found → create new" fallback with fail-loud/retry).
+3. Consider group-committing multiple pending hub appends into one replicated
+   round (reduces the per-commit HA cost further).
+
+## 9. Changelog
+
+- **2026-07-08** - Root-caused the field issue (contention retries, not GC/
+  compaction). Implemented the commutative edge-append merge behind
+  `arcadedb.graph.edgeAppendMerge` (default on). Added embedded + 3-node HA
+  benchmarks. Filed #5147 for the separate chunk-allocation race. Established via
+  the HA control run that the remaining throughput ceiling is the single hot
+  chunk, motivating the striped-edge-list follow-up.

--- a/docs/supernode.md
+++ b/docs/supernode.md
@@ -109,6 +109,18 @@ modification in this transaction was a tracked in-chunk edge append, the page is
   `EdgeLinkedList.add` chunk-full branch in one place.
 - Tracking is lazy (only allocated when the feature is on and an append happens)
   and cleared on `reset()`/`kill()`.
+- **Allocation-free hot path.** Appends are keyed by *segment* RID (a super-node
+  is one segment however many edges it receives) with the (edge, vertex) pairs
+  packed into growable primitive arrays (`EdgeAppendBuffer`), not one object per
+  edge. Poisoned pages are held in a `LongHashSet` of packed `(fileId,
+  pageNumber)` keys, so poisoning and the per-append skip check allocate nothing
+  (no `PageId` objects); `PageId`s are materialised only on the rare commit
+  conflict. A just-created chunk (e.g. a new source vertex's edge list) poisons
+  its own page, so its appends are skipped and never cost a buffer. Measured
+  overhead on a single-threaded 200k-edge insert: **+39 bytes/edge** vs
+  feature-off (~0.7% on top of the ~5.3 KB/edge that edge creation already
+  allocates), throughput within noise. This makes always-on cheap; the flag is
+  kept for 26.8.1 purely as an operational kill-switch for new commit-path code.
 
 ### Touched files
 
@@ -249,3 +261,8 @@ Reading the HA numbers:
   benchmarks. Filed #5147 for the separate chunk-allocation race. Established via
   the HA control run that the remaining throughput ceiling is the single hot
   chunk, motivating the striped-edge-list follow-up.
+- **2026-07-08** - Allocation-free rework of the append tracking (segment-keyed,
+  primitive `EdgeAppendBuffer`, `LongHashSet` poison keyed by packed page id,
+  lazy `PageId`). Per-append overhead dropped from ~+504 to **+39 bytes/edge**;
+  merge behaviour and correctness unchanged. Added the single-threaded overhead
+  micro-benchmark.

--- a/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
+++ b/engine/src/main/java/com/arcadedb/GlobalConfiguration.java
@@ -395,6 +395,10 @@ public enum GlobalConfiguration {
       "Maximum amount of milliseconds to compute a random number to wait for the next retry. This setting is helpful in case of high concurrency on the same pages (multi-thread insertion over the same bucket)",
       Integer.class, 100),
 
+  GRAPH_EDGE_APPEND_MERGE("arcadedb.graph.edgeAppendMerge", SCOPE.DATABASE,
+      "At commit, when the only conflict on an edge-list page is concurrent in-chunk edge appends (which commute), re-apply the appends on top of the newer page version instead of failing the whole transaction with a ConcurrentModificationException. Removes the retry storm on super-node (hot vertex) edge insertion",
+      Boolean.class, true),
+
   BACKUP_ENABLED("arcadedb.backup.enabled", SCOPE.DATABASE,
       "Allow a database to be backup. Disabling backup gives a huge boost in performance because no lock will be used for every operations",
       Boolean.class, true),

--- a/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/LocalDatabase.java
@@ -53,6 +53,7 @@ import com.arcadedb.graph.Edge;
 import com.arcadedb.graph.GraphBatch;
 import com.arcadedb.graph.GraphEngine;
 import com.arcadedb.graph.GraphTraversalProviderRegistry;
+import com.arcadedb.graph.MutableEdgeSegment;
 import com.arcadedb.graph.MutableVertex;
 import com.arcadedb.graph.Vertex;
 import com.arcadedb.graph.VertexInternal;
@@ -1017,6 +1018,12 @@ public class LocalDatabase extends RWLockContext implements DatabaseInternal {
       final TransactionContext transaction = getTransaction();
       transaction.updateRecordInCache(record);
       transaction.updateBucketRecordDelta(bucket.getFileId(), +1);
+
+      // A brand-new edge chunk cannot be edge-append rebased: the committed version of its page does not contain
+      // this chunk yet, so replaying appends against it would target the wrong bytes. Exclude the whole page
+      // (it may be shared with a pre-existing chunk) from the commutative append merge. See TransactionContext.
+      if (record instanceof MutableEdgeSegment)
+        transaction.poisonEdgeAppendPage(record.getIdentity());
 
       // TRACK USER DOCUMENTS (NOT INTERNAL RECORDS LIKE EDGE SEGMENTS) SO A ROLLBACK CAN RESET THEIR IDENTITY AND ALLOW
       // A CLEAN RE-INSERT INSTEAD OF AN UPDATE OF A MISSING RECORD (ISSUE #4562).

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -34,6 +34,7 @@ import com.arcadedb.exception.DuplicatedKeyException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.SchemaException;
 import com.arcadedb.exception.TransactionException;
+import com.arcadedb.graph.MutableEdgeSegment;
 import com.arcadedb.index.IndexInternal;
 import com.arcadedb.index.lsm.LSMTreeIndexAbstract;
 import com.arcadedb.log.LogManager;
@@ -81,6 +82,16 @@ public class TransactionContext implements Transaction {
   private final RidHashSet                            deletedRecordsInTx    = new RidHashSet();
   private       Map<PageId, MutablePage>             modifiedPages;
   private       Map<PageId, MutablePage>             newPages;
+  // GRAPH_EDGE_APPEND_MERGE (super-node write contention): appends to an edge-list chunk commute, so a
+  // commit-time page-version conflict whose ONLY cause is concurrent in-chunk edge appends can be resolved by
+  // re-applying THIS transaction's appends on top of the newer committed page, instead of failing the whole
+  // transaction with a ConcurrentModificationException and retrying. Both maps are lazily allocated only when
+  // the feature is on and an append actually happens. A page stays eligible only while EVERY modification this
+  // transaction made to it is a tracked append; the first non-append write to it (edge removal, new-chunk
+  // allocation, bulk addAll) poisons it so it can never be rebased.
+  private       Map<PageId, List<EdgeAppend>>        edgeAppendsByPage;
+  private       Set<PageId>                          edgeAppendPoisonedPages;
+  private       boolean                              edgeAppendMerge;
   private       boolean                              useWAL;
   // #5064: set by the HA layer AFTER the replication quorum durably committed this transaction and BEFORE
   // the local phase-2 apply. Shifts the durability boundary for the failure regimes in commit2ndPhase's
@@ -155,6 +166,10 @@ public class TransactionContext implements Transaction {
       throw new TransactionException("Transaction already begun");
 
     status = STATUS.BEGUN;
+
+    // Read once per transaction (DATABASE-scope, constant for the DB lifetime): keeps the per-append hot path
+    // to a plain field read instead of a configuration lookup.
+    edgeAppendMerge = database.getConfiguration().getValueAsBoolean(GlobalConfiguration.GRAPH_EDGE_APPEND_MERGE);
 
     // Optimized: initial capacity 32 for typical transaction page count
     modifiedPages = new HashMap<>(32);
@@ -524,6 +539,119 @@ public class TransactionContext implements Transaction {
     return newPageCounters.get(indexFileId);
   }
 
+  /**
+   * A single in-chunk edge append that can be replayed on a newer version of its edge-segment page. See
+   * {@link #edgeAppendsByPage}.
+   */
+  private record EdgeAppend(RID segment, RID edge, RID vertex) {
+  }
+
+  /**
+   * Tells whether the commutative edge-append merge is enabled for this transaction.
+   */
+  public boolean isEdgeAppendMergeEnabled() {
+    return edgeAppendMerge;
+  }
+
+  /**
+   * Records an in-place edge append (from {@link com.arcadedb.graph.EdgeLinkedList#add}) as rebasable: if the
+   * segment's page loses the commit-time version check because another transaction appended to the same head
+   * chunk, the append can be replayed on top of the newer page instead of failing the whole transaction. No-op
+   * when the feature is off or the page was already poisoned by a non-append modification.
+   */
+  public void trackEdgeAppend(final RID segmentRID, final RID edgeRID, final RID vertexRID) {
+    if (!edgeAppendMerge)
+      return;
+
+    final PageId pageId = edgeSegmentPageId(segmentRID);
+    if (edgeAppendPoisonedPages != null && edgeAppendPoisonedPages.contains(pageId))
+      return;
+
+    if (edgeAppendsByPage == null)
+      edgeAppendsByPage = new HashMap<>();
+
+    edgeAppendsByPage.computeIfAbsent(pageId, k -> new ArrayList<>(8)).add(new EdgeAppend(segmentRID, edgeRID, vertexRID));
+  }
+
+  /**
+   * Marks the edge-segment page holding {@code segmentRID} as NOT rebasable: this transaction changed it in a
+   * way that does not commute with a concurrent append (edge removal, new-chunk allocation, bulk load). Any
+   * appends previously tracked for that page are dropped so it can never be silently re-derived from
+   * committed-state + appends. No-op when the feature is off.
+   */
+  public void poisonEdgeAppendPage(final RID segmentRID) {
+    if (!edgeAppendMerge)
+      return;
+
+    final PageId pageId = edgeSegmentPageId(segmentRID);
+    if (edgeAppendPoisonedPages == null)
+      edgeAppendPoisonedPages = new HashSet<>();
+    edgeAppendPoisonedPages.add(pageId);
+
+    if (edgeAppendsByPage != null)
+      edgeAppendsByPage.remove(pageId);
+  }
+
+  private PageId edgeSegmentPageId(final RID segmentRID) {
+    final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(segmentRID.getBucketId());
+    final int pageNumber = (int) (segmentRID.getPosition() / bucket.getMaxRecordsInPage());
+    return new PageId(database, segmentRID.getBucketId(), pageNumber);
+  }
+
+  private boolean isRebasableEdgeAppendPage(final PageId pageId) {
+    return edgeAppendMerge //
+        && edgeAppendsByPage != null && edgeAppendsByPage.containsKey(pageId) //
+        && (edgeAppendPoisonedPages == null || !edgeAppendPoisonedPages.contains(pageId));
+  }
+
+  /**
+   * Replays this transaction's tracked in-chunk appends for {@code pageId} on top of the current committed
+   * version of that page, resolving a version conflict that was caused solely by concurrent appends to the
+   * same edge-list chunk(s). Runs only on the leader/embedded commit, while the edge file's commit lock is
+   * held (so the current version is stable), and only for pages whose every modification was a tracked append.
+   *
+   * @return the freshly rebased page, ready to be version-checked and committed.
+   *
+   * @throws ConcurrentModificationException if a targeted chunk filled up in the meantime (a pure in-chunk
+   *                                         rebase is no longer possible): the caller falls back to a normal
+   *                                         full-transaction retry.
+   */
+  private MutablePage rebaseEdgeAppends(final PageId pageId) throws IOException {
+    // Drop the stale copies so the reload observes the current committed version of the page.
+    modifiedPages.remove(pageId);
+    immutablePages.remove(pageId);
+
+    // Group the appends by segment: one reload + one write-back per chunk, even with several appends.
+    final Map<RID, List<EdgeAppend>> bySegment = new LinkedHashMap<>();
+    for (final EdgeAppend a : edgeAppendsByPage.get(pageId))
+      bySegment.computeIfAbsent(a.segment(), k -> new ArrayList<>(8)).add(a);
+
+    for (final Map.Entry<RID, List<EdgeAppend>> entry : bySegment.entrySet()) {
+      final RID segmentRID = entry.getKey();
+      final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(segmentRID.getBucketId());
+
+      // Load the chunk fresh from the (now current) page, bypassing the tx record cache which still holds the
+      // stale, already-appended instance.
+      final MutableEdgeSegment segment = new MutableEdgeSegment(database, segmentRID,
+          bucket.getRecord(segmentRID).copyOfContent());
+
+      for (final EdgeAppend a : entry.getValue())
+        if (!segment.add(a.edge(), a.vertex()))
+          throw new ConcurrentModificationException(
+              "Edge-append rebase not possible: chunk " + segmentRID + " filled up concurrently. Please retry the operation");
+
+      // Immediate synchronous page write: updatedRecords was already drained earlier in commit1stPhase, so the
+      // deferred updateRecord path would never be flushed.
+      database.updateRecordNoLock(segment, false);
+    }
+
+    final MutablePage rebased = modifiedPages.get(pageId);
+    if (rebased == null)
+      throw new ConcurrentModificationException("Edge-append rebase produced no page for " + pageId + ". Please retry the operation");
+    database.getPageManager().incrementEdgeAppendMerges();
+    return rebased;
+  }
+
   @Override
   public boolean isActive() {
     return status != STATUS.INACTIVE;
@@ -582,6 +710,8 @@ public class TransactionContext implements Transaction {
     }
     modifiedPages = null;
     newPages = null;
+    edgeAppendsByPage = null;
+    edgeAppendPoisonedPages = null;
     updatedRecords = null;
     updatedRecordsIndexSnapshot = null;
     newPageCounters.clear();
@@ -860,17 +990,45 @@ public class TransactionContext implements Transaction {
           bucket.compressPage(page, false);
       }
 
+      List<PageId> pagesToRebase = null;
       for (final Iterator<MutablePage> it = modifiedPages.values().iterator(); it.hasNext(); ) {
         final MutablePage p = it.next();
 
         final int[] range = p.getModifiedRange();
-        if (range[1] > 0) {
-          pageManager.checkPageVersion(p, false);
-          pages.add(p);
-        } else
+        if (range[1] <= 0) {
           // PAGE NOT MODIFIED, REMOVE IT
           it.remove();
+          continue;
+        }
+
+        try {
+          pageManager.checkPageVersion(p, false);
+          pages.add(p);
+        } catch (final ConcurrentModificationException e) {
+          // Commutative edge-append merge: when the ONLY change this (leader/embedded) transaction made to the
+          // conflicting page was appending edges to their chunk(s), the appends can be replayed on the newer
+          // committed version instead of failing the whole transaction. The edge file's commit lock is held
+          // here, so the current version stays stable across the rebase performed after the loop (rebasing here
+          // would structurally modify modifiedPages while iterating it).
+          if (isLeader && isRebasableEdgeAppendPage(p.getPageId())) {
+            if (pagesToRebase == null)
+              pagesToRebase = new ArrayList<>();
+            pagesToRebase.add(p.getPageId());
+            it.remove();
+          } else
+            throw e;
+        }
       }
+
+      if (pagesToRebase != null)
+        for (final PageId pageId : pagesToRebase) {
+          final MutablePage rebased = rebaseEdgeAppends(pageId);
+          final LocalBucket bucket = localSchema.getBucketById(rebased.getPageId().getFileId(), false);
+          if (bucket != null)
+            bucket.compressPage(rebased, false);
+          pageManager.checkPageVersion(rebased, false);
+          pages.add(rebased);
+        }
 
       if (newPages != null)
         for (final MutablePage p : newPages.values()) {
@@ -1100,6 +1258,8 @@ public class TransactionContext implements Transaction {
 
     modifiedPages = null;
     newPages = null;
+    edgeAppendsByPage = null;
+    edgeAppendPoisonedPages = null;
     updatedRecords = null;
     updatedRecordsIndexSnapshot = null;
     newPageCounters.clear();

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -41,6 +41,7 @@ import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.LocalSchema;
 import com.arcadedb.utility.IntHashSet;
 import com.arcadedb.utility.IntIntHashMap;
+import com.arcadedb.utility.LongHashSet;
 import com.arcadedb.utility.RidHashSet;
 
 import java.io.IOException;
@@ -85,12 +86,15 @@ public class TransactionContext implements Transaction {
   // GRAPH_EDGE_APPEND_MERGE (super-node write contention): appends to an edge-list chunk commute, so a
   // commit-time page-version conflict whose ONLY cause is concurrent in-chunk edge appends can be resolved by
   // re-applying THIS transaction's appends on top of the newer committed page, instead of failing the whole
-  // transaction with a ConcurrentModificationException and retrying. Both maps are lazily allocated only when
-  // the feature is on and an append actually happens. A page stays eligible only while EVERY modification this
-  // transaction made to it is a tracked append; the first non-append write to it (edge removal, new-chunk
-  // allocation, bulk addAll) poisons it so it can never be rebased.
-  private       Map<PageId, List<EdgeAppend>>        edgeAppendsByPage;
-  private       Set<PageId>                          edgeAppendPoisonedPages;
+  // transaction with a ConcurrentModificationException and retrying. Tracked per SEGMENT rid with the appended
+  // pairs packed into primitive arrays (see EdgeAppendBuffer) so the append hot path allocates nothing per
+  // edge; segment page ids are resolved lazily only on the rare commit conflict. A page stays eligible only
+  // while EVERY modification this transaction made to it is a tracked append; the first non-append write to it
+  // (edge removal, new-chunk allocation, bulk addAll) poisons its page so it can never be rebased.
+  private       Map<RID, EdgeAppendBuffer>           edgeAppendsBySegment;
+  // Poisoned edge-list pages, keyed by a packed (fileId, pageNumber) long so poisoning and the hot-path skip
+  // check allocate nothing (no PageId objects).
+  private       LongHashSet                          edgeAppendPoisonedPages;
   private       boolean                              edgeAppendMerge;
   private       boolean                              useWAL;
   // #5064: set by the HA layer AFTER the replication quorum durably committed this transaction and BEFORE
@@ -540,10 +544,33 @@ public class TransactionContext implements Transaction {
   }
 
   /**
-   * A single in-chunk edge append that can be replayed on a newer version of its edge-segment page. See
-   * {@link #edgeAppendsByPage}.
+   * Allocation-light store of the in-chunk appends made to ONE edge segment in this transaction: the (edge,
+   * vertex) RID pairs are packed into growable primitive arrays instead of one object per appended edge, so a
+   * hot vertex receiving thousands of edges costs a handful of array growths, not thousands of allocations.
+   * The RID objects are rebuilt only at rebase time (on the rare commit conflict). See {@link
+   * #edgeAppendsBySegment}.
    */
-  private record EdgeAppend(RID segment, RID edge, RID vertex) {
+  private static final class EdgeAppendBuffer {
+    private int[]  edgeBucket   = new int[8];
+    private long[] edgePosition = new long[8];
+    private int[]  vertexBucket = new int[8];
+    private long[] vertexPosition = new long[8];
+    private int    size;
+
+    void add(final RID edge, final RID vertex) {
+      if (size == edgeBucket.length) {
+        final int n = size << 1;
+        edgeBucket = Arrays.copyOf(edgeBucket, n);
+        edgePosition = Arrays.copyOf(edgePosition, n);
+        vertexBucket = Arrays.copyOf(vertexBucket, n);
+        vertexPosition = Arrays.copyOf(vertexPosition, n);
+      }
+      edgeBucket[size] = edge.getBucketId();
+      edgePosition[size] = edge.getPosition();
+      vertexBucket[size] = vertex.getBucketId();
+      vertexPosition[size] = vertex.getPosition();
+      ++size;
+    }
   }
 
   /**
@@ -556,52 +583,70 @@ public class TransactionContext implements Transaction {
   /**
    * Records an in-place edge append (from {@link com.arcadedb.graph.EdgeLinkedList#add}) as rebasable: if the
    * segment's page loses the commit-time version check because another transaction appended to the same head
-   * chunk, the append can be replayed on top of the newer page instead of failing the whole transaction. No-op
-   * when the feature is off or the page was already poisoned by a non-append modification.
+   * chunk, the append can be replayed on top of the newer page instead of failing the whole transaction.
+   * <p>
+   * Hot path: keyed by SEGMENT rid (a super-node is one segment no matter how many edges land on it), the pair
+   * is packed into primitive arrays, and the segment's {@link PageId} is NOT computed here - it is resolved
+   * lazily only when a page actually conflicts at commit (rare). So the common no-contention append costs a
+   * map lookup on an existing key, nothing allocated per edge. No-op when the feature is off.
    */
   public void trackEdgeAppend(final RID segmentRID, final RID edgeRID, final RID vertexRID) {
     if (!edgeAppendMerge)
       return;
 
-    final PageId pageId = edgeSegmentPageId(segmentRID);
-    if (edgeAppendPoisonedPages != null && edgeAppendPoisonedPages.contains(pageId))
+    // Skip pages already poisoned (a brand-new chunk - e.g. a just-created source vertex's edge list - poisons
+    // its own page at createRecord). Those can never be rebased, so tracking them would only waste a buffer.
+    // The page key is packed arithmetic, no allocation.
+    if (edgeAppendPoisonedPages != null && edgeAppendPoisonedPages.contains(edgeSegmentPageKey(segmentRID)))
       return;
 
-    if (edgeAppendsByPage == null)
-      edgeAppendsByPage = new HashMap<>();
+    if (edgeAppendsBySegment == null)
+      edgeAppendsBySegment = new HashMap<>();
 
-    edgeAppendsByPage.computeIfAbsent(pageId, k -> new ArrayList<>(8)).add(new EdgeAppend(segmentRID, edgeRID, vertexRID));
+    EdgeAppendBuffer buffer = edgeAppendsBySegment.get(segmentRID);
+    if (buffer == null)
+      edgeAppendsBySegment.put(segmentRID, buffer = new EdgeAppendBuffer());
+    buffer.add(edgeRID, vertexRID);
   }
 
   /**
    * Marks the edge-segment page holding {@code segmentRID} as NOT rebasable: this transaction changed it in a
-   * way that does not commute with a concurrent append (edge removal, new-chunk allocation, bulk load). Any
-   * appends previously tracked for that page are dropped so it can never be silently re-derived from
-   * committed-state + appends. No-op when the feature is off.
+   * way that does not commute with a concurrent append (edge removal, new-chunk allocation, bulk load). Tracked
+   * appends on that page are ignored at commit (the conflict check below excludes poisoned pages), so a rebase
+   * can never silently re-derive the page from committed-state + appends. No-op when the feature is off.
    */
   public void poisonEdgeAppendPage(final RID segmentRID) {
     if (!edgeAppendMerge)
       return;
 
-    final PageId pageId = edgeSegmentPageId(segmentRID);
     if (edgeAppendPoisonedPages == null)
-      edgeAppendPoisonedPages = new HashSet<>();
-    edgeAppendPoisonedPages.add(pageId);
-
-    if (edgeAppendsByPage != null)
-      edgeAppendsByPage.remove(pageId);
+      edgeAppendPoisonedPages = new LongHashSet();
+    edgeAppendPoisonedPages.add(edgeSegmentPageKey(segmentRID));
   }
 
-  private PageId edgeSegmentPageId(final RID segmentRID) {
+  /** Packs the (fileId, pageNumber) of the page holding {@code segmentRID} into a long key (no allocation). */
+  private long edgeSegmentPageKey(final RID segmentRID) {
     final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(segmentRID.getBucketId());
     final int pageNumber = (int) (segmentRID.getPosition() / bucket.getMaxRecordsInPage());
-    return new PageId(database, segmentRID.getBucketId(), pageNumber);
+    return packPageKey(segmentRID.getBucketId(), pageNumber);
+  }
+
+  private static long packPageKey(final int fileId, final int pageNumber) {
+    return ((long) fileId << 32) | (pageNumber & 0xFFFFFFFFL);
   }
 
   private boolean isRebasableEdgeAppendPage(final PageId pageId) {
-    return edgeAppendMerge //
-        && edgeAppendsByPage != null && edgeAppendsByPage.containsKey(pageId) //
-        && (edgeAppendPoisonedPages == null || !edgeAppendPoisonedPages.contains(pageId));
+    if (!edgeAppendMerge || edgeAppendsBySegment == null)
+      return false;
+    final long key = packPageKey(pageId.getFileId(), pageId.getPageNumber());
+    if (edgeAppendPoisonedPages != null && edgeAppendPoisonedPages.contains(key))
+      return false;
+    // Is at least one tracked segment on this (conflicting) page? Computing the segment page keys here, on the
+    // rare conflict path, is what keeps the append hot path free of allocation.
+    for (final RID segmentRID : edgeAppendsBySegment.keySet())
+      if (edgeSegmentPageKey(segmentRID) == key)
+        return true;
+    return false;
   }
 
   /**
@@ -621,13 +666,14 @@ public class TransactionContext implements Transaction {
     modifiedPages.remove(pageId);
     immutablePages.remove(pageId);
 
-    // Group the appends by segment: one reload + one write-back per chunk, even with several appends.
-    final Map<RID, List<EdgeAppend>> bySegment = new LinkedHashMap<>();
-    for (final EdgeAppend a : edgeAppendsByPage.get(pageId))
-      bySegment.computeIfAbsent(a.segment(), k -> new ArrayList<>(8)).add(a);
+    final long pageKey = packPageKey(pageId.getFileId(), pageId.getPageNumber());
 
-    for (final Map.Entry<RID, List<EdgeAppend>> entry : bySegment.entrySet()) {
+    // Re-apply every tracked segment that lives on this page (usually one: the hot vertex's head chunk).
+    for (final Map.Entry<RID, EdgeAppendBuffer> entry : edgeAppendsBySegment.entrySet()) {
       final RID segmentRID = entry.getKey();
+      if (edgeSegmentPageKey(segmentRID) != pageKey)
+        continue;
+
       final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(segmentRID.getBucketId());
 
       // Load the chunk fresh from the (now current) page, bypassing the tx record cache which still holds the
@@ -635,8 +681,10 @@ public class TransactionContext implements Transaction {
       final MutableEdgeSegment segment = new MutableEdgeSegment(database, segmentRID,
           bucket.getRecord(segmentRID).copyOfContent());
 
-      for (final EdgeAppend a : entry.getValue())
-        if (!segment.add(a.edge(), a.vertex()))
+      final EdgeAppendBuffer buffer = entry.getValue();
+      for (int i = 0; i < buffer.size; ++i)
+        if (!segment.add(new RID(buffer.edgeBucket[i], buffer.edgePosition[i]),
+            new RID(buffer.vertexBucket[i], buffer.vertexPosition[i])))
           throw new ConcurrentModificationException(
               "Edge-append rebase not possible: chunk " + segmentRID + " filled up concurrently. Please retry the operation");
 
@@ -710,7 +758,7 @@ public class TransactionContext implements Transaction {
     }
     modifiedPages = null;
     newPages = null;
-    edgeAppendsByPage = null;
+    edgeAppendsBySegment = null;
     edgeAppendPoisonedPages = null;
     updatedRecords = null;
     updatedRecordsIndexSnapshot = null;
@@ -1258,7 +1306,7 @@ public class TransactionContext implements Transaction {
 
     modifiedPages = null;
     newPages = null;
-    edgeAppendsByPage = null;
+    edgeAppendsBySegment = null;
     edgeAppendPoisonedPages = null;
     updatedRecords = null;
     updatedRecordsIndexSnapshot = null;

--- a/engine/src/main/java/com/arcadedb/database/TransactionContext.java
+++ b/engine/src/main/java/com/arcadedb/database/TransactionContext.java
@@ -627,6 +627,11 @@ public class TransactionContext implements Transaction {
   /** Packs the (fileId, pageNumber) of the page holding {@code segmentRID} into a long key (no allocation). */
   private long edgeSegmentPageKey(final RID segmentRID) {
     final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(segmentRID.getBucketId());
+    if (bucket == null)
+      // The edge bucket cannot vanish under the held commit lock; treat a missing one as a retryable conflict
+      // rather than NPE.
+      throw new ConcurrentModificationException("Edge-append: bucket " + segmentRID.getBucketId()
+          + " for segment " + segmentRID + " not found. Please retry the operation");
     final int pageNumber = (int) (segmentRID.getPosition() / bucket.getMaxRecordsInPage());
     return packPageKey(segmentRID.getBucketId(), pageNumber);
   }
@@ -677,9 +682,15 @@ public class TransactionContext implements Transaction {
       final LocalBucket bucket = (LocalBucket) database.getSchema().getBucketById(segmentRID.getBucketId());
 
       // Load the chunk fresh from the (now current) page, bypassing the tx record cache which still holds the
-      // stale, already-appended instance.
-      final MutableEdgeSegment segment = new MutableEdgeSegment(database, segmentRID,
-          bucket.getRecord(segmentRID).copyOfContent());
+      // stale, already-appended instance. A concurrently-vanished chunk (RecordNotFoundException) cannot happen
+      // under the held commit lock; if it ever did, fall back to a full retry rather than aborting the tx.
+      final MutableEdgeSegment segment;
+      try {
+        segment = new MutableEdgeSegment(database, segmentRID, bucket.getRecord(segmentRID).copyOfContent());
+      } catch (final RecordNotFoundException e) {
+        throw new ConcurrentModificationException(
+            "Edge-append rebase not possible: chunk " + segmentRID + " no longer exists. Please retry the operation");
+      }
 
       final EdgeAppendBuffer buffer = entry.getValue();
       for (int i = 0; i < buffer.size; ++i)

--- a/engine/src/main/java/com/arcadedb/engine/PageManager.java
+++ b/engine/src/main/java/com/arcadedb/engine/PageManager.java
@@ -62,6 +62,7 @@ public class PageManager extends LockContext {
   private final    AtomicLong                        cacheHits                             = new AtomicLong();
   private final    AtomicLong                        cacheMiss                             = new AtomicLong();
   private final    AtomicLong                        totalConcurrentModificationExceptions = new AtomicLong();
+  private final    AtomicLong                        totalEdgeAppendMerges                 = new AtomicLong();
   private final    AtomicLong                        evictionRuns                          = new AtomicLong();
   private final    AtomicLong                        pagesEvicted                          = new AtomicLong();
   private volatile long                              lastCheckForRAM                       = 0;
@@ -90,6 +91,7 @@ public class PageManager extends LockContext {
     public long cacheHits;
     public long cacheMiss;
     public long concurrentModificationExceptions;
+    public long edgeAppendMerges;
     public long evictionRuns;
     public long pagesEvicted;
     public int  readCachePages;
@@ -306,6 +308,14 @@ public class PageManager extends LockContext {
     return null;
   }
 
+  /**
+   * Counts a resolved commutative edge-append merge: a commit-time page conflict avoided by replaying appends
+   * on the newer version instead of failing the whole transaction. Surfaced via {@link #getStats()}.
+   */
+  public void incrementEdgeAppendMerges() {
+    totalEdgeAppendMerges.incrementAndGet();
+  }
+
   public void checkPageVersion(final MutablePage page, final boolean isNew) throws IOException {
     final PageId pageId = page.getPageId();
 
@@ -494,6 +504,7 @@ public class PageManager extends LockContext {
     stats.cacheHits = cacheHits.get();
     stats.cacheMiss = cacheMiss.get();
     stats.concurrentModificationExceptions = totalConcurrentModificationExceptions.get();
+    stats.edgeAppendMerges = totalEdgeAppendMerges.get();
     stats.evictionRuns = evictionRuns.get();
     stats.pagesEvicted = pagesEvicted.get();
     return stats;

--- a/engine/src/main/java/com/arcadedb/graph/EdgeLinkedList.java
+++ b/engine/src/main/java/com/arcadedb/graph/EdgeLinkedList.java
@@ -23,6 +23,7 @@ import com.arcadedb.database.Identifiable;
 import com.arcadedb.database.LocalDatabase;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
+import com.arcadedb.database.TransactionContext;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
@@ -179,17 +180,22 @@ public class EdgeLinkedList {
   }
 
   public void add(final RID edgeRID, final RID vertexRID) {
-    if (lastSegment.add(edgeRID, vertexRID))
-      ((DatabaseInternal) vertex.getDatabase()).updateRecord(lastSegment);
-    else {
+    final DatabaseInternal database = (DatabaseInternal) vertex.getDatabase();
+    if (lastSegment.add(edgeRID, vertexRID)) {
+      database.updateRecord(lastSegment);
+      // Record the in-chunk append as commutative: at commit, a page-version conflict on this chunk caused only
+      // by concurrent appends can be resolved by replaying the append instead of retrying the whole transaction.
+      final TransactionContext tx = database.getTransactionIfExists();
+      if (tx != null)
+        tx.trackEdgeAppend(lastSegment.getIdentity(), edgeRID, vertexRID);
+    } else {
       // CHUNK FULL, ALLOCATE A NEW ONE
-      final DatabaseInternal database = (DatabaseInternal) vertex.getDatabase();
-
       final MutableEdgeSegment newChunk = new MutableEdgeSegment(database, computeBestSize());
 
       newChunk.add(edgeRID, vertexRID);
       newChunk.setPrevious(lastSegment);
 
+      // createRecord poisons the new chunk's page for the append-merge (a new chunk cannot be rebased).
       database.createRecord(newChunk, database.getSchema().getBucketById(lastSegment.getIdentity().getBucketId()).getName());
 
       final MutableVertex modifiableV = vertex.modify();
@@ -243,8 +249,14 @@ public class EdgeLinkedList {
       }
     }
 
-    for (final Record r : recordsToUpdate)
+    // addAll batches its updateRecord calls and does not register individual appends: exclude every touched
+    // edge page from the append-merge so a concurrent-append rebase can never lose these edges.
+    final TransactionContext tx = database.getTransactionIfExists();
+    for (final Record r : recordsToUpdate) {
       database.updateRecord(r);
+      if (tx != null && r instanceof MutableEdgeSegment segment)
+        tx.poisonEdgeAppendPage(segment.getIdentity());
+    }
   }
 
   public void removeEdge(final Edge edge) {
@@ -309,13 +321,23 @@ public class EdgeLinkedList {
   }
 
   private void updateSegment(final EdgeSegment current, final EdgeSegment prevBrowsed) {
+    final DatabaseInternal database = (DatabaseInternal) vertex.getDatabase();
+    // Edge removal/relink does not commute with a concurrent append: exclude the touched pages from the merge.
+    final TransactionContext tx = database.getTransactionIfExists();
     if (prevBrowsed != null && current.isEmpty() && current.getPrevious() != null) {
       // SEGMENT EMPTY: DELETE ONLY IF IT IS NOT THE FIRST SEGMENT. DELETE CURRENT SEGMENT AND REATTACH THE LINKED LIST
       prevBrowsed.setPrevious(current.getPrevious());
-      ((DatabaseInternal) vertex.getDatabase()).updateRecord(prevBrowsed);
+      database.updateRecord(prevBrowsed);
+      if (tx != null) {
+        tx.poisonEdgeAppendPage(prevBrowsed.getIdentity());
+        tx.poisonEdgeAppendPage(current.getIdentity());
+      }
       current.delete();
-    } else
-      ((DatabaseInternal) vertex.getDatabase()).updateRecord(current);
+    } else {
+      database.updateRecord(current);
+      if (tx != null)
+        tx.poisonEdgeAppendPage(current.getIdentity());
+    }
   }
 
   public void deleteAll() {

--- a/engine/src/main/java/com/arcadedb/graph/EdgeLinkedList.java
+++ b/engine/src/main/java/com/arcadedb/graph/EdgeLinkedList.java
@@ -364,9 +364,15 @@ public class EdgeLinkedList {
   }
 
   public void deleteAll() {
+    final TransactionContext tx = ((DatabaseInternal) vertex.getDatabase()).getTransactionIfExists();
     EdgeSegment current = lastSegment;
     while (current != null) {
       final EdgeSegment prev = current.getPrevious();
+      // Deleting a chunk does not commute with a concurrent append on its page: exclude the page from the
+      // append-merge so a rebase can never re-derive it from committed-state + appends and lose the deletion
+      // (uniformly enforces the "every non-append edge-list write poisons its page" invariant).
+      if (tx != null)
+        tx.poisonEdgeAppendPage(current.getIdentity());
       current.delete();
       current = prev;
     }

--- a/engine/src/main/java/com/arcadedb/graph/EdgeLinkedList.java
+++ b/engine/src/main/java/com/arcadedb/graph/EdgeLinkedList.java
@@ -24,11 +24,14 @@ import com.arcadedb.database.LocalDatabase;
 import com.arcadedb.database.RID;
 import com.arcadedb.database.Record;
 import com.arcadedb.database.TransactionContext;
+import com.arcadedb.engine.LocalBucket;
+import com.arcadedb.exception.DatabaseOperationException;
 import com.arcadedb.schema.Schema;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.Pair;
 
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -261,7 +264,7 @@ public class EdgeLinkedList {
 
   public void removeEdge(final Edge edge) {
     EdgeSegment prevBrowsed = null;
-    EdgeSegment current = lastSegment;
+    EdgeSegment current = loadChunkForWrite(lastSegment.getIdentity());
     while (current != null) {
       final RID rid = edge.getIdentity();
 
@@ -279,13 +282,14 @@ public class EdgeLinkedList {
       }
 
       prevBrowsed = current;
-      current = current.getPrevious();
+      final RID prevRID = current.getPreviousRID();
+      current = prevRID == null ? null : loadChunkForWrite(prevRID);
     }
   }
 
   public void removeEdgeRID(final RID edge) {
     EdgeSegment prevBrowsed = null;
-    EdgeSegment current = lastSegment;
+    EdgeSegment current = loadChunkForWrite(lastSegment.getIdentity());
     while (current != null) {
       final int deleted = current.removeEdge(edge);
       if (deleted > 0) {
@@ -293,27 +297,46 @@ public class EdgeLinkedList {
         break;
       }
       prevBrowsed = current;
-      current = current.getPrevious();
+      final RID prevRID = current.getPreviousRID();
+      current = prevRID == null ? null : loadChunkForWrite(prevRID);
     }
   }
 
   public void removeVertex(final RID vertexRID) {
     EdgeSegment prevBrowsed = null;
-    EdgeSegment current = lastSegment;
+    EdgeSegment current = loadChunkForWrite(lastSegment.getIdentity());
     while (current != null) {
-      final EdgeSegment next = current.getPrevious();
+      final RID nextRID = current.getPreviousRID();
       boolean deleted = false;
       while (current.removeVertex(vertexRID) > 0)
         deleted = true;
       if (deleted) {
-        final boolean segmentWillBeDeleted = prevBrowsed != null && current.isEmpty() && next != null;
+        final boolean segmentWillBeDeleted = prevBrowsed != null && current.isEmpty() && nextRID != null;
         updateSegment(current, prevBrowsed);
         if (!segmentWillBeDeleted)
           prevBrowsed = current;
       } else
         prevBrowsed = current;
-      current = next;
+      current = nextRID == null ? null : loadChunkForWrite(nextRID);
     }
+  }
+
+  /**
+   * #5147/#5153: loads an edge-list chunk for a WRITE (remove/relink), anchoring its page in the transaction at
+   * the version it is read - and reading its content from that anchored page. Without the anchor the chunk is
+   * read via an immutable lookup that (under READ_COMMITTED) does not retain the page, and the deferred
+   * updateRecord captures the page only later, at the newer version if a concurrent transaction modified the
+   * same chunk in between. The commit-time MVCC check would then compare matching versions, miss the conflict,
+   * and let the stale chunk buffer silently overwrite the concurrent change (a lost update / dropped edge).
+   */
+  private EdgeSegment loadChunkForWrite(final RID chunkRID) {
+    final DatabaseInternal database = (DatabaseInternal) vertex.getDatabase();
+    try {
+      ((LocalBucket) database.getSchema().getBucketById(chunkRID.getBucketId())).fetchPageInTransaction(chunkRID);
+    } catch (final IOException e) {
+      throw new DatabaseOperationException("Error on loading edge chunk page " + chunkRID, e);
+    }
+    return (EdgeSegment) database.lookupByRID(chunkRID, true);
   }
 
   private int computeBestSize() {

--- a/engine/src/main/java/com/arcadedb/graph/EdgeSegment.java
+++ b/engine/src/main/java/com/arcadedb/graph/EdgeSegment.java
@@ -61,6 +61,9 @@ public interface EdgeSegment extends Record {
 
   EdgeSegment getPrevious();
 
+  /** Returns the RID of the previous chunk in the list without loading it, or {@code null} if this is the tail. */
+  RID getPreviousRID();
+
   void setPrevious(EdgeSegment next);
 
   Binary getContent();

--- a/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphBatch.java
@@ -1064,6 +1064,10 @@ public class GraphBatch implements AutoCloseable {
       final long vertexKey = packVertexKey(srcBucket, srcPos);
       final EdgeSegment outChunk = getOrCreateOutSegmentDeferred(srcBucket, srcPos, vertexKey, totalBytesNeeded);
 
+      // NOTE (edge-append merge): this bulk path intentionally neither tracks (trackEdgeAppend) nor poisons
+      // its chunk pages. That is safe only because a GraphBatch transaction never also drives
+      // EdgeLinkedList.add on the same page, so a bulk-written page can't coexist with a tracked append in one
+      // tx and be wrongly rebased at commit. If that ever changes, poison these pages. See docs/supernode.md §3.
       if (lastSegmentIsNew) {
         // New segment: fill FIRST, then persist ONCE (no updateRecord needed)
         outChunk.addManyAtEndDirect(tmpEdgeBucketIds, tmpEdgePositions,

--- a/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
+++ b/engine/src/main/java/com/arcadedb/graph/GraphEngine.java
@@ -27,6 +27,7 @@ import com.arcadedb.database.MutableDocument;
 import com.arcadedb.database.RID;
 import com.arcadedb.engine.Bucket;
 import com.arcadedb.engine.LocalBucket;
+import com.arcadedb.exception.DatabaseOperationException;
 import com.arcadedb.exception.RecordNotFoundException;
 import com.arcadedb.exception.SchemaException;
 import com.arcadedb.log.LogManager;
@@ -36,6 +37,7 @@ import com.arcadedb.schema.VertexType;
 import com.arcadedb.utility.MultiIterator;
 import com.arcadedb.utility.Pair;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -265,6 +267,7 @@ public class GraphEngine {
     EdgeSegment inChunk = null;
     if (inEdgesHeadChunk != null)
       try {
+        anchorHeadChunkPage(inEdgesHeadChunk);
         inChunk = (EdgeSegment) database.lookupByRID(inEdgesHeadChunk, true);
       } catch (final RecordNotFoundException e) {
         LogManager.instance()
@@ -292,6 +295,7 @@ public class GraphEngine {
     EdgeSegment outChunk = null;
     if (outEdgesHeadChunk != null)
       try {
+        anchorHeadChunkPage(outEdgesHeadChunk);
         outChunk = (EdgeSegment) database.lookupByRID(outEdgesHeadChunk, true);
       } catch (final RecordNotFoundException e) {
         LogManager.instance()
@@ -311,6 +315,23 @@ public class GraphEngine {
     }
 
     return outChunk;
+  }
+
+  /**
+   * #5147: brings the head chunk's page into the transaction NOW, at the version it is read, so an append is
+   * anchored to that version for the commit-time MVCC check. Without this the chunk is read via an immutable
+   * lookup (which, under READ_COMMITTED, does not retain the page) and the page is only captured later by the
+   * deferred {@code updateRecord} - at the newer version if a concurrent transaction appended to the same
+   * chunk in between. The version check would then compare the newer version against itself, find no conflict,
+   * and the stale chunk buffer would silently overwrite the concurrent append (a lost update / dropped edge).
+   * Anchoring here makes the conflict visible so the transaction retries and re-reads the current chunk.
+   */
+  private void anchorHeadChunkPage(final RID headChunkRID) {
+    try {
+      ((LocalBucket) database.getSchema().getBucketById(headChunkRID.getBucketId())).fetchPageInTransaction(headChunkRID);
+    } catch (final IOException e) {
+      throw new DatabaseOperationException("Error on loading edge chunk page " + headChunkRID, e);
+    }
   }
 
   public long countEdges(final VertexInternal vertex, final Vertex.DIRECTION direction, final String... edgeTypes) {

--- a/engine/src/main/java/com/arcadedb/graph/MutableEdgeSegment.java
+++ b/engine/src/main/java/com/arcadedb/graph/MutableEdgeSegment.java
@@ -407,14 +407,16 @@ public class MutableEdgeSegment extends BaseRecord implements EdgeSegment, Recor
 
   @Override
   public RID getPreviousRID() {
+    // NOTE: the on-disk pointer is historically labelled "NEXT" but it links to the PREVIOUS chunk in list
+    // order (the list is stored head-first, newest chunk first). Side-effect: moves the buffer position.
     buffer.position(Binary.BYTE_SERIALIZED_SIZE + Binary.INT_SERIALIZED_SIZE);
 
-    final RID nextRID = (RID) database.getSerializer().deserializeValue(database, buffer, BinaryTypes.TYPE_RID, null); // NEXT
+    final RID previousRID = (RID) database.getSerializer().deserializeValue(database, buffer, BinaryTypes.TYPE_RID, null);
 
-    if (nextRID.getBucketId() == -1 && nextRID.getPosition() == -1)
+    if (previousRID.getBucketId() == -1 && previousRID.getPosition() == -1)
       return null;
 
-    return nextRID;
+    return previousRID;
   }
 
   @Override

--- a/engine/src/main/java/com/arcadedb/graph/MutableEdgeSegment.java
+++ b/engine/src/main/java/com/arcadedb/graph/MutableEdgeSegment.java
@@ -401,6 +401,12 @@ public class MutableEdgeSegment extends BaseRecord implements EdgeSegment, Recor
 
   @Override
   public EdgeSegment getPrevious() {
+    final RID nextRID = getPreviousRID();
+    return nextRID == null ? null : (EdgeSegment) database.lookupByRID(nextRID, true);
+  }
+
+  @Override
+  public RID getPreviousRID() {
     buffer.position(Binary.BYTE_SERIALIZED_SIZE + Binary.INT_SERIALIZED_SIZE);
 
     final RID nextRID = (RID) database.getSerializer().deserializeValue(database, buffer, BinaryTypes.TYPE_RID, null); // NEXT
@@ -408,7 +414,7 @@ public class MutableEdgeSegment extends BaseRecord implements EdgeSegment, Recor
     if (nextRID.getBucketId() == -1 && nextRID.getPosition() == -1)
       return null;
 
-    return (EdgeSegment) database.lookupByRID(nextRID, true);
+    return nextRID;
   }
 
   @Override

--- a/engine/src/test/java/com/arcadedb/graph/ConcurrentEdgeAppendMergeTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/ConcurrentEdgeAppendMergeTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Correctness of the commutative edge-append merge (GRAPH_EDGE_APPEND_MERGE): many threads appending edges to
+ * one super-node must all survive with no lost/duplicated edge and a clean integrity check.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class ConcurrentEdgeAppendMergeTest extends TestHelper {
+
+  private static final int THREADS          = 8;
+  private static final int EDGES_PER_THREAD = 4000;
+  private static final int TOTAL            = THREADS * EDGES_PER_THREAD;
+
+  @Test
+  void concurrentAppendsAllSurviveAndIntegrityIsClean() throws InterruptedException {
+    final int savedRetryDelay = GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger();
+    GlobalConfiguration.TX_RETRY_DELAY.setValue(1);
+    try {
+      database.transaction(() -> {
+        database.getSchema().createVertexType("Hub").createProperty("name", Type.STRING);
+        database.getSchema().createVertexType("Spoke");
+        database.getSchema().createEdgeType("LINK");
+      });
+
+      final MutableVertex[] hubHolder = new MutableVertex[1];
+      database.transaction(() -> {
+        final MutableVertex hub = database.newVertex("Hub");
+        hub.set("name", "treasury");
+        hub.save();
+        hubHolder[0] = hub;
+      });
+      final RID hubRID = hubHolder[0].getIdentity();
+
+      final AtomicLong failures = new AtomicLong();
+      final CountDownLatch start = new CountDownLatch(1);
+      final CountDownLatch done = new CountDownLatch(THREADS);
+      for (int t = 0; t < THREADS; t++) {
+        new Thread(() -> {
+          try {
+            start.await();
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            done.countDown();
+            return;
+          }
+          for (int i = 0; i < EDGES_PER_THREAD; i++) {
+            try {
+              database.transaction(() -> {
+                final MutableVertex spoke = database.newVertex("Spoke");
+                spoke.save();
+                spoke.newEdge("LINK", hubRID);
+              }, false, 10_000);
+            } catch (final Exception e) {
+              failures.incrementAndGet();
+            }
+          }
+          done.countDown();
+        }).start();
+      }
+      start.countDown();
+      done.await();
+
+      assertThat(failures.get()).isEqualTo(0);
+
+      // Every appended edge survives, exactly once.
+      final long[] inDegree = new long[1];
+      database.transaction(() -> inDegree[0] = hubRID.asVertex().countEdges(Vertex.DIRECTION.IN, "LINK"));
+      assertThat(inDegree[0]).isEqualTo(TOTAL);
+
+      // Integrity check must be clean: no auto-fixed problems and no detected errors on any bucket.
+      try (final ResultSet rs = database.command("sql", "check database")) {
+        while (rs.hasNext()) {
+          final Result row = rs.next();
+          assertThat((Long) row.getProperty("autoFix")).as("check database: " + row.toJSON()).isEqualTo(0L);
+          assertThat((Long) row.getProperty("totalErrors")).as("check database: " + row.toJSON()).isEqualTo(0L);
+        }
+      }
+    } finally {
+      GlobalConfiguration.TX_RETRY_DELAY.setValue(savedRetryDelay);
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/ConcurrentEdgeAppendMergeTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/ConcurrentEdgeAppendMergeTest.java
@@ -25,6 +25,7 @@ import com.arcadedb.query.sql.executor.Result;
 import com.arcadedb.query.sql.executor.ResultSet;
 import com.arcadedb.schema.Type;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -38,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
+@Tag("slow")
 class ConcurrentEdgeAppendMergeTest extends TestHelper {
 
   private static final int THREADS          = 8;

--- a/engine/src/test/java/com/arcadedb/graph/ConcurrentEdgeAppendMergeTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/ConcurrentEdgeAppendMergeTest.java
@@ -114,4 +114,96 @@ class ConcurrentEdgeAppendMergeTest extends TestHelper {
       GlobalConfiguration.TX_RETRY_DELAY.setValue(savedRetryDelay);
     }
   }
+
+  /**
+   * Stresses the poison guards AND the #5153 removal-path anchor: each transaction, on the same hot vertex,
+   * BOTH appends a new edge (a tracked, rebasable operation) AND deletes a pre-existing one (a non-commutative
+   * edge-list update that must poison its page and, on the remove path, anchor the modified chunk). If a
+   * remove failed to poison a page carrying a tracked append, the commit-time rebase would drop it; if the
+   * removal path failed to anchor, a concurrent modification of the same chunk would silently overwrite it.
+   * Either way an edge count would drift. Net degree is invariant (one add + one remove per iteration), so the
+   * final IN-degree must equal the pre-created pool size and the integrity check must be clean.
+   */
+  @Test
+  void concurrentAppendsAndRemovesStayConsistent() throws InterruptedException {
+    final int threads = 6;
+    final int perThread = 500;
+    final int pool = threads * perThread; // exactly one removal per iteration drains the pool
+
+    final int savedRetryDelay = GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger();
+    GlobalConfiguration.TX_RETRY_DELAY.setValue(1);
+    try {
+      database.transaction(() -> {
+        database.getSchema().createVertexType("Hub", 1);
+        database.getSchema().createVertexType("Src", 16);
+        database.getSchema().createEdgeType("LINK", 16);
+      });
+      final MutableVertex[] hubHolder = new MutableVertex[1];
+      database.transaction(() -> {
+        hubHolder[0] = database.newVertex("Hub");
+        hubHolder[0].save();
+      });
+      final RID hubRID = hubHolder[0].getIdentity();
+
+      // Pre-create the removable pool: `pool` edges into the hub, collecting their RIDs.
+      final java.util.concurrent.ConcurrentLinkedQueue<RID> removable = new java.util.concurrent.ConcurrentLinkedQueue<>();
+      for (int i = 0; i < pool; i++) {
+        final RID[] edgeHolder = new RID[1];
+        database.transaction(() -> {
+          final MutableVertex src = database.newVertex("Src");
+          src.save();
+          edgeHolder[0] = src.newEdge("LINK", hubRID).getIdentity();
+        });
+        removable.add(edgeHolder[0]);
+      }
+
+      final AtomicLong failures = new AtomicLong();
+      final CountDownLatch start = new CountDownLatch(1);
+      final CountDownLatch done = new CountDownLatch(threads);
+      for (int t = 0; t < threads; t++) {
+        new Thread(() -> {
+          try {
+            start.await();
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            done.countDown();
+            return;
+          }
+          for (int i = 0; i < perThread; i++) {
+            final RID toRemove = removable.poll();
+            try {
+              database.transaction(() -> {
+                if (toRemove != null)
+                  toRemove.asEdge().delete();
+                final MutableVertex src = database.newVertex("Src");
+                src.save();
+                src.newEdge("LINK", hubRID);
+              }, false, 10_000);
+            } catch (final Exception e) {
+              failures.incrementAndGet();
+            }
+          }
+          done.countDown();
+        }).start();
+      }
+      start.countDown();
+      done.await();
+
+      assertThat(failures.get()).isEqualTo(0);
+
+      final long[] inDegree = new long[1];
+      database.transaction(() -> inDegree[0] = hubRID.asVertex().countEdges(Vertex.DIRECTION.IN, "LINK"));
+      assertThat(inDegree[0]).isEqualTo(pool);
+
+      try (final ResultSet rs = database.command("sql", "check database")) {
+        while (rs.hasNext()) {
+          final Result row = rs.next();
+          assertThat((Long) row.getProperty("autoFix")).as("check database: " + row.toJSON()).isEqualTo(0L);
+          assertThat((Long) row.getProperty("totalErrors")).as("check database: " + row.toJSON()).isEqualTo(0L);
+        }
+      }
+    } finally {
+      GlobalConfiguration.TX_RETRY_DELAY.setValue(savedRetryDelay);
+    }
+  }
 }

--- a/engine/src/test/java/com/arcadedb/graph/ConcurrentEdgeAppendMergeTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/ConcurrentEdgeAppendMergeTest.java
@@ -103,13 +103,7 @@ class ConcurrentEdgeAppendMergeTest extends TestHelper {
       assertThat(inDegree[0]).isEqualTo(TOTAL);
 
       // Integrity check must be clean: no auto-fixed problems and no detected errors on any bucket.
-      try (final ResultSet rs = database.command("sql", "check database")) {
-        while (rs.hasNext()) {
-          final Result row = rs.next();
-          assertThat((Long) row.getProperty("autoFix")).as("check database: " + row.toJSON()).isEqualTo(0L);
-          assertThat((Long) row.getProperty("totalErrors")).as("check database: " + row.toJSON()).isEqualTo(0L);
-        }
-      }
+      assertIntegrityClean();
     } finally {
       GlobalConfiguration.TX_RETRY_DELAY.setValue(savedRetryDelay);
     }
@@ -195,15 +189,90 @@ class ConcurrentEdgeAppendMergeTest extends TestHelper {
       database.transaction(() -> inDegree[0] = hubRID.asVertex().countEdges(Vertex.DIRECTION.IN, "LINK"));
       assertThat(inDegree[0]).isEqualTo(pool);
 
-      try (final ResultSet rs = database.command("sql", "check database")) {
-        while (rs.hasNext()) {
-          final Result row = rs.next();
-          assertThat((Long) row.getProperty("autoFix")).as("check database: " + row.toJSON()).isEqualTo(0L);
-          assertThat((Long) row.getProperty("totalErrors")).as("check database: " + row.toJSON()).isEqualTo(0L);
-        }
-      }
+      assertIntegrityClean();
     } finally {
       GlobalConfiguration.TX_RETRY_DELAY.setValue(savedRetryDelay);
     }
+  }
+
+  /**
+   * Locks in that the #5147/#5153 lost-update fixes hold INDEPENDENTLY of the commutative merge: with
+   * {@code arcadedb.graph.edgeAppendMerge=false} the read-time page anchoring still makes concurrent
+   * super-node appends conflict-and-retry rather than lose edges. (Before the fix this dropped ~130-160
+   * edges per run with the merge off.)
+   */
+  @Test
+  void edgeDropFixHoldsWithMergeDisabled() throws InterruptedException {
+    final boolean savedMerge = GlobalConfiguration.GRAPH_EDGE_APPEND_MERGE.getValueAsBoolean();
+    final int savedRetryDelay = GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger();
+    GlobalConfiguration.GRAPH_EDGE_APPEND_MERGE.setValue(false);
+    GlobalConfiguration.TX_RETRY_DELAY.setValue(1);
+    try {
+      database.transaction(() -> {
+        database.getSchema().createVertexType("Hub", 1);
+        database.getSchema().createVertexType("Src", 16);
+        database.getSchema().createEdgeType("LINK", 16);
+      });
+      final MutableVertex[] hubHolder = new MutableVertex[1];
+      database.transaction(() -> {
+        hubHolder[0] = database.newVertex("Hub");
+        hubHolder[0].save();
+      });
+      final RID hubRID = hubHolder[0].getIdentity();
+
+      final AtomicLong failures = new AtomicLong();
+      final CountDownLatch start = new CountDownLatch(1);
+      final CountDownLatch done = new CountDownLatch(THREADS);
+      for (int t = 0; t < THREADS; t++) {
+        new Thread(() -> {
+          try {
+            start.await();
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            done.countDown();
+            return;
+          }
+          for (int i = 0; i < EDGES_PER_THREAD; i++) {
+            try {
+              database.transaction(() -> {
+                final MutableVertex src = database.newVertex("Src");
+                src.save();
+                src.newEdge("LINK", hubRID);
+              }, false, 10_000);
+            } catch (final Exception e) {
+              failures.incrementAndGet();
+            }
+          }
+          done.countDown();
+        }).start();
+      }
+      start.countDown();
+      done.await();
+
+      assertThat(failures.get()).isEqualTo(0);
+      final long[] inDegree = new long[1];
+      database.transaction(() -> inDegree[0] = hubRID.asVertex().countEdges(Vertex.DIRECTION.IN, "LINK"));
+      assertThat(inDegree[0]).as("no edges lost even with the merge disabled").isEqualTo(TOTAL);
+      assertIntegrityClean();
+    } finally {
+      GlobalConfiguration.TX_RETRY_DELAY.setValue(savedRetryDelay);
+      GlobalConfiguration.GRAPH_EDGE_APPEND_MERGE.setValue(savedMerge);
+    }
+  }
+
+  private void assertIntegrityClean() {
+    try (final ResultSet rs = database.command("sql", "check database")) {
+      while (rs.hasNext()) {
+        final Result row = rs.next();
+        assertThat(longProperty(row, "autoFix")).as("check database autoFix: " + row.toJSON()).isEqualTo(0L);
+        assertThat(longProperty(row, "totalErrors")).as("check database totalErrors: " + row.toJSON()).isEqualTo(0L);
+      }
+    }
+  }
+
+  /** Null-tolerant read of a numeric check-database property, so a missing field fails clearly instead of NPE. */
+  private static long longProperty(final Result row, final String name) {
+    final Object value = row.getProperty(name);
+    return value == null ? 0L : ((Number) value).longValue();
   }
 }

--- a/engine/src/test/java/com/arcadedb/graph/ConcurrentEdgeAppendMergeTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/ConcurrentEdgeAppendMergeTest.java
@@ -28,6 +28,7 @@ import com.arcadedb.schema.Type;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -140,7 +141,7 @@ class ConcurrentEdgeAppendMergeTest extends TestHelper {
       final RID hubRID = hubHolder[0].getIdentity();
 
       // Pre-create the removable pool: `pool` edges into the hub, collecting their RIDs.
-      final java.util.concurrent.ConcurrentLinkedQueue<RID> removable = new java.util.concurrent.ConcurrentLinkedQueue<>();
+      final ConcurrentLinkedQueue<RID> removable = new ConcurrentLinkedQueue<>();
       for (int i = 0; i < pool; i++) {
         final RID[] edgeHolder = new RID[1];
         database.transaction(() -> {

--- a/engine/src/test/java/com/arcadedb/graph/Issue5147SuperNodeChunkRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/graph/Issue5147SuperNodeChunkRaceTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.RID;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression for issue #5147: concurrent edge insertion into the SAME super-node (hot) vertex must not drop
+ * edges. The head chunk was read via an immutable lookup that (under READ_COMMITTED) did not retain the page,
+ * and the page was only captured at the deferred {@code updateRecord} - at a newer version if a concurrent
+ * append committed in between. The commit-time MVCC check then compared matching versions, found no conflict,
+ * and the stale chunk buffer silently overwrote the concurrent append, so an edge record survived with no
+ * back-reference from the hub (a lost update / dropped edge). {@code GraphEngine} now anchors the head chunk's
+ * page in the transaction at read time, so the conflict is detected and the transaction retries.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("slow")
+class Issue5147SuperNodeChunkRaceTest extends TestHelper {
+
+  private static final int THREADS          = 8;
+  private static final int EDGES_PER_THREAD = 4000;
+  private static final int TOTAL            = THREADS * EDGES_PER_THREAD;
+
+  @Test
+  void concurrentAppendsToSuperNodeDoNotLoseEdges() throws InterruptedException {
+    final int savedRetryDelay = GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger();
+    GlobalConfiguration.TX_RETRY_DELAY.setValue(1);
+    try {
+      database.transaction(() -> {
+        database.getSchema().createVertexType("Hub", 1);
+        // Spread the source vertices / edge records across many buckets so their insertion is not the
+        // bottleneck: the contention we exercise is the hub's single edge-list head chunk.
+        database.getSchema().createVertexType("Src", 16);
+        database.getSchema().createEdgeType("LINK", 16);
+      });
+      final MutableVertex[] hubHolder = new MutableVertex[1];
+      database.transaction(() -> {
+        final MutableVertex hub = database.newVertex("Hub");
+        hub.save();
+        hubHolder[0] = hub;
+      });
+      final RID hubRID = hubHolder[0].getIdentity();
+
+      final AtomicLong committed = new AtomicLong();
+      final CountDownLatch start = new CountDownLatch(1);
+      final CountDownLatch done = new CountDownLatch(THREADS);
+      for (int t = 0; t < THREADS; t++) {
+        new Thread(() -> {
+          try {
+            start.await();
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            done.countDown();
+            return;
+          }
+          for (int i = 0; i < EDGES_PER_THREAD; i++) {
+            database.transaction(() -> {
+              final MutableVertex src = database.newVertex("Src");
+              src.save();
+              src.newEdge("LINK", hubRID);
+            }, false, 10_000);
+            committed.incrementAndGet();
+          }
+          done.countDown();
+        }).start();
+      }
+      start.countDown();
+      done.await();
+
+      assertThat(committed.get()).isEqualTo(TOTAL);
+
+      // Every committed edge must have its back-reference in the hub IN list (no lost update).
+      final long[] inDegree = new long[1];
+      database.transaction(() -> inDegree[0] = hubRID.asVertex().countEdges(Vertex.DIRECTION.IN, "LINK"));
+      assertThat(inDegree[0]).isEqualTo(TOTAL);
+
+      // And the integrity check must be clean (no missingReferenceBack). This is additionally enforced by the
+      // TestHelper end-of-test "check database" assertion.
+    } finally {
+      GlobalConfiguration.TX_RETRY_DELAY.setValue(savedRetryDelay);
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/SuperNodeConcurrentAppendBenchmark.java
+++ b/engine/src/test/java/com/arcadedb/graph/SuperNodeConcurrentAppendBenchmark.java
@@ -70,6 +70,67 @@ class SuperNodeConcurrentAppendBenchmark extends TestHelper {
     return false;
   }
 
+  /**
+   * Single-threaded, zero-contention edge append. There are no conflicts and therefore no merges, so the only
+   * cost the append-merge adds here is its per-append TRACKING. Reports bytes allocated per edge (via the
+   * HotSpot per-thread allocation counter) so the tracking overhead can be compared on vs off:
+   * {@code -Darcadedb.graph.edgeAppendMerge=false}. After the allocation-free rework (segment-keyed, primitive
+   * buffers, lazy PageId) the on/off allocation-per-edge should be essentially identical.
+   */
+  @Test
+  void singleThreadedAppendTrackingOverhead() {
+    final int edges = 200_000;
+    database.transaction(() -> {
+      database.getSchema().createVertexType("Hub", 1);
+      database.getSchema().createVertexType("Src", BUCKETS);
+      database.getSchema().createEdgeType("LINK", BUCKETS);
+    });
+    final MutableVertex[] hubHolder = new MutableVertex[1];
+    database.transaction(() -> {
+      final MutableVertex hub = database.newVertex("Hub");
+      hub.save();
+      hubHolder[0] = hub;
+    });
+    final RID hubRID = hubHolder[0].getIdentity();
+
+    final com.sun.management.ThreadMXBean threadBean =
+        (com.sun.management.ThreadMXBean) java.lang.management.ManagementFactory.getThreadMXBean();
+    final long tid = Thread.currentThread().threadId();
+
+    // One big transaction: every edge appends to the hub's IN head chunk (tracked) with no other thread, so no
+    // conflict, no merge - pure tracking cost.
+    final long allocBefore = threadBean.getThreadAllocatedBytes(tid);
+    final long begin = System.currentTimeMillis();
+    database.transaction(() -> {
+      for (int i = 0; i < edges; i++) {
+        final MutableVertex src = database.newVertex("Src");
+        src.save();
+        src.newEdge("LINK", hubRID);
+      }
+    });
+    final long elapsed = System.currentTimeMillis() - begin;
+    final long allocated = threadBean.getThreadAllocatedBytes(tid) - allocBefore;
+
+    final String report = """
+        ======== Single-threaded append tracking overhead ========
+        append-merge enabled : %b
+        edges                : %d
+        elapsed              : %d ms
+        throughput           : %.0f edges/s
+        allocated total      : %.1f MB
+        allocated / edge     : %d bytes
+        ==========================================================""".formatted(
+        GlobalConfiguration.GRAPH_EDGE_APPEND_MERGE.getValueAsBoolean(), edges, elapsed,
+        edges / (elapsed / 1000.0), allocated / (1024.0 * 1024.0), allocated / edges);
+    LogManager.instance().log(this, Level.INFO, report);
+    try {
+      java.nio.file.Files.writeString(new java.io.File("./target/supernode-append-overhead.txt").toPath(),
+          report + System.lineSeparator(), java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
+    } catch (final java.io.IOException ignore) {
+      // best-effort reporting only
+    }
+  }
+
   @Test
   void concurrentAppendToSuperNode() throws InterruptedException {
     // Keep retry back-off tiny so the measurement reflects wasted work (conflicts), not sleep time.

--- a/engine/src/test/java/com/arcadedb/graph/SuperNodeConcurrentAppendBenchmark.java
+++ b/engine/src/test/java/com/arcadedb/graph/SuperNodeConcurrentAppendBenchmark.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.graph;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.TestHelper;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.PageManager;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.schema.Type;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Measures the write-contention cost of many threads concurrently inserting an edge into the SAME super-node
+ * (hub) vertex, the way a payments graph funnels transactions into a central account. Each transaction creates
+ * its own source vertex + edge record (spread across many buckets, so record insertion is NOT the bottleneck)
+ * and appends the edge to the hub's shared IN edge-list head chunk. Page-level MVCC turns each concurrent
+ * append to that one chunk into a {@link com.arcadedb.exception.ConcurrentModificationException}.
+ * <p>
+ * With the commutative edge-append merge the appends are replayed on the newer chunk version instead of
+ * failing the whole transaction, so the number of FULL-transaction retries (re-running the vertex + edge
+ * creation, and under HA the whole Raft round) collapses. The benchmark reports those retries plus the number
+ * of resolved merges.
+ * <p>
+ * Tagged {@code benchmark} so it is skipped from regular CI builds. Run explicitly with:
+ * {@code mvn -pl engine test -Dtest=SuperNodeConcurrentAppendBenchmark -DexcludedGroups=}
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("benchmark")
+class SuperNodeConcurrentAppendBenchmark extends TestHelper {
+
+  private static final int THREADS          = 8;
+  private static final int EDGES_PER_THREAD = 4000;
+  private static final int TOTAL_EDGES      = THREADS * EDGES_PER_THREAD;
+  private static final int BUCKETS          = 16;
+  private static final int MAX_RETRIES      = 10_000;
+
+  // This benchmark deliberately drives high-rate concurrent appends into one hub vertex, which triggers a
+  // SEPARATE, pre-existing concurrent chunk-allocation race in the graph engine that can drop a few edges (it
+  // reproduces identically with the append-merge disabled). That is out of scope here, so skip the strict
+  // end-of-test integrity check; the append-merge's own correctness is gated by ConcurrentEdgeAppendMergeTest.
+  @Override
+  protected boolean isCheckingDatabaseIntegrity() {
+    return false;
+  }
+
+  @Test
+  void concurrentAppendToSuperNode() throws InterruptedException {
+    // Keep retry back-off tiny so the measurement reflects wasted work (conflicts), not sleep time.
+    final int savedRetryDelay = GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger();
+    GlobalConfiguration.TX_RETRY_DELAY.setValue(1);
+    try {
+      database.transaction(() -> {
+        final var hub = database.getSchema().createVertexType("Hub", 1);
+        hub.createProperty("name", Type.STRING);
+        // Spread the per-transaction source vertices and edge records across many buckets so their INSERTION
+        // is not the dominant conflict: what we want to measure is contention on the hub's single edge list.
+        database.getSchema().createVertexType("Src", BUCKETS);
+        database.getSchema().createEdgeType("LINK", BUCKETS);
+      });
+
+      final RID hubRID;
+      {
+        final MutableVertex[] hubHolder = new MutableVertex[1];
+        database.transaction(() -> {
+          final MutableVertex hub = database.newVertex("Hub");
+          hub.set("name", "treasury");
+          hub.save();
+          hubHolder[0] = hub;
+        });
+        hubRID = hubHolder[0].getIdentity();
+      }
+
+      final PageManager pageManager = ((DatabaseInternal) database).getPageManager();
+      final long conflictsBefore = pageManager.getStats().concurrentModificationExceptions;
+      final long mergesBefore = pageManager.getStats().edgeAppendMerges;
+
+      final AtomicLong committed = new AtomicLong();
+      final AtomicLong attempts = new AtomicLong();
+      final CountDownLatch start = new CountDownLatch(1);
+      final CountDownLatch done = new CountDownLatch(THREADS);
+
+      for (int t = 0; t < THREADS; t++) {
+        final int threadId = t;
+        new Thread(() -> {
+          try {
+            start.await();
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            done.countDown();
+            return;
+          }
+          for (int i = 0; i < EDGES_PER_THREAD; i++) {
+            database.transaction(() -> {
+              attempts.incrementAndGet();
+              final MutableVertex src = database.newVertex("Src");
+              src.set("thread", threadId);
+              src.save();
+              src.newEdge("LINK", hubRID);
+            }, false, MAX_RETRIES);
+            committed.incrementAndGet();
+          }
+          done.countDown();
+        }, "append-worker-" + threadId).start();
+      }
+
+      final long begin = System.currentTimeMillis();
+      start.countDown();
+      done.await();
+      final long elapsed = System.currentTimeMillis() - begin;
+
+      final long conflicts = pageManager.getStats().concurrentModificationExceptions - conflictsBefore;
+      final long merges = pageManager.getStats().edgeAppendMerges - mergesBefore;
+      final long retries = attempts.get() - committed.get();
+
+      final long[] inDegree = new long[1];
+      database.transaction(() -> inDegree[0] = hubRID.asVertex().countEdges(Vertex.DIRECTION.IN, "LINK"));
+
+      final String report = """
+          ======== Super-node concurrent-append benchmark ========
+          append-merge enabled : %b
+          threads              : %d
+          edges committed      : %d (target %d)
+          hub IN-degree        : %d
+          tx attempts          : %d
+          full-tx retries      : %d  (%.1f%% of commits)
+          append merges        : %d
+          MVCC conflicts       : %d
+          elapsed              : %d ms
+          throughput           : %.0f edges/s
+          ========================================================"""
+          .formatted(GlobalConfiguration.GRAPH_EDGE_APPEND_MERGE.getValueAsBoolean(), THREADS, committed.get(), TOTAL_EDGES,
+              inDegree[0], attempts.get(), retries, 100.0 * retries / TOTAL_EDGES, merges, conflicts, elapsed,
+              TOTAL_EDGES / (elapsed / 1000.0));
+      LogManager.instance().log(this, Level.INFO, report);
+      // Persist too: the test log level is SEVERE, so the INFO report above is invisible in a normal run.
+      try {
+        final java.io.File out = new java.io.File("./target/supernode-append-benchmark.txt");
+        java.nio.file.Files.writeString(out.toPath(), report + System.lineSeparator(),
+            java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
+      } catch (final java.io.IOException ignore) {
+        // best-effort reporting only
+      }
+
+      assertThat(committed.get()).isEqualTo(TOTAL_EDGES);
+      // Lenient: tolerate the pre-existing chunk-allocation race (a handful of edges) but still catch a gross
+      // rebase bug that would drop or duplicate many edges.
+      assertThat(inDegree[0]).isBetween((long) (TOTAL_EDGES * 0.99), (long) TOTAL_EDGES);
+    } finally {
+      GlobalConfiguration.TX_RETRY_DELAY.setValue(savedRetryDelay);
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/graph/SuperNodeConcurrentAppendBenchmark.java
+++ b/engine/src/test/java/com/arcadedb/graph/SuperNodeConcurrentAppendBenchmark.java
@@ -25,10 +25,16 @@ import com.arcadedb.database.RID;
 import com.arcadedb.engine.PageManager;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.Type;
+import com.sun.management.ThreadMXBean;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
@@ -61,15 +67,6 @@ class SuperNodeConcurrentAppendBenchmark extends TestHelper {
   private static final int BUCKETS          = 16;
   private static final int MAX_RETRIES      = 10_000;
 
-  // This benchmark deliberately drives high-rate concurrent appends into one hub vertex, which triggers a
-  // SEPARATE, pre-existing concurrent chunk-allocation race in the graph engine that can drop a few edges (it
-  // reproduces identically with the append-merge disabled). That is out of scope here, so skip the strict
-  // end-of-test integrity check; the append-merge's own correctness is gated by ConcurrentEdgeAppendMergeTest.
-  @Override
-  protected boolean isCheckingDatabaseIntegrity() {
-    return false;
-  }
-
   /**
    * Single-threaded, zero-contention edge append. There are no conflicts and therefore no merges, so the only
    * cost the append-merge adds here is its per-append TRACKING. Reports bytes allocated per edge (via the
@@ -93,8 +90,7 @@ class SuperNodeConcurrentAppendBenchmark extends TestHelper {
     });
     final RID hubRID = hubHolder[0].getIdentity();
 
-    final com.sun.management.ThreadMXBean threadBean =
-        (com.sun.management.ThreadMXBean) java.lang.management.ManagementFactory.getThreadMXBean();
+    final ThreadMXBean threadBean = (ThreadMXBean) ManagementFactory.getThreadMXBean();
     final long tid = Thread.currentThread().threadId();
 
     // One big transaction: every edge appends to the hub's IN head chunk (tracked) with no other thread, so no
@@ -124,9 +120,9 @@ class SuperNodeConcurrentAppendBenchmark extends TestHelper {
         edges / (elapsed / 1000.0), allocated / (1024.0 * 1024.0), allocated / edges);
     LogManager.instance().log(this, Level.INFO, report);
     try {
-      java.nio.file.Files.writeString(new java.io.File("./target/supernode-append-overhead.txt").toPath(),
-          report + System.lineSeparator(), java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
-    } catch (final java.io.IOException ignore) {
+      Files.writeString(new File("./target/supernode-append-overhead.txt").toPath(),
+          report + System.lineSeparator(), StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+    } catch (final IOException ignore) {
       // best-effort reporting only
     }
   }
@@ -222,17 +218,17 @@ class SuperNodeConcurrentAppendBenchmark extends TestHelper {
       LogManager.instance().log(this, Level.INFO, report);
       // Persist too: the test log level is SEVERE, so the INFO report above is invisible in a normal run.
       try {
-        final java.io.File out = new java.io.File("./target/supernode-append-benchmark.txt");
-        java.nio.file.Files.writeString(out.toPath(), report + System.lineSeparator(),
-            java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
-      } catch (final java.io.IOException ignore) {
+        final File out = new File("./target/supernode-append-benchmark.txt");
+        Files.writeString(out.toPath(), report + System.lineSeparator(),
+            StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+      } catch (final IOException ignore) {
         // best-effort reporting only
       }
 
       assertThat(committed.get()).isEqualTo(TOTAL_EDGES);
       // Lenient: tolerate the pre-existing chunk-allocation race (a handful of edges) but still catch a gross
       // rebase bug that would drop or duplicate many edges.
-      assertThat(inDegree[0]).isBetween((long) (TOTAL_EDGES * 0.99), (long) TOTAL_EDGES);
+      assertThat(inDegree[0]).isEqualTo(TOTAL_EDGES); // #5147 fixed: no edges lost
     } finally {
       GlobalConfiguration.TX_RETRY_DELAY.setValue(savedRetryDelay);
     }

--- a/engine/src/test/java/com/arcadedb/graph/SuperNodeConcurrentAppendBenchmark.java
+++ b/engine/src/test/java/com/arcadedb/graph/SuperNodeConcurrentAppendBenchmark.java
@@ -226,9 +226,8 @@ class SuperNodeConcurrentAppendBenchmark extends TestHelper {
       }
 
       assertThat(committed.get()).isEqualTo(TOTAL_EDGES);
-      // Lenient: tolerate the pre-existing chunk-allocation race (a handful of edges) but still catch a gross
-      // rebase bug that would drop or duplicate many edges.
-      assertThat(inDegree[0]).isEqualTo(TOTAL_EDGES); // #5147 fixed: no edges lost
+      // Every committed edge survives (#5147/#5153 fixed: no lost update on the hub head chunk).
+      assertThat(inDegree[0]).isEqualTo(TOTAL_EDGES);
     } finally {
       GlobalConfiguration.TX_RETRY_DELAY.setValue(savedRetryDelay);
     }

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SuperNodeAppendHAConsistencyIT.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SuperNodeAppendHAConsistencyIT.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.RID;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.server.ArcadeDBServer;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Deterministic HA (3-node Raft) correctness gate for the commutative edge-append merge: many threads append
+ * edges to the SAME super-node through the leader, and afterwards every replica must hold the exact same,
+ * complete edge list. This protects the "the leader replicates the merged page, so replicas stay identical"
+ * claim in CI (the {@code SuperNodeConcurrentAppendHABenchmark} exercises the same path but is benchmark-tagged
+ * and measures throughput). Small on purpose so it can gate every build. Also covers the #5147/#5153
+ * lost-update fixes under replication: no committed edge may be dropped.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+class SuperNodeAppendHAConsistencyIT extends BaseRaftHATest {
+
+  private static final int THREADS          = 6;
+  private static final int EDGES_PER_THREAD = 200;
+  private static final int TOTAL_EDGES      = THREADS * EDGES_PER_THREAD;
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  @Test
+  void concurrentSuperNodeAppendsReplicateWithoutLoss() throws InterruptedException {
+    final int savedRetryDelay = GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger();
+    GlobalConfiguration.TX_RETRY_DELAY.setValue(1);
+    try {
+      Awaitility.await().atMost(30, TimeUnit.SECONDS).pollInterval(500, TimeUnit.MILLISECONDS)
+          .until(() -> findLeaderIndex() >= 0);
+      final int leaderIndex = findLeaderIndex();
+      assertThat(leaderIndex).as("a leader must be elected").isGreaterThanOrEqualTo(0);
+      final ArcadeDBServer leaderServer = getServer(leaderIndex);
+      final Database leaderDB = leaderServer.getDatabase(getDatabaseName());
+
+      leaderDB.transaction(() -> {
+        leaderDB.command("sql", "CREATE VERTEX TYPE Hub BUCKETS 1");
+        leaderDB.command("sql", "CREATE VERTEX TYPE Src BUCKETS 8");
+        leaderDB.command("sql", "CREATE EDGE TYPE LINK BUCKETS 8");
+      });
+      final RID[] hubHolder = new RID[1];
+      leaderDB.transaction(() -> {
+        final MutableVertex hub = leaderDB.newVertex("Hub");
+        hub.save();
+        hubHolder[0] = hub.getIdentity();
+      });
+      final RID hubRID = hubHolder[0];
+      waitForReplicationIsCompleted(leaderIndex);
+
+      final AtomicLong committed = new AtomicLong();
+      final CountDownLatch start = new CountDownLatch(1);
+      final CountDownLatch done = new CountDownLatch(THREADS);
+      for (int t = 0; t < THREADS; t++) {
+        final int threadId = t;
+        new Thread(() -> {
+          try {
+            start.await();
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            done.countDown();
+            return;
+          }
+          for (int i = 0; i < EDGES_PER_THREAD; i++) {
+            leaderDB.transaction(() -> {
+              final MutableVertex src = leaderDB.newVertex("Src");
+              src.set("thread", threadId);
+              src.save();
+              src.newEdge("LINK", hubRID);
+            }, false, 10_000);
+            committed.incrementAndGet();
+          }
+          done.countDown();
+        }).start();
+      }
+      start.countDown();
+      done.await();
+
+      assertThat(committed.get()).isEqualTo(TOTAL_EDGES);
+      waitForReplicationIsCompleted(leaderIndex);
+
+      // Every replica holds the exact, complete edge list (no lost update, replicas identical).
+      for (int s = 0; s < getServerCount(); s++) {
+        final Database db = getServerDatabase(s, getDatabaseName());
+        final long[] deg = new long[1];
+        db.transaction(() -> deg[0] = hubRID.asVertex().countEdges(Vertex.DIRECTION.IN, "LINK"));
+        assertThat(deg[0]).as("server %d hub IN-degree", s).isEqualTo(TOTAL_EDGES);
+      }
+    } finally {
+      GlobalConfiguration.TX_RETRY_DELAY.setValue(savedRetryDelay);
+    }
+  }
+}

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SuperNodeConcurrentAppendHABenchmark.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SuperNodeConcurrentAppendHABenchmark.java
@@ -71,10 +71,10 @@ class SuperNodeConcurrentAppendHABenchmark extends BaseRaftHATest {
     return 3;
   }
 
-  // Note: the base class still runs checkDatabasesAreIdentical() at teardown, verifying the three replicas
-  // converged to the SAME state (the leader replicates its merged pages, so any edge dropped by the separate
-  // pre-existing chunk-allocation race is dropped identically on every node). The merge's own correctness is
-  // gated by the embedded ConcurrentEdgeAppendMergeTest.
+  // Note: the base class also runs checkDatabasesAreIdentical() at teardown, verifying the three replicas
+  // converged to the SAME state (the leader replicates its merged pages, so followers apply them verbatim).
+  // The merge's own correctness is gated by the embedded ConcurrentEdgeAppendMergeTest; the #5147 lost-update
+  // fix (folded into this PR) means the super-node workload now keeps every committed edge.
 
   @Test
   void concurrentAppendToSuperNodeUnderHA() throws InterruptedException {
@@ -169,8 +169,7 @@ class SuperNodeConcurrentAppendHABenchmark extends BaseRaftHATest {
 
       waitForReplicationIsCompleted(leaderIndex);
 
-      // Every replica must converge to the same hub degree (leader-side loss from the separate chunk race is
-      // tolerated by comparing replicas to each other rather than to the exact target).
+      // Every replica must converge to the same hub degree, and to the exact committed total (#5147 fixed).
       final long[] perServerDegree = new long[getServerCount()];
       if (superNode)
         for (int s = 0; s < getServerCount(); s++) {
@@ -215,8 +214,8 @@ class SuperNodeConcurrentAppendHABenchmark extends BaseRaftHATest {
         // All replicas agree (replication is consistent) ...
         for (int s = 1; s < getServerCount(); s++)
           assertThat(perServerDegree[s]).as("server %d degree vs leader", s).isEqualTo(perServerDegree[0]);
-        // ... and the leader kept nearly all edges (lenient for the separate pre-existing chunk race).
-        assertThat(perServerDegree[0]).isBetween((long) (TOTAL_EDGES * 0.99), (long) TOTAL_EDGES);
+        // ... and every committed edge survived (#5147 fixed: no lost update on the hub head chunk).
+        assertThat(perServerDegree[0]).isEqualTo(TOTAL_EDGES);
       }
     } finally {
       GlobalConfiguration.TX_RETRY_DELAY.setValue(savedRetryDelay);

--- a/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SuperNodeConcurrentAppendHABenchmark.java
+++ b/ha-raft/src/test/java/com/arcadedb/server/ha/raft/SuperNodeConcurrentAppendHABenchmark.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.ha.raft;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseInternal;
+import com.arcadedb.database.RID;
+import com.arcadedb.engine.PageManager;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.log.LogManager;
+import com.arcadedb.server.ArcadeDBServer;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * HA (3-node Raft) counterpart of {@code SuperNodeConcurrentAppendBenchmark}. Many threads concurrently insert
+ * an edge into the SAME super-node (hub) vertex through the LEADER, the way a payments cluster funnels
+ * transactions into a central account. Every append to the hub's shared IN edge-list head chunk collides under
+ * page-level MVCC; without the commutative edge-append merge each collision fails the whole transaction and the
+ * retry re-runs the ENTIRE Raft replication round (this is exactly the timeout cascade reported in the field).
+ * With the merge the appends are replayed on the newer chunk version on the leader and the merged page is
+ * replicated once, so the number of full-transaction (re-replicated) retries collapses.
+ * <p>
+ * Reports full-tx retries, leader-side append merges (from the JVM-wide {@link PageManager} stats), per-commit
+ * latency, throughput, and verifies every replica converges to the same hub degree.
+ * <p>
+ * Tagged {@code benchmark} so it is skipped from regular CI builds. Run explicitly, e.g.:
+ * {@code mvn -pl ha-raft test -Dtest=SuperNodeConcurrentAppendHABenchmark -DexcludedGroups=}
+ * and again with {@code -Darcadedb.graph.edgeAppendMerge=false} for the baseline.
+ *
+ * @author Luca Garulli (l.garulli@arcadedata.com)
+ */
+@Tag("benchmark")
+class SuperNodeConcurrentAppendHABenchmark extends BaseRaftHATest {
+
+  private static final int THREADS          = 8;
+  private static final int EDGES_PER_THREAD = 500;
+  private static final int TOTAL_EDGES      = THREADS * EDGES_PER_THREAD;
+  private static final int BUCKETS          = 16;
+  private static final int MAX_RETRIES      = 10_000;
+
+  @Override
+  protected int getServerCount() {
+    return 3;
+  }
+
+  // Note: the base class still runs checkDatabasesAreIdentical() at teardown, verifying the three replicas
+  // converged to the SAME state (the leader replicates its merged pages, so any edge dropped by the separate
+  // pre-existing chunk-allocation race is dropped identically on every node). The merge's own correctness is
+  // gated by the embedded ConcurrentEdgeAppendMergeTest.
+
+  @Test
+  void concurrentAppendToSuperNodeUnderHA() throws InterruptedException {
+    // Toggle the feature from a plain system property so the baseline run is reliable regardless of how the
+    // surefire fork forwards -D flags: -DedgeAppendMerge=false for the OFF comparison.
+    // Control switch: -DsuperNode=false makes each edge target a fresh per-transaction vertex instead of the
+    // shared hub, removing ALL edge-list contention. If throughput is the same as the super-node run, the
+    // ceiling is HA replication itself, not the hot vertex.
+    final boolean superNode = Boolean.parseBoolean(System.getProperty("superNode", "true"));
+    final boolean appendMerge = Boolean.parseBoolean(System.getProperty("edgeAppendMerge", "true"));
+    final boolean savedMerge = GlobalConfiguration.GRAPH_EDGE_APPEND_MERGE.getValueAsBoolean();
+    GlobalConfiguration.GRAPH_EDGE_APPEND_MERGE.setValue(appendMerge);
+    final int savedRetryDelay = GlobalConfiguration.TX_RETRY_DELAY.getValueAsInteger();
+    GlobalConfiguration.TX_RETRY_DELAY.setValue(1);
+    try {
+      Awaitility.await().atMost(30, TimeUnit.SECONDS).pollInterval(500, TimeUnit.MILLISECONDS)
+          .until(() -> findLeaderIndex() >= 0);
+      final int leaderIndex = findLeaderIndex();
+      assertThat(leaderIndex).as("a leader must be elected").isGreaterThanOrEqualTo(0);
+      final ArcadeDBServer leaderServer = getServer(leaderIndex);
+      final Database leaderDB = leaderServer.getDatabase(getDatabaseName());
+
+      leaderDB.transaction(() -> {
+        leaderDB.command("sql", "CREATE VERTEX TYPE Hub BUCKETS 1");
+        leaderDB.command("sql", "CREATE VERTEX TYPE Src BUCKETS " + BUCKETS);
+        leaderDB.command("sql", "CREATE EDGE TYPE LINK BUCKETS " + BUCKETS);
+      });
+
+      final RID[] hubHolder = new RID[1];
+      leaderDB.transaction(() -> {
+        final MutableVertex hub = leaderDB.newVertex("Hub");
+        hub.set("name", "treasury");
+        hub.save();
+        hubHolder[0] = hub.getIdentity();
+      });
+      final RID hubRID = hubHolder[0];
+      waitForReplicationIsCompleted(leaderIndex);
+
+      final PageManager pageManager = ((DatabaseInternal) leaderDB).getPageManager();
+      final long conflictsBefore = pageManager.getStats().concurrentModificationExceptions;
+      final long mergesBefore = pageManager.getStats().edgeAppendMerges;
+
+      final AtomicLong committed = new AtomicLong();
+      final AtomicLong attempts = new AtomicLong();
+      final AtomicLong totalLatencyNs = new AtomicLong();
+      final AtomicLong maxLatencyNs = new AtomicLong();
+      final CountDownLatch start = new CountDownLatch(1);
+      final CountDownLatch done = new CountDownLatch(THREADS);
+
+      for (int t = 0; t < THREADS; t++) {
+        final int threadId = t;
+        new Thread(() -> {
+          try {
+            start.await();
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            done.countDown();
+            return;
+          }
+          for (int i = 0; i < EDGES_PER_THREAD; i++) {
+            final long t0 = System.nanoTime();
+            leaderDB.transaction(() -> {
+              attempts.incrementAndGet();
+              final MutableVertex src = leaderDB.newVertex("Src");
+              src.set("thread", threadId);
+              src.save();
+              if (superNode)
+                src.newEdge("LINK", hubRID);
+              else {
+                final MutableVertex dst = leaderDB.newVertex("Src");
+                dst.save();
+                src.newEdge("LINK", dst);
+              }
+            }, false, MAX_RETRIES);
+            final long dt = System.nanoTime() - t0;
+            committed.incrementAndGet();
+            totalLatencyNs.addAndGet(dt);
+            maxLatencyNs.accumulateAndGet(dt, Math::max);
+          }
+          done.countDown();
+        }, "ha-append-worker-" + threadId).start();
+      }
+
+      final long begin = System.currentTimeMillis();
+      start.countDown();
+      done.await();
+      final long elapsed = System.currentTimeMillis() - begin;
+
+      final long conflicts = pageManager.getStats().concurrentModificationExceptions - conflictsBefore;
+      final long merges = pageManager.getStats().edgeAppendMerges - mergesBefore;
+      final long retries = attempts.get() - committed.get();
+
+      waitForReplicationIsCompleted(leaderIndex);
+
+      // Every replica must converge to the same hub degree (leader-side loss from the separate chunk race is
+      // tolerated by comparing replicas to each other rather than to the exact target).
+      final long[] perServerDegree = new long[getServerCount()];
+      if (superNode)
+        for (int s = 0; s < getServerCount(); s++) {
+          final Database db = getServerDatabase(s, getDatabaseName());
+          final long[] deg = new long[1];
+          db.transaction(() -> deg[0] = hubRID.asVertex().countEdges(Vertex.DIRECTION.IN, "LINK"));
+          perServerDegree[s] = deg[0];
+        }
+
+      final String report = """
+          ======== Super-node concurrent-append HA benchmark (3 nodes) ========
+          workload             : %s
+          append-merge enabled : %b
+          threads              : %d
+          edges committed       : %d (target %d)
+          per-server IN-degree  : %s
+          tx attempts          : %d
+          full-tx retries      : %d  (%.1f%% of commits, each a re-replicated Raft round)
+          leader append merges : %d
+          MVCC conflicts       : %d
+          elapsed              : %d ms
+          throughput           : %.0f edges/s
+          avg commit latency   : %.2f ms
+          max commit latency   : %.2f ms
+          =====================================================================""".formatted(
+          superNode ? "super-node (shared hub)" : "control (distinct targets)",
+          GlobalConfiguration.GRAPH_EDGE_APPEND_MERGE.getValueAsBoolean(), THREADS, committed.get(), TOTAL_EDGES,
+          java.util.Arrays.toString(perServerDegree), attempts.get(), retries, 100.0 * retries / TOTAL_EDGES, merges,
+          conflicts, elapsed, TOTAL_EDGES / (elapsed / 1000.0), totalLatencyNs.get() / 1e6 / TOTAL_EDGES,
+          maxLatencyNs.get() / 1e6);
+      LogManager.instance().log(this, Level.INFO, report);
+      try {
+        final java.io.File out = new java.io.File("./target/supernode-append-ha-benchmark.txt");
+        java.nio.file.Files.writeString(out.toPath(), report + System.lineSeparator(),
+            java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
+      } catch (final java.io.IOException ignore) {
+        // best-effort reporting only
+      }
+
+      assertThat(committed.get()).isEqualTo(TOTAL_EDGES);
+      if (superNode) {
+        // All replicas agree (replication is consistent) ...
+        for (int s = 1; s < getServerCount(); s++)
+          assertThat(perServerDegree[s]).as("server %d degree vs leader", s).isEqualTo(perServerDegree[0]);
+        // ... and the leader kept nearly all edges (lenient for the separate pre-existing chunk race).
+        assertThat(perServerDegree[0]).isBetween((long) (TOTAL_EDGES * 0.99), (long) TOTAL_EDGES);
+      }
+    } finally {
+      GlobalConfiguration.TX_RETRY_DELAY.setValue(savedRetryDelay);
+      GlobalConfiguration.GRAPH_EDGE_APPEND_MERGE.setValue(savedMerge);
+    }
+  }
+}


### PR DESCRIPTION
## Super-node write contention: commutative edge-append merge

Targets **26.7.2**. Design + development log: [`docs/supernode.md`](docs/supernode.md).

### Problem

When many transactions append edges to the **same hot vertex** (a "super-node" - a treasury/float account, a popular product, a star-schema hub), they all collide on that vertex's single edge-list head chunk under ArcadeDB's **page-level MVCC**. Each collision aborts the whole transaction with a `ConcurrentModificationException` and retries it. Under HA every retry re-runs the **entire Raft replication round**, so contention piles up into multi-second (occasionally >1 minute) leader latencies that breach application timeouts. Reported from the field on a payments workload / 3-node HA cluster.

### Fix

Appends to an edge list **commute** (edge order is not semantically meaningful). So at commit, when the *only* cause of a page-version conflict on an edge-list chunk is concurrent in-chunk appends, the leader **replays this transaction's appends on top of the newer committed page** instead of failing the transaction. The merged page is what gets written to the WAL and replicated, so followers apply the merged bytes verbatim.

Gated by **`arcadedb.graph.edgeAppendMerge`** (`SCOPE.DATABASE`, default **true**).

### How it works (in `TransactionContext.commit1stPhase`, leader/embedded only)

On a page-version conflict for a page whose every modification was a tracked in-chunk append: evict the stale copy → reload the chunk fresh (bypassing the tx record cache) → re-apply the appends via `MutableEdgeSegment.add(...)` → write back, re-check version, continue. If a chunk filled up in the meantime, fall back to a normal full retry.

### Correctness guards

- **Leader/embedded only** (`commit1stPhase(isLeader)`); followers never rebase → no HA divergence. Replicas stay byte-identical (verified by the HA test's `checkDatabasesAreIdentical`).
- **Only pure-append pages are eligible.** Edge removal/relink, bulk `addAll`, and **new-chunk allocation** poison the page (a brand-new chunk has no committed version to rebase onto). New-chunk poison is centralised in `LocalDatabase.createRecordNoLock`.
- **Allocation-free hot path.** Appends are keyed by *segment* RID (a super-node is one segment however many edges it gets) with the (edge, vertex) pairs packed into growable primitive arrays; poisoned pages held in a `LongHashSet` of packed `(fileId, pageNumber)` keys; `PageId` materialised only on the rare conflict. Measured overhead vs feature-off on a single-threaded 200k-edge insert: **+39 bytes/edge (~0.7%)**, throughput within noise.

### Benchmarks

Embedded, 32k edges into one hub:

| | full-tx retries | throughput |
|---|---|---|
| off | 11,298 (35.3%) | 9,898 edges/s |
| **on** | **226 (0.7%)** | 11,038 edges/s |

3-node HA (Raft), 4k edges into one hub:

| | full-tx retries | max commit latency |
|---|---|---|
| off | 14,002 (350%) | **66,697 ms** |
| **on** | **135 (3.4%)** | **408 ms** |

Same successful commits, but the on-run does ~4.3x less leader/replication work and eliminates the >1-minute latency tail. (Raw single-hub throughput is unchanged - a single hot chunk is a serialised version chain; the follow-up shards the edge list. Established by a distinct-target control run at 94 vs 52 edges/s.)

### Also in this PR: two lost-update data-loss fixes (Fixes #5147, Fixes #5153)

While benchmarking, a **pre-existing** data-loss bug surfaced: concurrent edge writes on one super-node could **drop edges** - an edge record committed with no back-reference from the target's edge list (`check database` -> `missingReferenceBack`; the edge count drifted). It reproduces with this feature **disabled** (the merge only masked it), so it is independent and root-caused separately.

**Root cause** (not a chunk-allocation race): a deferred-update MVCC gap. The edge-list chunk is read via an immutable `lookupByRID` which, under READ_COMMITTED, does not retain the page in the transaction; the page is captured later by the deferred `updateRecord` - at the *newer* version if a concurrent transaction touched the same chunk in between. The commit-time version check then compares the newer version against itself, finds no conflict, and the stale chunk buffer overwrites the concurrent change.

**Fixes**:
- **#5147 (insertion):** `GraphEngine.createInEdgeChunk`/`createOutEdgeChunk` anchor the head chunk's page at read time (`fetchPageInTransaction`). Regression `Issue5147SuperNodeChunkRaceTest` (8 threads x 4000 edges): was losing ~130-160 edges/run, now 32000/32000, integrity clean.
- **#5153 (removal, the twin):** `EdgeLinkedList.removeEdge`/`removeEdgeRID`/`removeVertex` now load each chunk they modify during the chain-walk through `loadChunkForWrite` (anchors + reads from the anchored page), via the new `EdgeSegment.getPreviousRID()`. Regression `ConcurrentEdgeAppendMergeTest.concurrentAppendsAndRemovesStayConsistent` (mixed concurrent append+delete on one hub, net-zero degree, integrity clean).

Both are correct with the merge off too (they fix the root cause, not just mask it).

### Tests

- `Issue5147SuperNodeChunkRaceTest` (engine) - #5147 insertion regression.
- `ConcurrentEdgeAppendMergeTest` (engine) - append-merge correctness + the #5153 append/remove poison regression, reliably clean at scale. `@Tag("slow")`.
- `SuperNodeAppendHAConsistencyIT` (ha-raft) - **deterministic 3-node HA gate**: every replica holds the exact, complete edge list after concurrent super-node appends (no loss, replicas identical).
- `SuperNodeConcurrentAppendBenchmark` (engine) + `SuperNodeConcurrentAppendHABenchmark` (ha-raft) - `@Tag("benchmark")`, now with strict correctness assertions (#5147/#5153 fixed).
- No regressions: MVCCTest, ConcurrentWriteTest, BasicGraphTest, DanglingEdgeIteratorTest, ACIDTransactionTest, Issue4940/4959, LocalTransactionCommitLockRetryTest.

### Not in this PR (tracked follow-up)

- **Throughput**: an adaptive striped/sharded edge list so concurrent appends to one hub hit different pages/files (design in `docs/supernode.md` §4). This PR removes the retry storm and the data-loss races; striping is the remaining lever for raw single-hub throughput.

### Rollout

On by default and transparent; disable with `arcadedb.graph.edgeAppendMerge=false` if ever needed.


