### PR TITLE
fix(#5152): serialize cached-counter recompute with concurrent commits

### DIFF
--- a/docs/5152-count-recompute-race.md
+++ b/docs/5152-count-recompute-race.md
@@ -27,3 +27,16 @@ The recompute holds the bucket's file lock for the duration of its O(N) page sca
 
 ## Impact
 Eliminates the source of `count(*)` drift. Combined with #5150 (which repairs already-drifted databases and now recomputes race-free), `count(*)` stays consistent under concurrent load. No change to the read fast-path; the file lock is engaged only during a rare full recompute.
+
+## PR and review history
+- PR: https://github.com/ArcadeData/arcadedb/pull/5154
+- Review cycles (bots: `claude`, `gemini-code-assist`):
+  - cycle 1 (`9abf9569`): both bots. gemini raised (critical) don't cache the lock-free timeout scan, and (high) return the cached counter for non-transactional callers instead of a full scan. Both verified and applied.
+  - cycle 2 (`4aa2aa4c`): claude found a real, pre-existing over-count - an in-transaction recompute scans the tx view, so it now caches the committed base (`total - delta`); also simplified the requester (never null), added a `FINE` log on the timeout fallback, and added deterministic in-tx + non-tx tests (moved `@Tag("slow")` to the stress method only). gemini did not re-review.
+  - cycle 3 (`5bc1ba08`): claude LGTM with one substantive ask (document the commit-latency tradeoff). Added the operational note, a recheck-after-lock short-circuit to skip a duplicate scan, and timeout + delete-in-tx tests. gemini did not re-review.
+  - cycle 4 (`166c359c`): claude LGTM ("correct, carefully scoped, well-tested, and clearly documented"); all remaining points non-blocking. Applied the one cheap clarity item (comment on the pure `getRequester()` acquisition-path usage).
+- Final state: `max-cycles-reached` (converged - claude LGTM; gemini reviewed only cycle 1, its known re-review behavior).
+
+## Deferred (non-blocking) follow-ups
+1. Optional focused unit test for the concurrent-recompute short-circuit (two recomputes racing for the lock, the loser skipping the scan) - currently exercised indirectly by the stress test.
+2. The `LocalBucket.check(... fix)` caveat comment added by #5150 may now be overly conservative: this PR's lock serializes a concurrent `count()` against the CHECK-FIX commit fold (and CHECK-FIX deletions register no bucket delta anyway). Left untouched here as out of scope.

--- a/docs/5152-count-recompute-race.md
+++ b/docs/5152-count-recompute-race.md
@@ -22,5 +22,8 @@ In `LocalBucket.count()`, the recompute path (scan + `set`) now acquires the buc
 - New stress regression `Issue5152CountRecomputeRaceTest` (`@Tag("slow")`): large single bucket forced to `-1`, a reader triggers a long recompute while a writer commits concurrently; asserts `count(*) == count(@rid)`. Red before the fix (e.g. 52998 vs 53000), green after (repeated runs).
 - Regressions green: `Issue5149CountStarCacheDriftTest`, `CheckDatabaseTest`, `CheckDatabaseExtendedTest`, `CRUDTest`, `ConcurrentWriteTest`, `MVCCTest`, `ReusingSpaceTest`, `TransactionTypeTest`, plus `RandomTestMultiThreadsTest` (32 concurrent workers) and `PolymorphicTest` - no deadlock or perf regression.
 
+## Operational note
+The recompute holds the bucket's file lock for the duration of its O(N) page scan, so while a recompute runs, commits touching that bucket wait on the lock (and, on a very large bucket whose scan approaches `COMMIT_LOCK_TIMEOUT`, could hit a lock-acquisition timeout and retry). This is the intended correctness tradeoff and is confined to the rare `-1` recompute path (fresh open with no `statistics.json`, post-unclean-shutdown, post-`CHECK ... FIX`); steady-state `count(*)` uses the O(1) cached fast-path and takes no lock. A recompute that loses the race for the lock falls back to a lock-free best-effort scan without caching, and a concurrent recompute that already repopulated the counter short-circuits the duplicate scan.
+
 ## Impact
 Eliminates the source of `count(*)` drift. Combined with #5150 (which repairs already-drifted databases and now recomputes race-free), `count(*)` stays consistent under concurrent load. No change to the read fast-path; the file lock is engaged only during a rare full recompute.

--- a/docs/5152-count-recompute-race.md
+++ b/docs/5152-count-recompute-race.md
@@ -1,0 +1,25 @@
+# #5152 - count(*) drift root cause: lazy cached-counter recompute races with concurrent commits
+
+## Symptom
+`SELECT count(*)` permanently under/over-reports vs `count()` / a real scan (the drift behind #5149). PR #5150 added a reactive repair (`CHECK ... FIX` invalidates the counter); this fixes the underlying cause.
+
+## Root cause
+`count(*)` is served from `LocalBucket.cachedRecordCount`. That counter is repopulated from a scan only on the `cachedRecordCount == -1` branch of `LocalBucket.count()`, via an unconditional `set(total)` after a lock-free page scan. Commits fold their per-bucket deltas at `TransactionContext.commit2ndPhase` (guarded by `> -1`, so a `-1` counter drops the delta). Both `commit()` and `countType()` run under `executeInReadLock` (concurrent holders), and commits additionally hold the per-bucket file lock across `publishPages` + the fold - but the recompute took no file lock, so it was not serialized against commits.
+
+Race (counter at `-1`, concurrent writes): a recompute scans while a commit publishes a record and folds its delta; the fold sees `-1` and drops the delta, and the recompute stores a total that missed the record. The committed record is absent from the counter until the next `-1` recompute -> persistent drift. A seqlock/version probe cannot fix it: the record becomes scan-visible at `publishPages` but the counter is folded later, so a version-only scheme still admits a double-count in that gap.
+
+Vulnerable windows (counter `== -1` with concurrent load): first `count(*)` after a fresh open with no `statistics.json` entry; after an unclean shutdown; after `CHECK ... FIX` (#5150).
+
+## Fix
+In `LocalBucket.count()`, the recompute path (scan + `set`) now acquires the bucket's own file lock (via `TransactionManager.tryLockFile`, `COMMIT_LOCK_TIMEOUT`) - the same lock a commit holds across `publishPages` + fold - making the recompute mutually exclusive with commits on that bucket. Details:
+- Taken only on the rare recompute path (counter unknown, or no active transaction); the O(1) cached fast-path is untouched.
+- Requester mirrors the current transaction's (`getRequester()`) so a recompute invoked while the same transaction already holds the lock re-enters (`ALREADY_ACQUIRED`) instead of self-deadlocking; the lock is released only when this call actually acquired it (`YES`).
+- On lock-acquire timeout (`NO`) it falls back to the previous lock-free scan - degraded but no worse than before, and bounded.
+- No deadlock: a recompute locks a single file and does no further lock acquisition, so it cannot form a cycle with the ordered multi-file locks commits take; both acquire the shared DB read lock first.
+
+## Verification
+- New stress regression `Issue5152CountRecomputeRaceTest` (`@Tag("slow")`): large single bucket forced to `-1`, a reader triggers a long recompute while a writer commits concurrently; asserts `count(*) == count(@rid)`. Red before the fix (e.g. 52998 vs 53000), green after (repeated runs).
+- Regressions green: `Issue5149CountStarCacheDriftTest`, `CheckDatabaseTest`, `CheckDatabaseExtendedTest`, `CRUDTest`, `ConcurrentWriteTest`, `MVCCTest`, `ReusingSpaceTest`, `TransactionTypeTest`, plus `RandomTestMultiThreadsTest` (32 concurrent workers) and `PolymorphicTest` - no deadlock or perf regression.
+
+## Impact
+Eliminates the source of `count(*)` drift. Combined with #5150 (which repairs already-drifted databases and now recomputes race-free), `count(*)` stays consistent under concurrent load. No change to the read fast-path; the file lock is engaged only during a rare full recompute.

--- a/docs/5152-count-recompute-race.md
+++ b/docs/5152-count-recompute-race.md
@@ -14,8 +14,9 @@ Vulnerable windows (counter `== -1` with concurrent load): first `count(*)` afte
 In `LocalBucket.count()`, the recompute path (scan + `set`) now acquires the bucket's own file lock (via `TransactionManager.tryLockFile`, `COMMIT_LOCK_TIMEOUT`) - the same lock a commit holds across `publishPages` + fold - making the recompute mutually exclusive with commits on that bucket. Details:
 - Taken only on the rare recompute path (counter unknown, or no active transaction); the O(1) cached fast-path is untouched.
 - Requester mirrors the current transaction's (`getRequester()`) so a recompute invoked while the same transaction already holds the lock re-enters (`ALREADY_ACQUIRED`) instead of self-deadlocking; the lock is released only when this call actually acquired it (`YES`).
-- On lock-acquire timeout (`NO`) it falls back to the previous lock-free scan - degraded but no worse than before, and bounded.
+- On lock-acquire timeout (`NO`) it falls back to a lock-free scan and returns a best-effort value but does **not** cache it (leaves the counter at `-1`), so a possibly-drifted value is never persisted and a later call recomputes cleanly.
 - No deadlock: a recompute locks a single file and does no further lock acquisition, so it cannot form a cycle with the ordered multi-file locks commits take; both acquire the shared DB read lock first.
+- The cached fast-path now returns the counter directly whenever it is known (`> -1`), for both transactional and non-transactional calls (adding the transaction delta only when a transaction is active). Previously a call with no active transaction always did a full O(N) scan, contradicting the O(1) contract relied on by cardinality estimation (`StatisticsProvider`) and external-bucket cleanup; the recompute path is now entered only when the counter is genuinely unknown.
 
 ## Verification
 - New stress regression `Issue5152CountRecomputeRaceTest` (`@Tag("slow")`): large single bucket forced to `-1`, a reader triggers a long recompute while a writer commits concurrently; asserts `count(*) == count(@rid)`. Red before the fix (e.g. 52998 vs 53000), green after (repeated runs).

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -435,8 +435,7 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     // above. The requester mirrors the transaction's so a recompute invoked while the same transaction already
     // holds the lock re-enters instead of self-deadlocking.
     final TransactionManager txManager = database.getTransactionManager();
-    final Object requester = transaction != null && transaction.getRequester() != null ?
-            transaction.getRequester() : Thread.currentThread();
+    final Object requester = transaction != null ? transaction.getRequester() : Thread.currentThread();
     final long lockTimeout = database.getConfiguration().getValueAsLong(GlobalConfiguration.COMMIT_LOCK_TIMEOUT);
 
     LockManager.LOCK_STATUS lockStatus = LockManager.LOCK_STATUS.NO;
@@ -474,7 +473,15 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
       // an enclosing transaction). On a lock-acquisition timeout (NO) the scan ran lock-free and may be drifted,
       // so leave the counter at -1 and return a best-effort value: a later call recomputes cleanly.
       if (lockStatus != LockManager.LOCK_STATUS.NO)
-        cachedRecordCount.set(total);
+        // The scan reads the transaction's view (getPage returns its uncommitted pages first), so `total`
+        // already includes this transaction's pending delta. Cache the COMMITTED base (total - pending) so the
+        // commit-time fold adds the delta exactly once instead of double-counting it; the caller still gets the
+        // transaction-visible `total` below.
+        cachedRecordCount.set(transaction != null ? total - transaction.getBucketRecordDelta(fileId) : total);
+      else
+        LogManager.instance().log(this, Level.FINE,
+                "count() recompute on bucket '%s' ran lock-free after a %dms lock-acquisition timeout; result not cached", componentName,
+                lockTimeout);
       return total;
 
     } catch (final IOException e) {

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -419,8 +419,11 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     final TransactionContext transaction = database.getTransactionIfExists();
 
     final long cached = cachedRecordCount.get();
-    if (cached > -1 && transaction != null)
-      return cached + transaction.getBucketRecordDelta(fileId);
+    if (cached > -1)
+      // O(1) fast path: the counter is kept up to date on every commit, so return it directly. With an active
+      // transaction add its uncommitted delta; without one there is nothing pending, so the cached value is the
+      // committed count. Only a still-unknown (-1) counter falls through to the full recompute below.
+      return cached + (transaction != null ? transaction.getBucketRecordDelta(fileId) : 0);
 
     // #5152: the recompute below (scan + publish of cachedRecordCount) must be mutually exclusive with a
     // commit's publishPages + record-count fold on this bucket. A commit holds this bucket's file lock across
@@ -428,9 +431,9 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     // recompute with commits. Without it a commit could publish a record and then, seeing the still-(-1)
     // counter, drop its delta at the fold while our scan misses that just-published record (lost update), or
     // conversely our scan counts a published record whose delta the fold then re-adds (double count). The lock
-    // is taken only on this rare recompute path (counter unknown, or no active transaction) - never on the
-    // O(1) cached fast-path returned above. The requester mirrors the transaction's so a recompute invoked
-    // while the same transaction already holds the lock re-enters instead of self-deadlocking.
+    // is taken only on this rare recompute path (counter unknown) - never on the O(1) cached fast-path returned
+    // above. The requester mirrors the transaction's so a recompute invoked while the same transaction already
+    // holds the lock re-enters instead of self-deadlocking.
     final TransactionManager txManager = database.getTransactionManager();
     final Object requester = transaction != null && transaction.getRequester() != null ?
             transaction.getRequester() : Thread.currentThread();
@@ -467,7 +470,11 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
         }
       }
 
-      cachedRecordCount.set(total);
+      // Publish the recomputed value only when this scan ran under the lock (acquired now, or already held by
+      // an enclosing transaction). On a lock-acquisition timeout (NO) the scan ran lock-free and may be drifted,
+      // so leave the counter at -1 and return a best-effort value: a later call recomputes cleanly.
+      if (lockStatus != LockManager.LOCK_STATUS.NO)
+        cachedRecordCount.set(total);
       return total;
 
     } catch (final IOException e) {

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -442,6 +442,12 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     try {
       lockStatus = txManager.tryLockFile(fileId, lockTimeout, requester);
 
+      // Another thread may have recomputed the counter while we were queued on the lock. Re-check now that we
+      // hold it (or timed out) and skip the duplicate O(N) scan, which also shortens how long we hold the lock.
+      final long recomputed = cachedRecordCount.get();
+      if (recomputed > -1)
+        return recomputed + (transaction != null ? transaction.getBucketRecordDelta(fileId) : 0);
+
       long total = 0;
 
       final int txPageCount = getTotalPages();

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -435,6 +435,9 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     // above. The requester mirrors the transaction's so a recompute invoked while the same transaction already
     // holds the lock re-enters instead of self-deadlocking.
     final TransactionManager txManager = database.getTransactionManager();
+    // Deliberately the pure getRequester() read (not captureRequester()): this call acquires and releases the
+    // lock symmetrically on one thread, so there is nothing to capture, and reading avoids mutating the
+    // transaction's requester field from a possibly-foreign counting thread. Falls back to the current thread.
     final Object requester = transaction != null ? transaction.getRequester() : Thread.currentThread();
     final long lockTimeout = database.getConfiguration().getValueAsLong(GlobalConfiguration.COMMIT_LOCK_TIMEOUT);
 

--- a/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
+++ b/engine/src/main/java/com/arcadedb/engine/LocalBucket.java
@@ -40,6 +40,7 @@ import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.utility.FileUtils;
 import com.arcadedb.utility.IntIntHashMap;
+import com.arcadedb.utility.LockManager;
 
 import java.io.IOException;
 import java.util.*;
@@ -421,11 +422,28 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
     if (cached > -1 && transaction != null)
       return cached + transaction.getBucketRecordDelta(fileId);
 
-    long total = 0;
+    // #5152: the recompute below (scan + publish of cachedRecordCount) must be mutually exclusive with a
+    // commit's publishPages + record-count fold on this bucket. A commit holds this bucket's file lock across
+    // both (TransactionContext.commit2ndPhase, until reset()), so acquiring the same lock here serializes the
+    // recompute with commits. Without it a commit could publish a record and then, seeing the still-(-1)
+    // counter, drop its delta at the fold while our scan misses that just-published record (lost update), or
+    // conversely our scan counts a published record whose delta the fold then re-adds (double count). The lock
+    // is taken only on this rare recompute path (counter unknown, or no active transaction) - never on the
+    // O(1) cached fast-path returned above. The requester mirrors the transaction's so a recompute invoked
+    // while the same transaction already holds the lock re-enters instead of self-deadlocking.
+    final TransactionManager txManager = database.getTransactionManager();
+    final Object requester = transaction != null && transaction.getRequester() != null ?
+            transaction.getRequester() : Thread.currentThread();
+    final long lockTimeout = database.getConfiguration().getValueAsLong(GlobalConfiguration.COMMIT_LOCK_TIMEOUT);
 
-    final int txPageCount = getTotalPages();
-
+    LockManager.LOCK_STATUS lockStatus = LockManager.LOCK_STATUS.NO;
     try {
+      lockStatus = txManager.tryLockFile(fileId, lockTimeout, requester);
+
+      long total = 0;
+
+      final int txPageCount = getTotalPages();
+
       for (int pageId = 0; pageId < txPageCount; ++pageId) {
         final PageId pageIdToLoad = new PageId(database, file.getFileId(), pageId);
         final BasePage page = transaction != null ?
@@ -450,11 +468,16 @@ public class LocalBucket extends PaginatedComponent implements Bucket {
       }
 
       cachedRecordCount.set(total);
+      return total;
 
     } catch (final IOException e) {
       throw new DatabaseOperationException("Cannot count bucket '" + componentName + "'", e);
+    } finally {
+      // Release only if WE acquired it. ALREADY_ACQUIRED means an enclosing transaction owns the lock and is
+      // responsible for releasing it; NO means the acquisition timed out and we ran the scan lock-free.
+      if (lockStatus == LockManager.LOCK_STATUS.YES)
+        txManager.unlockFile(fileId, requester);
     }
-    return total;
   }
 
   public Map<String, Object> check(final int verboseLevel, final boolean fix) {

--- a/engine/src/test/java/com/arcadedb/Issue5152CountRecomputeRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue5152CountRecomputeRaceTest.java
@@ -41,7 +41,6 @@ import static org.assertj.core.api.Assertions.fail;
  * (long) recompute while a writer commits new records concurrently. Afterwards the cached {@code count(*)}
  * must equal the authoritative scan {@code count(@rid)}.
  */
-@Tag("slow")
 class Issue5152CountRecomputeRaceTest extends TestHelper {
   private static final int BASE   = 50000;
   private static final int EXTRA  = 3000;
@@ -82,6 +81,39 @@ class Issue5152CountRecomputeRaceTest extends TestHelper {
   }
 
   @Test
+  void recomputeInsideTransactionDoesNotDoubleCountOnCommit() {
+    insert(0, 10);
+    bucket().setCachedRecordCount(-1); // force a recompute on the next count()
+
+    database.begin();
+    try {
+      database.command("sql", "INSERT INTO Doc SET n = 999"); // pending, uncommitted insert in this transaction
+      // The recompute scans the transaction view (11) but must cache only the committed base (10) so the
+      // commit-time fold does not add the pending delta a second time.
+      assertThat(countStar()).isEqualTo(11L);
+    } finally {
+      database.commit();
+    }
+
+    // After commit the counter must be exactly 11, not 12 (no double count of the pending insert).
+    assertThat(countStar()).isEqualTo(11L);
+    assertThat(countScan()).isEqualTo(11L);
+  }
+
+  @Test
+  void nonTransactionalCountReturnsCachedValueWithoutScanning() {
+    insert(0, 5);
+    final LocalBucket b = bucket();
+    b.count(); // prime the cached counter
+
+    // Poison the cache with a value that disagrees with the real records. A non-transactional count() must
+    // return the cached value directly (O(1)) rather than rescanning, which is the restored fast-path contract.
+    b.setCachedRecordCount(42L);
+    assertThat(b.count()).isEqualTo(42L);
+  }
+
+  @Test
+  @Tag("slow")
   void cachedCounterStaysConsistentUnderConcurrentRecomputeAndCommits() throws InterruptedException {
     insert(0, BASE);
     int expected = BASE;

--- a/engine/src/test/java/com/arcadedb/Issue5152CountRecomputeRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue5152CountRecomputeRaceTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb;
+
+import com.arcadedb.engine.Bucket;
+import com.arcadedb.engine.LocalBucket;
+import com.arcadedb.query.sql.executor.ResultSet;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * Regression test for #5152: the lazy recompute of the cached per-bucket record counter
+ * ({@code LocalBucket.count()} on the {@code cachedRecordCount == -1} branch) must be serialized against
+ * concurrent commits. Before the fix, a recompute could scan pages while a commit published a record and
+ * folded its delta; the fold saw the still-{@code -1} counter and dropped the delta, and the recompute then
+ * stored a total that missed the record, leaving {@code count(*)} permanently below the real count.
+ * <p>
+ * Stress test: with a large pre-populated single bucket forced into the {@code -1} state, a reader triggers a
+ * (long) recompute while a writer commits new records concurrently. Afterwards the cached {@code count(*)}
+ * must equal the authoritative scan {@code count(@rid)}.
+ */
+@Tag("slow")
+class Issue5152CountRecomputeRaceTest extends TestHelper {
+  private static final int BASE   = 50000;
+  private static final int EXTRA  = 3000;
+  private static final int ROUNDS = 3;
+
+  @Override
+  protected void beginTest() {
+    database.transaction(() -> {
+      if (!database.getSchema().existsType("Doc"))
+        // single bucket so all records share one cached counter, concentrating the race
+        database.getSchema().createDocumentType("Doc", 1);
+    });
+  }
+
+  private long countStar() {
+    try (final ResultSet rs = database.query("sql", "SELECT count(*) AS c FROM Doc")) {
+      return ((Number) rs.next().getProperty("c")).longValue();
+    }
+  }
+
+  private long countScan() {
+    // count(@rid) bypasses the count(*) cached fast-path and performs a real record scan.
+    try (final ResultSet rs = database.query("sql", "SELECT count(@rid) AS c FROM Doc")) {
+      return ((Number) rs.next().getProperty("c")).longValue();
+    }
+  }
+
+  private LocalBucket bucket() {
+    final Bucket b = database.getSchema().getType("Doc").getBuckets(false).getFirst();
+    return (LocalBucket) b;
+  }
+
+  private void insert(final int from, final int count) {
+    for (int i = 0; i < count; i++) {
+      final int id = from + i;
+      database.transaction(() -> database.command("sql", "INSERT INTO Doc SET n = ?", id));
+    }
+  }
+
+  @Test
+  void cachedCounterStaysConsistentUnderConcurrentRecomputeAndCommits() throws InterruptedException {
+    insert(0, BASE);
+    int expected = BASE;
+
+    for (int round = 0; round < ROUNDS; round++) {
+      // Force the cached counter into the vulnerable "unknown" state, as happens after an unclean shutdown,
+      // a fresh open without a statistics file, or CHECK ... FIX.
+      bucket().setCachedRecordCount(-1);
+
+      final int start = expected;
+      final CountDownLatch go = new CountDownLatch(1);
+      final AtomicReference<Throwable> error = new AtomicReference<>();
+
+      final Thread writer = new Thread(() -> {
+        try {
+          go.await();
+          insert(start, EXTRA);
+        } catch (final Throwable t) {
+          error.set(t);
+        }
+      }, "writer-" + round);
+
+      final Thread reader = new Thread(() -> {
+        try {
+          go.await();
+          // The first count() over BASE+ records is a long recompute that overlaps the writer's commits.
+          countStar();
+        } catch (final Throwable t) {
+          error.set(t);
+        }
+      }, "reader-" + round);
+
+      writer.start();
+      reader.start();
+      go.countDown();
+      writer.join();
+      reader.join();
+
+      if (error.get() != null)
+        fail("worker failed in round " + round, error.get());
+
+      expected = start + EXTRA;
+
+      // The authoritative scan is always correct.
+      assertThat(countScan()).as("count(@rid) after round %d", round).isEqualTo((long) expected);
+      // The cached count(*) must match it - i.e. the concurrent recompute did not lose any committed record.
+      assertThat(countStar()).as("count(*) after round %d", round).isEqualTo((long) expected);
+    }
+  }
+}

--- a/engine/src/test/java/com/arcadedb/Issue5152CountRecomputeRaceTest.java
+++ b/engine/src/test/java/com/arcadedb/Issue5152CountRecomputeRaceTest.java
@@ -18,6 +18,8 @@
  */
 package com.arcadedb;
 
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.engine.Bucket;
 import com.arcadedb.engine.LocalBucket;
 import com.arcadedb.query.sql.executor.ResultSet;
@@ -98,6 +100,49 @@ class Issue5152CountRecomputeRaceTest extends TestHelper {
     // After commit the counter must be exactly 11, not 12 (no double count of the pending insert).
     assertThat(countStar()).isEqualTo(11L);
     assertThat(countScan()).isEqualTo(11L);
+  }
+
+  @Test
+  void recomputeInsideTransactionWithPendingDeleteDoesNotDoubleSubtractOnCommit() {
+    insert(0, 10);
+    bucket().setCachedRecordCount(-1); // force a recompute on the next count()
+
+    database.begin();
+    try {
+      database.command("sql", "DELETE FROM Doc WHERE n = 0"); // pending, uncommitted delete in this transaction
+      // The recompute scans the transaction view (9) but must cache the committed base (10) so the commit-time
+      // fold applies the negative delta only once.
+      assertThat(countStar()).isEqualTo(9L);
+    } finally {
+      database.commit();
+    }
+
+    // After commit the counter must be exactly 9, not 8 (no double subtraction of the pending delete).
+    assertThat(countStar()).isEqualTo(9L);
+    assertThat(countScan()).isEqualTo(9L);
+  }
+
+  @Test
+  void lockAcquisitionTimeoutRunsLockFreeAndLeavesCounterUnset() {
+    insert(0, 5);
+    final LocalBucket b = bucket();
+    b.setCachedRecordCount(-1);
+
+    final DatabaseInternal db = (DatabaseInternal) database;
+    final Object foreign = new Object();
+    final long savedTimeout = db.getConfiguration().getValueAsLong(GlobalConfiguration.COMMIT_LOCK_TIMEOUT);
+    db.getConfiguration().setValue(GlobalConfiguration.COMMIT_LOCK_TIMEOUT, 100L);
+
+    // Hold the bucket's file lock from a foreign requester so the recompute cannot acquire it.
+    db.getTransactionManager().tryLockFile(b.getFileId(), 5000, foreign);
+    try {
+      // The recompute times out on the lock, runs a lock-free best-effort scan, returns it, but must NOT cache.
+      assertThat(b.count()).isEqualTo(5L);
+      assertThat(b.getCachedRecordCount()).isEqualTo(-1L);
+    } finally {
+      db.getTransactionManager().unlockFile(b.getFileId(), foreign);
+      db.getConfiguration().setValue(GlobalConfiguration.COMMIT_LOCK_TIMEOUT, savedTimeout);
+    }
   }
 
   @Test


### PR DESCRIPTION
Closes #5152

## Summary
Root-cause fix for the `count(*)` drift reported in #5149 (PR #5150 was the reactive `CHECK ... FIX` repair). `count(*)` is served from `LocalBucket.cachedRecordCount`, repopulated from a scan only on the `== -1` branch of `LocalBucket.count()`. Commits fold their per-bucket delta at `TransactionContext.commit2ndPhase` (skipped when the counter is `-1`) while holding the bucket's file lock across `publishPages` + the fold. The recompute took **no** file lock, so a commit publishing a record while a recompute was mid-scan had its delta dropped (fold saw `-1`) and the recompute stored a total that missed the record - a lost update leaving `count(*)` permanently drifted.

The recompute now acquires the bucket's own file lock (`TransactionManager.tryLockFile`, `COMMIT_LOCK_TIMEOUT`) for the scan + cache publish, making it mutually exclusive with a commit's publish+fold on that bucket. Only the rare recompute path (`-1` counter) takes the lock; requester mirrors the transaction's for re-entrancy; the lock is released only when this call acquired it. A seqlock/version probe alone cannot fix this: a record becomes scan-visible at `publishPages` but its delta is folded later, so a version-only scheme still admits a double-count in that gap - mutual exclusion over publish+fold is required.

Additional correctness/robustness items handled in the same change:
- **In-transaction recompute** scans the transaction's own view (`getPage` returns uncommitted pages first), so the scanned total already includes the transaction's pending delta. The recompute now caches the **committed base** (`total - pendingDelta`) so the commit-time fold adds the delta exactly once instead of double-counting it (a pre-existing over-count in the same drift family).
- **Timeout fallback**: on a lock-acquire timeout the scan runs lock-free, returns a best-effort value, and does **not** cache it (leaves `-1` for a clean later recompute); a `FINE` log records the event.
- **Behavior change (intentional)**: the O(1) cached fast-path now serves non-transactional callers too (previously any call with no active transaction did a full O(N) scan, contradicting the O(1) contract relied on by `StatisticsProvider` cardinality estimation and external-bucket cleanup). Correctness now depends on the counter being maintained on every mutation plus `CHECK ... FIX` for repair - the right tradeoff given this fix.

## Test plan
- [x] `cachedCounterStaysConsistentUnderConcurrentRecomputeAndCommits` (`@Tag("slow")`) - concurrent recompute vs commits; asserts `count(*) == count(@rid)`. Red before the fix (52998 vs 53000), green after across repeated runs.
- [x] `recomputeInsideTransactionDoesNotDoubleCountOnCommit` - recompute with a pending insert in the same transaction, asserts `count(*)` is not double-counted after commit.
- [x] `nonTransactionalCountReturnsCachedValueWithoutScanning` - asserts the restored O(1) fast-path for non-transactional callers.
- [x] `Issue5149CountStarCacheDriftTest` (`CHECK ... FIX` now recomputes race-free) - green.
- [x] Regressions green: `CheckDatabaseTest`, `CheckDatabaseExtendedTest`, `CRUDTest`, `ConcurrentWriteTest`, `MVCCTest`, `ReusingSpaceTest`, `TransactionTypeTest`, `PolymorphicTest`, and `RandomTestMultiThreadsTest` (32 workers, no deadlock).

## Related
- Symptom + reactive repair: #5149, PR #5150 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)