### PR TITLE
fix(#5159): make TRAVERSE MAXDEPTH return a monotonic d-hop ball

### DIFF
--- a/engine/src/main/java/com/arcadedb/query/sql/executor/DepthFirstTraverseStep.java
+++ b/engine/src/main/java/com/arcadedb/query/sql/executor/DepthFirstTraverseStep.java
@@ -20,9 +20,11 @@ package com.arcadedb.query.sql.executor;
 
 import com.arcadedb.database.Document;
 import com.arcadedb.database.Identifiable;
+import com.arcadedb.database.RID;
 import com.arcadedb.query.sql.parser.PInteger;
 import com.arcadedb.query.sql.parser.TraverseProjectionItem;
 import com.arcadedb.query.sql.parser.WhereClause;
+import com.arcadedb.utility.RidHashSet;
 
 import java.util.*;
 
@@ -32,6 +34,14 @@ import static com.arcadedb.schema.Property.RID_PROPERTY;
  * Created by luigidellaquila on 26/10/16.
  */
 public class DepthFirstTraverseStep extends AbstractTraverseStep {
+
+  // Relaxation state so TRAVERSE ... MAXDEPTH d returns the correct d-hop ball. A depth-first walk can reach a node through a long path before a short one; the
+  // legacy code recorded only that first-arrival depth and gated subtree expansion on it, so when MAXDEPTH fell between the two path lengths a whole subtree was
+  // wrongly pruned and the result became non-monotonic in d (issue #5159). We instead keep the smallest depth seen per node and re-expand it whenever a strictly
+  // shorter path arrives, so every node reachable within d hops is expanded. Nodes are still emitted once. On single-path graphs no relaxation fires, so the walk
+  // is byte-for-byte identical to before.
+  private final Map<RID, Integer> bestDepthByRid = new HashMap<>();
+  private final RidHashSet        emitted        = new RidHashSet();
 
   public DepthFirstTraverseStep(final List<TraverseProjectionItem> projections, final WhereClause whileClause, final PInteger maxDepth,
       final CommandContext context) {
@@ -66,11 +76,15 @@ public class DepthFirstTraverseStep extends AbstractTraverseStep {
       ((ResultInternal) item).setMetadata("$path", path);
 
       if (item.isElement() && !traversed.contains(item.getElement().get().getIdentity())) {
+        final RID rid = item.getElement().get().getIdentity();
         tryAddEntryPointAtTheEnd(item, context);
-        traversed.add(item.getElement().get().getIdentity());
+        traversed.add(rid);
+        bestDepthByRid.put(rid, 0);
       } else if (item.getProperty(RID_PROPERTY) instanceof Identifiable) {
+        final RID rid = ((Identifiable) item.getProperty(RID_PROPERTY)).getIdentity();
         tryAddEntryPointAtTheEnd(item, context);
-        traversed.add(((Identifiable) item.getProperty(RID_PROPERTY)).getIdentity());
+        traversed.add(rid);
+        bestDepthByRid.put(rid, 0);
       }
     }
   }
@@ -105,11 +119,23 @@ public class DepthFirstTraverseStep extends AbstractTraverseStep {
   protected void fetchNextResults(final CommandContext context, final int nRecords) {
     if (!this.entryPoints.isEmpty()) {
       final TraverseResult item = (TraverseResult) this.entryPoints.removeFirst();
-      if (postFilter == null || postFilter.matchesFilters(item, context))
+      final Integer depth = item.depth != null ? item.depth : (Integer) item.getMetadata("$depth");
+      final RID rid = item.getIdentity().orElse(null);
+
+      // A strictly shorter path to this node was found after this copy was queued: a better-depth copy is (or was) in the queue, so this one is stale. Skipping it
+      // avoids both a duplicate emission and a redundant (deeper) expansion; the better copy carries the correct depth and re-expands the subtree.
+      if (rid != null) {
+        final Integer best = bestDepthByRid.get(rid);
+        if (best != null && depth > best)
+          return;
+      }
+
+      // Emit each node at most once (its first non-stale visit). Non-element results carry no RID and keep the historical emit-always behavior.
+      if ((rid == null || emitted.add(rid)) && (postFilter == null || postFilter.matchesFilters(item, context)))
         this.results.add(item);
+
       for (final TraverseProjectionItem proj : projections) {
         final Object nextStep = proj.execute(item, context);
-        final Integer depth = item.depth != null ? item.depth : (Integer) item.getMetadata("$depth");
         if (this.maxDepth == null || this.maxDepth.getValue().intValue() > depth)
           addNextEntryPoints(nextStep, depth + 1, (List) item.getMetadata("$path"), (List) item.getMetadata("$stack"), context);
       }
@@ -136,7 +162,7 @@ public class DepthFirstTraverseStep extends AbstractTraverseStep {
 
   private void addNextEntryPoint(final Identifiable nextStep, final int depth, final List<Identifiable> path, final List<Identifiable> stack,
       final CommandContext context) {
-    if (this.traversed.contains(nextStep.getIdentity()))
+    if (!improvesDepth(nextStep.getIdentity(), depth))
       return;
 
     final TraverseResult res = new TraverseResult((Document) nextStep);
@@ -163,7 +189,7 @@ public class DepthFirstTraverseStep extends AbstractTraverseStep {
     if (!nextStep.isElement())
       return;
 
-    if (this.traversed.contains(nextStep.getElement().get().getIdentity()))
+    if (!improvesDepth(nextStep.getElement().get().getIdentity(), depth))
       return;
 
     if (nextStep instanceof TraverseResult result) {
@@ -193,6 +219,19 @@ public class DepthFirstTraverseStep extends AbstractTraverseStep {
       res.setMetadata("$stack", newStack);
       tryAddEntryPoint(res, context);
     }
+  }
+
+  /**
+   * Records {@code depth} as the new best (smallest) depth for {@code rid} when it strictly improves on any previously seen depth, returning true so the caller
+   * queues the node for (re-)expansion. Returns false when a path of equal or smaller depth was already recorded, leaving the queue untouched. This relaxation is
+   * what keeps MAXDEPTH monotonic: a node first reached through a long path is re-queued (and its subtree re-expanded) once a shorter path arrives.
+   */
+  private boolean improvesDepth(final RID rid, final int depth) {
+    final Integer prev = bestDepthByRid.get(rid);
+    if (prev != null && prev <= depth)
+      return false;
+    bestDepthByRid.put(rid, depth);
+    return true;
   }
 
   private void tryAddEntryPoint(final Result res, final CommandContext context) {

--- a/engine/src/test/java/com/arcadedb/query/sql/executor/TraverseStatementExecutionTest.java
+++ b/engine/src/test/java/com/arcadedb/query/sql/executor/TraverseStatementExecutionTest.java
@@ -145,6 +145,62 @@ class TraverseStatementExecutionTest extends TestHelper {
   }
 
   @Test
+  void maxDepthReturnsMonotonicBallOnMultiPathGraph() {
+    // Contract: TRAVERSE ... MAXDEPTH d must return the nodes reachable within d hops (the d-hop ball). That set is monotonically non-decreasing in d -- raising
+    // the bound can only add nodes, never remove them -- and once d reaches the root's eccentricity the set is the whole reachable graph. This must hold
+    // irrespective of edge-insertion order or of multiple paths to the same node.
+    //
+    // Graph (a DAG -- cycles are NOT needed to trigger the bug): R reaches X by a short path R->a->X (X at true depth 2) and a long path R->b->c->d->X (depth 4),
+    // and X fans out to s1..s10. 16 nodes total. True d-hop ball sizes: d2 = 5; d>=3 = 16 (every node). The two R out-edges are created long-branch-first
+    // (R->b before R->a) so the depth-first walk pops the long path first and first-reaches X at depth 4.
+    //
+    // Regression guard for issue #5159. Before the fix DepthFirstTraverseStep recorded a node's depth on FIRST arrival with no relaxation when a shorter path
+    // arrived later, and gated subtree expansion on that recorded depth. So at MAXDEPTH 4, X was stamped depth 4 (via the long path), the gate 4 > 4 was false,
+    // and X's 10-node subtree was never expanded -> 6 nodes; at MAXDEPTH 3 the long path is cut before X, so X is reached via the short path at depth 2, expanded,
+    // and all 16 appear. The result thus DROPPED from 16 (d3) to 6 (d4) before returning to 16 (d5): a non-monotonic under-approximation, now yielding [16,16,16].
+    database.transaction(() -> {
+      final String v = "MaxDepthBallV";
+      final String e = "MaxDepthBallE";
+      database.getSchema().createVertexType(v);
+      database.getSchema().createEdgeType(e);
+
+      final Map<String, RID> ids = new HashMap<>();
+      final String[] names = { "R", "a", "b", "c", "d", "X", "s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8", "s9", "s10" };
+      for (final String name : names)
+        ids.put(name, database.command("sql", "create vertex " + v + " set name = '" + name + "'").next().getIdentity().get());
+
+      // R->b (long branch) is created before R->a (short branch) so the DFS pops the long path to X first -- the exact order that triggered the pre-fix bug. With
+      // the relaxation fix the expected [16,16,16] holds for any adjacency iteration order; this order is kept only so the test keeps exercising that scenario.
+      final String[][] edges = { { "R", "b" }, { "R", "a" }, { "a", "X" }, { "b", "c" }, { "c", "d" }, { "d", "X" }, //
+          { "X", "s1" }, { "X", "s2" }, { "X", "s3" }, { "X", "s4" }, { "X", "s5" }, { "X", "s6" }, { "X", "s7" }, { "X", "s8" }, { "X", "s9" }, { "X", "s10" } };
+      final Map<String, Object> params = new HashMap<>();
+      for (final String[] edge : edges) {
+        params.put("from", ids.get(edge[0]));
+        params.put("to", ids.get(edge[1]));
+        database.command("sql", "create edge " + e + " from :from to :to", params).close();
+      }
+
+      final int d3 = countWithinDepth(ids.get("R"), e, 3);
+      final int d4 = countWithinDepth(ids.get("R"), e, 4);
+      final int d5 = countWithinDepth(ids.get("R"), e, 5);
+
+      // Every one of MAXDEPTH 3/4/5 must return the full 16-node graph. The bug yields [16, 6, 16] -- MAXDEPTH 4 loses X's whole subtree.
+      assertThat(new int[] { d3, d4, d5 })
+          .as("d-hop ball sizes at MAXDEPTH 3,4,5 must all be 16; a dip means raising the bound dropped reachable nodes")
+          .containsExactly(16, 16, 16);
+    });
+  }
+
+  private int countWithinDepth(final RID root, final String edgeType, final int maxDepth) {
+    final Map<String, Object> params = new HashMap<>();
+    params.put("root", root);
+    try (final ResultSet rs = database.query("sql",
+        "select count(*) as c from (traverse out('" + edgeType + "') from :root MAXDEPTH " + maxDepth + ")", params)) {
+      return ((Number) rs.next().getProperty("c")).intValue();
+    }
+  }
+
+  @Test
   void breadthFirstOrder() {
     // Contract: STRATEGY BREADTH_FIRST must visit the graph level by level -- every node at depth d is emitted before any node at depth d+1. That level-ordering
     // is the definition of a breadth-first traversal and the only observable difference from DEPTH_FIRST. (Sibling order *within* a level is intentionally not


### PR DESCRIPTION
Fixes #5159. Supersedes #5135 (the disabled reproducer), whose test is enabled here as a regression guard.

`DepthFirstTraverseStep` recorded a node's depth on first arrival with no relaxation and gated subtree expansion on that recorded depth. A node reached first via a long path and later via a short one kept the long depth, so when MAXDEPTH fell between the two path lengths its whole subtree was wrongly pruned - the d-hop ball became non-monotonic in d (16 -> 6 -> 16 nodes at MAXDEPTH 3/4/5 on the reproducer).

**Fix:** track the smallest depth seen per node and re-expand its subtree whenever a strictly shorter path arrives (SPFA-style relaxation). Nodes are still emitted once; on single-path graphs no relaxation fires and the walk is identical to before. The ball content and count are now correct and monotonic.

**Verification:** the reproducer contributed by @saevarb (enabled here) now returns `[16,16,16]` (was `[16,6,16]`); 149 traverse/match/select tests pass; cycles, self-loops and diamond graphs were probed for termination and monotonicity.

**Documented behavior kept:** for a node reachable by multiple paths, its reported `$depth` still reflects the depth-first arrival path (pre-existing DFS behavior, unchanged); only the ball membership/count is corrected here.

Test credit: @saevarb (co-authored).