### PR TITLE
fix(#5031): server registry lock-free hot path, guarded registry mutations, volatile HA fields

### DIFF
--- a/docs/5031-server-registry-lock-hotpath.md
+++ b/docs/5031-server-registry-lock-hotpath.md
@@ -28,3 +28,17 @@ Regression: `PluginManagerTest` (15) and `RemoteSafeCloseDatabaseIT` (1) pass. `
 
 ## Impact
 Request hot path no longer serializes on a JVM-wide monitor for already-open databases; registry mutations are race-safe against concurrent opens; HA fields are reliably visible to worker threads immediately after plugin start. No API changes; behavior for the miss/slow path is unchanged.
+
+## PR
+https://github.com/ArcadeData/arcadedb/pull/5168
+
+## Review cycles
+Bots: claude (issue comments) + gemini-code-assist (inline). Gemini re-posted the same "unwrapped DB during startup" comment on every SHA; its suggested code matched the already-applied ONLINE gate from cycle 1 onward, so it was a stale false-positive after the first cycle.
+
+- Cycle 1 - `8a7debe`: Gemini + Claude flagged the fast path could return a pre-wrap (non-replicated) database while HA `rewrapDatabases()` runs during startup. Applied: gate the fast path on `status == STATUS.ONLINE` (status flips to ONLINE only after re-wrap completes), added `fastPathIsDisabledWhileServerNotOnline` regression test, tagged the IT `@Tag("slow")`. -> `63ffd17`.
+- Cycle 2 - `63ffd17`: Claude approval with minor notes; asked to document the runtime snapshot-install interaction and fix the PR test-count. Applied: extended the fast-path comment for the runtime installer case; updated PR body to list 5 tests. Gemini re-posted the stale comment (no action). -> `aa4901a`.
+- Cycle 3 - `aa4901a`: Claude "production change looks correct"; one pre-merge test-robustness ask - the negative gate test could pass for the wrong reason if the lookup thread was unscheduled. Applied: latch-gate the lookup thread so it counts down immediately before `getDatabase` and is awaited before the liveness check. Gemini stale re-post (no action). -> `caa22e0`.
+- Cycle 4 - `caa22e0`: Claude "Neither blocks merge"; two non-blocking polish asks. Applied: routed the startup restore-path `databases.remove` through `removeDatabase()` for full defect-2 consistency; softened the "deflected with 503" comment so it does not read as a hard guarantee. Gemini stale re-post (no action). -> `7226a89`.
+
+## Final state
+max-cycles-reached (4 cycles run). All actionable review feedback was applied; the remaining bot output was Gemini's stale duplicate. Merge is the developer's responsibility. Note: `HTTPGraphIT` could not be run locally because an unrelated external ArcadeDB server (homebrew v26.6.1) held port 2480; the new IT and the lifecycle regressions (`PluginManagerTest`, `RemoteSafeCloseDatabaseIT`) pass. CI `mvn -pl server verify` should confirm green.

--- a/docs/5031-server-registry-lock-hotpath.md
+++ b/docs/5031-server-registry-lock-hotpath.md
@@ -1,0 +1,30 @@
+# Issue #5031 - Server registry: lock on request hot path, registry mutation bypasses lock, HA fields lack volatile
+
+## Symptom
+Three related defects in `ArcadeDBServer`'s database registry and HA wiring:
+1. Every database-scoped request serialized on a single JVM-wide `synchronized (databasesLock)` monitor, even the pure lookup of an already-open database. The same monitor is held across long I/O (create/open, HA snapshot install close-swap-reopen), blocking all ~500 Undertow workers on every database.
+2. `registerDatabase`/`removeDatabase` mutated the registry map without `databasesLock`, so they could race `getDatabase`'s check-then-open into two `DatabaseInternal` instances over the same directory.
+3. `haServer` and `databaseWrapper` (written by the HA plugin during `startPlugins(AFTER_HTTP_ON)`, after the HTTP server already accepts requests) were non-`volatile`; under the JMM concurrent readers on worker threads could observe `null` indefinitely.
+
+## Root cause
+- Defect 1: the lookup fast path was inside the monitor with no lock-free short-circuit.
+- Defect 2: the two registry mutators used `ConcurrentMap` atomics only, not the documented registry monitor that `getDatabase`/`createDatabase`/`rewrapDatabases` serialize on.
+- Defect 3: missing `volatile` on fields mutated after startup.
+
+## Fix
+`server/src/main/java/com/arcadedb/server/ArcadeDBServer.java`:
+- `getDatabase(...)`: added a lock-free fast path - `databases.get(name)` on the `ConcurrentMap`, returned immediately if present and open. Only a miss (absent/closed) falls through to the existing locked slow path, which re-checks under the lock, so `createIfNotExists`/`allowLoad` semantics are preserved.
+- `registerDatabase`/`removeDatabase`: now wrap their map mutation in `synchronized (databasesLock)`.
+- `haServer`, `databaseWrapper`, `security`, `httpServer`: declared `volatile` (last two for symmetry, same after-startup publication pattern).
+
+## Tests
+`server/src/test/java/com/arcadedb/server/Issue5031ServerRegistryConcurrencyIT.java` (4 tests, all pass; the three defect tests were confirmed red before the fix):
+- `openDatabaseLookupDoesNotBlockOnRegistryLock` - holds `databasesLock` in a background thread and asserts a concurrent lookup of the open database still returns promptly (defect 1).
+- `concurrentLookupsReturnSameInstance` - 32 threads x 100 lookups all observe one identity (defect 1 correctness).
+- `removeDatabaseAcquiresRegistryLock` - `removeDatabase` blocks while the lock is held, completes after release (defect 2).
+- `haRelatedFieldsAreVolatile` - reflection assertion that the four fields are `volatile` (defect 3).
+
+Regression: `PluginManagerTest` (15) and `RemoteSafeCloseDatabaseIT` (1) pass. `HTTPGraphIT` is unrunnable in this environment because an unrelated external ArcadeDB server occupies port 2480 (401/403 to the test client); not caused by this change.
+
+## Impact
+Request hot path no longer serializes on a JVM-wide monitor for already-open databases; registry mutations are race-safe against concurrent opens; HA fields are reliably visible to worker threads immediately after plugin start. No API changes; behavior for the miss/slow path is unchanged.

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -107,9 +107,12 @@ public class ArcadeDBServer {
   private             FileServerEventLog                    eventLog;
   private             PluginManager                         pluginManager;
   private             String                                serverRootPath;
-  private             HAServerPlugin                        haServer;
-  private             ServerSecurity                        security;
-  private             HttpServer                            httpServer;
+  // volatile: written by the HA plugin during startPlugins(AFTER_HTTP_ON), i.e. after httpServer.startService()
+  // has begun accepting requests. Undertow worker threads reading these (readiness/cluster handlers, getDatabase's
+  // HA wrapping) need a happens-before with those writes, otherwise under the JMM they may observe null indefinitely.
+  private volatile    HAServerPlugin                        haServer;
+  private volatile    ServerSecurity                        security;
+  private volatile    HttpServer                            httpServer;
   private             MCPConfiguration                      mcpConfiguration;
   private             AiConfiguration                       aiConfiguration;
   private             ServerQueryProfiler                   queryProfiler;
@@ -122,7 +125,7 @@ public class ArcadeDBServer {
   private final       List<ReplicationCallback>             testEventListeners                   = new ArrayList<>();
   private volatile    STATUS                                status                               = STATUS.OFFLINE;
   private final       AtomicBoolean snapshotInstallInProgress            = new AtomicBoolean(false);
-  private             Function<LocalDatabase, DatabaseInternal> databaseWrapper;
+  private volatile    Function<LocalDatabase, DatabaseInternal> databaseWrapper;
 //  private             ServerMonitor                         serverMonitor;
 
   static {
@@ -602,15 +605,21 @@ public class ArcadeDBServer {
   }
 
   public ServerDatabase registerDatabase(final String databaseName, final DatabaseInternal database) {
-    final ServerDatabase serverDatabase = new ServerDatabase(this, database);
-    final ServerDatabase existing = databases.putIfAbsent(databaseName, serverDatabase);
-    if (existing != null)
-      throw new IllegalArgumentException("Database '" + databaseName + "' already registered");
-    return serverDatabase;
+    // Serialise with getDatabase/createDatabase/rewrapDatabases on databasesLock so a concurrent open-from-disk
+    // cannot interleave with this registration and end up with two DatabaseInternal instances over the same directory.
+    synchronized (databasesLock) {
+      final ServerDatabase serverDatabase = new ServerDatabase(this, database);
+      final ServerDatabase existing = databases.putIfAbsent(databaseName, serverDatabase);
+      if (existing != null)
+        throw new IllegalArgumentException("Database '" + databaseName + "' already registered");
+      return serverDatabase;
+    }
   }
 
   public void removeDatabase(final String databaseName) {
-    databases.remove(databaseName);
+    synchronized (databasesLock) {
+      databases.remove(databaseName);
+    }
   }
 
   public String getServerName() {
@@ -717,7 +726,14 @@ public class ArcadeDBServer {
     if (databaseName == null || databaseName.trim().isEmpty())
       throw new IllegalArgumentException("Invalid database name " + databaseName);
 
-    ServerDatabase db;
+    // Lock-free fast path: an already-open database is served straight off the ConcurrentMap without entering
+    // databasesLock. This keeps the request hot path off the JVM-wide monitor that createDatabase/open and the HA
+    // snapshot installer hold across long I/O. Only the miss (absent or closed) falls through to the locked slow
+    // path, which re-checks under the lock, so createIfNotExists/allowLoad semantics are preserved.
+    ServerDatabase db = databases.get(databaseName);
+    if (db != null && db.isOpen())
+      return db;
+
     synchronized (databasesLock) {
       db = databases.get(databaseName);
 

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -738,10 +738,11 @@ public class ArcadeDBServer {
     // so restricting the fast path to ONLINE makes concurrent startup lookups fall through to the locked slow path
     // and block until the wrapped instances are published - exactly the pre-fast-path behaviour.
     //
-    // The other lock holder is the runtime HA snapshot installer (close->swap->reopen while ONLINE). The request
-    // hot path is already deflected with 503 during an install (snapshotInstallInProgress), and once the installer
-    // closes and removeDatabase-s the entry, databases.get() returns null/closed here and the lookup falls through
-    // to the locked slow path - preserving the #4832 guarantee of never reopening a half-swapped directory.
+    // The other lock holder is the runtime HA snapshot installer (close->swap->reopen while ONLINE). The HTTP request
+    // path is normally deflected with 503 during an install (snapshotInstallInProgress), though that is a check at
+    // request entry rather than a hard guarantee for the whole request or for non-HTTP callers. Once the installer
+    // closes and removeDatabase-s the entry, databases.get() returns null/closed here and the lookup falls through to
+    // the locked slow path - preserving the #4832 guarantee of never reopening a half-swapped directory.
     ServerDatabase db = databases.get(databaseName);
     if (status == STATUS.ONLINE && db != null && db.isOpen())
       return db;
@@ -872,7 +873,10 @@ public class ArcadeDBServer {
               // DROP THE DATABASE BECAUSE THE RESTORE OPERATION WILL TAKE CARE OF CREATING A NEW DATABASE
               if (database != null) {
                 ((DatabaseInternal) database).getEmbedded().drop();
-                databases.remove(dbName);
+                // Route through removeDatabase so this registry mutation also runs under databasesLock, keeping the
+                // defect-2 invariant consistent (this path is startup-single-threaded, but consistency is cheaper
+                // to keep than to reason about the exception).
+                removeDatabase(dbName);
               }
               final String dbPath =
                   configuration.getValueAsString(GlobalConfiguration.SERVER_DATABASE_DIRECTORY) + File.separator + dbName;

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -737,6 +737,11 @@ public class ArcadeDBServer {
     // pre-wrap (non-replicated) instance mid-swap. status flips to ONLINE only after that re-wrapping completes,
     // so restricting the fast path to ONLINE makes concurrent startup lookups fall through to the locked slow path
     // and block until the wrapped instances are published - exactly the pre-fast-path behaviour.
+    //
+    // The other lock holder is the runtime HA snapshot installer (close->swap->reopen while ONLINE). The request
+    // hot path is already deflected with 503 during an install (snapshotInstallInProgress), and once the installer
+    // closes and removeDatabase-s the entry, databases.get() returns null/closed here and the lookup falls through
+    // to the locked slow path - preserving the #4832 guarantee of never reopening a half-swapped directory.
     ServerDatabase db = databases.get(databaseName);
     if (status == STATUS.ONLINE && db != null && db.isOpen())
       return db;

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -730,8 +730,15 @@ public class ArcadeDBServer {
     // databasesLock. This keeps the request hot path off the JVM-wide monitor that createDatabase/open and the HA
     // snapshot installer hold across long I/O. Only the miss (absent or closed) falls through to the locked slow
     // path, which re-checks under the lock, so createIfNotExists/allowLoad semantics are preserved.
+    //
+    // The fast path is gated on STATUS.ONLINE. During startup (STATUS.STARTING) the HTTP server is already
+    // accepting requests while the HA plugin still has to run rewrapDatabases() under databasesLock to swap the
+    // plain LocalDatabase entries for HA-wrapped ones. Bypassing the lock in that window could hand a caller the
+    // pre-wrap (non-replicated) instance mid-swap. status flips to ONLINE only after that re-wrapping completes,
+    // so restricting the fast path to ONLINE makes concurrent startup lookups fall through to the locked slow path
+    // and block until the wrapped instances are published - exactly the pre-fast-path behaviour.
     ServerDatabase db = databases.get(databaseName);
-    if (db != null && db.isOpen())
+    if (status == STATUS.ONLINE && db != null && db.isOpen())
       return db;
 
     synchronized (databasesLock) {

--- a/server/src/test/java/com/arcadedb/server/Issue5031ServerRegistryConcurrencyIT.java
+++ b/server/src/test/java/com/arcadedb/server/Issue5031ServerRegistryConcurrencyIT.java
@@ -157,8 +157,15 @@ class Issue5031ServerRegistryConcurrencyIT {
       assertThat(lockHeld.await(5, TimeUnit.SECONDS)).isTrue();
 
       final AtomicReference<ServerDatabase> looked = new AtomicReference<>();
-      final Thread lookup = new Thread(() -> looked.set(server.getDatabase("registry", false, true)), "registry-lookup");
+      final CountDownLatch lookupReached = new CountDownLatch(1);
+      final Thread lookup = new Thread(() -> {
+        lookupReached.countDown();
+        looked.set(server.getDatabase("registry", false, true));
+      }, "registry-lookup");
       lookup.start();
+      // Ensure the lookup thread actually reached the getDatabase call before judging whether it blocked,
+      // so a merely-unscheduled thread cannot make the test pass without exercising the gate.
+      assertThat(lookupReached.await(5, TimeUnit.SECONDS)).isTrue();
       lookup.join(TimeUnit.SECONDS.toMillis(1));
 
       final boolean returnedWhileLocked = !lookup.isAlive();

--- a/server/src/test/java/com/arcadedb/server/Issue5031ServerRegistryConcurrencyIT.java
+++ b/server/src/test/java/com/arcadedb/server/Issue5031ServerRegistryConcurrencyIT.java
@@ -23,6 +23,7 @@ import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.engine.ComponentFile;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -55,6 +56,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *   values written by the HA plugin after the HTTP server already started serving requests.</li>
  * </ul>
  */
+@Tag("slow")
 class Issue5031ServerRegistryConcurrencyIT {
   private ArcadeDBServer server;
 
@@ -121,6 +123,56 @@ class Issue5031ServerRegistryConcurrencyIT {
         .isTrue();
     assertThat(looked.get()).isNotNull();
     assertThat(looked.get().isOpen()).isTrue();
+  }
+
+  /**
+   * Defect 1 (startup safety): the lock-free fast path must be inactive while the server is not yet
+   * {@code ONLINE}. During startup the HA plugin re-wraps the open databases under {@code databasesLock};
+   * a lookup in that window must fall through to the locked slow path (and block) instead of handing out
+   * the pre-wrap instance. We simulate the startup window by flipping {@code status} back to {@code STARTING}
+   * and holding {@code databasesLock}: the lookup must block until the lock is released.
+   */
+  @Test
+  void fastPathIsDisabledWhileServerNotOnline() throws Exception {
+    final Field statusField = ArcadeDBServer.class.getDeclaredField("status");
+    statusField.setAccessible(true);
+    final Object online = statusField.get(server);
+
+    final CountDownLatch lockHeld = new CountDownLatch(1);
+    final CountDownLatch releaseLock = new CountDownLatch(1);
+    try {
+      statusField.set(server, ArcadeDBServer.STATUS.STARTING);
+
+      final Thread holder = new Thread(() -> {
+        synchronized (server.getDatabasesLock()) {
+          lockHeld.countDown();
+          try {
+            releaseLock.await(10, TimeUnit.SECONDS);
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+        }
+      }, "registry-lock-holder");
+      holder.start();
+      assertThat(lockHeld.await(5, TimeUnit.SECONDS)).isTrue();
+
+      final AtomicReference<ServerDatabase> looked = new AtomicReference<>();
+      final Thread lookup = new Thread(() -> looked.set(server.getDatabase("registry", false, true)), "registry-lookup");
+      lookup.start();
+      lookup.join(TimeUnit.SECONDS.toMillis(1));
+
+      final boolean returnedWhileLocked = !lookup.isAlive();
+      releaseLock.countDown();
+      holder.join(TimeUnit.SECONDS.toMillis(5));
+      lookup.join(TimeUnit.SECONDS.toMillis(5));
+
+      assertThat(returnedWhileLocked)
+          .as("while the server is not ONLINE the lookup must take the locked slow path and block")
+          .isFalse();
+      assertThat(looked.get()).isNotNull();
+    } finally {
+      statusField.set(server, online);
+    }
   }
 
   /**

--- a/server/src/test/java/com/arcadedb/server/Issue5031ServerRegistryConcurrencyIT.java
+++ b/server/src/test/java/com/arcadedb/server/Issue5031ServerRegistryConcurrencyIT.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server;
+
+import com.arcadedb.ContextConfiguration;
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.engine.ComponentFile;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for issue #5031: the server database registry serialized every request on a single
+ * JVM-wide monitor, the register/remove registry mutations bypassed that monitor, and the HA-related
+ * fields were published to concurrent readers without {@code volatile}.
+ *
+ * <ul>
+ *   <li>Defect 1: {@code getDatabase} must serve an already-open database via a lock-free fast path,
+ *   so a lookup does not block while another thread holds {@code databasesLock} (e.g. across the HA
+ *   snapshot installer's close-swap-reopen sequence).</li>
+ *   <li>Defect 2: {@code registerDatabase} / {@code removeDatabase} must acquire {@code databasesLock}
+ *   so they cannot race {@code getDatabase} into two instances over the same directory.</li>
+ *   <li>Defect 3: {@code haServer} / {@code databaseWrapper} (and, for symmetry, {@code security} /
+ *   {@code httpServer}) must be {@code volatile} so readers on the Undertow worker threads observe the
+ *   values written by the HA plugin after the HTTP server already started serving requests.</li>
+ * </ul>
+ */
+class Issue5031ServerRegistryConcurrencyIT {
+  private ArcadeDBServer server;
+
+  @TempDir
+  Path tempDir;
+
+  @BeforeEach
+  void setup() {
+    final ContextConfiguration configuration = new ContextConfiguration();
+    configuration.setValue(GlobalConfiguration.SERVER_ROOT_PATH, tempDir.toString());
+    configuration.setValue(GlobalConfiguration.SERVER_DATABASE_DIRECTORY, tempDir.resolve("databases").toString());
+    configuration.setValue(GlobalConfiguration.HA_ENABLED, false);
+    configuration.setValue(GlobalConfiguration.SERVER_ROOT_PASSWORD, "DevTestPassword123!");
+    configuration.setValue(GlobalConfiguration.TEST, true);
+
+    server = new ArcadeDBServer(configuration);
+    server.start();
+    server.createDatabase("registry", ComponentFile.MODE.READ_WRITE);
+  }
+
+  @AfterEach
+  void teardown() {
+    if (server != null && server.isStarted())
+      server.stop();
+  }
+
+  /**
+   * Defect 1: an already-open database must be returned via the lock-free fast path. We hold
+   * {@code databasesLock} in a background thread (simulating the HA snapshot installer or a long
+   * create/open) and assert that a concurrent lookup for the already-open database still completes
+   * promptly instead of blocking on the monitor.
+   */
+  @Test
+  void openDatabaseLookupDoesNotBlockOnRegistryLock() throws Exception {
+    final CountDownLatch lockHeld = new CountDownLatch(1);
+    final CountDownLatch releaseLock = new CountDownLatch(1);
+
+    final Thread holder = new Thread(() -> {
+      synchronized (server.getDatabasesLock()) {
+        lockHeld.countDown();
+        try {
+          releaseLock.await(10, TimeUnit.SECONDS);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+    }, "registry-lock-holder");
+    holder.start();
+
+    assertThat(lockHeld.await(5, TimeUnit.SECONDS)).isTrue();
+
+    final AtomicReference<ServerDatabase> looked = new AtomicReference<>();
+    final Thread lookup = new Thread(() -> looked.set(server.getDatabase("registry", false, true)), "registry-lookup");
+    lookup.start();
+    lookup.join(TimeUnit.SECONDS.toMillis(3));
+
+    final boolean returnedWhileLocked = !lookup.isAlive();
+    releaseLock.countDown();
+    holder.join(TimeUnit.SECONDS.toMillis(5));
+    lookup.join(TimeUnit.SECONDS.toMillis(5));
+
+    assertThat(returnedWhileLocked)
+        .as("getDatabase on an already-open database must not block while databasesLock is held")
+        .isTrue();
+    assertThat(looked.get()).isNotNull();
+    assertThat(looked.get().isOpen()).isTrue();
+  }
+
+  /**
+   * Defect 1 (correctness): concurrent lookups for the same open database all observe the identical
+   * registered instance - the fast path never creates a second wrapper.
+   */
+  @Test
+  void concurrentLookupsReturnSameInstance() throws Exception {
+    final int threads = 32;
+    final CyclicBarrier barrier = new CyclicBarrier(threads);
+    final Map<ServerDatabase, Boolean> seen = Collections.synchronizedMap(new IdentityHashMap<>());
+    final Thread[] pool = new Thread[threads];
+
+    for (int i = 0; i < threads; i++) {
+      pool[i] = new Thread(() -> {
+        try {
+          barrier.await(5, TimeUnit.SECONDS);
+          for (int j = 0; j < 100; j++)
+            seen.put(server.getDatabase("registry", false, true), Boolean.TRUE);
+        } catch (final Exception e) {
+          throw new RuntimeException(e);
+        }
+      });
+      pool[i].start();
+    }
+    for (final Thread t : pool)
+      t.join(TimeUnit.SECONDS.toMillis(15));
+
+    assertThat(seen).hasSize(1);
+  }
+
+  /**
+   * Defect 2: {@code removeDatabase} must acquire {@code databasesLock}. While the lock is held by
+   * another thread, a concurrent {@code removeDatabase} must block until the lock is released.
+   */
+  @Test
+  void removeDatabaseAcquiresRegistryLock() throws Exception {
+    final CountDownLatch lockHeld = new CountDownLatch(1);
+    final CountDownLatch releaseLock = new CountDownLatch(1);
+    final CountDownLatch removeStarted = new CountDownLatch(1);
+    final CountDownLatch removeFinished = new CountDownLatch(1);
+
+    final Thread holder = new Thread(() -> {
+      synchronized (server.getDatabasesLock()) {
+        lockHeld.countDown();
+        try {
+          releaseLock.await(10, TimeUnit.SECONDS);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+    }, "registry-lock-holder");
+    holder.start();
+
+    assertThat(lockHeld.await(5, TimeUnit.SECONDS)).isTrue();
+
+    final Thread remover = new Thread(() -> {
+      removeStarted.countDown();
+      server.removeDatabase("registry");
+      removeFinished.countDown();
+    }, "registry-remover");
+    remover.start();
+
+    assertThat(removeStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+    // With the lock held, removeDatabase must NOT complete.
+    final boolean finishedWhileLocked = removeFinished.await(1, TimeUnit.SECONDS);
+    releaseLock.countDown();
+
+    final boolean finishedAfterRelease = removeFinished.await(5, TimeUnit.SECONDS);
+    holder.join(TimeUnit.SECONDS.toMillis(5));
+    remover.join(TimeUnit.SECONDS.toMillis(5));
+
+    assertThat(finishedWhileLocked)
+        .as("removeDatabase must block while databasesLock is held (it must acquire the lock)")
+        .isFalse();
+    assertThat(finishedAfterRelease)
+        .as("removeDatabase must complete once databasesLock is released")
+        .isTrue();
+    assertThat(server.existsDatabase("registry")).isFalse();
+  }
+
+  /**
+   * Defect 3: the fields mutated after the HTTP server has started serving requests must be
+   * {@code volatile} so concurrent readers on the Undertow worker threads observe the writes.
+   */
+  @Test
+  void haRelatedFieldsAreVolatile() {
+    assertFieldVolatile("haServer");
+    assertFieldVolatile("databaseWrapper");
+    assertFieldVolatile("security");
+    assertFieldVolatile("httpServer");
+  }
+
+  private static void assertFieldVolatile(final String fieldName) {
+    final Field field = findField(fieldName);
+    assertThat(field).as("field '%s' must exist on ArcadeDBServer", fieldName).isNotNull();
+    assertThat(Modifier.isVolatile(field.getModifiers()))
+        .as("field '%s' must be declared volatile so post-startup writes are visible to worker threads", fieldName)
+        .isTrue();
+  }
+
+  private static Field findField(final String fieldName) {
+    for (final Field f : ArcadeDBServer.class.getDeclaredFields())
+      if (f.getName().equals(fieldName))
+        return f;
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #5031

## Summary
Fixes the three related defects in `ArcadeDBServer`'s database registry and HA wiring flagged by the 2026-07 server audit.

- **Defect 1 (HIGH perf):** `getDatabase(...)` now has a lock-free fast path. It reads `databases.get(name)` off the `ConcurrentMap` and returns immediately when the server is `ONLINE` and the database is present and open, so the request hot path no longer serializes ~500 Undertow workers on the JVM-wide `databasesLock` (which is held across create/open and the HA snapshot install close-swap-reopen). The fast path is gated on `STATUS.ONLINE` so that during startup - while the HA plugin re-wraps databases under the lock - lookups still fall through to the locked slow path and block until the wrapped instances are published. Only a miss (absent or closed) falls through, preserving `createIfNotExists`/`allowLoad` semantics.
- **Defect 2 (MEDIUM concurrency):** `registerDatabase`/`removeDatabase` now mutate the registry under `synchronized (databasesLock)`, so a plugin's `registerDatabase` cannot race `getDatabase`'s check-then-open into two `DatabaseInternal` instances over the same directory. Reentrancy-safe (the snapshot installer already holds the lock when it calls `removeDatabase`).
- **Defect 3 (MEDIUM concurrency):** `haServer` and `databaseWrapper` (and `security`/`httpServer` for symmetry) are now `volatile`. They are written by the HA plugin during `startPlugins(AFTER_HTTP_ON)`, after the HTTP server already accepts requests; `volatile` gives worker-thread readers a happens-before so they never observe `null` indefinitely.

No public API changes; the miss/slow path behavior is unchanged.

## Test plan
`Issue5031ServerRegistryConcurrencyIT` (5 tests, `@Tag("slow")`) - all pass; the defect tests were confirmed red before the fix:
- [x] `openDatabaseLookupDoesNotBlockOnRegistryLock` - lookup of an open DB returns while `databasesLock` is held (defect 1, ONLINE fast path).
- [x] `fastPathIsDisabledWhileServerNotOnline` - with status forced to `STARTING`, the lookup takes the locked slow path and blocks (defect 1, startup-window safety).
- [x] `concurrentLookupsReturnSameInstance` - 32 threads x 100 lookups observe one identity (defect 1 correctness).
- [x] `removeDatabaseAcquiresRegistryLock` - `removeDatabase` blocks while the lock is held (defect 2).
- [x] `haRelatedFieldsAreVolatile` - reflection assertion the four fields are `volatile` (defect 3).
- [x] Regression: `PluginManagerTest` (15) and `RemoteSafeCloseDatabaseIT` (1) pass.
- [ ] `mvn -pl server verify` in CI (note: `HTTPGraphIT` cannot run in the author's local env because an unrelated external ArcadeDB server occupied port 2480; not affected by this change).