### PR TITLE
fix(#5035): reduce HTTP hot-path allocations and cache static Studio assets

### DIFF
--- a/docs/5035-hot-path-allocations.md
+++ b/docs/5035-hot-path-allocations.md
@@ -1,0 +1,56 @@
+# Issue #5035 — Request/response hot-path allocations & Studio content serving
+
+**Type:** bug (performance / GC pressure), server module audit 2026-07.
+**Branch:** `fix/5035-hot-path-allocations`
+
+## Scope of this PR
+
+The issue groups six independent allocation/serving-efficiency defects on the HTTP
+path and explicitly permits splitting them into separate PRs ("result streaming vs
+command-heuristic vs static-content caching are independent"). This PR takes the
+three contained, behavior-preserving, unit-testable ones:
+
+- **Defect 2 — per-request full-command copies + regex in the LIMIT heuristic**
+  (`PostCommandHandler`). The old code did `command.toLowerCase(...)` (full copy of
+  every SQL command), compiled a `split("\\R")` `Pattern` per call, and did a second
+  full `command.toUpperCase(...)` just to test a `"PROFILE "` prefix. Replaced with
+  `regionMatches`-based prefix checks, a `static final Pattern` for the line break,
+  an allocation-free case-insensitive scan for the existing-LIMIT test, and lowercasing
+  only the last line when an explicit LIMIT may already be present. Logic extracted to
+  the package-private static `appendAutomaticLimit(command, language, limit)` so it is
+  unit-testable in isolation. Behavior is identical to the previous heuristic.
+
+- **Defect 4 — `UUID.randomUUID()` per request when no `X-Request-Id`**
+  (`AbstractServerHttpHandler`). The generated value is only a log/echo correlation id
+  (it is NOT the idempotency key — that uses the raw client header, which is null when
+  the client sends none). Replaced the shared-`SecureRandom` `UUID.randomUUID()` with a
+  cheap non-cryptographic id (`ThreadLocalRandom` hex + a process-wide monotonic
+  counter), extracted to the static `generateCorrelationId()`.
+
+- **Defect 6 (safe subset) — static content re-read + copied on every request**
+  (`GetDynamicContentHandler`). Non-templated Studio assets (js/css/svg/fonts/json/ico)
+  are immutable for the process lifetime; their raw bytes are now cached in a bounded
+  `ConcurrentHashMap` keyed by resource path, so repeated requests skip
+  `getResourceAsStream` + full read + `toByteArray` copy. Templated `.html` pages are
+  deliberately NOT cached because they embed per-request dynamic content (`now`, `uuid`,
+  role-gated `protectBegin` sections). Loading + caching extracted to the static
+  `loadStaticResource(resourcePath)`.
+
+## Deferred to follow-up PRs (higher regression risk / more invasive)
+
+- Defect 1 — incremental result serialization (removing the intermediate `List` + JSON
+  tree). Large refactor of the serialization path; separate PR.
+- Defect 3 — parse the POST body from bytes/Reader instead of `new String(...).trim()`.
+- Defect 5 — respect the remaining `limit` budget inside the Studio edge-filter loops.
+
+## Verification
+
+- `PostCommandHandlerAutoLimitTest` — behavior-equivalence unit tests for the LIMIT
+  heuristic across select/match, uppercase, existing-LIMIT, trailing `;`, non-SQL.
+- `CorrelationIdGenerationTest` — format/uniqueness of the generated correlation id and
+  that `sanitizeRequestId` leaves it unchanged.
+- `GetDynamicContentHandlerCacheTest` — cache hit returns the same array instance;
+  missing resource returns null.
+- Existing `GetDynamicContentHandlerIT`, `PostCommandHandler*` tests must stay green.
+</content>
+</invoke>

--- a/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/AbstractServerHttpHandler.java
@@ -49,8 +49,9 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.IdentityHashMap;
 import java.util.Set;
-import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 
@@ -61,6 +62,9 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
   private static final HttpString REQUEST_ID_HEADER = HttpString.tryFromString(IdempotencyCache.HEADER_REQUEST_ID);
   // Upper bound on a client-supplied X-Request-Id we echo and log, to keep a hostile value bounded.
   private static final int        MAX_REQUEST_ID_LENGTH = 128;
+  // Process-wide monotonic counter used, together with a per-thread random, to mint cheap correlation ids
+  // when the client sends no X-Request-Id. Avoids the shared-SecureRandom cost of UUID.randomUUID() per request.
+  private static final AtomicLong CORRELATION_ID_COUNTER = new AtomicLong();
   protected final HttpServer httpServer;
 
   public AbstractServerHttpHandler(final HttpServer httpServer) {
@@ -148,7 +152,7 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
       // leaking across pooled Undertow worker threads.
       String correlationRequestId = sanitizeRequestId(exchange.getRequestHeaders().getFirst(IdempotencyCache.HEADER_REQUEST_ID));
       if (correlationRequestId == null)
-        correlationRequestId = UUID.randomUUID().toString();
+        correlationRequestId = generateCorrelationId();
       exchange.getResponseHeaders().put(REQUEST_ID_HEADER, correlationRequestId);
       // The supplier is an SPI: tolerate an array shorter than 2 (or null) instead of indexing blindly.
       final String[] traceContext = LogManager.instance().currentTraceContext();
@@ -502,6 +506,20 @@ public abstract class AbstractServerHttpHandler implements HttpHandler {
     final String result = cleaned != null ? cleaned.toString()
         : raw.length() > MAX_REQUEST_ID_LENGTH ? raw.substring(0, MAX_REQUEST_ID_LENGTH) : raw;
     return result.isEmpty() ? null : result;
+  }
+
+  /**
+   * Mints a cheap, non-cryptographic correlation id for a request that carries no {@code X-Request-Id}.
+   * This value is used only for response echo and log correlation - it is never the idempotency key, which
+   * always comes from the raw client header - so a fast {@link ThreadLocalRandom} high-entropy prefix plus a
+   * process-wide monotonic counter is sufficient and avoids the shared-{@code SecureRandom} synchronization
+   * of {@code UUID.randomUUID()} on the request hot path. The result is short and printable, so
+   * {@link #sanitizeRequestId(String)} returns it unchanged.
+   * Package-private for direct unit testing.
+   */
+  static String generateCorrelationId() {
+    return Long.toHexString(ThreadLocalRandom.current().nextLong()) + "-"
+        + Long.toHexString(CORRELATION_ID_COUNTER.incrementAndGet());
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetDynamicContentHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetDynamicContentHandler.java
@@ -36,9 +36,18 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 
 public class GetDynamicContentHandler extends AbstractServerHttpHandler {
+
+  // Non-templated Studio assets (js/css/svg/fonts/json/ico) are immutable classpath resources for the
+  // process lifetime. Cache their raw bytes so repeated requests skip the getResourceAsStream + full read
+  // + toByteArray copy on every hit. Bounded so a pathological set of distinct URIs cannot grow it without
+  // limit. Templated (.html) pages are intentionally NOT cached: they embed per-request dynamic content
+  // (now, uuid, role-gated protectBegin sections).
+  private static final int                     STATIC_CACHE_MAX_ENTRIES = 512;
+  private static final Map<String, byte[]>     STATIC_CONTENT_CACHE     = new ConcurrentHashMap<>();
 
   public GetDynamicContentHandler(final HttpServer httpServer) {
     super(httpServer);
@@ -99,25 +108,57 @@ public class GetDynamicContentHandler extends AbstractServerHttpHandler {
 
     Metrics.counter("http.static-content").increment();
 
-    LogManager.instance().log(this, Level.FINE, "Loading file %s ", "/static" + uri);
+    final String resourcePath = "static" + uri;
+    LogManager.instance().log(this, Level.FINE, "Loading file %s ", "/" + resourcePath);
 
-    final InputStream file = getClass().getClassLoader().getResourceAsStream("static" + uri);
-    if (file == null)
-      return new ExecutionResponse(404, "Not Found");
-
-    final Binary fileContent = FileUtils.readStreamAsBinary(file);
-    file.close();
-
-    byte[] bytes = fileContent.toByteArray();
-
-    if (processTemplate)
-      bytes = templating(exchange, new String(bytes, DatabaseFactory.getDefaultCharset()), new HashMap<>()).getBytes(
-          DatabaseFactory.getDefaultCharset());
-
-    if (!processTemplate)
+    final byte[] bytes;
+    if (processTemplate) {
+      // Templated pages are re-rendered per request (they embed now/uuid/role-gated sections) and are not cached.
+      final InputStream file = getClass().getClassLoader().getResourceAsStream(resourcePath);
+      if (file == null)
+        return new ExecutionResponse(404, "Not Found");
+      final Binary fileContent = FileUtils.readStreamAsBinary(file);
+      file.close();
+      bytes = templating(exchange, new String(fileContent.toByteArray(), DatabaseFactory.getDefaultCharset()),
+          new HashMap<>()).getBytes(DatabaseFactory.getDefaultCharset());
+    } else {
+      // Immutable static asset: served from the in-process cache after the first read.
+      bytes = loadStaticResource(resourcePath);
+      if (bytes == null)
+        return new ExecutionResponse(404, "Not Found");
       exchange.getResponseHeaders().put(Headers.CACHE_CONTROL, "max-age=86400");
+    }
 
     return new ExecutionResponse(200, bytes);
+  }
+
+  /**
+   * Loads an immutable classpath static asset, caching its raw bytes for the process lifetime so repeated
+   * requests avoid re-reading the stream and re-copying the bytes. Returns {@code null} when the resource
+   * does not exist. The cache is bounded; once full, further distinct resources are still served but not
+   * cached. Package-private for direct unit testing.
+   */
+  static byte[] loadStaticResource(final String resourcePath) throws IOException {
+    final byte[] cached = STATIC_CONTENT_CACHE.get(resourcePath);
+    if (cached != null)
+      return cached;
+
+    final InputStream file = GetDynamicContentHandler.class.getClassLoader().getResourceAsStream(resourcePath);
+    if (file == null)
+      return null;
+
+    final byte[] bytes;
+    try {
+      bytes = FileUtils.readStreamAsBinary(file).toByteArray();
+    } finally {
+      file.close();
+    }
+
+    if (STATIC_CONTENT_CACHE.size() < STATIC_CACHE_MAX_ENTRIES) {
+      final byte[] existing = STATIC_CONTENT_CACHE.putIfAbsent(resourcePath, bytes);
+      return existing != null ? existing : bytes;
+    }
+    return bytes;
   }
 
   protected String templating(final HttpServerExchange exchange, final String file, final Map<String, Object> variables)

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostCommandHandler.java
@@ -39,11 +39,61 @@ import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
+import java.util.regex.Pattern;
 
 public class PostCommandHandler extends AbstractQueryHandler {
 
+  // Precompiled once: recompiling the line-break pattern on every command carrying an explicit LIMIT is wasteful.
+  private static final Pattern LINE_BREAK = Pattern.compile("\\R");
+
   public PostCommandHandler(final HttpServer httpServer) {
     super(httpServer);
+  }
+
+  /**
+   * Appends an automatic trailing {@code LIMIT} to SELECT/MATCH SQL commands that do not already carry one,
+   * mirroring the historical heuristic while avoiding a full-command {@code toLowerCase} copy per request.
+   * The command is expected to be already trimmed. Only case-insensitive prefix/substring probes are used,
+   * and the last line is lowercased only when an explicit LIMIT may already be present.
+   */
+  static String appendAutomaticLimit(final String command, final String language, final int limit) {
+    if (limit == -1)
+      return command;
+    if (!"sql".equalsIgnoreCase(language) && !"sqlScript".equalsIgnoreCase(language))
+      return command;
+
+    final boolean isSelect = command.regionMatches(true, 0, "select", 0, 6);
+    final boolean isMatch = command.regionMatches(true, 0, "match", 0, 5);
+    if ((!isSelect && !isMatch) || command.endsWith(";"))
+      return command;
+
+    if (!containsIgnoreCase(command, " limit ") && !containsIgnoreCase(command, "\nlimit "))
+      return command + " limit " + limit;
+
+    // An explicit LIMIT may already be present somewhere: only the last line decides whether to append.
+    final String[] lines = LINE_BREAK.split(command);
+    final String[] words = lines[lines.length - 1].toLowerCase(Locale.ENGLISH).split(" ");
+    if (words.length > 1 //
+        && !"limit".equals(words[words.length - 2]) //
+        && (words.length < 5 || !"limit".equals(words[words.length - 4])))
+      return command + " limit " + limit;
+
+    return command;
+  }
+
+  /**
+   * Allocation-free case-insensitive substring test, avoiding the full-command lowercase copy the previous
+   * {@code String.contains} check required.
+   */
+  private static boolean containsIgnoreCase(final String haystack, final String needle) {
+    final int needleLen = needle.length();
+    if (needleLen == 0)
+      return true;
+    final int max = haystack.length() - needleLen;
+    for (int i = 0; i <= max; i++)
+      if (haystack.regionMatches(true, i, needle, 0, needleLen))
+        return true;
+    return false;
   }
 
   @Override
@@ -120,24 +170,7 @@ public class PostCommandHandler extends AbstractQueryHandler {
     // and downgraded to HTTP 500.
     paramMap = AbstractQueryHandler.decodeTypedJsonMarkers(paramMap);
 
-    if (limit != -1) {
-      if ("sql".equalsIgnoreCase(language) || "sqlScript".equalsIgnoreCase(language)) {
-        final String commandLC = command.toLowerCase(Locale.ENGLISH).trim();
-        if ((commandLC.startsWith("select") || commandLC.startsWith("match")) && !commandLC.endsWith(";")) {
-          if (!commandLC.contains(" limit ") && !commandLC.contains("\nlimit ")) {
-            command += " limit " + limit;
-          } else {
-            final String[] lines = commandLC.split("\\R");
-            final String[] words = lines[lines.length - 1].split(" ");
-            if (words.length > 1) {
-              if (!"limit".equals(words[words.length - 2]) && //
-                  (words.length < 5 || !"limit".equals(words[words.length - 4])))
-                command += " limit " + limit;
-            }
-          }
-        }
-      }
-    }
+    command = appendAutomaticLimit(command, language, limit);
 
     if ("sqlScript".equalsIgnoreCase(language) && !command.endsWith(";"))
       command += ";";
@@ -200,7 +233,7 @@ public class PostCommandHandler extends AbstractQueryHandler {
 
           if (qResult != null && qResult.getExecutionPlan().isPresent() &&
               (profileExecution != null ||
-                  command.toUpperCase(Locale.ENGLISH).startsWith("PROFILE "))) {
+                  command.regionMatches(true, 0, "PROFILE ", 0, 8))) {
             final var executionPlan = qResult.getExecutionPlan().get();
             response.put("explain", executionPlan.prettyPrint(0, 2));
             response.put("explainPlan", executionPlan.toResult().toJSON());

--- a/server/src/test/java/com/arcadedb/server/http/handler/CorrelationIdGenerationTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/CorrelationIdGenerationTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link AbstractServerHttpHandler#generateCorrelationId()}: the cheap non-cryptographic
+ * request-correlation id (used when the client sends no X-Request-Id) must be non-blank, unique across
+ * calls, safely bounded, and printable so {@code sanitizeRequestId} echoes it unchanged.
+ */
+class CorrelationIdGenerationTest {
+
+  @Test
+  void generatesNonBlankIds() {
+    final String id = AbstractServerHttpHandler.generateCorrelationId();
+    assertThat(id).isNotNull().isNotBlank();
+  }
+
+  @Test
+  void generatedIdsAreUnique() {
+    final Set<String> ids = new HashSet<>();
+    for (int i = 0; i < 10_000; i++)
+      ids.add(AbstractServerHttpHandler.generateCorrelationId());
+    assertThat(ids).hasSize(10_000);
+  }
+
+  @Test
+  void generatedIdContainsOnlyHexAndSeparator() {
+    final String id = AbstractServerHttpHandler.generateCorrelationId();
+    assertThat(id).matches("[0-9a-f]+-[0-9a-f]+");
+  }
+
+  @Test
+  void generatedIdSurvivesSanitizationUnchanged() {
+    // The generated id is echoed and logged through sanitizeRequestId; it must be short and printable
+    // enough that sanitization returns it verbatim.
+    final String id = AbstractServerHttpHandler.generateCorrelationId();
+    assertThat(id).hasSizeLessThanOrEqualTo(128);
+    assertThat(AbstractServerHttpHandler.sanitizeRequestId(id)).isEqualTo(id);
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/GetDynamicContentHandlerCacheTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/GetDynamicContentHandlerCacheTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link GetDynamicContentHandler#loadStaticResource(String)}: immutable classpath assets
+ * are read once and their raw bytes cached for the process lifetime, so repeated requests skip the
+ * stream read + copy. A missing resource returns {@code null}.
+ */
+class GetDynamicContentHandlerCacheTest {
+
+  private static final String PROBE = "static/js/cache-probe.js";
+
+  @Test
+  void returnsResourceBytes() throws IOException {
+    final byte[] bytes = GetDynamicContentHandler.loadStaticResource(PROBE);
+    assertThat(bytes).isNotNull();
+    assertThat(new String(bytes, StandardCharsets.UTF_8)).contains("cache-probe");
+  }
+
+  @Test
+  void secondCallReturnsSameCachedInstance() throws IOException {
+    final byte[] first = GetDynamicContentHandler.loadStaticResource(PROBE);
+    final byte[] second = GetDynamicContentHandler.loadStaticResource(PROBE);
+    assertThat(first).isNotNull();
+    // Cache hit: the exact same array is handed back rather than a fresh copy.
+    assertThat(second).isSameAs(first);
+  }
+
+  @Test
+  void missingResourceReturnsNull() throws IOException {
+    assertThat(GetDynamicContentHandler.loadStaticResource("static/js/does-not-exist-5035.js")).isNull();
+  }
+}

--- a/server/src/test/java/com/arcadedb/server/http/handler/PostCommandHandlerAutoLimitTest.java
+++ b/server/src/test/java/com/arcadedb/server/http/handler/PostCommandHandlerAutoLimitTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2021-present Arcade Data Ltd (info@arcadedata.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: 2021-present Arcade Data Ltd (info@arcadedata.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.arcadedb.server.http.handler;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link PostCommandHandler#appendAutomaticLimit(String, String, int)}: the automatic
+ * trailing-LIMIT heuristic must behave exactly as the previous inline implementation while avoiding a
+ * full-command {@code toLowerCase} copy per request. The command passed in is already trimmed, as in the
+ * handler.
+ */
+class PostCommandHandlerAutoLimitTest {
+
+  private static final int LIMIT = 20_000;
+
+  @Test
+  void appendsLimitToPlainSelect() {
+    assertThat(PostCommandHandler.appendAutomaticLimit("select from V", "sql", LIMIT))
+        .isEqualTo("select from V limit " + LIMIT);
+  }
+
+  @Test
+  void appendsLimitToMatch() {
+    assertThat(PostCommandHandler.appendAutomaticLimit("match {type: V, as: v} return v", "sql", LIMIT))
+        .isEqualTo("match {type: V, as: v} return v limit " + LIMIT);
+  }
+
+  @Test
+  void prefixCheckIsCaseInsensitive() {
+    assertThat(PostCommandHandler.appendAutomaticLimit("SELECT from V", "sql", LIMIT))
+        .isEqualTo("SELECT from V limit " + LIMIT);
+  }
+
+  @Test
+  void doesNotAppendWhenExplicitLowercaseLimitAlreadyPresent() {
+    final String cmd = "select from V limit 5";
+    assertThat(PostCommandHandler.appendAutomaticLimit(cmd, "sql", LIMIT)).isEqualTo(cmd);
+  }
+
+  @Test
+  void doesNotAppendWhenExplicitUppercaseLimitAlreadyPresent() {
+    final String cmd = "select from V LIMIT 5";
+    assertThat(PostCommandHandler.appendAutomaticLimit(cmd, "sql", LIMIT)).isEqualTo(cmd);
+  }
+
+  @Test
+  void doesNotAppendWhenCommandEndsWithSemicolon() {
+    final String cmd = "select from V;";
+    assertThat(PostCommandHandler.appendAutomaticLimit(cmd, "sql", LIMIT)).isEqualTo(cmd);
+  }
+
+  @Test
+  void doesNotAppendToNonSelectOrMatch() {
+    final String cmd = "insert into V set name = 'a'";
+    assertThat(PostCommandHandler.appendAutomaticLimit(cmd, "sql", LIMIT)).isEqualTo(cmd);
+  }
+
+  @Test
+  void doesNotAppendForNonSqlLanguage() {
+    final String cmd = "MATCH (n) RETURN n";
+    assertThat(PostCommandHandler.appendAutomaticLimit(cmd, "cypher", LIMIT)).isEqualTo(cmd);
+  }
+
+  @Test
+  void doesNotAppendWhenLimitDisabled() {
+    final String cmd = "select from V";
+    assertThat(PostCommandHandler.appendAutomaticLimit(cmd, "sql", -1)).isEqualTo(cmd);
+  }
+
+  @Test
+  void appendsWhenLimitSubstringIsNotAStandaloneClause() {
+    // "limitless" must not be mistaken for an existing LIMIT clause.
+    final String cmd = "select limitless from V";
+    assertThat(PostCommandHandler.appendAutomaticLimit(cmd, "sql", LIMIT))
+        .isEqualTo("select limitless from V limit " + LIMIT);
+  }
+
+  @Test
+  void appendsWhenLimitOnlyOnEarlierLineButNotOnLastLine() {
+    // A subquery LIMIT on an earlier line must still let the outer query receive a trailing LIMIT.
+    final String cmd = "select from (select from V limit 3)\nwhere x > 1";
+    assertThat(PostCommandHandler.appendAutomaticLimit(cmd, "sql", LIMIT))
+        .isEqualTo(cmd + " limit " + LIMIT);
+  }
+
+  @Test
+  void handlesSqlScriptLanguage() {
+    assertThat(PostCommandHandler.appendAutomaticLimit("select from V", "sqlScript", LIMIT))
+        .isEqualTo("select from V limit " + LIMIT);
+  }
+}

--- a/server/src/test/resources/static/js/cache-probe.js
+++ b/server/src/test/resources/static/js/cache-probe.js
@@ -1,0 +1,2 @@
+// cache probe asset for GetDynamicContentHandlerCacheTest
+console.log("cache-probe");


### PR DESCRIPTION
Closes #5035

## Summary

Addresses three contained, behavior-preserving defects from the 2026-07 `server` module audit (issue #5035). None are correctness bugs; all target the low-GC / high-throughput goal. The issue explicitly permits splitting its six defects into separate PRs; this PR takes the three that are behavior-preserving and directly unit-testable.

- **Defect 2 - per-request full-command copies + regex in the LIMIT heuristic** (`PostCommandHandler`). The old code did `command.toLowerCase(...)` (full copy of every SQL command), compiled a `split("\\R")` `Pattern` per call, and did a second full `command.toUpperCase(...)` just to test a `"PROFILE "` prefix. Extracted the heuristic to the package-private static `appendAutomaticLimit(command, language, limit)`: `regionMatches` prefix checks, a `static final Pattern` for the line break, an allocation-free case-insensitive scan for the existing-LIMIT test, and lowercasing only the last line. The PROFILE prefix check uses `regionMatches`. Behavior is identical to the previous heuristic.
- **Defect 4 - `UUID.randomUUID()` per request when no `X-Request-Id`** (`AbstractServerHttpHandler`). The generated value is only a log/echo correlation id (never the idempotency key - that uses the raw client header). Replaced with a cheap non-cryptographic id (`ThreadLocalRandom` hex + a process-wide monotonic counter) via the static `generateCorrelationId()`, avoiding shared-`SecureRandom` synchronization on the hot path.
- **Defect 6 (safe subset) - static content re-read + copied on every request** (`GetDynamicContentHandler`). Non-templated Studio assets (js/css/svg/fonts/json/ico) are immutable classpath resources for the process lifetime; their raw bytes are now cached in a bounded `ConcurrentHashMap` keyed by resource path via the static `loadStaticResource()`, skipping `getResourceAsStream` + full read + `toByteArray` copy on every hit. Templated `.html` pages are deliberately NOT cached because they embed per-request dynamic content (`now`, `uuid`, role-gated `protectBegin` sections).

Defects 1 (incremental result serialization), 3 (parse POST body without the extra String copy), and 5 (Studio edge-filter limit budget) are deferred to follow-up PRs as noted in `docs/5035-hot-path-allocations.md` - they are more invasive and carry higher regression risk.

## Test plan

- [ ] `PostCommandHandlerAutoLimitTest` (12 cases): behavior-equivalence of the LIMIT heuristic across select/match, uppercase prefix, existing lowercase/uppercase LIMIT, trailing `;`, non-SELECT, non-SQL language, `limit == -1`, `limitless` non-clause, subquery-only LIMIT, `sqlScript`.
- [ ] `CorrelationIdGenerationTest` (4 cases): non-blank, unique across 10k calls, hex-plus-separator format, survives `sanitizeRequestId` unchanged.
- [ ] `GetDynamicContentHandlerCacheTest` (3 cases): resource bytes returned, cache hit returns the same array instance, missing resource returns null.
- [ ] Existing regression suites stay green: `GetDynamicContentHandlerIT` (14), `LogCorrelationIT` (3), `RequestIdSanitizationTest` (6), `PostCommandHandlerProfileIT` (9), `PostCommandStatisticsIT` (4), `PostCommandHandlerLargeContentTest`, `PostCommandHtmlEntityTest`, `PostCommandHandlerDecodeTest`.