### PR TITLE
bindings/python: align set_commit_every with engine #4961 (reject commit_every < 1)

### DIFF
--- a/bindings/python/src/arcadedb_embedded/async_executor.py
+++ b/bindings/python/src/arcadedb_embedded/async_executor.py
@@ -116,8 +116,9 @@ class AsyncExecutor:
         Auto-commit every N operations.
 
         Args:
-            count: Commit frequency (operations per commit).
-                   0 = manual commits only (default).
+            count: Commit frequency (operations per commit). Must be >= 1;
+                   the engine rejects lower values (0 used to be silently
+                   accepted but broke async task execution, engine #4961).
                    Recommended: 1000-10000 for bulk inserts.
 
         Returns:
@@ -126,6 +127,12 @@ class AsyncExecutor:
         Example:
             >>> async_exec.set_commit_every(5000)  # Commit every 5K ops
         """
+        # engine #4961: commitEvery < 1 breaks async task execution
+        if count < 1:
+            raise ValueError(
+                f"commit_every must be >= 1 (got {count}); the async "
+                "executor always commits in batches"
+            )
         self._java_async.setCommitEvery(count)
         return self
 

--- a/bindings/python/tests/test_importer_api.py
+++ b/bindings/python/tests/test_importer_api.py
@@ -64,7 +64,7 @@ def test_import_documents_applies_and_restores_runtime_settings(temp_db_path, tm
         db.set_read_your_writes(True)
         async_exec = db.async_executor()
         async_exec.set_parallel_level(1)
-        async_exec.set_commit_every(0)
+        async_exec.set_commit_every(7)
         async_exec.set_transaction_use_wal(True)
 
         result = db.import_documents(
@@ -79,8 +79,17 @@ def test_import_documents_applies_and_restores_runtime_settings(temp_db_path, tm
         assert result.result == "OK"
         assert db.is_read_your_writes() is True
         assert async_exec.get_parallel_level() == 1
-        assert async_exec.get_commit_every() == 0
+        assert async_exec.get_commit_every() == 7
         assert async_exec.is_transaction_use_wal() is True
+
+
+def test_set_commit_every_rejects_below_one(temp_db_path):
+    with arcadedb.create_database(temp_db_path) as db:
+        async_exec = db.async_executor()
+        with pytest.raises(ValueError, match="commit_every must be >= 1"):
+            async_exec.set_commit_every(0)
+        with pytest.raises(ValueError, match="commit_every must be >= 1"):
+            async_exec.set_commit_every(-5)
 
 
 def test_import_documents_missing_file_raises_arcadedb_error(temp_db_path, tmp_path):
@@ -100,7 +109,7 @@ def test_import_documents_restores_runtime_settings_after_failure(
         db.set_read_your_writes(True)
         async_exec = db.async_executor()
         async_exec.set_parallel_level(1)
-        async_exec.set_commit_every(0)
+        async_exec.set_commit_every(7)
         async_exec.set_transaction_use_wal(True)
 
         with pytest.raises(arcadedb.ArcadeDBError):
@@ -115,5 +124,5 @@ def test_import_documents_restores_runtime_settings_after_failure(
 
         assert db.is_read_your_writes() is True
         assert async_exec.get_parallel_level() == 1
-        assert async_exec.get_commit_every() == 0
+        assert async_exec.get_commit_every() == 7
         assert async_exec.is_transaction_use_wal() is True


### PR DESCRIPTION
Follow-up to the async executor validation added in #4961.

The engine now rejects `commitEvery < 1` (0 previously slipped through and broke async task execution). This aligns the Python wrapper with that contract:

- `AsyncExecutor.set_commit_every()` raises a clear `ValueError` when `count < 1`, so callers get a Python-side error instead of a Java `IllegalArgumentException`.
- Updates the docstring, which previously described `0` as "manual commits only".
- Updates `test_importer_api` where the restore-settings test used the now-invalid `0` as its baseline (changed to a valid value; the test still verifies the executor applies and restores its settings).

Scope is limited to `bindings/python`. No engine changes.
