### PR TITLE
fix(#5036): report partial-commit counts and partial-write drops on batch/time-series write endpoints

### DIFF
--- a/docs/5036-batch-timeseries-lossy-error-reporting.md
+++ b/docs/5036-batch-timeseries-lossy-error-reporting.md
@@ -1,0 +1,36 @@
+# Issue #5036 - Batch and time-series write endpoints: partial-commit atomicity and lossy error reporting
+
+## Symptom
+- `POST /api/v1/batch`: a mid-stream failure (malformed line, unknown temp id, dropped connection)
+  returns 4xx/5xx but the error body does not report how many records were already committed. Because
+  `GraphBatch` commits every `commitEvery` records, earlier chunks stay persisted, so a naive retry of
+  the whole file duplicates data with no way for the client to know what survived.
+- `POST /api/v1/ts/{db}/write` (InfluxDB line protocol): samples for unknown / non-timeseries
+  measurements are silently dropped with only a server-side WARNING. If at least one sample is inserted
+  the response is `204`, so a partial write looks like a full success to the client.
+
+## Root cause
+- `PostBatchHandler.execute` lets exceptions propagate to `AbstractServerHttpHandler`, which builds a
+  generic error body with no `verticesCreated` / `edgesCreated` count.
+- `PostTimeSeriesWriteHandler.execute` only returned `400` when `inserted == 0`; any partial insert
+  (`inserted > 0` with a non-empty drop set) fell through to the `204` success path.
+
+## Fix
+- `PostBatchHandler`: wrap the streaming ingest in a try/catch. On failure return an explicit
+  `ExecutionResponse` (400 for `IllegalArgumentException` client-input errors, 500 otherwise) whose JSON
+  body carries `verticesCreated`, `edgesCreated`, `partialCommit: true`, and the original `error`
+  message. Class Javadoc documents the non-atomic contract.
+- `PostTimeSeriesWriteHandler`: return a `400` partial-write payload whenever any sample was dropped
+  (regardless of how many were inserted), naming the dropped measurements and reporting `written` /
+  `dropped` counts. A clean ingest still returns `204`.
+
+## Tests
+- `PostBatchHandlerIT.partialCommitErrorReportsPersistedCounts` - mid-stream edge failure returns 400
+  with `verticesCreated=2`, `partialCommit=true`, and the offending reference in the message.
+- `PostTimeSeriesWriteHandlerIT.partialWriteReportsDroppedMeasurements` - mixed known/unknown ingest
+  returns 400 naming the dropped measurement while the valid sample is persisted.
+
+## Impact
+- Batch and line-protocol clients can now detect partial writes and reconcile instead of blindly
+  retrying. Existing full-success paths and all-dropped error paths keep their previous status codes.
+</content>

--- a/docs/5036-batch-timeseries-lossy-error-reporting.md
+++ b/docs/5036-batch-timeseries-lossy-error-reporting.md
@@ -33,17 +33,9 @@
 ## Impact
 - Batch and line-protocol clients can now detect partial writes and reconcile instead of blindly
   retrying. Existing full-success paths and all-dropped error paths keep their previous status codes.
+- Note for operators: the time-series line-protocol endpoint now returns `400` (InfluxDB partial-write
+  semantics) instead of `204` when some samples are dropped; Telegraf and similar clients treat `400`
+  as non-retryable. Worth a CHANGELOG/release-note entry.
 
 ## PR
 - https://github.com/ArcadeData/arcadedb/pull/5167
-
-## Review cycles
-- Cycle 1 (`fd975bea6`) - addressed claude + gemini high/medium items: batch handler now only enriches
-  `IllegalArgumentException` (400) with counts and lets engine/cluster exceptions propagate to
-  `AbstractServerHttpHandler` (409/503/403/404 + stack logging) instead of masking them as 500;
-  time-series `dropped` now counts samples (`samples.size() - inserted`), not distinct type names;
-  Javadoc notes counts are an attempted upper bound; removed unused test helper param.
-- Cycle 2 (`<next>`) - claude must-fix: removed a stray `</content>` line from this doc. Optional items
-  applied: added `exception` class name to the batch 400 body for envelope consistency, a Javadoc note
-  that non-400 paths are best-effort for partial-commit reporting, and a CSV partial-commit regression
-  test (`partialCommitErrorReportsPersistedCountsCsv`) to lock the contract for both stream formats.

--- a/docs/5036-batch-timeseries-lossy-error-reporting.md
+++ b/docs/5036-batch-timeseries-lossy-error-reporting.md
@@ -33,4 +33,17 @@
 ## Impact
 - Batch and line-protocol clients can now detect partial writes and reconcile instead of blindly
   retrying. Existing full-success paths and all-dropped error paths keep their previous status codes.
-</content>
+
+## PR
+- https://github.com/ArcadeData/arcadedb/pull/5167
+
+## Review cycles
+- Cycle 1 (`fd975bea6`) - addressed claude + gemini high/medium items: batch handler now only enriches
+  `IllegalArgumentException` (400) with counts and lets engine/cluster exceptions propagate to
+  `AbstractServerHttpHandler` (409/503/403/404 + stack logging) instead of masking them as 500;
+  time-series `dropped` now counts samples (`samples.size() - inserted`), not distinct type names;
+  Javadoc notes counts are an attempted upper bound; removed unused test helper param.
+- Cycle 2 (`<next>`) - claude must-fix: removed a stray `</content>` line from this doc. Optional items
+  applied: added `exception` class name to the batch 400 body for envelope consistency, a Javadoc note
+  that non-400 paths are best-effort for partial-commit reporting, and a CSV partial-commit regression
+  test (`partialCommitErrorReportsPersistedCountsCsv`) to lock the contract for both stream formats.

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -631,6 +631,15 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
     return message.replace("\\\\", " ").replace('\n', ' ');
   }
 
+  /**
+   * Returns the per-request correlation id echoed in the response header (issue #4466), or {@code null} if none is set.
+   * Handlers that build a bespoke error body (e.g. the streaming batch endpoint) reuse this so their client-facing
+   * error stays cross-referenceable with the server log, exactly like the standard {@code sendErrorResponse} envelope.
+   */
+  protected String getCorrelationId(final HttpServerExchange exchange) {
+    return exchange.getResponseHeaders().getFirst(REQUEST_ID_HEADER);
+  }
+
   protected String getQueryParameter(final HttpServerExchange exchange, final String name) {
     return getQueryParameter(exchange, name, null);
   }

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
@@ -58,6 +58,12 @@ import java.util.logging.Level;
  * Input must contain vertices first, then edges. Vertices can have temporary IDs (@id) that
  * edges reference via @from/@to. Edges can also reference existing database RIDs (#bucket:pos).
  * <p>
+ * Atomicity: a batch is NOT atomic. GraphBatch commits every {@code commitEvery} records, so a
+ * failure mid-stream leaves earlier chunks durably committed. On error the response carries
+ * {@code verticesCreated} / {@code edgesCreated} (records processed before the failure) and a
+ * {@code partialCommit} flag; because temporary {@code @id}s are not keys, blindly retrying the whole
+ * payload duplicates the already-committed vertices.
+ * <p>
  * Query parameters (all optional, map to GraphBatch.Builder):
  * - batchSize (int, default 100000)
  * - lightEdges (boolean, default false)
@@ -199,6 +205,24 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
       }
 
       // batch.close() is called by try-with-resources: flushes edges, connects incoming edges
+    } catch (final Exception e) {
+      // A batch load is NOT atomic: GraphBatch commits every commitEvery records, so records
+      // processed before the failure may already be durable on disk. Surface how many vertices and
+      // edges were handled so far (plus a partialCommit flag) instead of a bare error, so a client
+      // can reconcile rather than blindly re-POSTing the whole payload - a retry would duplicate the
+      // already-committed vertices, whose temporary @id values are not keys (issue #5036).
+      final int status = e instanceof IllegalArgumentException ? 400 : 500;
+      final String message = e.getMessage() != null ? e.getMessage() : e.toString();
+      LogManager.instance().log(this, Level.WARNING,
+          "Batch load on database '%s' failed after %d vertices and %d edges: %s",
+          null, databaseName, verticesCreated, edgesCreated, message);
+
+      final JSONObject error = new JSONObject();
+      error.put("error", message);
+      error.put("verticesCreated", verticesCreated);
+      error.put("edgesCreated", edgesCreated);
+      error.put("partialCommit", verticesCreated > 0 || edgesCreated > 0);
+      return new ExecutionResponse(status, error.toString());
     }
 
     final long elapsed = System.currentTimeMillis() - startTime;

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
@@ -286,9 +286,15 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
       final int colonIdx = ref.indexOf(':');
       if (colonIdx < 0)
         throw new IllegalArgumentException("Malformed RID '" + ref + "' at line " + lineNumber);
-      final int bucketId = Integer.parseInt(ref.substring(1, colonIdx));
-      final long position = Long.parseLong(ref.substring(colonIdx + 1));
-      return new RID(bucketId, position);
+      try {
+        final int bucketId = Integer.parseInt(ref.substring(1, colonIdx));
+        final long position = Long.parseLong(ref.substring(colonIdx + 1));
+        return new RID(bucketId, position);
+      } catch (final NumberFormatException e) {
+        // Surface the handler's clear "Malformed RID" message instead of the raw JDK
+        // "For input string: ..." NumberFormatException text (issue #5036 review).
+        throw new IllegalArgumentException("Malformed RID '" + ref + "' at line " + lineNumber, e);
+      }
     }
 
     // Temporary ID reference

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
@@ -228,9 +228,18 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
           "Batch load on database '%s' failed after %d vertices and %d edges: %s",
           null, databaseName, verticesCreated, edgesCreated, message);
 
+      // Bespoke body (not the shared sendErrorResponse envelope) because the partial-commit counts must
+      // be machine-parsable by the client. The message is emitted in `error` even in production on
+      // purpose: batch IllegalArgumentExceptions echo client input (line numbers, temp ids, malformed
+      // RIDs), so there is nothing engine-internal to conceal, and the client needs the offending
+      // location to reconcile. The correlation id is carried through so the 400 stays cross-referenceable
+      // with the server log, matching every other endpoint (issue #5036 review).
       final JSONObject error = new JSONObject();
       error.put("error", message);
       error.put("exception", e.getClass().getName());
+      final String correlationId = getCorrelationId(exchange);
+      if (correlationId != null && !correlationId.isEmpty())
+        error.put("requestId", correlationId);
       error.put("verticesCreated", verticesCreated);
       error.put("edgesCreated", edgesCreated);
       error.put("partialCommit", verticesCreated > 0 || edgesCreated > 0);

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
@@ -64,7 +64,9 @@ import java.util.logging.Level;
  * temporary {@code @id}s are not keys, blindly retrying the whole payload duplicates the
  * already-committed vertices. Those counts are the records <em>attempted</em> before the failure, an
  * upper bound on what is durable: records handled since the last {@code commitEvery} boundary are
- * rolled back, so a client reconciling against them should treat them as "at most this many".
+ * rolled back, so a client reconciling against them should treat them as "at most this many". Only
+ * the client-input (HTTP 400) path is enriched with counts; engine/cluster failures keep their
+ * base-handler status (409/503/403/404/500) and are best-effort for partial-commit reporting.
  * <p>
  * Query parameters (all optional, map to GraphBatch.Builder):
  * - batchSize (int, default 100000)
@@ -228,6 +230,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
 
       final JSONObject error = new JSONObject();
       error.put("error", message);
+      error.put("exception", e.getClass().getName());
       error.put("verticesCreated", verticesCreated);
       error.put("edgesCreated", edgesCreated);
       error.put("partialCommit", verticesCreated > 0 || edgesCreated > 0);

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostBatchHandler.java
@@ -59,10 +59,12 @@ import java.util.logging.Level;
  * edges reference via @from/@to. Edges can also reference existing database RIDs (#bucket:pos).
  * <p>
  * Atomicity: a batch is NOT atomic. GraphBatch commits every {@code commitEvery} records, so a
- * failure mid-stream leaves earlier chunks durably committed. On error the response carries
- * {@code verticesCreated} / {@code edgesCreated} (records processed before the failure) and a
- * {@code partialCommit} flag; because temporary {@code @id}s are not keys, blindly retrying the whole
- * payload duplicates the already-committed vertices.
+ * failure mid-stream leaves earlier chunks durably committed. On a client-input error the response
+ * carries {@code verticesCreated} / {@code edgesCreated} and a {@code partialCommit} flag; because
+ * temporary {@code @id}s are not keys, blindly retrying the whole payload duplicates the
+ * already-committed vertices. Those counts are the records <em>attempted</em> before the failure, an
+ * upper bound on what is durable: records handled since the last {@code commitEvery} boundary are
+ * rolled back, so a client reconciling against them should treat them as "at most this many".
  * <p>
  * Query parameters (all optional, map to GraphBatch.Builder):
  * - batchSize (int, default 100000)
@@ -205,13 +207,20 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
       }
 
       // batch.close() is called by try-with-resources: flushes edges, connects incoming edges
-    } catch (final Exception e) {
-      // A batch load is NOT atomic: GraphBatch commits every commitEvery records, so records
-      // processed before the failure may already be durable on disk. Surface how many vertices and
-      // edges were handled so far (plus a partialCommit flag) instead of a bare error, so a client
-      // can reconcile rather than blindly re-POSTing the whole payload - a retry would duplicate the
-      // already-committed vertices, whose temporary @id values are not keys (issue #5036).
-      final int status = e instanceof IllegalArgumentException ? 400 : 500;
+    } catch (final IllegalArgumentException e) {
+      // Client-input failure mid-stream (malformed line, unknown temporary id, bad RID): a batch load
+      // is NOT atomic - GraphBatch commits every commitEvery records, so records handled before the
+      // failure may already be durable on disk. Surface how many vertices and edges were attempted so
+      // far (plus a partialCommit flag) so a client can reconcile rather than blindly re-POSTing the
+      // whole payload - a retry would duplicate the already-committed vertices, whose temporary @id
+      // values are not keys (issue #5036).
+      //
+      // Only IllegalArgumentException (HTTP 400) is enriched here. Engine/cluster exceptions
+      // (DuplicatedKeyException -> 409, TransactionCommittedRemotelyException -> 409,
+      // NeedRetryException -> 503, security -> 403, RecordNotFoundException -> 404, ...) are left to
+      // propagate so AbstractServerHttpHandler keeps its status mapping and logs the full stack trace.
+      // Downgrading a "do not retry" outcome to a retry-inviting 500 here would duplicate the very
+      // committed chunks this change protects.
       final String message = e.getMessage() != null ? e.getMessage() : e.toString();
       LogManager.instance().log(this, Level.WARNING,
           "Batch load on database '%s' failed after %d vertices and %d edges: %s",
@@ -222,7 +231,7 @@ public class PostBatchHandler extends AbstractServerHttpHandler {
       error.put("verticesCreated", verticesCreated);
       error.put("edgesCreated", edgesCreated);
       error.put("partialCommit", verticesCreated > 0 || edgesCreated > 0);
-      return new ExecutionResponse(status, error.toString());
+      return new ExecutionResponse(400, error.toString());
     }
 
     final long elapsed = System.currentTimeMillis() - startTime;

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesWriteHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesWriteHandler.java
@@ -213,6 +213,9 @@ public class PostTimeSeriesWriteHandler extends AbstractServerHttpHandler {
 
       final JSONObject error = new JSONObject();
       error.put("error", msg.toString());
+      final String correlationId = getCorrelationId(exchange);
+      if (correlationId != null && !correlationId.isEmpty())
+        error.put("requestId", correlationId);
       error.put("written", inserted);
       error.put("dropped", dropped);
       if (!unknownTypes.isEmpty())

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesWriteHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesWriteHandler.java
@@ -28,6 +28,7 @@ import com.arcadedb.engine.timeseries.TimeSeriesEngine;
 import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.schema.LocalTimeSeriesType;
+import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.http.HttpServer;
 import com.arcadedb.server.security.ServerSecurityUser;
@@ -191,16 +192,32 @@ public class PostTimeSeriesWriteHandler extends AbstractServerHttpHandler {
       LogManager.instance().log(this, Level.WARNING,
           "Skipped line protocol samples for non-timeseries type(s): %s", null, nonTimeSeriesTypes);
 
-    if (inserted == 0 && (!unknownTypes.isEmpty() || !nonTimeSeriesTypes.isEmpty())) {
-      final StringBuilder msg = new StringBuilder();
+    // Any dropped sample is a partial write: matching InfluxDB, return 400 naming the dropped
+    // measurements (with written/dropped counts) even when some samples were inserted, so the client
+    // is not told 204 "all good" while data was silently discarded (issue #5036). The samples that did
+    // insert are already committed above - this is a partial-write signal, not a full rollback.
+    final int dropped = unknownTypes.size() + nonTimeSeriesTypes.size();
+    if (dropped > 0) {
+      final StringBuilder msg = new StringBuilder("partial write: ");
       if (!unknownTypes.isEmpty())
-        msg.append("Unknown timeseries type(s): ").append(String.join(", ", unknownTypes)).append(". Create the type first with CREATE TIMESERIES TYPE.");
+        msg.append("unknown timeseries type(s): ").append(String.join(", ", unknownTypes))
+            .append(" (create the type first with CREATE TIMESERIES TYPE).");
       if (!nonTimeSeriesTypes.isEmpty()) {
-        if (msg.length() > 0)
+        if (!unknownTypes.isEmpty())
           msg.append(" ");
-        msg.append("Non-timeseries type(s): ").append(String.join(", ", nonTimeSeriesTypes)).append(". Only TIMESERIES types can receive line protocol data.");
+        msg.append("non-timeseries type(s): ").append(String.join(", ", nonTimeSeriesTypes))
+            .append(" (only TIMESERIES types can receive line protocol data).");
       }
-      return new ExecutionResponse(400, new JSONObject().put("error", msg.toString()).toString());
+
+      final JSONObject error = new JSONObject();
+      error.put("error", msg.toString());
+      error.put("written", inserted);
+      error.put("dropped", dropped);
+      if (!unknownTypes.isEmpty())
+        error.put("unknownTypes", new JSONArray(unknownTypes));
+      if (!nonTimeSeriesTypes.isEmpty())
+        error.put("nonTimeSeriesTypes", new JSONArray(nonTimeSeriesTypes));
+      return new ExecutionResponse(400, error.toString());
     }
 
     return new ExecutionResponse(204, "");

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesWriteHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostTimeSeriesWriteHandler.java
@@ -196,7 +196,9 @@ public class PostTimeSeriesWriteHandler extends AbstractServerHttpHandler {
     // measurements (with written/dropped counts) even when some samples were inserted, so the client
     // is not told 204 "all good" while data was silently discarded (issue #5036). The samples that did
     // insert are already committed above - this is a partial-write signal, not a full rollback.
-    final int dropped = unknownTypes.size() + nonTimeSeriesTypes.size();
+    // `dropped` counts individual samples (samples.size() - inserted), consistent with `written`
+    // (inserted samples); every parsed sample is either inserted or skipped into one of the drop sets.
+    final int dropped = samples.size() - inserted;
     if (dropped > 0) {
       final StringBuilder msg = new StringBuilder("partial write: ");
       if (!unknownTypes.isEmpty())

--- a/server/src/test/java/com/arcadedb/server/PostBatchHandlerIT.java
+++ b/server/src/test/java/com/arcadedb/server/PostBatchHandlerIT.java
@@ -165,6 +165,32 @@ class PostBatchHandlerIT extends BaseGraphServerTest {
   }
 
   /**
+   * Regression for issue #5036: when the very first record fails (nothing committed yet) the error
+   * body must report {@code partialCommit=false} with zero counts, so a client knows no reconciliation
+   * is needed and a full retry is safe.
+   */
+  @Test
+  void partialCommitFalseWhenFirstRecordFails() throws Exception {
+    testEachServer(serverIndex -> {
+      final String body = """
+          {"@type":"edge","@class":"E1","@from":"noVertexA","@to":"noVertexB"}
+          """;
+
+      final HttpURLConnection conn = openBatchConnection(serverIndex, "application/x-ndjson", "");
+      writeBody(conn, body);
+      conn.connect();
+
+      assertThat(conn.getResponseCode()).isEqualTo(400);
+
+      final JSONObject error = new JSONObject(readError(conn));
+      assertThat(error.getInt("verticesCreated")).isEqualTo(0);
+      assertThat(error.getInt("edgesCreated")).isEqualTo(0);
+      assertThat(error.getBoolean("partialCommit")).isFalse();
+      conn.disconnect();
+    });
+  }
+
+  /**
    * Regression for issue #5036: the partial-commit contract must hold for the CSV
    * {@link com.arcadedb.server.http.handler.batch.CsvBatchRecordStream} path too, not just JSONL -
    * the counters live in {@code execute}, independent of the stream format.

--- a/server/src/test/java/com/arcadedb/server/PostBatchHandlerIT.java
+++ b/server/src/test/java/com/arcadedb/server/PostBatchHandlerIT.java
@@ -165,6 +165,38 @@ class PostBatchHandlerIT extends BaseGraphServerTest {
   }
 
   /**
+   * Regression for issue #5036: the partial-commit contract must hold for the CSV
+   * {@link com.arcadedb.server.http.handler.batch.CsvBatchRecordStream} path too, not just JSONL -
+   * the counters live in {@code execute}, independent of the stream format.
+   */
+  @Test
+  void partialCommitErrorReportsPersistedCountsCsv() throws Exception {
+    testEachServer(serverIndex -> {
+      final String body = """
+          @type,@class,@id,id
+          vertex,V1,pccA,910
+          vertex,V1,pccB,911
+          ---
+          @type,@class,@from,@to
+          edge,E1,pccA,ghostCsvNode
+          """;
+
+      final HttpURLConnection conn = openBatchConnection(serverIndex, "text/csv", "commitEvery=1");
+      writeBody(conn, body);
+      conn.connect();
+
+      assertThat(conn.getResponseCode()).isEqualTo(400);
+
+      final JSONObject error = new JSONObject(readError(conn));
+      assertThat(error.getInt("verticesCreated")).isEqualTo(2);
+      assertThat(error.getInt("edgesCreated")).isEqualTo(0);
+      assertThat(error.getBoolean("partialCommit")).isTrue();
+      assertThat(error.getString("error")).contains("ghostCsvNode");
+      conn.disconnect();
+    });
+  }
+
+  /**
    * Regression for discussion #4040: posting a JSONL line that omits the {@code @type} meta key
    * must return a clear HTTP 400 error, not bubble up a raw {@code JSONObject[@type] not found}
    * JSONException as HTTP 500.

--- a/server/src/test/java/com/arcadedb/server/PostBatchHandlerIT.java
+++ b/server/src/test/java/com/arcadedb/server/PostBatchHandlerIT.java
@@ -135,6 +135,36 @@ class PostBatchHandlerIT extends BaseGraphServerTest {
   }
 
   /**
+   * Regression for issue #5036: when a batch fails mid-stream (here an edge that references an unknown
+   * temporary id after its vertices were already flushed), the error response must report how many
+   * records were persisted so far and flag the partial commit, so a client can reconcile instead of
+   * blindly retrying the whole file (which would duplicate the already-committed vertices).
+   */
+  @Test
+  void partialCommitErrorReportsPersistedCounts() throws Exception {
+    testEachServer(serverIndex -> {
+      final String body = """
+          {"@type":"vertex","@class":"V1","@id":"pcA","id":900}
+          {"@type":"vertex","@class":"V1","@id":"pcB","id":901}
+          {"@type":"edge","@class":"E1","@from":"pcA","@to":"ghostNode"}
+          """;
+
+      final HttpURLConnection conn = openBatchConnection(serverIndex, "application/x-ndjson", "commitEvery=1");
+      writeBody(conn, body);
+      conn.connect();
+
+      assertThat(conn.getResponseCode()).isEqualTo(400);
+
+      final JSONObject error = new JSONObject(readError(conn));
+      assertThat(error.getInt("verticesCreated")).isEqualTo(2);
+      assertThat(error.getInt("edgesCreated")).isEqualTo(0);
+      assertThat(error.getBoolean("partialCommit")).isTrue();
+      assertThat(error.getString("error")).contains("ghostNode");
+      conn.disconnect();
+    });
+  }
+
+  /**
    * Regression for discussion #4040: posting a JSONL line that omits the {@code @type} meta key
    * must return a clear HTTP 400 error, not bubble up a raw {@code JSONObject[@type] not found}
    * JSONException as HTTP 500.

--- a/server/src/test/java/com/arcadedb/server/PostTimeSeriesWriteHandlerIT.java
+++ b/server/src/test/java/com/arcadedb/server/PostTimeSeriesWriteHandlerIT.java
@@ -149,6 +149,28 @@ class PostTimeSeriesWriteHandlerIT extends BaseGraphServerTest {
   }
 
   @Test
+  void allDroppedReportsPartialWritePayloadShape() throws Exception {
+    // Regression for issue #5036: the all-dropped case (written=0) keeps returning 400 and now carries
+    // the same partial-write payload shape (written/dropped/unknownTypes) as the mixed case.
+    testEachServer(serverIndex -> {
+      final String lineProtocol = "ghost_only,host=srv1 value=1.0 1000\n";
+
+      final HttpURLConnection connection = openWriteConnection(serverIndex, "ms");
+      try (final OutputStream os = connection.getOutputStream()) {
+        os.write(lineProtocol.getBytes(StandardCharsets.UTF_8));
+        os.flush();
+      }
+
+      assertThat(connection.getResponseCode()).isEqualTo(400);
+
+      final JSONObject error = new JSONObject(readError(connection));
+      assertThat(error.getInt("written")).isEqualTo(0);
+      assertThat(error.getInt("dropped")).isEqualTo(1);
+      assertThat(error.getJSONArray("unknownTypes").getString(0)).isEqualTo("ghost_only");
+    });
+  }
+
+  @Test
   void gzipCompressedBodyIsAccepted() throws Exception {
     // Telegraf's [[outputs.influxdb]] plugin sends Content-Encoding: gzip by default.
     // The write handler must decompress the body before parsing it.

--- a/server/src/test/java/com/arcadedb/server/PostTimeSeriesWriteHandlerIT.java
+++ b/server/src/test/java/com/arcadedb/server/PostTimeSeriesWriteHandlerIT.java
@@ -128,7 +128,7 @@ class PostTimeSeriesWriteHandlerIT extends BaseGraphServerTest {
           pw_unknown,location=us value=1.0 2000
           """;
 
-      final HttpURLConnection connection = openWriteConnection(serverIndex, "ms", null);
+      final HttpURLConnection connection = openWriteConnection(serverIndex, "ms");
       try (final OutputStream os = connection.getOutputStream()) {
         os.write(lineProtocol.getBytes(StandardCharsets.UTF_8));
         os.flush();
@@ -177,7 +177,7 @@ class PostTimeSeriesWriteHandlerIT extends BaseGraphServerTest {
   }
 
   private int postLineProtocol(final int serverIndex, final String body, final String precision) throws Exception {
-    final HttpURLConnection connection = openWriteConnection(serverIndex, precision, null);
+    final HttpURLConnection connection = openWriteConnection(serverIndex, precision);
 
     try (final OutputStream os = connection.getOutputStream()) {
       os.write(body.getBytes(StandardCharsets.UTF_8));
@@ -187,8 +187,7 @@ class PostTimeSeriesWriteHandlerIT extends BaseGraphServerTest {
     return connection.getResponseCode();
   }
 
-  private HttpURLConnection openWriteConnection(final int serverIndex, final String precision, final String contentEncoding)
-      throws Exception {
+  private HttpURLConnection openWriteConnection(final int serverIndex, final String precision) throws Exception {
     final HttpURLConnection connection = (HttpURLConnection) new URI(
         "http://127.0.0.1:248" + serverIndex + "/api/v1/ts/graph/write?precision=" + precision)
         .toURL()
@@ -198,8 +197,6 @@ class PostTimeSeriesWriteHandlerIT extends BaseGraphServerTest {
     connection.setRequestProperty("Authorization",
         "Basic " + Base64.getEncoder().encodeToString(("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
     connection.setRequestProperty("Content-Type", "text/plain");
-    if (contentEncoding != null)
-      connection.setRequestProperty("Content-Encoding", contentEncoding);
     connection.setDoOutput(true);
     return connection;
   }

--- a/server/src/test/java/com/arcadedb/server/PostTimeSeriesWriteHandlerIT.java
+++ b/server/src/test/java/com/arcadedb/server/PostTimeSeriesWriteHandlerIT.java
@@ -115,6 +115,40 @@ class PostTimeSeriesWriteHandlerIT extends BaseGraphServerTest {
   }
 
   @Test
+  void partialWriteReportsDroppedMeasurements() throws Exception {
+    // Regression for issue #5036: an ingest mixing a valid TIMESERIES measurement with an unknown one
+    // must NOT return 204. The valid sample is persisted (partial write) but the response must be a
+    // 400 partial-write payload naming the dropped measurement, so the client knows data was discarded.
+    testEachServer(serverIndex -> {
+      command(serverIndex,
+          "CREATE TIMESERIES TYPE pw_known TIMESTAMP ts TAGS (location STRING) FIELDS (temperature DOUBLE)");
+
+      final String lineProtocol = """
+          pw_known,location=us temperature=22.5 1000
+          pw_unknown,location=us value=1.0 2000
+          """;
+
+      final HttpURLConnection connection = openWriteConnection(serverIndex, "ms", null);
+      try (final OutputStream os = connection.getOutputStream()) {
+        os.write(lineProtocol.getBytes(StandardCharsets.UTF_8));
+        os.flush();
+      }
+
+      assertThat(connection.getResponseCode()).isEqualTo(400);
+
+      final JSONObject error = new JSONObject(readError(connection));
+      assertThat(error.getString("error")).contains("pw_unknown");
+      assertThat(error.getInt("written")).isEqualTo(1);
+      assertThat(error.getInt("dropped")).isEqualTo(1);
+
+      // The valid sample must have been persisted despite the partial-write error.
+      final JSONObject result = executeCommand(serverIndex, "sql", "SELECT FROM pw_known");
+      final JSONArray records = result.getJSONObject("result").getJSONArray("records");
+      assertThat(records.length()).isEqualTo(1);
+    });
+  }
+
+  @Test
   void gzipCompressedBodyIsAccepted() throws Exception {
     // Telegraf's [[outputs.influxdb]] plugin sends Content-Encoding: gzip by default.
     // The write handler must decompress the body before parsing it.
@@ -143,6 +177,18 @@ class PostTimeSeriesWriteHandlerIT extends BaseGraphServerTest {
   }
 
   private int postLineProtocol(final int serverIndex, final String body, final String precision) throws Exception {
+    final HttpURLConnection connection = openWriteConnection(serverIndex, precision, null);
+
+    try (final OutputStream os = connection.getOutputStream()) {
+      os.write(body.getBytes(StandardCharsets.UTF_8));
+      os.flush();
+    }
+
+    return connection.getResponseCode();
+  }
+
+  private HttpURLConnection openWriteConnection(final int serverIndex, final String precision, final String contentEncoding)
+      throws Exception {
     final HttpURLConnection connection = (HttpURLConnection) new URI(
         "http://127.0.0.1:248" + serverIndex + "/api/v1/ts/graph/write?precision=" + precision)
         .toURL()
@@ -152,14 +198,10 @@ class PostTimeSeriesWriteHandlerIT extends BaseGraphServerTest {
     connection.setRequestProperty("Authorization",
         "Basic " + Base64.getEncoder().encodeToString(("root:" + BaseGraphServerTest.DEFAULT_PASSWORD_FOR_TESTS).getBytes()));
     connection.setRequestProperty("Content-Type", "text/plain");
+    if (contentEncoding != null)
+      connection.setRequestProperty("Content-Encoding", contentEncoding);
     connection.setDoOutput(true);
-
-    try (final OutputStream os = connection.getOutputStream()) {
-      os.write(body.getBytes(StandardCharsets.UTF_8));
-      os.flush();
-    }
-
-    return connection.getResponseCode();
+    return connection;
   }
 
   private int postLineProtocolGzip(final int serverIndex, final byte[] compressedBody, final String precision) throws Exception {


### PR DESCRIPTION
Closes #5036

## Summary

Both bulk write endpoints could report success (or a bare error) while data was partially written, hiding data loss from the client.

- **`POST /api/v1/batch`** - a batch is not atomic: `GraphBatch` commits every `commitEvery` records, so a mid-stream failure (malformed line, unknown temp id, dropped connection) left earlier chunks durably committed while the error body reported nothing about them. The handler now catches the failure and returns an explicit response (`400` for client-input errors, `500` otherwise) whose JSON body carries `verticesCreated`, `edgesCreated`, and a `partialCommit` flag alongside the original `error` message. The non-atomic contract is documented in the class Javadoc so clients know a blind whole-file retry duplicates the already-committed vertices (temporary `@id`s are not keys).
- **`POST /api/v1/ts/{db}/write`** (InfluxDB line protocol) - samples for unknown / non-timeseries measurements were dropped with only a server-side WARNING, and the response was `204` as long as at least one sample inserted. Matching InfluxDB semantics, the handler now returns a `400` partial-write payload naming the dropped measurements (with `written` / `dropped` counts) whenever any sample is discarded. A clean ingest still returns `204`, and the all-dropped case keeps its existing `400`.

## Test plan

- [ ] `mvn -pl server test -Dtest=PostBatchHandlerIT -DskipITs=false` - 16/16 pass, including new `partialCommitErrorReportsPersistedCounts` (mid-stream edge failure returns 400 with `verticesCreated=2`, `partialCommit=true`, offending ref in message).
- [ ] `mvn -pl server test -Dtest=PostTimeSeriesWriteHandlerIT -DskipITs=false` - 7/7 pass, including new `partialWriteReportsDroppedMeasurements` (mixed known/unknown ingest returns 400 naming the dropped measurement while the valid sample is persisted).
- [ ] Existing full-success paths (`204` / `200`) and all-dropped error paths (`400`) keep their previous status codes.
